### PR TITLE
[PWGCF/FemtoUniverse] Add more flags to efficiency calculator script + fix configurable for timestamps 

### DIFF
--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseEfficiencyCalculator.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseEfficiencyCalculator.h
@@ -40,7 +40,7 @@ struct EfficiencyConfigurableGroup : ConfigurableGroup {
   Configurable<bool> confEfficiencyApplyCorrections{"confEfficiencyApplyCorrections", false, "Should apply corrections from efficiency"};
   Configurable<std::vector<std::string>> confEfficiencyCCDBLabels{"confEfficiencyCCDBLabels", {}, "Custom labels for efficiency objects in CCDB"};
   Configurable<int> confCCDBTrainNumber{"confCCDBTrainNumber", -1, "Train number for which to query CCDB objects (set to -1 to ignore)"};
-  Configurable<std::vector<std::string>> confEfficiencyCCDBTimestamps{"confEfficiencyCCDBTimestamps", {"-1", "-1"}, "Timestamps in CCDB, to query for specific objects (default: -1 for both, the latest valid object)"}; // o2-linter: disable=name/configurable
+  Configurable<std::vector<std::string>> confEfficiencyCCDBTimestamps{"confEfficiencyCCDBTimestamps", {"-1", "-1"}, "Timestamps in CCDB, to query for specific objects (default: -1 for both, the latest valid object)"};
 
   // NOTE: in the future we might move the below configurables to a separate struct, eg. CCDBConfigurableGroup
   Configurable<std::string> confCCDBUrl{"confCCDBUrl", "http://alice-ccdb.cern.ch", "CCDB URL to be used"};

--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseEfficiencyCalculator.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseEfficiencyCalculator.h
@@ -40,7 +40,7 @@ struct EfficiencyConfigurableGroup : ConfigurableGroup {
   Configurable<bool> confEfficiencyApplyCorrections{"confEfficiencyApplyCorrections", false, "Should apply corrections from efficiency"};
   Configurable<std::vector<std::string>> confEfficiencyCCDBLabels{"confEfficiencyCCDBLabels", {}, "Custom labels for efficiency objects in CCDB"};
   Configurable<int> confCCDBTrainNumber{"confCCDBTrainNumber", -1, "Train number for which to query CCDB objects (set to -1 to ignore)"};
-  ConfigurableAxis confEfficiencyCCDBTimestamps{"confEfficiencyCCDBTimestamps", {-1, -1}, "Timestamps in CCDB, to query for specific objects (default: -1 for both)"};
+  Configurable<std::vector<std::string>> confEfficiencyCCDBTimestamps{"confEfficiencyCCDBTimestamps", {"-1", "-1"}, "Timestamps in CCDB, to query for specific objects (default: -1 for both, the latest valid object)"}; // o2-linter: disable=name/configurable
 
   // NOTE: in the future we might move the below configurables to a separate struct, eg. CCDBConfigurableGroup
   Configurable<std::string> confCCDBUrl{"confCCDBUrl", "http://alice-ccdb.cern.ch", "CCDB URL to be used"};
@@ -119,7 +119,7 @@ class EfficiencyCalculator
     }
 
     auto timestamp = partNo - 1 < config->confEfficiencyCCDBTimestamps->size()
-                       ? static_cast<int64_t>(config->confEfficiencyCCDBTimestamps.value[partNo - 1])
+                       ? std::stoll(config->confEfficiencyCCDBTimestamps.value[partNo - 1])
                        : -1;
 
     auto hEff = ccdb.getSpecific<TH1>(config->confCCDBPath, timestamp, metadata);

--- a/PWGCF/FemtoUniverse/Scripts/femto_universe_efficiency_calculator.py
+++ b/PWGCF/FemtoUniverse/Scripts/femto_universe_efficiency_calculator.py
@@ -95,7 +95,7 @@ if len(args.ccdb_labels) > 0 and len(args.ccdb_labels) != len(args.mc_reco):
     sys.exit(1)
 
 if len(args.ccdb_labels) == 0:
-    # if flag is not provided, fill with empty strings as a placeholders
+    # if flag is not provided, fill with empty strings to match size
     args.ccdb_labels = [""] * len(args.mc_reco)
 
 ANALYSIS_RESULTS = "AnalysisResults.root"

--- a/PWGCF/FemtoUniverse/Scripts/femto_universe_efficiency_calculator.py
+++ b/PWGCF/FemtoUniverse/Scripts/femto_universe_efficiency_calculator.py
@@ -76,7 +76,7 @@ parser.add_argument(
     type=str,
     nargs="+",
     help="custom labels to add to objects' metadata in CCDB [example: label1 label2]",
-    default=[""] * 2,
+    default=[],
 )
 parser.add_argument(
     "--ccdb-lifetime",
@@ -89,6 +89,14 @@ args = parser.parse_args()
 if len(args.mc_reco) != len(args.mc_truth):
     print("[!] Provided number of histograms with MC Reco must match MC Truth", file=sys.stderr)
     sys.exit(1)
+
+if len(args.ccdb_labels) > 0 and len(args.ccdb_labels) != len(args.mc_reco):
+    print("[!] You must provide labels for all particles", file=sys.stderr)
+    sys.exit(1)
+
+if len(args.ccdb_labels) == 0:
+    # if flag is not provided, fill with empty strings as a placeholders
+    args.ccdb_labels = [""] * len(args.mc_reco)
 
 ANALYSIS_RESULTS = "AnalysisResults.root"
 results_path = args.alien_path / ANALYSIS_RESULTS
@@ -203,4 +211,5 @@ except subprocess.CalledProcessError as error:
     print(f"\n[!] Error while uploading: {error.stderr.decode('utf-8')}", file=sys.stderr)
     sys.exit(1)
 
-print("\n[✓] Success!", file=sys.stderr)
+print()
+print("[✓] Success!", file=sys.stderr)

--- a/PWGCF/FemtoUniverse/Scripts/femto_universe_efficiency_calculator.py
+++ b/PWGCF/FemtoUniverse/Scripts/femto_universe_efficiency_calculator.py
@@ -25,52 +25,73 @@ from pathlib import Path
 
 import ROOT  # pylint: disable=import-error
 
-parser = argparse.ArgumentParser(description="A tool to calculate efficiency and upload it to CCDB")
-parser.add_argument(
-    "run_dir",
-    type=Path,
-    help="Path to run directory with analysis results",
+
+class CustomHelpFormatter(argparse.HelpFormatter):
+    "Add default value to help format"
+
+    def _get_help_string(self, action):
+        help_str = action.help
+        if help_str is not None and action.default not in [argparse.SUPPRESS, None]:
+            help_str += f" (default: {action.default})"
+        return help_str
+
+
+parser = argparse.ArgumentParser(
+    description="A tool to calculate efficiency and upload it to CCDB",
+    formatter_class=CustomHelpFormatter,
 )
 parser.add_argument(
-    "--task",
-    "-t",
+    "--alien-path",
+    type=Path,
+    help="path to train run's directory in Alien with analysis results [example: /alice/cern.ch/user/a/alihyperloop/outputs/0033/332611/70301]",
+)
+parser.add_argument(
+    "--mc-reco",
     type=str,
-    help="Task name to query histograms from",
+    nargs="+",
+    help="paths to MC Reco histograms, separated by space [example: task/mcreco_one/hPt task/mcreco_two/hPt]",
+    required=True,
+)
+parser.add_argument(
+    "--mc-truth",
+    type=str,
+    nargs="+",
+    help="paths to MC Truth histograms, separated by space [example: task/mctruth_one/hPt task/mctruth_one/hPt]",
     required=True,
 )
 parser.add_argument(
     "--ccdb-path",
-    "-P",
     type=str,
-    help="Path where to save in CCDB",
+    help="location in CCDB to where objects will be uploaded",
     required=True,
 )
 parser.add_argument(
     "--ccdb-url",
-    "-U",
     type=str,
-    help="Path where to save in CCDB",
+    help="URL to CCDB",
     default="http://ccdb-test.cern.ch:8080",
 )
 parser.add_argument(
     "--ccdb-labels",
-    "-L",
     type=str,
     nargs="+",
-    help="Labels for objects' metadata in CCDB",
+    help="custom labels to add to objects' metadata in CCDB [example: label1 label2]",
     default=[""] * 2,
 )
 parser.add_argument(
     "--ccdb-lifetime",
-    "-T",
     type=int,
-    help="How long should the objects' validity in CCDB last (default: 1 year)",
+    help="how long should objects in CCDB remain valid",
     default=365 * 24 * 60 * 60 * 1000,  # one year
 )
 args = parser.parse_args()
 
+if len(args.mc_reco) != len(args.mc_truth):
+    print("[!] Provided number of histograms with MC Reco must match MC Truth", file=sys.stderr)
+    sys.exit(1)
+
 ANALYSIS_RESULTS = "AnalysisResults.root"
-results_path = args.run_dir / ANALYSIS_RESULTS
+results_path = args.alien_path / ANALYSIS_RESULTS
 job_id = results_path.parent.name
 train_number = results_path.parent.parent.name
 
@@ -81,7 +102,7 @@ eff_dest = tmp_dir / f"{train_number}-{job_id}-Efficiency.root"
 
 # get file from alien
 if not res_dest.is_file():
-    print(f"[↓] Downloading analysis results from Alien to {res_dest} ...", file=sys.stderr)
+    print(f"[↓] Downloading analysis results from Alien to '{res_dest}' ...", file=sys.stderr)
     ROOT.TGrid.Connect("alien://")
     try:
         subprocess.run(
@@ -92,14 +113,15 @@ if not res_dest.is_file():
         print("[-] Download complete!", file=sys.stderr)
     except subprocess.CalledProcessError as error:
         print(f"[!] Error while downloading results file: {error.stderr}", file=sys.stderr)
-        sys.exit(0)
+        sys.exit(1)
 else:
     print(
-        f"[-] Skipping download from Alien, since {res_dest} is already present",
+        f"[-] Skipping download from Alien, since '{res_dest}' is already present",
         file=sys.stderr,
     )
 
-particles = {1: "one", 2: "two"}
+print()
+
 histos_to_upload = []
 
 # get reco & truth histos
@@ -107,26 +129,28 @@ with (
     ROOT.TFile.Open(res_dest.as_uri()) as res_file,
     ROOT.TFile.Open(eff_dest.as_uri(), "recreate") as eff_file,
 ):
-    for idx, part_num in particles.items():
-        reco = res_file.Get(f"{args.task}/Tracks_{part_num}_MC/hPt")
-        truth = res_file.Get(f"{args.task}/MCTruthTracks_{part_num}/hPt")
-        if not reco and not truth:
-            print(
-                f"[-] No MC Reco nor MC Truth histogram found for particle {part_num}",
-                file=sys.stderr,
-            )
-            continue
+    for idx, (mc_reco, mc_truth) in enumerate(zip(args.mc_reco, args.mc_truth)):
+        hist_reco = res_file.Get(mc_reco)
+        if not hist_reco:
+            print(f"[!] Cannot find MC Reco histogram in '{mc_reco}', aborting", file=sys.stderr)
+            sys.exit(1)
 
-        num_bins = reco.GetNbinsX()
-        x_max = reco.GetXaxis().GetBinLowEdge(num_bins) + reco.GetXaxis().GetBinWidth(num_bins)
+        hist_truth = res_file.Get(mc_truth)
+        if not hist_truth:
+            print(f"[!] Cannot find MC Truth histogram in '{mc_truth}', aborting", file=sys.stderr)
+            sys.exit(1)
 
-        hist_name = f"Efficiency_part{idx}"
+        num_bins = hist_reco.GetNbinsX()
+        x_max = hist_reco.GetXaxis().GetBinLowEdge(num_bins)
+        x_max += hist_reco.GetXaxis().GetBinWidth(num_bins)
+
+        hist_name = f"Efficiency_part{idx + 1}"
 
         # calculate efficiency
         eff = ROOT.TH1F(hist_name, "", num_bins, 0, x_max)
         for bin_idx in range(len(eff)):
-            denom = truth.GetBinContent(bin_idx)
-            eff.SetBinContent(bin_idx, reco.GetBinContent(bin_idx) / denom if denom > 0 else 0)
+            denom = hist_truth.GetBinContent(bin_idx)
+            eff.SetBinContent(bin_idx, hist_reco.GetBinContent(bin_idx) / denom if denom > 0 else 0)
 
         # save efficiency object to file
         eff_file.WriteObject(eff, hist_name)
@@ -134,7 +158,7 @@ with (
 
 if len(histos_to_upload) == 0:
     print("[-] Exiting, since there is nothing to upload", file=sys.stderr)
-    sys.exit(0)
+    sys.exit(1)
 
 # upload objects to ccdb
 try:
@@ -142,7 +166,7 @@ try:
         timestamp_start = int(time.time() * 1000)
         timestamp_end = timestamp_start + args.ccdb_lifetime
 
-        print(f"[↑] Uploading {key} to CCDB ... ", file=sys.stderr, end="")
+        print(f"[↑] Uploading {key} to {args.ccdb_url} ... ", file=sys.stderr, end="")
         upload_cmd = [
             "o2-ccdb-upload",
             "--file",
@@ -161,14 +185,22 @@ try:
             f"trainNumber={train_number};label={args.ccdb_labels[idx]}",
         ]
         result = subprocess.run(upload_cmd, capture_output=True, check=True)
+
+        if "html" in result.stdout.decode("utf-8"):
+            print(
+                f"\n[!] Something went wrong with upload request: {result.stdout.decode('utf-8')}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
         if result.stderr:
-            print(f"[!] Error while uploading: {result.stderr.decode('utf-8')}", file=sys.stderr)
-            sys.exit(0)
+            print(f"\n[!] Error while uploading: {result.stderr.decode('utf-8')}", file=sys.stderr)
+            sys.exit(1)
 
         print("complete!", file=sys.stderr)
 
 except subprocess.CalledProcessError as error:
-    print(f"[!] Error while uploading: {error.stderr.decode('utf-8')}", file=sys.stderr)
-    sys.exit(0)
+    print(f"\n[!] Error while uploading: {error.stderr.decode('utf-8')}", file=sys.stderr)
+    sys.exit(1)
 
-print("[✓] Success!", file=sys.stderr)
+print("\n[✓] Success!", file=sys.stderr)

--- a/PWGCF/FemtoUniverse/Scripts/femto_universe_efficiency_calculator.py
+++ b/PWGCF/FemtoUniverse/Scripts/femto_universe_efficiency_calculator.py
@@ -81,7 +81,7 @@ parser.add_argument(
 parser.add_argument(
     "--ccdb-lifetime",
     type=int,
-    help="how long should objects in CCDB remain valid",
+    help="how long should objects in CCDB remain valid (milliseconds)",
     default=365 * 24 * 60 * 60 * 1000,  # one year
 )
 args = parser.parse_args()

--- a/PWGCF/FemtoUniverse/Scripts/femto_universe_efficiency_calculator.py
+++ b/PWGCF/FemtoUniverse/Scripts/femto_universe_efficiency_calculator.py
@@ -43,7 +43,8 @@ parser = argparse.ArgumentParser(
 parser.add_argument(
     "--alien-path",
     type=Path,
-    help="path to train run's directory in Alien with analysis results [example: /alice/cern.ch/user/a/alihyperloop/outputs/0033/332611/70301]",
+    help="path to train run's directory in Alien with analysis results "
+    "[example: /alice/cern.ch/user/a/alihyperloop/outputs/0033/332611/70301]",
 )
 parser.add_argument(
     "--mc-reco",


### PR DESCRIPTION
### Changes in this PR:
- expand help messages for efficiency calculator script
- update script flags:
  - now Alien path to analysis results is provided through `--alien-path` flag instead of positional argument
  - replace general flag `--task` with more specific `--mc-reco` & `--mc-truth` to have more control over which histograms to use in efficiency calculation 
  - if `--ccdb-labels` flag is provided, the number of its values must match the number of specified histograms 
- change `ConfigurableAxis` to just `std::vector<std::string>` for CCDB timestamps configurable

### Current script flags:

```
$ ./PWGCF/FemtoUniverse/Scripts/femto_universe_efficiency_calculator.py --help
usage: femto_universe_efficiency_calculator.py [-h] [--alien-path ALIEN_PATH] --mc-reco MC_RECO [MC_RECO ...] --mc-truth
                                               MC_TRUTH [MC_TRUTH ...] --ccdb-path CCDB_PATH [--ccdb-url CCDB_URL]
                                               [--ccdb-labels CCDB_LABELS [CCDB_LABELS ...]] [--ccdb-lifetime CCDB_LIFETIME]

A tool to calculate efficiency and upload it to CCDB

optional arguments:
  -h, --help            show this help message and exit
  --alien-path ALIEN_PATH
                        path to train run's directory in Alien with analysis results [example: /alice/cern.ch/user/a/alihyperloop/outputs/0033/332611/70301]
  --mc-reco MC_RECO [MC_RECO ...]
                        paths to MC Reco histograms, separated by space [example: task/mcreco_one/hPt task/mcreco_two/hPt]
  --mc-truth MC_TRUTH [MC_TRUTH ...]
                        paths to MC Truth histograms, separated by space [example: task/mctruth_one/hPt task/mctruth_one/hPt]
  --ccdb-path CCDB_PATH
                        location in CCDB to where objects will be uploaded
  --ccdb-url CCDB_URL   URL to CCDB (default: http://ccdb-test.cern.ch:8080)
  --ccdb-labels CCDB_LABELS [CCDB_LABELS ...]
                        custom labels to add to objects' metadata in CCDB [example: label1 label2] (default: [])
  --ccdb-lifetime CCDB_LIFETIME
                        how long should objects in CCDB remain valid (milliseconds) (default: 31536000000)
```

#### Example usage:
```
~/work/alice/O2Physics/PWGCF/FemtoUniverse/Scripts/femto_universe_efficiency_calculator.py \
    --alien-path /alice/cern.ch/user/a/alihyperloop/outputs/0033/332611/70301 \
    --mc-reco \
        femto-universe-pair-task-track-track-extended/Tracks_one_MC/hPt \
        femto-universe-pair-task-track-track-extended/Tracks_two_MC/hPt \
    --mc-truth \
        femto-universe-pair-task-track-track-extended/MCTruthTracks_one/hPt \
        femto-universe-pair-task-track-track-extended/MCTruthTracks_two/hPt \
    --ccdb-url http://alice-ccdb.cern.ch \
    --ccdb-path Users/d/dkarpins/Efficiency \
    --ccdb-labels proton1 proton2
```