### PR TITLE
Updates in HF filters

### DIFF
--- a/EventFiltering/PWGHF/HFFilter.cxx
+++ b/EventFiltering/PWGHF/HFFilter.cxx
@@ -68,14 +68,13 @@ struct HfFilter { // Main struct for HF triggers
   Produces<aod::HFOptimisationTreeCollisions> optimisationTreeCollisions;
 
   Configurable<int> activateQA{"activateQA", 0, "flag to enable QA histos (0 no QA, 1 basic QA, 2 extended QA, 3 very extended QA)"};
-  Configurable<bool> applyEventSelection{"applyEventSelection", true, "flag to enable event selection (sel8 + Zvt and possibly time-frame border cut)"};
   Configurable<bool> activateSecVtxForB{"activateSecVtxForB", false, "flag to enable 2nd vertex fitting - only beauty hadrons"};
 
   // parameters for all triggers
   // nsigma PID (except for V0 and cascades)
-  Configurable<LabeledArray<float>> nSigmaPidCuts{"nSigmaPidCuts", {cutsNsigma[0], 4, 7, labelsRowsNsigma, labelsColumnsNsigma}, "Nsigma cuts for ITS/TPC/TOF PID (except for V0 and cascades)"};
+  Configurable<LabeledArray<float>> nSigmaPidCuts{"nSigmaPidCuts", {cutsNsigma[0], 4, 8, labelsRowsNsigma, labelsColumnsNsigma}, "Nsigma cuts for ITS/TPC/TOF PID (except for V0 and cascades)"};
   // min and max pts for tracks and bachelors (except for V0 and cascades)
-  Configurable<LabeledArray<float>> ptCuts{"ptCuts", {cutsPt[0], 2, 7, labelsRowsCutsPt, labelsColumnsCutsPt}, "minimum and maximum pT for bachelor tracks (except for V0 and cascades)"};
+  Configurable<LabeledArray<float>> ptCuts{"ptCuts", {cutsPt[0], 2, 8, labelsRowsCutsPt, labelsColumnsCutsPt}, "minimum and maximum pT for bachelor tracks (except for V0 and cascades)"};
 
   // parameters for high-pT triggers
   Configurable<LabeledArray<float>> ptThresholds{"ptThresholds", {cutsHighPtThresholds[0], 1, 2, labelsEmpty, labelsColumnsHighPtThresholds}, "pT treshold for high pT charm hadron candidates for kHighPt triggers in GeV/c"};
@@ -84,20 +83,21 @@ struct HfFilter { // Main struct for HF triggers
   Configurable<std::vector<double>> pTBinsTrack{"pTBinsTrack", std::vector<double>{hf_cuts_single_track::vecBinsPtTrack}, "track pT bin limits for DCAXY pT-dependent cut"};
   Configurable<LabeledArray<double>> cutsTrackBeauty3Prong{"cutsTrackBeauty3Prong", {hf_cuts_single_track::cutsTrack[0], hf_cuts_single_track::nBinsPtTrack, hf_cuts_single_track::nCutVarsTrack, hf_cuts_single_track::labelsPtTrack, hf_cuts_single_track::labelsCutVarTrack}, "Single-track selections per pT bin for 3-prong beauty candidates"};
   Configurable<LabeledArray<double>> cutsTrackBeauty4Prong{"cutsTrackBeauty4Prong", {hf_cuts_single_track::cutsTrack[0], hf_cuts_single_track::nBinsPtTrack, hf_cuts_single_track::nCutVarsTrack, hf_cuts_single_track::labelsPtTrack, hf_cuts_single_track::labelsCutVarTrack}, "Single-track selections per pT bin for 4-prong beauty candidates"};
+  Configurable<LabeledArray<double>> cutsTrackBeautyToJPsi{"cutsTrackBeautyToJPsi", {hf_cuts_single_track::cutsTrack[0], hf_cuts_single_track::nBinsPtTrack, hf_cuts_single_track::nCutVarsTrack, hf_cuts_single_track::labelsPtTrack, hf_cuts_single_track::labelsCutVarTrack}, "Single-track selections per pT bin for beauty->JPsi candidates (not muons)"};
   Configurable<std::string> paramCharmMassShape{"paramCharmMassShape", "2023_pass3", "Parametrisation of charm-hadron mass shape (options: 2023_pass3)"};
   Configurable<float> numSigmaDeltaMassCharmHad{"numSigmaDeltaMassCharmHad", 2.5, "Number of sigma for charm-hadron delta mass cut in B and D resonance triggers"};
   Configurable<std::vector<double>> pTBinsBHadron{"pTBinsBHadron", std::vector<double>{hf_trigger_cuts_presel_beauty::vecBinsPt}, "pT bin limits for beauty hadrons preselections"};
-  Configurable<LabeledArray<double>> cutsBplus{"cutsBplus", {hf_trigger_cuts_presel_beauty::cuts[0], hf_trigger_cuts_presel_beauty::nBinsPt, hf_trigger_cuts_presel_beauty::nCutVars, hf_trigger_cuts_presel_beauty::labelsPt, hf_trigger_cuts_presel_beauty::labelsRowsTopolBeauty}, "B+ candidate selection per pT bin"};
-  Configurable<LabeledArray<double>> cutsBzeroToDstar{"cutsBzeroToDstar", {hf_trigger_cuts_presel_beauty::cuts[0], hf_trigger_cuts_presel_beauty::nBinsPt, hf_trigger_cuts_presel_beauty::nCutVars, hf_trigger_cuts_presel_beauty::labelsPt, hf_trigger_cuts_presel_beauty::labelsRowsTopolBeauty}, "B0 -> D*+ candidate selection per pT bin"};
-  Configurable<LabeledArray<double>> cutsBzero{"cutsBzero", {hf_trigger_cuts_presel_beauty::cuts[0], hf_trigger_cuts_presel_beauty::nBinsPt, hf_trigger_cuts_presel_beauty::nCutVars, hf_trigger_cuts_presel_beauty::labelsPt, hf_trigger_cuts_presel_beauty::labelsRowsTopolBeauty}, "B0 candidate selection per pT bin"};
-  Configurable<LabeledArray<double>> cutsBs{"cutsBs", {hf_trigger_cuts_presel_beauty::cuts[0], hf_trigger_cuts_presel_beauty::nBinsPt, hf_trigger_cuts_presel_beauty::nCutVars, hf_trigger_cuts_presel_beauty::labelsPt, hf_trigger_cuts_presel_beauty::labelsRowsTopolBeauty}, "Bs candidate selection per pT bin"};
-  Configurable<LabeledArray<double>> cutsLb{"cutsLb", {hf_trigger_cuts_presel_beauty::cuts[0], hf_trigger_cuts_presel_beauty::nBinsPt, hf_trigger_cuts_presel_beauty::nCutVars, hf_trigger_cuts_presel_beauty::labelsPt, hf_trigger_cuts_presel_beauty::labelsRowsTopolBeauty}, "Lb candidate selection per pT bin"};
-  Configurable<LabeledArray<double>> cutsXib{"cutsXib", {hf_trigger_cuts_presel_beauty::cuts[0], hf_trigger_cuts_presel_beauty::nBinsPt, hf_trigger_cuts_presel_beauty::nCutVars, hf_trigger_cuts_presel_beauty::labelsPt, hf_trigger_cuts_presel_beauty::labelsRowsTopolBeauty}, "Xib candidate selection per pT bin"};
+  Configurable<LabeledArray<double>> cutsBplus{"cutsBplus", {hf_trigger_cuts_presel_beauty::cuts[0], hf_trigger_cuts_presel_beauty::nBinsPt, hf_trigger_cuts_presel_beauty::nCutVars, hf_trigger_cuts_presel_beauty::labelsPt, hf_trigger_cuts_presel_beauty::labelsColumnsTopolBeauty}, "B+ candidate selection per pT bin"};
+  Configurable<LabeledArray<double>> cutsBzeroToDstar{"cutsBzeroToDstar", {hf_trigger_cuts_presel_beauty::cuts[0], hf_trigger_cuts_presel_beauty::nBinsPt, hf_trigger_cuts_presel_beauty::nCutVars, hf_trigger_cuts_presel_beauty::labelsPt, hf_trigger_cuts_presel_beauty::labelsColumnsTopolBeauty}, "B0 -> D*+ candidate selection per pT bin"};
+  Configurable<LabeledArray<double>> cutsBzero{"cutsBzero", {hf_trigger_cuts_presel_beauty::cuts[0], hf_trigger_cuts_presel_beauty::nBinsPt, hf_trigger_cuts_presel_beauty::nCutVars, hf_trigger_cuts_presel_beauty::labelsPt, hf_trigger_cuts_presel_beauty::labelsColumnsTopolBeauty}, "B0 candidate selection per pT bin"};
+  Configurable<LabeledArray<double>> cutsBs{"cutsBs", {hf_trigger_cuts_presel_beauty::cuts[0], hf_trigger_cuts_presel_beauty::nBinsPt, hf_trigger_cuts_presel_beauty::nCutVars, hf_trigger_cuts_presel_beauty::labelsPt, hf_trigger_cuts_presel_beauty::labelsColumnsTopolBeauty}, "Bs candidate selection per pT bin"};
+  Configurable<LabeledArray<double>> cutsLb{"cutsLb", {hf_trigger_cuts_presel_beauty::cuts[0], hf_trigger_cuts_presel_beauty::nBinsPt, hf_trigger_cuts_presel_beauty::nCutVars, hf_trigger_cuts_presel_beauty::labelsPt, hf_trigger_cuts_presel_beauty::labelsColumnsTopolBeauty}, "Lb candidate selection per pT bin"};
+  Configurable<LabeledArray<double>> cutsXib{"cutsXib", {hf_trigger_cuts_presel_beauty::cuts[0], hf_trigger_cuts_presel_beauty::nBinsPt, hf_trigger_cuts_presel_beauty::nCutVars, hf_trigger_cuts_presel_beauty::labelsPt, hf_trigger_cuts_presel_beauty::labelsColumnsTopolBeauty}, "Xib candidate selection per pT bin"};
+  Configurable<LabeledArray<double>> cutsBtoJPsiX{"cutsBtoJPsiX", {hf_trigger_cuts_presel_beauty::cutsBtoJPsi[0], hf_trigger_cuts_presel_beauty::nBinsPt, hf_trigger_cuts_presel_beauty::nCutVarsBtoJPsi, hf_trigger_cuts_presel_beauty::labelsPt, hf_trigger_cuts_presel_beauty::labelsColumnsCutsBeautyToJPsi}, "B->JPsiX candidate selection"};
 
   // parameters for femto triggers
   Configurable<float> femtoMaxRelativeMomentum{"femtoMaxRelativeMomentum", 2., "Maximal allowed value for relative momentum between charm-proton pairs in GeV/c"};
   Configurable<LabeledArray<int>> enableFemtoChannels{"enableFemtoChannels", {activeFemtoChannels[0], 2, 5, labelsRowsFemtoChannels, labelsColumnsFemtoChannels}, "Flags to enable/disable femto channels"};
-  Configurable<bool> requireCharmMassForFemto{"requireCharmMassForFemto", false, "Flags to enable/disable cut on charm-hadron invariant-mass window for femto"};
   Configurable<LabeledArray<float>> ptThresholdsForFemto{"ptThresholdsForFemto", {cutsPtThresholdsForFemto[0], 1, 2, labelsEmpty, labelsColumnsPtThresholdsForFemto}, "pT treshold for proton or deuteron for kFemto triggers in GeV/c"};
   Configurable<bool> forceTofProtonForFemto{"forceTofProtonForFemto", true, "flag to force TOF PID for protons"};
   Configurable<bool> forceTofDeuteronForFemto{"forceTofDeuteronForFemto", false, "flag to force TOF PID for deuterons"};
@@ -155,7 +155,8 @@ struct HfFilter { // Main struct for HF triggers
   std::array<LabeledArray<double>, kNCharmParticles> thresholdBDTScores;
 
   o2::vertexing::DCAFitterN<2> df2; // fitter for Charm Hadron vertex (2-prong vertex fitter)
-  o2::vertexing::DCAFitterN<3> df3; // fitter for Charm Hadron vertex (3-prong vertex fitter)
+  o2::vertexing::DCAFitterN<3> df3; // fitter for Charm/Beauty Hadron vertex (3-prong vertex fitter)
+  o2::vertexing::DCAFitterN<4> df4; // fitter for Beauty Hadron vertex (4-prong vertex fitter)
   o2::vertexing::DCAFitterN<2> dfB; // fitter for Beauty Hadron vertex (2-prong vertex fitter)
   o2::vertexing::DCAFitterN<3> dfBtoDstar; // fitter for Beauty Hadron to D* vertex (3-prong vertex fitter)
   o2::vertexing::DCAFitterN<2> dfStrangeness; // fitter for V0s and cascades (2-prong vertex fitter)
@@ -168,10 +169,9 @@ struct HfFilter { // Main struct for HF triggers
   std::array<std::shared_ptr<TH1>, kNCharmParticles> hCharmHighPt{};
   std::array<std::shared_ptr<TH1>, kNCharmParticles> hCharmProtonKstarDistr{};
   std::array<std::shared_ptr<TH1>, kNCharmParticles> hCharmDeuteronKstarDistr{};
-  std::array<std::shared_ptr<TH2>, kNBeautyParticles> hMassVsPtB{};
-  std::array<std::shared_ptr<TH2>, kNCharmParticles + 18> hMassVsPtC{}; // +9 for resonances (D*+, D*0, Ds*+, Ds1+, Ds2*+, Xic+* right sign, Xic+* wrong sign, Xic0* right sign, Xic0* wrong sign) +2 for SigmaC (SigmaC++, SigmaC0) +2 for SigmaCK pairs (SigmaC++K-, SigmaC0K0s) +3 for charm baryons (Xi+Pi, Xi+Ka, Xi+Pi+Pi)
-  std::shared_ptr<TH2> hProtonTPCPID, hProtonTOFPID;
-  std::shared_ptr<TH2> hDeuteronTPCPID, hDeuteronTOFPID;
+  std::array<std::shared_ptr<TH2>, nTotBeautyParts> hMassVsPtB{};
+  std::array<std::shared_ptr<TH2>, kNCharmParticles + 19> hMassVsPtC{}; // +9 for resonances (D*+, D*0, Ds*+, Ds1+, Ds2*+, Xic+* right sign, Xic+* wrong sign, Xic0* right sign, Xic0* wrong sign) +2 for SigmaC (SigmaC++, SigmaC0) +2 for SigmaCK pairs (SigmaC++K-, SigmaC0K0s) +3 for charm baryons (Xi+Pi, Xi+Ka, Xi+Pi+Pi) + JPsi
+  std::array<std::shared_ptr<TH2>, 4> hPrDePID; // proton TPC, proton TOF, deuteron TPC, deuteron TOF
   std::array<std::shared_ptr<TH1>, kNCharmParticles> hBDTScoreBkg{};
   std::array<std::shared_ptr<TH1>, kNCharmParticles> hBDTScorePrompt{};
   std::array<std::shared_ptr<TH1>, kNCharmParticles> hBDTScoreNonPrompt{};
@@ -196,19 +196,21 @@ struct HfFilter { // Main struct for HF triggers
     helper.setPtTriggerThresholdsForFemto(ptThresholdsForFemto->get(0u, 0u), ptThresholdsForFemto->get(0u, 1u));
     helper.setPtBinsSingleTracks(pTBinsTrack);
     helper.setPtBinsBeautyHadrons(pTBinsBHadron);
-    helper.setPtLimitsBeautyBachelor(ptCuts->get(0u, 0u), ptCuts->get(1u, 0u));
+    helper.setPtLimitsBeautyBachelor(ptCuts->get(0u, 0u), ptCuts->get(1u, 0u), ptCuts->get(0u, 7u), ptCuts->get(1u, 7u));
     helper.setPtLimitsDstarSoftPion(ptCuts->get(0u, 1u), ptCuts->get(1u, 1u));
     helper.setPtLimitsProtonForFemto(ptCuts->get(0u, 2u), ptCuts->get(1u, 2u));
     helper.setPtLimitsDeuteronForFemto(ptCuts->get(0u, 6u), ptCuts->get(1u, 6u));
     helper.setPtLimitsCharmBaryonBachelor(ptCuts->get(0u, 3u), ptCuts->get(1u, 3u));
-    helper.setCutsSingleTrackBeauty(cutsTrackBeauty3Prong, cutsTrackBeauty4Prong);
+    helper.setCutsSingleTrackBeauty(cutsTrackBeauty3Prong, cutsTrackBeauty4Prong, cutsTrackBeauty4Prong);
     helper.setCutsSingleTrackCharmBaryonBachelor(cutsTrackCharmBaryonBachelor);
     helper.setCutsBhadrons(cutsBplus, cutsBzeroToDstar, cutsBzero, cutsBs, cutsLb, cutsXib);
+    helper.setCutsBtoJPsi(cutsBtoJPsiX);
     helper.setNsigmaProtonCutsForFemto(std::array{nSigmaPidCuts->get(0u, 3u), nSigmaPidCuts->get(1u, 3u), nSigmaPidCuts->get(2u, 3u), nSigmaPidCuts->get(3u, 3u)});
     helper.setNsigmaDeuteronCutsForFemto(std::array{nSigmaPidCuts->get(0u, 6u), nSigmaPidCuts->get(1u, 6u), nSigmaPidCuts->get(2u, 6u), nSigmaPidCuts->get(3u, 6u)});
     helper.setNsigmaProtonCutsForCharmBaryons(nSigmaPidCuts->get(0u, 0u), nSigmaPidCuts->get(1u, 0u));
     helper.setNsigmaPionKaonCutsForDzero(nSigmaPidCuts->get(0u, 1u), nSigmaPidCuts->get(1u, 1u));
     helper.setNsigmaKaonCutsFor3Prongs(nSigmaPidCuts->get(0u, 2u), nSigmaPidCuts->get(1u, 2u));
+    helper.setNsigmaKaonProtonCutsForBeautyToJPsi(nSigmaPidCuts->get(0u, 7u), nSigmaPidCuts->get(1u, 7u));
     helper.setForceTofForFemto(forceTofProtonForFemto, forceTofDeuteronForFemto);
     helper.setV0Selections(cutsGammaK0sLambda->get(0u, 0u), cutsGammaK0sLambda->get(0u, 1u), cutsGammaK0sLambda->get(0u, 2u), cutsGammaK0sLambda->get(0u, 3u), cutsGammaK0sLambda->get(0u, 4u), cutsGammaK0sLambda->get(0u, 5u));
     helper.setXiSelections(cutsXiCascades->get(0u, 0u), cutsXiCascades->get(0u, 1u), cutsXiCascades->get(0u, 2u), cutsXiCascades->get(0u, 3u), cutsXiCascades->get(0u, 4u), cutsXiCascades->get(0u, 5u), cutsXiCascades->get(0u, 6u), cutsXiCascades->get(0u, 7u));
@@ -224,6 +226,7 @@ struct HfFilter { // Main struct for HF triggers
     dfStrangeness.setMatCorrType(matCorr);
     helper.setVtxConfiguration(df2, false); // (DCAFitterN, useAbsDCA)
     helper.setVtxConfiguration(df3, false);
+    helper.setVtxConfiguration(df4, false);
     if (activateSecVtxForB) {
       helper.setVtxConfiguration(dfB, true);
       helper.setVtxConfiguration(dfBtoDstar, true);
@@ -273,6 +276,8 @@ struct HfFilter { // Main struct for HF triggers
       hMassVsPtC[kNCharmParticles + 15] = registry.add<TH2>("fMassVsPtCharmBaryonToXiPi", "#it{M} vs. #it{p}_{T} distribution of triggered #Xi+#pi candidates;#it{p}_{T} (GeV/#it{c});#it{M} (GeV/#it{c}^{2});counts", HistType::kTH2D, {ptAxis, massAxisC[kNCharmParticles + 15]});
       hMassVsPtC[kNCharmParticles + 16] = registry.add<TH2>("fMassVsPtCharmBaryonToXiKa", "#it{M} vs. #it{p}_{T} distribution of triggered #Xi+K candidates;#it{p}_{T} (GeV/#it{c});#it{M} (GeV/#it{c}^{2});counts", HistType::kTH2D, {ptAxis, massAxisC[kNCharmParticles + 16]});
       hMassVsPtC[kNCharmParticles + 17] = registry.add<TH2>("fMassVsPtCharmBaryonToXiPiPi", "#it{M} vs. #it{p}_{T} distribution of triggered #Xi+#pi+#pi candidates;#it{p}_{T} (GeV/#it{c});#it{M} (GeV/#it{c}^{2});counts", HistType::kTH2D, {ptAxis, massAxisC[kNCharmParticles + 17]});
+      // JPsi
+      hMassVsPtC[kNCharmParticles + 18] = registry.add<TH2>("fMassVsPtJPsiToMuMu", "#it{M} vs. #it{p}_{T} distribution of triggered J/#psi to #mu#mu candidates;#it{p}_{T} (GeV/#it{c});#it{M} (GeV/#it{c}^{2});counts", HistType::kTH2D, {ptAxis, massAxisC[kNCharmParticles + 18]});
 
       for (int iBeautyPart{0}; iBeautyPart < kNBeautyParticles; ++iBeautyPart) {
         hMassVsPtB[iBeautyPart] = registry.add<TH2>(Form("fMassVsPt%s", beautyParticleNames[iBeautyPart].data()), Form("#it{M} vs. #it{p}_{T} distribution of triggered %s candidates;#it{p}_{T} (GeV/#it{c});#it{M} (GeV/#it{c}^{2});counts", beautyParticleNames[iBeautyPart].data()), HistType::kTH2D, {ptAxis, massAxisB[iBeautyPart]});
@@ -281,6 +286,9 @@ struct HfFilter { // Main struct for HF triggers
         if (iBeautyPart != kB0toDStar) {
           hImpactParamProductVsPtB[iBeautyPart] = registry.add<TH2>(Form("fImpactParamProductVsPt%s", beautyParticleNames[iBeautyPart].data()), Form("ImpactParamProduct vs. #it{p}_{T} distribution of triggered %s candidates;#it{p}_{T} (GeV/#it{c});#it{M} (GeV/#it{c}^{2});counts", beautyParticleNames[iBeautyPart].data()), HistType::kTH2D, {ptAxis, {100, -2.5, +2.5}});
         }
+      }
+      for (int iBeautyPart{kNBeautyParticles}; iBeautyPart < nTotBeautyParts; ++iBeautyPart) {
+        hMassVsPtB[iBeautyPart] = registry.add<TH2>(Form("fMassVsPt%s", beautyParticleNames[iBeautyPart].data()), Form("#it{M} vs. #it{p}_{T} distribution of triggered %s candidates;#it{p}_{T} (GeV/#it{c});#it{M} (GeV/#it{c}^{2});counts", beautyParticleNames[iBeautyPart].data()), HistType::kTH2D, {ptAxis, massAxisB[iBeautyPart]});
       }
       constexpr int kNBinsHfVtxStages = kNHfVtxStage;
       std::string labels[kNBinsHfVtxStages];
@@ -303,10 +311,10 @@ struct HfFilter { // Main struct for HF triggers
       hMassXi[1] = registry.add<TH1>("fMassTrackedXi", "#it{M} distribution of #Xi candidates;#it{M} (GeV/#it{c}^{2});counts", HistType::kTH1D, {{100, 1.28f, 1.36f}});
 
       if (activateQA > 1) {
-        hProtonTPCPID = registry.add<TH2>("fProtonTPCPID", "#it{N}_{#sigma}^{TPC} vs. #it{p} for selected protons;#it{p} (GeV/#it{c});#it{N}_{#sigma}^{TPC}", HistType::kTH2D, {pAxis, nSigmaAxis});
-        hProtonTOFPID = registry.add<TH2>("fProtonTOFPID", "#it{N}_{#sigma}^{TOF} vs. #it{p} for selected protons;#it{p} (GeV/#it{c});#it{N}_{#sigma}^{TOF}", HistType::kTH2D, {pAxis, nSigmaAxis});
-        hDeuteronTPCPID = registry.add<TH2>("fDeuteronTPCPID", "#it{N}_{#sigma}^{TPC} vs. #it{p} for selected deuterons;#it{p} (GeV/#it{c});#it{N}_{#sigma}^{TPC}", HistType::kTH2D, {pAxis, nSigmaAxis});
-        hDeuteronTOFPID = registry.add<TH2>("fDeuteronTOFPID", "#it{N}_{#sigma}^{TOF} vs. #it{p} for selected deuterons;#it{p} (GeV/#it{c});#it{N}_{#sigma}^{TOF}", HistType::kTH2D, {pAxis, nSigmaAxis});
+        hPrDePID[0] = registry.add<TH2>("fProtonTPCPID", "#it{N}_{#sigma}^{TPC} vs. #it{p} for selected protons;#it{p} (GeV/#it{c});#it{N}_{#sigma}^{TPC}", HistType::kTH2D, {pAxis, nSigmaAxis});
+        hPrDePID[1] = registry.add<TH2>("fProtonTOFPID", "#it{N}_{#sigma}^{TOF} vs. #it{p} for selected protons;#it{p} (GeV/#it{c});#it{N}_{#sigma}^{TOF}", HistType::kTH2D, {pAxis, nSigmaAxis});
+        hPrDePID[2] = registry.add<TH2>("fDeuteronTPCPID", "#it{N}_{#sigma}^{TPC} vs. #it{p} for selected deuterons;#it{p} (GeV/#it{c});#it{N}_{#sigma}^{TPC}", HistType::kTH2D, {pAxis, nSigmaAxis});
+        hPrDePID[3] = registry.add<TH2>("fDeuteronTOFPID", "#it{N}_{#sigma}^{TOF} vs. #it{p} for selected deuterons;#it{p} (GeV/#it{c});#it{N}_{#sigma}^{TOF}", HistType::kTH2D, {pAxis, nSigmaAxis});
 
         hV0Selected = registry.add<TH2>("fV0Selected", "Selections for V0s;;counts", HistType::kTH2D, {{9, -0.5, 8.5}, {kNV0, -0.5, +kNV0 - 0.5}});
 
@@ -367,8 +375,8 @@ struct HfFilter { // Main struct for HF triggers
     for (const auto& collision : collisions) {
 
       bool keepEvent[kNtriggersHF]{false};
-      if (applyEventSelection && (!collision.sel8() || std::fabs(collision.posZ()) > 11.f)) { // safety margin for Zvtx
-        tags(keepEvent[kHighPt2P], keepEvent[kHighPt3P], keepEvent[kBeauty3P], keepEvent[kBeauty4P], keepEvent[kFemto2P], keepEvent[kFemto3P], keepEvent[kDoubleCharm2P], keepEvent[kDoubleCharm3P], keepEvent[kDoubleCharmMix], keepEvent[kV0Charm2P], keepEvent[kV0Charm3P], keepEvent[kCharmBarToXiBach], keepEvent[kSigmaCPPK], keepEvent[kSigmaC0K0], keepEvent[kPhotonCharm2P], keepEvent[kPhotonCharm3P], keepEvent[kSingleCharm2P], keepEvent[kSingleCharm3P], keepEvent[kSingleNonPromptCharm2P], keepEvent[kSingleNonPromptCharm3P], keepEvent[kCharmBarToXi2Bach]);
+      if (!collision.sel8() || std::fabs(collision.posZ()) > 11.f) { // safety margin for Zvtx
+        tags(keepEvent[kHighPt2P], keepEvent[kHighPt3P], keepEvent[kBeauty3P], keepEvent[kBeauty4P], keepEvent[kFemto2P], keepEvent[kFemto3P], keepEvent[kDoubleCharm2P], keepEvent[kDoubleCharm3P], keepEvent[kDoubleCharmMix], keepEvent[kV0Charm2P], keepEvent[kV0Charm3P], keepEvent[kCharmBarToXiBach], keepEvent[kSigmaCPPK], keepEvent[kSigmaC0K0], keepEvent[kPhotonCharm2P], keepEvent[kPhotonCharm3P], keepEvent[kSingleCharm2P], keepEvent[kSingleCharm3P], keepEvent[kSingleNonPromptCharm2P], keepEvent[kSingleNonPromptCharm3P], keepEvent[kCharmBarToXi2Bach], keepEvent[kBtoJPsiKa], keepEvent[kBtoJPsiKstar], keepEvent[kBtoJPsiPhi], keepEvent[kBtoJPsiPrKa], keepEvent[kBtoJPsiPi]);
         continue;
       }
 
@@ -412,16 +420,18 @@ struct HfFilter { // Main struct for HF triggers
 
       auto cand2ProngsThisColl = cand2Prongs.sliceBy(hf2ProngPerCollision, thisCollId);
       for (const auto& cand2Prong : cand2ProngsThisColl) {                                // start loop over 2 prongs
-        if (!TESTBIT(cand2Prong.hfflag(), o2::aod::hf_cand_2prong::DecayType::D0ToPiK)) { // check if it's a D0
+
+        int8_t preselD0 = TESTBIT(cand2Prong.hfflag(), o2::aod::hf_cand_2prong::DecayType::D0ToPiK); // check if it's a D0
+        int8_t preselJPsiToMuMu = TESTBIT(cand2Prong.hfflag(), o2::aod::hf_cand_2prong::DecayType::JpsiToMuMu); // check if it's a JPsi
+        if (preselD0 == 0 && preselJPsiToMuMu == 0) {
           continue;
         }
 
         auto trackPos = tracks.rawIteratorAt(cand2Prong.prong0Id()); // positive daughter
         auto trackNeg = tracks.rawIteratorAt(cand2Prong.prong1Id()); // negative daughter
 
-        auto preselD0 = helper.isDzeroPreselected(trackPos, trackNeg);
-        if (!preselD0) {
-          continue;
+        if (preselD0) {
+          preselD0 = helper.isDzeroPreselected(trackPos, trackNeg);
         }
 
         auto trackParPos = getTrackParCov(trackPos);
@@ -439,58 +449,76 @@ struct HfFilter { // Main struct for HF triggers
           getPxPyPz(trackParNeg, pVecNeg);
         }
 
-        // apply ML models
+        // apply ML models for D0
+        bool isD0CharmTagged{false}, isD0BeautyTagged{false}, isD0SignalTagged{false};
         std::vector<float> scores{};
-        scores.insert(scores.end(), cand2Prong.mlProbSkimD0ToKPi().begin(), cand2Prong.mlProbSkimD0ToKPi().end());
-        if (scores.size() != 3) {
-          scores.resize(3);
-          scores[0] = 2.;
-          scores[1] = -1.;
-          scores[2] = -1.;
-        }
-        auto tagBDT = helper.isBDTSelected(scores, thresholdBDTScores[kD0]);
-        bool isCharmTagged = TESTBIT(tagBDT, RecoDecay::OriginType::Prompt);
-        bool isBeautyTagged = TESTBIT(tagBDT, RecoDecay::OriginType::NonPrompt);
-        bool isSignalTagged = acceptBdtBkgOnly ? TESTBIT(tagBDT, RecoDecay::OriginType::None) : (isCharmTagged || isBeautyTagged);
+        if (preselD0) {
+          scores.insert(scores.end(), cand2Prong.mlProbSkimD0ToKPi().begin(), cand2Prong.mlProbSkimD0ToKPi().end());
+          if (scores.size() != 3) {
+            scores.resize(3);
+            scores[0] = 2.;
+            scores[1] = -1.;
+            scores[2] = -1.;
+          }
+          auto tagBDT = helper.isBDTSelected(scores, thresholdBDTScores[kD0]);
+          isD0CharmTagged = TESTBIT(tagBDT, RecoDecay::OriginType::Prompt);
+          isD0BeautyTagged = TESTBIT(tagBDT, RecoDecay::OriginType::NonPrompt);
+          isD0SignalTagged = acceptBdtBkgOnly ? TESTBIT(tagBDT, RecoDecay::OriginType::None) : (isD0CharmTagged || isD0BeautyTagged);
 
-        if (activateQA > 1) {
-          hBDTScoreBkg[kD0]->Fill(scores[0]);
-          hBDTScorePrompt[kD0]->Fill(scores[1]);
-          hBDTScoreNonPrompt[kD0]->Fill(scores[2]);
-        }
-
-        if (!isSignalTagged) {
-          continue;
-        }
-
-        keepEvent[kSingleCharm2P] = true;
-        if (isBeautyTagged) {
-          keepEvent[kSingleNonPromptCharm2P] = true;
+          if (activateQA > 1) {
+            hBDTScoreBkg[kD0]->Fill(scores[0]);
+            hBDTScorePrompt[kD0]->Fill(scores[1]);
+            hBDTScoreNonPrompt[kD0]->Fill(scores[2]);
+          }
         }
 
         auto pVec2Prong = RecoDecay::pVec(pVecPos, pVecNeg);
         auto pt2Prong = RecoDecay::pt(pVec2Prong);
 
-        if (applyOptimisation) {
-          optimisationTreeCharm(thisCollId, o2::constants::physics::Pdg::kD0, pt2Prong, scores[0], scores[1], scores[2]);
+        if (preselJPsiToMuMu) {
+          float ptMuonMin = cutsBtoJPsiX->get(0u, 0u); // assuming that the cut is looser in the first pT bin
+          auto ptPos = RecoDecay::pt(pVecPos);
+          auto ptNeg = RecoDecay::pt(pVecNeg);
+          if (ptPos < ptMuonMin || ptNeg < ptMuonMin) {
+            preselJPsiToMuMu = 0u;
+          } else {
+            auto massJPsiCand = RecoDecay::m(std::array{pVecPos, pVecNeg}, std::array{massMu, massMu});
+            hMassVsPtC[kNCharmParticles + 18]->Fill(pt2Prong, massJPsiCand);
+          }
         }
 
-        auto selD0 = helper.isSelectedD0InMassRange(pVecPos, pVecNeg, pt2Prong, preselD0, activateQA, hMassVsPtC[kD0]);
+        if (!isD0SignalTagged && !preselJPsiToMuMu) {
+          continue;
+        }
 
-        if (helper.isSelectedHighPt2Prong(pt2Prong)) {
-          keepEvent[kHighPt2P] = true;
-          if (activateQA) {
-            hCharmHighPt[kD0]->Fill(pt2Prong);
+        int8_t selD0InMass{0};
+        double massD0Cand{-1.}, massD0BarCand{-1.};
+        if (isD0SignalTagged) {
+           // single D0
+          keepEvent[kSingleCharm2P] = true;
+          if (isD0BeautyTagged) {
+            keepEvent[kSingleNonPromptCharm2P] = true;
           }
-        } // end high-pT selection
+          // single D0 at high pT
+          if (helper.isSelectedHighPt2Prong(pt2Prong)) {
+            keepEvent[kHighPt2P] = true;
+            if (activateQA) {
+              hCharmHighPt[kD0]->Fill(pt2Prong);
+            }
+          }
+          // multi-charm selection
+          if (isD0CharmTagged) {
+            indicesDau2Prong.push_back(std::vector<int64_t>{trackPos.globalIndex(), trackNeg.globalIndex()});
+          } 
 
-        if (isCharmTagged) {
-          indicesDau2Prong.push_back(std::vector<int64_t>{trackPos.globalIndex(), trackNeg.globalIndex()});
-        } // end multi-charm selection
-
-        // compute masses already here, needed both for B0 --> D* (--> D0 Pi) Pi and Ds1 --> D* (--> D0 Pi) K0S
-        auto massD0Cand = RecoDecay::m(std::array{pVecPos, pVecNeg}, std::array{massPi, massKa});
-        auto massD0BarCand = RecoDecay::m(std::array{pVecPos, pVecNeg}, std::array{massKa, massPi});
+          if (applyOptimisation) {
+            optimisationTreeCharm(thisCollId, o2::constants::physics::Pdg::kD0, pt2Prong, scores[0], scores[1], scores[2]);
+          }
+          selD0InMass = helper.isSelectedD0InMassRange(pVecPos, pVecNeg, pt2Prong, preselD0, activateQA, hMassVsPtC[kD0]);
+          // compute masses already here, needed both for B0 --> D* (--> D0 Pi) Pi and Ds1 --> D* (--> D0 Pi) K0S
+          massD0Cand = RecoDecay::m(std::array{pVecPos, pVecNeg}, std::array{massPi, massKa});
+          massD0BarCand = RecoDecay::m(std::array{pVecPos, pVecNeg}, std::array{massKa, massPi});
+        }
 
         auto trackIdsThisCollision = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
         auto tracksWithItsPid = soa::Attach<BigTracksPID, aod::pidits::ITSNSigmaPr, aod::pidits::ITSNSigmaDe>(tracks);
@@ -509,9 +537,10 @@ struct HfFilter { // Main struct for HF triggers
             getPxPyPz(trackParThird, pVecThird);
           }
 
-          if (!keepEvent[kBeauty3P] && isBeautyTagged) {
-            auto isTrackSelected = helper.isSelectedTrackForSoftPionOrBeauty(track, trackParThird, dcaThird, kBeauty3P);
-            if (TESTBIT(isTrackSelected, kForBeauty) && ((TESTBIT(selD0, 0) && track.sign() < 0) || (TESTBIT(selD0, 1) && track.sign() > 0))) { // D0 pi- and D0bar pi+
+          // Beauty with D0
+          if (!keepEvent[kBeauty3P] && isD0BeautyTagged) {
+            auto isTrackSelected = helper.isSelectedTrackForSoftPionOrBeauty<kBeauty3P>(track, trackParThird, dcaThird);
+            if (TESTBIT(isTrackSelected, kForBeauty) && ((TESTBIT(selD0InMass, 0) && track.sign() < 0) || (TESTBIT(selD0InMass, 1) && track.sign() > 0))) { // D0 pi- and D0bar pi+
               auto massCand = RecoDecay::m(std::array{pVec2Prong, pVecThird}, std::array{massD0, massPi});
               auto pVecBeauty3Prong = RecoDecay::pVec(pVec2Prong, pVecThird);
               auto ptCand = RecoDecay::pt(pVecBeauty3Prong);
@@ -530,6 +559,7 @@ struct HfFilter { // Main struct for HF triggers
                   }
                 } else {
                   df2.process(trackParPos, trackParNeg);
+                  df2.propagateTracksToVertex();
                   std::array<float, 3> pVecPosVtx{}, pVecNegVtx{};
                   df2.getTrack(0).getPxPyPzGlo(pVecPosVtx);
                   df2.getTrack(1).getPxPyPzGlo(pVecNegVtx);
@@ -540,8 +570,8 @@ struct HfFilter { // Main struct for HF triggers
                     if (activateQA) {
                       registry.fill(HIST("fHfVtxStages"), 1 + HfVtxStage::BeautyVertex, kBplus);
                     }
-                    const auto& secondaryVertexBplus = dfB.getPCACandidate();
                     dfB.propagateTracksToVertex();
+                    const auto& secondaryVertexBplus = dfB.getPCACandidate();
                     std::array<float, 3> pVecThirdVtx{};
                     dfB.getTrack(0).getPxPyPzGlo(pVec2ProngVtx);
                     dfB.getTrack(1).getPxPyPzGlo(pVecThirdVtx);
@@ -566,7 +596,7 @@ struct HfFilter { // Main struct for HF triggers
                 }
               }
             }
-            if (!keepEvent[kBeauty3P] && TESTBIT(isTrackSelected, kSoftPionForBeauty) && ((TESTBIT(selD0, 0) && track.sign() > 0) || (TESTBIT(selD0, 1) && track.sign() < 0))) { // D0 pi+ and D0bar pi-
+            if (!keepEvent[kBeauty3P] && TESTBIT(isTrackSelected, kSoftPionForBeauty) && ((TESTBIT(selD0InMass, 0) && track.sign() > 0) || (TESTBIT(selD0InMass, 1) && track.sign() < 0))) { // D0 pi+ and D0bar pi-
               auto pVecBeauty3Prong = RecoDecay::pVec(pVec2Prong, pVecThird);
               auto ptCand = RecoDecay::pt(pVecBeauty3Prong);
               std::array<float, 2> massDausD0{massPi, massKa};
@@ -595,7 +625,7 @@ struct HfFilter { // Main struct for HF triggers
                     getPxPyPz(trackParFourth, pVecFourth);
                   }
 
-                  auto isTrackFourthSelected = helper.isSelectedTrackForSoftPionOrBeauty(trackB, trackParFourth, dcaFourth, kBeauty3P);
+                  auto isTrackFourthSelected = helper.isSelectedTrackForSoftPionOrBeauty<kBeauty3P>(trackB, trackParFourth, dcaFourth);
                   if (track.sign() * trackB.sign() < 0 && TESTBIT(isTrackFourthSelected, kForBeauty)) {
                     auto massCandB0 = RecoDecay::m(std::array{pVecBeauty3Prong, pVecFourth}, std::array{massDStar, massPi});
                     auto pVecBeauty4Prong = RecoDecay::pVec(pVec2Prong, pVecThird, pVecFourth);
@@ -615,6 +645,7 @@ struct HfFilter { // Main struct for HF triggers
                         }
                       } else {
                         df2.process(trackParPos, trackParNeg);
+                        df2.propagateTracksToVertex();
                         std::array<float, 3> pVecPosVtx{}, pVecNegVtx{};
                         df2.getTrack(0).getPxPyPzGlo(pVecPosVtx);
                         df2.getTrack(1).getPxPyPzGlo(pVecNegVtx);
@@ -625,8 +656,8 @@ struct HfFilter { // Main struct for HF triggers
                           if (activateQA) {
                             registry.fill(HIST("fHfVtxStages"), 1 + HfVtxStage::BeautyVertex, kB0toDStar);
                           }
-                          const auto& secondaryVertexBzero = dfBtoDstar.getPCACandidate();
                           dfBtoDstar.propagateTracksToVertex();
+                          const auto& secondaryVertexBzero = dfBtoDstar.getPCACandidate();
                           std::array<float, 3> pVecThirdVtx{}, pVecFourthVtx{};
                           dfBtoDstar.getTrack(0).getPxPyPzGlo(pVec2ProngVtx);
                           dfBtoDstar.getTrack(1).getPxPyPzGlo(pVecThirdVtx);
@@ -655,8 +686,8 @@ struct HfFilter { // Main struct for HF triggers
           } // end beauty selection
 
           // 2-prong femto
-          if (!keepEvent[kFemto2P] && enableFemtoChannels->get(0u, 0u) && isCharmTagged && track.collisionId() == thisCollId && (TESTBIT(selD0, 0) || TESTBIT(selD0, 1) || !requireCharmMassForFemto)) {
-            bool isProton = helper.isSelectedTrack4Femto(track, trackParThird, activateQA, hProtonTPCPID, hProtonTOFPID, kProtonForFemto);
+          if (!keepEvent[kFemto2P] && enableFemtoChannels->get(0u, 0u) && isD0CharmTagged && track.collisionId() == thisCollId) {
+            bool isProton = helper.isSelectedTrack4Femto(track, trackParThird, activateQA, hPrDePID[0], hPrDePID[1], kProtonForFemto);
             if (isProton) {
               float relativeMomentum = helper.computeRelativeMomentum(pVecThird, pVec2Prong, massD0);
               if (applyOptimisation) {
@@ -671,10 +702,74 @@ struct HfFilter { // Main struct for HF triggers
             }
           } // end femto selection
 
+          // Beauty with JPsi
+          if (preselJPsiToMuMu) {
+            if (TESTBIT(helper.isSelectedTrackForSoftPionOrBeauty<kBtoJPsiKa>(track, trackParThird, dcaThird), kForBeauty)) { // same for all channels
+              continue;
+            }
+            std::array<float, 3> pVecPosVtx{}, pVecNegVtx{}, pVecThirdVtx{}, pVecFourthVtx{};
+            // 3-prong vertices
+            if (!keepEvent[kBtoJPsiKa] || !keepEvent[kBtoJPsiPi]) {
+              if(df3.process(trackParPos, trackParNeg, trackParThird) != 0) {
+                df3.propagateTracksToVertex();
+                const auto& secondaryVertexBto3tracks = df3.getPCACandidate();
+                df3.getTrack(0).getPxPyPzGlo(pVecPosVtx);
+                df3.getTrack(1).getPxPyPzGlo(pVecNegVtx);
+                df3.getTrack(2).getPxPyPzGlo(pVecThirdVtx);
+                auto isBhadSel = helper.isSelectedBhadronToJPsi<3>(std::array{pVecPosVtx, pVecNegVtx, pVecThirdVtx}, std::array{track}, std::array<double, 3>{static_cast<double>(collision.posX()), static_cast<double>(collision.posY()), static_cast<double>(collision.posZ())}, std::array{secondaryVertexBto3tracks[0], secondaryVertexBto3tracks[1], secondaryVertexBto3tracks[2]}, activateQA, hMassVsPtB);
+                if (TESTBIT(isBhadSel, kBplusToJPsi)) {
+                  keepEvent[kBtoJPsiKa] = true;
+                }
+                if (TESTBIT(isBhadSel, kBcToJPsi)) {
+                  keepEvent[kBtoJPsiPi] = true;
+                }
+              }
+            }
+            // 4-prong vertices
+            if (!keepEvent[kBtoJPsiKstar] || !keepEvent[kBtoJPsiPhi] || !keepEvent[kBtoJPsiPrKa]) {
+              for (const auto& trackIdB : trackIdsThisCollision) { // start loop over tracks
+                if (keepEvent[kBtoJPsiKstar] && keepEvent[kBtoJPsiPhi] && keepEvent[kBtoJPsiPrKa]) {
+                  break;
+                }
+                auto trackFourth = tracksWithItsPid.rawIteratorAt(trackIdB.trackId());
+                if (trackFourth.globalIndex() == track.globalIndex() || trackFourth.globalIndex() == trackPos.globalIndex() || trackFourth.globalIndex() == trackNeg.globalIndex() || trackFourth.sign() * track.sign() > 0) {
+                  continue;
+                }
+                auto trackParFourth = getTrackParCov(trackFourth);
+                o2::gpu::gpustd::array<float, 2> dcaFourth{trackFourth.dcaXY(), trackFourth.dcaZ()};
+                std::array<float, 3> pVecFourth = trackFourth.pVector();
+                if (trackFourth.collisionId() != thisCollId) {
+                  o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParFourth, 2.f, noMatCorr, &dcaFourth);
+                  getPxPyPz(trackParFourth, pVecFourth);
+                }
+                if (TESTBIT(helper.isSelectedTrackForSoftPionOrBeauty<kBtoJPsiKa>(trackFourth, trackParFourth, dcaFourth), kForBeauty)) { // same for all channels
+                  continue;
+                }
+                if (df4.process(trackParPos, trackParNeg, trackParThird, trackParFourth) != 0) {
+                  df4.propagateTracksToVertex();
+                  const auto& secondaryVertexBto4tracks = df4.getPCACandidate();
+                  df4.getTrack(0).getPxPyPzGlo(pVecPosVtx);
+                  df4.getTrack(1).getPxPyPzGlo(pVecNegVtx);
+                  df4.getTrack(2).getPxPyPzGlo(pVecThirdVtx);
+                  df4.getTrack(3).getPxPyPzGlo(pVecFourthVtx);
+                  auto isBhadSel = helper.isSelectedBhadronToJPsi<4>(std::array{pVecPosVtx, pVecNegVtx, pVecThirdVtx, pVecFourthVtx}, std::array{track, trackFourth}, std::array<double, 3>{static_cast<double>(collision.posX()), static_cast<double>(collision.posY()), static_cast<double>(collision.posZ())}, std::array{secondaryVertexBto4tracks[0], secondaryVertexBto4tracks[1], secondaryVertexBto4tracks[2]}, activateQA, hMassVsPtB);
+                  if (TESTBIT(isBhadSel, kB0ToJPsi)) {
+                    keepEvent[kBtoJPsiKstar] = true;
+                  }
+                  if (TESTBIT(isBhadSel, kBsToJPsi)) {
+                    keepEvent[kBtoJPsiPhi] = true;
+                  }
+                  if (TESTBIT(isBhadSel, kLbToJPsi)) {
+                    keepEvent[kBtoJPsiPrKa] = true;
+                  }
+                }
+              }
+            }
+          }
         } // end loop over tracks
 
         // 2-prong with Gamma (conversion photon)
-        if (!keepEvent[kPhotonCharm2P] && isSignalTagged && (TESTBIT(selD0, 0) || TESTBIT(selD0, 1))) {
+        if (!keepEvent[kPhotonCharm2P] && isD0SignalTagged && (TESTBIT(selD0InMass, 0) || TESTBIT(selD0InMass, 1))) {
           auto photonsThisCollision = photons.sliceBy(photonsPerCollision, thisCollId);
           for (const auto& photon : photonsThisCollision) {
             auto posTrack = photon.posTrack_as<aod::V0Legs>();
@@ -695,11 +790,11 @@ struct HfFilter { // Main struct for HF triggers
             auto pVecReso2Prong = RecoDecay::pVec(pVec2Prong, pVecPhoton);
             auto ptCand = RecoDecay::pt(pVecReso2Prong);
             if (ptCand > cutsPtDeltaMassCharmReso->get(2u, 1u)) {
-              if (TESTBIT(selD0, 0)) {
+              if (TESTBIT(selD0InMass, 0)) {
                 massDStarCand = RecoDecay::m(std::array{pVecPos, pVecNeg, pVecPhoton}, std::array{massPi, massKa, massGamma});
                 massDiffDstar = massDStarCand - massD0Cand;
               }
-              if (TESTBIT(selD0, 1)) {
+              if (TESTBIT(selD0InMass, 1)) {
                 massDStarBarCand = RecoDecay::m(std::array{pVecPos, pVecNeg, pVecPhoton}, std::array{massKa, massPi, massGamma});
                 massDiffDstarBar = massDStarBarCand - massD0BarCand;
               }
@@ -723,7 +818,7 @@ struct HfFilter { // Main struct for HF triggers
         }
 
         // 2-prong with K0S or Lambda
-        if (!keepEvent[kV0Charm2P] && isSignalTagged && (TESTBIT(selD0, 0) || TESTBIT(selD0, 1))) {
+        if (!keepEvent[kV0Charm2P] && isD0SignalTagged && (TESTBIT(selD0InMass, 0) || TESTBIT(selD0InMass, 1))) {
           auto v0sThisCollision = v0s.sliceBy(v0sPerCollision, thisCollId);
           for (const auto& v0 : v0sThisCollision) {
             V0Cand v0Cand;
@@ -752,8 +847,8 @@ struct HfFilter { // Main struct for HF triggers
                   getPxPyPz(trackParBachelor, pVecBachelor);
                 }
 
-                int isTrackSelected = helper.isSelectedTrackForSoftPionOrBeauty(trackBachelor, trackParBachelor, dcaBachelor, -1);
-                if (TESTBIT(isTrackSelected, kSoftPion) && ((TESTBIT(selD0, 0) && trackBachelor.sign() > 0) || (TESTBIT(selD0, 1) && trackBachelor.sign() < 0))) {
+                int isTrackSelected = helper.isSelectedTrackForSoftPionOrBeauty<kV0Charm2P>(trackBachelor, trackParBachelor, dcaBachelor);
+                if (TESTBIT(isTrackSelected, kSoftPion) && ((TESTBIT(selD0InMass, 0) && trackBachelor.sign() > 0) || (TESTBIT(selD0InMass, 1) && trackBachelor.sign() < 0))) {
                   std::array<float, 2> massDausD0{massPi, massKa};
                   auto massD0dau = massD0Cand;
                   if (trackBachelor.sign() < 0) {
@@ -796,12 +891,12 @@ struct HfFilter { // Main struct for HF triggers
               auto pVecReso2Prong = RecoDecay::pVec(pVec2Prong, v0Cand.mom);
               auto ptCand = RecoDecay::pt(pVecReso2Prong);
               if (ptCand > cutsPtDeltaMassCharmReso->get(2u, 5u)) {
-                if (TESTBIT(selD0, 0)) {
+                if (TESTBIT(selD0InMass, 0)) {
                   massXicStarCand = RecoDecay::m(std::array{pVecPos, pVecNeg, v0Cand.mom}, std::array{massPi, massKa, massLambda});
                   massDiffXicStarCand = massXicStarCand - massD0Cand;
                   isRightSignXicStar = TESTBIT(selV0, kLambda); // right sign if Lambda
                 }
-                if (TESTBIT(selD0, 1)) {
+                if (TESTBIT(selD0InMass, 1)) {
                   massXicStarBarCand = RecoDecay::m(std::array{pVecPos, pVecNeg, v0Cand.mom}, std::array{massKa, massPi, massLambda});
                   massDiffXicStarBarCand = massXicStarBarCand - massD0BarCand;
                   isRightSignXicStarBar = TESTBIT(selV0, kAntiLambda); // right sign if AntiLambda
@@ -998,7 +1093,7 @@ struct HfFilter { // Main struct for HF triggers
           int charmParticleID[kNBeautyParticles - 2] = {o2::constants::physics::Pdg::kDPlus, o2::constants::physics::Pdg::kDS, o2::constants::physics::Pdg::kLambdaCPlus, o2::constants::physics::Pdg::kXiCPlus};
 
           float massCharmHypos[kNBeautyParticles - 2] = {massDPlus, massDs, massLc, massXic};
-          auto isTrackSelected = helper.isSelectedTrackForSoftPionOrBeauty(track, trackParFourth, dcaFourth, kBeauty4P);
+          auto isTrackSelected = helper.isSelectedTrackForSoftPionOrBeauty<kBeauty4P>(track, trackParFourth, dcaFourth);
           if (track.sign() * sign3Prong < 0 && TESTBIT(isTrackSelected, kForBeauty)) {
             for (int iHypo{0}; iHypo < kNBeautyParticles - 2 && !keepEvent[kBeauty4P]; ++iHypo) {
               if (isBeautyTagged[iHypo] && (TESTBIT(is3ProngInMass[iHypo], 0) || TESTBIT(is3ProngInMass[iHypo], 1))) {
@@ -1019,6 +1114,7 @@ struct HfFilter { // Main struct for HF triggers
                     }
                   } else {
                     df3.process(trackParFirst, trackParSecond, trackParThird);
+                    df3.propagateTracksToVertex();
                     std::array<float, 3> pVecFirstVtx{}, pVecSecondVtx{}, pVecThirdVtx{};
                     df3.getTrack(0).getPxPyPzGlo(pVecFirstVtx);
                     df3.getTrack(1).getPxPyPzGlo(pVecSecondVtx);
@@ -1030,8 +1126,8 @@ struct HfFilter { // Main struct for HF triggers
                       if (activateQA) {
                         registry.fill(HIST("fHfVtxStages"), 1 + HfVtxStage::BeautyVertex, iHypo + 2);
                       }
-                      const auto& secondaryVertexB = dfB.getPCACandidate();
                       dfB.propagateTracksToVertex();
+                      const auto& secondaryVertexB = dfB.getPCACandidate();
                       std::array<float, 3> pVecFourtVtx{};
                       dfB.getTrack(0).getPxPyPzGlo(pVec3ProngVtx);
                       dfB.getTrack(1).getPxPyPzGlo(pVecFourtVtx);
@@ -1060,12 +1156,12 @@ struct HfFilter { // Main struct for HF triggers
           } // end beauty selection
 
           // 3-prong femto
-          bool isProton = helper.isSelectedTrack4Femto(track, trackParFourth, activateQA, hProtonTPCPID, hProtonTOFPID, kProtonForFemto);
-          bool isDeuteron = helper.isSelectedTrack4Femto(track, trackParFourth, activateQA, hDeuteronTPCPID, hDeuteronTOFPID, kDeuteronForFemto);
+          bool isProton = helper.isSelectedTrack4Femto(track, trackParFourth, activateQA, hPrDePID[0], hPrDePID[1], kProtonForFemto);
+          bool isDeuteron = helper.isSelectedTrack4Femto(track, trackParFourth, activateQA, hPrDePID[2], hPrDePID[3], kDeuteronForFemto);
 
           if (isProton && track.collisionId() == thisCollId) {
             for (int iHypo{0}; iHypo < kNCharmParticles - 1 && !keepEvent[kFemto3P]; ++iHypo) {
-              if (isCharmTagged[iHypo] && enableFemtoChannels->get(0u, iHypo + 1) && (TESTBIT(is3ProngInMass[iHypo], 0) || TESTBIT(is3ProngInMass[iHypo], 1) || !requireCharmMassForFemto)) {
+              if (isCharmTagged[iHypo] && enableFemtoChannels->get(0u, iHypo + 1)) {
                 float relativeMomentum = helper.computeRelativeMomentum(pVecFourth, pVec3Prong, massCharmHypos[iHypo]);
                 if (applyOptimisation) {
                   optimisationTreeFemto(thisCollId, charmParticleID[iHypo], pt3Prong, scores[iHypo][0], scores[iHypo][1], scores[iHypo][2], relativeMomentum, track.tpcNSigmaPr(), track.tofNSigmaPr(), track.tpcNSigmaDe(), track.tofNSigmaDe());
@@ -1080,7 +1176,7 @@ struct HfFilter { // Main struct for HF triggers
             }
           } else if (isDeuteron && track.collisionId() == thisCollId) {
             for (int iHypo{0}; iHypo < kNCharmParticles - 1 && !keepEvent[kFemto3P]; ++iHypo) {
-              if (isCharmTagged[iHypo] && enableFemtoChannels->get(1u, iHypo + 1) && (TESTBIT(is3ProngInMass[iHypo], 0) || TESTBIT(is3ProngInMass[iHypo], 1) || !requireCharmMassForFemto)) {
+              if (isCharmTagged[iHypo] && enableFemtoChannels->get(1u, iHypo + 1)) {
                 float relativeMomentum = helper.computeRelativeMomentum(pVecFourth, pVec3Prong, massCharmHypos[iHypo]);
                 if (applyOptimisation) {
                   optimisationTreeFemto(thisCollId, charmParticleID[iHypo], pt3Prong, scores[iHypo][0], scores[iHypo][1], scores[iHypo][2], relativeMomentum, track.tpcNSigmaPr(), track.tofNSigmaPr(), track.tpcNSigmaDe(), track.tofNSigmaDe());
@@ -1134,7 +1230,7 @@ struct HfFilter { // Main struct for HF triggers
                 o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParSoftPi, 2.f, noMatCorr, &dcaSoftPi);
                 getPxPyPz(trackParSoftPi, pVecSoftPi);
               }
-              int8_t isSoftPionSelected = helper.isSelectedTrackForSoftPionOrBeauty(trackSoftPi, trackParSoftPi, dcaSoftPi, kSigmaCPPK);
+              int8_t isSoftPionSelected = helper.isSelectedTrackForSoftPionOrBeauty<kSigmaCPPK>(trackSoftPi, trackParSoftPi, dcaSoftPi);
               if (TESTBIT(isSoftPionSelected, kSoftPionForSigmaC) /*&& (TESTBIT(is3Prong[2], 0) || TESTBIT(is3Prong[2], 1))*/) {
 
                 // check the mass of the SigmaC++ candidate
@@ -1340,7 +1436,7 @@ struct HfFilter { // Main struct for HF triggers
                   o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParSoftPi, 2.f, noMatCorr, &dcaSoftPi);
                   getPxPyPz(trackParSoftPi, pVecSoftPi);
                 }
-                int8_t isSoftPionSelected = helper.isSelectedTrackForSoftPionOrBeauty(trackSoftPi, trackParSoftPi, dcaSoftPi, kSigmaC0K0);
+                int8_t isSoftPionSelected = helper.isSelectedTrackForSoftPionOrBeauty<kSigmaC0K0>(trackSoftPi, trackParSoftPi, dcaSoftPi);
                 if (TESTBIT(isSoftPionSelected, kSoftPionForSigmaC) /*&& (TESTBIT(is3Prong[2], 0) || TESTBIT(is3Prong[2], 1))*/) {
 
                   // check the mass of the SigmaC0 candidate
@@ -1567,7 +1663,7 @@ struct HfFilter { // Main struct for HF triggers
         }
       }
 
-      tags(keepEvent[kHighPt2P], keepEvent[kHighPt3P], keepEvent[kBeauty3P], keepEvent[kBeauty4P], keepEvent[kFemto2P], keepEvent[kFemto3P], keepEvent[kDoubleCharm2P], keepEvent[kDoubleCharm3P], keepEvent[kDoubleCharmMix], keepEvent[kV0Charm2P], keepEvent[kV0Charm3P], keepEvent[kCharmBarToXiBach], keepEvent[kSigmaCPPK], keepEvent[kSigmaC0K0], keepEvent[kPhotonCharm2P], keepEvent[kPhotonCharm3P], keepEvent[kSingleCharm2P], keepEvent[kSingleCharm3P], keepEvent[kSingleNonPromptCharm2P], keepEvent[kSingleNonPromptCharm3P], keepEvent[kCharmBarToXi2Bach]);
+      tags(keepEvent[kHighPt2P], keepEvent[kHighPt3P], keepEvent[kBeauty3P], keepEvent[kBeauty4P], keepEvent[kFemto2P], keepEvent[kFemto3P], keepEvent[kDoubleCharm2P], keepEvent[kDoubleCharm3P], keepEvent[kDoubleCharmMix], keepEvent[kV0Charm2P], keepEvent[kV0Charm3P], keepEvent[kCharmBarToXiBach], keepEvent[kSigmaCPPK], keepEvent[kSigmaC0K0], keepEvent[kPhotonCharm2P], keepEvent[kPhotonCharm3P], keepEvent[kSingleCharm2P], keepEvent[kSingleCharm3P], keepEvent[kSingleNonPromptCharm2P], keepEvent[kSingleNonPromptCharm3P], keepEvent[kCharmBarToXi2Bach], keepEvent[kBtoJPsiKa], keepEvent[kBtoJPsiKstar], keepEvent[kBtoJPsiPhi], keepEvent[kBtoJPsiPrKa], keepEvent[kBtoJPsiPi]);
 
       if (!std::accumulate(keepEvent, keepEvent + kNtriggersHF, 0)) {
         hProcessedEvents->Fill(1);

--- a/EventFiltering/PWGHF/HFFilter.cxx
+++ b/EventFiltering/PWGHF/HFFilter.cxx
@@ -272,7 +272,7 @@ struct HfFilter { // Main struct for HF triggers
       // charm baryons to LF cascades
       hMassVsPtC[kNCharmParticles + 15] = registry.add<TH2>("fMassVsPtCharmBaryonToXiPi", "#it{M} vs. #it{p}_{T} distribution of triggered #Xi+#pi candidates;#it{p}_{T} (GeV/#it{c});#it{M} (GeV/#it{c}^{2});counts", HistType::kTH2D, {ptAxis, massAxisC[kNCharmParticles + 15]});
       hMassVsPtC[kNCharmParticles + 16] = registry.add<TH2>("fMassVsPtCharmBaryonToXiKa", "#it{M} vs. #it{p}_{T} distribution of triggered #Xi+K candidates;#it{p}_{T} (GeV/#it{c});#it{M} (GeV/#it{c}^{2});counts", HistType::kTH2D, {ptAxis, massAxisC[kNCharmParticles + 16]});
-      hMassVsPtC[kNCharmParticles + 17] = registry.add<TH2>("fMassVsPtCharmBaryonToXiPiPi", "#it{M} vs. #it{p}_{T} distribution of triggered #Xi+K candidates;#it{p}_{T} (GeV/#it{c});#it{M} (GeV/#it{c}^{2});counts", HistType::kTH2D, {ptAxis, massAxisC[kNCharmParticles + 17]});
+      hMassVsPtC[kNCharmParticles + 17] = registry.add<TH2>("fMassVsPtCharmBaryonToXiPiPi", "#it{M} vs. #it{p}_{T} distribution of triggered #Xi+#pi+#pi candidates;#it{p}_{T} (GeV/#it{c});#it{M} (GeV/#it{c}^{2});counts", HistType::kTH2D, {ptAxis, massAxisC[kNCharmParticles + 17]});
 
       for (int iBeautyPart{0}; iBeautyPart < kNBeautyParticles; ++iBeautyPart) {
         hMassVsPtB[iBeautyPart] = registry.add<TH2>(Form("fMassVsPt%s", beautyParticleNames[iBeautyPart].data()), Form("#it{M} vs. #it{p}_{T} distribution of triggered %s candidates;#it{p}_{T} (GeV/#it{c});#it{M} (GeV/#it{c}^{2});counts", beautyParticleNames[iBeautyPart].data()), HistType::kTH2D, {ptAxis, massAxisB[iBeautyPart]});
@@ -368,7 +368,7 @@ struct HfFilter { // Main struct for HF triggers
 
       bool keepEvent[kNtriggersHF]{false};
       if (applyEventSelection && (!collision.sel8() || std::fabs(collision.posZ()) > 11.f)) { // safety margin for Zvtx
-        tags(keepEvent[kHighPt2P], keepEvent[kHighPt3P], keepEvent[kBeauty3P], keepEvent[kBeauty4P], keepEvent[kFemto2P], keepEvent[kFemto3P], keepEvent[kDoubleCharm2P], keepEvent[kDoubleCharm3P], keepEvent[kDoubleCharmMix], keepEvent[kV0Charm2P], keepEvent[kV0Charm3P], keepEvent[kCharmBarToXiBach], keepEvent[kSigmaCPPK], keepEvent[kSigmaC0K0], keepEvent[kPhotonCharm2P], keepEvent[kPhotonCharm3P], keepEvent[kSingleCharm2P], keepEvent[kSingleCharm3P], keepEvent[kSingleNonPromptCharm2P], keepEvent[kSingleNonPromptCharm3P], keepEvent[kCharmBarToXiBachBach]);
+        tags(keepEvent[kHighPt2P], keepEvent[kHighPt3P], keepEvent[kBeauty3P], keepEvent[kBeauty4P], keepEvent[kFemto2P], keepEvent[kFemto3P], keepEvent[kDoubleCharm2P], keepEvent[kDoubleCharm3P], keepEvent[kDoubleCharmMix], keepEvent[kV0Charm2P], keepEvent[kV0Charm3P], keepEvent[kCharmBarToXiBach], keepEvent[kSigmaCPPK], keepEvent[kSigmaC0K0], keepEvent[kPhotonCharm2P], keepEvent[kPhotonCharm3P], keepEvent[kSingleCharm2P], keepEvent[kSingleCharm3P], keepEvent[kSingleNonPromptCharm2P], keepEvent[kSingleNonPromptCharm3P], keepEvent[kCharmBarToXi2Bach]);
         continue;
       }
 
@@ -1398,7 +1398,7 @@ struct HfFilter { // Main struct for HF triggers
         }
       } // end loop over 3-prong candidates
 
-      if (!keepEvent[kCharmBarToXiBach] || !keepEvent[kCharmBarToXiBachBach]) {
+      if (!keepEvent[kCharmBarToXiBach] || !keepEvent[kCharmBarToXi2Bach]) {
         auto cascThisColl = cascades.sliceBy(cascPerCollision, thisCollId);
         for (const auto& casc : cascThisColl) {
 
@@ -1478,10 +1478,9 @@ struct HfFilter { // Main struct for HF triggers
 
               bool isSelXiBach{false};
               if (requireStrangenessTracking->get(0u, 0u) > 0) {
-                if (!hasStrangeTrack) {
-                  continue;
+                if (hasStrangeTrack) {
+                  isSelXiBach = helper.isSelectedXiBach(trackParCascTrack, trackParBachelor, isSelBachelor, collision, df2, activateQA, hMassVsPtC[kNCharmParticles + 15], hMassVsPtC[kNCharmParticles + 16]);
                 }
-                isSelXiBach = helper.isSelectedXiBach(trackParCascTrack, trackParBachelor, isSelBachelor, collision, df2, activateQA, hMassVsPtC[kNCharmParticles + 15], hMassVsPtC[kNCharmParticles + 16]);
               } else {
                 isSelXiBach = helper.isSelectedXiBach(trackParCasc, trackParBachelor, isSelBachelor, collision, dfStrangeness, activateQA, hMassVsPtC[kNCharmParticles + 15], hMassVsPtC[kNCharmParticles + 16]);
               }
@@ -1495,7 +1494,7 @@ struct HfFilter { // Main struct for HF triggers
               continue;
             }
 
-            if (!keepEvent[kCharmBarToXiBachBach]) {
+            if (!keepEvent[kCharmBarToXi2Bach]) {
               for (const auto& trackIdSecond : trackIdsThisCollision) { // start loop over tracks (second bachelor)
                 auto trackSecond = tracks.rawIteratorAt(trackIdSecond.trackId());
 
@@ -1518,20 +1517,18 @@ struct HfFilter { // Main struct for HF triggers
                 if (!TESTBIT(isSelBachelorSecond, kPionForCharmBaryon)) {
                   continue;
                 }
-
-                if (!keepEvent[kCharmBarToXiBachBach]) { // XiPiPi
+                if (!keepEvent[kCharmBarToXi2Bach]) { // XiPiPi
 
                   bool isSelXiBachBach{false};
                   if (requireStrangenessTracking->get(0u, 1u) > 0) {
-                    if (!hasStrangeTrack) {
-                      continue;
+                    if (hasStrangeTrack) {
+                      isSelXiBachBach = helper.isSelectedXiBachBach<3>(trackParCascTrack, {trackParBachelor, trackParBachelorSecond}, collision, df3, activateQA, hMassVsPtC[kNCharmParticles + 17]);
                     }
-                    isSelXiBachBach = helper.isSelectedXiBachBach<3>(trackParCascTrack, {trackParBachelor, trackParBachelorSecond}, collision, df3, activateQA, hMassVsPtC[kNCharmParticles + 17]);
                   } else { // vertex with only the two bachelors
-                    isSelXiBachBach = helper.isSelectedXiBachBach<2>(trackParCascTrack, {trackParBachelor, trackParBachelorSecond}, collision, df2, activateQA, hMassVsPtC[kNCharmParticles + 17]);
+                    isSelXiBachBach = helper.isSelectedXiBachBach<2>(trackParCasc, {trackParBachelor, trackParBachelorSecond}, collision, df2, activateQA, hMassVsPtC[kNCharmParticles + 17]);
                   }
                   if (isSelXiBachBach) {
-                    keepEvent[kCharmBarToXiBachBach] = true;
+                    keepEvent[kCharmBarToXi2Bach] = true;
                   }
                 }
               }
@@ -1570,7 +1567,7 @@ struct HfFilter { // Main struct for HF triggers
         }
       }
 
-      tags(keepEvent[kHighPt2P], keepEvent[kHighPt3P], keepEvent[kBeauty3P], keepEvent[kBeauty4P], keepEvent[kFemto2P], keepEvent[kFemto3P], keepEvent[kDoubleCharm2P], keepEvent[kDoubleCharm3P], keepEvent[kDoubleCharmMix], keepEvent[kV0Charm2P], keepEvent[kV0Charm3P], keepEvent[kCharmBarToXiBach], keepEvent[kSigmaCPPK], keepEvent[kSigmaC0K0], keepEvent[kPhotonCharm2P], keepEvent[kPhotonCharm3P], keepEvent[kSingleCharm2P], keepEvent[kSingleCharm3P], keepEvent[kSingleNonPromptCharm2P], keepEvent[kSingleNonPromptCharm3P], keepEvent[kCharmBarToXiBachBach]);
+      tags(keepEvent[kHighPt2P], keepEvent[kHighPt3P], keepEvent[kBeauty3P], keepEvent[kBeauty4P], keepEvent[kFemto2P], keepEvent[kFemto3P], keepEvent[kDoubleCharm2P], keepEvent[kDoubleCharm3P], keepEvent[kDoubleCharmMix], keepEvent[kV0Charm2P], keepEvent[kV0Charm3P], keepEvent[kCharmBarToXiBach], keepEvent[kSigmaCPPK], keepEvent[kSigmaC0K0], keepEvent[kPhotonCharm2P], keepEvent[kPhotonCharm3P], keepEvent[kSingleCharm2P], keepEvent[kSingleCharm3P], keepEvent[kSingleNonPromptCharm2P], keepEvent[kSingleNonPromptCharm3P], keepEvent[kCharmBarToXi2Bach]);
 
       if (!std::accumulate(keepEvent, keepEvent + kNtriggersHF, 0)) {
         hProcessedEvents->Fill(1);

--- a/EventFiltering/PWGHF/HFFilterCharmHadronSignals.cxx
+++ b/EventFiltering/PWGHF/HFFilterCharmHadronSignals.cxx
@@ -97,7 +97,7 @@ struct HfFilterCharmHadronSignals { // Main struct for HF triggers
   {
     helper.setPtLimitsDstarSoftPion(minPtSoftPion, maxPtSoftPion);
     helper.setPtBinsSingleTracks(pTBinsTrack);
-    helper.setCutsSingleTrackBeauty(cutsTrackBeauty3Prong, cutsTrackBeauty3Prong);
+    helper.setCutsSingleTrackBeauty(cutsTrackBeauty3Prong, cutsTrackBeauty3Prong, cutsTrackBeauty3Prong);
     helper.setMassResolParametrisation(paramCharmMassShape);
     helper.setNumSigmaForDeltaMassCharmHadCut(numSigmaDeltaMassCharmHad);
 
@@ -221,7 +221,7 @@ struct HfFilterCharmHadronSignals { // Main struct for HF triggers
             o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParThird, 2.f, noMatCorr, &dcaThird);
             getPxPyPz(trackParThird, pVecThird);
           }
-          auto isTrackSelected = helper.isSelectedTrackForSoftPionOrBeauty(track, trackParThird, dcaThird, kBeauty3P);
+          auto isTrackSelected = helper.isSelectedTrackForSoftPionOrBeauty<kBeauty3P>(track, trackParThird, dcaThird);
           if (TESTBIT(isTrackSelected, kSoftPion)) {
             std::array<float, 2> massDausD0{massPi, massKa};
             auto invMassD0dau = invMassD0;

--- a/EventFiltering/PWGHF/HFFilterHelpers.h
+++ b/EventFiltering/PWGHF/HFFilterHelpers.h
@@ -81,7 +81,7 @@ enum HfTriggers {
   kSingleCharm3P,
   kSingleNonPromptCharm2P,
   kSingleNonPromptCharm3P,
-  kCharmBarToXiBachBach,
+  kCharmBarToXi2Bach,
   kNtriggersHF
 };
 
@@ -218,7 +218,7 @@ static const std::array<std::string, kNCharmParticles> charmParticleNames{"D0", 
 static const std::array<std::string, kNBeautyParticles> beautyParticleNames{"Bplus", "B0toDStar", "B0", "Bs", "Lb", "Xib"};
 static const std::array<int, kNCharmParticles> pdgCodesCharm{421, 411, 431, 4122, 4232};
 static const std::array<std::string, 2> eventTitles = {"all", "rejected"};
-static const std::vector<std::string> hfTriggerNames{filtering::HfHighPt2P::columnLabel(), filtering::HfHighPt3P::columnLabel(), filtering::HfBeauty3P::columnLabel(), filtering::HfBeauty4P::columnLabel(), filtering::HfFemto2P::columnLabel(), filtering::HfFemto3P::columnLabel(), filtering::HfDoubleCharm2P::columnLabel(), filtering::HfDoubleCharm3P::columnLabel(), filtering::HfDoubleCharmMix::columnLabel(), filtering::HfV0Charm2P::columnLabel(), filtering::HfV0Charm3P::columnLabel(), filtering::HfCharmBarToXiBach::columnLabel(), filtering::HfSigmaCPPK::columnLabel(), filtering::HfSigmaC0K0::columnLabel(), filtering::HfPhotonCharm2P::columnLabel(), filtering::HfPhotonCharm3P::columnLabel(), filtering::HfSingleCharm2P::columnLabel(), filtering::HfSingleCharm3P::columnLabel(), filtering::HfSingleNonPromptCharm2P::columnLabel(), filtering::HfSingleNonPromptCharm3P::columnLabel(), filtering::HfCharmBarToXiBachBach::columnLabel()};
+static const std::vector<std::string> hfTriggerNames{filtering::HfHighPt2P::columnLabel(), filtering::HfHighPt3P::columnLabel(), filtering::HfBeauty3P::columnLabel(), filtering::HfBeauty4P::columnLabel(), filtering::HfFemto2P::columnLabel(), filtering::HfFemto3P::columnLabel(), filtering::HfDoubleCharm2P::columnLabel(), filtering::HfDoubleCharm3P::columnLabel(), filtering::HfDoubleCharmMix::columnLabel(), filtering::HfV0Charm2P::columnLabel(), filtering::HfV0Charm3P::columnLabel(), filtering::HfCharmBarToXiBach::columnLabel(), filtering::HfSigmaCPPK::columnLabel(), filtering::HfSigmaC0K0::columnLabel(), filtering::HfPhotonCharm2P::columnLabel(), filtering::HfPhotonCharm3P::columnLabel(), filtering::HfSingleCharm2P::columnLabel(), filtering::HfSingleCharm3P::columnLabel(), filtering::HfSingleNonPromptCharm2P::columnLabel(), filtering::HfSingleNonPromptCharm3P::columnLabel(), filtering::HfCharmBarToXi2Bach::columnLabel()};
 
 static const std::array<std::string, kNV0> v0Labels{"#gamma", "K_{S}^{0}", "#Lambda", "#bar{#Lambda}"};
 static const std::array<std::string, kNV0> v0Names{"Photon", "K0S", "Lambda", "AntiLambda"};
@@ -262,7 +262,7 @@ static const o2::framework::AxisSpec alphaAxis{100, -1.f, 1.f};
 static const o2::framework::AxisSpec qtAxis{100, 0.f, 0.25f};
 static const o2::framework::AxisSpec bdtAxis{100, 0.f, 1.f};
 static const o2::framework::AxisSpec phiAxis{36, 0., o2::constants::math::TwoPI};
-static const std::array<o2::framework::AxisSpec, kNCharmParticles + 18> massAxisC = {o2::framework::AxisSpec{250, 1.65f, 2.15f}, o2::framework::AxisSpec{250, 1.65f, 2.15f}, o2::framework::AxisSpec{250, 1.75f, 2.25f}, o2::framework::AxisSpec{250, 2.05f, 2.55f}, o2::framework::AxisSpec{250, 2.25f, 2.75f}, o2::framework::AxisSpec{200, 0.139f, 0.159f}, o2::framework::AxisSpec{250, 0.f, 0.25f}, o2::framework::AxisSpec{250, 0.f, 0.25f}, o2::framework::AxisSpec{200, 0.48f, 0.88f}, o2::framework::AxisSpec{200, 0.48f, 0.88f}, o2::framework::AxisSpec{200, 1.1f, 1.4f}, o2::framework::AxisSpec{200, 1.1f, 1.4f}, o2::framework::AxisSpec{200, 1.1f, 1.4f}, o2::framework::AxisSpec{200, 1.1f, 1.4f}, o2::framework::AxisSpec{170, 0.13f, 0.3f}, o2::framework::AxisSpec{170, 0.13f, 0.3f}, o2::framework::AxisSpec{200, 0.4f, 0.8f}, o2::framework::AxisSpec{200, 0.4f, 0.8f}, o2::framework::AxisSpec{200, 0.4f, 0.8f}, o2::framework::AxisSpec{200, 0.4f, 0.8f}, o2::framework::AxisSpec{200, 2.3f, 2.9f}, o2::framework::AxisSpec{200, 2.3f, 2.9f}, o2::framework::AxisSpec{200, 2.3f, 2.9f}};
+static const std::array<o2::framework::AxisSpec, kNCharmParticles + 18> massAxisC = {o2::framework::AxisSpec{250, 1.65f, 2.15f}, o2::framework::AxisSpec{250, 1.65f, 2.15f}, o2::framework::AxisSpec{250, 1.75f, 2.25f}, o2::framework::AxisSpec{250, 2.05f, 2.55f}, o2::framework::AxisSpec{250, 2.25f, 2.75f}, o2::framework::AxisSpec{200, 0.139f, 0.159f}, o2::framework::AxisSpec{250, 0.f, 0.25f}, o2::framework::AxisSpec{250, 0.f, 0.25f}, o2::framework::AxisSpec{200, 0.48f, 0.88f}, o2::framework::AxisSpec{200, 0.48f, 0.88f}, o2::framework::AxisSpec{200, 1.1f, 1.4f}, o2::framework::AxisSpec{200, 1.1f, 1.4f}, o2::framework::AxisSpec{200, 1.1f, 1.4f}, o2::framework::AxisSpec{200, 1.1f, 1.4f}, o2::framework::AxisSpec{170, 0.13f, 0.3f}, o2::framework::AxisSpec{170, 0.13f, 0.3f}, o2::framework::AxisSpec{200, 0.4f, 0.8f}, o2::framework::AxisSpec{200, 0.4f, 0.8f}, o2::framework::AxisSpec{200, 0.4f, 0.8f}, o2::framework::AxisSpec{200, 0.4f, 0.8f}, o2::framework::AxisSpec{350, 2.3f, 3.0f}, o2::framework::AxisSpec{350, 2.3f, 3.0f}, o2::framework::AxisSpec{350, 2.3f, 3.0f}};
 static const std::array<o2::framework::AxisSpec, kNBeautyParticles> massAxisB = {o2::framework::AxisSpec{240, 4.8f, 6.0f}, o2::framework::AxisSpec{240, 4.8f, 6.0f}, o2::framework::AxisSpec{240, 4.8f, 6.0f}, o2::framework::AxisSpec{240, 4.8f, 6.0f}, o2::framework::AxisSpec{240, 5.0f, 6.2f}, o2::framework::AxisSpec{240, 5.0f, 6.2f}};
 
 // default values for configurables
@@ -2070,8 +2070,6 @@ inline bool HfFilterHelper::isSelectedXiBach(T const& trackParCasc, T const& tra
 template <int Nprongs, typename T, typename C, typename H2>
 inline bool HfFilterHelper::isSelectedXiBachBach(T const& trackParCasc, std::array<T, 2> const& trackParBachelor, C const& collision, o2::vertexing::DCAFitterN<Nprongs>& dcaFitter, const int& activateQA, H2 hMassVsPtXiPiPi)
 {
-  bool isSelected{false};
-
   // compute pT
   std::array<float, 3> pVecBachelorFirst{}, pVecBachelorSecond{}, pVecCascade{};
   getPxPyPz(trackParBachelor[0], pVecBachelorFirst);
@@ -2079,13 +2077,13 @@ inline bool HfFilterHelper::isSelectedXiBachBach(T const& trackParCasc, std::arr
   getPxPyPz(trackParCasc, pVecCascade);
   auto ptXiBachBach = RecoDecay::pt(RecoDecay::pVec(pVecCascade, pVecBachelorFirst, pVecBachelorSecond));
   if (ptXiBachBach < mPtMinXiBach[2]) {
-    return isSelected;
+    return false;
   }
 
   // compute mass
   float massXiPiPi = RecoDecay::m(std::array{pVecCascade, pVecBachelorFirst, pVecBachelorSecond}, std::array{massXi, massPi, massPi});
   if (massXiPiPi < mMassMinXiBach[2] || massXiPiPi > 3.f) {
-    return isSelected;
+    return false;
   }
 
   if (mCosPaMinXiBach[1] > -1.f) { // check topology if applicable
@@ -2130,15 +2128,15 @@ inline bool HfFilterHelper::isSelectedXiBachBach(T const& trackParCasc, std::arr
       return false;
     }
 
-    if (activateQA && isSelected) {
+    if (activateQA) {
       hMassVsPtXiPiPi->Fill(ptXiBachBach, massXiPiPi);
     }
   }
 
-  return isSelected;
+  return true;
 }
 
-/// Update the TPC PID baesd on the spline of particles
+/// Update the TPC PID based on the spline of particles
 /// \param track is a track parameter
 /// \param pidSpecies is the particle species to be considered
 /// \return updated nsigma value for TPC PID

--- a/EventFiltering/PWGHF/HFFilterHelpers.h
+++ b/EventFiltering/PWGHF/HFFilterHelpers.h
@@ -931,7 +931,7 @@ inline bool HfFilterHelper::isSelectedTrack4Femto(const T1& track, const T2& tra
   if (trackSpecies == kDeuteronForFemto) {
     // Apply different PID strategy in different pt range
     if (pt <= ptThresholdPidStrategy) {
-      if (std::fabs(NSigmaTPC) > nSigmaCuts[0] && NSigmaITS > nSigmaCuts[3]) { // Use TPC and ITS below the threshold, NSigmaITS for deuteron with a lower limit
+      if (std::fabs(NSigmaTPC) > nSigmaCuts[0] || NSigmaITS < nSigmaCuts[3]) { // Use TPC and ITS below the threshold, NSigmaITS for deuteron with a lower limit
         return false;
       }
     } else {

--- a/EventFiltering/PWGHF/HFFilterHelpers.h
+++ b/EventFiltering/PWGHF/HFFilterHelpers.h
@@ -82,6 +82,11 @@ enum HfTriggers {
   kSingleNonPromptCharm2P,
   kSingleNonPromptCharm3P,
   kCharmBarToXi2Bach,
+  kBtoJPsiKa,
+  kBtoJPsiKstar,
+  kBtoJPsiPhi,
+  kBtoJPsiPrKa,
+  kBtoJPsiPi,
   kNtriggersHF
 };
 
@@ -102,6 +107,15 @@ enum beautyParticles {
   kLb,
   kXib,
   kNBeautyParticles
+};
+
+enum beautyToJPsiParticles {
+  kBplusToJPsi = 0,
+  kB0ToJPsi,
+  kBsToJPsi,
+  kLbToJPsi,
+  kBcToJPsi,
+  kNBeautyParticlesToJPsi
 };
 
 enum bachelorTrackSelection {
@@ -215,10 +229,11 @@ struct CascCand {
 };
 
 static const std::array<std::string, kNCharmParticles> charmParticleNames{"D0", "Dplus", "Ds", "Lc", "Xic"};
-static const std::array<std::string, kNBeautyParticles> beautyParticleNames{"Bplus", "B0toDStar", "B0", "Bs", "Lb", "Xib"};
+static const int nTotBeautyParts = static_cast<int>(kNBeautyParticles) + static_cast<int>(kNBeautyParticlesToJPsi);
+static const std::array<std::string, nTotBeautyParts> beautyParticleNames{"Bplus", "B0toDStar", "B0", "Bs", "Lb", "Xib", "BplusToJPsi", "B0ToJPsi", "BsToJPsi", "LbToJPsi", "BcToJPsi"};
 static const std::array<int, kNCharmParticles> pdgCodesCharm{421, 411, 431, 4122, 4232};
 static const std::array<std::string, 2> eventTitles = {"all", "rejected"};
-static const std::vector<std::string> hfTriggerNames{filtering::HfHighPt2P::columnLabel(), filtering::HfHighPt3P::columnLabel(), filtering::HfBeauty3P::columnLabel(), filtering::HfBeauty4P::columnLabel(), filtering::HfFemto2P::columnLabel(), filtering::HfFemto3P::columnLabel(), filtering::HfDoubleCharm2P::columnLabel(), filtering::HfDoubleCharm3P::columnLabel(), filtering::HfDoubleCharmMix::columnLabel(), filtering::HfV0Charm2P::columnLabel(), filtering::HfV0Charm3P::columnLabel(), filtering::HfCharmBarToXiBach::columnLabel(), filtering::HfSigmaCPPK::columnLabel(), filtering::HfSigmaC0K0::columnLabel(), filtering::HfPhotonCharm2P::columnLabel(), filtering::HfPhotonCharm3P::columnLabel(), filtering::HfSingleCharm2P::columnLabel(), filtering::HfSingleCharm3P::columnLabel(), filtering::HfSingleNonPromptCharm2P::columnLabel(), filtering::HfSingleNonPromptCharm3P::columnLabel(), filtering::HfCharmBarToXi2Bach::columnLabel()};
+static const std::vector<std::string> hfTriggerNames{filtering::HfHighPt2P::columnLabel(), filtering::HfHighPt3P::columnLabel(), filtering::HfBeauty3P::columnLabel(), filtering::HfBeauty4P::columnLabel(), filtering::HfFemto2P::columnLabel(), filtering::HfFemto3P::columnLabel(), filtering::HfDoubleCharm2P::columnLabel(), filtering::HfDoubleCharm3P::columnLabel(), filtering::HfDoubleCharmMix::columnLabel(), filtering::HfV0Charm2P::columnLabel(), filtering::HfV0Charm3P::columnLabel(), filtering::HfCharmBarToXiBach::columnLabel(), filtering::HfSigmaCPPK::columnLabel(), filtering::HfSigmaC0K0::columnLabel(), filtering::HfPhotonCharm2P::columnLabel(), filtering::HfPhotonCharm3P::columnLabel(), filtering::HfSingleCharm2P::columnLabel(), filtering::HfSingleCharm3P::columnLabel(), filtering::HfSingleNonPromptCharm2P::columnLabel(), filtering::HfSingleNonPromptCharm3P::columnLabel(), filtering::HfCharmBarToXi2Bach::columnLabel(), filtering::HfBtoJPsiKa::columnLabel(), filtering::HfBtoJPsiKstar::columnLabel(), filtering::HfBtoJPsiPhi::columnLabel(), filtering::HfBtoJPsiPrKa::columnLabel(), filtering::HfBtoJPsiPi::columnLabel()};
 
 static const std::array<std::string, kNV0> v0Labels{"#gamma", "K_{S}^{0}", "#Lambda", "#bar{#Lambda}"};
 static const std::array<std::string, kNV0> v0Names{"Photon", "K0S", "Lambda", "AntiLambda"};
@@ -233,6 +248,7 @@ static const std::tuple pdgCharmDaughters{
 constexpr float massPi = o2::constants::physics::MassPiPlus;
 constexpr float massKa = o2::constants::physics::MassKPlus;
 constexpr float massProton = o2::constants::physics::MassProton;
+constexpr float massMu = o2::constants::physics::MassMuon;
 constexpr float massDeuteron = o2::constants::physics::MassDeuteron;
 constexpr float massGamma = o2::constants::physics::MassGamma;
 constexpr float massK0S = o2::constants::physics::MassK0Short;
@@ -250,8 +266,11 @@ constexpr float massB0 = o2::constants::physics::MassB0;
 constexpr float massBs = o2::constants::physics::MassBS;
 constexpr float massLb = o2::constants::physics::MassLambdaB0;
 constexpr float massXib = o2::constants::physics::MassXiB0;
+constexpr float massBc = 6.2744700f; // TODO add Bc mass to o2::constants::physics
 constexpr float massSigmaCPlusPlus = o2::constants::physics::MassSigmaCPlusPlus;
 constexpr float massSigmaC0 = o2::constants::physics::MassSigmaC0;
+constexpr float massK0Star892 = o2::constants::physics::MassK0Star892;
+constexpr float massJPsi = o2::constants::physics::MassJPsi;
 
 static const o2::framework::AxisSpec ptAxis{50, 0.f, 50.f};
 static const o2::framework::AxisSpec pAxis{50, 0.f, 10.f};
@@ -262,8 +281,8 @@ static const o2::framework::AxisSpec alphaAxis{100, -1.f, 1.f};
 static const o2::framework::AxisSpec qtAxis{100, 0.f, 0.25f};
 static const o2::framework::AxisSpec bdtAxis{100, 0.f, 1.f};
 static const o2::framework::AxisSpec phiAxis{36, 0., o2::constants::math::TwoPI};
-static const std::array<o2::framework::AxisSpec, kNCharmParticles + 18> massAxisC = {o2::framework::AxisSpec{250, 1.65f, 2.15f}, o2::framework::AxisSpec{250, 1.65f, 2.15f}, o2::framework::AxisSpec{250, 1.75f, 2.25f}, o2::framework::AxisSpec{250, 2.05f, 2.55f}, o2::framework::AxisSpec{250, 2.25f, 2.75f}, o2::framework::AxisSpec{200, 0.139f, 0.159f}, o2::framework::AxisSpec{250, 0.f, 0.25f}, o2::framework::AxisSpec{250, 0.f, 0.25f}, o2::framework::AxisSpec{200, 0.48f, 0.88f}, o2::framework::AxisSpec{200, 0.48f, 0.88f}, o2::framework::AxisSpec{200, 1.1f, 1.4f}, o2::framework::AxisSpec{200, 1.1f, 1.4f}, o2::framework::AxisSpec{200, 1.1f, 1.4f}, o2::framework::AxisSpec{200, 1.1f, 1.4f}, o2::framework::AxisSpec{170, 0.13f, 0.3f}, o2::framework::AxisSpec{170, 0.13f, 0.3f}, o2::framework::AxisSpec{200, 0.4f, 0.8f}, o2::framework::AxisSpec{200, 0.4f, 0.8f}, o2::framework::AxisSpec{200, 0.4f, 0.8f}, o2::framework::AxisSpec{200, 0.4f, 0.8f}, o2::framework::AxisSpec{350, 2.3f, 3.0f}, o2::framework::AxisSpec{350, 2.3f, 3.0f}, o2::framework::AxisSpec{350, 2.3f, 3.0f}};
-static const std::array<o2::framework::AxisSpec, kNBeautyParticles> massAxisB = {o2::framework::AxisSpec{240, 4.8f, 6.0f}, o2::framework::AxisSpec{240, 4.8f, 6.0f}, o2::framework::AxisSpec{240, 4.8f, 6.0f}, o2::framework::AxisSpec{240, 4.8f, 6.0f}, o2::framework::AxisSpec{240, 5.0f, 6.2f}, o2::framework::AxisSpec{240, 5.0f, 6.2f}};
+static const std::array<o2::framework::AxisSpec, kNCharmParticles + 19> massAxisC = {o2::framework::AxisSpec{250, 1.65f, 2.15f}, o2::framework::AxisSpec{250, 1.65f, 2.15f}, o2::framework::AxisSpec{250, 1.75f, 2.25f}, o2::framework::AxisSpec{250, 2.05f, 2.55f}, o2::framework::AxisSpec{250, 2.25f, 2.75f}, o2::framework::AxisSpec{200, 0.139f, 0.159f}, o2::framework::AxisSpec{250, 0.f, 0.25f}, o2::framework::AxisSpec{250, 0.f, 0.25f}, o2::framework::AxisSpec{200, 0.48f, 0.88f}, o2::framework::AxisSpec{200, 0.48f, 0.88f}, o2::framework::AxisSpec{200, 1.1f, 1.4f}, o2::framework::AxisSpec{200, 1.1f, 1.4f}, o2::framework::AxisSpec{200, 1.1f, 1.4f}, o2::framework::AxisSpec{200, 1.1f, 1.4f}, o2::framework::AxisSpec{170, 0.13f, 0.3f}, o2::framework::AxisSpec{170, 0.13f, 0.3f}, o2::framework::AxisSpec{200, 0.4f, 0.8f}, o2::framework::AxisSpec{200, 0.4f, 0.8f}, o2::framework::AxisSpec{200, 0.4f, 0.8f}, o2::framework::AxisSpec{200, 0.4f, 0.8f}, o2::framework::AxisSpec{350, 2.3f, 3.0f}, o2::framework::AxisSpec{350, 2.3f, 3.0f}, o2::framework::AxisSpec{350, 2.3f, 3.0f}, o2::framework::AxisSpec{240, 2.4f, 3.6f}};
+static const std::array<o2::framework::AxisSpec, nTotBeautyParts> massAxisB = {o2::framework::AxisSpec{240, 4.8f, 6.0f}, o2::framework::AxisSpec{240, 4.8f, 6.0f}, o2::framework::AxisSpec{240, 4.8f, 6.0f}, o2::framework::AxisSpec{240, 4.8f, 6.0f}, o2::framework::AxisSpec{240, 5.0f, 6.2f}, o2::framework::AxisSpec{240, 5.0f, 6.2f}, o2::framework::AxisSpec{240, 4.8f, 6.0f}, o2::framework::AxisSpec{240, 4.8f, 6.0f}, o2::framework::AxisSpec{240, 5.0f, 6.2f}, o2::framework::AxisSpec{240, 5.0f, 6.2f}, o2::framework::AxisSpec{240, 5.8f, 7.0f}};
 
 // default values for configurables
 // channels to trigger on for femto
@@ -275,19 +294,19 @@ constexpr float cutsPtThresholdsForFemto[1][2] = {{8., 1.4}}; // proton, deutero
 static const std::vector<std::string> labelsColumnsPtThresholdsForFemto = {"Proton", "Deuteron"};
 
 // min and max pT for all tracks combined  (except for V0 and cascades)
-constexpr float cutsPt[2][7] = {{1., 0.1, 0.8, 0.5, 0.1, 0.2, 0.4},
-                                {100000., 100000., 5., 100000., 100000., 100000., 100000.}}; // beauty, D*, femto, SigmaC, Xic*+ -> SigmaC++K-
-static const std::vector<std::string> labelsColumnsCutsPt = {"Beauty", "DstarPlus", "PrForFemto", "CharmBaryon", "SoftPiSigmaC", "SoftKaonXicResoToSigmaC", "DeForFemto"};
+constexpr float cutsPt[2][8] = {{1., 0.1, 0.8, 0.5, 0.1, 0.2, 0.4, 0.5},
+                                {100000., 100000., 5., 100000., 100000., 100000., 100000., 100000.}}; // beauty, D*, femto, SigmaC, Xic*+ -> SigmaC++K-, beauty to JPsi
+static const std::vector<std::string> labelsColumnsCutsPt = {"Beauty", "DstarPlus", "PrForFemto", "CharmBaryon", "SoftPiSigmaC", "SoftKaonXicResoToSigmaC", "DeForFemto", "BeautyToJPsi"};
 static const std::vector<std::string> labelsRowsCutsPt = {"Minimum", "Maximum"};
 
 // PID cuts
-constexpr float cutsNsigma[4][7] = {
-  {3., 3., 3., 5., 3., 3., 5.},             // TPC proton from Lc, pi/K from D0, K from 3-prong, femto selected proton, pi/K from Xic/Omegac, K from Xic*->SigmaC-Kaon, femto selected deuteron
-  {3., 3., 3., 2.5, 3., 3., 5.},            // TOF proton from Lc, pi/K from D0, K from 3-prong, femto selected proton, pi/K from Xic/Omegac, K from Xic*->SigmaC-Kaon, femto selected deuteron
-  {999., 999., 999., 2.5, 999., 999., 5.},  // Sum in quadrature of TPC and TOF (used only for femto selected proton and deuteron for pT < 4 GeV/c)
-  {999., 999., 999., 999., 999., 999., -4.} // ITS used only for femto selected deuteron for less than pt threshold
+constexpr float cutsNsigma[4][8] = {
+  {3., 3., 3., 5., 3., 3., 5., 3.},             // TPC proton from Lc, pi/K from D0, K from 3-prong, femto selected proton, pi/K from Xic/Omegac, K from Xic*->SigmaC-Kaon, femto selected deuteron, K/p from beauty->JPsiX
+  {3., 3., 3., 2.5, 3., 3., 5., 3.},            // TOF proton from Lc, pi/K from D0, K from 3-prong, femto selected proton, pi/K from Xic/Omegac, K from Xic*->SigmaC-Kaon, femto selected deuteron, K/p from beauty->JPsiX
+  {999., 999., 999., 2.5, 999., 999., 5., 999.},  // Sum in quadrature of TPC and TOF (used only for femto selected proton and deuteron for pT < 4 GeV/c)
+  {999., 999., 999., 999., 999., 999., -4., 999.} // ITS used only for femto selected deuteron for less than pt threshold
 };
-static const std::vector<std::string> labelsColumnsNsigma = {"PrFromLc", "PiKaFromDZero", "KaFrom3Prong", "PrForFemto", "PiKaFromCharmBaryon", "SoftKaonFromXicResoToSigmaC", "DeForFemto"};
+static const std::vector<std::string> labelsColumnsNsigma = {"PrFromLc", "PiKaFromDZero", "KaFrom3Prong", "PrForFemto", "PiKaFromCharmBaryon", "SoftKaonFromXicResoToSigmaC", "DeForFemto", "KaPrFromBeautyToJPsi"};
 static const std::vector<std::string> labelsRowsNsigma = {"TPC", "TOF", "Comb", "ITS"};
 
 // high pt
@@ -298,21 +317,26 @@ namespace hf_trigger_cuts_presel_beauty
 {
 static constexpr int nBinsPt = 2;
 static constexpr int nCutVars = 4;
+static constexpr int nCutVarsBtoJPsi = 4;
 // default values for the pT bin edges (can be used to configure histogram axis)
 // common for any beauty candidate
 constexpr double binsPt[nBinsPt + 1] = {
-  1.,
+  0.,
   5.,
   1000.0};
 auto vecBinsPt = std::vector<double>{binsPt, binsPt + nBinsPt + 1};
 // default values for the cuts
-constexpr double cuts[nBinsPt][nCutVars] = {{0.4, -1, -1, 10.},  /* 1 < pt < 5 */
+constexpr double cuts[nBinsPt][nCutVars] = {{0.4, -1, -1, 10.},  /* 0 < pt < 5 */
                                             {0.4, -1, -1, 10.}}; /* 5 < pt < 1000 */
+
+constexpr double cutsBtoJPsi[nBinsPt][nCutVarsBtoJPsi] = {{1., 0.6, 0.9, 0.02},  /* 0 < pt < 5 */
+                                                          {1., 0.8, 0.9, 0.02}}; /* 5 < pt < 1000 */
 
 // row labels
 static const std::vector<std::string> labelsPt{};
 // column labels
-static const std::vector<std::string> labelsRowsTopolBeauty = {"DeltaMassB", "minCPA", "minDecayLength", "maxImpParProd"};
+static const std::vector<std::string> labelsColumnsTopolBeauty = {"DeltaMassB", "minCPA", "minDecayLength", "maxImpParProd"};
+static const std::vector<std::string> labelsColumnsCutsBeautyToJPsi = {"minPtMuon", "DeltaMassB", "minCPA", "minDecayLength"};
 
 } // namespace hf_trigger_cuts_presel_beauty
 
@@ -345,7 +369,7 @@ static constexpr double cutsTrackDummy[o2::analysis::hf_cuts_single_track::nBins
 o2::framework::LabeledArray<double> cutsSingleTrackDummy{cutsTrackDummy[0], o2::analysis::hf_cuts_single_track::nBinsPtTrack, o2::analysis::hf_cuts_single_track::nCutVarsTrack, o2::analysis::hf_cuts_single_track::labelsPtTrack, o2::analysis::hf_cuts_single_track::labelsCutVarTrack};
 
 // manual downscale factors for tests
-constexpr double defDownscaleFactors[kNtriggersHF][1] = {{1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}}; // one for each trigger
+constexpr double defDownscaleFactors[kNtriggersHF][1] = {{1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}, {1.1}}; // one for each trigger
 static const std::vector<std::string> labelsDownscaleFactor = {"Downscale factor"};
 
 // Main helper class
@@ -374,10 +398,11 @@ class HfFilterHelper
   }
   void setPtBinsSingleTracks(std::vector<double> ptBins) { mPtBinsTracks = ptBins; }
   void setPtBinsBeautyHadrons(std::vector<double> ptBins) { mPtBinsBeautyHadrons = ptBins; }
-  void setCutsSingleTrackBeauty(o2::framework::LabeledArray<double> cutsSingleTrack3P, o2::framework::LabeledArray<double> cutsSingleTrack4P)
+  void setCutsSingleTrackBeauty(o2::framework::LabeledArray<double> cutsSingleTrack3P, o2::framework::LabeledArray<double> cutsSingleTrack4P, o2::framework::LabeledArray<double> cutsSingleToJPsi)
   {
     mCutsSingleTrackBeauty3Prong = cutsSingleTrack3P;
     mCutsSingleTrackBeauty4Prong = cutsSingleTrack4P;
+    mCutsSingleTrackBeautyToJPsi = cutsSingleToJPsi;
   }
   void setCutsBhadrons(o2::framework::LabeledArray<double> cutsBplus, o2::framework::LabeledArray<double> cutsB0toDstar, o2::framework::LabeledArray<double> cutsB0, o2::framework::LabeledArray<double> cutsBs, o2::framework::LabeledArray<double> cutsLb, o2::framework::LabeledArray<double> cutsXib)
   {
@@ -387,6 +412,10 @@ class HfFilterHelper
     mCutsBhad[kBs] = cutsBs;
     mCutsBhad[kLb] = cutsLb;
     mCutsBhad[kXib] = cutsXib;
+  }
+  void setCutsBtoJPsi(o2::framework::LabeledArray<double> cuts)
+  {
+    mCutsBhadToJPsi = cuts;
   }
   void setPtLimitsProtonForFemto(float minPt, float maxPt)
   {
@@ -398,10 +427,12 @@ class HfFilterHelper
     mPtMinDeuteronForFemto = minPt;
     mPtMaxDeuteronForFemto = maxPt;
   }
-  void setPtLimitsBeautyBachelor(float minPt, float maxPt)
+  void setPtLimitsBeautyBachelor(float minPt, float maxPt, float minPtBtoJPsiBach, float maxPtBtoJPsiBach)
   {
     mPtMinBeautyBachelor = minPt;
     mPtMaxBeautyBachelor = maxPt;
+    mPtMinBeautyToJPsiBachelor = minPtBtoJPsiBach;
+    mPtMaxBeautyToJPsiBachelor = maxPtBtoJPsiBach;
   }
   void setPtLimitsDstarSoftPion(float minPt, float maxPt)
   {
@@ -455,6 +486,11 @@ class HfFilterHelper
   {
     mNSigmaTpcPiKaCutForDzero = nSigmaTpc;
     mNSigmaTofPiKaCutForDzero = nSigmaTof;
+  }
+  void setNsigmaKaonProtonCutsForBeautyToJPsi(float nSigmaTpc, float nSigmaTof)
+  {
+    mNSigmaTpcPrKaCutForBeautyToJPsi = nSigmaTpc;
+    mNSigmaTofPrKaCutForBeautyToJPsi = nSigmaTof;
   }
   void setV0Selections(float minGammaCosPa, float minK0sLambdaCosPa, float minK0sLambdaRadius, float nSigmaPrFromLambda, float deltaMassK0s, float deltaMassLambda)
   {
@@ -525,8 +561,8 @@ class HfFilterHelper
   bool isSelectedHighPt2Prong(const T& pt);
   template <typename T>
   bool isSelectedHighPt3Prong(const T& pt);
-  template <typename T, typename T1, typename T2>
-  int8_t isSelectedTrackForSoftPionOrBeauty(const T& track, const T1& trackPar, const T2& dca, const int& whichTrigger);
+  template <o2::aod::hffilters::HfTriggers whichTrigger, typename T, typename T1, typename T2>
+  int8_t isSelectedTrackForSoftPionOrBeauty(const T& track, const T1& trackPar, const T2& dca);
   template <typename T1, typename T2, typename H2>
   bool isSelectedTrack4Femto(const T1& track, const T2& trackPar, const int& activateQA, H2 hTPCPID, H2 hTOFPID, const int& trackSpecies);
   template <typename T>
@@ -567,6 +603,8 @@ class HfFilterHelper
   bool isSelectedBhadronInMassRange(T1 const& ptCand, T2 const& massCand, const int whichB);
   template <typename T1, typename T2, typename T3>
   bool isSelectedBzeroToDstar(T1 const& pVecTrack0, T1 const& pVecTrack1, T1 const& pVecTrack2, const T2& primVtx, const T3& secVtx);
+  template <int Nprongs, typename T1, typename T2, typename T3, typename T4, typename H2>
+  int8_t isSelectedBhadronToJPsi(std::array<T1, Nprongs> pVecDauTracks, std::array<T2, Nprongs - 2> tracksDauNoMu, const T3& primVtx, const T4& secVtx, const int& activateQA, std::array<H2, nTotBeautyParts>& hMassVsPt);
   template <typename T1>
   bool isCharmHadronMassInSbRegions(T1 const& massHypo1, T1 const& massHypo2, const float& lowLimitSB, const float& upLimitSB);
   template <typename T, typename C, typename H2>
@@ -592,10 +630,10 @@ class HfFilterHelper
 
  private:
   // selections
-  template <typename T>
-  bool isSelectedKaon4Charm3Prong(const T& track);
-  template <typename T>
-  bool isSelectedProton4CharmBaryons(const T& track);
+  template <bool is4beauty = false, typename T>
+  bool isSelectedKaon4Charm3ProngOrBeautyToJPsi(const T& track);
+  template <bool is4beauty = false, typename T>
+  bool isSelectedProton4CharmOrBeautyBaryons(const T& track);
 
   // PID
   float getTPCSplineCalib(const float tpcPin, const float dEdx, const int& pidSpecies);
@@ -616,17 +654,20 @@ class HfFilterHelper
   std::vector<double> mPtBinsBeautyHadrons{};                                     // vector of pT bins for beauty hadron candidates
   o2::framework::LabeledArray<double> mCutsSingleTrackBeauty3Prong{};             // dca selections for the 3-prong b-hadron pion daughter
   o2::framework::LabeledArray<double> mCutsSingleTrackBeauty4Prong{};             // dca selections for the 4-prong b-hadron pion daughter
+  o2::framework::LabeledArray<double> mCutsSingleTrackBeautyToJPsi{};             // dca selections for the b-hadron -> JPsi X daughters (not the muons)
   float mPtMinSoftPionForDstar{0.1};                                              // minimum pt for the D*+ soft pion
   float mPtMinSoftPionForSigmaC{0.1};                                             // minimum pt for the Σ0,++ soft pion
   float mPtMaxSoftPionForSigmaC{10000.f};                                         // maximum pt for the Σ0,++ soft pion
   float mPtMinSoftKaonForXicResoToSigmaC{0.1};                                    // minimum pt for the soft kaon of Xic* to SigmaC-Kaon
   float mPtMaxSoftKaonForXicResoToSigmaC{10000.f};                                // maximum pt for the soft kaon of Xic* to SigmaC-Kaon
   float mPtMinBeautyBachelor{0.5};                                                // minimum pt for the b-hadron pion daughter
+  float mPtMinBeautyToJPsiBachelor{0.5};                                          // minimum pt for the b-hadron -> JPsi X daughters (not the muons)
   float mPtMinProtonForFemto{0.8};                                                // minimum pt for the proton for femto
   float mPtMinDeuteronForFemto{0.8};                                              // minimum pt for the deuteron for femto
   float mPtMinCharmBaryonBachelor{0.5};                                           // minimum pt for the bachelor pion from Xic/Omegac decays
   float mPtMaxSoftPionForDstar{2.};                                               // maximum pt for the D*+ soft pion
   float mPtMaxBeautyBachelor{100000.};                                            // maximum pt for the b-hadron pion daughter
+  float mPtMaxBeautyToJPsiBachelor{100000.};                                      // maximum pt for the b-hadron -> JPsi X daughters (not the muons)
   float mPtMaxProtonForFemto{5.0};                                                // maximum pt for the proton for femto
   float mPtMaxDeuteronForFemto{5.0};                                              // maximum pt for the deuteron for femto
   float mPtMaxCharmBaryonBachelor{100000.};                                       // maximum pt for the bachelor pion from Xic/Omegac decays
@@ -644,6 +685,8 @@ class HfFilterHelper
   float mNSigmaTofKaCutFor3Prongs{3.};                                            // maximum Nsigma TOF for kaons in 3-prong decays
   float mNSigmaTpcPiKaCutForDzero{3.};                                            // maximum Nsigma TPC for pions/kaons in D0 decays
   float mNSigmaTofPiKaCutForDzero{3.};                                            // maximum Nsigma TOF for pions/kaons in D0 decays
+  float mNSigmaTpcPrKaCutForBeautyToJPsi{3.};                                     // maximum Nsigma TPC for kaons and protons in B->JPsiX decays
+  float mNSigmaTofPrKaCutForBeautyToJPsi{3.};                                     // maximum Nsigma TPC for kaons and protons in B->JPsiX decays
   float mDeltaMassMinSigmaCZero{0.155};                                           // minimum delta mass M(pKpipi)-M(pKpi) of SigmaC0 candidates
   float mDeltaMassMaxSigmaCZero{0.18};                                            // maximum delta mass M(pKpipi)-M(pKpi) of SigmaC0 candidates
   float mDeltaMassMinSigmaC2520Zero{0.2};                                         // minimum delta mass M(pKpipi)-M(pKpi) of SigmaC(2520)0 candidates
@@ -684,6 +727,7 @@ class HfFilterHelper
   std::array<float, 3> mMassMinXiBach{2.35, 2.6, 2.35};                           // minimum invariant-mass for XiBachelor candidates
   std::array<float, 2> mCosPaMinXiBach{-2.f, -2.f};                               // minimum cosine of pointing angle for XiBachelor candidates
   std::array<o2::framework::LabeledArray<double>, kNBeautyParticles> mCutsBhad{}; // selections for B-hadron candidates (DeltaMass, CPA, DecayLength, ImpactParameterProduct)
+  o2::framework::LabeledArray<double> mCutsBhadToJPsi{};                          // selections for B->JPsi candidates (PtMinMu, DeltaMass, CPA, DecayLength)
 
   // PID recalibrations
   int mTpcPidCalibrationOption{0};                          // Option for TPC PID calibration (0 -> AO2D, 1 -> postcalibrations, 2 -> alternative bethe bloch parametrisation)
@@ -718,8 +762,8 @@ inline bool HfFilterHelper::isSelectedHighPt3Prong(const T& pt)
 /// \param trackPar is a track parameter
 /// \param dca is the 2d array with dcaXY and dcaZ of the track
 /// \return a flag that encodes the selection for soft pions BIT(kSoftPion), tracks for beauty BIT(kForBeauty), or soft pions for beauty BIT(kSoftPionForBeauty)
-template <typename T, typename T1, typename T2>
-inline int8_t HfFilterHelper::isSelectedTrackForSoftPionOrBeauty(const T& track, const T1& trackPar, const T2& dca, const int& whichTrigger)
+template <o2::aod::hffilters::HfTriggers whichTrigger, typename T, typename T1, typename T2>
+inline int8_t HfFilterHelper::isSelectedTrackForSoftPionOrBeauty(const T& track, const T1& trackPar, const T2& dca)
 {
 
   int8_t retValue{BIT(kSoftPion) | BIT(kForBeauty) | BIT(kSoftPionForBeauty) | BIT(kSoftPionForSigmaC)};
@@ -748,7 +792,7 @@ inline int8_t HfFilterHelper::isSelectedTrackForSoftPionOrBeauty(const T& track,
     return kRejected;
   }
 
-  if (whichTrigger == kSigmaCPPK || whichTrigger == kSigmaC0K0) {
+  if constexpr (whichTrigger == kSigmaCPPK || whichTrigger == kSigmaC0K0) {
 
     // SigmaC0,++ soft pion pt cut
     if (pT < mPtMinSoftPionForSigmaC || pT > mPtMaxSoftPionForSigmaC) {
@@ -766,18 +810,29 @@ inline int8_t HfFilterHelper::isSelectedTrackForSoftPionOrBeauty(const T& track,
   }
 
   // below only regular beauty tracks, not required for soft pions
-  if (pT < mPtMinBeautyBachelor || pT > mPtMaxBeautyBachelor) {
+  float ptMin{-1.f}, ptMax{1000.f};
+  if constexpr (whichTrigger == kBeauty3P || whichTrigger == kBeauty4P) {
+    ptMin = mPtMinBeautyBachelor;
+    ptMax = mPtMaxBeautyBachelor;
+  } else if constexpr (whichTrigger == kBtoJPsiKa || whichTrigger == kBtoJPsiPi || whichTrigger == kBtoJPsiKstar || whichTrigger == kBtoJPsiPhi || whichTrigger == kBtoJPsiPrKa) {
+    ptMin = mPtMinBeautyToJPsiBachelor;
+    ptMax = mPtMaxBeautyToJPsiBachelor;
+  }
+
+  if (pT < ptMin || pT > ptMax) {
     CLRBIT(retValue, kForBeauty);
   }
 
-  float minDca = 1000.f;
-  float maxDca = 0.f;
-  if (whichTrigger == kBeauty3P) {
+  float minDca{1000.f}, maxDca{0.f};
+  if constexpr (whichTrigger == kBeauty3P) {
     minDca = mCutsSingleTrackBeauty3Prong.get(pTBinTrack, 0u);
     maxDca = mCutsSingleTrackBeauty3Prong.get(pTBinTrack, 1u);
-  } else if (whichTrigger == kBeauty4P) {
+  } else if constexpr (whichTrigger == kBeauty4P) {
     minDca = mCutsSingleTrackBeauty4Prong.get(pTBinTrack, 0u);
     maxDca = mCutsSingleTrackBeauty4Prong.get(pTBinTrack, 1u);
+  } else if constexpr (whichTrigger == kBtoJPsiKa || whichTrigger == kBtoJPsiPi || whichTrigger == kBtoJPsiKstar || whichTrigger == kBtoJPsiPhi || whichTrigger == kBtoJPsiPrKa) {
+    minDca = mCutsSingleTrackBeautyToJPsi.get(pTBinTrack, 0u);
+    maxDca = mCutsSingleTrackBeautyToJPsi.get(pTBinTrack, 1u);
   }
 
   if (std::fabs(dca[0]) < minDca) { // minimum DCAxy
@@ -910,7 +965,7 @@ inline int8_t HfFilterHelper::isDplusPreselected(const T& trackOppositeCharge)
   int8_t retValue = 0;
 
   // check PID of opposite charge track
-  if (!isSelectedKaon4Charm3Prong(trackOppositeCharge)) {
+  if (!isSelectedKaon4Charm3ProngOrBeautyToJPsi(trackOppositeCharge)) {
     return retValue;
   }
 
@@ -930,7 +985,7 @@ inline int8_t HfFilterHelper::isDsPreselected(const P& pTrackSameChargeFirst, co
   int8_t retValue = 0;
 
   // check PID of opposite charge track
-  if (!isSelectedKaon4Charm3Prong(trackOppositeCharge)) {
+  if (!isSelectedKaon4Charm3ProngOrBeautyToJPsi(trackOppositeCharge)) {
     return retValue;
   }
 
@@ -958,13 +1013,13 @@ inline int8_t HfFilterHelper::isCharmBaryonPreselected(const T& trackSameChargeF
 {
   int8_t retValue = 0;
   // check PID of opposite charge track
-  if (!isSelectedKaon4Charm3Prong(trackOppositeCharge)) {
+  if (!isSelectedKaon4Charm3ProngOrBeautyToJPsi(trackOppositeCharge)) {
     return retValue;
   }
-  if (isSelectedProton4CharmBaryons(trackSameChargeFirst)) {
+  if (isSelectedProton4CharmOrBeautyBaryons(trackSameChargeFirst)) {
     retValue |= BIT(0);
   }
-  if (isSelectedProton4CharmBaryons(trackSameChargeSecond)) {
+  if (isSelectedProton4CharmOrBeautyBaryons(trackSameChargeSecond)) {
     retValue |= BIT(1);
   }
 
@@ -1772,8 +1827,8 @@ inline void HfFilterHelper::setTpcRecalibMaps(o2::framework::Service<o2::ccdb::B
 /// \param nsigmaTPCProton max NsigmaTPC for proton candidates
 /// \param nsigmaTOFProton max NsigmaTOF for proton candidates
 /// \return true if track passes all cuts
-template <typename T>
-inline bool HfFilterHelper::isSelectedProton4CharmBaryons(const T& track)
+template <bool is4beauty, typename T>
+inline bool HfFilterHelper::isSelectedProton4CharmOrBeautyBaryons(const T& track)
 {
   float NSigmaTPC = track.tpcNSigmaPr();
   float NSigmaTOF = track.tofNSigmaPr();
@@ -1788,11 +1843,20 @@ inline bool HfFilterHelper::isSelectedProton4CharmBaryons(const T& track)
     }
   }
 
-  if (std::fabs(NSigmaTPC) > mNSigmaTpcPrCutForCharmBaryons) {
-    return false;
-  }
-  if (track.hasTOF() && std::fabs(NSigmaTOF) > mNSigmaTofPrCutForCharmBaryons) {
-    return false;
+  if constexpr (is4beauty) {
+    if (std::fabs(NSigmaTPC) > mNSigmaTpcPrKaCutForBeautyToJPsi) {
+      return false;
+    }
+    if (track.hasTOF() && std::fabs(NSigmaTOF) > mNSigmaTofPrKaCutForBeautyToJPsi) {
+      return false;
+    }
+  } else {
+    if (std::fabs(NSigmaTPC) > mNSigmaTpcPrCutForCharmBaryons) {
+      return false;
+    }
+    if (track.hasTOF() && std::fabs(NSigmaTOF) > mNSigmaTofPrCutForCharmBaryons) {
+      return false;
+    }
   }
 
   return true;
@@ -1814,7 +1878,7 @@ inline bool HfFilterHelper::isSelectedKaonFromXicResoToSigmaC(const T& track)
 
   if constexpr (isKaonTrack) {
     /// if the kaon is a track, and not a K0s (V0), check the PID as well
-    return isSelectedKaon4Charm3Prong(track);
+    return isSelectedKaon4Charm3ProngOrBeautyToJPsi(track);
   }
 
   return true;
@@ -1823,8 +1887,8 @@ inline bool HfFilterHelper::isSelectedKaonFromXicResoToSigmaC(const T& track)
 /// Basic selection of kaon candidates for charm candidates
 /// \param track is a track
 /// \return true if track passes all cuts
-template <typename T>
-inline bool HfFilterHelper::isSelectedKaon4Charm3Prong(const T& track)
+template <bool is4beauty, typename T>
+inline bool HfFilterHelper::isSelectedKaon4Charm3ProngOrBeautyToJPsi(const T& track)
 {
   float NSigmaTPC = track.tpcNSigmaKa();
   float NSigmaTOF = track.tofNSigmaKa();
@@ -1839,11 +1903,20 @@ inline bool HfFilterHelper::isSelectedKaon4Charm3Prong(const T& track)
     }
   }
 
-  if (std::fabs(NSigmaTPC) > mNSigmaTpcKaCutFor3Prongs) {
-    return false;
-  }
-  if (track.hasTOF() && std::fabs(NSigmaTOF) > mNSigmaTofKaCutFor3Prongs) {
-    return false;
+  if constexpr (is4beauty) {
+    if (std::fabs(NSigmaTPC) > mNSigmaTpcPrKaCutForBeautyToJPsi) {
+      return false;
+    }
+    if (track.hasTOF() && std::fabs(NSigmaTOF) > mNSigmaTofPrKaCutForBeautyToJPsi) {
+      return false;
+    }
+  } else {
+    if (std::fabs(NSigmaTPC) > mNSigmaTpcKaCutFor3Prongs) {
+      return false;
+    }
+    if (track.hasTOF() && std::fabs(NSigmaTOF) > mNSigmaTofKaCutFor3Prongs) {
+      return false;
+    }
   }
 
   return true;
@@ -1965,6 +2038,143 @@ inline bool HfFilterHelper::isSelectedBhadronInMassRange(T1 const& ptCand, T2 co
   return true;
 }
 
+/// Method to perform selections for B -> JPsiX candidates after vertex reconstruction
+/// \param pVecDauTracks is the array of momentum vectors of all daughter tracks
+/// \param tracksDauNoMu is the array of tracks for the daughters that are no muons
+/// \param primVtx is the primary vertex
+/// \param secVtx is the secondary vertex
+/// \param activateQA is the flag to enable the 
+/// \param hMassVsPt is the array of histograms for QA
+/// \return true if the beauty candidate passes all cuts
+template <int Nprongs, typename T1, typename T2, typename T3, typename T4, typename H2>
+inline int8_t HfFilterHelper::isSelectedBhadronToJPsi(std::array<T1, Nprongs> pVecDauTracks, std::array<T2, Nprongs - 2> tracksDauNoMu, const T3& primVtx, const T4& secVtx, const int& activateQA, std::array<H2, nTotBeautyParts>& hMassVsPt)
+{
+  int8_t isSelected{0};
+
+  auto pVecJPsi = RecoDecay::pVec(pVecDauTracks[0], pVecDauTracks[1]);
+  const int offset = static_cast<int>(kNBeautyParticles);
+
+  if constexpr (Nprongs == 3) {
+    auto pVecBhad = RecoDecay::pVec(pVecDauTracks[0], pVecDauTracks[1], pVecDauTracks[2]);
+    auto ptBhad = RecoDecay::pt(pVecBhad);
+    auto binPtB = findBin(mPtBinsBeautyHadrons, ptBhad);
+    if (binPtB == -1) {
+      return isSelected;
+    }
+    auto ptMu1 = RecoDecay::pt(pVecDauTracks[0]);
+    auto ptMu2 = RecoDecay::pt(pVecDauTracks[1]);
+    if (ptMu1 < mCutsBhadToJPsi.get(binPtB, 0u) || ptMu2 < mCutsBhadToJPsi.get(binPtB, 0u)) {
+      return isSelected;
+    }
+
+    if (RecoDecay::cpa(primVtx, secVtx, pVecBhad) < mCutsBhadToJPsi.get(binPtB, 2u)) {
+      return isSelected;
+    }
+
+    if (RecoDecay::distance(primVtx, secVtx) < mCutsBhadToJPsi.get(binPtB, 3u)) {
+      return isSelected;
+    }
+
+    if (isSelectedKaon4Charm3ProngOrBeautyToJPsi<true>(tracksDauNoMu[0])) {
+      auto massJPsiKa = RecoDecay::m(std::array{pVecJPsi, pVecDauTracks[2]}, std::array{massJPsi, massKa});
+      if (std::fabs(massJPsiKa - massBPlus) < mCutsBhadToJPsi.get(binPtB, 1u)) {
+        SETBIT(isSelected, kBplusToJPsi);
+        if (activateQA) {
+          hMassVsPt[offset + kBplusToJPsi]->Fill(ptBhad, massJPsiKa);
+        }
+      }
+    }
+    auto massJPsiPi = RecoDecay::m(std::array{pVecJPsi, pVecDauTracks[2]}, std::array{massJPsi, massPi});
+    if (std::fabs(massJPsiPi - massBc) < mCutsBhadToJPsi.get(binPtB, 1u)) {
+      SETBIT(isSelected, kBcToJPsi);
+      if (activateQA) {
+        hMassVsPt[offset + kBcToJPsi]->Fill(ptBhad, massJPsiPi);
+      }
+    }
+  } else if constexpr (Nprongs == 4) {
+    auto pVecBhad = RecoDecay::pVec(pVecDauTracks[0], pVecDauTracks[1], pVecDauTracks[2], pVecDauTracks[3]);
+    auto ptBhad = RecoDecay::pt(pVecBhad);
+    auto binPtB = findBin(mPtBinsBeautyHadrons, ptBhad);
+    if (binPtB == -1) {
+      return isSelected;
+    }
+    auto ptMu1 = RecoDecay::pt(pVecDauTracks[0]);
+    auto ptMu2 = RecoDecay::pt(pVecDauTracks[1]);
+    if (ptMu1 < mCutsBhadToJPsi.get(binPtB, 0u) || ptMu2 < mCutsBhadToJPsi.get(binPtB, 0u)) {
+      return isSelected;
+    }
+
+    if (RecoDecay::cpa(primVtx, secVtx, pVecBhad) < mCutsBhadToJPsi.get(binPtB, 2u)) {
+      return isSelected;
+    }
+
+    if (RecoDecay::distance(primVtx, secVtx) < mCutsBhadToJPsi.get(binPtB, 3u)) {
+      return isSelected;
+    }
+
+    bool isFirstKaon = isSelectedKaon4Charm3ProngOrBeautyToJPsi<true>(tracksDauNoMu[0]);
+    bool isSeconKaon = isSelectedKaon4Charm3ProngOrBeautyToJPsi<true>(tracksDauNoMu[1]);
+    bool isFirstProton = isSelectedProton4CharmOrBeautyBaryons<true>(tracksDauNoMu[0]);
+    bool isSecondProton = isSelectedProton4CharmOrBeautyBaryons<true>(tracksDauNoMu[1]);
+    auto massKaKa = RecoDecay::m(std::array{pVecDauTracks[2], pVecDauTracks[3]}, std::array{massKa, massKa});
+    if (isFirstKaon && isSeconKaon) {
+      if (std::fabs(massKaKa - massPhi) < 0.02f) {
+        auto massJPsiKaKa = RecoDecay::m(std::array{pVecJPsi, pVecDauTracks[2], pVecDauTracks[3]}, std::array{massJPsi, massKa, massKa});
+        if (std::fabs(massJPsiKaKa - massBs) < mCutsBhadToJPsi.get(binPtB, 1u)) {
+          SETBIT(isSelected, kBsToJPsi);
+          if (activateQA) {
+            hMassVsPt[offset + kBsToJPsi]->Fill(ptBhad, massJPsiKaKa);
+          }
+        }
+      }
+    }
+    if (isFirstKaon) {
+      auto massKaPi = RecoDecay::m(std::array{pVecDauTracks[2], pVecDauTracks[3]}, std::array{massKa, massPi});
+      if (std::fabs(massKaPi - massPhi) < 0.1f) {
+        auto massJPsiKaPi = RecoDecay::m(std::array{pVecJPsi, pVecDauTracks[2], pVecDauTracks[3]}, std::array{massJPsi, massKa, massPi});
+        if (std::fabs(massJPsiKaPi - massB0) < mCutsBhadToJPsi.get(binPtB, 1u)) {
+          SETBIT(isSelected, kB0ToJPsi);
+          if (activateQA) {
+            hMassVsPt[offset + kB0ToJPsi]->Fill(ptBhad, massJPsiKaPi);
+          }
+        }
+      }
+    }
+    if (isSeconKaon) {
+      auto massPiKa = RecoDecay::m(std::array{pVecDauTracks[2], pVecDauTracks[3]}, std::array{massPi, massKa});
+      if (std::fabs(massPiKa - massPhi) < 0.1f) {
+        auto massJPsiPiKa = RecoDecay::m(std::array{pVecJPsi, pVecDauTracks[2], pVecDauTracks[3]}, std::array{massJPsi, massPi, massKa});
+        if (std::fabs(massJPsiPiKa - massB0) < mCutsBhadToJPsi.get(binPtB, 1u)) {
+          SETBIT(isSelected, kB0ToJPsi);
+          if (activateQA) {
+            hMassVsPt[offset + kB0ToJPsi]->Fill(ptBhad, massJPsiPiKa);
+          }
+        }
+      }
+    }
+    if (isFirstProton && isSeconKaon) {
+      auto massLbToJPsiPrKa = RecoDecay::m(std::array{pVecDauTracks[0], pVecDauTracks[1], pVecDauTracks[2], pVecDauTracks[3]}, std::array{massMu, massMu, massProton, massKa});
+      if (std::fabs(massLbToJPsiPrKa - massLb) < mCutsBhadToJPsi.get(binPtB, 1u)) {
+        SETBIT(isSelected, kLbToJPsi);
+        if (activateQA) {
+          hMassVsPt[offset + kLbToJPsi]->Fill(ptBhad, massLbToJPsiPrKa);
+        }
+      }
+    }
+    if (isFirstKaon && isSecondProton) {
+      auto massLbToJPsiKaPr = RecoDecay::m(std::array{pVecDauTracks[0], pVecDauTracks[1], pVecDauTracks[2], pVecDauTracks[3]}, std::array{massMu, massMu, massKa, massProton});
+      if (std::fabs(massLbToJPsiKaPr - massLb) < mCutsBhadToJPsi.get(binPtB, 1u)) {
+        SETBIT(isSelected, kLbToJPsi);
+        if (activateQA) {
+          hMassVsPt[offset + kLbToJPsi]->Fill(ptBhad, massLbToJPsiKaPr);
+        }
+      }
+    }
+  }
+
+  return isSelected;
+}
+
 /// Method to check if charm candidates has mass between sideband limits
 /// \param massHypo1 is the array for the candidate D daughter momentum after reconstruction of secondary vertex
 /// \param massHypo2 is the array for the candidate bachelor pion momentum after reconstruction of secondary vertex
@@ -2035,6 +2245,7 @@ inline bool HfFilterHelper::isSelectedXiBach(T const& trackParCasc, T const& tra
     }
 
     const auto& vtx = dcaFitter.getPCACandidate();
+    dcaFitter.propagateTracksToVertex();
     const auto& trackCascProp = dcaFitter.getTrack(0);
     const auto& trackBachProp = dcaFitter.getTrack(1);
     std::array<float, 3> momCasc{}, momBach{};
@@ -2113,6 +2324,7 @@ inline bool HfFilterHelper::isSelectedXiBachBach(T const& trackParCasc, std::arr
     const auto& vtx = dcaFitter.getPCACandidate();
 
     std::array<float, 3> momCasc{pVecCascade}, momBachFirst{}, momBachSecond{};
+    dcaFitter.propagateTracksToVertex();
     const auto& trackBachFirstProp = dcaFitter.getTrack(0);
     const auto& trackBachSecondProp = dcaFitter.getTrack(1);
     trackBachFirstProp.getPxPyPzGlo(momBachFirst);
@@ -2337,6 +2549,7 @@ inline bool HfFilterHelper::buildV0(V const& v0Indices, T const& tracks, C const
   }
 
   // compute candidate momentum from tracks propagated to decay vertex
+  dcaFitter.propagateTracksToVertex();
   auto& trackPosProp = dcaFitter.getTrack(0);
   auto& trackNegProp = dcaFitter.getTrack(1);
   std::array<float, 3> momPos{}, momNeg{};
@@ -2468,6 +2681,7 @@ inline bool HfFilterHelper::buildCascade(Casc const& cascIndices, V const& v0Ind
   }
 
   // compute candidate momentum from tracks propagated to decay vertex
+  dcaFitter.propagateTracksToVertex();
   auto& trackV0Prop = dcaFitter.getTrack(0);
   auto& trackBachProp = dcaFitter.getTrack(1);
   std::array<float, 3> momV0{}, momBach{};

--- a/EventFiltering/filterTables.h
+++ b/EventFiltering/filterTables.h
@@ -92,6 +92,11 @@ DECLARE_SOA_COLUMN(HfSingleCharm2P, hasHfSingleCharm2P, bool);                  
 DECLARE_SOA_COLUMN(HfSingleCharm3P, hasHfSingleCharm3P, bool);                   //! 3-prong charm hadron (for efficiency studies)
 DECLARE_SOA_COLUMN(HfSingleNonPromptCharm2P, hasHfSingleNonPromptCharm2P, bool); //! 2-prong charm hadron (for efficiency studies)
 DECLARE_SOA_COLUMN(HfSingleNonPromptCharm3P, hasHfSingleNonPromptCharm3P, bool); //! 3-prong charm hadron (for efficiency studies)
+DECLARE_SOA_COLUMN(HfBtoJPsiKa, hasHfBtoJPsiKa, bool);                           //! B+ -> JPsi(->mumu)K+
+DECLARE_SOA_COLUMN(HfBtoJPsiKstar, hasHfBtoJPsiKstar, bool);                     //! B0 -> JPsi(->mumu)K*+(->Kpi)
+DECLARE_SOA_COLUMN(HfBtoJPsiPhi, hasHfBtoJPsiPhi, bool);                         //! B0s -> JPsi(->mumu)phi(->KK)
+DECLARE_SOA_COLUMN(HfBtoJPsiPrKa, hasHfBtoJPsiPrKa, bool);                       //! Lb -> JPsi(->mumu)pK+
+DECLARE_SOA_COLUMN(HfBtoJPsiPi, hasHfBtoJPsiPi, bool);                           //! Bc -> JPsi(->mumu)pi+
 
 // CF two body triggers
 DECLARE_SOA_COLUMN(PD, hasPD, bool); //! has d-p pair
@@ -235,7 +240,12 @@ DECLARE_SOA_TABLE(HfFilters, "AOD", "HfFilters", //!
                   filtering::HfSingleCharm3P,
                   filtering::HfSingleNonPromptCharm2P,
                   filtering::HfSingleNonPromptCharm3P,
-                  filtering::HfCharmBarToXi2Bach);
+                  filtering::HfCharmBarToXi2Bach,
+                  filtering::HfBtoJPsiKa,
+                  filtering::HfBtoJPsiKstar,
+                  filtering::HfBtoJPsiPhi,
+                  filtering::HfBtoJPsiPrKa,
+                  filtering::HfBtoJPsiPi);
 
 using HfFilter = HfFilters::iterator;
 

--- a/EventFiltering/filterTables.h
+++ b/EventFiltering/filterTables.h
@@ -83,7 +83,7 @@ DECLARE_SOA_COLUMN(HfDoubleCharmMix, hasHfDoubleCharmMix, bool);                
 DECLARE_SOA_COLUMN(HfV0Charm2P, hasHfV0Charm2P, bool);                           //! V0 with 2-prong charm hadron
 DECLARE_SOA_COLUMN(HfV0Charm3P, hasHfV0Charm3P, bool);                           //! V0 with 3-prong charm hadron
 DECLARE_SOA_COLUMN(HfCharmBarToXiBach, hasHfCharmBarToXiBach, bool);             //! Charm baryon to Xi + bachelor
-DECLARE_SOA_COLUMN(HfCharmBarToXiBachBach, hasHfCharmBarToXiBachBach, bool);     //! Charm baryon to Xi + 2 bachelors
+DECLARE_SOA_COLUMN(HfCharmBarToXi2Bach, hasHfCharmBarToXi2Bach, bool);           //! Charm baryon to Xi + 2 bachelors
 DECLARE_SOA_COLUMN(HfSigmaCPPK, hasHfSigmaCPPK, bool);                           //! SigmaC(2455)++K- and SigmaC(2520)++K- + c.c.
 DECLARE_SOA_COLUMN(HfSigmaC0K0, hasHfSigmaC0K0, bool);                           //! SigmaC(2455)0KS0 and SigmaC(2520)0KS0
 DECLARE_SOA_COLUMN(HfPhotonCharm2P, hasHfPhotonCharm2P, bool);                   //! photon with 2-prong charm hadron
@@ -235,7 +235,7 @@ DECLARE_SOA_TABLE(HfFilters, "AOD", "HfFilters", //!
                   filtering::HfSingleCharm3P,
                   filtering::HfSingleNonPromptCharm2P,
                   filtering::HfSingleNonPromptCharm3P,
-                  filtering::HfCharmBarToXiBachBach);
+                  filtering::HfCharmBarToXi2Bach);
 
 using HfFilter = HfFilters::iterator;
 


### PR DESCRIPTION
@zhangbiao-phy @mpuccio this PR:
- fixes a couple of mistakes in the Xi+bachelors triggers
- adds the H_b -> JPsi(->mumu) + X triggers
- fixes a small bug in the deuteron selection with ITS PID (or at least this is what looked to me, but please @zhangbiao-phy take a look)

For the new B triggers, I added one flag per channel, even if there is quite large overlap among them. @mpuccio let me know if this is fine!