### PR TITLE
General types of inputs and outputs for MlResponse and OnnxModel

### DIFF
--- a/Tools/ML/MlResponse.h
+++ b/Tools/ML/MlResponse.h
@@ -158,7 +158,7 @@ class MlResponse
       LOG(fatal) << "Model index " << nModel << " is out of range! The number of initialised models is " << mModels.size() << ". Please check your configurables.";
     }
 
-    TypeOutputScore* outputPtr = mModels[nModel].evalModel(input);
+    TypeOutputScore* outputPtr = mModels[nModel].template evalModel<TypeOutputScore>(input);
     return std::vector<TypeOutputScore>{outputPtr, outputPtr + mNClasses};
   }
 


### PR DESCRIPTION
`MlResponse.h`
- I have updated ln 161 to resolve the template ambiguity issue first.

I plan to make a draft `MlResponse` to be capable of utilizing the most general types of inputs and outputs (multiple, variable-sized, multi-dimensional tensors). However, since I would like to use `MlResponse` as soon as possible, I would appreciate it if you could merge the current changes first, if possible.

Thank you.