### PR TITLE
Add an axis into THnSpares for ML study in the task 

### DIFF
--- a/PWGHF/D2H/Tasks/taskXicToXiPiPi.cxx
+++ b/PWGHF/D2H/Tasks/taskXicToXiPiPi.cxx
@@ -53,12 +53,6 @@ struct HfTaskXicToXiPiPi {
   Filter filterSelectCandidates = (aod::hf_sel_candidate_xic::isSelXicToXiPiPi >= selectionFlagXic);
 
   // Axis
-  ConfigurableAxis binsDecLength{"binsDecLength", {200, 0., 0.5}, ""};
-  ConfigurableAxis binsErrDecLength{"binsErrDecLength", {100, 0., 1.}, ""};
-  ConfigurableAxis binsDCA{"binsDCA", {100, -0.05, 0.05}, ""};
-  ConfigurableAxis binsImpParErr{"binsImpParErr", {200, -0.1, 0.1}, ""};
-  ConfigurableAxis binsSV{"binsSV", {200, -5., 5.}, ""};
-  ConfigurableAxis binsChi2{"binsChi2", {200, 0., 0.1}, ""};
   ConfigurableAxis thnConfigAxisPt{"thnConfigAxisPt", {400, 0., 40.}, ""};
   ConfigurableAxis thnConfigAxisMass{"thnConfigAxisMass", {300, 1.8, 3.0}, ""};
   ConfigurableAxis thnConfigAxisPtProng{"thnConfigAxisPtProng", {300, 0., 30.}, ""};
@@ -69,6 +63,12 @@ struct HfTaskXicToXiPiPi {
   ConfigurableAxis thnConfigAxisBdtScoreBkg{"thnConfigAxisBdtScoreBkg", {100, 0., 1.}, ""};
   ConfigurableAxis thnConfigAxisBdtScorePrompt{"thnConfigAxisBdtScorePrompt", {100, 0., 1.}, ""};
   ConfigurableAxis thnConfigAxisBdtScoreNonPrompt{"thnConfigAxisBdtScoreNonPrompt", {100, 0., 1.}, ""};
+  ConfigurableAxis binsDecLength{"binsDecLength", {200, 0., 0.5}, ""};
+  ConfigurableAxis binsErrDecLength{"binsErrDecLength", {100, 0., 1.}, ""};
+  ConfigurableAxis binsDCA{"binsDCA", {100, -0.05, 0.05}, ""};
+  ConfigurableAxis binsImpParErr{"binsImpParErr", {200, -0.1, 0.1}, ""};
+  ConfigurableAxis binsSV{"binsSV", {200, -5., 5.}, ""};
+  ConfigurableAxis binsChi2{"binsChi2", {200, 0., 0.1}, ""};
     
   HistogramRegistry registry{"registry"};
 

--- a/PWGHF/D2H/Tasks/taskXicToXiPiPi.cxx
+++ b/PWGHF/D2H/Tasks/taskXicToXiPiPi.cxx
@@ -47,6 +47,18 @@ struct HfTaskXicToXiPiPi {
   Configurable<bool> checkDecayTypeMc{"checkDecayTypeMc", false, "Flag to enable DecayType histogram"};
   // THnSparese for ML selection check
   Configurable<bool> enableTHn{"enableTHn", false, "Fill THnSparse for Xic"};
+
+  Service<o2::framework::O2DatabasePDG> pdg;
+
+  Filter filterSelectCandidates = (aod::hf_sel_candidate_xic::isSelXicToXiPiPi >= selectionFlagXic);
+
+  // Axis
+  ConfigurableAxis binsDecLength{"binsDecLength", {200, 0., 0.5}, ""};
+  ConfigurableAxis binsErrDecLength{"binsErrDecLength", {100, 0., 1.}, ""};
+  ConfigurableAxis binsDCA{"binsDCA", {100, -0.05, 0.05}, ""};
+  ConfigurableAxis binsImpParErr{"binsImpParErr", {200, -0.1, 0.1}, ""};
+  ConfigurableAxis binsSV{"binsSV", {200, -5., 5.}, ""};
+  ConfigurableAxis binsChi2{"binsChi2", {200, 0., 0.1}, ""};
   ConfigurableAxis thnConfigAxisPt{"thnConfigAxisPt", {400, 0., 40.}, ""};
   ConfigurableAxis thnConfigAxisMass{"thnConfigAxisMass", {300, 1.8, 3.0}, ""};
   ConfigurableAxis thnConfigAxisPtProng{"thnConfigAxisPtProng", {300, 0., 30.}, ""};
@@ -57,18 +69,7 @@ struct HfTaskXicToXiPiPi {
   ConfigurableAxis thnConfigAxisBdtScoreBkg{"thnConfigAxisBdtScoreBkg", {100, 0., 1.}, ""};
   ConfigurableAxis thnConfigAxisBdtScorePrompt{"thnConfigAxisBdtScorePrompt", {100, 0., 1.}, ""};
   ConfigurableAxis thnConfigAxisBdtScoreNonPrompt{"thnConfigAxisBdtScoreNonPrompt", {100, 0., 1.}, ""};
-  // Axis
-  ConfigurableAxis binsDecLength{"binsDecLength", {200, 0., 0.5}, ""};
-  ConfigurableAxis binsErrDecLength{"binsErrDecLength", {100, 0., 1.}, ""};
-  ConfigurableAxis binsDCA{"binsDCA", {100, -0.05, 0.05}, ""};
-  ConfigurableAxis binsImpParErr{"binsImpParErr", {200, -0.1, 0.1}, ""};
-  ConfigurableAxis binsSV{"binsSV", {200, -5., 5.}, ""};
-  ConfigurableAxis binsChi2{"binsChi2", {200, 0., 0.1}, ""};
-
-  Service<o2::framework::O2DatabasePDG> pdg;
-
-  Filter filterSelectCandidates = (aod::hf_sel_candidate_xic::isSelXicToXiPiPi >= selectionFlagXic);
-
+    
   HistogramRegistry registry{"registry"};
 
   void init(InitContext const&)

--- a/PWGHF/D2H/Tasks/taskXicToXiPiPi.cxx
+++ b/PWGHF/D2H/Tasks/taskXicToXiPiPi.cxx
@@ -55,7 +55,8 @@ struct HfTaskXicToXiPiPi {
   ConfigurableAxis thnConfigAxisDecLengthXY{"thnConfigAxisDecLengthXY", {200, 0., 0.5}, ""};
   ConfigurableAxis thnConfigAxisCPA{"thnConfigAxisCPA", {110, -1.1, 1.1}, ""};
   ConfigurableAxis thnConfigAxisBdtScoreBkg{"thnConfigAxisBdtScoreBkg", {100, 0., 1.}, ""};
-  ConfigurableAxis thnConfigAxisBdtScoreSignal{"thnConfigAxisBdtScoreSignal", {100, 0., 1.}, ""};
+  ConfigurableAxis thnConfigAxisBdtScorePrompt{"thnConfigAxisBdtScorePrompt", {100, 0., 1.}, ""};
+  ConfigurableAxis thnConfigAxisBdtScoreNonPrompt{"thnConfigAxisBdtScoreNonPrompt", {100, 0., 1.}, ""};
   // Axis
   ConfigurableAxis binsDecLength{"binsDecLength", {200, 0., 0.5}, ""};
   ConfigurableAxis binsErrDecLength{"binsErrDecLength", {100, 0., 1.}, ""};
@@ -251,11 +252,12 @@ struct HfTaskXicToXiPiPi {
       const AxisSpec thnAxisDecLengthXY{thnConfigAxisDecLengthXY, "decay length xy (cm)"};
       const AxisSpec thnAxisCPA{thnConfigAxisCPA, "#Xi^{#plus}_{c} candidate cosine of pointing angle"};
       const AxisSpec thnAxisBdtScoreBkg{thnConfigAxisBdtScoreBkg, "BDT score of background"};
-      const AxisSpec thnAxisBdtScoreSignal{thnConfigAxisBdtScoreSignal, "BDT score of prompt Xic"};
+      const AxisSpec thnAxisBdtScorePrompt{thnConfigAxisBdtScorePrompt, "BDT score of prompt #Xi^{#plus}_{c}"};
+      const AxisSpec thnAxisBdtScoreNonPrompt{thnConfigAxisBdtScoreNonPrompt, "BDT score of non-prompt #Xi^{#plus}_{c}"};
 
       if (doprocessWithKFParticleAndML || doprocessWithDCAFitterAndML || doprocessMcWithKFParticleAndML || doprocessMcWithDCAFitterAndML) {
         // with ML information
-        registry.add("hXicToXiPiPiVarsWithML", "THnSparse for Xic with ML", HistType::kTHnSparseF, {thnAxisPt, thnAxisMass, thnAxisChi2PCA, thnAxisDecLength, thnAxisDecLengthXY, thnAxisCPA, thnAxisBdtScoreBkg, thnAxisBdtScoreSignal});
+        registry.add("hXicToXiPiPiVarsWithML", "THnSparse for Xic with ML", HistType::kTHnSparseF, {thnAxisPt, thnAxisMass, thnAxisChi2PCA, thnAxisDecLength, thnAxisDecLengthXY, thnAxisCPA, thnAxisBdtScoreBkg, thnAxisBdtScorePrompt, thnAxisBdtScoreNonPrompt});
       } else {
         // without ML information
         registry.add("hXicToXiPiPiVars", "THnSparse for Xic", HistType::kTHnSparseF, {thnAxisPt, thnAxisMass, thnAxisChi2PCA, thnAxisDecLength, thnAxisDecLengthXY, thnAxisCPA});
@@ -274,13 +276,15 @@ struct HfTaskXicToXiPiPi {
 
     if constexpr (useMl) {
       // with ML information
-      double outputBkg = -99.;
-      double outputPrompt = -99.;
+      double outputBkg = -99.;      // bkg score
+      double outputPrompt = -99.;   // prompt score
+      double outputFD = -99.;       // non-prompt score
       if (candidate.mlProbXicToXiPiPi().size() > 0) {
         outputBkg = candidate.mlProbXicToXiPiPi()[0];
         outputPrompt = candidate.mlProbXicToXiPiPi()[1];
+        outputFD = candidate.mlProbXicToXiPiPi()[2];
       }
-      registry.get<THnSparse>(HIST("hXicToXiPiPiVarsWithML"))->Fill(candidate.pt(), candidate.invMassXicPlus(), candidate.chi2PCA(), candidate.decayLength(), candidate.decayLengthXY(), candidate.cpa(), outputBkg, outputPrompt);
+      registry.get<THnSparse>(HIST("hXicToXiPiPiVarsWithML"))->Fill(candidate.pt(), candidate.invMassXicPlus(), candidate.chi2PCA(), candidate.decayLength(), candidate.decayLengthXY(), candidate.cpa(), outputBkg, outputPrompt, outputFD);
     } else {
       // without ML information
       registry.get<THnSparse>(HIST("hXicToXiPiPiVars"))->Fill(candidate.pt(), candidate.invMassXicPlus(), candidate.chi2PCA(), candidate.decayLength(), candidate.decayLengthXY(), candidate.cpa());


### PR DESCRIPTION
In this PR,
1) An axis has been added into THnSpares in the task, to store the non-prompt score 
2) THnSpares axis name with signal has been changed to distinguish prompt and non-prompt
3) Struct member categories were reorganized to follow the coding guidelines (suggestion from O2linter)

@pstahlhu and @creetz16 