### PR TITLE
[PWGJE] Add event rejection for MB-gap productions

### DIFF
--- a/PWGJE/Tasks/jetFinderQA.cxx
+++ b/PWGJE/Tasks/jetFinderQA.cxx
@@ -880,7 +880,7 @@ struct JetFinderQATask {
     }
     if (checkMcCollisionIsMatched) {
       auto collisionspermcpjet = collisions.sliceBy(CollisionsPerMCPCollision, jet.mcCollisionId());
-      if (collisionspermcpjet.size() >= 1) {
+      if (collisionspermcpjet.size() >= 1  && jetderiveddatautilities::selectCollision(collisionspermcpjet.begin(), eventSelection)) {
         fillMCPHistograms(jet, jet.eventWeight());
       }
     } else {


### PR DESCRIPTION
- option to reject events with event weight = 1 - required for MB-gap productions where only the weighted events should be analysed
- event selection fix for particle-level analysis