### PR TITLE
[PWGLF] Update type alias in lambda1520_PbPb.cxx

### DIFF
--- a/PWGLF/DataModel/LFResonanceTables.h
+++ b/PWGLF/DataModel/LFResonanceTables.h
@@ -140,6 +140,7 @@ namespace resodaughter
 {
 
 DECLARE_SOA_INDEX_COLUMN(ResoCollision, resoCollision);
+DECLARE_SOA_INDEX_COLUMN(ResoCollisionDF, resoCollisionDF);
 DECLARE_SOA_INDEX_COLUMN_FULL(Track, track, int, Tracks, "_Trk");       //!
 DECLARE_SOA_INDEX_COLUMN_FULL(V0, v0, int, V0s, "_V0");                 //!
 DECLARE_SOA_INDEX_COLUMN_FULL(Cascade, cascade, int, Cascades, "_Cas"); //!
@@ -254,7 +255,7 @@ using ResoTrack = ResoTracks::iterator;
 // For DF mixing study
 DECLARE_SOA_TABLE(ResoTrackDFs, "AOD", "RESOTRACKDFs",
                   o2::soa::Index<>,
-                  resodaughter::ResoCollisionId,
+                  resodaughter::ResoCollisionDFId,
                   resodaughter::TrackId,
                   resodaughter::Pt,
                   resodaughter::Px,

--- a/PWGLF/Tasks/Resonances/lambda1520_PbPb.cxx
+++ b/PWGLF/Tasks/Resonances/lambda1520_PbPb.cxx
@@ -655,7 +655,7 @@ struct lambdaAnalysis_pb {
 
   Preslice<aod::ResoTrackDFs> perRColdf = aod::resodaughter::resoCollisionId;
 
-  using resoColDFs = aod::ResoCollisions;
+  using resoColDFs = aod::ResoCollisionDFs;
   using resoTrackDFs = aod::ResoTrackDFs;
 
   void processDatadf(resoColDFs::iterator const& collision, resoTrackDFs const& tracks)

--- a/PWGLF/Tasks/Resonances/lambda1520_PbPb.cxx
+++ b/PWGLF/Tasks/Resonances/lambda1520_PbPb.cxx
@@ -653,7 +653,7 @@ struct lambdaAnalysis_pb {
 
   PROCESS_SWITCH(lambdaAnalysis_pb, processMix, "Process for Mixed Events", false);
 
-  Preslice<aod::ResoTrackDFs> perRColdf = aod::resodaughter::resoCollisionId;
+  Preslice<aod::ResoTrackDFs> perRColdf = aod::resodaughter::resoCollisionDFId;
 
   using resoColDFs = aod::ResoCollisionDFs;
   using resoTrackDFs = aod::ResoTrackDFs;


### PR DESCRIPTION
- Updated the type alias from `aod::ResoCollisions` to `aod::ResoCollisionDFs` to match the latest framework changes.