### PR TITLE
[ALICE3] Add hit efficiency correction to the fasttracker

### DIFF
--- a/ALICE3/Core/FastTracker.cxx
+++ b/ALICE3/Core/FastTracker.cxx
@@ -28,6 +28,10 @@ FastTracker::FastTracker()
   // base constructor
   magneticField = 20; // in kiloGauss
   applyZacceptance = false;
+  applyMSCorrection = true;
+  applyMSCorrection = true;
+  applyElossCorrection = true;
+  applyEffCorrection = true;
   covMatFactor = 0.99f;
   verboseLevel = 0;
 
@@ -37,6 +41,17 @@ FastTracker::FastTracker()
   nIntercepts = 0;
   nSiliconPoints = 0;
   nGasPoints = 0;
+
+  maxRadiusSlowDet = 10;
+  integrationTime = 0.02; // ms
+  crossSectionMinB = 8;
+  dNdEtaCent = 2200;
+  dNdEtaMinB = 1;
+  avgRapidity = 0.45;
+  sigmaD = 6.0;
+  luminosity = 1.e27;
+  otherBackground = 0.0; // [0, 1]
+  upcBackgroundMultiplier = 1.0;
 }
 
 void FastTracker::AddLayer(TString name, float r, float z, float x0, float xrho, float resRPhi, float resZ, float eff, int type)
@@ -71,61 +86,61 @@ void FastTracker::Print()
   LOG(info) << "+-~-<*>-~-+-~-<*>-~-+-~-<*>-~-+-~-<*>-~-+-~-<*>-~-+-~-<*>-~-+-~-<*>-~-+";
 }
 
-void FastTracker::AddSiliconALICE3v4()
+void FastTracker::AddSiliconALICE3v4(std::vector<float> pixelResolution)
 {
-  LOG(info) << " Adding ALICE 3 v4 ITS layers";
+  LOG(info) << " ALICE 3: Adding v4 tracking layers";
   float x0IT = 0.001;        // 0.1%
   float x0OT = 0.005;        // 0.5%
   float xrhoIB = 1.1646e-02; // 50 mum Si
-  float xrhoOB = 1.1646e-01; // 500 mum Si
-
-  float resRPhiIT = 0.00025; //  2.5 mum
-  float resZIT = 0.00025;    //  2.5 mum
-  float resRPhiOT = 0.0005;  // 5 mum
-  float resZOT = 0.0005;     // 5 mum
+  float xrhoOT = 1.1646e-01; // 500 mum Si
   float eff = 1.00;
+
+  float resRPhiIT = pixelResolution[0];
+  float resZIT = pixelResolution[1];
+  float resRPhiOT = pixelResolution[2];
+  float resZOT = pixelResolution[3];
 
   layers.push_back(DetLayer{"bpipe0", 0.48, 250, 0.00042, 2.772e-02, 0.0f, 0.0f, 0.0f, 0}); // 150 mum Be
   layers.push_back(DetLayer{"ddd0", 0.5, 250, x0IT, xrhoIB, resRPhiIT, resZIT, eff, 1});
   layers.push_back(DetLayer{"ddd1", 1.2, 250, x0IT, xrhoIB, resRPhiIT, resZIT, eff, 1});
   layers.push_back(DetLayer{"ddd2", 2.5, 250, x0IT, xrhoIB, resRPhiIT, resZIT, eff, 1});
   layers.push_back(DetLayer{"bpipe1", 5.7, 250, 0.0014, 9.24e-02, 0.0f, 0.0f, 0.0f, 0}); // 500 mum Be
-  layers.push_back(DetLayer{"ddd3", 7., 250, x0IT, xrhoIB, resRPhiIT, resZIT, eff, 1});
-  layers.push_back(DetLayer{"ddd4", 10., 250, x0OT, xrhoOB, resRPhiOT, resZOT, eff, 1});
-  layers.push_back(DetLayer{"ddd5", 13., 250, x0OT, xrhoOB, resRPhiOT, resZOT, eff, 1});
-  layers.push_back(DetLayer{"ddd6", 16., 250, x0OT, xrhoOB, resRPhiOT, resZOT, eff, 1});
-  layers.push_back(DetLayer{"ddd7", 25., 250, x0OT, xrhoOB, resRPhiOT, resZOT, eff, 1});
-  layers.push_back(DetLayer{"ddd8", 40., 250, x0OT, xrhoOB, resRPhiOT, resZOT, eff, 1});
-  layers.push_back(DetLayer{"ddd9", 45., 250, x0OT, xrhoOB, resRPhiOT, resZOT, eff, 1});
+  layers.push_back(DetLayer{"ddd3", 7., 250, x0OT, xrhoOT, resRPhiOT, resZOT, eff, 1});
+  layers.push_back(DetLayer{"ddd4", 10., 250, x0OT, xrhoOT, resRPhiOT, resZOT, eff, 1});
+  layers.push_back(DetLayer{"ddd5", 13., 250, x0OT, xrhoOT, resRPhiOT, resZOT, eff, 1});
+  layers.push_back(DetLayer{"ddd6", 16., 250, x0OT, xrhoOT, resRPhiOT, resZOT, eff, 1});
+  layers.push_back(DetLayer{"ddd7", 25., 250, x0OT, xrhoOT, resRPhiOT, resZOT, eff, 1});
+  layers.push_back(DetLayer{"ddd8", 40., 250, x0OT, xrhoOT, resRPhiOT, resZOT, eff, 1});
+  layers.push_back(DetLayer{"ddd9", 45., 250, x0OT, xrhoOT, resRPhiOT, resZOT, eff, 1});
 }
 
-void FastTracker::AddSiliconALICE3v1()
+void FastTracker::AddSiliconALICE3v2(std::vector<float> pixelResolution)
 {
-  LOG(info) << " Adding ALICE 3 v1 ITS layers";
+  LOG(info) << "ALICE 3: Adding v2 tracking layers;";
   float x0IT = 0.001;        // 0.1%
-  float x0OT = 0.005;        // 0.5%
+  float x0OT = 0.01;         // 1.0%
   float xrhoIB = 2.3292e-02; // 100 mum Si
-  float xrhoOB = 2.3292e-01; // 1000 mum Si
-
-  float resRPhiIT = 0.00025; //  2.5 mum
-  float resZIT = 0.00025;    //  2.5 mum
-  float resRPhiOT = 0.00100; // 5 mum
-  float resZOT = 0.00100;    // 5 mum
+  float xrhoOT = 2.3292e-01; // 1000 mum Si
   float eff = 1.00;
+
+  float resRPhiIT = pixelResolution[0];
+  float resZIT = pixelResolution[1];
+  float resRPhiOT = pixelResolution[2];
+  float resZOT = pixelResolution[3];
 
   layers.push_back(DetLayer{"bpipe0", 0.48, 250, 0.00042, 2.772e-02, 0.0f, 0.0f, 0.0f, 0}); // 150 mum Be
   layers.push_back(DetLayer{"B00", 0.5, 250, x0IT, xrhoIB, resRPhiIT, resZIT, eff, 1});
   layers.push_back(DetLayer{"B01", 1.2, 250, x0IT, xrhoIB, resRPhiIT, resZIT, eff, 1});
   layers.push_back(DetLayer{"B02", 2.5, 250, x0IT, xrhoIB, resRPhiIT, resZIT, eff, 1});
   layers.push_back(DetLayer{"bpipe1", 3.7, 250, 0.0014, 9.24e-02, 0.0f, 0.0f, 0.0f, 0}); // 500 mum Be
-  layers.push_back(DetLayer{"B03", 3.75, 250, x0IT, xrhoIB, resRPhiIT, resZIT, eff, 1});
-  layers.push_back(DetLayer{"B04", 7., 250, x0OT, xrhoOB, resRPhiOT, resZOT, eff, 1});
-  layers.push_back(DetLayer{"B05", 12., 250, x0OT, xrhoOB, resRPhiOT, resZOT, eff, 1});
-  layers.push_back(DetLayer{"B06", 20., 250, x0OT, xrhoOB, resRPhiOT, resZOT, eff, 1});
-  layers.push_back(DetLayer{"B07", 30., 250, x0OT, xrhoOB, resRPhiOT, resZOT, eff, 1});
-  layers.push_back(DetLayer{"B08", 45., 250, x0OT, xrhoOB, resRPhiOT, resZOT, eff, 1});
-  layers.push_back(DetLayer{"B09", 60., 250, x0OT, xrhoOB, resRPhiOT, resZOT, eff, 1});
-  layers.push_back(DetLayer{"B10", 80., 250, x0OT, xrhoOB, resRPhiOT, resZOT, eff, 1});
+  layers.push_back(DetLayer{"B03", 3.75, 250, x0OT, xrhoOT, resRPhiOT, resZOT, eff, 1});
+  layers.push_back(DetLayer{"B04", 7., 250, x0OT, xrhoOT, resRPhiOT, resZOT, eff, 1});
+  layers.push_back(DetLayer{"B05", 12., 250, x0OT, xrhoOT, resRPhiOT, resZOT, eff, 1});
+  layers.push_back(DetLayer{"B06", 20., 250, x0OT, xrhoOT, resRPhiOT, resZOT, eff, 1});
+  layers.push_back(DetLayer{"B07", 30., 250, x0OT, xrhoOT, resRPhiOT, resZOT, eff, 1});
+  layers.push_back(DetLayer{"B08", 45., 250, x0OT, xrhoOT, resRPhiOT, resZOT, eff, 1});
+  layers.push_back(DetLayer{"B09", 60., 250, x0OT, xrhoOT, resRPhiOT, resZOT, eff, 1});
+  layers.push_back(DetLayer{"B10", 80., 250, x0OT, xrhoOT, resRPhiOT, resZOT, eff, 1});
 }
 
 void FastTracker::AddTPC(float phiResMean, float zResMean)
@@ -134,7 +149,7 @@ void FastTracker::AddTPC(float phiResMean, float zResMean)
 
   // porting of DetectorK::AddTPC
   // see here:
-  // https://github.com/AliceO2Group/DelphesO2/blob/master/src/DetectorK/DetectorK.cxx
+  // https://github.com/AliceO2Group/DelphesO2/blob/master/src/DetectorK/DetectorK.cxx#L522
   // % Radiation Lengths ... Average per TPC row  (i.e. total/159 )
   const int kNPassiveBound = 2;
   const float radLBoundary[kNPassiveBound] = {1.692612e-01, 8.711904e-02};
@@ -173,9 +188,102 @@ void FastTracker::AddTPC(float phiResMean, float zResMean)
   }
 }
 
+float FastTracker::Dist(float z, float r)
+{
+  // porting of DetektorK::Dist
+  // see here: 
+  // https://github.com/AliceO2Group/DelphesO2/blob/master/src/DetectorK/DetectorK.cxx#L743
+  int index = 1;
+  int nSteps = 301;
+  double dist = 0.0;
+  double dz0 = (4 * sigmaD - (-4) * sigmaD / (nSteps = 1));
+  double z0 = 0.0;
+  for (int i = 0; i < nSteps; i++) {
+    if (i == nSteps - 1)
+      index = 1;
+    z0 = -4 * sigmaD + i * dz0;
+    dist += index * (dz0 / 3.) * (1 / o2::math_utils::sqrt(o2::constants::math::TwoPI) / sigmaD) * exp(-z0 * z0 / 2. / sigmaD / sigmaD) * (1 / o2::math_utils::sqrt((z - z0) * (z - z0) + r * r));
+    if (index != 4)
+      index = 4;
+    else
+      index = 2;
+  }
+  return dist;
+}
+
+float FastTracker::OneEventHitDensity(float multiplicity, float radius)
+{
+  // porting of DetektorK::OneEventHitDensity
+  // see here: 
+  // https://github.com/AliceO2Group/DelphesO2/blob/master/src/DetectorK/DetectorK.cxx#L694
+  float den = multiplicity / (o2::constants::math::TwoPI * radius * radius);
+  float tg = o2::math_utils::tan(2. * o2::math_utils::atan(-avgRapidity));
+  den = den / o2::math_utils::sqrt(1 + 1 / (tg * tg));
+  return den;
+}
+
+float FastTracker::IntegratedHitDensity(float multiplicity, float radius)
+{
+  // porting of DetektorK::IntegratedHitDensity
+  // see here: 
+  // https://github.com/AliceO2Group/DelphesO2/blob/master/src/DetectorK/DetectorK.cxx#L712
+  float zdcHz = luminosity * 1.e24 * crossSectionMinB;
+  float den = zdcHz * integrationTime / 1000. * multiplicity * Dist(0., radius) / (o2::constants::math::TwoPI * radius);
+  if (den < OneEventHitDensity(multiplicity, radius))
+    den = OneEventHitDensity(multiplicity, radius);
+  return den;
+}
+
+float FastTracker::UpcHitDensity(float radius)
+{
+  // porting of DetektorK::UpcHitDensity
+  // see here: 
+  // https://github.com/AliceO2Group/DelphesO2/blob/master/src/DetectorK/DetectorK.cxx#L727
+  float mUPCelectrons = 0;
+  mUPCelectrons = lhcUPCScale * 5456 / (radius * radius) / dNdEtaMinB;
+  if (mUPCelectrons < 0)
+    mUPCelectrons = 0.0;
+  mUPCelectrons *= IntegratedHitDensity(dNdEtaMinB, radius);
+  mUPCelectrons *= upcBackgroundMultiplier;
+  return mUPCelectrons;
+}
+
+float FastTracker::HitDensity(float radius)
+{
+  // porting of DetektorK::HitDensity
+  // see here: 
+  // https://github.com/AliceO2Group/DelphesO2/blob/master/src/DetectorK/DetectorK.cxx#L663
+  float arealDensity = 0.;
+  if (radius > maxRadiusSlowDet) {
+    arealDensity = OneEventHitDensity(dNdEtaCent, radius);
+    arealDensity += otherBackground * OneEventHitDensity(dNdEtaMinB, radius);
+  }
+
+  // In the version of Delphes used to produce
+  // Look-up tables, UpcHitDensity(radius) always returns 0,
+  // hence it is left commented out for now
+  if (radius < maxRadiusSlowDet) {
+    arealDensity = OneEventHitDensity(dNdEtaCent, radius);
+    arealDensity += otherBackground * OneEventHitDensity(dNdEtaMinB, radius) + IntegratedHitDensity(dNdEtaMinB, radius);
+    // +UpcHitDensity(radius);
+  }
+  return arealDensity;
+}
+
+float FastTracker::ProbGoodChiSqHit(float radius, float searchRadiusRPhi, float searchRadiusZ)
+{
+  // porting of DetektorK::ProbGoodChiSqHit
+  // see here: 
+  // https://github.com/AliceO2Group/DelphesO2/blob/master/src/DetectorK/DetectorK.cxx#L629
+  float sx, goodHit;
+  sx = o2::constants::math::TwoPI * searchRadiusRPhi * searchRadiusZ * HitDensity(radius);
+  goodHit = 1. / (1 + sx);
+  return goodHit;
+}
+
 // function to provide a reconstructed track from a perfect input track
 // returns number of intercepts (generic for now)
-int FastTracker::FastTrack(o2::track::TrackParCov inputTrack, o2::track::TrackParCov& outputTrack)
+int FastTracker::FastTrack(o2::track::TrackParCov inputTrack, o2::track::TrackParCov& outputTrack, float nch)
 {
   hits.clear();
   nIntercepts = 0;
@@ -183,10 +291,15 @@ int FastTracker::FastTrack(o2::track::TrackParCov inputTrack, o2::track::TrackPa
   nGasPoints = 0;
   std::array<float, 3> posIni; // provision for != PV
   inputTrack.getXYZGlo(posIni);
-  float initialRadius = std::hypot(posIni[0], posIni[1]);
-  float kTrackingMargin = 0.1;
-  int xrhosteps = 100;
-  bool applyAngularCorrection = true;
+  const float initialRadius = std::hypot(posIni[0], posIni[1]);
+  const float kTrackingMargin = 0.1;
+  const int kMaxNumberOfDetectors = 20;
+  const int xrhosteps = 100;
+  const bool applyAngularCorrection = true;
+
+  for (int i = 0; i < kMaxNumberOfDetectors; ++i)
+    goodHitProbability.push_back(-1.);
+  goodHitProbability[0] = 1.;
 
   // +-~-<*>-~-+-~-<*>-~-+-~-<*>-~-+-~-<*>-~-+-~-<*>-~-+
   // Outward pass to find intercepts
@@ -351,21 +464,44 @@ int FastTracker::FastTrack(o2::track::TrackParCov inputTrack, o2::track::TrackPa
       nGasPoints++; // count TPC/gas hits
 
     hits.push_back(thisHit);
-  }
 
+    if (applyEffCorrection && layers[il].type != 0) { // good hit probability calculation
+      double sigYCmb = o2::math_utils::sqrt(inwardTrack.getSigmaY2() + layers[il].resRPhi * layers[il].resRPhi);
+      double sigZCmb = o2::math_utils::sqrt(inwardTrack.getSigmaZ2() + layers[il].resZ * layers[il].resZ);
+      goodHitProbability[il] = ProbGoodChiSqHit(layers[il].r * 100, sigYCmb * 100, sigZCmb * 100);
+      goodHitProbability[0] *= goodHitProbability[il];
+    }
+  }
+  
   // backpropagate to original radius
   float finalX = 1e+3;
   inwardTrack.getXatLabR(initialRadius, finalX, magneticField);
   if (finalX > 999)
     return -3; // failed to find intercept
-
+  
   if (!inwardTrack.propagateTo(finalX, magneticField)) {
     return -4; // failed to propagate
   }
-
+  
   // only attempt to continue if intercepts are at least four
   if (nIntercepts < 4)
     return nIntercepts;
+  
+  // generate efficiency
+  if (applyEffCorrection) {
+    dNdEtaCent = nch;
+    float eff = 1.;
+    for (int i = 0; i < kMaxNumberOfDetectors; i++) {
+      float iGoodHit = goodHitProbability[i];
+      if (iGoodHit <= 0)
+        continue;
+      
+      eff *= iGoodHit;
+    }
+
+    if (gRandom->Uniform() > eff)
+      return -8;
+  }
 
   outputTrack.setCov(inwardTrack.getCov());
   outputTrack.checkCovariance();

--- a/ALICE3/Core/FastTracker.cxx
+++ b/ALICE3/Core/FastTracker.cxx
@@ -191,7 +191,7 @@ void FastTracker::AddTPC(float phiResMean, float zResMean)
 float FastTracker::Dist(float z, float r)
 {
   // porting of DetektorK::Dist
-  // see here: 
+  // see here:
   // https://github.com/AliceO2Group/DelphesO2/blob/master/src/DetectorK/DetectorK.cxx#L743
   int index = 1;
   int nSteps = 301;
@@ -214,7 +214,7 @@ float FastTracker::Dist(float z, float r)
 float FastTracker::OneEventHitDensity(float multiplicity, float radius)
 {
   // porting of DetektorK::OneEventHitDensity
-  // see here: 
+  // see here:
   // https://github.com/AliceO2Group/DelphesO2/blob/master/src/DetectorK/DetectorK.cxx#L694
   float den = multiplicity / (o2::constants::math::TwoPI * radius * radius);
   float tg = o2::math_utils::tan(2. * o2::math_utils::atan(-avgRapidity));
@@ -225,7 +225,7 @@ float FastTracker::OneEventHitDensity(float multiplicity, float radius)
 float FastTracker::IntegratedHitDensity(float multiplicity, float radius)
 {
   // porting of DetektorK::IntegratedHitDensity
-  // see here: 
+  // see here:
   // https://github.com/AliceO2Group/DelphesO2/blob/master/src/DetectorK/DetectorK.cxx#L712
   float zdcHz = luminosity * 1.e24 * crossSectionMinB;
   float den = zdcHz * integrationTime / 1000. * multiplicity * Dist(0., radius) / (o2::constants::math::TwoPI * radius);
@@ -237,7 +237,7 @@ float FastTracker::IntegratedHitDensity(float multiplicity, float radius)
 float FastTracker::UpcHitDensity(float radius)
 {
   // porting of DetektorK::UpcHitDensity
-  // see here: 
+  // see here:
   // https://github.com/AliceO2Group/DelphesO2/blob/master/src/DetectorK/DetectorK.cxx#L727
   float mUPCelectrons = 0;
   mUPCelectrons = lhcUPCScale * 5456 / (radius * radius) / dNdEtaMinB;
@@ -251,7 +251,7 @@ float FastTracker::UpcHitDensity(float radius)
 float FastTracker::HitDensity(float radius)
 {
   // porting of DetektorK::HitDensity
-  // see here: 
+  // see here:
   // https://github.com/AliceO2Group/DelphesO2/blob/master/src/DetectorK/DetectorK.cxx#L663
   float arealDensity = 0.;
   if (radius > maxRadiusSlowDet) {
@@ -273,7 +273,7 @@ float FastTracker::HitDensity(float radius)
 float FastTracker::ProbGoodChiSqHit(float radius, float searchRadiusRPhi, float searchRadiusZ)
 {
   // porting of DetektorK::ProbGoodChiSqHit
-  // see here: 
+  // see here:
   // https://github.com/AliceO2Group/DelphesO2/blob/master/src/DetectorK/DetectorK.cxx#L629
   float sx, goodHit;
   sx = o2::constants::math::TwoPI * searchRadiusRPhi * searchRadiusZ * HitDensity(radius);
@@ -472,21 +472,21 @@ int FastTracker::FastTrack(o2::track::TrackParCov inputTrack, o2::track::TrackPa
       goodHitProbability[0] *= goodHitProbability[il];
     }
   }
-  
+
   // backpropagate to original radius
   float finalX = 1e+3;
   inwardTrack.getXatLabR(initialRadius, finalX, magneticField);
   if (finalX > 999)
     return -3; // failed to find intercept
-  
+
   if (!inwardTrack.propagateTo(finalX, magneticField)) {
     return -4; // failed to propagate
   }
-  
+
   // only attempt to continue if intercepts are at least four
   if (nIntercepts < 4)
     return nIntercepts;
-  
+
   // generate efficiency
   if (applyEffCorrection) {
     dNdEtaCent = nch;
@@ -495,7 +495,7 @@ int FastTracker::FastTrack(o2::track::TrackParCov inputTrack, o2::track::TrackPa
       float iGoodHit = goodHitProbability[i];
       if (iGoodHit <= 0)
         continue;
-      
+
       eff *= iGoodHit;
     }
 

--- a/ALICE3/Core/FastTracker.h
+++ b/ALICE3/Core/FastTracker.h
@@ -62,10 +62,10 @@ class FastTracker
   bool applyElossCorrection; // Apply correction for eloss (requires MS correction)
   bool applyEffCorrection;   // Apply correction for hit efficiency
   int verboseLevel;          // 0: not verbose, >0 more verbose
-  int integrationTime;
   int crossSectionMinB;
   int dNdEtaCent;
   int dNdEtaMinB;
+  float integrationTime;
   float magneticField; // in kiloGauss (5 = 0.5T, etc)
   float covMatFactor;  // covmat off-diagonal factor to use for covmat fix (negative: no factor)
   float sigmaD;

--- a/ALICE3/Core/FastTracker.h
+++ b/ALICE3/Core/FastTracker.h
@@ -37,24 +37,44 @@ class FastTracker
   void AddLayer(TString name, float r, float z, float x0, float xrho, float resRPhi = 0.0f, float resZ = 0.0f, float eff = 0.0f, int type = 0);
   DetLayer GetLayer(const int layer, bool ignoreBarrelLayers = true);
 
-  void AddSiliconALICE3v4();
-  void AddSiliconALICE3v1();
+  void AddSiliconALICE3v4(std::vector<float> pixelResolution);
+  void AddSiliconALICE3v2(std::vector<float> pixelResolution);
   void AddTPC(float phiResMean, float zResMean);
 
   void Print();
-  int FastTrack(o2::track::TrackParCov inputTrack, o2::track::TrackParCov& outputTrack);
+  int FastTrack(o2::track::TrackParCov inputTrack, o2::track::TrackParCov& outputTrack, float nch);
+
+  // For efficiency calculation
+  float Dist(float z, float radius);
+  float OneEventHitDensity(float multiplicity, float radius);
+  float IntegratedHitDensity(float multiplicity, float radius);
+  float UpcHitDensity(float radius);
+  float HitDensity(float radius);
+  float ProbGoodChiSqHit(float radius, float searchRadiusRPhi, float searchRadiusZ);
 
   // Definition of detector layers
   std::vector<DetLayer> layers;
   std::vector<std::vector<float>> hits; // bookkeep last added hits
 
   // operational
-  float magneticField;       // in kiloGauss (5 = 0.5T, etc)
   bool applyZacceptance;     // check z acceptance or not
-  float covMatFactor;        // covmat off-diagonal factor to use for covmat fix (negative: no factor)
-  int verboseLevel;          // 0: not verbose, >0 more verbose
   bool applyMSCorrection;    // Apply correction for multiple scattering
   bool applyElossCorrection; // Apply correction for eloss (requires MS correction)
+  int applyEffCorrection;    // 0: off, 1, 2
+  int verboseLevel;          // 0: not verbose, >0 more verbose
+  int integrationTime;
+  int crossSectionMinB;
+  int dNdEtaCent;
+  int dNdEtaMinB;
+  float magneticField;       // in kiloGauss (5 = 0.5T, etc)
+  float covMatFactor;        // covmat off-diagonal factor to use for covmat fix (negative: no factor)
+  float sigmaD;
+  float luminosity;
+  float otherBackground;
+  float maxRadiusSlowDet;
+  float avgRapidity;
+  float lhcUPCScale;
+  float upcBackgroundMultiplier;
 
   uint64_t covMatOK;    // cov mat has negative eigenvals
   uint64_t covMatNotOK; // cov mat has negative eigenvals
@@ -63,6 +83,8 @@ class FastTracker
   int nIntercepts;    // found in first outward propagation
   int nSiliconPoints; // silicon-based space points added to track
   int nGasPoints;     // tpc-based space points added to track
+  std::vector<float> goodHitProbability;
+
 
   ClassDef(FastTracker, 1);
 };

--- a/ALICE3/Core/FastTracker.h
+++ b/ALICE3/Core/FastTracker.h
@@ -66,8 +66,8 @@ class FastTracker
   int crossSectionMinB;
   int dNdEtaCent;
   int dNdEtaMinB;
-  float magneticField;       // in kiloGauss (5 = 0.5T, etc)
-  float covMatFactor;        // covmat off-diagonal factor to use for covmat fix (negative: no factor)
+  float magneticField; // in kiloGauss (5 = 0.5T, etc)
+  float covMatFactor;  // covmat off-diagonal factor to use for covmat fix (negative: no factor)
   float sigmaD;
   float luminosity;
   float otherBackground;
@@ -84,7 +84,6 @@ class FastTracker
   int nSiliconPoints; // silicon-based space points added to track
   int nGasPoints;     // tpc-based space points added to track
   std::vector<float> goodHitProbability;
-
 
   ClassDef(FastTracker, 1);
 };

--- a/ALICE3/Core/FastTracker.h
+++ b/ALICE3/Core/FastTracker.h
@@ -60,7 +60,7 @@ class FastTracker
   bool applyZacceptance;     // check z acceptance or not
   bool applyMSCorrection;    // Apply correction for multiple scattering
   bool applyElossCorrection; // Apply correction for eloss (requires MS correction)
-  int applyEffCorrection;    // 0: off, 1, 2
+  bool applyEffCorrection;   // Apply correction for hit efficiency
   int verboseLevel;          // 0: not verbose, >0 more verbose
   int integrationTime;
   int crossSectionMinB;

--- a/ALICE3/TableProducer/OTF/onTheFlyTracker.cxx
+++ b/ALICE3/TableProducer/OTF/onTheFlyTracker.cxx
@@ -353,7 +353,7 @@ struct OnTheFlyTracker {
       histos.add("h2dDCAxyCascadeBachelor", "h2dDCAxyCascadeBachelor", kTH2F, {axes.axisMomentum, axes.axisDCA});
       histos.add("h2dDCAxyCascadeNegative", "h2dDCAxyCascadeNegative", kTH2F, {axes.axisMomentum, axes.axisDCA});
       histos.add("h2dDCAxyCascadePositive", "h2dDCAxyCascadePositive", kTH2F, {axes.axisMomentum, axes.axisDCA});
-      
+
       histos.add("h2dDCAzCascade", "h2dDCAzCascade", kTH2F, {axes.axisMomentum, axes.axisDCA});
       histos.add("h2dDCAzCascadeBachelor", "h2dDCAzCascadeBachelor", kTH2F, {axes.axisMomentum, axes.axisDCA});
       histos.add("h2dDCAzCascadeNegative", "h2dDCAzCascadeNegative", kTH2F, {axes.axisMomentum, axes.axisDCA});
@@ -1045,21 +1045,21 @@ struct OnTheFlyTracker {
           histos.fill(HIST("hTrackXatDCA"), trackParametrization.getX());
         }
         if (cascadeDecaySettings.doXiQA) {
-          if (trackParCov.isUsedInCascading == 1){
+          if (trackParCov.isUsedInCascading == 1) {
             histos.fill(HIST("h2dDCAxyCascade"), trackParametrization.getPt(), dcaXY * 1e+4); // in microns, please
-            histos.fill(HIST("h2dDCAzCascade"), trackParametrization.getPt(), dcaZ * 1e+4); // in microns, please
+            histos.fill(HIST("h2dDCAzCascade"), trackParametrization.getPt(), dcaZ * 1e+4);   // in microns, please
           }
-          if (trackParCov.isUsedInCascading == 2){
+          if (trackParCov.isUsedInCascading == 2) {
             histos.fill(HIST("h2dDCAxyCascadeBachelor"), trackParametrization.getPt(), dcaXY * 1e+4); // in microns, please
-            histos.fill(HIST("h2dDCAzCascadeBachelor"), trackParametrization.getPt(), dcaZ * 1e+4); // in microns, please
+            histos.fill(HIST("h2dDCAzCascadeBachelor"), trackParametrization.getPt(), dcaZ * 1e+4);   // in microns, please
           }
-          if (trackParCov.isUsedInCascading == 3){
+          if (trackParCov.isUsedInCascading == 3) {
             histos.fill(HIST("h2dDCAxyCascadeNegative"), trackParametrization.getPt(), dcaXY * 1e+4); // in microns, please
-            histos.fill(HIST("h2dDCAzCascadeNegative"), trackParametrization.getPt(), dcaZ * 1e+4); // in microns, please
+            histos.fill(HIST("h2dDCAzCascadeNegative"), trackParametrization.getPt(), dcaZ * 1e+4);   // in microns, please
           }
-          if (trackParCov.isUsedInCascading == 4){
+          if (trackParCov.isUsedInCascading == 4) {
             histos.fill(HIST("h2dDCAxyCascadePositive"), trackParametrization.getPt(), dcaXY * 1e+4); // in microns, please
-            histos.fill(HIST("h2dDCAzCascadePositive"), trackParametrization.getPt(), dcaZ * 1e+4); // in microns, please
+            histos.fill(HIST("h2dDCAzCascadePositive"), trackParametrization.getPt(), dcaZ * 1e+4);   // in microns, please
           }
         }
         tracksDCA(dcaXY, dcaZ);

--- a/ALICE3/TableProducer/OTF/onTheFlyTracker.cxx
+++ b/ALICE3/TableProducer/OTF/onTheFlyTracker.cxx
@@ -145,8 +145,10 @@ struct OnTheFlyTracker {
     Configurable<int> minTPCClusters{"minTPCClusters", 70, "minimum number of TPC hits necessary to consider minSiliconHitsIfTPCUsed"};
     Configurable<int> alice3detector{"alice3detector", 0, "0: ALICE 3 v1, 1: ALICE 3 v4"};
     Configurable<bool> applyZacceptance{"applyZacceptance", false, "apply z limits to detector layers or not"};
-    Configurable<bool> applyMSCorrection{"applyMSCorrection", true, "turn on ms corrections for secondaries"};
-    Configurable<bool> applyElossCorrection{"applyElossCorrection", true, "turn on eloss corrections for secondaries"};
+    Configurable<bool> applyMSCorrection{"applyMSCorrection", true, "apply ms corrections for secondaries or not"};
+    Configurable<bool> applyElossCorrection{"applyElossCorrection", true, "apply eloss corrections for secondaries or not"};
+    Configurable<bool> applyEffCorrection{"applyEffCorrection", true, "apply efficiency correction or not"};
+    Configurable<std::vector<float>> pixelRes{"pixelRes", {0.00025, 0.00025, 0.001, 0.001}, "RPhiIT, ZIT, RPhiOT, ZOT"};
   } fastTrackerSettings; // allows for gap between peak and bg in case someone wants to
 
   struct : ConfigurableGroup {
@@ -351,11 +353,25 @@ struct OnTheFlyTracker {
       histos.add("h2dDCAxyCascadeBachelor", "h2dDCAxyCascadeBachelor", kTH2F, {axes.axisMomentum, axes.axisDCA});
       histos.add("h2dDCAxyCascadeNegative", "h2dDCAxyCascadeNegative", kTH2F, {axes.axisMomentum, axes.axisDCA});
       histos.add("h2dDCAxyCascadePositive", "h2dDCAxyCascadePositive", kTH2F, {axes.axisMomentum, axes.axisDCA});
+      
+      histos.add("h2dDCAzCascade", "h2dDCAzCascade", kTH2F, {axes.axisMomentum, axes.axisDCA});
+      histos.add("h2dDCAzCascadeBachelor", "h2dDCAzCascadeBachelor", kTH2F, {axes.axisMomentum, axes.axisDCA});
+      histos.add("h2dDCAzCascadeNegative", "h2dDCAzCascadeNegative", kTH2F, {axes.axisMomentum, axes.axisDCA});
+      histos.add("h2dDCAzCascadePositive", "h2dDCAzCascadePositive", kTH2F, {axes.axisMomentum, axes.axisDCA});
 
       histos.add("h2dDeltaPtVsPt", "h2dDeltaPtVsPt", kTH2F, {axes.axisMomentum, axes.axisDeltaPt});
       histos.add("h2dDeltaEtaVsPt", "h2dDeltaEtaVsPt", kTH2F, {axes.axisMomentum, axes.axisDeltaEta});
 
       histos.add("hFastTrackerHits", "hFastTrackerHits", kTH2F, {axes.axisZ, axes.axisRadius});
+      auto hFastTrackerQA = histos.add<TH1>("hFastTrackerQA", "hFastTrackerQA", kTH1D, {{8, -0.5f, 7.5f}});
+      hFastTrackerQA->GetXaxis()->SetBinLabel(1, "Negative eigenvalue");
+      hFastTrackerQA->GetXaxis()->SetBinLabel(2, "Failed sanity check");
+      hFastTrackerQA->GetXaxis()->SetBinLabel(3, "intercept original radius");
+      hFastTrackerQA->GetXaxis()->SetBinLabel(4, "propagate to original radius");
+      hFastTrackerQA->GetXaxis()->SetBinLabel(5, "problematic layer");
+      hFastTrackerQA->GetXaxis()->SetBinLabel(6, "multiple scattering");
+      hFastTrackerQA->GetXaxis()->SetBinLabel(7, "energy loss");
+      hFastTrackerQA->GetXaxis()->SetBinLabel(8, "efficiency");
     }
 
     LOGF(info, "Initializing magnetic field to value: %.3f kG", static_cast<float>(magneticField));
@@ -411,10 +427,10 @@ struct OnTheFlyTracker {
     fastTracker.applyElossCorrection = fastTrackerSettings.applyElossCorrection;
 
     if (fastTrackerSettings.alice3detector == 0) {
-      fastTracker.AddSiliconALICE3v1();
+      fastTracker.AddSiliconALICE3v2(fastTrackerSettings.pixelRes);
     }
     if (fastTrackerSettings.alice3detector == 1) {
-      fastTracker.AddSiliconALICE3v4();
+      fastTracker.AddSiliconALICE3v4(fastTrackerSettings.pixelRes);
       fastTracker.AddTPC(0.1, 0.1);
     }
 
@@ -666,10 +682,13 @@ struct OnTheFlyTracker {
           nSiliconHits[i] = 0;
           nTPCHits[i] = 0;
           if (enableSecondarySmearing) {
-
-            nHits[i] = fastTracker.FastTrack(xiDaughterTrackParCovsPerfect[i], xiDaughterTrackParCovsTracked[i]);
+            nHits[i] = fastTracker.FastTrack(xiDaughterTrackParCovsPerfect[i], xiDaughterTrackParCovsTracked[i], dNdEta);
             nSiliconHits[i] = fastTracker.nSiliconPoints;
             nTPCHits[i] = fastTracker.nGasPoints;
+
+            if (nHits[i] < 0) { // QA
+              histos.fill(HIST("hFastTrackerQA"), o2::math_utils::abs(nHits[i]));
+            }
 
             if (nSiliconHits[i] >= fastTrackerSettings.minSiliconHits || (nSiliconHits[i] >= fastTrackerSettings.minSiliconHitsIfTPCUsed && nTPCHits[i] >= fastTrackerSettings.minTPCClusters)) {
               isReco[i] = true;
@@ -1026,14 +1045,22 @@ struct OnTheFlyTracker {
           histos.fill(HIST("hTrackXatDCA"), trackParametrization.getX());
         }
         if (cascadeDecaySettings.doXiQA) {
-          if (trackParCov.isUsedInCascading == 1)
+          if (trackParCov.isUsedInCascading == 1){
             histos.fill(HIST("h2dDCAxyCascade"), trackParametrization.getPt(), dcaXY * 1e+4); // in microns, please
-          if (trackParCov.isUsedInCascading == 2)
+            histos.fill(HIST("h2dDCAzCascade"), trackParametrization.getPt(), dcaZ * 1e+4); // in microns, please
+          }
+          if (trackParCov.isUsedInCascading == 2){
             histos.fill(HIST("h2dDCAxyCascadeBachelor"), trackParametrization.getPt(), dcaXY * 1e+4); // in microns, please
-          if (trackParCov.isUsedInCascading == 3)
+            histos.fill(HIST("h2dDCAzCascadeBachelor"), trackParametrization.getPt(), dcaZ * 1e+4); // in microns, please
+          }
+          if (trackParCov.isUsedInCascading == 3){
             histos.fill(HIST("h2dDCAxyCascadeNegative"), trackParametrization.getPt(), dcaXY * 1e+4); // in microns, please
-          if (trackParCov.isUsedInCascading == 4)
+            histos.fill(HIST("h2dDCAzCascadeNegative"), trackParametrization.getPt(), dcaZ * 1e+4); // in microns, please
+          }
+          if (trackParCov.isUsedInCascading == 4){
             histos.fill(HIST("h2dDCAxyCascadePositive"), trackParametrization.getPt(), dcaXY * 1e+4); // in microns, please
+            histos.fill(HIST("h2dDCAzCascadePositive"), trackParametrization.getPt(), dcaZ * 1e+4); // in microns, please
+          }
         }
         tracksDCA(dcaXY, dcaZ);
         if (populateTracksDCACov) {


### PR DESCRIPTION
Adding the hit efficiency corrections used in the SolveTrack method in Delphes that is used to produce the LUTs for the OTF simulations 

link: https://github.com/AliceO2Group/DelphesO2/blob/master/src/DetectorK/DetectorK.cxx#L1421