### PR TITLE
[PWGHF] XicToXiPiPi: Update output table structures

### DIFF
--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -1743,8 +1743,7 @@ DECLARE_SOA_TABLE(HfCandXicKF, "AOD", "HFCANDXICKF",
                   cascdata::KFCascadeChi2, cascdata::KFV0Chi2,
                   hf_cand_xic_to_xi_pi_pi::Chi2TopoXicPlusToPVBeforeConstraint, hf_cand_xic_to_xi_pi_pi::Chi2TopoXicPlusToPV, hf_cand_xic_to_xi_pi_pi::Chi2TopoXiToXicPlusBeforeConstraint, hf_cand_xic_to_xi_pi_pi::Chi2TopoXiToXicPlus,
                   hf_cand_xic_to_xi_pi_pi::DcaXYPi0Pi1, hf_cand_xic_to_xi_pi_pi::DcaXYPi0Xi, hf_cand_xic_to_xi_pi_pi::DcaXYPi1Xi,
-                  hf_cand_xic_to_xi_pi_pi::DcaPi0Pi1, hf_cand_xic_to_xi_pi_pi::DcaPi0Xi, hf_cand_xic_to_xi_pi_pi::DcaPi1Xi,
-                  cascdata::DCACascDaughters);
+                  hf_cand_xic_to_xi_pi_pi::DcaPi0Pi1, hf_cand_xic_to_xi_pi_pi::DcaPi0Xi, hf_cand_xic_to_xi_pi_pi::DcaPi1Xi);
 
 // table with results of reconstruction level MC matching
 DECLARE_SOA_TABLE(HfCandXicMcRec, "AOD", "HFCANDXICMCREC", //!

--- a/PWGHF/TableProducer/candidateCreatorXicToXiPiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXicToXiPiPi.cxx
@@ -14,6 +14,7 @@
 ///
 /// \author Phil Lennart Stahlhut <phil.lennart.stahlhut@cern.ch>, Heidelberg University
 /// \author Carolina Reetz <c.reetz@cern.ch>, Heidelberg University
+/// \author Jaeyoon Cho <jaeyoon.cho@cern.ch>, Inha University
 /// \author Jinjoo Seo <jseo@cern.ch>, Heidelberg University
 
 #ifndef HomogeneousField
@@ -178,7 +179,9 @@ struct HfCandidateCreatorXicToXiPiPi {
       auto trackCharmBachelor0 = rowTrackIndexXicPlus.prong0_as<TracksWCovDcaPidPrPi>();
       auto trackCharmBachelor1 = rowTrackIndexXicPlus.prong1_as<TracksWCovDcaPidPrPi>();
       auto collision = rowTrackIndexXicPlus.collision();
-      registry.fill(HIST("hCandCounter"), 1 + AllIdTriplets);
+      if (fillHistograms) {
+        registry.fill(HIST("hCandCounter"), 1 + AllIdTriplets);
+      }
 
       // preselect cascade candidates
       if (doCascadePreselection) {
@@ -189,7 +192,9 @@ struct HfCandidateCreatorXicToXiPiPi {
           continue;
         }
       }
-      registry.fill(HIST("hCandCounter"), 1 + CascPreSel);
+      if (fillHistograms) {
+        registry.fill(HIST("hCandCounter"), 1 + CascPreSel);
+      }
 
       //----------------------Set the magnetic field from ccdb---------------------------------------
       /// The static instance of the propagator was already modified in the HFTrackIndexSkimCreator,
@@ -241,7 +246,9 @@ struct HfCandidateCreatorXicToXiPiPi {
         LOG(info) << "Run time error found: " << error.what() << ". DCAFitterN cannot work, skipping the candidate.";
         continue;
       }
-      registry.fill(HIST("hCandCounter"), 1 + VertexFit);
+      if (fillHistograms) {
+        registry.fill(HIST("hCandCounter"), 1 + VertexFit);
+      }
 
       //----------------------------calculate physical properties-----------------------
       // Charge of charm baryon
@@ -399,7 +406,9 @@ struct HfCandidateCreatorXicToXiPiPi {
       auto trackCharmBachelor0 = rowTrackIndexXicPlus.prong0_as<TracksWCovExtraPidPrPi>();
       auto trackCharmBachelor1 = rowTrackIndexXicPlus.prong1_as<TracksWCovExtraPidPrPi>();
       auto collision = rowTrackIndexXicPlus.collision();
-      registry.fill(HIST("hCandCounter"), 1 + AllIdTriplets);
+      if (fillHistograms) {
+        registry.fill(HIST("hCandCounter"), 1 + AllIdTriplets);
+      }
 
       //-------------------preselect cascade candidates--------------------------------------
       if (doCascadePreselection) {
@@ -410,7 +419,9 @@ struct HfCandidateCreatorXicToXiPiPi {
           continue;
         }
       }
-      registry.fill(HIST("hCandCounter"), 1 + CascPreSel);
+      if (fillHistograms) {
+        registry.fill(HIST("hCandCounter"), 1 + CascPreSel);
+      }
 
       //----------------------Set the magnetic field from ccdb-----------------------------
       /// The static instance of the propagator was already modified in the HFTrackIndexSkimCreator,
@@ -464,7 +475,9 @@ struct HfCandidateCreatorXicToXiPiPi {
         LOG(debug) << "Failed to construct XicPlus : " << e.what();
         continue;
       }
-      registry.fill(HIST("hCandCounter"), 1 + VertexFit);
+      if (fillHistograms) {
+        registry.fill(HIST("hCandCounter"), 1 + VertexFit);
+      }
 
       // get geometrical chi2 of XicPlus
       float chi2GeoXicPlus = kfXicPlus.GetChi2() / kfXicPlus.GetNDF();
@@ -645,8 +658,7 @@ struct HfCandidateCreatorXicToXiPiPi {
       rowCandidateKF(casc.kfCascadeChi2(), casc.kfV0Chi2(),
                      chi2topoXicPlusToPVBeforeConstraint, chi2topoXicPlusToPV, chi2topoXiToXicPlusBeforeConstraint, chi2topoXiToXicPlus,
                      dcaXYPi0Pi1, dcaXYPi0Xi, dcaXYPi1Xi,
-                     dcaPi0Pi1, dcaPi0Xi, dcaPi1Xi,
-                     casc.dcacascdaughters());
+                     dcaPi0Pi1, dcaPi0Xi, dcaPi1Xi);
     } // loop over track triplets
   }
   PROCESS_SWITCH(HfCandidateCreatorXicToXiPiPi, processXicplusWithKFParticle, "Run candidate creator with KFParticle using derived data from HfTrackIndexSkimCreatorLfCascades.", false);

--- a/PWGHF/TableProducer/treeCreatorXicToXiPiPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorXicToXiPiPi.cxx
@@ -14,6 +14,7 @@
 ///
 /// \author Phil Lennart Stahlhut <phil.lennart.stahlhut@cern.ch>, Heidelberg University
 /// \author Carolina Reetz <c.reetz@cern.ch>, Heidelberg University
+/// \author Jaeyoon Cho <jaeyoon.cho@cern.ch>, Inha University
 
 #include <vector>
 
@@ -35,12 +36,6 @@ namespace full
 {
 DECLARE_SOA_COLUMN(CandidateSelFlag, candidateSelFlag, int); //! Selection flag of candidate (output of candidateSelector)
 // vertices
-DECLARE_SOA_COLUMN(XPvErr, xPvErr, float);
-DECLARE_SOA_COLUMN(YPvErr, yPvErr, float);
-DECLARE_SOA_COLUMN(ZPvErr, zPvErr, float);
-DECLARE_SOA_COLUMN(XSvErr, xSvErr, float);
-DECLARE_SOA_COLUMN(YSvErr, ySvErr, float);
-DECLARE_SOA_COLUMN(ZSvErr, zSvErr, float);
 DECLARE_SOA_COLUMN(Chi2Sv, chi2Sv, float);
 DECLARE_SOA_COLUMN(Chi2XiVtx, chi2XiVtx, float);
 DECLARE_SOA_COLUMN(Chi2LamVtx, chi2LamVtx, float);
@@ -89,7 +84,6 @@ DECLARE_SOA_COLUMN(DcaXYPi1Xi, dcaXYPi1Xi, float);
 DECLARE_SOA_COLUMN(DcaPi0Pi1, dcaPi0Pi1, float);
 DECLARE_SOA_COLUMN(DcaPi0Xi, dcaPi0Xi, float);
 DECLARE_SOA_COLUMN(DcaPi1Xi, dcaPi1Xi, float);
-DECLARE_SOA_COLUMN(DcaXiDaughters, dcaXiDaughters, float);
 DECLARE_SOA_COLUMN(InvMassXi, invMassXi, float);
 DECLARE_SOA_COLUMN(InvMassLambda, invMassLambda, float);
 DECLARE_SOA_COLUMN(InvMassXiPi0, invMassXiPi0, float);
@@ -169,6 +163,7 @@ DECLARE_SOA_TABLE(HfCandXicToXiPiPiLiteKfs, "AOD", "HFXICXI2PILITKF",
                   full::PtPi1,
                   full::M,
                   full::InvMassXi,
+                  full::InvMassLambda,
                   full::InvMassXiPi0,
                   full::InvMassXiPi1,
                   full::Chi2Sv,
@@ -202,8 +197,7 @@ DECLARE_SOA_TABLE(HfCandXicToXiPiPiLiteKfs, "AOD", "HFXICXI2PILITKF",
                   full::DcaXYPi1Xi,
                   full::DcaPi0Pi1,
                   full::DcaPi0Xi,
-                  full::DcaPi1Xi,
-                  full::DcaXiDaughters);
+                  full::DcaPi1Xi);
 
 DECLARE_SOA_TABLE(HfCandXicToXiPiPiFulls, "AOD", "HFXICXI2PIFULL",
                   hf_cand_xic_to_xi_pi_pi::FlagMcMatchRec,
@@ -244,12 +238,6 @@ DECLARE_SOA_TABLE(HfCandXicToXiPiPiFulls, "AOD", "HFXICXI2PIFULL",
                   full::ImpactParameterNormalisedPi1,
                   full::MaxNormalisedDeltaIP,
                   // additional columns only stored in the full candidate table
-                  full::XPvErr,
-                  full::YPvErr,
-                  full::ZPvErr,
-                  full::XSvErr,
-                  full::YSvErr,
-                  full::ZSvErr,
                   full::CpaLamToXi,
                   full::CpaXYLamToXi,
                   full::PPi0,
@@ -291,6 +279,7 @@ DECLARE_SOA_TABLE(HfCandXicToXiPiPiFullKfs, "AOD", "HFXICXI2PIFULKF",
                   full::PtPi1,
                   full::M,
                   full::InvMassXi,
+                  full::InvMassLambda,
                   full::InvMassXiPi0,
                   full::InvMassXiPi1,
                   full::Chi2Sv,
@@ -313,12 +302,6 @@ DECLARE_SOA_TABLE(HfCandXicToXiPiPiFullKfs, "AOD", "HFXICXI2PIFULKF",
                   full::ImpactParameterNormalisedPi1,
                   full::MaxNormalisedDeltaIP,
                   // additional columns only stored in the full candidate table
-                  full::XPvErr,
-                  full::YPvErr,
-                  full::ZPvErr,
-                  full::XSvErr,
-                  full::YSvErr,
-                  full::ZSvErr,
                   full::CpaLamToXi,
                   full::CpaXYLamToXi,
                   full::PPi0,
@@ -326,6 +309,13 @@ DECLARE_SOA_TABLE(HfCandXicToXiPiPiFullKfs, "AOD", "HFXICXI2PIFULKF",
                   full::PBachelorPi,
                   full::PPiFromLambda,
                   full::PPrFromLambda,
+                  hf_cand_xic_to_xi_pi_pi::DcaXiDaughters,
+                  hf_cand_xic_to_xi_pi_pi::DcaV0Daughters,
+                  hf_cand_xic_to_xi_pi_pi::DcaPosToPV,
+                  hf_cand_xic_to_xi_pi_pi::DcaNegToPV,
+                  hf_cand_xic_to_xi_pi_pi::DcaBachelorToPV,
+                  hf_cand_xic_to_xi_pi_pi::DcaXYCascToPV,
+                  hf_cand_xic_to_xi_pi_pi::DcaZCascToPV,
                   hf_cand_xic_to_xi_pi_pi::NSigTpcPiFromXicPlus0,
                   hf_cand_xic_to_xi_pi_pi::NSigTpcPiFromXicPlus1,
                   hf_cand_xic_to_xi_pi_pi::NSigTpcBachelorPi,
@@ -348,8 +338,7 @@ DECLARE_SOA_TABLE(HfCandXicToXiPiPiFullKfs, "AOD", "HFXICXI2PIFULKF",
                   full::DcaXYPi1Xi,
                   full::DcaPi0Pi1,
                   full::DcaPi0Xi,
-                  full::DcaPi1Xi,
-                  full::DcaXiDaughters);
+                  full::DcaPi1Xi);
 
 DECLARE_SOA_TABLE(HfCandXicToXiPiPiFullPs, "AOD", "HFXICXI2PIFULLP",
                   hf_cand_xic_to_xi_pi_pi::FlagMcMatchGen,
@@ -503,12 +492,6 @@ struct HfTreeCreatorXicToXiPiPi {
           candidate.impactParameterNormalised2(),
           candidate.maxNormalisedDeltaIP(),
           // additional columns only stored in the full candidate table
-          candidate.xPvErr(),
-          candidate.yPvErr(),
-          candidate.zPvErr(),
-          candidate.xSvErr(),
-          candidate.ySvErr(),
-          candidate.zSvErr(),
           candidate.cosPaLambdaToXi(),
           candidate.cosPaXYLambdaToXi(),
           candidate.pProng1(),
@@ -552,6 +535,7 @@ struct HfTreeCreatorXicToXiPiPi {
           candidate.ptProng2(),
           candidate.invMassXicPlus(),
           candidate.invMassXi(),
+          candidate.invMassLambda(),
           candidate.invMassXiPi0(),
           candidate.invMassXiPi1(),
           candidate.chi2PCA(),
@@ -585,8 +569,7 @@ struct HfTreeCreatorXicToXiPiPi {
           candidate.dcaXYPi1Xi(),
           candidate.dcaPi0Pi1(),
           candidate.dcaPi0Xi(),
-          candidate.dcaPi1Xi(),
-          candidate.dcacascdaughters());
+          candidate.dcaPi1Xi());
       } else {
         rowCandidateFullKf(
           flagMc,
@@ -604,6 +587,7 @@ struct HfTreeCreatorXicToXiPiPi {
           candidate.ptProng2(),
           candidate.invMassXicPlus(),
           candidate.invMassXi(),
+          candidate.invMassLambda(),
           candidate.invMassXiPi0(),
           candidate.invMassXiPi1(),
           candidate.chi2PCA(),
@@ -626,12 +610,6 @@ struct HfTreeCreatorXicToXiPiPi {
           candidate.impactParameterNormalised2(),
           candidate.maxNormalisedDeltaIP(),
           // additional columns only stored in the full candidate table
-          candidate.xPvErr(),
-          candidate.yPvErr(),
-          candidate.zPvErr(),
-          candidate.xSvErr(),
-          candidate.ySvErr(),
-          candidate.zSvErr(),
           candidate.cosPaLambdaToXi(),
           candidate.cosPaXYLambdaToXi(),
           candidate.pProng1(),
@@ -639,6 +617,13 @@ struct HfTreeCreatorXicToXiPiPi {
           candidate.pBachelorPi(),
           candidate.pPiFromLambda(),
           candidate.pPrFromLambda(),
+          candidate.dcaXiDaughters(),
+          candidate.dcaV0Daughters(),
+          candidate.dcaPosToPV(),
+          candidate.dcaNegToPV(),
+          candidate.dcaBachelorToPV(),
+          candidate.dcaXYCascToPV(),
+          candidate.dcaZCascToPV(),
           candidate.nSigTpcPiFromXicPlus0(),
           candidate.nSigTpcPiFromXicPlus1(),
           candidate.nSigTpcBachelorPi(),
@@ -661,8 +646,7 @@ struct HfTreeCreatorXicToXiPiPi {
           candidate.dcaXYPi1Xi(),
           candidate.dcaPi0Pi1(),
           candidate.dcaPi0Xi(),
-          candidate.dcaPi1Xi(),
-          candidate.dcacascdaughters());
+          candidate.dcaPi1Xi());
       }
     }
   }


### PR DESCRIPTION
@JaeYoonCHO
- bug fix: add 'fillHistogram' condition before filling counter histogram
- remove PV and SV uncertainties from output tables
- add DCA values associated to Xi (and its daughters) to KF tables