### PR TITLE
[Common,PWGDQ] A First version of process using realigned muon tracks in table-maker

### DIFF
--- a/Common/DataModel/FwdTrackReAlignTables.h
+++ b/Common/DataModel/FwdTrackReAlignTables.h
@@ -20,48 +20,136 @@
 
 namespace o2::aod
 {
-namespace fwdtrack
+namespace fwdtrackrealign
 {
-// Extra columns for re-aligned forward tracks
+// FwdTracksRealign Columns definitions
+DECLARE_SOA_INDEX_COLUMN(Collision, collision);    //!
+DECLARE_SOA_INDEX_COLUMN(FwdTrack, fwdtrack);      //! FwdTrack index
+DECLARE_SOA_COLUMN(TrackType, trackType, uint8_t); //! Type of track. See enum ForwardTrackTypeEnum
+DECLARE_SOA_COLUMN(X, x, float);                   //! TrackParFwd parameter x
+DECLARE_SOA_COLUMN(Y, y, float);                   //! TrackParFwd parameter y
+DECLARE_SOA_COLUMN(Z, z, float);                   //! TrackParFwd propagation parameter z
+DECLARE_SOA_COLUMN(Phi, phi, float);               //! TrackParFwd parameter phi; (i.e. pt pointing direction)
+DECLARE_SOA_COLUMN(Tgl, tgl, float);               //! TrackParFwd parameter tan(\lamba); (\lambda = 90 - \theta_{polar})
+DECLARE_SOA_COLUMN(Signed1Pt, signed1Pt, float);   //! TrackParFwd parameter: charged inverse transverse momentum; (q/pt)
 DECLARE_SOA_COLUMN(IsRemovable, isRemovable, int); //! flag to validate the re-aligned track
-} // namespace fwdtrack
+DECLARE_SOA_COLUMN(Chi2, chi2, float);             //! Track chi^2
+
+// FwdTracksCovRealign columns definitions
+DECLARE_SOA_COLUMN(SigmaX, sigmaX, float);        //! Covariance matrix
+DECLARE_SOA_COLUMN(SigmaY, sigmaY, float);        //! Covariance matrix
+DECLARE_SOA_COLUMN(SigmaPhi, sigmaPhi, float);    //! Covariance matrix
+DECLARE_SOA_COLUMN(SigmaTgl, sigmaTgl, float);    //! Covariance matrix
+DECLARE_SOA_COLUMN(Sigma1Pt, sigma1Pt, float);    //! Covariance matrix
+DECLARE_SOA_COLUMN(RhoXY, rhoXY, int8_t);         //! Covariance matrix in compressed form
+DECLARE_SOA_COLUMN(RhoPhiX, rhoPhiX, int8_t);     //! Covariance matrix in compressed form
+DECLARE_SOA_COLUMN(RhoPhiY, rhoPhiY, int8_t);     //! Covariance matrix in compressed form
+DECLARE_SOA_COLUMN(RhoTglX, rhoTglX, int8_t);     //! Covariance matrix in compressed form
+DECLARE_SOA_COLUMN(RhoTglY, rhoTglY, int8_t);     //! Covariance matrix in compressed form
+DECLARE_SOA_COLUMN(RhoTglPhi, rhoTglPhi, int8_t); //! Covariance matrix in compressed form
+DECLARE_SOA_COLUMN(Rho1PtX, rho1PtX, int8_t);     //! Covariance matrix in compressed form
+DECLARE_SOA_COLUMN(Rho1PtY, rho1PtY, int8_t);     //! Covariance matrix in compressed form
+DECLARE_SOA_COLUMN(Rho1PtPhi, rho1PtPhi, int8_t); //! Covariance matrix in compressed form
+DECLARE_SOA_COLUMN(Rho1PtTgl, rho1PtTgl, int8_t); //! Covariance matrix in compressed form
+
+// Dynamic and expression columns
+DECLARE_SOA_DYNAMIC_COLUMN(Sign, sign, //! Sign of the track eletric charge
+                           [](float signed1Pt) -> short { return (signed1Pt > 0) ? 1 : -1; });
+DECLARE_SOA_DYNAMIC_COLUMN(Px, px, //!
+                           [](float pt, float phi) -> float {
+                             return pt * std::cos(phi);
+                           });
+DECLARE_SOA_DYNAMIC_COLUMN(Py, py, //!
+                           [](float pt, float phi) -> float {
+                             return pt * std::sin(phi);
+                           });
+DECLARE_SOA_DYNAMIC_COLUMN(Pz, pz, //!
+                           [](float pt, float tgl) -> float {
+                             return pt * tgl;
+                           });
+
+DECLARE_SOA_EXPRESSION_COLUMN(Eta, eta, float, //!
+                              -1.f * nlog(ntan(o2::constants::math::PIQuarter - 0.5f * natan(aod::fwdtrackrealign::tgl))));
+DECLARE_SOA_EXPRESSION_COLUMN(Pt, pt, float, //!
+                              ifnode(nabs(aod::fwdtrackrealign::signed1Pt) < o2::constants::math::Almost0, o2::constants::math::VeryBig, nabs(1.f / aod::fwdtrackrealign::signed1Pt)));
+DECLARE_SOA_EXPRESSION_COLUMN(P, p, float, //!
+                              ifnode((nabs(aod::fwdtrackrealign::signed1Pt) < o2::constants::math::Almost0) || (nabs(o2::constants::math::PIQuarter - 0.5f * natan(aod::fwdtrackrealign::tgl)) < o2::constants::math::Almost0), o2::constants::math::VeryBig, 0.5f * (ntan(o2::constants::math::PIQuarter - 0.5f * natan(aod::fwdtrackrealign::tgl)) + 1.f / ntan(o2::constants::math::PIQuarter - 0.5f * natan(aod::fwdtrackrealign::tgl))) / nabs(aod::fwdtrackrealign::signed1Pt)));
+DECLARE_SOA_EXPRESSION_COLUMN(CXX, cXX, float, //!
+                              aod::fwdtrackrealign::sigmaX* aod::fwdtrackrealign::sigmaX);
+DECLARE_SOA_EXPRESSION_COLUMN(CXY, cXY, float, //!
+                              (aod::fwdtrackrealign::rhoXY / 128.f) * (aod::fwdtrackrealign::sigmaX * aod::fwdtrackrealign::sigmaY));
+DECLARE_SOA_EXPRESSION_COLUMN(CYY, cYY, float, //!
+                              aod::fwdtrackrealign::sigmaY* aod::fwdtrackrealign::sigmaY);
+DECLARE_SOA_EXPRESSION_COLUMN(CPhiX, cPhiX, float, //!
+                              (aod::fwdtrackrealign::rhoPhiX / 128.f) * (aod::fwdtrackrealign::sigmaPhi * aod::fwdtrackrealign::sigmaX));
+DECLARE_SOA_EXPRESSION_COLUMN(CPhiY, cPhiY, float, //!
+                              (aod::fwdtrackrealign::rhoPhiY / 128.f) * (aod::fwdtrackrealign::sigmaPhi * aod::fwdtrackrealign::sigmaY));
+DECLARE_SOA_EXPRESSION_COLUMN(CPhiPhi, cPhiPhi, float, //!
+                              aod::fwdtrackrealign::sigmaPhi* aod::fwdtrackrealign::sigmaPhi);
+DECLARE_SOA_EXPRESSION_COLUMN(CTglX, cTglX, float, //!
+                              (aod::fwdtrackrealign::rhoTglX / 128.f) * (aod::fwdtrackrealign::sigmaTgl * aod::fwdtrackrealign::sigmaX));
+DECLARE_SOA_EXPRESSION_COLUMN(CTglY, cTglY, float, //!
+                              (aod::fwdtrackrealign::rhoTglY / 128.f) * (aod::fwdtrackrealign::sigmaTgl * aod::fwdtrackrealign::sigmaY));
+DECLARE_SOA_EXPRESSION_COLUMN(CTglPhi, cTglPhi, float, //!
+                              (aod::fwdtrackrealign::rhoTglPhi / 128.f) * (aod::fwdtrackrealign::sigmaTgl * aod::fwdtrackrealign::sigmaPhi));
+DECLARE_SOA_EXPRESSION_COLUMN(CTglTgl, cTglTgl, float, //!
+                              aod::fwdtrackrealign::sigmaTgl* aod::fwdtrackrealign::sigmaTgl);
+DECLARE_SOA_EXPRESSION_COLUMN(C1PtY, c1PtY, float, //!
+                              (aod::fwdtrackrealign::rho1PtY / 128.f) * (aod::fwdtrackrealign::sigma1Pt * aod::fwdtrackrealign::sigmaY));
+DECLARE_SOA_EXPRESSION_COLUMN(C1PtX, c1PtX, float, //!
+                              (aod::fwdtrackrealign::rho1PtX / 128.f) * (aod::fwdtrackrealign::sigma1Pt * aod::fwdtrackrealign::sigmaX));
+DECLARE_SOA_EXPRESSION_COLUMN(C1PtPhi, c1PtPhi, float, //!
+                              (aod::fwdtrackrealign::rho1PtPhi / 128.f) * (aod::fwdtrackrealign::sigma1Pt * aod::fwdtrackrealign::sigmaPhi));
+DECLARE_SOA_EXPRESSION_COLUMN(C1PtTgl, c1PtTgl, float, //!
+                              (aod::fwdtrackrealign::rho1PtTgl / 128.f) * (aod::fwdtrackrealign::sigma1Pt * aod::fwdtrackrealign::sigmaTgl));
+DECLARE_SOA_EXPRESSION_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float, //!
+                              aod::fwdtrackrealign::sigma1Pt* aod::fwdtrackrealign::sigma1Pt);
+} // namespace fwdtrackrealign
 
 // Tracks including MCH and/or MCH (plus optionally MFT)          //!
 DECLARE_SOA_TABLE_FULL(StoredFwdTracksReAlign, "FwdTracksReAlign", "AOD", "FWDTRACKREALIGN",
-                       fwdtrack::X, fwdtrack::Y, fwdtrack::Z, fwdtrack::Phi, fwdtrack::Tgl,
-                       fwdtrack::Signed1Pt,
-                       fwdtrack::Px<fwdtrack::Pt, fwdtrack::Phi>,
-                       fwdtrack::Py<fwdtrack::Pt, fwdtrack::Phi>,
-                       fwdtrack::Pz<fwdtrack::Pt, fwdtrack::Tgl>,
-                       fwdtrack::Chi2,
-                       fwdtrack::IsRemovable);
+                       o2::soa::Index<>, fwdtrackrealign::CollisionId, fwdtrackrealign::FwdTrackId, fwdtrackrealign::TrackType, fwdtrackrealign::X, fwdtrackrealign::Y, fwdtrackrealign::Z, fwdtrackrealign::Phi, fwdtrackrealign::Tgl,
+                       fwdtrackrealign::Signed1Pt,
+                       fwdtrackrealign::Px<fwdtrackrealign::Pt, fwdtrackrealign::Phi>,
+                       fwdtrackrealign::Py<fwdtrackrealign::Pt, fwdtrackrealign::Phi>,
+                       fwdtrackrealign::Pz<fwdtrackrealign::Pt, fwdtrackrealign::Tgl>,
+                       fwdtrackrealign::Sign<fwdtrackrealign::Signed1Pt>,
+                       fwdtrackrealign::Chi2,
+                       fwdtrackrealign::IsRemovable);
 
-DECLARE_SOA_EXTENDED_TABLE(FwdTracksReAlign, StoredFwdTracksReAlign, "FWDTRACKREALIGN", //!
-                           aod::fwdtrack::Eta,
-                           aod::fwdtrack::Pt,
-                           aod::fwdtrack::P);
+DECLARE_SOA_TABLE_FULL(StoredFwdTrksCovReAlign, "FwdCovsReAlign", "AOD", "FWDCOVREALIGN", //!
+                       fwdtrackrealign::SigmaX, fwdtrackrealign::SigmaY, fwdtrackrealign::SigmaPhi, fwdtrackrealign::SigmaTgl, fwdtrackrealign::Sigma1Pt,
+                       fwdtrackrealign::RhoXY, fwdtrackrealign::RhoPhiY, fwdtrackrealign::RhoPhiX, fwdtrackrealign::RhoTglX, fwdtrackrealign::RhoTglY,
+                       fwdtrackrealign::RhoTglPhi, fwdtrackrealign::Rho1PtX, fwdtrackrealign::Rho1PtY, fwdtrackrealign::Rho1PtPhi, fwdtrackrealign::Rho1PtTgl);
 
-DECLARE_SOA_TABLE_FULL(StoredFwdTrksCovReAlign, "FwdTrksCovReAlign", "AOD", "FWDTRKCOVREALIGN", //!
-                       fwdtrack::SigmaX, fwdtrack::SigmaY, fwdtrack::SigmaPhi, fwdtrack::SigmaTgl, fwdtrack::Sigma1Pt,
-                       fwdtrack::RhoXY, fwdtrack::RhoPhiY, fwdtrack::RhoPhiX, fwdtrack::RhoTglX, fwdtrack::RhoTglY,
-                       fwdtrack::RhoTglPhi, fwdtrack::Rho1PtX, fwdtrack::Rho1PtY, fwdtrack::Rho1PtPhi, fwdtrack::Rho1PtTgl);
+// extended table with expression columns that can be used as arguments of dynamic columns
+DECLARE_SOA_EXTENDED_TABLE_USER(FwdTracksReAlign, StoredFwdTracksReAlign, "FWDTRKREALIGNEXT", //!
+                                fwdtrackrealign::Pt,
+                                fwdtrackrealign::Eta,
+                                fwdtrackrealign::P); // the table name has here to be the one with EXT which is not nice and under study
 
-DECLARE_SOA_EXTENDED_TABLE(FwdTrksCovReAlign, StoredFwdTrksCovReAlign, "FWDTRKCOVREALIGN", //!
-                           aod::fwdtrack::CXX,
-                           aod::fwdtrack::CXY,
-                           aod::fwdtrack::CYY,
-                           aod::fwdtrack::CPhiX,
-                           aod::fwdtrack::CPhiY,
-                           aod::fwdtrack::CPhiPhi,
-                           aod::fwdtrack::CTglX,
-                           aod::fwdtrack::CTglY,
-                           aod::fwdtrack::CTglPhi,
-                           aod::fwdtrack::CTglTgl,
-                           aod::fwdtrack::C1PtX,
-                           aod::fwdtrack::C1PtY,
-                           aod::fwdtrack::C1PtPhi,
-                           aod::fwdtrack::C1PtTgl,
-                           aod::fwdtrack::C1Pt21Pt2);
+// extended table with expression columns that can be used as arguments of dynamic columns
+DECLARE_SOA_EXTENDED_TABLE_USER(FwdTrksCovReAlign, StoredFwdTrksCovReAlign, "FWDCOVREALIGNEXT", //!
+                                fwdtrackrealign::CXX,
+                                fwdtrackrealign::CXY,
+                                fwdtrackrealign::CYY,
+                                fwdtrackrealign::CPhiX,
+                                fwdtrackrealign::CPhiY,
+                                fwdtrackrealign::CPhiPhi,
+                                fwdtrackrealign::CTglX,
+                                fwdtrackrealign::CTglY,
+                                fwdtrackrealign::CTglPhi,
+                                fwdtrackrealign::CTglTgl,
+                                fwdtrackrealign::C1PtX,
+                                fwdtrackrealign::C1PtY,
+                                fwdtrackrealign::C1PtPhi,
+                                fwdtrackrealign::C1PtTgl,
+                                fwdtrackrealign::C1Pt21Pt2); // the table name has here to be the one with EXT which is not nice and under study
+
+using FwdTrackRealign = FwdTracksReAlign::iterator;
+using FwdTrkCovRealign = FwdTrksCovReAlign::iterator;
+using FullFwdTracksRealign = soa::Join<FwdTracksReAlign, FwdTrksCovReAlign>;
+using FullFwdTrackRealign = FullFwdTracksRealign::iterator;
 } // namespace o2::aod
 
 #endif // COMMON_DATAMODEL_FWDTRACKREALIGNTABLES_H_

--- a/PWGDQ/Core/CMakeLists.txt
+++ b/PWGDQ/Core/CMakeLists.txt
@@ -21,7 +21,7 @@ o2physics_add_library(PWGDQCore
                         AnalysisCompositeCut.cxx
                         MCProng.cxx
                         MCSignal.cxx
-               PUBLIC_LINK_LIBRARIES O2::Framework O2::DCAFitter O2::GlobalTracking O2Physics::AnalysisCore  KFParticle::KFParticle)
+               PUBLIC_LINK_LIBRARIES O2::Framework O2::DCAFitter O2::GlobalTracking O2Physics::AnalysisCore KFParticle::KFParticle)
 
 o2physics_target_root_dictionary(PWGDQCore
                           HEADERS   AnalysisCut.h

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -129,7 +129,9 @@ class VarManager : public TObject
     TrackTPCPID = BIT(22),
     TrackMFT = BIT(23),
     ReducedTrackCollInfo = BIT(24), // TODO: remove it once new reduced data tables are produced for dielectron with ReducedTracksBarrelInfo
-    ReducedMuonCollInfo = BIT(25)   // TODO: remove it once new reduced data tables are produced for dielectron with ReducedTracksBarrelInfo
+    ReducedMuonCollInfo = BIT(25),  // TODO: remove it once new reduced data tables are produced for dielectron with ReducedTracksBarrelInfo
+    MuonRealign = BIT(26),
+    MuonCovRealign = BIT(27)
   };
 
   enum PairCandidateType {
@@ -1303,7 +1305,7 @@ void VarManager::FillPropagateMuon(const T& muon, const C& collision, float* val
     }
   }
 
-  if constexpr ((fillMap & MuonCov) > 0 || (fillMap & ReducedMuonCov) > 0) {
+  if constexpr ((fillMap & MuonCov) > 0 || (fillMap & ReducedMuonCov) > 0 || (fillMap & MuonCovRealign) > 0) {
     o2::dataformats::GlobalFwdTrack propmuon = PropagateMuon(muon, collision);
     values[kPt] = propmuon.getPt();
     values[kX] = propmuon.getX();
@@ -2012,7 +2014,7 @@ void VarManager::FillTrack(T const& track, float* values)
   }
 
   // Quantities based on the basic table (contains just kine information and filter bits)
-  if constexpr ((fillMap & Track) > 0 || (fillMap & Muon) > 0 || (fillMap & ReducedTrack) > 0 || (fillMap & ReducedMuon) > 0) {
+  if constexpr ((fillMap & Track) > 0 || (fillMap & Muon) > 0 || (fillMap & MuonRealign) > 0 || (fillMap & ReducedTrack) > 0 || (fillMap & ReducedMuon) > 0) {
     values[kPt] = track.pt();
     values[kSignedPt] = track.pt() * track.sign();
     if (fgUsedVars[kP]) {
@@ -2070,6 +2072,10 @@ void VarManager::FillTrack(T const& track, float* values)
       for (int i = 0; i < 8; i++) {
         values[kIsDalitzLeg + i] = track.filteringFlags_bit(VarManager::kDalitzBits + i);
       }
+    }
+
+    if constexpr ((fillMap & MuonRealign) > 0) {
+      values[kMuonChi2] = track.chi2();
     }
   }
 
@@ -2397,7 +2403,7 @@ void VarManager::FillTrack(T const& track, float* values)
     values[kMuonTimeRes] = track.trackTimeRes();
   }
   // Quantities based on the muon covariance table
-  if constexpr ((fillMap & ReducedMuonCov) > 0 || (fillMap & MuonCov) > 0) {
+  if constexpr ((fillMap & ReducedMuonCov) > 0 || (fillMap & MuonCov) > 0 || (fillMap & MuonCovRealign) > 0) {
     values[kX] = track.x();
     values[kY] = track.y();
     values[kZ] = track.z();
@@ -2454,7 +2460,7 @@ void VarManager::FillTrackCollision(T const& track, C const& collision, float* v
       }
     }
   }
-  if constexpr ((fillMap & MuonCov) > 0 || (fillMap & ReducedMuonCov) > 0) {
+  if constexpr ((fillMap & MuonCov) > 0 || (fillMap & MuonCovRealign) > 0 || (fillMap & ReducedMuonCov) > 0) {
 
     o2::dataformats::GlobalFwdTrack propmuonAtDCA = PropagateMuon(track, collision, kToDCA);
 

--- a/PWGDQ/TableProducer/tableMaker.cxx
+++ b/PWGDQ/TableProducer/tableMaker.cxx
@@ -37,6 +37,7 @@
 #include "Common/DataModel/PIDResponse.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 #include "Common/DataModel/MftmchMatchingML.h"
+#include "Common/DataModel/FwdTrackReAlignTables.h"
 #include "PWGDQ/DataModel/ReducedInfoTables.h"
 #include "PWGDQ/Core/VarManager.h"
 #include "PWGDQ/Core/HistogramManager.h"
@@ -118,6 +119,7 @@ using MyMuons = soa::Join<aod::FwdTracks, aod::FwdTracksDCA>;
 using MyMuonsWithCov = soa::Join<aod::FwdTracks, aod::FwdTracksCov, aod::FwdTracksDCA>;
 using MyMuonsColl = soa::Join<aod::FwdTracks, aod::FwdTracksDCA, aod::FwdTrkCompColls>;
 using MyMuonsCollWithCov = soa::Join<aod::FwdTracks, aod::FwdTracksCov, aod::FwdTracksDCA, aod::FwdTrkCompColls>;
+using MyMuonsRealignWithCov = soa::Join<aod::FwdTracksReAlign, aod::FwdTrksCovReAlign>;
 using ExtBCs = soa::Join<aod::BCs, aod::Timestamps, aod::MatchedBCCollisionsSparseMulti>;
 
 constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision;
@@ -137,6 +139,7 @@ constexpr static uint32_t gkTrackFillMapForElectronMuon = VarManager::ObjTypes::
 constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::Muon;
 constexpr static uint32_t gkMuonFillMapWithCov = VarManager::ObjTypes::Muon | VarManager::ObjTypes::MuonCov;
 constexpr static uint32_t gkMuonFillMapWithCovAmbi = VarManager::ObjTypes::Muon | VarManager::ObjTypes::MuonCov | VarManager::ObjTypes::AmbiMuon;
+constexpr static uint32_t gkMuonRealignFillMapWithCov = VarManager::ObjTypes::MuonRealign | VarManager::ObjTypes::MuonCovRealign;
 constexpr static uint32_t gkTrackFillMapWithAmbi = VarManager::ObjTypes::Track | VarManager::ObjTypes::AmbiTrack;
 constexpr static uint32_t gkMFTFillMap = VarManager::ObjTypes::TrackMFT;
 
@@ -843,8 +846,8 @@ struct TableMaker {
   } // end fullSkimming()
 
   // Templated function instantianed for all of the process functions
-  template <uint32_t TEventFillMap, uint32_t TTrackFillMap, uint32_t TMuonFillMap, typename TEvent, typename TTracks, typename TMuons, typename AssocTracks, typename AssocMuons>
-  void fullSkimmingIndices(TEvent const& collision, aod::BCsWithTimestamps const&, TTracks const& tracksBarrel, TMuons const& tracksMuon, AssocTracks const& trackIndices, AssocMuons const& fwdtrackIndices)
+  template <uint32_t TEventFillMap, uint32_t TTrackFillMap, uint32_t TMuonFillMap, uint32_t TMuonRealignFillMap, typename TEvent, typename TTracks, typename TMuons, typename TMuonsRealign, typename AssocTracks, typename AssocMuons>
+  void fullSkimmingIndices(TEvent const& collision, aod::BCsWithTimestamps const&, TTracks const& tracksBarrel, TMuons const& tracksMuon, TMuonsRealign const& tracksMuonRealign, AssocTracks const& trackIndices, AssocMuons const& fwdtrackIndices)
   {
     auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
     if (fCurrentRun != bc.runNumber()) {
@@ -1104,7 +1107,7 @@ struct TableMaker {
       muonBasic.reserve(tracksMuon.size());
       muonExtra.reserve(tracksMuon.size());
       muonInfo.reserve(tracksMuon.size());
-      if constexpr (static_cast<bool>(TMuonFillMap & VarManager::ObjTypes::MuonCov)) {
+      if constexpr (static_cast<bool>((TMuonFillMap & VarManager::ObjTypes::MuonCov) || (TMuonRealignFillMap & VarManager::ObjTypes::MuonCovRealign))) {
         muonCov.reserve(tracksMuon.size());
       }
       // loop over muons
@@ -1150,13 +1153,48 @@ struct TableMaker {
         trackFilteringTag = static_cast<uint64_t>(0);
         trackTempFilterMap = uint8_t(0);
 
-        VarManager::FillTrack<TMuonFillMap>(muon);
+        if constexpr (static_cast<bool>(TMuonRealignFillMap)) {
+          // Update muon information using realigned tracks
+          if (static_cast<int>(muon.trackType()) > 2) {
+            // Update only MCH or MCH-MID tracks with realigned information
+            auto muonRealignSelected = tracksMuonRealign.select(aod::fwdtrackrealign::fwdtrackId == muonId.fwdtrackId() && aod::fwdtrackrealign::collisionId == collision.globalIndex());
+            if (muonRealignSelected.size() == 1) {
+              for (const auto& muonRealign : muonRealignSelected) {
+                LOGF(debug, "Muon original  - collisionId:%d x:%g y:%g z:%g phi:%g tgl:%g signed1pt:%g pt:%g p:%g eta:%g chi2:%g", muon.collisionId(), muon.x(), muon.y(), muon.z(), muon.phi(), muon.tgl(), muon.signed1Pt(), muon.pt(), muon.p(), muon.eta(), muon.chi2());
+                LOGF(debug, "Muon realigned - collisionId:%d x:%g y:%g z:%g phi:%g tgl:%g signed1pt:%g pt:%g p:%g eta:%g chi2:%g", muonRealign.collisionId(), muonRealign.x(), muonRealign.y(), muonRealign.z(), muonRealign.phi(), muonRealign.tgl(), muonRealign.signed1Pt(), muonRealign.pt(), muonRealign.p(), muonRealign.eta(), muonRealign.chi2());
+                VarManager::FillTrack<TMuonRealignFillMap>(muonRealign);
 
-        // recalculte pDca for global muon tracks
-        VarManager::FillTrackCollision<TMuonFillMap>(muon, collision);
+                // recalculte pDca for global muon tracks
+                VarManager::FillTrackCollision<TMuonRealignFillMap>(muonRealign, collision);
 
-        if (fPropMuon) {
-          VarManager::FillPropagateMuon<TMuonFillMap>(muon, collision);
+                if (fPropMuon) {
+                  VarManager::FillPropagateMuon<TMuonRealignFillMap>(muonRealign, collision);
+                }
+              }
+            } else {
+              LOGF(fatal, "Inconsistent size of realigned muon track candidates.");
+            }
+          } else {
+            // For global tracks, their matched muon tracks should be updated already
+
+            VarManager::FillTrack<TMuonFillMap>(muon);
+
+            // recalculte pDca for global muon tracks
+            VarManager::FillTrackCollision<TMuonFillMap>(muon, collision);
+
+            if (fPropMuon) {
+              VarManager::FillPropagateMuon<TMuonFillMap>(muon, collision);
+            }
+          }
+        } else {
+          VarManager::FillTrack<TMuonFillMap>(muon);
+
+          // recalculte pDca for global muon tracks
+          VarManager::FillTrackCollision<TMuonFillMap>(muon, collision);
+
+          if (fPropMuon) {
+            VarManager::FillPropagateMuon<TMuonFillMap>(muon, collision);
+          }
         }
 
         if (fDoDetailedQA) {
@@ -1211,17 +1249,17 @@ struct TableMaker {
 
         muonBasic(event.lastIndex(), newMatchIndex.find(muon.index())->second, -1, trackFilteringTag, VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], muon.sign(), isAmbiguous);
         muonInfo(muon.collisionId(), collision.posX(), collision.posY(), collision.posZ());
-        if constexpr (static_cast<bool>(TMuonFillMap & VarManager::ObjTypes::MuonCov)) {
+        if constexpr (static_cast<bool>((TMuonFillMap & VarManager::ObjTypes::MuonCov))) {
 
           if (fPropMuon) {
             muonExtra(muon.nClusters(), VarManager::fgValues[VarManager::kMuonPDca], VarManager::fgValues[VarManager::kMuonRAtAbsorberEnd],
-                      muon.chi2(), muon.chi2MatchMCHMID(), muon.chi2MatchMCHMFT(),
+                      VarManager::fgValues[VarManager::kMuonChi2], muon.chi2MatchMCHMID(), muon.chi2MatchMCHMFT(),
                       muon.matchScoreMCHMFT(), muon.mchBitMap(), muon.midBitMap(),
                       muon.midBoards(), muon.trackType(), VarManager::fgValues[VarManager::kMuonDCAx], VarManager::fgValues[VarManager::kMuonDCAy],
                       muon.trackTime(), muon.trackTimeRes());
           } else {
             muonExtra(muon.nClusters(), muon.pDca(), muon.rAtAbsorberEnd(),
-                      muon.chi2(), muon.chi2MatchMCHMID(), muon.chi2MatchMCHMFT(),
+                      VarManager::fgValues[VarManager::kMuonChi2], muon.chi2MatchMCHMID(), muon.chi2MatchMCHMFT(),
                       muon.matchScoreMCHMFT(), muon.mchBitMap(), muon.midBitMap(),
                       muon.midBoards(), muon.trackType(), muon.fwdDcaX(), muon.fwdDcaY(),
                       muon.trackTime(), muon.trackTimeRes());
@@ -1621,7 +1659,16 @@ struct TableMaker {
   {
     for (auto& collision : collisions) {
       auto muonIdsThisCollision = fwdtrackIndices.sliceBy(fwdtrackIndicesPerCollision, collision.globalIndex());
-      fullSkimmingIndices<gkEventFillMap, 0u, gkMuonFillMapWithCovAmbi>(collision, bcs, nullptr, tracksMuon, nullptr, muonIdsThisCollision);
+      fullSkimmingIndices<gkEventFillMap, 0u, gkMuonFillMapWithCovAmbi, 0u>(collision, bcs, nullptr, tracksMuon, nullptr, nullptr, muonIdsThisCollision);
+    }
+  }
+
+  void processAssociatedRealignedMuonOnlyWithCov(MyEvents const& collisions, aod::BCsWithTimestamps const& bcs,
+                                                 soa::Filtered<MyMuonsCollWithCov> const& tracksMuon, MyMuonsRealignWithCov const& tracksMuonRealign, aod::AmbiguousFwdTracks const&, aod::FwdTrackAssoc const& fwdtrackIndices)
+  {
+    for (auto& collision : collisions) {
+      auto muonIdsThisCollision = fwdtrackIndices.sliceBy(fwdtrackIndicesPerCollision, collision.globalIndex());
+      fullSkimmingIndices<gkEventFillMap, 0u, gkMuonFillMapWithCovAmbi, gkMuonRealignFillMapWithCov>(collision, bcs, nullptr, tracksMuon, tracksMuonRealign, nullptr, muonIdsThisCollision);
     }
   }
 
@@ -1630,7 +1677,7 @@ struct TableMaker {
   {
     for (auto& collision : collisions) {
       auto muonIdsThisCollision = fwdtrackIndices.sliceBy(fwdtrackIndicesPerCollision, collision.globalIndex());
-      fullSkimmingIndices<gkEventFillMapWithCentAndMults, 0u, gkMuonFillMapWithCovAmbi>(collision, bcs, nullptr, tracksMuon, nullptr, muonIdsThisCollision);
+      fullSkimmingIndices<gkEventFillMapWithCentAndMults, 0u, gkMuonFillMapWithCovAmbi, 0u>(collision, bcs, nullptr, tracksMuon, nullptr, nullptr, muonIdsThisCollision);
     }
   }
 
@@ -1639,7 +1686,7 @@ struct TableMaker {
   {
     for (auto& collision : collisions) {
       auto muonIdsThisCollision = fwdtrackIndices.sliceBy(fwdtrackIndicesPerCollision, collision.globalIndex());
-      fullSkimmingIndices<gkEventFillMapWithMult, 0u, gkMuonFillMapWithCovAmbi>(collision, bcs, nullptr, tracksMuon, nullptr, muonIdsThisCollision);
+      fullSkimmingIndices<gkEventFillMapWithMult, 0u, gkMuonFillMapWithCovAmbi, 0u>(collision, bcs, nullptr, tracksMuon, nullptr, nullptr, muonIdsThisCollision);
     }
   }
 
@@ -1801,6 +1848,7 @@ struct TableMaker {
   PROCESS_SWITCH(TableMaker, processAmbiguousMuonOnlyWithCov, "Build muon-only with cov DQ skimmed data model with QA plots for ambiguous muons", false);
   PROCESS_SWITCH(TableMaker, processAmbiguousBarrelOnly, "Build barrel-only DQ skimmed data model with QA plots for ambiguous tracks", false);
   PROCESS_SWITCH(TableMaker, processAssociatedMuonOnlyWithCov, "Build muon-only with cov DQ skimmed data model using track-collision association tables", false);
+  PROCESS_SWITCH(TableMaker, processAssociatedRealignedMuonOnlyWithCov, "Build realigned muon-only with cov DQ skimmed data model using track-collision association tables", false);
   PROCESS_SWITCH(TableMaker, processAssociatedMuonOnlyWithCovAndCentMults, "Build muon-only with cov DQ skimmed data model using track-collision association tables and centrality", false);
   PROCESS_SWITCH(TableMaker, processAssociatedMuonOnlyWithCovAndMults, "Build muon-only with cov DQ skimmed data model using track-collision association tables and multiplicity", false);
   PROCESS_SWITCH(TableMaker, processMuonsAndMFT, "Build MFT and muons DQ skimmed data model", false);


### PR DESCRIPTION
1. Small adaptations in `FwdTrackReAlign` table definitions
2. Add new process for associated muons using realigned tracks (kinematics and propagation are re-evaluated using realigned tracks)
3. Few adaptations in `VarManager.h` to allow the case of using realigned forward tracks