### PR TITLE
[PWGCF] FemtoUniverse - producer and D0 task update (ML)

### DIFF
--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -80,7 +80,6 @@ using FemtoFullTracks =
             aod::pidTPCMu, aod::pidTPCPi, aod::pidTPCKa, aod::pidTPCPr,
             aod::pidTPCDe, aod::pidTOFEl, aod::pidTOFMu, aod::pidTOFPi,
             aod::pidTOFKa, aod::pidTOFPr, aod::pidTOFDe>;
-using SelectedCandidatesDataMl = soa::Filtered<soa::Join<aod::HfCand2Prong, aod::HfSelD0, aod::HfMlD0>>;
 
 // using FilteredFullV0s = soa::Filtered<aod::V0Datas>; /// predefined Join
 // table for o2::aod::V0s = soa::Join<o2::aod::TransientV0s, o2::aod::StoredV0s>
@@ -1940,7 +1939,7 @@ struct FemtoUniverseProducerTask {
   void processTrackD0DataML(aod::FemtoFullCollision const& col,
                             aod::BCsWithTimestamps const&,
                             soa::Filtered<aod::FemtoFullTracks> const& tracks,
-                            aod::SelectedCandidatesDataMl const& candidates)
+                            soa::Join<aod::HfCand2Prong, aod::HfSelD0, aod::HfMlD0> const& candidates)
   {
     // get magnetic field for run
     getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());

--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -80,6 +80,8 @@ using FemtoFullTracks =
             aod::pidTPCMu, aod::pidTPCPi, aod::pidTPCKa, aod::pidTPCPr,
             aod::pidTPCDe, aod::pidTOFEl, aod::pidTOFMu, aod::pidTOFPi,
             aod::pidTOFKa, aod::pidTOFPr, aod::pidTOFDe>;
+using SelectedCandidatesDataMl = 
+  soa::Filtered<soa::Join<aod::HfCand2Prong, aod::HfSelD0, aod::HfMlD0>>;
 
 // using FilteredFullV0s = soa::Filtered<aod::V0Datas>; /// predefined Join
 // table for o2::aod::V0s = soa::Join<o2::aod::TransientV0s, o2::aod::StoredV0s>
@@ -299,6 +301,9 @@ struct FemtoUniverseProducerTask {
   struct : o2::framework::ConfigurableGroup {
     Configurable<float> confD0D0barCandMaxY{"confD0D0barCandMaxY", -1., "max. cand. rapidity"};
     Configurable<float> confD0D0barCandEtaCut{"confD0D0barCandEtaCut", 0.8, "max. cand. pseudorapidity"};
+    Configurable<bool> storeD0D0barDoubleMassHypo{"storeD0D0barDoubleMassHypo", false, "Store D0/D0bar cand. which pass selection criteria for both, D0 and D0bar"};
+    Configurable<bool> applyMLSelD0D0bar{"applyMLSelD0D0bar", false, "Use ML D0/D0bar selection"};
+    Configurable<std::vector<int>> classMlD0D0bar{"classMl", {0, 1, 2}, "Indexes of ML scores to be stored. Three indexes max."};
   } ConfD0Selection;
 
   HfHelper hfHelper;
@@ -459,10 +464,10 @@ struct FemtoUniverseProducerTask {
 
   void init(InitContext&)
   {
-    if ((doprocessFullData || doprocessTrackPhiData || doprocessTrackData || doprocessTrackV0 || doprocessTrackCascadeData || doprocessTrackD0mesonData || doprocessTrackCentRun2Data || doprocessTrackV0CentRun2Data || doprocessTrackCentRun3Data || doprocessV0CentRun3Data || doprocessCascadeCentRun3Data || doprocessTrackDataCentPP) == false && (doprocessFullMC || doprocessTrackMC || doprocessTrackMCTruth || doprocessTrackMCGen || doprocessTruthAndFullMC || doprocessFullMCCent || doprocessTrackCentRun3DataMC) == false) {
+    if ((doprocessFullData || doprocessTrackPhiData || doprocessTrackData || doprocessTrackV0 || doprocessTrackCascadeData || doprocessTrackD0mesonData || doprocessTrackD0DataML || doprocessTrackCentRun2Data || doprocessTrackV0CentRun2Data || doprocessTrackCentRun3Data || doprocessV0CentRun3Data || doprocessCascadeCentRun3Data || doprocessTrackDataCentPP) == false && (doprocessFullMC || doprocessTrackMC || doprocessTrackMCTruth || doprocessTrackMCGen || doprocessTruthAndFullMC || doprocessFullMCCent || doprocessTrackCentRun3DataMC) == false) {
       LOGF(fatal, "Neither processFullData nor processFullMC enabled. Please choose one.");
     }
-    if ((doprocessFullData || doprocessTrackPhiData || doprocessTrackData || doprocessTrackV0 || doprocessTrackCascadeData || doprocessTrackD0mesonData || doprocessTrackCentRun2Data || doprocessTrackV0CentRun2Data || doprocessTrackCentRun3Data || doprocessV0CentRun3Data || doprocessCascadeCentRun3Data || doprocessTrackDataCentPP) == true && (doprocessFullMC || doprocessTrackMC || doprocessTrackMCTruth || doprocessTrackMCGen || doprocessTruthAndFullMC || doprocessFullMCCent || doprocessTrackCentRun3DataMC) == true) {
+    if ((doprocessFullData || doprocessTrackPhiData || doprocessTrackData || doprocessTrackV0 || doprocessTrackCascadeData || doprocessTrackD0mesonData || doprocessTrackD0DataML || doprocessTrackCentRun2Data || doprocessTrackV0CentRun2Data || doprocessTrackCentRun3Data || doprocessV0CentRun3Data || doprocessCascadeCentRun3Data || doprocessTrackDataCentPP) == true && (doprocessFullMC || doprocessTrackMC || doprocessTrackMCTruth || doprocessTrackMCGen || doprocessTruthAndFullMC || doprocessFullMCCent || doprocessTrackCentRun3DataMC) == true) {
       LOGF(fatal,
            "Cannot enable process Data and process MC at the same time. "
            "Please choose one.");
@@ -1264,8 +1269,13 @@ struct FemtoUniverseProducerTask {
       } else if (hfCand.isSelD0() == 1 && hfCand.isSelD0bar() == 1) {
         invMassD0 = hfHelper.invMassD0ToPiK(hfCand);
         invMassD0bar = hfHelper.invMassD0barToKPi(hfCand);
-        isD0D0bar = true;
-        daughFlag = 0;
+        if (ConfD0Selection.storeD0D0barDoubleMassHypo) {
+          isD0D0bar = true;
+          daughFlag = 0;
+        } else {
+          isD0D0bar = false;
+          daughFlag = 0;
+        }
       } else {
         invMassD0 = 0.0;
         invMassD0bar = 0.0;
@@ -1319,7 +1329,141 @@ struct FemtoUniverseProducerTask {
                     aod::femtouniverseparticle::ParticleType::kD0,
                     -999, // cut, CutContainerType
                     -999, // PID, CutContainerType
+                    -999.,
+                    indexChildID,
+                    invMassD0,     // D0 mass (mLambda)
+                    invMassD0bar); // D0bar mass (mAntiLambda)
+
+        if (confIsDebug) {
+          fillDebugParticle<false, true, false>(postrack); // QA for positive daughter
+          fillDebugParticle<false, true, false>(negtrack); // QA for negative daughter
+          fillDebugParticle<false, true, false>(hfCand);   // QA for D0/D0bar
+        }
+        if constexpr (isMC) {
+          fillMCParticle(hfCand, o2::aod::femtouniverseparticle::ParticleType::kD0);
+        }
+      }
+    }
+  }
+
+  template <bool isMC, typename HfCandidate, typename TrackType, typename CollisionType>
+  void fillD0D0barUsingML(CollisionType const&, TrackType const&, HfCandidate const& hfCands)
+  {
+    std::vector<int> childIDs = {0, 0}; // these IDs are necessary to keep track of the children
+    std::vector<int> tmpIDtrack;        // this vector keeps track of the matching of the primary track table row <-> aod::track table global index
+    double invMassD0 = 0.0;
+    double invMassD0bar = 0.0;
+    bool isD0D0bar = false;
+    std::vector<float> outputMlD0D0bar = {-1., -1., -1.}; // this vector keeps the probabilities from the ML model for D0/D0bar
+    uint8_t daughFlag = 0; // flag = 0 (daugh of D0 or D0bar), 1 (daug of D0), -1 (daugh of D0bar)
+
+    for (const auto& hfCand : hfCands) {
+
+      if (!(hfCand.hfflag() & 1 << aod::hf_cand_2prong::DecayType::D0ToPiK)) {
+        continue;
+      }
+
+      if (ConfD0Selection.confD0D0barCandMaxY >= 0. && std::abs(hfHelper.yD0(hfCand)) > ConfD0Selection.confD0D0barCandMaxY) {
+        continue;
+      }
+
+      if (std::abs(hfCand.eta()) > ConfD0Selection.confD0D0barCandEtaCut) {
+        continue;
+      }
+
+      // int postrackID = hfCand.prong0().globalIndex();
+      int postrackID = hfCand.prong0Id(); // Index to first prong
+      int rowInPrimaryTrackTablePos = -1;
+      rowInPrimaryTrackTablePos = getRowDaughters(postrackID, tmpIDtrack);
+      childIDs[0] = rowInPrimaryTrackTablePos;
+      childIDs[1] = 0;
+      auto postrack = hfCand.template prong0_as<TrackType>();
+      auto negtrack = hfCand.template prong1_as<TrackType>();
+
+      if (hfCand.isSelD0() == 1 && hfCand.isSelD0bar() == 0) {
+        invMassD0 = hfHelper.invMassD0ToPiK(hfCand);
+        invMassD0bar = -hfHelper.invMassD0barToKPi(hfCand);
+        if(ConfD0Selection.applyMLSelD0D0bar) {
+          for (unsigned int iClass = 0; iClass < ConfD0Selection.classMlD0D0bar->size(); iClass++) {
+            outputMlD0D0bar[iClass] = hfCand.mlProbD0()[ConfD0Selection.classMlD0D0bar->at(iClass)];
+          }
+        }
+        isD0D0bar = true;
+        daughFlag = 1;
+      } else if (hfCand.isSelD0() == 0 && hfCand.isSelD0bar() == 1) {
+        invMassD0 = -hfHelper.invMassD0ToPiK(hfCand);
+        invMassD0bar = hfHelper.invMassD0barToKPi(hfCand);
+        if(ConfD0Selection.applyMLSelD0D0bar) {
+          for (unsigned int iClass = 0; iClass < ConfD0Selection.classMlD0D0bar->size(); iClass++) {
+            outputMlD0D0bar[iClass] = hfCand.mlProbD0bar()[ConfD0Selection.classMlD0D0bar->at(iClass)];
+          }
+        }
+        isD0D0bar = true;
+        daughFlag = -1;
+      } else if (hfCand.isSelD0() == 1 && hfCand.isSelD0bar() == 1) {
+        invMassD0 = hfHelper.invMassD0ToPiK(hfCand);
+        invMassD0bar = hfHelper.invMassD0barToKPi(hfCand);
+        if (ConfD0Selection.storeD0D0barDoubleMassHypo) {
+          isD0D0bar = true;
+          daughFlag = 0;
+        } else {
+          isD0D0bar = false;
+          daughFlag = 0;
+        }
+      } else {
+        invMassD0 = 0.0;
+        invMassD0bar = 0.0;
+        isD0D0bar = false;
+      }
+
+      if (isD0D0bar) {
+        outputParts(outputCollision.lastIndex(),
+                    hfCand.ptProng0(),
+                    RecoDecay::eta(std::array{hfCand.pxProng0(), hfCand.pyProng0(), hfCand.pzProng0()}), // eta
+                    RecoDecay::phi(hfCand.pxProng0(), hfCand.pyProng0()),                                // phi
+                    aod::femtouniverseparticle::ParticleType::kD0Child,
+                    -999, // cutContainerV0.at(femto_universe_v0_selection::V0ContainerPosition::kPosCuts),
+                    -999, // cutContainerV0.at(femto_universe_v0_selection::V0ContainerPosition::kPosPID),
                     -999,
+                    childIDs,
+                    postrack.sign(), // D0 mass -> positive daughter of D0/D0bar
+                    daughFlag);      // D0bar mass -> sign that the daugh is from D0 or D0 decay
+        const int rowOfPosTrack = outputParts.lastIndex();
+        if constexpr (isMC) {
+          fillMCParticle(postrack, o2::aod::femtouniverseparticle::ParticleType::kD0Child);
+        }
+        // int negtrackID = hfCand.prong1().globalIndex();
+        int negtrackID = hfCand.prong1Id();
+        int rowInPrimaryTrackTableNeg = -1;
+        rowInPrimaryTrackTableNeg = getRowDaughters(negtrackID, tmpIDtrack);
+        childIDs[0] = 0;
+        childIDs[1] = rowInPrimaryTrackTableNeg;
+
+        outputParts(outputCollision.lastIndex(),
+                    hfCand.ptProng1(),
+                    RecoDecay::eta(std::array{hfCand.pxProng1(), hfCand.pyProng1(), hfCand.pzProng1()}), // eta
+                    RecoDecay::phi(hfCand.pxProng1(), hfCand.pyProng1()),                                // phi
+                    aod::femtouniverseparticle::ParticleType::kD0Child,
+                    -999, // cutContainerV0.at(femto_universe_v0_selection::V0ContainerPosition::kNegCuts),
+                    -999, // cutContainerV0.at(femto_universe_v0_selection::V0ContainerPosition::kNegPID),
+                    -999,
+                    childIDs,
+                    negtrack.sign(), // negative daughter of D0/D0bar
+                    daughFlag);      // sign that the daugh is from D0 or D0 decay
+        const int rowOfNegTrack = outputParts.lastIndex();
+        if constexpr (isMC) {
+          fillMCParticle(negtrack, o2::aod::femtouniverseparticle::ParticleType::kD0Child);
+        }
+        std::vector<int> indexChildID = {rowOfPosTrack, rowOfNegTrack};
+
+        outputParts(outputCollision.lastIndex(),
+                    hfCand.pt(),
+                    hfCand.eta(),
+                    hfCand.phi(),
+                    aod::femtouniverseparticle::ParticleType::kD0,
+                    -999, // cut, CutContainerType
+                    -999, // PID, CutContainerType
+                    outputMlD0D0bar[0], // saving only the probaility for store class 1 - background
                     indexChildID,
                     invMassD0,     // D0 mass (mLambda)
                     invMassD0bar); // D0bar mass (mAntiLambda)
@@ -1793,6 +1937,23 @@ struct FemtoUniverseProducerTask {
   }
   PROCESS_SWITCH(FemtoUniverseProducerTask, processTrackD0mesonData,
                  "Provide experimental data for track D0 meson", false);
+
+  void processTrackD0DataML(aod::FemtoFullCollision const& col,
+                               aod::BCsWithTimestamps const&,
+                               soa::Filtered<aod::FemtoFullTracks> const& tracks,
+                               aod::SelectedCandidatesDataMl const& candidates)
+  {
+    // get magnetic field for run
+    getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());
+    // fill the tables
+    const auto colcheck = fillCollisions<false>(col, tracks);
+    if (colcheck) {
+      fillTracks<false>(tracks);
+      fillD0D0barUsingML<false>(col, tracks, candidates);
+    }
+  }
+  PROCESS_SWITCH(FemtoUniverseProducerTask, processTrackD0DataML,
+                 "Provide experimental data for track D0 meson using ML selection for D0s", false);
 
   void processTrackMCTruth(aod::McCollision const&,
                            soa::SmallGroups<soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::McCollisionLabels>> const& collisions,

--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -80,8 +80,7 @@ using FemtoFullTracks =
             aod::pidTPCMu, aod::pidTPCPi, aod::pidTPCKa, aod::pidTPCPr,
             aod::pidTPCDe, aod::pidTOFEl, aod::pidTOFMu, aod::pidTOFPi,
             aod::pidTOFKa, aod::pidTOFPr, aod::pidTOFDe>;
-using SelectedCandidatesDataMl = 
-  soa::Filtered<soa::Join<aod::HfCand2Prong, aod::HfSelD0, aod::HfMlD0>>;
+using SelectedCandidatesDataMl = soa::Filtered<soa::Join<aod::HfCand2Prong, aod::HfSelD0, aod::HfMlD0>>;
 
 // using FilteredFullV0s = soa::Filtered<aod::V0Datas>; /// predefined Join
 // table for o2::aod::V0s = soa::Join<o2::aod::TransientV0s, o2::aod::StoredV0s>
@@ -303,7 +302,7 @@ struct FemtoUniverseProducerTask {
     Configurable<float> confD0D0barCandEtaCut{"confD0D0barCandEtaCut", 0.8, "max. cand. pseudorapidity"};
     Configurable<bool> storeD0D0barDoubleMassHypo{"storeD0D0barDoubleMassHypo", false, "Store D0/D0bar cand. which pass selection criteria for both, D0 and D0bar"};
     Configurable<bool> applyMLSelD0D0bar{"applyMLSelD0D0bar", false, "Use ML D0/D0bar selection"};
-    Configurable<std::vector<int>> classMlD0D0bar{"classMl", {0, 1, 2}, "Indexes of ML scores to be stored. Three indexes max."};
+    Configurable<std::vector<int>> classMlD0D0bar{"classMlD0D0bar", {0, 1, 2}, "Indexes of ML scores to be stored. Three indexes max."};
   } ConfD0Selection;
 
   HfHelper hfHelper;
@@ -1355,7 +1354,7 @@ struct FemtoUniverseProducerTask {
     double invMassD0bar = 0.0;
     bool isD0D0bar = false;
     std::vector<float> outputMlD0D0bar = {-1., -1., -1.}; // this vector keeps the probabilities from the ML model for D0/D0bar
-    uint8_t daughFlag = 0; // flag = 0 (daugh of D0 or D0bar), 1 (daug of D0), -1 (daugh of D0bar)
+    uint8_t daughFlag = 0;                                // flag = 0 (daugh of D0 or D0bar), 1 (daug of D0), -1 (daugh of D0bar)
 
     for (const auto& hfCand : hfCands) {
 
@@ -1383,7 +1382,7 @@ struct FemtoUniverseProducerTask {
       if (hfCand.isSelD0() == 1 && hfCand.isSelD0bar() == 0) {
         invMassD0 = hfHelper.invMassD0ToPiK(hfCand);
         invMassD0bar = -hfHelper.invMassD0barToKPi(hfCand);
-        if(ConfD0Selection.applyMLSelD0D0bar) {
+        if (ConfD0Selection.applyMLSelD0D0bar) {
           for (unsigned int iClass = 0; iClass < ConfD0Selection.classMlD0D0bar->size(); iClass++) {
             outputMlD0D0bar[iClass] = hfCand.mlProbD0()[ConfD0Selection.classMlD0D0bar->at(iClass)];
           }
@@ -1393,7 +1392,7 @@ struct FemtoUniverseProducerTask {
       } else if (hfCand.isSelD0() == 0 && hfCand.isSelD0bar() == 1) {
         invMassD0 = -hfHelper.invMassD0ToPiK(hfCand);
         invMassD0bar = hfHelper.invMassD0barToKPi(hfCand);
-        if(ConfD0Selection.applyMLSelD0D0bar) {
+        if (ConfD0Selection.applyMLSelD0D0bar) {
           for (unsigned int iClass = 0; iClass < ConfD0Selection.classMlD0D0bar->size(); iClass++) {
             outputMlD0D0bar[iClass] = hfCand.mlProbD0bar()[ConfD0Selection.classMlD0D0bar->at(iClass)];
           }
@@ -1461,8 +1460,8 @@ struct FemtoUniverseProducerTask {
                     hfCand.eta(),
                     hfCand.phi(),
                     aod::femtouniverseparticle::ParticleType::kD0,
-                    -999, // cut, CutContainerType
-                    -999, // PID, CutContainerType
+                    -999,               // cut, CutContainerType
+                    -999,               // PID, CutContainerType
                     outputMlD0D0bar[0], // saving only the probaility for store class 1 - background
                     indexChildID,
                     invMassD0,     // D0 mass (mLambda)
@@ -1939,9 +1938,9 @@ struct FemtoUniverseProducerTask {
                  "Provide experimental data for track D0 meson", false);
 
   void processTrackD0DataML(aod::FemtoFullCollision const& col,
-                               aod::BCsWithTimestamps const&,
-                               soa::Filtered<aod::FemtoFullTracks> const& tracks,
-                               aod::SelectedCandidatesDataMl const& candidates)
+                            aod::BCsWithTimestamps const&,
+                            soa::Filtered<aod::FemtoFullTracks> const& tracks,
+                            aod::SelectedCandidatesDataMl const& candidates)
   {
     // get magnetic field for run
     getMagneticFieldTesla(col.bc_as<aod::BCsWithTimestamps>());

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
@@ -120,6 +120,7 @@ struct FemtoUniversePairTaskTrackD0 {
     Configurable<float> confMaxPtD0D0bar{"confMaxPtD0D0bar", 3.0, "D0/D0bar sel. - max. pT"};
     Configurable<float> confMinInvMassD0D0bar{"confMinInvMassD0D0bar", 1.65, "D0/D0bar sel. - min. invMass"};
     Configurable<float> confMaxInvMassD0D0bar{"confMaxInvMassD0D0bar", 2.05, "D0/D0bar sel. - max. invMass"};
+    Configurable<float> confMaxProbMlClass1Bg{"confMaxProbMlClass1Bg", 0.4, "ML: max prob. that D0/D0bar cand. is from the backgound"};
   } ConfDmesons;
 
   struct : o2::framework::ConfigurableGroup {
@@ -132,7 +133,7 @@ struct FemtoUniversePairTaskTrackD0 {
   } ConfD0D0barSideBand;
 
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_d0_to_pi_k::vecBinsPt}, "pT bin limits"};
-  Configurable<uint8_t> confChooseD0trackCorr{"confChooseD0trackCorr", 2, "If 0 - only D0s, 1 - only D0bars, 2 - D0/D0bar (one mass hypo.), 3 - all D0/D0bar cand."};
+  Configurable<uint8_t> confChooseD0trackCorr{"confChooseD0trackCorr", 2, "If 0 - only D0s, 1 - only D0bars, 2 - D0/D0bar (one mass hypo.)"};
 
   /// Partitions for particle 1
   Partition<FemtoFullParticles> partsTrack = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack)) && (aod::femtouniverseparticle::sign == int8_t(ConfTrack.confTrackSign)) && (aod::femtouniverseparticle::pt > ConfTrack.confTrackLowPtCut) && (aod::femtouniverseparticle::pt < ConfTrack.confTrackHighPtCut);
@@ -140,13 +141,13 @@ struct FemtoUniversePairTaskTrackD0 {
 
   /// Partitions for particle 2
   /// Partition with all D0/D0bar mesons (which pass double mass hypothesis)
-  Partition<FemtoFullParticles> partsAllDmesons = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && (aod::femtouniverseparticle::mLambda > 0.0f) && (aod::femtouniverseparticle::mAntiLambda > 0.0f);
+  // Partition<FemtoFullParticles> partsAllDmesons = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && (aod::femtouniverseparticle::mLambda > 0.0f) && (aod::femtouniverseparticle::mAntiLambda > 0.0f);
   /// Partition with D0/D0bar candidates, which pass only one mass hypothesis
-  Partition<FemtoFullParticles> partsOnlyD0D0bar = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && (aod::femtouniverseparticle::mLambda < 0.0f || aod::femtouniverseparticle::mAntiLambda < 0.0f);
+  Partition<FemtoFullParticles> partsOnlyD0D0bar = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && (aod::femtouniverseparticle::mLambda < 0.0f || aod::femtouniverseparticle::mAntiLambda < 0.0f) && (aod::femtouniverseparticle::tempFitVar < ConfDmesons.confMaxProbMlClass1Bg);
   /// Partition with D0 mesons only (one mass hypothesis)
-  Partition<FemtoFullParticles> partsD0s = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && (aod::femtouniverseparticle::mLambda > ConfDmesons.confMinInvMassD0D0bar) && (aod::femtouniverseparticle::mLambda < ConfDmesons.confMaxInvMassD0D0bar) && (aod::femtouniverseparticle::mAntiLambda < 0.0f) && (aod::femtouniverseparticle::pt > ConfDmesons.confMinPtD0D0bar) && (aod::femtouniverseparticle::pt < ConfDmesons.confMaxPtD0D0bar);
+  Partition<FemtoFullParticles> partsD0s = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && (aod::femtouniverseparticle::mLambda > ConfDmesons.confMinInvMassD0D0bar) && (aod::femtouniverseparticle::mLambda < ConfDmesons.confMaxInvMassD0D0bar) && (aod::femtouniverseparticle::mAntiLambda < 0.0f) && (aod::femtouniverseparticle::pt > ConfDmesons.confMinPtD0D0bar) && (aod::femtouniverseparticle::pt < ConfDmesons.confMaxPtD0D0bar) && (aod::femtouniverseparticle::tempFitVar < ConfDmesons.confMaxProbMlClass1Bg);
   /// Partition with D0bar mesons only (one mass hypothesis)
-  Partition<FemtoFullParticles> partsD0bars = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && (aod::femtouniverseparticle::mLambda < 0.0f) && (aod::femtouniverseparticle::mAntiLambda > ConfDmesons.confMinInvMassD0D0bar) && (aod::femtouniverseparticle::mAntiLambda < ConfDmesons.confMaxInvMassD0D0bar) && (aod::femtouniverseparticle::pt > ConfDmesons.confMinPtD0D0bar) && (aod::femtouniverseparticle::pt < ConfDmesons.confMaxPtD0D0bar);
+  Partition<FemtoFullParticles> partsD0bars = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && (aod::femtouniverseparticle::mLambda < 0.0f) && (aod::femtouniverseparticle::mAntiLambda > ConfDmesons.confMinInvMassD0D0bar) && (aod::femtouniverseparticle::mAntiLambda < ConfDmesons.confMaxInvMassD0D0bar) && (aod::femtouniverseparticle::pt > ConfDmesons.confMinPtD0D0bar) && (aod::femtouniverseparticle::pt < ConfDmesons.confMaxPtD0D0bar) && (aod::femtouniverseparticle::tempFitVar < ConfDmesons.confMaxProbMlClass1Bg);
   /// Partition for D0/D0bar mesons from MC
   Partition<soa::Join<aod::FDParticles, aod::FDMCLabels>> partsD0D0barMC = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0));
 
@@ -194,6 +195,8 @@ struct FemtoUniversePairTaskTrackD0 {
   Configurable<float> confCPRdeltaEtaCutMax{"confCPRdeltaEtaCutMax", 0.0, "Delta Eta max cut for Close Pair Rejection"};
   Configurable<float> confCPRdeltaEtaCutMin{"confCPRdeltaEtaCutMin", 0.0, "Delta Eta min cut for Close Pair Rejection"};
   Configurable<float> confCPRChosenRadii{"confCPRChosenRadii", 0.80, "Delta Eta cut for Close Pair Rejection"};
+
+  Configurable<bool> applyMLOpt{"applyMLOpt", false, "Enable for ML selection optimization"};
 
   FemtoUniverseFemtoContainer<femto_universe_femto_container::EventType::same, femto_universe_femto_container::Observable::kstar> sameEventFemtoCont;
   FemtoUniverseFemtoContainer<femto_universe_femto_container::EventType::mixed, femto_universe_femto_container::Observable::kstar> mixedEventFemtoCont;
@@ -412,6 +415,24 @@ struct FemtoUniversePairTaskTrackD0 {
     registry.add("hDeltaPhiBgBg", "BxB correlation;#Delta#varphi (rad);counts", {HistType::kTH1F, {{10, 0.0, o2::constants::math::PI}}});
     registry.add("hPtCand1VsPtCand2", "2-prong candidates;#it{p}_{T} (GeV/#it{c});#it{p}_{T} (GeV/#it{c})", {HistType::kTH2F, {{vbins, "#it{p}_{T} (GeV/#it{c})"}, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
     registry.add("hDeltaEtaDeltaPhi", "2-prong candidates;#Delta #eta;#Delta #varphi (rad)", {HistType::kTH2F, {{29, -2., 2.}, {29, 0.0, o2::constants::math::PI}}});
+    if (applyMLOpt) {
+      registry.add("D0D0bar_MLSel/hMassVsPt001", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt0015", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt002", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt0025", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt003", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt004", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt005", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt006", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt007", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt008", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt009", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt01", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt015", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt02", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt025", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt03", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    }
   }
 
   template <typename CollisionType>
@@ -420,6 +441,54 @@ struct FemtoUniversePairTaskTrackD0 {
     mixQaRegistry.fill(HIST("MixingQA/hSECollisionBins"), colBinning.getBin({col.posZ(), col.multNtr()}));
     eventHisto.fillQA(col);
   }
+
+  void processD0MLOpt(o2::aod::FdCollision const& col, FemtoFullParticles const&)
+  {
+    auto groupD0D0barCands = partsOnlyD0D0bar->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
+
+    // loop over selected D0/D0bar candidates
+    for (auto const& charmCand : groupD0D0barCands) {
+      // D0 candidates
+      if (charmCand.mLambda() > 0.0f && charmCand.mAntiLambda() < 0.0f) {
+        if (charmCand.tempFitVar() < 0.01) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt001"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.015) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt0015"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.02) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt002"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.025) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt0025"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.03) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt003"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.04) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt004"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.05) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt005"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.06) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt006"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.07) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt007"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.08) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt008"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.09) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt009"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.1) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt01"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.15) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt015"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.2) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt02"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.25) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt025"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.3) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt03"), charmCand.mLambda(), charmCand.pt());
+      }
+      // DObar candidates
+      if (charmCand.mLambda() < 0.0f && charmCand.mAntiLambda() > 0.0f) {
+        if (charmCand.tempFitVar() < 0.01) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt001"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.015) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt0015"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.02) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt002"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.025) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt0025"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.03) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt003"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.04) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt004"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.05) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt005"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.06) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt006"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.07) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt007"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.08) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt008"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.09) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt009"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.1) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt01"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.15) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt015"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.2) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt02"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.25) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt025"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.3) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt03"), charmCand.mAntiLambda(), charmCand.pt());
+      }
+    }
+  }
+  PROCESS_SWITCH(FemtoUniversePairTaskTrackD0, processD0MLOpt, "Enable filling QA plots for ML D0/D0bar selection optimization", false);
 
   void processQAD0D0barSel(o2::aod::FdCollision const& col, FemtoFullParticles const&)
   {
@@ -444,16 +513,7 @@ struct FemtoUniversePairTaskTrackD0 {
   void processD0mesons(o2::aod::FdCollision const& col, FemtoFullParticles const&)
   {
     auto groupPartsOnlyD0D0bar = partsOnlyD0D0bar->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
-    auto groupPartsAllDmesons = partsAllDmesons->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
     auto groupPartsD0D0barChildren = partsDmesonsChildren->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
-
-    // loop over all D mesons
-    for (auto const& dmeson : groupPartsAllDmesons) {
-
-      registry.fill(HIST("hPtDmesonCand"), dmeson.pt());
-      registry.fill(HIST("hPhiDmesonCand"), dmeson.phi());
-      registry.fill(HIST("hEtaDmesonCand"), dmeson.eta());
-    }
 
     // loop over D0/D0bar mesons (ONLY)
     for (auto const& d0d0bar : groupPartsOnlyD0D0bar) {
@@ -642,7 +702,6 @@ struct FemtoUniversePairTaskTrackD0 {
     fillCollision(col);
 
     auto thegroupPartsTrack = partsTrack->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
-    auto thegroupPartsAllD0D0bar = partsAllDmesons->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
     auto thegroupPartsOnlyD0D0bar = partsOnlyD0D0bar->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
     auto theGroupPartsD0s = partsD0s->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
     auto theGroupPartsD0bars = partsD0bars->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
@@ -656,9 +715,6 @@ struct FemtoUniversePairTaskTrackD0 {
         break;
       case 2:
         doSameEvent<false>(thegroupPartsTrack, thegroupPartsOnlyD0D0bar, parts, col.magField(), col.multNtr());
-        break;
-      case 3:
-        doSameEvent<false>(thegroupPartsTrack, thegroupPartsAllD0D0bar, parts, col.magField(), col.multNtr());
         break;
       default:
         break;
@@ -727,7 +783,6 @@ struct FemtoUniversePairTaskTrackD0 {
       mixQaRegistry.fill(HIST("MixingQA/hMECollisionBins"), colBinning.getBin({collision1.posZ(), multiplicityCol}));
 
       auto groupPartsTrack = partsTrack->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision2.globalIndex(), cache);
-      auto groupPartsAllD0D0bar = partsAllDmesons->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision1.globalIndex(), cache);
       auto groupPartsOnlyD0D0bar = partsOnlyD0D0bar->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision1.globalIndex(), cache);
       auto theGroupPartsD0s = partsD0s->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision1.globalIndex(), cache);
       auto theGroupPartsD0bars = partsD0bars->sliceByCached(aod::femtouniverseparticle::fdCollisionId, collision1.globalIndex(), cache);
@@ -750,9 +805,6 @@ struct FemtoUniversePairTaskTrackD0 {
           break;
         case 2:
           doMixedEvent<false>(groupPartsTrack, groupPartsOnlyD0D0bar, parts, magFieldTesla1, multiplicityCol);
-          break;
-        case 3:
-          doMixedEvent<false>(groupPartsTrack, groupPartsAllD0D0bar, parts, magFieldTesla1, multiplicityCol);
           break;
         default:
           break;

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
@@ -450,41 +450,73 @@ struct FemtoUniversePairTaskTrackD0 {
     for (auto const& charmCand : groupD0D0barCands) {
       // D0 candidates
       if (charmCand.mLambda() > 0.0f && charmCand.mAntiLambda() < 0.0f) {
-        if (charmCand.tempFitVar() < 0.01) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt001"), charmCand.mLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.015) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt0015"), charmCand.mLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.02) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt002"), charmCand.mLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.025) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt0025"), charmCand.mLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.03) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt003"), charmCand.mLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.04) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt004"), charmCand.mLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.05) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt005"), charmCand.mLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.06) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt006"), charmCand.mLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.07) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt007"), charmCand.mLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.08) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt008"), charmCand.mLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.09) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt009"), charmCand.mLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.1) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt01"), charmCand.mLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.15) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt015"), charmCand.mLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.2) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt02"), charmCand.mLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.25) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt025"), charmCand.mLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.3) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt03"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.01)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt001"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.015)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt0015"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.02)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt002"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.025)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt0025"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.03)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt003"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.04)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt004"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.05)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt005"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.06)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt006"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.07)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt007"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.08)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt008"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.09)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt009"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.1)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt01"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.15)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt015"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.2)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt02"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.25)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt025"), charmCand.mLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.3)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt03"), charmCand.mLambda(), charmCand.pt());
       }
       // DObar candidates
       if (charmCand.mLambda() < 0.0f && charmCand.mAntiLambda() > 0.0f) {
-        if (charmCand.tempFitVar() < 0.01) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt001"), charmCand.mAntiLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.015) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt0015"), charmCand.mAntiLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.02) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt002"), charmCand.mAntiLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.025) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt0025"), charmCand.mAntiLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.03) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt003"), charmCand.mAntiLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.04) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt004"), charmCand.mAntiLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.05) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt005"), charmCand.mAntiLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.06) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt006"), charmCand.mAntiLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.07) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt007"), charmCand.mAntiLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.08) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt008"), charmCand.mAntiLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.09) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt009"), charmCand.mAntiLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.1) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt01"), charmCand.mAntiLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.15) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt015"), charmCand.mAntiLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.2) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt02"), charmCand.mAntiLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.25) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt025"), charmCand.mAntiLambda(), charmCand.pt());
-        if (charmCand.tempFitVar() < 0.3) registry.fill(HIST("D0D0bar_MLSel/hMassVsPt03"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.01)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt001"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.015)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt0015"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.02)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt002"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.025)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt0025"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.03)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt003"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.04)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt004"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.05)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt005"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.06)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt006"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.07)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt007"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.08)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt008"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.09)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt009"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.1)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt01"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.15)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt015"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.2)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt02"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.25)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt025"), charmCand.mAntiLambda(), charmCand.pt());
+        if (charmCand.tempFitVar() < 0.3)
+          registry.fill(HIST("D0D0bar_MLSel/hMassVsPt03"), charmCand.mAntiLambda(), charmCand.pt());
       }
     }
   }


### PR DESCRIPTION
Changes:
- saving D0/D0bar candidates with double mass hypothesis -> optional, configurable added for it
- removing the correlation with D0/D0bar cand. with double mass hypothesis as well as filling the corresponding histograms
- new process function in the producer processTrackD0DataML and new dedicated function fillD0D0barUsingML, implemented to run D0 analysis with ML selection (It will be developed)
- new process function in the task for optimization of ML selection criteria