### PR TITLE
PWGCF: fix to apply event cuts when confDoSpher is false

### DIFF
--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -797,10 +797,8 @@ struct FemtoUniverseProducerTask {
           outputCollision(vtxZ, mult, multNtr, 2, mMagField);
         }
       } else {
-        if (confDoSpher && (!confEvNoSameBunchPileup || col.selection_bit(aod::evsel::kNoSameBunchPileup)) && (!confEvIsGoodZvtxFT0vsPV || col.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV)) && (!confEvIsVertexITSTPC || col.selection_bit(aod::evsel::kIsVertexITSTPC))) {
-          outputCollision(vtxZ, mult, multNtr, colCuts.computeSphericity(col, tracks), mMagField);
-        } else {
-          outputCollision(vtxZ, mult, multNtr, 2, mMagField);
+        if ((!confEvNoSameBunchPileup || col.selection_bit(aod::evsel::kNoSameBunchPileup)) && (!confEvIsGoodZvtxFT0vsPV || col.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV)) && (!confEvIsVertexITSTPC || col.selection_bit(aod::evsel::kIsVertexITSTPC))) {
+          outputCollision(vtxZ, mult, multNtr, confDoSpher ? colCuts.computeSphericity(col, tracks) : 2, mMagField);
         }
       }
       colCuts.fillQA(col);


### PR DESCRIPTION
In femtoUniverseProducerTask.cxx, change the if structure, so event cuts are check also when sphericity is not calculated.