### PR TITLE
[PWGHF] update the collision type in MC process

### DIFF
--- a/PWGHF/D2H/Tasks/taskD0.cxx
+++ b/PWGHF/D2H/Tasks/taskD0.cxx
@@ -763,7 +763,7 @@ struct HfTaskD0 {
         unsigned maxNumContrib = 0;
         float cent{-1.f};
         float occ{-1.f};
-        if constexpr (std::is_same_v<CollType, CollisionsCent>) {
+        if constexpr (std::is_same_v<CollType, CollisionsWithMcLabelsCent>) {
           const auto& recoCollsPerMcCollCent = collisions.sliceBy(colPerMcCollisionCent, particle.mcCollision().globalIndex());
           for (const auto& recCol : recoCollsPerMcCollCent) {
             maxNumContrib = recCol.numContrib() > maxNumContrib ? recCol.numContrib() : maxNumContrib;


### PR DESCRIPTION
Hi @mfaggin , @fcatalan92 , and @zhangbiao-phy , this pr is about updating the `if` condition of collision type in MC process. 

Since I split the process into one with and without centrality, the `if` condition of collision type in MC process should be modified at the same time. (#9294 )

Last time, I overlooked this part, so it led to the centrality and occupancy not being filled in the `Gen` THnSparse. This pr is addressing this issue.

Please let me know if you have further suggestions or comments! Thanks a lot!