### PR TITLE
[Common] cover versioned tables in table autodetect

### DIFF
--- a/Common/Core/TableHelper.cxx
+++ b/Common/Core/TableHelper.cxx
@@ -47,11 +47,11 @@ bool isTableRequiredInWorkflow(o2::framework::InitContext& initContext, const st
       if (input.matcher.binding == table) {
         LOG(debug) << "Table: " << input.matcher.binding << " is needed in device: " << device.name;
         tableNeeded = true;
-      }else{
-        std::string versionedTable = table; 
+      } else {
+        std::string versionedTable = table;
         versionedTable.append("_00"); // would need fixing in case of more than 9 versions
         if (input.matcher.binding.find(versionedTable) != std::string::npos) {
-          LOG(debug) << "Versioned table: " << input.matcher.binding << " is needed in device: " << device.name <<  "(original table name: "<<table<<")";
+          LOG(debug) << "Versioned table: " << input.matcher.binding << " is needed in device: " << device.name << "(original table name: " << table << ")";
           tableNeeded = true;
         }
       }

--- a/Common/Core/TableHelper.cxx
+++ b/Common/Core/TableHelper.cxx
@@ -47,6 +47,13 @@ bool isTableRequiredInWorkflow(o2::framework::InitContext& initContext, const st
       if (input.matcher.binding == table) {
         LOG(debug) << "Table: " << input.matcher.binding << " is needed in device: " << device.name;
         tableNeeded = true;
+      }else{
+        std::string versionedTable = table; 
+        versionedTable.append("_00"); // would need fixing in case of more than 9 versions
+        if (input.matcher.binding.find(versionedTable) != std::string::npos) {
+          LOG(debug) << "Versioned table: " << input.matcher.binding << " is needed in device: " << device.name <<  "(original table name: "<<table<<")";
+          tableNeeded = true;
+        }
       }
     }
   }


### PR DESCRIPTION
@njacazio @aalkin I'm unsure if there are better ways to do this, but this should already do the trick to first order. This fixes table autodetect in case a table that is being detected is actually versioned. @aalkin: the capturing of the versioned table binding is very primitive, so if there are better ways to do this, please do let me know. 