### PR TITLE
[PWGCF] FemtoDream: Implementing Cascades

### DIFF
--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -111,9 +111,10 @@ static constexpr std::string_view TempFitVarName[kNParticleTypes] = {"/hDCAxy", 
 using cutContainerType = uint32_t; //! Definition of the data type for the bit-wise container for the different selection criteria
 
 enum TrackType {
-  kNoChild,    //! Not a V0 child
+  kNoChild,    //! Not any child
   kPosChild,   //! Positive V0 child
   kNegChild,   //! Negative V0 child
+  kBachelor,   //! Bachelor Cascade child
   kNTrackTypes //! Number of child types
 };
 

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -94,6 +94,8 @@ enum ParticleType {
   kV0,              //! V0
   kV0Child,         //! Child track of a V0
   kCascade,         //! Cascade
+  kCascadeV0,
+  kCascadeV0Child,
   kCascadeBachelor, //! Bachelor track of a cascade
   kCharmHadron,     //! Bachelor track of a cascade
   kNParticleTypes   //! Number of particle types
@@ -105,8 +107,8 @@ enum MomentumType {
   kPtpc   //! momentum at the inner wall of the TPC (useful for PID plots)
 };
 
-static constexpr std::string_view ParticleTypeName[kNParticleTypes] = {"Tracks", "V0", "V0Child", "Cascade", "CascadeBachelor", "CharmHadron"}; //! Naming of the different particle types
-static constexpr std::string_view TempFitVarName[kNParticleTypes] = {"/hDCAxy", "/hCPA", "/hDCAxy", "/hCPA", "/hDCAxy", "/hCPA"};
+static constexpr std::string_view ParticleTypeName[kNParticleTypes] = {"Tracks", "V0", "V0Child", "Cascade", "CascadeV0", "CascadeV0Child", "CascadeBachelor", "CharmHadron"}; //! Naming of the different particle types
+static constexpr std::string_view TempFitVarName[kNParticleTypes] = {"/hDCAxy", "/hCPA", "/hDCAxy", "/hCPA", "/hCPA", "/hDCAxy", "/hDCAxy", "/hCPA"};
 
 using cutContainerType = uint32_t; //! Definition of the data type for the bit-wise container for the different selection criteria
 
@@ -118,7 +120,7 @@ enum TrackType {
   kNTrackTypes //! Number of child types
 };
 
-static constexpr std::string_view TrackTypeName[kNTrackTypes] = {"Trk", "Pos", "Neg"}; //! Naming of the different particle types
+static constexpr std::string_view TrackTypeName[kNTrackTypes] = {"Trk", "Pos", "Neg", "Bach"}; //! Naming of the different particle types
 
 DECLARE_SOA_INDEX_COLUMN(FDCollision, fdCollision);
 DECLARE_SOA_COLUMN(Pt, pt, float);                       //! p_T (GeV/c)

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -90,10 +90,10 @@ namespace femtodreamparticle
 {
 /// Distinuishes the different particle types
 enum ParticleType {
-  kTrack,           //! Track
-  kV0,              //! V0
-  kV0Child,         //! Child track of a V0
-  kCascade,         //! Cascade
+  kTrack,   //! Track
+  kV0,      //! V0
+  kV0Child, //! Child track of a V0
+  kCascade, //! Cascade
   kCascadeV0,
   kCascadeV0Child,
   kCascadeBachelor, //! Bachelor track of a cascade

--- a/PWGCF/FemtoDream/Core/femtoDreamCascadeSelection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamCascadeSelection.h
@@ -665,7 +665,6 @@ bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& c
   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeDecVtxZ"), decVtx.at(2));
   }
   }
-  //LOGF(info, "GG CascadeSelection: Passing Xi!"); //REMOVE COMMENT
   
   
   //v0 criteria
@@ -757,7 +756,6 @@ bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& c
       return false;
     }
   */
-  //LOGF(info, "GG CascadeSelection: A Xi is selected!"); //REMOVE COMMENT
   return true;
 }
 
@@ -823,9 +821,9 @@ std::array<cutContainerType, 8> FemtoDreamCascadeSelection::getCutContainer(Col 
 {
   //Cut bit
   //auto outputV0Daugh = V0DaughSel.getCutContainer<cutContainerType>(v0Daugh, posTrack, negTrack);
-  auto outputPosTrack = PosDaughTrack.getCutContainer<cutContainerType>(posTrack, casc.positivept(), casc.positiveeta(), casc.dcapostopv());
-  auto outputNegTrack = NegDaughTrack.getCutContainer<cutContainerType>(negTrack, casc.negativept(), casc.negativeeta(), casc.dcanegtopv());
-  auto outputBachTrack = BachTrack.getCutContainer<cutContainerType>(bachTrack, casc.bachelorpt(), casc.bacheloreta(), casc.dcabachtopv());
+  auto outputPosTrack = PosDaughTrack.getCutContainer<false, cutContainerType>(posTrack, casc.positivept(), casc.positiveeta(), casc.dcapostopv());
+  auto outputNegTrack = NegDaughTrack.getCutContainer<false, cutContainerType>(negTrack, casc.negativept(), casc.negativeeta(), casc.dcanegtopv());
+  auto outputBachTrack = BachTrack.getCutContainer<false, cutContainerType>(bachTrack, casc.bachelorpt(), casc.bacheloreta(), casc.dcabachtopv());
   cutContainerType output = 0;
   size_t counter = 0;
 
@@ -937,13 +935,6 @@ std::array<cutContainerType, 8> FemtoDreamCascadeSelection::getCutContainer(Col 
     //}
   } //for loop
 
-    /*
-    outputV0Daugh.at(0), //daughter V0
-    outputV0Daugh.at(1), //posDaughterCuts
-    outputV0Daugh.at(2), //posDaughterPID
-    outputV0Daugh.at(3), //negDaughterCuts
-    outputV0Daugh.at(4), //negDaugherPID
-    */
   return {
     output,
     outputPosTrack.at(femtoDreamTrackSelection::TrackContainerPosition::kCuts),

--- a/PWGCF/FemtoDream/Core/femtoDreamCascadeSelection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamCascadeSelection.h
@@ -1,0 +1,583 @@
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file femtoDreamCascadeSelection.h
+/// \brief Definition of the femtoDreamCascadeSelection
+/// \author Valentina Mantovani Sarti, TU München valentina.mantovani-sarti@tum.de
+/// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
+/// \author Luca Barioglio, TU München, luca.barioglio@cern.ch
+/// \author Zuzanna Chochulska, WUT Warsaw & CTU Prague, zchochul@cern.ch
+/// \author Barbara Chytla, WUT Warsaw, barbara.chytla@cern.ch
+/// \author Shirajum Monira, WUT Warsaw, shirajum.monira@cern.ch
+
+#ifndef PWGCF_FEMTODREAM_CORE_FEMTODREAMCASCADESELECTION_H_
+#define PWGCF_FEMTODREAM_CORE_FEMTODREAMCASCADESELECTION_H_
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <TDatabasePDG.h> // FIXME
+
+#include "PWGCF/FemtoDream/Core/femtoDreamObjectSelection.h"
+#include "PWGCF/FemtoDream/Core/femtoDreamSelection.h"
+#include "PWGCF/FemtoDream/Core/femtoDreamTrackSelection.h"
+
+#include "Common/Core/RecoDecay.h"
+#include "Framework/HistogramRegistry.h"
+#include "ReconstructionDataFormats/PID.h"
+
+using namespace o2::framework;
+
+namespace o2::analysis::femtoDream
+{
+namespace femtoDreamCascadeSelection
+{
+/// The different selections this task is capable of doing
+enum CascadeSel {
+  kCascadeSign, ///< +1 particle, -1 antiparticle
+  kCascadepTMin,
+  kCascadepTMax,
+};
+
+enum ChildTrackType { kPosTrack,
+                      kNegTrack,
+                      kBachTrack };
+
+/*enum CascadeContainerPosition {
+  kCascade,
+  kPosCuts,
+  kPosPID,
+  kNegCuts,
+  kNegPID,
+}; /// Position in the full VO cut container (for cutculator)
+*/
+} // namespace femtoDreamCascadeSelection
+
+/// \class FemtoDreamCascadeSelection
+/// \brief Cut class to contain and execute all cuts applied to Cascades
+class FemtoDreamCascadeSelection
+  : public FemtoDreamObjectSelection<float, femtoDreamCascadeSelection::CascadeSel>
+{
+ public:
+  FemtoDreamCascadeSelection()
+    : nPtCascadeMinSel(0), nPtCascadeMaxSel(0), pTCascadeMin(9999999.), pTCascadeMax(-9999999.) , fInvMassLowLimit(1.25), fInvMassUpLimit(1.4), fRejectCompetingMass(false), fInvMassCompetingLowLimit(1.5), fInvMassCompetingUpLimit(2.0), isCascOmega(false)
+  {
+  }
+
+  /// Initializes histograms for the task
+  template <o2::aod::femtodreamparticle::ParticleType part,
+            o2::aod::femtodreamparticle::ParticleType v0daugh,
+            o2::aod::femtodreamparticle::ParticleType bach,
+            typename cutContainerType>
+  void init(HistogramRegistry* QAregistry, HistogramRegistry* Registry, bool isSelectCascOmega = false);
+
+  template <typename Col, typename Casc, typename Track>
+  bool isSelectedMinimal(Col const& col, Casc const& cascade, Track const& posTrack, Track const& negTrack, Track const& bachTrack);
+
+  template <typename Col, typename Casc, typename Track>
+  void fillCascadeQA(Col const& col, Casc const& cascade, Track const& posTrack, Track const& negTrack);
+
+  template <typename Col, typename Casc, typename Track>
+  void fillQA(Col const& col, Casc const& cascade, Track const& posTrack, Track const& negTrack, Track const& bachTrack);
+
+  template <typename cutContainerType, typename Col, typename Casc, typename Track>
+  std::array<cutContainerType, 8> getCutContainer(Col const& /*col*/, Casc const& casc, Track const& posTrack, Track const& negTrack, Track const& bachTrack);
+
+  template <typename T1, typename T2>
+  void setChildCuts(femtoDreamCascadeSelection::ChildTrackType child,
+                    T1 selVal,
+                    T2 selVar,
+                    femtoDreamSelection::SelectionType selType)
+  {
+    if (child == femtoDreamCascadeSelection::kPosTrack) {
+      PosDaughTrack.setSelection(selVal, selVar, selType);
+    } else if (child == femtoDreamCascadeSelection::kNegTrack) {
+      NegDaughTrack.setSelection(selVal, selVar, selType);
+    } else if (child == femtoDreamCascadeSelection::kBachTrack) {
+      BachTrack.setSelection(selVal, selVar, selType);
+    }
+  }
+
+  template <typename T>
+  void setChildPIDSpecies(femtoDreamCascadeSelection::ChildTrackType child,
+                          T& pids)
+  {
+    if (child == femtoDreamCascadeSelection::kPosTrack) {
+      PosDaughTrack.setPIDSpecies(pids);
+    } else if (child == femtoDreamCascadeSelection::kNegTrack) {
+      NegDaughTrack.setPIDSpecies(pids);
+    } else if (child == femtoDreamCascadeSelection::kBachTrack) {
+      BachTrack.setPIDSpecies(pids);
+    }
+  }
+
+  /// Helper function to obtain the name of a given selection criterion for consistent naming of the configurables
+  /// \param iSel Track selection variable to be examined
+  /// \param prefix Additional prefix for the name of the configurable
+  /// \param suffix Additional suffix for the name of the configurable
+  static std::string getSelectionName(femtoDreamCascadeSelection::CascadeSel iSel,
+                                      std::string_view prefix = "",
+                                      std::string_view suffix = "")
+  {
+    std::string outString = static_cast<std::string>(prefix);
+    outString += static_cast<std::string>(mSelectionNames[iSel]);
+    outString += suffix;
+    return outString;
+  }
+
+  /// Helper function to obtain the helper string of a given selection criterion
+  /// for consistent description of the configurables
+  /// \param iSel Track selection variable to be examined
+  /// \param prefix Additional prefix for the output of the configurable
+  static std::string getSelectionHelper(femtoDreamCascadeSelection::CascadeSel iSel,
+                                        std::string_view prefix = "")
+  {
+    std::string outString = static_cast<std::string>(prefix);
+    outString += static_cast<std::string>(mSelectionHelper[iSel]);
+    return outString;
+  }
+
+  /// Set limit for the selection on the invariant mass
+  /// \param lowLimit Lower limit for the invariant mass distribution
+  /// \param upLimit Upper limit for the invariant mass distribution
+  void setInvMassLimits(float lowLimit, float upLimit)
+  {
+    fInvMassLowLimit = lowLimit;
+    fInvMassUpLimit = upLimit;
+  }
+
+  /// Set limit for the omega rejection on the invariant mass
+  /// \param lowLimit Lower limit for the invariant mass distribution
+  /// \param upLimit Upper limit for the invariant mass distribution
+  void setCompetingInvMassLimits(float lowLimit, float upLimit)
+  {
+    fRejectCompetingMass = true;
+    fInvMassCompetingLowLimit = lowLimit;
+    fInvMassCompetingUpLimit = upLimit;
+  }
+
+ private:
+  int nPtCascadeMinSel;
+  int nPtCascadeMaxSel;
+  float pTCascadeMin;
+  float pTCascadeMax;
+  
+  float fInvMassLowLimit;
+  float fInvMassUpLimit;
+
+  float fRejectCompetingMass;
+  float fInvMassCompetingLowLimit;
+  float fInvMassCompetingUpLimit;
+
+  bool isCascOmega;
+
+  // float nSigmaPIDOffsetTPC;
+
+  FemtoDreamTrackSelection PosDaughTrack;
+  FemtoDreamTrackSelection NegDaughTrack;
+  FemtoDreamTrackSelection BachTrack;
+
+  static constexpr int kNcascadeSelection = 20; // can I do less ?
+
+  static constexpr std::string_view mSelectionNames[kNcascadeSelection] = {
+    "Sign", "PtMin", "PtMax"};
+    /*
+    "Sign", "PtMin", "PtMax", "EtaMax", "DCAv0daughMax", "v0CPAMin",
+    "v0TranRadMin", "v0TranRadMax", "v0DecVecMax", "DCAcascDaugh",
+    "CPAMin", "TranRadMin", "TranRadMax", "DecVtxMax",
+    "DCAPosToPV", "DCANegToPV", "DCABachToPV", "DCAV0ToPV",
+    "kV0MassMin", "V0MassMax"}; ///< Name of the different
+                                ///< selections
+    */ 
+
+  static constexpr femtoDreamSelection::SelectionType
+    mSelectionTypes[kNcascadeSelection]{
+      femtoDreamSelection::kEqual,      // sign
+      femtoDreamSelection::kLowerLimit, // pt min
+      femtoDreamSelection::kUpperLimit, // pt max
+    }; ///< Map to match a variable with
+       ///< its type
+
+  static constexpr std::string_view mSelectionHelper[kNcascadeSelection] = {
+    "Cascade particle sign (+1 or -1)",
+    "Minimum pT (GeV/c)",
+    "Maximum pT (GeV/c)"}; ///< Helper information for the
+                        ///< different selections
+
+}; // namespace femtoDream
+
+template <o2::aod::femtodreamparticle::ParticleType part, o2::aod::femtodreamparticle::ParticleType daugh, o2::aod::femtodreamparticle::ParticleType bach, typename cutContainerType>
+void FemtoDreamCascadeSelection::init(HistogramRegistry* QAregistry, HistogramRegistry* Registry, bool isSelectCascOmega)
+{
+
+  if (QAregistry && Registry) {
+    mHistogramRegistry = Registry;
+    mQAHistogramRegistry = QAregistry;
+    fillSelectionHistogram<part>();  // cascade
+    fillSelectionHistogram<daugh>(); // pos, neg
+    fillSelectionHistogram<bach>();  // bach
+
+    AxisSpec massAxisCascade = {2200, 1.25f, 1.8f, "m_{#Cascade} (GeV/#it{c}^{2})"};
+    AxisSpec ptAxis = {100, 0.0f, 10.0f, "#it{p}_{T} (GeV/#it{c})"};
+    /*
+    AxisSpec massAxisV0 = {600, 0.0f, 3.0f, "m_{#V0} (GeV/#it{c}^{2})"};
+    AxisSpec DCADaughAxis = {1000, 0.0f, 2.0f, "DCA (cm)"};
+    AxisSpec DCAToPVAxis = {1000, -10.0f, 10.0f, "DCA to PV (cm)"};
+    AxisSpec etaAxis = {100, -2.0f, 2.0f, "#it{#eta}"};
+    AxisSpec phiAxis = {100, 0.0f, 6.0f, "#it{#phi}"};
+    AxisSpec CPAAxis = {1000, 0.95f, 1.0f, "#it{cos #theta_{p}}"};
+    AxisSpec tranRadAxis = {1000, 0.0f, 100.0f, "#it{r}_{xy} (cm)"};
+    */
+
+    /// \todo this should be an automatic check in the parent class, and the
+    /// return type should be templated
+    size_t nSelections = getNSelections();
+    if (nSelections > 3 * sizeof(cutContainerType)) {
+      LOG(fatal) << "FemtoDreamCascadeCuts: Number of selections to large for your "
+                    "container - quitting!";
+    }
+
+    PosDaughTrack.init<aod::femtodreamparticle::ParticleType::kV0Child,
+                       aod::femtodreamparticle::TrackType::kPosChild,
+                       aod::femtodreamparticle::cutContainerType>(
+      mQAHistogramRegistry, mQAHistogramRegistry);
+    NegDaughTrack.init<aod::femtodreamparticle::ParticleType::kV0Child,
+                       aod::femtodreamparticle::TrackType::kNegChild,
+                       aod::femtodreamparticle::cutContainerType>(
+      mQAHistogramRegistry, mQAHistogramRegistry);
+    BachTrack.init<aod::femtodreamparticle::ParticleType::kCascadeBachelor,
+                   aod::femtodreamparticle::TrackType::kBachelor,
+                   aod::femtodreamparticle::cutContainerType>(
+      mQAHistogramRegistry, mQAHistogramRegistry);
+
+    // V0 (Lambda)
+    //mQAHistogramRegistry->add("CascadeQA/hInvMassV0NoCuts", "No cuts", kTH1F, {massAxisV0});
+    // mQAHistogramRegistry->add("CascadeQA/hInvMassV0Cut", "Invariant mass cut", kTH1F, {massAxisV0});
+    // mQAHistogramRegistry->add("CascadeQA/hDCAV0Daugh", "V0-daughters DCA", kTH1F, {DCADaughAxis});
+    // mQAHistogramRegistry->add("CascadeQA/hV0CPA", "V0 cos PA", kTH1F, {CPAAxis});
+    // mQAHistogramRegistry->add("CascadeQA/hV0TranRad", "V0 transverse radius", kTH1F, {tranRadAxis});
+    // mQAHistogramRegistry->add("CascadeQA/hV0DecVtxMax", "V0 maximum distance on decay vertex", kTH1F, {massAxisV0});
+
+    // Cascade (Xi, Omega)
+    // mQAHistogramRegistry->add("CascadeQA/hInvMassCascadeNoCuts", "No cuts", kTH1F, {massAxisCascade});
+    mQAHistogramRegistry->add("CascadeQA/hInvMassCascadeCut", "Invariant mass with cut", kTH1F, {massAxisCascade});
+    mQAHistogramRegistry->add("CascadeQA/hCascadePt", "pT distribution", kTH1F, {ptAxis});
+    // mQAHistogramRegistry->add("CascadeQA/hCascadeEta", "Eta distribution", kTH1F, {etaAxis});
+    // mQAHistogramRegistry->add("CascadeQA/hCascadePhi", "Phi distribution", kTH1F, {phiAxis});
+    // mQAHistogramRegistry->add("CascadeQA/hDCACascadeDaugh", "Cascade-daughters DCA", kTH1F, {DCADaughAxis});
+    // mQAHistogramRegistry->add("CascadeQA/hCascadeCPA", "Cos PA", kTH1F, {CPAAxis});
+    // mQAHistogramRegistry->add("CascadeQA/hCascadeTranRad", "Transverse radius", kTH1F, {tranRadAxis});
+    // mQAHistogramRegistry->add("CascadeQA/hDCAPosToPV", "Pos V0 daughter DCA to primary vertex", kTH1F, {DCAToPVAxis});
+    // mQAHistogramRegistry->add("CascadeQA/hDCANegToPV", "Neg V0 daughter DCA to primary vertex", kTH1F, {DCAToPVAxis});
+    // mQAHistogramRegistry->add("CascadeQA/hDCABachToPV", "Bachelor DCA to primary vertex", kTH1F, {DCAToPVAxis});
+    // mQAHistogramRegistry->add("CascadeQA/hDCAV0ToPV", "V0 DCA to primary vertex", kTH1F, {DCAToPVAxis});
+  }
+
+  /// check whether the most open cuts are fulfilled - most of this should have
+  /// already be done by the filters
+  nPtCascadeMinSel = getNSelections(femtoDreamCascadeSelection::kCascadepTMin);
+  nPtCascadeMaxSel = getNSelections(femtoDreamCascadeSelection::kCascadepTMax);
+  // nEtaCascadeMaxSel = getNSelections(femtoDreamCascadeSelection::kCascadeetaMax);
+  // nDCAV0DaughMax = getNSelections(femtoDreamCascadeSelection::kCascadeV0DCADaughMax);
+  // nCPAV0Min = getNSelections(femtoDreamCascadeSelection::kCascadeV0CPAMin);
+  // nTranRadV0Min = getNSelections(femtoDreamCascadeSelection::kCascadeV0TranRadMin);
+  // nTranRadV0Max = getNSelections(femtoDreamCascadeSelection::kCascadeV0TranRadMax);
+  // nV0DecVtxMax = getNSelections(femtoDreamCascadeSelection::kCascadeV0DecVtxMax);
+  // nDCACascadeDaughMax = getNSelections(femtoDreamCascadeSelection::kCascadeDCADaughMax);
+  // nCPACascadeMin = getNSelections(femtoDreamCascadeSelection::kCascadeCPAMin);
+  // nTranRadCascadeMin = getNSelections(femtoDreamCascadeSelection::kCascadeTranRadMin);
+  // nTranRadCascadeMax = getNSelections(femtoDreamCascadeSelection::kCascadeTranRadMax);
+  // nDecVtxMax = getNSelections(femtoDreamCascadeSelection::kCascadeDecVtxMax);
+  // nDCAPosToPV = getNSelections(femtoDreamCascadeSelection::kCascadeDCAPosToPV);
+  // nDCANegToPV = getNSelections(femtoDreamCascadeSelection::kCascadeDCANegToPV);
+  // nDCABachToPV = getNSelections(femtoDreamCascadeSelection::kCascadeDCABachToPV);
+  // nDCAV0ToPV = getNSelections(femtoDreamCascadeSelection::kCascadeDCAV0ToPV);
+  // dodac V0 mass min i max
+
+  pTCascadeMin = getMinimalSelection(femtoDreamCascadeSelection::kCascadepTMin,
+                                     femtoDreamSelection::kLowerLimit);
+  pTCascadeMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadepTMax,
+                                     femtoDreamSelection::kUpperLimit);
+  // etaCascadeMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeetaMax,
+  //                                     femtoDreamSelection::kAbsUpperLimit);
+  // DCAV0DaughMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0DCADaughMax,
+  //                                     femtoDreamSelection::kUpperLimit);
+  // CPAV0Min = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0CPAMin,
+  //                                femtoDreamSelection::kLowerLimit);
+  // TranRadV0Min = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0TranRadMin,
+  //                                    femtoDreamSelection::kLowerLimit);
+  // TranRadV0Max = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0TranRadMax,
+  //                                    femtoDreamSelection::kUpperLimit);
+  // V0DecVtxMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0DecVtxMax,
+  //                                   femtoDreamSelection::kAbsUpperLimit);
+  // DCACascadeDaughMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeDCADaughMax,
+  //                                          femtoDreamSelection::kUpperLimit);
+  // CPACascadeMin = getMinimalSelection(femtoDreamCascadeSelection::kCascadeCPAMin,
+  //                                     femtoDreamSelection::kLowerLimit);
+  // TranRadCascadeMin = getMinimalSelection(femtoDreamCascadeSelection::kCascadeTranRadMin,
+  //                                         femtoDreamSelection::kLowerLimit);
+  // TranRadCascadeMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeTranRadMax,
+  //                                         femtoDreamSelection::kUpperLimit);
+  // DecVtxMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeDecVtxMax,
+  //                                 femtoDreamSelection::kAbsUpperLimit);
+  // DCAPosToPV = getMinimalSelection(femtoDreamCascadeSelection::kCascadeDCAPosToPV,
+  //                                  femtoDreamSelection::kLowerLimit);
+  // DCANegToPV = getMinimalSelection(femtoDreamCascadeSelection::kCascadeDCANegToPV,
+  //                                  femtoDreamSelection::kLowerLimit);
+  // DCABachToPV = getMinimalSelection(femtoDreamCascadeSelection::kCascadeDCABachToPV,
+  //                                   femtoDreamSelection::kLowerLimit);
+  // DCAV0ToPV = getMinimalSelection(femtoDreamCascadeSelection::kCascadeDCAV0ToPV,
+  //                                 femtoDreamSelection::kLowerLimit);
+  // fV0InvMassLowLimit = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0MassMin,
+  //                                          femtoDreamSelection::kLowerLimit);
+  // fV0InvMassUpLimit = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0MassMax,
+  //                                           femtoDreamSelection::kUpperLimit);
+  isCascOmega = isSelectCascOmega;
+}
+
+template <typename Col, typename Casc, typename Track>
+bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& cascade, Track const& posTrack, Track const& negTrack, Track const& bachTrack)
+{
+  const auto signPos = posTrack.sign();
+  const auto signNeg = negTrack.sign();
+
+  if (signPos < 0 || signNeg > 0) {
+    LOG(warn) << "Something wrong in isSelectedMinimal";
+    LOG(warn) << "ERROR - Wrong sign for V0 daughters";
+  }
+
+  const std::vector<float> decVtx = {cascade.x(), cascade.y(), cascade.z()};
+
+  //const float cpav0 = cascade.v0cosPA(col.posX(), col.posY(), col.posZ());
+  //const float cpaCasc = cascade.casccosPA(col.posX(), col.posY(), col.posZ());
+  //const float dcav0topv = cascade.dcav0topv(col.posX(), col.posY(), col.posZ());
+  // const float invMassLambda = cascade.mLambda();
+  const float invMass = isCascOmega ? cascade.mOmega() : cascade.mXi();
+
+  /*
+  if (invMassLambda < fV0InvMassLowLimit || invMassLambda > fV0InvMassUpLimit) {
+    return false;
+  }
+  */
+  if (invMass < fInvMassLowLimit || invMass > fInvMassUpLimit) {
+    return false;
+  }
+  if (fRejectCompetingMass) {
+    const float invMassCompeting = isCascOmega ? cascade.mXi() : cascade.mOmega();
+    if (invMassCompeting > fInvMassCompetingLowLimit &&
+        invMassCompeting < fInvMassCompetingUpLimit) {
+      return false;
+    }
+  }
+  if (nPtCascadeMinSel > 0 && cascade.pt() < pTCascadeMin) {
+    return false;
+  }
+  if (nPtCascadeMaxSel > 0 && cascade.pt() > pTCascadeMax) {
+    return false;
+  }
+  /*
+  if (nEtaCascadeMaxSel > 0 && std::abs(cascade.eta()) > etaCascadeMax) {
+    return false;
+  }
+  if (nDCAV0DaughMax > 0 && cascade.dcaV0daughters() > DCAV0DaughMax) {
+    return false;
+  }
+  if (nCPAV0Min > 0 && cpav0 < CPAV0Min) {
+    return false;
+  }
+  if (nTranRadV0Min > 0 && cascade.v0radius() < TranRadV0Min) {
+    return false;
+  }
+  if (nTranRadV0Max > 0 && cascade.v0radius() > TranRadV0Max) {
+    return false;
+  }
+  if (nDCACascadeDaughMax > 0 && cascade.dcacascdaughters() > DCACascadeDaughMax) {
+    return false;
+  }
+  if (nCPACascadeMin > 0 && cpaCasc < CPACascadeMin) {
+    return false;
+  }
+  if (nTranRadCascadeMin > 0 && cascade.cascradius() < TranRadCascadeMin) {
+    return false;
+  }
+  if (nTranRadCascadeMax > 0 && cascade.cascradius() > TranRadCascadeMax) {
+    return false;
+  }
+  for (size_t i = 0; i < decVtx.size(); i++) {
+    if (nDecVtxMax > 0 && decVtx.at(i) > DecVtxMax) {
+      return false;
+    }
+  }
+  if (nDCAPosToPV > 0 && abs(cascade.dcapostopv()) < DCAPosToPV) {
+    return false;
+  }
+  if (nDCANegToPV > 0 && abs(cascade.dcanegtopv()) < DCANegToPV) {
+    return false;
+  }
+  if (nDCABachToPV > 0 && abs(cascade.dcabachtopv()) < DCABachToPV) {
+    return false;
+  }
+  if (nDCAV0ToPV > 0 && abs(dcav0topv) < DCAV0ToPV) {
+    return false;
+  }
+
+  if (!PosDaughTrack.isSelectedMinimal(posTrack)) {
+    return false;
+  }
+  if (!NegDaughTrack.isSelectedMinimal(negTrack)) {
+    return false;
+  }
+  if (!BachTrack.isSelectedMinimal(bachTrack)) {
+    return false;
+  }
+  */
+
+  /*
+    // check that track combinations for V0 or antiV0 would be fulfilling PID
+    float nSigmaPIDMax = PosDaughTrack.getSigmaPIDMax();
+    // antiV0
+    auto nSigmaPrNeg = negTrack.tpcNSigmaPr();
+    auto nSigmaPiPos = posTrack.tpcNSigmaPi();
+    // v0
+    auto nSigmaPiNeg = negTrack.tpcNSigmaPi();
+    auto nSigmaPrPos = posTrack.tpcNSigmaPr();
+    if (!(abs(nSigmaPrNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax &&
+          abs(nSigmaPiPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax) &&
+        !(abs(nSigmaPrPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax &&
+          abs(nSigmaPiNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax)) {
+      return false;
+    }
+  */
+  return true;
+}
+
+template <typename Col, typename Casc, typename Track>
+void FemtoDreamCascadeSelection::fillCascadeQA(Col const& col, Casc const& cascade, Track const& posTrack, Track const& negTrack)
+{
+  const auto signPos = posTrack.sign();
+  const auto signNeg = negTrack.sign();
+  if (signPos < 0 || signNeg > 0) {
+    LOG(warn) << "Something wrong in isSelectedMinimal";
+    LOG(warn) << "ERROR - Wrong sign for V0 daughters";
+  }
+
+  // const std::vector<float> decVtx = {cascade.x(), cascade.y(), cascade.z()};
+  // const float cpav0 = cascade.v0cosPA(col.posX(), col.posY(), col.posZ());
+  // const float cpaCasc = cascade.casccosPA(col.posX(), col.posY(), col.posZ());
+  // const float dcav0topv = cascade.dcav0topv(col.posX(), col.posY(), col.posZ());
+
+  const float invMassLambda = cascade.mLambda();
+  const float invMass = isCascOmega ? cascade.mOmega() : cascade.mXi();
+
+  // mQAHistogramRegistry->fill(HIST("CascadeQA/hInvMassV0Cut"), invMassLambda);
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hInvMassCascadeCut"), invMass);
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadePt"), cascade.pt());
+  // mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeEta"), cascade.eta());
+  // mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadePhi"), cascade.phi());
+  // mQAHistogramRegistry->fill(HIST("CascadeQA/hDCAV0Daugh"), cascade.dcaV0daughters());
+  // mQAHistogramRegistry->fill(HIST("CascadeQA/hV0CPA"), cpav0);
+  // mQAHistogramRegistry->fill(HIST("CascadeQA/hV0TranRad"), cascade.v0radius());
+  // mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeCPA"), cpaCasc);
+  // mQAHistogramRegistry->fill(HIST("CascadeQA/hDCACascadeDaugh"), cascade.dcacascdaughters());
+  // mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeTranRad"), cascade.cascradius());
+  // mQAHistogramRegistry->fill(HIST("CascadeQA/hDCAPosToPV"), cascade.dcapostopv());
+  // mQAHistogramRegistry->fill(HIST("CascadeQA/hDCANegToPV"), cascade.dcanegtopv());
+  // mQAHistogramRegistry->fill(HIST("CascadeQA/hDCABachToPV"), cascade.dcabachtopv());
+  // mQAHistogramRegistry->fill(HIST("CascadeQA/hDCAV0ToPV"), dcav0topv);
+
+  // is this necessary
+  /*
+  bool write = true;
+  for (size_t i = 0; i < decVtx.size(); i++) {
+    write = write && (decVtx.at(i) < DecVtxMax);
+  }
+  if (write) {
+    mQAHistogramRegistry->fill(HIST("CAscadeQA/hInvMassCascadeDecVtxMax"),
+                             cascade.mXi());
+  }
+  */
+}
+
+template <typename cutContainerType, typename Col, typename Casc, typename Track>
+std::array<cutContainerType, 8> FemtoDreamCascadeSelection::getCutContainer(Col const& /*col*/, Casc const& casc, Track const& posTrack, Track const& negTrack, Track const& bachTrack)
+{
+  //Cut bit shenanigan
+  auto outputPosTrack = PosDaughTrack.getCutContainer<cutContainerType>(posTrack, casc.positivept(), casc.positiveeta(), casc.dcapostopv());
+  auto outputNegTrack = NegDaughTrack.getCutContainer<cutContainerType>(negTrack, casc.negativept(), casc.negativeeta(), casc.dcanegtopv());
+  auto outputBachTrack = BachTrack.getCutContainer<cutContainerType>(bachTrack, casc.bachelorpt(), casc.bacheloreta(), casc.dcabachtopv());
+  cutContainerType output = 0;
+  size_t counter = 0;
+
+  auto xiMassNominal = o2::constants::physics::MassXiMinus;
+  auto xiMassHypothesis = casc.mXi();
+  auto antiXiMassHypothesis = casc.mAntiXi();
+  auto diffXi = abs(xiMassNominal - xiMassHypothesis);
+  auto diffAntiXi = abs(xiMassNominal - antiXiMassHypothesis);
+
+  float sign = 0.;
+  int nSigmaPIDMax = PosDaughTrack.getSigmaPIDMax();
+  auto nSigmaV0Pr = posTrack.tpcNSigmaPr(); 
+  auto nSigmaV0Pi = negTrack.tpcNSigmaPi(); 
+  auto nSigmaV0Ba = posTrack.tpcNSigmaPr(); 
+  
+  auto nSigmaAntiV0Pr = negTrack.tpcNSigmaPr(); 
+  auto nSigmaAntiV0Pi = posTrack.tpcNSigmaPi(); 
+  auto nSigmaAntiV0Ba = bachTrack.tpcNSigmaPi(); 
+
+  if (diffAntiXi < diffXi) {
+    sign = -1.;
+  } else if (diffAntiXi > diffXi){
+    sign = 1.;
+  }
+
+  const auto pT = casc.pt();
+
+  float observable = 0.;
+  for (auto& sel : mSelections) {
+    const auto selVariable = sel.getSelectionVariable();
+    switch (selVariable) {
+      case (femtoDreamCascadeSelection::kCascadeSign):
+        observable = sign;
+        break;
+      case (femtoDreamCascadeSelection::kCascadepTMin):
+        observable = pT;
+        break;
+      case (femtoDreamCascadeSelection::kCascadepTMax):
+        observable = pT;
+        break;
+    } //switch
+    sel.checkSelectionSetBit(observable, output, counter, nullptr);
+  }
+  return {
+    output,
+    outputPosTrack.at(femtoDreamTrackSelection::TrackContainerPosition::kCuts),
+    outputPosTrack.at(femtoDreamTrackSelection::TrackContainerPosition::kPID),
+    outputNegTrack.at(femtoDreamTrackSelection::TrackContainerPosition::kCuts),
+    outputNegTrack.at(femtoDreamTrackSelection::TrackContainerPosition::kPID),
+    outputBachTrack.at(femtoDreamTrackSelection::TrackContainerPosition::kCuts),
+    outputBachTrack.at(femtoDreamTrackSelection::TrackContainerPosition::kPID)};
+}
+
+template <typename Col, typename Casc, typename Track>
+void FemtoDreamCascadeSelection::fillQA(Col const& /*col*/, Casc const& /*cascade*/, Track const& posTrack, Track const& negTrack, Track const& bachTrack)
+{
+  PosDaughTrack.fillQA<aod::femtodreamparticle::ParticleType::kV0Child,
+                       aod::femtodreamparticle::TrackType::kPosChild>(posTrack);
+  NegDaughTrack.fillQA<aod::femtodreamparticle::ParticleType::kV0Child,
+                       aod::femtodreamparticle::TrackType::kNegChild>(negTrack);
+  BachTrack.fillQA<aod::femtodreamparticle::ParticleType::kCascadeBachelor,
+                   aod::femtodreamparticle::TrackType::kBachelor>(bachTrack);
+}
+
+} // namespace o2::analysis::femtoDream
+
+#endif // PWGCF_FEMTODREAM_CORE_FEMTODREAMCASCADESELECTION_H_

--- a/PWGCF/FemtoDream/Core/femtoDreamCascadeSelection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamCascadeSelection.h
@@ -53,22 +53,22 @@ enum CascadeSel {
   kCascadeTranRadMin,
   kCascadeTranRadMax,
   kCascadeDecVtxMax,
-  
+
   kCascadeV0DCADaughMax,
   kCascadeV0CPAMin,
   kCascadeV0TranRadMin,
   kCascadeV0TranRadMax,
   kCascadeV0DCAtoPVMin,
   kCascadeV0DCAtoPVMax
-  //kNcascadeSelection
-  //kCascadeV0MassMin,
-  //kCascadeV0MassMax
-}; 
-  /*
-  kCascadeDCAPosToPV,
-  kCascadeDCANegToPV,
-  kCascadeDCABachToPV,
-  */
+  // kNcascadeSelection
+  // kCascadeV0MassMin,
+  // kCascadeV0MassMax
+};
+/*
+kCascadeDCAPosToPV,
+kCascadeDCANegToPV,
+kCascadeDCABachToPV,
+*/
 
 enum ChildTrackType { kPosTrack,
                       kNegTrack,
@@ -101,7 +101,7 @@ class FemtoDreamCascadeSelection
       nCascadeTranRadMin(0),
       nCascadeTranRadMax(0),
       nCascadeDecVtxMax(0),
-      /* 
+      /*
       nCascadeDCAPosToPV(0),
       nCascadeDCANegToPV(0),
       nCascadeDCABachToPV(0),
@@ -112,7 +112,6 @@ class FemtoDreamCascadeSelection
       nCascadeV0TranRadMax(0),
       nCascadeV0DCAToPVMin(0),
       nCascadeV0DCAToPVMax(0),
-
 
       fCascadePtMin(9999999),
       fCascadePtMax(-9999999),
@@ -134,7 +133,6 @@ class FemtoDreamCascadeSelection
       fCascadeV0DCAToPVMin(9999999),
       fCascadeV0DCAToPVMax(-9999999),
 
-
       fV0InvMassLowLimit(1.05),
       fV0InvMassUpLimit(1.3),
       fInvMassLowLimit(1.25),
@@ -143,7 +141,7 @@ class FemtoDreamCascadeSelection
       fInvMassCompetingLowLimit(1.5),
       fInvMassCompetingUpLimit(2.0),
       isCascOmega(false)
-      /*,nSigmaPIDOffsetTPC(0.)*/
+  /*,nSigmaPIDOffsetTPC(0.)*/
   {
   }
 
@@ -209,7 +207,7 @@ class FemtoDreamCascadeSelection
     outString += suffix;
     return outString;
   }
-  
+
   /// Helper function to obtain the index of a given selection variable for consistent naming of the configurables
   /// \param obs Cascade selection variable (together with prefix) got from file
   /// \param prefix Additional prefix for the output of the configurable
@@ -225,7 +223,7 @@ class FemtoDreamCascadeSelection
     }
     LOGF(info, "Variable %s not found", obs);
     return -1;
-  } 
+  }
 
   /// Helper function to obtain the type of a given selection variable for consistent naming of the configurables
   /// \param iSel Casc selection variable whose type is returned
@@ -254,7 +252,7 @@ class FemtoDreamCascadeSelection
     fInvMassLowLimit = lowLimit;
     fInvMassUpLimit = upLimit;
   }
-  
+
   void setV0InvMassLimits(float lowLimit, float upLimit)
   {
     fV0InvMassLowLimit = lowLimit;
@@ -280,7 +278,7 @@ class FemtoDreamCascadeSelection
   int nCascadeTranRadMin;
   int nCascadeTranRadMax;
   int nCascadeDecVtxMax;
-  /* 
+  /*
   int nCascadeDCAPosToPV;
   int nCascadeDCANegToPV;
   int nCascadeDCABachToPV;
@@ -300,18 +298,18 @@ class FemtoDreamCascadeSelection
   float fCascadeTranRadMin;
   float fCascadeTranRadMax;
   float fCascadeDecVtxMax;
-  /* 
+  /*
   float fCascadeDCAPosToPV;
   float fCascadeDCANegToPV;
   float fCascadeDCABachToPV;
-  */  
+  */
   float fCascadeV0DCADaughMax;
   float fCascadeV0CPAMin;
   float fCascadeV0TranRadMin;
   float fCascadeV0TranRadMax;
   float fCascadeV0DCAToPVMin;
   float fCascadeV0DCAToPVMax;
-  
+
   float fV0InvMassLowLimit;
   float fV0InvMassUpLimit;
 
@@ -329,16 +327,16 @@ class FemtoDreamCascadeSelection
   FemtoDreamTrackSelection PosDaughTrack;
   FemtoDreamTrackSelection NegDaughTrack;
   FemtoDreamTrackSelection BachTrack;
-  //FemtoDreamV0Selection V0DaughSel;
+  // FemtoDreamV0Selection V0DaughSel;
 
   static constexpr int kNcascadeSelection = 16;
 
   static constexpr std::string_view mSelectionNames[kNcascadeSelection] = {
-    "Sign", "PtMin", "PtMax", "EtaMax", "DCAcascDaugh", "CPAMin", "TranRadMin", "TranRadMax", "DecVtxMax",                   //Cascade Selections
-    "DCAv0daughMax", "v0CPAMin", "v0TranRadMin", "v0TranRadMax", "DCAV0ToPVMin", "DCAV0ToPVMax"};                            //CascadeV0 selections
-    //"kV0MassMin", "V0MassMax"}; //CascadeV0 selections
-    // "DCAPosToPV", "DCANegToPV", "DCABachToPV",                                                             //Cascade daughter track selections
-    // }; //<< Name of the different selections
+    "Sign", "PtMin", "PtMax", "EtaMax", "DCAcascDaugh", "CPAMin", "TranRadMin", "TranRadMax", "DecVtxMax", // Cascade Selections
+    "DCAv0daughMax", "v0CPAMin", "v0TranRadMin", "v0TranRadMax", "DCAV0ToPVMin", "DCAV0ToPVMax"};          // CascadeV0 selections
+  //"kV0MassMin", "V0MassMax"}; //CascadeV0 selections
+  // "DCAPosToPV", "DCANegToPV", "DCABachToPV",                                                             //Cascade daughter track selections
+  // }; //<< Name of the different selections
 
   static constexpr femtoDreamSelection::SelectionType
     mSelectionTypes[kNcascadeSelection]{
@@ -351,24 +349,23 @@ class FemtoDreamCascadeSelection
       femtoDreamSelection::kLowerLimit, // cascade tran rad min
       femtoDreamSelection::kUpperLimit, // cascade tran rad max
       femtoDreamSelection::kUpperLimit, // cascade maximum distance of decay vertex to PV
-      
+
       femtoDreamSelection::kUpperLimit, // v0 daughters DCA max
       femtoDreamSelection::kLowerLimit, // v0 cos PA min
       femtoDreamSelection::kLowerLimit, // v0 tran rad min
       femtoDreamSelection::kUpperLimit, // v0 tran rad max
       femtoDreamSelection::kLowerLimit, // v0 minimum distance of decay vertex to PV
       femtoDreamSelection::kUpperLimit  // v0 maximum distance of decay vertex to PV
-      //femtoDreamSelection::kLowerLimit, // v0 mass min
-      //femtoDreamSelection::kUpperLimit // v0 mass max
+      // femtoDreamSelection::kLowerLimit, // v0 mass min
+      // femtoDreamSelection::kUpperLimit // v0 mass max
     }; ///< Map to match a variable with
        ///< its type
-      
-      /*
-      femtoDreamSelection::kLowerLimit, // DCA pos to PV max
-      femtoDreamSelection::kLowerLimit, // DCA neg to PV max
-      femtoDreamSelection::kLowerLimit, // DCA bach to PV max
-      */
-      
+
+  /*
+  femtoDreamSelection::kLowerLimit, // DCA pos to PV max
+  femtoDreamSelection::kLowerLimit, // DCA neg to PV max
+  femtoDreamSelection::kLowerLimit, // DCA bach to PV max
+  */
 
   static constexpr std::string_view mSelectionHelper[kNcascadeSelection] = {
     "Cascade particle sign (+1 or -1)",
@@ -380,7 +377,7 @@ class FemtoDreamCascadeSelection
     "Minimum cascade transverse radius (cm)",
     "Maximum cascade transverse radius (cm)",
     "Maximum distance of cascade from primary vertex",
-    
+
     "Maximum DCA between v0 daughters (cm)",
     "Minimum Cosine of Pointing Angle for v0",
     "Minimum v0 transverse radius (cm)",
@@ -391,15 +388,15 @@ class FemtoDreamCascadeSelection
     //"Maximum V0 mass"
   }; ///< Helper information for the
      ///< different selections
-    
-    /*
-    "Maximum DCA of positive track form primary vertex",
-    "Maximum DCA of negative track form primary vertex",
-    "Maximum DCA of bachelor track form primary vertex",
 
-    }; ///< Helper information for the
-                        ///< different selections             ///< different selections
-    */ 
+  /*
+  "Maximum DCA of positive track form primary vertex",
+  "Maximum DCA of negative track form primary vertex",
+  "Maximum DCA of bachelor track form primary vertex",
+
+  }; ///< Helper information for the
+                      ///< different selections             ///< different selections
+  */
 }; // namespace femtoDream
 
 template <o2::aod::femtodreamparticle::ParticleType part, o2::aod::femtodreamparticle::ParticleType daugh, o2::aod::femtodreamparticle::ParticleType bach, typename cutContainerType>
@@ -409,9 +406,9 @@ void FemtoDreamCascadeSelection::init(HistogramRegistry* QAregistry, HistogramRe
   if (QAregistry && Registry) {
     mHistogramRegistry = Registry;
     mQAHistogramRegistry = QAregistry;
-    //fillSelectionHistogram<part>();  // cascade
-    //fillSelectionHistogram<daugh>(); // pos, neg
-    //fillSelectionHistogram<bach>();  // bach
+    // fillSelectionHistogram<part>();  // cascade
+    // fillSelectionHistogram<daugh>(); // pos, neg
+    // fillSelectionHistogram<bach>();  // bach
 
     AxisSpec ptAxis = {100, 0.0f, 10.0f, "#it{p}_{T} (GeV/#it{c})"};
     AxisSpec etaAxis = {100, -2.0f, 2.0f, "#it{#eta}"};
@@ -421,11 +418,10 @@ void FemtoDreamCascadeSelection::init(HistogramRegistry* QAregistry, HistogramRe
     AxisSpec tranRadAxis = {1000, 0.0f, 100.0f, "#it{r}_{xy} (cm)"};
     AxisSpec decVtxAxis = {2000, 0, 200, "#it{Vtx}_{z} (cm)"};
     AxisSpec massAxisCascade = {2200, 1.25f, 1.8f, "m_{#Cascade} (GeV/#it{c}^{2})"};
-    
+
     AxisSpec DCAToPVAxis = {1000, -10.0f, 10.0f, "DCA to PV (cm)"};
-    
+
     AxisSpec massAxisV0 = {600, 0.0f, 3.0f, "m_{#V0} (GeV/#it{c}^{2})"};
-    
 
     /// \todo this should be an automatic check in the parent class, and the
     /// return type should be templated
@@ -448,7 +444,7 @@ void FemtoDreamCascadeSelection::init(HistogramRegistry* QAregistry, HistogramRe
     mQAHistogramRegistry->add((folderName + "/hDecVtxY").c_str(), "; Decay vertex y position; Entries", kTH1F, {tranRadAxis});
     mQAHistogramRegistry->add((folderName + "/hDecVtxZ").c_str(), "; Decay vertex z position; Entries", kTH1F, {tranRadAxis});
     mQAHistogramRegistry->add((folderName + "/hInvMass").c_str(), "; Invariant mass; Entries", kTH1F, {tranRadAxis});
-    
+
     mQAHistogramRegistry->add((folderName + "/hV0DCADaugh").c_str(), "; V0-daughters DCA; Entries", kTH1F, {DCADaughAxis});
     mQAHistogramRegistry->add((folderName + "/hV0CPA").c_str(), "; V0 cos PA; Entries", kTH1F, {CPAAxis});
     mQAHistogramRegistry->add((folderName + "/hV0TranRad").c_str(), "; V0 transverse radius; Entries", kTH1F, {tranRadAxis});
@@ -458,11 +454,11 @@ void FemtoDreamCascadeSelection::init(HistogramRegistry* QAregistry, HistogramRe
     PosDaughTrack.init<aod::femtodreamparticle::ParticleType::kCascadeV0Child,
                        aod::femtodreamparticle::TrackType::kPosChild,
                        aod::femtodreamparticle::cutContainerType>(mQAHistogramRegistry, mHistogramRegistry);
-    
+
     NegDaughTrack.init<aod::femtodreamparticle::ParticleType::kCascadeV0Child,
                        aod::femtodreamparticle::TrackType::kNegChild,
                        aod::femtodreamparticle::cutContainerType>(mQAHistogramRegistry, mHistogramRegistry);
-    
+
     BachTrack.init<aod::femtodreamparticle::ParticleType::kCascadeBachelor,
                    aod::femtodreamparticle::TrackType::kBachelor,
                    aod::femtodreamparticle::cutContainerType>(mQAHistogramRegistry, mHistogramRegistry);
@@ -484,8 +480,8 @@ void FemtoDreamCascadeSelection::init(HistogramRegistry* QAregistry, HistogramRe
     mQAHistogramRegistry->add("CascadeQA/hCascadeV0TranRad", "V0 transverse radius", kTH1F, {tranRadAxis});
     mQAHistogramRegistry->add("CascadeQA/hCascadeV0DCAToPV", "DCA of the V0 to the PV", kTH1F, {massAxisV0});
     mQAHistogramRegistry->add("CascadeQA/hInvMassV0", "Invariant mass Cascade V0", kTH1F, {massAxisV0});
-    
-    /* 
+
+    /*
     // Dauchter Tracks
     mQAHistogramRegistry->add("CascadeQA/hCascadeDCAPosToPV", "Pos V0 daughter DCA to primary vertex", kTH1F, {DCAToPVAxis});
     mQAHistogramRegistry->add("CascadeQA/hCascadeDCANegToPV", "Neg V0 daughter DCA to primary vertex", kTH1F, {DCAToPVAxis});
@@ -503,21 +499,19 @@ void FemtoDreamCascadeSelection::init(HistogramRegistry* QAregistry, HistogramRe
   nCascadeTranRadMin = getNSelections(femtoDreamCascadeSelection::kCascadeTranRadMin);
   nCascadeTranRadMax = getNSelections(femtoDreamCascadeSelection::kCascadeTranRadMax);
   nCascadeDecVtxMax = getNSelections(femtoDreamCascadeSelection::kCascadeDecVtxMax);
-  
+
   nCascadeV0DCADaughMax = getNSelections(femtoDreamCascadeSelection::kCascadeV0DCADaughMax);
   nCascadeV0CPAMin = getNSelections(femtoDreamCascadeSelection::kCascadeV0CPAMin);
   nCascadeV0TranRadMin = getNSelections(femtoDreamCascadeSelection::kCascadeV0TranRadMin);
   nCascadeV0TranRadMax = getNSelections(femtoDreamCascadeSelection::kCascadeV0TranRadMax);
   nCascadeV0DCAToPVMin = getNSelections(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin);
-  nCascadeV0DCAToPVMax = getNSelections(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax); 
-  
+  nCascadeV0DCAToPVMax = getNSelections(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax);
+
   /*
   nCascadeDCAPosToPV = getNSelections(femtoDreamCascadeSelection::kCascadeDCAPosToPV);
   nCascadeDCANegToPV = getNSelections(femtoDreamCascadeSelection::kCascadeDCANegToPV);
   nCascadeDCABachToPV = getNSelections(femtoDreamCascadeSelection::kCascadeDCABachToPV);
-  */ 
-
-
+  */
 
   fCascadePtMin = getMinimalSelection(femtoDreamCascadeSelection::kCascadePtMin,
                                       femtoDreamSelection::kLowerLimit);
@@ -535,7 +529,7 @@ void FemtoDreamCascadeSelection::init(HistogramRegistry* QAregistry, HistogramRe
                                            femtoDreamSelection::kUpperLimit);
   fCascadeDecVtxMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeDecVtxMax,
                                           femtoDreamSelection::kAbsUpperLimit);
-  
+
   fCascadeV0DCADaughMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0DCADaughMax,
                                               femtoDreamSelection::kUpperLimit);
   fCascadeV0CPAMin = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0CPAMin,
@@ -548,11 +542,11 @@ void FemtoDreamCascadeSelection::init(HistogramRegistry* QAregistry, HistogramRe
                                              femtoDreamSelection::kLowerLimit);
   fCascadeV0DCAToPVMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax,
                                              femtoDreamSelection::kUpperLimit);
-  //fV0InvMassLowLimit = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0MassMin,
-  //                                         femtoDreamSelection::kLowerLimit);
-  //fV0InvMassUpLimit = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0MassMax,
-  //                                        femtoDreamSelection::kUpperLimit);
-   
+  // fV0InvMassLowLimit = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0MassMin,
+  //                                          femtoDreamSelection::kLowerLimit);
+  // fV0InvMassUpLimit = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0MassMax,
+  //                                         femtoDreamSelection::kUpperLimit);
+
   /*
   fCascadeDCAPosToPV = getMinimalSelection(femtoDreamCascadeSelection::kCascadeDCAPosToPV,
                                            femtoDreamSelection::kLowerLimit);
@@ -560,7 +554,7 @@ void FemtoDreamCascadeSelection::init(HistogramRegistry* QAregistry, HistogramRe
                                            femtoDreamSelection::kLowerLimit);
   fCascadeDCABachToPV = getMinimalSelection(femtoDreamCascadeSelection::kCascadeDCABachToPV,
                                             femtoDreamSelection::kLowerLimit);
-  */ 
+  */
   isCascOmega = isSelectCascOmega;
 }
 
@@ -581,24 +575,24 @@ bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& c
   const float cpaCasc = cascade.casccosPA(col.posX(), col.posY(), col.posZ());
   const float dcav0topv = cascade.dcav0topv(col.posX(), col.posY(), col.posZ());
   const float invMassLambda = cascade.mLambda();
-  //const float invMass = isCascOmega ? cascade.mOmega() : cascade.mXi();
+  // const float invMass = isCascOmega ? cascade.mOmega() : cascade.mXi();
   const float invMass = cascade.mXi();
-  
+
   if (invMassLambda < fV0InvMassLowLimit || invMassLambda > fV0InvMassUpLimit) {
     return false;
   }
-  //else{
-  //  mQAHistogramRegistry->fill(HIST("CascadeQA/hInvMassV0"), invMassLambda);
-  //}
-  
+  // else{
+  //   mQAHistogramRegistry->fill(HIST("CascadeQA/hInvMassV0"), invMassLambda);
+  // }
+
   if (invMass < fInvMassLowLimit || invMass > fInvMassUpLimit) {
     return false;
   }
-  //else{
-  //  mQAHistogramRegistry->fill(HIST("CascadeQA/hInvMassCascade"), invMass);
-  //}
-  
-  /* 
+  // else{
+  //   mQAHistogramRegistry->fill(HIST("CascadeQA/hInvMassCascade"), invMass);
+  // }
+
+  /*
   if (fRejectCompetingMass) {
     const float invMassCompeting = isCascOmega ? cascade.mXi() : cascade.mOmega();
     if (invMassCompeting > fInvMassCompetingLowLimit &&
@@ -634,19 +628,18 @@ bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& c
       return false;
     }
   }
-  
-  
-  //v0 criteria
+
+  // v0 criteria
   if (nCascadeV0DCADaughMax > 0 && cascade.dcaV0daughters() > fCascadeV0DCADaughMax) {
     return false;
   }
-  if (nCascadeV0CPAMin> 0 && cpav0 < fCascadeV0CPAMin) {
+  if (nCascadeV0CPAMin > 0 && cpav0 < fCascadeV0CPAMin) {
     return false;
   }
-  if (nCascadeV0TranRadMin> 0 && cascade.v0radius() < fCascadeV0TranRadMin) {
+  if (nCascadeV0TranRadMin > 0 && cascade.v0radius() < fCascadeV0TranRadMin) {
     return false;
   }
-  if (nCascadeV0TranRadMax> 0 && cascade.v0radius() > fCascadeV0TranRadMax) {
+  if (nCascadeV0TranRadMax > 0 && cascade.v0radius() > fCascadeV0TranRadMax) {
     return false;
   }
   if (nCascadeV0DCAToPVMin > 0 && abs(dcav0topv) < fCascadeV0DCAToPVMin) {
@@ -655,7 +648,7 @@ bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& c
   if (nCascadeV0DCAToPVMax > 0 && abs(dcav0topv) > fCascadeV0DCAToPVMax) {
     return false;
   }
-  //Chech the selection criteria for the tracks as well 
+  // Chech the selection criteria for the tracks as well
   if (!PosDaughTrack.isSelectedMinimal(posTrack)) {
     return false;
   }
@@ -665,8 +658,7 @@ bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& c
   if (!BachTrack.isSelectedMinimal(bachTrack)) {
     return false;
   }
-  
-  
+
   /*
   if (nCascadeDCAPosToPV > 0 && abs(cascade.dcapostopv()) < fCascadeDCAPosToPV) {
     return false;
@@ -677,8 +669,8 @@ bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& c
   if (nCascadeDCABachToPV > 0 && abs(cascade.dcabachtopv()) < fCascadeDCABachToPV) {
     return false;
   }
-  */ 
-  
+  */
+
   return true;
 }
 
@@ -695,12 +687,12 @@ void FemtoDreamCascadeSelection::fillCascadeQA(Col const& col, Casc const& casca
   const std::vector<float> decVtx = {cascade.x(), cascade.y(), cascade.z()};
   const float cpaCasc = cascade.casccosPA(col.posX(), col.posY(), col.posZ());
   const float invMass = isCascOmega ? cascade.mOmega() : cascade.mXi();
-  
+
   const float cpav0 = cascade.v0cosPA(col.posX(), col.posY(), col.posZ());
   const float dcav0topv = cascade.dcav0topv(col.posX(), col.posY(), col.posZ());
   const float invMassLambda = cascade.mLambda();
 
-  //Cascade
+  // Cascade
   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadePt"), cascade.pt());
   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeEta"), cascade.eta());
   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadePhi"), cascade.phi());
@@ -716,8 +708,8 @@ void FemtoDreamCascadeSelection::fillCascadeQA(Col const& col, Casc const& casca
   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeDCAPosToPV"), cascade.dcapostopv());
   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeDCANegToPV"), cascade.dcanegtopv());
   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeDCABachToPV"), cascade.dcabachtopv());
-  */ 
-  //V0 (Lambda)
+  */
+  // V0 (Lambda)
   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0DCADaugh"), cascade.dcaV0daughters());
   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0CPA"), cpav0);
   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0TranRad"), cascade.v0radius());
@@ -742,31 +734,31 @@ void FemtoDreamCascadeSelection::fillCascadeQA(Col const& col, Casc const& casca
 template <typename cutContainerType, typename Col, typename Casc, typename Track>
 std::array<cutContainerType, 8> FemtoDreamCascadeSelection::getCutContainer(Col const& col, Casc const& casc, Track const& posTrack, Track const& negTrack, Track const& bachTrack)
 {
-  //Cut bit
-  //auto outputV0Daugh = V0DaughSel.getCutContainer<cutContainerType>(v0Daugh, posTrack, negTrack);
+  // Cut bit
+  // auto outputV0Daugh = V0DaughSel.getCutContainer<cutContainerType>(v0Daugh, posTrack, negTrack);
   auto outputPosTrack = PosDaughTrack.getCutContainer<false, cutContainerType>(posTrack, casc.positivept(), casc.positiveeta(), casc.dcapostopv());
   auto outputNegTrack = NegDaughTrack.getCutContainer<false, cutContainerType>(negTrack, casc.negativept(), casc.negativeeta(), casc.dcanegtopv());
   auto outputBachTrack = BachTrack.getCutContainer<false, cutContainerType>(bachTrack, casc.bachelorpt(), casc.bacheloreta(), casc.dcabachtopv());
   cutContainerType output = 0;
   size_t counter = 0;
 
-  //auto xiMassNominal = o2::constants::physics::MassXiMinus;
-  //auto xiMassHypothesis = casc.mXi();
-  //auto antiXiMassHypothesis = casc.mAntiXi();
-  //auto diffXi = abs(xiMassNominal - xiMassHypothesis);
-  //auto diffAntiXi = abs(xiMassNominal - antiXiMassHypothesis);
+  // auto xiMassNominal = o2::constants::physics::MassXiMinus;
+  // auto xiMassHypothesis = casc.mXi();
+  // auto antiXiMassHypothesis = casc.mAntiXi();
+  // auto diffXi = abs(xiMassNominal - xiMassHypothesis);
+  // auto diffAntiXi = abs(xiMassNominal - antiXiMassHypothesis);
 
   float sign = 0.;
   int nSigmaPIDMax = PosDaughTrack.getSigmaPIDMax();
-  
+
   auto nSigmaPrNeg = negTrack.tpcNSigmaPr();
   auto nSigmaPiPos = posTrack.tpcNSigmaPi();
   auto nSigmaPiNeg = negTrack.tpcNSigmaPi();
   auto nSigmaPrPos = posTrack.tpcNSigmaPr();
   float nSigmaPIDOffsetTPC = 0.;
 
-  //negative charge: Antiparticle (Xi+)
-  //positive charge: Particle (Xi-) 
+  // negative charge: Antiparticle (Xi+)
+  // positive charge: Particle (Xi-)
   if (abs(nSigmaPrNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax && abs(nSigmaPiPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax) {
     sign = -1.;
   } else if (abs(nSigmaPrPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax && abs(nSigmaPiNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax) {
@@ -778,10 +770,9 @@ std::array<cutContainerType, 8> FemtoDreamCascadeSelection::getCutContainer(Col 
   const auto cpav0 = casc.v0cosPA(col.posX(), col.posY(), col.posZ());
   const auto dcav0topv = casc.dcav0topv(col.posX(), col.posY(), col.posZ());
 
-
   float observable = 0.;
   for (auto& sel : mSelections) {
-    
+
     const auto selVariable = sel.getSelectionVariable();
     switch (selVariable) {
       case (femtoDreamCascadeSelection::kCascadeSign):
@@ -814,9 +805,9 @@ std::array<cutContainerType, 8> FemtoDreamCascadeSelection::getCutContainer(Col 
           auto decVtxValue = decVtx.at(i);
           sel.checkSelectionSetBit(decVtxValue, output, counter, nullptr);
         }
-      continue;
-      break;
-      
+        continue;
+        break;
+
       case (femtoDreamCascadeSelection::kCascadeV0DCADaughMax):
         observable = casc.dcaV0daughters();
         break;
@@ -830,34 +821,34 @@ std::array<cutContainerType, 8> FemtoDreamCascadeSelection::getCutContainer(Col 
         observable = casc.v0radius();
         break;
       case (femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin):
-        observable = dcav0topv; 
+        observable = dcav0topv;
         break;
       case (femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax):
-        observable = dcav0topv; 
+        observable = dcav0topv;
         break;
-      //case (femtoDreamCascadeSelection::kCascadeV0MassMin):
-      //  observable = casc.mLambda(); 
-      //  break;
-      //case (femtoDreamCascadeSelection::kCascadeV0MassMax):
-      //  observable = casc.mLambda(); 
-      //  break;
-      
-      /*
-      case (femtoDreamCascadeSelection::kCascadeDCAPosToPV):
-        observable = casc.dcapostopv();
-        break;
-      case (femtoDreamCascadeSelection::kCascadeDCANegToPV):
-        observable = casc.dcanegtopv();
-        break;
-      case (femtoDreamCascadeSelection::kCascadeDCABachToPV):
-        observable = casc.dcabachtopv();
-        break;
-      */ 
+        // case (femtoDreamCascadeSelection::kCascadeV0MassMin):
+        //   observable = casc.mLambda();
+        //   break;
+        // case (femtoDreamCascadeSelection::kCascadeV0MassMax):
+        //   observable = casc.mLambda();
+        //   break;
 
-    } //switch
+        /*
+        case (femtoDreamCascadeSelection::kCascadeDCAPosToPV):
+          observable = casc.dcapostopv();
+          break;
+        case (femtoDreamCascadeSelection::kCascadeDCANegToPV):
+          observable = casc.dcanegtopv();
+          break;
+        case (femtoDreamCascadeSelection::kCascadeDCABachToPV):
+          observable = casc.dcabachtopv();
+          break;
+        */
+
+    } // switch
     sel.checkSelectionSetBit(observable, output, counter, nullptr);
     //}
-  } //for loop
+  } // for loop
 
   return {
     output,
@@ -877,7 +868,7 @@ void FemtoDreamCascadeSelection::fillQA(Col const& col, Casc const& casc, Track 
   const float cpaCasc = casc.casccosPA(col.posX(), col.posY(), col.posZ());
   const float cpav0 = casc.v0cosPA(col.posX(), col.posY(), col.posZ());
   const float dcav0topv = casc.dcav0topv(col.posX(), col.posY(), col.posZ());
-  
+
   if (mQAHistogramRegistry) {
     mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hPt"), casc.pt());
     mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hEta"), casc.eta());
@@ -889,7 +880,7 @@ void FemtoDreamCascadeSelection::fillQA(Col const& col, Casc const& casc, Track 
     mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hDecVtxY"), decVtx.at(1));
     mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hDecVtxZ"), decVtx.at(2));
     mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hInvMass"), casc.mXi());
-  
+
     mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hV0DCADaugh"), casc.dcaV0daughters());
     mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hV0CPA"), cpav0);
     mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hV0TranRad"), casc.v0radius());

--- a/PWGCF/FemtoDream/Core/femtoDreamCascadeSelection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamCascadeSelection.h
@@ -437,25 +437,34 @@ void FemtoDreamCascadeSelection::init(HistogramRegistry* QAregistry, HistogramRe
 
     std::string folderName = static_cast<std::string>(
       o2::aod::femtodreamparticle::ParticleTypeName[part]);
-    mQAHistogramRegistry->add((folderName + "/hPt").c_str(),
-                              "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F,
-                              {{1000, 0, 10}});
-    mQAHistogramRegistry->add((folderName + "/hEta").c_str(), "; #eta; Entries",
-                              kTH1F, {{1000, -1, 1}});
-    mQAHistogramRegistry->add((folderName + "/hPhi").c_str(), "; #phi; Entries",
-                              kTH1F, {{1000, 0, 2. * M_PI}});
+    mQAHistogramRegistry->add((folderName + "/hPt").c_str(), "; #it{p}_{T} (GeV/#it{c}); Entries", kTH1F, {{1000, 0, 10}});
+    mQAHistogramRegistry->add((folderName + "/hEta").c_str(), "; #eta; Entries", kTH1F, {{1000, -1, 1}});
+    mQAHistogramRegistry->add((folderName + "/hPhi").c_str(), "; #phi; Entries", kTH1F, {{1000, 0, 2. * M_PI}});
+    mQAHistogramRegistry->add((folderName + "/hDCADaugh").c_str(), "; daughters DCA; Entries", kTH1F, {DCADaughAxis});
+    mQAHistogramRegistry->add((folderName + "/hCPA").c_str(), "; Cos PA; Entries", kTH1F, {CPAAxis});
+    mQAHistogramRegistry->add((folderName + "/hTranRad").c_str(), "; Transverse Radius; Entries", kTH1F, {tranRadAxis});
+    mQAHistogramRegistry->add((folderName + "/hDecVtxX").c_str(), "; Decay vertex x position; Entries", kTH1F, {tranRadAxis});
+    mQAHistogramRegistry->add((folderName + "/hDecVtxY").c_str(), "; Decay vertex y position; Entries", kTH1F, {tranRadAxis});
+    mQAHistogramRegistry->add((folderName + "/hDecVtxZ").c_str(), "; Decay vertex z position; Entries", kTH1F, {tranRadAxis});
+    mQAHistogramRegistry->add((folderName + "/hInvMass").c_str(), "; Invariant mass; Entries", kTH1F, {tranRadAxis});
+    
+    mQAHistogramRegistry->add((folderName + "/hV0DCADaugh").c_str(), "; V0-daughters DCA; Entries", kTH1F, {DCADaughAxis});
+    mQAHistogramRegistry->add((folderName + "/hV0CPA").c_str(), "; V0 cos PA; Entries", kTH1F, {CPAAxis});
+    mQAHistogramRegistry->add((folderName + "/hV0TranRad").c_str(), "; V0 transverse radius; Entries", kTH1F, {tranRadAxis});
+    mQAHistogramRegistry->add((folderName + "/hV0DCAToPV").c_str(), "; DCA of the V0 to the PV; Entries", kTH1F, {massAxisV0});
+    mQAHistogramRegistry->add((folderName + "/hV0InvMass").c_str(), "; Invariant mass Cascade V0; Entries", kTH1F, {massAxisV0});
 
     PosDaughTrack.init<aod::femtodreamparticle::ParticleType::kCascadeV0Child,
                        aod::femtodreamparticle::TrackType::kPosChild,
-                       aod::femtodreamparticle::cutContainerType>(mQAHistogramRegistry, mQAHistogramRegistry);
+                       aod::femtodreamparticle::cutContainerType>(mQAHistogramRegistry, mHistogramRegistry);
     
     NegDaughTrack.init<aod::femtodreamparticle::ParticleType::kCascadeV0Child,
                        aod::femtodreamparticle::TrackType::kNegChild,
-                       aod::femtodreamparticle::cutContainerType>(mQAHistogramRegistry, mQAHistogramRegistry);
+                       aod::femtodreamparticle::cutContainerType>(mQAHistogramRegistry, mHistogramRegistry);
     
     BachTrack.init<aod::femtodreamparticle::ParticleType::kCascadeBachelor,
                    aod::femtodreamparticle::TrackType::kBachelor,
-                   aod::femtodreamparticle::cutContainerType>(mQAHistogramRegistry, mQAHistogramRegistry);
+                   aod::femtodreamparticle::cutContainerType>(mQAHistogramRegistry, mHistogramRegistry);
 
     // Cascade (Xi, Omega)
     mQAHistogramRegistry->add("CascadeQA/hCascadePt", "pT distribution", kTH1F, {ptAxis});
@@ -578,9 +587,15 @@ bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& c
   if (invMassLambda < fV0InvMassLowLimit || invMassLambda > fV0InvMassUpLimit) {
     return false;
   }
+  else{
+    mQAHistogramRegistry->fill(HIST("CascadeQA/hInvMassV0"), invMassLambda);
+  }
   
   if (invMass < fInvMassLowLimit || invMass > fInvMassUpLimit) {
     return false;
+  }
+  else{
+    mQAHistogramRegistry->fill(HIST("CascadeQA/hInvMassCascade"), invMass);
   }
   
   /* 
@@ -596,50 +611,109 @@ bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& c
   if (nCascadePtMin > 0 && cascade.pt() < fCascadePtMin) {
     return false;
   }
+  else{
+   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadePt"), cascade.pt());
+  }
+  
   if (nCascadePtMax > 0 && cascade.pt() > fCascadePtMax) {
     return false;
   }
+  else{
+   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadePt"), cascade.pt());
+  }
+  
   if (nCascadeEtaMax > 0 && std::abs(cascade.eta()) > fCascadeEtaMax) {
     return false;
   }
+  else{
+   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeEta"), cascade.eta());
+  }
+  
   if (nCascadeDCADaughMax > 0 && cascade.dcacascdaughters() > fCascadeDCADaughMax) {
     return false;
   }
+  else{
+   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeDCADaugh"), cascade.dcacascdaughters());
+  }
+  
   if (fCascadeCPAMin > 0 && cpaCasc < fCascadeCPAMin) {
     return false;
   }
+  else{
+   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeCPA"), cpaCasc);
+  }
+  
   if (nCascadeTranRadMin > 0 && cascade.cascradius() < fCascadeTranRadMin) {
     return false;
   }
+  else{
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeTranRad"), cascade.cascradius());
+  }
+  
   if (nCascadeTranRadMax > 0 && cascade.cascradius() > fCascadeTranRadMax) {
     return false;
   }
+  else{
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeTranRad"), cascade.cascradius());
+  }
+  
   for (size_t i = 0; i < decVtx.size(); i++) {
     if (nCascadeDecVtxMax > 0 && decVtx.at(i) > fCascadeDecVtxMax) {
       return false;
     }
+  else{
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeDecVtxZ"), decVtx.at(2));
   }
-
+  }
+  //LOGF(info, "GG CascadeSelection: Passing Xi!"); //REMOVE COMMENT
+  
+  
   //v0 criteria
   if (nCascadeV0DCADaughMax > 0 && cascade.dcaV0daughters() > fCascadeV0DCADaughMax) {
     return false;
   }
+  else{
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0DCADaugh"), cascade.dcaV0daughters());
+  }
+  
   if (nCascadeV0CPAMin> 0 && cpav0 < fCascadeV0CPAMin) {
     return false;
   }
+  else{
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0CPA"), cpav0);
+  }
+  
   if (nCascadeV0TranRadMin> 0 && cascade.v0radius() < fCascadeV0TranRadMin) {
     return false;
   }
-  if (nCascadeV0TranRadMax> 0 && cascade.v0radius() < fCascadeV0TranRadMax) {
+  else{
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0TranRad"), cascade.v0radius());
+  }
+  
+  if (nCascadeV0TranRadMax> 0 && cascade.v0radius() > fCascadeV0TranRadMax) {
     return false;
   }
+  else{
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0TranRad"), cascade.v0radius());
+  }
+
+  /* 
   if (nCascadeV0DCAToPVMin > 0 && abs(dcav0topv) < fCascadeV0DCAToPVMin) {
     return false;
   }
-  if (nCascadeV0DCAToPVMax > 0 && abs(dcav0topv) < fCascadeV0DCAToPVMax) {
+  else{
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0DCAToPV"), dcav0topv);
+  }
+  
+  if (nCascadeV0DCAToPVMax > 0 && abs(dcav0topv) > fCascadeV0DCAToPVMax) {
     return false;
   }
+  else{
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0DCAToPV"), dcav0topv);
+  }
+  */
   //Chech the selection criteria for the tracks as well (TODO) 
+  /*
   if (!PosDaughTrack.isSelectedMinimal(posTrack)) {
     return false;
   }
@@ -649,6 +723,7 @@ bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& c
   if (!BachTrack.isSelectedMinimal(bachTrack)) {
     return false;
   }
+  */ 
   
   
   /*
@@ -720,13 +795,13 @@ void FemtoDreamCascadeSelection::fillCascadeQA(Col const& col, Casc const& casca
   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeDCAPosToPV"), cascade.dcapostopv());
   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeDCANegToPV"), cascade.dcanegtopv());
   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeDCABachToPV"), cascade.dcabachtopv());
+  */ 
   //V0 (Lambda)
   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0DCADaugh"), cascade.dcaV0daughters());
   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0CPA"), cpav0);
   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0TranRad"), cascade.v0radius());
   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0DCAToPV"), dcav0topv);
   mQAHistogramRegistry->fill(HIST("CascadeQA/hInvMassV0"), invMassLambda);
-  */ 
 
   // is this necessary
   /*
@@ -880,27 +955,36 @@ std::array<cutContainerType, 8> FemtoDreamCascadeSelection::getCutContainer(Col 
 }
 
 template <o2::aod::femtodreamparticle::ParticleType part, typename Col, typename Casc, typename Track>
-void FemtoDreamCascadeSelection::fillQA(Col const& /*col*/, Casc const& casc, Track const& posTrack, Track const& negTrack, Track const& bachTrack)
+void FemtoDreamCascadeSelection::fillQA(Col const& col, Casc const& casc, Track const& posTrack, Track const& negTrack, Track const& bachTrack)
 {
 
+  const std::vector<float> decVtx = {casc.x(), casc.y(), casc.z()};
+  const float cpaCasc = casc.casccosPA(col.posX(), col.posY(), col.posZ());
+  const float cpav0 = casc.v0cosPA(col.posX(), col.posY(), col.posZ());
+  const float dcav0topv = casc.dcav0topv(col.posX(), col.posY(), col.posZ());
+  
   if (mQAHistogramRegistry) {
-    mQAHistogramRegistry->fill(
-      HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
-        HIST("/hPt"),
-      casc.pt());
-    mQAHistogramRegistry->fill(
-      HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
-        HIST("/hEta"),
-      casc.eta());
-    mQAHistogramRegistry->fill(
-      HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) +
-        HIST("/hPhi"),
-      casc.phi());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hPt"), casc.pt());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hEta"), casc.eta());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hPhi"), casc.phi());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hDCADaugh"), casc.dcacascdaughters());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hCPA"), cpaCasc);
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hTranRad"), casc.cascradius());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hDecVtxX"), decVtx.at(0));
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hDecVtxY"), decVtx.at(1));
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hDecVtxZ"), decVtx.at(2));
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hInvMass"), casc.mXi());
+  
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hV0DCADaugh"), casc.dcaV0daughters());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hV0CPA"), cpav0);
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hV0TranRad"), casc.v0radius());
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hV0DCAToPV"), dcav0topv);
+    mQAHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[part]) + HIST("/hV0InvMass"), casc.mLambda());
   }
-  //PosDaughTrack.fillQA<aod::femtodreamparticle::ParticleType::kCascadeV0Child,
-  //                     aod::femtodreamparticle::TrackType::kPosChild>(posTrack);
-  //NegDaughTrack.fillQA<aod::femtodreamparticle::ParticleType::kCascadeV0Child,
-  //                     aod::femtodreamparticle::TrackType::kNegChild>(negTrack);
+  PosDaughTrack.fillQA<aod::femtodreamparticle::ParticleType::kCascadeV0Child,
+                       aod::femtodreamparticle::TrackType::kPosChild>(posTrack);
+  NegDaughTrack.fillQA<aod::femtodreamparticle::ParticleType::kCascadeV0Child,
+                       aod::femtodreamparticle::TrackType::kNegChild>(negTrack);
   BachTrack.fillQA<aod::femtodreamparticle::ParticleType::kCascadeBachelor,
                    aod::femtodreamparticle::TrackType::kBachelor>(bachTrack);
 }

--- a/PWGCF/FemtoDream/Core/femtoDreamCascadeSelection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamCascadeSelection.h
@@ -44,9 +44,29 @@ namespace femtoDreamCascadeSelection
 /// The different selections this task is capable of doing
 enum CascadeSel {
   kCascadeSign, ///< +1 particle, -1 antiparticle
-  kCascadepTMin,
-  kCascadepTMax,
-};
+  kCascadePtMin,
+  kCascadePtMax,
+  kCascadeEtaMax,
+  kCascadeDCADaughMax,
+  kCascadeCPAMin,
+  kCascadeTranRadMin,
+  kCascadeTranRadMax,
+  kCascadeDecVtxMax,
+  
+  kCascadeV0DCADaughMax,
+  kCascadeV0CPAMin,
+  kCascadeV0TranRadMin,
+  kCascadeV0TranRadMax,
+  kCascadeV0DCAtoPVMin,
+  kCascadeV0DCAtoPVMax,
+  kCascadeV0MassMin,
+  kCascadeV0MassMax
+}; 
+  /*
+  kCascadeDCAPosToPV,
+  kCascadeDCANegToPV,
+  kCascadeDCABachToPV,
+  */
 
 enum ChildTrackType { kPosTrack,
                       kNegTrack,
@@ -71,7 +91,57 @@ class FemtoDreamCascadeSelection
 {
  public:
   FemtoDreamCascadeSelection()
-    : nPtCascadeMinSel(0), nPtCascadeMaxSel(0), pTCascadeMin(9999999.), pTCascadeMax(-9999999.) , fInvMassLowLimit(1.25), fInvMassUpLimit(1.4), fRejectCompetingMass(false), fInvMassCompetingLowLimit(1.5), fInvMassCompetingUpLimit(2.0), isCascOmega(false)
+    : nCascadePtMin(0),
+      nCascadePtMax(0),
+      nCascadeEtaMax(0),
+      nCascadeDCADaughMax(0),
+      nCascadeCPAMin(0),
+      nCascadeTranRadMin(0),
+      nCascadeTranRadMax(0),
+      nCascadeDecVtxMax(0),
+      /* 
+      nCascadeDCAPosToPV(0),
+      nCascadeDCANegToPV(0),
+      nCascadeDCABachToPV(0),
+      */
+      nCascadeV0DCADaughMax(0),
+      nCascadeV0CPAMin(0),
+      nCascadeV0TranRadMin(0),
+      nCascadeV0TranRadMax(0),
+      nCascadeV0DCAToPVMin(0),
+      nCascadeV0DCAToPVMax(0),
+
+
+      fCascadePtMin(9999999),
+      fCascadePtMax(-9999999),
+      fCascadeEtaMax(-9999999),
+      fCascadeDCADaughMax(-9999999),
+      fCascadeCPAMin(9999999),
+      fCascadeTranRadMin(9999999),
+      fCascadeTranRadMax(-9999999),
+      fCascadeDecVtxMax(-9999999),
+      /*
+      fCascadeDCAPosToPV(9999999),
+      fCascadeDCANegToPV(9999999),
+      fCascadeDCABachToPV(9999999),
+      */
+      fCascadeV0DCADaughMax(-9999999),
+      fCascadeV0CPAMin(9999999),
+      fCascadeV0TranRadMin(9999999),
+      fCascadeV0TranRadMax(-9999999),
+      fCascadeV0DCAToPVMin(9999999),
+      fCascadeV0DCAToPVMax(-9999999),
+
+
+      fV0InvMassLowLimit(1.05),
+      fV0InvMassUpLimit(1.3),
+      fInvMassLowLimit(1.25),
+      fInvMassUpLimit(1.4),
+      fRejectCompetingMass(false),
+      fInvMassCompetingLowLimit(1.5),
+      fInvMassCompetingUpLimit(2.0),
+      isCascOmega(false)
+      /*,nSigmaPIDOffsetTPC(0.)*/
   {
   }
 
@@ -91,8 +161,10 @@ class FemtoDreamCascadeSelection
   template <o2::aod::femtodreamparticle::ParticleType part, typename Col, typename Casc, typename Track>
   void fillQA(Col const& col, Casc const& cascade, Track const& posTrack, Track const& negTrack, Track const& bachTrack);
 
+  // template <typename cutContainerType, typename Col, typename Casc, typename V0, typename Track>
+  // std::array<cutContainerType, 8> getCutContainer(Col const& col, Casc const& casc, V0 const& v0Daugh, Track const& posTrack, Track const& negTrack, Track const& bachTrack);
   template <typename cutContainerType, typename Col, typename Casc, typename Track>
-  std::array<cutContainerType, 8> getCutContainer(Col const& /*col*/, Casc const& casc, Track const& posTrack, Track const& negTrack, Track const& bachTrack);
+  std::array<cutContainerType, 8> getCutContainer(Col const& col, Casc const& casc, Track const& posTrack, Track const& negTrack, Track const& bachTrack);
 
   template <typename T1, typename T2>
   void setChildCuts(femtoDreamCascadeSelection::ChildTrackType child,
@@ -192,11 +264,49 @@ class FemtoDreamCascadeSelection
   }
 
  private:
-  int nPtCascadeMinSel;
-  int nPtCascadeMaxSel;
-  float pTCascadeMin;
-  float pTCascadeMax;
+  int nCascadePtMin;
+  int nCascadePtMax;
+  int nCascadeEtaMax;
+  int nCascadeDCADaughMax;
+  int nCascadeCPAMin;
+  int nCascadeTranRadMin;
+  int nCascadeTranRadMax;
+  int nCascadeDecVtxMax;
+  /* 
+  int nCascadeDCAPosToPV;
+  int nCascadeDCANegToPV;
+  int nCascadeDCABachToPV;
+  */
+  int nCascadeV0DCADaughMax;
+  int nCascadeV0CPAMin;
+  int nCascadeV0TranRadMin;
+  int nCascadeV0TranRadMax;
+  int nCascadeV0DCAToPVMin;
+  int nCascadeV0DCAToPVMax;
+
+  float fCascadePtMin;
+  float fCascadePtMax;
+  float fCascadeEtaMax;
+  float fCascadeDCADaughMax;
+  float fCascadeCPAMin;
+  float fCascadeTranRadMin;
+  float fCascadeTranRadMax;
+  float fCascadeDecVtxMax;
+  /* 
+  float fCascadeDCAPosToPV;
+  float fCascadeDCANegToPV;
+  float fCascadeDCABachToPV;
+  */  
+  float fCascadeV0DCADaughMax;
+  float fCascadeV0CPAMin;
+  float fCascadeV0TranRadMin;
+  float fCascadeV0TranRadMax;
+  float fCascadeV0DCAToPVMin;
+  float fCascadeV0DCAToPVMax;
   
+  float fV0InvMassLowLimit;
+  float fV0InvMassUpLimit;
+
   float fInvMassLowLimit;
   float fInvMassUpLimit;
 
@@ -211,34 +321,76 @@ class FemtoDreamCascadeSelection
   FemtoDreamTrackSelection PosDaughTrack;
   FemtoDreamTrackSelection NegDaughTrack;
   FemtoDreamTrackSelection BachTrack;
+  //FemtoDreamV0Selection V0DaughSel;
 
-  static constexpr int kNcascadeSelection = 3; // can I do less ?
+  static constexpr int kNcascadeSelection = 17; //TODO can I do less ?
 
   static constexpr std::string_view mSelectionNames[kNcascadeSelection] = {
-    "Sign", "PtMin", "PtMax"};
-    /*
-    "Sign", "PtMin", "PtMax", "EtaMax", "DCAv0daughMax", "v0CPAMin",
-    "v0TranRadMin", "v0TranRadMax", "v0DecVecMax", "DCAcascDaugh",
-    "CPAMin", "TranRadMin", "TranRadMax", "DecVtxMax",
-    "DCAPosToPV", "DCANegToPV", "DCABachToPV", "DCAV0ToPV",
-    "kV0MassMin", "V0MassMax"}; ///< Name of the different
-                                ///< selections
-    */ 
+    "Sign", "PtMin", "PtMax", "EtaMax", "DCAcascDaugh", "CPAMin", "TranRadMin", "TranRadMax", "DecVtxMax",                   //Cascade Selections
+    "DCAv0daughMax", "v0CPAMin", "v0TranRadMin", "v0TranRadMax", "DCAV0ToPVMin", "DCAV0ToPVMax", "kV0MassMin", "V0MassMax"}; //CascadeV0 selections
+    // "DCAPosToPV", "DCANegToPV", "DCABachToPV",                                                             //Cascade daughter track selections
+    // }; //<< Name of the different selections
 
   static constexpr femtoDreamSelection::SelectionType
     mSelectionTypes[kNcascadeSelection]{
       femtoDreamSelection::kEqual,      // sign
       femtoDreamSelection::kLowerLimit, // pt min
       femtoDreamSelection::kUpperLimit, // pt max
+      femtoDreamSelection::kUpperLimit, // eta max
+      femtoDreamSelection::kUpperLimit, // DCA cascade daughters max
+      femtoDreamSelection::kLowerLimit, // cascade cos PA min
+      femtoDreamSelection::kLowerLimit, // cascade tran rad min
+      femtoDreamSelection::kUpperLimit, // cascade tran rad max
+      femtoDreamSelection::kUpperLimit, // cascade maximum distance of decay vertex to PV
+      
+      femtoDreamSelection::kUpperLimit, // v0 daughters DCA max
+      femtoDreamSelection::kLowerLimit, // v0 cos PA min
+      femtoDreamSelection::kLowerLimit, // v0 tran rad min
+      femtoDreamSelection::kUpperLimit, // v0 tran rad max
+      femtoDreamSelection::kLowerLimit, // v0 minimum distance of decay vertex to PV
+      femtoDreamSelection::kUpperLimit, // v0 maximum distance of decay vertex to PV
+      femtoDreamSelection::kLowerLimit, // v0 mass min
+      femtoDreamSelection::kUpperLimit // v0 mass max
     }; ///< Map to match a variable with
        ///< its type
+      
+      /*
+      femtoDreamSelection::kLowerLimit, // DCA pos to PV max
+      femtoDreamSelection::kLowerLimit, // DCA neg to PV max
+      femtoDreamSelection::kLowerLimit, // DCA bach to PV max
+      */
+      
 
   static constexpr std::string_view mSelectionHelper[kNcascadeSelection] = {
     "Cascade particle sign (+1 or -1)",
     "Minimum pT (GeV/c)",
-    "Maximum pT (GeV/c)"}; ///< Helper information for the
-                        ///< different selections
+    "Maximum pT (GeV/c)",
+    "Maximum |Eta|",
+    "Maximum DCA between cascade daughters (cm)",
+    "Minimum Cosine of Pointing Angle for cascade",
+    "Minimum cascade transverse radius (cm)",
+    "Maximum cascade transverse radius (cm)",
+    "Maximum distance of cascade from primary vertex",
+    
+    "Maximum DCA between v0 daughters (cm)",
+    "Minimum Cosine of Pointing Angle for v0",
+    "Minimum v0 transverse radius (cm)",
+    "Maximum v0 transverse radius (cm)",
+    "Minimum distance of v0 from primary vertex",
+    "Maximum distance of v0 from primary vertex",
+    "Minimum V0 mass",
+    "Maximum V0 mass"
+  }; ///< Helper information for the
+     ///< different selections
+    
+    /*
+    "Maximum DCA of positive track form primary vertex",
+    "Maximum DCA of negative track form primary vertex",
+    "Maximum DCA of bachelor track form primary vertex",
 
+    }; ///< Helper information for the
+                        ///< different selections             ///< different selections
+    */ 
 }; // namespace femtoDream
 
 template <o2::aod::femtodreamparticle::ParticleType part, o2::aod::femtodreamparticle::ParticleType daugh, o2::aod::femtodreamparticle::ParticleType bach, typename cutContainerType>
@@ -248,26 +400,29 @@ void FemtoDreamCascadeSelection::init(HistogramRegistry* QAregistry, HistogramRe
   if (QAregistry && Registry) {
     mHistogramRegistry = Registry;
     mQAHistogramRegistry = QAregistry;
-    fillSelectionHistogram<part>();  // cascade
-    fillSelectionHistogram<daugh>(); // pos, neg
-    fillSelectionHistogram<bach>();  // bach
+    //fillSelectionHistogram<part>();  // cascade
+    //fillSelectionHistogram<daugh>(); // pos, neg
+    //fillSelectionHistogram<bach>();  // bach
 
-    AxisSpec massAxisCascade = {2200, 1.25f, 1.8f, "m_{#Cascade} (GeV/#it{c}^{2})"};
     AxisSpec ptAxis = {100, 0.0f, 10.0f, "#it{p}_{T} (GeV/#it{c})"};
-    /*
-    AxisSpec massAxisV0 = {600, 0.0f, 3.0f, "m_{#V0} (GeV/#it{c}^{2})"};
-    AxisSpec DCADaughAxis = {1000, 0.0f, 2.0f, "DCA (cm)"};
-    AxisSpec DCAToPVAxis = {1000, -10.0f, 10.0f, "DCA to PV (cm)"};
     AxisSpec etaAxis = {100, -2.0f, 2.0f, "#it{#eta}"};
     AxisSpec phiAxis = {100, 0.0f, 6.0f, "#it{#phi}"};
+    AxisSpec DCADaughAxis = {1000, 0.0f, 2.0f, "DCA (cm)"};
     AxisSpec CPAAxis = {1000, 0.95f, 1.0f, "#it{cos #theta_{p}}"};
     AxisSpec tranRadAxis = {1000, 0.0f, 100.0f, "#it{r}_{xy} (cm)"};
-    */
+    AxisSpec decVtxAxis = {2000, 0, 200, "#it{Vtx}_{z} (cm)"};
+    AxisSpec massAxisCascade = {2200, 1.25f, 1.8f, "m_{#Cascade} (GeV/#it{c}^{2})"};
+    
+    AxisSpec DCAToPVAxis = {1000, -10.0f, 10.0f, "DCA to PV (cm)"};
+    
+    AxisSpec massAxisV0 = {600, 0.0f, 3.0f, "m_{#V0} (GeV/#it{c}^{2})"};
+    
 
     /// \todo this should be an automatic check in the parent class, and the
     /// return type should be templated
     size_t nSelections = getNSelections();
-    if (nSelections > 3 * sizeof(cutContainerType)) {
+    if (nSelections > 8 * sizeof(cutContainerType)) {
+      LOGF(info, "Number of selections %i", nSelections);
       LOG(fatal) << "FemtoDreamCascadeCuts: Number of selections to large for your "
                     "container - quitting!";
     }
@@ -284,99 +439,111 @@ void FemtoDreamCascadeSelection::init(HistogramRegistry* QAregistry, HistogramRe
 
     PosDaughTrack.init<aod::femtodreamparticle::ParticleType::kCascadeV0Child,
                        aod::femtodreamparticle::TrackType::kPosChild,
-                       aod::femtodreamparticle::cutContainerType>(
-      mQAHistogramRegistry, mQAHistogramRegistry);
+                       aod::femtodreamparticle::cutContainerType>(mQAHistogramRegistry, mQAHistogramRegistry);
+    
     NegDaughTrack.init<aod::femtodreamparticle::ParticleType::kCascadeV0Child,
                        aod::femtodreamparticle::TrackType::kNegChild,
-                       aod::femtodreamparticle::cutContainerType>(
-      mQAHistogramRegistry, mQAHistogramRegistry);
+                       aod::femtodreamparticle::cutContainerType>(mQAHistogramRegistry, mQAHistogramRegistry);
+    
     BachTrack.init<aod::femtodreamparticle::ParticleType::kCascadeBachelor,
                    aod::femtodreamparticle::TrackType::kBachelor,
-                   aod::femtodreamparticle::cutContainerType>(
-      mQAHistogramRegistry, mQAHistogramRegistry);
-
-    // V0 (Lambda)
-    //mQAHistogramRegistry->add("CascadeQA/hInvMassV0NoCuts", "No cuts", kTH1F, {massAxisV0});
-    // mQAHistogramRegistry->add("CascadeQA/hInvMassV0Cut", "Invariant mass cut", kTH1F, {massAxisV0});
-    // mQAHistogramRegistry->add("CascadeQA/hDCAV0Daugh", "V0-daughters DCA", kTH1F, {DCADaughAxis});
-    // mQAHistogramRegistry->add("CascadeQA/hV0CPA", "V0 cos PA", kTH1F, {CPAAxis});
-    // mQAHistogramRegistry->add("CascadeQA/hV0TranRad", "V0 transverse radius", kTH1F, {tranRadAxis});
-    // mQAHistogramRegistry->add("CascadeQA/hV0DecVtxMax", "V0 maximum distance on decay vertex", kTH1F, {massAxisV0});
+                   aod::femtodreamparticle::cutContainerType>(mQAHistogramRegistry, mQAHistogramRegistry);
 
     // Cascade (Xi, Omega)
-    // mQAHistogramRegistry->add("CascadeQA/hInvMassCascadeNoCuts", "No cuts", kTH1F, {massAxisCascade});
-    mQAHistogramRegistry->add("CascadeQA/hInvMassCascadeCut", "Invariant mass with cut", kTH1F, {massAxisCascade});
     mQAHistogramRegistry->add("CascadeQA/hCascadePt", "pT distribution", kTH1F, {ptAxis});
-    // mQAHistogramRegistry->add("CascadeQA/hCascadeEta", "Eta distribution", kTH1F, {etaAxis});
-    // mQAHistogramRegistry->add("CascadeQA/hCascadePhi", "Phi distribution", kTH1F, {phiAxis});
-    // mQAHistogramRegistry->add("CascadeQA/hDCACascadeDaugh", "Cascade-daughters DCA", kTH1F, {DCADaughAxis});
-    // mQAHistogramRegistry->add("CascadeQA/hCascadeCPA", "Cos PA", kTH1F, {CPAAxis});
-    // mQAHistogramRegistry->add("CascadeQA/hCascadeTranRad", "Transverse radius", kTH1F, {tranRadAxis});
-    // mQAHistogramRegistry->add("CascadeQA/hDCAPosToPV", "Pos V0 daughter DCA to primary vertex", kTH1F, {DCAToPVAxis});
-    // mQAHistogramRegistry->add("CascadeQA/hDCANegToPV", "Neg V0 daughter DCA to primary vertex", kTH1F, {DCAToPVAxis});
-    // mQAHistogramRegistry->add("CascadeQA/hDCABachToPV", "Bachelor DCA to primary vertex", kTH1F, {DCAToPVAxis});
-    // mQAHistogramRegistry->add("CascadeQA/hDCAV0ToPV", "V0 DCA to primary vertex", kTH1F, {DCAToPVAxis});
+    mQAHistogramRegistry->add("CascadeQA/hCascadeEta", "Eta distribution", kTH1F, {etaAxis});
+    mQAHistogramRegistry->add("CascadeQA/hCascadePhi", "Phi distribution", kTH1F, {phiAxis});
+    mQAHistogramRegistry->add("CascadeQA/hCascadeDCADaugh", "Cascade-daughters DCA", kTH1F, {DCADaughAxis});
+    mQAHistogramRegistry->add("CascadeQA/hCascadeCPA", "Cos PA", kTH1F, {CPAAxis});
+    mQAHistogramRegistry->add("CascadeQA/hCascadeTranRad", "Transverse radius", kTH1F, {tranRadAxis});
+    mQAHistogramRegistry->add("CascadeQA/hCascadeDecVtxX", "Decay vertex x position", kTH1F, {decVtxAxis});
+    mQAHistogramRegistry->add("CascadeQA/hCascadeDecVtxY", "Decay vertex y position", kTH1F, {decVtxAxis});
+    mQAHistogramRegistry->add("CascadeQA/hCascadeDecVtxZ", "Decay vertex z position", kTH1F, {decVtxAxis});
+    mQAHistogramRegistry->add("CascadeQA/hInvMassCascade", "Invariant mass Cascade", kTH1F, {massAxisCascade});
+    // V0 (Lambda)
+    mQAHistogramRegistry->add("CascadeQA/hCascadeV0DCADaugh", "V0-daughters DCA", kTH1F, {DCADaughAxis});
+    mQAHistogramRegistry->add("CascadeQA/hCascadeV0CPA", "V0 cos PA", kTH1F, {CPAAxis});
+    mQAHistogramRegistry->add("CascadeQA/hCascadeV0TranRad", "V0 transverse radius", kTH1F, {tranRadAxis});
+    mQAHistogramRegistry->add("CascadeQA/hCascadeV0DCAToPV", "DCA of the V0 to the PV", kTH1F, {massAxisV0});
+    mQAHistogramRegistry->add("CascadeQA/hInvMassV0", "Invariant mass Cascade V0", kTH1F, {massAxisV0});
+    
+    /* 
+    // Dauchter Tracks
+    mQAHistogramRegistry->add("CascadeQA/hCascadeDCAPosToPV", "Pos V0 daughter DCA to primary vertex", kTH1F, {DCAToPVAxis});
+    mQAHistogramRegistry->add("CascadeQA/hCascadeDCANegToPV", "Neg V0 daughter DCA to primary vertex", kTH1F, {DCAToPVAxis});
+    mQAHistogramRegistry->add("CascadeQA/hCascadeDCABachToPV", "Bachelor DCA to primary vertex", kTH1F, {DCAToPVAxis});
+    */
   }
 
   /// check whether the most open cuts are fulfilled - most of this should have
   /// already be done by the filters
-  nPtCascadeMinSel = getNSelections(femtoDreamCascadeSelection::kCascadepTMin);
-  nPtCascadeMaxSel = getNSelections(femtoDreamCascadeSelection::kCascadepTMax);
-  // nEtaCascadeMaxSel = getNSelections(femtoDreamCascadeSelection::kCascadeetaMax);
-  // nDCAV0DaughMax = getNSelections(femtoDreamCascadeSelection::kCascadeV0DCADaughMax);
-  // nCPAV0Min = getNSelections(femtoDreamCascadeSelection::kCascadeV0CPAMin);
-  // nTranRadV0Min = getNSelections(femtoDreamCascadeSelection::kCascadeV0TranRadMin);
-  // nTranRadV0Max = getNSelections(femtoDreamCascadeSelection::kCascadeV0TranRadMax);
-  // nV0DecVtxMax = getNSelections(femtoDreamCascadeSelection::kCascadeV0DecVtxMax);
-  // nDCACascadeDaughMax = getNSelections(femtoDreamCascadeSelection::kCascadeDCADaughMax);
-  // nCPACascadeMin = getNSelections(femtoDreamCascadeSelection::kCascadeCPAMin);
-  // nTranRadCascadeMin = getNSelections(femtoDreamCascadeSelection::kCascadeTranRadMin);
-  // nTranRadCascadeMax = getNSelections(femtoDreamCascadeSelection::kCascadeTranRadMax);
-  // nDecVtxMax = getNSelections(femtoDreamCascadeSelection::kCascadeDecVtxMax);
-  // nDCAPosToPV = getNSelections(femtoDreamCascadeSelection::kCascadeDCAPosToPV);
-  // nDCANegToPV = getNSelections(femtoDreamCascadeSelection::kCascadeDCANegToPV);
-  // nDCABachToPV = getNSelections(femtoDreamCascadeSelection::kCascadeDCABachToPV);
-  // nDCAV0ToPV = getNSelections(femtoDreamCascadeSelection::kCascadeDCAV0ToPV);
-  // dodac V0 mass min i max
+  nCascadePtMin = getNSelections(femtoDreamCascadeSelection::kCascadePtMin);
+  nCascadePtMax = getNSelections(femtoDreamCascadeSelection::kCascadePtMax);
+  nCascadeEtaMax = getNSelections(femtoDreamCascadeSelection::kCascadeEtaMax);
+  nCascadeDCADaughMax = getNSelections(femtoDreamCascadeSelection::kCascadeDCADaughMax);
+  nCascadeCPAMin = getNSelections(femtoDreamCascadeSelection::kCascadeCPAMin);
+  nCascadeTranRadMin = getNSelections(femtoDreamCascadeSelection::kCascadeTranRadMin);
+  nCascadeTranRadMax = getNSelections(femtoDreamCascadeSelection::kCascadeTranRadMax);
+  nCascadeDecVtxMax = getNSelections(femtoDreamCascadeSelection::kCascadeDecVtxMax);
+  
+  nCascadeV0DCADaughMax = getNSelections(femtoDreamCascadeSelection::kCascadeV0DCADaughMax);
+  nCascadeV0CPAMin = getNSelections(femtoDreamCascadeSelection::kCascadeV0CPAMin);
+  nCascadeV0TranRadMin = getNSelections(femtoDreamCascadeSelection::kCascadeV0TranRadMin);
+  nCascadeV0TranRadMax = getNSelections(femtoDreamCascadeSelection::kCascadeV0TranRadMax);
+  nCascadeV0DCAToPVMin = getNSelections(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin);
+  nCascadeV0DCAToPVMax = getNSelections(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax); 
+  
+  /*
+  nCascadeDCAPosToPV = getNSelections(femtoDreamCascadeSelection::kCascadeDCAPosToPV);
+  nCascadeDCANegToPV = getNSelections(femtoDreamCascadeSelection::kCascadeDCANegToPV);
+  nCascadeDCABachToPV = getNSelections(femtoDreamCascadeSelection::kCascadeDCABachToPV);
+  */ 
+  //TODO v0mass??? 
 
-  pTCascadeMin = getMinimalSelection(femtoDreamCascadeSelection::kCascadepTMin,
-                                     femtoDreamSelection::kLowerLimit);
-  pTCascadeMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadepTMax,
-                                     femtoDreamSelection::kUpperLimit);
-  // etaCascadeMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeetaMax,
-  //                                     femtoDreamSelection::kAbsUpperLimit);
-  // DCAV0DaughMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0DCADaughMax,
-  //                                     femtoDreamSelection::kUpperLimit);
-  // CPAV0Min = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0CPAMin,
-  //                                femtoDreamSelection::kLowerLimit);
-  // TranRadV0Min = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0TranRadMin,
-  //                                    femtoDreamSelection::kLowerLimit);
-  // TranRadV0Max = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0TranRadMax,
-  //                                    femtoDreamSelection::kUpperLimit);
-  // V0DecVtxMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0DecVtxMax,
-  //                                   femtoDreamSelection::kAbsUpperLimit);
-  // DCACascadeDaughMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeDCADaughMax,
-  //                                          femtoDreamSelection::kUpperLimit);
-  // CPACascadeMin = getMinimalSelection(femtoDreamCascadeSelection::kCascadeCPAMin,
-  //                                     femtoDreamSelection::kLowerLimit);
-  // TranRadCascadeMin = getMinimalSelection(femtoDreamCascadeSelection::kCascadeTranRadMin,
-  //                                         femtoDreamSelection::kLowerLimit);
-  // TranRadCascadeMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeTranRadMax,
-  //                                         femtoDreamSelection::kUpperLimit);
-  // DecVtxMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeDecVtxMax,
-  //                                 femtoDreamSelection::kAbsUpperLimit);
-  // DCAPosToPV = getMinimalSelection(femtoDreamCascadeSelection::kCascadeDCAPosToPV,
-  //                                  femtoDreamSelection::kLowerLimit);
-  // DCANegToPV = getMinimalSelection(femtoDreamCascadeSelection::kCascadeDCANegToPV,
-  //                                  femtoDreamSelection::kLowerLimit);
-  // DCABachToPV = getMinimalSelection(femtoDreamCascadeSelection::kCascadeDCABachToPV,
-  //                                   femtoDreamSelection::kLowerLimit);
-  // DCAV0ToPV = getMinimalSelection(femtoDreamCascadeSelection::kCascadeDCAV0ToPV,
-  //                                 femtoDreamSelection::kLowerLimit);
-  // fV0InvMassLowLimit = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0MassMin,
-  //                                          femtoDreamSelection::kLowerLimit);
-  // fV0InvMassUpLimit = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0MassMax,
-  //                                           femtoDreamSelection::kUpperLimit);
+
+
+  fCascadePtMin = getMinimalSelection(femtoDreamCascadeSelection::kCascadePtMin,
+                                      femtoDreamSelection::kLowerLimit);
+  fCascadePtMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadePtMax,
+                                      femtoDreamSelection::kUpperLimit);
+  fCascadeEtaMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeEtaMax,
+                                       femtoDreamSelection::kAbsUpperLimit);
+  fCascadeDCADaughMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeDCADaughMax,
+                                            femtoDreamSelection::kUpperLimit);
+  fCascadeCPAMin = getMinimalSelection(femtoDreamCascadeSelection::kCascadeCPAMin,
+                                       femtoDreamSelection::kLowerLimit);
+  fCascadeTranRadMin = getMinimalSelection(femtoDreamCascadeSelection::kCascadeTranRadMin,
+                                           femtoDreamSelection::kLowerLimit);
+  fCascadeTranRadMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeTranRadMax,
+                                           femtoDreamSelection::kUpperLimit);
+  fCascadeDecVtxMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeDecVtxMax,
+                                          femtoDreamSelection::kAbsUpperLimit);
+  
+  fCascadeV0DCADaughMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0DCADaughMax,
+                                              femtoDreamSelection::kUpperLimit);
+  fCascadeV0CPAMin = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0CPAMin,
+                                         femtoDreamSelection::kLowerLimit);
+  fCascadeV0TranRadMin = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0TranRadMin,
+                                             femtoDreamSelection::kLowerLimit);
+  fCascadeV0TranRadMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0TranRadMax,
+                                             femtoDreamSelection::kUpperLimit);
+  fCascadeV0DCAToPVMin = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin,
+                                             femtoDreamSelection::kLowerLimit);
+  fCascadeV0DCAToPVMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax,
+                                             femtoDreamSelection::kUpperLimit);
+  fV0InvMassLowLimit = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0MassMin,
+                                           femtoDreamSelection::kLowerLimit);
+  fV0InvMassUpLimit = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0MassMax,
+                                          femtoDreamSelection::kUpperLimit);
+   
+  /*
+  fCascadeDCAPosToPV = getMinimalSelection(femtoDreamCascadeSelection::kCascadeDCAPosToPV,
+                                           femtoDreamSelection::kLowerLimit);
+  fCascadeDCANegToPV = getMinimalSelection(femtoDreamCascadeSelection::kCascadeDCANegToPV,
+                                           femtoDreamSelection::kLowerLimit);
+  fCascadeDCABachToPV = getMinimalSelection(femtoDreamCascadeSelection::kCascadeDCABachToPV,
+                                            femtoDreamSelection::kLowerLimit);
+  */ 
   isCascOmega = isSelectCascOmega;
 }
 
@@ -393,20 +560,21 @@ bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& c
 
   const std::vector<float> decVtx = {cascade.x(), cascade.y(), cascade.z()};
 
-  //const float cpav0 = cascade.v0cosPA(col.posX(), col.posY(), col.posZ());
-  //const float cpaCasc = cascade.casccosPA(col.posX(), col.posY(), col.posZ());
-  //const float dcav0topv = cascade.dcav0topv(col.posX(), col.posY(), col.posZ());
-  // const float invMassLambda = cascade.mLambda();
+  const float cpav0 = cascade.v0cosPA(col.posX(), col.posY(), col.posZ());
+  const float cpaCasc = cascade.casccosPA(col.posX(), col.posY(), col.posZ());
+  const float dcav0topv = cascade.dcav0topv(col.posX(), col.posY(), col.posZ());
+  const float invMassLambda = cascade.mLambda();
   //const float invMass = isCascOmega ? cascade.mOmega() : cascade.mXi();
   const float invMass = cascade.mXi();
-  /*
+  
   if (invMassLambda < fV0InvMassLowLimit || invMassLambda > fV0InvMassUpLimit) {
     return false;
   }
-  */
+  
   if (invMass < fInvMassLowLimit || invMass > fInvMassUpLimit) {
     return false;
   }
+  
   /* 
   if (fRejectCompetingMass) {
     const float invMassCompeting = isCascOmega ? cascade.mXi() : cascade.mOmega();
@@ -416,58 +584,66 @@ bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& c
     }
   }
   */
-  if (nPtCascadeMinSel > 0 && cascade.pt() < pTCascadeMin) {
+
+  if (nCascadePtMin > 0 && cascade.pt() < fCascadePtMin) {
     return false;
   }
-  if (nPtCascadeMaxSel > 0 && cascade.pt() > pTCascadeMax) {
+  if (nCascadePtMax > 0 && cascade.pt() > fCascadePtMax) {
     return false;
   }
-  /*
-  if (nEtaCascadeMaxSel > 0 && std::abs(cascade.eta()) > etaCascadeMax) {
+  if (nCascadeEtaMax > 0 && std::abs(cascade.eta()) > fCascadeEtaMax) {
     return false;
   }
-  if (nDCAV0DaughMax > 0 && cascade.dcaV0daughters() > DCAV0DaughMax) {
+  if (nCascadeDCADaughMax > 0 && cascade.dcacascdaughters() > fCascadeDCADaughMax) {
     return false;
   }
-  if (nCPAV0Min > 0 && cpav0 < CPAV0Min) {
+  if (fCascadeCPAMin > 0 && cpaCasc < fCascadeCPAMin) {
     return false;
   }
-  if (nTranRadV0Min > 0 && cascade.v0radius() < TranRadV0Min) {
+  if (nCascadeTranRadMin > 0 && cascade.cascradius() < fCascadeTranRadMin) {
     return false;
   }
-  if (nTranRadV0Max > 0 && cascade.v0radius() > TranRadV0Max) {
-    return false;
-  }
-  if (nDCACascadeDaughMax > 0 && cascade.dcacascdaughters() > DCACascadeDaughMax) {
-    return false;
-  }
-  if (nCPACascadeMin > 0 && cpaCasc < CPACascadeMin) {
-    return false;
-  }
-  if (nTranRadCascadeMin > 0 && cascade.cascradius() < TranRadCascadeMin) {
-    return false;
-  }
-  if (nTranRadCascadeMax > 0 && cascade.cascradius() > TranRadCascadeMax) {
+  if (nCascadeTranRadMax > 0 && cascade.cascradius() > fCascadeTranRadMax) {
     return false;
   }
   for (size_t i = 0; i < decVtx.size(); i++) {
-    if (nDecVtxMax > 0 && decVtx.at(i) > DecVtxMax) {
+    if (nCascadeDecVtxMax > 0 && decVtx.at(i) > fCascadeDecVtxMax) {
       return false;
     }
   }
-  if (nDCAPosToPV > 0 && abs(cascade.dcapostopv()) < DCAPosToPV) {
-    return false;
-  }
-  if (nDCANegToPV > 0 && abs(cascade.dcanegtopv()) < DCANegToPV) {
-    return false;
-  }
-  if (nDCABachToPV > 0 && abs(cascade.dcabachtopv()) < DCABachToPV) {
-    return false;
-  }
-  if (nDCAV0ToPV > 0 && abs(dcav0topv) < DCAV0ToPV) {
-    return false;
-  }
 
+  //v0 criteria
+  if (nCascadeV0DCADaughMax > 0 && cascade.dcaV0daughters() > fCascadeV0DCADaughMax) {
+    return false;
+  }
+  if (nCascadeV0CPAMin> 0 && cpav0 < fCascadeV0CPAMin) {
+    return false;
+  }
+  if (nCascadeV0TranRadMin> 0 && cascade.v0radius() < fCascadeV0TranRadMin) {
+    return false;
+  }
+  if (nCascadeV0TranRadMax> 0 && cascade.v0radius() < fCascadeV0TranRadMax) {
+    return false;
+  }
+  if (nCascadeV0DCAToPVMin > 0 && abs(dcav0topv) < fCascadeV0DCAToPVMin) {
+    return false;
+  }
+  if (nCascadeV0DCAToPVMax > 0 && abs(dcav0topv) < fCascadeV0DCAToPVMax) {
+    return false;
+  }
+  
+  
+  /*
+  if (nCascadeDCAPosToPV > 0 && abs(cascade.dcapostopv()) < fCascadeDCAPosToPV) {
+    return false;
+  }
+  if (nCascadeDCANegToPV > 0 && abs(cascade.dcanegtopv()) < fCascadeDCANegToPV) {
+    return false;
+  }
+  if (nCascadeDCABachToPV > 0 && abs(cascade.dcabachtopv()) < fCascadeDCABachToPV) {
+    return false;
+  }
+  //Chech the selection criteria for the tracks as well (TODO) 
   if (!PosDaughTrack.isSelectedMinimal(posTrack)) {
     return false;
   }
@@ -477,7 +653,10 @@ bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& c
   if (!BachTrack.isSelectedMinimal(bachTrack)) {
     return false;
   }
-  */
+  */ 
+  
+  
+
 
   /*
     // check that track combinations for V0 or antiV0 would be fulfilling PID
@@ -495,7 +674,7 @@ bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& c
       return false;
     }
   */
-  LOGF(info, "GG CascadeSelection: A Xi is selected!"); //REMOVE COMMENT
+  //LOGF(info, "GG CascadeSelection: A Xi is selected!"); //REMOVE COMMENT
   return true;
 }
 
@@ -509,29 +688,37 @@ void FemtoDreamCascadeSelection::fillCascadeQA(Col const& col, Casc const& casca
     LOG(warn) << "ERROR - Wrong sign for V0 daughters";
   }
 
-  // const std::vector<float> decVtx = {cascade.x(), cascade.y(), cascade.z()};
-  // const float cpav0 = cascade.v0cosPA(col.posX(), col.posY(), col.posZ());
-  // const float cpaCasc = cascade.casccosPA(col.posX(), col.posY(), col.posZ());
-  // const float dcav0topv = cascade.dcav0topv(col.posX(), col.posY(), col.posZ());
-
-  const float invMassLambda = cascade.mLambda();
+  const std::vector<float> decVtx = {cascade.x(), cascade.y(), cascade.z()};
+  const float cpaCasc = cascade.casccosPA(col.posX(), col.posY(), col.posZ());
   const float invMass = isCascOmega ? cascade.mOmega() : cascade.mXi();
+  
+  const float cpav0 = cascade.v0cosPA(col.posX(), col.posY(), col.posZ());
+  const float dcav0topv = cascade.dcav0topv(col.posX(), col.posY(), col.posZ());
+  const float invMassLambda = cascade.mLambda();
 
-  // mQAHistogramRegistry->fill(HIST("CascadeQA/hInvMassV0Cut"), invMassLambda);
-  mQAHistogramRegistry->fill(HIST("CascadeQA/hInvMassCascadeCut"), invMass);
+  //Cascade
   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadePt"), cascade.pt());
-  // mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeEta"), cascade.eta());
-  // mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadePhi"), cascade.phi());
-  // mQAHistogramRegistry->fill(HIST("CascadeQA/hDCAV0Daugh"), cascade.dcaV0daughters());
-  // mQAHistogramRegistry->fill(HIST("CascadeQA/hV0CPA"), cpav0);
-  // mQAHistogramRegistry->fill(HIST("CascadeQA/hV0TranRad"), cascade.v0radius());
-  // mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeCPA"), cpaCasc);
-  // mQAHistogramRegistry->fill(HIST("CascadeQA/hDCACascadeDaugh"), cascade.dcacascdaughters());
-  // mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeTranRad"), cascade.cascradius());
-  // mQAHistogramRegistry->fill(HIST("CascadeQA/hDCAPosToPV"), cascade.dcapostopv());
-  // mQAHistogramRegistry->fill(HIST("CascadeQA/hDCANegToPV"), cascade.dcanegtopv());
-  // mQAHistogramRegistry->fill(HIST("CascadeQA/hDCABachToPV"), cascade.dcabachtopv());
-  // mQAHistogramRegistry->fill(HIST("CascadeQA/hDCAV0ToPV"), dcav0topv);
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeEta"), cascade.eta());
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadePhi"), cascade.phi());
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeDCADaugh"), cascade.dcacascdaughters());
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeCPA"), cpaCasc);
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeTranRad"), cascade.cascradius());
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeDecVtxX"), decVtx.at(0));
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeDecVtxY"), decVtx.at(1));
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeDecVtxZ"), decVtx.at(2));
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hInvMassCascade"), invMass);
+  /*
+  // Daughter Tracks
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeDCAPosToPV"), cascade.dcapostopv());
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeDCANegToPV"), cascade.dcanegtopv());
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeDCABachToPV"), cascade.dcabachtopv());
+  //V0 (Lambda)
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0DCADaugh"), cascade.dcaV0daughters());
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0CPA"), cpav0);
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0TranRad"), cascade.v0radius());
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0DCAToPV"), dcav0topv);
+  mQAHistogramRegistry->fill(HIST("CascadeQA/hInvMassV0"), invMassLambda);
+  */ 
 
   // is this necessary
   /*
@@ -546,10 +733,13 @@ void FemtoDreamCascadeSelection::fillCascadeQA(Col const& col, Casc const& casca
   */
 }
 
+// template <typename cutContainerType, typename Col, typename Casc, typename V0, typename Track>
+// std::array<cutContainerType, 8> FemtoDreamCascadeSelection::getCutContainer(Col const& col, Casc const& casc, V0 const& v0Daugh, Track const& posTrack, Track const& negTrack, Track const& bachTrack)
 template <typename cutContainerType, typename Col, typename Casc, typename Track>
-std::array<cutContainerType, 8> FemtoDreamCascadeSelection::getCutContainer(Col const& /*col*/, Casc const& casc, Track const& posTrack, Track const& negTrack, Track const& bachTrack)
+std::array<cutContainerType, 8> FemtoDreamCascadeSelection::getCutContainer(Col const& col, Casc const& casc, Track const& posTrack, Track const& negTrack, Track const& bachTrack)
 {
-  //Cut bit shenanigan
+  //Cut bit
+  //auto outputV0Daugh = V0DaughSel.getCutContainer<cutContainerType>(v0Daugh, posTrack, negTrack);
   auto outputPosTrack = PosDaughTrack.getCutContainer<cutContainerType>(posTrack, casc.positivept(), casc.positiveeta(), casc.dcapostopv());
   auto outputNegTrack = NegDaughTrack.getCutContainer<cutContainerType>(negTrack, casc.negativept(), casc.negativeeta(), casc.dcanegtopv());
   auto outputBachTrack = BachTrack.getCutContainer<cutContainerType>(bachTrack, casc.bachelorpt(), casc.bacheloreta(), casc.dcabachtopv());
@@ -578,24 +768,99 @@ std::array<cutContainerType, 8> FemtoDreamCascadeSelection::getCutContainer(Col 
     sign = 1.;
   }
 
-  const auto pT = casc.pt();
+  const auto cpaCasc = casc.casccosPA(col.posX(), col.posY(), col.posZ());
+  const std::vector<float> decVtx = {casc.x(), casc.y(), casc.z()};
+  const auto cpav0 = casc.v0cosPA(col.posX(), col.posY(), col.posZ());
+  const auto dcav0topv = casc.dcav0topv(col.posX(), col.posY(), col.posZ());
+
 
   float observable = 0.;
   for (auto& sel : mSelections) {
+    
     const auto selVariable = sel.getSelectionVariable();
     switch (selVariable) {
       case (femtoDreamCascadeSelection::kCascadeSign):
         observable = sign;
         break;
-      case (femtoDreamCascadeSelection::kCascadepTMin):
-        observable = pT;
+      case (femtoDreamCascadeSelection::kCascadePtMin):
+        observable = casc.pt();
         break;
-      case (femtoDreamCascadeSelection::kCascadepTMax):
-        observable = pT;
+      case (femtoDreamCascadeSelection::kCascadePtMax):
+        observable = casc.pt();
         break;
+      case (femtoDreamCascadeSelection::kCascadeEtaMax):
+        observable = casc.eta();
+        break;
+      case (femtoDreamCascadeSelection::kCascadeDCADaughMax):
+        observable = casc.dcacascdaughters();
+        break;
+      case (femtoDreamCascadeSelection::kCascadeCPAMin):
+        observable = cpaCasc;
+        break;
+      case (femtoDreamCascadeSelection::kCascadeTranRadMin):
+        observable = casc.cascradius();
+        break;
+      case (femtoDreamCascadeSelection::kCascadeTranRadMax):
+        observable = casc.cascradius();
+        break;
+      // kCascadeDecVtxMax is done above
+      case (femtoDreamCascadeSelection::kCascadeDecVtxMax):
+        for (size_t i = 0; i < decVtx.size(); ++i) {
+          auto decVtxValue = decVtx.at(i);
+          sel.checkSelectionSetBit(decVtxValue, output, counter, nullptr);
+        }
+      continue;
+      break;
+      
+      case (femtoDreamCascadeSelection::kCascadeV0DCADaughMax):
+        observable = casc.dcaV0daughters();
+        break;
+      case (femtoDreamCascadeSelection::kCascadeV0CPAMin):
+        observable = cpav0;
+        break;
+      case (femtoDreamCascadeSelection::kCascadeV0TranRadMin):
+        observable = casc.v0radius();
+        break;
+      case (femtoDreamCascadeSelection::kCascadeV0TranRadMax):
+        observable = casc.v0radius();
+        break;
+      case (femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin):
+        observable = dcav0topv; 
+        break;
+      case (femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax):
+        observable = dcav0topv; 
+        break;
+      case (femtoDreamCascadeSelection::kCascadeV0MassMin):
+        observable = casc.mLambda(); 
+        break;
+      case (femtoDreamCascadeSelection::kCascadeV0MassMax):
+        observable = casc.mLambda(); 
+        break;
+      
+      /*
+      case (femtoDreamCascadeSelection::kCascadeDCAPosToPV):
+        observable = casc.dcapostopv();
+        break;
+      case (femtoDreamCascadeSelection::kCascadeDCANegToPV):
+        observable = casc.dcanegtopv();
+        break;
+      case (femtoDreamCascadeSelection::kCascadeDCABachToPV):
+        observable = casc.dcabachtopv();
+        break;
+      */ 
+
     } //switch
     sel.checkSelectionSetBit(observable, output, counter, nullptr);
-  }
+    //}
+  } //for loop
+
+    /*
+    outputV0Daugh.at(0), //daughter V0
+    outputV0Daugh.at(1), //posDaughterCuts
+    outputV0Daugh.at(2), //posDaughterPID
+    outputV0Daugh.at(3), //negDaughterCuts
+    outputV0Daugh.at(4), //negDaugherPID
+    */
   return {
     output,
     outputPosTrack.at(femtoDreamTrackSelection::TrackContainerPosition::kCuts),
@@ -624,10 +889,10 @@ void FemtoDreamCascadeSelection::fillQA(Col const& /*col*/, Casc const& casc, Tr
         HIST("/hPhi"),
       casc.phi());
   }
-  PosDaughTrack.fillQA<aod::femtodreamparticle::ParticleType::kV0Child,
-                       aod::femtodreamparticle::TrackType::kPosChild>(posTrack);
-  NegDaughTrack.fillQA<aod::femtodreamparticle::ParticleType::kV0Child,
-                       aod::femtodreamparticle::TrackType::kNegChild>(negTrack);
+  //PosDaughTrack.fillQA<aod::femtodreamparticle::ParticleType::kCascadeV0Child,
+  //                     aod::femtodreamparticle::TrackType::kPosChild>(posTrack);
+  //NegDaughTrack.fillQA<aod::femtodreamparticle::ParticleType::kCascadeV0Child,
+  //                     aod::femtodreamparticle::TrackType::kNegChild>(negTrack);
   BachTrack.fillQA<aod::femtodreamparticle::ParticleType::kCascadeBachelor,
                    aod::femtodreamparticle::TrackType::kBachelor>(bachTrack);
 }

--- a/PWGCF/FemtoDream/Core/femtoDreamCascadeSelection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamCascadeSelection.h
@@ -52,14 +52,16 @@ enum ChildTrackType { kPosTrack,
                       kNegTrack,
                       kBachTrack };
 
-/*enum CascadeContainerPosition {
+enum CascadeContainerPosition {
   kCascade,
   kPosCuts,
   kPosPID,
   kNegCuts,
   kNegPID,
+  kBachCuts,
+  kBachPID,
 }; /// Position in the full VO cut container (for cutculator)
-*/
+
 } // namespace femtoDreamCascadeSelection
 
 /// \class FemtoDreamCascadeSelection

--- a/PWGCF/FemtoDream/Core/femtoDreamCascadeSelection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamCascadeSelection.h
@@ -58,9 +58,10 @@ enum CascadeSel {
   kCascadeV0TranRadMin,
   kCascadeV0TranRadMax,
   kCascadeV0DCAtoPVMin,
-  kCascadeV0DCAtoPVMax,
-  kCascadeV0MassMin,
-  kCascadeV0MassMax
+  kCascadeV0DCAtoPVMax
+  //kNcascadeSelection
+  //kCascadeV0MassMin,
+  //kCascadeV0MassMax
 }; 
   /*
   kCascadeDCAPosToPV,
@@ -252,6 +253,12 @@ class FemtoDreamCascadeSelection
     fInvMassLowLimit = lowLimit;
     fInvMassUpLimit = upLimit;
   }
+  
+  void setV0InvMassLimits(float lowLimit, float upLimit)
+  {
+    fV0InvMassLowLimit = lowLimit;
+    fV0InvMassUpLimit = upLimit;
+  }
 
   /// Set limit for the omega rejection on the invariant mass
   /// \param lowLimit Lower limit for the invariant mass distribution
@@ -323,11 +330,12 @@ class FemtoDreamCascadeSelection
   FemtoDreamTrackSelection BachTrack;
   //FemtoDreamV0Selection V0DaughSel;
 
-  static constexpr int kNcascadeSelection = 17; //TODO can I do less ?
+  static constexpr int kNcascadeSelection = 16; //TODO can I do less ?
 
   static constexpr std::string_view mSelectionNames[kNcascadeSelection] = {
     "Sign", "PtMin", "PtMax", "EtaMax", "DCAcascDaugh", "CPAMin", "TranRadMin", "TranRadMax", "DecVtxMax",                   //Cascade Selections
-    "DCAv0daughMax", "v0CPAMin", "v0TranRadMin", "v0TranRadMax", "DCAV0ToPVMin", "DCAV0ToPVMax", "kV0MassMin", "V0MassMax"}; //CascadeV0 selections
+    "DCAv0daughMax", "v0CPAMin", "v0TranRadMin", "v0TranRadMax", "DCAV0ToPVMin", "DCAV0ToPVMax"};                            //CascadeV0 selections
+    //"kV0MassMin", "V0MassMax"}; //CascadeV0 selections
     // "DCAPosToPV", "DCANegToPV", "DCABachToPV",                                                             //Cascade daughter track selections
     // }; //<< Name of the different selections
 
@@ -348,9 +356,9 @@ class FemtoDreamCascadeSelection
       femtoDreamSelection::kLowerLimit, // v0 tran rad min
       femtoDreamSelection::kUpperLimit, // v0 tran rad max
       femtoDreamSelection::kLowerLimit, // v0 minimum distance of decay vertex to PV
-      femtoDreamSelection::kUpperLimit, // v0 maximum distance of decay vertex to PV
-      femtoDreamSelection::kLowerLimit, // v0 mass min
-      femtoDreamSelection::kUpperLimit // v0 mass max
+      femtoDreamSelection::kUpperLimit  // v0 maximum distance of decay vertex to PV
+      //femtoDreamSelection::kLowerLimit, // v0 mass min
+      //femtoDreamSelection::kUpperLimit // v0 mass max
     }; ///< Map to match a variable with
        ///< its type
       
@@ -377,9 +385,9 @@ class FemtoDreamCascadeSelection
     "Minimum v0 transverse radius (cm)",
     "Maximum v0 transverse radius (cm)",
     "Minimum distance of v0 from primary vertex",
-    "Maximum distance of v0 from primary vertex",
-    "Minimum V0 mass",
-    "Maximum V0 mass"
+    "Maximum distance of v0 from primary vertex"
+    //"Minimum V0 mass",
+    //"Maximum V0 mass"
   }; ///< Helper information for the
      ///< different selections
     
@@ -531,10 +539,10 @@ void FemtoDreamCascadeSelection::init(HistogramRegistry* QAregistry, HistogramRe
                                              femtoDreamSelection::kLowerLimit);
   fCascadeV0DCAToPVMax = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax,
                                              femtoDreamSelection::kUpperLimit);
-  fV0InvMassLowLimit = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0MassMin,
-                                           femtoDreamSelection::kLowerLimit);
-  fV0InvMassUpLimit = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0MassMax,
-                                          femtoDreamSelection::kUpperLimit);
+  //fV0InvMassLowLimit = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0MassMin,
+  //                                         femtoDreamSelection::kLowerLimit);
+  //fV0InvMassUpLimit = getMinimalSelection(femtoDreamCascadeSelection::kCascadeV0MassMax,
+  //                                        femtoDreamSelection::kUpperLimit);
    
   /*
   fCascadeDCAPosToPV = getMinimalSelection(femtoDreamCascadeSelection::kCascadeDCAPosToPV,
@@ -631,6 +639,16 @@ bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& c
   if (nCascadeV0DCAToPVMax > 0 && abs(dcav0topv) < fCascadeV0DCAToPVMax) {
     return false;
   }
+  //Chech the selection criteria for the tracks as well (TODO) 
+  if (!PosDaughTrack.isSelectedMinimal(posTrack)) {
+    return false;
+  }
+  if (!NegDaughTrack.isSelectedMinimal(negTrack)) {
+    return false;
+  }
+  if (!BachTrack.isSelectedMinimal(bachTrack)) {
+    return false;
+  }
   
   
   /*
@@ -641,16 +659,6 @@ bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& c
     return false;
   }
   if (nCascadeDCABachToPV > 0 && abs(cascade.dcabachtopv()) < fCascadeDCABachToPV) {
-    return false;
-  }
-  //Chech the selection criteria for the tracks as well (TODO) 
-  if (!PosDaughTrack.isSelectedMinimal(posTrack)) {
-    return false;
-  }
-  if (!NegDaughTrack.isSelectedMinimal(negTrack)) {
-    return false;
-  }
-  if (!BachTrack.isSelectedMinimal(bachTrack)) {
     return false;
   }
   */ 
@@ -830,12 +838,12 @@ std::array<cutContainerType, 8> FemtoDreamCascadeSelection::getCutContainer(Col 
       case (femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax):
         observable = dcav0topv; 
         break;
-      case (femtoDreamCascadeSelection::kCascadeV0MassMin):
-        observable = casc.mLambda(); 
-        break;
-      case (femtoDreamCascadeSelection::kCascadeV0MassMax):
-        observable = casc.mLambda(); 
-        break;
+      //case (femtoDreamCascadeSelection::kCascadeV0MassMin):
+      //  observable = casc.mLambda(); 
+      //  break;
+      //case (femtoDreamCascadeSelection::kCascadeV0MassMax):
+      //  observable = casc.mLambda(); 
+      //  break;
       
       /*
       case (femtoDreamCascadeSelection::kCascadeDCAPosToPV):

--- a/PWGCF/FemtoDream/Core/femtoDreamCascadeSelection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamCascadeSelection.h
@@ -17,6 +17,7 @@
 /// \author Zuzanna Chochulska, WUT Warsaw & CTU Prague, zchochul@cern.ch
 /// \author Barbara Chytla, WUT Warsaw, barbara.chytla@cern.ch
 /// \author Shirajum Monira, WUT Warsaw, shirajum.monira@cern.ch
+/// \author Georgios Mantzaridis, TU München, georgios.mantzaridis@tum.de
 
 #ifndef PWGCF_FEMTODREAM_CORE_FEMTODREAMCASCADESELECTION_H_
 #define PWGCF_FEMTODREAM_CORE_FEMTODREAMCASCADESELECTION_H_
@@ -330,7 +331,7 @@ class FemtoDreamCascadeSelection
   FemtoDreamTrackSelection BachTrack;
   //FemtoDreamV0Selection V0DaughSel;
 
-  static constexpr int kNcascadeSelection = 16; //TODO can I do less ?
+  static constexpr int kNcascadeSelection = 16;
 
   static constexpr std::string_view mSelectionNames[kNcascadeSelection] = {
     "Sign", "PtMin", "PtMax", "EtaMax", "DCAcascDaugh", "CPAMin", "TranRadMin", "TranRadMax", "DecVtxMax",                   //Cascade Selections

--- a/PWGCF/FemtoDream/Core/femtoDreamCascadeSelection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamCascadeSelection.h
@@ -515,7 +515,6 @@ void FemtoDreamCascadeSelection::init(HistogramRegistry* QAregistry, HistogramRe
   nCascadeDCANegToPV = getNSelections(femtoDreamCascadeSelection::kCascadeDCANegToPV);
   nCascadeDCABachToPV = getNSelections(femtoDreamCascadeSelection::kCascadeDCABachToPV);
   */ 
-  //TODO v0mass??? 
 
 
 
@@ -587,16 +586,16 @@ bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& c
   if (invMassLambda < fV0InvMassLowLimit || invMassLambda > fV0InvMassUpLimit) {
     return false;
   }
-  else{
-    mQAHistogramRegistry->fill(HIST("CascadeQA/hInvMassV0"), invMassLambda);
-  }
+  //else{
+  //  mQAHistogramRegistry->fill(HIST("CascadeQA/hInvMassV0"), invMassLambda);
+  //}
   
   if (invMass < fInvMassLowLimit || invMass > fInvMassUpLimit) {
     return false;
   }
-  else{
-    mQAHistogramRegistry->fill(HIST("CascadeQA/hInvMassCascade"), invMass);
-  }
+  //else{
+  //  mQAHistogramRegistry->fill(HIST("CascadeQA/hInvMassCascade"), invMass);
+  //}
   
   /* 
   if (fRejectCompetingMass) {
@@ -611,59 +610,28 @@ bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& c
   if (nCascadePtMin > 0 && cascade.pt() < fCascadePtMin) {
     return false;
   }
-  else{
-   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadePt"), cascade.pt());
-  }
-  
   if (nCascadePtMax > 0 && cascade.pt() > fCascadePtMax) {
     return false;
   }
-  else{
-   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadePt"), cascade.pt());
-  }
-  
   if (nCascadeEtaMax > 0 && std::abs(cascade.eta()) > fCascadeEtaMax) {
     return false;
   }
-  else{
-   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeEta"), cascade.eta());
-  }
-  
   if (nCascadeDCADaughMax > 0 && cascade.dcacascdaughters() > fCascadeDCADaughMax) {
     return false;
   }
-  else{
-   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeDCADaugh"), cascade.dcacascdaughters());
-  }
-  
   if (fCascadeCPAMin > 0 && cpaCasc < fCascadeCPAMin) {
     return false;
   }
-  else{
-   mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeCPA"), cpaCasc);
-  }
-  
   if (nCascadeTranRadMin > 0 && cascade.cascradius() < fCascadeTranRadMin) {
     return false;
   }
-  else{
-  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeTranRad"), cascade.cascradius());
-  }
-  
   if (nCascadeTranRadMax > 0 && cascade.cascradius() > fCascadeTranRadMax) {
     return false;
   }
-  else{
-  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeTranRad"), cascade.cascradius());
-  }
-  
   for (size_t i = 0; i < decVtx.size(); i++) {
     if (nCascadeDecVtxMax > 0 && decVtx.at(i) > fCascadeDecVtxMax) {
       return false;
     }
-  else{
-  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeDecVtxZ"), decVtx.at(2));
-  }
   }
   
   
@@ -671,48 +639,22 @@ bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& c
   if (nCascadeV0DCADaughMax > 0 && cascade.dcaV0daughters() > fCascadeV0DCADaughMax) {
     return false;
   }
-  else{
-  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0DCADaugh"), cascade.dcaV0daughters());
-  }
-  
   if (nCascadeV0CPAMin> 0 && cpav0 < fCascadeV0CPAMin) {
     return false;
   }
-  else{
-  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0CPA"), cpav0);
-  }
-  
   if (nCascadeV0TranRadMin> 0 && cascade.v0radius() < fCascadeV0TranRadMin) {
     return false;
   }
-  else{
-  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0TranRad"), cascade.v0radius());
-  }
-  
   if (nCascadeV0TranRadMax> 0 && cascade.v0radius() > fCascadeV0TranRadMax) {
     return false;
   }
-  else{
-  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0TranRad"), cascade.v0radius());
-  }
-
-  /* 
   if (nCascadeV0DCAToPVMin > 0 && abs(dcav0topv) < fCascadeV0DCAToPVMin) {
     return false;
   }
-  else{
-  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0DCAToPV"), dcav0topv);
-  }
-  
   if (nCascadeV0DCAToPVMax > 0 && abs(dcav0topv) > fCascadeV0DCAToPVMax) {
     return false;
   }
-  else{
-  mQAHistogramRegistry->fill(HIST("CascadeQA/hCascadeV0DCAToPV"), dcav0topv);
-  }
-  */
-  //Chech the selection criteria for the tracks as well (TODO) 
-  /*
+  //Chech the selection criteria for the tracks as well 
   if (!PosDaughTrack.isSelectedMinimal(posTrack)) {
     return false;
   }
@@ -722,7 +664,6 @@ bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& c
   if (!BachTrack.isSelectedMinimal(bachTrack)) {
     return false;
   }
-  */ 
   
   
   /*
@@ -737,25 +678,6 @@ bool FemtoDreamCascadeSelection::isSelectedMinimal(Col const& col, Casc const& c
   }
   */ 
   
-  
-
-
-  /*
-    // check that track combinations for V0 or antiV0 would be fulfilling PID
-    float nSigmaPIDMax = PosDaughTrack.getSigmaPIDMax();
-    // antiV0
-    auto nSigmaPrNeg = negTrack.tpcNSigmaPr();
-    auto nSigmaPiPos = posTrack.tpcNSigmaPi();
-    // v0
-    auto nSigmaPiNeg = negTrack.tpcNSigmaPi();
-    auto nSigmaPrPos = posTrack.tpcNSigmaPr();
-    if (!(abs(nSigmaPrNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax &&
-          abs(nSigmaPiPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax) &&
-        !(abs(nSigmaPrPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax &&
-          abs(nSigmaPiNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax)) {
-      return false;
-    }
-  */
   return true;
 }
 
@@ -842,7 +764,8 @@ std::array<cutContainerType, 8> FemtoDreamCascadeSelection::getCutContainer(Col 
   auto nSigmaPrPos = posTrack.tpcNSigmaPr();
   float nSigmaPIDOffsetTPC = 0.;
 
-  //TODO: improve the selection of the Xi candidates (now I select only Xi/ antiXi based on the daughter Lambda)
+  //negative charge: Antiparticle (Xi+)
+  //positive charge: Particle (Xi-) 
   if (abs(nSigmaPrNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax && abs(nSigmaPiPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax) {
     sign = -1.;
   } else if (abs(nSigmaPrPos - nSigmaPIDOffsetTPC) < nSigmaPIDMax && abs(nSigmaPiNeg - nSigmaPIDOffsetTPC) < nSigmaPIDMax) {

--- a/PWGCF/FemtoDream/Core/femtoDreamDetaDphiStar.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamDetaDphiStar.h
@@ -117,7 +117,7 @@ class FemtoDreamDetaDphiStar
       }
     }
     if constexpr (mPartOneType == o2::aod::femtodreamparticle::ParticleType::kTrack && mPartTwoType == o2::aod::femtodreamparticle::ParticleType::kCascade) {
-      for (int i = 0; i < 3; i++){
+      for (int i = 0; i < 3; i++) {
         std::string dirName = static_cast<std::string>(dirNames[3]);
         histdetadpi[i][0] = mHistogramRegistry->add<TH2>((dirName + static_cast<std::string>(histNames[0][i]) + static_cast<std::string>(histNameSEorME[meORse])).c_str(), "; #Delta #eta; #Delta #phi^{*}", kTH2F, {{100, -0.15, 0.15}, {100, -0.15, 0.15}});
         histdetadpi[i][1] = mHistogramRegistry->add<TH2>((dirName + static_cast<std::string>(histNames[1][i]) + static_cast<std::string>(histNameSEorME[meORse])).c_str(), "; #Delta #eta; #Delta #phi^{*}", kTH2F, {{100, -0.15, 0.15}, {100, -0.15, 0.15}});
@@ -132,7 +132,6 @@ class FemtoDreamDetaDphiStar
           histdetadpi_eta[i] = mHistogramRegistry->add<THnSparse>((dirName + "dEtadPhi_Eta_" + std::to_string(i) + static_cast<std::string>(histNameSEorME[meORse])).c_str(), "; #Delta #eta; #Delta #phi^{*}; #eta_{1}; #eta_{2}", kTHnSparseF, {{100, -0.15, 0.15}, {100, -0.15, 0.15}, {100, -0.8, 0.8}, {100, -0.8, 0.8}});
           histdetadpi_phi[i] = mHistogramRegistry->add<THnSparse>((dirName + "dEtadPhi_Phi_" + std::to_string(i) + static_cast<std::string>(histNameSEorME[meORse])).c_str(), "; #Delta #eta; #Delta #phi^{*}; #phi_{1}; #phi_{2}", kTHnSparseF, {{100, -0.15, 0.15}, {100, -0.15, 0.15}, {100, 0, 6.28}, {100, 0, 6.28}});
         }
-
       }
     }
   }
@@ -145,8 +144,8 @@ class FemtoDreamDetaDphiStar
     if constexpr (mPartOneType == o2::aod::femtodreamparticle::ParticleType::kTrack && (mPartTwoType == o2::aod::femtodreamparticle::ParticleType::kTrack || mPartTwoType == o2::aod::femtodreamparticle::ParticleType::kCascadeV0Child)) {
       /// Track-Track combination
       // check if provided particles are in agreement with the class instantiation
-      if (part1.partType() != o2::aod::femtodreamparticle::ParticleType::kTrack || !(part2.partType() == o2::aod::femtodreamparticle::ParticleType::kTrack || part2.partType() == o2::aod::femtodreamparticle::ParticleType::kCascadeV0Child)) { //hotfix to use the CPR
-        //LOG(fatal) << "FemtoDreamDetaDphiStar: passed arguments don't agree with FemtoDreamDetaDphiStar instantiation! Please provide kTrack,kTrack candidates.";
+      if (part1.partType() != o2::aod::femtodreamparticle::ParticleType::kTrack || !(part2.partType() == o2::aod::femtodreamparticle::ParticleType::kTrack || part2.partType() == o2::aod::femtodreamparticle::ParticleType::kCascadeV0Child)) { // hotfix to use the CPR
+        // LOG(fatal) << "FemtoDreamDetaDphiStar: passed arguments don't agree with FemtoDreamDetaDphiStar instantiation! Please provide kTrack,kTrack candidates.";
         LOGF(fatal, "FemtoDreamDetaDphiStar: passed arguments don't agree with FemtoDreamDetaDphiStar instantiation! Please provide kTrack,kTrack candidates. Currently: %i", part2.partType());
         return false;
       }
@@ -447,7 +446,6 @@ class FemtoDreamDetaDphiStar
               }
             }
 
-          
           } else if (atWhichRadiiToSelect == 0) {
             if (pow(dphi_AT_PV, 2) / pow(deltaPhiMax, 2) + pow(deta, 2) / pow(deltaEtaMax, 2) < 1.) {
               pass = true;

--- a/PWGCF/FemtoDream/Core/femtoDreamDetaDphiStar.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamDetaDphiStar.h
@@ -116,6 +116,25 @@ class FemtoDreamDetaDphiStar
         }
       }
     }
+    if constexpr (mPartOneType == o2::aod::femtodreamparticle::ParticleType::kTrack && mPartTwoType == o2::aod::femtodreamparticle::ParticleType::kCascade) {
+      for (int i = 0; i < 3; i++){
+        std::string dirName = static_cast<std::string>(dirNames[3]);
+        histdetadpi[i][0] = mHistogramRegistry->add<TH2>((dirName + static_cast<std::string>(histNames[0][i]) + static_cast<std::string>(histNameSEorME[meORse])).c_str(), "; #Delta #eta; #Delta #phi^{*}", kTH2F, {{100, -0.15, 0.15}, {100, -0.15, 0.15}});
+        histdetadpi[i][1] = mHistogramRegistry->add<TH2>((dirName + static_cast<std::string>(histNames[1][i]) + static_cast<std::string>(histNameSEorME[meORse])).c_str(), "; #Delta #eta; #Delta #phi^{*}", kTH2F, {{100, -0.15, 0.15}, {100, -0.15, 0.15}});
+        histdetadpi[i][2] = mHistogramRegistry->add<TH2>((dirName + "at_PV_" + std::to_string(i) + "_before" + static_cast<std::string>(histNameSEorME[meORse])).c_str(), "; #Delta #eta; #Delta #phi^{*}", kTH2F, {{100, -0.15, 0.15}, {100, -0.15, 0.15}});
+        histdetadpi[i][3] = mHistogramRegistry->add<TH2>((dirName + "at_PV_" + std::to_string(i) + "_after" + static_cast<std::string>(histNameSEorME[meORse])).c_str(), "; #Delta #eta; #Delta #phi^{*}", kTH2F, {{100, -0.15, 0.15}, {100, -0.15, 0.15}});
+        if (plotForEveryRadii) {
+          for (int j = 0; j < 9; j++) {
+            histdetadpiRadii[i][j] = mHistogramRegistryQA->add<TH2>((dirName + static_cast<std::string>(histNamesRadii[i][j]) + static_cast<std::string>(histNameSEorME[meORse])).c_str(), "; #Delta #eta; #Delta #phi^{*}", kTH2F, {{100, -0.15, 0.15}, {100, -0.15, 0.15}});
+          }
+        }
+        if (fillQA) {
+          histdetadpi_eta[i] = mHistogramRegistry->add<THnSparse>((dirName + "dEtadPhi_Eta_" + std::to_string(i) + static_cast<std::string>(histNameSEorME[meORse])).c_str(), "; #Delta #eta; #Delta #phi^{*}; #eta_{1}; #eta_{2}", kTHnSparseF, {{100, -0.15, 0.15}, {100, -0.15, 0.15}, {100, -0.8, 0.8}, {100, -0.8, 0.8}});
+          histdetadpi_phi[i] = mHistogramRegistry->add<THnSparse>((dirName + "dEtadPhi_Phi_" + std::to_string(i) + static_cast<std::string>(histNameSEorME[meORse])).c_str(), "; #Delta #eta; #Delta #phi^{*}; #phi_{1}; #phi_{2}", kTHnSparseF, {{100, -0.15, 0.15}, {100, -0.15, 0.15}, {100, 0, 6.28}, {100, 0, 6.28}});
+        }
+
+      }
+    }
   }
   ///  Check if pair is close or not
   template <typename Part1, typename Part2, typename Parts>
@@ -376,6 +395,92 @@ class FemtoDreamDetaDphiStar
 
       return pass;
 
+    } else if constexpr (mPartOneType == o2::aod::femtodreamparticle::ParticleType::kTrack && mPartTwoType == o2::aod::femtodreamparticle::ParticleType::kCascade) {
+      /// Track-V0 combination
+      // check if provided particles are in agreement with the class instantiation
+      if (part1.partType() != o2::aod::femtodreamparticle::ParticleType::kTrack || part2.partType() != o2::aod::femtodreamparticle::ParticleType::kCascade) {
+        LOG(fatal) << "FemtoDreamDetaDphiStar: passed arguments don't agree with FemtoDreamDetaDphiStar instantiation! Please provide kTrack,kV0 candidates.";
+        return false;
+      }
+
+      bool pass = false;
+      for (int i = 0; i < 3; i++) {
+        int indexOfDaughter;
+        if (isMixedEventLambda) {
+          indexOfDaughter = part2.globalIndex() - 3 + i;
+        } else {
+          indexOfDaughter = part2.index() - 3 + i;
+        }
+        auto daughter = particles.begin() + indexOfDaughter;
+        auto deta = part1.eta() - daughter.eta();
+        auto dphi_AT_PV = part1.phi() - daughter.phi();
+        auto dphi_AT_SpecificRadii = PhiAtSpecificRadiiTPC(part1, radiiTPC) - PhiAtSpecificRadiiTPC(daughter, radiiTPC);
+        bool sameCharge = false;
+        auto dphiAvg = AveragePhiStar(part1, *daughter, i, &sameCharge);
+        if (Q3 == 999) {
+          histdetadpi[i][0]->Fill(deta, dphiAvg);
+          histdetadpi[i][2]->Fill(deta, dphi_AT_PV);
+          if (fillQA) {
+            histdetadpi_eta[i]->Fill(deta, dphiAvg, part1.eta(), daughter.eta());
+            histdetadpi_phi[i]->Fill(deta, dphiAvg, part1.phi(), daughter.phi());
+          }
+        /*
+        } else if (Q3 < upperQ3LimitForPlotting) {
+          histdetadpi[i][0]->Fill(deta, dphiAvg);
+          histdetadpi[i][2]->Fill(deta, dphi_AT_PV);
+          if (fillQA) {
+            histdetadpi_eta[i]->Fill(deta, dphiAvg, part1.eta(), daughter.eta());
+            histdetadpi_phi[i]->Fill(deta, dphiAvg, part1.phi(), daughter.phi());
+          }
+        }
+        */
+        if (sameCharge) {
+          if (atWhichRadiiToSelect == 1) {
+            if (pow(dphiAvg, 2) / pow(deltaPhiMax, 2) + pow(deta, 2) / pow(deltaEtaMax, 2) < 1.) {
+              pass = true;
+            } else {
+              if (Q3 == 999) {
+                histdetadpi[i][1]->Fill(deta, dphiAvg);
+                histdetadpi[i][3]->Fill(deta, dphi_AT_PV);
+              /*
+              } else if (Q3 < upperQ3LimitForPlotting) {
+                histdetadpi[i][1]->Fill(deta, dphiAvg);
+                histdetadpi[i][3]->Fill(deta, dphi_AT_PV);
+              }
+              */ 
+            }
+
+          
+          /*
+          } else if (atWhichRadiiToSelect == 0) {
+            if (pow(dphi_AT_PV, 2) / pow(deltaPhiMax, 2) + pow(deta, 2) / pow(deltaEtaMax, 2) < 1.) {
+              pass = true;
+            } else {
+              if (Q3 == 999) {
+                histdetadpi[i][1]->Fill(deta, dphiAvg);
+                histdetadpi[i][3]->Fill(deta, dphi_AT_PV);
+              } else if (Q3 < upperQ3LimitForPlotting) {
+                histdetadpi[i][1]->Fill(deta, dphiAvg);
+                histdetadpi[i][3]->Fill(deta, dphi_AT_PV);
+              }
+            }
+          } else if (atWhichRadiiToSelect == 2) {
+            if (pow(dphi_AT_SpecificRadii, 2) / pow(deltaPhiMax, 2) + pow(deta, 2) / pow(deltaEtaMax, 2) < 1.) {
+              pass = true;
+            } else {
+              if (Q3 == 999) {
+                histdetadpi[i][1]->Fill(deta, dphiAvg);
+                histdetadpi[i][3]->Fill(deta, dphi_AT_PV);
+              } else if (Q3 < upperQ3LimitForPlotting) {
+                histdetadpi[i][1]->Fill(deta, dphiAvg);
+                histdetadpi[i][3]->Fill(deta, dphi_AT_PV);
+              }
+            }
+          }
+          */ 
+        }
+      }
+      return pass;
     } else {
       LOG(fatal) << "FemtoDreamPairCleaner: Combination of objects not defined - quitting!";
       return false;
@@ -385,14 +490,14 @@ class FemtoDreamDetaDphiStar
  private:
   HistogramRegistry* mHistogramRegistry = nullptr;   ///< For main output
   HistogramRegistry* mHistogramRegistryQA = nullptr; ///< For QA output
-  static constexpr std::string_view dirNames[3] = {"kTrack_kTrack/", "kTrack_kV0/", "kTrack_kCharmHadron/"};
+  static constexpr std::string_view dirNames[4] = {"kTrack_kTrack/", "kTrack_kV0/", "kTrack_kCharmHadron/", "kTrack_kCascade/"};
 
   static constexpr std::string_view histNameSEorME[3] = {"_SEandME", "_SE", "_ME"};
 
-  static constexpr std::string_view histNames[2][3] = {{"detadphidetadphi0Before_0", "detadphidetadphi0Before_1", "detadphidetadphi0Before_2"},
-                                                       {"detadphidetadphi0After_0", "detadphidetadphi0After_1", "detadphidetadphi0After_2"}};
+  static constexpr std::string_view histNames[2][4] = {{"detadphidetadphi0Before_0", "detadphidetadphi0Before_1", "detadphidetadphi0Before_2", "detadphidetadphi0Before_3"},
+                                                       {"detadphidetadphi0After_0", "detadphidetadphi0After_1", "detadphidetadphi0After_2", "detadphidetadphi0After_3"}};
 
-  static constexpr std::string_view histNamesRadii[3][9] = {
+  static constexpr std::string_view histNamesRadii[4][9] = {
     {"detadphidetadphi0Before_0_0", "detadphidetadphi0Before_0_1", "detadphidetadphi0Before_0_2",
      "detadphidetadphi0Before_0_3", "detadphidetadphi0Before_0_4", "detadphidetadphi0Before_0_5",
      "detadphidetadphi0Before_0_6", "detadphidetadphi0Before_0_7", "detadphidetadphi0Before_0_8"},
@@ -401,7 +506,10 @@ class FemtoDreamDetaDphiStar
      "detadphidetadphi0Before_1_6", "detadphidetadphi0Before_1_7", "detadphidetadphi0Before_1_8"},
     {"detadphidetadphi0Before_2_0", "detadphidetadphi0Before_2_1", "detadphidetadphi0Before_2_2",
      "detadphidetadphi0Before_2_3", "detadphidetadphi0Before_2_4", "detadphidetadphi0Before_2_5",
-     "detadphidetadphi0Before_2_6", "detadphidetadphi0Before_2_7", "detadphidetadphi0Before_2_8"}};
+     "detadphidetadphi0Before_2_6", "detadphidetadphi0Before_2_7", "detadphidetadphi0Before_2_8"},
+    {"detadphidetadphi0Before_3_0", "detadphidetadphi0Before_3_1", "detadphidetadphi0Before_3_2",
+     "detadphidetadphi0Before_3_3", "detadphidetadphi0Before_3_4", "detadphidetadphi0Before_3_5",
+     "detadphidetadphi0Before_3_6", "detadphidetadphi0Before_3_7", "detadphidetadphi0Before_3_8"}};
 
   static constexpr o2::aod::femtodreamparticle::ParticleType mPartOneType = partOne; ///< Type of particle 1
   static constexpr o2::aod::femtodreamparticle::ParticleType mPartTwoType = partTwo; ///< Type of particle 2

--- a/PWGCF/FemtoDream/Core/femtoDreamDetaDphiStar.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamDetaDphiStar.h
@@ -64,7 +64,7 @@ class FemtoDreamDetaDphiStar
     radiiTPC = radiiTPCtoCut;
     fillQA = fillTHSparse;
 
-    if constexpr (mPartOneType == o2::aod::femtodreamparticle::ParticleType::kTrack && mPartTwoType == o2::aod::femtodreamparticle::ParticleType::kTrack) {
+    if constexpr (mPartOneType == o2::aod::femtodreamparticle::ParticleType::kTrack && (mPartTwoType == o2::aod::femtodreamparticle::ParticleType::kTrack || mPartTwoType == o2::aod::femtodreamparticle::ParticleType::kCascadeV0Child)) {
       std::string dirName = static_cast<std::string>(dirNames[0]);
       histdetadpi[0][0] = mHistogramRegistry->add<TH2>((dirName + static_cast<std::string>(histNames[0][0]) + static_cast<std::string>(histNameSEorME[meORse])).c_str(), "; #Delta #eta; #Delta #phi^{*}", kTH2F, {{100, -0.15, 0.15}, {100, -0.15, 0.15}});
       histdetadpi[0][1] = mHistogramRegistry->add<TH2>((dirName + static_cast<std::string>(histNames[1][0]) + static_cast<std::string>(histNameSEorME[meORse])).c_str(), "; #Delta #eta; #Delta #phi^{*}", kTH2F, {{100, -0.15, 0.15}, {100, -0.15, 0.15}});
@@ -142,7 +142,7 @@ class FemtoDreamDetaDphiStar
   {
     magfield = lmagfield;
 
-    if constexpr (mPartOneType == o2::aod::femtodreamparticle::ParticleType::kTrack && mPartTwoType == o2::aod::femtodreamparticle::ParticleType::kTrack) {
+    if constexpr (mPartOneType == o2::aod::femtodreamparticle::ParticleType::kTrack && (mPartTwoType == o2::aod::femtodreamparticle::ParticleType::kTrack || mPartTwoType == o2::aod::femtodreamparticle::ParticleType::kCascadeV0Child)) {
       /// Track-Track combination
       // check if provided particles are in agreement with the class instantiation
       if (part1.partType() != o2::aod::femtodreamparticle::ParticleType::kTrack || !(part2.partType() == o2::aod::femtodreamparticle::ParticleType::kTrack || part2.partType() == o2::aod::femtodreamparticle::ParticleType::kCascadeV0Child)) { //hotfix to use the CPR

--- a/PWGCF/FemtoDream/Core/femtoDreamDetaDphiStar.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamDetaDphiStar.h
@@ -145,8 +145,9 @@ class FemtoDreamDetaDphiStar
     if constexpr (mPartOneType == o2::aod::femtodreamparticle::ParticleType::kTrack && mPartTwoType == o2::aod::femtodreamparticle::ParticleType::kTrack) {
       /// Track-Track combination
       // check if provided particles are in agreement with the class instantiation
-      if (part1.partType() != o2::aod::femtodreamparticle::ParticleType::kTrack || part2.partType() != o2::aod::femtodreamparticle::ParticleType::kTrack) {
-        LOG(fatal) << "FemtoDreamDetaDphiStar: passed arguments don't agree with FemtoDreamDetaDphiStar instantiation! Please provide kTrack,kTrack candidates.";
+      if (part1.partType() != o2::aod::femtodreamparticle::ParticleType::kTrack || !(part2.partType() == o2::aod::femtodreamparticle::ParticleType::kTrack || part2.partType() == o2::aod::femtodreamparticle::ParticleType::kCascadeV0Child)) { //hotfix to use the CPR
+        //LOG(fatal) << "FemtoDreamDetaDphiStar: passed arguments don't agree with FemtoDreamDetaDphiStar instantiation! Please provide kTrack,kTrack candidates.";
+        LOGF(fatal, "FemtoDreamDetaDphiStar: passed arguments don't agree with FemtoDreamDetaDphiStar instantiation! Please provide kTrack,kTrack candidates. Currently: %i", part2.partType());
         return false;
       }
       auto deta = part1.eta() - part2.eta();

--- a/PWGCF/FemtoDream/Core/femtoDreamDetaDphiStar.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamDetaDphiStar.h
@@ -424,7 +424,6 @@ class FemtoDreamDetaDphiStar
             histdetadpi_eta[i]->Fill(deta, dphiAvg, part1.eta(), daughter.eta());
             histdetadpi_phi[i]->Fill(deta, dphiAvg, part1.phi(), daughter.phi());
           }
-        /*
         } else if (Q3 < upperQ3LimitForPlotting) {
           histdetadpi[i][0]->Fill(deta, dphiAvg);
           histdetadpi[i][2]->Fill(deta, dphi_AT_PV);
@@ -433,7 +432,6 @@ class FemtoDreamDetaDphiStar
             histdetadpi_phi[i]->Fill(deta, dphiAvg, part1.phi(), daughter.phi());
           }
         }
-        */
         if (sameCharge) {
           if (atWhichRadiiToSelect == 1) {
             if (pow(dphiAvg, 2) / pow(deltaPhiMax, 2) + pow(deta, 2) / pow(deltaEtaMax, 2) < 1.) {
@@ -442,16 +440,13 @@ class FemtoDreamDetaDphiStar
               if (Q3 == 999) {
                 histdetadpi[i][1]->Fill(deta, dphiAvg);
                 histdetadpi[i][3]->Fill(deta, dphi_AT_PV);
-              /*
               } else if (Q3 < upperQ3LimitForPlotting) {
                 histdetadpi[i][1]->Fill(deta, dphiAvg);
                 histdetadpi[i][3]->Fill(deta, dphi_AT_PV);
               }
-              */ 
             }
 
           
-          /*
           } else if (atWhichRadiiToSelect == 0) {
             if (pow(dphi_AT_PV, 2) / pow(deltaPhiMax, 2) + pow(deta, 2) / pow(deltaEtaMax, 2) < 1.) {
               pass = true;
@@ -477,7 +472,6 @@ class FemtoDreamDetaDphiStar
               }
             }
           }
-          */ 
         }
       }
       return pass;

--- a/PWGCF/FemtoDream/Core/femtoDreamPairCleaner.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamPairCleaner.h
@@ -85,6 +85,19 @@ class FemtoDreamPairCleaner
         return true;
       }
       return false;
+    } else if constexpr (mPartOneType == o2::aod::femtodreamparticle::ParticleType::kTrack && mPartTwoType == o2::aod::femtodreamparticle::ParticleType::kCascade) {
+      /// Track-Cascade combination
+      if (part2.partType() != o2::aod::femtodreamparticle::ParticleType::kCascade) {
+        LOG(fatal) << "FemtoDreamPairCleaner: passed arguments don't agree with FemtoDreamPairCleaner instantiation! Please provide second argument kCascade candidate.";
+        return false;
+      }
+      const auto& posChild = particles.iteratorAt(part2.index() - 3);
+      const auto& negChild = particles.iteratorAt(part2.index() - 2);
+      const auto& bachChild = particles.iteratorAt(part2.index() - 1);
+      if (part1.index() != posChild.childrenIds()[0] && part1.index() != negChild.childrenIds()[1] && part1.index() != bachChild.childrenIds()[2]) {
+        return true;
+      }
+      return false;
     } else {
       LOG(fatal) << "FemtoDreamPairCleaner: Combination of objects not defined - quitting!";
       return false;

--- a/PWGCF/FemtoDream/Core/femtoDreamParticleHisto.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamParticleHisto.h
@@ -61,7 +61,7 @@ class FemtoDreamParticleHisto
     if constexpr (o2::aod::femtodreamMCparticle::MCType::kRecon == mc) {
       mHistogramRegistry->add((folderName + folderSuffix + static_cast<std::string>(o2::aod::femtodreamparticle::TempFitVarName[mParticleType])).c_str(), ("; #it{p}_{T} (GeV/#it{c}); " + tempFitVarAxisTitle).c_str(), kTH2F, {{pTAxis}, {tempFitVarAxis}});
     }
-    if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0 && mc == o2::aod::femtodreamMCparticle::MCType::kRecon) {
+    if constexpr ((mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0 || mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascadeV0) && mc == o2::aod::femtodreamMCparticle::MCType::kRecon) {
       mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassLambda").c_str(), "; M_{#Lambda}; Entries", kTH1F, {InvMassAxis});
       mHistogramRegistry->add((folderName + folderSuffix + "/hpTInvMassLambda").c_str(), "; p_{T} (GeV/#it{c{}); M_{#Lambda}", kTH2F, {pTAxis, InvMassAxis});
       mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassAntiLambda").c_str(), "; M_{#bar{#Lambda}}; Entries", kTH1F, {InvMassAxis});
@@ -168,7 +168,7 @@ class FemtoDreamParticleHisto
     mHistogramRegistry->add((folderName + folderSuffix + "/hEta_DiffTruthReco").c_str(), "; #eta^{truth}; #eta^{reco} - #eta^{truth}", kTH2F, {{200, -1, 1}, {200, -1, 1}});
     mHistogramRegistry->add((folderName + folderSuffix + "/hPhi_DiffTruthReco").c_str(), "; #varphi^{truth}; #varphi^{reco} - #varphi^{truth}", kTH2F, {{720, 0, TMath::TwoPi()}, {200, -1, 1}});
 
-    if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child) {
+    if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child || mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascadeV0Child || mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascadeBachelor) {
       /// Track histograms
       if (isDebug) {
         mHistogramRegistry->add((folderName + folderSuffix + "/Debug/hPDGmother_Primary").c_str(), "; PDG mother; Entries", kTH1I, {{6001, -3000.5, 3000.5}});
@@ -200,7 +200,7 @@ class FemtoDreamParticleHisto
       }
 
       // DCA plots
-    } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0) {
+    } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0 || mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascadeV0) {
       if (isDebug) {
         mHistogramRegistry->add((folderName + folderSuffix + "/hCPA_Primary").c_str(), "; #it{p}_{T} (GeV/#it{c}); CPA", kTHnSparseF, {tempFitVarpTAxis, tempFitVarAxis, multAxis});
         mHistogramRegistry->add((folderName + folderSuffix + "/hCPA_Secondary").c_str(), "; #it{p}_{T} (GeV/#it{c}); CPA", kTHnSparseF, {tempFitVarpTAxis, tempFitVarAxis, multAxis});
@@ -251,7 +251,7 @@ class FemtoDreamParticleHisto
       if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child) {
         /// Track histograms
         tempFitVarAxisTitle = "DCA_{xy} (cm)";
-      } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0 || o2::aod::femtodreamparticle::ParticleType::kCascadeV0) {
+      } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0 || mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascadeV0) {
         /// V0 histograms
         tempFitVarAxisTitle = "cos#alpha";
       } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascade) {
@@ -342,7 +342,7 @@ class FemtoDreamParticleHisto
     mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hEtaVsPhi"), part.eta(), part.phi());
 
     // Histograms holding further debug information
-    if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child || o2::aod::femtodreamparticle::ParticleType::kCascadeV0Child || o2::aod::femtodreamparticle::ParticleType::kCascadeBachelor) {
+    if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child || mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascadeV0Child || mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascadeBachelor) {
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hCharge"), part.sign());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCfindable"), part.tpcNClsFindable());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCfound"), part.tpcNClsFound());

--- a/PWGCF/FemtoDream/Core/femtoDreamParticleHisto.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamParticleHisto.h
@@ -68,6 +68,10 @@ class FemtoDreamParticleHisto
       mHistogramRegistry->add((folderName + folderSuffix + "/hpTInvMassAntiLambda").c_str(), "; M_{#bar{#Lambda}}; Entries", kTH2F, {pTAxis, InvMassAxis});
       mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassLambdaAntiLambda").c_str(), "; M_{#Lambda}; M_{#bar{#Lambda}}", kTH2F, {InvMassAxis, InvMassAxis});
     }
+    if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascade){
+      mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassCascade").c_str(), "; M_{Cascade}; Entries", kTH1F, {InvMassAxis});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hpTInvMassCascade").c_str(), "; p_{T} (GeV/#it{c{}); M_{Cascade}", kTH2F, {pTAxis, InvMassAxis});
+    } 
   }
 
   // comment
@@ -81,7 +85,7 @@ class FemtoDreamParticleHisto
     mHistogramRegistry->add((folderName + folderSuffix + "/hMomentumVsPhi").c_str(), "; #it{p} (GeV/#it{c}); #phi", kTH2F, {{500, 0, 10}, {360, 0., TMath::TwoPi()}});
     mHistogramRegistry->add((folderName + folderSuffix + "/hEtaVsPhi").c_str(), "; #eta; #phi", kTH2F, {{300, -1.5, 1.5}, {360, 0., TMath::TwoPi()}});
 
-    if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child) {
+    if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child || mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascadeV0Child || mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascadeBachelor) {
       mHistogramRegistry->add((folderName + folderSuffix + "/hCharge").c_str(), "; Charge; Entries", kTH1F, {{5, -2.5, 2.5}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hTPCfindable").c_str(), "; TPC findable clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hTPCfound").c_str(), "; TPC found clusters; Entries", kTH1F, {{163, -0.5, 162.5}});
@@ -128,7 +132,13 @@ class FemtoDreamParticleHisto
       if (correlatedPlots) {
         mHistogramRegistry->add((folderName + folderSuffix + "/HighDcorrelator").c_str(), "", kTHnSparseF, {multAxis, multPercentileAxis, pTAxis, etaAxis, phiAxis, tempFitVarAxis, dcazAxis, NsigmaTPCAxis, NsigmaTOFAxis});
       }
-    } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0) {
+    } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0 || mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascadeV0) {
+      mHistogramRegistry->add((folderName + folderSuffix + "/hDaughDCA").c_str(), "; DCA^{daugh} (cm); Entries", kTH1F, {{1000, 0, 10}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hTransRadius").c_str(), "; #it{r}_{xy} (cm); Entries", kTH1F, {{1500, 0, 150}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hDecayVtxX").c_str(), "; #it{Vtx}_{x} (cm); Entries", kTH1F, {{2000, 0, 200}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hDecayVtxY").c_str(), "; #it{Vtx}_{y} (cm)); Entries", kTH1F, {{2000, 0, 200}});
+      mHistogramRegistry->add((folderName + folderSuffix + "/hDecayVtxZ").c_str(), "; #it{Vtx}_{z} (cm); Entries", kTH1F, {{2000, 0, 200}});
+    } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascade) {
       mHistogramRegistry->add((folderName + folderSuffix + "/hDaughDCA").c_str(), "; DCA^{daugh} (cm); Entries", kTH1F, {{1000, 0, 10}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hTransRadius").c_str(), "; #it{r}_{xy} (cm); Entries", kTH1F, {{1500, 0, 150}});
       mHistogramRegistry->add((folderName + folderSuffix + "/hDecayVtxX").c_str(), "; #it{Vtx}_{x} (cm); Entries", kTH1F, {{2000, 0, 200}});
@@ -241,7 +251,7 @@ class FemtoDreamParticleHisto
       if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child) {
         /// Track histograms
         tempFitVarAxisTitle = "DCA_{xy} (cm)";
-      } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0) {
+      } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0 || o2::aod::femtodreamparticle::ParticleType::kCascadeV0) {
         /// V0 histograms
         tempFitVarAxisTitle = "cos#alpha";
       } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascade) {
@@ -294,12 +304,16 @@ class FemtoDreamParticleHisto
     if constexpr (mc == o2::aod::femtodreamMCparticle::MCType::kRecon) {
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST(o2::aod::femtodreamparticle::TempFitVarName[mParticleType]), part.pt(), part.tempFitVar());
     }
-    if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0 && mc == o2::aod::femtodreamMCparticle::MCType::kRecon) {
+    if constexpr ( (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0 || mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascadeV0) && mc == o2::aod::femtodreamMCparticle::MCType::kRecon) {
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hInvMassLambda"), part.mLambda());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hpTInvMassLambda"), part.pt(), part.mLambda());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hInvMassAntiLambda"), part.mAntiLambda());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hpTInvMassAntiLambda"), part.pt(), part.mAntiLambda());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hInvMassLambdaAntiLambda"), part.mLambda(), part.mAntiLambda());
+    }
+    if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascade){
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hInvMassCascade"), part.mLambda());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hpTInvMassCascade"), part.pt(), part.mLambda());
     }
   }
 
@@ -328,7 +342,7 @@ class FemtoDreamParticleHisto
     mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hEtaVsPhi"), part.eta(), part.phi());
 
     // Histograms holding further debug information
-    if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child) {
+    if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child || o2::aod::femtodreamparticle::ParticleType::kCascadeV0Child || o2::aod::femtodreamparticle::ParticleType::kCascadeBachelor) {
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hCharge"), part.sign());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCfindable"), part.tpcNClsFindable());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTPCfound"), part.tpcNClsFound());
@@ -421,7 +435,13 @@ class FemtoDreamParticleHisto
                                  pidTPC,
                                  pidTOF);
       }
-    } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0) {
+    } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0 || mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascadeV0 ) {
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDaughDCA"), part.daughDCA());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTransRadius"), part.transRadius());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDecayVtxX"), part.decayVtxX());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDecayVtxY"), part.decayVtxY());
+      mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDecayVtxZ"), part.decayVtxZ());
+    } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascade) {
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDaughDCA"), part.daughDCA());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTransRadius"), part.transRadius());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDecayVtxX"), part.decayVtxX());

--- a/PWGCF/FemtoDream/Core/femtoDreamParticleHisto.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamParticleHisto.h
@@ -248,7 +248,7 @@ class FemtoDreamParticleHisto
       mHistogramRegistry = registry;
       /// The folder names are defined by the type of the object and the suffix (if applicable)
       std::string tempFitVarAxisTitle;
-      if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child) {
+      if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kTrack || mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0Child || mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascadeV0Child || mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascadeBachelor) {
         /// Track histograms
         tempFitVarAxisTitle = "DCA_{xy} (cm)";
       } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0 || mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascadeV0) {
@@ -314,6 +314,8 @@ class FemtoDreamParticleHisto
     if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascade){
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hInvMassCascade"), part.mLambda());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hpTInvMassCascade"), part.pt(), part.mLambda());
+      //mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hInvMassCascade"), part.mLambda());
+      //mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hpTInvMassCascade"), part.pt(), part.mLambda());
     }
   }
 
@@ -680,7 +682,7 @@ class FemtoDreamParticleHisto
   HistogramRegistry* mHistogramRegistry;                                                                                                             ///< For QA output
   static constexpr o2::aod::femtodreamparticle::ParticleType mParticleType = particleType;                                                           ///< Type of the particle under analysis
   static constexpr int mFolderSuffixType = suffixType;                                                                                               ///< Counter for the folder suffix specified below
-  static constexpr std::string_view mFolderSuffix[8] = {"", "_one", "_two", "_pos", "_neg", "_allSelected", "_allSelected_pos", "_allSelected_neg"}; ///< Suffix for the folder name in case of analyses of pairs of the same kind (T-T, V-V, C-C)
+  static constexpr std::string_view mFolderSuffix[9] = {"", "_one", "_two", "_pos", "_neg", "_allSelected", "_allSelected_pos", "_allSelected_neg", "_bach"}; ///< Suffix for the folder name in case of analyses of pairs of the same kind (T-T, V-V, C-C)
   int mPDG = 0;                                                                                                                                      ///< PDG code of the selected particle
 };
 } // namespace o2::analysis::femtoDream

--- a/PWGCF/FemtoDream/Core/femtoDreamParticleHisto.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamParticleHisto.h
@@ -68,10 +68,10 @@ class FemtoDreamParticleHisto
       mHistogramRegistry->add((folderName + folderSuffix + "/hpTInvMassAntiLambda").c_str(), "; M_{#bar{#Lambda}}; Entries", kTH2F, {pTAxis, InvMassAxis});
       mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassLambdaAntiLambda").c_str(), "; M_{#Lambda}; M_{#bar{#Lambda}}", kTH2F, {InvMassAxis, InvMassAxis});
     }
-    if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascade){
+    if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascade) {
       mHistogramRegistry->add((folderName + folderSuffix + "/hInvMassCascade").c_str(), "; M_{Cascade}; Entries", kTH1F, {InvMassAxis});
       mHistogramRegistry->add((folderName + folderSuffix + "/hpTInvMassCascade").c_str(), "; p_{T} (GeV/#it{c{}); M_{Cascade}", kTH2F, {pTAxis, InvMassAxis});
-    } 
+    }
   }
 
   // comment
@@ -304,18 +304,18 @@ class FemtoDreamParticleHisto
     if constexpr (mc == o2::aod::femtodreamMCparticle::MCType::kRecon) {
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST(o2::aod::femtodreamparticle::TempFitVarName[mParticleType]), part.pt(), part.tempFitVar());
     }
-    if constexpr ( (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0 || mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascadeV0) && mc == o2::aod::femtodreamMCparticle::MCType::kRecon) {
+    if constexpr ((mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0 || mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascadeV0) && mc == o2::aod::femtodreamMCparticle::MCType::kRecon) {
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hInvMassLambda"), part.mLambda());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hpTInvMassLambda"), part.pt(), part.mLambda());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hInvMassAntiLambda"), part.mAntiLambda());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hpTInvMassAntiLambda"), part.pt(), part.mAntiLambda());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hInvMassLambdaAntiLambda"), part.mLambda(), part.mAntiLambda());
     }
-    if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascade){
+    if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascade) {
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hInvMassCascade"), part.mLambda());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hpTInvMassCascade"), part.pt(), part.mLambda());
-      //mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hInvMassCascade"), part.mLambda());
-      //mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hpTInvMassCascade"), part.pt(), part.mLambda());
+      // mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hInvMassCascade"), part.mLambda());
+      // mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hpTInvMassCascade"), part.pt(), part.mLambda());
     }
   }
 
@@ -437,7 +437,7 @@ class FemtoDreamParticleHisto
                                  pidTPC,
                                  pidTOF);
       }
-    } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0 || mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascadeV0 ) {
+    } else if constexpr (mParticleType == o2::aod::femtodreamparticle::ParticleType::kV0 || mParticleType == o2::aod::femtodreamparticle::ParticleType::kCascadeV0) {
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDaughDCA"), part.daughDCA());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hTransRadius"), part.transRadius());
       mHistogramRegistry->fill(HIST(o2::aod::femtodreamparticle::ParticleTypeName[mParticleType]) + HIST(mFolderSuffix[mFolderSuffixType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/hDecayVtxX"), part.decayVtxX());
@@ -679,11 +679,11 @@ class FemtoDreamParticleHisto
   }
 
  private:
-  HistogramRegistry* mHistogramRegistry;                                                                                                             ///< For QA output
-  static constexpr o2::aod::femtodreamparticle::ParticleType mParticleType = particleType;                                                           ///< Type of the particle under analysis
-  static constexpr int mFolderSuffixType = suffixType;                                                                                               ///< Counter for the folder suffix specified below
+  HistogramRegistry* mHistogramRegistry;                                                                                                                      ///< For QA output
+  static constexpr o2::aod::femtodreamparticle::ParticleType mParticleType = particleType;                                                                    ///< Type of the particle under analysis
+  static constexpr int mFolderSuffixType = suffixType;                                                                                                        ///< Counter for the folder suffix specified below
   static constexpr std::string_view mFolderSuffix[9] = {"", "_one", "_two", "_pos", "_neg", "_allSelected", "_allSelected_pos", "_allSelected_neg", "_bach"}; ///< Suffix for the folder name in case of analyses of pairs of the same kind (T-T, V-V, C-C)
-  int mPDG = 0;                                                                                                                                      ///< PDG code of the selected particle
+  int mPDG = 0;                                                                                                                                               ///< PDG code of the selected particle
 };
 } // namespace o2::analysis::femtoDream
 

--- a/PWGCF/FemtoDream/Core/femtoDreamTrackSelection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamTrackSelection.h
@@ -284,7 +284,7 @@ class FemtoDreamTrackSelection : public FemtoDreamObjectSelection<float, femtoDr
                                                                                         femtoDreamSelection::kLowerLimit,
                                                                                         femtoDreamSelection::kAbsUpperLimit,
                                                                                         femtoDreamSelection::kAbsUpperLimit,
-                                                                                        femtoDreamSelection::kAbsUpperLimit,
+                                                                                        femtoDreamSelection::kAbsUpperLimit,   // <-----TODO this should be a lower limit, no??
                                                                                         femtoDreamSelection::kAbsUpperLimit}; ///< Map to match a variable with its type
 
   static constexpr std::string_view mSelectionHelper[kNtrackSelection] = {"Sign of the track",

--- a/PWGCF/FemtoDream/Core/femtoDreamTrackSelection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamTrackSelection.h
@@ -284,7 +284,7 @@ class FemtoDreamTrackSelection : public FemtoDreamObjectSelection<float, femtoDr
                                                                                         femtoDreamSelection::kLowerLimit,
                                                                                         femtoDreamSelection::kAbsUpperLimit,
                                                                                         femtoDreamSelection::kAbsUpperLimit,
-                                                                                        femtoDreamSelection::kAbsUpperLimit,   // <-----TODO this should be a lower limit, no??
+                                                                                        femtoDreamSelection::kAbsUpperLimit,  // <-----TODO this should be a lower limit, no??
                                                                                         femtoDreamSelection::kAbsUpperLimit}; ///< Map to match a variable with its type
 
   static constexpr std::string_view mSelectionHelper[kNtrackSelection] = {"Sign of the track",

--- a/PWGCF/FemtoDream/Core/femtoDreamUtils.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamUtils.h
@@ -46,6 +46,9 @@ inline float getMass(int pdgCode)
     case kLambda0:
       mass = o2::constants::physics::MassLambda;
       break;
+    case kXiMinus:
+      mass = o2::constants::physics::MassXiMinus;
+      break;
     case o2::constants::physics::Pdg::kPhi:
       mass = o2::constants::physics::MassPhi;
       break;

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
@@ -215,29 +215,6 @@ struct femtoDreamProducerTask {
     Configurable<std::vector<float>> ConfCascadeDCAPosToPV{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeDCAPosToPV, "ConfCascade"), std::vector<float>{0.1f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeDCAPosToPV, "Cascade selection: ")};
     Configurable<std::vector<float>> ConfCascadeDCANegToPV{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeDCANegToPV, "ConfCascade"), std::vector<float>{0.1f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeDCANegToPV, "Cascade selection: ")};
     Configurable<std::vector<float>> ConfCascadeDCABachToPV{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeDCABachToPV, "ConfCascade"), std::vector<float>{0.1f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeDCABachToPV, "Cascade selection: ")};
-    */ 
-    
-    /* 
-    Configurable<std::vector<float>> confCascV0DCADaughMax{FemtoUniverseCascadeSelection::getSelectionName(femto_universe_cascade_selection::kCascadeV0DCADaughMax, "ConfCasc"), std::vector<float>{1.f, 1.2f, 1.5f}, FemtoUniverseCascadeSelection::getSelectionHelper(femto_universe_cascade_selection::kCascadeV0DCADaughMax, "Cascade selection: ")};
-    Configurable<std::vector<float>> confCascV0CPAMin{FemtoUniverseCascadeSelection::getSelectionName(femto_universe_cascade_selection::kCascadeV0CPAMin, "ConfCasc"), std::vector<float>{0.99f, 0.95f}, FemtoUniverseCascadeSelection::getSelectionHelper(femto_universe_cascade_selection::kCascadeV0CPAMin, "Cascade selection: ")};
-    Configurable<std::vector<float>> confCascV0TranRadMin{FemtoUniverseCascadeSelection::getSelectionName(femto_universe_cascade_selection::kCascadeV0TranRadMin, "ConfCasc"), std::vector<float>{0.2f}, FemtoUniverseCascadeSelection::getSelectionHelper(femto_universe_cascade_selection::kCascadeV0TranRadMin, "Cascade selection: ")};
-    Configurable<std::vector<float>> confCascV0TranRadMax{FemtoUniverseCascadeSelection::getSelectionName(femto_universe_cascade_selection::kCascadeV0TranRadMax, "ConfCasc"), std::vector<float>{100.f}, FemtoUniverseCascadeSelection::getSelectionHelper(femto_universe_cascade_selection::kCascadeV0TranRadMax, "Cascade selection: ")};
-    Configurable<std::vector<float>> confCascV0DecVtxMax{FemtoUniverseCascadeSelection::getSelectionName(femto_universe_cascade_selection::kCascadeV0DecVtxMax, "ConfCasc"), std::vector<float>{100.f}, FemtoUniverseCascadeSelection::getSelectionHelper(femto_universe_cascade_selection::kCascadeV0DecVtxMax, "Cascade selection: ")};
-
-    
-    Configurable<std::vector<float>> confCascDCAV0ToPV{FemtoUniverseCascadeSelection::getSelectionName(femto_universe_cascade_selection::kCascadeDCAV0ToPV, "ConfCasc"), std::vector<float>{0.01f}, FemtoUniverseCascadeSelection::getSelectionHelper(femto_universe_cascade_selection::kCascadeDCAV0ToPV, "Cascade selection: ")};
-    Configurable<std::vector<float>> confCascV0MassLowLimit{FemtoUniverseCascadeSelection::getSelectionName(femto_universe_cascade_selection::kCascadeV0MassMin, "ConfCasc"), std::vector<float>{1.05f}, FemtoUniverseCascadeSelection::getSelectionHelper(femto_universe_cascade_selection::kCascadeV0MassMin, "Cascade selection: ")};
-    Configurable<std::vector<float>> confCascV0MassUpLimit{FemtoUniverseCascadeSelection::getSelectionName(femto_universe_cascade_selection::kCascadeV0MassMax, "ConfCasc"), std::vector<float>{1.30f}, FemtoUniverseCascadeSelection::getSelectionHelper(femto_universe_cascade_selection::kCascadeV0MassMax, "Cascade selection: ")};
-
-    Configurable<std::vector<float>> confCascChildCharge{"confCascChildCharge", std::vector<float>{-1, 1}, "Cascade Child sel: Charge"};
-    Configurable<std::vector<float>> confCascChildEtaMax{"confCascChildEtaMax", std::vector<float>{0.8f}, "Cascade Child sel: max eta"};
-    Configurable<std::vector<float>> confCascChildTPCnClsMin{"confCascChildTPCnClsMin", std::vector<float>{80.f, 70.f, 60.f}, "Cascade Child sel: Min. nCls TPC"};
-    // Configurable<std::vector<float>> confCascChildDCAMin{"confCascChildDCAMin", std::vector<float>{0.05f, 0.06f}, "Cascade Child sel:  Max. DCA Daugh to PV (cm)"}; //Commented: not used variable
-    Configurable<std::vector<float>> confCascChildPIDnSigmaMax{"confCascChildPIDnSigmaMax", std::vector<float>{3.f, 4.f}, "Cascade Child sel: Max. PID nSigma TPC"};
-    Configurable<std::vector<int>> confCascChildPIDspecies{"confCascChildPIDspecies", std::vector<int>{o2::track::PID::Pion, o2::track::PID::Proton}, "Cascade Child sel: particle species for PID"};
-
-    Configurable<float> confCascInvMassLowLimit{"confCascInvMassLowLimit", 1.25, "Lower limit of the cascade invariant mass"};
-    Configurable<float> confCascInvMassUpLimit{"confCascInvMassUpLimit", 1.40, "Upper limit of the cascade invariant mass"};
 
     Configurable<bool> confCascRejectCompetingMass{"confCascRejectCompetingMass", false, "Switch on to reject Omegas (for Xi) or Xis (for Omegas)"};
     Configurable<float> confCascInvCompetingMassLowLimit{"confCascInvCompetingMassLowLimit", 1.66, "Lower limit of the cascade invariant mass for competing mass rejection"};
@@ -400,28 +377,28 @@ struct femtoDreamProducerTask {
       cascadeCuts.setSelection(ConfCascSel.ConfCascadeV0TranRadMax, femtoDreamCascadeSelection::kCascadeV0TranRadMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0TranRadMax)); 
       cascadeCuts.setSelection(ConfCascSel.ConfCascadeV0DCAtoPVMin, femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin)); 
       cascadeCuts.setSelection(ConfCascSel.ConfCascadeV0DCAtoPVMax, femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax)); 
+      
       //Cascade Daughter Tracks
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildCharge, femtoDreamTrackSelection::kSign, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kSign)); 
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildEtaMax, femtoDreamTrackSelection::kEtaMax, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kEtaMax)); 
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kTPCnClsMin)); 
-      //cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildDCAMin, femtoDreamTrackSelection::kDCAMin, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kDCAMin)); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildEtaMax, femtoDreamTrackSelection::kEtaMax, femtoDreamSelection::kAbsUpperLimit); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, femtoDreamSelection::kLowerLimit);
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildDCAMin, femtoDreamTrackSelection::kDCAMin, femtoDreamSelection::kLowerLimit); 
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kPIDnSigmaMax)); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit);
       cascadeCuts.setChildPIDSpecies(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildPIDspecies);
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildCharge, femtoDreamTrackSelection::kSign, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kSign)); 
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildEtaMax, femtoDreamTrackSelection::kEtaMax, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kEtaMax)); 
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kTPCnClsMin)); 
-      //cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildDCAMin, femtoDreamTrackSelection::kDCAMin, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kDCAMin)); 
+      
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildEtaMax, femtoDreamTrackSelection::kEtaMax, femtoDreamSelection::kAbsUpperLimit);
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, femtoDreamSelection::kLowerLimit);
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildDCAMin, femtoDreamTrackSelection::kDCAMin, femtoDreamSelection::kLowerLimit); 
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kPIDnSigmaMax)); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit);
       cascadeCuts.setChildPIDSpecies(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildPIDspecies);
+      
       //Cascade Bachelor Track
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorCharge, femtoDreamTrackSelection::kSign, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kSign)); 
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorEtaMax, femtoDreamTrackSelection::kEtaMax, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kEtaMax)); 
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kTPCnClsMin)); 
-      //cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorDCAMin, femtoDreamTrackSelection::kDCAMin, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kDCAMin)); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorEtaMax, femtoDreamTrackSelection::kEtaMax, femtoDreamSelection::kAbsUpperLimit);
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, femtoDreamSelection::kLowerLimit);
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorDCAMin, femtoDreamTrackSelection::kDCAMin, femtoDreamSelection::kLowerLimit); 
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kPIDnSigmaMax)); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit);
       cascadeCuts.setChildPIDSpecies(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorPIDspecies);
 
       /*
@@ -576,17 +553,11 @@ struct femtoDreamProducerTask {
   template <typename ParticleType>
   void fillDebugCascade(ParticleType)
   {
-      outputDebugParts(-999., -999., -999., -999., -999., -999., -999.,
-                       -999., -999., -999., -999., -999., -999., -999.,
-                       -999., -999., -999., -999., -999., -999., -999.,
-                       -999., -999., -999., -999.,
-                       -999., //particle.dcaV0daughters(),
-                       -999., //particle.v0radius(),
-                       -999., //particle.x(),
-                       -999., //particle.y(),
-                       -999., //particle.z(),
-                       -999. //particle.mK0Short());
-      );
+   outputDebugParts(-999., -999., -999., -999., -999., -999., -999., -999.,
+                    -999., -999., -999., -999., -999., -999., -999., -999.,
+                    -999., -999., -999., -999., -999., -999., -999., -999.,
+                    -999., -999., -999., -999., -999., -999., -999., -999.,
+                    -999., -999. - 999., -999., -999., -999., -999., -999.); // QA for Reso
   }
 
   template <typename CollisionType, typename ParticleType>
@@ -975,23 +946,10 @@ struct femtoDreamProducerTask {
       //TODO: include here MC filling
       //------
 
-      /*
-      outputParts(outputCollision.lastIndex(),
-                  casc.pt(),
-                  9999.,  //eta
-                  9999.,  //phi
-                  aod::femtodreamparticle::ParticleType::kCascade, //ParticleType
-                  nullptr,      //cutbit
-                  nullptr,      // ??
-                  9999.,  //cpa
-                  nullptr,      //child Index
-                  9999.,  //mLambda
-                  9999.); //mAntiLambda
-        */
        if(ConfIsDebug.value) {
-         fillDebugParticle<true>(posTrackCasc);  // QA for positive daughter
-         fillDebugParticle<true>(negTrackCasc);  // QA for negative daughter
-         fillDebugParticle<true>(bachTrackCasc); // QA for negative daughter
+         fillDebugParticle<true, true>(posTrackCasc);  // QA for positive daughter
+         fillDebugParticle<true, true>(negTrackCasc);  // QA for negative daughter
+         fillDebugParticle<true, true>(bachTrackCasc); // QA for negative daughter
          fillDebugCascade(casc);                 // QA for Cascade 
        }
     }
@@ -1077,9 +1035,9 @@ struct femtoDreamProducerTask {
     auto tracksWithItsPid = soa::Attach<aod::FemtoFullTracks, aod::pidits::ITSNSigmaEl, aod::pidits::ITSNSigmaPi, aod::pidits::ITSNSigmaKa,
                                         aod::pidits::ITSNSigmaPr, aod::pidits::ITSNSigmaDe, aod::pidits::ITSNSigmaTr, aod::pidits::ITSNSigmaHe>(tracks);
     if (ConfUseItsPid.value) {
-      fillCollisionsAndTracksAndV0<false, true, true, false>(col, tracks, tracksWithItsPid, fullV0s);
+      fillCollisionsAndTracksAndV0AndCascade<false, true, true, false>(col, tracks, tracksWithItsPid, fullV0s, fullCascades);
     } else {
-      fillCollisionsAndTracksAndV0<false, false, true, false>(col, tracks, tracks, fullV0s);
+      fillCollisionsAndTracksAndV0AndCascade<false, false, true, false>(col, tracks, tracks, fullV0s, fullCascades);
     }
   }
   PROCESS_SWITCH(femtoDreamProducerTask, processData,

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
@@ -176,7 +176,7 @@ struct femtoDreamProducerTask {
   struct : o2::framework::ConfigurableGroup {
     Configurable<float> ConfCascadeInvMassLowLimit{"ConfCascadeInvMassLowLimit", 1.2, "Lower limit of the Cascade invariant mass"};
     Configurable<float> ConfCascadeInvMassUpLimit{"ConfCascadeInvMassUpLimit", 1.5, "Upper limit of the Cascade invariant mass"};
-    //Cascade 
+    // Cascade
     Configurable<std::vector<float>> ConfCascadeSign{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeSign, "ConfCascade"), std::vector<float>{-1, 1}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeSign, "Cascade selection: ")};
     Configurable<std::vector<float>> ConfCascadePtMin{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadePtMin, "ConfCascade"), std::vector<float>{0.3f, 0.4f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadePtMin, "Cascade selection: ")};
     Configurable<std::vector<float>> ConfCascadePtMax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadePtMax, "ConfCascade"), std::vector<float>{5.5f, 6.0f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadePtMax, "Cascade selection: ")};
@@ -186,7 +186,7 @@ struct femtoDreamProducerTask {
     Configurable<std::vector<float>> ConfCascadeTranRadMin{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeTranRadMin, "ConfCascade"), std::vector<float>{0.2f, 0.5f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeTranRadMin, "Cascade selection: ")};
     Configurable<std::vector<float>> ConfCascadeTranRadMax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeTranRadMax, "ConfCascade"), std::vector<float>{100.f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeTranRadMax, "Cascade selection: ")};
     Configurable<std::vector<float>> ConfCascadeDecVtxMax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeDecVtxMax, "ConfCascade"), std::vector<float>{100.f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeDecVtxMax, "Cascade selection: ")};
-    //Cascade v0 daughters
+    // Cascade v0 daughters
     Configurable<std::vector<float>> ConfCascadeV0DCADaughMax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0DCADaughMax, "ConfCascade"), std::vector<float>{1.2f, 1.5f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0DCADaughMax, "CascV0 selection: ")};
     Configurable<std::vector<float>> ConfCascadeV0CPAMin{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0CPAMin, "ConfCascade"), std::vector<float>{0.99f, 0.995f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0CPAMin, "CascV0 selection: ")};
     Configurable<std::vector<float>> ConfCascadeV0TranRadMin{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0TranRadMin, "ConfCascade"), std::vector<float>{0.2f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0TranRadMin, "CascV0 selection: ")};
@@ -195,14 +195,14 @@ struct femtoDreamProducerTask {
     Configurable<std::vector<float>> ConfCascadeV0DCAtoPVMax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax, "ConfCascade"), std::vector<float>{100.f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax, "CascV0 selection: ")};
     Configurable<float> ConfCascadeV0InvMassLowLimit{"ConfCascadeV0InvMassLowLimit", 1.011461, "Lower limit of the Cascade invariant mass"};
     Configurable<float> ConfCascadeV0InvMassUpLimit{"ConfCascadeV0InvMassUpLimit", 1.027461, "Upper limit of the Cascade invariant mass"};
-    //Cascade Daughter Tracks 
+    // Cascade Daughter Tracks
     Configurable<std::vector<float>> ConfCascV0ChildCharge{"ConfCascV0ChildSign", std::vector<float>{-1, 1}, "CascV0 Child sel: Charge"};
     Configurable<std::vector<float>> ConfCascV0ChildEtaMax{"ConfCascV0ChildEtaMax", std::vector<float>{0.8f}, "CascV0 Child sel: max eta"};
     Configurable<std::vector<float>> ConfCascV0ChildTPCnClsMin{"ConfCascV0ChildTPCnClsMin", std::vector<float>{80.f, 70.f, 60.f}, "CascV0 Child sel: Min. nCls TPC"};
     Configurable<std::vector<float>> ConfCascV0ChildDCAMin{"ConfCascV0ChildDCAMin", std::vector<float>{0.05f, 0.06f}, "CascV0 Child sel:  Max. DCA Daugh to PV (cm)"};
     Configurable<std::vector<float>> ConfCascV0ChildPIDnSigmaMax{"ConfCascV0ChildPIDnSigmaMax", std::vector<float>{5.f, 4.f}, "CascV0 Child sel: Max. PID nSigma TPC"};
     Configurable<std::vector<int>> ConfCascV0ChildPIDspecies{"ConfCascV0ChildPIDspecies", std::vector<int>{o2::track::PID::Pion, o2::track::PID::Proton}, "CascV0 Child sel: Particles species for PID"};
-    //Cascade Bachelor Track 
+    // Cascade Bachelor Track
     Configurable<std::vector<float>> ConfCascBachelorCharge{"ConfCascBachelorSign", std::vector<float>{-1, 1}, "Cascade Bachelor sel: Charge"};
     Configurable<std::vector<float>> ConfCascBachelorEtaMax{"ConfCascBachelorEtaMax", std::vector<float>{0.8f}, "Cascade Bachelor sel: max eta"};
     Configurable<std::vector<float>> ConfCascBachelorTPCnClsMin{"ConfCascBachelorTPCnClsMin", std::vector<float>{80.f, 70.f, 60.f}, "Cascade Bachelor sel: Min. nCls TPC"};
@@ -217,10 +217,10 @@ struct femtoDreamProducerTask {
     Configurable<bool> confCascRejectCompetingMass{"confCascRejectCompetingMass", false, "Switch on to reject Omegas (for Xi) or Xis (for Omegas)"};
     Configurable<float> confCascInvCompetingMassLowLimit{"confCascInvCompetingMassLowLimit", 1.66, "Lower limit of the cascade invariant mass for competing mass rejection"};
     Configurable<float> confCascInvCompetingMassUpLimit{"confCascInvCompetingMassUpLimit", 1.68, "Upper limit of the cascade invariant mass for competing mass rejection"};
-    */ 
-  }ConfCascSel;
+    */
+  } ConfCascSel;
 
-  //Resonances
+  // Resonances
   Configurable<float> ConfResoInvMassLowLimit{"ConfResoInvMassLowLimit", 1.011461, "Lower limit of the Reso invariant mass"};
   Configurable<float> ConfResoInvMassUpLimit{"ConfResoInvMassUpLimit", 1.027461, "Upper limit of the Reso invariant mass"};
   Configurable<std::vector<float>> ConfDaughterCharge{"ConfDaughterCharge", std::vector<float>{1, -1}, "Reso Daughter sel: Charge"};
@@ -333,7 +333,7 @@ struct femtoDreamProducerTask {
       v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfChildTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, femtoDreamSelection::kLowerLimit);
       v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfChildDCAMin, femtoDreamTrackSelection::kDCAMin, femtoDreamSelection::kAbsLowerLimit);
       v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfChildPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit);
-      
+
       v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual);
       v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildEtaMax, femtoDreamTrackSelection::kEtaMax, femtoDreamSelection::kAbsUpperLimit);
       v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, femtoDreamSelection::kLowerLimit);
@@ -356,49 +356,49 @@ struct femtoDreamProducerTask {
       }
     }
     if (ConfIsActivateCascade) {
-      //Cascades
+      // Cascades
       cascadeCuts.setSelection(ConfCascSel.ConfCascadeSign, femtoDreamCascadeSelection::kCascadeSign, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeSign));
       cascadeCuts.setSelection(ConfCascSel.ConfCascadePtMin, femtoDreamCascadeSelection::kCascadePtMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadePtMin));
       cascadeCuts.setSelection(ConfCascSel.ConfCascadePtMax, femtoDreamCascadeSelection::kCascadePtMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadePtMax));
-      cascadeCuts.setSelection(ConfCascSel.ConfCascadeEtaMax, femtoDreamCascadeSelection::kCascadeEtaMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeEtaMax)); 
-      cascadeCuts.setSelection(ConfCascSel.ConfCascadeDCADaughMax, femtoDreamCascadeSelection::kCascadeDCADaughMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeDCADaughMax)); 
-      cascadeCuts.setSelection(ConfCascSel.ConfCascadeCPAMin, femtoDreamCascadeSelection::kCascadeCPAMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeCPAMin)); 
-      cascadeCuts.setSelection(ConfCascSel.ConfCascadeTranRadMin, femtoDreamCascadeSelection::kCascadeTranRadMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeTranRadMin)); 
-      cascadeCuts.setSelection(ConfCascSel.ConfCascadeTranRadMax, femtoDreamCascadeSelection::kCascadeTranRadMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeTranRadMax)); 
-      cascadeCuts.setSelection(ConfCascSel.ConfCascadeDecVtxMax, femtoDreamCascadeSelection::kCascadeDecVtxMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeDecVtxMax)); 
-      //Cascade v0
-      cascadeCuts.setSelection(ConfCascSel.ConfCascadeV0DCADaughMax, femtoDreamCascadeSelection::kCascadeV0DCADaughMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0DCADaughMax)); 
-      cascadeCuts.setSelection(ConfCascSel.ConfCascadeV0CPAMin, femtoDreamCascadeSelection::kCascadeV0CPAMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0CPAMin)); 
-      cascadeCuts.setSelection(ConfCascSel.ConfCascadeV0TranRadMin, femtoDreamCascadeSelection::kCascadeV0TranRadMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0TranRadMin)); 
-      cascadeCuts.setSelection(ConfCascSel.ConfCascadeV0TranRadMax, femtoDreamCascadeSelection::kCascadeV0TranRadMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0TranRadMax)); 
-      cascadeCuts.setSelection(ConfCascSel.ConfCascadeV0DCAtoPVMin, femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin)); 
-      cascadeCuts.setSelection(ConfCascSel.ConfCascadeV0DCAtoPVMax, femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax)); 
-      
-      //Cascade Daughter Tracks
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual); 
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildEtaMax, femtoDreamTrackSelection::kEtaMax, femtoDreamSelection::kAbsUpperLimit); 
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeEtaMax, femtoDreamCascadeSelection::kCascadeEtaMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeEtaMax));
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeDCADaughMax, femtoDreamCascadeSelection::kCascadeDCADaughMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeDCADaughMax));
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeCPAMin, femtoDreamCascadeSelection::kCascadeCPAMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeCPAMin));
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeTranRadMin, femtoDreamCascadeSelection::kCascadeTranRadMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeTranRadMin));
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeTranRadMax, femtoDreamCascadeSelection::kCascadeTranRadMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeTranRadMax));
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeDecVtxMax, femtoDreamCascadeSelection::kCascadeDecVtxMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeDecVtxMax));
+      // Cascade v0
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeV0DCADaughMax, femtoDreamCascadeSelection::kCascadeV0DCADaughMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0DCADaughMax));
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeV0CPAMin, femtoDreamCascadeSelection::kCascadeV0CPAMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0CPAMin));
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeV0TranRadMin, femtoDreamCascadeSelection::kCascadeV0TranRadMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0TranRadMin));
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeV0TranRadMax, femtoDreamCascadeSelection::kCascadeV0TranRadMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0TranRadMax));
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeV0DCAtoPVMin, femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin));
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeV0DCAtoPVMax, femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax));
+
+      // Cascade Daughter Tracks
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual);
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildEtaMax, femtoDreamTrackSelection::kEtaMax, femtoDreamSelection::kAbsUpperLimit);
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, femtoDreamSelection::kLowerLimit);
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildDCAMin, femtoDreamTrackSelection::kDCAMin, femtoDreamSelection::kLowerLimit); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildDCAMin, femtoDreamTrackSelection::kDCAMin, femtoDreamSelection::kLowerLimit);
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit);
       cascadeCuts.setChildPIDSpecies(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildPIDspecies);
-      
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual); 
+
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual);
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildEtaMax, femtoDreamTrackSelection::kEtaMax, femtoDreamSelection::kAbsUpperLimit);
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, femtoDreamSelection::kLowerLimit);
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildDCAMin, femtoDreamTrackSelection::kDCAMin, femtoDreamSelection::kLowerLimit); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildDCAMin, femtoDreamTrackSelection::kDCAMin, femtoDreamSelection::kLowerLimit);
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit);
       cascadeCuts.setChildPIDSpecies(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildPIDspecies);
-      
-      //Cascade Bachelor Track
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual); 
+
+      // Cascade Bachelor Track
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual);
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorEtaMax, femtoDreamTrackSelection::kEtaMax, femtoDreamSelection::kAbsUpperLimit);
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, femtoDreamSelection::kLowerLimit);
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorDCAMin, femtoDreamTrackSelection::kDCAMin, femtoDreamSelection::kLowerLimit); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorDCAMin, femtoDreamTrackSelection::kDCAMin, femtoDreamSelection::kLowerLimit);
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit);
       cascadeCuts.setChildPIDSpecies(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorPIDspecies);
 
       /*
-      //Cascade daughter tracks 
+      //Cascade daughter tracks
       cascadeCuts.setSelection(ConfCascSel.ConfCascadeDCAPosToPV, femtoDreamCascadeSelection::kCascadeDCAPosToPV, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::CascadeSel::kCascadeDCAPosToPV));
       cascadeCuts.setSelection(ConfCascSel.ConfCascadeDCANegToPV, femtoDreamCascadeSelection::kCascadeDCANegToPV, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::CascadeSel::kCascadeDCANegToPV));
       cascadeCuts.setSelection(ConfCascSel.ConfCascadeDCABachToPV, femtoDreamCascadeSelection::kCascadeDCABachToPV, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::CascadeSel::kCascadeDCABachToPV));
@@ -549,11 +549,11 @@ struct femtoDreamProducerTask {
   template <typename ParticleType>
   void fillDebugCascade(ParticleType)
   {
-   outputDebugParts(-999., -999., -999., -999., -999., -999., -999., -999.,
-                    -999., -999., -999., -999., -999., -999., -999., -999.,
-                    -999., -999., -999., -999., -999., -999., -999., -999.,
-                    -999., -999., -999., -999., -999., -999., -999., -999.,
-                    -999., -999. - 999., -999., -999., -999., -999., -999.); // QA for Reso
+    outputDebugParts(-999., -999., -999., -999., -999., -999., -999., -999.,
+                     -999., -999., -999., -999., -999., -999., -999., -999.,
+                     -999., -999., -999., -999., -999., -999., -999., -999.,
+                     -999., -999., -999., -999., -999., -999., -999., -999.,
+                     -999., -999. - 999., -999., -999., -999., -999., -999.); // QA for Reso
   }
 
   template <typename CollisionType, typename ParticleType>
@@ -667,7 +667,7 @@ struct femtoDreamProducerTask {
     if (!colCuts.isSelectedCollision(col)) {
       return;
     }
-    /* 
+    /*
     if (ConfIsActivatecascade.value) {
       if (colCuts.isEmptyCollision(col, tracks, trackCuts) && colCuts.isEmptyCollision(col, fullV0s, v0Cuts, tracks)) {
         return;
@@ -689,9 +689,9 @@ struct femtoDreamProducerTask {
       fillMCCollision(col);
     }
 
-    std::vector<int> childIDs = {0, 0}; // these IDs are necessary to keep track of the children
+    std::vector<int> childIDs = {0, 0};           // these IDs are necessary to keep track of the children
     std::vector<int> cascadechildIDs = {0, 0, 0}; // these IDs are necessary to keep track of the children
-    std::vector<int> tmpIDtrack;        // this vector keeps track of the matching of the primary track table row <-> aod::track table global index
+    std::vector<int> tmpIDtrack;                  // this vector keeps track of the matching of the primary track table row <-> aod::track table global index
     std::vector<typename TrackTypeWithItsPid::iterator> Daughter1, Daughter2;
 
     for (auto& track : tracksWithItsPid) {
@@ -838,34 +838,34 @@ struct femtoDreamProducerTask {
       }
     }
     if (ConfIsActivateCascade.value) {
-    for (auto& casc : fullCascades) {
-      //get the daughter tracks
-      const auto& posTrackCasc = casc.template posTrack_as<TrackType>();
-      const auto& negTrackCasc = casc.template negTrack_as<TrackType>();
-      const auto& bachTrackCasc = casc.template bachelor_as<TrackType>();
-      
-      //const auto& v0daughLink = casc.template v0_as<aod::V0sLinked>();
-      //get the daughter v0
+      for (auto& casc : fullCascades) {
+        // get the daughter tracks
+        const auto& posTrackCasc = casc.template posTrack_as<TrackType>();
+        const auto& negTrackCasc = casc.template negTrack_as<TrackType>();
+        const auto& bachTrackCasc = casc.template bachelor_as<TrackType>();
 
-      //QA before the cuts
-      cascadeCuts.fillCascadeQA(col, casc, posTrackCasc, negTrackCasc); //TODO include the bachelor
-      
-      if (!cascadeCuts.isSelectedMinimal(col, casc, posTrackCasc, negTrackCasc, bachTrackCasc)) {
-        continue;
-      }
-      cascadeCuts.fillQA<aod::femtodreamparticle::ParticleType::kCascade>(col, casc, posTrackCasc, negTrackCasc, bachTrackCasc);
+        // const auto& v0daughLink = casc.template v0_as<aod::V0sLinked>();
+        // get the daughter v0
 
-      //auto cutContainerCasc = cascadeCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(col, casc, v0daugh, posTrackCasc, negTrackCasc, bachTrackCasc);
-      auto cutContainerCasc = cascadeCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(col, casc, posTrackCasc, negTrackCasc, bachTrackCasc);
+        // QA before the cuts
+        cascadeCuts.fillCascadeQA(col, casc, posTrackCasc, negTrackCasc); // TODO include the bachelor
 
-      //Fill positive child
-      int poscasctrackID = casc.posTrackId(); 
-      int rowInPrimaryTrackTablePosCasc = -1;
-      rowInPrimaryTrackTablePosCasc = getRowDaughters(poscasctrackID, tmpIDtrack);
-      cascadechildIDs[0] = rowInPrimaryTrackTablePosCasc;
-      cascadechildIDs[1] = 0;
-      cascadechildIDs[2] = 0;
-      outputParts(outputCollision.lastIndex(),
+        if (!cascadeCuts.isSelectedMinimal(col, casc, posTrackCasc, negTrackCasc, bachTrackCasc)) {
+          continue;
+        }
+        cascadeCuts.fillQA<aod::femtodreamparticle::ParticleType::kCascade>(col, casc, posTrackCasc, negTrackCasc, bachTrackCasc);
+
+        // auto cutContainerCasc = cascadeCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(col, casc, v0daugh, posTrackCasc, negTrackCasc, bachTrackCasc);
+        auto cutContainerCasc = cascadeCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(col, casc, posTrackCasc, negTrackCasc, bachTrackCasc);
+
+        // Fill positive child
+        int poscasctrackID = casc.posTrackId();
+        int rowInPrimaryTrackTablePosCasc = -1;
+        rowInPrimaryTrackTablePosCasc = getRowDaughters(poscasctrackID, tmpIDtrack);
+        cascadechildIDs[0] = rowInPrimaryTrackTablePosCasc;
+        cascadechildIDs[1] = 0;
+        cascadechildIDs[2] = 0;
+        outputParts(outputCollision.lastIndex(),
                     casc.positivept(),
                     casc.positiveeta(),
                     casc.positivephi(),
@@ -876,18 +876,18 @@ struct femtoDreamProducerTask {
                     cascadechildIDs,
                     0,
                     0);
-      const int rowOfPosCascadeTrack = outputParts.lastIndex();
-      //TODO: include here MC filling
-      //------
-      
-      //Fill negative child
-      int negcasctrackID = casc.negTrackId(); 
-      int rowInPrimaryTrackTableNegCasc = -1;
-      rowInPrimaryTrackTableNegCasc = getRowDaughters(negcasctrackID, tmpIDtrack);
-      cascadechildIDs[0] = 0;
-      cascadechildIDs[1] = rowInPrimaryTrackTableNegCasc;
-      cascadechildIDs[2] = 0;
-      outputParts(outputCollision.lastIndex(),
+        const int rowOfPosCascadeTrack = outputParts.lastIndex();
+        // TODO: include here MC filling
+        //------
+
+        // Fill negative child
+        int negcasctrackID = casc.negTrackId();
+        int rowInPrimaryTrackTableNegCasc = -1;
+        rowInPrimaryTrackTableNegCasc = getRowDaughters(negcasctrackID, tmpIDtrack);
+        cascadechildIDs[0] = 0;
+        cascadechildIDs[1] = rowInPrimaryTrackTableNegCasc;
+        cascadechildIDs[2] = 0;
+        outputParts(outputCollision.lastIndex(),
                     casc.negativept(),
                     casc.negativeeta(),
                     casc.negativephi(),
@@ -898,18 +898,18 @@ struct femtoDreamProducerTask {
                     cascadechildIDs,
                     0,
                     0);
-      const int rowOfNegCascadeTrack = outputParts.lastIndex();
-      //TODO: include here MC filling
-      //------
-      
-      //Fill bachelor child
-      int bachelorcasctrackID = casc.bachelorId(); 
-      int rowInPrimaryTrackTableBachelorCasc = -1;
-      rowInPrimaryTrackTableBachelorCasc = getRowDaughters(bachelorcasctrackID, tmpIDtrack);
-      cascadechildIDs[0] = 0;
-      cascadechildIDs[1] = 0;
-      cascadechildIDs[2] = rowInPrimaryTrackTableBachelorCasc;
-      outputParts(outputCollision.lastIndex(),
+        const int rowOfNegCascadeTrack = outputParts.lastIndex();
+        // TODO: include here MC filling
+        //------
+
+        // Fill bachelor child
+        int bachelorcasctrackID = casc.bachelorId();
+        int rowInPrimaryTrackTableBachelorCasc = -1;
+        rowInPrimaryTrackTableBachelorCasc = getRowDaughters(bachelorcasctrackID, tmpIDtrack);
+        cascadechildIDs[0] = 0;
+        cascadechildIDs[1] = 0;
+        cascadechildIDs[2] = rowInPrimaryTrackTableBachelorCasc;
+        outputParts(outputCollision.lastIndex(),
                     casc.bachelorpt(),
                     casc.bacheloreta(),
                     casc.bachelorphi(),
@@ -920,13 +920,13 @@ struct femtoDreamProducerTask {
                     cascadechildIDs,
                     0,
                     0);
-      const int rowOfBachelorCascadeTrack = outputParts.lastIndex();
-      //TODO: include here MC filling
-      //------
+        const int rowOfBachelorCascadeTrack = outputParts.lastIndex();
+        // TODO: include here MC filling
+        //------
 
-      //Fill cascades 
-      std::vector<int> indexCascadeChildID = {rowOfPosCascadeTrack, rowOfNegCascadeTrack, rowOfBachelorCascadeTrack};
-      outputParts(outputCollision.lastIndex(),
+        // Fill cascades
+        std::vector<int> indexCascadeChildID = {rowOfPosCascadeTrack, rowOfNegCascadeTrack, rowOfBachelorCascadeTrack};
+        outputParts(outputCollision.lastIndex(),
                     casc.pt(),
                     casc.eta(),
                     casc.phi(),
@@ -937,17 +937,17 @@ struct femtoDreamProducerTask {
                     indexCascadeChildID,
                     casc.mXi(),
                     casc.mLambda());
-      //TODO: include here MC filling
-      //------
+        // TODO: include here MC filling
+        //------
 
-       if(ConfIsDebug.value) {
-         fillDebugParticle<true, false>(posTrackCasc);  // QA for positive daughter
-         fillDebugParticle<true, false>(negTrackCasc);  // QA for negative daughter
-         fillDebugParticle<true, false>(bachTrackCasc); // QA for negative daughter
-         fillDebugCascade(casc);                 // QA for Cascade 
-       }
+        if (ConfIsDebug.value) {
+          fillDebugParticle<true, false>(posTrackCasc);  // QA for positive daughter
+          fillDebugParticle<true, false>(negTrackCasc);  // QA for negative daughter
+          fillDebugParticle<true, false>(bachTrackCasc); // QA for negative daughter
+          fillDebugCascade(casc);                        // QA for Cascade
+        }
+      }
     }
-   }
 
     if (ConfIsActivateReso.value) {
       for (std::size_t iDaug1 = 0; iDaug1 < Daughter1.size(); ++iDaug1) {
@@ -1058,7 +1058,7 @@ struct femtoDreamProducerTask {
   }
   PROCESS_SWITCH(femtoDreamProducerTask, processData_noCentrality,
                  "Provide experimental data without centrality information", false);
-  
+
   void processData_CentPbPb(aod::FemtoFullCollision_CentPbPb const& col,
                             aod::BCsWithTimestamps const&,
                             aod::FemtoFullTracks const& tracks,
@@ -1078,7 +1078,7 @@ struct femtoDreamProducerTask {
   }
   PROCESS_SWITCH(femtoDreamProducerTask, processData_CentPbPb,
                  "Provide experimental data with centrality information for PbPb collisions", false);
-  
+
   void processMC(aod::FemtoFullCollisionMC const& col,
                  aod::BCsWithTimestamps const&,
                  soa::Join<aod::FemtoFullTracks, aod::McTrackLabels> const& tracks,

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
@@ -300,6 +300,7 @@ struct femtoDreamProducerTask {
     TrackRegistry.add("AnalysisQA/Mother", "; Bit; Entries", kTH1F, {{4000, -4000, 4000}});
     TrackRegistry.add("AnalysisQA/Particle", "; Bit; Entries", kTH1F, {{4000, -4000, 4000}});
     V0Registry.add("AnalysisQA/CutCounter", "; Bit; Counter", kTH1F, {{CutBits + 1, -0.5, CutBits + 0.5}});
+    CascadeRegistry.add("AnalysisQA/CutCounter", "; Bit; Counter", kTH1F, {{CutBits + 1, -0.5, CutBits + 0.5}});
     ResoRegistry.add("AnalysisQA/Reso/InvMass", "Invariant mass V0s;M_{KK};Entries", HistType::kTH1F, {{7000, 0.8, 1.5}});
     ResoRegistry.add("AnalysisQA/Reso/InvMass_selected", "Invariant mass V0s;M_{KK};Entries", HistType::kTH1F, {{7000, 0.8, 1.5}});
     ResoRegistry.add("AnalysisQA/Reso/Daughter1/Pt", "Transverse momentum of all processed tracks;p_{T} (GeV/c);Entries", HistType::kTH1F, {{1000, 0, 10}});
@@ -403,20 +404,23 @@ struct femtoDreamProducerTask {
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildCharge, femtoDreamTrackSelection::kSign, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kSign)); 
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildEtaMax, femtoDreamTrackSelection::kEtaMax, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kEtaMax)); 
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kTPCnClsMin)); 
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildDCAMin, femtoDreamTrackSelection::kDCAMin, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kDCAMin)); 
+      //cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildDCAMin, femtoDreamTrackSelection::kDCAMin, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kDCAMin)); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildDCAMin, femtoDreamTrackSelection::kDCAMin, femtoDreamSelection::kLowerLimit); 
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kPIDnSigmaMax)); 
       cascadeCuts.setChildPIDSpecies(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildPIDspecies);
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildCharge, femtoDreamTrackSelection::kSign, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kSign)); 
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildEtaMax, femtoDreamTrackSelection::kEtaMax, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kEtaMax)); 
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kTPCnClsMin)); 
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildDCAMin, femtoDreamTrackSelection::kDCAMin, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kDCAMin)); 
+      //cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildDCAMin, femtoDreamTrackSelection::kDCAMin, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kDCAMin)); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildDCAMin, femtoDreamTrackSelection::kDCAMin, femtoDreamSelection::kLowerLimit); 
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kPIDnSigmaMax)); 
       cascadeCuts.setChildPIDSpecies(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildPIDspecies);
       //Cascade Bachelor Track
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorCharge, femtoDreamTrackSelection::kSign, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kSign)); 
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorEtaMax, femtoDreamTrackSelection::kEtaMax, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kEtaMax)); 
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kTPCnClsMin)); 
-      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorDCAMin, femtoDreamTrackSelection::kDCAMin, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kDCAMin)); 
+      //cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorDCAMin, femtoDreamTrackSelection::kDCAMin, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kDCAMin)); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorDCAMin, femtoDreamTrackSelection::kDCAMin, femtoDreamSelection::kLowerLimit); 
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kPIDnSigmaMax)); 
       cascadeCuts.setChildPIDSpecies(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorPIDspecies);
 
@@ -567,6 +571,22 @@ struct femtoDreamProducerTask {
                        particle.z(),
                        particle.mK0Short());
     }
+  }
+
+  template <typename ParticleType>
+  void fillDebugCascade(ParticleType)
+  {
+      outputDebugParts(-999., -999., -999., -999., -999., -999., -999.,
+                       -999., -999., -999., -999., -999., -999., -999.,
+                       -999., -999., -999., -999., -999., -999., -999.,
+                       -999., -999., -999., -999.,
+                       -999., //particle.dcaV0daughters(),
+                       -999., //particle.v0radius(),
+                       -999., //particle.x(),
+                       -999., //particle.y(),
+                       -999., //particle.z(),
+                       -999. //particle.mK0Short());
+      );
   }
 
   template <typename CollisionType, typename ParticleType>
@@ -862,13 +882,14 @@ struct femtoDreamProducerTask {
       //get the daughter v0
 
       //QA before the cuts
-      cascadeCuts.fillCascadeQA(col, casc, posTrackCasc, negTrackCasc); //TODO include the bachelor
+      //cascadeCuts.fillCascadeQA(col, casc, posTrackCasc, negTrackCasc); //TODO include the bachelor
+      
       if (!cascadeCuts.isSelectedMinimal(col, casc, posTrackCasc, negTrackCasc, bachTrackCasc)) {
         continue;
       }
       //LOGF(info, "GG Producer: A Xi is selected"); //REMOVE COMMENT
-
       cascadeCuts.fillQA<aod::femtodreamparticle::ParticleType::kCascade>(col, casc, posTrackCasc, negTrackCasc, bachTrackCasc);
+
       //auto cutContainerCasc = cascadeCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(col, casc, v0daugh, posTrackCasc, negTrackCasc, bachTrackCasc);
       auto cutContainerCasc = cascadeCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(col, casc, posTrackCasc, negTrackCasc, bachTrackCasc);
 
@@ -967,6 +988,12 @@ struct femtoDreamProducerTask {
                   9999.,  //mLambda
                   9999.); //mAntiLambda
         */
+       if(ConfIsDebug.value) {
+         fillDebugParticle<true>(posTrackCasc);  // QA for positive daughter
+         fillDebugParticle<true>(negTrackCasc);  // QA for negative daughter
+         fillDebugParticle<true>(bachTrackCasc); // QA for negative daughter
+         fillDebugCascade(casc);                 // QA for Cascade 
+       }
     }
    }
 

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
@@ -187,12 +187,12 @@ struct femtoDreamProducerTask {
     Configurable<std::vector<float>> ConfCascadeTranRadMax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeTranRadMax, "ConfCascade"), std::vector<float>{100.f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeTranRadMax, "Cascade selection: ")};
     Configurable<std::vector<float>> ConfCascadeDecVtxMax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeDecVtxMax, "ConfCascade"), std::vector<float>{100.f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeDecVtxMax, "Cascade selection: ")};
     //Cascade v0 daughters
-    Configurable<std::vector<float>> ConfCascV0DCADaughMax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0DCADaughMax, "ConfCascade"), std::vector<float>{1.2f, 1.5f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0DCADaughMax, "CascV0 selection: ")};
-    Configurable<std::vector<float>> ConfCascV0CPAMin{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0CPAMin, "ConfCascade"), std::vector<float>{0.99f, 0.995f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0CPAMin, "CascV0 selection: ")};
-    Configurable<std::vector<float>> ConfCascV0TranRadMin{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0TranRadMin, "ConfCascade"), std::vector<float>{0.2f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0TranRadMin, "CascV0 selection: ")};
-    Configurable<std::vector<float>> ConfCascV0TranRadMax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0TranRadMax, "ConfCascade"), std::vector<float>{100.f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0TranRadMax, "CascV0 selection: ")};
-    Configurable<std::vector<float>> ConfCascV0DCAtoPVMin{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin, "ConfCascade"), std::vector<float>{100.f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin, "CascV0 selection: ")};
-    Configurable<std::vector<float>> ConfCascV0DCAtoPVMax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax, "ConfCascade"), std::vector<float>{100.f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax, "CascV0 selection: ")};
+    Configurable<std::vector<float>> ConfCascadeV0DCADaughMax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0DCADaughMax, "ConfCascade"), std::vector<float>{1.2f, 1.5f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0DCADaughMax, "CascV0 selection: ")};
+    Configurable<std::vector<float>> ConfCascadeV0CPAMin{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0CPAMin, "ConfCascade"), std::vector<float>{0.99f, 0.995f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0CPAMin, "CascV0 selection: ")};
+    Configurable<std::vector<float>> ConfCascadeV0TranRadMin{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0TranRadMin, "ConfCascade"), std::vector<float>{0.2f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0TranRadMin, "CascV0 selection: ")};
+    Configurable<std::vector<float>> ConfCascadeV0TranRadMax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0TranRadMax, "ConfCascade"), std::vector<float>{100.f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0TranRadMax, "CascV0 selection: ")};
+    Configurable<std::vector<float>> ConfCascadeV0DCAtoPVMin{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin, "ConfCascade"), std::vector<float>{100.f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin, "CascV0 selection: ")};
+    Configurable<std::vector<float>> ConfCascadeV0DCAtoPVMax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax, "ConfCascade"), std::vector<float>{100.f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax, "CascV0 selection: ")};
     Configurable<float> ConfCascadeV0InvMassLowLimit{"ConfCascadeV0InvMassLowLimit", 1.011461, "Lower limit of the Cascade invariant mass"};
     Configurable<float> ConfCascadeV0InvMassUpLimit{"ConfCascadeV0InvMassUpLimit", 1.027461, "Upper limit of the Cascade invariant mass"};
     //Cascade Daughter Tracks 
@@ -393,12 +393,12 @@ struct femtoDreamProducerTask {
       cascadeCuts.setSelection(ConfCascSel.ConfCascadeTranRadMax, femtoDreamCascadeSelection::kCascadeTranRadMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeTranRadMax)); 
       cascadeCuts.setSelection(ConfCascSel.ConfCascadeDecVtxMax, femtoDreamCascadeSelection::kCascadeDecVtxMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeDecVtxMax)); 
       //Cascade v0
-      cascadeCuts.setSelection(ConfCascSel.ConfCascV0DecVtxMax, femtoDreamCascadeSelection::kCascadeV0DCADaughMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0DCADaughMax)); 
-      cascadeCuts.setSelection(ConfCascSel.ConfCascV0CPAMin, femtoDreamCascadeSelection::kCascadeV0CPAMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0CPAMin)); 
-      cascadeCuts.setSelection(ConfCascSel.ConfCascV0TranRadMin, femtoDreamCascadeSelection::kCascadeV0TranRadMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0TranRadMin)); 
-      cascadeCuts.setSelection(ConfCascSel.ConfCascV0TRanRadMax, femtoDreamCascadeSelection::kCascadeV0TranRadMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0TranRadMax)); 
-      cascadeCuts.setSelection(ConfCascSel.ConfCascV0DCAtoPVMin, femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin)); 
-      cascadeCuts.setSelection(ConfCascSel.ConfCascV0DCAtoPVMax, femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax)); 
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeV0DCADaughMax, femtoDreamCascadeSelection::kCascadeV0DCADaughMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0DCADaughMax)); 
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeV0CPAMin, femtoDreamCascadeSelection::kCascadeV0CPAMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0CPAMin)); 
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeV0TranRadMin, femtoDreamCascadeSelection::kCascadeV0TranRadMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0TranRadMin)); 
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeV0TranRadMax, femtoDreamCascadeSelection::kCascadeV0TranRadMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0TranRadMax)); 
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeV0DCAtoPVMin, femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin)); 
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeV0DCAtoPVMax, femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax)); 
       //Cascade Daughter Tracks
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildCharge, femtoDreamTrackSelection::kSign, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kSign)); 
       cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildEtaMax, femtoDreamTrackSelection::kEtaMax, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kEtaMax)); 
@@ -429,6 +429,7 @@ struct femtoDreamProducerTask {
 
       cascadeCuts.init<aod::femtodreamparticle::ParticleType::kCascade, aod::femtodreamparticle::ParticleType::kCascadeV0Child, aod::femtodreamparticle::ParticleType::kCascadeBachelor, aod::femtodreamparticle::cutContainerType>(&qaRegistry, &CascadeRegistry, false);
       cascadeCuts.setInvMassLimits(ConfCascSel.ConfCascadeInvMassLowLimit, ConfCascSel.ConfCascadeInvMassUpLimit);
+      // --> uncomment this after including the function in the cascade selection: cascadeCuts.setInvMassV0Limits(ConfCascSel.ConfCascadeV0InvMassLowLimit, ConfCascSel.ConfCascadeV0InvMassUpLimit);
     }
 
     mRunNumber = 0;

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
@@ -209,8 +209,6 @@ struct femtoDreamProducerTask {
     Configurable<std::vector<float>> ConfCascBachelorDCAMin{"ConfCascBachelorDCAMin", std::vector<float>{0.05f, 0.06f}, "Cascade Bachelor sel:  Max. DCA Daugh to PV (cm)"};
     Configurable<std::vector<float>> ConfCascBachelorPIDnSigmaMax{"ConfCascBachelorPIDnSigmaMax", std::vector<float>{5.f, 4.f}, "Cascade Bachelor sel: Max. PID nSigma TPC"};
     Configurable<std::vector<int>> ConfCascBachelorPIDspecies{"ConfCascBachelorPIDspecies", std::vector<int>{o2::track::PID::Pion}, "Cascade Bachelor sel: Particles species for PID"};
-    
-    
     /*
     Configurable<std::vector<float>> ConfCascadeDCAPosToPV{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeDCAPosToPV, "ConfCascade"), std::vector<float>{0.1f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeDCAPosToPV, "Cascade selection: ")};
     Configurable<std::vector<float>> ConfCascadeDCANegToPV{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeDCANegToPV, "ConfCascade"), std::vector<float>{0.1f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeDCANegToPV, "Cascade selection: ")};
@@ -259,7 +257,6 @@ struct femtoDreamProducerTask {
 
   void init(InitContext&)
   {
-    /*
     if (doprocessData == false && doprocessData_noCentrality == false && doprocessData_CentPbPb == false && doprocessMC == false && doprocessMC_noCentrality == false && doprocessMC_CentPbPb == false) {
       LOGF(fatal, "Neither processData nor processMC enabled. Please choose one.");
     }
@@ -268,7 +265,6 @@ struct femtoDreamProducerTask {
            "Cannot enable more than one process switch at the same time. "
            "Please choose one.");
     }
-    */
 
     int CutBits = 8 * sizeof(o2::aod::femtodreamparticle::cutContainerType);
     TrackRegistry.add("AnalysisQA/CutCounter", "; Bit; Counter", kTH1F, {{CutBits + 1, -0.5, CutBits + 0.5}});

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
@@ -173,11 +173,77 @@ struct femtoDreamProducerTask {
   Configurable<std::vector<int>> ConfChildPIDspecies{"ConfChildPIDspecies", std::vector<int>{o2::track::PID::Pion, o2::track::PID::Proton}, "V0 Child sel: Particles species for PID"};
 
   FemtoDreamCascadeSelection cascadeCuts;
-  Configurable<float> ConfCascadeInvMassLowLimit{"ConfCascadeInvMassLowLimit", 1.011461, "Lower limit of the Cascade invariant mass"};
-  Configurable<float> ConfCascadeInvMassUpLimit{"ConfCascadeInvMassUpLimit", 1.027461, "Upper limit of the Cascade invariant mass"};
-  Configurable<std::vector<float>> ConfCascadeSign{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeSign, "ConfCascade"), std::vector<float>{-1, 1}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeSign, "Cascade selection: ")};
-  Configurable<std::vector<float>> ConfCascadePtmin{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadepTMin, "ConfCascade"), std::vector<float>{0.3f, 0.4f, 0.5f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadepTMin, "Cascade selection: ")};
-  Configurable<std::vector<float>> ConfCascadePtmax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadepTMax, "ConfCascade"), std::vector<float>{5.5f, 5.6f, 5.7f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadepTMax, "Cascade selection: ")};
+  struct : o2::framework::ConfigurableGroup {
+    Configurable<float> ConfCascadeInvMassLowLimit{"ConfCascadeInvMassLowLimit", 1.2, "Lower limit of the Cascade invariant mass"};
+    Configurable<float> ConfCascadeInvMassUpLimit{"ConfCascadeInvMassUpLimit", 1.5, "Upper limit of the Cascade invariant mass"};
+    //Cascade 
+    Configurable<std::vector<float>> ConfCascadeSign{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeSign, "ConfCascade"), std::vector<float>{-1, 1}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeSign, "Cascade selection: ")};
+    Configurable<std::vector<float>> ConfCascadePtMin{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadePtMin, "ConfCascade"), std::vector<float>{0.3f, 0.4f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadePtMin, "Cascade selection: ")};
+    Configurable<std::vector<float>> ConfCascadePtMax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadePtMax, "ConfCascade"), std::vector<float>{5.5f, 6.0f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadePtMax, "Cascade selection: ")};
+    Configurable<std::vector<float>> ConfCascadeEtaMax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeEtaMax, "ConfCascade"), std::vector<float>{0.8f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeEtaMax, "Cascade selection: ")};
+    Configurable<std::vector<float>> ConfCascadeDCADaughMax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeDCADaughMax, "ConfCascade"), std::vector<float>{1.f, 1.2f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeDCADaughMax, "Cascade selection: ")};
+    Configurable<std::vector<float>> ConfCascadeCPAMin{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeCPAMin, "ConfCascade"), std::vector<float>{0.99f, 0.95f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeCPAMin, "Cascade selection: ")};
+    Configurable<std::vector<float>> ConfCascadeTranRadMin{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeTranRadMin, "ConfCascade"), std::vector<float>{0.2f, 0.5f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeTranRadMin, "Cascade selection: ")};
+    Configurable<std::vector<float>> ConfCascadeTranRadMax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeTranRadMax, "ConfCascade"), std::vector<float>{100.f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeTranRadMax, "Cascade selection: ")};
+    Configurable<std::vector<float>> ConfCascadeDecVtxMax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeDecVtxMax, "ConfCascade"), std::vector<float>{100.f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeDecVtxMax, "Cascade selection: ")};
+    //Cascade v0 daughters
+    Configurable<std::vector<float>> ConfCascV0DCADaughMax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0DCADaughMax, "ConfCascade"), std::vector<float>{1.2f, 1.5f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0DCADaughMax, "CascV0 selection: ")};
+    Configurable<std::vector<float>> ConfCascV0CPAMin{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0CPAMin, "ConfCascade"), std::vector<float>{0.99f, 0.995f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0CPAMin, "CascV0 selection: ")};
+    Configurable<std::vector<float>> ConfCascV0TranRadMin{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0TranRadMin, "ConfCascade"), std::vector<float>{0.2f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0TranRadMin, "CascV0 selection: ")};
+    Configurable<std::vector<float>> ConfCascV0TranRadMax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0TranRadMax, "ConfCascade"), std::vector<float>{100.f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0TranRadMax, "CascV0 selection: ")};
+    Configurable<std::vector<float>> ConfCascV0DCAtoPVMin{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin, "ConfCascade"), std::vector<float>{100.f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin, "CascV0 selection: ")};
+    Configurable<std::vector<float>> ConfCascV0DCAtoPVMax{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax, "ConfCascade"), std::vector<float>{100.f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax, "CascV0 selection: ")};
+    Configurable<float> ConfCascadeV0InvMassLowLimit{"ConfCascadeV0InvMassLowLimit", 1.011461, "Lower limit of the Cascade invariant mass"};
+    Configurable<float> ConfCascadeV0InvMassUpLimit{"ConfCascadeV0InvMassUpLimit", 1.027461, "Upper limit of the Cascade invariant mass"};
+    //Cascade Daughter Tracks 
+    Configurable<std::vector<float>> ConfCascV0ChildCharge{"ConfCascV0ChildSign", std::vector<float>{-1, 1}, "CascV0 Child sel: Charge"};
+    Configurable<std::vector<float>> ConfCascV0ChildEtaMax{"ConfCascV0ChildEtaMax", std::vector<float>{0.8f}, "CascV0 Child sel: max eta"};
+    Configurable<std::vector<float>> ConfCascV0ChildTPCnClsMin{"ConfCascV0ChildTPCnClsMin", std::vector<float>{80.f, 70.f, 60.f}, "CascV0 Child sel: Min. nCls TPC"};
+    Configurable<std::vector<float>> ConfCascV0ChildDCAMin{"ConfCascV0ChildDCAMin", std::vector<float>{0.05f, 0.06f}, "CascV0 Child sel:  Max. DCA Daugh to PV (cm)"};
+    Configurable<std::vector<float>> ConfCascV0ChildPIDnSigmaMax{"ConfCascV0ChildPIDnSigmaMax", std::vector<float>{5.f, 4.f}, "CascV0 Child sel: Max. PID nSigma TPC"};
+    Configurable<std::vector<int>> ConfCascV0ChildPIDspecies{"ConfCascV0ChildPIDspecies", std::vector<int>{o2::track::PID::Pion, o2::track::PID::Proton}, "CascV0 Child sel: Particles species for PID"};
+    //Cascade Bachelor Track 
+    Configurable<std::vector<float>> ConfCascBachelorCharge{"ConfCascBachelorSign", std::vector<float>{-1, 1}, "Cascade Bachelor sel: Charge"};
+    Configurable<std::vector<float>> ConfCascBachelorEtaMax{"ConfCascBachelorEtaMax", std::vector<float>{0.8f}, "Cascade Bachelor sel: max eta"};
+    Configurable<std::vector<float>> ConfCascBachelorTPCnClsMin{"ConfCascBachelorTPCnClsMin", std::vector<float>{80.f, 70.f, 60.f}, "Cascade Bachelor sel: Min. nCls TPC"};
+    Configurable<std::vector<float>> ConfCascBachelorDCAMin{"ConfCascBachelorDCAMin", std::vector<float>{0.05f, 0.06f}, "Cascade Bachelor sel:  Max. DCA Daugh to PV (cm)"};
+    Configurable<std::vector<float>> ConfCascBachelorPIDnSigmaMax{"ConfCascBachelorPIDnSigmaMax", std::vector<float>{5.f, 4.f}, "Cascade Bachelor sel: Max. PID nSigma TPC"};
+    Configurable<std::vector<int>> ConfCascBachelorPIDspecies{"ConfCascBachelorPIDspecies", std::vector<int>{o2::track::PID::Pion}, "Cascade Bachelor sel: Particles species for PID"};
+    
+    
+    /*
+    Configurable<std::vector<float>> ConfCascadeDCAPosToPV{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeDCAPosToPV, "ConfCascade"), std::vector<float>{0.1f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeDCAPosToPV, "Cascade selection: ")};
+    Configurable<std::vector<float>> ConfCascadeDCANegToPV{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeDCANegToPV, "ConfCascade"), std::vector<float>{0.1f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeDCANegToPV, "Cascade selection: ")};
+    Configurable<std::vector<float>> ConfCascadeDCABachToPV{FemtoDreamCascadeSelection::getSelectionName(femtoDreamCascadeSelection::kCascadeDCABachToPV, "ConfCascade"), std::vector<float>{0.1f}, FemtoDreamCascadeSelection::getSelectionHelper(femtoDreamCascadeSelection::kCascadeDCABachToPV, "Cascade selection: ")};
+    */ 
+    
+    /* 
+    Configurable<std::vector<float>> confCascV0DCADaughMax{FemtoUniverseCascadeSelection::getSelectionName(femto_universe_cascade_selection::kCascadeV0DCADaughMax, "ConfCasc"), std::vector<float>{1.f, 1.2f, 1.5f}, FemtoUniverseCascadeSelection::getSelectionHelper(femto_universe_cascade_selection::kCascadeV0DCADaughMax, "Cascade selection: ")};
+    Configurable<std::vector<float>> confCascV0CPAMin{FemtoUniverseCascadeSelection::getSelectionName(femto_universe_cascade_selection::kCascadeV0CPAMin, "ConfCasc"), std::vector<float>{0.99f, 0.95f}, FemtoUniverseCascadeSelection::getSelectionHelper(femto_universe_cascade_selection::kCascadeV0CPAMin, "Cascade selection: ")};
+    Configurable<std::vector<float>> confCascV0TranRadMin{FemtoUniverseCascadeSelection::getSelectionName(femto_universe_cascade_selection::kCascadeV0TranRadMin, "ConfCasc"), std::vector<float>{0.2f}, FemtoUniverseCascadeSelection::getSelectionHelper(femto_universe_cascade_selection::kCascadeV0TranRadMin, "Cascade selection: ")};
+    Configurable<std::vector<float>> confCascV0TranRadMax{FemtoUniverseCascadeSelection::getSelectionName(femto_universe_cascade_selection::kCascadeV0TranRadMax, "ConfCasc"), std::vector<float>{100.f}, FemtoUniverseCascadeSelection::getSelectionHelper(femto_universe_cascade_selection::kCascadeV0TranRadMax, "Cascade selection: ")};
+    Configurable<std::vector<float>> confCascV0DecVtxMax{FemtoUniverseCascadeSelection::getSelectionName(femto_universe_cascade_selection::kCascadeV0DecVtxMax, "ConfCasc"), std::vector<float>{100.f}, FemtoUniverseCascadeSelection::getSelectionHelper(femto_universe_cascade_selection::kCascadeV0DecVtxMax, "Cascade selection: ")};
+
+    
+    Configurable<std::vector<float>> confCascDCAV0ToPV{FemtoUniverseCascadeSelection::getSelectionName(femto_universe_cascade_selection::kCascadeDCAV0ToPV, "ConfCasc"), std::vector<float>{0.01f}, FemtoUniverseCascadeSelection::getSelectionHelper(femto_universe_cascade_selection::kCascadeDCAV0ToPV, "Cascade selection: ")};
+    Configurable<std::vector<float>> confCascV0MassLowLimit{FemtoUniverseCascadeSelection::getSelectionName(femto_universe_cascade_selection::kCascadeV0MassMin, "ConfCasc"), std::vector<float>{1.05f}, FemtoUniverseCascadeSelection::getSelectionHelper(femto_universe_cascade_selection::kCascadeV0MassMin, "Cascade selection: ")};
+    Configurable<std::vector<float>> confCascV0MassUpLimit{FemtoUniverseCascadeSelection::getSelectionName(femto_universe_cascade_selection::kCascadeV0MassMax, "ConfCasc"), std::vector<float>{1.30f}, FemtoUniverseCascadeSelection::getSelectionHelper(femto_universe_cascade_selection::kCascadeV0MassMax, "Cascade selection: ")};
+
+    Configurable<std::vector<float>> confCascChildCharge{"confCascChildCharge", std::vector<float>{-1, 1}, "Cascade Child sel: Charge"};
+    Configurable<std::vector<float>> confCascChildEtaMax{"confCascChildEtaMax", std::vector<float>{0.8f}, "Cascade Child sel: max eta"};
+    Configurable<std::vector<float>> confCascChildTPCnClsMin{"confCascChildTPCnClsMin", std::vector<float>{80.f, 70.f, 60.f}, "Cascade Child sel: Min. nCls TPC"};
+    // Configurable<std::vector<float>> confCascChildDCAMin{"confCascChildDCAMin", std::vector<float>{0.05f, 0.06f}, "Cascade Child sel:  Max. DCA Daugh to PV (cm)"}; //Commented: not used variable
+    Configurable<std::vector<float>> confCascChildPIDnSigmaMax{"confCascChildPIDnSigmaMax", std::vector<float>{3.f, 4.f}, "Cascade Child sel: Max. PID nSigma TPC"};
+    Configurable<std::vector<int>> confCascChildPIDspecies{"confCascChildPIDspecies", std::vector<int>{o2::track::PID::Pion, o2::track::PID::Proton}, "Cascade Child sel: particle species for PID"};
+
+    Configurable<float> confCascInvMassLowLimit{"confCascInvMassLowLimit", 1.25, "Lower limit of the cascade invariant mass"};
+    Configurable<float> confCascInvMassUpLimit{"confCascInvMassUpLimit", 1.40, "Upper limit of the cascade invariant mass"};
+
+    Configurable<bool> confCascRejectCompetingMass{"confCascRejectCompetingMass", false, "Switch on to reject Omegas (for Xi) or Xis (for Omegas)"};
+    Configurable<float> confCascInvCompetingMassLowLimit{"confCascInvCompetingMassLowLimit", 1.66, "Lower limit of the cascade invariant mass for competing mass rejection"};
+    Configurable<float> confCascInvCompetingMassUpLimit{"confCascInvCompetingMassUpLimit", 1.68, "Upper limit of the cascade invariant mass for competing mass rejection"};
+    */ 
+  }ConfCascSel;
 
   //Resonances
   Configurable<float> ConfResoInvMassLowLimit{"ConfResoInvMassLowLimit", 1.011461, "Lower limit of the Reso invariant mass"};
@@ -293,6 +359,7 @@ struct femtoDreamProducerTask {
       v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfChildTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, femtoDreamSelection::kLowerLimit);
       v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfChildDCAMin, femtoDreamTrackSelection::kDCAMin, femtoDreamSelection::kAbsLowerLimit);
       v0Cuts.setChildCuts(femtoDreamV0Selection::kPosTrack, ConfChildPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, femtoDreamSelection::kAbsUpperLimit);
+      
       v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildCharge, femtoDreamTrackSelection::kSign, femtoDreamSelection::kEqual);
       v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildEtaMax, femtoDreamTrackSelection::kEtaMax, femtoDreamSelection::kAbsUpperLimit);
       v0Cuts.setChildCuts(femtoDreamV0Selection::kNegTrack, ConfChildTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, femtoDreamSelection::kLowerLimit);
@@ -315,11 +382,53 @@ struct femtoDreamProducerTask {
       }
     }
     if (ConfIsActivateCascade) {
-      cascadeCuts.setSelection(ConfCascadeSign, femtoDreamCascadeSelection::kCascadeSign, femtoDreamSelection::kEqual);
-      cascadeCuts.setSelection(ConfCascadePtmin, femtoDreamCascadeSelection::kCascadepTMin, femtoDreamSelection::kLowerLimit);
-      cascadeCuts.setSelection(ConfCascadePtmax, femtoDreamCascadeSelection::kCascadepTMax, femtoDreamSelection::kUpperLimit);
+      //Cascades
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeSign, femtoDreamCascadeSelection::kCascadeSign, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeSign));
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadePtMin, femtoDreamCascadeSelection::kCascadePtMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadePtMin));
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadePtMax, femtoDreamCascadeSelection::kCascadePtMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadePtMax));
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeEtaMax, femtoDreamCascadeSelection::kCascadeEtaMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeEtaMax)); 
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeDCADaughMax, femtoDreamCascadeSelection::kCascadeDCADaughMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeDCADaughMax)); 
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeCPAMin, femtoDreamCascadeSelection::kCascadeCPAMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeCPAMin)); 
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeTranRadMin, femtoDreamCascadeSelection::kCascadeTranRadMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeTranRadMin)); 
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeTranRadMax, femtoDreamCascadeSelection::kCascadeTranRadMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeTranRadMax)); 
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeDecVtxMax, femtoDreamCascadeSelection::kCascadeDecVtxMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeDecVtxMax)); 
+      //Cascade v0
+      cascadeCuts.setSelection(ConfCascSel.ConfCascV0DecVtxMax, femtoDreamCascadeSelection::kCascadeV0DCADaughMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0DCADaughMax)); 
+      cascadeCuts.setSelection(ConfCascSel.ConfCascV0CPAMin, femtoDreamCascadeSelection::kCascadeV0CPAMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0CPAMin)); 
+      cascadeCuts.setSelection(ConfCascSel.ConfCascV0TranRadMin, femtoDreamCascadeSelection::kCascadeV0TranRadMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0TranRadMin)); 
+      cascadeCuts.setSelection(ConfCascSel.ConfCascV0TRanRadMax, femtoDreamCascadeSelection::kCascadeV0TranRadMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0TranRadMax)); 
+      cascadeCuts.setSelection(ConfCascSel.ConfCascV0DCAtoPVMin, femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMin)); 
+      cascadeCuts.setSelection(ConfCascSel.ConfCascV0DCAtoPVMax, femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::kCascadeV0DCAtoPVMax)); 
+      //Cascade Daughter Tracks
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildCharge, femtoDreamTrackSelection::kSign, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kSign)); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildEtaMax, femtoDreamTrackSelection::kEtaMax, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kEtaMax)); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kTPCnClsMin)); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildDCAMin, femtoDreamTrackSelection::kDCAMin, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kDCAMin)); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kPIDnSigmaMax)); 
+      cascadeCuts.setChildPIDSpecies(femtoDreamCascadeSelection::kPosTrack, ConfCascSel.ConfCascV0ChildPIDspecies);
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildCharge, femtoDreamTrackSelection::kSign, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kSign)); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildEtaMax, femtoDreamTrackSelection::kEtaMax, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kEtaMax)); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kTPCnClsMin)); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildDCAMin, femtoDreamTrackSelection::kDCAMin, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kDCAMin)); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kPIDnSigmaMax)); 
+      cascadeCuts.setChildPIDSpecies(femtoDreamCascadeSelection::kNegTrack, ConfCascSel.ConfCascV0ChildPIDspecies);
+      //Cascade Bachelor Track
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorCharge, femtoDreamTrackSelection::kSign, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kSign)); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorEtaMax, femtoDreamTrackSelection::kEtaMax, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kEtaMax)); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorTPCnClsMin, femtoDreamTrackSelection::kTPCnClsMin, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kTPCnClsMin)); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorDCAMin, femtoDreamTrackSelection::kDCAMin, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kDCAMin)); 
+      cascadeCuts.setChildCuts(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorPIDnSigmaMax, femtoDreamTrackSelection::kPIDnSigmaMax, FemtoDreamTrackSelection::getSelectionType(femtoDreamTrackSelection::kPIDnSigmaMax)); 
+      cascadeCuts.setChildPIDSpecies(femtoDreamCascadeSelection::kBachTrack, ConfCascSel.ConfCascBachelorPIDspecies);
+
+      /*
+      //Cascade daughter tracks 
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeDCAPosToPV, femtoDreamCascadeSelection::kCascadeDCAPosToPV, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::CascadeSel::kCascadeDCAPosToPV));
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeDCANegToPV, femtoDreamCascadeSelection::kCascadeDCANegToPV, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::CascadeSel::kCascadeDCANegToPV));
+      cascadeCuts.setSelection(ConfCascSel.ConfCascadeDCABachToPV, femtoDreamCascadeSelection::kCascadeDCABachToPV, FemtoDreamCascadeSelection::getSelectionType(femtoDreamCascadeSelection::CascadeSel::kCascadeDCABachToPV));
+      */
+
       cascadeCuts.init<aod::femtodreamparticle::ParticleType::kCascade, aod::femtodreamparticle::ParticleType::kCascadeV0Child, aod::femtodreamparticle::ParticleType::kCascadeBachelor, aod::femtodreamparticle::cutContainerType>(&qaRegistry, &CascadeRegistry, false);
-      cascadeCuts.setInvMassLimits(ConfCascadeInvMassLowLimit, ConfCascadeInvMassUpLimit);
+      cascadeCuts.setInvMassLimits(ConfCascSel.ConfCascadeInvMassLowLimit, ConfCascSel.ConfCascadeInvMassUpLimit);
     }
 
     mRunNumber = 0;
@@ -739,13 +848,15 @@ struct femtoDreamProducerTask {
         }
       }
     }
-   if (ConfIsActivateCascade.value) {
+    if (ConfIsActivateCascade.value) {
     for (auto& casc : fullCascades) {
-      LOGF(info, "GG Producer: Enter the Xi Loop"); //REMOVE COMMENT
+      //LOGF(info, "GG Producer: Enter the Xi Loop"); //REMOVE COMMENT
       //get the daughter tracks
       const auto& posTrackCasc = casc.template posTrack_as<TrackType>();
       const auto& negTrackCasc = casc.template negTrack_as<TrackType>();
       const auto& bachTrackCasc = casc.template bachelor_as<TrackType>();
+      
+      //const auto& v0daughLink = casc.template v0_as<aod::V0sLinked>();
       //get the daughter v0
 
       //QA before the cuts
@@ -753,9 +864,10 @@ struct femtoDreamProducerTask {
       if (!cascadeCuts.isSelectedMinimal(col, casc, posTrackCasc, negTrackCasc, bachTrackCasc)) {
         continue;
       }
-      LOGF(info, "GG Producer: A Xi is selected"); //REMOVE COMMENT
+      //LOGF(info, "GG Producer: A Xi is selected"); //REMOVE COMMENT
 
       cascadeCuts.fillQA<aod::femtodreamparticle::ParticleType::kCascade>(col, casc, posTrackCasc, negTrackCasc, bachTrackCasc);
+      //auto cutContainerCasc = cascadeCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(col, casc, v0daugh, posTrackCasc, negTrackCasc, bachTrackCasc);
       auto cutContainerCasc = cascadeCuts.getCutContainer<aod::femtodreamparticle::cutContainerType>(col, casc, posTrackCasc, negTrackCasc, bachTrackCasc);
 
       std::vector<int> indexChildID = {0, 0};
@@ -769,7 +881,7 @@ struct femtoDreamProducerTask {
                     0,
                     casc.casccosPA(col.posX(), col.posY(), col.posZ()),
                     indexChildID,
-                    0.,
+                    casc.mXi(),
                     0.);
 
       /*
@@ -859,6 +971,7 @@ struct femtoDreamProducerTask {
                 aod::BCsWithTimestamps const&,
                 aod::FemtoFullTracks const& tracks,
                 o2::aod::V0Datas const& fullV0s,
+                o2::aod::V0sLinked const&,
                 o2::aod::CascDatas const& fullCascades)
   {
     // get magnetic field for run
@@ -875,12 +988,13 @@ struct femtoDreamProducerTask {
   PROCESS_SWITCH(femtoDreamProducerTask, processData,
                  "Provide experimental data", true);
 
-/*
   void
     processData_noCentrality(aod::FemtoFullCollision_noCent const& col,
                              aod::BCsWithTimestamps const&,
                              aod::FemtoFullTracks const& tracks,
-                             o2::aod::V0Datas const& fullV0s)
+                             o2::aod::V0Datas const& fullV0s,
+                             o2::aod::V0sLinked const&,
+                             o2::aod::CascDatas const& fullCascades)
   {
     // get magnetic field for run
     initCCDB_Mag_Trig(col.bc_as<aod::BCsWithTimestamps>());
@@ -888,14 +1002,14 @@ struct femtoDreamProducerTask {
     auto tracksWithItsPid = soa::Attach<aod::FemtoFullTracks, aod::pidits::ITSNSigmaEl, aod::pidits::ITSNSigmaPi, aod::pidits::ITSNSigmaKa,
                                         aod::pidits::ITSNSigmaPr, aod::pidits::ITSNSigmaDe, aod::pidits::ITSNSigmaTr, aod::pidits::ITSNSigmaHe>(tracks);
     if (ConfUseItsPid.value) {
-      fillCollisionsAndTracksAndV0<false, true, false, false>(col, tracks, tracksWithItsPid, fullV0s);
+      fillCollisionsAndTracksAndV0AndCascade<false, true, false, false>(col, tracks, tracksWithItsPid, fullV0s, fullCascades);
     } else {
-      fillCollisionsAndTracksAndV0<false, false, false, false>(col, tracks, tracks, fullV0s);
+      fillCollisionsAndTracksAndV0AndCascade<false, false, false, false>(col, tracks, tracks, fullV0s, fullCascades);
     }
   }
   PROCESS_SWITCH(femtoDreamProducerTask, processData_noCentrality,
                  "Provide experimental data without centrality information", false);
-
+  /*
   void
     processData_CentPbPb(aod::FemtoFullCollision_CentPbPb const& col,
                          aod::BCsWithTimestamps const&,

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTaskForSpecificAnalysis.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTaskForSpecificAnalysis.cxx
@@ -51,6 +51,7 @@ struct femtoDreamProducerTaskForSpecificAnalysis {
 
   Configurable<int> ConfNumberOfTracks{"ConfNumberOfTracks", 3, "Number of tracks"};
   Configurable<int> ConfNumberOfV0{"ConfNumberOfV0", 0, "Number of V0"};
+  Configurable<int> ConfNumberOfCascades{"ConfNumberOfCascades", 0, "Number of Cascades"};
 
   /// Track selection
   Configurable<float> ConfPIDthrMom{"ConfPIDthrMom", 1.f, "Momentum threshold from which TPC and TOF are required for PID"};
@@ -66,11 +67,17 @@ struct femtoDreamProducerTaskForSpecificAnalysis {
   Configurable<float> Conf_maxInvMass_V0{"Conf_maxInvMass_V0", 1.15, "Maximum invariant mass of V0 (particle)"};
   Configurable<float> Conf_minInvMassAnti_V0{"Conf_minInvMassAnti_V0", 1.08, "Minimum invariant mass of V0 (antiparticle)"};
   Configurable<float> Conf_maxInvMassAnti_V0{"Conf_maxInvMassAnti_V0", 1.15, "Maximum invariant mass of V0 (antiparticle)"};
+  /// Cascade selection 
+  Configurable<float> Conf_minInvMass_Cascade{"Conf_minInvMass_Cascade", 1.2, "Minimum invariant mass of Cascade (particle)"};
+  Configurable<float> Conf_maxInvMass_Cascade{"Conf_maxInvMass_Cascade", 1.5, "Maximum invariant mass of Cascade (particle)"};
 
   // Partition for selected particles
   Partition<aod::FDParticles> SelectedV0s = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0));
+  Partition<aod::FDParticles> SelectedCascades = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kCascade));
 
   HistogramRegistry EventRegistry{"EventRegistry", {}, OutputObjHandlingPolicy::AnalysisObject};
+  
+  static constexpr uint32_t kSignPlusMask = 1 << 1;
 
   template <typename T>
   int getRowDaughters(int daughID, T const& vecID)
@@ -200,6 +207,131 @@ struct femtoDreamProducerTaskForSpecificAnalysis {
     createSpecifiedDerivedData<false>(col, thegroupSelectedParts, thegroupSelectedV0s, parts);
   }
   PROCESS_SWITCH(femtoDreamProducerTaskForSpecificAnalysis, processCollisionsWithNTracksAndNV0, "Enable producing data with ppp collisions for data", true);
+
+
+  /// This function stores accepted collisions in derived data
+  /// @tparam PartitionType
+  /// @tparam PartType
+  /// @tparam isMC: enables Monte Carlo truth specific histograms
+  /// @param groupSelectedTracks partition for the first particle passed by the process function
+  /// @param groupSelectedV0s partition for the second particle passed by the process function
+  /// @param parts femtoDreamParticles table
+  template <bool isMC, typename PartitionType, typename PartType>
+  void createSpecifiedDerivedData_TrkCascade(o2::aod::FDCollision& col, PartitionType groupSelectedTracks, PartitionType groupSelectedCascades, PartType parts)
+  {
+    
+    /// check tracks
+    int tracksCount = 0;
+    int antitracksCount = 0;
+    for (auto& part : groupSelectedTracks) {
+      if (part.cut() & 1) {
+        antitracksCount++;
+      } else {
+        tracksCount++;
+      }
+    }
+    
+    /// check Cascades
+    int CascadeCount = 0;
+    int antiCascadeCount = 0;
+    for (auto& casc : groupSelectedCascades) {
+      if ((casc.cut() & kSignPlusMask) == kSignPlusMask){
+        CascadeCount++;
+      } else{
+        antiCascadeCount++;
+      }
+    }
+    
+    std::vector<int> tmpIDtrack;
+    
+    if ((CascadeCount >= ConfNumberOfCascades && tracksCount >= ConfNumberOfTracks) || (antiCascadeCount >= ConfNumberOfCascades && antitracksCount >= ConfNumberOfTracks)) {
+      EventRegistry.fill(HIST("hStatistiscs"), 1);
+      outputCollision(col.posZ(), col.multV0M(), col.multNtr(), col.sphericity(), col.magField());
+      
+      for (auto& femtoParticle : parts) {
+        if (aod::femtodreamparticle::ParticleType::kTrack == femtoParticle.partType()) {
+          std::vector<int> childIDs = {0, 0};
+          outputParts(outputCollision.lastIndex(),
+                      femtoParticle.pt(),
+                      femtoParticle.eta(),
+                      femtoParticle.phi(),
+                      femtoParticle.partType(),
+                      femtoParticle.cut(),
+                      femtoParticle.pidcut(),
+                      femtoParticle.tempFitVar(),
+                      childIDs,
+                      femtoParticle.mLambda(),
+                      femtoParticle.mAntiLambda());
+          tmpIDtrack.push_back(femtoParticle.index());
+        }
+        if (aod::femtodreamparticle::ParticleType::kCascadeV0Child == femtoParticle.partType() || aod::femtodreamparticle::ParticleType::kCascadeBachelor == femtoParticle.partType()) {
+          std::vector<int> childIDs = {0, 0, 0};
+          const auto& children = femtoParticle.childrenIds();
+          int childId = 0;
+          if (children[0] != 0){ childId = children[0]; } 
+          else if (children[1] != 0){ childId = children[1]; }
+          else if (children[2] != 0){ childId = children[2]; }
+
+          if (childId != -1) {
+            int rowInPrimaryTrackTable = getRowDaughters(childId, tmpIDtrack);
+            if (children[0] != 0){ childIDs = std::vector<int>{rowInPrimaryTrackTable, 0, 0}; } 
+            else if (children[1] != 0){ childIDs = std::vector<int>{0, rowInPrimaryTrackTable, 0}; } 
+            else if (children[2] != 0){ childIDs = std::vector<int>{0, 0, rowInPrimaryTrackTable}; } 
+          } else {
+            if (children[0] != 0){ childIDs = std::vector<int>{-1, 0, 0}; } 
+            else if (children[1] != 0){ childIDs = std::vector<int>{0, -1, 0}; } 
+            else if (children[2] != 0){ childIDs = std::vector<int>{0, 0, -1}; } 
+          }
+          outputParts(outputCollision.lastIndex(),
+                      femtoParticle.pt(),
+                      femtoParticle.eta(),
+                      femtoParticle.phi(),
+                      femtoParticle.partType(),
+                      femtoParticle.cut(),
+                      femtoParticle.pidcut(),
+                      femtoParticle.tempFitVar(),
+                      childIDs,
+                      femtoParticle.mLambda(),
+                      femtoParticle.mAntiLambda());
+        }
+        if (aod::femtodreamparticle::ParticleType::kCascade == femtoParticle.partType()) {
+          // If the order in primary producer is changed of storing first pos, neg daughters and then V0 - this must be updated
+          const int rowOfLastTrack = outputParts.lastIndex();
+          std::vector<int> childIDs = {rowOfLastTrack - 2, rowOfLastTrack - 1, rowOfLastTrack};
+          outputParts(outputCollision.lastIndex(),
+                      femtoParticle.pt(),
+                      femtoParticle.eta(),
+                      femtoParticle.phi(),
+                      femtoParticle.partType(),
+                      femtoParticle.cut(),
+                      femtoParticle.pidcut(),
+                      femtoParticle.tempFitVar(),
+                      childIDs,
+                      femtoParticle.mLambda(),
+                      femtoParticle.mAntiLambda());
+        }
+      }
+    } else {
+      EventRegistry.fill(HIST("hStatistiscs"), 2);
+    }
+
+
+   }
+
+
+  /// process function to create derived data with only collisions containing n tracks
+  /// \param col subscribe to the collision table (Data)
+  /// \param parts subscribe to the femtoDreamParticleTable
+  void processCollisionsWithNTracksAndNCascades(o2::aod::FDCollision& col,
+                                                o2::aod::FDParticles& parts)
+  {
+    EventRegistry.fill(HIST("hStatistiscs"), 0);
+    auto thegroupSelectedParts = SelectedParts->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
+    auto thegroupSelectedCascades = SelectedCascades->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
+
+    createSpecifiedDerivedData_TrkCascade<false>(col, thegroupSelectedParts, thegroupSelectedCascades, parts);
+  }
+  PROCESS_SWITCH(femtoDreamProducerTaskForSpecificAnalysis, processCollisionsWithNTracksAndNCascades, "Enable producing data with tracks and Cascades collisions for data", true);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTaskForSpecificAnalysis.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTaskForSpecificAnalysis.cxx
@@ -67,7 +67,7 @@ struct femtoDreamProducerTaskForSpecificAnalysis {
   Configurable<float> Conf_maxInvMass_V0{"Conf_maxInvMass_V0", 1.15, "Maximum invariant mass of V0 (particle)"};
   Configurable<float> Conf_minInvMassAnti_V0{"Conf_minInvMassAnti_V0", 1.08, "Minimum invariant mass of V0 (antiparticle)"};
   Configurable<float> Conf_maxInvMassAnti_V0{"Conf_maxInvMassAnti_V0", 1.15, "Maximum invariant mass of V0 (antiparticle)"};
-  /// Cascade selection 
+  /// Cascade selection
   Configurable<float> Conf_minInvMass_Cascade{"Conf_minInvMass_Cascade", 1.2, "Minimum invariant mass of Cascade (particle)"};
   Configurable<float> Conf_maxInvMass_Cascade{"Conf_maxInvMass_Cascade", 1.5, "Maximum invariant mass of Cascade (particle)"};
 
@@ -76,7 +76,7 @@ struct femtoDreamProducerTaskForSpecificAnalysis {
   Partition<aod::FDParticles> SelectedCascades = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kCascade));
 
   HistogramRegistry EventRegistry{"EventRegistry", {}, OutputObjHandlingPolicy::AnalysisObject};
-  
+
   static constexpr uint32_t kSignPlusMask = 1 << 1;
 
   template <typename T>
@@ -208,7 +208,6 @@ struct femtoDreamProducerTaskForSpecificAnalysis {
   }
   PROCESS_SWITCH(femtoDreamProducerTaskForSpecificAnalysis, processCollisionsWithNTracksAndNV0, "Enable producing data with ppp collisions for data", true);
 
-
   /// This function stores accepted collisions in derived data
   /// @tparam PartitionType
   /// @tparam PartType
@@ -219,7 +218,7 @@ struct femtoDreamProducerTaskForSpecificAnalysis {
   template <bool isMC, typename PartitionType, typename PartType>
   void createSpecifiedDerivedData_TrkCascade(o2::aod::FDCollision& col, PartitionType groupSelectedTracks, PartitionType groupSelectedCascades, PartType parts)
   {
-    
+
     /// check tracks
     int tracksCount = 0;
     int antitracksCount = 0;
@@ -230,24 +229,24 @@ struct femtoDreamProducerTaskForSpecificAnalysis {
         tracksCount++;
       }
     }
-    
+
     /// check Cascades
     int CascadeCount = 0;
     int antiCascadeCount = 0;
     for (auto& casc : groupSelectedCascades) {
-      if ((casc.cut() & kSignPlusMask) == kSignPlusMask){
+      if ((casc.cut() & kSignPlusMask) == kSignPlusMask) {
         CascadeCount++;
-      } else{
+      } else {
         antiCascadeCount++;
       }
     }
-    
+
     std::vector<int> tmpIDtrack;
-    
+
     if ((CascadeCount >= ConfNumberOfCascades && tracksCount >= ConfNumberOfTracks) || (antiCascadeCount >= ConfNumberOfCascades && antitracksCount >= ConfNumberOfTracks)) {
       EventRegistry.fill(HIST("hStatistiscs"), 1);
       outputCollision(col.posZ(), col.multV0M(), col.multNtr(), col.sphericity(), col.magField());
-      
+
       for (auto& femtoParticle : parts) {
         if (aod::femtodreamparticle::ParticleType::kTrack == femtoParticle.partType()) {
           std::vector<int> childIDs = {0, 0};
@@ -268,19 +267,31 @@ struct femtoDreamProducerTaskForSpecificAnalysis {
           std::vector<int> childIDs = {0, 0, 0};
           const auto& children = femtoParticle.childrenIds();
           int childId = 0;
-          if (children[0] != 0){ childId = children[0]; } 
-          else if (children[1] != 0){ childId = children[1]; }
-          else if (children[2] != 0){ childId = children[2]; }
+          if (children[0] != 0) {
+            childId = children[0];
+          } else if (children[1] != 0) {
+            childId = children[1];
+          } else if (children[2] != 0) {
+            childId = children[2];
+          }
 
           if (childId != -1) {
             int rowInPrimaryTrackTable = getRowDaughters(childId, tmpIDtrack);
-            if (children[0] != 0){ childIDs = std::vector<int>{rowInPrimaryTrackTable, 0, 0}; } 
-            else if (children[1] != 0){ childIDs = std::vector<int>{0, rowInPrimaryTrackTable, 0}; } 
-            else if (children[2] != 0){ childIDs = std::vector<int>{0, 0, rowInPrimaryTrackTable}; } 
+            if (children[0] != 0) {
+              childIDs = std::vector<int>{rowInPrimaryTrackTable, 0, 0};
+            } else if (children[1] != 0) {
+              childIDs = std::vector<int>{0, rowInPrimaryTrackTable, 0};
+            } else if (children[2] != 0) {
+              childIDs = std::vector<int>{0, 0, rowInPrimaryTrackTable};
+            }
           } else {
-            if (children[0] != 0){ childIDs = std::vector<int>{-1, 0, 0}; } 
-            else if (children[1] != 0){ childIDs = std::vector<int>{0, -1, 0}; } 
-            else if (children[2] != 0){ childIDs = std::vector<int>{0, 0, -1}; } 
+            if (children[0] != 0) {
+              childIDs = std::vector<int>{-1, 0, 0};
+            } else if (children[1] != 0) {
+              childIDs = std::vector<int>{0, -1, 0};
+            } else if (children[2] != 0) {
+              childIDs = std::vector<int>{0, 0, -1};
+            }
           }
           outputParts(outputCollision.lastIndex(),
                       femtoParticle.pt(),
@@ -314,10 +325,7 @@ struct femtoDreamProducerTaskForSpecificAnalysis {
     } else {
       EventRegistry.fill(HIST("hStatistiscs"), 2);
     }
-
-
-   }
-
+  }
 
   /// process function to create derived data with only collisions containing n tracks
   /// \param col subscribe to the collision table (Data)

--- a/PWGCF/FemtoDream/Tasks/CMakeLists.txt
+++ b/PWGCF/FemtoDream/Tasks/CMakeLists.txt
@@ -39,6 +39,11 @@ o2physics_add_dpl_workflow(femtodream-debug-v0
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
           COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(femtodream-debug-cascade
+          SOURCES femtoDreamDebugCascade.cxx
+          PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+          COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(femtodream-collision-masker
           SOURCES femtoDreamCollisionMasker.cxx
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore

--- a/PWGCF/FemtoDream/Tasks/CMakeLists.txt
+++ b/PWGCF/FemtoDream/Tasks/CMakeLists.txt
@@ -24,6 +24,11 @@ o2physics_add_dpl_workflow(femtodream-pair-track-v0
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
           COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(femtodream-pair-track-cascade
+          SOURCES femtoDreamPairTaskTrackCascade.cxx
+          PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+          COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(femtodream-triplet-track-track-v0
           SOURCES femtoDreamTripletTaskTrackTrackV0.cxx
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore

--- a/PWGCF/FemtoDream/Tasks/femtoDreamDebugCascade.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamDebugCascade.cxx
@@ -86,9 +86,9 @@ struct femtoDreamDebugCascade {
   void init(InitContext&)
   {
     eventHisto.init(&EventRegistry, false);
-    posChildHistos.init(&CascadeRegistry, ConfBinmult, ConfDummy, ConfCascadeChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfCascadeChildTempFitVarBins, ConfCascadeChildNsigmaTPCBins, ConfCascadeChildNsigmaTOFBins, ConfCascadeChildNsigmaTPCTOFBins, ConfDummy, ConfCascadeInvMassBins, false, ConfCascade_ChildPos_PDGCode.value, true);
-    negChildHistos.init(&CascadeRegistry, ConfBinmult, ConfDummy, ConfCascadeChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfCascadeChildTempFitVarBins, ConfCascadeChildNsigmaTPCBins, ConfCascadeChildNsigmaTOFBins, ConfCascadeChildNsigmaTPCTOFBins, ConfDummy, ConfCascadeInvMassBins, false, ConfCascade_ChildNeg_PDGCode.value, true);
-    bachelorHistos.init(&CascadeRegistry, ConfBinmult, ConfDummy, ConfCascadeChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfCascadeChildTempFitVarBins, ConfCascadeChildNsigmaTPCBins, ConfCascadeChildNsigmaTOFBins, ConfCascadeChildNsigmaTPCTOFBins, ConfDummy, ConfCascadeInvMassBins, false, ConfCascade_Bach_PDGCode.value, true);
+    //posChildHistos.init(&CascadeRegistry, ConfBinmult, ConfDummy, ConfCascadeChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfCascadeChildTempFitVarBins, ConfCascadeChildNsigmaTPCBins, ConfCascadeChildNsigmaTOFBins, ConfCascadeChildNsigmaTPCTOFBins, ConfDummy, ConfCascadeInvMassBins, false, ConfCascade_ChildPos_PDGCode.value, true);
+    //negChildHistos.init(&CascadeRegistry, ConfBinmult, ConfDummy, ConfCascadeChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfCascadeChildTempFitVarBins, ConfCascadeChildNsigmaTPCBins, ConfCascadeChildNsigmaTOFBins, ConfCascadeChildNsigmaTPCTOFBins, ConfDummy, ConfCascadeInvMassBins, false, ConfCascade_ChildNeg_PDGCode.value, true);
+    //bachelorHistos.init(&CascadeRegistry, ConfBinmult, ConfDummy, ConfCascadeChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfCascadeChildTempFitVarBins, ConfCascadeChildNsigmaTPCBins, ConfCascadeChildNsigmaTOFBins, ConfCascadeChildNsigmaTPCTOFBins, ConfDummy, ConfCascadeInvMassBins, false, ConfCascade_Bach_PDGCode.value, true);
     CascadeHistos.init(&CascadeRegistry, ConfBinmult, ConfDummy, ConfCascadeTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfCascadeTempFitVarBins, ConfCascadeChildNsigmaTPCBins, ConfCascadeChildNsigmaTOFBins, ConfCascadeChildNsigmaTPCTOFBins, ConfDummy, ConfCascadeInvMassBins, false, ConfCascade_PDGCode.value, true);
   }
 
@@ -124,9 +124,9 @@ struct femtoDreamDebugCascade {
           (bachChild.pidcut() & ConfCascade_ChildBach_TPCBit) == ConfCascade_ChildBach_TPCBit) {
         
         CascadeHistos.fillQA<false, true>(part, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());
-        posChildHistos.fillQA<false, true>(posChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());
-        negChildHistos.fillQA<false, true>(negChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());
-        bachelorHistos.fillQA<false, true>(bachChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());
+        //posChildHistos.fillQA<false, true>(posChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());
+        //negChildHistos.fillQA<false, true>(negChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());
+        //bachelorHistos.fillQA<false, true>(bachChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());
       }
     }
   }

--- a/PWGCF/FemtoDream/Tasks/femtoDreamDebugCascade.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamDebugCascade.cxx
@@ -65,6 +65,7 @@ struct femtoDreamDebugCascade {
   Configurable<aod::femtodreamparticle::cutContainerType> ConfCascade_ChildNeg_TPCBit{"ConfCascade_ChildNeg_TPCBit", 8, "Negative Child of Cascade - PID bit from cutCulator"};
   Configurable<aod::femtodreamparticle::cutContainerType> ConfCascade_ChildBach_CutBit{"ConfCascade_ChildBach_CutBit", 149, "Bachelor Child of Cascade - PID bit from cutCulator"};
   Configurable<aod::femtodreamparticle::cutContainerType> ConfCascade_ChildBach_TPCBit{"ConfCascade_ChildBach_TPCBit", 8, "Bachelor Child of Cascade - PID bit from cutCulator"};
+  Configurable<bool> ConfUseChildCuts{"ConfUseChildCuts", true, "Use cuts on the children of the Cascades additional to those of the selection of the cascade builder"};
   ConfigurableAxis ConfCascadeChildTempFitVarBins{"ConfCascadeChildTempFitVarBins", {300, -0.15, 0.15}, "Cascade child: binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfCascadeChildTempFitVarpTBins{"ConfCascadeChildTempFitVarpTBins", {20, 0.5, 4.05}, "Cascade child: pT binning of the pT vs. TempFitVar plot"};
 
@@ -113,24 +114,19 @@ struct femtoDreamDebugCascade {
         continue;
       }
       // check cuts on V0 children
-      //if (posChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeV0Child) &&
-      //    (posChild.cut() & ConfCascade_ChildPos_CutBit) == ConfCascade_ChildPos_CutBit &&
-      //    (posChild.pidcut() & ConfCascade_ChildPos_TPCBit) == ConfCascade_ChildPos_TPCBit && 
-      //    negChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeV0Child) &&
-      //    (negChild.cut() & ConfCascade_ChildNeg_CutBit) == ConfCascade_ChildNeg_CutBit &&
-      //    (negChild.pidcut() & ConfCascade_ChildNeg_TPCBit) == ConfCascade_ChildNeg_TPCBit &&
-          if( bachChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeBachelor) &&
+      if (posChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeV0Child) &&
+          negChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeV0Child) &&
+          bachChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeBachelor)){
+        
+        if( ConfUseChildCuts &&
+          (posChild.cut() & ConfCascade_ChildPos_CutBit) == ConfCascade_ChildPos_CutBit &&
+          (posChild.pidcut() & ConfCascade_ChildPos_TPCBit) == ConfCascade_ChildPos_TPCBit && 
+          (negChild.cut() & ConfCascade_ChildNeg_CutBit) == ConfCascade_ChildNeg_CutBit &&
+          (negChild.pidcut() & ConfCascade_ChildNeg_TPCBit) == ConfCascade_ChildNeg_TPCBit &&
           (bachChild.cut() & ConfCascade_ChildBach_CutBit) == ConfCascade_ChildBach_CutBit &&
           (bachChild.pidcut() & ConfCascade_ChildBach_TPCBit) == ConfCascade_ChildBach_TPCBit) {
-      /*
-      LOG(info, "--- NEW CANDIDATE ---");
-      if (posChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeV0Child) &&
-          (posChild.cut() & ConfCascade_ChildPos_CutBit) == ConfCascade_ChildPos_CutBit &&
-          (posChild.pidcut() & ConfCascade_ChildPos_TPCBit) == ConfCascade_ChildPos_TPCBit &&
-          negChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeV0Child)){
-            LOG(info, "GG debugger: V0 child passed");
-        
-      */
+            continue;
+          }
         CascadeHistos.fillQA<false, false>(part, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M()); //set isDebug to true
         posChildHistos.fillQA<false, true>(posChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());
         negChildHistos.fillQA<false, true>(negChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());

--- a/PWGCF/FemtoDream/Tasks/femtoDreamDebugCascade.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamDebugCascade.cxx
@@ -43,7 +43,7 @@ struct femtoDreamDebugCascade {
   Configurable<int> ConfCascade_ChildPos_PDGCode{"ConfCascade_PosChild_PDGCode", 2212, "Positive Child - PDG code"};
   Configurable<int> ConfCascade_ChildNeg_PDGCode{"ConfCascade_NegChild_PDGCode", 211, "Negative Child- PDG code"};
   Configurable<int> ConfCascade_Bach_PDGCode{"ConfCascade_Bach_PDGCode", 211, "Bachelor Child- PDG code"};
-  
+
   Configurable<aod::femtodreamparticle::cutContainerType> ConfCascade_CutBit{"ConfCascade_CutBit", 338, "Cascade - Selection bit from cutCulator"};
   ConfigurableAxis ConfCascadeTempFitVarBins{"ConfCascadeTempFitVarBins", {300, 0.95, 1.}, "Cascade: binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfCascadeTempFitVarMomentumBins{"ConfCascadeTempFitVarMomentumBins", {20, 0.5, 4.05}, "Cascade: pT binning of the pT vs. TempFitVar plot"};
@@ -116,18 +116,18 @@ struct femtoDreamDebugCascade {
       // check cuts on V0 children
       if (posChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeV0Child) &&
           negChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeV0Child) &&
-          bachChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeBachelor)){
-        
-        if( ConfUseChildCuts &&
-          !((posChild.cut() & ConfCascade_ChildPos_CutBit) == ConfCascade_ChildPos_CutBit &&
-          (posChild.pidcut() & ConfCascade_ChildPos_TPCBit) == ConfCascade_ChildPos_TPCBit && 
-          (negChild.cut() & ConfCascade_ChildNeg_CutBit) == ConfCascade_ChildNeg_CutBit &&
-          (negChild.pidcut() & ConfCascade_ChildNeg_TPCBit) == ConfCascade_ChildNeg_TPCBit &&
-          (bachChild.cut() & ConfCascade_ChildBach_CutBit) == ConfCascade_ChildBach_CutBit &&
-          (bachChild.pidcut() & ConfCascade_ChildBach_TPCBit) == ConfCascade_ChildBach_TPCBit)) {
-            continue;
-          }
-        CascadeHistos.fillQA<false, false>(part, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M()); //set isDebug to true
+          bachChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeBachelor)) {
+
+        if (ConfUseChildCuts &&
+            !((posChild.cut() & ConfCascade_ChildPos_CutBit) == ConfCascade_ChildPos_CutBit &&
+              (posChild.pidcut() & ConfCascade_ChildPos_TPCBit) == ConfCascade_ChildPos_TPCBit &&
+              (negChild.cut() & ConfCascade_ChildNeg_CutBit) == ConfCascade_ChildNeg_CutBit &&
+              (negChild.pidcut() & ConfCascade_ChildNeg_TPCBit) == ConfCascade_ChildNeg_TPCBit &&
+              (bachChild.cut() & ConfCascade_ChildBach_CutBit) == ConfCascade_ChildBach_CutBit &&
+              (bachChild.pidcut() & ConfCascade_ChildBach_TPCBit) == ConfCascade_ChildBach_TPCBit)) {
+          continue;
+        }
+        CascadeHistos.fillQA<false, false>(part, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M()); // set isDebug to true
         posChildHistos.fillQA<false, true>(posChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());
         negChildHistos.fillQA<false, true>(negChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());
         bachelorHistos.fillQA<false, true>(bachChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());

--- a/PWGCF/FemtoDream/Tasks/femtoDreamDebugCascade.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamDebugCascade.cxx
@@ -12,6 +12,7 @@
 /// \file femtoDreamDebugV0.cxx
 /// \brief Tasks that reads the particle tables and fills QA histograms for V0s
 /// \author Luca Barioglio, TU München, luca.barioglio@cern.ch
+/// \author Georgios Mantzaridis, TU München, luca.barioglio@cern.ch
 
 #include <cstdint>
 #include <iostream>
@@ -44,8 +45,8 @@ struct femtoDreamDebugCascade {
   Configurable<int> ConfCascade_Bach_PDGCode{"ConfCascade_Bach_PDGCode", 211, "Bachelor Child- PDG code"};
   
   Configurable<aod::femtodreamparticle::cutContainerType> ConfCascade_CutBit{"ConfCascade_CutBit", 338, "Cascade - Selection bit from cutCulator"};
-  ConfigurableAxis ConfCascadeTempFitVarBins{"ConfV0TempFitVarBins", {300, 0.95, 1.}, "Cascade: binning of the TempFitVar in the pT vs. TempFitVar plot"};
-  ConfigurableAxis ConfCascadeTempFitVarMomentumBins{"ConfV0TempFitVarMomentumBins", {20, 0.5, 4.05}, "V0: pT binning of the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfCascadeTempFitVarBins{"ConfCascadeTempFitVarBins", {300, 0.95, 1.}, "Cascade: binning of the TempFitVar in the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfCascadeTempFitVarMomentumBins{"ConfCascadeTempFitVarMomentumBins", {20, 0.5, 4.05}, "Cascade: pT binning of the pT vs. TempFitVar plot"};
   ConfigurableAxis ConfBinmult{"ConfBinmult", {1, 0, 1}, "multiplicity Binning"};
   ConfigurableAxis ConfDummy{"ConfDummy", {1, 0, 1}, "Dummy axis for inv mass"};
 
@@ -64,8 +65,8 @@ struct femtoDreamDebugCascade {
   Configurable<aod::femtodreamparticle::cutContainerType> ConfCascade_ChildNeg_TPCBit{"ConfCascade_ChildNeg_TPCBit", 8, "Negative Child of Cascade - PID bit from cutCulator"};
   Configurable<aod::femtodreamparticle::cutContainerType> ConfCascade_ChildBach_CutBit{"ConfCascade_ChildBach_CutBit", 149, "Bachelor Child of Cascade - PID bit from cutCulator"};
   Configurable<aod::femtodreamparticle::cutContainerType> ConfCascade_ChildBach_TPCBit{"ConfCascade_ChildBach_TPCBit", 8, "Bachelor Child of Cascade - PID bit from cutCulator"};
-  ConfigurableAxis ConfChildTempFitVarBins{"ConfChildTempFitVarBins", {300, -0.15, 0.15}, "Cascade child: binning of the TempFitVar in the pT vs. TempFitVar plot"};
-  ConfigurableAxis ConfChildTempFitVarpTBins{"ConfChildTempFitVarpTBins", {20, 0.5, 4.05}, "Cascade child: pT binning of the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfCascadeChildTempFitVarBins{"ConfCascadeChildTempFitVarBins", {300, -0.15, 0.15}, "Cascade child: binning of the TempFitVar in the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfCascadeChildTempFitVarpTBins{"ConfCascadeChildTempFitVarpTBins", {20, 0.5, 4.05}, "Cascade child: pT binning of the pT vs. TempFitVar plot"};
 
   using FemtoFullParticles = soa::Join<aod::FDParticles, aod::FDExtParticles>;
   Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kCascade)) && (ncheckbit(aod::femtodreamparticle::cut, ConfCascade_CutBit));
@@ -73,21 +74,22 @@ struct femtoDreamDebugCascade {
 
   /// Histogramming
   FemtoDreamEventHisto eventHisto;
-  //FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0Child, 3> posChildHistos;
-  //FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0Child, 4> negChildHistos;
-  //FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0> V0Histos;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascadeV0Child, 3> posChildHistos;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascadeV0Child, 4> negChildHistos;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascadeBachelor, 5> bachelorHistos;
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascade> CascadeHistos;
 
   /// Histogram output
   HistogramRegistry EventRegistry{"Event", {}, OutputObjHandlingPolicy::AnalysisObject};
-  HistogramRegistry V0Registry{"FullV0QA", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry CascadeRegistry{"FullCascQA", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   void init(InitContext&)
   {
     eventHisto.init(&EventRegistry, false);
-    posChildHistos.init(&V0Registry, ConfBinmult, ConfDummy, ConfV0ChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfChildTempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfDummy, ConfV0InvMassBins, false, ConfV01_ChildPos_PDGCode.value, true);
-    negChildHistos.init(&V0Registry, ConfBinmult, ConfDummy, ConfV0ChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfChildTempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfDummy, ConfV0InvMassBins, false, ConfV01_ChildNeg_PDGCode, true);
-    V0Histos.init(&V0Registry, ConfBinmult, ConfDummy, ConfV0TempFitVarMomentumBins, ConfDummy, ConfDummy, ConfV0TempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfDummy, ConfV0InvMassBins, false, ConfV01_PDGCode.value, true);
+    posChildHistos.init(&CascadeRegistry, ConfBinmult, ConfDummy, ConfCascadeChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfCascadeChildTempFitVarBins, ConfCascadeChildNsigmaTPCBins, ConfCascadeChildNsigmaTOFBins, ConfCascadeChildNsigmaTPCTOFBins, ConfDummy, ConfCascadeInvMassBins, false, ConfCascade_ChildPos_PDGCode.value, true);
+    negChildHistos.init(&CascadeRegistry, ConfBinmult, ConfDummy, ConfCascadeChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfCascadeChildTempFitVarBins, ConfCascadeChildNsigmaTPCBins, ConfCascadeChildNsigmaTOFBins, ConfCascadeChildNsigmaTPCTOFBins, ConfDummy, ConfCascadeInvMassBins, false, ConfCascade_ChildNeg_PDGCode.value, true);
+    bachelorHistos.init(&CascadeRegistry, ConfBinmult, ConfDummy, ConfCascadeChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfCascadeChildTempFitVarBins, ConfCascadeChildNsigmaTPCBins, ConfCascadeChildNsigmaTOFBins, ConfCascadeChildNsigmaTPCTOFBins, ConfDummy, ConfCascadeInvMassBins, false, ConfCascade_Bach_PDGCode.value, true);
+    CascadeHistos.init(&CascadeRegistry, ConfBinmult, ConfDummy, ConfCascadeTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfCascadeTempFitVarBins, ConfCascadeChildNsigmaTPCBins, ConfCascadeChildNsigmaTOFBins, ConfCascadeChildNsigmaTPCTOFBins, ConfDummy, ConfCascadeInvMassBins, false, ConfCascade_PDGCode.value, true);
   }
 
   /// Porduce QA plots for V0 selection in FemtoDream framework
@@ -103,22 +105,28 @@ struct femtoDreamDebugCascade {
       // TODO: check if this should be possible
       // auto posChild = part.template children_as<FemtoFullParticles>().front();
       // auto negChild = part.template children_as<FemtoFullParticles>().back();
-      const auto& posChild = parts.iteratorAt(part.index() - 2);
-      const auto& negChild = parts.iteratorAt(part.index() - 1);
-      if (posChild.globalIndex() != part.childrenIds()[0] || negChild.globalIndex() != part.childrenIds()[1]) {
+      const auto& posChild = parts.iteratorAt(part.index() - 3);
+      const auto& negChild = parts.iteratorAt(part.index() - 2);
+      const auto& bachChild = parts.iteratorAt(part.index() - 1);
+      if (posChild.globalIndex() != part.childrenIds()[0] || negChild.globalIndex() != part.childrenIds()[1] || bachChild.globalIndex() != part.childrenIds()[2]) {
         LOG(warn) << "Indices of V0 children do not match";
         continue;
       }
       // check cuts on V0 children
-      if (posChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) &&
-          (posChild.cut() & ConfV01_ChildPos_CutBit) == ConfV01_ChildPos_CutBit &&
-          (posChild.pidcut() & ConfV01_ChildPos_TPCBit) == ConfV01_ChildPos_TPCBit &&
-          negChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) &&
-          (negChild.cut() & ConfV01_ChildNeg_CutBit) == ConfV01_ChildNeg_CutBit &&
-          (negChild.pidcut() & ConfV01_ChildNeg_TPCBit) == ConfV01_ChildNeg_TPCBit) {
-        V0Histos.fillQA<false, true>(part, static_cast<aod::femtodreamparticle::MomentumType>(ConfV0TempFitVarMomentum.value), col.multNtr(), col.multV0M());
-        posChildHistos.fillQA<false, true>(posChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfV0TempFitVarMomentum.value), col.multNtr(), col.multV0M());
-        negChildHistos.fillQA<false, true>(negChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfV0TempFitVarMomentum.value), col.multNtr(), col.multV0M());
+      if (posChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeV0Child) &&
+          (posChild.cut() & ConfCascade_ChildPos_CutBit) == ConfCascade_ChildPos_CutBit &&
+          (posChild.pidcut() & ConfCascade_ChildPos_TPCBit) == ConfCascade_ChildPos_TPCBit &&
+          negChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeV0Child) &&
+          (negChild.cut() & ConfCascade_ChildNeg_CutBit) == ConfCascade_ChildNeg_CutBit &&
+          (negChild.pidcut() & ConfCascade_ChildNeg_TPCBit) == ConfCascade_ChildNeg_TPCBit &&
+          bachChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeBachelor) &&
+          (bachChild.cut() & ConfCascade_ChildBach_CutBit) == ConfCascade_ChildBach_CutBit &&
+          (bachChild.pidcut() & ConfCascade_ChildBach_TPCBit) == ConfCascade_ChildBach_TPCBit) {
+        
+        CascadeHistos.fillQA<false, true>(part, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());
+        posChildHistos.fillQA<false, true>(posChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());
+        negChildHistos.fillQA<false, true>(negChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());
+        bachelorHistos.fillQA<false, true>(bachChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());
       }
     }
   }
@@ -128,7 +136,7 @@ WorkflowSpec
   defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec workflow{
-    adaptAnalysisTask<femtoDreamDebugV0>(cfgc),
+    adaptAnalysisTask<femtoDreamDebugCascade>(cfgc),
   };
   return workflow;
 }

--- a/PWGCF/FemtoDream/Tasks/femtoDreamDebugCascade.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamDebugCascade.cxx
@@ -119,12 +119,12 @@ struct femtoDreamDebugCascade {
           bachChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeBachelor)){
         
         if( ConfUseChildCuts &&
-          (posChild.cut() & ConfCascade_ChildPos_CutBit) == ConfCascade_ChildPos_CutBit &&
+          !((posChild.cut() & ConfCascade_ChildPos_CutBit) == ConfCascade_ChildPos_CutBit &&
           (posChild.pidcut() & ConfCascade_ChildPos_TPCBit) == ConfCascade_ChildPos_TPCBit && 
           (negChild.cut() & ConfCascade_ChildNeg_CutBit) == ConfCascade_ChildNeg_CutBit &&
           (negChild.pidcut() & ConfCascade_ChildNeg_TPCBit) == ConfCascade_ChildNeg_TPCBit &&
           (bachChild.cut() & ConfCascade_ChildBach_CutBit) == ConfCascade_ChildBach_CutBit &&
-          (bachChild.pidcut() & ConfCascade_ChildBach_TPCBit) == ConfCascade_ChildBach_TPCBit) {
+          (bachChild.pidcut() & ConfCascade_ChildBach_TPCBit) == ConfCascade_ChildBach_TPCBit)) {
             continue;
           }
         CascadeHistos.fillQA<false, false>(part, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M()); //set isDebug to true

--- a/PWGCF/FemtoDream/Tasks/femtoDreamDebugCascade.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamDebugCascade.cxx
@@ -1,0 +1,134 @@
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file femtoDreamDebugV0.cxx
+/// \brief Tasks that reads the particle tables and fills QA histograms for V0s
+/// \author Luca Barioglio, TU München, luca.barioglio@cern.ch
+
+#include <cstdint>
+#include <iostream>
+#include <vector>
+#include "Framework/AnalysisTask.h"
+#include "Framework/runDataProcessing.h"
+#include "Framework/HistogramRegistry.h"
+#include "Framework/ASoAHelpers.h"
+#include "Framework/RunningWorkflowInfo.h"
+#include "Framework/StepTHn.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "fairlogger/Logger.h"
+
+#include "PWGCF/DataModel/FemtoDerived.h"
+#include "PWGCF/FemtoDream/Core/femtoDreamParticleHisto.h"
+#include "PWGCF/FemtoDream/Core/femtoDreamEventHisto.h"
+
+using namespace o2;
+using namespace o2::analysis::femtoDream;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using namespace o2::soa;
+
+struct femtoDreamDebugCascade {
+  SliceCache cache;
+
+  Configurable<int> ConfCascade_PDGCode{"ConfCascade_PDGCode", 3312, "Cascade - PDG code"};
+  Configurable<int> ConfCascade_ChildPos_PDGCode{"ConfCascade_PosChild_PDGCode", 2212, "Positive Child - PDG code"};
+  Configurable<int> ConfCascade_ChildNeg_PDGCode{"ConfCascade_NegChild_PDGCode", 211, "Negative Child- PDG code"};
+  Configurable<int> ConfCascade_Bach_PDGCode{"ConfCascade_Bach_PDGCode", 211, "Bachelor Child- PDG code"};
+  
+  Configurable<aod::femtodreamparticle::cutContainerType> ConfCascade_CutBit{"ConfCascade_CutBit", 338, "Cascade - Selection bit from cutCulator"};
+  ConfigurableAxis ConfCascadeTempFitVarBins{"ConfV0TempFitVarBins", {300, 0.95, 1.}, "Cascade: binning of the TempFitVar in the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfCascadeTempFitVarMomentumBins{"ConfV0TempFitVarMomentumBins", {20, 0.5, 4.05}, "V0: pT binning of the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfBinmult{"ConfBinmult", {1, 0, 1}, "multiplicity Binning"};
+  ConfigurableAxis ConfDummy{"ConfDummy", {1, 0, 1}, "Dummy axis for inv mass"};
+
+  Configurable<int> ConfCascadeTempFitVarMomentum{"ConfCascadeTempFitVarMomentum", 0, "Momentum used for binning: 0 -> pt; 1 -> preco; 2 -> ptpc"};
+
+  ConfigurableAxis ConfCascadeInvMassBins{"ConfCascadeInvMassBins", {200, 1, 1.2}, "Cascade: InvMass binning"};
+
+  ConfigurableAxis ConfCascadeChildTempFitVarMomentumBins{"ConfCascadeChildTempFitVarMomentumBins", {600, 0, 6}, "p binning for the p vs Nsigma TPC/TOF plot"};
+  ConfigurableAxis ConfCascadeChildNsigmaTPCBins{"ConfCascadeChildNsigmaTPCBins", {1600, -8, 8}, "binning of Nsigma TPC plot"};
+  ConfigurableAxis ConfCascadeChildNsigmaTOFBins{"ConfCascadeChildNsigmaTOFBins", {3000, -15, 15}, "binning of the Nsigma TOF plot"};
+  ConfigurableAxis ConfCascadeChildNsigmaTPCTOFBins{"ConfCascadeChildNsigmaTPCTOFBins", {1000, 0, 10}, "binning of the Nsigma TPC+TOF plot"};
+
+  Configurable<aod::femtodreamparticle::cutContainerType> ConfCascade_ChildPos_CutBit{"ConfCascade_ChildPos_CutBit", 150, "Positive Child of Cascade - Selection bit from cutCulator"};
+  Configurable<aod::femtodreamparticle::cutContainerType> ConfCascade_ChildPos_TPCBit{"ConfCascade_ChildPos_TPCBit", 4, "Positive Child of Cascade - PID bit from cutCulator"};
+  Configurable<aod::femtodreamparticle::cutContainerType> ConfCascade_ChildNeg_CutBit{"ConfCascade_ChildNeg_CutBit", 149, "Negative Child of Cascade - PID bit from cutCulator"};
+  Configurable<aod::femtodreamparticle::cutContainerType> ConfCascade_ChildNeg_TPCBit{"ConfCascade_ChildNeg_TPCBit", 8, "Negative Child of Cascade - PID bit from cutCulator"};
+  Configurable<aod::femtodreamparticle::cutContainerType> ConfCascade_ChildBach_CutBit{"ConfCascade_ChildBach_CutBit", 149, "Bachelor Child of Cascade - PID bit from cutCulator"};
+  Configurable<aod::femtodreamparticle::cutContainerType> ConfCascade_ChildBach_TPCBit{"ConfCascade_ChildBach_TPCBit", 8, "Bachelor Child of Cascade - PID bit from cutCulator"};
+  ConfigurableAxis ConfChildTempFitVarBins{"ConfChildTempFitVarBins", {300, -0.15, 0.15}, "Cascade child: binning of the TempFitVar in the pT vs. TempFitVar plot"};
+  ConfigurableAxis ConfChildTempFitVarpTBins{"ConfChildTempFitVarpTBins", {20, 0.5, 4.05}, "Cascade child: pT binning of the pT vs. TempFitVar plot"};
+
+  using FemtoFullParticles = soa::Join<aod::FDParticles, aod::FDExtParticles>;
+  Partition<FemtoFullParticles> partsOne = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kCascade)) && (ncheckbit(aod::femtodreamparticle::cut, ConfCascade_CutBit));
+  Preslice<FemtoFullParticles> perCol = aod::femtodreamparticle::fdCollisionId;
+
+  /// Histogramming
+  FemtoDreamEventHisto eventHisto;
+  //FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0Child, 3> posChildHistos;
+  //FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0Child, 4> negChildHistos;
+  //FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0> V0Histos;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascade> CascadeHistos;
+
+  /// Histogram output
+  HistogramRegistry EventRegistry{"Event", {}, OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry V0Registry{"FullV0QA", {}, OutputObjHandlingPolicy::AnalysisObject};
+
+  void init(InitContext&)
+  {
+    eventHisto.init(&EventRegistry, false);
+    posChildHistos.init(&V0Registry, ConfBinmult, ConfDummy, ConfV0ChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfChildTempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfDummy, ConfV0InvMassBins, false, ConfV01_ChildPos_PDGCode.value, true);
+    negChildHistos.init(&V0Registry, ConfBinmult, ConfDummy, ConfV0ChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfChildTempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfDummy, ConfV0InvMassBins, false, ConfV01_ChildNeg_PDGCode, true);
+    V0Histos.init(&V0Registry, ConfBinmult, ConfDummy, ConfV0TempFitVarMomentumBins, ConfDummy, ConfDummy, ConfV0TempFitVarBins, ConfV0ChildNsigmaTPCBins, ConfV0ChildNsigmaTOFBins, ConfV0ChildNsigmaTPCTOFBins, ConfDummy, ConfV0InvMassBins, false, ConfV01_PDGCode.value, true);
+  }
+
+  /// Porduce QA plots for V0 selection in FemtoDream framework
+  void process(o2::aod::FDCollision const& col, FemtoFullParticles const& parts)
+  {
+    auto groupPartsOne = partsOne->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
+    eventHisto.fillQA<false>(col);
+    for (auto& part : groupPartsOne) {
+      if (!part.has_children()) {
+        continue;
+      }
+      // check cut on v0 children
+      // TODO: check if this should be possible
+      // auto posChild = part.template children_as<FemtoFullParticles>().front();
+      // auto negChild = part.template children_as<FemtoFullParticles>().back();
+      const auto& posChild = parts.iteratorAt(part.index() - 2);
+      const auto& negChild = parts.iteratorAt(part.index() - 1);
+      if (posChild.globalIndex() != part.childrenIds()[0] || negChild.globalIndex() != part.childrenIds()[1]) {
+        LOG(warn) << "Indices of V0 children do not match";
+        continue;
+      }
+      // check cuts on V0 children
+      if (posChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) &&
+          (posChild.cut() & ConfV01_ChildPos_CutBit) == ConfV01_ChildPos_CutBit &&
+          (posChild.pidcut() & ConfV01_ChildPos_TPCBit) == ConfV01_ChildPos_TPCBit &&
+          negChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kV0Child) &&
+          (negChild.cut() & ConfV01_ChildNeg_CutBit) == ConfV01_ChildNeg_CutBit &&
+          (negChild.pidcut() & ConfV01_ChildNeg_TPCBit) == ConfV01_ChildNeg_TPCBit) {
+        V0Histos.fillQA<false, true>(part, static_cast<aod::femtodreamparticle::MomentumType>(ConfV0TempFitVarMomentum.value), col.multNtr(), col.multV0M());
+        posChildHistos.fillQA<false, true>(posChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfV0TempFitVarMomentum.value), col.multNtr(), col.multV0M());
+        negChildHistos.fillQA<false, true>(negChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfV0TempFitVarMomentum.value), col.multNtr(), col.multV0M());
+      }
+    }
+  }
+};
+
+WorkflowSpec
+  defineDataProcessing(ConfigContext const& cfgc)
+{
+  WorkflowSpec workflow{
+    adaptAnalysisTask<femtoDreamDebugV0>(cfgc),
+  };
+  return workflow;
+}

--- a/PWGCF/FemtoDream/Tasks/femtoDreamDebugCascade.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamDebugCascade.cxx
@@ -52,7 +52,7 @@ struct femtoDreamDebugCascade {
 
   Configurable<int> ConfCascadeTempFitVarMomentum{"ConfCascadeTempFitVarMomentum", 0, "Momentum used for binning: 0 -> pt; 1 -> preco; 2 -> ptpc"};
 
-  ConfigurableAxis ConfCascadeInvMassBins{"ConfCascadeInvMassBins", {200, 1, 1.2}, "Cascade: InvMass binning"};
+  ConfigurableAxis ConfCascadeInvMassBins{"ConfCascadeInvMassBins", {200, 1.25, 1.45}, "Cascade: InvMass binning"};
 
   ConfigurableAxis ConfCascadeChildTempFitVarMomentumBins{"ConfCascadeChildTempFitVarMomentumBins", {600, 0, 6}, "p binning for the p vs Nsigma TPC/TOF plot"};
   ConfigurableAxis ConfCascadeChildNsigmaTPCBins{"ConfCascadeChildNsigmaTPCBins", {1600, -8, 8}, "binning of Nsigma TPC plot"};
@@ -76,7 +76,7 @@ struct femtoDreamDebugCascade {
   FemtoDreamEventHisto eventHisto;
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascadeV0Child, 3> posChildHistos;
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascadeV0Child, 4> negChildHistos;
-  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascadeBachelor, 5> bachelorHistos;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascadeBachelor, 8> bachelorHistos;
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascade> CascadeHistos;
 
   /// Histogram output
@@ -86,10 +86,10 @@ struct femtoDreamDebugCascade {
   void init(InitContext&)
   {
     eventHisto.init(&EventRegistry, false);
-    //posChildHistos.init(&CascadeRegistry, ConfBinmult, ConfDummy, ConfCascadeChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfCascadeChildTempFitVarBins, ConfCascadeChildNsigmaTPCBins, ConfCascadeChildNsigmaTOFBins, ConfCascadeChildNsigmaTPCTOFBins, ConfDummy, ConfCascadeInvMassBins, false, ConfCascade_ChildPos_PDGCode.value, true);
-    //negChildHistos.init(&CascadeRegistry, ConfBinmult, ConfDummy, ConfCascadeChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfCascadeChildTempFitVarBins, ConfCascadeChildNsigmaTPCBins, ConfCascadeChildNsigmaTOFBins, ConfCascadeChildNsigmaTPCTOFBins, ConfDummy, ConfCascadeInvMassBins, false, ConfCascade_ChildNeg_PDGCode.value, true);
-    //bachelorHistos.init(&CascadeRegistry, ConfBinmult, ConfDummy, ConfCascadeChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfCascadeChildTempFitVarBins, ConfCascadeChildNsigmaTPCBins, ConfCascadeChildNsigmaTOFBins, ConfCascadeChildNsigmaTPCTOFBins, ConfDummy, ConfCascadeInvMassBins, false, ConfCascade_Bach_PDGCode.value, true);
-    CascadeHistos.init(&CascadeRegistry, ConfBinmult, ConfDummy, ConfCascadeTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfCascadeTempFitVarBins, ConfCascadeChildNsigmaTPCBins, ConfCascadeChildNsigmaTOFBins, ConfCascadeChildNsigmaTPCTOFBins, ConfDummy, ConfCascadeInvMassBins, false, ConfCascade_PDGCode.value, true);
+    posChildHistos.init(&CascadeRegistry, ConfBinmult, ConfDummy, ConfCascadeChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfCascadeChildTempFitVarBins, ConfCascadeChildNsigmaTPCBins, ConfCascadeChildNsigmaTOFBins, ConfCascadeChildNsigmaTPCTOFBins, ConfDummy, ConfCascadeInvMassBins, false, ConfCascade_ChildPos_PDGCode.value, true);
+    negChildHistos.init(&CascadeRegistry, ConfBinmult, ConfDummy, ConfCascadeChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfCascadeChildTempFitVarBins, ConfCascadeChildNsigmaTPCBins, ConfCascadeChildNsigmaTOFBins, ConfCascadeChildNsigmaTPCTOFBins, ConfDummy, ConfCascadeInvMassBins, false, ConfCascade_ChildNeg_PDGCode.value, true);
+    bachelorHistos.init(&CascadeRegistry, ConfBinmult, ConfDummy, ConfCascadeChildTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfCascadeChildTempFitVarBins, ConfCascadeChildNsigmaTPCBins, ConfCascadeChildNsigmaTOFBins, ConfCascadeChildNsigmaTPCTOFBins, ConfDummy, ConfCascadeInvMassBins, false, ConfCascade_Bach_PDGCode.value, true);
+    CascadeHistos.init(&CascadeRegistry, ConfBinmult, ConfDummy, ConfCascadeTempFitVarMomentumBins, ConfDummy, ConfDummy, ConfCascadeTempFitVarBins, ConfCascadeChildNsigmaTPCBins, ConfCascadeChildNsigmaTOFBins, ConfCascadeChildNsigmaTPCTOFBins, ConfDummy, ConfCascadeInvMassBins, false, ConfCascade_PDGCode.value, false);
   }
 
   /// Porduce QA plots for V0 selection in FemtoDream framework
@@ -113,20 +113,28 @@ struct femtoDreamDebugCascade {
         continue;
       }
       // check cuts on V0 children
+      //if (posChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeV0Child) &&
+      //    (posChild.cut() & ConfCascade_ChildPos_CutBit) == ConfCascade_ChildPos_CutBit &&
+      //    (posChild.pidcut() & ConfCascade_ChildPos_TPCBit) == ConfCascade_ChildPos_TPCBit && 
+      //    negChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeV0Child) &&
+      //    (negChild.cut() & ConfCascade_ChildNeg_CutBit) == ConfCascade_ChildNeg_CutBit &&
+      //    (negChild.pidcut() & ConfCascade_ChildNeg_TPCBit) == ConfCascade_ChildNeg_TPCBit &&
+          if( bachChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeBachelor) &&
+          (bachChild.cut() & ConfCascade_ChildBach_CutBit) == ConfCascade_ChildBach_CutBit &&
+          (bachChild.pidcut() & ConfCascade_ChildBach_TPCBit) == ConfCascade_ChildBach_TPCBit) {
+      /*
+      LOG(info, "--- NEW CANDIDATE ---");
       if (posChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeV0Child) &&
           (posChild.cut() & ConfCascade_ChildPos_CutBit) == ConfCascade_ChildPos_CutBit &&
           (posChild.pidcut() & ConfCascade_ChildPos_TPCBit) == ConfCascade_ChildPos_TPCBit &&
-          negChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeV0Child) &&
-          (negChild.cut() & ConfCascade_ChildNeg_CutBit) == ConfCascade_ChildNeg_CutBit &&
-          (negChild.pidcut() & ConfCascade_ChildNeg_TPCBit) == ConfCascade_ChildNeg_TPCBit &&
-          bachChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeBachelor) &&
-          (bachChild.cut() & ConfCascade_ChildBach_CutBit) == ConfCascade_ChildBach_CutBit &&
-          (bachChild.pidcut() & ConfCascade_ChildBach_TPCBit) == ConfCascade_ChildBach_TPCBit) {
+          negChild.partType() == uint8_t(aod::femtodreamparticle::ParticleType::kCascadeV0Child)){
+            LOG(info, "GG debugger: V0 child passed");
         
-        CascadeHistos.fillQA<false, true>(part, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());
-        //posChildHistos.fillQA<false, true>(posChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());
-        //negChildHistos.fillQA<false, true>(negChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());
-        //bachelorHistos.fillQA<false, true>(bachChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());
+      */
+        CascadeHistos.fillQA<false, false>(part, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M()); //set isDebug to true
+        posChildHistos.fillQA<false, true>(posChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());
+        negChildHistos.fillQA<false, true>(negChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());
+        bachelorHistos.fillQA<false, true>(bachChild, static_cast<aod::femtodreamparticle::MomentumType>(ConfCascadeTempFitVarMomentum.value), col.multNtr(), col.multV0M());
       }
     }
   }

--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackCascade.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackCascade.cxx
@@ -62,11 +62,11 @@ struct femtoDreamPairTaskTrackCascade {
     Configurable<float> MultPercentileMin{"MultPercentileMin", 0, "Minimum Multiplicity Percentile"};
     Configurable<float> MultPercentileMax{"MultPercentileMax", 100, "Maximum Multiplicity Percentile"};
   } EventSel;
-  //Filter EventMultiplicity = aod::femtodreamcollision::multNtr >= EventSel.MultMin && aod::femtodreamcollision::multNtr <= EventSel.MultMax;
-  //Filter EventMultiplicityPercentile = aod::femtodreamcollision::multV0M >= EventSel.MultPercentileMin && aod::femtodreamcollision::multV0M <= EventSel.MultPercentileMax;
+  // Filter EventMultiplicity = aod::femtodreamcollision::multNtr >= EventSel.MultMin && aod::femtodreamcollision::multNtr <= EventSel.MultMax;
+  // Filter EventMultiplicityPercentile = aod::femtodreamcollision::multV0M >= EventSel.MultPercentileMin && aod::femtodreamcollision::multV0M <= EventSel.MultPercentileMax;
   /// Histogramming for Event
   FemtoDreamEventHisto eventHisto;
-  //using FilteredCollisions = soa::Filtered<FDCollisions>;
+  // using FilteredCollisions = soa::Filtered<FDCollisions>;
   using FilteredCollisions = FDCollisions;
   using FilteredCollision = FilteredCollisions::iterator;
   using FDMCParts = soa::Join<aod::FDParticles, aod::FDMCLabels>;
@@ -179,7 +179,6 @@ struct femtoDreamPairTaskTrackCascade {
   FemtoDreamDetaDphiStar<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kCascadeV0Child> pairCloseRejectionSE;
   FemtoDreamDetaDphiStar<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kCascadeV0Child> pairCloseRejectionME;
 
-
   static constexpr uint32_t kSignPlusMask = 1 << 1;
 
   /// Histogram output
@@ -202,25 +201,25 @@ struct femtoDreamPairTaskTrackCascade {
                        Option.IsMC, Option.Use4D, Option.ExtendedPlots,
                        Option.HighkstarCut,
                        Option.smearingByOrigin);
-    
+
     sameEventCont.setPDGCodes(Track1.PDGCode, Cascade2.PDGCode);
-    
+
     mixedEventCont.init(&Registry,
                         Binning.kstar, Binning.pT, Binning.kT, Binning.mT, Mixing.BinMult, Mixing.BinMultPercentile,
                         Binning4D.kstar, Binning4D.mT, Binning4D.Mult, Binning4D.multPercentile,
                         Option.IsMC, Option.Use4D, Option.ExtendedPlots,
                         Option.HighkstarCut,
                         Option.smearingByOrigin);
-    
+
     mixedEventCont.setPDGCodes(Track1.PDGCode, Cascade2.PDGCode);
-    
+
     pairCleaner.init(&Registry);
     if (Option.CPROn.value) {
       pairCloseRejectionSE.init(&Registry, &Registry, Option.CPRdeltaPhiMax.value, Option.CPRdeltaEtaMax.value, Option.CPRPlotPerRadii.value, 1, Option.CPROld.value);
       pairCloseRejectionME.init(&Registry, &Registry, Option.CPRdeltaPhiMax.value, Option.CPRdeltaEtaMax.value, Option.CPRPlotPerRadii.value, 2, Option.CPROld.value, 99, true);
     }
   }
-  
+
   /// This function processes the same event and takes care of all the histogramming
   template <bool isMC, typename PartitionType, typename TableTracks, typename Collision>
   void doSameEvent(PartitionType& SliceTrk1, PartitionType& SliceCascade2, TableTracks const& parts, Collision const& col)
@@ -240,16 +239,16 @@ struct femtoDreamPairTaskTrackCascade {
       // auto posChild = v0.template children_as<S>().front();
       // auto negChild = v0.template children_as<S>().back();
       // check cuts on V0 children
-      
-      if ( Cascade2.UseChildCuts &&
+
+      if (Cascade2.UseChildCuts &&
           !(((posChild.cut() & Cascade2.ChildPos_CutBit) == Cascade2.ChildPos_CutBit) &&
-          ((posChild.pidcut() & Cascade2.ChildPos_TPCBit) == Cascade2.ChildPos_TPCBit) &&
-          ((negChild.cut() & Cascade2.ChildNeg_CutBit) == Cascade2.ChildNeg_CutBit) &&
-          ((negChild.pidcut() & Cascade2.ChildNeg_TPCBit) == Cascade2.ChildNeg_TPCBit) && 
-          ((bachChild.cut() & Cascade2.ChildBach_CutBit) == Cascade2.ChildBach_CutBit) &&
-          ((bachChild.pidcut() & Cascade2.ChildBach_TPCBit) == Cascade2.ChildBach_TPCBit))) {
-            continue;   
-      } //cutbit
+            ((posChild.pidcut() & Cascade2.ChildPos_TPCBit) == Cascade2.ChildPos_TPCBit) &&
+            ((negChild.cut() & Cascade2.ChildNeg_CutBit) == Cascade2.ChildNeg_CutBit) &&
+            ((negChild.pidcut() & Cascade2.ChildNeg_TPCBit) == Cascade2.ChildNeg_TPCBit) &&
+            ((bachChild.cut() & Cascade2.ChildBach_CutBit) == Cascade2.ChildBach_CutBit) &&
+            ((bachChild.pidcut() & Cascade2.ChildBach_TPCBit) == Cascade2.ChildBach_TPCBit))) {
+        continue;
+      } // cutbit
       trackHistoPartTwo.fillQA<isMC, false>(casc, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
       posChildHistos.fillQA<false, false>(posChild, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
       negChildHistos.fillQA<false, false>(negChild, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
@@ -262,21 +261,21 @@ struct femtoDreamPairTaskTrackCascade {
       const auto& bachChild = parts.iteratorAt(p2.index() - 1);
       // cuts on Cascade children still need to be applied
 
-      if ( Cascade2.UseChildCuts &&
+      if (Cascade2.UseChildCuts &&
           !(((posChild.cut() & Cascade2.ChildPos_CutBit) == Cascade2.ChildPos_CutBit) &&
-          ((posChild.pidcut() & Cascade2.ChildPos_TPCBit) == Cascade2.ChildPos_TPCBit) &&
-          ((negChild.cut() & Cascade2.ChildNeg_CutBit) == Cascade2.ChildNeg_CutBit) &&
-          ((negChild.pidcut() & Cascade2.ChildNeg_TPCBit) == Cascade2.ChildNeg_TPCBit) &&
-          ((bachChild.cut() & Cascade2.ChildBach_CutBit) == Cascade2.ChildBach_CutBit) &&
-          ((bachChild.pidcut() & Cascade2.ChildBach_TPCBit) == Cascade2.ChildBach_TPCBit))) {
-            continue;
-          } 
+            ((posChild.pidcut() & Cascade2.ChildPos_TPCBit) == Cascade2.ChildPos_TPCBit) &&
+            ((negChild.cut() & Cascade2.ChildNeg_CutBit) == Cascade2.ChildNeg_CutBit) &&
+            ((negChild.pidcut() & Cascade2.ChildNeg_TPCBit) == Cascade2.ChildNeg_TPCBit) &&
+            ((bachChild.cut() & Cascade2.ChildBach_CutBit) == Cascade2.ChildBach_CutBit) &&
+            ((bachChild.pidcut() & Cascade2.ChildBach_TPCBit) == Cascade2.ChildBach_TPCBit))) {
+        continue;
+      }
       if (Option.CPROn.value) {
-        if ((p1.cut() & kSignPlusMask) == kSignPlusMask){
+        if ((p1.cut() & kSignPlusMask) == kSignPlusMask) {
           if (pairCloseRejectionSE.isClosePair(p1, posChild, parts, col.magField())) {
             continue;
           }
-        }else{
+        } else {
           if (pairCloseRejectionSE.isClosePair(p1, posChild, parts, col.magField())) {
             continue;
           }
@@ -290,68 +289,67 @@ struct femtoDreamPairTaskTrackCascade {
   }
   void processSameEvent(FilteredCollision const& col, FDParticles const& parts)
   {
-    //if ((col.bitmaskTrackOne() & BitMask) != BitMask || (col.bitmaskTrackTwo() & BitMask) != BitMask) {
-    //  return;
-    //}
+    // if ((col.bitmaskTrackOne() & BitMask) != BitMask || (col.bitmaskTrackTwo() & BitMask) != BitMask) {
+    //   return;
+    // }
     eventHisto.fillQA<false>(col);
     auto SliceTrk1 = PartitionTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     auto SliceCascade2 = PartitionCascade2->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     doSameEvent<false>(SliceTrk1, SliceCascade2, parts, col);
   }
   PROCESS_SWITCH(femtoDreamPairTaskTrackCascade, processSameEvent, "Enable processing same event", true);
-  
+
   template <bool isMC, typename CollisionType, typename PartType, typename PartitionType, typename BinningType>
   void doMixedEvent(CollisionType const& cols, PartType const& parts, PartitionType& part1, PartitionType& part2, BinningType policy)
   {
-      //Partition<CollisionType> PartitionMaskedCol = ncheckbit(aod::femtodreamcollision::bitmaskTrackOne, BitMask) && ncheckbit(aod::femtodreamcollision::bitmaskTrackTwo, BitMask);// && aod::femtodreamcollision::downsample == true;
-      //PartitionMaskedCol.bindTable(cols);
-      
-      // use *Partition.mFiltered when passing the partition to mixing object
-      // there is an issue when the partition is passed directly
-      // workaround for now, change back once it is fixed
-      for (auto const& [collision1, collision2] : soa::selfCombinations(policy, Mixing.Depth.value, -1, cols, cols)) {
-        // make sure that tracks in same events are not mixed
-        if (collision1.globalIndex() == collision2.globalIndex()) {
-          continue;
-        }
-        auto SliceTrk1 = part1->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision1.globalIndex(), cache);
-        auto SliceCasc2 = part2->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);
-        for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(SliceTrk1, SliceCasc2))) {
-          const auto& posChild = parts.iteratorAt(p2.index() - 3);
-          const auto& negChild = parts.iteratorAt(p2.index() - 2);
-          const auto& bachChild = parts.iteratorAt(p2.index() - 1);
-          // check cuts on Cascade children
-          if ( Cascade2.UseChildCuts &&
-              !(((posChild.cut() & Cascade2.ChildPos_CutBit) == Cascade2.ChildPos_CutBit) &&
+    // Partition<CollisionType> PartitionMaskedCol = ncheckbit(aod::femtodreamcollision::bitmaskTrackOne, BitMask) && ncheckbit(aod::femtodreamcollision::bitmaskTrackTwo, BitMask);// && aod::femtodreamcollision::downsample == true;
+    // PartitionMaskedCol.bindTable(cols);
+
+    // use *Partition.mFiltered when passing the partition to mixing object
+    // there is an issue when the partition is passed directly
+    // workaround for now, change back once it is fixed
+    for (auto const& [collision1, collision2] : soa::selfCombinations(policy, Mixing.Depth.value, -1, cols, cols)) {
+      // make sure that tracks in same events are not mixed
+      if (collision1.globalIndex() == collision2.globalIndex()) {
+        continue;
+      }
+      auto SliceTrk1 = part1->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision1.globalIndex(), cache);
+      auto SliceCasc2 = part2->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);
+      for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(SliceTrk1, SliceCasc2))) {
+        const auto& posChild = parts.iteratorAt(p2.index() - 3);
+        const auto& negChild = parts.iteratorAt(p2.index() - 2);
+        const auto& bachChild = parts.iteratorAt(p2.index() - 1);
+        // check cuts on Cascade children
+        if (Cascade2.UseChildCuts &&
+            !(((posChild.cut() & Cascade2.ChildPos_CutBit) == Cascade2.ChildPos_CutBit) &&
               ((posChild.pidcut() & Cascade2.ChildPos_TPCBit) == Cascade2.ChildPos_TPCBit) &&
               ((negChild.cut() & Cascade2.ChildNeg_CutBit) == Cascade2.ChildNeg_CutBit) &&
               ((negChild.pidcut() & Cascade2.ChildNeg_TPCBit) == Cascade2.ChildNeg_TPCBit) &&
               ((bachChild.cut() & Cascade2.ChildBach_CutBit) == Cascade2.ChildBach_CutBit) &&
               ((bachChild.pidcut() & Cascade2.ChildBach_TPCBit) == Cascade2.ChildBach_TPCBit))) {
-                continue;  
-          }
-          if (Option.CPROn.value) {
-            if ((p1.cut() & kSignPlusMask) == kSignPlusMask){
-              if (pairCloseRejectionME.isClosePair(p1, posChild, parts, collision1.magField())) {
-                continue;
-              }
-            }else{
-              if (pairCloseRejectionME.isClosePair(p1, negChild, parts, collision1.magField())) {
-                continue;
-              }
+          continue;
+        }
+        if (Option.CPROn.value) {
+          if ((p1.cut() & kSignPlusMask) == kSignPlusMask) {
+            if (pairCloseRejectionME.isClosePair(p1, posChild, parts, collision1.magField())) {
+              continue;
+            }
+          } else {
+            if (pairCloseRejectionME.isClosePair(p1, negChild, parts, collision1.magField())) {
+              continue;
             }
           }
-          // Pair cleaner not needed in the mixing
-          //if (!pairCleaner.isCleanPair(p1, p2, parts)) {
-          //  continue;
-          //}
-
-          mixedEventCont.setPair<isMC>(p1, p2, collision1.multNtr(), collision1.multV0M(), Option.Use4D, Option.ExtendedPlots, Option.smearingByOrigin);
-          
         }
+        // Pair cleaner not needed in the mixing
+        // if (!pairCleaner.isCleanPair(p1, p2, parts)) {
+        //  continue;
+        //}
+
+        mixedEventCont.setPair<isMC>(p1, p2, collision1.multNtr(), collision1.multV0M(), Option.Use4D, Option.ExtendedPlots, Option.smearingByOrigin);
       }
+    }
   }
-  
+
   void processMixedEvent(FilteredCollisions const& cols, FDParticles const& parts)
   {
     switch (Mixing.Policy.value) {

--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackCascade.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackCascade.cxx
@@ -39,7 +39,7 @@ using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::analysis::femtoDream;
 
-struct femtoDreamPairTaskTrackCascade {
+struct femtoDreamPairTaskTrackV0 {
   SliceCache cache;
   Preslice<aod::FDParticles> perCol = aod::femtodreamparticle::fdCollisionId;
 
@@ -115,7 +115,6 @@ struct femtoDreamPairTaskTrackCascade {
                                                 ((aod::femtodreamparticle::tempFitVar >= Track1.TempFitVarMin) &&
                                                  (aod::femtodreamparticle::tempFitVar <= Track1.TempFitVarMax)));
 
-  /*
   Partition<FDMCParts> PartitionMCTrk1 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
                                          (ncheckbit(aod::femtodreamparticle::cut, Track1.CutBit)) &&
                                          ifnode(aod::femtodreamparticle::pt * (nexp(aod::femtodreamparticle::eta) + nexp(-1.f * aod::femtodreamparticle::eta)) / 2.f <= Track1.PIDThres, ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCBit) && ((aod::femtodreamparticle::pidcut & Track1.TPCBit_Reject) == 0u), ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCTOFBit)) &&
@@ -126,63 +125,58 @@ struct femtoDreamPairTaskTrackCascade {
                                          ifnode(Option.DCACutPtDep, (nabs(aod::femtodreamparticle::tempFitVar) <= 0.0105f + (0.035f / npow(aod::femtodreamparticle::pt, 1.1f))),
                                                 ((aod::femtodreamparticle::tempFitVar >= Track1.TempFitVarMin) &&
                                                  (aod::femtodreamparticle::tempFitVar <= Track1.TempFitVarMax)));
-  */
 
   /// Histogramming for particle 1
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kTrack, 1> trackHistoPartOne;
 
   /// Particle 2 (V0)
   struct : ConfigurableGroup {
-    std::string prefix = std::string("Cascade2");
-    Configurable<int> PDGCode{"PDGCode", 3312, "PDG code of particle 2 (V0)"};
-    Configurable<femtodreamparticle::cutContainerType> CutBit{"CutBit", 338, "Selection bit for particle 2 (Cascade)"};
-    Configurable<femtodreamparticle::cutContainerType> ChildPos_CutBit{"ChildPos_CutBit", 149, "Selection bit for positive child of Cascade"};
-    Configurable<femtodreamparticle::cutContainerType> ChildPos_TPCBit{"ChildPos_TPCBit", 2, "PID TPC bit for positive child of Cascade"};
-    Configurable<femtodreamparticle::cutContainerType> ChildNeg_CutBit{"ChildNeg_CutBit", 149, "Selection bit for negative child of Cascade"};
-    Configurable<femtodreamparticle::cutContainerType> ChildNeg_TPCBit{"ChildNeg_TPCBit", 2, "PID TPC bit for negative child of Cascade"};
-    Configurable<femtodreamparticle::cutContainerType> ChildBach_CutBit{"ChildBach_CutBit", 149, "Selection bit for negative child of Cascade"};
-    Configurable<femtodreamparticle::cutContainerType> ChildBach_TPCBit{"ChildBach_TPCBit", 2, "PID TPC bit for bachelor child of Cascade"};
+    std::string prefix = std::string("V02");
+    Configurable<int> PDGCode{"PDGCode", 3122, "PDG code of particle 2 (V0)"};
+    Configurable<femtodreamparticle::cutContainerType> CutBit{"CutBit", 338, "Selection bit for particle 2 (V0)"};
+    Configurable<femtodreamparticle::cutContainerType> ChildPos_CutBit{"ChildPos_CutBit", 149, "Selection bit for positive child of V0"};
+    Configurable<femtodreamparticle::cutContainerType> ChildPos_TPCBit{"ChildPos_TPCBit", 2, "PID TPC bit for positive child of V0"};
+    Configurable<femtodreamparticle::cutContainerType> ChildNeg_CutBit{"ChildNeg_CutBit", 149, "Selection bit for negative child of V0"};
+    Configurable<femtodreamparticle::cutContainerType> ChildNeg_TPCBit{"ChildNeg_TPCBit", 2, "PID TPC bit for negative child of V0"};
 
-    Configurable<float> InvMassMin{"InvMassMin", 1.08, "Minimum invariant mass of Partricle 2 (particle) (Cascade)"};
-    Configurable<float> InvMassMax{"InvMassMax", 1.15, "Maximum invariant mass of Partricle 2 (particle) (Cascade)"};
-    Configurable<float> InvMassV0DaughMin{"InvMassV0DaugMin", 0., "Minimum invariant mass of the V0 Daughter"};
-    Configurable<float> InvMassV0DaughMax{"InvMassV0DaugMax", 999., "Maximum invariant mass of the V0 Daughter"};
+    Configurable<float> InvMassMin{"InvMassMin", 1.08, "Minimum invariant mass of Partricle 2 (particle) (V0)"};
+    Configurable<float> InvMassMax{"InvMassMax", 1.15, "Maximum invariant mass of Partricle 2 (particle) (V0)"};
+    Configurable<float> InvMassAntiMin{"InvMassAntiMin", 0., "Minimum invariant mass of Partricle 2 (antiparticle) (V0)"};
+    Configurable<float> InvMassAntiMax{"InvMassAntiMax", 999., "Maximum invariant mass of Partricle 2 (antiparticle) (V0)"};
 
     Configurable<float> PtMin{"PtMin", 0., "Minimum pT of Partricle 2 (V0)"};
     Configurable<float> PtMax{"PtMax", 999., "Maximum pT of Partricle 2 (V0)"};
     Configurable<float> EtaMin{"EtaMin", -10., "Minimum eta of Partricle 2 (V0)"};
     Configurable<float> EtaMax{"EtaMax", 10., "Maximum eta of Partricle 2 (V0)"};
-  } Cascade2;
+  } V02;
 
   /// Partition for particle 2
-  Partition<FDParticles> PartitionCascade2 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) &&
-                                             ((aod::femtodreamparticle::cut & Cascade2.CutBit) == Cascade2.CutBit) &&
-                                             (aod::femtodreamparticle::pt > Cascade2.PtMin) &&
-                                             (aod::femtodreamparticle::pt < Cascade2.PtMax) &&
-                                             (aod::femtodreamparticle::eta > Cascade2.EtaMin) &&
-                                             (aod::femtodreamparticle::eta < Cascade2.EtaMax) &&
-                                             (aod::femtodreamparticle::mLambda > Cascade2.InvMassMin) &&
-                                             (aod::femtodreamparticle::mLambda < Cascade2.InvMassMax) &&
-                                             (aod::femtodreamparticle::mAntiLambda > Cascade2.InvMassV0DaughMin) &&
-                                             (aod::femtodreamparticle::mAntiLambda < Cascade2.InvMassV0DaughMax);
-  /*
+  Partition<FDParticles> PartitionV02 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) &&
+                                        ((aod::femtodreamparticle::cut & V02.CutBit) == V02.CutBit) &&
+                                        (aod::femtodreamparticle::pt > V02.PtMin) &&
+                                        (aod::femtodreamparticle::pt < V02.PtMax) &&
+                                        (aod::femtodreamparticle::eta > V02.EtaMin) &&
+                                        (aod::femtodreamparticle::eta < V02.EtaMax) &&
+                                        (aod::femtodreamparticle::mLambda > V02.InvMassMin) &&
+                                        (aod::femtodreamparticle::mLambda < V02.InvMassMax) &&
+                                        (aod::femtodreamparticle::mAntiLambda > V02.InvMassAntiMin) &&
+                                        (aod::femtodreamparticle::mAntiLambda < V02.InvMassAntiMax);
+
   Partition<FDMCParts> PartitionMCV02 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) &&
-                                        ((aod::femtodreamparticle::cut & Cascade2.CutBit) == Cascade2.CutBit) &&
-                                        (aod::femtodreamparticle::pt > Cascade2.PtMin) &&
-                                        (aod::femtodreamparticle::pt < Cascade2.PtMax) &&
-                                        (aod::femtodreamparticle::eta > Cascade2.EtaMax) &&
-                                        (aod::femtodreamparticle::eta < Cascade2.EtaMin) &&
-                                        (aod::femtodreamparticle::mLambda > Cascade2.InvMassMin) &&
-                                        (aod::femtodreamparticle::mLambda < Cascade2.InvMassMax) &&
-                                        (aod::femtodreamparticle::mAntiLambda > Cascade2.InvMassAntiMin) &&
-                                        (aod::femtodreamparticle::mAntiLambda < Cascade2.InvMassAntiMax);
-  */
+                                        ((aod::femtodreamparticle::cut & V02.CutBit) == V02.CutBit) &&
+                                        (aod::femtodreamparticle::pt > V02.PtMin) &&
+                                        (aod::femtodreamparticle::pt < V02.PtMax) &&
+                                        (aod::femtodreamparticle::eta > V02.EtaMax) &&
+                                        (aod::femtodreamparticle::eta < V02.EtaMin) &&
+                                        (aod::femtodreamparticle::mLambda > V02.InvMassMin) &&
+                                        (aod::femtodreamparticle::mLambda < V02.InvMassMax) &&
+                                        (aod::femtodreamparticle::mAntiLambda > V02.InvMassAntiMin) &&
+                                        (aod::femtodreamparticle::mAntiLambda < V02.InvMassAntiMax);
 
   /// Histogramming for particle 2
-  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascade, 2> trackHistoPartTwo;
-  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascadeV0Child, 3> posChildHistos;
-  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascadeV0Child, 4> negChildHistos;
-  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascadeBachelor, 5> bachChildHistos;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0, 2> trackHistoPartTwo;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0Child, 3> posChildHistos;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0Child, 4> negChildHistos;
 
   /// Binning configurables
   struct : ConfigurableGroup {
@@ -225,9 +219,9 @@ struct femtoDreamPairTaskTrackCascade {
 
   FemtoDreamContainer<femtoDreamContainer::EventType::same, femtoDreamContainer::Observable::kstar> sameEventCont;
   FemtoDreamContainer<femtoDreamContainer::EventType::mixed, femtoDreamContainer::Observable::kstar> mixedEventCont;
-  FemtoDreamPairCleaner<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kCascade> pairCleaner;
-  //FemtoDreamDetaDphiStar<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kCascade> pairCloseRejectionSE;
-  //FemtoDreamDetaDphiStar<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kCascade> pairCloseRejectionME;
+  FemtoDreamPairCleaner<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kV0> pairCleaner;
+  FemtoDreamDetaDphiStar<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kV0> pairCloseRejectionSE;
+  FemtoDreamDetaDphiStar<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kV0> pairCloseRejectionME;
 
   /// Histogram output
   HistogramRegistry Registry{"Output", {}, OutputObjHandlingPolicy::AnalysisObject};
@@ -241,7 +235,7 @@ struct femtoDreamPairTaskTrackCascade {
 
     eventHisto.init(&Registry, Option.IsMC);
     trackHistoPartOne.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTTrack, Option.Dummy, Option.Dummy, Binning.TempFitVarTrack, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.IsMC, Track1.PDGCode);
-    trackHistoPartTwo.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTV0, Option.Dummy, Option.Dummy, Binning.TempFitVarV0, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Binning.InvMass, Option.IsMC, Cascade2.PDGCode);
+    trackHistoPartTwo.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTV0, Option.Dummy, Option.Dummy, Binning.TempFitVarV0, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Binning.InvMass, Option.IsMC, V02.PDGCode);
     posChildHistos.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTV0Child, Option.Dummy, Option.Dummy, Binning.TempFitVarV0Child, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, false, 0);
     negChildHistos.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTV0Child, Option.Dummy, Option.Dummy, Binning.TempFitVarV0Child, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, false, 0);
 
@@ -252,7 +246,7 @@ struct femtoDreamPairTaskTrackCascade {
                        Option.HighkstarCut,
                        Option.smearingByOrigin);
 
-    sameEventCont.setPDGCodes(Track1.PDGCode, Cascade2.PDGCode);
+    sameEventCont.setPDGCodes(Track1.PDGCode, V02.PDGCode);
     mixedEventCont.init(&Registry,
                         Binning.kstar, Binning.pT, Binning.kT, Binning.mT, Mixing.BinMult, Mixing.BinMultPercentile,
                         Binning4D.kstar, Binning4D.mT, Binning4D.Mult, Binning4D.multPercentile,
@@ -260,14 +254,12 @@ struct femtoDreamPairTaskTrackCascade {
                         Option.HighkstarCut,
                         Option.smearingByOrigin);
 
-    mixedEventCont.setPDGCodes(Track1.PDGCode, Cascade2.PDGCode);
+    mixedEventCont.setPDGCodes(Track1.PDGCode, V02.PDGCode);
     pairCleaner.init(&Registry);
-    /*
     if (Option.CPROn.value) {
       pairCloseRejectionSE.init(&Registry, &Registry, Option.CPRdeltaPhiMax.value, Option.CPRdeltaEtaMax.value, Option.CPRPlotPerRadii.value, 1, Option.CPROld.value);
       pairCloseRejectionME.init(&Registry, &Registry, Option.CPRdeltaPhiMax.value, Option.CPRdeltaEtaMax.value, Option.CPRPlotPerRadii.value, 2, Option.CPROld.value, 99, true);
     }
-    */ 
 
     // get bit for the collision mask
     std::bitset<8 * sizeof(femtodreamcollision::BitMaskType)> mask;
@@ -286,19 +278,19 @@ struct femtoDreamPairTaskTrackCascade {
             containsNameValuePair(device.options, "Track1.EtaMax", Track1.EtaMax.value) &&
             containsNameValuePair(device.options, "Track1.TempFitVarMin", Track1.TempFitVarMin.value) &&
             containsNameValuePair(device.options, "Track1.TempFitVarMax", Track1.TempFitVarMax.value) &&
-            containsNameValuePair(device.options, "Cascade2.CutBit", Cascade2.CutBit.value) &&
-            containsNameValuePair(device.options, "Cascade2.ChildPos_CutBit", Cascade2.ChildPos_CutBit.value) &&
-            containsNameValuePair(device.options, "Cascade2.ChildPos_TPCBit", Cascade2.ChildPos_TPCBit.value) &&
-            containsNameValuePair(device.options, "Cascade2.ChildNeg_CutBit", Cascade2.ChildNeg_CutBit.value) &&
-            containsNameValuePair(device.options, "Cascade2.ChildNeg_TPCBit", Cascade2.ChildNeg_TPCBit.value) &&
-            containsNameValuePair(device.options, "Cascade2.InvMassMin", Cascade2.InvMassMin.value) &&
-            containsNameValuePair(device.options, "Cascade2.InvMassMax", Cascade2.InvMassMax.value) &&
-            containsNameValuePair(device.options, "Cascade2.InvMassAntiMin", Cascade2.InvMassAntiMin.value) &&
-            containsNameValuePair(device.options, "Cascade2.InvMassAntiMax", Cascade2.InvMassAntiMax.value) &&
-            containsNameValuePair(device.options, "Cascade2.PtMin", Cascade2.PtMin.value) &&
-            containsNameValuePair(device.options, "Cascade2.PtMax", Cascade2.PtMax.value) &&
-            containsNameValuePair(device.options, "Cascade2.EtaMin", Cascade2.EtaMin.value) &&
-            containsNameValuePair(device.options, "Cascade2.EtaMax", Cascade2.EtaMax.value)) {
+            containsNameValuePair(device.options, "V02.CutBit", V02.CutBit.value) &&
+            containsNameValuePair(device.options, "V02.ChildPos_CutBit", V02.ChildPos_CutBit.value) &&
+            containsNameValuePair(device.options, "V02.ChildPos_TPCBit", V02.ChildPos_TPCBit.value) &&
+            containsNameValuePair(device.options, "V02.ChildNeg_CutBit", V02.ChildNeg_CutBit.value) &&
+            containsNameValuePair(device.options, "V02.ChildNeg_TPCBit", V02.ChildNeg_TPCBit.value) &&
+            containsNameValuePair(device.options, "V02.InvMassMin", V02.InvMassMin.value) &&
+            containsNameValuePair(device.options, "V02.InvMassMax", V02.InvMassMax.value) &&
+            containsNameValuePair(device.options, "V02.InvMassAntiMin", V02.InvMassAntiMin.value) &&
+            containsNameValuePair(device.options, "V02.InvMassAntiMax", V02.InvMassAntiMax.value) &&
+            containsNameValuePair(device.options, "V02.PtMin", V02.PtMin.value) &&
+            containsNameValuePair(device.options, "V02.PtMax", V02.PtMax.value) &&
+            containsNameValuePair(device.options, "V02.EtaMin", V02.EtaMin.value) &&
+            containsNameValuePair(device.options, "V02.EtaMax", V02.EtaMax.value)) {
           mask.set(index);
           BitMask = static_cast<femtodreamcollision::BitMaskType>(mask.to_ulong());
           LOG(info) << "Device name matched: " << device.name;
@@ -329,10 +321,10 @@ struct femtoDreamPairTaskTrackCascade {
       // auto posChild = v0.template children_as<S>().front();
       // auto negChild = v0.template children_as<S>().back();
       // check cuts on V0 children
-      if (((posChild.cut() & Cascade2.ChildPos_CutBit) == Cascade2.ChildPos_CutBit) &&
-          ((posChild.pidcut() & Cascade2.ChildPos_TPCBit) == Cascade2.ChildPos_TPCBit) &&
-          ((negChild.cut() & Cascade2.ChildNeg_CutBit) == Cascade2.ChildNeg_CutBit) &&
-          ((negChild.pidcut() & Cascade2.ChildNeg_TPCBit) == Cascade2.ChildNeg_TPCBit)) {
+      if (((posChild.cut() & V02.ChildPos_CutBit) == V02.ChildPos_CutBit) &&
+          ((posChild.pidcut() & V02.ChildPos_TPCBit) == V02.ChildPos_TPCBit) &&
+          ((negChild.cut() & V02.ChildNeg_CutBit) == V02.ChildNeg_CutBit) &&
+          ((negChild.pidcut() & V02.ChildNeg_TPCBit) == V02.ChildNeg_TPCBit)) {
         trackHistoPartTwo.fillQA<isMC, false>(v0, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
         posChildHistos.fillQA<false, false>(posChild, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
         negChildHistos.fillQA<false, false>(negChild, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
@@ -343,17 +335,15 @@ struct femtoDreamPairTaskTrackCascade {
       const auto& posChild = parts.iteratorAt(p2.index() - 2);
       const auto& negChild = parts.iteratorAt(p2.index() - 1);
       // cuts on V0 children still need to be applied
-      if (((posChild.cut() & Cascade2.ChildPos_CutBit) == Cascade2.ChildPos_CutBit) &&
-          ((posChild.pidcut() & Cascade2.ChildPos_TPCBit) == Cascade2.ChildPos_TPCBit) &&
-          ((negChild.cut() & Cascade2.ChildNeg_CutBit) == Cascade2.ChildNeg_CutBit) &&
-          ((negChild.pidcut() & Cascade2.ChildNeg_TPCBit) == Cascade2.ChildNeg_TPCBit)) {
-       /*
-       if (Option.CPROn.value) {
+      if (((posChild.cut() & V02.ChildPos_CutBit) == V02.ChildPos_CutBit) &&
+          ((posChild.pidcut() & V02.ChildPos_TPCBit) == V02.ChildPos_TPCBit) &&
+          ((negChild.cut() & V02.ChildNeg_CutBit) == V02.ChildNeg_CutBit) &&
+          ((negChild.pidcut() & V02.ChildNeg_TPCBit) == V02.ChildNeg_TPCBit)) {
+        if (Option.CPROn.value) {
           if (pairCloseRejectionSE.isClosePair(p1, p2, parts, col.magField())) {
             continue;
           }
         }
-       */ 
         if (!pairCleaner.isCleanPair(p1, p2, parts)) {
           continue;
         }
@@ -369,12 +359,11 @@ struct femtoDreamPairTaskTrackCascade {
     }
     eventHisto.fillQA<false>(col);
     auto SliceTrk1 = PartitionTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
-    auto SliceV02 = PartitionCascade2->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
+    auto SliceV02 = PartitionV02->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     doSameEvent<false>(SliceTrk1, SliceV02, parts, col);
   }
   PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processSameEventMasked, "Enable processing same event with masks", true);
 
-  /*
   void processSameEventMCMasked(FilteredMaskedMCCollision const& col, o2::aod::FDMCCollisions&, FDMCParts const& parts, o2::aod::FDMCParticles const&)
   {
     if ((col.bitmaskTrackOne() & BitMask) != BitMask && (col.bitmaskTrackTwo() & BitMask) != BitMask) {
@@ -386,10 +375,7 @@ struct femtoDreamPairTaskTrackCascade {
     doSameEvent<true>(SliceMCTrk1, SliceMCV02, parts, col);
   }
   PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processSameEventMCMasked, "Enable processing same event MC with masks", false);
-  */
-  
 
-  /*
   template <bool isMC, typename CollisionType, typename PartType, typename PartitionType, typename BinningType>
   void doMixedEvent_Masked(CollisionType const& cols, PartType const& parts, PartitionType& part1, PartitionType& part2, BinningType policy)
   {
@@ -411,10 +397,10 @@ struct femtoDreamPairTaskTrackCascade {
           const auto& posChild = parts.iteratorAt(p2.index() - 2);
           const auto& negChild = parts.iteratorAt(p2.index() - 1);
           // check cuts on V0 children
-          if (((posChild.cut() & Cascade2.ChildPos_CutBit) == Cascade2.ChildPos_CutBit) &&
-              ((posChild.pidcut() & Cascade2.ChildPos_TPCBit) == Cascade2.ChildPos_TPCBit) &&
-              ((negChild.cut() & Cascade2.ChildNeg_CutBit) == Cascade2.ChildNeg_CutBit) &&
-              ((negChild.pidcut() & Cascade2.ChildNeg_TPCBit) == Cascade2.ChildNeg_TPCBit)) {
+          if (((posChild.cut() & V02.ChildPos_CutBit) == V02.ChildPos_CutBit) &&
+              ((posChild.pidcut() & V02.ChildPos_TPCBit) == V02.ChildPos_TPCBit) &&
+              ((negChild.cut() & V02.ChildNeg_CutBit) == V02.ChildNeg_CutBit) &&
+              ((negChild.pidcut() & V02.ChildNeg_TPCBit) == V02.ChildNeg_TPCBit)) {
             continue;
           }
           if (Option.CPROn.value) {
@@ -448,10 +434,10 @@ struct femtoDreamPairTaskTrackCascade {
           const auto& posChild = parts.iteratorAt(p2.index() - 2);
           const auto& negChild = parts.iteratorAt(p2.index() - 1);
           // check cuts on V0 children
-          if (((posChild.cut() & Cascade2.ChildPos_CutBit) == Cascade2.ChildPos_CutBit) &&
-              ((posChild.pidcut() & Cascade2.ChildPos_TPCBit) == Cascade2.ChildPos_TPCBit) &&
-              ((negChild.cut() & Cascade2.ChildNeg_CutBit) == Cascade2.ChildNeg_CutBit) &&
-              ((negChild.pidcut() & Cascade2.ChildNeg_TPCBit) == Cascade2.ChildNeg_TPCBit)) {
+          if (((posChild.cut() & V02.ChildPos_CutBit) == V02.ChildPos_CutBit) &&
+              ((posChild.pidcut() & V02.ChildPos_TPCBit) == V02.ChildPos_TPCBit) &&
+              ((negChild.cut() & V02.ChildNeg_CutBit) == V02.ChildNeg_CutBit) &&
+              ((negChild.pidcut() & V02.ChildNeg_TPCBit) == V02.ChildNeg_TPCBit)) {
             continue;
           }
           if (Option.CPROn.value) {
@@ -503,7 +489,6 @@ struct femtoDreamPairTaskTrackCascade {
     }
   }
   PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processMixedEventMCMasked, "Enable processing mixed events MC with masks", false);
-  */
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackCascade.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackCascade.cxx
@@ -1,0 +1,515 @@
+// Copyright 2019-2022 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file femtoDreamPairTaskTrackTrack.cxx
+/// \brief Tasks that reads the track tables used for the pairing and builds pairs of two tracks
+/// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
+
+#include <sys/stat.h>
+#include <cstdint>
+#include <vector>
+#include <string>
+#include "Framework/AnalysisTask.h"
+#include "Framework/runDataProcessing.h"
+#include "Framework/HistogramRegistry.h"
+#include "Framework/ASoAHelpers.h"
+#include "Framework/RunningWorkflowInfo.h"
+#include "Framework/Expressions.h"
+
+#include "PWGCF/DataModel/FemtoDerived.h"
+#include "PWGCF/FemtoDream/Core/femtoDreamParticleHisto.h"
+#include "PWGCF/FemtoDream/Core/femtoDreamEventHisto.h"
+#include "PWGCF/FemtoDream/Core/femtoDreamPairCleaner.h"
+#include "PWGCF/FemtoDream/Core/femtoDreamContainer.h"
+#include "PWGCF/FemtoDream/Core/femtoDreamDetaDphiStar.h"
+#include "PWGCF/FemtoDream/Core/femtoDreamUtils.h"
+
+using namespace o2;
+using namespace o2::aod;
+using namespace o2::soa;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using namespace o2::analysis::femtoDream;
+
+struct femtoDreamPairTaskTrackCascade {
+  SliceCache cache;
+  Preslice<aod::FDParticles> perCol = aod::femtodreamparticle::fdCollisionId;
+
+  /// General options
+  struct : ConfigurableGroup {
+    std::string prefix = std::string("Option");
+    Configurable<bool> IsMC{"IsMC", false, "Enable additional Histogramms in the case of a MonteCarlo Run"};
+    Configurable<bool> Use4D{"Use4D", false, "Enable four dimensional histogramms (to be used only for analysis with high statistics): k* vs multiplicity vs multiplicity percentil vs mT"};
+    Configurable<bool> ExtendedPlots{"ExtendedPlots", false, "Enable additional three dimensional histogramms. High memory consumption. Use for debugging"};
+    Configurable<float> HighkstarCut{"HighkstarCut", -1., "Set a cut for high k*, above which the pairs are rejected. Set it to -1 to deactivate it"};
+    Configurable<bool> CPROn{"CPROn", true, "Close Pair Rejection"};
+    Configurable<bool> CPROld{"CPROld", false, "Set to FALSE to use fixed version of CPR (for testing now, will be default soon)"};
+    Configurable<bool> CPRPlotPerRadii{"CPRPlotPerRadii", false, "Plot CPR per radii"};
+    Configurable<float> CPRdeltaPhiMax{"CPRdeltaPhiMax", 0.01, "Max. Delta Phi for Close Pair Rejection"};
+    Configurable<float> CPRdeltaEtaMax{"CPRdeltaEtaMax", 0.01, "Max. Delta Eta for Close Pair Rejection"};
+    Configurable<bool> DCACutPtDep{"DCACutPtDep", false, "Use pt dependent dca cut"};
+    Configurable<bool> MixEventWithPairs{"MixEventWithPairs", false, "Only use events that contain particle 1 and partile 2 for the event mixing"};
+    Configurable<bool> smearingByOrigin{"smearingByOrigin", false, "Obtain the smearing matrix differential in the MC origin of particle 1 and particle 2. High memory consumption. Use with care!"};
+    ConfigurableAxis Dummy{"Dummy", {1, 0, 1}, "Dummy axis"};
+  } Option;
+
+  /// Event selection
+  struct : ConfigurableGroup {
+    std::string prefix = std::string("EventSel");
+    Configurable<int> MultMin{"MultMin", 0, "Minimum Multiplicity (MultNtr)"};
+    Configurable<int> MultMax{"MultMax", 99999, "Maximum Multiplicity (MultNtr)"};
+    Configurable<float> MultPercentileMin{"MultPercentileMin", 0, "Minimum Multiplicity Percentile"};
+    Configurable<float> MultPercentileMax{"MultPercentileMax", 100, "Maximum Multiplicity Percentile"};
+  } EventSel;
+
+  Filter EventMultiplicity = aod::femtodreamcollision::multNtr >= EventSel.MultMin && aod::femtodreamcollision::multNtr <= EventSel.MultMax;
+  Filter EventMultiplicityPercentile = aod::femtodreamcollision::multV0M >= EventSel.MultPercentileMin && aod::femtodreamcollision::multV0M <= EventSel.MultPercentileMax;
+
+  /// Histogramming for Event
+  FemtoDreamEventHisto eventHisto;
+
+  using FilteredMaskedCollisions = soa::Filtered<soa::Join<FDCollisions, FDColMasks, FDDownSample>>;
+  using FilteredMaskedCollision = FilteredMaskedCollisions::iterator;
+  using FilteredMaskedMCCollisions = soa::Filtered<soa::Join<FDCollisions, aod::FDMCCollLabels, FDColMasks, FDDownSample>>;
+  using FilteredMaskedMCCollision = FilteredMaskedMCCollisions::iterator;
+
+  using FDMCParts = soa::Join<aod::FDParticles, aod::FDMCLabels>;
+  using FDMCPart = FDMCParts::iterator;
+
+  femtodreamcollision::BitMaskType BitMask = 1;
+
+  /// Particle 1 (track)
+  struct : ConfigurableGroup {
+    std::string prefix = std::string("Track1");
+    Configurable<int> PDGCode{"PDGCode", 2212, "PDG code of Particle 1 (Track)"};
+    Configurable<femtodreamparticle::cutContainerType> CutBit{"CutBit", 5542474, "Particle 1 (Track) - Selection bit from cutCulator"};
+    Configurable<femtodreamparticle::cutContainerType> TPCBit{"TPCBit", 4, "PID TPC bit from cutCulator for particle 1 (Track)"};
+    Configurable<femtodreamparticle::cutContainerType> TPCBit_Reject{"TPCBit_Reject", 0, "Reject PID TPC bit from cutCulator for particle 1 (Track). Set to 0 to turn off"};
+    Configurable<femtodreamparticle::cutContainerType> TPCTOFBit{"TPCTOFBit", 2, "PID TPCTOF bit from cutCulator for particle 1 (Track)"};
+    Configurable<float> PIDThres{"PIDThres", 0.75, "Momentum threshold for PID selection for particle 1 (Track)"};
+    Configurable<float> PtMin{"PtMin", 0., "Minimum pT of partricle 1 (Track)"};
+    Configurable<float> PtMax{"PtMax", 999., "Maximum pT of partricle 1 (Track)"};
+    Configurable<float> EtaMin{"EtaMin", -10., "Minimum eta of partricle 1 (Track)"};
+    Configurable<float> EtaMax{"EtaMax", 10., "Maximum eta of partricle 1 (Track)"};
+    Configurable<float> TempFitVarMin{"TempFitVarMin", -10., "Minimum DCAxy of partricle 1 (Track)"};
+    Configurable<float> TempFitVarMax{"TempFitVarMax", 10., "Maximum DCAxy of partricle 1 (Track)"};
+  } Track1;
+
+  /// Partition for particle 1
+  Partition<FDParticles> PartitionTrk1 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
+                                         (ncheckbit(aod::femtodreamparticle::cut, Track1.CutBit)) &&
+                                         ifnode(aod::femtodreamparticle::pt * (nexp(aod::femtodreamparticle::eta) + nexp(-1.f * aod::femtodreamparticle::eta)) / 2.f <= Track1.PIDThres, ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCBit) && ((aod::femtodreamparticle::pidcut & Track1.TPCBit_Reject) == 0u), ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCTOFBit)) &&
+                                         (aod::femtodreamparticle::pt > Track1.PtMin) &&
+                                         (aod::femtodreamparticle::pt < Track1.PtMax) &&
+                                         (aod::femtodreamparticle::eta > Track1.EtaMin) &&
+                                         (aod::femtodreamparticle::eta < Track1.EtaMax) &&
+                                         ifnode(Option.DCACutPtDep, (nabs(aod::femtodreamparticle::tempFitVar) <= 0.0105f + (0.035f / npow(aod::femtodreamparticle::pt, 1.1f))),
+                                                ((aod::femtodreamparticle::tempFitVar >= Track1.TempFitVarMin) &&
+                                                 (aod::femtodreamparticle::tempFitVar <= Track1.TempFitVarMax)));
+
+  /*
+  Partition<FDMCParts> PartitionMCTrk1 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
+                                         (ncheckbit(aod::femtodreamparticle::cut, Track1.CutBit)) &&
+                                         ifnode(aod::femtodreamparticle::pt * (nexp(aod::femtodreamparticle::eta) + nexp(-1.f * aod::femtodreamparticle::eta)) / 2.f <= Track1.PIDThres, ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCBit) && ((aod::femtodreamparticle::pidcut & Track1.TPCBit_Reject) == 0u), ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCTOFBit)) &&
+                                         (aod::femtodreamparticle::pt > Track1.PtMin) &&
+                                         (aod::femtodreamparticle::pt < Track1.PtMax) &&
+                                         (aod::femtodreamparticle::eta > Track1.EtaMin) &&
+                                         (aod::femtodreamparticle::eta < Track1.EtaMax) &&
+                                         ifnode(Option.DCACutPtDep, (nabs(aod::femtodreamparticle::tempFitVar) <= 0.0105f + (0.035f / npow(aod::femtodreamparticle::pt, 1.1f))),
+                                                ((aod::femtodreamparticle::tempFitVar >= Track1.TempFitVarMin) &&
+                                                 (aod::femtodreamparticle::tempFitVar <= Track1.TempFitVarMax)));
+  */
+
+  /// Histogramming for particle 1
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kTrack, 1> trackHistoPartOne;
+
+  /// Particle 2 (V0)
+  struct : ConfigurableGroup {
+    std::string prefix = std::string("Cascade2");
+    Configurable<int> PDGCode{"PDGCode", 3312, "PDG code of particle 2 (V0)"};
+    Configurable<femtodreamparticle::cutContainerType> CutBit{"CutBit", 338, "Selection bit for particle 2 (Cascade)"};
+    Configurable<femtodreamparticle::cutContainerType> ChildPos_CutBit{"ChildPos_CutBit", 149, "Selection bit for positive child of Cascade"};
+    Configurable<femtodreamparticle::cutContainerType> ChildPos_TPCBit{"ChildPos_TPCBit", 2, "PID TPC bit for positive child of Cascade"};
+    Configurable<femtodreamparticle::cutContainerType> ChildNeg_CutBit{"ChildNeg_CutBit", 149, "Selection bit for negative child of Cascade"};
+    Configurable<femtodreamparticle::cutContainerType> ChildNeg_TPCBit{"ChildNeg_TPCBit", 2, "PID TPC bit for negative child of Cascade"};
+    Configurable<femtodreamparticle::cutContainerType> ChildBach_CutBit{"ChildBach_CutBit", 149, "Selection bit for negative child of Cascade"};
+    Configurable<femtodreamparticle::cutContainerType> ChildBach_TPCBit{"ChildBach_TPCBit", 2, "PID TPC bit for bachelor child of Cascade"};
+
+    Configurable<float> InvMassMin{"InvMassMin", 1.08, "Minimum invariant mass of Partricle 2 (particle) (Cascade)"};
+    Configurable<float> InvMassMax{"InvMassMax", 1.15, "Maximum invariant mass of Partricle 2 (particle) (Cascade)"};
+    Configurable<float> InvMassV0DaughMin{"InvMassV0DaugMin", 0., "Minimum invariant mass of the V0 Daughter"};
+    Configurable<float> InvMassV0DaughMax{"InvMassV0DaugMax", 999., "Maximum invariant mass of the V0 Daughter"};
+
+    Configurable<float> PtMin{"PtMin", 0., "Minimum pT of Partricle 2 (V0)"};
+    Configurable<float> PtMax{"PtMax", 999., "Maximum pT of Partricle 2 (V0)"};
+    Configurable<float> EtaMin{"EtaMin", -10., "Minimum eta of Partricle 2 (V0)"};
+    Configurable<float> EtaMax{"EtaMax", 10., "Maximum eta of Partricle 2 (V0)"};
+  } Cascade2;
+
+  /// Partition for particle 2
+  Partition<FDParticles> PartitionCascade2 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) &&
+                                             ((aod::femtodreamparticle::cut & Cascade2.CutBit) == Cascade2.CutBit) &&
+                                             (aod::femtodreamparticle::pt > Cascade2.PtMin) &&
+                                             (aod::femtodreamparticle::pt < Cascade2.PtMax) &&
+                                             (aod::femtodreamparticle::eta > Cascade2.EtaMin) &&
+                                             (aod::femtodreamparticle::eta < Cascade2.EtaMax) &&
+                                             (aod::femtodreamparticle::mLambda > Cascade2.InvMassMin) &&
+                                             (aod::femtodreamparticle::mLambda < Cascade2.InvMassMax) &&
+                                             (aod::femtodreamparticle::mAntiLambda > Cascade2.InvMassV0DaughMin) &&
+                                             (aod::femtodreamparticle::mAntiLambda < Cascade2.InvMassV0DaughMax);
+  /*
+  Partition<FDMCParts> PartitionMCV02 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) &&
+                                        ((aod::femtodreamparticle::cut & Cascade2.CutBit) == Cascade2.CutBit) &&
+                                        (aod::femtodreamparticle::pt > Cascade2.PtMin) &&
+                                        (aod::femtodreamparticle::pt < Cascade2.PtMax) &&
+                                        (aod::femtodreamparticle::eta > Cascade2.EtaMax) &&
+                                        (aod::femtodreamparticle::eta < Cascade2.EtaMin) &&
+                                        (aod::femtodreamparticle::mLambda > Cascade2.InvMassMin) &&
+                                        (aod::femtodreamparticle::mLambda < Cascade2.InvMassMax) &&
+                                        (aod::femtodreamparticle::mAntiLambda > Cascade2.InvMassAntiMin) &&
+                                        (aod::femtodreamparticle::mAntiLambda < Cascade2.InvMassAntiMax);
+  */
+
+  /// Histogramming for particle 2
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascade, 2> trackHistoPartTwo;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascadeV0Child, 3> posChildHistos;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascadeV0Child, 4> negChildHistos;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascadeBachelor, 5> bachChildHistos;
+
+  /// Binning configurables
+  struct : ConfigurableGroup {
+    std::string prefix = std::string("Binning");
+    ConfigurableAxis TempFitVarTrack{"TempFitVarTrack", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot (Track)"};
+    ConfigurableAxis TempFitVarV0{"TempFitVarV0", {300, 0.9, 1}, "binning of the TempFitVar in the pT vs. TempFitVar plot (V0)"};
+    ConfigurableAxis TempFitVarV0Child{"TempFitVarV0Child", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot (V0 child)"};
+    ConfigurableAxis InvMass{"InvMass", {200, 1, 1.2}, "InvMass binning"};
+    ConfigurableAxis pTTrack{"pTTrack", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot (Track)"};
+    ConfigurableAxis pTV0{"pTV0", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot (V0)"};
+    ConfigurableAxis pTV0Child{"pTV0Child", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot (V0)"};
+    ConfigurableAxis pT{"pT", {20, 0.5, 4.05}, "pT binning"};
+    ConfigurableAxis kstar{"kstar", {1500, 0., 6.}, "binning kstar"};
+    ConfigurableAxis kT{"kT", {150, 0., 9.}, "binning kT"};
+    ConfigurableAxis mT{"mT", {225, 0., 7.5}, "binning mT"};
+    ConfigurableAxis multTempFit{"multTempFit", {1, 0, 1}, "multiplicity for the TempFitVar plot"};
+  } Binning;
+
+  struct : ConfigurableGroup {
+    std::string prefix = std::string("Binning4D");
+    ConfigurableAxis kstar{"kstar", {1500, 0., 6.}, "binning kstar for the 4Dimensional plot: k* vs multiplicity vs multiplicity percentile vs mT (set <<ConfUse4D>> to true in order to use)"};
+    ConfigurableAxis mT{"mT", {VARIABLE_WIDTH, 1.02f, 1.14f, 1.20f, 1.26f, 1.38f, 1.56f, 1.86f, 4.50f}, "mT Binning for the 4Dimensional plot: k* vs multiplicity vs multiplicity percentile vs mT (set <<ConfUse4D>> to true in order to use)"};
+    ConfigurableAxis Mult{"mult", {VARIABLE_WIDTH, 0.0f, 4.0f, 8.0f, 12.0f, 16.0f, 20.0f, 24.0f, 28.0f, 32.0f, 36.0f, 40.0f, 44.0f, 48.0f, 52.0f, 56.0f, 60.0f, 64.0f, 68.0f, 72.0f, 76.0f, 80.0f, 84.0f, 88.0f, 92.0f, 96.0f, 100.0f, 200.0f}, "multiplicity Binning for the 4Dimensional plot: k* vs multiplicity vs multiplicity percentile vs mT (set <<ConfUse4D>> to true in order to use)"};
+    ConfigurableAxis multPercentile{"multPercentile", {10, 0.0f, 100.0f}, "multiplicity percentile Binning for the 4Dimensional plot: k* vs multiplicity vs multiplicity percentile vs mT (set <<ConfUse4D>> to true in order to use)"};
+  } Binning4D;
+
+  // Mixing configurables
+  struct : ConfigurableGroup {
+    std::string prefix = std::string("Mixing");
+    ConfigurableAxis BinMult{"BinMult", {VARIABLE_WIDTH, 0.0f, 4.0f, 8.0f, 12.0f, 16.0f, 20.0f, 24.0f, 28.0f, 32.0f, 36.0f, 40.0f, 44.0f, 48.0f, 52.0f, 56.0f, 60.0f, 64.0f, 68.0f, 72.0f, 76.0f, 80.0f, 84.0f, 88.0f, 92.0f, 96.0f, 100.0f, 200.0f}, "bins - multiplicity"};
+    ConfigurableAxis BinMultPercentile{"BinMultPercentile", {VARIABLE_WIDTH, 0.0f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f, 70.0f, 80.0f, 90.0f, 100.f}, "bins - multiplicity percentile"};
+    ConfigurableAxis BinVztx{"BinVztx", {VARIABLE_WIDTH, -10.0f, -8.f, -6.f, -4.f, -2.f, 0.f, 2.f, 4.f, 6.f, 8.f, 10.f}, "bins - z-vertex"};
+    Configurable<int> Depth{"Depth", 5, "Number of events for mixing"};
+    Configurable<int> Policy{"BinPolicy", 0, "Binning policy for mixing - 0: multiplicity, 1: multipliciy percentile, 2: both"};
+  } Mixing;
+
+  ColumnBinningPolicy<aod::collision::PosZ, aod::femtodreamcollision::MultNtr> colBinningMult{{Mixing.BinVztx, Mixing.BinMult}, true};
+  ColumnBinningPolicy<aod::collision::PosZ, aod::femtodreamcollision::MultV0M> colBinningMultPercentile{{Mixing.BinVztx, Mixing.BinMultPercentile}, true};
+  ColumnBinningPolicy<aod::collision::PosZ, aod::femtodreamcollision::MultNtr, aod::femtodreamcollision::MultV0M> colBinningMultMultPercentile{{Mixing.BinVztx, Mixing.BinMult, Mixing.BinMultPercentile}, true};
+
+  FemtoDreamContainer<femtoDreamContainer::EventType::same, femtoDreamContainer::Observable::kstar> sameEventCont;
+  FemtoDreamContainer<femtoDreamContainer::EventType::mixed, femtoDreamContainer::Observable::kstar> mixedEventCont;
+  FemtoDreamPairCleaner<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kCascade> pairCleaner;
+  //FemtoDreamDetaDphiStar<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kCascade> pairCloseRejectionSE;
+  //FemtoDreamDetaDphiStar<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kCascade> pairCloseRejectionME;
+
+  /// Histogram output
+  HistogramRegistry Registry{"Output", {}, OutputObjHandlingPolicy::AnalysisObject};
+
+  void init(InitContext& context)
+  {
+    // setup binnnig policy for mixing
+    colBinningMult = {{Mixing.BinVztx, Mixing.BinMult}, true};
+    colBinningMultPercentile = {{Mixing.BinVztx, Mixing.BinMultPercentile}, true};
+    colBinningMultMultPercentile = {{Mixing.BinVztx, Mixing.BinMult, Mixing.BinMultPercentile}, true};
+
+    eventHisto.init(&Registry, Option.IsMC);
+    trackHistoPartOne.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTTrack, Option.Dummy, Option.Dummy, Binning.TempFitVarTrack, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.IsMC, Track1.PDGCode);
+    trackHistoPartTwo.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTV0, Option.Dummy, Option.Dummy, Binning.TempFitVarV0, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Binning.InvMass, Option.IsMC, Cascade2.PDGCode);
+    posChildHistos.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTV0Child, Option.Dummy, Option.Dummy, Binning.TempFitVarV0Child, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, false, 0);
+    negChildHistos.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTV0Child, Option.Dummy, Option.Dummy, Binning.TempFitVarV0Child, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, false, 0);
+
+    sameEventCont.init(&Registry,
+                       Binning.kstar, Binning.pT, Binning.kT, Binning.mT, Mixing.BinMult, Mixing.BinMultPercentile,
+                       Binning4D.kstar, Binning4D.mT, Binning4D.Mult, Binning4D.multPercentile,
+                       Option.IsMC, Option.Use4D, Option.ExtendedPlots,
+                       Option.HighkstarCut,
+                       Option.smearingByOrigin);
+
+    sameEventCont.setPDGCodes(Track1.PDGCode, Cascade2.PDGCode);
+    mixedEventCont.init(&Registry,
+                        Binning.kstar, Binning.pT, Binning.kT, Binning.mT, Mixing.BinMult, Mixing.BinMultPercentile,
+                        Binning4D.kstar, Binning4D.mT, Binning4D.Mult, Binning4D.multPercentile,
+                        Option.IsMC, Option.Use4D, Option.ExtendedPlots,
+                        Option.HighkstarCut,
+                        Option.smearingByOrigin);
+
+    mixedEventCont.setPDGCodes(Track1.PDGCode, Cascade2.PDGCode);
+    pairCleaner.init(&Registry);
+    /*
+    if (Option.CPROn.value) {
+      pairCloseRejectionSE.init(&Registry, &Registry, Option.CPRdeltaPhiMax.value, Option.CPRdeltaEtaMax.value, Option.CPRPlotPerRadii.value, 1, Option.CPROld.value);
+      pairCloseRejectionME.init(&Registry, &Registry, Option.CPRdeltaPhiMax.value, Option.CPRdeltaEtaMax.value, Option.CPRPlotPerRadii.value, 2, Option.CPROld.value, 99, true);
+    }
+    */ 
+
+    // get bit for the collision mask
+    std::bitset<8 * sizeof(femtodreamcollision::BitMaskType)> mask;
+    int index = 0;
+    auto& workflows = context.services().get<RunningWorkflowInfo const>();
+    for (DeviceSpec const& device : workflows.devices) {
+      if (device.name.find("femto-dream-pair-task-track-v0") != std::string::npos) {
+        if (containsNameValuePair(device.options, "Track1.CutBit", Track1.CutBit.value) &&
+            containsNameValuePair(device.options, "Track1.TPCBit", Track1.TPCBit.value) &&
+            containsNameValuePair(device.options, "Track1.TPCBit_Reject", Track1.TPCBit_Reject.value) &&
+            containsNameValuePair(device.options, "Track1.TPCTOFBit", Track1.TPCTOFBit.value) &&
+            containsNameValuePair(device.options, "Track1.PIDThres", Track1.PIDThres.value) &&
+            containsNameValuePair(device.options, "Track1.PtMin", Track1.PtMin.value) &&
+            containsNameValuePair(device.options, "Track1.PtMax", Track1.PtMax.value) &&
+            containsNameValuePair(device.options, "Track1.EtaMin", Track1.EtaMin.value) &&
+            containsNameValuePair(device.options, "Track1.EtaMax", Track1.EtaMax.value) &&
+            containsNameValuePair(device.options, "Track1.TempFitVarMin", Track1.TempFitVarMin.value) &&
+            containsNameValuePair(device.options, "Track1.TempFitVarMax", Track1.TempFitVarMax.value) &&
+            containsNameValuePair(device.options, "Cascade2.CutBit", Cascade2.CutBit.value) &&
+            containsNameValuePair(device.options, "Cascade2.ChildPos_CutBit", Cascade2.ChildPos_CutBit.value) &&
+            containsNameValuePair(device.options, "Cascade2.ChildPos_TPCBit", Cascade2.ChildPos_TPCBit.value) &&
+            containsNameValuePair(device.options, "Cascade2.ChildNeg_CutBit", Cascade2.ChildNeg_CutBit.value) &&
+            containsNameValuePair(device.options, "Cascade2.ChildNeg_TPCBit", Cascade2.ChildNeg_TPCBit.value) &&
+            containsNameValuePair(device.options, "Cascade2.InvMassMin", Cascade2.InvMassMin.value) &&
+            containsNameValuePair(device.options, "Cascade2.InvMassMax", Cascade2.InvMassMax.value) &&
+            containsNameValuePair(device.options, "Cascade2.InvMassAntiMin", Cascade2.InvMassAntiMin.value) &&
+            containsNameValuePair(device.options, "Cascade2.InvMassAntiMax", Cascade2.InvMassAntiMax.value) &&
+            containsNameValuePair(device.options, "Cascade2.PtMin", Cascade2.PtMin.value) &&
+            containsNameValuePair(device.options, "Cascade2.PtMax", Cascade2.PtMax.value) &&
+            containsNameValuePair(device.options, "Cascade2.EtaMin", Cascade2.EtaMin.value) &&
+            containsNameValuePair(device.options, "Cascade2.EtaMax", Cascade2.EtaMax.value)) {
+          mask.set(index);
+          BitMask = static_cast<femtodreamcollision::BitMaskType>(mask.to_ulong());
+          LOG(info) << "Device name matched: " << device.name;
+          LOG(info) << "Bitmask for collisions: " << mask.to_string();
+          break;
+        } else {
+          index++;
+        }
+      }
+    }
+  }
+
+  /// This function processes the same event and takes care of all the histogramming
+  template <bool isMC, typename PartitionType, typename TableTracks, typename Collision>
+  void doSameEvent(PartitionType& SliceTrk1, PartitionType& SliceV02, TableTracks const& parts, Collision const& col)
+  {
+    /// Histogramming same event
+    for (auto const& part : SliceTrk1) {
+      trackHistoPartOne.fillQA<isMC, false>(part, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
+    }
+    for (auto& v0 : SliceV02) {
+      const auto& posChild = parts.iteratorAt(v0.index() - 2);
+      const auto& negChild = parts.iteratorAt(v0.index() - 1);
+      // This is how it is supposed to work but there seems to be an issue
+      // with partitions and accessing elements in tables that have been declared
+      // with an SELF_INDEX column. Under investigation. Maybe need to change
+      // femtdream dataformat to take special care of v0 candidates
+      // auto posChild = v0.template children_as<S>().front();
+      // auto negChild = v0.template children_as<S>().back();
+      // check cuts on V0 children
+      if (((posChild.cut() & Cascade2.ChildPos_CutBit) == Cascade2.ChildPos_CutBit) &&
+          ((posChild.pidcut() & Cascade2.ChildPos_TPCBit) == Cascade2.ChildPos_TPCBit) &&
+          ((negChild.cut() & Cascade2.ChildNeg_CutBit) == Cascade2.ChildNeg_CutBit) &&
+          ((negChild.pidcut() & Cascade2.ChildNeg_TPCBit) == Cascade2.ChildNeg_TPCBit)) {
+        trackHistoPartTwo.fillQA<isMC, false>(v0, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
+        posChildHistos.fillQA<false, false>(posChild, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
+        negChildHistos.fillQA<false, false>(negChild, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
+      }
+    }
+    /// Now build particle combinations
+    for (auto const& [p1, p2] : combinations(CombinationsFullIndexPolicy(SliceTrk1, SliceV02))) {
+      const auto& posChild = parts.iteratorAt(p2.index() - 2);
+      const auto& negChild = parts.iteratorAt(p2.index() - 1);
+      // cuts on V0 children still need to be applied
+      if (((posChild.cut() & Cascade2.ChildPos_CutBit) == Cascade2.ChildPos_CutBit) &&
+          ((posChild.pidcut() & Cascade2.ChildPos_TPCBit) == Cascade2.ChildPos_TPCBit) &&
+          ((negChild.cut() & Cascade2.ChildNeg_CutBit) == Cascade2.ChildNeg_CutBit) &&
+          ((negChild.pidcut() & Cascade2.ChildNeg_TPCBit) == Cascade2.ChildNeg_TPCBit)) {
+       /*
+       if (Option.CPROn.value) {
+          if (pairCloseRejectionSE.isClosePair(p1, p2, parts, col.magField())) {
+            continue;
+          }
+        }
+       */ 
+        if (!pairCleaner.isCleanPair(p1, p2, parts)) {
+          continue;
+        }
+        sameEventCont.setPair<isMC>(p1, p2, col.multNtr(), col.multV0M(), Option.Use4D, Option.ExtendedPlots, Option.smearingByOrigin);
+      }
+    }
+  }
+
+  void processSameEventMasked(FilteredMaskedCollision const& col, FDParticles const& parts)
+  {
+    if ((col.bitmaskTrackOne() & BitMask) != BitMask || (col.bitmaskTrackTwo() & BitMask) != BitMask) {
+      return;
+    }
+    eventHisto.fillQA<false>(col);
+    auto SliceTrk1 = PartitionTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
+    auto SliceV02 = PartitionCascade2->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
+    doSameEvent<false>(SliceTrk1, SliceV02, parts, col);
+  }
+  PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processSameEventMasked, "Enable processing same event with masks", true);
+
+  /*
+  void processSameEventMCMasked(FilteredMaskedMCCollision const& col, o2::aod::FDMCCollisions&, FDMCParts const& parts, o2::aod::FDMCParticles const&)
+  {
+    if ((col.bitmaskTrackOne() & BitMask) != BitMask && (col.bitmaskTrackTwo() & BitMask) != BitMask) {
+      return;
+    }
+    eventHisto.fillQA<true>(col);
+    auto SliceMCTrk1 = PartitionMCTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
+    auto SliceMCV02 = PartitionMCV02->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
+    doSameEvent<true>(SliceMCTrk1, SliceMCV02, parts, col);
+  }
+  PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processSameEventMCMasked, "Enable processing same event MC with masks", false);
+  */
+  
+
+  /*
+  template <bool isMC, typename CollisionType, typename PartType, typename PartitionType, typename BinningType>
+  void doMixedEvent_Masked(CollisionType const& cols, PartType const& parts, PartitionType& part1, PartitionType& part2, BinningType policy)
+  {
+
+    if (Option.MixEventWithPairs.value) {
+      Partition<CollisionType> PartitionMaskedCol = ncheckbit(aod::femtodreamcollision::bitmaskTrackOne, BitMask) && ncheckbit(aod::femtodreamcollision::bitmaskTrackTwo, BitMask) && aod::femtodreamcollision::downsample == true;
+      PartitionMaskedCol.bindTable(cols);
+      // use *Partition.mFiltered when passing the partition to mixing object
+      // there is an issue when the partition is passed directly
+      // workaround for now, change back once it is fixed
+      for (auto const& [collision1, collision2] : selfCombinations(policy, Mixing.Depth.value, -1, *PartitionMaskedCol.mFiltered, *PartitionMaskedCol.mFiltered)) {
+        // make sure that tracks in same events are not mixed
+        if (collision1.globalIndex() == collision2.globalIndex()) {
+          continue;
+        }
+        auto SliceTrk1 = part1->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision1.globalIndex(), cache);
+        auto SliceV02 = part2->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);
+        for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(SliceTrk1, SliceV02))) {
+          const auto& posChild = parts.iteratorAt(p2.index() - 2);
+          const auto& negChild = parts.iteratorAt(p2.index() - 1);
+          // check cuts on V0 children
+          if (((posChild.cut() & Cascade2.ChildPos_CutBit) == Cascade2.ChildPos_CutBit) &&
+              ((posChild.pidcut() & Cascade2.ChildPos_TPCBit) == Cascade2.ChildPos_TPCBit) &&
+              ((negChild.cut() & Cascade2.ChildNeg_CutBit) == Cascade2.ChildNeg_CutBit) &&
+              ((negChild.pidcut() & Cascade2.ChildNeg_TPCBit) == Cascade2.ChildNeg_TPCBit)) {
+            continue;
+          }
+          if (Option.CPROn.value) {
+            if (pairCloseRejectionME.isClosePair(p1, p2, parts, collision1.magField())) {
+              continue;
+            }
+          }
+          if (!pairCleaner.isCleanPair(p1, p2, parts)) {
+            continue;
+          }
+          mixedEventCont.setPair<isMC>(p1, p2, collision1.multNtr(), collision1.multV0M(), Option.Use4D, Option.ExtendedPlots, Option.smearingByOrigin);
+        }
+      }
+    } else {
+      Partition<CollisionType> PartitionMaskedCol1 = ncheckbit(aod::femtodreamcollision::bitmaskTrackOne, BitMask) && aod::femtodreamcollision::downsample == true;
+      Partition<CollisionType> PartitionMaskedCol2 = ncheckbit(aod::femtodreamcollision::bitmaskTrackTwo, BitMask) && aod::femtodreamcollision::downsample == true;
+      PartitionMaskedCol1.bindTable(cols);
+      PartitionMaskedCol2.bindTable(cols);
+
+      // use *Partition.mFiltered when passing the partition to mixing object
+      // there is an issue when the partition is passed directly
+      // workaround for now, change back once it is fixed
+      for (auto const& [collision1, collision2] : combinations(soa::CombinationsBlockUpperIndexPolicy(policy, Mixing.Depth.value, -1, *PartitionMaskedCol1.mFiltered, *PartitionMaskedCol2.mFiltered))) {
+        // make sure that tracks in same events are not mixed
+        if (collision1.globalIndex() == collision2.globalIndex()) {
+          continue;
+        }
+        auto SliceTrk1 = part1->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision1.globalIndex(), cache);
+        auto SliceV02 = part2->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);
+        for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(SliceTrk1, SliceV02))) {
+          const auto& posChild = parts.iteratorAt(p2.index() - 2);
+          const auto& negChild = parts.iteratorAt(p2.index() - 1);
+          // check cuts on V0 children
+          if (((posChild.cut() & Cascade2.ChildPos_CutBit) == Cascade2.ChildPos_CutBit) &&
+              ((posChild.pidcut() & Cascade2.ChildPos_TPCBit) == Cascade2.ChildPos_TPCBit) &&
+              ((negChild.cut() & Cascade2.ChildNeg_CutBit) == Cascade2.ChildNeg_CutBit) &&
+              ((negChild.pidcut() & Cascade2.ChildNeg_TPCBit) == Cascade2.ChildNeg_TPCBit)) {
+            continue;
+          }
+          if (Option.CPROn.value) {
+            if (pairCloseRejectionME.isClosePair(p1, p2, parts, collision1.magField())) {
+              continue;
+            }
+          }
+          if (!pairCleaner.isCleanPair(p1, p2, parts)) {
+            continue;
+          }
+          mixedEventCont.setPair<isMC>(p1, p2, collision1.multNtr(), collision1.multV0M(), Option.Use4D, Option.ExtendedPlots, Option.smearingByOrigin);
+        }
+      }
+    }
+  }
+
+  void processMixedEventMasked(FilteredMaskedCollisions const& cols, FDParticles const& parts)
+  {
+    switch (Mixing.Policy.value) {
+      case femtodreamcollision::kMult:
+        doMixedEvent_Masked<false>(cols, parts, PartitionTrk1, PartitionV02, colBinningMult);
+        break;
+      case femtodreamcollision::kMultPercentile:
+        doMixedEvent_Masked<false>(cols, parts, PartitionTrk1, PartitionV02, colBinningMultPercentile);
+        break;
+      case femtodreamcollision::kMultMultPercentile:
+        doMixedEvent_Masked<false>(cols, parts, PartitionTrk1, PartitionV02, colBinningMultMultPercentile);
+        break;
+      default:
+        LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
+    }
+  }
+  PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processMixedEventMasked, "Enable processing mixed events with masks", true);
+
+  void processMixedEventMCMasked(FilteredMaskedMCCollisions const& cols, o2::aod::FDMCCollisions&, FDMCParts const& parts, o2::aod::FDMCParticles const&)
+  {
+    switch (Mixing.Policy.value) {
+      case femtodreamcollision::kMult:
+        doMixedEvent_Masked<true>(cols, parts, PartitionMCTrk1, PartitionMCV02, colBinningMult);
+        break;
+      case femtodreamcollision::kMultPercentile:
+        doMixedEvent_Masked<true>(cols, parts, PartitionMCTrk1, PartitionMCV02, colBinningMultPercentile);
+        break;
+      case femtodreamcollision::kMultMultPercentile:
+        doMixedEvent_Masked<true>(cols, parts, PartitionMCTrk1, PartitionMCV02, colBinningMultMultPercentile);
+        break;
+      default:
+        LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
+    }
+  }
+  PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processMixedEventMCMasked, "Enable processing mixed events MC with masks", false);
+  */
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  WorkflowSpec workflow{
+    adaptAnalysisTask<femtoDreamPairTaskTrackV0>(cfgc),
+  };
+  return workflow;
+}

--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackCascade.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackCascade.cxx
@@ -242,12 +242,12 @@ struct femtoDreamPairTaskTrackCascade {
       // check cuts on V0 children
       
       if ( Cascade2.UseChildCuts &&
-          ((posChild.cut() & Cascade2.ChildPos_CutBit) == Cascade2.ChildPos_CutBit) &&
+          !(((posChild.cut() & Cascade2.ChildPos_CutBit) == Cascade2.ChildPos_CutBit) &&
           ((posChild.pidcut() & Cascade2.ChildPos_TPCBit) == Cascade2.ChildPos_TPCBit) &&
           ((negChild.cut() & Cascade2.ChildNeg_CutBit) == Cascade2.ChildNeg_CutBit) &&
           ((negChild.pidcut() & Cascade2.ChildNeg_TPCBit) == Cascade2.ChildNeg_TPCBit) && 
           ((bachChild.cut() & Cascade2.ChildBach_CutBit) == Cascade2.ChildBach_CutBit) &&
-          ((bachChild.pidcut() & Cascade2.ChildBach_TPCBit) == Cascade2.ChildBach_TPCBit)) {
+          ((bachChild.pidcut() & Cascade2.ChildBach_TPCBit) == Cascade2.ChildBach_TPCBit))) {
             continue;   
       } //cutbit
       trackHistoPartTwo.fillQA<isMC, false>(casc, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
@@ -263,12 +263,12 @@ struct femtoDreamPairTaskTrackCascade {
       // cuts on Cascade children still need to be applied
 
       if ( Cascade2.UseChildCuts &&
-          ((posChild.cut() & Cascade2.ChildPos_CutBit) == Cascade2.ChildPos_CutBit) &&
+          !(((posChild.cut() & Cascade2.ChildPos_CutBit) == Cascade2.ChildPos_CutBit) &&
           ((posChild.pidcut() & Cascade2.ChildPos_TPCBit) == Cascade2.ChildPos_TPCBit) &&
           ((negChild.cut() & Cascade2.ChildNeg_CutBit) == Cascade2.ChildNeg_CutBit) &&
           ((negChild.pidcut() & Cascade2.ChildNeg_TPCBit) == Cascade2.ChildNeg_TPCBit) &&
           ((bachChild.cut() & Cascade2.ChildBach_CutBit) == Cascade2.ChildBach_CutBit) &&
-          ((bachChild.pidcut() & Cascade2.ChildBach_TPCBit) == Cascade2.ChildBach_TPCBit)) {
+          ((bachChild.pidcut() & Cascade2.ChildBach_TPCBit) == Cascade2.ChildBach_TPCBit))) {
             continue;
           } 
       if (Option.CPROn.value) {
@@ -322,12 +322,12 @@ struct femtoDreamPairTaskTrackCascade {
           const auto& bachChild = parts.iteratorAt(p2.index() - 1);
           // check cuts on Cascade children
           if ( Cascade2.UseChildCuts &&
-              ((posChild.cut() & Cascade2.ChildPos_CutBit) == Cascade2.ChildPos_CutBit) &&
+              !(((posChild.cut() & Cascade2.ChildPos_CutBit) == Cascade2.ChildPos_CutBit) &&
               ((posChild.pidcut() & Cascade2.ChildPos_TPCBit) == Cascade2.ChildPos_TPCBit) &&
               ((negChild.cut() & Cascade2.ChildNeg_CutBit) == Cascade2.ChildNeg_CutBit) &&
               ((negChild.pidcut() & Cascade2.ChildNeg_TPCBit) == Cascade2.ChildNeg_TPCBit) &&
               ((bachChild.cut() & Cascade2.ChildBach_CutBit) == Cascade2.ChildBach_CutBit) &&
-              ((bachChild.pidcut() & Cascade2.ChildBach_TPCBit) == Cascade2.ChildBach_TPCBit)) {
+              ((bachChild.pidcut() & Cascade2.ChildBach_TPCBit) == Cascade2.ChildBach_TPCBit))) {
                 continue;  
           }
           if (Option.CPROn.value) {

--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackCascade.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackCascade.cxx
@@ -8,11 +8,9 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-
 /// \file femtoDreamPairTaskTrackTrack.cxx
 /// \brief Tasks that reads the track tables used for the pairing and builds pairs of two tracks
 /// \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
-
 #include <sys/stat.h>
 #include <cstdint>
 #include <vector>
@@ -23,7 +21,6 @@
 #include "Framework/ASoAHelpers.h"
 #include "Framework/RunningWorkflowInfo.h"
 #include "Framework/Expressions.h"
-
 #include "PWGCF/DataModel/FemtoDerived.h"
 #include "PWGCF/FemtoDream/Core/femtoDreamParticleHisto.h"
 #include "PWGCF/FemtoDream/Core/femtoDreamEventHisto.h"
@@ -31,18 +28,15 @@
 #include "PWGCF/FemtoDream/Core/femtoDreamContainer.h"
 #include "PWGCF/FemtoDream/Core/femtoDreamDetaDphiStar.h"
 #include "PWGCF/FemtoDream/Core/femtoDreamUtils.h"
-
 using namespace o2;
 using namespace o2::aod;
 using namespace o2::soa;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::analysis::femtoDream;
-
-struct femtoDreamPairTaskTrackV0 {
+struct femtoDreamPairTaskTrackCascade {
   SliceCache cache;
   Preslice<aod::FDParticles> perCol = aod::femtodreamparticle::fdCollisionId;
-
   /// General options
   struct : ConfigurableGroup {
     std::string prefix = std::string("Option");
@@ -60,7 +54,6 @@ struct femtoDreamPairTaskTrackV0 {
     Configurable<bool> smearingByOrigin{"smearingByOrigin", false, "Obtain the smearing matrix differential in the MC origin of particle 1 and particle 2. High memory consumption. Use with care!"};
     ConfigurableAxis Dummy{"Dummy", {1, 0, 1}, "Dummy axis"};
   } Option;
-
   /// Event selection
   struct : ConfigurableGroup {
     std::string prefix = std::string("EventSel");
@@ -69,23 +62,18 @@ struct femtoDreamPairTaskTrackV0 {
     Configurable<float> MultPercentileMin{"MultPercentileMin", 0, "Minimum Multiplicity Percentile"};
     Configurable<float> MultPercentileMax{"MultPercentileMax", 100, "Maximum Multiplicity Percentile"};
   } EventSel;
-
-  Filter EventMultiplicity = aod::femtodreamcollision::multNtr >= EventSel.MultMin && aod::femtodreamcollision::multNtr <= EventSel.MultMax;
-  Filter EventMultiplicityPercentile = aod::femtodreamcollision::multV0M >= EventSel.MultPercentileMin && aod::femtodreamcollision::multV0M <= EventSel.MultPercentileMax;
-
+  //Filter EventMultiplicity = aod::femtodreamcollision::multNtr >= EventSel.MultMin && aod::femtodreamcollision::multNtr <= EventSel.MultMax;
+  //Filter EventMultiplicityPercentile = aod::femtodreamcollision::multV0M >= EventSel.MultPercentileMin && aod::femtodreamcollision::multV0M <= EventSel.MultPercentileMax;
   /// Histogramming for Event
   FemtoDreamEventHisto eventHisto;
-
-  using FilteredMaskedCollisions = soa::Filtered<soa::Join<FDCollisions, FDColMasks, FDDownSample>>;
-  using FilteredMaskedCollision = FilteredMaskedCollisions::iterator;
-  using FilteredMaskedMCCollisions = soa::Filtered<soa::Join<FDCollisions, aod::FDMCCollLabels, FDColMasks, FDDownSample>>;
-  using FilteredMaskedMCCollision = FilteredMaskedMCCollisions::iterator;
-
+  //using FilteredCollisions = soa::Filtered<FDCollisions>;
+  using FilteredCollisions = FDCollisions;
+  using FilteredCollision = FilteredCollisions::iterator;
+  //using FilteredMaskedCollisions = soa::Filtered<soa::Join<FDCollisions, FDColMasks, FDDownSample>>;
+  //using FilteredMaskedCollision = FilteredMaskedCollisions::iterator;
   using FDMCParts = soa::Join<aod::FDParticles, aod::FDMCLabels>;
   using FDMCPart = FDMCParts::iterator;
-
   femtodreamcollision::BitMaskType BitMask = 1;
-
   /// Particle 1 (track)
   struct : ConfigurableGroup {
     std::string prefix = std::string("Track1");
@@ -102,7 +90,6 @@ struct femtoDreamPairTaskTrackV0 {
     Configurable<float> TempFitVarMin{"TempFitVarMin", -10., "Minimum DCAxy of partricle 1 (Track)"};
     Configurable<float> TempFitVarMax{"TempFitVarMax", 10., "Maximum DCAxy of partricle 1 (Track)"};
   } Track1;
-
   /// Partition for particle 1
   Partition<FDParticles> PartitionTrk1 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
                                          (ncheckbit(aod::femtodreamparticle::cut, Track1.CutBit)) &&
@@ -114,87 +101,60 @@ struct femtoDreamPairTaskTrackV0 {
                                          ifnode(Option.DCACutPtDep, (nabs(aod::femtodreamparticle::tempFitVar) <= 0.0105f + (0.035f / npow(aod::femtodreamparticle::pt, 1.1f))),
                                                 ((aod::femtodreamparticle::tempFitVar >= Track1.TempFitVarMin) &&
                                                  (aod::femtodreamparticle::tempFitVar <= Track1.TempFitVarMax)));
-
-  Partition<FDMCParts> PartitionMCTrk1 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kTrack)) &&
-                                         (ncheckbit(aod::femtodreamparticle::cut, Track1.CutBit)) &&
-                                         ifnode(aod::femtodreamparticle::pt * (nexp(aod::femtodreamparticle::eta) + nexp(-1.f * aod::femtodreamparticle::eta)) / 2.f <= Track1.PIDThres, ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCBit) && ((aod::femtodreamparticle::pidcut & Track1.TPCBit_Reject) == 0u), ncheckbit(aod::femtodreamparticle::pidcut, Track1.TPCTOFBit)) &&
-                                         (aod::femtodreamparticle::pt > Track1.PtMin) &&
-                                         (aod::femtodreamparticle::pt < Track1.PtMax) &&
-                                         (aod::femtodreamparticle::eta > Track1.EtaMin) &&
-                                         (aod::femtodreamparticle::eta < Track1.EtaMax) &&
-                                         ifnode(Option.DCACutPtDep, (nabs(aod::femtodreamparticle::tempFitVar) <= 0.0105f + (0.035f / npow(aod::femtodreamparticle::pt, 1.1f))),
-                                                ((aod::femtodreamparticle::tempFitVar >= Track1.TempFitVarMin) &&
-                                                 (aod::femtodreamparticle::tempFitVar <= Track1.TempFitVarMax)));
-
   /// Histogramming for particle 1
   FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kTrack, 1> trackHistoPartOne;
-
-  /// Particle 2 (V0)
+  /// Particle 2 (Cascade)
   struct : ConfigurableGroup {
-    std::string prefix = std::string("V02");
-    Configurable<int> PDGCode{"PDGCode", 3122, "PDG code of particle 2 (V0)"};
-    Configurable<femtodreamparticle::cutContainerType> CutBit{"CutBit", 338, "Selection bit for particle 2 (V0)"};
-    Configurable<femtodreamparticle::cutContainerType> ChildPos_CutBit{"ChildPos_CutBit", 149, "Selection bit for positive child of V0"};
-    Configurable<femtodreamparticle::cutContainerType> ChildPos_TPCBit{"ChildPos_TPCBit", 2, "PID TPC bit for positive child of V0"};
-    Configurable<femtodreamparticle::cutContainerType> ChildNeg_CutBit{"ChildNeg_CutBit", 149, "Selection bit for negative child of V0"};
-    Configurable<femtodreamparticle::cutContainerType> ChildNeg_TPCBit{"ChildNeg_TPCBit", 2, "PID TPC bit for negative child of V0"};
-
-    Configurable<float> InvMassMin{"InvMassMin", 1.08, "Minimum invariant mass of Partricle 2 (particle) (V0)"};
-    Configurable<float> InvMassMax{"InvMassMax", 1.15, "Maximum invariant mass of Partricle 2 (particle) (V0)"};
-    Configurable<float> InvMassAntiMin{"InvMassAntiMin", 0., "Minimum invariant mass of Partricle 2 (antiparticle) (V0)"};
-    Configurable<float> InvMassAntiMax{"InvMassAntiMax", 999., "Maximum invariant mass of Partricle 2 (antiparticle) (V0)"};
-
+    std::string prefix = std::string("Cascade2");
+    Configurable<int> PDGCode{"PDGCode", 3312, "PDG code of particle 2 (V0)"};
+    Configurable<femtodreamparticle::cutContainerType> CutBit{"CutBit", 32221874, "Selection bit for particle 2 (Cascade)"};
+    Configurable<femtodreamparticle::cutContainerType> ChildPos_CutBit{"ChildPos_CutBit", 278, "Selection bit for positive child of Cascade"};
+    Configurable<femtodreamparticle::cutContainerType> ChildPos_TPCBit{"ChildPos_TPCBit", 1024, "PID TPC bit for positive child of Cascade"};
+    Configurable<femtodreamparticle::cutContainerType> ChildNeg_CutBit{"ChildNeg_CutBit", 277, "Selection bit for negative child of Cascade"};
+    Configurable<femtodreamparticle::cutContainerType> ChildNeg_TPCBit{"ChildNeg_TPCBit", 4096, "PID TPC bit for negative child of Cascade"};
+    Configurable<femtodreamparticle::cutContainerType> ChildBach_CutBit{"ChildBach_CutBit", 277, "Selection bit for negative child of Cascade"};
+    Configurable<femtodreamparticle::cutContainerType> ChildBach_TPCBit{"ChildBach_TPCBit", 64, "PID TPC bit for bachelor child of Cascade"};
+    Configurable<float> InvMassMin{"InvMassMin", 1.2, "Minimum invariant mass of Partricle 2 (particle) (Cascade)"};
+    Configurable<float> InvMassMax{"InvMassMax", 1.4, "Maximum invariant mass of Partricle 2 (particle) (Cascade)"};
+    Configurable<float> InvMassV0DaughMin{"InvMassV0DaugMin", 0., "Minimum invariant mass of the V0 Daughter"};
+    Configurable<float> InvMassV0DaughMax{"InvMassV0DaugMax", 999., "Maximum invariant mass of the V0 Daughter"};
     Configurable<float> PtMin{"PtMin", 0., "Minimum pT of Partricle 2 (V0)"};
     Configurable<float> PtMax{"PtMax", 999., "Maximum pT of Partricle 2 (V0)"};
     Configurable<float> EtaMin{"EtaMin", -10., "Minimum eta of Partricle 2 (V0)"};
     Configurable<float> EtaMax{"EtaMax", 10., "Maximum eta of Partricle 2 (V0)"};
-  } V02;
-
+  } Cascade2;
   /// Partition for particle 2
-  Partition<FDParticles> PartitionV02 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) &&
-                                        ((aod::femtodreamparticle::cut & V02.CutBit) == V02.CutBit) &&
-                                        (aod::femtodreamparticle::pt > V02.PtMin) &&
-                                        (aod::femtodreamparticle::pt < V02.PtMax) &&
-                                        (aod::femtodreamparticle::eta > V02.EtaMin) &&
-                                        (aod::femtodreamparticle::eta < V02.EtaMax) &&
-                                        (aod::femtodreamparticle::mLambda > V02.InvMassMin) &&
-                                        (aod::femtodreamparticle::mLambda < V02.InvMassMax) &&
-                                        (aod::femtodreamparticle::mAntiLambda > V02.InvMassAntiMin) &&
-                                        (aod::femtodreamparticle::mAntiLambda < V02.InvMassAntiMax);
-
-  Partition<FDMCParts> PartitionMCV02 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kV0)) &&
-                                        ((aod::femtodreamparticle::cut & V02.CutBit) == V02.CutBit) &&
-                                        (aod::femtodreamparticle::pt > V02.PtMin) &&
-                                        (aod::femtodreamparticle::pt < V02.PtMax) &&
-                                        (aod::femtodreamparticle::eta > V02.EtaMax) &&
-                                        (aod::femtodreamparticle::eta < V02.EtaMin) &&
-                                        (aod::femtodreamparticle::mLambda > V02.InvMassMin) &&
-                                        (aod::femtodreamparticle::mLambda < V02.InvMassMax) &&
-                                        (aod::femtodreamparticle::mAntiLambda > V02.InvMassAntiMin) &&
-                                        (aod::femtodreamparticle::mAntiLambda < V02.InvMassAntiMax);
-
+  Partition<FDParticles> PartitionCascade2 = (aod::femtodreamparticle::partType == uint8_t(aod::femtodreamparticle::ParticleType::kCascade)) &&
+                                             ((aod::femtodreamparticle::cut & Cascade2.CutBit) == Cascade2.CutBit) &&
+                                             (aod::femtodreamparticle::pt > Cascade2.PtMin) &&
+                                             (aod::femtodreamparticle::pt < Cascade2.PtMax) &&
+                                             (aod::femtodreamparticle::eta > Cascade2.EtaMin) &&
+                                             (aod::femtodreamparticle::eta < Cascade2.EtaMax) &&
+                                             (aod::femtodreamparticle::mLambda > Cascade2.InvMassMin) &&
+                                             (aod::femtodreamparticle::mLambda < Cascade2.InvMassMax) &&
+                                             (aod::femtodreamparticle::mAntiLambda > Cascade2.InvMassV0DaughMin) &&
+                                             (aod::femtodreamparticle::mAntiLambda < Cascade2.InvMassV0DaughMax);
   /// Histogramming for particle 2
-  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0, 2> trackHistoPartTwo;
-  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0Child, 3> posChildHistos;
-  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kV0Child, 4> negChildHistos;
-
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascade, 2> trackHistoPartTwo;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascadeV0Child, 3> posChildHistos;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascadeV0Child, 4> negChildHistos;
+  FemtoDreamParticleHisto<aod::femtodreamparticle::ParticleType::kCascadeBachelor, 8> bachChildHistos;
   /// Binning configurables
   struct : ConfigurableGroup {
     std::string prefix = std::string("Binning");
     ConfigurableAxis TempFitVarTrack{"TempFitVarTrack", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot (Track)"};
-    ConfigurableAxis TempFitVarV0{"TempFitVarV0", {300, 0.9, 1}, "binning of the TempFitVar in the pT vs. TempFitVar plot (V0)"};
-    ConfigurableAxis TempFitVarV0Child{"TempFitVarV0Child", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot (V0 child)"};
-    ConfigurableAxis InvMass{"InvMass", {200, 1, 1.2}, "InvMass binning"};
+    ConfigurableAxis TempFitVarCascade{"TempFitVarCascade", {300, 0.9, 1}, "binning of the TempFitVar in the pT vs. TempFitVar plot (Cascade)"};
+    ConfigurableAxis TempFitVarCascadeChild{"TempFitVarCascadeChild", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot (Cascade child)"};
+    ConfigurableAxis InvMass{"InvMass", {200, 1.22, 1.42}, "InvMass binning"};
     ConfigurableAxis pTTrack{"pTTrack", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot (Track)"};
-    ConfigurableAxis pTV0{"pTV0", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot (V0)"};
-    ConfigurableAxis pTV0Child{"pTV0Child", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot (V0)"};
+    ConfigurableAxis pTCascade{"pTCascade", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot (Cascade)"};
+    ConfigurableAxis pTCascadeChild{"pTCascadeChild", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot (Cascade)"};
     ConfigurableAxis pT{"pT", {20, 0.5, 4.05}, "pT binning"};
     ConfigurableAxis kstar{"kstar", {1500, 0., 6.}, "binning kstar"};
     ConfigurableAxis kT{"kT", {150, 0., 9.}, "binning kT"};
     ConfigurableAxis mT{"mT", {225, 0., 7.5}, "binning mT"};
     ConfigurableAxis multTempFit{"multTempFit", {1, 0, 1}, "multiplicity for the TempFitVar plot"};
   } Binning;
-
   struct : ConfigurableGroup {
     std::string prefix = std::string("Binning4D");
     ConfigurableAxis kstar{"kstar", {1500, 0., 6.}, "binning kstar for the 4Dimensional plot: k* vs multiplicity vs multiplicity percentile vs mT (set <<ConfUse4D>> to true in order to use)"};
@@ -202,7 +162,6 @@ struct femtoDreamPairTaskTrackV0 {
     ConfigurableAxis Mult{"mult", {VARIABLE_WIDTH, 0.0f, 4.0f, 8.0f, 12.0f, 16.0f, 20.0f, 24.0f, 28.0f, 32.0f, 36.0f, 40.0f, 44.0f, 48.0f, 52.0f, 56.0f, 60.0f, 64.0f, 68.0f, 72.0f, 76.0f, 80.0f, 84.0f, 88.0f, 92.0f, 96.0f, 100.0f, 200.0f}, "multiplicity Binning for the 4Dimensional plot: k* vs multiplicity vs multiplicity percentile vs mT (set <<ConfUse4D>> to true in order to use)"};
     ConfigurableAxis multPercentile{"multPercentile", {10, 0.0f, 100.0f}, "multiplicity percentile Binning for the 4Dimensional plot: k* vs multiplicity vs multiplicity percentile vs mT (set <<ConfUse4D>> to true in order to use)"};
   } Binning4D;
-
   // Mixing configurables
   struct : ConfigurableGroup {
     std::string prefix = std::string("Mixing");
@@ -212,108 +171,70 @@ struct femtoDreamPairTaskTrackV0 {
     Configurable<int> Depth{"Depth", 5, "Number of events for mixing"};
     Configurable<int> Policy{"BinPolicy", 0, "Binning policy for mixing - 0: multiplicity, 1: multipliciy percentile, 2: both"};
   } Mixing;
-
   ColumnBinningPolicy<aod::collision::PosZ, aod::femtodreamcollision::MultNtr> colBinningMult{{Mixing.BinVztx, Mixing.BinMult}, true};
   ColumnBinningPolicy<aod::collision::PosZ, aod::femtodreamcollision::MultV0M> colBinningMultPercentile{{Mixing.BinVztx, Mixing.BinMultPercentile}, true};
   ColumnBinningPolicy<aod::collision::PosZ, aod::femtodreamcollision::MultNtr, aod::femtodreamcollision::MultV0M> colBinningMultMultPercentile{{Mixing.BinVztx, Mixing.BinMult, Mixing.BinMultPercentile}, true};
-
   FemtoDreamContainer<femtoDreamContainer::EventType::same, femtoDreamContainer::Observable::kstar> sameEventCont;
   FemtoDreamContainer<femtoDreamContainer::EventType::mixed, femtoDreamContainer::Observable::kstar> mixedEventCont;
-  FemtoDreamPairCleaner<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kV0> pairCleaner;
-  FemtoDreamDetaDphiStar<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kV0> pairCloseRejectionSE;
-  FemtoDreamDetaDphiStar<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kV0> pairCloseRejectionME;
+  FemtoDreamPairCleaner<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kCascade> pairCleaner;
+  FemtoDreamDetaDphiStar<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kTrack> pairCloseRejectionSE;
+  FemtoDreamDetaDphiStar<aod::femtodreamparticle::ParticleType::kTrack, aod::femtodreamparticle::ParticleType::kTrack> pairCloseRejectionME;
+
+
+  static constexpr uint32_t kSignPlusMask = 1 << 1;
 
   /// Histogram output
   HistogramRegistry Registry{"Output", {}, OutputObjHandlingPolicy::AnalysisObject};
-
   void init(InitContext& context)
   {
     // setup binnnig policy for mixing
     colBinningMult = {{Mixing.BinVztx, Mixing.BinMult}, true};
     colBinningMultPercentile = {{Mixing.BinVztx, Mixing.BinMultPercentile}, true};
     colBinningMultMultPercentile = {{Mixing.BinVztx, Mixing.BinMult, Mixing.BinMultPercentile}, true};
-
     eventHisto.init(&Registry, Option.IsMC);
     trackHistoPartOne.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTTrack, Option.Dummy, Option.Dummy, Binning.TempFitVarTrack, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.IsMC, Track1.PDGCode);
-    trackHistoPartTwo.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTV0, Option.Dummy, Option.Dummy, Binning.TempFitVarV0, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Binning.InvMass, Option.IsMC, V02.PDGCode);
-    posChildHistos.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTV0Child, Option.Dummy, Option.Dummy, Binning.TempFitVarV0Child, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, false, 0);
-    negChildHistos.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTV0Child, Option.Dummy, Option.Dummy, Binning.TempFitVarV0Child, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, false, 0);
-
+    trackHistoPartTwo.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTCascade, Option.Dummy, Option.Dummy, Binning.TempFitVarCascade, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Binning.InvMass, Option.IsMC, Cascade2.PDGCode);
+    posChildHistos.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTCascadeChild, Option.Dummy, Option.Dummy, Binning.TempFitVarCascadeChild, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, false, 0);
+    negChildHistos.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTCascadeChild, Option.Dummy, Option.Dummy, Binning.TempFitVarCascadeChild, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, false, 0);
+    bachChildHistos.init(&Registry, Binning.multTempFit, Option.Dummy, Binning.pTCascadeChild, Option.Dummy, Option.Dummy, Binning.TempFitVarCascadeChild, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, Option.Dummy, false, 0);
+    
     sameEventCont.init(&Registry,
                        Binning.kstar, Binning.pT, Binning.kT, Binning.mT, Mixing.BinMult, Mixing.BinMultPercentile,
                        Binning4D.kstar, Binning4D.mT, Binning4D.Mult, Binning4D.multPercentile,
                        Option.IsMC, Option.Use4D, Option.ExtendedPlots,
                        Option.HighkstarCut,
                        Option.smearingByOrigin);
-
-    sameEventCont.setPDGCodes(Track1.PDGCode, V02.PDGCode);
+    
+    sameEventCont.setPDGCodes(Track1.PDGCode, Cascade2.PDGCode);
+    
     mixedEventCont.init(&Registry,
                         Binning.kstar, Binning.pT, Binning.kT, Binning.mT, Mixing.BinMult, Mixing.BinMultPercentile,
                         Binning4D.kstar, Binning4D.mT, Binning4D.Mult, Binning4D.multPercentile,
                         Option.IsMC, Option.Use4D, Option.ExtendedPlots,
                         Option.HighkstarCut,
                         Option.smearingByOrigin);
-
-    mixedEventCont.setPDGCodes(Track1.PDGCode, V02.PDGCode);
+    
+    mixedEventCont.setPDGCodes(Track1.PDGCode, Cascade2.PDGCode);
+    
     pairCleaner.init(&Registry);
     if (Option.CPROn.value) {
       pairCloseRejectionSE.init(&Registry, &Registry, Option.CPRdeltaPhiMax.value, Option.CPRdeltaEtaMax.value, Option.CPRPlotPerRadii.value, 1, Option.CPROld.value);
       pairCloseRejectionME.init(&Registry, &Registry, Option.CPRdeltaPhiMax.value, Option.CPRdeltaEtaMax.value, Option.CPRPlotPerRadii.value, 2, Option.CPROld.value, 99, true);
     }
-
-    // get bit for the collision mask
-    std::bitset<8 * sizeof(femtodreamcollision::BitMaskType)> mask;
-    int index = 0;
-    auto& workflows = context.services().get<RunningWorkflowInfo const>();
-    for (DeviceSpec const& device : workflows.devices) {
-      if (device.name.find("femto-dream-pair-task-track-v0") != std::string::npos) {
-        if (containsNameValuePair(device.options, "Track1.CutBit", Track1.CutBit.value) &&
-            containsNameValuePair(device.options, "Track1.TPCBit", Track1.TPCBit.value) &&
-            containsNameValuePair(device.options, "Track1.TPCBit_Reject", Track1.TPCBit_Reject.value) &&
-            containsNameValuePair(device.options, "Track1.TPCTOFBit", Track1.TPCTOFBit.value) &&
-            containsNameValuePair(device.options, "Track1.PIDThres", Track1.PIDThres.value) &&
-            containsNameValuePair(device.options, "Track1.PtMin", Track1.PtMin.value) &&
-            containsNameValuePair(device.options, "Track1.PtMax", Track1.PtMax.value) &&
-            containsNameValuePair(device.options, "Track1.EtaMin", Track1.EtaMin.value) &&
-            containsNameValuePair(device.options, "Track1.EtaMax", Track1.EtaMax.value) &&
-            containsNameValuePair(device.options, "Track1.TempFitVarMin", Track1.TempFitVarMin.value) &&
-            containsNameValuePair(device.options, "Track1.TempFitVarMax", Track1.TempFitVarMax.value) &&
-            containsNameValuePair(device.options, "V02.CutBit", V02.CutBit.value) &&
-            containsNameValuePair(device.options, "V02.ChildPos_CutBit", V02.ChildPos_CutBit.value) &&
-            containsNameValuePair(device.options, "V02.ChildPos_TPCBit", V02.ChildPos_TPCBit.value) &&
-            containsNameValuePair(device.options, "V02.ChildNeg_CutBit", V02.ChildNeg_CutBit.value) &&
-            containsNameValuePair(device.options, "V02.ChildNeg_TPCBit", V02.ChildNeg_TPCBit.value) &&
-            containsNameValuePair(device.options, "V02.InvMassMin", V02.InvMassMin.value) &&
-            containsNameValuePair(device.options, "V02.InvMassMax", V02.InvMassMax.value) &&
-            containsNameValuePair(device.options, "V02.InvMassAntiMin", V02.InvMassAntiMin.value) &&
-            containsNameValuePair(device.options, "V02.InvMassAntiMax", V02.InvMassAntiMax.value) &&
-            containsNameValuePair(device.options, "V02.PtMin", V02.PtMin.value) &&
-            containsNameValuePair(device.options, "V02.PtMax", V02.PtMax.value) &&
-            containsNameValuePair(device.options, "V02.EtaMin", V02.EtaMin.value) &&
-            containsNameValuePair(device.options, "V02.EtaMax", V02.EtaMax.value)) {
-          mask.set(index);
-          BitMask = static_cast<femtodreamcollision::BitMaskType>(mask.to_ulong());
-          LOG(info) << "Device name matched: " << device.name;
-          LOG(info) << "Bitmask for collisions: " << mask.to_string();
-          break;
-        } else {
-          index++;
-        }
-      }
-    }
   }
-
+  
   /// This function processes the same event and takes care of all the histogramming
   template <bool isMC, typename PartitionType, typename TableTracks, typename Collision>
-  void doSameEvent(PartitionType& SliceTrk1, PartitionType& SliceV02, TableTracks const& parts, Collision const& col)
+  void doSameEvent(PartitionType& SliceTrk1, PartitionType& SliceCascade2, TableTracks const& parts, Collision const& col)
   {
     /// Histogramming same event
     for (auto const& part : SliceTrk1) {
       trackHistoPartOne.fillQA<isMC, false>(part, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
     }
-    for (auto& v0 : SliceV02) {
-      const auto& posChild = parts.iteratorAt(v0.index() - 2);
-      const auto& negChild = parts.iteratorAt(v0.index() - 1);
+    for (auto& casc : SliceCascade2) {
+      const auto& posChild = parts.iteratorAt(casc.index() - 3);
+      const auto& negChild = parts.iteratorAt(casc.index() - 2);
+      const auto& bachChild = parts.iteratorAt(casc.index() - 1);
       // This is how it is supposed to work but there seems to be an issue
       // with partitions and accessing elements in tables that have been declared
       // with an SELF_INDEX column. Under investigation. Maybe need to change
@@ -321,180 +242,141 @@ struct femtoDreamPairTaskTrackV0 {
       // auto posChild = v0.template children_as<S>().front();
       // auto negChild = v0.template children_as<S>().back();
       // check cuts on V0 children
-      if (((posChild.cut() & V02.ChildPos_CutBit) == V02.ChildPos_CutBit) &&
-          ((posChild.pidcut() & V02.ChildPos_TPCBit) == V02.ChildPos_TPCBit) &&
-          ((negChild.cut() & V02.ChildNeg_CutBit) == V02.ChildNeg_CutBit) &&
-          ((negChild.pidcut() & V02.ChildNeg_TPCBit) == V02.ChildNeg_TPCBit)) {
-        trackHistoPartTwo.fillQA<isMC, false>(v0, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
+      
+      if (((posChild.cut() & Cascade2.ChildPos_CutBit) == Cascade2.ChildPos_CutBit) &&
+          ((posChild.pidcut() & Cascade2.ChildPos_TPCBit) == Cascade2.ChildPos_TPCBit) &&
+          ((negChild.cut() & Cascade2.ChildNeg_CutBit) == Cascade2.ChildNeg_CutBit) &&
+          ((negChild.pidcut() & Cascade2.ChildNeg_TPCBit) == Cascade2.ChildNeg_TPCBit) && 
+          ((bachChild.cut() & Cascade2.ChildBach_CutBit) == Cascade2.ChildBach_CutBit) &&
+          ((bachChild.pidcut() & Cascade2.ChildBach_TPCBit) == Cascade2.ChildBach_TPCBit)) {
+        
+        trackHistoPartTwo.fillQA<isMC, false>(casc, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
         posChildHistos.fillQA<false, false>(posChild, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
         negChildHistos.fillQA<false, false>(negChild, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
-      }
+        bachChildHistos.fillQA<false, false>(bachChild, aod::femtodreamparticle::kPt, col.multNtr(), col.multV0M());
+      } //cutbit
     }
     /// Now build particle combinations
-    for (auto const& [p1, p2] : combinations(CombinationsFullIndexPolicy(SliceTrk1, SliceV02))) {
-      const auto& posChild = parts.iteratorAt(p2.index() - 2);
-      const auto& negChild = parts.iteratorAt(p2.index() - 1);
-      // cuts on V0 children still need to be applied
-      if (((posChild.cut() & V02.ChildPos_CutBit) == V02.ChildPos_CutBit) &&
-          ((posChild.pidcut() & V02.ChildPos_TPCBit) == V02.ChildPos_TPCBit) &&
-          ((negChild.cut() & V02.ChildNeg_CutBit) == V02.ChildNeg_CutBit) &&
-          ((negChild.pidcut() & V02.ChildNeg_TPCBit) == V02.ChildNeg_TPCBit)) {
+    for (auto const& [p1, p2] : combinations(CombinationsFullIndexPolicy(SliceTrk1, SliceCascade2))) {
+      const auto& posChild = parts.iteratorAt(p2.index() - 3);
+      const auto& negChild = parts.iteratorAt(p2.index() - 2);
+      const auto& bachChild = parts.iteratorAt(p2.index() - 1);
+      // cuts on Cascade children still need to be applied
+      if (((posChild.cut() & Cascade2.ChildPos_CutBit) == Cascade2.ChildPos_CutBit) &&
+          ((posChild.pidcut() & Cascade2.ChildPos_TPCBit) == Cascade2.ChildPos_TPCBit) &&
+          ((negChild.cut() & Cascade2.ChildNeg_CutBit) == Cascade2.ChildNeg_CutBit) &&
+          ((negChild.pidcut() & Cascade2.ChildNeg_TPCBit) == Cascade2.ChildNeg_TPCBit) &&
+          ((bachChild.cut() & Cascade2.ChildBach_CutBit) == Cascade2.ChildBach_CutBit) &&
+          ((bachChild.pidcut() & Cascade2.ChildBach_TPCBit) == Cascade2.ChildBach_TPCBit)) {
+        
         if (Option.CPROn.value) {
-          if (pairCloseRejectionSE.isClosePair(p1, p2, parts, col.magField())) {
-            continue;
+          if ((p1.cut() & kSignPlusMask) == kSignPlusMask){
+            if (pairCloseRejectionSE.isClosePair(p1, posChild, parts, col.magField())) {
+              continue;
+            }
+          }else{
+            if (pairCloseRejectionSE.isClosePair(p1, posChild, parts, col.magField())) {
+              continue;
+            }
           }
         }
         if (!pairCleaner.isCleanPair(p1, p2, parts)) {
           continue;
         }
         sameEventCont.setPair<isMC>(p1, p2, col.multNtr(), col.multV0M(), Option.Use4D, Option.ExtendedPlots, Option.smearingByOrigin);
-      }
+      } //cut bits of children
     }
   }
-
-  void processSameEventMasked(FilteredMaskedCollision const& col, FDParticles const& parts)
+  void processSameMasked(FilteredCollision const& col, FDParticles const& parts)
   {
-    if ((col.bitmaskTrackOne() & BitMask) != BitMask || (col.bitmaskTrackTwo() & BitMask) != BitMask) {
-      return;
-    }
+    //if ((col.bitmaskTrackOne() & BitMask) != BitMask || (col.bitmaskTrackTwo() & BitMask) != BitMask) {
+    //  return;
+    //}
     eventHisto.fillQA<false>(col);
     auto SliceTrk1 = PartitionTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
-    auto SliceV02 = PartitionV02->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
-    doSameEvent<false>(SliceTrk1, SliceV02, parts, col);
+    auto SliceCascade2 = PartitionCascade2->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
+    doSameEvent<false>(SliceTrk1, SliceCascade2, parts, col);
   }
-  PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processSameEventMasked, "Enable processing same event with masks", true);
-
-  void processSameEventMCMasked(FilteredMaskedMCCollision const& col, o2::aod::FDMCCollisions&, FDMCParts const& parts, o2::aod::FDMCParticles const&)
-  {
-    if ((col.bitmaskTrackOne() & BitMask) != BitMask && (col.bitmaskTrackTwo() & BitMask) != BitMask) {
-      return;
-    }
-    eventHisto.fillQA<true>(col);
-    auto SliceMCTrk1 = PartitionMCTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
-    auto SliceMCV02 = PartitionMCV02->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
-    doSameEvent<true>(SliceMCTrk1, SliceMCV02, parts, col);
-  }
-  PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processSameEventMCMasked, "Enable processing same event MC with masks", false);
-
+  PROCESS_SWITCH(femtoDreamPairTaskTrackCascade, processSameMasked, "Enable processing same event", true);
+  
+  
   template <bool isMC, typename CollisionType, typename PartType, typename PartitionType, typename BinningType>
-  void doMixedEvent_Masked(CollisionType const& cols, PartType const& parts, PartitionType& part1, PartitionType& part2, BinningType policy)
+  void doMixedEvent(CollisionType const& cols, PartType const& parts, PartitionType& part1, PartitionType& part2, BinningType policy)
   {
-
-    if (Option.MixEventWithPairs.value) {
-      Partition<CollisionType> PartitionMaskedCol = ncheckbit(aod::femtodreamcollision::bitmaskTrackOne, BitMask) && ncheckbit(aod::femtodreamcollision::bitmaskTrackTwo, BitMask) && aod::femtodreamcollision::downsample == true;
-      PartitionMaskedCol.bindTable(cols);
+      //Partition<CollisionType> PartitionMaskedCol = ncheckbit(aod::femtodreamcollision::bitmaskTrackOne, BitMask) && ncheckbit(aod::femtodreamcollision::bitmaskTrackTwo, BitMask);// && aod::femtodreamcollision::downsample == true;
+      //PartitionMaskedCol.bindTable(cols);
+      
       // use *Partition.mFiltered when passing the partition to mixing object
       // there is an issue when the partition is passed directly
       // workaround for now, change back once it is fixed
-      for (auto const& [collision1, collision2] : selfCombinations(policy, Mixing.Depth.value, -1, *PartitionMaskedCol.mFiltered, *PartitionMaskedCol.mFiltered)) {
+      for (auto const& [collision1, collision2] : soa::selfCombinations(policy, Mixing.Depth.value, -1, cols, cols)) {
+        //LOGF(info, "GG Mixing: entering the mixing");
         // make sure that tracks in same events are not mixed
         if (collision1.globalIndex() == collision2.globalIndex()) {
+          //LOGF(info, "GG Mixing: Rejecting same collisions");
           continue;
         }
         auto SliceTrk1 = part1->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision1.globalIndex(), cache);
-        auto SliceV02 = part2->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);
-        for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(SliceTrk1, SliceV02))) {
-          const auto& posChild = parts.iteratorAt(p2.index() - 2);
-          const auto& negChild = parts.iteratorAt(p2.index() - 1);
-          // check cuts on V0 children
-          if (((posChild.cut() & V02.ChildPos_CutBit) == V02.ChildPos_CutBit) &&
-              ((posChild.pidcut() & V02.ChildPos_TPCBit) == V02.ChildPos_TPCBit) &&
-              ((negChild.cut() & V02.ChildNeg_CutBit) == V02.ChildNeg_CutBit) &&
-              ((negChild.pidcut() & V02.ChildNeg_TPCBit) == V02.ChildNeg_TPCBit)) {
-            continue;
-          }
-          if (Option.CPROn.value) {
-            if (pairCloseRejectionME.isClosePair(p1, p2, parts, collision1.magField())) {
-              continue;
+        auto SliceCasc2 = part2->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);
+        for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(SliceTrk1, SliceCasc2))) {
+          //LOGF(info, "GG Mixing: Pairing the pairs");
+          const auto& posChild = parts.iteratorAt(p2.index() - 3);
+          const auto& negChild = parts.iteratorAt(p2.index() - 2);
+          const auto& bachChild = parts.iteratorAt(p2.index() - 1);
+          // check cuts on Cascade children
+          if (((posChild.cut() & Cascade2.ChildPos_CutBit) == Cascade2.ChildPos_CutBit) &&
+              ((posChild.pidcut() & Cascade2.ChildPos_TPCBit) == Cascade2.ChildPos_TPCBit) &&
+              ((negChild.cut() & Cascade2.ChildNeg_CutBit) == Cascade2.ChildNeg_CutBit) &&
+              ((negChild.pidcut() & Cascade2.ChildNeg_TPCBit) == Cascade2.ChildNeg_TPCBit) &&
+              ((bachChild.cut() & Cascade2.ChildBach_CutBit) == Cascade2.ChildBach_CutBit) &&
+              ((bachChild.pidcut() & Cascade2.ChildBach_TPCBit) == Cascade2.ChildBach_TPCBit)) {
+            
+            if (Option.CPROn.value) {
+              if ((p1.cut() & kSignPlusMask) == kSignPlusMask){
+                if (pairCloseRejectionME.isClosePair(p1, posChild, parts, collision1.magField())) {
+                  continue;
+                }
+              }else{
+                if (pairCloseRejectionME.isClosePair(p1, negChild, parts, collision1.magField())) {
+                  continue;
+                }
+              }
             }
           }
-          if (!pairCleaner.isCleanPair(p1, p2, parts)) {
-            continue;
-          }
-          mixedEventCont.setPair<isMC>(p1, p2, collision1.multNtr(), collision1.multV0M(), Option.Use4D, Option.ExtendedPlots, Option.smearingByOrigin);
-        }
-      }
-    } else {
-      Partition<CollisionType> PartitionMaskedCol1 = ncheckbit(aod::femtodreamcollision::bitmaskTrackOne, BitMask) && aod::femtodreamcollision::downsample == true;
-      Partition<CollisionType> PartitionMaskedCol2 = ncheckbit(aod::femtodreamcollision::bitmaskTrackTwo, BitMask) && aod::femtodreamcollision::downsample == true;
-      PartitionMaskedCol1.bindTable(cols);
-      PartitionMaskedCol2.bindTable(cols);
+          //if (!pairCleaner.isCleanPair(p1, p2, parts)) {
+          //  LOGF(info, "GG Mixing: Entering Pair Cleaner");
+          //  continue;
+          //}
 
-      // use *Partition.mFiltered when passing the partition to mixing object
-      // there is an issue when the partition is passed directly
-      // workaround for now, change back once it is fixed
-      for (auto const& [collision1, collision2] : combinations(soa::CombinationsBlockUpperIndexPolicy(policy, Mixing.Depth.value, -1, *PartitionMaskedCol1.mFiltered, *PartitionMaskedCol2.mFiltered))) {
-        // make sure that tracks in same events are not mixed
-        if (collision1.globalIndex() == collision2.globalIndex()) {
-          continue;
-        }
-        auto SliceTrk1 = part1->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision1.globalIndex(), cache);
-        auto SliceV02 = part2->sliceByCached(aod::femtodreamparticle::fdCollisionId, collision2.globalIndex(), cache);
-        for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(SliceTrk1, SliceV02))) {
-          const auto& posChild = parts.iteratorAt(p2.index() - 2);
-          const auto& negChild = parts.iteratorAt(p2.index() - 1);
-          // check cuts on V0 children
-          if (((posChild.cut() & V02.ChildPos_CutBit) == V02.ChildPos_CutBit) &&
-              ((posChild.pidcut() & V02.ChildPos_TPCBit) == V02.ChildPos_TPCBit) &&
-              ((negChild.cut() & V02.ChildNeg_CutBit) == V02.ChildNeg_CutBit) &&
-              ((negChild.pidcut() & V02.ChildNeg_TPCBit) == V02.ChildNeg_TPCBit)) {
-            continue;
-          }
-          if (Option.CPROn.value) {
-            if (pairCloseRejectionME.isClosePair(p1, p2, parts, collision1.magField())) {
-              continue;
-            }
-          }
-          if (!pairCleaner.isCleanPair(p1, p2, parts)) {
-            continue;
-          }
+          //LOGF(info, "GG Mixing: Filling the histos");
           mixedEventCont.setPair<isMC>(p1, p2, collision1.multNtr(), collision1.multV0M(), Option.Use4D, Option.ExtendedPlots, Option.smearingByOrigin);
+          //LOGF(info, "GG Mixing: ALIVE");
         }
       }
-    }
   }
-
-  void processMixedEventMasked(FilteredMaskedCollisions const& cols, FDParticles const& parts)
+  
+  void processMixedEvent(FilteredCollisions const& cols, FDParticles const& parts)
   {
     switch (Mixing.Policy.value) {
       case femtodreamcollision::kMult:
-        doMixedEvent_Masked<false>(cols, parts, PartitionTrk1, PartitionV02, colBinningMult);
+        doMixedEvent<false>(cols, parts, PartitionTrk1, PartitionCascade2, colBinningMult);
         break;
       case femtodreamcollision::kMultPercentile:
-        doMixedEvent_Masked<false>(cols, parts, PartitionTrk1, PartitionV02, colBinningMultPercentile);
+        doMixedEvent<false>(cols, parts, PartitionTrk1, PartitionCascade2, colBinningMultPercentile);
         break;
       case femtodreamcollision::kMultMultPercentile:
-        doMixedEvent_Masked<false>(cols, parts, PartitionTrk1, PartitionV02, colBinningMultMultPercentile);
+        doMixedEvent<false>(cols, parts, PartitionTrk1, PartitionCascade2, colBinningMultMultPercentile);
         break;
       default:
         LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
     }
   }
-  PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processMixedEventMasked, "Enable processing mixed events with masks", true);
-
-  void processMixedEventMCMasked(FilteredMaskedMCCollisions const& cols, o2::aod::FDMCCollisions&, FDMCParts const& parts, o2::aod::FDMCParticles const&)
-  {
-    switch (Mixing.Policy.value) {
-      case femtodreamcollision::kMult:
-        doMixedEvent_Masked<true>(cols, parts, PartitionMCTrk1, PartitionMCV02, colBinningMult);
-        break;
-      case femtodreamcollision::kMultPercentile:
-        doMixedEvent_Masked<true>(cols, parts, PartitionMCTrk1, PartitionMCV02, colBinningMultPercentile);
-        break;
-      case femtodreamcollision::kMultMultPercentile:
-        doMixedEvent_Masked<true>(cols, parts, PartitionMCTrk1, PartitionMCV02, colBinningMultMultPercentile);
-        break;
-      default:
-        LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
-    }
-  }
-  PROCESS_SWITCH(femtoDreamPairTaskTrackV0, processMixedEventMCMasked, "Enable processing mixed events MC with masks", false);
+  PROCESS_SWITCH(femtoDreamPairTaskTrackCascade, processMixedEvent, "Enable processing mixed events", true);
 };
-
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   WorkflowSpec workflow{
-    adaptAnalysisTask<femtoDreamPairTaskTrackV0>(cfgc),
+    adaptAnalysisTask<femtoDreamPairTaskTrackCascade>(cfgc),
   };
   return workflow;
 }

--- a/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.cxx
+++ b/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.cxx
@@ -50,13 +50,23 @@ int main(int /*argc*/, char* argv[])
       cut.setTrackSelectionFromFile("ConfChild");
       cut.setPIDSelectionFromFile("ConfChild");
     } else if (choice == std::string("C")) {
-      std::cout << "Do you want to select Cascades, V0s or the Bachelor Track (C/V/T)? >";
+      std::cout << "Do you want to select cascades, V0-Daughter tracks of the cascades or the Bachelor track (C/V/B)? >";
       std::cin >> choice;
-      cut.setCascadeSelectionFromFile("ConfCascade");
-      //cut.setV0SelectionFromFile("ConfV0");
-      //cut.setTrackSelectionFromFile("ConfChild");
-      //cut.setPIDSelectionFromFile("ConfChild");
-      //cut.setPIDSelectionFromFile("ConfBachelor");
+      if (choice == std::string("C")){
+        cut.setCascadeSelectionFromFile("ConfCascade");
+        choice = "C";
+      } else if (choice == std::string("V")){
+        cut.setTrackSelectionFromFile("ConfCascV0Child");
+        cut.setPIDSelectionFromFile("ConfCascV0Child");
+        choice = "T"; 
+      } else if (choice == std::string("B")){ 
+        cut.setTrackSelectionFromFile("ConfCascBachelor");
+        cut.setPIDSelectionFromFile("ConfCascBachelor");
+        choice = "T"; 
+      } else {
+        std::cout << "Option not recognized. Break...";
+        return 2;
+      }
     } else {
       std::cout << "Option not recognized. Break...";
       return 2;

--- a/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.cxx
+++ b/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.cxx
@@ -16,6 +16,7 @@
 #include <filesystem>
 #include <iostream>
 #include <random>
+#include <string>
 #include "PWGCF/FemtoDream/Utils/femtoDreamCutCulator.h"
 #include "PWGCF/FemtoDream/Core/femtoDreamSelection.h"
 #include "PWGCF/FemtoDream/Core/femtoDreamTrackSelection.h"

--- a/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.cxx
+++ b/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.cxx
@@ -52,17 +52,17 @@ int main(int /*argc*/, char* argv[])
     } else if (choice == std::string("C")) {
       std::cout << "Do you want to select cascades, V0-Daughter tracks of the cascades or the Bachelor track (C/V/B)? >";
       std::cin >> choice;
-      if (choice == std::string("C")){
+      if (choice == std::string("C")) {
         cut.setCascadeSelectionFromFile("ConfCascade");
         choice = "C";
-      } else if (choice == std::string("V")){
+      } else if (choice == std::string("V")) {
         cut.setTrackSelectionFromFile("ConfCascV0Child");
         cut.setPIDSelectionFromFile("ConfCascV0Child");
-        choice = "T"; 
-      } else if (choice == std::string("B")){ 
+        choice = "T";
+      } else if (choice == std::string("B")) {
         cut.setTrackSelectionFromFile("ConfCascBachelor");
         cut.setPIDSelectionFromFile("ConfCascBachelor");
-        choice = "T"; 
+        choice = "T";
       } else {
         std::cout << "Option not recognized. Break...";
         return 2;

--- a/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.cxx
+++ b/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.cxx
@@ -13,7 +13,6 @@
 /// \brief Executable that encodes physical selection criteria in a bit-wise
 /// selection \author Andi Mathis, TU München, andreas.mathis@ph.tum.de
 
-#include <filesystem>
 #include <iostream>
 #include <random>
 #include <string>

--- a/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.cxx
+++ b/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.cxx
@@ -29,8 +29,8 @@ using namespace o2::analysis::femtoDream;
 int main(int /*argc*/, char* argv[])
 {
   std::string configFileName(argv[1]);
-  std::ifstream configFile(configFileName); 
-  
+  std::ifstream configFile(configFileName);
+
   if (configFile.is_open()) {
     FemtoDreamCutculator cut;
     cut.init(argv[1]);

--- a/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.cxx
+++ b/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.cxx
@@ -36,7 +36,7 @@ int main(int /*argc*/, char* argv[])
     cut.init(argv[1]);
 
     std::cout
-      << "Do you want to work with tracks or V0s (T/V)? >";
+      << "Do you want to work with tracks or V0s or Cascades (T/V/C)? >";
     std::string choice;
     std::cin >> choice;
 
@@ -49,6 +49,14 @@ int main(int /*argc*/, char* argv[])
       cut.setV0SelectionFromFile("ConfV0");
       cut.setTrackSelectionFromFile("ConfChild");
       cut.setPIDSelectionFromFile("ConfChild");
+    } else if (choice == std::string("C")) {
+      std::cout << "Do you want to select Cascades, V0s or the Bachelor Track (C/V/T)? >";
+      std::cin >> choice;
+      cut.setCascadeSelectionFromFile("ConfCascade");
+      //cut.setV0SelectionFromFile("ConfV0");
+      //cut.setTrackSelectionFromFile("ConfChild");
+      //cut.setPIDSelectionFromFile("ConfChild");
+      //cut.setPIDSelectionFromFile("ConfBachelor");
     } else {
       std::cout << "Option not recognized. Break...";
       return 2;

--- a/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.cxx
+++ b/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.cxx
@@ -29,9 +29,9 @@ using namespace o2::analysis::femtoDream;
 int main(int /*argc*/, char* argv[])
 {
   std::string configFileName(argv[1]);
-  std::filesystem::path configFile{configFileName};
-
-  if (std::filesystem::exists(configFile)) {
+  std::ifstream configFile(configFileName); 
+  
+  if (configFile.is_open()) {
     FemtoDreamCutculator cut;
     cut.init(argv[1]);
 
@@ -97,7 +97,8 @@ int main(int /*argc*/, char* argv[])
 
   } else {
     std::cout << "The configuration file " << configFileName
-              << " could not be found.";
+              << " could not be found or could not be opened.";
+    return 1;
   }
 
   return 0;

--- a/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.h
+++ b/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.h
@@ -201,8 +201,8 @@ class FemtoDreamCutculator
   /// \param type Type of the track selection
   /// \param prefix Prefix which is added to the name of the Configurable
   void setCascadeSelection(femtoDreamCascadeSelection::CascadeSel obs,
-                      femtoDreamSelection::SelectionType type,
-                      const char* prefix)
+                           femtoDreamSelection::SelectionType type,
+                           const char* prefix)
   {
     auto tmpVec =
       setSelection(FemtoDreamCascadeSelection::getSelectionName(obs, prefix));
@@ -210,7 +210,7 @@ class FemtoDreamCutculator
       mCascadeSel.setSelection(tmpVec, obs, type);
     }
   }
-  
+
   /// Automatically retrieves V0 selections from the dpl-config.json
   /// \param prefix Prefix which is added to the name of the Configurable
   void setCascadeSelectionFromFile(const char* prefix)

--- a/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.h
+++ b/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.h
@@ -18,7 +18,6 @@
 #ifndef PWGCF_FEMTODREAM_UTILS_FEMTODREAMCUTCULATOR_H_
 #define PWGCF_FEMTODREAM_UTILS_FEMTODREAMCUTCULATOR_H_
 
-#include <filesystem>
 #include <bitset>
 #include <functional>
 #include <iostream>

--- a/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.h
+++ b/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.h
@@ -18,6 +18,7 @@
 #ifndef PWGCF_FEMTODREAM_UTILS_FEMTODREAMCUTCULATOR_H_
 #define PWGCF_FEMTODREAM_UTILS_FEMTODREAMCUTCULATOR_H_
 
+#include <filesystem>
 #include <bitset>
 #include <functional>
 #include <iostream>

--- a/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.h
+++ b/PWGCF/FemtoDream/Utils/femtoDreamCutCulator.h
@@ -32,6 +32,7 @@
 #include "PWGCF/FemtoDream/Core/femtoDreamSelection.h"
 #include "PWGCF/FemtoDream/Core/femtoDreamTrackSelection.h"
 #include "PWGCF/FemtoDream/Core/femtoDreamV0Selection.h"
+#include "PWGCF/FemtoDream/Core/femtoDreamCascadeSelection.h"
 
 namespace o2::analysis::femtoDream
 {
@@ -193,6 +194,44 @@ class FemtoDreamCutculator
     }
   }
 
+  /// Specialization of the setSelection function for Cascades
+
+  /// The selection passed to the function is retrieved from the dpl-config.json
+  /// \param obs Observable of the track selection
+  /// \param type Type of the track selection
+  /// \param prefix Prefix which is added to the name of the Configurable
+  void setCascadeSelection(femtoDreamCascadeSelection::CascadeSel obs,
+                      femtoDreamSelection::SelectionType type,
+                      const char* prefix)
+  {
+    auto tmpVec =
+      setSelection(FemtoDreamCascadeSelection::getSelectionName(obs, prefix));
+    if (tmpVec.size() > 0) {
+      mCascadeSel.setSelection(tmpVec, obs, type);
+    }
+  }
+  
+  /// Automatically retrieves V0 selections from the dpl-config.json
+  /// \param prefix Prefix which is added to the name of the Configurable
+  void setCascadeSelectionFromFile(const char* prefix)
+  {
+    for (const auto& sel : mConfigTree) {
+      std::string sel_name = sel.first;
+      femtoDreamCascadeSelection::CascadeSel obs;
+      if (sel_name.find(prefix) != std::string::npos) {
+        int index = FemtoDreamCascadeSelection::findSelectionIndex(
+          std::string_view(sel_name), prefix);
+        if (index >= 0) {
+          obs = femtoDreamCascadeSelection::CascadeSel(index);
+        } else {
+          continue;
+        }
+        setCascadeSelection(obs, FemtoDreamCascadeSelection::getSelectionType(obs),
+                            prefix);
+      }
+    }
+  }
+
   /// This function investigates a given selection criterion. The available
   /// options are displayed in the terminal and the bit-wise container is put
   /// together according to the user input \tparam T1 Selection class under
@@ -319,6 +358,8 @@ class FemtoDreamCutculator
       output = iterateSelection(mTrackSel, SysChecks, sign);
     } else if (choice == std::string("V")) {
       output = iterateSelection(mV0Sel, SysChecks, sign);
+    } else if (choice == std::string("C")) {
+      output = iterateSelection(mCascadeSel, SysChecks, sign);
     } else {
       std::cout << "Option " << choice
                 << " not recognized - available options are (T/V)" << std::endl;
@@ -380,6 +421,7 @@ class FemtoDreamCutculator
   boost::property_tree::ptree mConfigTree;     ///< the dpl-config.json buffered into a ptree
   FemtoDreamTrackSelection mTrackSel;          ///< for setting up the bit-wise selection container for tracks
   FemtoDreamV0Selection mV0Sel;                ///< for setting up the bit-wise selection container for V0s
+  FemtoDreamCascadeSelection mCascadeSel;      ///< for setting up the bit-wise selection container for Cascades
   std::vector<o2::track::PID::ID> mPIDspecies; ///< list of particle species for which PID is stored
   std::vector<float> mPIDValues;               ///< list of nsigma values for which PID is stored
 };


### PR DESCRIPTION
- The producer task can select now also Cascades (for now only Xis supported; Omegas will follow soon)
- Cutcullator and FemtoDreamParticleHisto updated accordingly
- Cascade selection happens in dedicated task
- Debug Cascade and pair-track-Cascade task included
- Updated the "femtoDreamProducerTaskForSpecificAnalysis.cxx" to support Cascades