### PR TITLE
[PWGLF] Hot fix absolute value check in K892PM flow task

### DIFF
--- a/PWGLF/Tasks/Resonances/chk892Flow.cxx
+++ b/PWGLF/Tasks/Resonances/chk892Flow.cxx
@@ -548,8 +548,8 @@ struct Chk892Flow {
   bool selectionK0s(CollisionType const& collision, K0sType const& candidate)
   {
     auto lDauDCA = candidate.dcaV0daughters();
-    auto lDauPosDCAtoPV = candidate.dcapostopv();
-    auto lDauNegDCAtoPV = candidate.dcanegtopv();
+    auto lDauPosDCAtoPV = std::abs(candidate.dcapostopv());
+    auto lDauNegDCAtoPV = std::abs(candidate.dcanegtopv());
     auto lPt = candidate.pt();
     auto lRapidity = candidate.yK0Short();
     auto lRadius = candidate.v0radius();


### PR DESCRIPTION
Add `std::abs` to the daughter DCA to PV values.