### PR TITLE
[PWGEM/PhotonMeson] Add missing JJ weight requirement for gen particles

### DIFF
--- a/PWGEM/PhotonMeson/Core/Pi0EtaToGammaGammaMC.h
+++ b/PWGEM/PhotonMeson/Core/Pi0EtaToGammaGammaMC.h
@@ -649,6 +649,10 @@ struct Pi0EtaToGammaGammaMC {
         continue; // I don't know why this is necessary in simulation.
       }
 
+      if (eventcuts.onlyKeepWeightedEvents && fabs(collision.weight() - 1.) < 1E-10) {
+        continue;
+      }
+
       float centralities[3] = {collision.centFT0M(), collision.centFT0A(), collision.centFT0C()};
       if (centralities[cfgCentEstimator] < cfgCentMin || cfgCentMax < centralities[cfgCentEstimator]) {
         continue;


### PR DESCRIPTION
Bug fix, so that we now also require events to be weighted before filling generated particles (when the JJ option is on)