### PR TITLE
[Common] Fix event selection for not-anchored simulations

### DIFF
--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -262,7 +262,7 @@ struct BcSelectionTask {
 
     int run = bcs.iteratorAt(0).runNumber();
 
-    if (run != lastRun && run >= 500000) {
+    if (run != lastRun && run >= 300000) {
       lastRun = run;
       auto runInfo = o2::parameters::AggregatedRunInfo::buildAggregatedRunInfo(o2::ccdb::BasicCCDBManager::instance(), run);
       // first bc of the first orbit


### PR DESCRIPTION
@ekryshen , the introduction of the `mapRCT` object broke the not-anchored simulations, where the default runNumber is set to 300000 and the `mapRCT` is not properly set. Does this trivial fix make sense to you? I checked it locally and it seems to be working.
