### PR TITLE
[PWGCF/FemtoUniverse] Fix `EfficiencyCalculator` not saving efficiency to the analysis output

### DIFF
--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseEfficiencyCalculator.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseEfficiencyCalculator.h
@@ -82,7 +82,7 @@ class EfficiencyCalculator
 
   template <uint8_t N>
     requires isOneOrTwo<N>
-  auto doMCTruth(FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kMCTruthTrack, N> hMCTruth, auto particles) const -> void
+  auto doMCTruth(FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kMCTruthTrack, N>& hMCTruth, const auto& particles) const -> void
   {
     for (const auto& particle : particles) {
       hMCTruth.template fillQA<false, false>(particle);
@@ -99,7 +99,7 @@ class EfficiencyCalculator
       shouldUploadOnStop = true;
 
       auto& callbacks = ic.services().get<CallbackService>();
-      callbacks.set<o2::framework::CallbackService::Id::EndOfStream>([this](EndOfStreamContext&) {
+      callbacks.set<o2::framework::CallbackService::Id::Stop>([this]() {
         for (auto i = 0UL; i < hOutput.size(); i++) {
           const auto& output = hOutput[i];
 
@@ -125,7 +125,7 @@ class EfficiencyCalculator
 
   template <uint8_t N>
     requires isOneOrTwo<N>
-  auto getWeight(auto const& particle) const -> float
+  auto getWeight(const auto& particle) const -> float
   {
     auto weight = 1.0f;
     auto hEff = hLoaded[N - 1];
@@ -187,7 +187,7 @@ class EfficiencyCalculator
     return true;
   }
 
-  auto createMetadata(uint8_t partNo) const -> std::map<std::string, std::string>
+  auto createMetadata(const uint8_t partNo) const -> std::map<std::string, std::string>
   {
     if (config->confEfficiencyCCDBLabels->size() != 2) {
       LOGF(fatal, notify("CCDB labels configurable should be exactly of size 2"));
@@ -199,7 +199,7 @@ class EfficiencyCalculator
 
   template <uint8_t N>
     requires isOneOrTwo<N>
-  auto loadEfficiencyFromCCDB(int64_t timestamp) const -> TH1*
+  auto loadEfficiencyFromCCDB(const int64_t timestamp) const -> TH1*
   {
     auto hEff = ccdb.getSpecific<TH1>(ccdbFullPath, timestamp, createMetadata(N - 1));
     if (!hEff || hEff->IsZombie()) {

--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseEfficiencyCalculator.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseEfficiencyCalculator.h
@@ -97,7 +97,7 @@ class EfficiencyCalculator
       shouldUploadOnStop = true;
 
       auto& callbacks = ic.services().get<CallbackService>();
-      callbacks.set<o2::framework::CallbackService::Id::Stop>([this]() {
+      callbacks.set<o2::framework::CallbackService::Id::EndOfStream>([this](EndOfStreamContext&) {
         for (auto i = 0UL; i < hOutput.size(); i++) {
           const auto& output = hOutput[i];
 

--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseEfficiencyCalculator.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseEfficiencyCalculator.h
@@ -37,11 +37,11 @@ struct EfficiencyConfigurableGroup : ConfigurableGroup {
   Configurable<bool> confEfficiencyCalculate{"confEfficiencyCalculate", false, "Should calculate efficiency"};
   Configurable<bool> confEfficiencyApplyCorrections{"confEfficiencyApplyCorrections", false, "Should apply corrections from efficiency"};
   Configurable<std::vector<std::string>> confEfficiencyCCDBLabels{"confEfficiencyCCDBLabels", {}, "Labels for efficiency objects in CCDB"};
+  ConfigurableAxis confEfficiencyCCDBTimestamps{"confEfficiencyCCDBTimestamps", {-1, -1}, "Timestamps from which to query CCDB objects (default: -1 for both)"};
 
   // NOTE: in the future we might move the below configurables to a separate struct, eg. CCDBConfigurableGroup
   Configurable<std::string> confCCDBUrl{"confCCDBUrl", "http://alice-ccdb.cern.ch", "CCDB URL to be used"};
   Configurable<std::string> confCCDBPath{"confCCDBPath", "", "CCDB base path to where to upload objects"};
-  Configurable<int64_t> confCCDBTimestamp{"confCCDBTimestamp", -1, "Timestamp from which to query CCDB objects (default: latest)"};
   Configurable<int64_t> confCCDBLifetime{"confCCDBLifetime", 365LL * 24 * 60 * 60 * 1000, "Lifetime of uploaded objects (default: 1 year)"};
 };
 
@@ -70,9 +70,12 @@ class EfficiencyCalculator
     ccdbFullPath = fmt::format("{}/{}", config->confCCDBPath.value, folderName);
 
     if (config->confEfficiencyApplyCorrections) {
+      if (config->confEfficiencyCCDBTimestamps->size() != 2) {
+        LOGF(fatal, notify("CCDB timestamps configurable should be exactly of size 2"));
+      }
       hLoaded = {
-        loadEfficiencyFromCCDB<1>(config->confCCDBTimestamp),
-        loadEfficiencyFromCCDB<2>(config->confCCDBTimestamp) //
+        loadEfficiencyFromCCDB<1>(config->confEfficiencyCCDBTimestamps.value[0]),
+        loadEfficiencyFromCCDB<2>(config->confEfficiencyCCDBTimestamps.value[1]) //
       };
     }
   }

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackPhi.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackPhi.cxx
@@ -209,9 +209,6 @@ struct FemtoUniversePairTaskTrackPhi {
   HistogramRegistry registryMCreco{"registryMCreco", {}, OutputObjHandlingPolicy::AnalysisObject, false, true};
   HistogramRegistry registryPhiMinvBackground{"registryPhiMinvBackground", {}, OutputObjHandlingPolicy::AnalysisObject, false, true};
 
-  OutputObj<TH1F> hEfficiency1{TH1F("Efficiency_part1", "Efficiency origin/generated part1; p_{T} (GeV/c); Efficiency", 100, 0, 4)};
-  OutputObj<TH1F> hEfficiency2{TH1F("Efficiency_part2", "Efficiency origin/generated part2; p_{T} (GeV/c); Efficiency", 100, 0, 4)};
-
   Configurable<bool> confDoEfficiency{"confDoEfficiency", true, "Do efficiency corrections."};
   EfficiencyConfigurableGroup effConfGroup;
   EfficiencyCalculator efficiencyCalculator{&effConfGroup};
@@ -407,13 +404,13 @@ struct FemtoUniversePairTaskTrackPhi {
 
   void init(InitContext& ic)
   {
-    hEfficiency1.setObject(new TH1F("Efficiency_part1", "Efficiency origin/generated part1; p_{T} (GeV/c); Efficiency", 100, 0, 4));
     hMCTruth1.init(&qaRegistry, confBinsTempFitVarpT, confBinsTempFitVarPDG, false, ConfTrack.confTrackPDGCode, false);
+    qaRegistry.add("Efficiency/part1", "Efficiency origin/generated part1; p_{T} (GeV/c); Efficiency", kTH1F, {{100, 0, 4}});
 
-    hEfficiency2.setObject(new TH1F("Efficiency_part2", "Efficiency origin/generated part2; p_{T} (GeV/c); Efficiency", 100, 0, 4));
     hMCTruth2.init(&qaRegistry, confBinsTempFitVarpT, confBinsTempFitVarPDG, false, 333, false);
+    qaRegistry.add("Efficiency/part2", "Efficiency origin/generated part2; p_{T} (GeV/c); Efficiency", kTH1F, {{100, 0, 4}});
 
-    efficiencyCalculator.init(hEfficiency1.object, hEfficiency2.object);
+    efficiencyCalculator.init();
     efficiencyCalculator.uploadOnStop(ic);
 
     eventHisto.init(&qaRegistry);
@@ -693,11 +690,13 @@ struct FemtoUniversePairTaskTrackPhi {
 
     auto truthTrack = qaRegistry.get<TH1>(HIST("MCTruthTracks_one/hPt"));
     auto recoTrack = qaRegistry.get<TH1>(HIST("Tracks_one_MC/hPt"));
-    efficiencyCalculator.calculate<1>(truthTrack, recoTrack);
+    auto effTrack = qaRegistry.get<TH1>(HIST("Efficiency/part1"));
+    efficiencyCalculator.calculate<1>(effTrack, truthTrack, recoTrack);
 
     auto truthPhi = qaRegistry.get<TH1>(HIST("MCTruthTracks_two/hPt"));
     auto recoPhi = qaRegistry.get<TH1>(HIST("Tracks_two_MC/hPt"));
-    efficiencyCalculator.calculate<2>(truthPhi, recoPhi);
+    auto effPhi = qaRegistry.get<TH1>(HIST("Efficiency/part2"));
+    efficiencyCalculator.calculate<2>(effPhi, truthPhi, recoPhi);
   }
   PROCESS_SWITCH(FemtoUniversePairTaskTrackPhi, processSameEventMC, "Enable processing same event for Monte Carlo", false);
 

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackExtended.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackExtended.cxx
@@ -176,7 +176,6 @@ struct FemtoUniversePairTaskTrackTrackExtended {
   HistogramRegistry resultRegistry{"Correlations", {}, OutputObjHandlingPolicy::AnalysisObject};
   HistogramRegistry mixQaRegistry{"mixQaRegistry", {}, OutputObjHandlingPolicy::AnalysisObject};
 
-
   EfficiencyConfigurableGroup effConfGroup;
   EfficiencyCalculator efficiencyCalculator{&effConfGroup};
 

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackExtended.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackExtended.cxx
@@ -650,10 +650,15 @@ struct FemtoUniversePairTaskTrackTrackExtended {
         }
       }
 
+      float weight = efficiencyCalculator.getWeight<1>(p1);
+      if (!confIsSame) {
+        weight *= efficiencyCalculator.getWeight<2>(p2);
+      }
+
       if (swpart)
-        mixedEventCont.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D);
+        mixedEventCont.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D, weight);
       else
-        mixedEventCont.setPair<isMC>(p2, p1, multCol, twotracksconfigs.confUse3D);
+        mixedEventCont.setPair<isMC>(p2, p1, multCol, twotracksconfigs.confUse3D, weight);
 
       swpart = !swpart;
     }


### PR DESCRIPTION
- Fix an issue with `EfficiencyCalculator` where the `OutputObj`, nested inside `EfficiencyConfigurableGroup`, was not registered by a task. The uploading to CCDB worked, however the efficiency histograms were not saved to analysis result root file.
- Replace `OutputObj` with `HistogramRegistry` for efficiency histograms.

#### Additionally:
- Apply corrections also in `processMixedEvent` function.
- Separate configurable for CCDB objects' timestamps.
- Add configurable for lifetime of the uploaded CCDB objects.
