### PR TITLE
[PWGDQ] fix bug in tableMakerMuonTrkEfficiency

### DIFF
--- a/PWGDQ/TableProducer/tableMakerMuonMchTrkEfficiency.cxx
+++ b/PWGDQ/TableProducer/tableMakerMuonMchTrkEfficiency.cxx
@@ -18,8 +18,10 @@
 ///
 /// \author Zaida Conesa del Valle <zaida.conesa.del.valle@cern.ch>
 ///
-#include <iostream>
+
 #include <vector>
+#include <memory>
+#include <string>
 #include <algorithm>
 #include <TH1F.h>
 #include <TH3F.h>

--- a/PWGDQ/TableProducer/tableMakerMuonMchTrkEfficiency.cxx
+++ b/PWGDQ/TableProducer/tableMakerMuonMchTrkEfficiency.cxx
@@ -128,8 +128,8 @@ struct tableMakerMuonMchTrkEfficiency {
 
   using myMuons = soa::Join<aod::FwdTracks, aod::FwdTracksDCA>;
   using myMuonsMC = soa::Join<aod::FwdTracks, aod::McFwdTrackLabels, aod::FwdTracksDCA>;
-  using myReducedMuons = soa::Join<aod::ReducedMuons, aod::ReducedMuonsExtra, aod::ReducedMuonsInfo>;
-  using myReducedMuonsMC = soa::Join<aod::ReducedMuons, aod::ReducedMuonsExtra, aod::ReducedMuonsLabels, aod::ReducedMuonsInfo>;
+  using myReducedMuons = soa::Join<aod::ReducedMuons, aod::ReducedMuonsExtra>;
+  using myReducedMuonsMC = soa::Join<aod::ReducedMuons, aod::ReducedMuonsExtra, aod::ReducedMuonsLabels>;
 
   // bit maps used for the Fill functions of the VarManager
   constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision;


### PR DESCRIPTION
This PR aims to fix a minor bug in the definition of "myReducedMuons" and  "myReducedMuonsMC" that was preventing the code from running on derived datasets. 