### PR TITLE
[PWGDQ] Couple of adaptation regarding muon (re-)alignment

### DIFF
--- a/Common/TableProducer/muonRealignment.cxx
+++ b/Common/TableProducer/muonRealignment.cxx
@@ -81,8 +81,8 @@ struct MuonRealignment {
   Configurable<std::string> geoNewPathLocal{"geoNewPathLocal", "", "Local path of the GRP object if not using CCDB"};
   Configurable<int64_t> nolaterthanRef{"ccdb-no-later-than-ref", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(), "latest acceptable timestamp of creation for the object of reference basis"};
   Configurable<int64_t> nolaterthanNew{"ccdb-no-later-than-new", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(), "latest acceptable timestamp of creation for the object of new basis"};
-  Configurable<double> cfgChamberResolutionX{"cfgChamberResolutionX", 0.04, "Chamber resolution along X configuration for refit"}; // 0.4cm pp, 0.2cm PbPb
-  Configurable<double> cfgChamberResolutionY{"cfgChamberResolutionY", 0.04, "Chamber resolution along Y configuration for refit"}; // 0.4cm pp, 0.2cm PbPb
+  Configurable<double> cfgChamberResolutionX{"cfgChamberResolutionX", 0.4, "Chamber resolution along X configuration for refit"}; // 0.4cm pp, 0.2cm PbPb
+  Configurable<double> cfgChamberResolutionY{"cfgChamberResolutionY", 0.4, "Chamber resolution along Y configuration for refit"}; // 0.4cm pp, 0.2cm PbPb
   Configurable<double> cfgSigmaCutImprove{"cfgSigmaCutImprove", 6., "Sigma cut for track improvement"};                            // 6 for pp, 4 for PbPb
   Configurable<bool> fUseRemoteField{"cfgUseRemoteField", true, "Chose whether to fetch the magnetic field from ccdb or set it manually"};
   Configurable<bool> fUseRemoteGeometry{"cfgUseRemoteGeometry", false, "Chose whether to fetch new geometry from ccdb or set it manually"};

--- a/PWGDQ/Tasks/mchAlignRecord.cxx
+++ b/PWGDQ/Tasks/mchAlignRecord.cxx
@@ -117,8 +117,8 @@ struct mchAlignRecordTask {
   Configurable<double> fAllowedVarZ{"variation-z", 2.0, "Allowed variation for z axis in cm"};
   Configurable<double> cfgSigmaX{"cfgSigmaX", 1000., "Sigma cut along X"};
   Configurable<double> cfgSigmaY{"cfgSigmaY", 1000., "Sigma cut along Y"};
-  Configurable<double> cfgChamberResolutionX{"cfgChamberResolutionX", 0.04, "Chamber resolution along X configuration for refit"}; // 0.4cm pp, 0.2cm PbPb
-  Configurable<double> cfgChamberResolutionY{"cfgChamberResolutionY", 0.04, "Chamber resolution along Y configuration for refit"}; // 0.4cm pp, 0.2cm PbPb
+  Configurable<double> cfgChamberResolutionX{"cfgChamberResolutionX", 0.4, "Chamber resolution along X configuration for refit"}; // 0.4cm pp, 0.2cm PbPb
+  Configurable<double> cfgChamberResolutionY{"cfgChamberResolutionY", 0.4, "Chamber resolution along Y configuration for refit"}; // 0.4cm pp, 0.2cm PbPb
   Configurable<double> cfgSigmaCutImprove{"cfgSigmaCutImprove", 6., "Sigma cut for track improvement"};
   struct : ConfigurableGroup {
     Configurable<std::vector<int>> cfgDetElem{"cfgDetElem",
@@ -128,6 +128,8 @@ struct mchAlignRecordTask {
                                               {},
                                               "List of param mask for d.o.f to be fixed"};
   } fFixDetElem;
+
+  Preslice<aod::FwdTrkCl> perMuon = aod::fwdtrkcl::fwdtrackId;
 
   void init(InitContext& ic)
   {
@@ -335,13 +337,9 @@ struct mchAlignRecordTask {
         continue;
       }
 
+      auto clustersSliced = clusters.sliceBy(perMuon, track.globalIndex()); // Slice clusters by muon id
       // Loop over attached clusters
-      for (auto const& cluster : clusters) {
-
-        if (cluster.template fwdtrack_as<TTracks>() != track) {
-          continue;
-        }
-
+      for (auto const& cluster : clustersSliced) {
         clIndex += 1;
 
         mch::Cluster* mch_cluster = new mch::Cluster();


### PR DESCRIPTION
1. Use realigned muon for matching index table in table-maker
2. Fix bug in default value of chamber resolution setting in muon realignment task.
3. Use slicing to ensure a correct cluster-muon matching with global index in record task. 