### PR TITLE
[PWGCF] Fix bug in collision masker

### DIFF
--- a/PWGCF/FemtoDream/Tasks/femtoDreamCollisionMasker.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamCollisionMasker.cxx
@@ -332,16 +332,18 @@ struct femoDreamCollisionMasker {
       // if they are not passed, skip the particle
       if (track.pt() < FilterPtMin.at(P).at(index) || track.pt() > FilterPtMax.at(P).at(index) ||
           track.eta() < FilterEtaMin.at(P).at(index) || track.eta() > FilterEtaMax.at(P).at(index)) {
-        // check if we apply pt dependend dca cut
-        if (TrackDCACutPtDep.at(index)) {
-          if (std::fabs(track.tempFitVar()) > 0.0105f * (0.035f / std::pow(track.pt(), 1.1f))) {
-            continue;
-          }
-        } else {
-          // or cut on the DCA directly
-          if (track.tempFitVar() < FilterTempFitVarMin.at(P).at(index) || track.tempFitVar() > FilterTempFitVarMax.at(P).at(index)) {
-            continue;
-          }
+        continue;
+      }
+      // check if we apply pt dependend dca cut
+      // if they do not pass this cut, skip particle as well
+      if (TrackDCACutPtDep.at(index)) {
+        if (std::fabs(track.tempFitVar()) > 0.0105f + (0.035f / std::pow(track.pt(), 1.1f))) {
+          continue;
+        }
+      } else {
+        // or cut on the DCA directly
+        if (track.tempFitVar() < FilterTempFitVarMin.at(P).at(index) || track.tempFitVar() > FilterTempFitVarMax.at(P).at(index)) {
+          continue;
         }
       }
       // set the bit at the index of the selection equal to one if the track passes all selections


### PR DESCRIPTION
Fix bug in collision masker for the track-track pairing. Due to the bug, collisions with tracks which passed the selections were not properly masked.