### PR TITLE
[PWGUD] Fix global forward tracks selection and store tan lambda information

### DIFF
--- a/PWGUD/DataModel/UDTables.h
+++ b/PWGUD/DataModel/UDTables.h
@@ -429,14 +429,9 @@ DECLARE_SOA_TABLE_VERSIONED(UDFwdTracksExtra_001, "AOD", "UDFWDTRACKEXTRA", 1,
 
 using UDFwdTracksExtra = UDFwdTracksExtra_001;
 
-// Tangent lambda information
-DECLARE_SOA_TABLE(UDFwdTracksTgl, "AOD", "UDFWDTRACKTGL",
-                  fwdtrack::Tgl);
-
 using UDFwdTrack = UDFwdTracks::iterator;
 using UDFwdIndex = UDFwdIndices::iterator;
 using UDFwdTrackExtra = UDFwdTracksExtra::iterator;
-using UDFwdTrackTgl = UDFwdTracksTgl::iterator;
 
 DECLARE_SOA_TABLE(UDFwdTracksProp, "AOD", "UDFWDTRACKPROP",
                   o2::soa::Index<>, fwdtrack::CollisionId, fwdtrack::TrackType,

--- a/PWGUD/DataModel/UDTables.h
+++ b/PWGUD/DataModel/UDTables.h
@@ -429,9 +429,14 @@ DECLARE_SOA_TABLE_VERSIONED(UDFwdTracksExtra_001, "AOD", "UDFWDTRACKEXTRA", 1,
 
 using UDFwdTracksExtra = UDFwdTracksExtra_001;
 
+// Tangent lambda information
+DECLARE_SOA_TABLE(UDFwdTracksTgl, "AOD", "UDFWDTRACKTGL",
+                  fwdtrack::Tgl);
+
 using UDFwdTrack = UDFwdTracks::iterator;
 using UDFwdIndex = UDFwdIndices::iterator;
 using UDFwdTrackExtra = UDFwdTracksExtra::iterator;
+using UDFwdTrackTgl = UDFwdTracksTgl::iterator;
 
 DECLARE_SOA_TABLE(UDFwdTracksProp, "AOD", "UDFWDTRACKPROP",
                   o2::soa::Index<>, fwdtrack::CollisionId, fwdtrack::TrackType,

--- a/PWGUD/TableProducer/UPCCandidateProducer.cxx
+++ b/PWGUD/TableProducer/UPCCandidateProducer.cxx
@@ -45,7 +45,6 @@ struct UpcCandProducer {
 
   Produces<o2::aod::UDFwdTracks> udFwdTracks;
   Produces<o2::aod::UDFwdTracksExtra> udFwdTracksExtra;
-  Produces<o2::aod::UDFwdTracksTgl> udFwdTracksTgl;
   Produces<o2::aod::UDFwdIndices> udFwdIndices;
   Produces<o2::aod::UDFwdTracksCls> udFwdTrkClusters;
   Produces<o2::aod::UDMcFwdTrackLabels> udFwdTrackLabels;
@@ -387,7 +386,6 @@ struct UpcCandProducer {
       udFwdTracks(candID, track.px(), track.py(), track.pz(), track.sign(), globalBC, trTime, track.trackTimeRes());
       udFwdTracksExtra(track.trackType(), track.nClusters(), track.pDca(), track.rAtAbsorberEnd(), track.chi2(), mchmidChi2, mchmftChi2,
                        track.mchBitMap(), track.midBitMap(), track.midBoards());
-      udFwdTracksTgl(track.tgl());
       udFwdIndices(candID, globalIndex, mchIndex, mftIndex);
       // fill MC labels and masks if needed
       if (fDoMC) {

--- a/PWGUD/TableProducer/UPCCandidateProducer.cxx
+++ b/PWGUD/TableProducer/UPCCandidateProducer.cxx
@@ -1613,11 +1613,10 @@ struct UpcCandProducer {
       // Find corresponding midTrackIDs using std::find_if
       auto midIt = std::find_if(bcsMatchedTrIdsMID.begin(), bcsMatchedTrIdsMID.end(),
                                 [globalBC](const auto& midPair) {
-                                  return midPair.first == globalBC;
+                                  return midPair.first == static_cast<uint64_t>(globalBC);
                                 });
 
       const auto* midTrackIDs = (midIt != bcsMatchedTrIdsMID.end()) ? &midIt->second : nullptr;
-      int32_t nMIDs = midTrackIDs ? midTrackIDs->size() : 0;
 
       if (nMFTs > fNFwdProngs) // Skip if too many tracks
         continue;


### PR DESCRIPTION
The global forward tracks (MFT-MCH-MID type) were not selected properly for each BC, now this is done using the global BC info. 
The tangent lambda information is stored in a new table to be able to perform the global muon refit as is done in DQ. 