### PR TITLE
[Common] MC information fuction is added into Common/TableProducer/match-mft-m…

### DIFF
--- a/Common/DataModel/MatchMFTMuonData.h
+++ b/Common/DataModel/MatchMFTMuonData.h
@@ -1,0 +1,135 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+#ifndef COMMON_DATAMODEL_MATCHMFTMUONDATA_H_
+#define COMMON_DATAMODEL_MATCHMFTMUONDATA_H_
+#include "Framework/AnalysisDataModel.h"
+#endif // COMMON_DATAMODEL_MATCHMFTMUONDATA_H_
+
+namespace o2::aod
+{
+namespace matching_params
+{
+// matching parameters
+DECLARE_SOA_COLUMN(DeltaPt, mDeltaPt, float);
+DECLARE_SOA_COLUMN(DeltaEta, mDeltaEta, float);
+DECLARE_SOA_COLUMN(DeltaPhi, mDeltaPhi, float);
+DECLARE_SOA_COLUMN(DeltaX, mDeltaX, float);
+DECLARE_SOA_COLUMN(DeltaY, mDeltaY, float);
+DECLARE_SOA_COLUMN(GMuonPt, mGMuonPt, float);
+DECLARE_SOA_COLUMN(GMuonEta, mGMuonEta, float);
+DECLARE_SOA_COLUMN(PairQ, mPairQ, int16_t);
+DECLARE_SOA_COLUMN(IsCorrectMatch, mIsCorrectMatch, bool);
+} // namespace matching_params
+
+DECLARE_SOA_TABLE(MatchParams, "AOD", "MATCHING",
+                  matching_params::GMuonPt,
+                  matching_params::GMuonEta,
+                  matching_params::PairQ,
+                  matching_params::DeltaPt,
+                  matching_params::DeltaX,
+                  matching_params::DeltaY,
+                  matching_params::DeltaEta,
+                  matching_params::DeltaPhi,
+                  matching_params::IsCorrectMatch);
+
+namespace tag_matching_params
+{
+// matching parameters
+DECLARE_SOA_COLUMN(DeltaPt, mDeltaPt, float);
+DECLARE_SOA_COLUMN(DeltaEta, mDeltaEta, float);
+DECLARE_SOA_COLUMN(DeltaPhi, mDeltaPhi, float);
+DECLARE_SOA_COLUMN(DeltaX, mDeltaX, float);
+DECLARE_SOA_COLUMN(DeltaY, mDeltaY, float);
+DECLARE_SOA_COLUMN(GMuonPt, mGMuonPt, float);
+DECLARE_SOA_COLUMN(GMuonEta, mGMuonEta, float);
+DECLARE_SOA_COLUMN(PairQ, mPairQ, int16_t);
+DECLARE_SOA_COLUMN(IsCorrectMatch, mIsCorrectMatch, bool);
+} // namespace tag_matching_params
+
+DECLARE_SOA_TABLE(TagMatchParams, "AOD", "TAGMATCHING",
+                  tag_matching_params::GMuonPt,
+                  tag_matching_params::GMuonEta,
+                  tag_matching_params::PairQ,
+                  tag_matching_params::DeltaPt,
+                  tag_matching_params::DeltaX,
+                  tag_matching_params::DeltaY,
+                  tag_matching_params::DeltaEta,
+                  tag_matching_params::DeltaPhi,
+                  tag_matching_params::IsCorrectMatch);
+
+namespace probe_matching_params
+{
+// matching parameters
+DECLARE_SOA_COLUMN(DeltaPt, mDeltaPt, float);
+DECLARE_SOA_COLUMN(DeltaEta, mDeltaEta, float);
+DECLARE_SOA_COLUMN(DeltaPhi, mDeltaPhi, float);
+DECLARE_SOA_COLUMN(DeltaX, mDeltaX, float);
+DECLARE_SOA_COLUMN(DeltaY, mDeltaY, float);
+DECLARE_SOA_COLUMN(TagGMuonPt, mTagGMuonPt, float);
+DECLARE_SOA_COLUMN(GMuonPt, mGMuonPt, float);
+DECLARE_SOA_COLUMN(GMuonEta, mGMuonEta, float);
+DECLARE_SOA_COLUMN(PairQ, mPairQ, int16_t);
+DECLARE_SOA_COLUMN(IsCorrectMatch, mIsCorrectMatch, bool);
+} // namespace probe_matching_params
+
+DECLARE_SOA_TABLE(ProbeMatchParams, "AOD", "PROBEMATCHING",
+                  probe_matching_params::TagGMuonPt,
+                  probe_matching_params::GMuonPt,
+                  probe_matching_params::GMuonEta,
+                  probe_matching_params::PairQ,
+                  probe_matching_params::DeltaPt,
+                  probe_matching_params::DeltaX,
+                  probe_matching_params::DeltaY,
+                  probe_matching_params::DeltaEta,
+                  probe_matching_params::DeltaPhi,
+                  probe_matching_params::IsCorrectMatch);
+
+namespace mix_matching_params
+{
+// matching parameters
+DECLARE_SOA_COLUMN(DeltaPt, mDeltaPt, float);
+DECLARE_SOA_COLUMN(DeltaEta, mDeltaEta, float);
+DECLARE_SOA_COLUMN(DeltaPhi, mDeltaPhi, float);
+DECLARE_SOA_COLUMN(DeltaX, mDeltaX, float);
+DECLARE_SOA_COLUMN(DeltaY, mDeltaY, float);
+DECLARE_SOA_COLUMN(GMuonPt, mGMuonPt, float);
+DECLARE_SOA_COLUMN(GMuonEta, mGMuonEta, float);
+DECLARE_SOA_COLUMN(PairQ, mPairQ, int16_t);
+DECLARE_SOA_COLUMN(IsCorrectMatch, mIsCorrectMatch, bool);
+} // namespace mix_matching_params
+
+DECLARE_SOA_TABLE(MixMatchParams, "AOD", "MIXMATCHING",
+                  mix_matching_params::GMuonPt,
+                  mix_matching_params::GMuonEta,
+                  mix_matching_params::PairQ,
+                  mix_matching_params::DeltaPt,
+                  mix_matching_params::DeltaX,
+                  mix_matching_params::DeltaY,
+                  mix_matching_params::DeltaEta,
+                  mix_matching_params::DeltaPhi,
+                  mix_matching_params::IsCorrectMatch);
+
+namespace muon_pair
+{
+// matching parameters
+DECLARE_SOA_COLUMN(Mass, mMass, float);
+DECLARE_SOA_COLUMN(Pt, mPt, float);
+DECLARE_SOA_COLUMN(Rap, mRap, float);
+DECLARE_SOA_COLUMN(PairQ, mPairQ, int16_t);
+} // namespace muon_pair
+
+DECLARE_SOA_TABLE(MuonPair, "AOD", "MUONPAIR",
+                  muon_pair::PairQ,
+                  muon_pair::Mass,
+                  muon_pair::Pt,
+                  muon_pair::Rap);
+
+} // namespace o2::aod

--- a/Common/TableProducer/CMakeLists.txt
+++ b/Common/TableProducer/CMakeLists.txt
@@ -134,3 +134,8 @@ o2physics_add_dpl_workflow(mftmch-matching-data
                     SOURCES match-mft-mch-data.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCCDB O2Physics::PWGDQCore O2Physics::EventFilteringUtils
                     COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(mftmch-matching-data-mc
+                    SOURCES match-mft-mch-data-mc.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2Physics::AnalysisCCDB O2Physics::PWGDQCore O2Physics::EventFilteringUtils
+                    COMPONENT_NAME Analysis)

--- a/Common/TableProducer/match-mft-mch-data-mc.cxx
+++ b/Common/TableProducer/match-mft-mch-data-mc.cxx
@@ -77,8 +77,8 @@ using namespace o2::framework::expressions;
 
 using MyCollisions = aod::Collisions;
 using MyBCs = soa::Join<aod::BCs, aod::Timestamps, aod::MatchedToFT0>;
-using MyMUONs = soa::Join<aod::FwdTracks, aod::FwdTracksCov>;
-using MyMFTs = aod::MFTTracks;
+using MyMUONs = soa::Join<aod::FwdTracks, aod::FwdTracksCov, aod::McFwdTrackLabels>;
+using MyMFTs = soa::Join<aod::MFTTracks, aod::McMFTTrackLabels>;
 
 using MyCollision = MyCollisions::iterator;
 using MyBC = MyBCs::iterator;
@@ -718,7 +718,7 @@ struct match_mft_mch_data_mc {
 
           matching.calcGlobalMuonParams();
 
-          bool isTrue = false;
+          bool isTrue = isCorrectMatching(muontrack1, mfttrack1);
 
           tableMatchingParams(matching.getGMPtAtDCA(),
                               matching.getGMEtaAtDCA(),
@@ -747,7 +747,7 @@ struct match_mft_mch_data_mc {
               continue;
             matching.calcGlobalMuonParams();
 
-            bool isTrue = false;
+            bool isTrue = isCorrectMatching(muontrack1, mfttrack1);
 
             tableMixMatchingParams(matching.getGMPtAtDCA(),
                                    matching.getGMEtaAtDCA(),
@@ -803,7 +803,7 @@ struct match_mft_mch_data_mc {
             matchingTag.calcGlobalMuonParams();
             if (isGoodTagMatching(matchingTag.getDx(), matchingTag.getDy(), matchingTag.getDeta(), matchingTag.getDphi()) &&
                 isPassMatchingPreselection(matchingTag.getDx(), matchingTag.getDy())) {
-              bool isTrue = false;
+              bool isTrue = isCorrectMatching(tagmuontrack, mfttrack1);
               tableTagMatchingParams(matchingTag.getGMPtAtDCA(),
                                      matchingTag.getGMEtaAtDCA(),
                                      matchingTag.getGMQ(),
@@ -830,7 +830,7 @@ struct match_mft_mch_data_mc {
             matchingProbe.calcMatchingParams();
             if (isPassMatchingPreselection(matchingProbe.getDx(), matchingProbe.getDy())) {
               float R = sqrt(matchingProbe.getDx() * matchingProbe.getDx() + matchingProbe.getDy() * matchingProbe.getDy());
-              bool isTrue = false;
+              bool isTrue = isCorrectMatching(probemuontrack, mfttrack1);
               matchingProbe.calcGlobalMuonParams();
               vector<float>& probeMatchingParams = map_probeMatchingParams[nProbeMFTCand];
               probeMatchingParams.push_back(tagGMPtAtDCA);


### PR DESCRIPTION
This is the code for the MFT-MUON matching with data driven ML training sample. Common/TableProducer/match-mft-mch-data.cxx. and Common/TableProducer/match-mft-mch-data-mc.cxx are the same but Common/TableProducer/match-mft-mch-data-mc.cxx uses the mc info. The table creating part has been move to Common/DataModel/MatchMFTMuonData.h. The header file is loaded in the both codes.