### PR TITLE
[PWGJE] Add centrality selection for MCP jets

### DIFF
--- a/PWGJE/Tasks/jetSpectraCharged.cxx
+++ b/PWGJE/Tasks/jetSpectraCharged.cxx
@@ -649,7 +649,7 @@ struct JetSpectraCharged {
     bool hasSel8Coll = false;
     bool centralityIsGood = false;
     bool occupancyIsGood = false;
-    if (acceptSplitCollisions == 2) {                                               
+    if (acceptSplitCollisions == 2) {
       if (jetderiveddatautilities::selectCollision(collisions.begin(), eventSelectionBits)) {
         hasSel8Coll = true;
       }
@@ -659,8 +659,7 @@ struct JetSpectraCharged {
       if ((trackOccupancyInTimeRangeMin < collisions.begin().trackOccupancyInTimeRange()) && (collisions.begin().trackOccupancyInTimeRange() < trackOccupancyInTimeRangeMax)) {
         occupancyIsGood = true;
       }
-    } 
-    else {
+    } else {
       for (auto& collision : collisions) {
         if (jetderiveddatautilities::selectCollision(collision, eventSelectionBits)) {
           hasSel8Coll = true;
@@ -744,13 +743,13 @@ struct JetSpectraCharged {
     registry.fill(HIST("h_mc_zvertex"), mccollision.posZ());
 
     for (auto const& jet : jets) {
-    if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
-      continue;
-    }
-    if (!isAcceptedJet<aod::JetParticles>(jet)) {
-      continue;
-    }
-    fillMCPHistograms(jet);
+      if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
+        continue;
+      }
+      if (!isAcceptedJet<aod::JetParticles>(jet)) {
+        continue;
+      }
+      fillMCPHistograms(jet);
     }
   }
   PROCESS_SWITCH(JetSpectraCharged, processSpectraMCP, "jet spectra for MC particle level", false);
@@ -759,7 +758,7 @@ struct JetSpectraCharged {
                                  soa::SmallGroups<aod::JetCollisionsMCD> const& collisions,
                                  soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents, aod::ChargedMCParticleLevelJetEventWeights> const& jets,
                                  aod::JetParticles const&)
-  { 
+  {
     registry.fill(HIST("h_mcColl_counts"), 0.5);
     if (std::abs(mccollision.posZ()) > vertexZCut) {
       return;

--- a/PWGJE/Tasks/jetSpectraCharged.cxx
+++ b/PWGJE/Tasks/jetSpectraCharged.cxx
@@ -83,7 +83,6 @@ struct JetSpectraCharged {
   Configurable<bool> checkGeoPtMatched{"checkGeoPtMatched", false, "0: turn off geometry and pT matching, 1: do geometry and pT matching"};
   Configurable<int> acceptSplitCollisions{"acceptSplitCollisions", 0, "0: only look at mcCollisions that are not split; 1: accept split mcCollisions, 2: accept split mcCollisions but only look at the first reco collision associated with it"};
 
-
   std::vector<int> eventSelectionBits;
   int trackSelection = -1;
 
@@ -111,7 +110,7 @@ struct JetSpectraCharged {
       }
     }
 
-    if (doprocessSpectraData || doprocessSpectraMCD || doprocessSpectraMCDWeighted){
+    if (doprocessSpectraData || doprocessSpectraMCD || doprocessSpectraMCDWeighted) {
       registry.add("h_jet_pt", "jet pT;#it{p}_{T,jet} (GeV/#it{c}); counts", {HistType::kTH1F, {jetPtAxis}});
       registry.add("h_jet_eta", "jet eta;#eta; counts", {HistType::kTH1F, {jetEtaAxis}});
       registry.add("h_jet_phi", "jet phi;#phi; counts", {HistType::kTH1F, {phiAxis}});
@@ -182,7 +181,7 @@ struct JetSpectraCharged {
       registry.add("h2_jet_pt_part_jet_area_part_rhoareasubtracted", "part jet #it{p}_{T,jet} vs. Area_{jet}; #it{p}_{T,jet}^{part} (GeV/#it{c}); Area_{jet}^{part}", {HistType::kTH2F, {jetPtAxisRhoAreaSub, {150, 0., 1.5}}});
       registry.add("h2_jet_pt_part_jet_ntracks_part_rhoareasubtracted", "part jet #it{p}_{T,jet} vs. N_{jet tracks}; #it{p}_{T,jet}^{part} (GeV/#it{c}); N_{jet, tracks}{part}", {HistType::kTH2F, {jetPtAxisRhoAreaSub, {200, -0.5, 199.5}}});
       registry.add("h3_jet_pt_eta_phi_part_rhoareasubtracted", "part jet pt vs. eta vs.phi", {HistType::kTH3F, {jetPtAxisRhoAreaSub, jetEtaAxis, phiAxis}});
-    } 
+    }
 
     if (doprocessEvtWiseConstSubJetsData || doprocessEvtWiseConstSubJetsMCD) {
       registry.add("h2_centrality_jet_pt_eventwiseconstituentsubtracted", "centrality vs. jet pT;centrality;#it{p}_{T,jet} (GeV/#it{c});entries", {HistType::kTH2F, {centralityAxis, jetPtAxis}});
@@ -325,7 +324,7 @@ struct JetSpectraCharged {
       registry.fill(HIST("h3_jet_pt_eta_phi_part"), jet.pt(), jet.eta(), jet.phi(), weight);
       registry.fill(HIST("h2_jet_pt_part_jet_area_part"), jet.pt(), jet.area(), weight);
       registry.fill(HIST("h2_jet_pt_part_jet_ntracks_part"), jet.pt(), jet.tracksIds().size(), weight);
-      }
+    }
 
     for (const auto& constituent : jet.template tracks_as<aod::JetParticles>()) {
       registry.fill(HIST("h2_jet_pt_part_track_pt_part"), jet.pt(), constituent.pt(), weight);
@@ -337,14 +336,14 @@ struct JetSpectraCharged {
   {
     if (jet.r() == round(selectedJetsRadius * 100.0f)) {
       // fill mcp jet histograms
-        double jetcorrpt = jet.pt() - (rho * jet.area());
-        registry.fill(HIST("h_jet_pt_part_rhoareasubtracted"), jetcorrpt, weight);
-        registry.fill(HIST("h3_jet_pt_eta_phi_part_rhoareasubtracted"), jetcorrpt, jet.eta(), jet.phi(), weight);
-        if (jetcorrpt > 0) {
-          registry.fill(HIST("h_jet_eta_part_rhoareasubtracted"), jet.eta(), weight);
-          registry.fill(HIST("h_jet_phi_part_rhoareasubtracted"), jet.phi(), weight);
-          registry.fill(HIST("h2_jet_pt_part_jet_area_part_rhoareasubtracted"), jetcorrpt, jet.area(), weight);
-          registry.fill(HIST("h2_jet_pt_part_jet_ntracks_part_rhoareasubtracted"), jetcorrpt, jet.tracksIds().size(), weight);
+      double jetcorrpt = jet.pt() - (rho * jet.area());
+      registry.fill(HIST("h_jet_pt_part_rhoareasubtracted"), jetcorrpt, weight);
+      registry.fill(HIST("h3_jet_pt_eta_phi_part_rhoareasubtracted"), jetcorrpt, jet.eta(), jet.phi(), weight);
+      if (jetcorrpt > 0) {
+        registry.fill(HIST("h_jet_eta_part_rhoareasubtracted"), jet.eta(), weight);
+        registry.fill(HIST("h_jet_phi_part_rhoareasubtracted"), jet.phi(), weight);
+        registry.fill(HIST("h2_jet_pt_part_jet_area_part_rhoareasubtracted"), jetcorrpt, jet.area(), weight);
+        registry.fill(HIST("h2_jet_pt_part_jet_ntracks_part_rhoareasubtracted"), jetcorrpt, jet.tracksIds().size(), weight);
       }
     }
   }
@@ -516,19 +515,19 @@ struct JetSpectraCharged {
                           aod::JetTracks const&)
   {
     if (!jetderiveddatautilities::selectCollision(collision, eventSelectionBits)) {
-    return;
+      return;
     }
     if (collision.trackOccupancyInTimeRange() < trackOccupancyInTimeRangeMin || trackOccupancyInTimeRangeMax < collision.trackOccupancyInTimeRange()) {
-    return;
+      return;
     }
     for (auto const& jet : jets) {
-    if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
-    continue;
-    }
-    if (!isAcceptedJet<aod::JetTracks>(jet)) {
-    continue;
-    }
-    fillJetHistograms(jet, collision.centrality());
+      if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
+        continue;
+      }
+      if (!isAcceptedJet<aod::JetTracks>(jet)) {
+        continue;
+      }
+      fillJetHistograms(jet, collision.centrality());
     }
   }
   PROCESS_SWITCH(JetSpectraCharged, processSpectraData, "jet spectra for Data", false);
@@ -538,19 +537,19 @@ struct JetSpectraCharged {
                          aod::JetTracks const&)
   {
     if (!jetderiveddatautilities::selectCollision(collision, eventSelectionBits)) {
-    return;
+      return;
     }
     if (collision.trackOccupancyInTimeRange() < trackOccupancyInTimeRangeMin || trackOccupancyInTimeRangeMax < collision.trackOccupancyInTimeRange()) {
-    return;
+      return;
     }
     for (auto const& jet : jets) {
-    if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
-    continue;
-    }
-    if (!isAcceptedJet<aod::JetTracks>(jet)) {
-    continue;
-    }
-    fillJetHistograms(jet, collision.centrality());
+      if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
+        continue;
+      }
+      if (!isAcceptedJet<aod::JetTracks>(jet)) {
+        continue;
+      }
+      fillJetHistograms(jet, collision.centrality());
     }
   }
   PROCESS_SWITCH(JetSpectraCharged, processSpectraMCD, "jet spectra for MCD", false);
@@ -633,61 +632,61 @@ struct JetSpectraCharged {
                                 soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents> const& jets,
                                 aod::JetParticles const&)
   {
-    registry.fill(HIST("h_mcColl_counts_areasub"), 0.5);  //all mc collisions
+    registry.fill(HIST("h_mcColl_counts_areasub"), 0.5);
     if (std::abs(mccollision.posZ()) > vertexZCut) {
       return;
     }
-    registry.fill(HIST("h_mcColl_counts_areasub"), 1.5);  //cut on mccollision.posZ()
+    registry.fill(HIST("h_mcColl_counts_areasub"), 1.5);
     if (collisions.size() < 1) {
       return;
     }
-    registry.fill(HIST("h_mcColl_counts_areasub"), 2.5);  //mcCollisions with at least one resonstructed collision
+    registry.fill(HIST("h_mcColl_counts_areasub"), 2.5);
     if (acceptSplitCollisions == 0 && collisions.size() > 1) {
       return;
     }
-    registry.fill(HIST("h_mcColl_counts_areasub"), 3.5); // split mcCollisions condition
+    registry.fill(HIST("h_mcColl_counts_areasub"), 3.5);
 
     bool hasSel8Coll = false;
     bool centralityIsGood = false;
     bool occupancyIsGood = false;
-    if (acceptSplitCollisions == 2) {                                                    
-      if (jetderiveddatautilities::selectCollision(collisions.begin(), eventSelectionBits)) { // Skipping MC events that have not a single selected reconstructed collision ; effect unclear if mcColl is split
+    if (acceptSplitCollisions == 2) {                                               
+      if (jetderiveddatautilities::selectCollision(collisions.begin(), eventSelectionBits)) {
         hasSel8Coll = true;
       }
-      if ((centralityMin < collisions.begin().centrality()) && (collisions.begin().centrality() < centralityMax)) { // effect unclear if mcColl is split
+      if ((centralityMin < collisions.begin().centrality()) && (collisions.begin().centrality() < centralityMax)) {
         centralityIsGood = true;
       }
       if ((trackOccupancyInTimeRangeMin < collisions.begin().trackOccupancyInTimeRange()) && (collisions.begin().trackOccupancyInTimeRange() < trackOccupancyInTimeRangeMax)) {
         occupancyIsGood = true;
       }
     } 
-    else { // check that at least one of the reconstructed collisions passes the checks
+    else {
       for (auto& collision : collisions) {
-        if (jetderiveddatautilities::selectCollision(collision, eventSelectionBits)) { // Skipping MC events that have not a single selected reconstructed collision ; effect unclear if mcColl is split
+        if (jetderiveddatautilities::selectCollision(collision, eventSelectionBits)) {
           hasSel8Coll = true;
         }
-        if ((centralityMin < collision.centrality()) && (collision.centrality() < centralityMax)) { // effect unclear if mcColl is split
+        if ((centralityMin < collision.centrality()) && (collision.centrality() < centralityMax)) {
           centralityIsGood = true;
         }
         if ((trackOccupancyInTimeRangeMin < collision.trackOccupancyInTimeRange()) && (collision.trackOccupancyInTimeRange() < trackOccupancyInTimeRangeMax)) {
-        occupancyIsGood = true;
+          occupancyIsGood = true;
         }
       }
     }
     if (!hasSel8Coll) {
       return;
     }
-    registry.fill(HIST("h_mcColl_counts_areasub"), 4.5); // at least one of the reconstructed collisions associated with this mcCollision is selected
+    registry.fill(HIST("h_mcColl_counts_areasub"), 4.5);
 
     if (!centralityIsGood) {
       return;
     }
-    registry.fill(HIST("h_mcColl_counts_areasub"), 5.5); // at least one of the reconstructed collisions associated with this mcCollision is selected with regard to centrality
+    registry.fill(HIST("h_mcColl_counts_areasub"), 5.5);
 
     if (!occupancyIsGood) {
       return;
     }
-    registry.fill(HIST("h_mcColl_counts_areasub"), 6.5); // at least one of the reconstructed collisions associated with this mcCollision is selected with regard to centrality
+    registry.fill(HIST("h_mcColl_counts_areasub"), 6.5);
     registry.fill(HIST("h_mcColl_rho"), mccollision.rho());
     for (auto const& jet : jets) {
       if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
@@ -706,15 +705,15 @@ struct JetSpectraCharged {
                          soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents> const& jets,
                          aod::JetParticles const&)
   {
-    registry.fill(HIST("h_mcColl_counts"), 0.5);  //all mc collisions
+    registry.fill(HIST("h_mcColl_counts"), 0.5);
     if (std::abs(mccollision.posZ()) > vertexZCut) {
       return;
     }
-    registry.fill(HIST("h_mcColl_counts"), 1.5);  //cut on mccollision.posZ()
+    registry.fill(HIST("h_mcColl_counts"), 1.5);
     if (collisions.size() < 1) {
       return;
     }
-    registry.fill(HIST("h_mcColl_counts"), 2.5);  //mcCollisions with at least one resonstructed collision
+    registry.fill(HIST("h_mcColl_counts"), 2.5);
 
     bool hasSel8Coll = false;
     bool centralityIsGood = false;
@@ -733,44 +732,43 @@ struct JetSpectraCharged {
     if (!hasSel8Coll) {
       return;
     }
-    registry.fill(HIST("h_mcColl_counts"), 3.5); // at least one of the reconstructed collisions associated with this mcCollision is selected
+    registry.fill(HIST("h_mcColl_counts"), 3.5);
     if (!centralityIsGood) {
       return;
     }
-    registry.fill(HIST("h_mcColl_counts"), 4.5); // at least one of the reconstructed collisions associated with this mcCollision is selected with regard to centrality
+    registry.fill(HIST("h_mcColl_counts"), 4.5);
     if (!occupancyIsGood) {
       return;
     }
-    registry.fill(HIST("h_mcColl_counts"), 5.5); // at least one of the reconstructed collisions associated with this mcCollision is selected with regard to centrality
+    registry.fill(HIST("h_mcColl_counts"), 5.5);
     registry.fill(HIST("h_mc_zvertex"), mccollision.posZ());
 
     for (auto const& jet : jets) {
     if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
-    continue;
+      continue;
     }
     if (!isAcceptedJet<aod::JetParticles>(jet)) {
-    continue;
+      continue;
     }
     fillMCPHistograms(jet);
     }
   }
   PROCESS_SWITCH(JetSpectraCharged, processSpectraMCP, "jet spectra for MC particle level", false);
 
-
   void processSpectraMCPWeighted(aod::JetMcCollision const& mccollision,
                                  soa::SmallGroups<aod::JetCollisionsMCD> const& collisions,
                                  soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents, aod::ChargedMCParticleLevelJetEventWeights> const& jets,
                                  aod::JetParticles const&)
   { 
-    registry.fill(HIST("h_mcColl_counts"), 0.5);  //all mc collisions
+    registry.fill(HIST("h_mcColl_counts"), 0.5);
     if (std::abs(mccollision.posZ()) > vertexZCut) {
       return;
     }
-    registry.fill(HIST("h_mcColl_counts"), 1.5);  //cut on mccollision.posZ()
+    registry.fill(HIST("h_mcColl_counts"), 1.5);
     if (collisions.size() < 1) {
       return;
     }
-    registry.fill(HIST("h_mcColl_counts"), 2.5);  //mcCollisions with at least one resonstructed collision
+    registry.fill(HIST("h_mcColl_counts"), 2.5);
 
     bool hasSel8Coll = false;
     for (auto& collision : collisions) {
@@ -781,7 +779,7 @@ struct JetSpectraCharged {
     if (!hasSel8Coll) {
       return;
     }
-    registry.fill(HIST("h_mcColl_counts"), 3.5); // at least one of the reconstructed collisions associated with this mcCollision is selected
+    registry.fill(HIST("h_mcColl_counts"), 3.5);
     registry.fill(HIST("h_mc_zvertex"), mccollision.posZ());
 
     for (auto const& jet : jets) {

--- a/PWGJE/Tasks/jetSpectraCharged.cxx
+++ b/PWGJE/Tasks/jetSpectraCharged.cxx
@@ -81,7 +81,8 @@ struct JetSpectraCharged {
   Configurable<bool> checkGeoMatched{"checkGeoMatched", true, "0: turn off geometry matching, 1: do geometry matching "};
   Configurable<bool> checkPtMatched{"checkPtMatched", false, "0: turn off pT matching, 1: do pT matching"};
   Configurable<bool> checkGeoPtMatched{"checkGeoPtMatched", false, "0: turn off geometry and pT matching, 1: do geometry and pT matching"};
-  Configurable<bool> doMCPJetSubtraction{"doMCPJetSubtraction", false, "0: turn off subtraction for MCP jets, 1: do subtraction for MCP jets"};
+  Configurable<int> acceptSplitCollisions{"acceptSplitCollisions", 0, "0: only look at mcCollisions that are not split; 1: accept split mcCollisions, 2: accept split mcCollisions but only look at the first reco collision associated with it"};
+
 
   std::vector<int> eventSelectionBits;
   int trackSelection = -1;
@@ -103,14 +104,31 @@ struct JetSpectraCharged {
       registry.add("h_collisions", "event status;event status;entries", {HistType::kTH1F, {{4, 0.0, 4.0}}});
       registry.add("h2_centrality_occupancy", "centrality vs occupancy; centrality; occupancy", {HistType::kTH2F, {centralityAxis, {60, 0, 30000}}});
       registry.add("h_collisions_Zvertex", "position of collision ;#it{Z} (cm)", {HistType::kTH1F, {{300, -15.0, 15.0}}});
-      registry.add("h_track_pt", "track pT ; #it{p}_{T,track} (GeV/#it{c})", {HistType::kTH1F, {trackPtAxis}});
+      registry.add("h_track_pt", "track #it{p}_{T} ; #it{p}_{T,track} (GeV/#it{c})", {HistType::kTH1F, {trackPtAxis}});
       registry.add("h2_track_eta_track_phi", "track eta vs. track phi; #eta; #phi; counts", {HistType::kTH2F, {trackEtaAxis, phiAxis}});
       if (doprocessQCWeighted) {
         registry.add("h_collisions_weighted", "event status;event status;entries", {HistType::kTH1F, {{4, 0.0, 4.0}}});
       }
     }
 
-    if (doprocessSpectraData || doprocessSpectraMCD || doprocessSpectraMCDWeighted) {
+    if (doprocessSpectraData || doprocessSpectraMCD || doprocessSpectraMCDWeighted){
+      registry.add("h_jet_pt", "jet pT;#it{p}_{T,jet} (GeV/#it{c}); counts", {HistType::kTH1F, {jetPtAxis}});
+      registry.add("h_jet_eta", "jet eta;#eta; counts", {HistType::kTH1F, {jetEtaAxis}});
+      registry.add("h_jet_phi", "jet phi;#phi; counts", {HistType::kTH1F, {phiAxis}});
+      registry.add("h2_centrality_jet_pt", "centrality vs. jet pT;centrality; #it{p}_{T,jet} (GeV/#it{c}); counts", {HistType::kTH2F, {centralityAxis, jetPtAxis}});
+      registry.add("h2_centrality_jet_eta", "centrality vs. jet eta;centrality; #eta; counts", {HistType::kTH2F, {centralityAxis, jetEtaAxis}});
+      registry.add("h2_centrality_jet_phi", "centrality vs. jet phi;centrality; #varphi; counts", {HistType::kTH2F, {centralityAxis, phiAxis}});
+      registry.add("h2_jet_pt_jet_area", "jet #it{p}_{T,jet} vs. Area_{jet}; #it{p}_{T,jet} (GeV/#it{c}); Area_{jet}", {HistType::kTH2F, {jetPtAxis, {150, 0., 1.5}}});
+      registry.add("h2_jet_pt_jet_ntracks", "jet #it{p}_{T,jet} vs. N_{jet tracks}; #it{p}_{T,jet} (GeV/#it{c}); N_{jet, tracks}", {HistType::kTH2F, {jetPtAxis, {200, -0.5, 199.5}}});
+      registry.add("h2_jet_pt_track_pt", "jet #it{p}_{T,jet} vs. #it{p}_{T,track}; #it{p}_{T,jet} (GeV/#it{c});  #it{p}_{T,track} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, trackPtAxis}});
+      registry.add("h3_jet_pt_eta_phi", "jet pt vs. eta vs. phi", {HistType::kTH3F, {jetPtAxis, jetEtaAxis, phiAxis}});
+      if (doprocessSpectraMCDWeighted) {
+        registry.add("h_jet_phat", "jet #hat{p};#hat{p} (GeV/#it{c});entries", {HistType::kTH1F, {{1000, 0, 1000}}});
+        registry.add("h_jet_phat_weighted", "jet #hat{p};#hat{p} (GeV/#it{c});entries", {HistType::kTH1F, {{1000, 0, 1000}}});
+      }
+    }
+
+    if (doprocessSpectraAreaSubData || doprocessSpectraAreaSubMCD) {
       registry.add("h_jet_pt_rhoareasubtracted", "jet pT;#it{p}_{T,jet} (GeV/#it{c}); counts", {HistType::kTH1F, {jetPtAxisRhoAreaSub}});
       registry.add("h_jet_eta_rhoareasubtracted", "jet eta;#eta; counts", {HistType::kTH1F, {jetEtaAxis}});
       registry.add("h_jet_phi_rhoareasubtracted", "jet phi;#phi; counts", {HistType::kTH1F, {phiAxis}});
@@ -122,33 +140,49 @@ struct JetSpectraCharged {
       registry.add("h2_jet_pt_jet_corr_pt_rhoareasubtracted", "jet #it{p}_{T,jet} vs. #it{p}_{T,corr}; #it{p}_{T,jet} (GeV/#it{c});  #it{p}_{T,corr} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, jetPtAxisRhoAreaSub}});
       registry.add("h2_jet_pt_track_pt_rhoareasubtracted", "jet #it{p}_{T,jet} vs. #it{p}_{T,track}; #it{p}_{T,jet} (GeV/#it{c});  #it{p}_{T,track} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxisRhoAreaSub, trackPtAxis}});
       registry.add("h3_jet_pt_eta_phi_rhoareasubtracted", "jet_pt_eta_phi_rhoareasubtracted", {HistType::kTH3F, {jetPtAxisRhoAreaSub, jetEtaAxis, phiAxis}});
-      if (doprocessSpectraMCDWeighted) {
-        registry.add("h_jet_phat", "jet #hat{p};#hat{p} (GeV/#it{c});entries", {HistType::kTH1F, {{1000, 0, 1000}}});
-        registry.add("h_jet_phat_weighted", "jet #hat{p};#hat{p} (GeV/#it{c});entries", {HistType::kTH1F, {{1000, 0, 1000}}});
-      }
     }
 
     if (doprocessSpectraMCP || doprocessSpectraMCPWeighted) {
+      registry.add("h_mcColl_counts", " number of mc events; event status; entries", {HistType::kTH1F, {{10, 0, 10}}});
+      registry.get<TH1>(HIST("h_mcColl_counts"))->GetXaxis()->SetBinLabel(1, "allMcColl");
+      registry.get<TH1>(HIST("h_mcColl_counts"))->GetXaxis()->SetBinLabel(2, "vertexZ");
+      registry.get<TH1>(HIST("h_mcColl_counts"))->GetXaxis()->SetBinLabel(3, "noRecoColl");
+      registry.get<TH1>(HIST("h_mcColl_counts"))->GetXaxis()->SetBinLabel(4, "recoEvtSel");
+      registry.get<TH1>(HIST("h_mcColl_counts"))->GetXaxis()->SetBinLabel(5, "centralitycut");
+      registry.get<TH1>(HIST("h_mcColl_counts"))->GetXaxis()->SetBinLabel(6, "occupancycut");
+
       registry.add("h_mc_zvertex", "position of collision ;#it{Z} (cm)", {HistType::kTH1F, {{300, -15.0, 15.0}}});
-      registry.add("h_mcp_jet_pt", "jet pT;#it{p}_{T,jet} (GeV/#it{c}); counts", {HistType::kTH1F, {jetPtAxis}});
-      registry.add("h_mcp_jet_eta", "jet eta;#eta; counts", {HistType::kTH1F, {jetEtaAxis}});
-      registry.add("h_mcp_jet_phi", "jet phi;#phi; counts", {HistType::kTH1F, {phiAxis}});
-      registry.add("h2_mcp_jet_pt_jet_area", "jet #it{p}_{T,jet} vs. Area_{jet}; #it{p}_{T,jet} (GeV/#it{c}); Area_{jet}", {HistType::kTH2F, {jetPtAxis, {150, 0., 1.5}}});
-      registry.add("h2_mcp_jet_pt_jet_ntracks", "jet #it{p}_{T,jet} vs. N_{jet tracks}; #it{p}_{T,jet} (GeV/#it{c}); N_{jet, tracks}", {HistType::kTH2F, {jetPtAxis, {200, -0.5, 199.5}}});
-      registry.add("h2_mcp_jet_pt_track_pt", "jet #it{p}_{T,jet} vs. #it{p}_{T,track}; #it{p}_{T,jet} (GeV/#it{c});  #it{p}_{T,track} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxisRhoAreaSub, trackPtAxis}});
-      registry.add("hsparse_mcp_jet_pt_eta_phi", "mcp jet_pt_eta_phi", HistType::kTHnSparseF, {jetPtAxis, jetEtaAxis, phiAxis});
-      if (doMCPJetSubtraction) {
-        registry.add("h_mcp_rho", "mc collision rho;#rho (GeV/#it{c}); counts", {HistType::kTH1F, {{500, 0.0, 500.0}}});
-        registry.add("h_mcp_jet_corr_pt", "mcp jet corr pT;#it{p}_{T,jet} (GeV/#it{c}); counts", {HistType::kTH1F, {jetPtAxisRhoAreaSub}});
-        registry.add("h2_mcp_jet_corr_pt_jet_area", "mcp jet #it{p}_{T,jet} vs. Area_{jet}; #it{p}_{T,jet} (GeV/#it{c}); Area_{jet}", {HistType::kTH2F, {jetPtAxisRhoAreaSub, {150, 0., 1.5}}});
-        registry.add("h2_mcp_jet_corr_pt_jet_ntracks", "mcp jet #it{p}_{T,jet} vs. N_{jet tracks}; #it{p}_{T,jet} (GeV/#it{c}); N_{jet, tracks}", {HistType::kTH2F, {jetPtAxisRhoAreaSub, {200, -0.5, 199.5}}});
-        registry.add("hsparse_mcp_jet_corr_pt_eta_phi", "mcp jet_corr_pt_eta_phi", HistType::kTHnSparseF, {jetPtAxisRhoAreaSub, jetEtaAxis, phiAxis});
-      }
+      registry.add("h_jet_pt_part", "partvjet pT;#it{p}_{T,jet}^{part} (GeV/#it{c}); counts", {HistType::kTH1F, {jetPtAxis}});
+      registry.add("h_jet_eta_part", "part jet #eta;#eta^{part}; counts", {HistType::kTH1F, {jetEtaAxis}});
+      registry.add("h_jet_phi_part", "part jet #varphi;#phi^{part}; counts", {HistType::kTH1F, {phiAxis}});
+      registry.add("h2_jet_pt_part_jet_area_part", "part jet #it{p}_{T,jet} vs. Area_{jet}; #it{p}_{T,jet}^{part} (GeV/#it{c}); Area_{jet}^{part}", {HistType::kTH2F, {jetPtAxis, {150, 0., 1.5}}});
+      registry.add("h2_jet_pt_part_jet_ntracks_part", "part jet #it{p}_{T,jet} vs. N_{jet tracks}; #it{p}_{T,jet}^{part} (GeV/#it{c}); N_{jet, tracks}^{part}", {HistType::kTH2F, {jetPtAxis, {200, -0.5, 199.5}}});
+      registry.add("h2_jet_pt_part_track_pt_part", "part jet #it{p}_{T,jet} vs. #it{p}_{T,track}; #it{p}_{T,jet}^{part} (GeV/#it{c}); #it{p}_{T,track}^{part} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxisRhoAreaSub, trackPtAxis}});
+      registry.add("h3_jet_pt_eta_phi_part", "part jet pt vs. eta vs. phi", {HistType::kTH3F, {jetPtAxis, jetEtaAxis, phiAxis}});
       if (doprocessSpectraMCPWeighted) {
-        registry.add("h2_mcp_jet_ptcut_part", "p_{T} cut;p_{T,jet}^{part} (GeV/#it{c});N;entries", {HistType::kTH2F, {{300, 0, 300}, {20, 0, 5}}});
-        registry.add("h_mcp_jet_phat_weighted", "jet #hat{p};#hat{p} (GeV/#it{c});entries", {HistType::kTH1F, {{1000, 0, 1000}}});
+        registry.add("h2_jet_ptcut_part", "p_{T} cut;p_{T,jet}^{part} (GeV/#it{c});N;entries", {HistType::kTH2F, {{300, 0, 300}, {20, 0, 5}}});
+        registry.add("h_jet_phat_part_weighted", "jet #hat{p};#hat{p} (GeV/#it{c});entries", {HistType::kTH1F, {{1000, 0, 1000}}});
       }
     }
+
+    if (doprocessSpectraAreaSubMCP) {
+      registry.add("h_mcColl_counts_areasub", " number of mc events; event status; entries", {HistType::kTH1F, {{10, 0, 10}}});
+      registry.get<TH1>(HIST("h_mcColl_counts_areasub"))->GetXaxis()->SetBinLabel(1, "allMcColl");
+      registry.get<TH1>(HIST("h_mcColl_counts_areasub"))->GetXaxis()->SetBinLabel(2, "vertexZ");
+      registry.get<TH1>(HIST("h_mcColl_counts_areasub"))->GetXaxis()->SetBinLabel(3, "noRecoColl");
+      registry.get<TH1>(HIST("h_mcColl_counts_areasub"))->GetXaxis()->SetBinLabel(4, "splitColl");
+      registry.get<TH1>(HIST("h_mcColl_counts_areasub"))->GetXaxis()->SetBinLabel(5, "recoEvtSel");
+      registry.get<TH1>(HIST("h_mcColl_counts_areasub"))->GetXaxis()->SetBinLabel(6, "centralitycut");
+      registry.get<TH1>(HIST("h_mcColl_counts_areasub"))->GetXaxis()->SetBinLabel(7, "occupancycut");
+
+      registry.add("h_mcColl_rho", "mc collision rho;#rho (GeV/#it{c}); counts", {HistType::kTH1F, {{500, 0.0, 500.0}}});
+      registry.add("h_jet_pt_part_rhoareasubtracted", "part jet corr pT;#it{p}_{T,jet}^{part} (GeV/#it{c}); counts", {HistType::kTH1F, {jetPtAxisRhoAreaSub}});
+      registry.add("h_jet_eta_part_rhoareasubtracted", "part jet #eta;#eta^{part}; counts", {HistType::kTH1F, {jetEtaAxis}});
+      registry.add("h_jet_phi_part_rhoareasubtracted", "part jet #varphi;#varphi^{part}; counts", {HistType::kTH1F, {phiAxis}});
+      registry.add("h2_jet_pt_part_jet_area_part_rhoareasubtracted", "part jet #it{p}_{T,jet} vs. Area_{jet}; #it{p}_{T,jet}^{part} (GeV/#it{c}); Area_{jet}^{part}", {HistType::kTH2F, {jetPtAxisRhoAreaSub, {150, 0., 1.5}}});
+      registry.add("h2_jet_pt_part_jet_ntracks_part_rhoareasubtracted", "part jet #it{p}_{T,jet} vs. N_{jet tracks}; #it{p}_{T,jet}^{part} (GeV/#it{c}); N_{jet, tracks}{part}", {HistType::kTH2F, {jetPtAxisRhoAreaSub, {200, -0.5, 199.5}}});
+      registry.add("h3_jet_pt_eta_phi_part_rhoareasubtracted", "part jet pt vs. eta vs.phi", {HistType::kTH3F, {jetPtAxisRhoAreaSub, jetEtaAxis, phiAxis}});
+    } 
 
     if (doprocessEvtWiseConstSubJetsData || doprocessEvtWiseConstSubJetsMCD) {
       registry.add("h2_centrality_jet_pt_eventwiseconstituentsubtracted", "centrality vs. jet pT;centrality;#it{p}_{T,jet} (GeV/#it{c});entries", {HistType::kTH2F, {centralityAxis, jetPtAxis}});
@@ -157,31 +191,31 @@ struct JetSpectraCharged {
 
     if (doprocessJetsMatched || doprocessJetsMatchedWeighted) {
       if (checkGeoMatched) {
-        registry.add("h2_jet_pt_reco_jet_pt_gen_matchedgeo", "pT reco vs. pT gen;#it{p}_{T,jet}^{reco} (GeV/#it{c});#it{p}_{T,jet}^{gen} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, jetPtAxis}});
-        registry.add("h2_jet_eta_reco_jet_eta_gen_matchedgeo", "Eta reco vs. Eta gen;#eta_{jet}^{reco};#eta_{jet}^{gen}", {HistType::kTH2F, {jetEtaAxis, jetEtaAxis}});
-        registry.add("h2_jet_phi_reco_jet_phi_gen_matchedgeo", "Phi reco vs. Phi gen;#varphi_{jet}^{reco};#varphi_{jet}^{gen}", {HistType::kTH2F, {phiAxis, phiAxis}});
-        registry.add("h2_jet_ntracks_reco_jet_ntracks_gen_matchedgeo", "Ntracks reco vs. Ntracks gen;N_{jet tracks}^{reco};N_{jet tracks}^{gen}", {HistType::kTH2F, {{200, -0.5, 199.5}, {200, -0.5, 199.5}}});
-        registry.add("h2_jet_pt_gen_jet_pt_diff_matchedgeo", "jet gen pT vs. delta pT / jet gen pt;#it{p}_{T,jet}^{gen} (GeV/#it{c}); (#it{p}_{T,jet}^{gen} (GeV/#it{c}) - #it{p}_{T,jet}^{reco} (GeV/#it{c})) / #it{p}_{T,jet}^{gen} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, {1000, -5.0, 2.0}}});
-        registry.add("h2_jet_pt_reco_jet_pt_diff_matchedgeo", "jet reco pT vs. delta pT / jet reco pt;#it{p}_{T,jet}^{reco} (GeV/#it{c}); (#it{p}_{T,jet}^{reco} (GeV/#it{c}) - #it{p}_{T,jet}^{gen} (GeV/#it{c})) / #it{p}_{T,jet}^{reco} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, {1000, -5.0, 2.0}}});
-        registry.add("h2_jet_pt_gen_jet_pt_ratio_matchedgeo", "jet gen pT vs. jet reco pT / jet gen pt;#it{p}_{T,jet}^{gen} (GeV/#it{c}); #it{p}_{T,jet}^{reco} (GeV/#it{c}) / #it{p}_{T,jet}^{gen} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, {1000, -5.0, 5.0}}});
+        registry.add("h2_jet_pt_mcd_jet_pt_mcp_matchedgeo", "pT mcd vs. pT mcp;#it{p}_{T,jet}^{mcd} (GeV/#it{c});#it{p}_{T,jet}^{mcp} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, jetPtAxis}});
+        registry.add("h2_jet_eta_mcd_jet_eta_mcp_matchedgeo", "Eta mcd vs. Eta mcp;#eta_{jet}^{mcd};#eta_{jet}^{mcp}", {HistType::kTH2F, {jetEtaAxis, jetEtaAxis}});
+        registry.add("h2_jet_phi_mcd_jet_phi_mcp_matchedgeo", "Phi mcd vs. Phi mcp;#varphi_{jet}^{mcd};#varphi_{jet}^{mcp}", {HistType::kTH2F, {phiAxis, phiAxis}});
+        registry.add("h2_jet_ntracks_mcd_jet_ntracks_mcp_matchedgeo", "Ntracks mcd vs. Ntracks mcp;N_{jet tracks}^{mcd};N_{jet tracks}^{mcp}", {HistType::kTH2F, {{200, -0.5, 199.5}, {200, -0.5, 199.5}}});
+        registry.add("h2_jet_pt_mcp_jet_pt_diff_matchedgeo", "jet mcp pT vs. delta pT / jet mcp pt;#it{p}_{T,jet}^{mcp} (GeV/#it{c}); (#it{p}_{T,jet}^{mcp} (GeV/#it{c}) - #it{p}_{T,jet}^{mcd} (GeV/#it{c})) / #it{p}_{T,jet}^{mcp} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, {1000, -5.0, 2.0}}});
+        registry.add("h2_jet_pt_mcd_jet_pt_diff_matchedgeo", "jet mcd pT vs. delta pT / jet mcd pt;#it{p}_{T,jet}^{mcd} (GeV/#it{c}); (#it{p}_{T,jet}^{mcd} (GeV/#it{c}) - #it{p}_{T,jet}^{mcp} (GeV/#it{c})) / #it{p}_{T,jet}^{mcd} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, {1000, -5.0, 2.0}}});
+        registry.add("h2_jet_pt_mcp_jet_pt_ratio_matchedgeo", "jet mcp pT vs. jet mcd pT / jet mcp pt;#it{p}_{T,jet}^{mcp} (GeV/#it{c}); #it{p}_{T,jet}^{mcd} (GeV/#it{c}) / #it{p}_{T,jet}^{mcp} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, {1000, -5.0, 5.0}}});
       }
       if (checkPtMatched) {
-        registry.add("h2_jet_pt_reco_jet_pt_gen_matchedpt", "pT reco vs. pT gen;#it{p}_{T,jet}^{reco} (GeV/#it{c});#it{p}_{T,jet}^{gen} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, jetPtAxis}});
-        registry.add("h2_jet_eta_reco_jet_eta_gen_matchedpt", "Eta reco vs. Eta gen;#eta_{jet}^{reco};#eta_{jet}^{gen}", {HistType::kTH2F, {jetEtaAxis, jetEtaAxis}});
-        registry.add("h2_jet_phi_reco_jet_phi_gen_matchedgpt", "Phi reco vs. Phi gen;#varphi_{jet}^{reco};#varphi_{jet}^{gen}", {HistType::kTH2F, {phiAxis, phiAxis}});
-        registry.add("h2_jet_ntracks_reco_jet_ntracks_gen_matchedpt", "Ntracks reco vs. Ntracks gen;N_{jet tracks}^{reco};N_{jet tracks}^{gen}", {HistType::kTH2F, {{200, -0.5, 199.5}, {200, -0.5, 199.5}}});
-        registry.add("h2_jet_pt_gen_jet_pt_diff_matchedpt", "jet gen pT vs. delta pT / jet gen pt;#it{p}_{T,jet}^{gen} (GeV/#it{c}); (#it{p}_{T,jet}^{gen} (GeV/#it{c}) - #it{p}_{T,jet}^{reco} (GeV/#it{c})) / #it{p}_{T,jet}^{gen} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, {1000, -5.0, 2.0}}});
-        registry.add("h2_jet_pt_reco_jet_pt_diff_matchedpt", "jet reco pT vs. delta pT / jet reco pt;#it{p}_{T,jet}^{reco} (GeV/#it{c}); (#it{p}_{T,jet}^{reco} (GeV/#it{c}) - #it{p}_{T,jet}^{gen} (GeV/#it{c})) / #it{p}_{T,jet}^{reco} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, {1000, -5.0, 2.0}}});
-        registry.add("h2_jet_pt_gen_jet_pt_ratio_matchedpt", "jet gen pT vs. jet reco pT / jet gen pt;#it{p}_{T,jet}^{gen} (GeV/#it{c}); #it{p}_{T,jet}^{reco} (GeV/#it{c}) / #it{p}_{T,jet}^{gen} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, {1000, -5.0, 5.0}}});
+        registry.add("h2_jet_pt_mcd_jet_pt_mcp_matchedpt", "pT mcd vs. pT mcp;#it{p}_{T,jet}^{mcd} (GeV/#it{c});#it{p}_{T,jet}^{mcp} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, jetPtAxis}});
+        registry.add("h2_jet_eta_mcd_jet_eta_mcp_matchedpt", "Eta mcd vs. Eta mcp;#eta_{jet}^{mcd};#eta_{jet}^{mcp}", {HistType::kTH2F, {jetEtaAxis, jetEtaAxis}});
+        registry.add("h2_jet_phi_mcd_jet_phi_mcp_matchedgpt", "Phi mcd vs. Phi mcp;#varphi_{jet}^{mcd};#varphi_{jet}^{mcp}", {HistType::kTH2F, {phiAxis, phiAxis}});
+        registry.add("h2_jet_ntracks_mcd_jet_ntracks_mcp_matchedpt", "Ntracks mcd vs. Ntracks mcp;N_{jet tracks}^{mcd};N_{jet tracks}^{mcp}", {HistType::kTH2F, {{200, -0.5, 199.5}, {200, -0.5, 199.5}}});
+        registry.add("h2_jet_pt_mcp_jet_pt_diff_matchedpt", "jet mcp pT vs. delta pT / jet mcp pt;#it{p}_{T,jet}^{mcp} (GeV/#it{c}); (#it{p}_{T,jet}^{mcp} (GeV/#it{c}) - #it{p}_{T,jet}^{mcd} (GeV/#it{c})) / #it{p}_{T,jet}^{mcp} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, {1000, -5.0, 2.0}}});
+        registry.add("h2_jet_pt_mcd_jet_pt_diff_matchedpt", "jet mcd pT vs. delta pT / jet mcd pt;#it{p}_{T,jet}^{mcd} (GeV/#it{c}); (#it{p}_{T,jet}^{mcd} (GeV/#it{c}) - #it{p}_{T,jet}^{mcp} (GeV/#it{c})) / #it{p}_{T,jet}^{mcd} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, {1000, -5.0, 2.0}}});
+        registry.add("h2_jet_pt_mcp_jet_pt_ratio_matchedpt", "jet mcp pT vs. jet mcd pT / jet mcp pt;#it{p}_{T,jet}^{mcp} (GeV/#it{c}); #it{p}_{T,jet}^{mcd} (GeV/#it{c}) / #it{p}_{T,jet}^{mcp} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, {1000, -5.0, 5.0}}});
       }
       if (checkGeoPtMatched) {
-        registry.add("h2_jet_pt_reco_jet_pt_gen_matchedgeopt", "pT reco vs. pT gen;#it{p}_{T,jet}^{reco} (GeV/#it{c});#it{p}_{T,jet}^{gen} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, jetPtAxis}});
-        registry.add("h2_jet_eta_reco_jet_eta_gen_matchedgeopt", "Eta reco vs. Eta gen;#eta_{jet}^{reco};#eta_{jet}^{gen}", {HistType::kTH2F, {jetEtaAxis, jetEtaAxis}});
-        registry.add("h2_jet_phi_reco_jet_phi_gen_matchedgeopt", "Phi reco vs. Phi gen;#varphi_{jet}^{reco};#varphi_{jet}^{gen}", {HistType::kTH2F, {phiAxis, phiAxis}});
-        registry.add("h2_jet_ntracks_reco_jet_ntracks_gen_matchedgeopt", "Ntracks reco vs. Ntracks gen;N_{jet tracks}^{reco};N_{jet tracks}^{gen}", {HistType::kTH2F, {{200, -0.5, 199.5}, {200, -0.5, 199.5}}});
-        registry.add("h2_jet_pt_gen_jet_pt_diff_matchedgeopt", "jet gen pT vs. delta pT / jet gen pt;#it{p}_{T,jet}^{gen} (GeV/#it{c}); (#it{p}_{T,jet}^{gen} (GeV/#it{c}) - #it{p}_{T,jet}^{reco} (GeV/#it{c})) / #it{p}_{T,jet}^{gen} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, {1000, -5.0, 2.0}}});
-        registry.add("h2_jet_pt_reco_jet_pt_diff_matchedgeopt", "jet reco pT vs. delta pT / jet reco pt;#it{p}_{T,jet}^{reco} (GeV/#it{c}); (#it{p}_{T,jet}^{reco} (GeV/#it{c}) - #it{p}_{T,jet}^{gen} (GeV/#it{c})) / #it{p}_{T,jet}^{reco} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, {1000, -5.0, 2.0}}});
-        registry.add("h2_jet_pt_gen_jet_pt_ratio_matchedgeopt", "jet gen pT vs. jet reco pT / jet gen pt;#it{p}_{T,jet}^{gen} (GeV/#it{c}); #it{p}_{T,jet}^{reco} (GeV/#it{c}) / #it{p}_{T,jet}^{gen} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, {1000, -5.0, 5.0}}});
+        registry.add("h2_jet_pt_mcd_jet_pt_mcp_matchedgeopt", "pT mcd vs. pT mcp;#it{p}_{T,jet}^{mcd} (GeV/#it{c});#it{p}_{T,jet}^{mcp} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, jetPtAxis}});
+        registry.add("h2_jet_eta_mcd_jet_eta_mcp_matchedgeopt", "Eta mcd vs. Eta mcp;#eta_{jet}^{mcd};#eta_{jet}^{mcp}", {HistType::kTH2F, {jetEtaAxis, jetEtaAxis}});
+        registry.add("h2_jet_phi_mcd_jet_phi_mcp_matchedgeopt", "Phi mcd vs. Phi mcp;#varphi_{jet}^{mcd};#varphi_{jet}^{mcp}", {HistType::kTH2F, {phiAxis, phiAxis}});
+        registry.add("h2_jet_ntracks_mcd_jet_ntracks_mcp_matchedgeopt", "Ntracks mcd vs. Ntracks mcp;N_{jet tracks}^{mcd};N_{jet tracks}^{mcp}", {HistType::kTH2F, {{200, -0.5, 199.5}, {200, -0.5, 199.5}}});
+        registry.add("h2_jet_pt_mcp_jet_pt_diff_matchedgeopt", "jet mcp pT vs. delta pT / jet mcp pt;#it{p}_{T,jet}^{mcp} (GeV/#it{c}); (#it{p}_{T,jet}^{mcp} (GeV/#it{c}) - #it{p}_{T,jet}^{mcd} (GeV/#it{c})) / #it{p}_{T,jet}^{mcp} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, {1000, -5.0, 2.0}}});
+        registry.add("h2_jet_pt_mcd_jet_pt_diff_matchedgeopt", "jet mcd pT vs. delta pT / jet mcd pt;#it{p}_{T,jet}^{mcd} (GeV/#it{c}); (#it{p}_{T,jet}^{mcd} (GeV/#it{c}) - #it{p}_{T,jet}^{mcp} (GeV/#it{c})) / #it{p}_{T,jet}^{mcd} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, {1000, -5.0, 2.0}}});
+        registry.add("h2_jet_pt_mcp_jet_pt_ratio_matchedgeopt", "jet mcp pT vs. jet mcd pT / jet mcp pt;#it{p}_{T,jet}^{mcp} (GeV/#it{c}); #it{p}_{T,jet}^{mcd} (GeV/#it{c}) / #it{p}_{T,jet}^{mcp} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxis, {1000, -5.0, 5.0}}});
       }
     }
 
@@ -189,10 +223,10 @@ struct JetSpectraCharged {
       registry.add("h_mc_collisions_matched", "mc collisions status;event status;entries", {HistType::kTH1F, {{5, 0.0, 5.0}}});
       registry.add("h_mcd_events_matched", "mcd event status;event status;entries", {HistType::kTH1F, {{5, 0.0, 5.0}}});
       registry.add("h_mc_rho_matched", "mc collision rho;#rho (GeV/#it{c}); counts", {HistType::kTH1F, {{500, -100.0, 500.0}}});
-      registry.add("h2_reco_jet_corr_pt_gen_jet_corr_pt_matchedgeo", "corr pT reco vs. corr cpT gen;#it{p}_{T,jet}^{reco} (GeV/#it{c});#it{p}_{T,jet}^{gen} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxisRhoAreaSub, jetPtAxisRhoAreaSub}});
-      registry.add("h2_gen_jet_corr_pt_jet_pt_diff_corr_matchedgeo", "jet gen corr pT vs. corr delta pT / jet gen corr pt;#it{p}_{T,jet}^{gen} (GeV/#it{c}); (#it{p}_{T,jet}^{gen} (GeV/#it{c}) - #it{p}_{T,jet}^{reco} (GeV/#it{c})) / #it{p}_{T,jet}^{gen} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxisRhoAreaSub, {1000, -5.0, 5.0}}});
-      registry.add("h2_reco_jet_corr_pt_jet_pt_diff_corr_matchedgeo", "jet reco corr pT vs. corr delta pT / jet reco corr pt;#it{p}_{T,jet}^{reco} (GeV/#it{c}); (#it{p}_{T,jet}^{reco} (GeV/#it{c}) - #it{p}_{T,jet}^{gen} (GeV/#it{c})) / #it{p}_{T,jet}^{reco} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxisRhoAreaSub, {1000, -5.0, 5.0}}});
-      registry.add("h2_gen_jet_corr_pt_jet_corr_pt_ratio_matchedgeo", "jet gen corr pT vs. jet reco corr pT / jet gen corr pt;#it{p}_{T,jet}^{gen} (GeV/#it{c}); #it{p}_{T,jet}^{reco} (GeV/#it{c}) / #it{p}_{T,jet}^{gen} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxisRhoAreaSub, {1000, -5.0, 5.0}}});
+      registry.add("h2_mcd_jet_pt_mcp_jet_pt_matchedgeo_rhoareasubtracted", "corr pT mcd vs. corr cpT mcp;#it{p}_{T,jet}^{mcd} (GeV/#it{c});#it{p}_{T,jet}^{mcp} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxisRhoAreaSub, jetPtAxisRhoAreaSub}});
+      registry.add("h2_mcp_jet_pt_jet_pt_diff_matchedgeo_rhoareasubtracted", "jet mcp corr pT vs. corr delta pT / jet mcp corr pt;#it{p}_{T,jet}^{mcp} (GeV/#it{c}); (#it{p}_{T,jet}^{mcp} (GeV/#it{c}) - #it{p}_{T,jet}^{mcd} (GeV/#it{c})) / #it{p}_{T,jet}^{mcp} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxisRhoAreaSub, {1000, -5.0, 5.0}}});
+      registry.add("h2_mcd_jet_pt_jet_pt_diff_matchedgeo_rhoareasubtracted", "jet mcd corr pT vs. corr delta pT / jet mcd corr pt;#it{p}_{T,jet}^{mcd} (GeV/#it{c}); (#it{p}_{T,jet}^{mcd} (GeV/#it{c}) - #it{p}_{T,jet}^{mcp} (GeV/#it{c})) / #it{p}_{T,jet}^{mcd} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxisRhoAreaSub, {1000, -5.0, 5.0}}});
+      registry.add("h2_mcp_jet_pt_jet_pt_ratio_matchedgeo_rhoareasubtracted", "jet mcp corr pT vs. jet mcd corr pT / jet mcp corr pt;#it{p}_{T,jet}^{mcp} (GeV/#it{c}); #it{p}_{T,jet}^{mcd} (GeV/#it{c}) / #it{p}_{T,jet}^{mcp} (GeV/#it{c})", {HistType::kTH2F, {jetPtAxisRhoAreaSub, {1000, -5.0, 5.0}}});
     }
   }
 
@@ -236,54 +270,82 @@ struct JetSpectraCharged {
   }
 
   template <typename TJets>
-  void fillJetHistograms(TJets const& jet, float centrality, float rho, float weight = 1.0)
+  void fillJetHistograms(TJets const& jet, float centrality, float weight = 1.0)
   {
     if (jet.r() == round(selectedJetsRadius * 100.0f)) {
-      double jetcorrpt = jet.pt() - (rho * jet.area());
+      registry.fill(HIST("h_jet_pt"), jet.pt(), weight);
+      registry.fill(HIST("h_jet_eta"), jet.eta(), weight);
+      registry.fill(HIST("h_jet_phi"), jet.phi(), weight);
+      registry.fill(HIST("h2_centrality_jet_pt"), centrality, jet.pt(), weight);
+      registry.fill(HIST("h2_centrality_jet_eta"), centrality, jet.eta(), weight);
+      registry.fill(HIST("h2_centrality_jet_phi"), centrality, jet.phi(), weight);
+      registry.fill(HIST("h2_jet_pt_jet_area"), jet.pt(), jet.area(), weight);
+      registry.fill(HIST("h2_jet_pt_jet_ntracks"), jet.pt(), jet.tracksIds().size(), weight);
+      registry.fill(HIST("h3_jet_pt_eta_phi"), jet.pt(), jet.eta(), jet.phi(), weight);
+    }
+
+    for (const auto& constituent : jet.template tracks_as<aod::JetTracks>()) {
+      registry.fill(HIST("h2_jet_pt_track_pt"), jet.pt(), constituent.pt(), weight);
+    }
+  }
+
+  template <typename TJets>
+  void fillJetAreaSubHistograms(TJets const& jet, float centrality, float rho, float weight = 1.0)
+  {
+    double jetcorrpt = jet.pt() - (rho * jet.area());
+    if (jet.r() == round(selectedJetsRadius * 100.0f)) {
       // fill jet histograms after area-based subtraction
       registry.fill(HIST("h_jet_pt_rhoareasubtracted"), jetcorrpt, weight);
-      registry.fill(HIST("h_jet_eta_rhoareasubtracted"), jet.eta(), weight);
-      registry.fill(HIST("h_jet_phi_rhoareasubtracted"), jet.phi(), weight);
       registry.fill(HIST("h2_centrality_jet_pt_rhoareasubtracted"), centrality, jetcorrpt, weight);
-      registry.fill(HIST("h2_centrality_jet_eta_rhoareasubtracted"), centrality, jet.eta(), weight);
-      registry.fill(HIST("h2_centrality_jet_phi_rhoareasubtracted"), centrality, jet.phi(), weight);
       registry.fill(HIST("h2_jet_pt_jet_corr_pt_rhoareasubtracted"), jet.pt(), jetcorrpt, weight);
       registry.fill(HIST("h3_jet_pt_eta_phi_rhoareasubtracted"), jetcorrpt, jet.eta(), jet.phi(), weight);
       if (jetcorrpt > 0) {
+        registry.fill(HIST("h_jet_eta_rhoareasubtracted"), jet.eta(), weight);
+        registry.fill(HIST("h_jet_phi_rhoareasubtracted"), jet.phi(), weight);
+        registry.fill(HIST("h2_centrality_jet_eta_rhoareasubtracted"), centrality, jet.eta(), weight);
+        registry.fill(HIST("h2_centrality_jet_phi_rhoareasubtracted"), centrality, jet.phi(), weight);
         registry.fill(HIST("h2_jet_pt_jet_area_rhoareasubtracted"), jetcorrpt, jet.area(), weight);
         registry.fill(HIST("h2_jet_pt_jet_ntracks_rhoareasubtracted"), jetcorrpt, jet.tracksIds().size(), weight);
       }
     }
 
     for (const auto& constituent : jet.template tracks_as<aod::JetTracks>()) {
-      registry.fill(HIST("h2_jet_pt_track_pt_rhoareasubtracted"), jet.pt(), constituent.pt(), weight);
+      registry.fill(HIST("h2_jet_pt_track_pt_rhoareasubtracted"), jetcorrpt, constituent.pt(), weight);
     }
   }
 
   template <typename TJets>
-  void fillMCPHistograms(TJets const& jet, float rho = 0.0, float weight = 1.0)
+  void fillMCPHistograms(TJets const& jet, float weight = 1.0)
   {
     if (jet.r() == round(selectedJetsRadius * 100.0f)) {
       // fill mcp jet histograms
-      registry.fill(HIST("h_mcp_jet_pt"), jet.pt(), weight);
-      registry.fill(HIST("h_mcp_jet_eta"), jet.eta(), weight);
-      registry.fill(HIST("h_mcp_jet_phi"), jet.phi(), weight);
-      registry.fill(HIST("hsparse_mcp_jet_pt_eta_phi"), jet.pt(), jet.eta(), jet.phi(), weight);
-      registry.fill(HIST("h2_mcp_jet_pt_jet_area"), jet.pt(), jet.area(), weight);
-      registry.fill(HIST("h2_mcp_jet_pt_jet_ntracks"), jet.pt(), jet.tracksIds().size(), weight);
-      if (doMCPJetSubtraction) {
-        double jetcorrpt = jet.pt() - (rho * jet.area());
-        registry.fill(HIST("h_mcp_jet_corr_pt"), jetcorrpt, weight);
-        registry.fill(HIST("hsparse_mcp_jet_corr_pt_eta_phi"), jet.pt(), jet.eta(), jet.phi(), weight);
-        if (jetcorrpt > 0) {
-          registry.fill(HIST("h2_mcp_jet_corr_pt_jet_area"), jetcorrpt, jet.area(), weight);
-          registry.fill(HIST("h2_mcp_jet_corr_pt_jet_ntracks"), jetcorrpt, jet.tracksIds().size(), weight);
-        }
+      registry.fill(HIST("h_jet_pt_part"), jet.pt(), weight);
+      registry.fill(HIST("h_jet_eta_part"), jet.eta(), weight);
+      registry.fill(HIST("h_jet_phi_part"), jet.phi(), weight);
+      registry.fill(HIST("h3_jet_pt_eta_phi_part"), jet.pt(), jet.eta(), jet.phi(), weight);
+      registry.fill(HIST("h2_jet_pt_part_jet_area_part"), jet.pt(), jet.area(), weight);
+      registry.fill(HIST("h2_jet_pt_part_jet_ntracks_part"), jet.pt(), jet.tracksIds().size(), weight);
       }
-    }
 
     for (const auto& constituent : jet.template tracks_as<aod::JetParticles>()) {
-      registry.fill(HIST("h2_mcp_jet_pt_track_pt"), jet.pt(), constituent.pt(), weight);
+      registry.fill(HIST("h2_jet_pt_part_track_pt_part"), jet.pt(), constituent.pt(), weight);
+    }
+  }
+
+  template <typename TJets>
+  void fillMCPAreaSubHistograms(TJets const& jet, float rho = 0.0, float weight = 1.0)
+  {
+    if (jet.r() == round(selectedJetsRadius * 100.0f)) {
+      // fill mcp jet histograms
+        double jetcorrpt = jet.pt() - (rho * jet.area());
+        registry.fill(HIST("h_jet_pt_part_rhoareasubtracted"), jetcorrpt, weight);
+        registry.fill(HIST("h3_jet_pt_eta_phi_part_rhoareasubtracted"), jetcorrpt, jet.eta(), jet.phi(), weight);
+        if (jetcorrpt > 0) {
+          registry.fill(HIST("h_jet_eta_part_rhoareasubtracted"), jet.eta(), weight);
+          registry.fill(HIST("h_jet_phi_part_rhoareasubtracted"), jet.phi(), weight);
+          registry.fill(HIST("h2_jet_pt_part_jet_area_part_rhoareasubtracted"), jetcorrpt, jet.area(), weight);
+          registry.fill(HIST("h2_jet_pt_part_jet_ntracks_part_rhoareasubtracted"), jetcorrpt, jet.tracksIds().size(), weight);
+      }
     }
   }
 
@@ -319,13 +381,13 @@ struct JetSpectraCharged {
           }
           if (jetBase.r() == round(selectedJetsRadius * 100.0f)) {
             double dpt = jetTag.pt() - jetBase.pt();
-            registry.fill(HIST("h2_jet_pt_reco_jet_pt_gen_matchedgeo"), jetBase.pt(), jetTag.pt(), weight);
-            registry.fill(HIST("h2_jet_eta_reco_jet_eta_gen_matchedgeo"), jetBase.eta(), jetTag.eta(), weight);
-            registry.fill(HIST("h2_jet_phi_reco_jet_phi_gen_matchedgeo"), jetBase.phi(), jetTag.phi(), weight);
-            registry.fill(HIST("h2_jet_ntracks_reco_jet_ntracks_gen_matchedgeo"), jetBase.tracksIds().size(), jetTag.tracksIds().size(), weight);
-            registry.fill(HIST("h2_jet_pt_gen_jet_pt_diff_matchedgeo"), jetTag.pt(), dpt / jetTag.pt(), weight);
-            registry.fill(HIST("h2_jet_pt_reco_jet_pt_diff_matchedgeo"), jetBase.pt(), dpt / jetBase.pt(), weight);
-            registry.fill(HIST("h2_jet_pt_gen_jet_pt_ratio_matchedgeo"), jetTag.pt(), jetBase.pt() / jetTag.pt(), weight);
+            registry.fill(HIST("h2_jet_pt_mcd_jet_pt_mcp_matchedgeo"), jetBase.pt(), jetTag.pt(), weight);
+            registry.fill(HIST("h2_jet_eta_mcd_jet_eta_mcp_matchedgeo"), jetBase.eta(), jetTag.eta(), weight);
+            registry.fill(HIST("h2_jet_phi_mcd_jet_phi_mcp_matchedgeo"), jetBase.phi(), jetTag.phi(), weight);
+            registry.fill(HIST("h2_jet_ntracks_mcd_jet_ntracks_mcp_matchedgeo"), jetBase.tracksIds().size(), jetTag.tracksIds().size(), weight);
+            registry.fill(HIST("h2_jet_pt_mcp_jet_pt_diff_matchedgeo"), jetTag.pt(), dpt / jetTag.pt(), weight);
+            registry.fill(HIST("h2_jet_pt_mcd_jet_pt_diff_matchedgeo"), jetBase.pt(), dpt / jetBase.pt(), weight);
+            registry.fill(HIST("h2_jet_pt_mcp_jet_pt_ratio_matchedgeo"), jetTag.pt(), jetBase.pt() / jetTag.pt(), weight);
           }
         }
       }
@@ -339,13 +401,13 @@ struct JetSpectraCharged {
           }
           if (jetBase.r() == round(selectedJetsRadius * 100.0f)) {
             double dpt = jetTag.pt() - jetBase.pt();
-            registry.fill(HIST("h2_jet_pt_reco_jet_pt_gen_matchedpt"), jetBase.pt(), jetTag.pt(), weight);
-            registry.fill(HIST("h2_jet_eta_reco_jet_eta_gen_matchedpt"), jetBase.eta(), jetTag.eta(), weight);
-            registry.fill(HIST("h2_jet_phi_reco_jet_phi_gen_matchedpt"), jetBase.phi(), jetTag.phi(), weight);
-            registry.fill(HIST("h2_jet_ntracks_reco_jet_ntracks_gen_matchedpt"), jetBase.tracksIds().size(), jetTag.tracksIds().size(), weight);
-            registry.fill(HIST("h2_jet_pt_gen_jet_pt_diff_matchedpt"), jetTag.pt(), dpt / jetTag.pt(), weight);
-            registry.fill(HIST("h2_jet_pt_reco_jet_pt_diff_matchedpt"), jetBase.pt(), dpt / jetBase.pt(), weight);
-            registry.fill(HIST("h2_jet_pt_gen_jet_pt_ratio_matchedpt"), jetTag.pt(), jetBase.pt() / jetTag.pt(), weight);
+            registry.fill(HIST("h2_jet_pt_mcd_jet_pt_mcp_matchedpt"), jetBase.pt(), jetTag.pt(), weight);
+            registry.fill(HIST("h2_jet_eta_mcd_jet_eta_mcp_matchedpt"), jetBase.eta(), jetTag.eta(), weight);
+            registry.fill(HIST("h2_jet_phi_mcd_jet_phi_mcp_matchedpt"), jetBase.phi(), jetTag.phi(), weight);
+            registry.fill(HIST("h2_jet_ntracks_mcd_jet_ntracks_mcp_matchedpt"), jetBase.tracksIds().size(), jetTag.tracksIds().size(), weight);
+            registry.fill(HIST("h2_jet_pt_mcp_jet_pt_diff_matchedpt"), jetTag.pt(), dpt / jetTag.pt(), weight);
+            registry.fill(HIST("h2_jet_pt_mcd_jet_pt_diff_matchedpt"), jetBase.pt(), dpt / jetBase.pt(), weight);
+            registry.fill(HIST("h2_jet_pt_mcp_jet_pt_ratio_matchedpt"), jetTag.pt(), jetBase.pt() / jetTag.pt(), weight);
           }
         }
       }
@@ -359,13 +421,13 @@ struct JetSpectraCharged {
           }
           if (jetBase.template matchedJetGeo_first_as<std::decay_t<TTag>>().globalIndex() == jetBase.template matchedJetPt_first_as<std::decay_t<TTag>>().globalIndex()) { // not a good way to do this
             double dpt = jetTag.pt() - jetBase.pt();
-            registry.fill(HIST("h2_jet_pt_reco_jet_pt_gen_matchedgeopt"), jetBase.pt(), jetTag.pt(), weight);
-            registry.fill(HIST("h2_jet_eta_reco_jet_eta_gen_matchedgeopt"), jetBase.eta(), jetTag.eta(), weight);
-            registry.fill(HIST("h2_jet_phi_reco_jet_phi_gen_matchedgeopt"), jetBase.phi(), jetTag.phi(), weight);
-            registry.fill(HIST("h2_jet_ntracks_reco_jet_ntracks_gen_matchedgeopt"), jetBase.tracksIds().size(), jetTag.tracksIds().size(), weight);
-            registry.fill(HIST("h2_jet_pt_gen_jet_pt_diff_matchedgeopt"), jetTag.pt(), dpt / jetTag.pt(), weight);
-            registry.fill(HIST("h2_jet_pt_reco_jet_pt_diff_matchedgeopt"), jetBase.pt(), dpt / jetBase.pt(), weight);
-            registry.fill(HIST("h2_jet_pt_gen_jet_pt_ratio_matchedgeopt"), jetTag.pt(), jetBase.pt() / jetTag.pt(), weight);
+            registry.fill(HIST("h2_jet_pt_mcd_jet_pt_mcp_matchedgeopt"), jetBase.pt(), jetTag.pt(), weight);
+            registry.fill(HIST("h2_jet_eta_mcd_jet_eta_mcp_matchedgeopt"), jetBase.eta(), jetTag.eta(), weight);
+            registry.fill(HIST("h2_jet_phi_mcd_jet_phi_mcp_matchedgeopt"), jetBase.phi(), jetTag.phi(), weight);
+            registry.fill(HIST("h2_jet_ntracks_mcd_jet_ntracks_mcp_matchedgeopt"), jetBase.tracksIds().size(), jetTag.tracksIds().size(), weight);
+            registry.fill(HIST("h2_jet_pt_mcp_jet_pt_diff_matchedgeopt"), jetTag.pt(), dpt / jetTag.pt(), weight);
+            registry.fill(HIST("h2_jet_pt_mcd_jet_pt_diff_matchedgeopt"), jetBase.pt(), dpt / jetBase.pt(), weight);
+            registry.fill(HIST("h2_jet_pt_mcp_jet_pt_ratio_matchedgeopt"), jetTag.pt(), jetBase.pt() / jetTag.pt(), weight);
           }
         }
       }
@@ -388,10 +450,10 @@ struct JetSpectraCharged {
           double corrTagjetpt = jetTag.pt() - (mcrho * jetTag.area());
           double corrBasejetpt = jetBase.pt() - (rho * jetBase.area());
           double dcorrpt = corrTagjetpt - corrBasejetpt;
-          registry.fill(HIST("h2_reco_jet_corr_pt_gen_jet_corr_pt_matchedgeo"), corrBasejetpt, corrTagjetpt, weight);
-          registry.fill(HIST("h2_gen_jet_corr_pt_jet_pt_diff_corr_matchedgeo"), corrTagjetpt, dcorrpt / corrTagjetpt, weight);
-          registry.fill(HIST("h2_reco_jet_corr_pt_jet_pt_diff_corr_matchedgeo"), corrBasejetpt, dcorrpt / corrBasejetpt, weight);
-          registry.fill(HIST("h2_gen_jet_corr_pt_jet_corr_pt_ratio_matchedgeo"), corrTagjetpt, corrBasejetpt / corrTagjetpt, weight);
+          registry.fill(HIST("h2_mcd_jet_pt_mcp_jet_pt_matchedgeo_rhoareasubtracted"), corrBasejetpt, corrTagjetpt, weight);
+          registry.fill(HIST("h2_mcp_jet_pt_jet_pt_diff_matchedgeo_rhoareasubtracted"), corrTagjetpt, dcorrpt / corrTagjetpt, weight);
+          registry.fill(HIST("h2_mcd_jet_pt_jet_pt_diff_matchedgeo_rhoareasubtracted"), corrBasejetpt, dcorrpt / corrBasejetpt, weight);
+          registry.fill(HIST("h2_mcp_jet_pt_jet_pt_ratio_matchedgeo_rhoareasubtracted"), corrTagjetpt, corrBasejetpt / corrTagjetpt, weight);
         }
       }
     }
@@ -449,31 +511,53 @@ struct JetSpectraCharged {
   }
   PROCESS_SWITCH(JetSpectraCharged, processQCWeighted, "weighted collsions and tracks QC for MC", false);
 
-  void processSpectraData(soa::Filtered<soa::Join<aod::JetCollisions, aod::BkgChargedRhos>>::iterator const& collision,
+  void processSpectraData(soa::Filtered<aod::JetCollisions>::iterator const& collision,
                           soa::Join<aod::ChargedJets, aod::ChargedJetConstituents> const& jets,
                           aod::JetTracks const&)
   {
     if (!jetderiveddatautilities::selectCollision(collision, eventSelectionBits)) {
-      return;
+    return;
     }
     if (collision.trackOccupancyInTimeRange() < trackOccupancyInTimeRangeMin || trackOccupancyInTimeRangeMax < collision.trackOccupancyInTimeRange()) {
-      return;
+    return;
     }
     for (auto const& jet : jets) {
-      if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
-        continue;
-      }
-      if (!isAcceptedJet<aod::JetTracks>(jet)) {
-        continue;
-      }
-      fillJetHistograms(jet, collision.centrality(), collision.rho());
+    if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
+    continue;
+    }
+    if (!isAcceptedJet<aod::JetTracks>(jet)) {
+    continue;
+    }
+    fillJetHistograms(jet, collision.centrality());
     }
   }
   PROCESS_SWITCH(JetSpectraCharged, processSpectraData, "jet spectra for Data", false);
 
-  void processSpectraMCD(soa::Filtered<soa::Join<aod::JetCollisions, aod::BkgChargedRhos>>::iterator const& collision,
+  void processSpectraMCD(soa::Filtered<aod::JetCollisions>::iterator const& collision,
                          soa::Join<aod::ChargedMCDetectorLevelJets, aod::ChargedMCDetectorLevelJetConstituents> const& jets,
                          aod::JetTracks const&)
+  {
+    if (!jetderiveddatautilities::selectCollision(collision, eventSelectionBits)) {
+    return;
+    }
+    if (collision.trackOccupancyInTimeRange() < trackOccupancyInTimeRangeMin || trackOccupancyInTimeRangeMax < collision.trackOccupancyInTimeRange()) {
+    return;
+    }
+    for (auto const& jet : jets) {
+    if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
+    continue;
+    }
+    if (!isAcceptedJet<aod::JetTracks>(jet)) {
+    continue;
+    }
+    fillJetHistograms(jet, collision.centrality());
+    }
+  }
+  PROCESS_SWITCH(JetSpectraCharged, processSpectraMCD, "jet spectra for MCD", false);
+
+  void processSpectraAreaSubData(soa::Filtered<soa::Join<aod::JetCollisions, aod::BkgChargedRhos>>::iterator const& collision,
+                                 soa::Join<aod::ChargedJets, aod::ChargedJetConstituents> const& jets,
+                                 aod::JetTracks const&)
   {
     if (!jetderiveddatautilities::selectCollision(collision, eventSelectionBits)) {
       return;
@@ -488,12 +572,34 @@ struct JetSpectraCharged {
       if (!isAcceptedJet<aod::JetTracks>(jet)) {
         continue;
       }
-      fillJetHistograms(jet, collision.centrality(), collision.rho());
+      fillJetAreaSubHistograms(jet, collision.centrality(), collision.rho());
     }
   }
-  PROCESS_SWITCH(JetSpectraCharged, processSpectraMCD, "jet spectra for Data", false);
+  PROCESS_SWITCH(JetSpectraCharged, processSpectraAreaSubData, "jet spectra with rho-area subtraction for Data", false);
 
-  void processSpectraMCDWeighted(soa::Filtered<soa::Join<aod::JetCollisions, aod::BkgChargedRhos>>::iterator const& collision,
+  void processSpectraAreaSubMCD(soa::Filtered<soa::Join<aod::JetCollisions, aod::BkgChargedRhos>>::iterator const& collision,
+                                soa::Join<aod::ChargedMCDetectorLevelJets, aod::ChargedMCDetectorLevelJetConstituents> const& jets,
+                                aod::JetTracks const&)
+  {
+    if (!jetderiveddatautilities::selectCollision(collision, eventSelectionBits)) {
+      return;
+    }
+    if (collision.trackOccupancyInTimeRange() < trackOccupancyInTimeRangeMin || trackOccupancyInTimeRangeMax < collision.trackOccupancyInTimeRange()) {
+      return;
+    }
+    for (auto const& jet : jets) {
+      if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
+        continue;
+      }
+      if (!isAcceptedJet<aod::JetTracks>(jet)) {
+        continue;
+      }
+      fillJetAreaSubHistograms(jet, collision.centrality(), collision.rho());
+    }
+  }
+  PROCESS_SWITCH(JetSpectraCharged, processSpectraAreaSubMCD, "jet spectra with rho-area subtraction for MCD", false);
+
+  void processSpectraMCDWeighted(soa::Filtered<aod::JetCollisions>::iterator const& collision,
                                  soa::Join<aod::ChargedMCDetectorLevelJets, aod::ChargedMCDetectorLevelJetConstituents, aod::ChargedMCDetectorLevelJetEventWeights> const& jets,
                                  aod::JetTracks const&)
   {
@@ -517,22 +623,72 @@ struct JetSpectraCharged {
       }
       registry.fill(HIST("h_jet_phat"), pTHat);
       registry.fill(HIST("h_jet_phat_weighted"), pTHat, jetweight);
-      fillJetHistograms(jet, collision.centrality(), collision.rho(), jetweight);
+      fillJetHistograms(jet, collision.centrality(), jetweight);
     }
   }
   PROCESS_SWITCH(JetSpectraCharged, processSpectraMCDWeighted, "jet finder QA mcd with weighted events", false);
 
-  void processSpectraMCP(McParticleCollision::iterator const& mccollision,
-                         soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents> const& jets,
-                         aod::JetParticles const&)
+  void processSpectraAreaSubMCP(McParticleCollision::iterator const& mccollision,
+                                soa::SmallGroups<aod::JetCollisionsMCD> const& collisions,
+                                soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents> const& jets,
+                                aod::JetParticles const&)
   {
+    registry.fill(HIST("h_mcColl_counts_areasub"), 0.5);  //all mc collisions
     if (std::abs(mccollision.posZ()) > vertexZCut) {
       return;
     }
-    registry.fill(HIST("h_mc_zvertex"), mccollision.posZ());
-    if (doMCPJetSubtraction) {
-      registry.fill(HIST("h_mcp_rho"), mccollision.rho());
+    registry.fill(HIST("h_mcColl_counts_areasub"), 1.5);  //cut on mccollision.posZ()
+    if (collisions.size() < 1) {
+      return;
     }
+    registry.fill(HIST("h_mcColl_counts_areasub"), 2.5);  //mcCollisions with at least one resonstructed collision
+    if (acceptSplitCollisions == 0 && collisions.size() > 1) {
+      return;
+    }
+    registry.fill(HIST("h_mcColl_counts_areasub"), 3.5); // split mcCollisions condition
+
+    bool hasSel8Coll = false;
+    bool centralityIsGood = false;
+    bool occupancyIsGood = false;
+    if (acceptSplitCollisions == 2) {                                                    
+      if (jetderiveddatautilities::selectCollision(collisions.begin(), eventSelectionBits)) { // Skipping MC events that have not a single selected reconstructed collision ; effect unclear if mcColl is split
+        hasSel8Coll = true;
+      }
+      if ((centralityMin < collisions.begin().centrality()) && (collisions.begin().centrality() < centralityMax)) { // effect unclear if mcColl is split
+        centralityIsGood = true;
+      }
+      if ((trackOccupancyInTimeRangeMin < collisions.begin().trackOccupancyInTimeRange()) && (collisions.begin().trackOccupancyInTimeRange() < trackOccupancyInTimeRangeMax)) {
+        occupancyIsGood = true;
+      }
+    } 
+    else { // check that at least one of the reconstructed collisions passes the checks
+      for (auto& collision : collisions) {
+        if (jetderiveddatautilities::selectCollision(collision, eventSelectionBits)) { // Skipping MC events that have not a single selected reconstructed collision ; effect unclear if mcColl is split
+          hasSel8Coll = true;
+        }
+        if ((centralityMin < collision.centrality()) && (collision.centrality() < centralityMax)) { // effect unclear if mcColl is split
+          centralityIsGood = true;
+        }
+        if ((trackOccupancyInTimeRangeMin < collision.trackOccupancyInTimeRange()) && (collision.trackOccupancyInTimeRange() < trackOccupancyInTimeRangeMax)) {
+        occupancyIsGood = true;
+        }
+      }
+    }
+    if (!hasSel8Coll) {
+      return;
+    }
+    registry.fill(HIST("h_mcColl_counts_areasub"), 4.5); // at least one of the reconstructed collisions associated with this mcCollision is selected
+
+    if (!centralityIsGood) {
+      return;
+    }
+    registry.fill(HIST("h_mcColl_counts_areasub"), 5.5); // at least one of the reconstructed collisions associated with this mcCollision is selected with regard to centrality
+
+    if (!occupancyIsGood) {
+      return;
+    }
+    registry.fill(HIST("h_mcColl_counts_areasub"), 6.5); // at least one of the reconstructed collisions associated with this mcCollision is selected with regard to centrality
+    registry.fill(HIST("h_mcColl_rho"), mccollision.rho());
     for (auto const& jet : jets) {
       if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
         continue;
@@ -540,23 +696,94 @@ struct JetSpectraCharged {
       if (!isAcceptedJet<aod::JetParticles>(jet)) {
         continue;
       }
-      if (doMCPJetSubtraction) {
-        fillMCPHistograms(jet, mccollision.rho());
-      } else {
-        fillMCPHistograms(jet);
+      fillMCPAreaSubHistograms(jet, mccollision.rho());
+    }
+  }
+  PROCESS_SWITCH(JetSpectraCharged, processSpectraAreaSubMCP, "jet spectra with area-based subtraction for MC particle level", false);
+
+  void processSpectraMCP(aod::JetMcCollision const& mccollision,
+                         soa::SmallGroups<aod::JetCollisionsMCD> const& collisions,
+                         soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents> const& jets,
+                         aod::JetParticles const&)
+  {
+    registry.fill(HIST("h_mcColl_counts"), 0.5);  //all mc collisions
+    if (std::abs(mccollision.posZ()) > vertexZCut) {
+      return;
+    }
+    registry.fill(HIST("h_mcColl_counts"), 1.5);  //cut on mccollision.posZ()
+    if (collisions.size() < 1) {
+      return;
+    }
+    registry.fill(HIST("h_mcColl_counts"), 2.5);  //mcCollisions with at least one resonstructed collision
+
+    bool hasSel8Coll = false;
+    bool centralityIsGood = false;
+    bool occupancyIsGood = false;
+    for (auto& collision : collisions) {
+      if (jetderiveddatautilities::selectCollision(collision, eventSelectionBits)) {
+        hasSel8Coll = true;
       }
+      if ((centralityMin < collision.centrality()) && (collision.centrality() < centralityMax)) {
+        centralityIsGood = true;
+      }
+      if ((trackOccupancyInTimeRangeMin < collision.trackOccupancyInTimeRange()) && (collision.trackOccupancyInTimeRange() < trackOccupancyInTimeRangeMax)) {
+        occupancyIsGood = true;
+      }
+    }
+    if (!hasSel8Coll) {
+      return;
+    }
+    registry.fill(HIST("h_mcColl_counts"), 3.5); // at least one of the reconstructed collisions associated with this mcCollision is selected
+    if (!centralityIsGood) {
+      return;
+    }
+    registry.fill(HIST("h_mcColl_counts"), 4.5); // at least one of the reconstructed collisions associated with this mcCollision is selected with regard to centrality
+    if (!occupancyIsGood) {
+      return;
+    }
+    registry.fill(HIST("h_mcColl_counts"), 5.5); // at least one of the reconstructed collisions associated with this mcCollision is selected with regard to centrality
+    registry.fill(HIST("h_mc_zvertex"), mccollision.posZ());
+
+    for (auto const& jet : jets) {
+    if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
+    continue;
+    }
+    if (!isAcceptedJet<aod::JetParticles>(jet)) {
+    continue;
+    }
+    fillMCPHistograms(jet);
     }
   }
   PROCESS_SWITCH(JetSpectraCharged, processSpectraMCP, "jet spectra for MC particle level", false);
 
-  void processSpectraMCPWeighted(aod::JetMcCollisions::iterator const& mccollision,
+
+  void processSpectraMCPWeighted(aod::JetMcCollision const& mccollision,
+                                 soa::SmallGroups<aod::JetCollisionsMCD> const& collisions,
                                  soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents, aod::ChargedMCParticleLevelJetEventWeights> const& jets,
                                  aod::JetParticles const&)
-  {
-    if (!(std::abs(mccollision.posZ()) < vertexZCut)) {
+  { 
+    registry.fill(HIST("h_mcColl_counts"), 0.5);  //all mc collisions
+    if (std::abs(mccollision.posZ()) > vertexZCut) {
       return;
     }
+    registry.fill(HIST("h_mcColl_counts"), 1.5);  //cut on mccollision.posZ()
+    if (collisions.size() < 1) {
+      return;
+    }
+    registry.fill(HIST("h_mcColl_counts"), 2.5);  //mcCollisions with at least one resonstructed collision
+
+    bool hasSel8Coll = false;
+    for (auto& collision : collisions) {
+      if (jetderiveddatautilities::selectCollision(collision, eventSelectionBits)) {
+        hasSel8Coll = true;
+      }
+    }
+    if (!hasSel8Coll) {
+      return;
+    }
+    registry.fill(HIST("h_mcColl_counts"), 3.5); // at least one of the reconstructed collisions associated with this mcCollision is selected
     registry.fill(HIST("h_mc_zvertex"), mccollision.posZ());
+
     for (auto const& jet : jets) {
       if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
         continue;
@@ -568,11 +795,11 @@ struct JetSpectraCharged {
       double pTHat = 10. / (std::pow(jetweight, 1.0 / pTHatExponent));
       for (int N = 1; N < 21; N++) {
         if (jet.pt() < N * 0.25 * pTHat && jet.r() == round(selectedJetsRadius * 100.0f)) {
-          registry.fill(HIST("h2_mcp_jet_ptcut_part"), jet.pt(), N * 0.25, jetweight);
+          registry.fill(HIST("h2_jet_ptcut_part"), jet.pt(), N * 0.25, jetweight);
         }
       }
-      registry.fill(HIST("h_mcp_jet_phat_weighted"), pTHat, jetweight);
-      fillMCPHistograms(jet, 0.0, jetweight);
+      registry.fill(HIST("h_jet_phat_part_weighted"), pTHat, jetweight);
+      fillMCPHistograms(jet, jetweight);
     }
   }
   PROCESS_SWITCH(JetSpectraCharged, processSpectraMCPWeighted, "jet spectra for MC particle level weighted", false);
@@ -708,11 +935,7 @@ struct JetSpectraCharged {
         if (!isAcceptedJet<aod::JetTracks>(mcdjet)) {
           continue;
         }
-        if (doMCPJetSubtraction) {
-          fillGeoMatchedCorrHistograms<ChargedMCDMatchedJets::iterator, ChargedMCPMatchedJets>(mcdjet, collision.rho(), mcrho);
-        } else {
-          fillGeoMatchedCorrHistograms<ChargedMCDMatchedJets::iterator, ChargedMCPMatchedJets>(mcdjet, collision.rho());
-        }
+        fillGeoMatchedCorrHistograms<ChargedMCDMatchedJets::iterator, ChargedMCPMatchedJets>(mcdjet, collision.rho());
       }
     }
   }


### PR DESCRIPTION
1. Add centrality selection and eventselection for mcCollisions which can be matched to the reconstructed events
2. Add jet histograms without background subtraction on Data and MCD level
3. Modify names of some histograms