### PR TITLE
[PWGHF] Extend information of sparses for efficiency evaluation. Refactor analysis utilities.

### DIFF
--- a/PWGCF/TwoParticleCorrelations/Tasks/lambdaR2Correlation.cxx
+++ b/PWGCF/TwoParticleCorrelations/Tasks/lambdaR2Correlation.cxx
@@ -93,6 +93,19 @@ DECLARE_SOA_TABLE(LambdaTracks, "AOD", "LAMBDATRACKS", o2::soa::Index<>,
                   lambdatrack::CorrFact);
 using LambdaTrack = LambdaTracks::iterator;
 
+namespace lambdatrackext
+{
+DECLARE_SOA_COLUMN(LambdaSharingDaughter, lambdaSharingDaughter, bool);
+DECLARE_SOA_COLUMN(LambdaSharingDauIds, lambdaSharingDauIds, std::vector<int64_t>);
+DECLARE_SOA_COLUMN(TrueLambdaFlag, trueLambdaFlag, bool);
+} // namespace lambdatrackext
+DECLARE_SOA_TABLE(LambdaTracksExt, "AOD", "LAMBDATRACKSEXT",
+                  lambdatrackext::LambdaSharingDaughter,
+                  lambdatrackext::LambdaSharingDauIds,
+                  lambdatrackext::TrueLambdaFlag);
+
+using LambdaTrackExt = LambdaTracksExt::iterator;
+
 namespace lambdamcgentrack
 {
 DECLARE_SOA_INDEX_COLUMN(LambdaMcGenCollision, lambdaMcGenCollision);
@@ -142,7 +155,7 @@ enum TrackLabels {
   kEffCorrPtY,
   kEffCorrPtYVz,
   kNoEffCorr,
-  kGenTotLambda,
+  kGenTotAccLambda,
   kGenLambdaNoDau,
   kGenLambdaToPrPi
 };
@@ -163,6 +176,11 @@ enum ParticlePairType {
   kAntiLambdaAntiLambda
 };
 
+enum ShareDauLambda {
+  kUniqueLambda = 0,
+  kLambdaShareDau
+};
+
 enum RecGenType {
   kRec = 0,
   kGen
@@ -173,7 +191,7 @@ enum DMCType {
   kMC
 };
 
-struct LambdaCorrTableProducer {
+struct LambdaTableProducer {
 
   Produces<aod::LambdaCollisions> lambdaCollisionTable;
   Produces<aod::LambdaTracks> lambdaTrackTable;
@@ -268,22 +286,22 @@ struct LambdaCorrTableProducer {
     const AxisSpec axisPID(8000, -4000, 4000, "PdgCode");
 
     const AxisSpec axisV0Mass(200, 1.09, 1.14, "M_{p#pi} (GeV/#it{c}^{2})");
-    const AxisSpec axisV0Pt(32, 0.3, 3.5, "p_{T} (GeV/#it{c})");
+    const AxisSpec axisV0Pt(38, 0.2, 4.0, "p_{T} (GeV/#it{c})");
     const AxisSpec axisV0Rap(24, -1.2, 1.2, "y");
     const AxisSpec axisV0Eta(24, -1.2, 1.2, "#eta");
     const AxisSpec axisV0Phi(36, 0., TwoPI, "#phi (rad)");
 
-    const AxisSpec axisRadius(400, 0, 200, "r(cm)");
-    const AxisSpec axisCosPA(100, 0.99, 1.0, "cos(#theta_{PA})");
-    const AxisSpec axisDcaV0PV(1000, -5., 5., "dca (cm)");
-    const AxisSpec axisDcaProngPV(1000, -50., 50., "dca (cm)");
+    const AxisSpec axisRadius(200, 0, 200, "r(cm)");
+    const AxisSpec axisCosPA(500, 0.995, 1.0, "cos(#theta_{PA})");
+    const AxisSpec axisDcaV0PV(1000, 0., 10., "dca (cm)");
+    const AxisSpec axisDcaProngPV(5000, -50., 50., "dca (cm)");
     const AxisSpec axisDcaDau(75, 0., 1.5, "Daug DCA (#sigma)");
-    const AxisSpec axisCTau(400, 0, 200, "c#tau (cm)");
-    const AxisSpec axisGCTau(400, 0, 200, "#gammac#tau (cm)");
+    const AxisSpec axisCTau(200, 0, 200, "c#tau (cm)");
+    const AxisSpec axisGCTau(200, 0, 200, "#gammac#tau (cm)");
     const AxisSpec axisAlpha(40, -1, 1, "#alpha");
     const AxisSpec axisQtarm(40, 0, 0.4, "q_{T}");
 
-    const AxisSpec axisTrackPt(80, 0, 4, "p_{T} (GeV/#it{c})");
+    const AxisSpec axisTrackPt(40, 0, 4, "p_{T} (GeV/#it{c})");
     const AxisSpec axisTrackDCA(200, -1, 1, "dca_{XY} (cm)");
     const AxisSpec axisMomPID(80, 0, 4, "p (GeV/#it{c})");
     const AxisSpec axisNsigma(401, -10.025, 10.025, {"n#sigma"});
@@ -355,7 +373,7 @@ struct LambdaCorrTableProducer {
       histos.get<TH1>(HIST("Tracks/h1f_tracks_info"))->GetXaxis()->SetBinLabel(TrackLabels::kLambdaNotPrPiMinus, "kLambdaNotPrPiMinus");
       histos.get<TH1>(HIST("Tracks/h1f_tracks_info"))->GetXaxis()->SetBinLabel(TrackLabels::kAntiLambdaNotAntiPrPiPlus, "kAntiLambdaNotAntiPrPiPlus");
       histos.get<TH1>(HIST("Tracks/h1f_tracks_info"))->GetXaxis()->SetBinLabel(TrackLabels::kPassTrueLambdaSel, "kPassTrueLambdaSel");
-      histos.get<TH1>(HIST("Tracks/h1f_tracks_info"))->GetXaxis()->SetBinLabel(TrackLabels::kGenTotLambda, "kGenTotLambda");
+      histos.get<TH1>(HIST("Tracks/h1f_tracks_info"))->GetXaxis()->SetBinLabel(TrackLabels::kGenTotAccLambda, "kGenTotAccLambda");
       histos.get<TH1>(HIST("Tracks/h1f_tracks_info"))->GetXaxis()->SetBinLabel(TrackLabels::kGenLambdaNoDau, "kGenLambdaNoDau");
       histos.get<TH1>(HIST("Tracks/h1f_tracks_info"))->GetXaxis()->SetBinLabel(TrackLabels::kGenLambdaToPrPi, "kGenLambdaToPrPi");
     }
@@ -837,14 +855,14 @@ struct LambdaCorrTableProducer {
     fillLambdaTables<kRun3, kData>(collision, V0s, tracks);
   }
 
-  PROCESS_SWITCH(LambdaCorrTableProducer, processDataRun3, "Process for Run3 DATA", true);
+  PROCESS_SWITCH(LambdaTableProducer, processDataRun3, "Process for Run3 DATA", true);
 
   void processDataRun2(CollisionsRun2::iterator const& collision, aod::V0Datas const& V0s, Tracks const& tracks)
   {
     fillLambdaTables<kRun2, kData>(collision, V0s, tracks);
   }
 
-  PROCESS_SWITCH(LambdaCorrTableProducer, processDataRun2, "Process for Run2 DATA", false);
+  PROCESS_SWITCH(LambdaTableProducer, processDataRun2, "Process for Run2 DATA", false);
 
   void processMCRecoRun3(soa::Join<CollisionsRun3, aod::McCollisionLabels>::iterator const& collision, aod::McCollisions const&,
                          McV0Tracks const& V0s, aod::McParticles const&, TracksMC const& tracks)
@@ -852,7 +870,7 @@ struct LambdaCorrTableProducer {
     fillLambdaTables<kRun3, kMC>(collision, V0s, tracks);
   }
 
-  PROCESS_SWITCH(LambdaCorrTableProducer, processMCRecoRun3, "Process for Run3 MC Reconstructed", false);
+  PROCESS_SWITCH(LambdaTableProducer, processMCRecoRun3, "Process for Run3 MC Reconstructed", false);
 
   void processMCRecoRun2(soa::Join<CollisionsRun2, aod::McCollisionLabels>::iterator const& collision, aod::McCollisions const&,
                          McV0Tracks const& V0s, aod::McParticles const&, TracksMC const& tracks)
@@ -860,7 +878,7 @@ struct LambdaCorrTableProducer {
     fillLambdaTables<kRun2, kMC>(collision, V0s, tracks);
   }
 
-  PROCESS_SWITCH(LambdaCorrTableProducer, processMCRecoRun2, "Process for Run2 MC Reconstructed", false);
+  PROCESS_SWITCH(LambdaTableProducer, processMCRecoRun2, "Process for Run2 MC Reconstructed", false);
 
   void processMCGen(aod::McCollisions::iterator const& mcCollision, aod::McParticles const& mcParticles)
   {
@@ -889,8 +907,6 @@ struct LambdaCorrTableProducer {
         continue;
       }
 
-      histos.fill(HIST("Tracks/h1f_tracks_info"), kGenTotLambda);
-
       // check for Primary Lambdas/AntiLambdas
       if (cGenPrimaryLambda && !mcpart.isPhysicalPrimary()) {
         continue;
@@ -900,6 +916,8 @@ struct LambdaCorrTableProducer {
       if (mcpart.pt() <= cMinV0Pt || mcpart.pt() >= cMaxV0Pt || std::abs(mcpart.y()) >= cMaxV0Rap) {
         continue;
       }
+
+      histos.fill(HIST("Tracks/h1f_tracks_info"), kGenTotAccLambda);
 
       // get daughter track info and check for decay channel flag
       if (!mcpart.has_daughters()) {
@@ -934,7 +952,169 @@ struct LambdaCorrTableProducer {
     }
   }
 
-  PROCESS_SWITCH(LambdaCorrTableProducer, processMCGen, "Process for MC Generated", false);
+  PROCESS_SWITCH(LambdaTableProducer, processMCGen, "Process for MC Generated", false);
+};
+
+struct LambdaTracksExtProducer {
+
+  Produces<aod::LambdaTracksExt> lambdaTrackExtTable;
+
+  // Configurables
+  Configurable<bool> cAcceptAllLambda{"cAcceptAllLambda", false, "Accept all Lambda"};
+  Configurable<bool> cRejAllLambdaShaDau{"cRejAllLambdaShaDau", true, "Reject all Lambda sharing daughters"};
+  Configurable<bool> cSelLambdaMassPdg{"cSelLambdaMassPdg", false, "Select Lambda closest to Pdg Mass"};
+  Configurable<bool> cSelLambdaTScore{"cSelLambdaTScore", false, "Select Lambda based on t-score"};
+  Configurable<float> cA{"cA", 0.6, "a * |lambdaMass - lambdaPdgMass|"};
+  Configurable<float> cB{"cB", 0.6, "b * DcaPrPi"};
+  Configurable<float> cC{"cC", 0.6, "c * Cos(theta_{PA})"};
+
+  // Histogram Registry.
+  HistogramRegistry histos{"histos", {}, OutputObjHandlingPolicy::AnalysisObject};
+
+  void init(InitContext const&)
+  {
+    // Axis Specifications
+    const AxisSpec axisMult(10, 0, 10);
+    const AxisSpec axisMass(100, 1.06, 1.16, "Inv Mass (GeV/#it{c}^{2})");
+    const AxisSpec axisCPA(100, 0.995, 1.0, "cos(#theta_{PA})");
+    const AxisSpec axisDcaDau(75, 0., 1.5, "Daug DCA (#sigma)");
+
+    // Histograms Booking
+    histos.add("h1i_totlambda_mult", "Multiplicity", kTH1I, {axisMult});
+    histos.add("h1i_totantilambda_mult", "Multiplicity", kTH1I, {axisMult});
+    histos.add("h1i_lambda_mult", "Multiplicity", kTH1I, {axisMult});
+    histos.add("h1i_antilambda_mult", "Multiplicity", kTH1I, {axisMult});
+
+    // InvMass, DcaDau and CosPA
+    histos.add("Reco/h1f_lambda_invmass", "M_{p#pi}", kTH1F, {axisMass});
+    histos.add("Reco/h1f_lambda_cospa", "cos(#theta_{PA})", kTH1F, {axisCPA});
+    histos.add("Reco/h1f_lambda_dcadau", "DCA_{p#pi} at V0 Decay Vertex", kTH1F, {axisDcaDau});
+    histos.add("Reco/h1f_lambda_cospa_vs_invm", "cos(#theta_{PA}) vs M_{p#pi}", kTH2F, {axisMass, axisCPA});
+    histos.add("Reco/h1f_lambda_dcadau_vs_invm", "DCA_{p#pi} vs M_{p#pi}", kTH2F, {axisMass, axisDcaDau});
+    histos.add("Reco/h1f_antilambda_invmass", "M_{p#pi}", kTH1F, {axisMass});
+    histos.add("Reco/h1f_antilambda_cospa", "cos(#theta_{PA})", kTH1F, {axisCPA});
+    histos.add("Reco/h1f_antilambda_dcadau", "DCA_{p#pi} at V0 Decay Vertex", kTH1F, {axisDcaDau});
+    histos.add("Reco/h1f_antilambda_cospa_vs_invm", "cos(#theta_{PA}) vs M_{p#pi}", kTH2F, {axisMass, axisCPA});
+    histos.add("Reco/h1f_antilambda_dcadau_vs_invm", "DCA_{p#pi} vs M_{p#pi}", kTH2F, {axisMass, axisDcaDau});
+
+    histos.addClone("Reco/", "SharingDau/");
+  }
+
+  template <ShareDauLambda sd, typename T>
+  void fillHistos(T const& track)
+  {
+    static constexpr std::string_view SubDir[] = {"Reco/", "SharingDau/"};
+
+    if (track.v0Type() == kLambda) {
+      histos.fill(HIST(SubDir[sd]) + HIST("h1f_lambda_invmass"), track.mass());
+      histos.fill(HIST(SubDir[sd]) + HIST("h1f_lambda_dcadau"), track.dcaDau());
+      histos.fill(HIST(SubDir[sd]) + HIST("h1f_lambda_cospa"), track.cosPA());
+      histos.fill(HIST(SubDir[sd]) + HIST("h1f_lambda_cospa_vs_invm"), track.mass(), track.cosPA());
+      histos.fill(HIST(SubDir[sd]) + HIST("h1f_lambda_dcadau_vs_invm"), track.dcaDau(), track.cosPA());
+    } else {
+      histos.fill(HIST(SubDir[sd]) + HIST("h1f_antilambda_invmass"), track.mass());
+      histos.fill(HIST(SubDir[sd]) + HIST("h1f_antilambda_dcadau"), track.dcaDau());
+      histos.fill(HIST(SubDir[sd]) + HIST("h1f_antilambda_cospa"), track.cosPA());
+      histos.fill(HIST(SubDir[sd]) + HIST("h1f_antilambda_cospa_vs_invm"), track.mass(), track.cosPA());
+      histos.fill(HIST(SubDir[sd]) + HIST("h1f_antilambda_dcadau_vs_invm"), track.dcaDau(), track.cosPA());
+    }
+  }
+
+  void process(aod::LambdaCollisions::iterator const&, aod::LambdaTracks const& tracks)
+  {
+
+    int nTotLambda = 0, nTotAntiLambda = 0, nSelLambda = 0, nSelAntiLambda = 0;
+
+    for (auto const& lambda : tracks) {
+      bool lambdaMinDeltaMassFlag = true, lambdaMinTScoreFlag = true;
+      bool lambdaSharingDauFlag = false, trueLambdaFlag = false;
+      std::vector<int64_t> vSharedDauLambdaIndex;
+      float tLambda = 0., tTrack = 0.;
+
+      if (lambda.v0Type() == kLambda) {
+        ++nTotLambda;
+      } else if (lambda.v0Type() == kAntiLambda) {
+        ++nTotAntiLambda;
+      }
+
+      tLambda = (cA * std::abs(lambda.mass() - MassLambda0)) + (cB * lambda.dcaDau()) + (cC * lambda.cosPA());
+
+      for (auto const& track : tracks) {
+        // check lambda index (don't analyze same lambda track !!!)
+        if (lambda.index() == track.index()) {
+          continue;
+        }
+
+        // check only lambda-lambda || antilambda-antilambda
+        if (lambda.v0Type() != track.v0Type()) {
+          continue;
+        }
+
+        // check if lambda shares daughters with any other track
+        if (lambda.posTrackId() == track.posTrackId() || lambda.negTrackId() == track.negTrackId()) {
+          vSharedDauLambdaIndex.push_back(track.index());
+          lambdaSharingDauFlag = true;
+
+          // decision based on mass closest to PdgMass of Lambda
+          if (std::abs(lambda.mass() - MassLambda0) > std::abs(track.mass() - MassLambda0)) {
+            lambdaMinDeltaMassFlag = false;
+          }
+
+          // decisions based on t-score
+          tTrack = (cA * std::abs(track.mass() - MassLambda0)) + (cB * track.dcaDau()) + (cC * track.cosPA());
+          if (tLambda > tTrack) {
+            lambdaMinTScoreFlag = false;
+          }
+        }
+      }
+
+      // fill QA histograms
+      if (lambdaSharingDauFlag) {
+        fillHistos<kLambdaShareDau>(lambda);
+      } else {
+        fillHistos<kUniqueLambda>(lambda);
+      }
+
+      if (cAcceptAllLambda) { // Accept all lambda
+        trueLambdaFlag = true;
+      } else if (cRejAllLambdaShaDau && !lambdaSharingDauFlag) { // Reject all lambda sharing daughter
+        trueLambdaFlag = true;
+      } else if (cSelLambdaMassPdg && lambdaMinDeltaMassFlag) { // Select lambda closest to pdg mass
+        trueLambdaFlag = true;
+      } else if (cSelLambdaTScore && lambdaMinTScoreFlag) { // Select lambda based on t-score
+        trueLambdaFlag = true;
+      }
+
+      // Multiplicity of selected lambda
+      if (trueLambdaFlag) {
+        if (lambda.v0Type() == kLambda) {
+          ++nSelLambda;
+        } else if (lambda.v0Type() == kAntiLambda) {
+          ++nSelAntiLambda;
+        }
+      }
+
+      // fill LambdaTrackExt table
+      lambdaTrackExtTable(lambdaSharingDauFlag, vSharedDauLambdaIndex, trueLambdaFlag);
+    }
+
+    // fill multiplicity histograms
+    if (nTotLambda != 0) {
+      histos.fill(HIST("h1i_totlambda_mult"), nTotLambda);
+    }
+
+    if (nTotAntiLambda != 0) {
+      histos.fill(HIST("h1i_totantilambda_mult"), nTotAntiLambda);
+    }
+
+    if (nSelLambda != 0) {
+      histos.fill(HIST("h1i_lambda_mult"), nSelLambda);
+    }
+
+    if (nSelAntiLambda != 0) {
+      histos.fill(HIST("h1i_antilambda_mult"), nSelAntiLambda);
+    }
+  }
 };
 
 struct LambdaR2Correlation {
@@ -984,8 +1164,6 @@ struct LambdaR2Correlation {
     const AxisSpec axisMass(100, 1.06, 1.16, "Inv Mass (GeV/#it{c}^{2})");
     const AxisSpec axisPt(32, 0.2, 3.4, "p_{T} (GeV/#it{c})");
     const AxisSpec axisEta(24, -1.2, 1.2, "#eta");
-    const AxisSpec axisCPA(100, 0.99, 1.0, "cos(#theta_{PA})");
-    const AxisSpec axisDcaDau(75, 0., 1.5, "Daug DCA (#sigma)");
     const AxisSpec axisRap(cNRapBins, cMinRap, cMaxRap, "y");
     const AxisSpec axisPhi(cNPhiBins, 0., TwoPI, "#phi (rad)");
     const AxisSpec axisRapPhi(knrapphibins, kminrapphi, kmaxrapphi, "y #phi");
@@ -1000,19 +1178,8 @@ struct LambdaR2Correlation {
     // Event
     histos.add("Event/Reco/h1f_collision_posz", "V_{Z} Distribution", kTH1F, {axisPosZ});
     histos.add("Event/Reco/h1f_ft0m_mult_percentile", "FT0M (%)", kTH1F, {axisCent});
-    histos.add("Event/Reco/h1i_lambda_multiplicity", "#Lambda - Multiplicity", kTH1I, {axisMult});
-    histos.add("Event/Reco/h1i_antilambda_multiplicity", "#bar{#Lambda} - Multiplicity", kTH1I, {axisMult});
-    histos.add("Event/Reco/h1i_lambda_sdau", "#Lambda - Multiplicity", kTH1I, {axisMult});
-    histos.add("Event/Reco/h1i_antilambda_sdau", "#bar{#Lambda} - Multiplicity", kTH1I, {axisMult});
-    histos.add("Event/Reco/h1i_lambda_totmult", "#Lambda - Multiplicity", kTH1I, {axisMult});
-    histos.add("Event/Reco/h1i_antilambda_totmult", "#bar{#Lambda} - Multiplicity", kTH1I, {axisMult});
-
-    // InvMass, DcaDau and CosPA
-    histos.add("Reco/QA_Lambda/h1f_invmass", "M_{p#pi}", kTH1F, {axisMass});
-    histos.add("Reco/QA_Lambda/h1f_cospa", "cos(#theta_{PA})", kTH1F, {axisCPA});
-    histos.add("Reco/QA_Lambda/h1f_dcadau", "DCA_{p#pi} at V0 Decay Vertex", kTH1F, {axisDcaDau});
-
-    histos.addClone("Reco/QA_Lambda/", "Reco/QA_AntiLambda/");
+    histos.add("Event/Reco/h1i_lambda_mult", "#Lambda - Multiplicity", kTH1I, {axisMult});
+    histos.add("Event/Reco/h1i_antilambda_mult", "#bar{#Lambda} - Multiplicity", kTH1I, {axisMult});
 
     // Efficiency Histograms
     histos.add("Reco/Efficiency/h1f_n1_pt_LaP", "#rho_{1}^{#Lambda}", kTH1F, {axisEfPt});
@@ -1046,6 +1213,8 @@ struct LambdaR2Correlation {
     // rho1 for R2 qinv histograms
     histos.add("Reco/h2d_n1_ptrap_LaP", "#rho_{1}^{#Lambda}", kTH2D, {axisPt, axisRap});
     histos.add("Reco/h2d_n1_ptrap_LaM", "#rho_{1}^{#bar{#Lambda}}", kTH2D, {axisPt, axisRap});
+    histos.add("Reco/h2d_n1_pteta_LaP", "#rho_{1}^{#Lambda}", kTH2D, {axisPt, axisEta});
+    histos.add("Reco/h2d_n1_pteta_LaM", "#rho_{1}^{#bar{#Lambda}}", kTH2D, {axisPt, axisEta});
 
     // rho2 for R2 deta dphi histograms
     histos.add("Reco/h2d_n2_rapphi_LaP_LaM", "#rho_{2}^{#Lambda - #bar{#Lambda}}", kTH2D, {axisRapPhi, axisRapPhi});
@@ -1087,36 +1256,6 @@ struct LambdaR2Correlation {
     }
   }
 
-  template <bool fillHist, ParticleType part, RecGenType rec_gen, typename T, typename V>
-  bool removeLambdaSharingDau(T const& v, V const& vs)
-  {
-    // check whether to remove lambda or not
-    if (!cRemoveLambdaSharingDau) {
-      return true;
-    }
-
-    static constexpr std::string_view SubDirRecGen[] = {"Reco/", "McGen/"};
-    static constexpr std::string_view SubDirHist[] = {"QA_Lambda/", "QA_AntiLambda/"};
-
-    bool retFlag = true;
-
-    for (auto const& x : vs) {
-      if ((v.index() != x.index()) && (v.posTrackId() == x.posTrackId() || v.negTrackId() == x.negTrackId())) {
-        if (fillHist) {
-          histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST(SubDirHist[part]) + HIST("h1f_invmass"), x.mass());
-          histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST(SubDirHist[part]) + HIST("h1f_cospa"), x.cosPA());
-          histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST(SubDirHist[part]) + HIST("h1f_dcadau"), x.dcaDau());
-        }
-        if (std::abs(v.mass() - MassLambda0) > std::abs(x.mass() - MassLambda0)) {
-          retFlag = false;
-          break;
-        }
-      }
-    }
-
-    return retFlag;
-  }
-
   template <ParticlePairType part_pair, RecGenType rec_gen, typename U>
   void fillPairHistos(U& p1, U& p2)
   {
@@ -1129,29 +1268,29 @@ struct LambdaR2Correlation {
     int phibin1 = static_cast<int>(p1.phi() / phibinwidth);
     int phibin2 = static_cast<int>(p2.phi() / phibinwidth);
 
-    float corfac1 = p1.corrFact(), corfac2 = p2.corrFact();
+    float corfac = p1.corrFact() * p2.corrFact();
 
-    histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h2d_n2_pt1pt2_") + HIST(SubDirHist[part_pair]), p1.pt(), p2.pt(), corfac1 * corfac2);
-    histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h2d_n2_eta1eta2_") + HIST(SubDirHist[part_pair]), p1.eta(), p2.eta(), corfac1 * corfac2);
-    histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h2d_n2_phi1phi2_") + HIST(SubDirHist[part_pair]), p1.phi(), p2.phi(), corfac1 * corfac2);
-    histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h2d_n2_rap1rap2_") + HIST(SubDirHist[part_pair]), p1.rap(), p2.rap(), corfac1 * corfac2);
-    histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h2d_n2_pt1eta2_") + HIST(SubDirHist[part_pair]), p1.pt(), p2.eta(), corfac1 * corfac2);
-    histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h2d_n2_pt1phi2_") + HIST(SubDirHist[part_pair]), p1.pt(), p2.phi(), corfac1 * corfac2);
-    histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h2d_n2_pt1rap2_") + HIST(SubDirHist[part_pair]), p1.pt(), p2.rap(), corfac1 * corfac2);
+    histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h2d_n2_pt1pt2_") + HIST(SubDirHist[part_pair]), p1.pt(), p2.pt(), corfac);
+    histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h2d_n2_eta1eta2_") + HIST(SubDirHist[part_pair]), p1.eta(), p2.eta(), corfac);
+    histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h2d_n2_phi1phi2_") + HIST(SubDirHist[part_pair]), p1.phi(), p2.phi(), corfac);
+    histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h2d_n2_rap1rap2_") + HIST(SubDirHist[part_pair]), p1.rap(), p2.rap(), corfac);
+    histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h2d_n2_pt1eta2_") + HIST(SubDirHist[part_pair]), p1.pt(), p2.eta(), corfac);
+    histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h2d_n2_pt1phi2_") + HIST(SubDirHist[part_pair]), p1.pt(), p2.phi(), corfac);
+    histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h2d_n2_pt1rap2_") + HIST(SubDirHist[part_pair]), p1.pt(), p2.rap(), corfac);
 
     if (rapbin1 >= 0 && rapbin2 >= 0 && phibin1 >= 0 && phibin2 >= 0 && rapbin1 < nrapbins && rapbin2 < nrapbins && phibin1 < nphibins && phibin2 < nphibins) {
 
       int rapphix = rapbin1 * nphibins + phibin1;
       int rapphiy = rapbin2 * nphibins + phibin2;
 
-      histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h2d_n2_rapphi_") + HIST(SubDirHist[part_pair]), rapphix + 0.5, rapphiy + 0.5, corfac1 * corfac2);
+      histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h2d_n2_rapphi_") + HIST(SubDirHist[part_pair]), rapphix + 0.5, rapphiy + 0.5, corfac);
     }
 
-    // qinv histos
+    // qinv histograms
     q = RecoDecay::p((p1.px() - p2.px()), (p1.py() - p2.py()), (p1.pz() - p2.pz()));
     e = RecoDecay::e(p1.px(), p1.py(), p1.pz(), MassLambda0) - RecoDecay::e(p2.px(), p2.py(), p2.pz(), MassLambda0);
     qinv = std::sqrt(-RecoDecay::m2(q, e));
-    histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h1d_n2_qinv_") + HIST(SubDirHist[part_pair]), qinv, corfac1 * corfac2);
+    histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h1d_n2_qinv_") + HIST(SubDirHist[part_pair]), qinv, corfac);
   }
 
   template <ParticleType part, RecGenType rec_gen, typename C, typename T>
@@ -1160,15 +1299,11 @@ struct LambdaR2Correlation {
     static constexpr std::string_view SubDirRecGen[] = {"Reco/", "McGen/"};
     static constexpr std::string_view SubDirHist[] = {"LaP", "LaM"};
 
-    int ntrk1 = 0, ntrk2 = 0, ntrk3 = 0;
+    int ntrk = 0;
 
     for (auto const& track : tracks) {
-      ++ntrk1;
-      if (!removeLambdaSharingDau<true, part, rec_gen>(track, tracks)) {
-        ++ntrk2;
-        continue;
-      }
-      ++ntrk3;
+      // count tracks
+      ++ntrk;
 
       // QA Plots
       histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h1d_n1_mass_") + HIST(SubDirHist[part]), track.mass());
@@ -1186,31 +1321,16 @@ struct LambdaR2Correlation {
 
       // Rho1 for R2 Calculation
       histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h2d_n1_ptrap_") + HIST(SubDirHist[part]), track.pt(), track.rap(), track.corrFact());
+      histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h2d_n1_pteta_") + HIST(SubDirHist[part]), track.pt(), track.eta(), track.corrFact());
       histos.fill(HIST(SubDirRecGen[rec_gen]) + HIST("h2d_n1_rapphi_") + HIST(SubDirHist[part]), track.rap(), track.phi(), track.corrFact());
     }
 
     // fill multiplicity histograms
-    if (ntrk1 != 0) {
+    if (ntrk != 0) {
       if (part == kLambda) {
-        histos.fill(HIST("Event/") + HIST(SubDirRecGen[rec_gen]) + HIST("h1i_lambda_totmult"), ntrk1);
+        histos.fill(HIST("Event/") + HIST(SubDirRecGen[rec_gen]) + HIST("h1i_lambda_mult"), ntrk);
       } else {
-        histos.fill(HIST("Event/") + HIST(SubDirRecGen[rec_gen]) + HIST("h1i_antilambda_totmult"), ntrk1);
-      }
-    }
-
-    if (ntrk2 != 0) {
-      if (part == kLambda) {
-        histos.fill(HIST("Event/") + HIST(SubDirRecGen[rec_gen]) + HIST("h1i_lambda_sdau"), ntrk2);
-      } else {
-        histos.fill(HIST("Event/") + HIST(SubDirRecGen[rec_gen]) + HIST("h1i_antilambda_sdau"), ntrk2);
-      }
-    }
-
-    if (ntrk3 != 0) {
-      if (part == kLambda) {
-        histos.fill(HIST("Event/") + HIST(SubDirRecGen[rec_gen]) + HIST("h1i_lambda_multiplicity"), ntrk3);
-      } else {
-        histos.fill(HIST("Event/") + HIST(SubDirRecGen[rec_gen]) + HIST("h1i_antilambda_multiplicity"), ntrk3);
+        histos.fill(HIST("Event/") + HIST(SubDirRecGen[rec_gen]) + HIST("h1i_antilambda_mult"), ntrk);
       }
     }
   }
@@ -1219,15 +1339,9 @@ struct LambdaR2Correlation {
   void analyzePairs(T const& trks_1, T const& trks_2)
   {
     for (auto const& trk_1 : trks_1) {
-      if (!removeLambdaSharingDau<false, kLambda, rec_gen>(trk_1, trks_1)) {
-        continue;
-      }
       for (auto const& trk_2 : trks_2) {
         // check for same index for Lambda-Lambda / AntiLambda-AntiLambda
         if (samelambda && ((trk_1.index() == trk_2.index()))) {
-          continue;
-        }
-        if (!removeLambdaSharingDau<false, kLambda, rec_gen>(trk_2, trks_2)) {
           continue;
         }
         fillPairHistos<partpair, rec_gen>(trk_1, trk_2);
@@ -1236,11 +1350,11 @@ struct LambdaR2Correlation {
   }
 
   using LambdaCollisions = aod::LambdaCollisions;
-  using LambdaTracks = aod::LambdaTracks;
+  using LambdaTracks = soa::Join<aod::LambdaTracks, aod::LambdaTracksExt>;
 
   SliceCache cache;
-  Partition<LambdaTracks> partLambdaTracks = (aod::lambdatrack::v0Type == (int8_t)kLambda);
-  Partition<LambdaTracks> partAntiLambdaTracks = (aod::lambdatrack::v0Type == (int8_t)kAntiLambda);
+  Partition<LambdaTracks> partLambdaTracks = (aod::lambdatrack::v0Type == (int8_t)kLambda) && (aod::lambdatrackext::trueLambdaFlag == true);
+  Partition<LambdaTracks> partAntiLambdaTracks = (aod::lambdatrack::v0Type == (int8_t)kAntiLambda) && (aod::lambdatrackext::trueLambdaFlag == true);
 
   void processDataReco(LambdaCollisions::iterator const& collision, LambdaTracks const&)
   {
@@ -1286,6 +1400,7 @@ struct LambdaR2Correlation {
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<LambdaCorrTableProducer>(cfgc),
+    adaptAnalysisTask<LambdaTableProducer>(cfgc),
+    adaptAnalysisTask<LambdaTracksExtProducer>(cfgc),
     adaptAnalysisTask<LambdaR2Correlation>(cfgc)};
 }

--- a/PWGHF/Core/CentralityEstimation.h
+++ b/PWGHF/Core/CentralityEstimation.h
@@ -120,42 +120,36 @@ float getCentralityColl(const Coll&)
 template <typename Coll>
 float getCentralityColl(const Coll& collision, int centEstimator)
 {
-  float cent = -999.;
   switch (centEstimator) {
     case CentralityEstimator::FT0A:
       if constexpr (hasFT0ACent<Coll>) {
-        cent = collision.centFT0A();
-      } else {
-        LOG(warning) << "Warning: Collision does not have centFT0A().\n";
+        return collision.centFT0A();
       }
+      LOG(fatal) << "Collision does not have centFT0A().";
       break;
     case CentralityEstimator::FT0C:
       if constexpr (hasFT0CCent<Coll>) {
-        cent = collision.centFT0C();
-      } else {
-        LOG(warning) << "Warning: Collision does not have centFT0C().\n";
+        return collision.centFT0C();
       }
+      LOG(fatal) << "Collision does not have centFT0C().";
       break;
     case CentralityEstimator::FT0M:
       if constexpr (hasFT0MCent<Coll>) {
-        cent = collision.centFT0M();
-      } else {
-        LOG(warning) << "Warning: Collision does not have centFT0M().\n";
+        return collision.centFT0M();
       }
+      LOG(fatal) << "Collision does not have centFT0M().";
       break;
     case CentralityEstimator::FV0A:
       if constexpr (hasFV0ACent<Coll>) {
-        cent = collision.centFV0A();
-      } else {
-        LOG(warning) << "Warning: Collision does not have centFV0A().\n";
+        return collision.centFV0A();
       }
+      LOG(fatal) << "Collision does not have centFV0A().";
       break;
     default:
-      LOG(warning) << "Centrality estimator not valid. Possible values are V0A, T0M, T0A, T0C. Setting value to -999.";
-      cent = -999.;
+      LOG(fatal) << "Centrality estimator not valid. Possible values are V0A, T0M, T0A, T0C.";
       break;
   }
-  return cent;
+  return -999.f;
 }
 
 /// \brief Function to get MC collision centrality

--- a/PWGHF/Core/CentralityEstimation.h
+++ b/PWGHF/Core/CentralityEstimation.h
@@ -151,7 +151,7 @@ float getCentralityColl(const Coll& collision, int centEstimator)
       break;
     default:
       LOG(warning) << "Centrality estimator not valid. Possible values are V0A, T0M, T0A, T0C. Fallback to V0A";
-      cent = collision.centFV0A();
+      cent = -999.;
       break;
   }
   return cent;
@@ -187,44 +187,6 @@ float getCentralityGenColl(CCs const& collSlice, int centEstimator)
     float collMult = collision.numContrib();
     if (collMult > multiplicity) {
       centrality = getCentralityColl(collision, centEstimator);
-      multiplicity = collMult;
-    }
-  }
-  return centrality;
-}
-
-/// Get the centrality
-/// \param collision is the collision with the centrality information
-/// \param centEstimator is the centrality estimator from hf_centrality::CentralityEstimator
-template <o2::hf_centrality::CentralityEstimator centEstimator, typename Coll>
-float evalCentralityColl(Coll const& collision)
-{
-  if constexpr (centEstimator == o2::hf_centrality::CentralityEstimator::FT0A) {
-    return collision.centFT0A();
-  } else if constexpr (centEstimator == o2::hf_centrality::CentralityEstimator::FT0C) {
-    return collision.centFT0C();
-  } else if constexpr (centEstimator == o2::hf_centrality::CentralityEstimator::FT0M) {
-    return collision.centFT0M();
-  } else if constexpr (centEstimator == o2::hf_centrality::CentralityEstimator::FV0A) {
-    return collision.centFV0A();
-  } else {
-    LOG(warning) << "Centrality estimator not valid. Possible values are V0A, T0M, T0A, T0C. Fallback to FT0c";
-    return collision.centFT0C();
-  }
-}
-
-/// \brief Function to get MC collision centrality
-/// \param collSlice collection of reconstructed collisions associated to a generated one
-/// \return generated MC collision centrality
-template <o2::hf_centrality::CentralityEstimator centEstimator, typename CCs>
-float evalCentralityGenColl(CCs const& collSlice)
-{
-  float centrality{-1};
-  float multiplicity{0.f};
-  for (const auto& collision : collSlice) {
-    float collMult = collision.numContrib();
-    if (collMult > multiplicity) {
-      centrality = evalCentralityColl<centEstimator>(collision);
       multiplicity = collMult;
     }
   }

--- a/PWGHF/Core/CentralityEstimation.h
+++ b/PWGHF/Core/CentralityEstimation.h
@@ -115,6 +115,7 @@ float getCentralityColl(const Coll&)
 
 /// Get the centrality
 /// \param collision is the collision with the centrality information
+/// \param centEstimator integer to select the centrality estimator
 /// \return collision centrality
 template <typename Coll>
 float getCentralityColl(const Coll& collision, int centEstimator)
@@ -150,7 +151,7 @@ float getCentralityColl(const Coll& collision, int centEstimator)
       }
       break;
     default:
-      LOG(warning) << "Centrality estimator not valid. Possible values are V0A, T0M, T0A, T0C. Fallback to V0A";
+      LOG(warning) << "Centrality estimator not valid. Possible values are V0A, T0M, T0A, T0C. Setting value to -999.";
       cent = -999.;
       break;
   }
@@ -177,6 +178,7 @@ float getCentralityGenColl(CCs const& collSlice)
 
 /// \brief Function to get MC collision centrality
 /// \param collSlice collection of reconstructed collisions associated to a generated one
+/// \param centEstimator integer to select the centrality estimator
 /// \return generated MC collision centrality
 template <typename CCs>
 float getCentralityGenColl(CCs const& collSlice, int centEstimator)

--- a/PWGHF/D2H/Tasks/taskDplus.cxx
+++ b/PWGHF/D2H/Tasks/taskDplus.cxx
@@ -41,12 +41,6 @@ enum OccupancyEstimator { None = 0,
                           ITS,
                           FT0C };
 
-// enum BHadMothers { NotMatched = 0,
-//                    BPlus,
-//                    BZero,
-//                    Bs,
-//                    LambdaBZero };
-
 /// D± analysis task
 struct HfTaskDplus {
   Configurable<int> selectionFlagDplus{"selectionFlagDplus", 7, "Selection Flag for DPlus"}; // 7 corresponds to topo+PID cuts
@@ -583,46 +577,6 @@ struct HfTaskDplus {
       }
     }
   }
-
-  // /// Get the centrality
-  // /// \param collision is the collision with the centrality information
-  // /// \return collision centrality
-  // template <typename Coll>
-  // float o2::hf_centrality::getCentralityColl(Coll const& collision, int centEstimator=0)
-  // {
-  //   float cent = -999.;
-  //   switch (centEstimator) {
-  //     case CentralityEstimator::FT0C:
-  //       cent = collision.centFT0C();
-  //       break;
-  //     case CentralityEstimator::FT0M:
-  //       cent = collision.centFT0M();
-  //       break;
-  //     default:
-  //       LOG(warning) << "Centrality estimator not valid. Possible values are FT0C, FT0M. Fallback to FT0C";
-  //       cent = collision.centFT0C();
-  //       break;
-  //   }
-  //   return cent;
-  // }
-
-  // /// \brief Function to get MC collision centrality
-  // /// \param collSlice collection of reconstructed collisions associated to a generated one
-  // /// \return generated MC collision centrality
-  // template <typename CCs>
-  // float o2::hf_centrality::getCentralityGenColl(CCs const& collSlice)
-  // {
-  //   float centrality{-1};
-  //   float multiplicity{0.f};
-  //   for (const auto& collision : collSlice) {
-  //     float collMult = collision.numContrib();
-  //     if (collMult > multiplicity) {
-  //       centrality = o2::hf_centrality::getCentralityColl(collision);
-  //       multiplicity = collMult;
-  //     }
-  //   }
-  //   return centrality;
-  // }
 
   // process functions
   void processData(CandDplusData const& candidates, CollisionsCent const& collisions)

--- a/PWGHF/D2H/Tasks/taskDs.cxx
+++ b/PWGHF/D2H/Tasks/taskDs.cxx
@@ -122,7 +122,7 @@ struct HfTaskDs {
   using CandDsMcGen = soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>;
 
   Filter filterDsFlag = (o2::aod::hf_track_index::hfflag & static_cast<uint8_t>(BIT(aod::hf_cand_3prong::DecayType::DsToKKPi))) != static_cast<uint8_t>(0);
-  
+
   Preslice<aod::HfCand3Prong> candDsPerCollision = aod::hf_cand::collisionId;
   PresliceUnsorted<aod::McCollisionLabels> colPerMcCollision = aod::mccollisionlabel::mcCollisionId;
 
@@ -205,7 +205,7 @@ struct HfTaskDs {
       axesGenFd.insert(axesGenFd.end(), {occupancybins});
       axesGenBkg.insert(axesGenBkg.end(), {occupancybins});
     }
-    
+
     for (auto i = 0; i < DataType::kDataTypes; ++i) {
       if (doprocessDataWithCentFT0C || doprocessDataWithCentFT0M || doprocessDataWithCentNTracksPV || doprocessData || doprocessMcWithCentFT0C || doprocessMcWithCentFT0M || doprocessMcWithCentNTracksPV || doprocessMc) {
         if (i == DataType::Data) { // If data do not fill PV contributors in sparse
@@ -219,7 +219,7 @@ struct HfTaskDs {
         if (i == DataType::Data) { // If data do not fill PV contributors in sparse
           histosPtr[i]["hSparseMass"] = registry.add<THnSparse>((folders[i] + "hSparseMass").c_str(), "THn for Ds", HistType::kTHnSparseF, axesMl);
         } else if (i == DataType::McDsNonPrompt) { // If data do not fill PV contributors in sparse
-          histosPtr[i]["hSparseMass"] = registry.add<THnSparse>((folders[i] + "hSparseMass").c_str(), "THn for Ds", HistType::kTHnSparseF, axesFdMl); 
+          histosPtr[i]["hSparseMass"] = registry.add<THnSparse>((folders[i] + "hSparseMass").c_str(), "THn for Ds", HistType::kTHnSparseF, axesFdMl);
         } else {
           histosPtr[i]["hSparseMass"] = registry.add<THnSparse>((folders[i] + "hSparseMass").c_str(), "THn for Ds", HistType::kTHnSparseF, axesWithNpvMl);
         }
@@ -267,10 +267,10 @@ struct HfTaskDs {
         }
         if (i == DataType::McDsPrompt || i == DataType::McDplusPrompt) {
           histosPtr[i]["hSparseGen"] = registry.add<THnSparse>((folders[i] + "hSparseGen").c_str(), "Thn for generated prompt candidates", HistType::kTHnSparseF, axesGenPrompt);
-        } 
+        }
         if (i == DataType::McDsNonPrompt || i == DataType::McDplusNonPrompt) {
           histosPtr[i]["hSparseGen"] = registry.add<THnSparse>((folders[i] + "hSparseGen").c_str(), "Thn for generated nonprompt candidates", HistType::kTHnSparseF, axesGenFd);
-        } 
+        }
         if (i == DataType::McBkg) {
           histosPtr[i]["hSparseGen"] = registry.add<THnSparse>((folders[i] + "hSparseGen").c_str(), "Thn for non-matched generated candidates", HistType::kTHnSparseF, axesGenBkg);
         }
@@ -757,7 +757,7 @@ struct HfTaskDs {
 
   template <typename Coll>
   void fillMcGenHistosSparse(CandDsMcGen const& mcParticles,
-                       Coll const& recoCollisions)
+                             Coll const& recoCollisions)
   {
 
     // MC gen.
@@ -795,11 +795,11 @@ struct HfTaskDs {
               }
             }
             if (particle.originMcGen() == RecoDecay::OriginType::NonPrompt) {
-              std::get<TH1Ptr>(histosPtr[DataType::McDsNonPrompt]["hPtGen"])->Fill(pt);                                    // gen. level pT
-              std::get<TH1Ptr>(histosPtr[DataType::McDsNonPrompt]["hEtaGen"])->Fill(particle.eta());  
+              std::get<TH1Ptr>(histosPtr[DataType::McDsNonPrompt]["hPtGen"])->Fill(pt); // gen. level pT
+              std::get<TH1Ptr>(histosPtr[DataType::McDsNonPrompt]["hEtaGen"])->Fill(particle.eta());
               auto bHadMother = mcParticles.rawIteratorAt(particle.idxBhadMotherPart() - mcParticles.offset());
               int flagGenB = getBHadMotherFlag(bHadMother.pdgCode());
-              float ptGenB = bHadMother.pt();         
+              float ptGenB = bHadMother.pt();
               if (storeOccupancy && occEstimator != OccupancyEstimator::None) {
                 std::get<THnSparsePtr>(histosPtr[DataType::McDsNonPrompt]["hSparseGen"])->Fill(pt, y, maxNumContrib, ptGenB, flagGenB, cent, occ);
               } else {

--- a/PWGHF/D2H/Tasks/taskDs.cxx
+++ b/PWGHF/D2H/Tasks/taskDs.cxx
@@ -456,10 +456,10 @@ struct HfTaskDs {
     if constexpr (isMc) {
       if (dataType == DataType::McDsNonPrompt) { // If data do not fill PV contributors in sparse
         if (storeOccupancy) {
-          std::get<THnSparsePtr>(histosPtr[dataType]["hSparseMass"])->Fill(mass, pt, evaluateCentralityCand<Coll>(candidate), outputMl[0], outputMl[1], outputMl[2], candidate.ptBhadMotherPart(), o2::analysis::getBHadMotherFlag(candidate.pdgBhadMotherPart()), o2::hf_occupancy::getOccupancyColl(candidate.template collision_as<Coll>(), occEstimator));
+          std::get<THnSparsePtr>(histosPtr[dataType]["hSparseMass"])->Fill(mass, pt, evaluateCentralityCand<Coll>(candidate), outputMl[0], outputMl[1], outputMl[2], candidate.ptBhadMotherPart(), getBHadMotherFlag(candidate.pdgBhadMotherPart()), o2::hf_occupancy::getOccupancyColl(candidate.template collision_as<Coll>(), occEstimator));
           return;
         } else {
-          std::get<THnSparsePtr>(histosPtr[dataType]["hSparseMass"])->Fill(mass, pt, evaluateCentralityCand<Coll>(candidate), outputMl[0], outputMl[1], outputMl[2], candidate.ptBhadMotherPart(), o2::analysis::getBHadMotherFlag(candidate.pdgBhadMotherPart()));
+          std::get<THnSparsePtr>(histosPtr[dataType]["hSparseMass"])->Fill(mass, pt, evaluateCentralityCand<Coll>(candidate), outputMl[0], outputMl[1], outputMl[2], candidate.ptBhadMotherPart(), getBHadMotherFlag(candidate.pdgBhadMotherPart()));
           return;
         }
       } else {
@@ -496,10 +496,10 @@ struct HfTaskDs {
     if constexpr (isMc) {
       if (dataType == DataType::McDsNonPrompt) { // If data do not fill PV contributors in sparse
         if (storeOccupancy) {
-          std::get<THnSparsePtr>(histosPtr[dataType]["hSparseMass"])->Fill(mass, pt, evaluateCentralityCand<Coll>(candidate), candidate.ptBhadMotherPart(), o2::analysis::getBHadMotherFlag(candidate.pdgBhadMotherPart()), o2::hf_occupancy::getOccupancyColl(candidate.template collision_as<Coll>(), occEstimator));
+          std::get<THnSparsePtr>(histosPtr[dataType]["hSparseMass"])->Fill(mass, pt, evaluateCentralityCand<Coll>(candidate), candidate.ptBhadMotherPart(), getBHadMotherFlag(candidate.pdgBhadMotherPart()), o2::hf_occupancy::getOccupancyColl(candidate.template collision_as<Coll>(), occEstimator));
           return;
         } else {
-          std::get<THnSparsePtr>(histosPtr[dataType]["hSparseMass"])->Fill(mass, pt, evaluateCentralityCand<Coll>(candidate), candidate.ptBhadMotherPart(), o2::analysis::getBHadMotherFlag(candidate.pdgBhadMotherPart()));
+          std::get<THnSparsePtr>(histosPtr[dataType]["hSparseMass"])->Fill(mass, pt, evaluateCentralityCand<Coll>(candidate), candidate.ptBhadMotherPart(), getBHadMotherFlag(candidate.pdgBhadMotherPart()));
           return;
         }
       } else {
@@ -710,7 +710,7 @@ struct HfTaskDs {
               std::get<TH1Ptr>(histosPtr[DataType::McDsNonPrompt]["hPtGen"])->Fill(pt); // gen. level pT
               std::get<TH1Ptr>(histosPtr[DataType::McDsNonPrompt]["hEtaGen"])->Fill(particle.eta());
               auto bHadMother = mcParticles.rawIteratorAt(particle.idxBhadMotherPart() - mcParticles.offset());
-              int flagGenB = o2::analysis::getBHadMotherFlag(bHadMother.pdgCode());
+              int flagGenB = getBHadMotherFlag(bHadMother.pdgCode());
               float ptGenB = bHadMother.pt();
               if (storeOccupancy && occEstimator != o2::hf_occupancy::OccupancyEstimator::None) {
                 std::get<THnSparsePtr>(histosPtr[DataType::McDsNonPrompt]["hSparseGen"])->Fill(pt, y, maxNumContrib, ptGenB, flagGenB, cent, occ);
@@ -736,7 +736,7 @@ struct HfTaskDs {
               std::get<TH1Ptr>(histosPtr[DataType::McDplusNonPrompt]["hPtGen"])->Fill(pt); // gen. level pT
               std::get<TH1Ptr>(histosPtr[DataType::McDplusNonPrompt]["hEtaGen"])->Fill(particle.eta());
               auto bHadMother = mcParticles.rawIteratorAt(particle.idxBhadMotherPart() - mcParticles.offset());
-              int flagGenB = o2::analysis::getBHadMotherFlag(bHadMother.pdgCode());
+              int flagGenB = getBHadMotherFlag(bHadMother.pdgCode());
               float ptGenB = bHadMother.pt();
               if (storeOccupancy && occEstimator != o2::hf_occupancy::OccupancyEstimator::None) {
                 std::get<THnSparsePtr>(histosPtr[DataType::McDplusNonPrompt]["hSparseGen"])->Fill(pt, y, maxNumContrib, ptGenB, flagGenB, cent, occ);

--- a/PWGHF/D2H/Tasks/taskDs.cxx
+++ b/PWGHF/D2H/Tasks/taskDs.cxx
@@ -57,16 +57,6 @@ enum DataType { Data = 0,
                 McBkg,
                 kDataTypes };
 
-// enum BHadMothers { NotMatched = 0,
-//                    BPlus,
-//                    BZero,
-//                    Bs,
-//                    LambdaBZero };
-
-// enum OccupancyEstimator { None = 0,
-//                           Its,
-//                           Ft0c };
-
 template <typename T>
 concept hasDsMlInfo = requires(T candidate)
 {
@@ -366,24 +356,6 @@ struct HfTaskDs {
   {
     return -1.f;
   }
-
-  // /// \brief Function to get MC collision centrality
-  // /// \param collSlice collection of reconstructed collisions associated to a generated one
-  // /// \return generated MC collision centrality
-  // template <typename CCs>
-  // float o2::hf_centrality::getCentralityGenColl(CCs const& collSlice)
-  // {
-  //   float centrality{-1};
-  //   float multiplicity{0.f};
-  //   for (const auto& collision : collSlice) {
-  //     float collMult = collision.numContrib();
-  //     if (collMult > multiplicity) {
-  //       centrality = evaluateCentralityColl(collision);
-  //       multiplicity = collMult;
-  //     }
-  //   }
-  //   return centrality;
-  // }
 
   /// Evaluate centrality/multiplicity percentile (centrality estimator is automatically selected based on the used table)
   /// \param candidate is candidate

--- a/PWGHF/D2H/Tasks/taskFlowCharmHadrons.cxx
+++ b/PWGHF/D2H/Tasks/taskFlowCharmHadrons.cxx
@@ -607,7 +607,7 @@ struct HfTaskFlowCharmHadrons {
                          aod::BCsWithTimestamps const& bcs)
   {
     float centrality{-1.f};
-    if (!isCollSelected<o2::hf_centrality::CentralityEstimator::None>(collision, bcs, centrality)) {
+    if (!isCollSelected<o2::hf_centrality::CentralityEstimator::FT0C>(collision, bcs, centrality)) {
       // no selection on the centrality is applied on purpose to allow for the resolution study in post-processing
       return;
     }

--- a/PWGHF/D2H/Tasks/taskFlowCharmHadrons.cxx
+++ b/PWGHF/D2H/Tasks/taskFlowCharmHadrons.cxx
@@ -330,32 +330,6 @@ struct HfTaskFlowCharmHadrons {
     }
   }
 
-  // /// Get the centrality
-  // /// \param collision is the collision with the centrality information
-  // float getCentrality(CollsWithQvecs::iterator const& collision)
-  // {
-  //   float cent = -999.;
-  //   switch (centEstimator) {
-  //     case CentralityEstimator::FV0A:
-  //       cent = collision.centFV0A();
-  //       break;
-  //     case CentralityEstimator::FT0M:
-  //       cent = collision.centFT0M();
-  //       break;
-  //     case CentralityEstimator::FT0A:
-  //       cent = collision.centFT0A();
-  //       break;
-  //     case CentralityEstimator::FT0C:
-  //       cent = collision.centFT0C();
-  //       break;
-  //     default:
-  //       LOG(warning) << "Centrality estimator not valid. Possible values are V0A, T0M, T0A, T0C. Fallback to V0A";
-  //       cent = collision.centFV0A();
-  //       break;
-  //   }
-  //   return cent;
-  // }
-
   /// Check if the collision is selected
   /// \param collision is the collision with the Q vector information
   /// \param bc is the bunch crossing with timestamp information

--- a/PWGHF/D2H/Tasks/taskFlowCharmHadrons.cxx
+++ b/PWGHF/D2H/Tasks/taskFlowCharmHadrons.cxx
@@ -37,6 +37,7 @@ using namespace o2::aod;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::hf_centrality;
+using namespace o2::hf_occupancy;
 using namespace o2::hf_evsel;
 
 enum DecayChannel { DplusToPiKPi = 0,
@@ -340,7 +341,7 @@ struct HfTaskFlowCharmHadrons {
                       aod::BCsWithTimestamps const&,
                       float& centrality)
   {
-    float occupancy = o2::hf_occupancy::getOccupancyColl(collision, occEstimator);
+    float occupancy = getOccupancyColl(collision, occEstimator);
     const auto rejectionMask = hfEvSel.getHfCollisionRejectionMask<true, centEstimator, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry);
     centrality = o2::hf_centrality::getCentralityColl(collision, centEstimator);
 
@@ -412,7 +413,7 @@ struct HfTaskFlowCharmHadrons {
     float occupancy = 0.;
     uint16_t hfevflag{};
     if (occEstimator != 0) {
-      occupancy = o2::hf_occupancy::getOccupancyColl(collision, occEstimator);
+      occupancy = getOccupancyColl(collision, occEstimator);
       registry.fill(HIST("trackOccVsFT0COcc"), collision.trackOccupancyInTimeRange(), collision.ft0cOccupancyInTimeRange());
       hfevflag = hfEvSel.getHfCollisionRejectionMask<true, o2::hf_centrality::CentralityEstimator::None, aod::BCsWithTimestamps>(collision, cent, ccdb, registry);
     }

--- a/PWGHF/D2H/Tasks/taskFlowCharmHadrons.cxx
+++ b/PWGHF/D2H/Tasks/taskFlowCharmHadrons.cxx
@@ -330,31 +330,31 @@ struct HfTaskFlowCharmHadrons {
     }
   }
 
-  /// Get the centrality
-  /// \param collision is the collision with the centrality information
-  float getCentrality(CollsWithQvecs::iterator const& collision)
-  {
-    float cent = -999.;
-    switch (centEstimator) {
-      case CentralityEstimator::FV0A:
-        cent = collision.centFV0A();
-        break;
-      case CentralityEstimator::FT0M:
-        cent = collision.centFT0M();
-        break;
-      case CentralityEstimator::FT0A:
-        cent = collision.centFT0A();
-        break;
-      case CentralityEstimator::FT0C:
-        cent = collision.centFT0C();
-        break;
-      default:
-        LOG(warning) << "Centrality estimator not valid. Possible values are V0A, T0M, T0A, T0C. Fallback to V0A";
-        cent = collision.centFV0A();
-        break;
-    }
-    return cent;
-  }
+  // /// Get the centrality
+  // /// \param collision is the collision with the centrality information
+  // float getCentrality(CollsWithQvecs::iterator const& collision)
+  // {
+  //   float cent = -999.;
+  //   switch (centEstimator) {
+  //     case CentralityEstimator::FV0A:
+  //       cent = collision.centFV0A();
+  //       break;
+  //     case CentralityEstimator::FT0M:
+  //       cent = collision.centFT0M();
+  //       break;
+  //     case CentralityEstimator::FT0A:
+  //       cent = collision.centFT0A();
+  //       break;
+  //     case CentralityEstimator::FT0C:
+  //       cent = collision.centFT0C();
+  //       break;
+  //     default:
+  //       LOG(warning) << "Centrality estimator not valid. Possible values are V0A, T0M, T0A, T0C. Fallback to V0A";
+  //       cent = collision.centFV0A();
+  //       break;
+  //   }
+  //   return cent;
+  // }
 
   /// Check if the collision is selected
   /// \param collision is the collision with the Q vector information
@@ -366,9 +366,9 @@ struct HfTaskFlowCharmHadrons {
                       aod::BCsWithTimestamps const&,
                       float& centrality)
   {
-    float occupancy = hfEvSel.getOccupancy(collision, occEstimator);
+    float occupancy = o2::hf_occupancy::getOccupancyColl(collision, occEstimator);
     const auto rejectionMask = hfEvSel.getHfCollisionRejectionMask<true, centEstimator, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry);
-    centrality = getCentrality(collision);
+    centrality = o2::hf_centrality::getCentralityColl(collision, centEstimator);
 
     /// monitor the satisfied event selections
     hfEvSel.fillHistograms(collision, rejectionMask, centrality, occupancy);
@@ -431,14 +431,14 @@ struct HfTaskFlowCharmHadrons {
   void runFlowAnalysis(CollsWithQvecs::iterator const& collision,
                        T1 const& candidates)
   {
-    float cent = getCentrality(collision);
+    float cent = o2::hf_centrality::getCentralityColl(collision, centEstimator);
     if (cent < centralityMin || cent > centralityMax) {
       return;
     }
     float occupancy = 0.;
     uint16_t hfevflag{};
     if (occEstimator != 0) {
-      occupancy = hfEvSel.getOccupancy(collision, occEstimator);
+      occupancy = o2::hf_occupancy::getOccupancyColl(collision, occEstimator);
       registry.fill(HIST("trackOccVsFT0COcc"), collision.trackOccupancyInTimeRange(), collision.ft0cOccupancyInTimeRange());
       hfevflag = hfEvSel.getHfCollisionRejectionMask<true, o2::hf_centrality::CentralityEstimator::None, aod::BCsWithTimestamps>(collision, cent, ccdb, registry);
     }

--- a/PWGHF/TableProducer/candidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator2Prong.cxx
@@ -628,7 +628,7 @@ struct HfCandidateCreator2Prong {
 
       /// bitmask with event. selection info
       float centrality{-1.f};
-      float occupancy = getOccupancyColl(collision);
+      float occupancy = getOccupancyColl(collision, OccupancyEstimator::Its);
       const auto rejectionMask = hfEvSel.getHfCollisionRejectionMask<true, CentralityEstimator::None, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry);
 
       /// monitor the satisfied event selections
@@ -646,7 +646,7 @@ struct HfCandidateCreator2Prong {
 
       /// bitmask with event. selection info
       float centrality{-1.f};
-      float occupancy = getOccupancyColl(collision);
+      float occupancy = getOccupancyColl(collision, OccupancyEstimator::Its);
       const auto rejectionMask = hfEvSel.getHfCollisionRejectionMask<true, CentralityEstimator::FT0C, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry);
 
       /// monitor the satisfied event selections
@@ -664,7 +664,7 @@ struct HfCandidateCreator2Prong {
 
       /// bitmask with event. selection info
       float centrality{-1.f};
-      float occupancy = getOccupancyColl(collision);
+      float occupancy = getOccupancyColl(collision, OccupancyEstimator::Its);
       const auto rejectionMask = hfEvSel.getHfCollisionRejectionMask<true, CentralityEstimator::FT0M, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry);
 
       /// monitor the satisfied event selections

--- a/PWGHF/TableProducer/candidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator2Prong.cxx
@@ -627,7 +627,7 @@ struct HfCandidateCreator2Prong {
 
       /// bitmask with event. selection info
       float centrality{-1.f};
-      float occupancy = hfEvSel.getOccupancy(collision);
+      float occupancy = o2::hf_occupancy::getOccupancyColl(collision);
       const auto rejectionMask = hfEvSel.getHfCollisionRejectionMask<true, CentralityEstimator::None, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry);
 
       /// monitor the satisfied event selections
@@ -645,7 +645,7 @@ struct HfCandidateCreator2Prong {
 
       /// bitmask with event. selection info
       float centrality{-1.f};
-      float occupancy = hfEvSel.getOccupancy(collision);
+      float occupancy = o2::hf_occupancy::getOccupancyColl(collision);
       const auto rejectionMask = hfEvSel.getHfCollisionRejectionMask<true, CentralityEstimator::FT0C, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry);
 
       /// monitor the satisfied event selections
@@ -663,7 +663,7 @@ struct HfCandidateCreator2Prong {
 
       /// bitmask with event. selection info
       float centrality{-1.f};
-      float occupancy = hfEvSel.getOccupancy(collision);
+      float occupancy = o2::hf_occupancy::getOccupancyColl(collision);
       const auto rejectionMask = hfEvSel.getHfCollisionRejectionMask<true, CentralityEstimator::FT0M, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry);
 
       /// monitor the satisfied event selections

--- a/PWGHF/TableProducer/candidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator2Prong.cxx
@@ -56,6 +56,7 @@ using namespace o2::hf_evsel;
 using namespace o2::hf_trkcandsel;
 using namespace o2::aod::hf_cand_2prong;
 using namespace o2::hf_centrality;
+using namespace o2::hf_occupancy;
 using namespace o2::constants::physics;
 using namespace o2::framework;
 using namespace o2::aod::pid_tpc_tof_utils;
@@ -627,7 +628,7 @@ struct HfCandidateCreator2Prong {
 
       /// bitmask with event. selection info
       float centrality{-1.f};
-      float occupancy = o2::hf_occupancy::getOccupancyColl(collision);
+      float occupancy = getOccupancyColl(collision);
       const auto rejectionMask = hfEvSel.getHfCollisionRejectionMask<true, CentralityEstimator::None, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry);
 
       /// monitor the satisfied event selections
@@ -645,7 +646,7 @@ struct HfCandidateCreator2Prong {
 
       /// bitmask with event. selection info
       float centrality{-1.f};
-      float occupancy = o2::hf_occupancy::getOccupancyColl(collision);
+      float occupancy = getOccupancyColl(collision);
       const auto rejectionMask = hfEvSel.getHfCollisionRejectionMask<true, CentralityEstimator::FT0C, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry);
 
       /// monitor the satisfied event selections
@@ -663,7 +664,7 @@ struct HfCandidateCreator2Prong {
 
       /// bitmask with event. selection info
       float centrality{-1.f};
-      float occupancy = o2::hf_occupancy::getOccupancyColl(collision);
+      float occupancy = getOccupancyColl(collision);
       const auto rejectionMask = hfEvSel.getHfCollisionRejectionMask<true, CentralityEstimator::FT0M, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry);
 
       /// monitor the satisfied event selections

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -406,7 +406,7 @@ struct HfCandidateCreator3Prong {
 
       /// bitmask with event. selection info
       float centrality{-1.f};
-      float occupancy = getOccupancyColl(collision);
+      float occupancy = getOccupancyColl(collision, OccupancyEstimator::Its);
       const auto rejectionMask = hfEvSel.getHfCollisionRejectionMask<true, CentralityEstimator::None, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry);
 
       /// monitor the satisfied event selections
@@ -424,7 +424,7 @@ struct HfCandidateCreator3Prong {
 
       /// bitmask with event. selection info
       float centrality{-1.f};
-      float occupancy = getOccupancyColl(collision);
+      float occupancy = getOccupancyColl(collision, OccupancyEstimator::Its);
       const auto rejectionMask = hfEvSel.getHfCollisionRejectionMask<true, CentralityEstimator::FT0C, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry);
 
       /// monitor the satisfied event selections
@@ -442,7 +442,7 @@ struct HfCandidateCreator3Prong {
 
       /// bitmask with event. selection info
       float centrality{-1.f};
-      float occupancy = getOccupancyColl(collision);
+      float occupancy = getOccupancyColl(collision, OccupancyEstimator::Its);
       const auto rejectionMask = hfEvSel.getHfCollisionRejectionMask<true, CentralityEstimator::FT0M, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry);
 
       /// monitor the satisfied event selections

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -405,7 +405,7 @@ struct HfCandidateCreator3Prong {
 
       /// bitmask with event. selection info
       float centrality{-1.f};
-      float occupancy = hfEvSel.getOccupancy(collision);
+      float occupancy = o2::hf_occupancy::getOccupancyColl(collision);
       const auto rejectionMask = hfEvSel.getHfCollisionRejectionMask<true, CentralityEstimator::None, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry);
 
       /// monitor the satisfied event selections
@@ -423,7 +423,7 @@ struct HfCandidateCreator3Prong {
 
       /// bitmask with event. selection info
       float centrality{-1.f};
-      float occupancy = hfEvSel.getOccupancy(collision);
+      float occupancy = o2::hf_occupancy::getOccupancyColl(collision);
       const auto rejectionMask = hfEvSel.getHfCollisionRejectionMask<true, CentralityEstimator::FT0C, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry);
 
       /// monitor the satisfied event selections
@@ -441,7 +441,7 @@ struct HfCandidateCreator3Prong {
 
       /// bitmask with event. selection info
       float centrality{-1.f};
-      float occupancy = hfEvSel.getOccupancy(collision);
+      float occupancy = o2::hf_occupancy::getOccupancyColl(collision);
       const auto rejectionMask = hfEvSel.getHfCollisionRejectionMask<true, CentralityEstimator::FT0M, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry);
 
       /// monitor the satisfied event selections

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -44,6 +44,7 @@ using namespace o2::hf_evsel;
 using namespace o2::hf_trkcandsel;
 using namespace o2::aod::hf_cand_3prong;
 using namespace o2::hf_centrality;
+using namespace o2::hf_occupancy;
 using namespace o2::constants::physics;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
@@ -405,7 +406,7 @@ struct HfCandidateCreator3Prong {
 
       /// bitmask with event. selection info
       float centrality{-1.f};
-      float occupancy = o2::hf_occupancy::getOccupancyColl(collision);
+      float occupancy = getOccupancyColl(collision);
       const auto rejectionMask = hfEvSel.getHfCollisionRejectionMask<true, CentralityEstimator::None, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry);
 
       /// monitor the satisfied event selections
@@ -423,7 +424,7 @@ struct HfCandidateCreator3Prong {
 
       /// bitmask with event. selection info
       float centrality{-1.f};
-      float occupancy = o2::hf_occupancy::getOccupancyColl(collision);
+      float occupancy = getOccupancyColl(collision);
       const auto rejectionMask = hfEvSel.getHfCollisionRejectionMask<true, CentralityEstimator::FT0C, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry);
 
       /// monitor the satisfied event selections
@@ -441,7 +442,7 @@ struct HfCandidateCreator3Prong {
 
       /// bitmask with event. selection info
       float centrality{-1.f};
-      float occupancy = o2::hf_occupancy::getOccupancyColl(collision);
+      float occupancy = getOccupancyColl(collision);
       const auto rejectionMask = hfEvSel.getHfCollisionRejectionMask<true, CentralityEstimator::FT0M, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry);
 
       /// monitor the satisfied event selections

--- a/PWGHF/Tasks/taskMcValidation.cxx
+++ b/PWGHF/Tasks/taskMcValidation.cxx
@@ -241,26 +241,26 @@ struct HfTaskMcValidationGen {
     hfEvSelMc.addHistograms(registry); // particles monitoring
   }
 
-  /// \brief Function to get MC collision occupancy
-  /// \param collSlice collection of reconstructed collisions
-  /// \return collision occupancy
-  template <typename CCs>
-  int getOccupancyColl(CCs const& collSlice)
-  {
-    float multiplicity{0.f};
-    int occupancy = 0;
-    for (const auto& collision : collSlice) {
-      float collMult{0.f};
-      collMult = collision.numContrib();
+  // /// \brief Function to get MC collision occupancy
+  // /// \param collSlice collection of reconstructed collisions
+  // /// \return collision occupancy
+  // template <typename CCs>
+  // int getOccupancyColl(CCs const& collSlice)
+  // {
+  //   float multiplicity{0.f};
+  //   int occupancy = 0;
+  //   for (const auto& collision : collSlice) {
+  //     float collMult{0.f};
+  //     collMult = collision.numContrib();
 
-      if (collMult > multiplicity) {
-        occupancy = collision.trackOccupancyInTimeRange();
-        multiplicity = collMult;
-      }
-    } // end loop over collisions
+  //     if (collMult > multiplicity) {
+  //       occupancy = collision.trackOccupancyInTimeRange();
+  //       multiplicity = collMult;
+  //     }
+  //   } // end loop over collisions
 
-    return occupancy;
-  }
+  //   return occupancy;
+  // }
 
   template <o2::hf_centrality::CentralityEstimator centEstimator, typename GenColl, typename Particles, typename RecoColls>
   void runCheckGenParticles(GenColl const& mcCollision, Particles const& mcParticles, RecoColls const& recoCollisions, BCsInfo const&, std::array<int, nChannels>& counterPrompt, std::array<int, nChannels>& counterNonPrompt)
@@ -274,7 +274,7 @@ struct HfTaskMcValidationGen {
     float centrality{105.f};
     int occupancy = 0;
     if (storeOccupancy) {
-      occupancy = getOccupancyColl(recoCollisions);
+      occupancy = o2::hf_occupancy::getOccupancyGenColl(recoCollisions, o2::hf_occupancy::OccupancyEstimator::Its);
     }
     uint16_t rejectionMask{0};
     if constexpr (centEstimator == CentralityEstimator::FT0C) {

--- a/PWGHF/Tasks/taskMcValidation.cxx
+++ b/PWGHF/Tasks/taskMcValidation.cxx
@@ -241,27 +241,6 @@ struct HfTaskMcValidationGen {
     hfEvSelMc.addHistograms(registry); // particles monitoring
   }
 
-  // /// \brief Function to get MC collision occupancy
-  // /// \param collSlice collection of reconstructed collisions
-  // /// \return collision occupancy
-  // template <typename CCs>
-  // int getOccupancyColl(CCs const& collSlice)
-  // {
-  //   float multiplicity{0.f};
-  //   int occupancy = 0;
-  //   for (const auto& collision : collSlice) {
-  //     float collMult{0.f};
-  //     collMult = collision.numContrib();
-
-  //     if (collMult > multiplicity) {
-  //       occupancy = collision.trackOccupancyInTimeRange();
-  //       multiplicity = collMult;
-  //     }
-  //   } // end loop over collisions
-
-  //   return occupancy;
-  // }
-
   template <o2::hf_centrality::CentralityEstimator centEstimator, typename GenColl, typename Particles, typename RecoColls>
   void runCheckGenParticles(GenColl const& mcCollision, Particles const& mcParticles, RecoColls const& recoCollisions, BCsInfo const&, std::array<int, nChannels>& counterPrompt, std::array<int, nChannels>& counterNonPrompt)
   {

--- a/PWGHF/Tasks/taskMcValidation.cxx
+++ b/PWGHF/Tasks/taskMcValidation.cxx
@@ -44,6 +44,7 @@ using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::hf_evsel;
 using namespace o2::hf_centrality;
+using namespace o2::hf_occupancy;
 
 namespace
 {
@@ -253,7 +254,7 @@ struct HfTaskMcValidationGen {
     float centrality{105.f};
     int occupancy = 0;
     if (storeOccupancy) {
-      occupancy = o2::hf_occupancy::getOccupancyGenColl(recoCollisions, o2::hf_occupancy::OccupancyEstimator::Its);
+      occupancy = getOccupancyGenColl(recoCollisions, OccupancyEstimator::Its);
     }
     uint16_t rejectionMask{0};
     if constexpr (centEstimator == CentralityEstimator::FT0C) {

--- a/PWGHF/Utils/utilsAnalysis.h
+++ b/PWGHF/Utils/utilsAnalysis.h
@@ -31,7 +31,7 @@ enum BHadMothers { NotMatched = 0,
 /// Convert the B hadron mother PDG for non prompt candidates to a flag
 /// \param pdg of the b hadron mother
 /// \return integer map to specific mothers' PDG codes
-int getBHadMotherFlag(const int& flagBHad)
+BHadMothers getBHadMotherFlag(const int flagBHad)
 {
   if (std::abs(flagBHad) == o2::constants::physics::kBPlus) {
     return BHadMothers::BPlus;

--- a/PWGHF/Utils/utilsAnalysis.h
+++ b/PWGHF/Utils/utilsAnalysis.h
@@ -21,6 +21,33 @@
 
 namespace o2::analysis
 {
+
+enum BHadMothers { NotMatched = 0,
+                   BPlus,
+                   BZero,
+                   Bs,
+                   LambdaBZero };
+
+/// Convert the B hadron mother PDG for non prompt candidates to a flag
+/// \param pdg of the b hadron mother
+/// \return integer map to specific mothers' PDG codes
+int getBHadMotherFlag(const int& flagBHad)
+{
+  if (std::abs(flagBHad) == o2::constants::physics::kBPlus) {
+    return BHadMothers::BPlus;
+  }
+  if (std::abs(flagBHad) == o2::constants::physics::kB0) {
+    return BHadMothers::BZero;
+  }
+  if (std::abs(flagBHad) == o2::constants::physics::kBS) {
+    return BHadMothers::Bs;
+  }
+  if (std::abs(flagBHad) == o2::constants::physics::kLambdaB0) {
+    return BHadMothers::LambdaBZero;
+  }
+  return BHadMothers::NotMatched;
+}
+
 /// Finds pT bin in an array.
 /// \param bins  array of pT bins
 /// \param value  pT

--- a/PWGHF/Utils/utilsEvSelHf.h
+++ b/PWGHF/Utils/utilsEvSelHf.h
@@ -42,29 +42,25 @@ enum OccupancyEstimator { None = 0,
 /// \param collision is the collision with the occupancy information
 /// \return collision occupancy
 template <typename Coll>
-float getOccupancyColl(Coll const& collision, int occEstimator = OccupancyEstimator::Its)
+float getOccupancyColl(Coll const& collision, int occEstimator)
 {
-  float occupancy = -999.;
   switch (occEstimator) {
     case OccupancyEstimator::Its:
-      occupancy = collision.trackOccupancyInTimeRange();
-      break;
+      return collision.trackOccupancyInTimeRange();
     case OccupancyEstimator::Ft0c:
-      occupancy = collision.ft0cOccupancyInTimeRange();
-      break;
+      return collision.ft0cOccupancyInTimeRange();
     default:
-      LOG(warning) << "Occupancy estimator not valid. Possible values are ITS or FT0C. Fallback to ITS";
-      occupancy = collision.trackOccupancyInTimeRange();
+      LOG(fatal) << "Occupancy estimator not valid. Possible values are ITS or FT0C.";
       break;
   }
-  return occupancy;
+  return -999.f;
 };
 
 /// \brief Function to get MC collision occupancy
 /// \param collSlice collection of reconstructed collisions associated to a generated one
 /// \return generated MC collision occupancy
 template <typename CCs>
-int getOccupancyGenColl(CCs const& collSlice, int occEstimator = OccupancyEstimator::Its)
+int getOccupancyGenColl(CCs const& collSlice, int occEstimator)
 {
   float multiplicity{0.f};
   int occupancy = 0;

--- a/PWGHF/Utils/utilsEvSelHf.h
+++ b/PWGHF/Utils/utilsEvSelHf.h
@@ -214,7 +214,7 @@ struct HfEventSelection : o2::framework::ConfigurableGroup {
     uint16_t rejectionMask{0}; // 16 bits, in case new ev. selections will be added
 
     if constexpr (centEstimator != o2::hf_centrality::CentralityEstimator::None) {
-      centrality = o2::hf_centrality::evalCentralityColl<centEstimator>(collision);
+      centrality = o2::hf_centrality::getCentralityColl(collision, centEstimator);
       if (centrality < centralityMin || centrality > centralityMax) {
         SETBIT(rejectionMask, EventRejection::Centrality);
       }
@@ -394,7 +394,7 @@ struct HfEventSelectionMc {
     auto bc = mcCollision.template bc_as<TBc>();
 
     if constexpr (centEstimator != o2::hf_centrality::CentralityEstimator::None) {
-      centrality = o2::hf_centrality::evalCentralityGenColl<centEstimator>(collSlice);
+      centrality = o2::hf_centrality::getCentralityGenColl(collSlice, centEstimator);
       /// centrality selection
       if (centrality < centralityMin || centrality > centralityMax) {
         SETBIT(rejectionMask, EventRejection::Centrality);

--- a/PWGHF/Utils/utilsEvSelHf.h
+++ b/PWGHF/Utils/utilsEvSelHf.h
@@ -42,7 +42,7 @@ enum OccupancyEstimator { None = 0,
 /// \param collision is the collision with the occupancy information
 /// \return collision occupancy
 template <typename Coll>
-float getOccupancyColl(Coll const& collision, int occEstimator=1)
+float getOccupancyColl(Coll const& collision, int occEstimator = 1)
 {
   float occupancy = -999.;
   switch (occEstimator) {
@@ -64,7 +64,7 @@ float getOccupancyColl(Coll const& collision, int occEstimator=1)
 /// \param collSlice collection of reconstructed collisions associated to a generated one
 /// \return generated MC collision occupancy
 template <typename CCs>
-int getOccupancyGenColl(CCs const& collSlice, int occEstimator=1)
+int getOccupancyGenColl(CCs const& collSlice, int occEstimator = 1)
 {
   float multiplicity{0.f};
   int occupancy = 0;

--- a/PWGHF/Utils/utilsEvSelHf.h
+++ b/PWGHF/Utils/utilsEvSelHf.h
@@ -215,7 +215,6 @@ struct HfEventSelection : o2::framework::ConfigurableGroup {
 
     if constexpr (centEstimator != o2::hf_centrality::CentralityEstimator::None) {
       centrality = o2::hf_centrality::evalCentralityColl<centEstimator>(collision);
-      // centrality = getCentrality<centEstimator>(collision);
       if (centrality < centralityMin || centrality > centralityMax) {
         SETBIT(rejectionMask, EventRejection::Centrality);
       }
@@ -309,46 +308,6 @@ struct HfEventSelection : o2::framework::ConfigurableGroup {
     return rejectionMask;
   }
 
-  // /// Get the occupancy
-  // /// \param collision is the collision with the occupancy information
-  // /// \param occEstimator is the occupancy estimator (1: ITS, 2: FT0C)
-  // template <typename Coll>
-  // float getOccupancyColl(Coll const& collision, int occEstimator = 1)
-  // {
-  //   switch (occEstimator) {
-  //     case 1: // ITS
-  //       return collision.trackOccupancyInTimeRange();
-  //       break;
-  //     case 2: // FT0c
-  //       return collision.ft0cOccupancyInTimeRange();
-  //       break;
-  //     default:
-  //       LOG(warning) << "Occupancy estimator not valid. Possible values are ITS or FT0C. Fallback to ITS";
-  //       return collision.trackOccupancyInTimeRange();
-  //       break;
-  //   }
-  // }
-
-  // /// Get the centrality
-  // /// \param collision is the collision with the centrality information
-  // /// \param centEstimator is the centrality estimator from hf_centrality::CentralityEstimator
-  // template <o2::hf_centrality::CentralityEstimator centEstimator, typename Coll>
-  // float getCentrality(Coll const& collision)
-  // {
-  //   if constexpr (centEstimator == o2::hf_centrality::CentralityEstimator::FT0A) {
-  //     return collision.centFT0A();
-  //   } else if constexpr (centEstimator == o2::hf_centrality::CentralityEstimator::FT0C) {
-  //     return collision.centFT0C();
-  //   } else if constexpr (centEstimator == o2::hf_centrality::CentralityEstimator::FT0M) {
-  //     return collision.centFT0M();
-  //   } else if constexpr (centEstimator == o2::hf_centrality::CentralityEstimator::FV0A) {
-  //     return collision.centFV0A();
-  //   } else {
-  //     LOG(warning) << "Centrality estimator not valid. Possible values are V0A, T0M, T0A, T0C. Fallback to FT0c";
-  //     return collision.centFT0C();
-  //   }
-  // }
-
   /// \brief Fills histograms for monitoring event selections satisfied by the collision.
   /// \param collision analysed collision
   /// \param rejectionMask bitmask storing the info about which ev. selections are not satisfied by the collision
@@ -436,27 +395,6 @@ struct HfEventSelectionMc {
 
     if constexpr (centEstimator != o2::hf_centrality::CentralityEstimator::None) {
       centrality = o2::hf_centrality::evalCentralityGenColl<centEstimator>(collSlice);
-      // float multiplicity{0.f};
-      // for (const auto& collision : collSlice) {
-      //   float collCent{0.f};
-      //   float collMult{0.f};
-      //   if constexpr (centEstimator == o2::hf_centrality::CentralityEstimator::FT0A) {
-      //     collCent = collision.centFT0A();
-      //   } else if constexpr (centEstimator == o2::hf_centrality::CentralityEstimator::FT0C) {
-      //     collCent = collision.centFT0C();
-      //   } else if constexpr (centEstimator == o2::hf_centrality::CentralityEstimator::FT0M) {
-      //     collCent = collision.centFT0M();
-      //   } else if constexpr (centEstimator == o2::hf_centrality::CentralityEstimator::FV0A) {
-      //     collCent = collision.centFV0A();
-      //   } else {
-      //     LOGP(fatal, "Unsupported centrality estimator!");
-      //   }
-      //   collMult = collision.numContrib();
-      //   if (collMult > multiplicity) {
-      //     centrality = collCent;
-      //     multiplicity = collMult;
-      //   }
-      // }
       /// centrality selection
       if (centrality < centralityMin || centrality > centralityMax) {
         SETBIT(rejectionMask, EventRejection::Centrality);

--- a/PWGHF/Utils/utilsEvSelHf.h
+++ b/PWGHF/Utils/utilsEvSelHf.h
@@ -42,7 +42,7 @@ enum OccupancyEstimator { None = 0,
 /// \param collision is the collision with the occupancy information
 /// \return collision occupancy
 template <typename Coll>
-float getOccupancyColl(Coll const& collision, int occEstimator = 1)
+float getOccupancyColl(Coll const& collision, int occEstimator = OccupancyEstimator::Its)
 {
   float occupancy = -999.;
   switch (occEstimator) {
@@ -64,7 +64,7 @@ float getOccupancyColl(Coll const& collision, int occEstimator = 1)
 /// \param collSlice collection of reconstructed collisions associated to a generated one
 /// \return generated MC collision occupancy
 template <typename CCs>
-int getOccupancyGenColl(CCs const& collSlice, int occEstimator = 1)
+int getOccupancyGenColl(CCs const& collSlice, int occEstimator = OccupancyEstimator::Its)
 {
   float multiplicity{0.f};
   int occupancy = 0;


### PR DESCRIPTION
In this PR, occupancy and centrality axes are added to existing sparses. Plus, the information on the B hadron mother pdg and pt is stored for nonprompt candidates. Finally, sparse histograms are added for generated MC candidates.