### PR TITLE
[PWGLF] chk892Flow - Add pT-depedent DCAxy selection

### DIFF
--- a/PWGLF/Tasks/Resonances/chk892Flow.cxx
+++ b/PWGLF/Tasks/Resonances/chk892Flow.cxx
@@ -161,6 +161,7 @@ struct Chk892Flow {
   Configurable<bool> cfgGlobalWoDCATrack{"cfgGlobalWoDCATrack", true, "Global track selection without DCA"}; // kQualityTracks (kTrackType | kTPCNCls | kTPCCrossedRows | kTPCCrossedRowsOverNCls | kTPCChi2NDF | kTPCRefit | kITSNCls | kITSChi2NDF | kITSRefit | kITSHits) | kInAcceptanceTracks (kPtRange | kEtaRange)
   Configurable<bool> cfgGlobalTrack{"cfgGlobalTrack", false, "Global track selection"};                      // kGoldenChi2 | kDCAxy | kDCAz
   Configurable<bool> cfgPVContributor{"cfgPVContributor", false, "PV contributor track selection"};          // PV Contriuibutor
+  Configurable<bool> cfgpTdepDCAxyCut{"cfgpTdepDCAxyCut", false, "pT-dependent DCAxy cut"};
 
   Configurable<int> cfgITScluster{"cfgITScluster", 0, "Number of ITS cluster"};
   Configurable<int> cfgTPCcluster{"cfgTPCcluster", 0, "Number of TPC cluster"};
@@ -521,8 +522,14 @@ struct Chk892Flow {
       return false;
     if (cfgPrimaryTrack && !track.isPrimaryTrack())
       return false;
-    if (std::abs(track.dcaXY()) > cMaxbDCArToPVcut)
-      return false;
+    if (cfgpTdepDCAxyCut) {
+      // Tuned on the LHC22f anchored MC LHC23d1d on primary pions. 7 Sigmas of the resolution
+      if (std::abs(track.dcaXY()) > 0.004 + 0.013 / track.pt())
+        return false;
+    } else {
+      if (std::abs(track.dcaXY()) > cMaxbDCArToPVcut)
+        return false;
+    }
     if (std::abs(track.dcaZ()) > cMaxbDCAzToPVcut)
       return false;
     return true;

--- a/PWGLF/Tasks/Resonances/chk892Flow.cxx
+++ b/PWGLF/Tasks/Resonances/chk892Flow.cxx
@@ -106,114 +106,128 @@ struct Chk892Flow {
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   o2::ccdb::CcdbApi ccdbApi;
 
-  Configurable<std::string> cfgURL{"cfgURL", "http://alice-ccdb.cern.ch", "Address of the CCDB to browse"};
+  struct : ConfigurableGroup {
+    Configurable<std::string> cfgURL{"cfgURL", "http://alice-ccdb.cern.ch", "Address of the CCDB to browse"};
+  } CCDBConfig;
   // Configurable<int64_t> nolaterthan{"ccdb-no-later-than", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(), "Latest acceptable timestamp of creation for the object"};
 
   // Configurables
-  ConfigurableAxis cfgBinsPt{"cfgBinsPt", {VARIABLE_WIDTH, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5.0, 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6.0, 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 6.9, 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9, 9.0, 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8, 9.9, 10.0, 10.1, 10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8, 10.9, 11.0, 11.1, 11.2, 11.3, 11.4, 11.5, 11.6, 11.7, 11.8, 11.9, 12.0, 12.1, 12.2, 12.3, 12.4, 12.5, 12.6, 12.7, 12.8, 12.9, 13.0, 13.1, 13.2, 13.3, 13.4, 13.5, 13.6, 13.7, 13.8, 13.9, 14.0, 14.1, 14.2, 14.3, 14.4, 14.5, 14.6, 14.7, 14.8, 14.9, 15.0}, "Binning of the pT axis"};
-  ConfigurableAxis cfgBinsPtQA{"cfgBinsPtQA", {VARIABLE_WIDTH, 0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0, 2.2, 2.4, 2.6, 2.8, 3.0, 3.2, 3.4, 3.6, 3.8, 4.0, 4.2, 4.4, 4.6, 4.8, 5.0, 5.2, 5.4, 5.6, 5.8, 6.0, 6.2, 6.4, 6.6, 6.8, 7.0, 7.2, 7.4, 7.6, 7.8, 8.0, 8.2, 8.4, 8.6, 8.8, 9.0, 9.2, 9.4, 9.6, 9.8, 10.0}, "Binning of the pT axis"};
-  ConfigurableAxis cfgBinsCent{"cfgBinsCent", {VARIABLE_WIDTH, 0.0, 1.0, 5.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0, 110.0}, "Binning of the centrality axis"};
-  ConfigurableAxis cfgBinsVtxZ{"cfgBinsVtxZ", {VARIABLE_WIDTH, -10.0, -9.0, -8.0, -7.0, -6.0, -5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0}, "Binning of the z-vertex axis"};
-  Configurable<int> cNbinsDiv{"cNbinsDiv", 1, "Integer to divide the number of bins"};
-  Configurable<int> cNbinsDivQA{"cNbinsDivQA", 1, "Integer to divide the number of bins for QA"};
-  ConfigurableAxis cfgAxisV2{"cfgAxisV2", {200, -1, 1}, "Binning of the v2 axis (+-1 for EP method)"};
-  Configurable<bool> cfgFillAdditionalAxis{"cfgFillAdditionalAxis", false, "Fill additional axis"};
-  ConfigurableAxis cfgAxisPhi{"cfgAxisPhi", {8, 0, constants::math::PI}, "Binning of the #phi axis"};
-  Configurable<bool> cfgUseScalProduct{"cfgUseScalProduct", false, "Use scalar product method"};
+  struct : ConfigurableGroup {
+    ConfigurableAxis cfgBinsPt{"cfgBinsPt", {VARIABLE_WIDTH, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5.0, 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6.0, 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 6.9, 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9, 9.0, 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8, 9.9, 10.0, 10.1, 10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8, 10.9, 11.0, 11.1, 11.2, 11.3, 11.4, 11.5, 11.6, 11.7, 11.8, 11.9, 12.0, 12.1, 12.2, 12.3, 12.4, 12.5, 12.6, 12.7, 12.8, 12.9, 13.0, 13.1, 13.2, 13.3, 13.4, 13.5, 13.6, 13.7, 13.8, 13.9, 14.0, 14.1, 14.2, 14.3, 14.4, 14.5, 14.6, 14.7, 14.8, 14.9, 15.0}, "Binning of the pT axis"};
+    ConfigurableAxis cfgBinsPtQA{"cfgBinsPtQA", {VARIABLE_WIDTH, 0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0, 2.2, 2.4, 2.6, 2.8, 3.0, 3.2, 3.4, 3.6, 3.8, 4.0, 4.2, 4.4, 4.6, 4.8, 5.0, 5.2, 5.4, 5.6, 5.8, 6.0, 6.2, 6.4, 6.6, 6.8, 7.0, 7.2, 7.4, 7.6, 7.8, 8.0, 8.2, 8.4, 8.6, 8.8, 9.0, 9.2, 9.4, 9.6, 9.8, 10.0}, "Binning of the pT axis"};
+    ConfigurableAxis cfgBinsCent{"cfgBinsCent", {VARIABLE_WIDTH, 0.0, 1.0, 5.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0, 110.0}, "Binning of the centrality axis"};
+    ConfigurableAxis cfgBinsVtxZ{"cfgBinsVtxZ", {VARIABLE_WIDTH, -10.0, -9.0, -8.0, -7.0, -6.0, -5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0}, "Binning of the z-vertex axis"};
+    Configurable<int> cNbinsDiv{"cNbinsDiv", 1, "Integer to divide the number of bins"};
+    Configurable<int> cNbinsDivQA{"cNbinsDivQA", 1, "Integer to divide the number of bins for QA"};
+    ConfigurableAxis cfgAxisV2{"cfgAxisV2", {200, -1, 1}, "Binning of the v2 axis (+-1 for EP method)"};
+    ConfigurableAxis cfgAxisPhi{"cfgAxisPhi", {8, 0, constants::math::PI}, "Binning of the #phi axis"};
+  } AxisConfig;
+
+  struct : ConfigurableGroup {
+    Configurable<bool> cfgQvecSel{"cfgQvecSel", true, "Reject events when no QVector"};
+    Configurable<int> cfgCentEst{"cfgCentEst", 1, "Centrality estimator, 1: FT0C, 2: FT0M"};
+    Configurable<bool> cfgFillAdditionalAxis{"cfgFillAdditionalAxis", false, "Fill additional axis"};
+    Configurable<bool> cfgUseScalProduct{"cfgUseScalProduct", false, "Use scalar product method"};
+  } AnalysisConfig;
 
   // Event cuts
   o2::analysis::CollisonCuts colCuts;
-  Configurable<float> cfgEvtZvtx{"cfgEvtZvtx", 10.f, "Evt sel: Max. z-Vertex (cm)"};
-  Configurable<int> cfgEvtOccupancyInTimeRangeMax{"cfgEvtOccupancyInTimeRangeMax", -1, "Evt sel: maximum track occupancy"};
-  Configurable<int> cfgEvtOccupancyInTimeRangeMin{"cfgEvtOccupancyInTimeRangeMin", -1, "Evt sel: minimum track occupancy"};
-  Configurable<bool> cfgEvtTriggerCheck{"cfgEvtTriggerCheck", false, "Evt sel: check for trigger"};
-  Configurable<bool> cfgEvtOfflineCheck{"cfgEvtOfflineCheck", true, "Evt sel: check for offline selection"};
-  Configurable<bool> cfgEvtTriggerTVXSel{"cfgEvtTriggerTVXSel", false, "Evt sel: triggerTVX selection (MB)"};
-  Configurable<bool> cfgEvtTFBorderCut{"cfgEvtTFBorderCut", false, "Evt sel: apply TF border cut"};
-  Configurable<bool> cfgEvtUseITSTPCvertex{"cfgEvtUseITSTPCvertex", false, "Evt sel: use at lease on ITS-TPC track for vertexing"};
-  Configurable<bool> cfgEvtZvertexTimedifference{"cfgEvtZvertexTimedifference", true, "Evt sel: apply Z-vertex time difference"};
-  Configurable<bool> cfgEvtPileupRejection{"cfgEvtPileupRejection", true, "Evt sel: apply pileup rejection"};
-  Configurable<bool> cfgEvtNoITSROBorderCut{"cfgEvtNoITSROBorderCut", false, "Evt sel: apply NoITSRO border cut"};
-  Configurable<bool> cfgEvtCollInTimeRangeStandard{"cfgEvtCollInTimeRangeStandard", true, "Evt sel: apply NoCollInTimeRangeStandard"};
-
-  /// Track selections
-  Configurable<float> cMinPtcut{"cMinPtcut", 0.15, "Track minium pt cut"};
-  Configurable<float> cMaxEtacut{"cMaxEtacut", 0.8, "Track maximum eta cut"};
-
-  // Cuts from polarization analysis
-  Configurable<bool> cfgQvecSel{"cfgQvecSel", true, "Reject events when no QVector"};
-  Configurable<int> cfgCentEst{"cfgCentEst", 1, "Centrality estimator, 1: FT0C, 2: FT0M"};
-
-  // DCAr to PV
-  Configurable<float> cMaxbDCArToPVcut{"cMaxbDCArToPVcut", 0.1, "Track DCAr cut to PV Maximum"};
-  // DCAz to PV
-  Configurable<float> cMaxbDCAzToPVcut{"cMaxbDCAzToPVcut", 0.1, "Track DCAz cut to PV Maximum"};
+  struct : ConfigurableGroup {
+    Configurable<float> cfgEvtZvtx{"cfgEvtZvtx", 10.f, "Evt sel: Max. z-Vertex (cm)"};
+    Configurable<int> cfgEvtOccupancyInTimeRangeMax{"cfgEvtOccupancyInTimeRangeMax", -1, "Evt sel: maximum track occupancy"};
+    Configurable<int> cfgEvtOccupancyInTimeRangeMin{"cfgEvtOccupancyInTimeRangeMin", -1, "Evt sel: minimum track occupancy"};
+    Configurable<bool> cfgEvtTriggerCheck{"cfgEvtTriggerCheck", false, "Evt sel: check for trigger"};
+    Configurable<bool> cfgEvtOfflineCheck{"cfgEvtOfflineCheck", true, "Evt sel: check for offline selection"};
+    Configurable<bool> cfgEvtTriggerTVXSel{"cfgEvtTriggerTVXSel", false, "Evt sel: triggerTVX selection (MB)"};
+    Configurable<bool> cfgEvtTFBorderCut{"cfgEvtTFBorderCut", false, "Evt sel: apply TF border cut"};
+    Configurable<bool> cfgEvtUseITSTPCvertex{"cfgEvtUseITSTPCvertex", false, "Evt sel: use at lease on ITS-TPC track for vertexing"};
+    Configurable<bool> cfgEvtZvertexTimedifference{"cfgEvtZvertexTimedifference", true, "Evt sel: apply Z-vertex time difference"};
+    Configurable<bool> cfgEvtPileupRejection{"cfgEvtPileupRejection", true, "Evt sel: apply pileup rejection"};
+    Configurable<bool> cfgEvtNoITSROBorderCut{"cfgEvtNoITSROBorderCut", false, "Evt sel: apply NoITSRO border cut"};
+    Configurable<bool> cfgEvtCollInTimeRangeStandard{"cfgEvtCollInTimeRangeStandard", true, "Evt sel: apply NoCollInTimeRangeStandard"};
+  } EventCuts;
 
   /// PID Selections, pion
-  Configurable<bool> cTPConly{"cTPConly", false, "Use only TPC for PID"};                                   // bool
-  Configurable<float> cMaxTPCnSigmaPion{"cMaxTPCnSigmaPion", 3.0, "TPC nSigma cut for Pion"};               // TPC
-  Configurable<float> cMaxTOFnSigmaPion{"cMaxTOFnSigmaPion", 3.0, "TOF nSigma cut for Pion"};               // TOF
-  Configurable<float> nsigmaCutCombinedPion{"nsigmaCutCombinedPion", -999, "Combined nSigma cut for Pion"}; // Combined
-  Configurable<bool> cTOFVeto{"cTOFVeto", true, "TOF Veto, if false, TOF is nessessary for PID selection"}; // TOF Veto
+  struct : ConfigurableGroup {
+    Configurable<bool> cfgTPConly{"cfgTPConly", false, "Use only TPC for PID"};                                     // bool
+    Configurable<float> cfgMaxTPCnSigmaPion{"cfgMaxTPCnSigmaPion", 3.0, "TPC nSigma cut for Pion"};                 // TPC
+    Configurable<float> cfgMaxTOFnSigmaPion{"cfgMaxTOFnSigmaPion", 3.0, "TOF nSigma cut for Pion"};                 // TOF
+    Configurable<float> cfgNsigmaCutCombinedPion{"cfgNsigmaCutCombinedPion", -999, "Combined nSigma cut for Pion"}; // Combined
+    Configurable<bool> cfgTOFVeto{"cfgTOFVeto", true, "TOF Veto, if false, TOF is nessessary for PID selection"};   // TOF Veto
+  } PIDCuts;
 
   // Track selections
-  Configurable<bool> cfgPrimaryTrack{"cfgPrimaryTrack", true, "Primary track selection"};                    // kGoldenChi2 | kDCAxy | kDCAz
-  Configurable<bool> cfgGlobalWoDCATrack{"cfgGlobalWoDCATrack", true, "Global track selection without DCA"}; // kQualityTracks (kTrackType | kTPCNCls | kTPCCrossedRows | kTPCCrossedRowsOverNCls | kTPCChi2NDF | kTPCRefit | kITSNCls | kITSChi2NDF | kITSRefit | kITSHits) | kInAcceptanceTracks (kPtRange | kEtaRange)
-  Configurable<bool> cfgGlobalTrack{"cfgGlobalTrack", false, "Global track selection"};                      // kGoldenChi2 | kDCAxy | kDCAz
-  Configurable<bool> cfgPVContributor{"cfgPVContributor", false, "PV contributor track selection"};          // PV Contriuibutor
-  Configurable<bool> cfgpTdepDCAxyCut{"cfgpTdepDCAxyCut", false, "pT-dependent DCAxy cut"};
-
-  Configurable<int> cfgITScluster{"cfgITScluster", 0, "Number of ITS cluster"};
-  Configurable<int> cfgTPCcluster{"cfgTPCcluster", 0, "Number of TPC cluster"};
-  Configurable<float> cfgRatioTPCRowsOverFindableCls{"cfgRatioTPCRowsOverFindableCls", 0.0f, "TPC Crossed Rows to Findable Clusters"};
-  Configurable<float> cfgITSChi2NCl{"cfgITSChi2NCl", 999.0, "ITS Chi2/NCl"};
-  Configurable<float> cfgTPCChi2NCl{"cfgTPCChi2NCl", 999.0, "TPC Chi2/NCl"};
-  Configurable<bool> cfgUseTPCRefit{"cfgUseTPCRefit", false, "Require TPC Refit"};
-  Configurable<bool> cfgUseITSRefit{"cfgUseITSRefit", false, "Require ITS Refit"};
-  Configurable<bool> cfgHasITS{"cfgHasITS", false, "Require ITS"};
-  Configurable<bool> cfgHasTPC{"cfgHasTPC", false, "Require TPC"};
-  Configurable<bool> cfgHasTOF{"cfgHasTOF", false, "Require TOF"};
+  struct : ConfigurableGroup {
+    Configurable<float> cfgMinPtcut{"cfgMinPtcut", 0.15, "Track minium pt cut"};
+    Configurable<float> cfgMaxEtacut{"cfgMaxEtacut", 0.8, "Track maximum eta cut"};
+    Configurable<bool> cfgPrimaryTrack{"cfgPrimaryTrack", true, "Primary track selection"};                    // kGoldenChi2 | kDCAxy | kDCAz
+    Configurable<bool> cfgGlobalWoDCATrack{"cfgGlobalWoDCATrack", true, "Global track selection without DCA"}; // kQualityTracks (kTrackType | kTPCNCls | kTPCCrossedRows | kTPCCrossedRowsOverNCls | kTPCChi2NDF | kTPCRefit | kITSNCls | kITSChi2NDF | kITSRefit | kITSHits) | kInAcceptanceTracks (kPtRange | kEtaRange)
+    Configurable<bool> cfgGlobalTrack{"cfgGlobalTrack", false, "Global track selection"};                      // kGoldenChi2 | kDCAxy | kDCAz
+    Configurable<bool> cfgPVContributor{"cfgPVContributor", false, "PV contributor track selection"};          // PV Contriuibutor
+    Configurable<bool> cfgpTdepDCAxyCut{"cfgpTdepDCAxyCut", false, "pT-dependent DCAxy cut"};
+    Configurable<int> cfgITScluster{"cfgITScluster", 0, "Number of ITS cluster"};
+    Configurable<int> cfgTPCcluster{"cfgTPCcluster", 0, "Number of TPC cluster"};
+    Configurable<float> cfgRatioTPCRowsOverFindableCls{"cfgRatioTPCRowsOverFindableCls", 0.0f, "TPC Crossed Rows to Findable Clusters"};
+    Configurable<float> cfgITSChi2NCl{"cfgITSChi2NCl", 999.0, "ITS Chi2/NCl"};
+    Configurable<float> cfgTPCChi2NCl{"cfgTPCChi2NCl", 999.0, "TPC Chi2/NCl"};
+    Configurable<bool> cfgUseTPCRefit{"cfgUseTPCRefit", false, "Require TPC Refit"};
+    Configurable<bool> cfgUseITSRefit{"cfgUseITSRefit", false, "Require ITS Refit"};
+    Configurable<bool> cfgHasITS{"cfgHasITS", false, "Require ITS"};
+    Configurable<bool> cfgHasTPC{"cfgHasTPC", false, "Require TPC"};
+    Configurable<bool> cfgHasTOF{"cfgHasTOF", false, "Require TOF"};
+    // DCA to PV
+    Configurable<float> cfgMaxbDCArToPVcut{"cfgMaxbDCArToPVcut", 0.1, "Track DCAr cut to PV Maximum"};
+    Configurable<float> cfgMaxbDCAzToPVcut{"cfgMaxbDCAzToPVcut", 0.1, "Track DCAz cut to PV Maximum"};
+  } TrackCuts;
 
   // Secondary Selection
-  Configurable<bool> cfgReturnFlag{"cfgReturnFlag", false, "Return Flag for debugging"};
-  Configurable<bool> cSecondaryRequire{"cSecondaryRequire", true, "Secondary cuts on/off"};
-  Configurable<bool> cSecondaryArmenterosCut{"cSecondaryArmenterosCut", true, "cut on Armenteros-Podolanski graph"};
-  Configurable<bool> cSecondaryCrossMassHypothesisCut{"cSecondaryCrossMassHypothesisCut", false, "Apply cut based on the lambda mass hypothesis"};
+  struct : ConfigurableGroup {
+    Configurable<bool> cfgReturnFlag{"cfgReturnFlag", false, "Return Flag for debugging"};
+    Configurable<bool> cfgSecondaryRequire{"cfgSecondaryRequire", true, "Secondary cuts on/off"};
+    Configurable<bool> cfgSecondaryArmenterosCut{"cfgSecondaryArmenterosCut", true, "cut on Armenteros-Podolanski graph"};
+    Configurable<bool> cfgSecondaryCrossMassHypothesisCut{"cfgSecondaryCrossMassHypothesisCut", false, "Apply cut based on the lambda mass hypothesis"};
 
-  Configurable<bool> cfgByPassDauPIDSelection{"cfgByPassDauPIDSelection", true, "Bypass Daughters PID selection"};
-  Configurable<float> cSecondaryDauDCAMax{"cSecondaryDauDCAMax", 0.2, "Maximum DCA Secondary daughters to PV"};
-  Configurable<float> cSecondaryDauPosDCAtoPVMin{"cSecondaryDauPosDCAtoPVMin", 0.0, "Minimum DCA Secondary positive daughters to PV"};
-  Configurable<float> cSecondaryDauNegDCAtoPVMin{"cSecondaryDauNegDCAtoPVMin", 0.0, "Minimum DCA Secondary negative daughters to PV"};
+    Configurable<bool> cfgByPassDauPIDSelection{"cfgByPassDauPIDSelection", true, "Bypass Daughters PID selection"};
+    Configurable<float> cfgSecondaryDauDCAMax{"cfgSecondaryDauDCAMax", 0.2, "Maximum DCA Secondary daughters to PV"};
+    Configurable<float> cfgSecondaryDauPosDCAtoPVMin{"cfgSecondaryDauPosDCAtoPVMin", 0.0, "Minimum DCA Secondary positive daughters to PV"};
+    Configurable<float> cfgSecondaryDauNegDCAtoPVMin{"cfgSecondaryDauNegDCAtoPVMin", 0.0, "Minimum DCA Secondary negative daughters to PV"};
 
-  Configurable<float> cSecondaryPtMin{"cSecondaryPtMin", 0.f, "Minimum transverse momentum of Secondary"};
-  Configurable<float> cSecondaryRapidityMax{"cSecondaryRapidityMax", 0.5, "Maximum rapidity of Secondary"};
-  Configurable<float> cSecondaryRadiusMin{"cSecondaryRadiusMin", 0.0, "Minimum transverse radius of Secondary"};
-  Configurable<float> cSecondaryRadiusMax{"cSecondaryRadiusMax", 999.9, "Maximum transverse radius of Secondary"};
-  Configurable<float> cSecondaryCosPAMin{"cSecondaryCosPAMin", 0.998, "Mininum cosine pointing angle of Secondary"};
-  Configurable<float> cSecondaryDCAtoPVMax{"cSecondaryDCAtoPVMax", 0.4, "Maximum DCA Secondary to PV"};
-  Configurable<float> cSecondaryProperLifetimeMax{"cSecondaryProperLifetimeMax", 20., "Maximum Secondary Lifetime"};
-  Configurable<float> cSecondaryparamArmenterosCut{"cSecondaryparamArmenterosCut", 0.2, "parameter for Armenteros Cut"};
-  Configurable<float> cSecondaryMassWindow{"cSecondaryMassWindow", 0.03, "Secondary inv mass selection window"};
-  Configurable<float> cSecondaryCrossMassCutWindow{"cSecondaryCrossMassCutWindow", 0.05, "Secondary inv mass selection window with (anti)lambda hypothesis"};
+    Configurable<float> cfgSecondaryPtMin{"cfgSecondaryPtMin", 0.f, "Minimum transverse momentum of Secondary"};
+    Configurable<float> cfgSecondaryRapidityMax{"cfgSecondaryRapidityMax", 0.5, "Maximum rapidity of Secondary"};
+    Configurable<float> cfgSecondaryRadiusMin{"cfgSecondaryRadiusMin", 0.0, "Minimum transverse radius of Secondary"};
+    Configurable<float> cfgSecondaryRadiusMax{"cfgSecondaryRadiusMax", 999.9, "Maximum transverse radius of Secondary"};
+    Configurable<float> cfgSecondaryCosPAMin{"cfgSecondaryCosPAMin", 0.998, "Mininum cosine pointing angle of Secondary"};
+    Configurable<float> cfgSecondaryDCAtoPVMax{"cfgSecondaryDCAtoPVMax", 0.4, "Maximum DCA Secondary to PV"};
+    Configurable<float> cfgSecondaryProperLifetimeMax{"cfgSecondaryProperLifetimeMax", 20., "Maximum Secondary Lifetime"};
+    Configurable<float> cfgSecondaryparamArmenterosCut{"cfgSecondaryparamArmenterosCut", 0.2, "parameter for Armenteros Cut"};
+    Configurable<float> cfgSecondaryMassWindow{"cfgSecondaryMassWindow", 0.03, "Secondary inv mass selection window"};
+    Configurable<float> cfgSecondaryCrossMassCutWindow{"cfgSecondaryCrossMassCutWindow", 0.05, "Secondary inv mass selection window with (anti)lambda hypothesis"};
+  } SecondaryCuts;
 
   // K* selection
-  Configurable<float> cKstarMaxRap{"cKstarMaxRap", 0.5, "Kstar maximum rapidity"};
-  Configurable<float> cKstarMinRap{"cKstarMinRap", -0.5, "Kstar minimum rapidity"};
+  struct : ConfigurableGroup {
+    Configurable<float> cfgKstarMaxRap{"cfgKstarMaxRap", 0.5, "Kstar maximum rapidity"};
+    Configurable<float> cfgKstarMinRap{"cfgKstarMinRap", -0.5, "Kstar minimum rapidity"};
+  } KstarCuts;
 
   // Confs from flow analysis
-  Configurable<int> cfgnMods{"cfgnMods", 1, "The number of modulations of interest starting from 2"};
-  Configurable<int> cfgNQvec{"cfgNQvec", 7, "The number of total Qvectors for looping over the task"};
+  struct : ConfigurableGroup {
+    Configurable<int> cfgnMods{"cfgnMods", 2, "The number of modulations of interest starting from 2"};
+    Configurable<int> cfgNQvec{"cfgNQvec", 7, "The number of total Qvectors for looping over the task"};
 
-  Configurable<std::string> cfgQvecDetName{"cfgQvecDetName", "FT0C", "The name of detector to be analyzed"};
-  Configurable<std::string> cfgQvecRefAName{"cfgQvecRefAName", "TPCpos", "The name of detector for reference A"};
-  Configurable<std::string> cfgQvecRefBName{"cfgQvecRefBName", "TPCneg", "The name of detector for reference B"};
+    Configurable<std::string> cfgQvecDetName{"cfgQvecDetName", "FT0C", "The name of detector to be analyzed"};
+    Configurable<std::string> cfgQvecRefAName{"cfgQvecRefAName", "TPCpos", "The name of detector for reference A"};
+    Configurable<std::string> cfgQvecRefBName{"cfgQvecRefBName", "TPCneg", "The name of detector for reference B"};
+  } EventPlaneConfig;
 
   // Bkg estimation
-  Configurable<bool> cfgFillRotBkg{"cfgFillRotBkg", true, "Fill rotated background"};
-  Configurable<float> cfgMinRot{"cfgMinRot", 5.0 * constants::math::PI / 6.0, "Minimum of rotation"};
-  Configurable<float> cfgMaxRot{"cfgMaxRot", 7.0 * constants::math::PI / 6.0, "Maximum of rotation"};
-  Configurable<bool> cfgRotPion{"cfgRotPion", true, "Rotate pion"};
-  Configurable<int> cfgNrotBkg{"cfgNrotBkg", 9, "Number of rotated copies (background) per each original candidate"};
+  struct : ConfigurableGroup {
+    Configurable<bool> cfgFillRotBkg{"cfgFillRotBkg", true, "Fill rotated background"};
+    Configurable<float> cfgMinRot{"cfgMinRot", 5.0 * constants::math::PI / 6.0, "Minimum of rotation"};
+    Configurable<float> cfgMaxRot{"cfgMaxRot", 7.0 * constants::math::PI / 6.0, "Maximum of rotation"};
+    Configurable<bool> cfgRotPion{"cfgRotPion", true, "Rotate pion"};
+    Configurable<int> cfgNrotBkg{"cfgNrotBkg", 9, "Number of rotated copies (background) per each original candidate"};
+  } BkgEstimationConfig;
 
   int lDetId;
   int lRefAId;
@@ -234,23 +248,24 @@ struct Chk892Flow {
   {
     lCentrality = -999;
 
-    colCuts.setCuts(cfgEvtZvtx, cfgEvtTriggerCheck, cfgEvtOfflineCheck, /*checkRun3*/ true, /*triggerTVXsel*/ false, cfgEvtOccupancyInTimeRangeMax, cfgEvtOccupancyInTimeRangeMin);
+    colCuts.setCuts(EventCuts.cfgEvtZvtx, EventCuts.cfgEvtTriggerCheck, EventCuts.cfgEvtOfflineCheck, /*checkRun3*/ true, /*triggerTVXsel*/ false, EventCuts.cfgEvtOccupancyInTimeRangeMax, EventCuts.cfgEvtOccupancyInTimeRangeMin);
     colCuts.init(&histos);
-    colCuts.setTriggerTVX(cfgEvtTriggerTVXSel);
-    colCuts.setApplyTFBorderCut(cfgEvtTFBorderCut);
-    colCuts.setApplyITSTPCvertex(cfgEvtUseITSTPCvertex);
-    colCuts.setApplyZvertexTimedifference(cfgEvtZvertexTimedifference);
-    colCuts.setApplyPileupRejection(cfgEvtPileupRejection);
-    colCuts.setApplyNoITSROBorderCut(cfgEvtNoITSROBorderCut);
-    colCuts.setApplyCollInTimeRangeStandard(cfgEvtCollInTimeRangeStandard);
+    colCuts.setTriggerTVX(EventCuts.cfgEvtTriggerTVXSel);
+    colCuts.setApplyTFBorderCut(EventCuts.cfgEvtTFBorderCut);
+    colCuts.setApplyITSTPCvertex(EventCuts.cfgEvtUseITSTPCvertex);
+    colCuts.setApplyZvertexTimedifference(EventCuts.cfgEvtZvertexTimedifference);
+    colCuts.setApplyPileupRejection(EventCuts.cfgEvtPileupRejection);
+    colCuts.setApplyNoITSROBorderCut(EventCuts.cfgEvtNoITSROBorderCut);
+    colCuts.setApplyCollInTimeRangeStandard(EventCuts.cfgEvtCollInTimeRangeStandard);
+    colCuts.printCuts();
 
-    AxisSpec centAxis = {cfgBinsCent, "T0M (%)"};
-    AxisSpec vtxzAxis = {cfgBinsVtxZ, "Z Vertex (cm)"};
+    AxisSpec centAxis = {AxisConfig.cfgBinsCent, "T0M (%)"};
+    AxisSpec vtxzAxis = {AxisConfig.cfgBinsVtxZ, "Z Vertex (cm)"};
     AxisSpec epAxis = {100, -1.0 * constants::math::PI, constants::math::PI};
-    AxisSpec ptAxis = {cfgBinsPt, "#it{p}_{T} (GeV/#it{c})"};
-    AxisSpec ptAxisQA = {cfgBinsPtQA, "#it{p}_{T} (GeV/#it{c})"};
-    AxisSpec v2Axis = {cfgAxisV2, "#v_{2}"};
-    AxisSpec phiAxis = {cfgAxisPhi, "2(#phi-#Psi_{2})"};
+    AxisSpec ptAxis = {AxisConfig.cfgBinsPt, "#it{p}_{T} (GeV/#it{c})"};
+    AxisSpec ptAxisQA = {AxisConfig.cfgBinsPtQA, "#it{p}_{T} (GeV/#it{c})"};
+    AxisSpec v2Axis = {AxisConfig.cfgAxisV2, "#v_{2}"};
+    AxisSpec phiAxis = {AxisConfig.cfgAxisPhi, "2(#phi-#Psi_{2})"};
     AxisSpec radiusAxis = {50, 0, 5, "Radius (cm)"};
     AxisSpec cpaAxis = {30, 0.97, 1.0, "CPA"};
     AxisSpec tauAxis = {250, 0, 25, "Lifetime (cm)"};
@@ -258,15 +273,15 @@ struct Chk892Flow {
     AxisSpec dcaxyAxis = {100, 0, 1, "DCA_{#it{xy}} (cm)"};
     AxisSpec dcazAxis = {200, 0, 2, "DCA_{#it{z}} (cm)"};
     AxisSpec yAxis = {50, -1, 1, "Rapidity"};
-    AxisSpec invMassAxisK0s = {400 / cNbinsDiv, 0.3, 0.7, "Invariant Mass (GeV/#it{c}^2)"};    // K0s ~497.611
-    AxisSpec invMassAxisReso = {900 / cNbinsDiv, 0.5f, 1.4f, "Invariant Mass (GeV/#it{c}^2)"}; // chK(892) ~892
-    AxisSpec pidQAAxis = {130 / cNbinsDivQA, -6.5, 6.5};
+    AxisSpec invMassAxisK0s = {400 / AxisConfig.cNbinsDiv, 0.3, 0.7, "Invariant Mass (GeV/#it{c}^2)"};    // K0s ~497.611
+    AxisSpec invMassAxisReso = {900 / AxisConfig.cNbinsDiv, 0.5f, 1.4f, "Invariant Mass (GeV/#it{c}^2)"}; // chK(892) ~892
+    AxisSpec pidQAAxis = {130 / AxisConfig.cNbinsDivQA, -6.5, 6.5};
 
     // THnSparse
     AxisSpec axisType = {BinType::kTYEnd, 0, BinType::kTYEnd, "Type of bin with charge and mix"};
     AxisSpec mcLabelAxis = {5, -0.5, 4.5, "MC Label"};
 
-    if (cfgReturnFlag) {
+    if (SecondaryCuts.cfgReturnFlag) {
       histos.add("QA/K0sCutCheck", "Check K0s cut", HistType::kTH1D, {AxisSpec{13, -0.5, 12.5, "Check"}});
     }
     histos.add("QA/before/CentDist", "Centrality distribution", {HistType::kTH1D, {centAxis}});
@@ -280,14 +295,14 @@ struct Chk892Flow {
     histos.add("QA/EP/hEPResAC", "cos(n(A-C))", {HistType::kTH2D, {centAxis, epAxis}});
     histos.add("QA/EP/hEPResBC", "cos(n(B-C))", {HistType::kTH2D, {centAxis, epAxis}});
 
-    if (cfgUseScalProduct) {
+    if (AnalysisConfig.cfgUseScalProduct) {
       histos.add("QA/EP/hEPSPResAB", "cos(n(A-B))", {HistType::kTH2D, {centAxis, epAxis}});
       histos.add("QA/EP/hEPSPResAC", "cos(n(A-C))", {HistType::kTH2D, {centAxis, epAxis}});
       histos.add("QA/EP/hEPSPResBC", "cos(n(B-C))", {HistType::kTH2D, {centAxis, epAxis}});
     }
 
     // Rotated background
-    if (cfgFillRotBkg) {
+    if (BkgEstimationConfig.cfgFillRotBkg) {
       histos.add("QA/RotBkg/hRotBkg", "Rotated angle of rotated background", HistType::kTH1F, {{360, 0.0, o2::constants::math::TwoPI}});
     }
 
@@ -353,7 +368,7 @@ struct Chk892Flow {
 
     // Kstar
     // Invariant mass nSparse
-    if (cfgFillAdditionalAxis) {
+    if (AnalysisConfig.cfgFillAdditionalAxis) {
       histos.add("hInvmass_Kstar", "Invariant mass of unlike-sign chK(892)", HistType::kTHnSparseD, {axisType, centAxis, ptAxis, invMassAxisReso, v2Axis, phiAxis});
       histos.add("hInvmass_K0s", "Invariant mass of unlike-sign K0s", HistType::kTHnSparseD, {centAxis, ptAxis, invMassAxisK0s, v2Axis, phiAxis});
     } else {
@@ -374,16 +389,19 @@ struct Chk892Flow {
     histos.add("QA/after/kstarv2vsinvmass", "Invariant mass vs v2 of unlike-sign chK(892)", HistType::kTH2D, {invMassAxisReso, v2Axis});
     histos.add("QA/after/kstarinvmass_Mix", "Invariant mass of unlike-sign chK(892) from mixed event", HistType::kTH1D, {invMassAxisReso});
 
-    lDetId = getlDetId(cfgQvecDetName);
-    lRefAId = getlDetId(cfgQvecRefAName);
-    lRefBId = getlDetId(cfgQvecRefBName);
+    lDetId = getlDetId(EventPlaneConfig.cfgQvecDetName);
+    lRefAId = getlDetId(EventPlaneConfig.cfgQvecRefAName);
+    lRefBId = getlDetId(EventPlaneConfig.cfgQvecRefBName);
 
     if (lDetId == lRefAId || lDetId == lRefBId || lRefAId == lRefBId) {
       LOGF(info, "Wrong detector configuration \n The FT0C will be used to get Q-Vector \n The TPCpos and TPCneg will be used as reference systems");
-      // LOGF(info) << "Wrong detector configuration \n The FT0C will be used to get Q-Vector \n The TPCpos and TPCneg will be used as reference systems";
       lDetId = 0;
       lRefAId = 4;
       lRefBId = 5;
+    }
+
+    if (EventPlaneConfig.cfgNQvec < 2) {
+      LOG(fatal) << "nMode must be larger than 1, current input (cfgNQvec): " << EventPlaneConfig.cfgNQvec;
     }
 
     // MC
@@ -434,13 +452,13 @@ struct Chk892Flow {
       histos.add("QAMC/kstarinvmass_noKstar", "Invariant mass of unlike-sign no chK(892)", HistType::kTH1D, {invMassAxisReso});
       histos.add("QAMC/kstarv2vsinvmass_noKstar", "Invariant mass vs v2 of unlike-sign no chK(892)", HistType::kTH2D, {invMassAxisReso, v2Axis});
 
-      if (cfgFillAdditionalAxis) {
+      if (AnalysisConfig.cfgFillAdditionalAxis) {
         histos.add("hInvmass_Kstar_MC", "Invariant mass of unlike chK(892)", HistType::kTHnSparseD, {axisType, centAxis, ptAxis, invMassAxisReso, v2Axis, phiAxis});
       } else {
         histos.add("hInvmass_Kstar_MC", "Invariant mass of unlike chK(892)", HistType::kTHnSparseD, {axisType, centAxis, ptAxis, invMassAxisReso, v2Axis});
       }
 
-      ccdb->setURL(cfgURL);
+      ccdb->setURL(CCDBConfig.cfgURL);
       ccdbApi.init("http://alice-ccdb.cern.ch");
       ccdb->setCaching(true);
       ccdb->setLocalObjectValidityChecking();
@@ -450,14 +468,15 @@ struct Chk892Flow {
     // Print output histograms statistics
     LOG(info) << "Size of the histograms in chK(892) Analysis Task";
     histos.print();
+    LOGF(info, "lDetId: %d, lRefAId: %d, lRefBId: %d", lDetId, lRefAId, lRefBId);
   }
 
   template <typename CollisionType>
   float getCentrality(CollisionType const& collision)
   {
-    if (cfgCentEst == 1) {
+    if (AnalysisConfig.cfgCentEst == 1) {
       return collision.centFT0C();
-    } else if (cfgCentEst == 2) {
+    } else if (AnalysisConfig.cfgCentEst == 2) {
       return collision.centFT0M();
     } else {
       return -999;
@@ -490,47 +509,47 @@ struct Chk892Flow {
   bool trackCut(TrackType const& track)
   {
     // basic track cuts
-    if (std::abs(track.pt()) < cMinPtcut)
+    if (std::abs(track.pt()) < TrackCuts.cfgMinPtcut)
       return false;
-    if (std::abs(track.eta()) > cMaxEtacut)
+    if (std::abs(track.eta()) > TrackCuts.cfgMaxEtacut)
       return false;
-    if (track.itsNCls() < cfgITScluster)
+    if (track.itsNCls() < TrackCuts.cfgITScluster)
       return false;
-    if (track.tpcNClsFound() < cfgTPCcluster)
+    if (track.tpcNClsFound() < TrackCuts.cfgTPCcluster)
       return false;
-    if (track.tpcCrossedRowsOverFindableCls() < cfgRatioTPCRowsOverFindableCls)
+    if (track.tpcCrossedRowsOverFindableCls() < TrackCuts.cfgRatioTPCRowsOverFindableCls)
       return false;
-    if (track.itsChi2NCl() >= cfgITSChi2NCl)
+    if (track.itsChi2NCl() >= TrackCuts.cfgITSChi2NCl)
       return false;
-    if (track.tpcChi2NCl() >= cfgTPCChi2NCl)
+    if (track.tpcChi2NCl() >= TrackCuts.cfgTPCChi2NCl)
       return false;
-    if (cfgHasITS && !track.hasITS())
+    if (TrackCuts.cfgHasITS && !track.hasITS())
       return false;
-    if (cfgHasTPC && !track.hasTPC())
+    if (TrackCuts.cfgHasTPC && !track.hasTPC())
       return false;
-    if (cfgHasTOF && !track.hasTOF())
+    if (TrackCuts.cfgHasTOF && !track.hasTOF())
       return false;
-    if (cfgUseITSRefit && !track.passedITSRefit())
+    if (TrackCuts.cfgUseITSRefit && !track.passedITSRefit())
       return false;
-    if (cfgUseTPCRefit && !track.passedTPCRefit())
+    if (TrackCuts.cfgUseTPCRefit && !track.passedTPCRefit())
       return false;
-    if (cfgPVContributor && !track.isPVContributor())
+    if (TrackCuts.cfgPVContributor && !track.isPVContributor())
       return false;
-    if (cfgGlobalWoDCATrack && !track.isGlobalTrackWoDCA())
+    if (TrackCuts.cfgGlobalWoDCATrack && !track.isGlobalTrackWoDCA())
       return false;
-    if (cfgGlobalTrack && !track.isGlobalTrack())
+    if (TrackCuts.cfgGlobalTrack && !track.isGlobalTrack())
       return false;
-    if (cfgPrimaryTrack && !track.isPrimaryTrack())
+    if (TrackCuts.cfgPrimaryTrack && !track.isPrimaryTrack())
       return false;
-    if (cfgpTdepDCAxyCut) {
+    if (TrackCuts.cfgpTdepDCAxyCut) {
       // Tuned on the LHC22f anchored MC LHC23d1d on primary pions. 7 Sigmas of the resolution
       if (std::abs(track.dcaXY()) > (0.004 + (0.013 / track.pt())))
         return false;
     } else {
-      if (std::abs(track.dcaXY()) > cMaxbDCArToPVcut)
+      if (std::abs(track.dcaXY()) > TrackCuts.cfgMaxbDCArToPVcut)
         return false;
     }
-    if (std::abs(track.dcaZ()) > cMaxbDCAzToPVcut)
+    if (std::abs(track.dcaZ()) > TrackCuts.cfgMaxbDCAzToPVcut)
       return false;
     return true;
   }
@@ -539,21 +558,21 @@ struct Chk892Flow {
   template <typename TrackType>
   bool selectionPIDPion(TrackType const& candidate)
   {
-    bool tpcPIDPassed = std::abs(candidate.tpcNSigmaPi()) < cMaxTPCnSigmaPion;
+    bool tpcPIDPassed = std::abs(candidate.tpcNSigmaPi()) < PIDCuts.cfgMaxTPCnSigmaPion;
     bool tofPIDPassed = false;
 
-    if (cTPConly) {
+    if (PIDCuts.cfgTPConly) {
       return tpcPIDPassed;
     }
 
     if (candidate.hasTOF()) {
-      tofPIDPassed = std::abs(candidate.tofNSigmaPi()) < cMaxTOFnSigmaPion ||
-                     (nsigmaCutCombinedPion > 0 &&
+      tofPIDPassed = std::abs(candidate.tofNSigmaPi()) < PIDCuts.cfgMaxTOFnSigmaPion ||
+                     (PIDCuts.cfgNsigmaCutCombinedPion > 0 &&
                       candidate.tpcNSigmaPi() * candidate.tpcNSigmaPi() +
                           candidate.tofNSigmaPi() * candidate.tofNSigmaPi() <
-                        nsigmaCutCombinedPion * nsigmaCutCombinedPion);
+                        PIDCuts.cfgNsigmaCutCombinedPion * PIDCuts.cfgNsigmaCutCombinedPion);
     } else {
-      tofPIDPassed = cTOFVeto;
+      tofPIDPassed = PIDCuts.cfgTOFVeto;
     }
 
     return tpcPIDPassed && tofPIDPassed;
@@ -576,92 +595,92 @@ struct Chk892Flow {
     auto lMALambda = candidate.mAntiLambda();
 
     auto checkCommonCuts = [&]() {
-      if (lDauDCA > cSecondaryDauDCAMax)
+      if (lDauDCA > SecondaryCuts.cfgSecondaryDauDCAMax)
         return false;
-      if (lDauPosDCAtoPV < cSecondaryDauPosDCAtoPVMin)
+      if (lDauPosDCAtoPV < SecondaryCuts.cfgSecondaryDauPosDCAtoPVMin)
         return false;
-      if (lDauNegDCAtoPV < cSecondaryDauNegDCAtoPVMin)
+      if (lDauNegDCAtoPV < SecondaryCuts.cfgSecondaryDauNegDCAtoPVMin)
         return false;
-      if (lPt < cSecondaryPtMin)
+      if (lPt < SecondaryCuts.cfgSecondaryPtMin)
         return false;
-      if (std::fabs(lRapidity) > cSecondaryRapidityMax)
+      if (std::fabs(lRapidity) > SecondaryCuts.cfgSecondaryRapidityMax)
         return false;
-      if (lRadius < cSecondaryRadiusMin || lRadius > cSecondaryRadiusMax)
+      if (lRadius < SecondaryCuts.cfgSecondaryRadiusMin || lRadius > SecondaryCuts.cfgSecondaryRadiusMax)
         return false;
-      if (lDCAtoPV > cSecondaryDCAtoPVMax)
+      if (lDCAtoPV > SecondaryCuts.cfgSecondaryDCAtoPVMax)
         return false;
-      if (lCPA < cSecondaryCosPAMin)
+      if (lCPA < SecondaryCuts.cfgSecondaryCosPAMin)
         return false;
-      if (lPropTauK0s > cSecondaryProperLifetimeMax)
+      if (lPropTauK0s > SecondaryCuts.cfgSecondaryProperLifetimeMax)
         return false;
-      if (candidate.qtarm() < cSecondaryparamArmenterosCut * std::abs(candidate.alpha()))
+      if (candidate.qtarm() < SecondaryCuts.cfgSecondaryparamArmenterosCut * std::abs(candidate.alpha()))
         return false;
-      if (std::fabs(lMk0s - MassK0Short) > cSecondaryMassWindow)
+      if (std::fabs(lMk0s - MassK0Short) > SecondaryCuts.cfgSecondaryMassWindow)
         return false;
-      if (cSecondaryCrossMassHypothesisCut &&
-          ((std::fabs(lMLambda - MassLambda0) < cSecondaryCrossMassCutWindow) || (std::fabs(lMALambda - MassLambda0Bar) < cSecondaryCrossMassCutWindow)))
+      if (SecondaryCuts.cfgSecondaryCrossMassHypothesisCut &&
+          ((std::fabs(lMLambda - MassLambda0) < SecondaryCuts.cfgSecondaryCrossMassCutWindow) || (std::fabs(lMALambda - MassLambda0Bar) < SecondaryCuts.cfgSecondaryCrossMassCutWindow)))
         return false;
       return true;
     };
 
-    if (cfgReturnFlag) { // For cut study
+    if (SecondaryCuts.cfgReturnFlag) { // For cut study
       bool returnFlag = true;
       histos.fill(HIST("QA/K0sCutCheck"), 0);
-      if (lDauDCA > cSecondaryDauDCAMax) {
+      if (lDauDCA > SecondaryCuts.cfgSecondaryDauDCAMax) {
         histos.fill(HIST("QA/K0sCutCheck"), 1);
         returnFlag = false;
       }
-      if (lDauPosDCAtoPV < cSecondaryDauPosDCAtoPVMin) {
+      if (lDauPosDCAtoPV < SecondaryCuts.cfgSecondaryDauPosDCAtoPVMin) {
         histos.fill(HIST("QA/K0sCutCheck"), 2);
         returnFlag = false;
       }
-      if (lDauNegDCAtoPV < cSecondaryDauNegDCAtoPVMin) {
+      if (lDauNegDCAtoPV < SecondaryCuts.cfgSecondaryDauNegDCAtoPVMin) {
         histos.fill(HIST("QA/K0sCutCheck"), 3);
         returnFlag = false;
       }
-      if (lPt < cSecondaryPtMin) {
+      if (lPt < SecondaryCuts.cfgSecondaryPtMin) {
         histos.fill(HIST("QA/K0sCutCheck"), 4);
         returnFlag = false;
       }
-      if (std::fabs(lRapidity) > cSecondaryRapidityMax) {
+      if (std::fabs(lRapidity) > SecondaryCuts.cfgSecondaryRapidityMax) {
         histos.fill(HIST("QA/K0sCutCheck"), 5);
         returnFlag = false;
       }
-      if (lRadius < cSecondaryRadiusMin || lRadius > cSecondaryRadiusMax) {
+      if (lRadius < SecondaryCuts.cfgSecondaryRadiusMin || lRadius > SecondaryCuts.cfgSecondaryRadiusMax) {
         histos.fill(HIST("QA/K0sCutCheck"), 6);
         returnFlag = false;
       }
-      if (lDCAtoPV > cSecondaryDCAtoPVMax) {
+      if (lDCAtoPV > SecondaryCuts.cfgSecondaryDCAtoPVMax) {
         histos.fill(HIST("QA/K0sCutCheck"), 7);
         returnFlag = false;
       }
-      if (lCPA < cSecondaryCosPAMin) {
+      if (lCPA < SecondaryCuts.cfgSecondaryCosPAMin) {
         histos.fill(HIST("QA/K0sCutCheck"), 8);
         returnFlag = false;
       }
-      if (lPropTauK0s > cSecondaryProperLifetimeMax) {
+      if (lPropTauK0s > SecondaryCuts.cfgSecondaryProperLifetimeMax) {
         histos.fill(HIST("QA/K0sCutCheck"), 9);
         returnFlag = false;
       }
-      if (candidate.qtarm() < cSecondaryparamArmenterosCut * std::abs(candidate.alpha())) {
+      if (candidate.qtarm() < SecondaryCuts.cfgSecondaryparamArmenterosCut * std::abs(candidate.alpha())) {
         histos.fill(HIST("QA/K0sCutCheck"), 10);
         returnFlag = false;
       }
-      if (std::fabs(lMk0s - MassK0Short) > cSecondaryMassWindow) {
+      if (std::fabs(lMk0s - MassK0Short) > SecondaryCuts.cfgSecondaryMassWindow) {
         histos.fill(HIST("QA/K0sCutCheck"), 11);
         returnFlag = false;
       }
-      if (cSecondaryCrossMassHypothesisCut &&
-          ((std::fabs(lMLambda - MassLambda0) < cSecondaryCrossMassCutWindow) || (std::fabs(lMALambda - MassLambda0Bar) < cSecondaryCrossMassCutWindow))) {
+      if (SecondaryCuts.cfgSecondaryCrossMassHypothesisCut &&
+          ((std::fabs(lMLambda - MassLambda0) < SecondaryCuts.cfgSecondaryCrossMassCutWindow) || (std::fabs(lMALambda - MassLambda0Bar) < SecondaryCuts.cfgSecondaryCrossMassCutWindow))) {
         histos.fill(HIST("QA/K0sCutCheck"), 12);
         returnFlag = false;
       }
       return returnFlag;
     } else { // normal usage
-      if (cSecondaryRequire) {
+      if (SecondaryCuts.cfgSecondaryRequire) {
         return checkCommonCuts();
       } else {
-        return std::fabs(lMk0s - MassK0Short) <= cSecondaryMassWindow; // always apply mass window cut
+        return std::fabs(lMk0s - MassK0Short) <= SecondaryCuts.cfgSecondaryMassWindow; // always apply mass window cut
       }
     }
   } // selectionK0s
@@ -707,9 +726,9 @@ struct Chk892Flow {
   {
     histos.fill(HIST("QA/before/CentDist"), lCentrality);
 
-    lQvecDetInd = lDetId * 4 + 3 + (nmode - 2) * cfgNQvec * 4;
-    lQvecRefAInd = lRefAId * 4 + 3 + (nmode - 2) * cfgNQvec * 4;
-    lQvecRefBInd = lRefBId * 4 + 3 + (nmode - 2) * cfgNQvec * 4;
+    lQvecDetInd = lDetId * 4 + 3 + (nmode - 2) * EventPlaneConfig.cfgNQvec * 4;
+    lQvecRefAInd = lRefAId * 4 + 3 + (nmode - 2) * EventPlaneConfig.cfgNQvec * 4;
+    lQvecRefBInd = lRefBId * 4 + 3 + (nmode - 2) * EventPlaneConfig.cfgNQvec * 4;
 
     double lEPDet = std::atan2(collision.qvecIm()[lQvecDetInd], collision.qvecRe()[lQvecDetInd]) / static_cast<float>(nmode);
     double lEPRefB = std::atan2(collision.qvecIm()[lQvecRefAInd], collision.qvecRe()[lQvecRefAInd]) / static_cast<float>(nmode);
@@ -727,7 +746,7 @@ struct Chk892Flow {
     histos.fill(HIST("QA/EP/hEPResAC"), lCentrality, lEPResAC);
     histos.fill(HIST("QA/EP/hEPResBC"), lCentrality, lEPResBC);
     // Scalar product method
-    if (cfgUseScalProduct) {
+    if (AnalysisConfig.cfgUseScalProduct) {
       double lEPSPResAB = collision.qvecRe()[lQvecDetInd] * collision.qvecRe()[lQvecRefAInd] + collision.qvecIm()[lQvecDetInd] * collision.qvecIm()[lQvecRefAInd] * lEPResAB;
       double lEPSPResAC = collision.qvecRe()[lQvecDetInd] * collision.qvecRe()[lQvecRefBInd] + collision.qvecIm()[lQvecDetInd] * collision.qvecIm()[lQvecRefBInd] * lEPResAC;
       double lEPSPResBC = collision.qvecRe()[lQvecRefAInd] * collision.qvecRe()[lQvecRefBInd] + collision.qvecIm()[lQvecRefAInd] * collision.qvecIm()[lQvecRefBInd] * lEPResBC;
@@ -834,9 +853,9 @@ struct Chk892Flow {
         histos.fill(HIST("QA/before/k0sv2vsinvmass"), lResoSecondary.M(), v2K0s);
       }
 
-      if (!cfgByPassDauPIDSelection && !selectionPIDPion(posDauTrack))
+      if (!SecondaryCuts.cfgByPassDauPIDSelection && !selectionPIDPion(posDauTrack))
         continue;
-      if (!cfgByPassDauPIDSelection && !selectionPIDPion(negDauTrack))
+      if (!SecondaryCuts.cfgByPassDauPIDSelection && !selectionPIDPion(negDauTrack))
         continue;
       if (!selectionK0s(collision, k0sCand))
         continue;
@@ -869,7 +888,7 @@ struct Chk892Flow {
         histos.fill(HIST("QA/after/hInvmassSecondary"), trkkMass);
 
         histos.fill(HIST("QA/after/k0sv2vsinvmass"), lResoSecondary.M(), v2K0s);
-        if (cfgFillAdditionalAxis) {
+        if (AnalysisConfig.cfgFillAdditionalAxis) {
           histos.fill(HIST("hInvmass_K0s"), lCentrality, lResoSecondary.Pt(), lResoSecondary.M(), v2K0s, static_cast<float>(nmode) * lPhiMinusPsiK0s);
         } else {
           histos.fill(HIST("hInvmass_K0s"), lCentrality, lResoSecondary.Pt(), lResoSecondary.M(), v2K0s);
@@ -891,7 +910,7 @@ struct Chk892Flow {
         auto lPhiMinusPsiKstar = RecoDecay::constrainAngle(resoPhi - lEPDet, 0.0, 2); // constrain angle to range 0, Pi
         auto resoFlowValue = std::cos(static_cast<float>(nmode) * lPhiMinusPsiKstar);
         // Scalar product method
-        if (cfgUseScalProduct) {
+        if (AnalysisConfig.cfgUseScalProduct) {
           float cosNPhi = std::cos(static_cast<float>(nmode) * resoPhi);
           float sinNPhi = std::sin(static_cast<float>(nmode) * resoPhi);
           resoFlowValue = cosNPhi * collision.qvecRe()[lQvecDetInd] + sinNPhi * collision.qvecIm()[lQvecDetInd];
@@ -904,7 +923,7 @@ struct Chk892Flow {
           histos.fill(HIST("QA/before/kstarv2vsinvmass"), lResoKstar.M(), resoFlowValue);
         }
 
-        if (lResoKstar.Rapidity() > cKstarMaxRap || lResoKstar.Rapidity() < cKstarMinRap)
+        if (lResoKstar.Rapidity() > KstarCuts.cfgKstarMaxRap || lResoKstar.Rapidity() < KstarCuts.cfgKstarMinRap)
           continue;
 
         if constexpr (!IsMix) {
@@ -913,17 +932,17 @@ struct Chk892Flow {
           histos.fill(HIST("QA/after/KstarRapidity"), lResoKstar.Rapidity());
           histos.fill(HIST("QA/after/kstarinvmass"), lResoKstar.M());
           histos.fill(HIST("QA/after/kstarv2vsinvmass"), lResoKstar.M(), resoFlowValue);
-          if (cfgFillAdditionalAxis) {
+          if (AnalysisConfig.cfgFillAdditionalAxis) {
             histos.fill(HIST("hInvmass_Kstar"), typeKstar, lCentrality, lResoKstar.Pt(), lResoKstar.M(), resoFlowValue, static_cast<float>(nmode) * lPhiMinusPsiKstar);
           } else {
             histos.fill(HIST("hInvmass_Kstar"), typeKstar, lCentrality, lResoKstar.Pt(), lResoKstar.M(), resoFlowValue);
           }
 
-          if (cfgFillRotBkg) {
-            for (int i = 0; i < cfgNrotBkg; i++) {
-              auto lRotAngle = cfgMinRot + i * (cfgMaxRot - cfgMinRot) / (1.0 * (cfgNrotBkg - 1));
+          if (BkgEstimationConfig.cfgFillRotBkg) {
+            for (int i = 0; i < BkgEstimationConfig.cfgNrotBkg; i++) {
+              auto lRotAngle = BkgEstimationConfig.cfgMinRot + i * ((BkgEstimationConfig.cfgMaxRot - BkgEstimationConfig.cfgMinRot) / (BkgEstimationConfig.cfgNrotBkg - 1));
               histos.fill(HIST("QA/RotBkg/hRotBkg"), lRotAngle);
-              if (cfgRotPion) {
+              if (BkgEstimationConfig.cfgRotPion) {
                 lDaughterRot = lDecayDaughter_bach;
                 lDaughterRot.RotateZ(lRotAngle);
                 lResonanceRot = lDaughterRot + lResoSecondary;
@@ -935,13 +954,13 @@ struct Chk892Flow {
               resoPhi = lResonanceRot.Phi();
               auto lPhiMinusPsiKstar = RecoDecay::constrainAngle(resoPhi - lEPDet, 0.0, 2); // constrain angle to range 0, Pi
               auto resoFlowValue = std::cos(static_cast<float>(nmode) * lPhiMinusPsiKstar);
-              if (cfgUseScalProduct) {
+              if (AnalysisConfig.cfgUseScalProduct) {
                 float cosNPhi = std::cos(static_cast<float>(nmode) * resoPhi);
                 float sinNPhi = std::sin(static_cast<float>(nmode) * resoPhi);
                 resoFlowValue = cosNPhi * collision.qvecRe()[lQvecDetInd] + sinNPhi * collision.qvecIm()[lQvecDetInd];
               }
               typeKstar = bTrack.sign() > 0 ? BinType::kKstarP_Rot : BinType::kKstarN_Rot;
-              if (cfgFillAdditionalAxis) {
+              if (AnalysisConfig.cfgFillAdditionalAxis) {
                 histos.fill(HIST("hInvmass_Kstar"), typeKstar, lCentrality, lResonanceRot.Pt(), lResonanceRot.M(), resoFlowValue, static_cast<float>(nmode) * lPhiMinusPsiKstar);
               } else {
                 histos.fill(HIST("hInvmass_Kstar"), typeKstar, lCentrality, lResonanceRot.Pt(), lResonanceRot.M(), resoFlowValue);
@@ -970,12 +989,12 @@ struct Chk892Flow {
   {
     if (!colCuts.isSelected(collision)) // Default event selection
       return;
-    if (cfgQvecSel && (collision.qvecAmp()[lDetId] < 1e-4 || collision.qvecAmp()[lRefAId] < 1e-4 || collision.qvecAmp()[lRefBId] < 1e-4))
+    if (AnalysisConfig.cfgQvecSel && (collision.qvecAmp()[lDetId] < 1e-4 || collision.qvecAmp()[lRefAId] < 1e-4 || collision.qvecAmp()[lRefBId] < 1e-4))
       return; // If we don't have a Q-vector
     colCuts.fillQA(collision);
     lCentrality = getCentrality(collision);
 
-    fillHistograms<false, false>(collision, tracks, v0s, 2); // second order
+    fillHistograms<false, false>(collision, tracks, v0s, EventPlaneConfig.cfgnMods); // second order
   }
   PROCESS_SWITCH(Chk892Flow, processData, "Process Event for data without Partitioning", false);
 
@@ -984,7 +1003,7 @@ struct Chk892Flow {
                  MCTrackCandidates const& tracks,
                  MCV0Candidates const& v0s)
   {
-    fillHistograms<true, false>(collision, tracks, v0s, 2);
+    fillHistograms<true, false>(collision, tracks, v0s, EventPlaneConfig.cfgnMods);
   }
   PROCESS_SWITCH(Chk892Flow, processMC, "Process Event for MC", false);
 };

--- a/PWGLF/Tasks/Resonances/chk892Flow.cxx
+++ b/PWGLF/Tasks/Resonances/chk892Flow.cxx
@@ -524,7 +524,7 @@ struct Chk892Flow {
       return false;
     if (cfgpTdepDCAxyCut) {
       // Tuned on the LHC22f anchored MC LHC23d1d on primary pions. 7 Sigmas of the resolution
-      if (std::abs(track.dcaXY()) > 0.004 + 0.013 / track.pt())
+      if (std::abs(track.dcaXY()) > (0.004 + (0.013 / track.pt())))
         return false;
     } else {
       if (std::abs(track.dcaXY()) > cMaxbDCArToPVcut)


### PR DESCRIPTION
- Add a new configurable `cfgpTdepDCAxyCut` to switch on the pT-dependent DCAxy selection
- Default values are reference from the tuned parameters based on the `LHC22f` anchored MC `LHC23d1d` on primary pions. 
  - 7 Sigmas of the resolution applied temporary