### PR TITLE
[PWGLF] Replace GetGeneratorID to GeneratorID

### DIFF
--- a/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
@@ -592,7 +592,7 @@ struct strangederivedbuilder {
       }
 
       strangeMCColl(mccollision.posX(), mccollision.posY(), mccollision.posZ(),
-                    mccollision.impactParameter(), mccollision.eventPlaneAngle(), mccollision.getGeneratorId());
+                    mccollision.impactParameter(), mccollision.eventPlaneAngle(), mccollision.generatorId());
       strangeMCMults(mccollision.multMCFT0A(), mccollision.multMCFT0C(),
                      mccollision.multMCNParticlesEta05(),
                      mccollision.multMCNParticlesEta08(),

--- a/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangederivedbuilder.cxx
@@ -592,7 +592,7 @@ struct strangederivedbuilder {
       }
 
       strangeMCColl(mccollision.posX(), mccollision.posY(), mccollision.posZ(),
-                    mccollision.impactParameter(), mccollision.eventPlaneAngle(), mccollision.generatorId());
+                    mccollision.impactParameter(), mccollision.eventPlaneAngle(), mccollision.generatorsID());
       strangeMCMults(mccollision.multMCFT0A(), mccollision.multMCFT0C(),
                      mccollision.multMCNParticlesEta05(),
                      mccollision.multMCNParticlesEta08(),


### PR DESCRIPTION
Replace GetGeneratorID (which is a 7-bits integer going from 0 to 127) to generatorID (which is a 16-bits integer going from 0 to 255), allowing to separate DPMjet events (generatorID=127) from Pythia events (generatorID = 255)

@nepeivodaRS for your information