### PR TITLE
[PWGLF] TPC PID info in f1 table, improved PID and background for f1

### DIFF
--- a/PWGLF/DataModel/ReducedF1ProtonTables.h
+++ b/PWGLF/DataModel/ReducedF1ProtonTables.h
@@ -60,6 +60,8 @@ DECLARE_SOA_COLUMN(F1d3Py, f1d3Py, float);                                 //! F
 DECLARE_SOA_COLUMN(F1d3Pz, f1d3Pz, float);                                 //! F1 d3 Pz
 DECLARE_SOA_COLUMN(F1d1TOFHit, f1d1TOFHit, int);                           //! TOF hit pion
 DECLARE_SOA_COLUMN(F1d2TOFHit, f1d2TOFHit, int);                           //! TOF hit pion
+DECLARE_SOA_COLUMN(F1d1TPC, f1d1TPC, float);                               //! TPC nsigma pion
+DECLARE_SOA_COLUMN(F1d2TPC, f1d2TPC, float);                               //! TPC nsigma kaon
 DECLARE_SOA_COLUMN(F1Mass, f1Mass, float);                                 //! F1 mass
 DECLARE_SOA_COLUMN(F1MassKaonKshort, f1MassKaonKshort, float);             //! F1 mass kaon kshort
 DECLARE_SOA_COLUMN(F1PionIndex, f1PionIndex, int64_t);                     //! F1 pion index
@@ -93,6 +95,8 @@ DECLARE_SOA_TABLE(F1Tracks, "AOD", "F1TRACK",
                   f1protondaughter::F1d3Pz,
                   f1protondaughter::F1d1TOFHit,
                   f1protondaughter::F1d2TOFHit,
+                  f1protondaughter::F1d1TPC,
+                  f1protondaughter::F1d2TPC,
                   f1protondaughter::F1Mass,
                   f1protondaughter::F1MassKaonKshort,
                   f1protondaughter::F1PionIndex,

--- a/PWGLF/TableProducer/Resonances/f1protonreducedtable.cxx
+++ b/PWGLF/TableProducer/Resonances/f1protonreducedtable.cxx
@@ -530,10 +530,14 @@ struct f1protonreducedtable {
     // keep TOF Hit of pion
     std::vector<int> PionTOFHit = {};
     std::vector<int> PionTOFHitFinal = {};
+    std::vector<float> PionTPC = {};
+    std::vector<float> PionTPCFinal = {};
 
     // keep TOF Hit of kaon
     std::vector<int> KaonTOFHit = {};
     std::vector<int> KaonTOFHitFinal = {};
+    std::vector<float> KaonTPC = {};
+    std::vector<float> KaonTPCFinal = {};
 
     // keep kaon-kshort mass of f1resonance
     std::vector<float> f1kaonkshortmass = {};
@@ -618,9 +622,11 @@ struct f1protonreducedtable {
             auto PionTOF = 0;
             if (track.sign() > 0) {
               qaRegistry.fill(HIST("hNsigmaPtpionTPC"), nTPCSigmaP[0], track.pt());
+              PionTPC.push_back(nTPCSigmaP[0]);
             }
             if (track.sign() < 0) {
               qaRegistry.fill(HIST("hNsigmaPtpionTPC"), nTPCSigmaN[0], track.pt());
+              PionTPC.push_back(nTPCSigmaN[0]);
             }
             if (track.hasTOF()) {
               qaRegistry.fill(HIST("hNsigmaPtpionTOF"), track.tofNSigmaPi(), track.pt());
@@ -637,9 +643,11 @@ struct f1protonreducedtable {
             auto KaonTOF = 0;
             if (track.sign() > 0) {
               qaRegistry.fill(HIST("hNsigmaPtkaonTPC"), nTPCSigmaP[1], track.pt());
+              KaonTPC.push_back(nTPCSigmaP[1]);
             }
             if (track.sign() < 0) {
               qaRegistry.fill(HIST("hNsigmaPtkaonTPC"), nTPCSigmaN[1], track.pt());
+              KaonTPC.push_back(nTPCSigmaN[1]);
             }
             if (track.hasTOF()) {
               qaRegistry.fill(HIST("hNsigmaPtkaonTOF"), track.tofNSigmaKa(), track.pt());
@@ -742,6 +750,8 @@ struct f1protonreducedtable {
                 F1KshortDaughterNegativeIndex.push_back(KshortNegDaughIndex.at(i3));
                 PionTOFHitFinal.push_back(PionTOFHit.at(i1)); // Pion TOF Hit
                 KaonTOFHitFinal.push_back(KaonTOFHit.at(i2)); // Kaon TOF Hit
+                PionTPCFinal.push_back(PionTPC.at(i1));       // Pion TPC
+                KaonTPCFinal.push_back(KaonTPC.at(i2));       // Kaon TPC
                 if (pairsign == 1) {
                   qaRegistry.fill(HIST("hInvMassf1"), F1Vector.M(), F1Vector.Pt());
                   numberF1 = numberF1 + 1;
@@ -798,7 +808,7 @@ struct f1protonreducedtable {
           F1d1dummy = f1resonanced1.at(i5);
           F1d2dummy = f1resonanced2.at(i5);
           F1d3dummy = f1resonanced3.at(i5);
-          f1track(indexEvent, f1signal.at(i5), F1VectorDummy.Px(), F1VectorDummy.Py(), F1VectorDummy.Pz(), F1d1dummy.Px(), F1d1dummy.Py(), F1d1dummy.Pz(), F1d2dummy.Px(), F1d2dummy.Py(), F1d2dummy.Pz(), F1d3dummy.Px(), F1d3dummy.Py(), F1d3dummy.Pz(), PionTOFHitFinal.at(i5), KaonTOFHitFinal.at(i5), F1VectorDummy.M(), f1kaonkshortmass.at(i5), F1PionIndex.at(i5), F1KaonIndex.at(i5), F1KshortDaughterPositiveIndex.at(i5), F1KshortDaughterNegativeIndex.at(i5));
+          f1track(indexEvent, f1signal.at(i5), F1VectorDummy.Px(), F1VectorDummy.Py(), F1VectorDummy.Pz(), F1d1dummy.Px(), F1d1dummy.Py(), F1d1dummy.Pz(), F1d2dummy.Px(), F1d2dummy.Py(), F1d2dummy.Pz(), F1d3dummy.Px(), F1d3dummy.Py(), F1d3dummy.Pz(), PionTOFHitFinal.at(i5), KaonTOFHitFinal.at(i5), PionTPCFinal.at(i5), KaonTPCFinal.at(i5), F1VectorDummy.M(), f1kaonkshortmass.at(i5), F1PionIndex.at(i5), F1KaonIndex.at(i5), F1KshortDaughterPositiveIndex.at(i5), F1KshortDaughterNegativeIndex.at(i5));
         }
         //// Fill track table for proton//////////////////
         for (auto iproton = protons.begin(); iproton != protons.end(); ++iproton) {


### PR DESCRIPTION
Add TPC PID info in f1 table + add momentum dependent PID cut to select f1 daughters + improved rotational background estimation