### PR TITLE
[PWGLF] Library cleanup for strangeness builder

### DIFF
--- a/PWGLF/TableProducer/Strangeness/CMakeLists.txt
+++ b/PWGLF/TableProducer/Strangeness/CMakeLists.txt
@@ -109,7 +109,7 @@ o2physics_add_dpl_workflow(strangederivedbuilder
 
 o2physics_add_dpl_workflow(strangenessbuilder
     SOURCES strangenessbuilder.cxx
-    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase KFParticle::KFParticle
+    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::DCAFitter KFParticle::KFParticle
     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(v0-selector

--- a/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
@@ -1124,7 +1124,7 @@ struct StrangenessBuilder {
       auto const& posTrack = v0.template posTrack_as<TTracks>();
       auto const& negTrack = v0.template negTrack_as<TTracks>();
       auto const& bachTrack = cascade.template bachelor_as<TTracks>();
-      if(v0Map[v0.globalIndex()]<0){
+      if (v0Map[v0.globalIndex()] < 0) {
         // this V0 hasn't been stored / cached
         cascdataLink(-1);
         interlinks.cascadeToCascCores.push_back(-1);

--- a/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
@@ -63,12 +63,12 @@ static const std::vector<std::string> tableNames{
   "V0MCCores",          //.21 (MC)
   "V0CoreMCLabels",     //.22 (MC)
   "V0MCCollRefs",       //.23 (MC)
-  "McCascLabels",       // 24 (MC/standard analysis)
-  "McKFCascLabels",     // 25 (MC)
-  "McTraCascLabels",    // 26 (MC)
-  "McCascBBTags",       // 27 (MC)
-  "CascMCCores",        // 28 (MC)
-  "CascCoreMCLabels",   // 29 (MC)
+  "McCascLabels",       //.24 (MC/standard analysis)
+  "McKFCascLabels",     //.25 (MC)
+  "McTraCascLabels",    //.26 (MC)
+  "McCascBBTags",       //.27 (MC)
+  "CascMCCores",        //.28 (MC)
+  "CascCoreMCLabels",   //.29 (MC)
   "CascMCCollRefs",     // 30 (MC)
   "StraCollision",      // 31 (derived)
   "StraCollLabels",     // 32 (derived)
@@ -1124,6 +1124,12 @@ struct StrangenessBuilder {
       auto const& posTrack = v0.template posTrack_as<TTracks>();
       auto const& negTrack = v0.template negTrack_as<TTracks>();
       auto const& bachTrack = cascade.template bachelor_as<TTracks>();
+      if(v0Map[v0.globalIndex()]<0){
+        // this V0 hasn't been stored / cached
+        cascdataLink(-1);
+        interlinks.cascadeToCascCores.push_back(-1);
+        continue; // didn't work out, skip
+      }
       if (!straHelper.buildCascadeCandidate(collision,
                                             v0sFromCascades[v0Map[v0.globalIndex()]],
                                             posTrack,


### PR DESCRIPTION
Meant to do further reduction of memory footprint of the new strangeness builder via removal of the unnecessary `O2::DetectorsBase`. 

For the record, current numbers indicate that the replacement of the `lambdakzerobuilder` and `cascadebuilder` as well as of the labeler services ('mc' builders) leads to a reduction of up to 1GB of memory use already, even still pulling in the entire `DetectorsBase` (which is unnecessary). Speed is also significantly better and is currently being tested. V0s have been proven to be fully equivalent to the ones provided by the canonical `lambdakzerobuilder`; cascades to be tested.