### PR TITLE
[PWGHF] Add variables in MlResponse and fix typo in XicToXiPiPI workflows

### DIFF
--- a/PWGHF/Core/HfMlResponseXicToXiPiPi.h
+++ b/PWGHF/Core/HfMlResponseXicToXiPiPi.h
@@ -66,9 +66,28 @@ enum class InputFeaturesXicToXiPiPi : uint8_t {
   cosPaXYXi,
   cosPaLambda,
   cosPaXYLambda,
-  impactParameterXY0,
-  impactParameterXY1,
-  impactParameterXY2
+  impactParameterXi,
+  impactParameterPi0,
+  impactParameterPi1,
+  invMassXi,
+  invMassLambda,
+  dcaXiDaughters,
+  dcaV0Daughters,
+  dcaPosToPV,
+  dcaNegToPV,
+  dcaBachelorToPV,
+  dcaXYCascToPV,
+  dcaZCascToPV,
+  nSigTpcPiFromXicPlus0,
+  nSigTpcPiFromXicPlus1,
+  nSigTpcBachelorPi,
+  nSigTpcPiFromLambda,
+  nSigTpcPrFromLambda,
+  nSigTofPiFromXicPlus0,
+  nSigTofPiFromXicPlus1,
+  nSigTofBachelorPi,
+  nSigTofPiFromLambda,
+  nSigTofPrFromLambda
 };
 
 template <typename TypeOutputScore = float>
@@ -104,9 +123,28 @@ class HfMlResponseXicToXiPiPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_XICTOXIPIPI(cosPaXYXi);
         CHECK_AND_FILL_VEC_XICTOXIPIPI(cosPaLambda);
         CHECK_AND_FILL_VEC_XICTOXIPIPI(cosPaXYLambda);
-        CHECK_AND_FILL_VEC_XICTOXIPIPI_FULL(candidate, impactParameterXY0, impactParameter0);
-        CHECK_AND_FILL_VEC_XICTOXIPIPI_FULL(candidate, impactParameterXY1, impactParameter1);
-        CHECK_AND_FILL_VEC_XICTOXIPIPI_FULL(candidate, impactParameterXY2, impactParameter2);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI_FULL(candidate, impactParameterXi, impactParameter0);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI_FULL(candidate, impactParameterPi0, impactParameter1);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI_FULL(candidate, impactParameterPi1, impactParameter2);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI(invMassXi);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI(invMassLambda);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI(dcaXiDaughters);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI(dcaV0Daughters);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI(dcaPosToPV);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI(dcaNegToPV);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI(dcaBachelorToPV);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI(dcaXYCascToPV);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI(dcaZCascToPV);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI(nSigTpcPiFromXicPlus0);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI(nSigTpcPiFromXicPlus1);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI(nSigTpcBachelorPi);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI(nSigTpcPiFromLambda);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI(nSigTpcPrFromLambda);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI(nSigTofPiFromXicPlus0);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI(nSigTofPiFromXicPlus1);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI(nSigTofBachelorPi);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI(nSigTofPiFromLambda);
+        CHECK_AND_FILL_VEC_XICTOXIPIPI(nSigTofPrFromLambda); 
       }
     }
 
@@ -132,9 +170,28 @@ class HfMlResponseXicToXiPiPi : public HfMlResponse<TypeOutputScore>
       FILL_MAP_XICTOXIPIPI(cosPaXYXi),
       FILL_MAP_XICTOXIPIPI(cosPaLambda),
       FILL_MAP_XICTOXIPIPI(cosPaXYLambda),
-      FILL_MAP_XICTOXIPIPI(impactParameterXY0),
-      FILL_MAP_XICTOXIPIPI(impactParameterXY1),
-      FILL_MAP_XICTOXIPIPI(impactParameterXY2)};
+      FILL_MAP_XICTOXIPIPI(impactParameterXi),
+      FILL_MAP_XICTOXIPIPI(impactParameterPi0),
+      FILL_MAP_XICTOXIPIPI(impactParameterPi1),
+      FILL_MAP_XICTOXIPIPI(invMassXi),
+      FILL_MAP_XICTOXIPIPI(invMassLambda),
+      FILL_MAP_XICTOXIPIPI(dcaXiDaughters),
+      FILL_MAP_XICTOXIPIPI(dcaV0Daughters),
+      FILL_MAP_XICTOXIPIPI(dcaPosToPV),
+      FILL_MAP_XICTOXIPIPI(dcaNegToPV),
+      FILL_MAP_XICTOXIPIPI(dcaBachelorToPV),
+      FILL_MAP_XICTOXIPIPI(dcaXYCascToPV),
+      FILL_MAP_XICTOXIPIPI(dcaZCascToPV),
+      FILL_MAP_XICTOXIPIPI(nSigTpcPiFromXicPlus0),
+      FILL_MAP_XICTOXIPIPI(nSigTpcPiFromXicPlus1),
+      FILL_MAP_XICTOXIPIPI(nSigTpcBachelorPi),
+      FILL_MAP_XICTOXIPIPI(nSigTpcPiFromLambda),
+      FILL_MAP_XICTOXIPIPI(nSigTpcPrFromLambda),
+      FILL_MAP_XICTOXIPIPI(nSigTofPiFromXicPlus0),
+      FILL_MAP_XICTOXIPIPI(nSigTofPiFromXicPlus1),
+      FILL_MAP_XICTOXIPIPI(nSigTofBachelorPi),
+      FILL_MAP_XICTOXIPIPI(nSigTofPiFromLambda),
+      FILL_MAP_XICTOXIPIPI(nSigTofPrFromLambda)};
   }
 };
 

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -1630,7 +1630,7 @@ DECLARE_SOA_COLUMN(DcaPosToPV, dcaPosToPV, float);
 DECLARE_SOA_COLUMN(DcaNegToPV, dcaNegToPV, float);
 DECLARE_SOA_COLUMN(DcaBachelorToPV, dcaBachelorToPV, float);
 DECLARE_SOA_COLUMN(DcaXYCascToPV, dcaXYCascToPV, float);
-DECLARE_SOA_COLUMN(DcaZCascToPV, dcaXCascToPV, float);
+DECLARE_SOA_COLUMN(DcaZCascToPV, dcaZCascToPV, float);
 // KF specific columns
 DECLARE_SOA_COLUMN(DcaXYPi0Pi1, dcaXYPi0Pi1, float);
 DECLARE_SOA_COLUMN(DcaXYPi0Xi, dcaXYPi0Xi, float);

--- a/PWGHF/TableProducer/treeCreatorXicToXiPiPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorXicToXiPiPi.cxx
@@ -856,25 +856,25 @@ struct HfTreeCreatorXicToXiPiPi {
       if (indexRecXicPlus == -1) {
         continue;
       }
-      auto xicPlusGen = particles.rawIteratorAt(indexRecXicPlus);
-      origin = RecoDecay::getCharmHadronOrigin(particles, xicPlusGen, true);
+      auto particleXicPlusGen = particles.rawIteratorAt(indexRecXicPlus);
+      origin = RecoDecay::getCharmHadronOrigin(particles, particleXicPlusGen, true);
 
       // get MC collision
-      auto mcCollision = xicPlusGen.mcCollision_as<aod::McCollisions>();
+      auto mcCollision = particleXicPlusGen.mcCollision_as<aod::McCollisions>();
 
       // get XicPlus daughters as MC particle
-      RecoDecay::getDaughters(xicPlusGen, &arrDaughIndex, std::array{+kXiMinus, +kPiPlus, +kPiPlus}, 2);
-      auto xicPlusDaugh0 = particles.rawIteratorAt(arrDaughIndex[0]);
+      RecoDecay::getDaughters(particleXicPlusGen, &arrDaughIndex, std::array{+kXiMinus, +kPiPlus, +kPiPlus}, 2);
+      auto daugh0XicPlus = particles.rawIteratorAt(arrDaughIndex[0]);
 
       // calculate residuals and pulls
-      float pResidual = candidate.p() - xicPlusGen.p();
-      float ptResidual = candidate.pt() - xicPlusGen.pt();
+      float pResidual = candidate.p() - particleXicPlusGen.p();
+      float ptResidual = candidate.pt() - particleXicPlusGen.pt();
       pvResiduals[0] = candidate.posX() - mcCollision.posX();
       pvResiduals[1] = candidate.posY() - mcCollision.posY();
       pvResiduals[2] = candidate.posZ() - mcCollision.posZ();
-      svResiduals[0] = candidate.xSecondaryVertex() - xicPlusDaugh0.vx();
-      svResiduals[1] = candidate.ySecondaryVertex() - xicPlusDaugh0.vy();
-      svResiduals[2] = candidate.zSecondaryVertex() - xicPlusDaugh0.vz();
+      svResiduals[0] = candidate.xSecondaryVertex() - daugh0XicPlus.vx();
+      svResiduals[1] = candidate.ySecondaryVertex() - daugh0XicPlus.vy();
+      svResiduals[2] = candidate.zSecondaryVertex() - daugh0XicPlus.vz();
       try {
         pvPulls[0] = pvResiduals[0] / candidate.xPvErr();
         pvPulls[1] = pvResiduals[1] / candidate.yPvErr();

--- a/PWGHF/TableProducer/treeCreatorXicToXiPiPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorXicToXiPiPi.cxx
@@ -522,7 +522,7 @@ struct HfTreeCreatorXicToXiPiPi {
           candidate.dcaNegToPV(),
           candidate.dcaBachelorToPV(),
           candidate.dcaXYCascToPV(),
-          candidate.dcaXCascToPV(),
+          candidate.dcaZCascToPV(),
           candidate.nSigTpcPiFromXicPlus0(),
           candidate.nSigTpcPiFromXicPlus1(),
           candidate.nSigTpcBachelorPi(),

--- a/PWGHF/TableProducer/treeCreatorXicToXiPiPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorXicToXiPiPi.cxx
@@ -856,25 +856,25 @@ struct HfTreeCreatorXicToXiPiPi {
       if (indexRecXicPlus == -1) {
         continue;
       }
-      auto XicPlusGen = particles.rawIteratorAt(indexRecXicPlus);
-      origin = RecoDecay::getCharmHadronOrigin(particles, XicPlusGen, true);
+      auto xicPlusGen = particles.rawIteratorAt(indexRecXicPlus);
+      origin = RecoDecay::getCharmHadronOrigin(particles, xicPlusGen, true);
 
       // get MC collision
-      auto mcCollision = XicPlusGen.mcCollision_as<aod::McCollisions>();
+      auto mcCollision = xicPlusGen.mcCollision_as<aod::McCollisions>();
 
       // get XicPlus daughters as MC particle
-      RecoDecay::getDaughters(XicPlusGen, &arrDaughIndex, std::array{+kXiMinus, +kPiPlus, +kPiPlus}, 2);
-      auto XicPlusDaugh0 = particles.rawIteratorAt(arrDaughIndex[0]);
+      RecoDecay::getDaughters(xicPlusGen, &arrDaughIndex, std::array{+kXiMinus, +kPiPlus, +kPiPlus}, 2);
+      auto xicPlusDaugh0 = particles.rawIteratorAt(arrDaughIndex[0]);
 
       // calculate residuals and pulls
-      float pResidual = candidate.p() - XicPlusGen.p();
-      float ptResidual = candidate.pt() - XicPlusGen.pt();
+      float pResidual = candidate.p() - xicPlusGen.p();
+      float ptResidual = candidate.pt() - xicPlusGen.pt();
       pvResiduals[0] = candidate.posX() - mcCollision.posX();
       pvResiduals[1] = candidate.posY() - mcCollision.posY();
       pvResiduals[2] = candidate.posZ() - mcCollision.posZ();
-      svResiduals[0] = candidate.xSecondaryVertex() - XicPlusDaugh0.vx();
-      svResiduals[1] = candidate.ySecondaryVertex() - XicPlusDaugh0.vy();
-      svResiduals[2] = candidate.zSecondaryVertex() - XicPlusDaugh0.vz();
+      svResiduals[0] = candidate.xSecondaryVertex() - xicPlusDaugh0.vx();
+      svResiduals[1] = candidate.ySecondaryVertex() - xicPlusDaugh0.vy();
+      svResiduals[2] = candidate.zSecondaryVertex() - xicPlusDaugh0.vz();
       try {
         pvPulls[0] = pvResiduals[0] / candidate.xPvErr();
         pvPulls[1] = pvResiduals[1] / candidate.yPvErr();


### PR DESCRIPTION
In this PR,
1) Several variables have been added into MlResponseXicToXiPiPi
2) Typo in the name of variable has been fixed in CandidateReconstructionTables and treeCreatorXicToXiPiPi