### PR TITLE
[PWGJE] fix event matching for particle level weighted process function

### DIFF
--- a/PWGJE/Tasks/jetFinderQA.cxx
+++ b/PWGJE/Tasks/jetFinderQA.cxx
@@ -873,7 +873,7 @@ struct JetFinderQATask {
     }
     if (checkMcCollisionIsMatched) {
       auto collisionspermcpjet = collisions.sliceBy(CollisionsPerMCPCollision, jet.mcCollisionId());
-      if (collisionspermcpjet.size() >= 1) {
+      if (collisionspermcpjet.size() >= 1 && jetderiveddatautilities::selectCollision(collisionspermcpjet.begin(), eventSelection)) {
         fillMCPHistograms(jet, jet.eventWeight());
       }
     } else {


### PR DESCRIPTION
fix to allow event selection on particle-level jets if option enabled