### PR TITLE
[PWGHF] Adding selections on impact parameter of D0 and Pi to B+ selection

### DIFF
--- a/PWGHF/Core/HfHelper.h
+++ b/PWGHF/Core/HfHelper.h
@@ -839,6 +839,16 @@ class HfHelper
       return false;
     }
 
+    // d0 of pi
+    if (std::abs(candBp.impactParameter1()) < cuts->get(pTBin, "d0 Pi")) {
+      return false;
+    }
+
+    // d0 of D
+    if (std::abs(candBp.impactParameter0()) < cuts->get(pTBin, "d0 D")) {
+      return false;
+    }
+
     return true;
   }
 


### PR DESCRIPTION
This change includes the impact parameters of the D0 and Pion in the selector, which were not cut on before