### PR TITLE
[PWGCF,PWGHF] Add ITS PID to femtodream

### DIFF
--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -175,6 +175,14 @@ DECLARE_SOA_COLUMN(TOFNSigmaPr, tofNSigmaPr, float); //! Nsigma separation with 
 DECLARE_SOA_COLUMN(TOFNSigmaDe, tofNSigmaDe, float); //! Nsigma separation with the TOF detector for deuteron
 DECLARE_SOA_COLUMN(TOFNSigmaTr, tofNSigmaTr, float); //! Nsigma separation with the TOF detector for triton
 DECLARE_SOA_COLUMN(TOFNSigmaHe, tofNSigmaHe, float); //! Nsigma separation with the TOF detector for helium3
+DECLARE_SOA_COLUMN(ITSSignal, itsSignal, float);
+DECLARE_SOA_COLUMN(ITSNSigmaEl, itsNSigmaEl, float); //! Nsigma separation with the Its detector for electron
+DECLARE_SOA_COLUMN(ITSNSigmaPi, itsNSigmaPi, float); //! Nsigma separation with the Its detector for pion
+DECLARE_SOA_COLUMN(ITSNSigmaKa, itsNSigmaKa, float); //! Nsigma separation with the Its detector for kaon
+DECLARE_SOA_COLUMN(ITSNSigmaPr, itsNSigmaPr, float); //! Nsigma separation with the Its detector for proton
+DECLARE_SOA_COLUMN(ITSNSigmaDe, itsNSigmaDe, float); //! Nsigma separation with the Its detector for deuteron
+DECLARE_SOA_COLUMN(ITSNSigmaTr, itsNSigmaTr, float); //! Nsigma separation with the Its detector for triton
+DECLARE_SOA_COLUMN(ITSNSigmaHe, itsNSigmaHe, float); //! Nsigma separation with the Its detector for helium3
 DECLARE_SOA_COLUMN(DaughDCA, daughDCA, float);       //! DCA between daughters
 DECLARE_SOA_COLUMN(TransRadius, transRadius, float); //! Transverse radius of the decay vertex
 DECLARE_SOA_COLUMN(DecayVtxX, decayVtxX, float);     //! X position of the decay vertex
@@ -359,6 +367,14 @@ DECLARE_SOA_TABLE_STAGED(FDExtParticles, "FDEXTPARTICLE",
                          femtodreamparticle::TOFNSigmaDe,
                          femtodreamparticle::TOFNSigmaTr,
                          femtodreamparticle::TOFNSigmaHe,
+                         femtodreamparticle::ITSSignal,
+                         femtodreamparticle::ITSNSigmaEl,
+                         femtodreamparticle::ITSNSigmaPi,
+                         femtodreamparticle::ITSNSigmaKa,
+                         femtodreamparticle::ITSNSigmaPr,
+                         femtodreamparticle::ITSNSigmaDe,
+                         femtodreamparticle::ITSNSigmaTr,
+                         femtodreamparticle::ITSNSigmaHe,
                          femtodreamparticle::DaughDCA,
                          femtodreamparticle::TransRadius,
                          femtodreamparticle::DecayVtxX,
@@ -457,3 +473,4 @@ using MixingHash = MixingHashes::iterator;
 } // namespace o2::aod
 
 #endif // PWGCF_DATAMODEL_FEMTODERIVED_H_
+       //

--- a/PWGCF/FemtoDream/Core/femtoDreamParticleHisto.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamParticleHisto.h
@@ -72,7 +72,7 @@ class FemtoDreamParticleHisto
 
   // comment
   template <o2::aod::femtodreamMCparticle::MCType mc, typename T>
-  void init_debug(std::string folderName, T& multAxis, T& multPercentileAxis, T& pTAxis, T& etaAxis, T& phiAxis, T& tempFitVarAxis, T& dcazAxis, T& NsigmaTPCAxis, T& NsigmaTOFAxis, T& NsigmaTPCTOFAxis, T& /*TPCclustersAxis*/, bool correlatedPlots)
+  void init_debug(std::string folderName, T& multAxis, T& multPercentileAxis, T& pTAxis, T& etaAxis, T& phiAxis, T& tempFitVarAxis, T& dcazAxis, T& NsigmaTPCAxis, T& NsigmaTOFAxis, T& NsigmaTPCTOFAxis, T& NsigmaITSAxis, bool correlatedPlots)
   {
 
     std::string folderSuffix = static_cast<std::string>(o2::aod::femtodreamMCparticle::MCTypeName[mc]).c_str();
@@ -117,6 +117,14 @@ class FemtoDreamParticleHisto
       mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_d").c_str(), "n#sigma_{comb}^{d}", kTH2F, {pTAxis, NsigmaTPCTOFAxis});
       mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_tr").c_str(), "n#sigma_{comb}^{tr}", kTH2F, {pTAxis, NsigmaTPCTOFAxis});
       mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaComb_he3").c_str(), "n#sigma_{comb}^{he3}", kTH2F, {pTAxis, NsigmaTPCTOFAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/ITSSignal").c_str(), "<cluster size>x<cos#lambda>", kTH2F, {pTAxis, NsigmaITSAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaITS_el").c_str(), "n#sigma_{ITS}^{e}", kTH2F, {pTAxis, NsigmaITSAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaITS_pi").c_str(), "n#sigma_{ITS}^{#pi}", kTH2F, {pTAxis, NsigmaITSAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaITS_K").c_str(), "n#sigma_{ITS}^{K}", kTH2F, {pTAxis, NsigmaITSAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaITS_p").c_str(), "n#sigma_{ITS}^{p}", kTH2F, {pTAxis, NsigmaITSAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaITS_d").c_str(), "n#sigma_{ITS}^{d}", kTH2F, {pTAxis, NsigmaITSAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaITS_tr").c_str(), "n#sigma_{ITS}^{tr}", kTH2F, {pTAxis, NsigmaITSAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/nSigmaITS_he3").c_str(), "n#sigma_{ITS}^{he3}", kTH2F, {pTAxis, NsigmaITSAxis});
       if (correlatedPlots) {
         mHistogramRegistry->add((folderName + folderSuffix + "/HighDcorrelator").c_str(), "", kTHnSparseF, {multAxis, multPercentileAxis, pTAxis, etaAxis, phiAxis, tempFitVarAxis, dcazAxis, NsigmaTPCAxis, NsigmaTOFAxis});
       }
@@ -217,7 +225,7 @@ class FemtoDreamParticleHisto
   /// \param tempFitVarBins binning of the tempFitVar (DCA_xy in case of tracks, CPA in case of V0s, etc.)
   /// \param isMC add Monte Carlo truth histograms to the output file
   template <typename T>
-  void init(HistogramRegistry* registry, T& MultBins, T& PercentileBins, T& pTBins, T& etaBins, T& phiBins, T& tempFitVarBins, T& NsigmaTPCBins, T& NsigmaTOFBins, T& NsigmaTPCTOFBins, T& TPCclustersBins, T& InvMassBins, bool isMC, int pdgCode, bool isDebug = false, bool correlatedPlots = false)
+  void init(HistogramRegistry* registry, T& MultBins, T& PercentileBins, T& pTBins, T& etaBins, T& phiBins, T& tempFitVarBins, T& NsigmaTPCBins, T& NsigmaTOFBins, T& NsigmaTPCTOFBins, T& NsigmaITSBins, T& InvMassBins, bool isMC, int pdgCode, bool isDebug = false, bool correlatedPlots = false)
   {
     mPDG = pdgCode;
     if (registry) {
@@ -247,7 +255,7 @@ class FemtoDreamParticleHisto
       framework::AxisSpec NsigmaTPCAxis = {NsigmaTPCBins, "n#sigma_{TPC}"};
       framework::AxisSpec NsigmaTOFAxis = {NsigmaTOFBins, "n#sigma_{TOF}"};
       framework::AxisSpec NsigmaTPCTOFAxis = {NsigmaTPCTOFBins, "n#sigma_{TPC+TOF}"};
-      framework::AxisSpec TPCclustersAxis = {TPCclustersBins, "TPC found clusters"};
+      framework::AxisSpec NsigmaITSAxis = {NsigmaITSBins, "n#sigma_{ITS}"};
       framework::AxisSpec InvMassAxis = {InvMassBins, "M_{inv} (GeV/#it{c}^{2})"};
 
       std::string folderName = (static_cast<std::string>(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]).c_str() + static_cast<std::string>(mFolderSuffix[mFolderSuffixType])).c_str();
@@ -255,7 +263,7 @@ class FemtoDreamParticleHisto
       // Fill here the actual histogramms by calling init_base and init_MC
       init_base<o2::aod::femtodreamMCparticle::MCType::kRecon>(folderName, tempFitVarAxisTitle, pTAxis, tempFitVarAxis, InvMassAxis, multAxis);
       if (isDebug) {
-        init_debug<o2::aod::femtodreamMCparticle::MCType::kRecon>(folderName, multAxis, multPercentileAxis, pTAxis, etaAxis, phiAxis, tempFitVarAxis, dcazAxis, NsigmaTPCAxis, NsigmaTOFAxis, NsigmaTPCTOFAxis, TPCclustersAxis, correlatedPlots);
+        init_debug<o2::aod::femtodreamMCparticle::MCType::kRecon>(folderName, multAxis, multPercentileAxis, pTAxis, etaAxis, phiAxis, tempFitVarAxis, dcazAxis, NsigmaTPCAxis, NsigmaTOFAxis, NsigmaTPCTOFAxis, NsigmaITSAxis, correlatedPlots);
       }
       if (isMC) {
         init_base<o2::aod::femtodreamMCparticle::MCType::kTruth>(folderName, tempFitVarAxisTitle, pTAxis, tempFitVarAxis, InvMassAxis, multAxis);
@@ -350,6 +358,14 @@ class FemtoDreamParticleHisto
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaComb_d"), momentum, std::sqrt(part.tpcNSigmaDe() * part.tpcNSigmaDe() + part.tofNSigmaDe() * part.tofNSigmaDe()));
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaComb_tr"), momentum, std::sqrt(part.tpcNSigmaTr() * part.tpcNSigmaTr() + part.tofNSigmaTr() * part.tofNSigmaTr()));
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaComb_he3"), momentum, std::sqrt(part.tpcNSigmaHe() * part.tpcNSigmaHe() + part.tofNSigmaHe() * part.tofNSigmaHe()));
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/ITSSignal"), momentum, part.itsSignal());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaITS_el"), momentum, part.itsNSigmaEl());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaITS_pi"), momentum, part.itsNSigmaPi());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaITS_K"), momentum, part.itsNSigmaKa());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaITS_p"), momentum, part.itsNSigmaPr());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaITS_d"), momentum, part.itsNSigmaDe());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaITS_tr"), momentum, part.itsNSigmaTr());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/nSigmaITS_he3"), momentum, part.itsNSigmaHe());
 
       if (correlatedPlots) {
 

--- a/PWGCF/FemtoDream/Core/femtoDreamTrackSelection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamTrackSelection.h
@@ -24,6 +24,8 @@
 
 #include "PWGCF/DataModel/FemtoDerived.h"
 #include "Common/DataModel/TrackSelectionTables.h"
+#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/PIDResponseITS.h"
 #include "Common/Core/TrackSelection.h"
 #include "Common/Core/TrackSelectionDefaults.h"
 #include "PWGCF/FemtoDream/Core/femtoDreamObjectSelection.h"
@@ -129,6 +131,14 @@ class FemtoDreamTrackSelection : public FemtoDreamObjectSelection<float, femtoDr
   template <typename T>
   auto getNsigmaTOF(T const& track, o2::track::PID pid);
 
+  /// Computes the n_sigma for a track and a particle-type hypothesis in the ITS
+  /// \tparam T Data type of the track
+  /// \param track Track for which PID is evaluated
+  /// \param pid Particle species for which PID is evaluated
+  /// \return Value of n_{sigma, ITS}
+  template <typename T>
+  auto getNsigmaITS(T const& track, o2::track::PID pid);
+
   /// Checks whether the most open combination of all selection criteria is fulfilled
   /// \tparam T Data type of the track
   /// \param track Track
@@ -146,7 +156,7 @@ class FemtoDreamTrackSelection : public FemtoDreamObjectSelection<float, femtoDr
   /// \param Eta eta of the track
   /// \param Dca dca of the track with respect to primary vertex
   /// \return The bit-wise container for the selections, separately with all selection criteria, and the PID
-  template <typename cutContainerType, typename T, typename R>
+  template <bool useItsPid = false, typename cutContainerType, typename T, typename R>
   std::array<cutContainerType, 2> getCutContainer(T const& track, R Pt, R Eta, R Dcaxy);
 
   /// Some basic QA histograms
@@ -291,7 +301,7 @@ class FemtoDreamTrackSelection : public FemtoDreamObjectSelection<float, femtoDr
                                                                           "Maximal DCA_z (cm)",
                                                                           "Minimal DCA (cm)",
                                                                           "Maximal PID (nSigma)"}; ///< Helper information for the different selections
-};                                                                                                 // namespace femtoDream
+}; // namespace femtoDream
 
 template <o2::aod::femtodreamparticle::ParticleType part, o2::aod::femtodreamparticle::TrackType tracktype, typename cutContainerType>
 void FemtoDreamTrackSelection::init(HistogramRegistry* QAregistry, HistogramRegistry* Registry)
@@ -385,6 +395,28 @@ auto FemtoDreamTrackSelection::getNsigmaTOF(T const& track, o2::track::PID pid)
 }
 
 template <typename T>
+auto FemtoDreamTrackSelection::getNsigmaITS(T const& track, o2::track::PID pid)
+{
+  if (pid == o2::track::PID::Electron) {
+    return track.itsNSigmaEl();
+  } else if (pid == o2::track::PID::Pion) {
+    return track.itsNSigmaPi();
+  } else if (pid == o2::track::PID::Kaon) {
+    return track.itsNSigmaKa();
+  } else if (pid == o2::track::PID::Proton) {
+    return track.itsNSigmaPr();
+  } else if (pid == o2::track::PID::Deuteron) {
+    return track.itsNSigmaDe();
+  } else if (pid == o2::track::PID::Triton) {
+    return track.itsNSigmaTr();
+  } else if (pid == o2::track::PID::Helium3) {
+    return track.itsNSigmaHe();
+  }
+  // if nothing matched, return default value
+  return -999.f;
+}
+
+template <typename T>
 bool FemtoDreamTrackSelection::isSelectedMinimal(T const& track)
 {
   const auto pT = track.pt();
@@ -460,7 +492,7 @@ bool FemtoDreamTrackSelection::isSelectedMinimal(T const& track)
   return true;
 }
 
-template <typename cutContainerType, typename T, typename R>
+template <bool useItsPid, typename cutContainerType, typename T, typename R>
 std::array<cutContainerType, 2> FemtoDreamTrackSelection::getCutContainer(T const& track, R Pt, R Eta, R Dca)
 {
   cutContainerType output = 0;
@@ -479,23 +511,30 @@ std::array<cutContainerType, 2> FemtoDreamTrackSelection::getCutContainer(T cons
   const auto dcaZ = track.dcaZ();
   const auto dca = Dca;
 
-  std::vector<float> pidTPC, pidTOF;
+  std::vector<float> pidTPC, pidTOF, pidITS;
   for (auto it : mPIDspecies) {
     pidTPC.push_back(getNsigmaTPC(track, it));
     pidTOF.push_back(getNsigmaTOF(track, it));
+    if constexpr (useItsPid) {
+      pidITS.push_back(getNsigmaITS(track, it));
+    }
   }
 
   float observable = 0.;
   for (auto& sel : mSelections) {
     const auto selVariable = sel.getSelectionVariable();
     if (selVariable == femtoDreamTrackSelection::kPIDnSigmaMax) {
-      /// PID needs to be handled a bit differently since we may need more than one species
+      /// PID needsgetNsigmaITSto be handled a bit differently since we may need more than one species
       for (size_t i = 0; i < mPIDspecies.size(); ++i) {
         auto pidTPCVal = pidTPC.at(i) - nSigmaPIDOffsetTPC;
         auto pidTOFVal = pidTOF.at(i) - nSigmaPIDOffsetTOF;
         auto pidComb = std::sqrt(pidTPCVal * pidTPCVal + pidTOFVal * pidTOFVal);
         sel.checkSelectionSetBitPID(pidTPCVal, outputPID);
         sel.checkSelectionSetBitPID(pidComb, outputPID);
+        if constexpr (useItsPid) {
+          auto pidITSVal = pidITS.at(i);
+          sel.checkSelectionSetBitPID(pidITSVal, outputPID);
+        }
       }
     } else {
       /// for the rest it's all the same

--- a/PWGCF/FemtoDream/Core/femtoDreamUtils.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamUtils.h
@@ -118,5 +118,22 @@ inline bool containsNameValuePair(const std::vector<T>& myVector, const std::str
   return false; // No match found
 }
 
+template <typename T>
+float itsSignal(T const& track)
+{
+  uint32_t clsizeflag = track.itsClusterSizes();
+  auto clSizeLayer0 = (clsizeflag >> (0 * 4)) & 0xf;
+  auto clSizeLayer1 = (clsizeflag >> (1 * 4)) & 0xf;
+  auto clSizeLayer2 = (clsizeflag >> (2 * 4)) & 0xf;
+  auto clSizeLayer3 = (clsizeflag >> (3 * 4)) & 0xf;
+  auto clSizeLayer4 = (clsizeflag >> (4 * 4)) & 0xf;
+  auto clSizeLayer5 = (clsizeflag >> (5 * 4)) & 0xf;
+  auto clSizeLayer6 = (clsizeflag >> (6 * 4)) & 0xf;
+  int numLayers = 7;
+  int sumClusterSizes = clSizeLayer1 + clSizeLayer2 + clSizeLayer3 + clSizeLayer4 + clSizeLayer5 + clSizeLayer6 + clSizeLayer0;
+  float cosLamnda = 1. / std::cosh(track.eta());
+  return (static_cast<float>(sumClusterSizes) / numLayers) * cosLamnda;
+};
+
 } // namespace o2::analysis::femtoDream
 #endif // PWGCF_FEMTODREAM_CORE_FEMTODREAMUTILS_H_

--- a/PWGCF/FemtoDream/Core/femtoDreamV0Selection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamV0Selection.h
@@ -550,8 +550,8 @@ template <typename cutContainerType, typename C, typename V, typename T>
 std::array<cutContainerType, 5>
   FemtoDreamV0Selection::getCutContainer(C const& /*col*/, V const& v0, T const& posTrack, T const& negTrack)
 {
-  auto outputPosTrack = PosDaughTrack.getCutContainer<cutContainerType>(posTrack, v0.positivept(), v0.positiveeta(), v0.dcapostopv());
-  auto outputNegTrack = NegDaughTrack.getCutContainer<cutContainerType>(negTrack, v0.negativept(), v0.negativeeta(), v0.dcanegtopv());
+  auto outputPosTrack = PosDaughTrack.getCutContainer<false, cutContainerType>(posTrack, v0.positivept(), v0.positiveeta(), v0.dcapostopv());
+  auto outputNegTrack = NegDaughTrack.getCutContainer<false, cutContainerType>(negTrack, v0.negativept(), v0.negativeeta(), v0.dcanegtopv());
   cutContainerType output = 0;
   size_t counter = 0;
 

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerReducedTask.cxx
@@ -15,6 +15,7 @@
 /// \author Georgios Mantzaridis, TU München, georgios.mantzaridis@tum.de
 /// \author Anton Riedel, TU München, anton.riedel@tum.de
 
+#include <vector>
 #include "TMath.h"
 #include <CCDB/BasicCCDBManager.h>
 #include "PWGCF/FemtoDream/Core/femtoDreamCollisionSelection.h"

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerReducedTask.cxx
@@ -28,6 +28,7 @@
 #include "Framework/ASoAHelpers.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 #include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/PIDResponseITS.h"
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/Multiplicity.h"
 #include "ReconstructionDataFormats/Track.h"
@@ -266,7 +267,7 @@ struct femtoDreamProducerReducedTask {
       trackCuts.fillQA<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::TrackType::kNoChild>(track);
       // an array of two bit-wise containers of the systematic variations is obtained
       // one container for the track quality cuts and one for the PID cuts
-      auto cutContainer = trackCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(track, track.pt(), track.eta(), sqrtf(powf(track.dcaXY(), 2.f) + powf(track.dcaZ(), 2.f)));
+      auto cutContainer = trackCuts.getCutContainer<true, aod::femtodreamparticle::cutContainerType>(track, track.pt(), track.eta(), sqrtf(powf(track.dcaXY(), 2.f) + powf(track.dcaZ(), 2.f)));
 
       // now the table is filled
       outputParts(outputCollision.lastIndex(),
@@ -307,6 +308,14 @@ struct femtoDreamProducerReducedTask {
                          track.tofNSigmaDe(),
                          track.tofNSigmaTr(),
                          track.tofNSigmaHe(),
+                         -1,
+                         track.itsNSigmaEl(),
+                         track.itsNSigmaPi(),
+                         track.itsNSigmaKa(),
+                         track.itsNSigmaPr(),
+                         track.itsNSigmaDe(),
+                         track.itsNSigmaTr(),
+                         track.itsNSigmaHe(),
                          -999., -999., -999., -999., -999., -999.);
       }
     }
@@ -317,8 +326,11 @@ struct femtoDreamProducerReducedTask {
   {
     // get magnetic field for run
     getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());
+
+    auto tracksWithItsPid = soa::Attach<aod::FemtoFullTracks, aod::pidits::ITSNSigmaEl, aod::pidits::ITSNSigmaPi, aod::pidits::ITSNSigmaKa,
+                                        aod::pidits::ITSNSigmaPr, aod::pidits::ITSNSigmaDe, aod::pidits::ITSNSigmaTr, aod::pidits::ITSNSigmaHe>(tracks);
     // fill the tables
-    fillCollisionsAndTracks<false, true>(col, tracks);
+    fillCollisionsAndTracks<false, true>(col, tracksWithItsPid);
   }
   PROCESS_SWITCH(femtoDreamProducerReducedTask, processData, "Provide experimental data", true);
 
@@ -329,8 +341,10 @@ struct femtoDreamProducerReducedTask {
   {
     // get magnetic field for run
     getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());
+    auto tracksWithItsPid = soa::Attach<soa::Join<aod::FemtoFullTracks, aod::McTrackLabels>, aod::pidits::ITSNSigmaEl, aod::pidits::ITSNSigmaPi, aod::pidits::ITSNSigmaKa,
+                                        aod::pidits::ITSNSigmaPr, aod::pidits::ITSNSigmaDe, aod::pidits::ITSNSigmaTr, aod::pidits::ITSNSigmaHe>(tracks);
     // fill the tables
-    fillCollisionsAndTracks<true, true>(col, tracks);
+    fillCollisionsAndTracks<true, true>(col, tracksWithItsPid);
   }
   PROCESS_SWITCH(femtoDreamProducerReducedTask, processMC, "Provide MC data", false);
 
@@ -341,8 +355,10 @@ struct femtoDreamProducerReducedTask {
   {
     // get magnetic field for run
     getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());
+    auto tracksWithItsPid = soa::Attach<soa::Join<aod::FemtoFullTracks, aod::McTrackLabels>, aod::pidits::ITSNSigmaEl, aod::pidits::ITSNSigmaPi, aod::pidits::ITSNSigmaKa,
+                                        aod::pidits::ITSNSigmaPr, aod::pidits::ITSNSigmaDe, aod::pidits::ITSNSigmaTr, aod::pidits::ITSNSigmaHe>(tracks);
     // fill the tables
-    fillCollisionsAndTracks<true, false>(col, tracks);
+    fillCollisionsAndTracks<true, false>(col, tracksWithItsPid);
   }
   PROCESS_SWITCH(femtoDreamProducerReducedTask, processMC_noCentrality, "Provide MC data", false);
 };

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerReducedTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerReducedTask.cxx
@@ -17,7 +17,7 @@
 
 #include <vector>
 #include "TMath.h"
-#include <CCDB/BasicCCDBManager.h>
+#include "CCDB/BasicCCDBManager.h"
 #include "PWGCF/FemtoDream/Core/femtoDreamCollisionSelection.h"
 #include "PWGCF/FemtoDream/Core/femtoDreamTrackSelection.h"
 #include "PWGCF/FemtoDream/Core/femtoDreamUtils.h"

--- a/PWGCF/FemtoDream/Tasks/femtoDreamDebugTrack.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamDebugTrack.cxx
@@ -61,6 +61,7 @@ struct femtoDreamDebugTrack {
   ConfigurableAxis ConfNsigmaTPCBins{"ConfNsigmaTPCBins", {1600, -8, 8}, "Binning of Nsigma TPC plot"};
   ConfigurableAxis ConfNsigmaTOFBins{"ConfNsigmaTOFBins", {3000, -15, 15}, "Binning of the Nsigma TOF plot"};
   ConfigurableAxis ConfNsigmaTPCTOFBins{"ConfNsigmaTPCTOFBins", {3000, -15, 15}, "Binning of the Nsigma TPC+TOF plot"};
+  ConfigurableAxis ConfNsigmaITSBins{"ConfNsigmaITSBins", {3000, -15, 15}, "Binning of the Nsigma ITS plot"};
   ConfigurableAxis ConfTPCclustersBins{"ConfTPCClustersBins", {163, -0.5, 162.5}, "Binning of TPC found clusters plot"};
   Configurable<int> ConfTempFitVarMomentum{"ConfTempFitVarMomentum", 0, "Momentum used for binning: 0 -> pt; 1 -> preco; 2 -> ptpc"};
   ConfigurableAxis ConfDummy{"ConfDummy", {1, 0, 1}, "Dummy axis for inv mass"};
@@ -101,7 +102,7 @@ struct femtoDreamDebugTrack {
   void init(InitContext&)
   {
     eventHisto.init(&qaRegistry, ConfIsMC);
-    trackHisto.init(&qaRegistry, ConfBinmult, ConfBinmultPercentile, ConfBinpT, ConfBineta, ConfBinphi, ConfTempFitVarBins, ConfNsigmaTPCBins, ConfNsigmaTOFBins, ConfNsigmaTPCTOFBins, ConfTPCclustersBins, ConfDummy, ConfIsMC, ConfTrk1_PDGCode.value, true, ConfOptCorrelatedPlots);
+    trackHisto.init(&qaRegistry, ConfBinmult, ConfBinmultPercentile, ConfBinpT, ConfBineta, ConfBinphi, ConfTempFitVarBins, ConfNsigmaTPCBins, ConfNsigmaTOFBins, ConfNsigmaTPCTOFBins, ConfNsigmaITSBins, ConfDummy, ConfIsMC, ConfTrk1_PDGCode.value, true, ConfOptCorrelatedPlots);
   }
 
   /// Porduce QA plots for sigle track selection in FemtoDream framework

--- a/PWGCF/FemtoDream/Tasks/femtoDreamDebugV0.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamDebugV0.cxx
@@ -55,6 +55,7 @@ struct femtoDreamDebugV0 {
   ConfigurableAxis ConfV0ChildNsigmaTPCBins{"ConfV0ChildNsigmaTPCBins", {1600, -8, 8}, "binning of Nsigma TPC plot"};
   ConfigurableAxis ConfV0ChildNsigmaTOFBins{"ConfV0ChildNsigmaTOFBins", {3000, -15, 15}, "binning of the Nsigma TOF plot"};
   ConfigurableAxis ConfV0ChildNsigmaTPCTOFBins{"ConfV0ChildNsigmaTPCTOFBins", {1000, 0, 10}, "binning of the Nsigma TPC+TOF plot"};
+  ConfigurableAxis ConfV0ChildNsigmaITSBins{"ConfV0ChildNsigmaITSBins", {600, -3, 3}, "binning of the Nsigma ITS plot"};
 
   Configurable<aod::femtodreamparticle::cutContainerType> ConfV01_ChildPos_CutBit{"ConfV01_ChildPos_CutBit", 150, "Positive Child of V0 - Selection bit from cutCulator"};
   Configurable<aod::femtodreamparticle::cutContainerType> ConfV01_ChildPos_TPCBit{"ConfV01_ChildPos_TPCBit", 4, "Positive Child of V0 - PID bit from cutCulator"};
@@ -80,9 +81,9 @@ struct femtoDreamDebugV0 {
   void init(InitContext&)
   {
     eventHisto.init(&EventRegistry, false);
-    posChildHistos.init(&V0Registry, ConfBinmult, ConfDummy, ConfV0ChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfChildTempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfDummy, ConfV0InvMassBins, false, ConfV01_ChildPos_PDGCode.value, true);
-    negChildHistos.init(&V0Registry, ConfBinmult, ConfDummy, ConfV0ChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfChildTempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfDummy, ConfV0InvMassBins, false, ConfV01_ChildNeg_PDGCode, true);
-    V0Histos.init(&V0Registry, ConfBinmult, ConfDummy, ConfV0TempFitVarMomentumBins, ConfDummy, ConfDummy, ConfV0TempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfDummy, ConfV0InvMassBins, false, ConfV01_PDGCode.value, true);
+    posChildHistos.init(&V0Registry, ConfBinmult, ConfDummy, ConfV0ChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfChildTempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfV0ChildNsigmaITSBins, ConfV0InvMassBins, false, ConfV01_ChildPos_PDGCode.value, true);
+    negChildHistos.init(&V0Registry, ConfBinmult, ConfDummy, ConfV0ChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfChildTempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfV0ChildNsigmaITSBins, ConfV0InvMassBins, false, ConfV01_ChildNeg_PDGCode, true);
+    V0Histos.init(&V0Registry, ConfBinmult, ConfDummy, ConfV0TempFitVarMomentumBins, ConfDummy, ConfDummy, ConfV0TempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfV0ChildNsigmaITSBins, ConfV0InvMassBins, false, ConfV01_PDGCode.value, true);
   }
 
   /// Porduce QA plots for V0 selection in FemtoDream framework

--- a/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.h
+++ b/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.h
@@ -338,22 +338,40 @@ class FemtoDreamCutculator
     std::sort(mPIDValues.begin(), mPIDValues.end(), std::greater<>());
     int Bit = 0;
 
+    std::cout << "Activate ITS PID (only valid for tracks)? (y/n)";
+    std::string choicePID;
+    std::cin >> choicePID;
+
     std::cout << "+++++++++++++++++++++++++++++++++" << std::endl;
-    for (std::size_t i = 0; i < mPIDspecies.size(); i++) {
-      for (std::size_t j = 0; j < mPIDValues.size(); j++) {
-        std::cout << "Species " << o2::track::PID::getName(mPIDspecies.at(i)) << " with |NSigma|<" << mPIDValues.at(j) << std::endl;
-        Bit = (2 * mPIDspecies.size() * (mPIDValues.size() - (j + 1)) + 1) + (mPIDspecies.size() - (1 + i)) * 2;
-        std::cout << "Bit for Nsigma TPC: " << (1 << (Bit + 1)) << std::endl;
-        std::cout << "Bit for Nsigma TPCTOF: " << (1 << Bit) << std::endl;
-        std::cout << "+++++++++++++++++++++++++++++++++" << std::endl;
+    if (choicePID == std::string("n")) {
+      for (std::size_t i = 0; i < mPIDspecies.size(); i++) {
+        for (std::size_t j = 0; j < mPIDValues.size(); j++) {
+          std::cout << "Species " << o2::track::PID::getName(mPIDspecies.at(i)) << " with |NSigma|<" << mPIDValues.at(j) << std::endl;
+          Bit = (2 * mPIDspecies.size() * (mPIDValues.size() - (j + 1)) + 1) + (mPIDspecies.size() - (1 + i)) * 2;
+          std::cout << "Bit for Nsigma TPC: " << (1 << (Bit + 1)) << std::endl;
+          std::cout << "Bit for Nsigma TPCTOF: " << (1 << Bit) << std::endl;
+          std::cout << "+++++++++++++++++++++++++++++++++" << std::endl;
+        }
+        if (SysChecks) {
+          // Seed the random number generator
+          // Select a random element
+          randomIndex = uni(rng);
+          std::cout << "Nsigma TPC: " << mPIDValues[randomIndex] << std::endl;
+          randomIndex = uni(rng);
+          std::cout << "Nsigma TPCTOF: " << mPIDValues[randomIndex] << std::endl;
+        }
       }
-      if (SysChecks) {
-        // Seed the random number generator
-        // Select a random element
-        randomIndex = uni(rng);
-        std::cout << "Nsigma TPC: " << mPIDValues[randomIndex] << std::endl;
-        randomIndex = uni(rng);
-        std::cout << "Nsigma TPCTOF: " << mPIDValues[randomIndex] << std::endl;
+    } else {
+      for (std::size_t i = 0; i < mPIDspecies.size(); i++) {
+        for (std::size_t j = 0; j < mPIDValues.size(); j++) {
+          std::cout << "Species " << o2::track::PID::getName(mPIDspecies.at(i)) << " with |NSigma|<" << mPIDValues.at(j) << std::endl;
+          // Bit = (2 * mPIDspecies.size() * (mPIDValues.size() - (j + 1)) + 1) + (mPIDspecies.size() - (1 + i)) * 2;
+          Bit = (3 * mPIDspecies.size() * (mPIDValues.size() - (j + 1)) + 1) + (mPIDspecies.size() - (1 + i)) * 3;
+          std::cout << "Bit for Nsigma TPC: " << (1 << (Bit + 2)) << std::endl;
+          std::cout << "Bit for Nsigma TPCTOF: " << (1 << (Bit + 1)) << std::endl;
+          std::cout << "Bit for Nsigma ITS: " << (1 << Bit) << std::endl;
+          std::cout << "+++++++++++++++++++++++++++++++++" << std::endl;
+        }
       }
     }
   }

--- a/PWGHF/HFC/TableProducer/femtoDreamProducer.cxx
+++ b/PWGHF/HFC/TableProducer/femtoDreamProducer.cxx
@@ -228,9 +228,10 @@ struct HfFemtoDreamProducer {
                      particle.tofNSigmaKa(),
                      particle.tofNSigmaPr(),
                      particle.tofNSigmaDe(),
-                     -999.,
-                     -999.,
-                     -999., -999., -999., -999., -999., -999.);
+                     -999., -999., -999., -999.,
+                     -999., -999., -999., -999.,
+                     -999., -999., -999., -999.,
+                     -999., -999., -999., -999.);
   }
 
   template <typename CollisionType, typename ParticleType>
@@ -320,7 +321,7 @@ struct HfFemtoDreamProducer {
 
       trackCuts.fillQA<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::TrackType::kNoChild, true>(track);
       // the bit-wise container of the systematic variations is obtained
-      auto cutContainer = trackCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(track, track.pt(), track.eta(), sqrtf(powf(track.dcaXY(), 2.f) + powf(track.dcaZ(), 2.f)));
+      auto cutContainer = trackCuts.getCutContainer<false, aod::femtodreamparticle::cutContainerType>(track, track.pt(), track.eta(), sqrtf(powf(track.dcaXY(), 2.f) + powf(track.dcaZ(), 2.f)));
 
       // track global index
       outputPartsIndex(track.globalIndex());


### PR DESCRIPTION
Add ITS PID in femtodream for analysis with light nuclei.

Adding the ITS PID information it was necessary to add new columns to the debug table with the ITS information. Similarly, since new information is added to the bitmask for PID selection, changes to the cutculator had to be made.

Using ITS PID is optional in the producer and has to be activated explicitly. Similarly, the calculator asks the user if ITS PID is to be considered for the bitmask.