### PR TITLE
Implementation of Xic⁰ reconstruction using the Kalman Filter method

### DIFF
--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -1313,7 +1313,6 @@ DECLARE_SOA_COLUMN(XicChi2OverNdf, xicChi2OverNdf, float);
 DECLARE_SOA_COLUMN(MassV0Chi2OverNdf, massV0Chi2OverNdf, float);
 DECLARE_SOA_COLUMN(MassCascChi2OverNdf, massCascChi2OverNdf, float);
 
-
 // MC matching result:
 DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t); // reconstruction level
 DECLARE_SOA_COLUMN(DebugMcRec, debugMcRec, int8_t);         // debug flag for mis-association reconstruction level
@@ -1500,7 +1499,7 @@ DECLARE_SOA_TABLE(HfCandToXiPiKf, "AOD", "HFCANDTOXIPIKF", //!
                   hf_cand_xic0_omegac0::V0Ndf, hf_cand_xic0_omegac0::CascNdf, hf_cand_xic0_omegac0::XicNdf,
                   hf_cand_xic0_omegac0::MassV0Ndf, hf_cand_xic0_omegac0::MassCascNdf,
                   hf_cand_xic0_omegac0::V0Chi2OverNdf, hf_cand_xic0_omegac0::CascChi2OverNdf, hf_cand_xic0_omegac0::XicChi2OverNdf,
-                  hf_cand_xic0_omegac0::MassV0Chi2OverNdf, hf_cand_xic0_omegac0::MassCascChi2OverNdf);                  
+                  hf_cand_xic0_omegac0::MassV0Chi2OverNdf, hf_cand_xic0_omegac0::MassCascChi2OverNdf);
 
 // table with results of reconstruction level MC matching
 DECLARE_SOA_TABLE(HfXicToXiPiMCRec, "AOD", "HFXICXIPIMCREC", //!

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -1258,45 +1258,61 @@ DECLARE_SOA_COLUMN(ErrorDecayLengthXYCharmBaryon, errorDecayLengthXYCharmBaryon,
 
 // KFParticle results
 DECLARE_SOA_COLUMN(KfDcaXYPiFromOmegac, kfDcaXYPiFromOmegac, float);
+DECLARE_SOA_COLUMN(KfDcaXYPiFromXic, kfDcaXYPiFromXic, float);
 DECLARE_SOA_COLUMN(KfDcaXYCascToPv, kfDcaXYCascToPv, float);
 DECLARE_SOA_COLUMN(Chi2GeoV0, chi2GeoV0, float);
 DECLARE_SOA_COLUMN(Chi2GeoCasc, chi2GeoCasc, float);
 DECLARE_SOA_COLUMN(Chi2GeoOmegac, chi2GeoOmegac, float);
+DECLARE_SOA_COLUMN(Chi2GeoXic, chi2GeoXic, float);
 DECLARE_SOA_COLUMN(Chi2MassV0, chi2MassV0, float);
 DECLARE_SOA_COLUMN(Chi2MassCasc, chi2MassCasc, float);
 DECLARE_SOA_COLUMN(V0ldl, v0ldl, float);
 DECLARE_SOA_COLUMN(Cascldl, cascldl, float);
 DECLARE_SOA_COLUMN(Omegacldl, omegacldl, float);
+DECLARE_SOA_COLUMN(Xicldl, xicldl, float);
 DECLARE_SOA_COLUMN(Chi2TopoV0ToPv, chi2TopoV0ToPv, float);
 DECLARE_SOA_COLUMN(Chi2TopoCascToPv, chi2TopoCascToPv, float);
 DECLARE_SOA_COLUMN(Chi2TopoPiFromOmegacToPv, chi2TopoPiFromOmegacToPv, float);
+DECLARE_SOA_COLUMN(Chi2TopoPiFromXicToPv, chi2TopoPiFromXicToPv, float);
 DECLARE_SOA_COLUMN(Chi2TopoOmegacToPv, chi2TopoOmegacToPv, float);
+DECLARE_SOA_COLUMN(Chi2TopoXicToPv, chi2TopoXicToPv, float);
 DECLARE_SOA_COLUMN(Chi2TopoV0ToCasc, chi2TopoV0ToCasc, float);
 DECLARE_SOA_COLUMN(Chi2TopoCascToOmegac, chi2TopoCascToOmegac, float);
+DECLARE_SOA_COLUMN(Chi2TopoCascToXic, chi2TopoCascToXic, float);
 DECLARE_SOA_COLUMN(DecayLenXYLambda, decayLenXYLambda, float);
 DECLARE_SOA_COLUMN(DecayLenXYCasc, decayLenXYCasc, float);
 DECLARE_SOA_COLUMN(DecayLenXYOmegac, decayLenXYOmegac, float);
+DECLARE_SOA_COLUMN(DecayLenXYXic, decayLenXYXic, float);
 DECLARE_SOA_COLUMN(CosPaV0ToCasc, cosPaV0ToCasc, float);
 DECLARE_SOA_COLUMN(CosPaCascToOmegac, cosPaCascToOmegac, float);
+DECLARE_SOA_COLUMN(CosPaCascToXic, cosPaCascToXic, float);
 DECLARE_SOA_COLUMN(CosPaXYV0ToCasc, cosPaXYV0ToCasc, float);
 DECLARE_SOA_COLUMN(CosPaXYCascToOmegac, cosPaXYCascToOmegac, float);
+DECLARE_SOA_COLUMN(CosPaXYCascToXic, cosPaXYCascToXic, float);
 DECLARE_SOA_COLUMN(KfMassV0, kfMassV0, float);
 DECLARE_SOA_COLUMN(KfMassCasc, kfMassCasc, float);
 DECLARE_SOA_COLUMN(KfMassOmegac, kfMassOmegac, float);
 DECLARE_SOA_COLUMN(KfRapOmegac, kfRapOmegac, float);
+DECLARE_SOA_COLUMN(KfRapXic, kfRapXic, float);
 DECLARE_SOA_COLUMN(KfptPiFromOmegac, kfptPiFromOmegac, float);
+DECLARE_SOA_COLUMN(KfptPiFromXic, kfptPiFromXic, float);
 DECLARE_SOA_COLUMN(KfptOmegac, kfptOmegac, float);
+DECLARE_SOA_COLUMN(KfptXic, kfptXic, float);
 DECLARE_SOA_COLUMN(CosThetaStarPiFromOmegac, cosThetaStarPiFromOmegac, float);
+DECLARE_SOA_COLUMN(CosThetaStarPiFromXic, cosThetaStarPiFromXic, float);
 DECLARE_SOA_COLUMN(V0Ndf, v0Ndf, float);
 DECLARE_SOA_COLUMN(CascNdf, cascNdf, float);
 DECLARE_SOA_COLUMN(OmegacNdf, omegacNdf, float);
+DECLARE_SOA_COLUMN(XicNdf, xicNdf, float);
 DECLARE_SOA_COLUMN(MassV0Ndf, massV0Ndf, float);
 DECLARE_SOA_COLUMN(MassCascNdf, massCascNdf, float);
 DECLARE_SOA_COLUMN(V0Chi2OverNdf, v0Chi2OverNdf, float);
 DECLARE_SOA_COLUMN(CascChi2OverNdf, cascChi2OverNdf, float);
 DECLARE_SOA_COLUMN(OmegacChi2OverNdf, omegacChi2OverNdf, float);
+DECLARE_SOA_COLUMN(XicChi2OverNdf, xicChi2OverNdf, float);
 DECLARE_SOA_COLUMN(MassV0Chi2OverNdf, massV0Chi2OverNdf, float);
 DECLARE_SOA_COLUMN(MassCascChi2OverNdf, massCascChi2OverNdf, float);
+
 
 // MC matching result:
 DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t); // reconstruction level
@@ -1442,6 +1458,49 @@ DECLARE_SOA_TABLE(HfOmegacKf, "AOD", "HFOMEGACKF", //!
                   hf_cand_xic0_omegac0::MassV0Ndf, hf_cand_xic0_omegac0::MassCascNdf,
                   hf_cand_xic0_omegac0::V0Chi2OverNdf, hf_cand_xic0_omegac0::CascChi2OverNdf, hf_cand_xic0_omegac0::OmegacChi2OverNdf,
                   hf_cand_xic0_omegac0::MassV0Chi2OverNdf, hf_cand_xic0_omegac0::MassCascChi2OverNdf);
+
+DECLARE_SOA_TABLE(HfCandToXiPiKf, "AOD", "HFCANDTOXIPIKF", //!
+                  o2::soa::Index<>,
+                  hf_cand_xic0_omegac0::CollisionId, hf_cand_xic0_omegac0::XPv, hf_cand_xic0_omegac0::YPv, hf_cand_xic0_omegac0::ZPv,
+                  hf_cand_xic0_omegac0::XDecayVtxCharmBaryon, hf_cand_xic0_omegac0::YDecayVtxCharmBaryon, hf_cand_xic0_omegac0::ZDecayVtxCharmBaryon,
+                  hf_cand_xic0_omegac0::XDecayVtxCascade, hf_cand_xic0_omegac0::YDecayVtxCascade, hf_cand_xic0_omegac0::ZDecayVtxCascade,
+                  hf_cand_xic0_omegac0::XDecayVtxV0, hf_cand_xic0_omegac0::YDecayVtxV0, hf_cand_xic0_omegac0::ZDecayVtxV0,
+                  hf_cand_xic0_omegac0::SignDecay,
+                  hf_cand_xic0_omegac0::CovVtxCharmBaryon0, hf_cand_xic0_omegac0::CovVtxCharmBaryon1, hf_cand_xic0_omegac0::CovVtxCharmBaryon2, hf_cand_xic0_omegac0::CovVtxCharmBaryon3, hf_cand_xic0_omegac0::CovVtxCharmBaryon4, hf_cand_xic0_omegac0::CovVtxCharmBaryon5,
+                  hf_cand_xic0_omegac0::PxCharmBaryon, hf_cand_xic0_omegac0::PyCharmBaryon, hf_cand_xic0_omegac0::PzCharmBaryon,
+                  hf_cand_xic0_omegac0::PxCasc, hf_cand_xic0_omegac0::PyCasc, hf_cand_xic0_omegac0::PzCasc,
+                  hf_cand_xic0_omegac0::PxBachFromCharmBaryon, hf_cand_xic0_omegac0::PyBachFromCharmBaryon, hf_cand_xic0_omegac0::PzBachFromCharmBaryon,
+                  hf_cand_xic0_omegac0::PxLambda, hf_cand_xic0_omegac0::PyLambda, hf_cand_xic0_omegac0::PzLambda,
+                  hf_cand_xic0_omegac0::PxBachFromCasc, hf_cand_xic0_omegac0::PyBachFromCasc, hf_cand_xic0_omegac0::PzBachFromCasc,
+                  hf_cand_xic0_omegac0::PxPosV0Dau, hf_cand_xic0_omegac0::PyPosV0Dau, hf_cand_xic0_omegac0::PzPosV0Dau,
+                  hf_cand_xic0_omegac0::PxNegV0Dau, hf_cand_xic0_omegac0::PyNegV0Dau, hf_cand_xic0_omegac0::PzNegV0Dau,
+                  hf_cand_xic0_omegac0::ImpactParCascXY, hf_cand_xic0_omegac0::ImpactParBachFromCharmBaryonXY, hf_cand_xic0_omegac0::ImpactParCascZ, hf_cand_xic0_omegac0::ImpactParBachFromCharmBaryonZ,
+                  hf_cand_xic0_omegac0::ErrImpactParCascXY, hf_cand_xic0_omegac0::ErrImpactParBachFromCharmBaryonXY,
+                  hf_cand_xic0_omegac0::V0Id, v0data::PosTrackId, v0data::NegTrackId, hf_cand_xic0_omegac0::CascadeId, hf_cand_xic0_omegac0::BachelorFromCharmBaryonId, cascdata::BachelorId,
+                  hf_cand_xic0_omegac0::InvMassLambda, hf_cand_xic0_omegac0::InvMassCascade, hf_cand_xic0_omegac0::InvMassCharmBaryon,
+                  hf_cand_xic0_omegac0::CosPAV0, hf_cand_xic0_omegac0::CosPACharmBaryon, hf_cand_xic0_omegac0::CosPACasc, hf_cand_xic0_omegac0::CosPAXYV0, hf_cand_xic0_omegac0::CosPAXYCharmBaryon, hf_cand_xic0_omegac0::CosPAXYCasc,
+                  hf_cand_xic0_omegac0::CTauOmegac, hf_cand_xic0_omegac0::CTauCascade, hf_cand_xic0_omegac0::CTauV0, hf_cand_xic0_omegac0::CTauXic,
+                  hf_cand_xic0_omegac0::EtaV0PosDau, hf_cand_xic0_omegac0::EtaV0NegDau, hf_cand_xic0_omegac0::EtaBachFromCasc, hf_cand_xic0_omegac0::EtaBachFromCharmBaryon,
+                  hf_cand_xic0_omegac0::EtaCharmBaryon, hf_cand_xic0_omegac0::EtaCascade, hf_cand_xic0_omegac0::EtaV0,
+                  hf_cand_xic0_omegac0::DcaXYToPvV0Dau0, hf_cand_xic0_omegac0::DcaXYToPvV0Dau1, hf_cand_xic0_omegac0::DcaXYToPvCascDau,
+                  hf_cand_xic0_omegac0::DcaZToPvV0Dau0, hf_cand_xic0_omegac0::DcaZToPvV0Dau1, hf_cand_xic0_omegac0::DcaZToPvCascDau,
+                  hf_cand_xic0_omegac0::DcaCascDau, hf_cand_xic0_omegac0::DcaV0Dau, hf_cand_xic0_omegac0::DcaCharmBaryonDau,
+                  hf_cand_xic0_omegac0::DecLenCharmBaryon, hf_cand_xic0_omegac0::DecLenCascade, hf_cand_xic0_omegac0::DecLenV0, hf_cand_xic0_omegac0::ErrorDecayLengthCharmBaryon, hf_cand_xic0_omegac0::ErrorDecayLengthXYCharmBaryon,
+                  hf_cand_xic0_omegac0::KfDcaXYPiFromXic, hf_cand_xic0_omegac0::KfDcaXYCascToPv,
+                  hf_cand_xic0_omegac0::Chi2GeoV0, hf_cand_xic0_omegac0::Chi2GeoCasc, hf_cand_xic0_omegac0::Chi2GeoXic,
+                  hf_cand_xic0_omegac0::Chi2MassV0, hf_cand_xic0_omegac0::Chi2MassCasc,
+                  hf_cand_xic0_omegac0::V0ldl, hf_cand_xic0_omegac0::Cascldl, hf_cand_xic0_omegac0::Xicldl,
+                  hf_cand_xic0_omegac0::Chi2TopoV0ToPv, hf_cand_xic0_omegac0::Chi2TopoCascToPv, hf_cand_xic0_omegac0::Chi2TopoPiFromXicToPv, hf_cand_xic0_omegac0::Chi2TopoXicToPv,
+                  hf_cand_xic0_omegac0::Chi2TopoV0ToCasc, hf_cand_xic0_omegac0::Chi2TopoCascToXic,
+                  hf_cand_xic0_omegac0::DecayLenXYLambda, hf_cand_xic0_omegac0::DecayLenXYCasc, hf_cand_xic0_omegac0::DecayLenXYXic,
+                  hf_cand_xic0_omegac0::CosPaV0ToCasc, hf_cand_xic0_omegac0::CosPaCascToXic, hf_cand_xic0_omegac0::CosPaXYV0ToCasc, hf_cand_xic0_omegac0::CosPaXYCascToXic,
+                  hf_cand_xic0_omegac0::KfRapXic,
+                  hf_cand_xic0_omegac0::KfptPiFromXic, hf_cand_xic0_omegac0::KfptXic,
+                  hf_cand_xic0_omegac0::CosThetaStarPiFromXic,
+                  hf_cand_xic0_omegac0::V0Ndf, hf_cand_xic0_omegac0::CascNdf, hf_cand_xic0_omegac0::XicNdf,
+                  hf_cand_xic0_omegac0::MassV0Ndf, hf_cand_xic0_omegac0::MassCascNdf,
+                  hf_cand_xic0_omegac0::V0Chi2OverNdf, hf_cand_xic0_omegac0::CascChi2OverNdf, hf_cand_xic0_omegac0::XicChi2OverNdf,
+                  hf_cand_xic0_omegac0::MassV0Chi2OverNdf, hf_cand_xic0_omegac0::MassCascChi2OverNdf);                  
 
 // table with results of reconstruction level MC matching
 DECLARE_SOA_TABLE(HfXicToXiPiMCRec, "AOD", "HFXICXIPIMCREC", //!

--- a/PWGHF/DataModel/CandidateSelectionTables.h
+++ b/PWGHF/DataModel/CandidateSelectionTables.h
@@ -136,11 +136,11 @@ DECLARE_SOA_TABLE(HfMlDsToKKPi, "AOD", "HFMLDS", //!
 
 namespace hf_sel_candidate_dstar
 {
-DECLARE_SOA_COLUMN(IsSelDstarToD0Pi, isSelDstarToD0Pi, bool); //! checking if all four of following check pass
-DECLARE_SOA_COLUMN(IsRecoD0Flag, isRecoD0Flag, bool);         //! checking DecayType::D0ToPiK of D0prong
-DECLARE_SOA_COLUMN(IsRecoTopol, isRecoTopol, bool);           //! checking conjugate independent Topological selection on Dstar
-DECLARE_SOA_COLUMN(IsRecoCand, isRecoCand, bool);             //! checking conjugate dependent Topological selecton on Dstar
-DECLARE_SOA_COLUMN(IsRecoPid, isRecoPid, bool);               //! checking PID selection on daughters of D0Prong
+DECLARE_SOA_COLUMN(IsSelDstarToD0Pi, isSelDstarToD0Pi, bool);                 //! checking if all four of following check pass
+DECLARE_SOA_COLUMN(IsRecoD0Flag, isRecoD0Flag, bool);                         //! checking DecayType::D0ToPiK of D0prong
+DECLARE_SOA_COLUMN(IsRecoTopol, isRecoTopol, bool);                           //! checking conjugate independent Topological selection on Dstar
+DECLARE_SOA_COLUMN(IsRecoCand, isRecoCand, bool);                             //! checking conjugate dependent Topological selecton on Dstar
+DECLARE_SOA_COLUMN(IsRecoPid, isRecoPid, bool);                               //! checking PID selection on daughters of D0Prong
 DECLARE_SOA_COLUMN(MlProbDstarToD0Pi, mlProbDstarToD0Pi, std::vector<float>); //! ML probability for Dstar to D0Pi
 } // namespace hf_sel_candidate_dstar
 
@@ -307,7 +307,7 @@ DECLARE_SOA_COLUMN(IsSelXicToPiKP, isSelXicToPiKP, int);                  //!
 DECLARE_SOA_COLUMN(MlProbXicToPKPi, mlProbXicToPKPi, std::vector<float>); //!
 DECLARE_SOA_COLUMN(MlProbXicToPiKP, mlProbXicToPiKP, std::vector<float>); //!
 // XicPlus to Xi Pi Pi
-DECLARE_SOA_COLUMN(IsSelXicToXiPiPi, isSelXicToXiPiPi, int); //!
+DECLARE_SOA_COLUMN(IsSelXicToXiPiPi, isSelXicToXiPiPi, int);                  //!
 DECLARE_SOA_COLUMN(MlProbXicToXiPiPi, mlProbXicToXiPiPi, std::vector<float>); //!
 } // namespace hf_sel_candidate_xic
 

--- a/PWGHF/DataModel/CandidateSelectionTables.h
+++ b/PWGHF/DataModel/CandidateSelectionTables.h
@@ -357,6 +357,13 @@ DECLARE_SOA_TABLE(HfSelToXiPi, "AOD", "HFSELTOXIPI",
                   hf_sel_toxipi::TpcNSigmaPiFromCharmBaryon, hf_sel_toxipi::TpcNSigmaPiFromCasc, hf_sel_toxipi::TpcNSigmaPiFromLambda, hf_sel_toxipi::TpcNSigmaPrFromLambda,
                   hf_sel_toxipi::TofNSigmaPiFromCharmBaryon, hf_sel_toxipi::TofNSigmaPiFromCasc, hf_sel_toxipi::TofNSigmaPiFromLambda, hf_sel_toxipi::TofNSigmaPrFromLambda);
 
+DECLARE_SOA_TABLE(HfSelToXiPiKf, "AOD", "HFSELTOXIPIKF",
+                  hf_sel_toxipi::StatusPidCharmBaryon, hf_sel_toxipi::StatusPidCascade, hf_sel_toxipi::StatusPidLambda,
+                  hf_sel_toxipi::StatusInvMassCharmBaryon, hf_sel_toxipi::StatusInvMassCascade, hf_sel_toxipi::StatusInvMassLambda,
+                  hf_sel_toxipi::ResultSelections, hf_sel_toxipi::PidTpcInfoStored, hf_sel_toxipi::PidTofInfoStored,
+                  hf_sel_toxipi::TpcNSigmaPiFromCharmBaryon, hf_sel_toxipi::TpcNSigmaPiFromCasc, hf_sel_toxipi::TpcNSigmaPiFromLambda, hf_sel_toxipi::TpcNSigmaPrFromLambda,
+                  hf_sel_toxipi::TofNSigmaPiFromCharmBaryon, hf_sel_toxipi::TofNSigmaPiFromCasc, hf_sel_toxipi::TofNSigmaPiFromLambda, hf_sel_toxipi::TofNSigmaPrFromLambda);
+
 namespace hf_sel_toomegapi
 {
 DECLARE_SOA_COLUMN(StatusPidLambda, statusPidLambda, bool);

--- a/PWGHF/TableProducer/CMakeLists.txt
+++ b/PWGHF/TableProducer/CMakeLists.txt
@@ -167,6 +167,11 @@ o2physics_add_dpl_workflow(candidate-selector-omegac0-to-omega-pi
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(candidate-selector-xic0-to-xi-pi-kf
+                    SOURCES candidateSelectorXic0ToXiPiKf.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(candidate-selector-to-xi-pi
                     SOURCES candidateSelectorToXiPi.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
@@ -251,6 +256,11 @@ o2physics_add_dpl_workflow(tree-creator-omegac0-to-omega-pi
 
 o2physics_add_dpl_workflow(tree-creator-to-xi-pi
                     SOURCES treeCreatorToXiPi.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(tree-creator-xic0-to-xi-pi-kf
+                    SOURCES treeCreatorXic0ToXiPiKf.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 

--- a/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
@@ -79,6 +79,7 @@ struct HfCandidateCreatorXic0Omegac0 {
   Produces<aod::HfCandToOmegaPi> rowCandToOmegaPi;
   Produces<aod::HfCandToOmegaK> rowCandToOmegaK;
   Produces<aod::HfOmegacKf> kfCandidateData;
+  Produces<aod::HfCandToXiPiKf> kfCandidateXicData;
 
   Configurable<bool> propagateToPCA{"propagateToPCA", false, "create tracks version propagated to PCA"};
   Configurable<bool> useAbsDCA{"useAbsDCA", true, "Minimise abs. distance rather than chi2"};
@@ -177,14 +178,61 @@ struct HfCandidateCreatorXic0Omegac0 {
     float chi2MassCasc;
     float etaOmegac;
   } kfOmegac0Candidate;
+
+  struct {
+    float chi2GeoV0;
+    float ldlV0;
+    float chi2TopoV0ToPv;
+    float chi2GeoCasc;
+    float ldlCasc;
+    float chi2TopoCascToPv;
+    float decayLenXYLambda;
+    float decayLenXYCasc;
+    float cosPaV0ToCasc;
+    float cosPaXYV0ToCasc;
+    float cosPaV0ToPv;
+    float cosPaXYV0ToPv;
+    float cosPaCascToXic;
+    float cosPaXYCascToXic;
+    float cosPaCascToPv;
+    float cosPaXYCascToPv;
+    float massV0;
+    float massCasc;
+    float ptPiFromXic;
+    float ptXic;
+    float rapXic;
+    float massXic;
+    float cosThetaStarPiFromXic;
+    float chi2TopoPiFromXicToPv;
+    float kfDcaXYPiFromXic;
+    float chi2TopoV0ToCasc;
+    float chi2TopoCascToXic;
+    float decayLenXYXic;
+    float chi2GeoXic;
+    float kfDcaV0Dau;
+    float kfDcaCascDau;
+    float kfDcaXicDau;
+    float kfDcaXYCascToPv;
+    float chi2TopoXicToPv;
+    float cosPaXicToPv;
+    float cosPaXYXicToPv;
+    float ldlXic;
+    float ctV0;
+    float ctCasc;
+    float ctXic;
+    float ctOmegac;
+    float chi2MassV0;
+    float chi2MassCasc;
+    float etaXic;
+  } kfXic0Candidate;
   void init(InitContext const&)
   {
-    std::array<bool, 11> allProcesses = {doprocessNoCentToXiPi, doprocessNoCentToXiPiTraCasc, doprocessCentFT0CToXiPi, doprocessCentFT0MToXiPi, doprocessNoCentToOmegaPi, doprocessOmegacToOmegaPiWithKFParticle, doprocessCentFT0CToOmegaPi, doprocessCentFT0MToOmegaPi, doprocessNoCentToOmegaK, doprocessCentFT0CToOmegaK, doprocessCentFT0MToOmegaK};
+    std::array<bool, 12> allProcesses = {doprocessNoCentToXiPi, doprocessNoCentToXiPiTraCasc, doprocessCentFT0CToXiPi, doprocessCentFT0MToXiPi, doprocessNoCentToOmegaPi, doprocessOmegacToOmegaPiWithKFParticle, doprocessCentFT0CToOmegaPi, doprocessCentFT0MToOmegaPi, doprocessNoCentToOmegaK, doprocessCentFT0CToOmegaK, doprocessCentFT0MToOmegaK, doprocessXicToXiPiWithKFParticle};
     if (std::accumulate(allProcesses.begin(), allProcesses.end(), 0) == 0) {
       LOGP(fatal, "No process function enabled, please select one for at least one channel.");
     }
 
-    std::array<bool, 4> processesToXiPi = {doprocessNoCentToXiPi, doprocessNoCentToXiPiTraCasc, doprocessCentFT0CToXiPi, doprocessCentFT0MToXiPi};
+    std::array<bool, 5> processesToXiPi = {doprocessNoCentToXiPi, doprocessNoCentToXiPiTraCasc, doprocessCentFT0CToXiPi, doprocessCentFT0MToXiPi, doprocessXicToXiPiWithKFParticle};
     if (std::accumulate(processesToXiPi.begin(), processesToXiPi.end(), 0) > 1) {
       LOGP(fatal, "One and only one ToXiPi process function must be enabled at a time.");
     }
@@ -203,7 +251,7 @@ struct HfCandidateCreatorXic0Omegac0 {
       LOGP(fatal, "At most one process function for collision monitoring can be enabled at a time.");
     }
     if (nProcessesCollisions == 1) {
-      if ((doprocessNoCentToXiPi && !doprocessCollisions) || (doprocessNoCentToXiPiTraCasc && !doprocessCollisions) || (doprocessNoCentToOmegaPi && !doprocessCollisions) || (doprocessNoCentToOmegaK && !doprocessCollisions) || (doprocessOmegacToOmegaPiWithKFParticle && !doprocessCollisions)) {
+      if ((doprocessNoCentToXiPi && !doprocessCollisions) || (doprocessNoCentToXiPiTraCasc && !doprocessCollisions) || (doprocessNoCentToOmegaPi && !doprocessCollisions) || (doprocessNoCentToOmegaK && !doprocessCollisions) || (doprocessOmegacToOmegaPiWithKFParticle && !doprocessCollisions) || (doprocessXicToXiPiWithKFParticle && !doprocessCollisions)) {
         LOGP(fatal, "Process function for collision monitoring not correctly enabled. Did you enable \"processCollisions\"?");
       }
       if ((doprocessCentFT0CToXiPi && !doprocessCollisionsCentFT0C) || (doprocessCentFT0CToOmegaPi && !doprocessCollisionsCentFT0C) || (doprocessCentFT0CToOmegaK && !doprocessCollisionsCentFT0C)) {
@@ -236,9 +284,12 @@ struct HfCandidateCreatorXic0Omegac0 {
     registry.add("hKFParticleDcaXYCascBachToPv", "hKFParticleDcaXYCascBachToPv", kTH1F, {{1000, -0.1f, 100.0f}});
     registry.add("hKfLambda_ldl", "hKfLambda_ldl", kTH1F, {{1000, 0.0f, 1000.0f}});
     registry.add("hKfOmega_ldl", "hKfOmega_ldl", kTH1F, {{1000, 0.0f, 1000.0f}});
+    registry.add("hKfXi_ldl", "hKfXi_ldl", kTH1F, {{1000, 0.0f, 1000.0f}});
     registry.add("hKfOmegaC0_ldl", "hKfOmegaC0_ldl", kTH1F, {{1000, 0.0f, 1000.0f}});
+    registry.add("hKfXiC0_ldl", "hKfXiC0_ldl", kTH1F, {{1000, 0.0f, 1000.0f}});
     registry.add("hDcaXYCascadeToPVKf", "hDcaXYCascadeToPVKf", kTH1F, {{1000, 0.0f, 2.0f}});
     registry.add("hInvMassOmegaMinus", "hInvMassOmegaMinus", kTH1F, {{1000, 1.6f, 2.0f}});
+    registry.add("hInvMassXiMinus", "hInvMassXiMinus", kTH1F, {{1000, 1.25f, 1.65f}});
 
     hfEvSel.addHistograms(registry); // collision monitoring
 
@@ -1040,7 +1091,436 @@ struct HfCandidateCreatorXic0Omegac0 {
 
     } // loop over LF Cascade-bachelor candidates
   }   // end of run function
+//==========================================================
+  template <int decayChannel, typename Coll, typename Hist>
+  void runKfXic0CreatorWithKFParticle(Coll const&,
+                                         aod::BCsWithTimestamps const& /*bcWithTimeStamps*/,
+                                         MyKfTracks const&,
+                                         MyKfCascTable const&, KFCascadesLinked const&,
+                                         aod::HfCascLf2Prongs const& candidates,
+                                         Hist& hInvMassCharmBaryon,
+                                         Hist& hFitterStatus,
+                                         Hist& hCandidateCounter,
+                                         Hist& hCascadesCounter)
+{
+    for (const auto& cand : candidates) {
+      hCandidateCounter->Fill(1);
 
+      auto collision = cand.collision_as<Coll>();
+
+      // set the magnetic field from CCDB
+      auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
+      if (runNumber != bc.runNumber()) {
+        LOG(info) << ">>>>>>>>>>>> Current run number: " << runNumber;
+        initCCDB(bc, runNumber, ccdb, isRun2 ? ccdbPathGrp : ccdbPathGrpMag, lut, isRun2);
+        magneticField = o2::base::Propagator::Instance()->getNominalBz();
+        LOG(info) << ">>>>>>>>>>>> Magnetic field: " << magneticField;
+        runNumber = bc.runNumber();
+      }
+      df.setBz(magneticField);
+      KFParticle::SetField(magneticField);
+      // bachelor from Xic0
+      auto trackCharmBachelor = cand.prong0_as<MyKfTracks>();
+
+      auto cascAodElement = cand.cascade_as<aod::KFCascadesLinked>();
+      hCascadesCounter->Fill(0);
+      int v0index = cascAodElement.v0Id();
+      if (!cascAodElement.has_kfCascData()) {
+        continue;
+      }
+      auto casc = cascAodElement.kfCascData_as<MyKfCascTable>();
+      hCascadesCounter->Fill(1);
+      auto trackCascDauCharged = casc.bachelor_as<MyKfTracks>(); // pion <- xi track
+      auto trackV0Dau0 = casc.posTrack_as<MyKfTracks>();         // V0 positive daughter track
+      auto trackV0Dau1 = casc.negTrack_as<MyKfTracks>();         // V0 negative daughter track
+
+      auto bachCharge = trackCascDauCharged.signed1Pt() > 0 ? +1 : -1;
+
+      //// pion & p TrackParCov
+      auto trackParCovV0Dau0 = getTrackParCov(trackV0Dau0);
+      auto trackParCovV0Dau1 = getTrackParCov(trackV0Dau1);
+      // pion <- casc TrackParCov
+      auto XiDauChargedTrackParCov = getTrackParCov(trackCascDauCharged);
+      // convert tracks into KFParticle object
+      KFPTrack kfTrack0 = createKFPTrackFromTrack(trackV0Dau0);
+      KFPTrack kfTrack1 = createKFPTrackFromTrack(trackV0Dau1);
+      KFPTrack kfTrackBach = createKFPTrackFromTrack(trackCascDauCharged);
+
+      KFParticle kfPosPr(kfTrack0, kProton);
+      KFParticle kfNegPi(kfTrack1, kPiMinus);
+      KFParticle kfNegBachPi(kfTrackBach, kPiMinus);
+      KFParticle kfPosPi(kfTrack0, kPiPlus);
+      KFParticle kfNegPr(kfTrack1, kProton);
+      KFParticle kfPosBachPi(kfTrackBach, kPiPlus);
+
+      KFParticle kfBachPion;
+      KFParticle kfPos;
+      KFParticle kfNeg;
+      if (bachCharge < 0) {
+        kfPos = kfPosPr;
+        kfNeg = kfNegPi;
+        kfBachPion = kfNegBachPi;
+      } else {
+        kfPos = kfPosPi;
+        kfNeg = kfNegPr;
+        kfBachPion = kfPosBachPi;
+      }
+
+      //__________________________________________
+      //*>~<* step 1 : construct V0 with KF
+      const KFParticle* v0Daughters[2] = {&kfPos, &kfNeg};
+      // construct V0
+      KFParticle kfV0;
+      kfV0.SetConstructMethod(kfConstructMethod);
+      try {
+        kfV0.Construct(v0Daughters, 2);
+      } catch (std::runtime_error& e) {
+        LOG(debug) << "Failed to construct cascade V0 from daughter tracks: " << e.what();
+        continue;
+      }
+
+      // mass window cut on lambda before mass constraint
+      float massLam, sigLam;
+      kfV0.GetMass(massLam, sigLam);
+      if (TMath::Abs(massLam - MassLambda0) > lambdaMassWindow)
+        continue;
+
+      // err_mass>0 of Lambda
+      if (sigLam <= 0)
+        continue;
+      // chi2>0 && NDF>0 for selecting Lambda
+      if ((kfV0.GetNDF() <= 0 || kfV0.GetChi2() <= 0))
+        continue;
+
+      kfXic0Candidate.chi2GeoV0 = kfV0.GetChi2();
+      KFParticle kfV0MassConstrained = kfV0;
+      kfV0MassConstrained.SetNonlinearMassConstraint(o2::constants::physics::MassLambda); // set mass constrain to Lambda
+      if (kfUseV0MassConstraint) {
+        KFParticle kfV0 = kfV0MassConstrained;
+      }
+      kfV0.TransportToDecayVertex();
+
+      //__________________________________________
+      //*>~<* step 2 : reconstruct cascade(Xi) with KF
+      const KFParticle* XiDaugthers[2] = {&kfBachPion, &kfV0};
+      // construct cascade
+      KFParticle kfXi;
+      kfXi.SetConstructMethod(kfConstructMethod);
+      try {
+        kfXi.Construct(XiDaugthers, 2);
+      } catch (std::runtime_error& e) {
+        LOG(debug) << "Failed to construct Xi from V0 and bachelor track: " << e.what();
+        continue;
+      }
+
+      float massCasc, sigCasc;
+      kfXi.GetMass(massCasc, sigCasc);
+      // err_massXi > 0
+      if (sigCasc <= 0)
+        continue;
+
+      if (std::abs(massCasc - MassXiMinus) > massToleranceCascade)
+        continue;
+      // chi2>0 && NDF>0
+      if (kfXi.GetNDF() <= 0 || kfXi.GetChi2() <= 0)
+        continue;
+      kfXic0Candidate.chi2GeoCasc = kfXi.GetChi2();
+      KFParticle kfXiMassConstrained = kfXi;
+      kfXiMassConstrained.SetNonlinearMassConstraint(o2::constants::physics::MassXiMinus); // set mass constrain to XiMinus
+      if (kfUseCascadeMassConstraint) {
+        // set mass constraint if requested
+        KFParticle kfXi = kfXiMassConstrained;
+      }
+      registry.fill(HIST("hInvMassXiMinus"), massCasc);
+      kfXi.TransportToDecayVertex();
+
+      //__________________________________________
+      //*>~<* step 3 : reconstruc Xic0 with KF
+      // Create KF charm bach Pion from track
+      KFPTrack kfTrackBachPion = createKFPTrackFromTrack(trackCharmBachelor);
+      KFParticle kfCharmBachPion(kfTrackBachPion, kPiPlus);
+      const KFParticle* XiC0Daugthers[2] = {&kfCharmBachPion, &kfXi};
+
+      // construct XiC0
+      KFParticle kfXiC0;
+      kfXiC0.SetConstructMethod(kfConstructMethod);
+      try {
+        kfXiC0.Construct(XiC0Daugthers, 2);
+      } catch (std::runtime_error& e) {
+        LOG(debug) << "Failed to construct XiC0 from Cascade and bachelor pion track: " << e.what();
+        continue;
+      }
+      float massXiC0, sigXiC0;
+      kfXiC0.GetMass(massXiC0, sigXiC0);
+      if (sigXiC0 <= 0)
+        continue;
+      // chi2>0 && NDF>0
+      if (kfXiC0.GetNDF() <= 0 || kfXiC0.GetChi2() <= 0)
+        continue;
+
+      hFitterStatus->Fill(0);
+      hCandidateCounter->Fill(2);
+      kfXiC0.TransportToDecayVertex();
+      // PV
+      KFPVertex kfVertex = createKFPVertexFromCollision(collision);
+      KFParticle kfPV(kfVertex);
+
+      // set production vertex;
+      kfNeg.SetProductionVertex(kfV0);
+      kfPos.SetProductionVertex(kfV0);
+
+      KFParticle kfBachPionToXi = kfBachPion;
+      KFParticle kfV0ToCasc = kfV0;
+      kfBachPionToXi.SetProductionVertex(kfXi);
+      kfV0ToCasc.SetProductionVertex(kfXi);
+
+      KFParticle kfXiToXiC = kfXi;
+      KFParticle kfCharmBachPionToXiC = kfCharmBachPion;
+      kfCharmBachPionToXiC.SetProductionVertex(kfXiC0);
+      kfXiToXiC.SetProductionVertex(kfXiC0);
+
+      // KFParticle to PV
+      KFParticle kfV0ToPv = kfV0;
+      KFParticle kfXiToPv = kfXi;
+      KFParticle kfXic0ToPv = kfXiC0;
+      KFParticle kfPiFromXicToPv = kfCharmBachPion;
+
+      kfV0ToPv.SetProductionVertex(kfPV);
+      kfXiToPv.SetProductionVertex(kfPV);
+      kfXic0ToPv.SetProductionVertex(kfPV);
+      kfPiFromXicToPv.SetProductionVertex(kfPV);
+      //------------get updated daughter tracks after vertex fit  ---------------
+      auto trackParVarCharmBachelor = getTrackParCovFromKFP(kfCharmBachPionToXiC, o2::track::PID::Pion, -bachCharge); // chrambaryon bach pion
+      trackParVarCharmBachelor.setAbsCharge(1);
+
+      XiDauChargedTrackParCov = getTrackParCovFromKFP(kfBachPionToXi, o2::track::PID::Pion, bachCharge); // Cascade bach pion
+      XiDauChargedTrackParCov.setAbsCharge(1);
+      o2::track::TrackParCov trackCasc = getTrackParCovFromKFP(kfXiToXiC, kfXiToXiC.GetPDG(), bachCharge);
+      trackCasc.setAbsCharge(1);
+
+      trackParCovV0Dau0 = getTrackParCovFromKFP(kfPos, kfPos.GetPDG(), 1); // V0 postive daughter
+      trackParCovV0Dau0.setAbsCharge(1);
+      trackParCovV0Dau1 = getTrackParCovFromKFP(kfNeg, kfNeg.GetPDG(), -1); // V0 negtive daughter
+      trackParCovV0Dau1.setAbsCharge(1);
+
+      //-------------------------- V0 info---------------------------
+      // pseudorapidity
+      float pseudorapV0Dau0 = kfPos.GetEta();
+      float pseudorapV0Dau1 = kfNeg.GetEta();
+
+      // info from from KFParticle
+      std::array<float, 3> pVecV0 = {kfV0.GetPx(), kfV0.GetPy(), kfV0.GetPz()}; // pVec stands for vector containing the 3-momentum components
+      std::array<float, 3> vertexV0 = {kfV0.GetX(), kfV0.GetY(), kfV0.GetZ()};
+      std::array<float, 3> pVecV0Dau0 = {kfPos.GetPx(), kfPos.GetPy(), kfPos.GetPz()};
+      std::array<float, 3> pVecV0Dau1 = {kfNeg.GetPx(), kfNeg.GetPy(), kfNeg.GetPz()};
+
+      //-------------------reconstruct cascade track------------------
+      // pseudorapidity
+      float pseudorapCascBachelor = kfBachPionToXi.GetEta();
+
+      // info from KFParticle
+      std::array<float, 3> vertexCasc = {kfXi.GetX(), kfXi.GetY(), kfXi.GetZ()};
+      std::array<float, 3> pVecCascBachelor = {kfBachPionToXi.GetPx(), kfBachPionToXi.GetPy(), kfBachPionToXi.GetPz()};
+
+      auto primaryVertex = getPrimaryVertex(collision);
+      std::array<float, 3> pvCoord = {collision.posX(), collision.posY(), collision.posZ()};
+      std::array<float, 3> vertexCharmBaryonFromFitter = {0.0, 0.0, 0.0}; // This variable get from DCAfitter in default process, in KF process it is set as 0.
+      std::array<float, 3> pVecCharmBachelorAsD;
+      pVecCharmBachelorAsD[0] = kfCharmBachPionToXiC.GetPx();
+      pVecCharmBachelorAsD[1] = kfCharmBachPionToXiC.GetPy();
+      pVecCharmBachelorAsD[2] = kfCharmBachPionToXiC.GetPz();
+
+      std::array<float, 3> pVecCharmBaryon = {kfXiC0.GetPx(), kfXiC0.GetPy(), kfXiC0.GetPz()};
+      std::array<float, 3> coordVtxCharmBaryon = {kfXiC0.GetX(), kfXiC0.GetY(), kfXiC0.GetZ()};
+      auto covVtxCharmBaryon = kfXiC0.CovarianceMatrix();
+      float covMatrixPV[6];
+      kfVertex.GetCovarianceMatrix(covMatrixPV);
+
+      // impact parameters
+      gpu::gpustd::array<float, 2> impactParameterV0Dau0;
+      gpu::gpustd::array<float, 2> impactParameterV0Dau1;
+      gpu::gpustd::array<float, 2> impactParameterKaFromCasc;
+      o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParCovV0Dau0, 2.f, matCorr, &impactParameterV0Dau0);
+      o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParCovV0Dau1, 2.f, matCorr, &impactParameterV0Dau1);
+      o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, XiDauChargedTrackParCov, 2.f, matCorr, &impactParameterKaFromCasc);
+      float dcaxyV0Dau0 = impactParameterV0Dau0[0];
+      float dcaxyV0Dau1 = impactParameterV0Dau1[0];
+      float dcaxyCascBachelor = impactParameterKaFromCasc[0];
+      float dcazV0Dau0 = impactParameterV0Dau0[1];
+      float dcazV0Dau1 = impactParameterV0Dau1[1];
+      float dcazCascBachelor = impactParameterKaFromCasc[1];
+
+      // pseudorapidity
+      float pseudorapCharmBachelor = kfCharmBachPionToXiC.GetEta();
+
+      // impact parameters
+      o2::dataformats::DCA impactParameterCasc;
+      o2::dataformats::DCA impactParameterCharmBachelor;
+      o2::base::Propagator::Instance()->propagateToDCABxByBz(primaryVertex, trackCasc, 2.f, matCorr, &impactParameterCasc);
+      o2::base::Propagator::Instance()->propagateToDCABxByBz(primaryVertex, trackParVarCharmBachelor, 2.f, matCorr, &impactParameterCharmBachelor);
+      float impactParBachFromCharmBaryonXY = impactParameterCharmBachelor.getY();
+      float impactParBachFromCharmBaryonZ = impactParameterCharmBachelor.getZ();
+
+      // computing decay length and ctau
+      float decLenCharmBaryon = RecoDecay::distance(pvCoord, coordVtxCharmBaryon);
+      float decLenCascade = RecoDecay::distance(coordVtxCharmBaryon, vertexCasc);
+      float decLenV0 = RecoDecay::distance(vertexCasc, vertexV0);
+
+      double phiCharmBaryon, thetaCharmBaryon;
+      getPointDirection(std::array{kfV0.GetX(), kfV0.GetY(), kfV0.GetZ()}, coordVtxCharmBaryon, phiCharmBaryon, thetaCharmBaryon);
+      auto errorDecayLengthCharmBaryon = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phiCharmBaryon, thetaCharmBaryon) + getRotatedCovMatrixXX(covVtxCharmBaryon, phiCharmBaryon, thetaCharmBaryon));
+      auto errorDecayLengthXYCharmBaryon = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phiCharmBaryon, 0.) + getRotatedCovMatrixXX(covVtxCharmBaryon, phiCharmBaryon, 0.));
+
+      // fill test histograms
+      hInvMassCharmBaryon->Fill(massXiC0);
+      hCandidateCounter->Fill(3);
+
+      //// KFParticle table information
+      // KF chi2
+      auto v0NDF = kfV0.GetNDF();
+      auto v0Chi2OverNdf = kfXic0Candidate.chi2GeoV0 / v0NDF;
+
+      auto cascNDF = kfXi.GetNDF();
+      auto cascChi2OverNdf = kfXic0Candidate.chi2GeoCasc / cascNDF;
+
+      kfXic0Candidate.chi2GeoXic = kfXiC0.GetChi2();
+      auto charmbaryonNDF = kfXiC0.GetNDF();
+      auto charmbaryonChi2OverNdf = kfXic0Candidate.chi2GeoXic / charmbaryonNDF;
+
+      kfXic0Candidate.chi2MassV0 = kfV0MassConstrained.GetChi2();
+      auto v0NDF_m = kfV0MassConstrained.GetNDF();
+      auto v0Chi2OverNdf_m = kfXic0Candidate.chi2MassV0 / v0NDF_m;
+
+      kfXic0Candidate.chi2MassCasc = kfXiMassConstrained.GetChi2();
+      auto cascNDF_m = kfXiMassConstrained.GetNDF();
+      auto cascChi2OverNdf_m = kfXic0Candidate.chi2MassCasc / cascNDF_m;
+
+      // KF topo Chi2
+      kfXic0Candidate.chi2TopoV0ToPv = kfV0ToPv.GetChi2();
+      kfXic0Candidate.chi2TopoCascToPv = kfXiToPv.GetChi2();
+      kfXic0Candidate.chi2TopoPiFromXicToPv = kfPiFromXicToPv.GetChi2();
+      kfXic0Candidate.chi2TopoXicToPv = kfXic0ToPv.GetChi2();
+
+      auto cascBachTopoChi2 = kfBachPionToXi.GetChi2();
+      kfXic0Candidate.chi2TopoV0ToCasc = kfV0ToCasc.GetChi2();
+      kfXic0Candidate.chi2TopoCascToXic = kfXiToXiC.GetChi2();
+
+      // KF ldl
+      kfXic0Candidate.ldlV0 = ldlFromKF(kfV0, kfPV);
+      kfXic0Candidate.ldlCasc = ldlFromKF(kfXi, kfPV);
+      kfXic0Candidate.ldlXic = ldlFromKF(kfXiC0, kfPV);
+
+      // KF dca
+      kfXic0Candidate.kfDcaXYPiFromXic = kfCharmBachPionToXiC.GetDistanceFromVertexXY(kfPV);
+      kfXic0Candidate.kfDcaV0Dau = kfNeg.GetDistanceFromParticle(kfPos);
+      kfXic0Candidate.kfDcaCascDau = kfBachPionToXi.GetDistanceFromParticle(kfV0ToCasc);
+      kfXic0Candidate.kfDcaXYCascToPv = kfXiToXiC.GetDistanceFromVertexXY(kfPV);
+      kfXic0Candidate.kfDcaXicDau = kfCharmBachPionToXiC.GetDistanceFromParticle(kfXiToXiC);
+
+      // KF decay length
+      float DecayLxy_Lam, err_DecayLxy_Lam;
+      kfV0ToCasc.GetDecayLengthXY(DecayLxy_Lam, err_DecayLxy_Lam);
+      kfXic0Candidate.decayLenXYLambda = DecayLxy_Lam;
+
+      float DecayLxy_Casc, err_DecayLxy_Casc;
+      kfXiToXiC.GetDecayLengthXY(DecayLxy_Casc, err_DecayLxy_Casc);
+      kfXic0Candidate.decayLenXYCasc = DecayLxy_Casc;
+
+      float DecayLxy_Xic0, err_DecayLxy_Xic0;
+      kfXic0ToPv.GetDecayLengthXY(DecayLxy_Xic0, err_DecayLxy_Xic0);
+      kfXic0Candidate.decayLenXYXic = DecayLxy_Xic0;
+
+      // KF cosPA
+      kfXic0Candidate.cosPaV0ToPv = cpaFromKF(kfV0, kfPV);
+      kfXic0Candidate.cosPaCascToPv = cpaFromKF(kfXi, kfPV);
+      kfXic0Candidate.cosPaXicToPv = cpaFromKF(kfXiC0, kfPV);
+      kfXic0Candidate.cosPaXYV0ToPv = cpaXYFromKF(kfV0, kfPV);
+      kfXic0Candidate.cosPaXYCascToPv = cpaXYFromKF(kfXi, kfPV);
+      kfXic0Candidate.cosPaXYXicToPv = cpaXYFromKF(kfXiC0, kfPV);
+
+      kfXic0Candidate.cosPaV0ToCasc = cpaFromKF(kfV0, kfXi);
+      kfXic0Candidate.cosPaCascToXic = cpaFromKF(kfXi, kfXiC0);
+      kfXic0Candidate.cosPaXYV0ToCasc = cpaXYFromKF(kfV0, kfXi);
+      kfXic0Candidate.cosPaXYCascToXic = cpaXYFromKF(kfXi, kfXiC0);
+      // KF mass
+      kfXic0Candidate.massV0 = massLam;
+      kfXic0Candidate.massCasc = massCasc;
+      kfXic0Candidate.massXic = massXiC0;
+
+      // KF pT
+      kfXic0Candidate.ptPiFromXic = kfCharmBachPionToXiC.GetPt();
+      kfXic0Candidate.ptXic = kfXiC0.GetPt();
+
+      // KF rapidity
+      kfXic0Candidate.rapXic = kfXiC0.GetRapidity();
+
+      // KF cosThetaStar
+      kfXic0Candidate.cosThetaStarPiFromXic = cosThetaStarFromKF(0, 4332, 211, 3312, kfCharmBachPionToXiC, kfXiToXiC);
+
+      // KF ct
+      kfXic0Candidate.ctV0 = kfV0.GetLifeTime();
+      kfXic0Candidate.ctCasc = kfXi.GetLifeTime();
+      kfXic0Candidate.ctXic = kfXiC0.GetLifeTime();
+      kfXic0Candidate.ctOmegac = kfXiC0.GetLifeTime();
+
+      // KF eta
+      kfXic0Candidate.etaXic = kfXiC0.GetEta();
+
+      // fill KF hist
+      registry.fill(HIST("hKFParticleCascBachTopoChi2"), cascBachTopoChi2);
+      registry.fill(HIST("hKFParticleV0TopoChi2"), kfXic0Candidate.chi2TopoV0ToCasc);
+      registry.fill(HIST("hKFParticleCascTopoChi2"), kfXic0Candidate.chi2TopoCascToXic);
+      registry.fill(HIST("hKFParticleDcaCharmBaryonDau"), kfXic0Candidate.kfDcaXicDau);
+      registry.fill(HIST("hKFParticleDcaXYCascBachToPv"), dcaxyCascBachelor);
+      registry.fill(HIST("hKFParticleDcaXYV0DauToPv"), dcaxyV0Dau0);
+      registry.fill(HIST("hKfLambda_ldl"), kfXic0Candidate.ldlV0);
+      registry.fill(HIST("hKfXi_ldl"), kfXic0Candidate.ldlCasc);
+      registry.fill(HIST("hKfXiC0_ldl"), kfXic0Candidate.ldlXic);
+      registry.fill(HIST("hDcaXYCascadeToPVKf"), kfXic0Candidate.kfDcaXYCascToPv);
+
+    // fill kf table
+    kfCandidateXicData(collision.globalIndex(),
+                      pvCoord[0], pvCoord[1], pvCoord[2],
+                      vertexCharmBaryonFromFitter[0], vertexCharmBaryonFromFitter[1], vertexCharmBaryonFromFitter[2],
+                      vertexCasc[0], vertexCasc[1], vertexCasc[2],
+                      vertexV0[0], vertexV0[1], vertexV0[2],
+                      trackCascDauCharged.sign(),
+                      covVtxCharmBaryon[0], covVtxCharmBaryon[1], covVtxCharmBaryon[2], covVtxCharmBaryon[3], covVtxCharmBaryon[4], covVtxCharmBaryon[5],
+                      pVecCharmBaryon[0], pVecCharmBaryon[1], pVecCharmBaryon[2],
+                      kfXiToXiC.GetPx(), kfXiToXiC.GetPy(), kfXiToXiC.GetPz(),
+                      pVecCharmBachelorAsD[0], pVecCharmBachelorAsD[1], pVecCharmBachelorAsD[2],
+                      pVecV0[0], pVecV0[1], pVecV0[2],
+                      pVecCascBachelor[0], pVecCascBachelor[1], pVecCascBachelor[2],
+                      pVecV0Dau0[0], pVecV0Dau0[1], pVecV0Dau0[2],
+                      pVecV0Dau1[0], pVecV0Dau1[1], pVecV0Dau1[2],
+                      impactParameterCasc.getY(), impactParBachFromCharmBaryonXY,
+                      impactParameterCasc.getZ(), impactParBachFromCharmBaryonZ,
+                      std::sqrt(impactParameterCasc.getSigmaY2()), std::sqrt(impactParameterCharmBachelor.getSigmaY2()),
+                      v0index, casc.posTrackId(), casc.negTrackId(),
+                      casc.cascadeId(), trackCharmBachelor.globalIndex(), casc.bachelorId(),
+                      kfXic0Candidate.massV0, kfXic0Candidate.massCasc, kfXic0Candidate.massXic,
+                      kfXic0Candidate.cosPaV0ToPv, kfXic0Candidate.cosPaXicToPv, kfXic0Candidate.cosPaCascToPv, kfXic0Candidate.cosPaXYV0ToPv, kfXic0Candidate.cosPaXYXicToPv, kfXic0Candidate.cosPaXYCascToPv,
+                      kfXic0Candidate.ctOmegac, kfXic0Candidate.ctCasc, kfXic0Candidate.ctV0, kfXic0Candidate.ctXic,
+                      pseudorapV0Dau0, pseudorapV0Dau1, pseudorapCascBachelor, pseudorapCharmBachelor,
+                      kfXic0Candidate.etaXic, kfXi.GetEta(), kfV0.GetEta(),
+                      dcaxyV0Dau0, dcaxyV0Dau1, dcaxyCascBachelor,
+                      dcazV0Dau0, dcazV0Dau1, dcazCascBachelor,
+                      kfXic0Candidate.kfDcaCascDau, kfXic0Candidate.kfDcaV0Dau, kfXic0Candidate.kfDcaXicDau,
+                      decLenCharmBaryon, decLenCascade, decLenV0, errorDecayLengthCharmBaryon, errorDecayLengthXYCharmBaryon,
+                      kfXic0Candidate.kfDcaXYPiFromXic, kfXic0Candidate.kfDcaXYCascToPv,
+                      kfXic0Candidate.chi2GeoV0, kfXic0Candidate.chi2GeoCasc, kfXic0Candidate.chi2GeoXic, kfXic0Candidate.chi2MassV0, kfXic0Candidate.chi2MassCasc,
+                      kfXic0Candidate.ldlV0, kfXic0Candidate.ldlCasc, kfXic0Candidate.ldlXic,
+                      kfXic0Candidate.chi2TopoV0ToPv, kfXic0Candidate.chi2TopoCascToPv, kfXic0Candidate.chi2TopoPiFromXicToPv, kfXic0Candidate.chi2TopoXicToPv,
+                      kfXic0Candidate.chi2TopoV0ToCasc, kfXic0Candidate.chi2TopoCascToXic,
+                      kfXic0Candidate.decayLenXYLambda, kfXic0Candidate.decayLenXYCasc, kfXic0Candidate.decayLenXYXic,
+                      kfXic0Candidate.cosPaV0ToCasc, kfXic0Candidate.cosPaCascToXic, kfXic0Candidate.cosPaXYV0ToCasc, kfXic0Candidate.cosPaXYCascToXic,
+                      kfXic0Candidate.rapXic, kfXic0Candidate.ptPiFromXic, kfXic0Candidate.ptXic,
+                      kfXic0Candidate.cosThetaStarPiFromXic,
+                      v0NDF, cascNDF, charmbaryonNDF, v0NDF_m, cascNDF_m,
+                      v0Chi2OverNdf, cascChi2OverNdf, charmbaryonChi2OverNdf, v0Chi2OverNdf_m, cascChi2OverNdf_m);
+
+    } // loop over LF Cascade-bachelor candidates
+  }
   /// @brief process function w/o centrality selections
   void processNoCentToXiPi(soa::Join<aod::Collisions, aod::EvSels> const& collisions,
                            aod::BCsWithTimestamps const& bcWithTimeStamps,
@@ -1088,6 +1568,17 @@ struct HfCandidateCreatorXic0Omegac0 {
     runKfOmegac0CreatorWithKFParticle<hf_cand_casc_lf::DecayType2Prong::OmegaczeroToOmegaPi>(collisions, bcWithTimeStamps, tracks, cascades, cascadeLinks, candidates, hInvMassCharmBaryonToOmegaPi, hFitterStatusToOmegaPi, hCandidateCounterToOmegaPi, hCascadesCounterToOmegaPi);
   }
   PROCESS_SWITCH(HfCandidateCreatorXic0Omegac0, processOmegacToOmegaPiWithKFParticle, "Run candidate creator w/o centrality selections for Omegac0 To omega pi decay channel using KFParticle", false);
+
+  void processXicToXiPiWithKFParticle(aod::Collisions const& collisions,
+                                            aod::BCsWithTimestamps const& bcWithTimeStamps,
+                                            MyKfTracks const& tracks,
+                                            MyKfCascTable const& cascades,
+                                            KFCascadesLinked const& cascadeLinks,
+                                            aod::HfCascLf2Prongs const& candidates)
+  {
+    runKfXic0CreatorWithKFParticle<hf_cand_casc_lf::DecayType2Prong::XiczeroOmegaczeroToXiPi>(collisions, bcWithTimeStamps, tracks, cascades, cascadeLinks, candidates, hInvMassCharmBaryonToXiPi, hFitterStatusToXiPi, hCandidateCounterToXiPi, hCascadesCounterToXiPi);
+  }
+  PROCESS_SWITCH(HfCandidateCreatorXic0Omegac0, processXicToXiPiWithKFParticle, "Run candidate creator w/o centrality selections for Xic0 To Xi pi decay channel using KFParticle", false);
 
   void processNoCentToOmegaK(soa::Join<aod::Collisions, aod::EvSels> const& collisions,
                              aod::BCsWithTimestamps const& bcWithTimeStamps,
@@ -1267,7 +1758,7 @@ struct HfCandidateCreatorXic0Omegac0Mc {
   // inspect for which zPvPosMax cut was set for reconstructed
   void init(InitContext& initContext)
   {
-    std::array<bool, 3> procCollisionsXicToXiPi{doprocessMcXicToXiPi, doprocessMcXicToXiPiFT0m, doprocessMcXicToXiPiFT0c};
+    std::array<bool, 4> procCollisionsXicToXiPi{doprocessMcXicToXiPi, doprocessMcXicToXiPiFT0m, doprocessMcXicToXiPiFT0c, doprocessMcXicToXiPiKf};
     if (std::accumulate(procCollisionsXicToXiPi.begin(), procCollisionsXicToXiPi.end(), 0) > 1) {
       LOGP(fatal, "At most one process function for XicToXiPi collision study can be enabled at a time.");
     }
@@ -1787,6 +2278,17 @@ struct HfCandidateCreatorXic0Omegac0Mc {
     runXic0Omegac0Mc<CentralityEstimator::None, aod::hf_cand_xic0_omegac0::DecayType::XiczeroToXiPi>(candidates, tracks, mcParticles, collsWithMcLabels, mcColls, bcs);
   }
   PROCESS_SWITCH(HfCandidateCreatorXic0Omegac0Mc, processMcXicToXiPi, "Run Xic0 to xi pi MC process function - no centrality", false);
+
+  void processMcXicToXiPiKf(aod::HfCandToXiPiKf const& candidates,
+                          MyTracksWMc const& tracks,
+                          aod::McParticles const& mcParticles,
+                          aod::McCollisions const& mcColls,
+                          McCollisionsNoCents const& collsWithMcLabels,
+                          BCsInfo const& bcs)
+  {
+    runXic0Omegac0Mc<CentralityEstimator::None, aod::hf_cand_xic0_omegac0::DecayType::XiczeroToXiPi>(candidates, tracks, mcParticles, collsWithMcLabels, mcColls, bcs);
+  }
+  PROCESS_SWITCH(HfCandidateCreatorXic0Omegac0Mc, processMcXicToXiPiKf, "Run Xic0 to xi pi MC process function - no centrality", false);
 
   void processMcXicToXiPiFT0m(aod::HfCandToXiPi const& candidates,
                               MyTracksWMc const& tracks,

--- a/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
@@ -665,7 +665,7 @@ struct HfCandidateCreatorXic0Omegac0 {
       }
 
     } // loop over LF Cascade-bachelor candidates
-  }   // end of run function
+  } // end of run function
 
   template <int decayChannel, typename Coll, typename Hist>
   void runKfOmegac0CreatorWithKFParticle(Coll const&,
@@ -1090,19 +1090,19 @@ struct HfCandidateCreatorXic0Omegac0 {
                       v0Chi2OverNdf, cascChi2OverNdf, charmbaryonChi2OverNdf, v0Chi2OverNdf_m, cascChi2OverNdf_m);
 
     } // loop over LF Cascade-bachelor candidates
-  }   // end of run function
-//==========================================================
+  } // end of run function
+  //==========================================================
   template <int decayChannel, typename Coll, typename Hist>
   void runKfXic0CreatorWithKFParticle(Coll const&,
-                                         aod::BCsWithTimestamps const& /*bcWithTimeStamps*/,
-                                         MyKfTracks const&,
-                                         MyKfCascTable const&, KFCascadesLinked const&,
-                                         aod::HfCascLf2Prongs const& candidates,
-                                         Hist& hInvMassCharmBaryon,
-                                         Hist& hFitterStatus,
-                                         Hist& hCandidateCounter,
-                                         Hist& hCascadesCounter)
-{
+                                      aod::BCsWithTimestamps const& /*bcWithTimeStamps*/,
+                                      MyKfTracks const&,
+                                      MyKfCascTable const&, KFCascadesLinked const&,
+                                      aod::HfCascLf2Prongs const& candidates,
+                                      Hist& hInvMassCharmBaryon,
+                                      Hist& hFitterStatus,
+                                      Hist& hCandidateCounter,
+                                      Hist& hCascadesCounter)
+  {
     for (const auto& cand : candidates) {
       hCandidateCounter->Fill(1);
 
@@ -1478,46 +1478,46 @@ struct HfCandidateCreatorXic0Omegac0 {
       registry.fill(HIST("hKfXiC0_ldl"), kfXic0Candidate.ldlXic);
       registry.fill(HIST("hDcaXYCascadeToPVKf"), kfXic0Candidate.kfDcaXYCascToPv);
 
-    // fill kf table
-    kfCandidateXicData(collision.globalIndex(),
-                      pvCoord[0], pvCoord[1], pvCoord[2],
-                      vertexCharmBaryonFromFitter[0], vertexCharmBaryonFromFitter[1], vertexCharmBaryonFromFitter[2],
-                      vertexCasc[0], vertexCasc[1], vertexCasc[2],
-                      vertexV0[0], vertexV0[1], vertexV0[2],
-                      trackCascDauCharged.sign(),
-                      covVtxCharmBaryon[0], covVtxCharmBaryon[1], covVtxCharmBaryon[2], covVtxCharmBaryon[3], covVtxCharmBaryon[4], covVtxCharmBaryon[5],
-                      pVecCharmBaryon[0], pVecCharmBaryon[1], pVecCharmBaryon[2],
-                      kfXiToXiC.GetPx(), kfXiToXiC.GetPy(), kfXiToXiC.GetPz(),
-                      pVecCharmBachelorAsD[0], pVecCharmBachelorAsD[1], pVecCharmBachelorAsD[2],
-                      pVecV0[0], pVecV0[1], pVecV0[2],
-                      pVecCascBachelor[0], pVecCascBachelor[1], pVecCascBachelor[2],
-                      pVecV0Dau0[0], pVecV0Dau0[1], pVecV0Dau0[2],
-                      pVecV0Dau1[0], pVecV0Dau1[1], pVecV0Dau1[2],
-                      impactParameterCasc.getY(), impactParBachFromCharmBaryonXY,
-                      impactParameterCasc.getZ(), impactParBachFromCharmBaryonZ,
-                      std::sqrt(impactParameterCasc.getSigmaY2()), std::sqrt(impactParameterCharmBachelor.getSigmaY2()),
-                      v0index, casc.posTrackId(), casc.negTrackId(),
-                      casc.cascadeId(), trackCharmBachelor.globalIndex(), casc.bachelorId(),
-                      kfXic0Candidate.massV0, kfXic0Candidate.massCasc, kfXic0Candidate.massXic,
-                      kfXic0Candidate.cosPaV0ToPv, kfXic0Candidate.cosPaXicToPv, kfXic0Candidate.cosPaCascToPv, kfXic0Candidate.cosPaXYV0ToPv, kfXic0Candidate.cosPaXYXicToPv, kfXic0Candidate.cosPaXYCascToPv,
-                      kfXic0Candidate.ctOmegac, kfXic0Candidate.ctCasc, kfXic0Candidate.ctV0, kfXic0Candidate.ctXic,
-                      pseudorapV0Dau0, pseudorapV0Dau1, pseudorapCascBachelor, pseudorapCharmBachelor,
-                      kfXic0Candidate.etaXic, kfXi.GetEta(), kfV0.GetEta(),
-                      dcaxyV0Dau0, dcaxyV0Dau1, dcaxyCascBachelor,
-                      dcazV0Dau0, dcazV0Dau1, dcazCascBachelor,
-                      kfXic0Candidate.kfDcaCascDau, kfXic0Candidate.kfDcaV0Dau, kfXic0Candidate.kfDcaXicDau,
-                      decLenCharmBaryon, decLenCascade, decLenV0, errorDecayLengthCharmBaryon, errorDecayLengthXYCharmBaryon,
-                      kfXic0Candidate.kfDcaXYPiFromXic, kfXic0Candidate.kfDcaXYCascToPv,
-                      kfXic0Candidate.chi2GeoV0, kfXic0Candidate.chi2GeoCasc, kfXic0Candidate.chi2GeoXic, kfXic0Candidate.chi2MassV0, kfXic0Candidate.chi2MassCasc,
-                      kfXic0Candidate.ldlV0, kfXic0Candidate.ldlCasc, kfXic0Candidate.ldlXic,
-                      kfXic0Candidate.chi2TopoV0ToPv, kfXic0Candidate.chi2TopoCascToPv, kfXic0Candidate.chi2TopoPiFromXicToPv, kfXic0Candidate.chi2TopoXicToPv,
-                      kfXic0Candidate.chi2TopoV0ToCasc, kfXic0Candidate.chi2TopoCascToXic,
-                      kfXic0Candidate.decayLenXYLambda, kfXic0Candidate.decayLenXYCasc, kfXic0Candidate.decayLenXYXic,
-                      kfXic0Candidate.cosPaV0ToCasc, kfXic0Candidate.cosPaCascToXic, kfXic0Candidate.cosPaXYV0ToCasc, kfXic0Candidate.cosPaXYCascToXic,
-                      kfXic0Candidate.rapXic, kfXic0Candidate.ptPiFromXic, kfXic0Candidate.ptXic,
-                      kfXic0Candidate.cosThetaStarPiFromXic,
-                      v0NDF, cascNDF, charmbaryonNDF, v0NDF_m, cascNDF_m,
-                      v0Chi2OverNdf, cascChi2OverNdf, charmbaryonChi2OverNdf, v0Chi2OverNdf_m, cascChi2OverNdf_m);
+      // fill kf table
+      kfCandidateXicData(collision.globalIndex(),
+                         pvCoord[0], pvCoord[1], pvCoord[2],
+                         vertexCharmBaryonFromFitter[0], vertexCharmBaryonFromFitter[1], vertexCharmBaryonFromFitter[2],
+                         vertexCasc[0], vertexCasc[1], vertexCasc[2],
+                         vertexV0[0], vertexV0[1], vertexV0[2],
+                         trackCascDauCharged.sign(),
+                         covVtxCharmBaryon[0], covVtxCharmBaryon[1], covVtxCharmBaryon[2], covVtxCharmBaryon[3], covVtxCharmBaryon[4], covVtxCharmBaryon[5],
+                         pVecCharmBaryon[0], pVecCharmBaryon[1], pVecCharmBaryon[2],
+                         kfXiToXiC.GetPx(), kfXiToXiC.GetPy(), kfXiToXiC.GetPz(),
+                         pVecCharmBachelorAsD[0], pVecCharmBachelorAsD[1], pVecCharmBachelorAsD[2],
+                         pVecV0[0], pVecV0[1], pVecV0[2],
+                         pVecCascBachelor[0], pVecCascBachelor[1], pVecCascBachelor[2],
+                         pVecV0Dau0[0], pVecV0Dau0[1], pVecV0Dau0[2],
+                         pVecV0Dau1[0], pVecV0Dau1[1], pVecV0Dau1[2],
+                         impactParameterCasc.getY(), impactParBachFromCharmBaryonXY,
+                         impactParameterCasc.getZ(), impactParBachFromCharmBaryonZ,
+                         std::sqrt(impactParameterCasc.getSigmaY2()), std::sqrt(impactParameterCharmBachelor.getSigmaY2()),
+                         v0index, casc.posTrackId(), casc.negTrackId(),
+                         casc.cascadeId(), trackCharmBachelor.globalIndex(), casc.bachelorId(),
+                         kfXic0Candidate.massV0, kfXic0Candidate.massCasc, kfXic0Candidate.massXic,
+                         kfXic0Candidate.cosPaV0ToPv, kfXic0Candidate.cosPaXicToPv, kfXic0Candidate.cosPaCascToPv, kfXic0Candidate.cosPaXYV0ToPv, kfXic0Candidate.cosPaXYXicToPv, kfXic0Candidate.cosPaXYCascToPv,
+                         kfXic0Candidate.ctOmegac, kfXic0Candidate.ctCasc, kfXic0Candidate.ctV0, kfXic0Candidate.ctXic,
+                         pseudorapV0Dau0, pseudorapV0Dau1, pseudorapCascBachelor, pseudorapCharmBachelor,
+                         kfXic0Candidate.etaXic, kfXi.GetEta(), kfV0.GetEta(),
+                         dcaxyV0Dau0, dcaxyV0Dau1, dcaxyCascBachelor,
+                         dcazV0Dau0, dcazV0Dau1, dcazCascBachelor,
+                         kfXic0Candidate.kfDcaCascDau, kfXic0Candidate.kfDcaV0Dau, kfXic0Candidate.kfDcaXicDau,
+                         decLenCharmBaryon, decLenCascade, decLenV0, errorDecayLengthCharmBaryon, errorDecayLengthXYCharmBaryon,
+                         kfXic0Candidate.kfDcaXYPiFromXic, kfXic0Candidate.kfDcaXYCascToPv,
+                         kfXic0Candidate.chi2GeoV0, kfXic0Candidate.chi2GeoCasc, kfXic0Candidate.chi2GeoXic, kfXic0Candidate.chi2MassV0, kfXic0Candidate.chi2MassCasc,
+                         kfXic0Candidate.ldlV0, kfXic0Candidate.ldlCasc, kfXic0Candidate.ldlXic,
+                         kfXic0Candidate.chi2TopoV0ToPv, kfXic0Candidate.chi2TopoCascToPv, kfXic0Candidate.chi2TopoPiFromXicToPv, kfXic0Candidate.chi2TopoXicToPv,
+                         kfXic0Candidate.chi2TopoV0ToCasc, kfXic0Candidate.chi2TopoCascToXic,
+                         kfXic0Candidate.decayLenXYLambda, kfXic0Candidate.decayLenXYCasc, kfXic0Candidate.decayLenXYXic,
+                         kfXic0Candidate.cosPaV0ToCasc, kfXic0Candidate.cosPaCascToXic, kfXic0Candidate.cosPaXYV0ToCasc, kfXic0Candidate.cosPaXYCascToXic,
+                         kfXic0Candidate.rapXic, kfXic0Candidate.ptPiFromXic, kfXic0Candidate.ptXic,
+                         kfXic0Candidate.cosThetaStarPiFromXic,
+                         v0NDF, cascNDF, charmbaryonNDF, v0NDF_m, cascNDF_m,
+                         v0Chi2OverNdf, cascChi2OverNdf, charmbaryonChi2OverNdf, v0Chi2OverNdf_m, cascChi2OverNdf_m);
 
     } // loop over LF Cascade-bachelor candidates
   }
@@ -1570,11 +1570,11 @@ struct HfCandidateCreatorXic0Omegac0 {
   PROCESS_SWITCH(HfCandidateCreatorXic0Omegac0, processOmegacToOmegaPiWithKFParticle, "Run candidate creator w/o centrality selections for Omegac0 To omega pi decay channel using KFParticle", false);
 
   void processXicToXiPiWithKFParticle(aod::Collisions const& collisions,
-                                            aod::BCsWithTimestamps const& bcWithTimeStamps,
-                                            MyKfTracks const& tracks,
-                                            MyKfCascTable const& cascades,
-                                            KFCascadesLinked const& cascadeLinks,
-                                            aod::HfCascLf2Prongs const& candidates)
+                                      aod::BCsWithTimestamps const& bcWithTimeStamps,
+                                      MyKfTracks const& tracks,
+                                      MyKfCascTable const& cascades,
+                                      KFCascadesLinked const& cascadeLinks,
+                                      aod::HfCascLf2Prongs const& candidates)
   {
     runKfXic0CreatorWithKFParticle<hf_cand_casc_lf::DecayType2Prong::XiczeroOmegaczeroToXiPi>(collisions, bcWithTimeStamps, tracks, cascades, cascadeLinks, candidates, hInvMassCharmBaryonToXiPi, hFitterStatusToXiPi, hCandidateCounterToXiPi, hCascadesCounterToXiPi);
   }
@@ -2259,8 +2259,8 @@ struct HfCandidateCreatorXic0Omegac0Mc {
           }
         }
       } // close loop on MCParticles
-    }   // close loop on MCCollisions
-  }     // close process
+    } // close loop on MCCollisions
+  } // close process
 
   void processDoNoMc(aod::Collisions::iterator const&)
   {
@@ -2280,11 +2280,11 @@ struct HfCandidateCreatorXic0Omegac0Mc {
   PROCESS_SWITCH(HfCandidateCreatorXic0Omegac0Mc, processMcXicToXiPi, "Run Xic0 to xi pi MC process function - no centrality", false);
 
   void processMcXicToXiPiKf(aod::HfCandToXiPiKf const& candidates,
-                          MyTracksWMc const& tracks,
-                          aod::McParticles const& mcParticles,
-                          aod::McCollisions const& mcColls,
-                          McCollisionsNoCents const& collsWithMcLabels,
-                          BCsInfo const& bcs)
+                            MyTracksWMc const& tracks,
+                            aod::McParticles const& mcParticles,
+                            aod::McCollisions const& mcColls,
+                            McCollisionsNoCents const& collsWithMcLabels,
+                            BCsInfo const& bcs)
   {
     runXic0Omegac0Mc<CentralityEstimator::None, aod::hf_cand_xic0_omegac0::DecayType::XiczeroToXiPi>(candidates, tracks, mcParticles, collsWithMcLabels, mcColls, bcs);
   }

--- a/PWGHF/TableProducer/candidateSelectorXic0ToXiPiKf.cxx
+++ b/PWGHF/TableProducer/candidateSelectorXic0ToXiPiKf.cxx
@@ -504,8 +504,8 @@ struct HfCandidateSelectorXic0ToXiPiKf {
       }
 
       hfSelToXiPi(statusPidCharmBaryon, statusPidCascade, statusPidLambda, statusInvMassCharmBaryon, statusInvMassCascade, statusInvMassLambda, resultSelections, infoTpcStored, infoTofStored,
-                     trackPiFromCharm.tpcNSigmaPi(), trackPiFromCasc.tpcNSigmaPi(), trackPiFromLam.tpcNSigmaPi(), trackPrFromLam.tpcNSigmaPr(),
-                     trackPiFromCharm.tofNSigmaPi(), trackPiFromCasc.tofNSigmaPi(), trackPiFromLam.tofNSigmaPi(), trackPrFromLam.tofNSigmaPr());
+                  trackPiFromCharm.tpcNSigmaPi(), trackPiFromCasc.tpcNSigmaPi(), trackPiFromLam.tpcNSigmaPi(), trackPrFromLam.tpcNSigmaPr(),
+                  trackPiFromCharm.tofNSigmaPi(), trackPiFromCasc.tofNSigmaPi(), trackPiFromLam.tofNSigmaPi(), trackPrFromLam.tofNSigmaPr());
 
       if (resultSelections) {
         if (!statusPidLambda) {
@@ -551,7 +551,7 @@ struct HfCandidateSelectorXic0ToXiPiKf {
       }
     }
   } // end process
-};  // end struct
+}; // end struct
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {

--- a/PWGHF/TableProducer/candidateSelectorXic0ToXiPiKf.cxx
+++ b/PWGHF/TableProducer/candidateSelectorXic0ToXiPiKf.cxx
@@ -1,0 +1,560 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file candidateSelectorToXiPi.cxx
+/// \brief Xic0 → Xi Pi selection task
+/// \author Ran Tu <ran.tu@cern.ch>, Fudan University
+
+#include "CommonConstants/PhysicsConstants.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/runDataProcessing.h"
+
+#include "Common/Core/TrackSelection.h"
+#include "Common/Core/TrackSelectorPID.h"
+
+#include "PWGHF/DataModel/CandidateReconstructionTables.h"
+#include "PWGHF/DataModel/CandidateSelectionTables.h"
+#include "PWGHF/Utils/utilsAnalysis.h"
+
+using namespace o2;
+using namespace o2::aod;
+using namespace o2::framework;
+using namespace o2::analysis;
+
+enum pidInfoStored {
+  kPiFromLam = 0,
+  kPrFromLam,
+  kPiFromCasc,
+  kPiFromCharm
+};
+
+/// Struct for applying Xic0 -> Xi pi selection cuts
+struct HfCandidateSelectorXic0ToXiPiKf {
+  Produces<aod::HfSelToXiPiKf> hfSelToXiPi;
+
+  // LF analysis selections
+  Configurable<double> radiusCascMin{"radiusCascMin", 0.5, "Min cascade radius"};
+  Configurable<double> radiusV0Min{"radiusV0Min", 1.1, "Min V0 radius"};
+  Configurable<double> cosPAV0Min{"cosPAV0Min", 0.97, "Min valueCosPA V0"};
+  Configurable<double> cosPACascMin{"cosPACascMin", 0.97, "Min value CosPA cascade"};
+  Configurable<double> dcaCascDauMax{"dcaCascDauMax", 1.0, "Max DCA cascade daughters"};
+  Configurable<double> dcaV0DauMax{"dcaV0DauMax", 1.0, "Max DCA V0 daughters"};
+  Configurable<float> dcaBachToPvMin{"dcaBachToPvMin", 0.04, "DCA Bach To PV"};
+  Configurable<float> dcaNegToPvMin{"dcaNegToPvMin", 0.06, "DCA Neg To PV"};
+  Configurable<float> dcaPosToPvMin{"dcaPosToPvMin", 0.06, "DCA Pos To PV"};
+  Configurable<float> v0MassWindow{"v0MassWindow", 0.01, "V0 mass window"};
+  Configurable<float> cascadeMassWindow{"cascadeMassWindow", 0.01, "Cascade mass window"};
+  Configurable<bool> applyTrkSelLf{"applyTrkSelLf", true, "Apply track selection for LF daughters"};
+
+  // limit charm baryon invariant mass spectrum
+  Configurable<double> invMassCharmBaryonMin{"invMassCharmBaryonMin", 2.0, "Lower limit invariant mass spectrum charm baryon"}; // 2.4 Omegac0 only
+  Configurable<double> invMassCharmBaryonMax{"invMassCharmBaryonMax", 3.1, "Upper limit invariant mass spectrum charm baryon"};
+
+  // kinematic selections
+  Configurable<double> etaTrackCharmBachMax{"etaTrackCharmBachMax", 0.8, "Max absolute value of eta for charm baryon bachelor"};
+  Configurable<double> etaTrackLFDauMax{"etaTrackLFDauMax", 1.0, "Max absolute value of eta for V0 and cascade daughters"};
+  Configurable<double> ptPiFromCascMin{"ptPiFromCascMin", 0.15, "Min pT pion <- casc"};
+  Configurable<double> ptPiFromCharmBaryonMin{"ptPiFromCharmBaryonMin", 0.2, "Min pT pi <- charm baryon"};
+
+  Configurable<double> impactParameterXYPiFromCharmBaryonMin{"impactParameterXYPiFromCharmBaryonMin", 0., "Min dcaxy pi from charm baryon track to PV"};
+  Configurable<double> impactParameterXYPiFromCharmBaryonMax{"impactParameterXYPiFromCharmBaryonMax", 10., "Max dcaxy pi from charm baryon track to PV"};
+  Configurable<double> impactParameterZPiFromCharmBaryonMin{"impactParameterZPiFromCharmBaryonMin", 0., "Min dcaz pi from charm baryon track to PV"};
+  Configurable<double> impactParameterZPiFromCharmBaryonMax{"impactParameterZPiFromCharmBaryonMax", 10., "Max dcaz pi from charm baryon track to PV"};
+
+  Configurable<double> impactParameterXYCascMin{"impactParameterXYCascMin", 0., "Min dcaxy cascade track to PV"};
+  Configurable<double> impactParameterXYCascMax{"impactParameterXYCascMax", 10., "Max dcaxy cascade track to PV"};
+  Configurable<double> impactParameterZCascMin{"impactParameterZCascMin", 0., "Min dcaz cascade track to PV"};
+  Configurable<double> impactParameterZCascMax{"impactParameterZCascMax", 10., "Max dcaz cascade track to PV"};
+
+  Configurable<double> ptCandMin{"ptCandMin", 0., "Lower bound of candidate pT"};
+  Configurable<double> ptCandMax{"ptCandMax", 50., "Upper bound of candidate pT"};
+
+  Configurable<double> dcaCharmBaryonDauMax{"dcaCharmBaryonDauMax", 2.0, "Max DCA charm baryon daughters"};
+
+  // PID options
+  Configurable<bool> usePidTpcOnly{"usePidTpcOnly", false, "Perform PID using only TPC"};
+  Configurable<bool> usePidTpcTofCombined{"usePidTpcTofCombined", true, "Perform PID using TPC & TOF"};
+
+  // PID - TPC selections
+
+  Configurable<double> ptPrPidTpcMin{"ptPrPidTpcMin", -1, "Lower bound of track pT for TPC PID for proton selection"};
+  Configurable<double> ptPrPidTpcMax{"ptPrPidTpcMax", 9999.9, "Upper bound of track pT for TPC PID for proton selection"};
+  Configurable<double> nSigmaTpcPrMax{"nSigmaTpcPrMax", 3., "Nsigma cut on TPC only for proton selection"};
+  Configurable<double> nSigmaTpcCombinedPrMax{"nSigmaTpcCombinedPrMax", 0., "Nsigma cut on TPC combined with TOF for proton selection"};
+
+  Configurable<double> ptPiPidTpcMin{"ptPiPidTpcMin", -1, "Lower bound of track pT for TPC PID for pion selection"};
+  Configurable<double> ptPiPidTpcMax{"ptPiPidTpcMax", 9999.9, "Upper bound of track pT for TPC PID for pion selection"};
+  Configurable<double> nSigmaTpcPiMax{"nSigmaTpcPiMax", 3., "Nsigma cut on TPC only for pion selection"};
+  Configurable<double> nSigmaTpcCombinedPiMax{"nSigmaTpcCombinedPiMax", 0., "Nsigma cut on TPC combined with TOF for pion selection"};
+
+  // PID - TOF selections
+
+  Configurable<double> ptPrPidTofMin{"ptPrPidTofMin", -1, "Lower bound of track pT for TOF PID for proton selection"};
+  Configurable<double> ptPrPidTofMax{"ptPrPidTofMax", 9999.9, "Upper bound of track pT for TOF PID for proton selection"};
+  Configurable<double> nSigmaTofPrMax{"nSigmaTofPrMax", 3., "Nsigma cut on TOF only for proton selection"};
+  Configurable<double> nSigmaTofCombinedPrMax{"nSigmaTofCombinedPrMax", 0., "Nsigma cut on TOF combined with TPC for proton selection"};
+
+  Configurable<double> ptPiPidTofMin{"ptPiPidTofMin", -1, "Lower bound of track pT for TOF PID for pion selection"};
+  Configurable<double> ptPiPidTofMax{"ptPiPidTofMax", 9999.9, "Upper bound of track pT for TOF PID for pion selection"};
+  Configurable<double> nSigmaTofPiMax{"nSigmaTofPiMax", 3., "Nsigma cut on TOF only for pion selection"};
+  Configurable<double> nSigmaTofCombinedPiMax{"nSigmaTofCombinedPiMax", 0., "Nsigma cut on TOF combined with TOF for pion selection"};
+
+  // detector clusters selections
+  Configurable<int> nClustersTpcMin{"nClustersTpcMin", 70, "Minimum number of TPC clusters requirement"};
+  Configurable<int> nTpcCrossedRowsMin{"nTpcCrossedRowsMin", 70, "Minimum number of TPC crossed rows requirement"};
+  Configurable<double> tpcCrossedRowsOverFindableClustersRatioMin{"tpcCrossedRowsOverFindableClustersRatioMin", 0.8, "Minimum ratio TPC crossed rows over findable clusters requirement"};
+  Configurable<float> tpcChi2PerClusterMax{"tpcChi2PerClusterMax", 4, "Maximum value of chi2 fit over TPC clusters"};
+  Configurable<int> nClustersItsMin{"nClustersItsMin", 3, "Minimum number of ITS clusters requirement for pi <- charm baryon"};
+  Configurable<int> nClustersItsInnBarrMin{"nClustersItsInnBarrMin", 1, "Minimum number of ITS clusters in inner barrel requirement for pi <- charm baryon"};
+  Configurable<float> itsChi2PerClusterMax{"itsChi2PerClusterMax", 36, "Maximum value of chi2 fit over ITS clusters for pi <- charm baryon"};
+
+  TrackSelectorPr selectorProton;
+  TrackSelectorPi selectorPion;
+
+  using TracksSel = soa::Join<aod::TracksWDcaExtra, aod::TracksPidPi, aod::TracksPidPr, aod::TracksPidPi>;
+  using TracksSelLf = soa::Join<aod::TracksIU, aod::TracksExtra, aod::TracksPidPi, aod::TracksPidPr, aod::TracksPidPi>;
+
+  HistogramRegistry registry{"registry"}; // for QA of selections
+
+  OutputObj<TH1F> hInvMassCharmBaryon{TH1F("hInvMassCharmBaryon", "Charm baryon invariant mass;inv mass;entries", 500, 2.3, 3.1)};
+
+  void init(InitContext const&)
+  {
+    selectorProton.setRangePtTpc(ptPrPidTpcMin, ptPrPidTpcMax);
+    selectorProton.setRangeNSigmaTpc(-nSigmaTpcPrMax, nSigmaTpcPrMax);
+    selectorProton.setRangeNSigmaTpcCondTof(-nSigmaTpcCombinedPrMax, nSigmaTpcCombinedPrMax);
+    selectorProton.setRangePtTof(ptPrPidTofMin, ptPrPidTofMax);
+    selectorProton.setRangeNSigmaTof(-nSigmaTofPrMax, nSigmaTofPrMax);
+    selectorProton.setRangeNSigmaTofCondTpc(-nSigmaTofCombinedPrMax, nSigmaTofCombinedPrMax);
+
+    selectorPion.setRangePtTpc(ptPiPidTpcMin, ptPiPidTpcMax);
+    selectorPion.setRangeNSigmaTpc(-nSigmaTpcPiMax, nSigmaTpcPiMax);
+    selectorPion.setRangeNSigmaTpcCondTof(-nSigmaTpcCombinedPiMax, nSigmaTpcCombinedPiMax);
+    selectorPion.setRangePtTof(ptPiPidTofMin, ptPiPidTofMax);
+    selectorPion.setRangeNSigmaTof(-nSigmaTofPiMax, nSigmaTofPiMax);
+    selectorPion.setRangeNSigmaTofCondTpc(-nSigmaTofCombinedPiMax, nSigmaTofCombinedPiMax);
+
+    const AxisSpec axisSel{2, -0.5, 1.5, "status"};
+
+    registry.add("hSelPID", "hSelPID;status;entries", {HistType::kTH1F, {{12, 0., 12.}}});
+    registry.add("hStatusCheck", "Check consecutive selections status;status;entries", {HistType::kTH1F, {{12, 0., 12.}}});
+
+    // for QA of the selections (bin 0 -> candidates that did not pass the selection, bin 1 -> candidates that passed the selection)
+    registry.add("hSelSignDec", "hSelSignDec;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelEtaPosV0Dau", "hSelEtaPosV0Dau;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelEtaNegV0Dau", "hSelEtaNegV0Dau;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelEtaPiFromCasc", "hSelEtaPiFromCasc;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelEtaPiFromCharm", "hSelEtaPiFromCharm;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelRadCasc", "hSelRadCasc;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelRadV0", "hSelRadV0;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelCosPACasc", "hSelCosPACasc;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelCosPAV0", "hSelCosPAV0;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelDCACascDau", "hSelDCACascDau;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelDCAV0Dau", "hSelDCAV0Dau;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelDCACharmDau", "hSelDCACharmDau;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelDCAXYPrimPi", "hSelDCAXYPrimPi;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelDCAZPrimPi", "hSelDCAZPrimPi;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelDCAXYCasc", "hSelDCAXYCasc;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelDCAZCasc", "hSelDCAZCasc;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelPtPiFromCasc", "hSelPtPiFromCasc;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelPtPiFromCharm", "hSelPtPiFromCharm;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelTPCQualityPiFromCharm", "hSelTPCQualityPiFromCharm;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelTPCQualityPiFromLam", "hSelTPCQualityPiFromLam;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelTPCQualityPrFromLam", "hSelTPCQualityPrFromLam;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelTPCQualityPiFromCasc", "hSelTPCQualityPiFromCasc;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelITSQualityPiFromCharm", "hSelITSQualityPiFromCharm;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelMassLam", "hSelMassLam;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelMassCasc", "hSelMassCasc;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelMassCharmBaryon", "hSelMassCharmBaryon;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelDcaXYToPvV0Daughters", "hSelDcaXYToPvV0Daughters;status;entries", {HistType::kTH1F, {axisSel}});
+    registry.add("hSelDcaXYToPvPiFromCasc", "hSelDcaXYToPvPiFromCasc;status;entries", {HistType::kTH1F, {axisSel}});
+  }
+
+  void process(aod::HfCandToXiPiKf const& candidates,
+               TracksSel const& tracks,
+               TracksSelLf const& lfTracks)
+  {
+
+    // looping over charm baryon candidates
+    for (const auto& candidate : candidates) {
+
+      bool resultSelections = true; // True if the candidate passes all the selections, False otherwise
+
+      auto trackV0PosDauId = candidate.posTrackId();                   // positive V0 daughter
+      auto trackV0NegDauId = candidate.negTrackId();                   // negative V0 daughter
+      auto trackPiFromCascId = candidate.bachelorId();                 // pion <- cascade
+      auto trackPiFromCharmId = candidate.bachelorFromCharmBaryonId(); // pion <- charm baryon
+      auto trackV0PosDau = lfTracks.rawIteratorAt(trackV0PosDauId);
+      auto trackV0NegDau = lfTracks.rawIteratorAt(trackV0NegDauId);
+      auto trackPiFromCasc = lfTracks.rawIteratorAt(trackPiFromCascId);
+      auto trackPiFromCharm = tracks.rawIteratorAt(trackPiFromCharmId);
+
+      auto trackPiFromLam = trackV0NegDau;
+      auto trackPrFromLam = trackV0PosDau;
+
+      int8_t signDecay = candidate.signDecay(); // sign of pi <- cascade
+
+      if (signDecay > 0) {
+        trackPiFromLam = trackV0PosDau;
+        trackPrFromLam = trackV0NegDau;
+        registry.fill(HIST("hSelSignDec"), 1); // anti-particle decay
+      } else if (signDecay < 0) {
+        registry.fill(HIST("hSelSignDec"), 0); // particle decay
+      }
+
+      // eta selection
+      double etaV0PosDau = candidate.etaV0PosDau();
+      double etaV0NegDau = candidate.etaV0NegDau();
+      double etaPiFromCasc = candidate.etaBachFromCasc();
+      double etaPiFromCharmBaryon = candidate.etaBachFromCharmBaryon();
+      if (std::abs(etaV0PosDau) > etaTrackLFDauMax) {
+        resultSelections = false;
+        registry.fill(HIST("hSelEtaPosV0Dau"), 0);
+      } else {
+        registry.fill(HIST("hSelEtaPosV0Dau"), 1);
+      }
+      if (std::abs(etaV0NegDau) > etaTrackLFDauMax) {
+        resultSelections = false;
+        registry.fill(HIST("hSelEtaNegV0Dau"), 0);
+      } else {
+        registry.fill(HIST("hSelEtaNegV0Dau"), 1);
+      }
+      if (std::abs(etaPiFromCasc) > etaTrackLFDauMax) {
+        resultSelections = false;
+        registry.fill(HIST("hSelEtaPiFromCasc"), 0);
+      } else {
+        registry.fill(HIST("hSelEtaPiFromCasc"), 1);
+      }
+      if (std::abs(etaPiFromCharmBaryon) > etaTrackCharmBachMax) {
+        resultSelections = false;
+        registry.fill(HIST("hSelEtaPiFromCharm"), 0);
+      } else {
+        registry.fill(HIST("hSelEtaPiFromCharm"), 1);
+      }
+
+      // minimum radius cut (LFcut)
+      if (RecoDecay::sqrtSumOfSquares(candidate.xDecayVtxCascade(), candidate.yDecayVtxCascade()) < radiusCascMin) {
+        resultSelections = false;
+        registry.fill(HIST("hSelRadCasc"), 0);
+      } else {
+        registry.fill(HIST("hSelRadCasc"), 1);
+      }
+      if (RecoDecay::sqrtSumOfSquares(candidate.xDecayVtxV0(), candidate.yDecayVtxV0()) < radiusV0Min) {
+        resultSelections = false;
+        registry.fill(HIST("hSelRadV0"), 0);
+      } else {
+        registry.fill(HIST("hSelRadV0"), 1);
+      }
+
+      // cosPA (LFcut)
+      if (candidate.cosPACasc() < cosPACascMin) {
+        resultSelections = false;
+        registry.fill(HIST("hSelCosPACasc"), 0);
+      } else {
+        registry.fill(HIST("hSelCosPACasc"), 1);
+      }
+      if (candidate.cosPAV0() < cosPAV0Min) {
+        resultSelections = false;
+        registry.fill(HIST("hSelCosPAV0"), 0);
+      } else {
+        registry.fill(HIST("hSelCosPAV0"), 1);
+      }
+
+      // cascade and v0 daughters dca cut (LF cut)
+      if (candidate.dcaCascDau() > dcaCascDauMax) {
+        resultSelections = false;
+        registry.fill(HIST("hSelDCACascDau"), 0);
+      } else {
+        registry.fill(HIST("hSelDCACascDau"), 1);
+      }
+
+      if (candidate.dcaV0Dau() > dcaV0DauMax) {
+        resultSelections = false;
+        registry.fill(HIST("hSelDCAV0Dau"), 0);
+      } else {
+        registry.fill(HIST("hSelDCAV0Dau"), 1);
+      }
+
+      // dca charm baryon daughters cut
+      if (candidate.dcaCharmBaryonDau() > dcaCharmBaryonDauMax) {
+        resultSelections = false;
+        registry.fill(HIST("hSelDCACharmDau"), 0);
+      } else {
+        registry.fill(HIST("hSelDCACharmDau"), 1);
+      }
+
+      // dcaXY v0 daughters to PV cut
+      if (std::abs(candidate.dcaXYToPvV0Dau0()) < dcaPosToPvMin || std::abs(candidate.dcaXYToPvV0Dau1()) < dcaNegToPvMin) {
+        resultSelections = false;
+        registry.fill(HIST("hSelDcaXYToPvV0Daughters"), 0);
+      } else {
+        registry.fill(HIST("hSelDcaXYToPvV0Daughters"), 1);
+      }
+
+      // dcaXY ka <-- cascade to PV cut
+      if (std::abs(candidate.dcaXYToPvCascDau()) < dcaBachToPvMin) {
+        resultSelections = false;
+        registry.fill(HIST("hSelDcaXYToPvPiFromCasc"), 0);
+      } else {
+        registry.fill(HIST("hSelDcaXYToPvPiFromCasc"), 1);
+      }
+
+      // cut on charm bachelor pion dcaXY and dcaZ
+      if ((std::abs(candidate.impactParBachFromCharmBaryonXY()) < impactParameterXYPiFromCharmBaryonMin) || (std::abs(candidate.impactParBachFromCharmBaryonXY()) > impactParameterXYPiFromCharmBaryonMax)) {
+        resultSelections = false;
+        registry.fill(HIST("hSelDCAXYPrimPi"), 0);
+      } else {
+        registry.fill(HIST("hSelDCAXYPrimPi"), 1);
+      }
+      if ((std::abs(candidate.impactParBachFromCharmBaryonZ()) < impactParameterZPiFromCharmBaryonMin) || (std::abs(candidate.impactParBachFromCharmBaryonZ()) > impactParameterZPiFromCharmBaryonMax)) {
+        resultSelections = false;
+        registry.fill(HIST("hSelDCAZPrimPi"), 0);
+      } else {
+        registry.fill(HIST("hSelDCAZPrimPi"), 1);
+      }
+
+      // cut on cascade dcaXY and dcaZ
+      if ((std::abs(candidate.impactParCascXY()) < impactParameterXYCascMin) || (std::abs(candidate.impactParCascXY()) > impactParameterXYCascMax)) {
+        resultSelections = false;
+        registry.fill(HIST("hSelDCAXYCasc"), 0);
+      } else {
+        registry.fill(HIST("hSelDCAXYCasc"), 1);
+      }
+      if ((std::abs(candidate.impactParCascZ()) < impactParameterZCascMin) || (std::abs(candidate.impactParCascZ()) > impactParameterZCascMax)) {
+        resultSelections = false;
+        registry.fill(HIST("hSelDCAZCasc"), 0);
+      } else {
+        registry.fill(HIST("hSelDCAZCasc"), 1);
+      }
+
+      // pT selections
+      double ptPiFromCasc = RecoDecay::sqrtSumOfSquares(candidate.pxBachFromCasc(), candidate.pyBachFromCasc());
+      double ptPiFromCharmBaryon = RecoDecay::sqrtSumOfSquares(candidate.pxBachFromCharmBaryon(), candidate.pyBachFromCharmBaryon());
+      if (std::abs(ptPiFromCasc) < ptPiFromCascMin) {
+        resultSelections = false;
+        registry.fill(HIST("hSelPtPiFromCasc"), 0);
+      } else {
+        registry.fill(HIST("hSelPtPiFromCasc"), 1);
+      }
+      if (std::abs(ptPiFromCharmBaryon) < ptPiFromCharmBaryonMin) {
+        resultSelections = false;
+        registry.fill(HIST("hSelPtPiFromCharm"), 0);
+      } else {
+        registry.fill(HIST("hSelPtPiFromCharm"), 1);
+      }
+
+      //  TPC clusters selections
+      if (applyTrkSelLf) {
+        if (!isSelectedTrackTpcQuality(trackPiFromLam, nClustersTpcMin, nTpcCrossedRowsMin, tpcCrossedRowsOverFindableClustersRatioMin, tpcChi2PerClusterMax)) {
+          resultSelections = false;
+          registry.fill(HIST("hSelTPCQualityPiFromLam"), 0);
+        } else {
+          registry.fill(HIST("hSelTPCQualityPiFromLam"), 1);
+        }
+        if (!isSelectedTrackTpcQuality(trackPrFromLam, nClustersTpcMin, nTpcCrossedRowsMin, tpcCrossedRowsOverFindableClustersRatioMin, tpcChi2PerClusterMax)) {
+          resultSelections = false;
+          registry.fill(HIST("hSelTPCQualityPrFromLam"), 0);
+        } else {
+          registry.fill(HIST("hSelTPCQualityPrFromLam"), 1);
+        }
+        if (!isSelectedTrackTpcQuality(trackPiFromCasc, nClustersTpcMin, nTpcCrossedRowsMin, tpcCrossedRowsOverFindableClustersRatioMin, tpcChi2PerClusterMax)) {
+          resultSelections = false;
+          registry.fill(HIST("hSelTPCQualityPiFromCasc"), 0);
+        } else {
+          registry.fill(HIST("hSelTPCQualityPiFromCasc"), 1);
+        }
+      }
+      if (!isSelectedTrackTpcQuality(trackPiFromCharm, nClustersTpcMin, nTpcCrossedRowsMin, tpcCrossedRowsOverFindableClustersRatioMin, tpcChi2PerClusterMax)) {
+        resultSelections = false;
+        registry.fill(HIST("hSelTPCQualityPiFromCharm"), 0);
+      } else {
+        registry.fill(HIST("hSelTPCQualityPiFromCharm"), 1);
+      }
+
+      //  ITS clusters selection
+      if (!isSelectedTrackItsQuality(trackPiFromCharm, nClustersItsMin, itsChi2PerClusterMax) || trackPiFromCharm.itsNClsInnerBarrel() < nClustersItsInnBarrMin) {
+        resultSelections = false;
+        registry.fill(HIST("hSelITSQualityPiFromCharm"), 0);
+      } else {
+        registry.fill(HIST("hSelITSQualityPiFromCharm"), 1);
+      }
+
+      // track-level PID selection
+
+      // for TrackSelectorPID
+      int statusPidPrFromLam = -999;
+      int statusPidPiFromLam = -999;
+      int statusPidPiFromCasc = -999;
+      int statusPidPiFromCharmBaryon = -999;
+
+      bool statusPidLambda = false;
+      bool statusPidCascade = false;
+      bool statusPidCharmBaryon = false;
+
+      int infoTpcStored = 0;
+      int infoTofStored = 0;
+
+      if (usePidTpcOnly == usePidTpcTofCombined) {
+        LOGF(fatal, "Check the PID configurables, usePidTpcOnly and usePidTpcTofCombined can't have the same value");
+      }
+
+      if (trackPiFromLam.hasTPC()) {
+        SETBIT(infoTpcStored, kPiFromLam);
+      }
+      if (trackPrFromLam.hasTPC()) {
+        SETBIT(infoTpcStored, kPrFromLam);
+      }
+      if (trackPiFromCasc.hasTPC()) {
+        SETBIT(infoTpcStored, kPiFromCasc);
+      }
+      if (trackPiFromCharm.hasTPC()) {
+        SETBIT(infoTpcStored, kPiFromCharm);
+      }
+      if (trackPiFromLam.hasTOF()) {
+        SETBIT(infoTofStored, kPiFromLam);
+      }
+      if (trackPrFromLam.hasTOF()) {
+        SETBIT(infoTofStored, kPrFromLam);
+      }
+      if (trackPiFromCasc.hasTOF()) {
+        SETBIT(infoTofStored, kPiFromCasc);
+      }
+      if (trackPiFromCharm.hasTOF()) {
+        SETBIT(infoTofStored, kPiFromCharm);
+      }
+
+      if (usePidTpcOnly) {
+        statusPidPrFromLam = selectorProton.statusTpc(trackPrFromLam);
+        statusPidPiFromLam = selectorPion.statusTpc(trackPiFromLam);
+        statusPidPiFromCasc = selectorPion.statusTpc(trackPiFromCasc);
+        statusPidPiFromCharmBaryon = selectorPion.statusTpc(trackPiFromCharm);
+      } else if (usePidTpcTofCombined) {
+        statusPidPrFromLam = selectorProton.statusTpcOrTof(trackPrFromLam);
+        statusPidPiFromLam = selectorPion.statusTpcOrTof(trackPiFromLam);
+        statusPidPiFromCasc = selectorPion.statusTpcOrTof(trackPiFromCasc);
+        statusPidPiFromCharmBaryon = selectorPion.statusTpcOrTof(trackPiFromCharm);
+      }
+
+      if (statusPidPrFromLam == TrackSelectorPID::Accepted && statusPidPiFromLam == TrackSelectorPID::Accepted) {
+        statusPidLambda = true;
+        if (resultSelections) {
+          registry.fill(HIST("hStatusCheck"), 0.5);
+        }
+      }
+
+      if (statusPidPrFromLam == TrackSelectorPID::Accepted && statusPidPiFromLam == TrackSelectorPID::Accepted && statusPidPiFromCasc == TrackSelectorPID::Accepted) {
+        statusPidCascade = true;
+        if (resultSelections) {
+          registry.fill(HIST("hStatusCheck"), 1.5);
+        }
+      }
+
+      if (statusPidPrFromLam == TrackSelectorPID::Accepted && statusPidPiFromLam == TrackSelectorPID::Accepted && statusPidPiFromCasc == TrackSelectorPID::Accepted && statusPidPiFromCharmBaryon == TrackSelectorPID::Accepted) {
+        statusPidCharmBaryon = true;
+        if (resultSelections) {
+          registry.fill(HIST("hStatusCheck"), 2.5);
+        }
+      }
+
+      // invariant mass cuts
+      bool statusInvMassLambda = false;
+      bool statusInvMassCascade = false;
+      bool statusInvMassCharmBaryon = false;
+
+      double invMassLambda = candidate.invMassLambda();
+      double invMassCascade = candidate.invMassCascade();
+      double invMassCharmBaryon = candidate.invMassCharmBaryon();
+
+      if (std::abs(invMassLambda - o2::constants::physics::MassLambda0) < v0MassWindow) {
+        statusInvMassLambda = true;
+        registry.fill(HIST("hSelMassLam"), 1);
+        if (statusPidLambda && statusPidCascade && statusPidCharmBaryon && resultSelections) {
+          registry.fill(HIST("hStatusCheck"), 3.5);
+        }
+      } else {
+        registry.fill(HIST("hSelMassLam"), 0);
+      }
+
+      if (std::abs(invMassCascade - o2::constants::physics::MassXiMinus) < cascadeMassWindow) {
+        statusInvMassCascade = true;
+        registry.fill(HIST("hSelMassCasc"), 1);
+        if (statusPidLambda && statusPidCascade && statusPidCharmBaryon && statusInvMassLambda && resultSelections) {
+          registry.fill(HIST("hStatusCheck"), 4.5);
+        }
+      } else {
+        registry.fill(HIST("hSelMassCasc"), 0);
+      }
+
+      if ((invMassCharmBaryon >= invMassCharmBaryonMin) && (invMassCharmBaryon <= invMassCharmBaryonMax)) {
+        statusInvMassCharmBaryon = true;
+        registry.fill(HIST("hSelMassCharmBaryon"), 1);
+        if (statusPidLambda && statusPidCascade && statusPidCharmBaryon && statusInvMassLambda && statusInvMassCascade && resultSelections) {
+          registry.fill(HIST("hStatusCheck"), 5.5);
+        }
+      } else {
+        registry.fill(HIST("hSelMassCharmBaryon"), 0);
+      }
+
+      hfSelToXiPi(statusPidCharmBaryon, statusPidCascade, statusPidLambda, statusInvMassCharmBaryon, statusInvMassCascade, statusInvMassLambda, resultSelections, infoTpcStored, infoTofStored,
+                     trackPiFromCharm.tpcNSigmaPi(), trackPiFromCasc.tpcNSigmaPi(), trackPiFromLam.tpcNSigmaPi(), trackPrFromLam.tpcNSigmaPr(),
+                     trackPiFromCharm.tofNSigmaPi(), trackPiFromCasc.tofNSigmaPi(), trackPiFromLam.tofNSigmaPi(), trackPrFromLam.tofNSigmaPr());
+
+      if (resultSelections) {
+        if (!statusPidLambda) {
+          registry.fill(HIST("hSelPID"), 0.5);
+        }
+        if (statusPidLambda) {
+          registry.fill(HIST("hSelPID"), 1.5);
+        }
+        if (!statusPidCascade) {
+          registry.fill(HIST("hSelPID"), 2.5);
+        }
+        if (statusPidCascade) {
+          registry.fill(HIST("hSelPID"), 3.5);
+        }
+        if (!statusPidCharmBaryon) {
+          registry.fill(HIST("hSelPID"), 4.5);
+        }
+        if (statusPidCharmBaryon) {
+          registry.fill(HIST("hSelPID"), 5.5);
+        }
+        if (!statusInvMassLambda) {
+          registry.fill(HIST("hSelPID"), 6.5);
+        }
+        if (statusInvMassLambda) {
+          registry.fill(HIST("hSelPID"), 7.5);
+        }
+        if (!statusInvMassCascade) {
+          registry.fill(HIST("hSelPID"), 8.5);
+        }
+        if (statusInvMassCascade) {
+          registry.fill(HIST("hSelPID"), 9.5);
+        }
+        if (!statusInvMassCharmBaryon) {
+          registry.fill(HIST("hSelPID"), 10.5);
+        }
+        if (statusInvMassCharmBaryon) {
+          registry.fill(HIST("hSelPID"), 11.5);
+        }
+      }
+
+      if (statusPidLambda && statusPidCascade && statusPidCharmBaryon && statusInvMassLambda && statusInvMassCascade && statusInvMassCharmBaryon && resultSelections) {
+        hInvMassCharmBaryon->Fill(invMassCharmBaryon);
+      }
+    }
+  } // end process
+};  // end struct
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<HfCandidateSelectorXic0ToXiPiKf>(cfgc)};
+}

--- a/PWGHF/TableProducer/treeCreatorXic0ToXiPiKf.cxx
+++ b/PWGHF/TableProducer/treeCreatorXic0ToXiPiKf.cxx
@@ -136,7 +136,7 @@ struct HfTreeCreatorXic0ToXiPiKf {
   template <typename T>
   void fillKfCandidate(const T& candidate, int8_t flagMc, int8_t debugMc, int8_t originMc, bool collisionMatched)
   {
-    
+
     if (candidate.resultSelections() && candidate.statusPidCharmBaryon() && candidate.statusInvMassLambda() && candidate.statusInvMassCascade() && candidate.statusInvMassCharmBaryon()) {
 
       rowKfCandidate(
@@ -201,11 +201,10 @@ struct HfTreeCreatorXic0ToXiPiKf {
         originMc,
         collisionMatched);
     }
-
   }
 
   void processKfData(MyEventTable const& collisions, MyTrackTable const&,
-                         soa::Join<aod::HfCandToXiPiKf, aod::HfSelToXiPiKf> const& candidates)
+                     soa::Join<aod::HfCandToXiPiKf, aod::HfSelToXiPiKf> const& candidates)
   {
     rowKfCandidate.reserve(candidates.size());
     for (const auto& candidate : candidates) {
@@ -215,7 +214,7 @@ struct HfTreeCreatorXic0ToXiPiKf {
   PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processKfData, "Process KF data", false);
 
   void processKfMcXic0(MyEventTable const& collisions, MyTrackTable const&,
-                         soa::Join<aod::HfCandToXiPiKf, aod::HfSelToXiPiKf, aod::HfXicToXiPiMCRec> const& candidates)
+                       soa::Join<aod::HfCandToXiPiKf, aod::HfSelToXiPiKf, aod::HfXicToXiPiMCRec> const& candidates)
   {
     rowKfCandidate.reserve(candidates.size());
     for (const auto& candidate : candidates) {

--- a/PWGHF/TableProducer/treeCreatorXic0ToXiPiKf.cxx
+++ b/PWGHF/TableProducer/treeCreatorXic0ToXiPiKf.cxx
@@ -1,0 +1,233 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file treeCreatorToXiPi.cxx
+/// \brief Writer of the xic0 to Xi Pi candidates in the form of flat tables to be stored in TTrees.
+///        In this file are defined and filled the output tables
+///
+/// \author Ran Tu <ran.tu@cern.ch>, Fudan University
+
+#include "Framework/AnalysisTask.h"
+#include "Framework/runDataProcessing.h"
+
+#include "Common/Core/RecoDecay.h"
+
+#include "PWGHF/DataModel/CandidateReconstructionTables.h"
+#include "PWGHF/DataModel/CandidateSelectionTables.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+namespace o2::aod
+{
+namespace full
+{
+DECLARE_SOA_COLUMN(InvMassLambda, invMassLambda, float);
+DECLARE_SOA_COLUMN(InvMassCascade, invMassCascade, float);
+DECLARE_SOA_COLUMN(InvMassCharmBaryon, invMassCharmBaryon, float);
+DECLARE_SOA_COLUMN(DcaXYToPvV0Dau0, dcaXYToPvV0Dau0, float);
+DECLARE_SOA_COLUMN(DcaXYToPvV0Dau1, dcaXYToPvV0Dau1, float);
+DECLARE_SOA_COLUMN(DcaXYToPvCascDau, dcaXYToPvCascDau, float);
+DECLARE_SOA_COLUMN(DcaCascDau, dcaCascDau, float);
+DECLARE_SOA_COLUMN(DcaCharmBaryonDau, dcaCharmBaryonDau, float);
+// from creator - MC
+DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t); // reconstruction level
+DECLARE_SOA_COLUMN(DebugMcRec, debugMcRec, int8_t);         // debug flag for mis-association reconstruction level
+DECLARE_SOA_COLUMN(OriginRec, originRec, int8_t);
+DECLARE_SOA_COLUMN(CollisionMatched, collisionMatched, bool);
+// from selector
+DECLARE_SOA_COLUMN(TpcNSigmaPiFromCharmBaryon, tpcNSigmaPiFromCharmBaryon, float);
+DECLARE_SOA_COLUMN(TpcNSigmaPiFromCasc, tpcNSigmaPiFromCasc, float);
+DECLARE_SOA_COLUMN(TpcNSigmaPiFromLambda, tpcNSigmaPiFromLambda, float);
+DECLARE_SOA_COLUMN(TpcNSigmaPrFromLambda, tpcNSigmaPrFromLambda, float);
+DECLARE_SOA_COLUMN(TofNSigmaPiFromCharmBaryon, tofNSigmaPiFromCharmBaryon, float);
+DECLARE_SOA_COLUMN(TofNSigmaPiFromCasc, tofNSigmaPiFromCasc, float);
+DECLARE_SOA_COLUMN(TofNSigmaPiFromLambda, tofNSigmaPiFromLambda, float);
+DECLARE_SOA_COLUMN(TofNSigmaPrFromLambda, tofNSigmaPrFromLambda, float);
+// from creator KF
+DECLARE_SOA_COLUMN(KfDcaXYPiFromXic, kfDcaXYPiFromXic, float);
+DECLARE_SOA_COLUMN(KfDcaXYCascToPv, kfDcaXYCascToPv, float);
+DECLARE_SOA_COLUMN(Chi2GeoV0, chi2GeoV0, float);
+DECLARE_SOA_COLUMN(Chi2GeoCasc, chi2GeoCasc, float);
+DECLARE_SOA_COLUMN(Chi2GeoXic, chi2GeoXic, float);
+DECLARE_SOA_COLUMN(Chi2MassV0, chi2MassV0, float);
+DECLARE_SOA_COLUMN(Chi2MassCasc, chi2MassCasc, float);
+DECLARE_SOA_COLUMN(V0ldl, v0ldl, float);
+DECLARE_SOA_COLUMN(Cascldl, cascldl, float);
+DECLARE_SOA_COLUMN(Xicldl, xicldl, float);
+DECLARE_SOA_COLUMN(Chi2TopoV0ToPv, chi2TopoV0ToPv, float);
+DECLARE_SOA_COLUMN(Chi2TopoCascToPv, chi2TopoCascToPv, float);
+DECLARE_SOA_COLUMN(Chi2TopoPiFromXicToPv, chi2TopoPiFromXicToPv, float);
+DECLARE_SOA_COLUMN(Chi2TopoXicToPv, chi2TopoXicToPv, float);
+DECLARE_SOA_COLUMN(Chi2TopoV0ToCasc, chi2TopoV0ToCasc, float);
+DECLARE_SOA_COLUMN(Chi2TopoCascToXic, chi2TopoCascToXic, float);
+DECLARE_SOA_COLUMN(DecayLenXYLambda, decayLenXYLambda, float);
+DECLARE_SOA_COLUMN(DecayLenXYCasc, decayLenXYCasc, float);
+DECLARE_SOA_COLUMN(DecayLenXYXic, decayLenXYXic, float);
+DECLARE_SOA_COLUMN(CosPaV0ToCasc, cosPaV0ToCasc, float);
+DECLARE_SOA_COLUMN(CosPaV0ToPv, cosPaV0ToPv, float);
+DECLARE_SOA_COLUMN(CosPaCascToXic, cosPaCascToXic, float);
+DECLARE_SOA_COLUMN(CosPaCascToPv, cosPaCascToPv, float);
+DECLARE_SOA_COLUMN(CosPaXicToPv, cosPaXicToPv, float);
+DECLARE_SOA_COLUMN(KfRapXic, kfRapXic, float);
+DECLARE_SOA_COLUMN(KfptPiFromXic, kfptPiFromXic, float);
+DECLARE_SOA_COLUMN(KfptXic, kfptXic, float);
+DECLARE_SOA_COLUMN(CosThetaStarPiFromXic, cosThetaStarPiFromXic, float);
+DECLARE_SOA_COLUMN(CtXic, ctXic, float);
+DECLARE_SOA_COLUMN(EtaXic, etaXic, float);
+DECLARE_SOA_COLUMN(V0Ndf, v0Ndf, float);
+DECLARE_SOA_COLUMN(CascNdf, cascNdf, float);
+DECLARE_SOA_COLUMN(XicNdf, xicNdf, float);
+DECLARE_SOA_COLUMN(MassV0Ndf, massV0Ndf, float);
+DECLARE_SOA_COLUMN(MassCascNdf, massCascNdf, float);
+DECLARE_SOA_COLUMN(V0Chi2OverNdf, v0Chi2OverNdf, float);
+DECLARE_SOA_COLUMN(CascChi2OverNdf, cascChi2OverNdf, float);
+DECLARE_SOA_COLUMN(XicChi2OverNdf, xicChi2OverNdf, float);
+DECLARE_SOA_COLUMN(MassV0Chi2OverNdf, massV0Chi2OverNdf, float);
+DECLARE_SOA_COLUMN(MassCascChi2OverNdf, massCascChi2OverNdf, float);
+
+} // namespace full
+
+DECLARE_SOA_TABLE(HfKfXicFulls, "AOD", "HFKFXICFULL",
+                  full::TpcNSigmaPiFromCharmBaryon, full::TofNSigmaPiFromCharmBaryon, full::TpcNSigmaPiFromCasc, full::TofNSigmaPiFromCasc,
+                  full::TpcNSigmaPiFromLambda, full::TofNSigmaPiFromLambda, full::TpcNSigmaPrFromLambda, full::TofNSigmaPrFromLambda,
+                  full::KfDcaXYPiFromXic, full::DcaCascDau, full::DcaCharmBaryonDau, full::KfDcaXYCascToPv,
+                  full::DcaXYToPvV0Dau0, full::DcaXYToPvV0Dau1, full::DcaXYToPvCascDau,
+                  full::Chi2GeoV0, full::Chi2GeoCasc, full::Chi2GeoXic,
+                  full::Chi2MassV0, full::Chi2MassCasc,
+                  full::V0ldl, full::Cascldl, full::Xicldl,
+                  full::Chi2TopoV0ToPv, full::Chi2TopoCascToPv, full::Chi2TopoPiFromXicToPv, full::Chi2TopoXicToPv,
+                  full::Chi2TopoV0ToCasc, full::Chi2TopoCascToXic,
+                  full::DecayLenXYLambda, full::DecayLenXYCasc, full::DecayLenXYXic,
+                  full::CosPaV0ToCasc, full::CosPaV0ToPv, full::CosPaCascToXic, full::CosPaCascToPv, full::CosPaXicToPv,
+                  full::InvMassLambda, full::InvMassCascade, full::InvMassCharmBaryon,
+                  full::KfRapXic, full::KfptPiFromXic, full::KfptXic,
+                  full::CosThetaStarPiFromXic, full::CtXic, full::EtaXic,
+                  full::V0Ndf, full::CascNdf, full::XicNdf,
+                  full::MassV0Ndf, full::MassCascNdf,
+                  full::V0Chi2OverNdf, full::CascChi2OverNdf, full::XicChi2OverNdf,
+                  full::MassV0Chi2OverNdf, full::MassCascChi2OverNdf,
+                  full::FlagMcMatchRec, full::DebugMcRec, full::OriginRec, full::CollisionMatched);
+
+} // namespace o2::aod
+
+/// Writes the full information in an output TTree
+struct HfTreeCreatorXic0ToXiPiKf {
+
+  Produces<o2::aod::HfKfXicFulls> rowKfCandidate;
+
+  Configurable<float> zPvCut{"zPvCut", 10., "Cut on absolute value of primary vertex z coordinate"};
+
+  using MyTrackTable = soa::Join<aod::Tracks, aod::TrackSelection, aod::TracksExtra>;
+  using MyEventTable = soa::Join<aod::Collisions, aod::EvSels>;
+
+  void init(InitContext const&)
+  {
+  }
+
+  template <typename T>
+  void fillKfCandidate(const T& candidate, int8_t flagMc, int8_t debugMc, int8_t originMc, bool collisionMatched)
+  {
+    
+    if (candidate.resultSelections() && candidate.statusPidCharmBaryon() && candidate.statusInvMassLambda() && candidate.statusInvMassCascade() && candidate.statusInvMassCharmBaryon()) {
+
+      rowKfCandidate(
+        candidate.tpcNSigmaPiFromCharmBaryon(),
+        candidate.tofNSigmaPiFromCharmBaryon(),
+        candidate.tpcNSigmaPiFromCasc(),
+        candidate.tofNSigmaPiFromCasc(),
+        candidate.tpcNSigmaPiFromLambda(),
+        candidate.tofNSigmaPiFromLambda(),
+        candidate.tpcNSigmaPrFromLambda(),
+        candidate.tofNSigmaPrFromLambda(),
+        candidate.kfDcaXYPiFromXic(),
+        candidate.dcaCascDau(),
+        candidate.dcaCharmBaryonDau(),
+        candidate.kfDcaXYCascToPv(),
+        candidate.dcaXYToPvV0Dau0(),
+        candidate.dcaXYToPvV0Dau1(),
+        candidate.dcaXYToPvCascDau(),
+        candidate.chi2GeoV0(),
+        candidate.chi2GeoCasc(),
+        candidate.chi2GeoXic(),
+        candidate.chi2MassV0(),
+        candidate.chi2MassCasc(),
+        candidate.v0ldl(),
+        candidate.cascldl(),
+        candidate.xicldl(),
+        candidate.chi2TopoV0ToPv(),
+        candidate.chi2TopoCascToPv(),
+        candidate.chi2TopoPiFromXicToPv(),
+        candidate.chi2TopoXicToPv(),
+        candidate.chi2TopoV0ToCasc(),
+        candidate.chi2TopoCascToXic(),
+        candidate.decayLenXYLambda(),
+        candidate.decayLenXYCasc(),
+        candidate.decayLenXYXic(),
+        candidate.cosPaV0ToCasc(),
+        candidate.cosPAV0(),
+        candidate.cosPaCascToXic(),
+        candidate.cosPACasc(),
+        candidate.cosPACharmBaryon(),
+        candidate.invMassLambda(),
+        candidate.invMassCascade(),
+        candidate.invMassCharmBaryon(),
+        candidate.kfRapXic(),
+        candidate.kfptPiFromXic(),
+        candidate.kfptXic(),
+        candidate.cosThetaStarPiFromXic(),
+        candidate.ctauXic(),
+        candidate.etaCharmBaryon(),
+        candidate.v0Ndf(),
+        candidate.cascNdf(),
+        candidate.xicNdf(),
+        candidate.massV0Ndf(),
+        candidate.massCascNdf(),
+        candidate.v0Chi2OverNdf(),
+        candidate.cascChi2OverNdf(),
+        candidate.xicChi2OverNdf(),
+        candidate.massV0Chi2OverNdf(),
+        candidate.massCascChi2OverNdf(),
+        flagMc,
+        debugMc,
+        originMc,
+        collisionMatched);
+    }
+
+  }
+
+  void processKfData(MyEventTable const& collisions, MyTrackTable const&,
+                         soa::Join<aod::HfCandToXiPiKf, aod::HfSelToXiPiKf> const& candidates)
+  {
+    rowKfCandidate.reserve(candidates.size());
+    for (const auto& candidate : candidates) {
+      fillKfCandidate(candidate, -7, -7, RecoDecay::OriginType::None, false);
+    }
+  }
+  PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processKfData, "Process KF data", false);
+
+  void processKfMcXic0(MyEventTable const& collisions, MyTrackTable const&,
+                         soa::Join<aod::HfCandToXiPiKf, aod::HfSelToXiPiKf, aod::HfXicToXiPiMCRec> const& candidates)
+  {
+    rowKfCandidate.reserve(candidates.size());
+    for (const auto& candidate : candidates) {
+      fillKfCandidate(candidate, candidate.flagMcMatchRec(), candidate.debugMcRec(), candidate.originRec(), candidate.collisionMatched());
+    }
+  }
+  PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processKfMcXic0, "Process MC with information for xic0", false);
+
+}; // end of struct
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<HfTreeCreatorXic0ToXiPiKf>(cfgc)};
+}

--- a/PWGHF/TableProducer/treeCreatorXic0ToXiPiKf.cxx
+++ b/PWGHF/TableProducer/treeCreatorXic0ToXiPiKf.cxx
@@ -127,7 +127,6 @@ struct HfTreeCreatorXic0ToXiPiKf {
   Configurable<float> zPvCut{"zPvCut", 10., "Cut on absolute value of primary vertex z coordinate"};
 
   using MyTrackTable = soa::Join<aod::Tracks, aod::TrackSelection, aod::TracksExtra>;
-  using MyEventTable = soa::Join<aod::Collisions, aod::EvSels>;
 
   void init(InitContext const&)
   {
@@ -203,7 +202,7 @@ struct HfTreeCreatorXic0ToXiPiKf {
     }
   }
 
-  void processKfData(MyEventTable const& collisions, MyTrackTable const&,
+  void processKfData(MyTrackTable const&,
                      soa::Join<aod::HfCandToXiPiKf, aod::HfSelToXiPiKf> const& candidates)
   {
     rowKfCandidate.reserve(candidates.size());
@@ -213,7 +212,7 @@ struct HfTreeCreatorXic0ToXiPiKf {
   }
   PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processKfData, "Process KF data", false);
 
-  void processKfMcXic0(MyEventTable const& collisions, MyTrackTable const&,
+  void processKfMcXic0(MyTrackTable const&,
                        soa::Join<aod::HfCandToXiPiKf, aod::HfSelToXiPiKf, aod::HfXicToXiPiMCRec> const& candidates)
   {
     rowKfCandidate.reserve(candidates.size());


### PR DESCRIPTION
This Pull Request introduces the implementation of Xic⁰ reconstruction using the Kalman Filter method. The main changes include:
1. Modifications to CandidateCreatorXic0Omegac0.cxx: Added new process functions to support the Kalman Filter-based Xic⁰ reconstruction.
2. Updates to CandidateReconstructionTables.h and CandidateSelectionTables.h: Added a new reconstruction table and selection table.
3. New analysis files CandidateSelectorXic0ToXiPiKf.cxx and TreeCreatorXic0ToXiPi.cxx: These files process the newly added reconstruction and selection tables.