### PR TITLE
[PWGCF] - improved memory management based on valgrind + massif profiling

### DIFF
--- a/PWGCF/MultiparticleCorrelations/Core/MuPa-Configurables.h
+++ b/PWGCF/MultiparticleCorrelations/Core/MuPa-Configurables.h
@@ -19,8 +19,8 @@
 // *) Task configuration:
 struct : ConfigurableGroup {
   // std::string prefix = "Task configuration"; // AA: now these configurables also appear grouped on hyperloop => TBI 20240522 check if this work, and if further modifications in init are needed
-  Configurable<string> cfTaskIsConfiguredFromJson{"cfTaskIsConfiguredFromJson", "no", "always set manaully to \"yes\" via JSON, merely to ensure that settings are not ignored silently"};
-  Configurable<string> cfTaskName{"cfTaskName", "Default task name", "set task name - use eventually to determine weights for this task"};
+  Configurable<std::string> cfTaskIsConfiguredFromJson{"cfTaskIsConfiguredFromJson", "no", "always set manaully to \"yes\" via JSON, merely to ensure that settings are not ignored silently"};
+  Configurable<std::string> cfTaskName{"cfTaskName", "Default task name", "set task name - use eventually to determine weights for this task"};
   Configurable<bool> cfDryRun{"cfDryRun", false, "book all histos and run without storing and calculating anything"};
   Configurable<bool> cfVerbose{"cfVerbose", false, "run or not in verbose mode (but not for simple utility functions or function calls per particle)"};
   Configurable<bool> cfVerboseUtility{"cfVerboseUtility", false, "run or not in verbose mode, also for simple utility functions (but not for function calls per particle)"};
@@ -37,8 +37,8 @@ struct : ConfigurableGroup {
   Configurable<float> cfFloatingPointPrecision{"cfFloatingPointPrecision", 0.000001, "two floats are the same if TMath::Abs(f1 - f2) < fFloatingPointPrecision"};
   Configurable<int> cfSequentialBailout{"cfSequentialBailout", 0, "if fSequentialBailout > 0, then each fSequentialBailout events the function BailOut() is called. Can be used for real analysis and for IV"};
   Configurable<bool> cfUseSpecificCuts{"cfUseSpecificCuts", false, "if true, analysis-specific cuts set via configurable cfWhichSpecificCuts are applied after DefaultCuts(). "};
-  Configurable<string> cfWhichSpecificCuts{"cfWhichSpecificCuts", "some supported set of analysis-specific cuts (e.g. LHC23zzh, ...)", "determine which set of analysis-specific cuts will be applied after DefaultCuts(). Use in combination with tc.fUseSpecificCuts"};
-
+  Configurable<std::string> cfWhichSpecificCuts{"cfWhichSpecificCuts", "some supported set of analysis-specific cuts (e.g. LHC23zzh, ...)", "determine which set of analysis-specific cuts will be applied after DefaultCuts(). Use in combination with tc.fUseSpecificCuts"};
+  Configurable<std::string> cfSkipTheseRuns{"cfSkipTheseRuns", "", "Set here via comma-separated list which runs will be skipped during hl analysis (a.k.a. \"bad runs\"). Leave empty to ignore. Example format and list for LHC23zzh: \"544116,544091\""};
 } cf_tc;
 
 // *) QA:
@@ -46,55 +46,60 @@ struct : ConfigurableGroup {
   Configurable<bool> cfCheckUnderflowAndOverflow{"cfCheckUnderflowAndOverflow", false, "check and bail out if in event and particle histograms there are entries which went to underflow or overflow bins (use only locally)"};
   Configurable<int> cfRebin{"cfRebin", 1, "number of bins of selected heavy 2D histograms are devided with this number"};
   Configurable<bool> cfFillQAEventHistograms2D{"cfFillQAEventHistograms2D", false, "if false, all QA 2D event histograms are not filled. if true, only the ones for which fBookQAEventHistograms2D[...] is true, are filled"};
-  Configurable<vector<string>> cfBookQAEventHistograms2D{"cfBookQAEventHistograms2D", {"1-Multiplicity_vs_ReferenceMultiplicity", "1-Multiplicity_vs_NContributors", "1-Multiplicity_vs_Centrality", "1-Multiplicity_vs_Vertex_z", "1-Multiplicity_vs_Occupancy", "1-ReferenceMultiplicity_vs_NContributors", "1-ReferenceMultiplicity_vs_Centrality", "1-ReferenceMultiplicity_vs_Vertex_z", "1-ReferenceMultiplicity_vs_Occupancy", "1-NContributors_vs_Centrality", "1-NContributors_vs_Vertex_z", "1-NContributors_vs_Occupancy", "1-Centrality_vs_Vertex_z", "1-Centrality_vs_Occupancy", "0-Centrality_vs_ImpactParameter", "1-Vertex_z_vs_Occupancy", "0-MultNTracksPV_vs_MultNTracksGlobal", "1-CentFT0C_vs_CentFT0CVariant1", "1-CentFT0C_vs_CentFT0M", "1-CentFT0C_vs_CentFV0A", "0-CentFT0C_vs_CentNTPV", "0-CentFT0C_vs_CentNGlobal", "0-CentFT0M_vs_CentNTPV", "0-CentRun2V0M_vs_CentRun2SPDTracklets", "1-TrackOccupancyInTimeRange_vs_FT0COccupancyInTimeRange", "1-CurrentRunDuration_vs_InteractionRate"}, "book (1) or do not book (0) this QA 2D event histogram"};
+  Configurable<std::vector<std::string>> cfBookQAEventHistograms2D{"cfBookQAEventHistograms2D", {"1-Multiplicity_vs_ReferenceMultiplicity", "1-Multiplicity_vs_NContributors", "1-Multiplicity_vs_Centrality", "1-Multiplicity_vs_Vertex_z", "1-Multiplicity_vs_Occupancy", "1-ReferenceMultiplicity_vs_NContributors", "1-ReferenceMultiplicity_vs_Centrality", "1-ReferenceMultiplicity_vs_Vertex_z", "1-ReferenceMultiplicity_vs_Occupancy", "1-NContributors_vs_Centrality", "1-NContributors_vs_Vertex_z", "1-NContributors_vs_Occupancy", "1-Centrality_vs_Vertex_z", "1-Centrality_vs_Occupancy", "0-Centrality_vs_ImpactParameter", "1-Vertex_z_vs_Occupancy", "0-MultNTracksPV_vs_MultNTracksGlobal", "1-CentFT0C_vs_CentFT0CVariant1", "1-CentFT0C_vs_CentFT0M", "1-CentFT0C_vs_CentFV0A", "0-CentFT0C_vs_CentNTPV", "0-CentFT0C_vs_CentNGlobal", "0-CentFT0M_vs_CentNTPV", "0-CentRun2V0M_vs_CentRun2SPDTracklets", "1-TrackOccupancyInTimeRange_vs_FT0COccupancyInTimeRange", "1-CurrentRunDuration_vs_InteractionRate"}, "book (1) or do not book (0) this QA 2D event histogram"};
   Configurable<bool> cfFillQAParticleHistograms2D{"cfFillQAParticleHistograms2D", false, "if false, all QA 2D particle histograms are not filled. if true, only the ones for which fBookQAParticleHistograms2D[...] is true, are filled"};
-  Configurable<vector<string>> cfBookQAParticleHistograms2D{"cfBookQAParticleHistograms2D", {"1-Pt_vs_dcaXY"}, "book (1) or do not book (0) this QA 2D particle histogram"};
+  Configurable<std::vector<std::string>> cfBookQAParticleHistograms2D{"cfBookQAParticleHistograms2D", {"1-Pt_vs_dcaXY"}, "book (1) or do not book (0) this QA 2D particle histogram"};
   Configurable<bool> cfFillQAParticleEventHistograms2D{"cfFillQAParticleEventHistograms2D", false, "if false, all QA 2D particle event histograms are not filled. if true, only the ones for which fBookQAParticleEventHistograms2D[...] is true, are filled"};
-  Configurable<vector<string>> cfBookQAParticleEventHistograms2D{"cfBookQAParticleEventHistograms2D", {"1-CurrentRunDuration_vs_itsNCls", "1-CurrentRunDuration_vs_itsNClsNegEtaEbyE", "1-CurrentRunDuration_vs_itsNClsPosEtaEbyE", "1-CurrentRunDuration_vs_Eta0804EbyE", "1-CurrentRunDuration_vs_Eta0400EbyE", "1-CurrentRunDuration_vs_Eta0004EbyE", "1-CurrentRunDuration_vs_Eta0408EbyE", "1-CurrentRunDuration_vs_Pt0005EbyE", "1-CurrentRunDuration_vs_Pt0510EbyE", "1-CurrentRunDuration_vs_Pt1050EbyE"}, "book (1) or do not book (0) this QA 2D particle event histogram"};
+  Configurable<std::vector<std::string>> cfBookQAParticleEventHistograms2D{"cfBookQAParticleEventHistograms2D", {"1-CurrentRunDuration_vs_itsNCls", "1-CurrentRunDuration_vs_itsNClsNegEtaEbyE", "1-CurrentRunDuration_vs_itsNClsPosEtaEbyE", "1-CurrentRunDuration_vs_Eta0804EbyE", "1-CurrentRunDuration_vs_Eta0400EbyE", "1-CurrentRunDuration_vs_Eta0004EbyE", "1-CurrentRunDuration_vs_Eta0408EbyE", "1-CurrentRunDuration_vs_Pt0005EbyE", "1-CurrentRunDuration_vs_Pt0510EbyE", "1-CurrentRunDuration_vs_Pt1050EbyE"}, "book (1) or do not book (0) this QA 2D particle event histogram"};
 
-  Configurable<bool> cfFillQACorrelationsVsHistograms2D{"cfFillQACorrelationsVsHistograms2D", true, "if false, all QA 2D histograms of this category are not filled. if true, only the ones for which fBookQACorrelationsVsHistograms2D[...] is true, are filled"};
+  Configurable<bool> cfFillQACorrelationsVsHistograms2D{"cfFillQACorrelationsVsHistograms2D", false, "if false, all QA 2D histograms of this category are not filled. if true, only the ones for which fBookQACorrelationsVsHistograms2D[...] is true, are filled"};
   Configurable<std::vector<std::string>> cfBookQACorrelationsVsHistograms2D{"cfBookQACorrelationsVsHistograms2D", {"1-Correlations_vs_Multiplicity", "1-Correlations_vs_ReferenceMultiplicity", "1-Correlations_vs_Centrality", "1-Correlations_vs_Phi", "1-Correlations_vs_Pt", "1-Correlations_vs_Eta"}, "book (1) or do not book (0) this QA 2D histogram"};
-  Configurable<vector<int>> cfQACorrelationsVsHistogramsMinMaxHarmonic{"cfQACorrelationsVsHistogramsMinMaxHarmonic", {1, 5}, "harmonics are filled for min <= harmonic < max"};
+  Configurable<std::vector<int>> cfQACorrelationsVsHistogramsMinMaxHarmonic{"cfQACorrelationsVsHistogramsMinMaxHarmonic", {1, 5}, "harmonics are filled for min <= harmonic < max"};
+
+  Configurable<bool> cfFillQACorrelationsVsInteractionRateVsProfiles2D{"cfFillQACorrelationsVsInteractionRateVsProfiles2D", false, "if false, all QA 2D profiles of this category are not filled. if true, only the ones for which fBookQACorrelationsVsInteractionRateVsProfiles2D[...] is true, are filled"};
+  Configurable<std::vector<std::string>> cfBookQACorrelationsVsInteractionRateVsProfiles2D{"cfBookQACorrelationsVsInteractionRateVsProfiles2D", {"1-CorrVsIR_vs_CurrentRunDuration", "1-CorrVsIR_vs_Multiplicity", "1-CorrVsIR_vs_ReferenceMultiplicity", "1-CorrVsIR_vs_Centrality", "1-CorrVsIR_vs_MeanPhi", "1-CorrVsIR_vs_SigmaMeanPhi", "1-CorrVsIR_vs_MeanPt", "1-CorrVsIR_vs_SigmaMeanPt", "1-CorrVsIR_vs_MeanEta", "1-CorrVsIR_vs_SigmaMeanEta"}, "book (1) or do not book (0) this QA 2D profile"};
+  Configurable<std::vector<int>> cfQACorrelationsVsInteractionRateVsProfilesMinMaxHarmonic{"cfQACorrelationsVsInteractionRateVsProfilesMinMaxHarmonic", {1, 5}, "harmonics are filled for min <= harmonic < max"};
+
 } cf_qa;
 
 // *) Event histograms:
 struct : ConfigurableGroup {
   Configurable<bool> cfFillEventHistograms{"cfFillEventHistograms", true, "if false, all event histograms are not filled. if true, only the ones for which fBookEventHistograms[...] is true, are filled"};
-  Configurable<vector<string>> cfBookEventHistograms{"cfBookEventHistograms", {"1-NumberOfEvents", "1-TotalMultiplicity", "1-Multiplicity", "1-ReferenceMultiplicity", "1-Centrality", "1-Vertex_x", "1-Vertex_y", "1-Vertex_z", "1-NContributors", "0-ImpactParameter", "0-EventPlaneAngle", "1-Occupancy", "1-InteractionRate", "1-CurrentRunDuration", "0-MultMCNParticlesEta08"}, "Book (1) or do not book (0) event histogram"};
+  Configurable<std::vector<std::string>> cfBookEventHistograms{"cfBookEventHistograms", {"1-NumberOfEvents", "1-TotalMultiplicity", "1-Multiplicity", "1-ReferenceMultiplicity", "1-Centrality", "1-Vertex_x", "1-Vertex_y", "1-Vertex_z", "1-NContributors", "0-ImpactParameter", "0-EventPlaneAngle", "1-Occupancy", "1-InteractionRate", "1-CurrentRunDuration", "0-MultMCNParticlesEta08"}, "Book (1) or do not book (0) event histogram"};
 } cf_eh;
 
 // *) Event cuts:
 struct : ConfigurableGroup {
-  Configurable<vector<string>> cfUseEventCuts{"cfUseEventCuts", {"1-NumberOfEvents", "1-TotalMultiplicity", "1-Multiplicity", "1-ReferenceMultiplicity", "1-Centrality", "1-Vertex_x", "1-Vertex_y", "1-Vertex_z", "1-NContributors", "1-ImpactParameter", "0-EventPlaneAngle", "1-Occupancy", "1-InteractionRate", "1-CurrentRunDuration", "0-MultMCNParticlesEta08", "0-Trigger", "0-Sel7", "1-Sel8", "1-MultiplicityEstimator", "1-ReferenceMultiplicityEstimator", "1-CentralityEstimator", "1-SelectedEvents", "1-NoSameBunchPileup", "1-IsGoodZvtxFT0vsPV", "1-IsVertexITSTPC", "1-IsVertexTOFmatched", "1-IsVertexTRDmatched", "0-NoCollInTimeRangeStrict", "0-NoCollInTimeRangeStandard", "0-NoCollInRofStrict", "0-NoCollInRofStandard", "0-NoHighMultCollInPrevRof", "0-IsGoodITSLayer3", "0-IsGoodITSLayer0123", "0-IsGoodITSLayersAll", "1-OccupancyEstimator", "1-MinVertexDistanceFromIP", "1-CentralityWeights"}, "use (1) or do not use (0) event cuts"};
+  Configurable<std::vector<std::string>> cfUseEventCuts{"cfUseEventCuts", {"1-NumberOfEvents", "1-TotalMultiplicity", "1-Multiplicity", "1-ReferenceMultiplicity", "1-Centrality", "1-Vertex_x", "1-Vertex_y", "1-Vertex_z", "1-NContributors", "1-ImpactParameter", "0-EventPlaneAngle", "1-Occupancy", "1-InteractionRate", "1-CurrentRunDuration", "0-MultMCNParticlesEta08", "0-Trigger", "0-Sel7", "1-Sel8", "1-MultiplicityEstimator", "1-ReferenceMultiplicityEstimator", "1-CentralityEstimator", "1-SelectedEvents", "1-NoSameBunchPileup", "1-IsGoodZvtxFT0vsPV", "1-IsVertexITSTPC", "1-IsVertexTOFmatched", "1-IsVertexTRDmatched", "0-NoCollInTimeRangeStrict", "0-NoCollInTimeRangeStandard", "0-NoCollInRofStrict", "0-NoCollInRofStandard", "0-NoHighMultCollInPrevRof", "0-IsGoodITSLayer3", "0-IsGoodITSLayer0123", "0-IsGoodITSLayersAll", "1-OccupancyEstimator", "1-MinVertexDistanceFromIP", "1-CentralityWeights"}, "use (1) or do not use (0) event cuts"};
   Configurable<bool> cfUseEventCutCounterAbsolute{"cfUseEventCutCounterAbsolute", false, "profile and save how many times each event cut counter triggered (absolute). Use with care, as this is computationally heavy"};
   Configurable<bool> cfUseEventCutCounterSequential{"cfUseEventCutCounterSequential", false, "profile and save how many times each event cut counter triggered (sequential). Use with care, as this is computationally heavy"};
   Configurable<bool> cfPrintCutCounterContent{"cfPrintCutCounterContent", false, "if true, prints on the screen after each event the content of fEventCutCounterHist[*][*] (all which were booked)"};
   // Remark: Preserve below the same ordering as in enum's eEventHistograms + eEventCuts. In hyperloop, in any case this ordering is lost, because there it's alphabetical TBI 20240521 check this, after I added now std::string prefix thingie
-  Configurable<vector<int>> cfNumberOfEvents{"cfNumberOfEvents", {-1, 1000000000}, "total number of events to process (whether or not they survive event cuts): {min, max}, with convention: min <= N < max"};
-  Configurable<vector<int>> cfTotalMultiplicity{"cfTotalMultiplicity", {-1, 1000000000}, "total multiplicity range: {min, max}, with convention: min <= M < max"};
-  Configurable<vector<float>> cfMultiplicity{"cfMultiplicity", {-1., 1000000000.}, "multiplicity (defined via cfMultiplicityEstimator) range {min, max}, with convention: min <= M < max"};
-  Configurable<vector<float>> cfReferenceMultiplicity{"cfReferenceMultiplicity", {-1., 1000000000.}, "reference multiplicity (defined via cfReferenceMultiplicityEstimator)  range {min, max}, with convention: min <= M < max"};
-  Configurable<vector<float>> cfCentrality{"cfCentrality", {-10., 110.}, "centrality range: {min, max}, with convention: min <= cent < max"};
-  Configurable<vector<float>> cfVertex_x{"cfVertex_x", {-10., 10.}, "vertex x position range: {min, max}[cm], with convention: min <= Vx < max"};
-  Configurable<vector<float>> cfVertex_y{"cfVertex_y", {-10., 10.}, "vertex y position range: {min, max}[cm], with convention: min <= Vy < max"};
-  Configurable<vector<float>> cfVertex_z{"cfVertex_z", {-10, 10.}, "vertex z position range: {min, max}[cm], with convention: min <= Vz < max"};
+  Configurable<std::vector<int>> cfNumberOfEvents{"cfNumberOfEvents", {-1, 1000000000}, "total number of events to process (whether or not they survive event cuts): {min, max}, with convention: min <= N < max"};
+  Configurable<std::vector<int>> cfTotalMultiplicity{"cfTotalMultiplicity", {-1, 1000000000}, "total multiplicity range: {min, max}, with convention: min <= M < max"};
+  Configurable<std::vector<float>> cfMultiplicity{"cfMultiplicity", {-1., 1000000000.}, "multiplicity (defined via cfMultiplicityEstimator) range {min, max}, with convention: min <= M < max"};
+  Configurable<std::vector<float>> cfReferenceMultiplicity{"cfReferenceMultiplicity", {-1., 1000000000.}, "reference multiplicity (defined via cfReferenceMultiplicityEstimator)  range {min, max}, with convention: min <= M < max"};
+  Configurable<std::vector<float>> cfCentrality{"cfCentrality", {-10., 110.}, "centrality range: {min, max}, with convention: min <= cent < max"};
+  Configurable<std::vector<float>> cfVertex_x{"cfVertex_x", {-10., 10.}, "vertex x position range: {min, max}[cm], with convention: min <= Vx < max"};
+  Configurable<std::vector<float>> cfVertex_y{"cfVertex_y", {-10., 10.}, "vertex y position range: {min, max}[cm], with convention: min <= Vy < max"};
+  Configurable<std::vector<float>> cfVertex_z{"cfVertex_z", {-10, 10.}, "vertex z position range: {min, max}[cm], with convention: min <= Vz < max"};
   Configurable<float> cfMinVertexDistanceFromIP{"cfMinVertexDistanceFromIP", {0.000001}, "if sqrt(vx^2+vy^2+vz^2) < cfMinVertexDistanceFromIP [cm], the event is reject. IP = nominal Interaction Point."};
-  Configurable<vector<int>> cfNContributors{"cfNContributors", {2, 1000000000}, "Number of vertex contributors: {min, max}, with convention: min <= N < max"};
-  Configurable<vector<float>> cfImpactParameter{"cfImpactParameter", {-1, 1000000000}, "Impact parameter range (can be used only for sim): {min, max}, with convention: min <= IP < max"};
-  Configurable<vector<float>> cfEventPlaneAngle{"cfEventPlaneAngle", {-o2::constants::math::PI, o2::constants::math::TwoPI}, "Event Plane Angle range (can be used only for sim): {min, max}, with convention: min <= EP < max"};
-  Configurable<vector<float>> cfOccupancy{"cfOccupancy", {-0.0001, 1000000000}, "Range for occupancy (use cfOccupancyEstimator to set specific estimator): {min, max}, with convention: min <= X < max. Important: remember that 0. has to be included, therefore I set -0.0001 by default for low edge"};
-  Configurable<vector<float>> cfInteractionRate{"cfInteractionRate", {0., 1000000000.}, "Range for interaction rate: {min, max}, with convention: min <= X < max"};
-  Configurable<vector<float>> cfCurrentRunDuration{"cfCurrentRunDuration", {-2, 1000000000}, "Range for current run duration (i.e. seconds since start of run) in seconds: {min, max}, with convention: min <= X < max. Only collisions taken in this range (measured from SOR) are taken for analysis"};
-  Configurable<vector<float>> cfMultMCNParticlesEta08{"cfMultMCNParticlesEta08", {-1, 1000000000}, "Range for MultMCNParticlesEta08 : {min, max}, with convention: min <= X < max"};
-  Configurable<string> cfTrigger{"cfTrigger", "some supported trigger (e.g. INT7 for Run 2, TVXinTRD for Run 3, etc...)", "set here some supported trigger"};
+  Configurable<std::vector<int>> cfNContributors{"cfNContributors", {2, 1000000000}, "Number of vertex contributors: {min, max}, with convention: min <= N < max"};
+  Configurable<std::vector<float>> cfImpactParameter{"cfImpactParameter", {-1, 1000000000}, "Impact parameter range (can be used only for sim): {min, max}, with convention: min <= IP < max"};
+  Configurable<std::vector<float>> cfEventPlaneAngle{"cfEventPlaneAngle", {-o2::constants::math::PI, o2::constants::math::TwoPI}, "Event Plane Angle range (can be used only for sim): {min, max}, with convention: min <= EP < max"};
+  Configurable<std::vector<float>> cfOccupancy{"cfOccupancy", {-0.0001, 1000000000}, "Range for occupancy (use cfOccupancyEstimator to set specific estimator): {min, max}, with convention: min <= X < max. Important: remember that 0. has to be included, therefore I set -0.0001 by default for low edge"};
+  Configurable<std::vector<float>> cfInteractionRate{"cfInteractionRate", {0., 1000000000.}, "Range for interaction rate: {min, max}, with convention: min <= X < max"};
+  Configurable<std::vector<float>> cfCurrentRunDuration{"cfCurrentRunDuration", {-2, 1000000000}, "Range for current run duration (i.e. seconds since start of run) in seconds: {min, max}, with convention: min <= X < max. Only collisions taken in this range (measured from SOR) are taken for analysis"};
+  Configurable<std::vector<float>> cfMultMCNParticlesEta08{"cfMultMCNParticlesEta08", {-1, 1000000000}, "Range for MultMCNParticlesEta08 : {min, max}, with convention: min <= X < max"};
+  Configurable<std::string> cfTrigger{"cfTrigger", "some supported trigger (e.g. INT7 for Run 2, TVXinTRD for Run 3, etc...)", "set here some supported trigger"};
   Configurable<bool> cfUseSel7{"cfUseSel7", false, "use for Run 1 and 2 data and MC (see official doc)"};
   Configurable<bool> cfUseSel8{"cfUseSel8", false, "use for Run 3 data and MC (see official doc)"};
-  Configurable<string> cfMultiplicityEstimator{"cfMultiplicityEstimator", "SelectedTracks", "all results vs. mult are calculated against this multiplicity. Can be set to SelectedTracks (calculated internally), ReferenceMultiplicity (calculated outside of my code), etc."};
-  //  Configurable<string> cfReferenceMultiplicityEstimator{"cfReferenceMultiplicityEstimator", "some supported option for ref. mult. (MultFT0C, MultFV0M, MultTPC, etc.)", "Reference multiplicity, calculated outside of my code. Can be MultFT0C, MultFV0M, MultTPC, etc."};
-  Configurable<string> cfReferenceMultiplicityEstimator{"cfReferenceMultiplicityEstimator", "MultFT0C", "Reference multiplicity, calculated outside of my code. Can be MultFT0C, MultFV0M, MultTPC, etc."};
-  //  Configurable<string> cfCentralityEstimator{"cfCentralityEstimator", "some supported centrality estimator (e.g. CentFT0C, ...)", "set here some supported centrality estimator (CentFT0C, CentFT0M, CentFV0A, CentNTPV, ... for Run 3, and CentRun2V0M, CentRun2SPDTracklets, ..., for Run 2 and 1) "};
-  Configurable<string> cfCentralityEstimator{"cfCentralityEstimator", "CentFT0C", "set here some supported centrality estimator (CentFT0C, CentFT0M, CentFV0A, CentNTPV, ... for Run 3, and CentRun2V0M, CentRun2SPDTracklets, ..., for Run 2 and 1) "};
-  Configurable<vector<int>> cfSelectedEvents{"cfSelectedEvents", {-1, 1000000000}, "Selected number of events to process (i.e. only events which survive event cuts): {min, max}, with convention: min <= N < max"};
+  Configurable<std::string> cfMultiplicityEstimator{"cfMultiplicityEstimator", "SelectedTracks", "all results vs. mult are calculated against this multiplicity. Can be set to SelectedTracks (calculated internally), ReferenceMultiplicity (calculated outside of my code), etc."};
+  //  Configurable<std::string> cfReferenceMultiplicityEstimator{"cfReferenceMultiplicityEstimator", "some supported option for ref. mult. (MultFT0C, MultFV0M, MultTPC, etc.)", "Reference multiplicity, calculated outside of my code. Can be MultFT0C, MultFV0M, MultTPC, etc."};
+  Configurable<std::string> cfReferenceMultiplicityEstimator{"cfReferenceMultiplicityEstimator", "MultFT0C", "Reference multiplicity, calculated outside of my code. Can be MultFT0C, MultFV0M, MultTPC, etc."};
+  //  Configurable<std::string> cfCentralityEstimator{"cfCentralityEstimator", "some supported centrality estimator (e.g. CentFT0C, ...)", "set here some supported centrality estimator (CentFT0C, CentFT0M, CentFV0A, CentNTPV, ... for Run 3, and CentRun2V0M, CentRun2SPDTracklets, ..., for Run 2 and 1) "};
+  Configurable<std::string> cfCentralityEstimator{"cfCentralityEstimator", "CentFT0C", "set here some supported centrality estimator (CentFT0C, CentFT0M, CentFV0A, CentNTPV, ... for Run 3, and CentRun2V0M, CentRun2SPDTracklets, ..., for Run 2 and 1) "};
+  Configurable<std::vector<int>> cfSelectedEvents{"cfSelectedEvents", {-1, 1000000000}, "Selected number of events to process (i.e. only events which survive event cuts): {min, max}, with convention: min <= N < max"};
   Configurable<bool> cfUseNoSameBunchPileup{"cfUseNoSameBunchPileup", false, "TBI 20240521 explanation"};
   Configurable<bool> cfUseIsGoodZvtxFT0vsPV{"cfUseIsGoodZvtxFT0vsPV", false, "TBI 20240521 explanation"};
   Configurable<bool> cfUseIsVertexITSTPC{"cfUseIsVertexITSTPC", false, "TBI 20240521 explanation"};
@@ -108,43 +113,43 @@ struct : ConfigurableGroup {
   Configurable<bool> cfUseIsGoodITSLayer3{"cfUseIsGoodITSLayer3", false, "TBI 20241220 explanation (or see enum)"};
   Configurable<bool> cfUseIsGoodITSLayer0123{"cfUseIsGoodITSLayer0123", false, "TBI 20241220 explanation (or see enum)"};
   Configurable<bool> cfUseIsGoodITSLayersAll{"cfUseIsGoodITSLayersAll", false, "TBI 20241220 explanation (or see enum)"};
-  Configurable<string> cfOccupancyEstimator{"cfOccupancyEstimator", "FT0COccupancyInTimeRange", "set here some supported occupancy estimator (TrackOccupancyInTimeRange, FT0COccupancyInTimeRange, ..."};
+  Configurable<std::string> cfOccupancyEstimator{"cfOccupancyEstimator", "FT0COccupancyInTimeRange", "set here some supported occupancy estimator (TrackOccupancyInTimeRange, FT0COccupancyInTimeRange, ..."};
 } cf_ec;
 
 // *) Particle histograms:
 struct : ConfigurableGroup {
   Configurable<bool> cfFillParticleHistograms{"cfFillParticleHistograms", true, "if false, all 1D particle histograms are not filled. if kTRUE, the ones for which fBookParticleHistograms[...] is kTRUE, are filled"};
-  Configurable<vector<string>> cfBookParticleHistograms{"cfBookParticleHistograms", {"1-Phi", "1-Pt", "1-Eta", "1-Charge", "1-tpcNClsFindable", "1-tpcNClsShared", "1-itsChi2NCl", "1-tpcNClsFound", "1-tpcNClsCrossedRows", "1-itsNCls", "1-itsNClsInnerBarrel", "1-tpcCrossedRowsOverFindableCls", "1-tpcFoundOverFindableCls", "1-tpcFractionSharedCls", "1-tpcChi2NCl", "1-dcaXY", "1-dcaZ", "0-PDG"}, "Book (1) or do not book (0) particle histogram"};
+  Configurable<std::vector<std::string>> cfBookParticleHistograms{"cfBookParticleHistograms", {"1-Phi", "1-Pt", "1-Eta", "1-Charge", "1-tpcNClsFindable", "1-tpcNClsShared", "1-itsChi2NCl", "1-tpcNClsFound", "1-tpcNClsCrossedRows", "1-itsNCls", "1-itsNClsInnerBarrel", "1-tpcCrossedRowsOverFindableCls", "1-tpcFoundOverFindableCls", "1-tpcFractionSharedCls", "1-tpcChi2NCl", "1-dcaXY", "1-dcaZ", "0-PDG"}, "Book (1) or do not book (0) particle histogram"};
   Configurable<bool> cfFillParticleHistograms2D{"cfFillParticleHistograms2D", false, "if false, all 2D particle histograms are not filled. if kTRUE, the ones for which fBookParticleHistograms2D[...] is kTRUE, are filled"};
-  Configurable<vector<string>> cfBookParticleHistograms2D{"cfBookParticleHistograms2D", {"1-Phi_vs_Pt", "1-Phi_vs_Eta"}, "Book (1) or do not book (0) 2D particle histograms"};
+  Configurable<std::vector<std::string>> cfBookParticleHistograms2D{"cfBookParticleHistograms2D", {"1-Phi_vs_Pt", "1-Phi_vs_Eta"}, "Book (1) or do not book (0) 2D particle histograms"};
   Configurable<int> cfRebinSparse{"cfRebinSparse", 1, "used only for all fixed-length bins which are implemented directly for sparse histograms (i.e. not inherited from results histograms)"};
-  Configurable<vector<string>> cfBookParticleSparseHistograms{"cfBookParticleSparseHistograms", {"0-DWPhi", "0-DWPt", "0-DWEta"}, "Book (1) or do not book (0) particular category of sparse histograms"};
+  Configurable<std::vector<std::string>> cfBookParticleSparseHistograms{"cfBookParticleSparseHistograms", {"0-DWPhi", "0-DWPt", "0-DWEta"}, "Book (1) or do not book (0) particular category of sparse histograms"};
   // TBI 20250223 add eventually configurable for FillParticleSparseHistogramsDimension
 } cf_ph;
 
 // *) Particle cuts:
 struct : ConfigurableGroup {
-  Configurable<vector<string>> cfUseParticleCuts{"cfUseParticleCuts", {"1-Phi", "1-Pt", "1-Eta", "1-Charge", "1-tpcNClsFindable", "1-tpcNClsShared", "1-itsChi2NCl", "1-tpcNClsFound", "1-tpcNClsCrossedRows", "1-itsNCls", "1-itsNClsInnerBarrel", "1-tpcCrossedRowsOverFindableCls", "1-tpcFoundOverFindableCls", "1-tpcFractionSharedCls", "1-tpcChi2NCl", "1-dcaXY", "1-dcaZ", "1-PDG", "0-trackCutFlag", "0-trackCutFlagFb1", "0-trackCutFlagFb2", "0-isQualityTrack", "0-isPrimaryTrack", "0-isInAcceptanceTrack", "0-isGlobalTrack", "1-isPVContributor", "0-PtDependentDCAxyParameterization"}, "Use (1) or do not use (0) particle cuts"};
+  Configurable<std::vector<std::string>> cfUseParticleCuts{"cfUseParticleCuts", {"1-Phi", "1-Pt", "1-Eta", "1-Charge", "1-tpcNClsFindable", "1-tpcNClsShared", "1-itsChi2NCl", "1-tpcNClsFound", "1-tpcNClsCrossedRows", "1-itsNCls", "1-itsNClsInnerBarrel", "1-tpcCrossedRowsOverFindableCls", "1-tpcFoundOverFindableCls", "1-tpcFractionSharedCls", "1-tpcChi2NCl", "1-dcaXY", "1-dcaZ", "1-PDG", "0-trackCutFlag", "0-trackCutFlagFb1", "0-trackCutFlagFb2", "0-isQualityTrack", "0-isPrimaryTrack", "0-isInAcceptanceTrack", "0-isGlobalTrack", "1-isPVContributor", "0-PtDependentDCAxyParameterization"}, "Use (1) or do not use (0) particle cuts"};
   Configurable<bool> cfUseParticleCutCounterAbsolute{"cfUseParticleCutCounterAbsolute", false, "profile and save how many times each particle cut counter triggered (absolute). Use with care, as this is computationally heavy"};
   Configurable<bool> cfUseParticleCutCounterSequential{"cfUseParticleCutCounterSequential", false, "profile and save how many times each particle cut counter triggered (sequential). Use with care, as this is computationally heavy"};
-  Configurable<vector<float>> cfPhi{"cfPhi", {0.0, o2::constants::math::TwoPI}, "phi range: {min, max}[rad], with convention: min <= phi < max"};
-  Configurable<vector<float>> cfPt{"cfPt", {0.2, 5.0}, "pt range: {min, max}[GeV], with convention: min <= pt < max"};
-  Configurable<vector<float>> cfEta{"cfEta", {-0.8, 0.8}, "eta range: {min, max}, with convention: min <= eta < max"};
-  Configurable<vector<float>> cfCharge{"cfCharge", {-1.5, 1.5}, "particle charge. {-1.5,0} = only negative, {0,1.5} = only positive"};
-  Configurable<vector<float>> cftpcNClsFindable{"cftpcNClsFindable", {-1000., 1000.}, "tpcNClsFindable range: {min, max}, with convention: min <= cftpcNClsFindable < max"};
-  Configurable<vector<float>> cftpcNClsShared{"cftpcNClsShared", {-1000., 1000.}, "tpcNClsShared range: {min, max}, with convention: min <= cftpcNClsShared < max"};
-  Configurable<vector<float>> cfitsChi2NCl{"cfitsChi2NCl", {-1000., 1000.}, "itsChi2NCl range: {min, max}, with convention: min <= cfitsChi2NCl < max"};
-  Configurable<vector<float>> cftpcNClsFound{"cftpcNClsFound", {70., 1000.}, "tpcNClsFound range: {min, max}, with convention: min <= cftpcNClsFound < max"};
-  Configurable<vector<float>> cftpcNClsCrossedRows{"cftpcNClsCrossedRows", {70., 1000.}, "tpcNClsCrossedRows range: {min, max}, with convention: min <= tpcNClsCrossedRows < max"};
-  Configurable<vector<float>> cfitsNCls{"cfitsNCls", {5., 1000.}, "itsNCls range: {min, max}, with convention: min <= itsNCls < max"};
-  Configurable<vector<float>> cfitsNClsInnerBarrel{"cfitsNClsInnerBarrel", {-1000., 1000.}, "itsNClsInnerBarrel range: {min, max}, with convention: min <= cfitsNClsInnerBarrel < max"};
-  Configurable<vector<float>> cftpcCrossedRowsOverFindableCls{"cftpcCrossedRowsOverFindableCls", {0.8, 1000.}, "tpcCrossedRowsOverFindableCls range: {min, max}, with convention: min <= cftpcCrossedRowsOverFindableCls < max"};
-  Configurable<vector<float>> cftpcFoundOverFindableCls{"cftpcFoundOverFindableCls", {0.8, 1000.}, "tpcFoundOverFindableCls range: {min, max}, with convention: min <= cftpcFoundOverFindableCls < max"};
-  Configurable<vector<float>> cftpcFractionSharedCls{"cftpcFractionSharedCls", {-1000., 0.4}, "tpcFractionSharedCls range: {min, max}, with convention: min <= cftpcFractionSharedCls < max"};
-  Configurable<vector<float>> cftpcChi2NCl{"cftpcChi2NCl", {-1000., 4.}, "tpcChi2NCl range: {min, max}, with convention: min <= cftpcChi2NCl < max"};
-  Configurable<vector<float>> cfdcaXY{"cfdcaXY", {-2.4, 2.4}, "dcaXY range: {min, max}, with convention: min <= dcaXY < max (yes, DCA can be negative!)"};
-  Configurable<vector<float>> cfdcaZ{"cfdcaZ", {-3.2, 3.2}, "dcaZ range: {min, max}, with convention: min <= dcaZ < max (yes, DCA can be negative!)"};
-  Configurable<vector<float>> cfPDG{"cfPDG", {-5000., 5000.}, "PDG code"};
+  Configurable<std::vector<float>> cfPhi{"cfPhi", {0.0, o2::constants::math::TwoPI}, "phi range: {min, max}[rad], with convention: min <= phi < max"};
+  Configurable<std::vector<float>> cfPt{"cfPt", {0.2, 5.0}, "pt range: {min, max}[GeV], with convention: min <= pt < max"};
+  Configurable<std::vector<float>> cfEta{"cfEta", {-0.8, 0.8}, "eta range: {min, max}, with convention: min <= eta < max"};
+  Configurable<std::vector<float>> cfCharge{"cfCharge", {-1.5, 1.5}, "particle charge. {-1.5,0} = only negative, {0,1.5} = only positive"};
+  Configurable<std::vector<float>> cftpcNClsFindable{"cftpcNClsFindable", {-1000., 1000.}, "tpcNClsFindable range: {min, max}, with convention: min <= cftpcNClsFindable < max"};
+  Configurable<std::vector<float>> cftpcNClsShared{"cftpcNClsShared", {-1000., 1000.}, "tpcNClsShared range: {min, max}, with convention: min <= cftpcNClsShared < max"};
+  Configurable<std::vector<float>> cfitsChi2NCl{"cfitsChi2NCl", {-1000., 1000.}, "itsChi2NCl range: {min, max}, with convention: min <= cfitsChi2NCl < max"};
+  Configurable<std::vector<float>> cftpcNClsFound{"cftpcNClsFound", {70., 1000.}, "tpcNClsFound range: {min, max}, with convention: min <= cftpcNClsFound < max"};
+  Configurable<std::vector<float>> cftpcNClsCrossedRows{"cftpcNClsCrossedRows", {70., 1000.}, "tpcNClsCrossedRows range: {min, max}, with convention: min <= tpcNClsCrossedRows < max"};
+  Configurable<std::vector<float>> cfitsNCls{"cfitsNCls", {5., 1000.}, "itsNCls range: {min, max}, with convention: min <= itsNCls < max"};
+  Configurable<std::vector<float>> cfitsNClsInnerBarrel{"cfitsNClsInnerBarrel", {-1000., 1000.}, "itsNClsInnerBarrel range: {min, max}, with convention: min <= cfitsNClsInnerBarrel < max"};
+  Configurable<std::vector<float>> cftpcCrossedRowsOverFindableCls{"cftpcCrossedRowsOverFindableCls", {0.8, 1000.}, "tpcCrossedRowsOverFindableCls range: {min, max}, with convention: min <= cftpcCrossedRowsOverFindableCls < max"};
+  Configurable<std::vector<float>> cftpcFoundOverFindableCls{"cftpcFoundOverFindableCls", {0.8, 1000.}, "tpcFoundOverFindableCls range: {min, max}, with convention: min <= cftpcFoundOverFindableCls < max"};
+  Configurable<std::vector<float>> cftpcFractionSharedCls{"cftpcFractionSharedCls", {-1000., 0.4}, "tpcFractionSharedCls range: {min, max}, with convention: min <= cftpcFractionSharedCls < max"};
+  Configurable<std::vector<float>> cftpcChi2NCl{"cftpcChi2NCl", {-1000., 4.}, "tpcChi2NCl range: {min, max}, with convention: min <= cftpcChi2NCl < max"};
+  Configurable<std::vector<float>> cfdcaXY{"cfdcaXY", {-2.4, 2.4}, "dcaXY range: {min, max}, with convention: min <= dcaXY < max (yes, DCA can be negative!)"};
+  Configurable<std::vector<float>> cfdcaZ{"cfdcaZ", {-3.2, 3.2}, "dcaZ range: {min, max}, with convention: min <= dcaZ < max (yes, DCA can be negative!)"};
+  Configurable<std::vector<float>> cfPDG{"cfPDG", {-5000., 5000.}, "PDG code"};
   Configurable<bool> cftrackCutFlag{"cftrackCutFlag", false, "general selection, particle cuts are tuned centrally. Use only in Run 3."};
   Configurable<bool> cftrackCutFlagFb1{"cftrackCutFlagFb1", false, "general selection + 1 point in ITS IB. Use only in Run 3."};
   Configurable<bool> cftrackCutFlagFb2{"cftrackCutFlagFb2", false, "general selection + 2 point in ITS IB. Use only in Run 3."};
@@ -153,7 +158,7 @@ struct : ConfigurableGroup {
   Configurable<bool> cfisInAcceptanceTrack{"cfisInAcceptanceTrack", false, "TBI 20250113 obsolete - see enum, to be removed"};
   Configurable<bool> cfisGlobalTrack{"cfisGlobalTrack", false, "TBI 20240510 add description"};
   Configurable<bool> cfisPVContributor{"cfisPVContributor", false, "Has this track contributed to the collision vertex fit"};
-  Configurable<string> cfPtDependentDCAxyParameterization{"cfPtDependentDCAxyParameterization", "some formula TBI add some default formula, e.g. 0.0105+0.0350/x^1.1", "set here formula for pt-dependence DCAxy cut, in the following example format 0.0105+0.0350/x^1.1"};
+  Configurable<std::string> cfPtDependentDCAxyParameterization{"cfPtDependentDCAxyParameterization", "some formula TBI add some default formula, e.g. 0.0105+0.0350/x^1.1", "set here formula for pt-dependence DCAxy cut, in the following example format 0.0105+0.0350/x^1.1"};
   // TBI 20240426 do I need to add separate support for booleans to use each specific cut?
 } cf_pc;
 
@@ -188,9 +193,9 @@ struct : ConfigurableGroup {
   Configurable<bool> cfCalculateTest0AsFunctionOfInteractionRate{"cfCalculateTest0AsFunctionOfInteractionRate", false, "calculate or not Test0 as a function of interaction rate"};
   Configurable<bool> cfCalculateTest0AsFunctionOfCurrentRunDuration{"cfCalculateTest0AsFunctionOfCurrentRunDuration", false, "calculate or not Test0 as a function of current run duration (i.e. vs. seconds since start of run)"};
   Configurable<bool> cfCalculateTest0AsFunctionOfVz{"cfCalculateTest0AsFunctionOfVz", false, "calculate or not Test0 as a function of vertex z position"};
-  Configurable<string> cfFileWithLabels{"cfFileWithLabels", "/home/abilandz/DatasetsO2/labels.root", "path to external ROOT file which specifies all labels"}; // for AliEn file prepend "/alice/cern.ch/", for CCDB prepend "/alice-ccdb.cern.ch"
+  Configurable<std::string> cfFileWithLabels{"cfFileWithLabels", "/home/abilandz/DatasetsO2/labels.root", "path to external ROOT file which specifies all labels"}; // for AliEn file prepend "/alice/cern.ch/", for CCDB prepend "/alice-ccdb.cern.ch"
   Configurable<bool> cfUseDefaultLabels{"cfUseDefaultLabels", false, "use default internally hardwired labels, only for testing purposes"};
-  Configurable<string> cfWhichDefaultLabels{"cfWhichDefaultLabels", "standard", "only for testing purposes, select one set of default labels, see GetDefaultObjArrayWithLabels for supported options"};
+  Configurable<std::string> cfWhichDefaultLabels{"cfWhichDefaultLabels", "standard", "only for testing purposes, select one set of default labels, see GetDefaultObjArrayWithLabels for supported options"};
 } cf_t0;
 
 // *) Eta separation:
@@ -205,8 +210,8 @@ struct : ConfigurableGroup {
   Configurable<bool> cfCalculateEtaSeparationsAsFunctionOfInteractionRate{"cfCalculateEtaSeparationsAsFunctionOfInteractionRate", false, "calculate or not 2p corr. vs. eta separations as a function of interaction rate"};
   Configurable<bool> cfCalculateEtaSeparationsAsFunctionOfCurrentRunDuration{"cfCalculateEtaSeparationsAsFunctionOfCurrentRunDuration", false, "calculate or not 2p corr. vs. eta separations as a function of current run duration (i.e. vs. seconds since start of run)"};
   Configurable<bool> cfCalculateEtaSeparationsAsFunctionOfVz{"cfCalculateEtaSeparationsAsFunctionOfVz", false, "calculate or not 2p corr. vs. eta separations as a function of vertex z position"};
-  Configurable<vector<float>> cfEtaSeparationsValues{"cfEtaSeparationsValues", {0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8}, "Eta separation between interval A (-eta) and B (+eta)"};
-  Configurable<vector<string>> cfEtaSeparationsSkipHarmonics{"cfEtaSeparationsSkipHarmonics", {"0-v1", "0-v2", "0-v3", "0-v4", "1-v5", "1-v6", "1-v7", "1-v8", "1-v9"}, "For calculation of 2p correlation with eta separation these harmonics will be skipped (if first flag = \"0-v1\", v1 will be NOT be skipped in the calculus of 2p correlations with eta separations, etc.)"};
+  Configurable<std::vector<float>> cfEtaSeparationsValues{"cfEtaSeparationsValues", {0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8}, "Eta separation between interval A (-eta) and B (+eta)"};
+  Configurable<std::vector<std::string>> cfEtaSeparationsSkipHarmonics{"cfEtaSeparationsSkipHarmonics", {"0-v1", "0-v2", "0-v3", "0-v4", "1-v5", "1-v6", "1-v7", "1-v8", "1-v9"}, "For calculation of 2p correlation with eta separation these harmonics will be skipped (if first flag = \"0-v1\", v1 will be NOT be skipped in the calculus of 2p correlations with eta separations, etc.)"};
 } cf_es;
 
 // *) Particle weights:
@@ -216,16 +221,16 @@ struct : ConfigurableGroup {
   Configurable<bool> cfUseEtaWeights{"cfUseEtaWeights", false, "use or not eta weights"};
   Configurable<bool> cfUseDiffPhiPtWeights{"cfUseDiffPhiPtWeights", false, "use or not differential phi(pt) weights"};
   Configurable<bool> cfUseDiffPhiEtaWeights{"cfUseDiffPhiEtaWeights", false, "use or not differential phi(eta) weights"};
-  Configurable<vector<string>> cfWhichDiffPhiWeights{"cfWhichDiffPhiWeights", {"1-wPhi", "1-wPt", "1-wEta", "1-wCharge", "1-wCentrality", "1-wVertex_z"}, "use (1) or do not use (0) differential phi weight for particular dimension. If only phi is set to 1, integrated phi weights are used. If phi is set to 0, ALL dimensions are switched off (yes!)"};
-  Configurable<vector<string>> cfWhichDiffPtWeights{"cfWhichDiffPtWeights", {"1-wPt"}, "use (1) or do not use (0) differential pt weight for particular dimension. If only pt is set to 1, integrated pt weights are used. If pt is set to 0, ALL dimensions are switched off (yes!)"};
-  Configurable<vector<string>> cfWhichDiffEtaWeights{"cfWhichDiffEtaWeights", {"1-wEta"}, "use (1) or do not use (0) differential eta weight for particular dimension. If only eta is set to 1, integrated eta weights are used. If eta is set to 0, ALL dimensions are switched off (yes!)"};
-  Configurable<string> cfFileWithWeights{"cfFileWithWeights", "/home/abilandz/DatasetsO2/weights.root", "path to external ROOT file which holds all particle weights in O2 format"}; // for AliEn file prepend "/alice/cern.ch/", for CCDB prepend "/alice-ccdb.cern.ch"
+  Configurable<std::vector<std::string>> cfWhichDiffPhiWeights{"cfWhichDiffPhiWeights", {"1-wPhi", "1-wPt", "1-wEta", "1-wCharge", "1-wCentrality", "1-wVertex_z"}, "use (1) or do not use (0) differential phi weight for particular dimension. If only phi is set to 1, integrated phi weights are used. If phi is set to 0, ALL dimensions are switched off (yes!)"};
+  Configurable<std::vector<std::string>> cfWhichDiffPtWeights{"cfWhichDiffPtWeights", {"1-wPt"}, "use (1) or do not use (0) differential pt weight for particular dimension. If only pt is set to 1, integrated pt weights are used. If pt is set to 0, ALL dimensions are switched off (yes!)"};
+  Configurable<std::vector<std::string>> cfWhichDiffEtaWeights{"cfWhichDiffEtaWeights", {"1-wEta"}, "use (1) or do not use (0) differential eta weight for particular dimension. If only eta is set to 1, integrated eta weights are used. If eta is set to 0, ALL dimensions are switched off (yes!)"};
+  Configurable<std::string> cfFileWithWeights{"cfFileWithWeights", "/home/abilandz/DatasetsO2/weights.root", "path to external ROOT file which holds all particle weights in O2 format"}; // for AliEn file prepend "/alice/cern.ch/", for CCDB prepend "/alice-ccdb.cern.ch"
 } cf_pw;
 
 // *) Centrality weights:
 struct : ConfigurableGroup {
   Configurable<bool> cfUseCentralityWeights{"cfUseCentralityWeights", false, "use or not centrality weights"};
-  Configurable<string> cfFileWithCentralityWeights{"cfFileWithCentralityWeights", "/home/abilandz/DatasetsO2/centralityWeights.root", "path to external ROOT file which holds centrality weights in O2 format"}; // for AliEn file prepend "/alice/cern.ch/", for CCDB prepend "/alice-ccdb.cern.ch"
+  Configurable<std::string> cfFileWithCentralityWeights{"cfFileWithCentralityWeights", "/home/abilandz/DatasetsO2/centralityWeights.root", "path to external ROOT file which holds centrality weights in O2 format"}; // for AliEn file prepend "/alice/cern.ch/", for CCDB prepend "/alice-ccdb.cern.ch"
 } cf_cw;
 
 // *) Nested loops:
@@ -238,10 +243,10 @@ struct : ConfigurableGroup {
 
 // *) Toy NUA:
 struct : ConfigurableGroup {
-  Configurable<vector<int>> cfApplyNUAPDF{"cfApplyNUAPDF", {0, 0, 0}, "Apply (1) or do not apply (0) NUA on variable, ordering is the same as in enum eNUAPDF (phi, pt, eta)"};
-  Configurable<vector<int>> cfUseDefaultNUAPDF{"cfUseDefaultNUAPDF", {1, 1, 1}, "Use (1) or do not use (0) default NUA profile, ordering is the same as in enum eNUAPDF (phi, pt, eta)"};
-  Configurable<vector<string>> cfCustomNUAPDFHistNames{"cfCustomNUAPDFHistNames", {"a", "bb", "ccc"}, "the names of histograms holding custom NUA in an external file."};
-  Configurable<string> cfFileWithCustomNUA{"cfFileWithCustomNUA", "/home/abilandz/DatasetsO2/customNUA.root", "path to external ROOT file which holds all histograms with custom NUA"}; // for AliEn file prepend "/alice/cern.ch/", for CCDB prepend "/alice-ccdb.cern.ch"
+  Configurable<std::vector<int>> cfApplyNUAPDF{"cfApplyNUAPDF", {0, 0, 0}, "Apply (1) or do not apply (0) NUA on variable, ordering is the same as in enum eNUAPDF (phi, pt, eta)"};
+  Configurable<std::vector<int>> cfUseDefaultNUAPDF{"cfUseDefaultNUAPDF", {1, 1, 1}, "Use (1) or do not use (0) default NUA profile, ordering is the same as in enum eNUAPDF (phi, pt, eta)"};
+  Configurable<std::vector<std::string>> cfCustomNUAPDFHistNames{"cfCustomNUAPDFHistNames", {"a", "bb", "ccc"}, "the names of histograms holding custom NUA in an external file."};
+  Configurable<std::string> cfFileWithCustomNUA{"cfFileWithCustomNUA", "/home/abilandz/DatasetsO2/customNUA.root", "path to external ROOT file which holds all histograms with custom NUA"}; // for AliEn file prepend "/alice/cern.ch/", for CCDB prepend "/alice-ccdb.cern.ch"
 } cf_nua;
 
 // *) Internal validation:
@@ -249,11 +254,11 @@ struct : ConfigurableGroup {
   Configurable<bool> cfUseInternalValidation{"cfUseInternalValidation", false, "perform internal validation using flow analysis on-the-fly"};
   Configurable<bool> cfInternalValidationForceBailout{"cfInternalValidationForceBailout", false, "force bailout (use only locally, since there is no graceful exit (yet))"};
   Configurable<unsigned int> cfnEventsInternalValidation{"cfnEventsInternalValidation", 0, "number of events simulated on-the-fly for internal validation"};
-  Configurable<string> cfHarmonicsOptionInternalValidation{"cfHarmonicsOptionInternalValidation", "constant", "for internal validation, supported options are \"constant\", \"correlated\" and \"persistent\""};
+  Configurable<std::string> cfHarmonicsOptionInternalValidation{"cfHarmonicsOptionInternalValidation", "constant", "for internal validation, supported options are \"constant\", \"correlated\" and \"persistent\""};
   Configurable<bool> cfRescaleWithTheoreticalInput{"cfRescaleWithTheoreticalInput", false, "if kTRUE, all correlators are rescaled with theoretical input, so that all results in profiles are 1"};
-  Configurable<vector<float>> cfInternalValidationAmplitudes{"cfInternalValidationAmplitudes", {0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09}, "{v1, v2, v3, v4, ...} + has an effect only in combination with cfHarmonicsOptionInternalValidation = \"constant\". Max number of vn's is gMaxHarmonic."};
-  Configurable<vector<float>> cfInternalValidationPlanes{"cfInternalValidationPlanes", {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, "{Psi1, Psi2, Psi3, Psi4, ...} + has an effect only in combination with cfHarmonicsOptionInternalValidation = \"constant\". Max number of Psin's is gMaxHarmonic."};
-  Configurable<vector<int>> cfMultRangeInternalValidation{"cfMultRangeInternalValidation", {1000, 1001}, "{min, max}, with convention: min <= M < max"};
+  Configurable<std::vector<float>> cfInternalValidationAmplitudes{"cfInternalValidationAmplitudes", {0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09}, "{v1, v2, v3, v4, ...} + has an effect only in combination with cfHarmonicsOptionInternalValidation = \"constant\". Max number of vn's is gMaxHarmonic."};
+  Configurable<std::vector<float>> cfInternalValidationPlanes{"cfInternalValidationPlanes", {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}, "{Psi1, Psi2, Psi3, Psi4, ...} + has an effect only in combination with cfHarmonicsOptionInternalValidation = \"constant\". Max number of Psin's is gMaxHarmonic."};
+  Configurable<std::vector<int>> cfMultRangeInternalValidation{"cfMultRangeInternalValidation", {1000, 1001}, "{min, max}, with convention: min <= M < max"};
 } cf_iv;
 
 // *) Results histograms:
@@ -261,32 +266,32 @@ struct : ConfigurableGroup {
   Configurable<bool> cfSaveResultsHistograms{"cfSaveResultsHistograms", false, "save or not results histograms"};
 
   // Fixed-length binning (default):
-  Configurable<vector<float>> cfFixedLength_mult_bins{"cfFixedLength_mult_bins", {2000, 0., 20000.}, "nMultBins, multMin, multMax (only for results histograms)"};
-  Configurable<vector<float>> cfFixedLength_cent_bins{"cfFixedLength_cent_bins", {110, 0., 110.}, "nCentBins, centMin, centMax (only for results histograms)"};
-  Configurable<vector<float>> cfFixedLength_pt_bins{"cfFixedLength_pt_bins", {1000, 0., 10.}, "nPtBins, ptMin, ptMax (only for results histograms)"};
-  Configurable<vector<float>> cfFixedLength_eta_bins{"cfFixedLength_eta_bins", {80, -2., 2.}, "nEtaBins, etaMin, etaMax (only for results histograms)"};
-  Configurable<vector<float>> cfFixedLength_occu_bins{"cfFixedLength_occu_bins", {200, 0., 60000.}, "nOccuBins, occuMin, occuMax (only for results histograms)"};
-  Configurable<vector<float>> cfFixedLength_ir_bins{"cfFixedLength_ir_bins", {1000, 0., 100.}, "nirBins, irMin, irMax (only for results histograms)"};
-  Configurable<vector<float>> cfFixedLength_crd_bins{"cfFixedLength_crd_bins", {100000, 0., 100000.}, "ncrdBins, crdMin, crdMax (only for results histograms)"};
-  Configurable<vector<float>> cfFixedLength_vz_bins{"cfFixedLength_vz_bins", {400, -20., 20.}, "nvzBins, vzMin, vzMax (only for results histograms)"};
+  Configurable<std::vector<float>> cfFixedLength_mult_bins{"cfFixedLength_mult_bins", {2000, 0., 20000.}, "nMultBins, multMin, multMax (only for results histograms)"};
+  Configurable<std::vector<float>> cfFixedLength_cent_bins{"cfFixedLength_cent_bins", {110, 0., 110.}, "nCentBins, centMin, centMax (only for results histograms)"};
+  Configurable<std::vector<float>> cfFixedLength_pt_bins{"cfFixedLength_pt_bins", {1000, 0., 10.}, "nPtBins, ptMin, ptMax (only for results histograms)"};
+  Configurable<std::vector<float>> cfFixedLength_eta_bins{"cfFixedLength_eta_bins", {80, -2., 2.}, "nEtaBins, etaMin, etaMax (only for results histograms)"};
+  Configurable<std::vector<float>> cfFixedLength_occu_bins{"cfFixedLength_occu_bins", {200, 0., 60000.}, "nOccuBins, occuMin, occuMax (only for results histograms)"};
+  Configurable<std::vector<float>> cfFixedLength_ir_bins{"cfFixedLength_ir_bins", {1000, 0., 100.}, "nirBins, irMin, irMax (only for results histograms)"};
+  Configurable<std::vector<float>> cfFixedLength_crd_bins{"cfFixedLength_crd_bins", {100000, 0., 100000.}, "ncrdBins, crdMin, crdMax (only for results histograms)"};
+  Configurable<std::vector<float>> cfFixedLength_vz_bins{"cfFixedLength_vz_bins", {400, -20., 20.}, "nvzBins, vzMin, vzMax (only for results histograms)"};
 
   // Variable-length binning (per request):
   Configurable<bool> cfUseVariableLength_mult_bins{"cfUseVariableLength_mult_bins", false, "use or not variable-length multiplicity bins"};
-  Configurable<vector<float>> cfVariableLength_mult_bins{"cfVariableLength_mult_bins", {0., 5., 6., 7., 8., 9., 100., 200., 500., 1000., 10000.}, "variable-length multiplicity bins"};
+  Configurable<std::vector<float>> cfVariableLength_mult_bins{"cfVariableLength_mult_bins", {0., 5., 6., 7., 8., 9., 100., 200., 500., 1000., 10000.}, "variable-length multiplicity bins"};
   Configurable<bool> cfUseVariableLength_cent_bins{"cfUseVariableLength_cent_bins", false, "use or not variable-length centrality bins"};
-  Configurable<vector<float>> cfVariableLength_cent_bins{"cfVariableLength_cent_bins", {0., 10., 50., 100.}, "variable-length centrality bins"};
+  Configurable<std::vector<float>> cfVariableLength_cent_bins{"cfVariableLength_cent_bins", {0., 10., 50., 100.}, "variable-length centrality bins"};
   Configurable<bool> cfUseVariableLength_pt_bins{"cfUseVariableLength_pt_bins", true, "use or not variable-length pt bins"};
-  Configurable<vector<float>> cfVariableLength_pt_bins{"cfVariableLength_pt_bins", {0.20, 0.25, 0.30, 0.35, 0.40, 0.50, 0.60, 0.80, 1.00, 1.25, 1.50, 1.75, 2.00, 2.50, 3.00, 4.00, 5.00}, "variable-length pt bins"};
+  Configurable<std::vector<float>> cfVariableLength_pt_bins{"cfVariableLength_pt_bins", {0.20, 0.25, 0.30, 0.35, 0.40, 0.50, 0.60, 0.80, 1.00, 1.25, 1.50, 1.75, 2.00, 2.50, 3.00, 4.00, 5.00}, "variable-length pt bins"};
   Configurable<bool> cfUseVariableLength_eta_bins{"cfUseVariableLength_eta_bins", true, "use or not variable-length eta bins"};
-  Configurable<vector<float>> cfVariableLength_eta_bins{"cfVariableLength_eta_bins", {-0.8, -0.6, -0.4, -0.3, -0.2, -0.1, 0.0, 0.1, 0.2, 0.3, 0.4, 0.6, 0.8}, "variable-length eta bins"};
+  Configurable<std::vector<float>> cfVariableLength_eta_bins{"cfVariableLength_eta_bins", {-0.8, -0.6, -0.4, -0.3, -0.2, -0.1, 0.0, 0.1, 0.2, 0.3, 0.4, 0.6, 0.8}, "variable-length eta bins"};
   Configurable<bool> cfUseVariableLength_occu_bins{"cfUseVariableLength_occu_bins", false, "use or not variable-length occupancy bins"};
-  Configurable<vector<float>> cfVariableLength_occu_bins{"cfVariableLength_occu_bins", {0., 5., 6., 7., 8., 9., 100., 200., 500., 1000., 10000.}, "variable-length occupancy bins"};
+  Configurable<std::vector<float>> cfVariableLength_occu_bins{"cfVariableLength_occu_bins", {0., 5., 6., 7., 8., 9., 100., 200., 500., 1000., 10000.}, "variable-length occupancy bins"};
   Configurable<bool> cfUseVariableLength_ir_bins{"cfUseVariableLength_ir_bins", false, "use or not variable-length interaction rate bins"};
-  Configurable<vector<float>> cfVariableLength_ir_bins{"cfVariableLength_ir_bins", {0., 5., 10., 50., 100., 200.}, "variable-length ineraction rate bins"};
+  Configurable<std::vector<float>> cfVariableLength_ir_bins{"cfVariableLength_ir_bins", {0., 5., 10., 50., 100., 200.}, "variable-length ineraction rate bins"};
   Configurable<bool> cfUseVariableLength_crd_bins{"cfUseVariableLength_crd_bins", false, "use or not variable-length current run duration bins"};
-  Configurable<vector<float>> cfVariableLength_crd_bins{"cfVariableLength_crd_bins", {0., 5., 10., 50., 100., 500.}, "variable-length current run duration bins"};
+  Configurable<std::vector<float>> cfVariableLength_crd_bins{"cfVariableLength_crd_bins", {0., 5., 10., 50., 100., 500.}, "variable-length current run duration bins"};
   Configurable<bool> cfUseVariableLength_vz_bins{"cfUseVariableLength_vz_bins", false, "use or not variable-length vertex z bins"};
-  Configurable<vector<float>> cfVariableLength_vz_bins{"cfVariableLength_vz_bins", {-10., -8., -6., -4, -2., -1., 0., 1., 2., 4., 6., 8., 10.}, "variable-length vertex z bins"};
+  Configurable<std::vector<float>> cfVariableLength_vz_bins{"cfVariableLength_vz_bins", {-10., -8., -6., -4, -2., -1., 0., 1., 2., 4., 6., 8., 10.}, "variable-length vertex z bins"};
 
 } cf_res;
 

--- a/PWGCF/MultiparticleCorrelations/Core/MuPa-DataMembers.h
+++ b/PWGCF/MultiparticleCorrelations/Core/MuPa-DataMembers.h
@@ -61,14 +61,17 @@ struct TaskConfiguration {
   UInt_t fRandomSeed = 0;                        // argument for TRandom3 constructor. By default it is 0 (seed is guaranteed to be unique in time and space)
   bool fUseFisherYates = false;                  // algorithm used to randomize particle indices, set via configurable
   TArrayI* fRandomIndices = NULL;                // array to store random indices obtained from Fisher-Yates algorithm
-  int fFixedNumberOfRandomlySelectedTracks = -1; // use a fixed number of randomly selected particles in each event. It is set and applied, if > 0. Set to <=0 to ignore.
-  bool fUseStopwatch = false;                    // do some basing profiling with TStopwatch for where the execution time is going
-  TStopwatch* fTimer[eTimer_N] = {NULL};         // stopwatch, global (overal execution time) and local
-  float fFloatingPointPrecision = 1.e-6;         // two floats are the same if TMath::Abs(f1 - f2) < fFloatingPointPrecision (there is configurable for it)
-  int fSequentialBailout = 0;                    // if fSequentialBailout > 0, then each fSequentialBailout events the function BailOut() is called. Can be used for real analysis and for IV.
-  bool fUseSpecificCuts = false;                 // apply after DefaultCuts() also hardwired analysis-specific cuts, determined via tc.fWhichSpecificCuts
-  TString fWhichSpecificCuts = "";               // determine which set of analysis-specific cuts will be applied after DefaultCuts(). Use in combination with tc.fUseSpecificCuts
-} tc;                                            // "tc" labels an instance of this group of variables.
+  int fFixedNumberOfRandomlySelectedTracks = -1; // use a fixed number of randomly selected particles in each event, applies to all centralities. It is set and applied if > 0. Set to <=0 to ignore.
+
+  bool fUseStopwatch = false;            // do some basing profiling with TStopwatch for where the execution time is going
+  TStopwatch* fTimer[eTimer_N] = {NULL}; // stopwatch, global (overal execution time) and local
+  float fFloatingPointPrecision = 1.e-6; // two floats are the same if TMath::Abs(f1 - f2) < fFloatingPointPrecision (there is configurable for it)
+  int fSequentialBailout = 0;            // if fSequentialBailout > 0, then each fSequentialBailout events the function BailOut() is called. Can be used for real analysis and for IV.
+  bool fUseSpecificCuts = false;         // apply after DefaultCuts() also hardwired analysis-specific cuts, determined via tc.fWhichSpecificCuts
+  TString fWhichSpecificCuts = "";       // determine which set of analysis-specific cuts will be applied after DefaultCuts(). Use in combination with tc.fUseSpecificCuts
+  TString fSkipTheseRuns = "";           // comma-separated list of runs which will be skipped during analysis in hl (a.k.a. "bad runs")
+  bool fSkipRun = false;                 // based on the content of fWhichSpecificCuts, skip or not the current run
+} tc;                                    // "tc" labels an instance of this group of variables.
 
 // *) Event-by-event quantities:
 struct EventByEventQuantities {
@@ -119,13 +122,21 @@ struct QualityAssurance {
   TProfile* fQAParticleEventProEbyE[2][2] = {{NULL}};                                      // helper profile to calculate <some-particle-property> event-by-event
                                                                                            // [reco, sim][before, after]. Type dimension is bin.
 
-  TList* fQACorrelationsVsList = NULL;                                                                //!<! base list to hold all QA particle event output object
+  TList* fQACorrelationsVsList = NULL;                                                                //!<! base list to hold all QA "CorrelationsVs" output object
   TH2F* fQACorrelationsVsHistograms2D[eQACorrelationsVsHistograms2D_N][gMaxHarmonic][2] = {{{NULL}}}; //! [ type - see enum eQACorrelationsVsHistograms2D ][reco,sim]. I do not have here support for [before, after], because I do not fill Q-vectors before cuts
   bool fFillQACorrelationsVsHistograms2D = true;                                                      // if false, all 2D histograms in this category are not filled. If true, the ones for which fBookQACorrelationsVsHistograms2D[...] is true, are filled
   bool fBookQACorrelationsVsHistograms2D[eQACorrelationsVsHistograms2D_N] = {true};                   // book or not this 2D histogram, see configurable cfBookQACorrelationsVsHistograms2D
   float fQACorrelationsVsHistogramsBins2D[eQACorrelationsVsHistograms2D_N][2][3] = {{{0.}}};          // [type - see enum][x,y][nBins,min,max]
   TString fQACorrelationsVsHistogramsName2D[eQACorrelationsVsHistograms2D_N] = {""};                  // name of fQACorrelationsVsHistograms2D, determined programatically from other 1D names, to ease bookkeeping
   int fQACorrelationsVsHistogramsMinMaxHarmonic[2];                                                   // book only for MinMaxHarmonic[0] <= harmonics < MinMaxHarmonic[1]
+
+  TList* fQACorrelationsVsInteractionRateVsList = NULL;                                                                    //!<! base list to hold all QA "CorrelationsVsInteractionRateVs" output object
+  TProfile2D* fQACorrVsIRVsProfiles2D[eQACorrelationsVsInteractionRateVsProfiles2D_N][gMaxHarmonic][2] = {{{NULL}}};       //! [ type - see enum eQACorrelationsVsInteractionRateVsProfiles2D_N ][reco,sim]. I do not have here support for [before, after], because I do not fill Q-vectors before cuts
+  bool fFillQACorrelationsVsInteractionRateVsProfiles2D = true;                                                            // if false, all 2D profiles in this category are not filled. If true, the ones for which fBookQACorrelationsVsInteractionRateVsProfiles2D[...] is true, are filled
+  bool fBookQACorrelationsVsInteractionRateVsProfiles2D[eQACorrelationsVsInteractionRateVsProfiles2D_N] = {true};          // book or not this 2D profile, see configurable cfBookQACorrelationsVsInteractionRateVsProfiles2D
+  float fQACorrelationsVsInteractionRateVsProfilesBins2D[eQACorrelationsVsInteractionRateVsProfiles2D_N][2][3] = {{{0.}}}; // [type - see enum][x,y][nBins,min,max]
+  TString fQACorrelationsVsInteractionRateVsProfilesName2D[eQACorrelationsVsInteractionRateVsProfiles2D_N] = {""};         // name of fQACorrelationsVsInteractionRateVsProfiles2D, determined programatically from other 1D names, to ease bookkeeping
+  int fQACorrelationsVsInteractionRateVsProfilesMinMaxHarmonic[2];                                                         // book only for MinMaxHarmonic[0] <= harmonics < MinMaxHarmonic[1]
 
   float fReferenceMultiplicity[eReferenceMultiplicityEstimators_N] = {0.};                // used mostly in QA correlation plots
   TString fReferenceMultiplicityEstimatorName[eReferenceMultiplicityEstimators_N] = {""}; // TBI 20241123 add comment
@@ -167,7 +178,7 @@ struct EventCuts {
   int fEventCutCounterBinNumber[2] = {1, 1};               // bin counter for set bin labels in fEventCutCounterHist
   float fdEventCuts[eEventCuts_N][2] = {{0.}};             // event cuts defined via [min,max)
   TString fsEventCuts[eEventCuts_N] = {""};                // event cuts defined via string
-  TH1I* fEventCutCounterHist[2][eCutCounter_N] = {{NULL}}; //!<! [rec,sim][see enum eCutCounter] histogram to store how many any times each event cut triggered
+  TH1F* fEventCutCounterHist[2][eCutCounter_N] = {{NULL}}; //!<! [rec,sim][see enum eCutCounter] histogram to store how many any times each event cut triggered
   int fBeforeAfterColor[2] = {kRed, kGreen};               // color code before and after cuts
 } ec;                                                      // "ec" is a common label for objects in this struct
 
@@ -302,15 +313,15 @@ struct NestedLoops {
 
 // *) Toy NUA (can be applied both in real data analysis and in analysis 'on-the-fly', e.g. when running internal validation):
 struct NUA {
-  TList* fNUAList = NULL;                              // list to hold all NUA objects
-  TProfile* fNUAFlagsPro = NULL;                       // profile to hold all flags for NUA objects
-  bool fApplyNUAPDF[eNUAPDF_N] = {false};              // apply NUA to particular kine variable (see the corresponding enum eNUAPDF)
-  bool fUseDefaultNUAPDF[eNUAPDF_N] = {true};          // by default, use simple hardcoded expressions for NUA acceptance profile
-  TF1* fDefaultNUAPDF[eNUAPDF_N] = {NULL};             // default distributions used as pdfs to simulate NUA on-the-fly
-  TH1D* fCustomNUAPDF[eNUAPDF_N] = {NULL};             // custom, user-supplied distributions used to simulate NUA
-  TString* fCustomNUAPDFHistNames[eNUAPDF_N] = {NULL}; // these are the names of histograms holding custom NUA in an external file. There is a configurable for this one.
-  TString fFileWithCustomNUA = "";                     // path to external ROOT file which holds all histograms with custom NUA
-  Double_t fMaxValuePDF[eNUAPDF_N] = {0.};             // see algorithm used in Accept(...). I implemented it as a data member, so that it is not calculated again and again at each particle call
+  TList* fNUAList = NULL;                                 // list to hold all NUA objects
+  TProfile* fNUAFlagsPro = NULL;                          // profile to hold all flags for NUA objects
+  bool fApplyNUAPDF[eNUAPDF_N] = {false};                 // apply NUA to particular kine variable (see the corresponding enum eNUAPDF)
+  bool fUseDefaultNUAPDF[eNUAPDF_N] = {true, true, true}; // by default, use simple hardcoded expressions for NUA acceptance profile
+  TF1* fDefaultNUAPDF[eNUAPDF_N] = {NULL};                // default distributions used as pdfs to simulate NUA on-the-fly
+  TH1D* fCustomNUAPDF[eNUAPDF_N] = {NULL};                // custom, user-supplied distributions used to simulate NUA
+  TString* fCustomNUAPDFHistNames[eNUAPDF_N] = {NULL};    // these are the names of histograms holding custom NUA in an external file. There is a configurable for this one.
+  TString fFileWithCustomNUA = "";                        // path to external ROOT file which holds all histograms with custom NUA
+  Double_t fMaxValuePDF[eNUAPDF_N] = {0.};                // see algorithm used in Accept(...). I implemented it as a data member, so that it is not calculated again and again at each particle call
 } nua;
 
 // *) Internal validation:

--- a/PWGCF/MultiparticleCorrelations/Core/MuPa-Enums.h
+++ b/PWGCF/MultiparticleCorrelations/Core/MuPa-Enums.h
@@ -33,6 +33,7 @@ enum eConfiguration {
   eSequentialBailout,
   eUseSpecificCuts,
   eWhichSpecificCuts,
+  eSkipTheseRuns,
   eConfiguration_N
 };
 
@@ -63,7 +64,7 @@ enum eRecSim { eRec = 0,
                eRec_Run1, // converted Run 1 data
                eSim_Run1,
                eRecAndSim_Run1,
-               eTest };
+               eTest }; // remember that as of 20250315 I can use "cfWhichSpecificCuts": "Test" in JSON, to configure quickly all cuts for this case
 
 enum eBeforeAfter { eBefore = 0, // use this one for cuts
                     eAfter = 1 };
@@ -405,6 +406,27 @@ enum eQACorrelationsVsHistograms2D {
   eQACorrelationsVsHistograms2D_N
 };
 
+enum eQACorrelationsVsInteractionRateVsProfiles2D_N {
+  // In this category I fill <2> in 2D profile spanned by IR vs. some-other-observable (IR is always x axis)
+  // For instance: <2> is filled in TProfile2D spanned by IR vs. CurrentRunDuration (crd)
+  //               <2> is filled in TProfile2D spanned by IR vs. <pT>, where <pT> is calculated from all particles in that event
+  // Remark 1: If I would ever need the same thingie for <4>, <6>, etc., just introduce new dimension in 2D profile
+  // Remark 2: All < ... > over particles are calculated with helper TProfile fQAParticleEventProEbyE
+  eCorrelationsVsInteractionRate_vs_CurrentRunDuration = 0,
+  eCorrelationsVsInteractionRate_vs_Multiplicity,
+  eCorrelationsVsInteractionRate_vs_ReferenceMultiplicity,
+  eCorrelationsVsInteractionRate_vs_Centrality,
+  // ...
+  eCorrelationsVsInteractionRate_vs_MeanPhi,
+  eCorrelationsVsInteractionRate_vs_SigmaMeanPhi,
+  eCorrelationsVsInteractionRate_vs_MeanPt,
+  eCorrelationsVsInteractionRate_vs_SigmaMeanPt,
+  eCorrelationsVsInteractionRate_vs_MeanEta,
+  eCorrelationsVsInteractionRate_vs_SigmaMeanEta,
+  // ...
+  eQACorrelationsVsInteractionRateVsProfiles2D_N
+};
+
 enum eReferenceMultiplicityEstimators {
   // Run 3:
   eMultTPC = 0,
@@ -453,6 +475,8 @@ enum eSpecificCuts {
   eLHC15o,
   // Run 1:
   // ...
+  // Cuts for minimal subscription, "processTest": "true in JSON
+  eTestCuts,
   eSpecificCuts_N
 };
 

--- a/PWGCF/MultiparticleCorrelations/Core/MuPa-MemberFunctions.h
+++ b/PWGCF/MultiparticleCorrelations/Core/MuPa-MemberFunctions.h
@@ -100,6 +100,8 @@ void BookBaseList()
 
   fBasePro->GetXaxis()->SetBinLabel(eWhichSpecificCuts, Form("WhichSpecificCuts = %s", tc.fWhichSpecificCuts.Data()));
 
+  fBasePro->GetXaxis()->SetBinLabel(eSkipTheseRuns, Form("SkipTheseRuns = %s", tc.fSkipTheseRuns.Data()));
+
   fBaseList->Add(fBasePro);
 
   if (tc.fVerbose) {
@@ -222,6 +224,7 @@ void DefaultConfiguration()
   tc.fSequentialBailout = cf_tc.cfSequentialBailout;
   tc.fUseSpecificCuts = cf_tc.cfUseSpecificCuts;
   tc.fWhichSpecificCuts = cf_tc.cfWhichSpecificCuts;
+  tc.fSkipTheseRuns = cf_tc.cfSkipTheseRuns;
 
   // *) Event histograms (for QA see below):
   eh.fEventHistogramsName[eNumberOfEvents] = "NumberOfEvents";
@@ -481,7 +484,7 @@ void DefaultConfiguration()
   // ...
 
   // *) Toy NUA:
-  auto lApplyNUAPDF = (vector<int>)cf_nua.cfApplyNUAPDF;
+  auto lApplyNUAPDF = (std::vector<int>)cf_nua.cfApplyNUAPDF;
   if (lApplyNUAPDF.size() != eNUAPDF_N) {
     LOGF(info, "\033[1;31m lApplyNUAPDF.size() = %d\033[0m", lApplyNUAPDF.size());
     LOGF(info, "\033[1;31m eNUAPDF_N = %d\033[0m", static_cast<int>(eNUAPDF_N));
@@ -494,7 +497,7 @@ void DefaultConfiguration()
   // **) Execute the lines below, only if toy NUA (either default or custom) is requested for at least one kine variable:
   if (nua.fApplyNUAPDF[ePhiNUAPDF] || nua.fApplyNUAPDF[ePtNUAPDF] || nua.fApplyNUAPDF[eEtaNUAPDF]) {
 
-    auto lUseDefaultNUAPDF = (vector<int>)cf_nua.cfUseDefaultNUAPDF;
+    auto lUseDefaultNUAPDF = (std::vector<int>)cf_nua.cfUseDefaultNUAPDF;
     if (lUseDefaultNUAPDF.size() != eNUAPDF_N) {
       LOGF(info, "\033[1;31m lUseDefaultNUAPDF.size() = %d\033[0m", lUseDefaultNUAPDF.size());
       LOGF(info, "\033[1;31m eNUAPDF_N = %d\033[0m", static_cast<int>(eNUAPDF_N));
@@ -515,7 +518,7 @@ void DefaultConfiguration()
       nua.fFileWithCustomNUA = TString(cf_nua.cfFileWithCustomNUA);
 
       // *) histogram names with custom NUA distributions in that file + get those histograms immediately here:
-      auto lCustomNUAPDFHistNames = (vector<string>)cf_nua.cfCustomNUAPDFHistNames;
+      auto lCustomNUAPDFHistNames = (std::vector<std::string>)cf_nua.cfCustomNUAPDFHistNames;
       // TBI 20241115 For some reason, the default values of configurable "cfCustomNUAPDFHistNames" are not correctly propagated in the local variables, but I can circumvent that with JSON settings for the time being
       if (lCustomNUAPDFHistNames.size() != eNUAPDF_N) {
         LOGF(info, "\033[1;31m lCustomNUAPDFHistNames.size() = %d\033[0m", lCustomNUAPDFHistNames.size());
@@ -686,6 +689,28 @@ void DefaultConfiguration()
   for (int t = 0; t < eQACorrelationsVsHistograms2D_N; t++) {
     if (qa.fQACorrelationsVsHistogramsName2D[t].EqualTo("")) {
       LOGF(fatal, "\033[1;31m%s at line %d : qa.fQACorrelationsVsHistogramsName2D[%d] is not set, check corresponding enum eQACorrelationsVsHistograms2D \033[0m", __FUNCTION__, __LINE__, t);
+    }
+  }
+
+  // **) Names of QA 2D "correlations vs. IR vs. " profiles:
+  qa.fQACorrelationsVsInteractionRateVsProfilesName2D[eCorrelationsVsInteractionRate_vs_CurrentRunDuration] = TString::Format("%s_vs_%s", "CorrVsIR", eh.fEventHistogramsName[eCurrentRunDuration].Data()).Data();
+  qa.fQACorrelationsVsInteractionRateVsProfilesName2D[eCorrelationsVsInteractionRate_vs_Multiplicity] = TString::Format("%s_vs_%s", "CorrVsIR", eh.fEventHistogramsName[eMultiplicity].Data()).Data();
+  qa.fQACorrelationsVsInteractionRateVsProfilesName2D[eCorrelationsVsInteractionRate_vs_ReferenceMultiplicity] = TString::Format("%s_vs_%s", "CorrVsIR", eh.fEventHistogramsName[eReferenceMultiplicity].Data()).Data();
+  qa.fQACorrelationsVsInteractionRateVsProfilesName2D[eCorrelationsVsInteractionRate_vs_Centrality] = TString::Format("%s_vs_%s", "CorrVsIR", eh.fEventHistogramsName[eCentrality].Data()).Data();
+  // ...
+  qa.fQACorrelationsVsInteractionRateVsProfilesName2D[eCorrelationsVsInteractionRate_vs_MeanPhi] = TString::Format("%s_vs_Mean%s", "CorrVsIR", ph.fParticleHistogramsName[ePhi].Data()).Data();
+  qa.fQACorrelationsVsInteractionRateVsProfilesName2D[eCorrelationsVsInteractionRate_vs_SigmaMeanPhi] = TString::Format("%s_vs_SigmaMean%s", "CorrVsIR", ph.fParticleHistogramsName[ePhi].Data()).Data();
+  qa.fQACorrelationsVsInteractionRateVsProfilesName2D[eCorrelationsVsInteractionRate_vs_MeanPt] = TString::Format("%s_vs_Mean%s", "CorrVsIR", ph.fParticleHistogramsName[ePt].Data()).Data();
+  qa.fQACorrelationsVsInteractionRateVsProfilesName2D[eCorrelationsVsInteractionRate_vs_SigmaMeanPt] = TString::Format("%s_vs_SigmaMean%s", "CorrVsIR", ph.fParticleHistogramsName[ePt].Data()).Data();
+  qa.fQACorrelationsVsInteractionRateVsProfilesName2D[eCorrelationsVsInteractionRate_vs_MeanEta] = TString::Format("%s_vs_Mean%s", "CorrVsIR", ph.fParticleHistogramsName[eEta].Data()).Data();
+  qa.fQACorrelationsVsInteractionRateVsProfilesName2D[eCorrelationsVsInteractionRate_vs_SigmaMeanEta] = TString::Format("%s_vs_SigmaMean%s", "CorrVsIR", ph.fParticleHistogramsName[eEta].Data()).Data();
+
+  // ...
+
+  // ***) Quick insanity check that all names are set:
+  for (int t = 0; t < eQACorrelationsVsInteractionRateVsProfiles2D_N; t++) {
+    if (qa.fQACorrelationsVsInteractionRateVsProfilesName2D[t].EqualTo("")) {
+      LOGF(fatal, "\033[1;31m%s at line %d : qa.fQACorrelationsVsInteractionRateVsProfilesName2D[%d] is not set, check corresponding enum eQACorrelationsVsInteractionRateVsProfiles2D \033[0m", __FUNCTION__, __LINE__, t);
     }
   }
 
@@ -1102,6 +1127,51 @@ void DefaultBooking()
     LOGF(fatal, "\033[1;31m%s at line %d : wrong setting for min and max harmonics: min = %d, max = %d \033[0m", __FUNCTION__, __LINE__, qa.fQACorrelationsVsHistogramsMinMaxHarmonic[eMin], qa.fQACorrelationsVsHistogramsMinMaxHarmonic[eMax]);
   }
 
+  // **) QA 2D "correlations vs. IR vs. " profiles:
+  qa.fFillQACorrelationsVsInteractionRateVsProfiles2D = cf_qa.cfFillQACorrelationsVsInteractionRateVsProfiles2D;
+
+  // *) If you do not want particular 2D correlations vs. IR vs. " profile to be booked, use configurable array cfBookQACorrelationsVsInteractionRateVsProfiles2D, where you can specify flags 1 (book) or 0 (do not book).
+  // Ordering of the flags in that array is interpreted through ordering of enums in enum eQACorrelationsVsInteractionRateVsProfiles2D.
+  auto lBookQACorrelationsVsInteractionRateVsProfiles2D = cf_qa.cfBookQACorrelationsVsInteractionRateVsProfiles2D.value; // this is now the local version of that string array from configurable
+  if (lBookQACorrelationsVsInteractionRateVsProfiles2D.size() != eQACorrelationsVsInteractionRateVsProfiles2D_N) {
+    LOGF(info, "\033[1;31m lBookQACorrelationsVsInteractionRateVsProfiles2D.size() = %d\033[0m", lBookQACorrelationsVsInteractionRateVsProfiles2D.size());
+    LOGF(info, "\033[1;31m eQACorrelationsVsInteractionRateVsProfiles2D_N = %d\033[0m", static_cast<int>(eQACorrelationsVsInteractionRateVsProfiles2D_N));
+    LOGF(fatal, "in function \033[1;31m%s at line %d Mismatch in the number of flags in configurable cfBookQACorrelationsVsInteractionRateVsProfiles2D, and number of entries in enum eCorrelationsVsInteractionRateVsProfiles2D \n \033[0m", __FUNCTION__, __LINE__);
+  }
+
+  // *) Insanity check on the content and ordering of QA 2D "correlations vs. IR vs. " profiles in the initialization in configurable cfBookQACorrelationsVsInteractionRateVsProfiles2D:
+  // TBI 20240518 I do not need this in fact, I can automate initialization even without ordering in configurable, but it feels with the ordering enforced, it's much safer.
+  for (int name = 0; name < eQACorrelationsVsInteractionRateVsProfiles2D_N; name++) {
+    // TBI 20240518 I could implement even a strickter EqualTo instead of EndsWith, but then I need to tokenize, etc., etc. This shall be safe enough.
+    if (!TString(lBookQACorrelationsVsInteractionRateVsProfiles2D[name]).EndsWith(qa.fQACorrelationsVsInteractionRateVsProfilesName2D[name].Data())) {
+      LOGF(fatal, "\033[1;31m%s at line %d : Wrong content or ordering of contents in configurable cfBookQACorrelationsVsInteractionRateVsProfiles2D => name = %d, lBookQACorrelationsVsInteractionRateVsProfiles2D[name] = \"%s\", qa.fCorrelationsVsInteractionRateVsProfilesName2D[name] = \"%s\" \n Check if you are using an up to date tag. \033[0m", __FUNCTION__, __LINE__, name, TString(lBookQACorrelationsVsInteractionRateVsProfiles2D[name]).Data(), qa.fQACorrelationsVsInteractionRateVsProfilesName2D[name].Data());
+    }
+  }
+
+  // I append "&& qa.fFillQACorrelationsVsInteractionRateVsProfiles2D" below, to switch off booking of all 2D "correlations vs. IR vs. " profiles with one common flag:
+  qa.fBookQACorrelationsVsInteractionRateVsProfiles2D[eCorrelationsVsInteractionRate_vs_CurrentRunDuration] = Alright(lBookQACorrelationsVsInteractionRateVsProfiles2D[eCorrelationsVsInteractionRate_vs_CurrentRunDuration]) && qa.fFillQACorrelationsVsInteractionRateVsProfiles2D;
+  qa.fBookQACorrelationsVsInteractionRateVsProfiles2D[eCorrelationsVsInteractionRate_vs_Multiplicity] = Alright(lBookQACorrelationsVsInteractionRateVsProfiles2D[eCorrelationsVsInteractionRate_vs_Multiplicity]) && qa.fFillQACorrelationsVsInteractionRateVsProfiles2D;
+  qa.fBookQACorrelationsVsInteractionRateVsProfiles2D[eCorrelationsVsInteractionRate_vs_ReferenceMultiplicity] = Alright(lBookQACorrelationsVsInteractionRateVsProfiles2D[eCorrelationsVsInteractionRate_vs_ReferenceMultiplicity]) && qa.fFillQACorrelationsVsInteractionRateVsProfiles2D;
+  qa.fBookQACorrelationsVsInteractionRateVsProfiles2D[eCorrelationsVsInteractionRate_vs_Centrality] = Alright(lBookQACorrelationsVsInteractionRateVsProfiles2D[eCorrelationsVsInteractionRate_vs_Centrality]) && qa.fFillQACorrelationsVsInteractionRateVsProfiles2D;
+  // .....
+  qa.fBookQACorrelationsVsInteractionRateVsProfiles2D[eCorrelationsVsInteractionRate_vs_MeanPhi] = Alright(lBookQACorrelationsVsInteractionRateVsProfiles2D[eCorrelationsVsInteractionRate_vs_MeanPhi]) && qa.fFillQACorrelationsVsInteractionRateVsProfiles2D;
+  qa.fBookQACorrelationsVsInteractionRateVsProfiles2D[eCorrelationsVsInteractionRate_vs_SigmaMeanPhi] = Alright(lBookQACorrelationsVsInteractionRateVsProfiles2D[eCorrelationsVsInteractionRate_vs_SigmaMeanPhi]) && qa.fFillQACorrelationsVsInteractionRateVsProfiles2D;
+  qa.fBookQACorrelationsVsInteractionRateVsProfiles2D[eCorrelationsVsInteractionRate_vs_MeanPt] = Alright(lBookQACorrelationsVsInteractionRateVsProfiles2D[eCorrelationsVsInteractionRate_vs_MeanPt]) && qa.fFillQACorrelationsVsInteractionRateVsProfiles2D;
+  qa.fBookQACorrelationsVsInteractionRateVsProfiles2D[eCorrelationsVsInteractionRate_vs_SigmaMeanPt] = Alright(lBookQACorrelationsVsInteractionRateVsProfiles2D[eCorrelationsVsInteractionRate_vs_SigmaMeanPt]) && qa.fFillQACorrelationsVsInteractionRateVsProfiles2D;
+  qa.fBookQACorrelationsVsInteractionRateVsProfiles2D[eCorrelationsVsInteractionRate_vs_MeanEta] = Alright(lBookQACorrelationsVsInteractionRateVsProfiles2D[eCorrelationsVsInteractionRate_vs_MeanEta]) && qa.fFillQACorrelationsVsInteractionRateVsProfiles2D;
+  qa.fBookQACorrelationsVsInteractionRateVsProfiles2D[eCorrelationsVsInteractionRate_vs_SigmaMeanEta] = Alright(lBookQACorrelationsVsInteractionRateVsProfiles2D[eCorrelationsVsInteractionRate_vs_SigmaMeanEta]) && qa.fFillQACorrelationsVsInteractionRateVsProfiles2D;
+
+  // .....
+
+  // *) min and max harmonics for which this series of histograms will be booked:
+  auto lQACorrelationsVsInteractionRateVsProfilesMinMaxHarmonic = cf_qa.cfQACorrelationsVsInteractionRateVsProfilesMinMaxHarmonic.value;
+  qa.fQACorrelationsVsInteractionRateVsProfilesMinMaxHarmonic[eMin] = lQACorrelationsVsInteractionRateVsProfilesMinMaxHarmonic[eMin];
+  qa.fQACorrelationsVsInteractionRateVsProfilesMinMaxHarmonic[eMax] = lQACorrelationsVsInteractionRateVsProfilesMinMaxHarmonic[eMax];
+  // **) insanity check:
+  if (!(qa.fQACorrelationsVsInteractionRateVsProfilesMinMaxHarmonic[eMin] < qa.fQACorrelationsVsInteractionRateVsProfilesMinMaxHarmonic[eMax])) {
+    LOGF(fatal, "\033[1;31m%s at line %d : wrong setting for min and max harmonics: min = %d, max = %d \033[0m", __FUNCTION__, __LINE__, qa.fQACorrelationsVsInteractionRateVsProfilesMinMaxHarmonic[eMin], qa.fQACorrelationsVsInteractionRateVsProfilesMinMaxHarmonic[eMax]);
+  }
+
   // ...
 
   if (tc.fVerbose) {
@@ -1352,37 +1422,46 @@ void InitializeFixedLengthBins(eAsFunctionOf AFO)
   }
 
   // Common local vector for all fixed-length bins:
-  vector<float> lFixedLength_bins;
+  std::vector<float> lFixedLength_bins;
 
   switch (AFO) {
-    case AFO_MULTIPLICITY:
+    case AFO_MULTIPLICITY: {
       lFixedLength_bins = cf_res.cfFixedLength_mult_bins.value;
       break;
-    case AFO_CENTRALITY:
+    }
+    case AFO_CENTRALITY: {
       lFixedLength_bins = cf_res.cfFixedLength_cent_bins.value;
       break;
-    case AFO_PT:
+    }
+    case AFO_PT: {
       lFixedLength_bins = cf_res.cfFixedLength_pt_bins.value;
       break;
-    case AFO_ETA:
+    }
+    case AFO_ETA: {
       lFixedLength_bins = cf_res.cfFixedLength_eta_bins.value;
       break;
-    case AFO_OCCUPANCY:
+    }
+    case AFO_OCCUPANCY: {
       lFixedLength_bins = cf_res.cfFixedLength_occu_bins.value;
       break;
-    case AFO_INTERACTIONRATE:
+    }
+    case AFO_INTERACTIONRATE: {
       lFixedLength_bins = cf_res.cfFixedLength_ir_bins.value;
       break;
-    case AFO_CURRENTRUNDURATION:
+    }
+    case AFO_CURRENTRUNDURATION: {
       lFixedLength_bins = cf_res.cfFixedLength_crd_bins.value;
       break;
-    case AFO_VZ:
+    }
+    case AFO_VZ: {
       lFixedLength_bins = cf_res.cfFixedLength_vz_bins.value;
       break;
+    }
     // ...
-    default:
+    default: {
       LOGF(fatal, "\033[1;31m%s at line %d : This enum AFO = %d is not supported yet. \033[0m", __FUNCTION__, __LINE__, static_cast<int>(AFO));
       break;
+    }
   } // switch(AFO)
 
   // From this point onward, the code is the same for any AFO variable:
@@ -1415,37 +1494,46 @@ void InitializeVariableLengthBins(eAsFunctionOf AFO)
   }
 
   // Common local vector for all variable-length bins:
-  vector<float> lVariableLength_bins;
+  std::vector<float> lVariableLength_bins;
 
   switch (AFO) {
-    case AFO_MULTIPLICITY:
+    case AFO_MULTIPLICITY: {
       lVariableLength_bins = cf_res.cfVariableLength_mult_bins.value;
       break;
-    case AFO_CENTRALITY:
+    }
+    case AFO_CENTRALITY: {
       lVariableLength_bins = cf_res.cfVariableLength_cent_bins.value;
       break;
-    case AFO_PT:
+    }
+    case AFO_PT: {
       lVariableLength_bins = cf_res.cfVariableLength_pt_bins.value;
       break;
-    case AFO_ETA:
+    }
+    case AFO_ETA: {
       lVariableLength_bins = cf_res.cfVariableLength_eta_bins.value;
       break;
-    case AFO_OCCUPANCY:
+    }
+    case AFO_OCCUPANCY: {
       lVariableLength_bins = cf_res.cfVariableLength_occu_bins.value;
       break;
-    case AFO_INTERACTIONRATE:
+    }
+    case AFO_INTERACTIONRATE: {
       lVariableLength_bins = cf_res.cfVariableLength_ir_bins.value;
       break;
-    case AFO_CURRENTRUNDURATION:
+    }
+    case AFO_CURRENTRUNDURATION: {
       lVariableLength_bins = cf_res.cfVariableLength_crd_bins.value;
       break;
-    case AFO_VZ:
+    }
+    case AFO_VZ: {
       lVariableLength_bins = cf_res.cfVariableLength_vz_bins.value;
       break;
+    }
     // ...
-    default:
+    default: {
       LOGF(fatal, "\033[1;31m%s at line %d : This enum AFO = %d is not supported yet. \033[0m", __FUNCTION__, __LINE__, static_cast<int>(AFO));
       break;
+    }
   } // switch(AFO)
 
   // From this point onward, the code is the same for any AFO variable:
@@ -1523,7 +1611,7 @@ void DefaultCuts()
 
   // *) Use or do not use a cut enumerated in eEventHistograms + eEventCuts.
   //    Default cuts are set in configurable cfUseEventCuts
-  auto lUseEventCuts = (vector<string>)cf_ec.cfUseEventCuts;
+  auto lUseEventCuts = (std::vector<std::string>)cf_ec.cfUseEventCuts;
   if (lUseEventCuts.size() != eEventCuts_N) {
     LOGF(info, "\033[1;31m lUseEventCuts.size() = %d\033[0m", lUseEventCuts.size());
     LOGF(info, "\033[1;31m eEventCuts_N = %d\033[0m", static_cast<int>(eEventCuts_N));
@@ -1613,6 +1701,10 @@ void DefaultCuts()
   auto lMultiplicity = (std::vector<float>)cf_ec.cfMultiplicity;
   ec.fdEventCuts[eMultiplicity][eMin] = lMultiplicity[eMin];
   ec.fdEventCuts[eMultiplicity][eMax] = lMultiplicity[eMax];
+  // If I have requested fFixedNumberOfRandomlySelectedTracks, then I do not care about events with smaller number of particles:
+  if (tc.fFixedNumberOfRandomlySelectedTracks > 0) {
+    ec.fdEventCuts[eMultiplicity][eMin] = tc.fFixedNumberOfRandomlySelectedTracks;
+  }
 
   auto lReferenceMultiplicity = (std::vector<float>)cf_ec.cfReferenceMultiplicity;
   ec.fdEventCuts[eReferenceMultiplicity][eMin] = lReferenceMultiplicity[eMin];
@@ -1682,7 +1774,7 @@ void DefaultCuts()
 
   // *) Use or do not use a cut enumerated in eParticleHistograms + eParticleCuts.
   //    Default cuts are set in configurable cfUseParticleCuts
-  auto lUseParticleCuts = (std::vector<string>)cf_pc.cfUseParticleCuts;
+  auto lUseParticleCuts = (std::vector<std::string>)cf_pc.cfUseParticleCuts;
   if (lUseParticleCuts.size() != eParticleCuts_N) {
     LOGF(info, "\033[1;31m lUseParticleCuts.size() = %d\033[0m", lUseParticleCuts.size());
     LOGF(info, "\033[1;31m eParticleCuts_N = %d\033[0m", static_cast<int>(eParticleCuts_N));
@@ -1847,6 +1939,8 @@ void SpecificCuts(TString whichSpecificCuts)
     specificCuts = eLHC24as;
   } else if (whichSpecificCuts.EqualTo("LHC15o")) {
     specificCuts = eLHC15o;
+  } else if (whichSpecificCuts.EqualTo("Test")) {
+    specificCuts = eTestCuts;
   } else {
     LOGF(fatal, "\033[1;31m%s at line %d : whichSpecificCuts = %s is not supported \033[0m", __FUNCTION__, __LINE__, whichSpecificCuts.Data());
   }
@@ -1860,7 +1954,7 @@ void SpecificCuts(TString whichSpecificCuts)
   //    Remark #3: Most up-to-date documentation of each cut is in enum file.
   switch (specificCuts) {
 
-    case eLHC23zzh:
+    case eLHC23zzh: {
 
       // In this branch I implement default cuts and settings for PbPb Run 3 datasets collected in 2023.
       // If I change some cut here, keep in sync. with other branches (e.g. for 2024 data).
@@ -1917,9 +2011,10 @@ void SpecificCuts(TString whichSpecificCuts)
       pc.fUseParticleCuts[eisPVContributor] = true;
 
       break;
+    }
 
     case eLHC24ar:
-    case eLHC24as:
+    case eLHC24as: {
 
       // In this branch I implement default cuts and settings for PbPb Run 3 datasets collected in 2024:
       // If I change some cut here, keep in sync. with other branches (e.g. for 2023 data).
@@ -1979,8 +2074,9 @@ void SpecificCuts(TString whichSpecificCuts)
       pc.fUseParticleCuts[eisPVContributor] = true;
 
       break;
+    }
 
-    case eLHC15o:
+    case eLHC15o: {
 
       // In this branch I implement default cuts and settings for Run 2 datasets:
 
@@ -2030,13 +2126,67 @@ void SpecificCuts(TString whichSpecificCuts)
       // ...
 
       break;
+    }
 
       // ...
 
-    default:
+    case eTestCuts: {
+
+      // In this branch I implement default cuts and settings for minimal subscription, "processTest": "true in JSON
+
+      // Event cuts:
+      // ec.fUseEventCuts[eSel7] = true; // TBI 20250115 ehen i procees in "Rec" some converted Run 2 MC, it removes 99% of events, see enum
+      ec.fUseEventCuts[eSel8] = false;
+      ec.fUseEventCuts[eNoSameBunchPileup] = false;
+      ec.fUseEventCuts[eIsGoodZvtxFT0vsPV] = false;
+      ec.fUseEventCuts[eIsVertexITSTPC] = false;
+      ec.fUseEventCuts[eNoCollInTimeRangeStrict] = false;
+      ec.fUseEventCuts[eNoCollInRofStrict] = false;
+      ec.fUseEventCuts[eNoHighMultCollInPrevRof] = false;
+      ec.fUseEventCuts[eNoCollInTimeRangeStandard] = false;
+      ec.fUseEventCuts[eNoCollInRofStrict] = false;
+      ec.fUseEventCuts[eNoCollInRofStandard] = false;
+      ec.fUseEventCuts[eNoCollInRofStandard] = false;
+      ec.fUseEventCuts[eIsGoodITSLayer3] = false;
+      ec.fUseEventCuts[eIsGoodITSLayer0123] = false;
+      ec.fUseEventCuts[eIsGoodITSLayersAll] = false;
+
+      // ec.fUseEventCuts[eTrigger] = true;
+      // ec.fsEventCuts[eTrigger] = "kINT7"; // TBI 20250115 cannot be used when i procees in "Rec" some converted Run 2 MC, see enum
+
+      // ...
+
+      // Particle cuts:
+      pc.fUseParticleCuts[eisInAcceptanceTrack] = false; // see enum
+      pc.fUseParticleCuts[etrackCutFlagFb1] = false;     // only for Run 3
+      pc.fUseParticleCuts[etrackCutFlagFb2] = false;     // only for Run 3
+      pc.fUseParticleCuts[eisPVContributor] = false;     // only for Run 3
+
+      // ...
+
+      // The rest:
+      mupa.fCalculateCorrelationsAsFunctionOf[AFO_OCCUPANCY] = false;
+      mupa.fCalculateCorrelationsAsFunctionOf[AFO_INTERACTIONRATE] = false;
+      mupa.fCalculateCorrelationsAsFunctionOf[AFO_CURRENTRUNDURATION] = false;
+
+      t0.fCalculateTest0AsFunctionOf[AFO_OCCUPANCY] = false;
+      t0.fCalculateTest0AsFunctionOf[AFO_INTERACTIONRATE] = false;
+      t0.fCalculateTest0AsFunctionOf[AFO_CURRENTRUNDURATION] = false;
+
+      es.fCalculateEtaSeparationsAsFunctionOf[AFO_OCCUPANCY] = false;
+      es.fCalculateEtaSeparationsAsFunctionOf[AFO_INTERACTIONRATE] = false;
+      es.fCalculateEtaSeparationsAsFunctionOf[AFO_CURRENTRUNDURATION] = false;
+
+      // ...
+
+      break;
+    }
+
+    default: {
       LOGF(fatal, "\033[1;31m%s at line %d : specificCuts = %d is not supported yet \033[0m", __FUNCTION__, __LINE__, static_cast<int>(specificCuts));
       break;
-  } // switch((specificCuts))
+    }
+  } // switch (specificCuts)
 
   if (tc.fVerbose) {
     ExitFunction(__FUNCTION__);
@@ -2186,9 +2336,14 @@ void InsanityChecksBeforeBooking()
     }
   }
 
-  // **) Enforce that if fixed number of randomly selected tracks is used in the analysis, that Fisher-Yates algorithm is enabled:
+  // **) Enforce that if the fixed number of randomly selected tracks is used in the analysis, that Fisher-Yates algorithm is enabled:
   if (tc.fFixedNumberOfRandomlySelectedTracks > 0 && !tc.fUseFisherYates) {
-    LOGF(fatal, "\033[1;31m%s at line %d\033[0m", __FUNCTION__, __LINE__);
+    LOGF(fatal, "\033[1;31m%s at line %d\033[0m : Did you forget to enable Fisher-Yates algorithm?", __FUNCTION__, __LINE__);
+  }
+
+  // **) Enforce that if the fixed number of randomly selected tracks is used that Toy NUA is disabled:
+  if (tc.fFixedNumberOfRandomlySelectedTracks > 0 && (nua.fApplyNUAPDF[ePhiNUAPDF] || nua.fApplyNUAPDF[ePtNUAPDF] || nua.fApplyNUAPDF[eEtaNUAPDF])) {
+    LOGF(fatal, "\033[1;31m%s at line %d : Not supported at the moment: use FixedNumberOfRandomlySelectedTracks + Toy NUA enabled.\nI cannot in an easy way ensure that ParticleCuts behave exactly the same in the Main and Banishment loops, because e.g. I call consequtively for same partcile gRandom->Uniform(...) in ParticleCuts, and that can't work.\033[0m", __FUNCTION__, __LINE__);
   }
 
   // **) When it comes to DCAxy cut, ensure that either flat or pt-dependent cut is used, but not both:
@@ -2627,6 +2782,8 @@ void BookAndNestAllLists()
   //  **) QA event histograms;
   //  **) QA particle histograms;
   //  **) QA particle event histograms;
+  //  **) QA "correlations vs." histograms:
+  //  **) QA "correlations vs. IR vs. " profiles;
   // *) Control event histograms;
   // *) Control particle histograms;
   // *) Correlations;
@@ -2650,7 +2807,7 @@ void BookAndNestAllLists()
   qa.fQAList->SetOwner(true);
   fBaseList->Add(qa.fQAList);
 
-  //  **) QA event histograms;
+  //  **) QA event histograms:
   if (qa.fFillQAEventHistograms2D) {
     qa.fQAEventList = new TList();
     qa.fQAEventList->SetName("QAEvent");
@@ -2658,7 +2815,7 @@ void BookAndNestAllLists()
     qa.fQAList->Add(qa.fQAEventList); // yes, this one is nested within base QA TList
   }
 
-  //  **) QA particle histograms;
+  //  **) QA particle histograms:
   if (qa.fFillQAParticleHistograms2D) {
     qa.fQAParticleList = new TList();
     qa.fQAParticleList->SetName("QAParticle");
@@ -2666,7 +2823,7 @@ void BookAndNestAllLists()
     qa.fQAList->Add(qa.fQAParticleList); // yes, this one is nested within base QA TList
   }
 
-  //  **) QA particle event histograms;
+  //  **) QA particle event histograms:
   if (qa.fFillQAParticleEventHistograms2D) {
     qa.fQAParticleEventList = new TList();
     qa.fQAParticleEventList->SetName("QAParticleEvent");
@@ -2674,12 +2831,20 @@ void BookAndNestAllLists()
     qa.fQAList->Add(qa.fQAParticleEventList); // yes, this one is nested within base QA TList
   }
 
-  //  **) QA "correlations vs." histograms;
+  //  **) QA "correlations vs." histograms:
   if (qa.fFillQACorrelationsVsHistograms2D) {
     qa.fQACorrelationsVsList = new TList();
     qa.fQACorrelationsVsList->SetName("QACorrelationsVs");
     qa.fQACorrelationsVsList->SetOwner(true);
     qa.fQAList->Add(qa.fQACorrelationsVsList); // yes, this one is nested within base QA TList
+  }
+
+  //  **) QA "correlations vs. IR vs. " profiles:
+  if (qa.fFillQACorrelationsVsInteractionRateVsProfiles2D) {
+    qa.fQACorrelationsVsInteractionRateVsList = new TList();
+    qa.fQACorrelationsVsInteractionRateVsList->SetName("QACorrelationsVsInteractionRateVsList");
+    qa.fQACorrelationsVsInteractionRateVsList->SetOwner(true);
+    qa.fQAList->Add(qa.fQACorrelationsVsInteractionRateVsList); // yes, this one is nested within base QA TList
   }
 
   // *) Event cuts:
@@ -2785,7 +2950,8 @@ void BookQAHistograms()
   // c) Book specific QA 2D event histograms;
   // d) Book specific QA 2D particle histograms;
   // e) Book specific QA 2D particle event histograms;
-  // f) Book specific QA 2D "correlations vs." histograms.
+  // f) Book specific QA 2D "correlations vs." histograms;
+  // g) Book specific QA 2D "correlations vs. IR vs. " profiles.
 
   if (tc.fVerbose) {
     StartFunction(__FUNCTION__);
@@ -2804,7 +2970,7 @@ void BookQAHistograms()
   }
 
   // a) Book the profile holding flags:
-  qa.fQAHistogramsPro = new TProfile("fQAHistogramsPro", "flags for QA histograms", 6, 0., 6.);
+  qa.fQAHistogramsPro = new TProfile("fQAHistogramsPro", "flags for QA histograms", 7, 0., 7.);
   qa.fQAHistogramsPro->SetStats(false);
   qa.fQAHistogramsPro->SetLineColor(eColor);
   qa.fQAHistogramsPro->SetFillColor(eFillColor);
@@ -2818,8 +2984,10 @@ void BookQAHistograms()
   qa.fQAHistogramsPro->Fill(3.5, static_cast<int>(qa.fFillQAParticleEventHistograms2D));
   qa.fQAHistogramsPro->GetXaxis()->SetBinLabel(5, "fFillQACorrelationsVsHistograms2D");
   qa.fQAHistogramsPro->Fill(4.5, static_cast<int>(qa.fFillQACorrelationsVsHistograms2D));
-  qa.fQAHistogramsPro->GetXaxis()->SetBinLabel(6, "fRebin");
-  qa.fQAHistogramsPro->Fill(5.5, static_cast<int>(qa.fRebin));
+  qa.fQAHistogramsPro->GetXaxis()->SetBinLabel(6, "fFillQACorrelationsVsInteractionRateVsProfiles2D");
+  qa.fQAHistogramsPro->Fill(5.5, static_cast<int>(qa.fFillQACorrelationsVsInteractionRateVsProfiles2D));
+  qa.fQAHistogramsPro->GetXaxis()->SetBinLabel(7, "fRebin");
+  qa.fQAHistogramsPro->Fill(6.5, static_cast<int>(qa.fRebin));
 
   // ...
 
@@ -3148,6 +3316,7 @@ void BookQAHistograms()
           continue;
         }
 
+        // valgrind --tool=massif => ~9.8 MiB (Last check: 20250315)
         qa.fQAEventHistograms2D[t][rs][ba] = new TH2F(
           TString::Format("fQAEventHistograms2D[%s][%s][%s]", qa.fEventHistogramsName2D[t].Data(), gc.srs[rs].Data(), gc.sba[ba].Data()),
           TString::Format("%s, %s, %s", "__RUN_NUMBER__", gc.srs_long[rs].Data(), gc.sba_long[ba].Data()), // __RUN_NUMBER__ is handled in PropagateRunNumber(...)
@@ -3212,6 +3381,7 @@ void BookQAHistograms()
 
       for (int ba = 0; ba < 2; ba++) // before/after cuts
       {
+        // valgrind --tool=massif => ~30.6 MiB (Last check: 20250315)
         qa.fQAParticleHistograms2D[t][rs][ba] = new TH2F(
           TString::Format("fQAParticleHistograms2D[%s][%s][%s]", qa.fParticleHistogramsName2D[t].Data(), gc.srs[rs].Data(), gc.sba[ba].Data()),
           TString::Format("%s, %s, %s", "__RUN_NUMBER__", gc.srs_long[rs].Data(), gc.sba_long[ba].Data()), // __RUN_NUMBER__ is handled in PropagateRunNumber(...)
@@ -3372,6 +3542,7 @@ void BookQAHistograms()
           continue;
         }
 
+        // valgrind --tool=massif => ~70.2 MiB (Last check: 20250315)
         qa.fQAParticleEventHistograms2D[t][rs][ba] = new TH2F(
           TString::Format("fQAParticleEventHistograms2D[%s][%s][%s]", qa.fQAParticleEventHistogramsName2D[t].Data(), gc.srs[rs].Data(), gc.sba[ba].Data()),
           TString::Format("%s, %s, %s", "__RUN_NUMBER__", gc.srs_long[rs].Data(), gc.sba_long[ba].Data()), // __RUN_NUMBER__ is handled in PropagateRunNumber(...)
@@ -3502,6 +3673,7 @@ void BookQAHistograms()
           continue;
         }
 
+        // valgrind --tool=massif => ~58.7 MiB (Last check: 20250315)
         qa.fQACorrelationsVsHistograms2D[t][h][rs] = new TH2F(
           TString::Format("fQACorrelationsVsHistograms2D[%s][%d][%s]", qa.fQACorrelationsVsHistogramsName2D[t].Data(), h, gc.srs[rs].Data()),
           TString::Format("%s, %s", "__RUN_NUMBER__", gc.srs_long[rs].Data()), // __RUN_NUMBER__ is handled in PropagateRunNumber(...)
@@ -3518,6 +3690,133 @@ void BookQAHistograms()
     } // for (int h = 0; h < gMaxHarmonic; h++) {
 
   } // for(int t=0;t<eQACorrelationsVsHistograms2D_N;t++) // type, see enum eCorrelationsVsHistograms2D
+
+  // g) Book specific QA 2D "correlations vs. IR vs. " profiles:
+
+  // Binning of 2D"correlations vs. IR vs. " profiles:
+  // Remark: I use the same binning for x axis (it's interaction rate) for all 2D QA profiles in this category, therefore here implementation in shorter.
+  int nBins_x_CorrelationsVsInteractionRateVs = static_cast<int>(eh.fEventHistogramsBins[eInteractionRate][0] / qa.fRebin);
+  double min_x_CorrelationsVsInteractionRateVs = eh.fEventHistogramsBins[eInteractionRate][1];
+  double max_x_CorrelationsVsInteractionRateVs = eh.fEventHistogramsBins[eInteractionRate][2];
+  TString title_x_CorrelationsVsInteractionRateVs = "interaction rate";
+  int nBins_y_CorrelationsVsInteractionRateVs[eQACorrelationsVsInteractionRateVsProfiles2D_N] = {0};
+  double min_y_CorrelationsVsInteractionRateVs[eQACorrelationsVsInteractionRateVsProfiles2D_N] = {0.};
+  double max_y_CorrelationsVsInteractionRateVs[eQACorrelationsVsInteractionRateVsProfiles2D_N] = {0.};
+  TString title_y_CorrelationsVsInteractionRateVs[eQACorrelationsVsInteractionRateVsProfiles2D_N] = {""};
+
+  // *) "eCorrelationsVsInteractionRate_vs_CurrentRunDuration":
+  nBins_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_CurrentRunDuration] = static_cast<int>(eh.fEventHistogramsBins[eCurrentRunDuration][0] / qa.fRebin);
+  min_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_CurrentRunDuration] = eh.fEventHistogramsBins[eCurrentRunDuration][1];
+  max_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_CurrentRunDuration] = eh.fEventHistogramsBins[eCurrentRunDuration][2];
+  title_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_CurrentRunDuration] = FancyFormatting(eh.fEventHistogramsName[eCurrentRunDuration].Data());
+
+  // *) "eCorrelationsVsInteractionRate_vs_Multiplicity":
+  nBins_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_Multiplicity] = static_cast<int>(eh.fEventHistogramsBins[eMultiplicity][0] / qa.fRebin);
+  min_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_Multiplicity] = eh.fEventHistogramsBins[eMultiplicity][1];
+  max_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_Multiplicity] = eh.fEventHistogramsBins[eMultiplicity][2];
+  title_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_Multiplicity] = FancyFormatting(eh.fEventHistogramsName[eMultiplicity].Data());
+
+  // *) "eCorrelationsVsInteractionRate_vs_ReferenceMultiplicity":
+  nBins_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_ReferenceMultiplicity] = static_cast<int>(eh.fEventHistogramsBins[eReferenceMultiplicity][0] / qa.fRebin);
+  min_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_ReferenceMultiplicity] = eh.fEventHistogramsBins[eReferenceMultiplicity][1];
+  max_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_ReferenceMultiplicity] = eh.fEventHistogramsBins[eReferenceMultiplicity][2];
+  title_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_ReferenceMultiplicity] = FancyFormatting(eh.fEventHistogramsName[eReferenceMultiplicity].Data());
+
+  // *) "eCorrelationsVsInteractionRate_vs_Centrality":
+  nBins_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_Centrality] = static_cast<int>(eh.fEventHistogramsBins[eCentrality][0]);
+  min_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_Centrality] = eh.fEventHistogramsBins[eCentrality][1];
+  max_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_Centrality] = eh.fEventHistogramsBins[eCentrality][2];
+  title_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_Centrality] = FancyFormatting(eh.fEventHistogramsName[eCentrality].Data());
+
+  // .....
+
+  // *) "eCorrelationsVsInteractionRate_vs_MeanPhi":
+  nBins_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_MeanPhi] = 200;
+  min_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_MeanPhi] = 0.;
+  max_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_MeanPhi] = o2::constants::math::TwoPI;
+  title_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_MeanPhi] = FancyFormatting(ph.fParticleHistogramsName[ePhi].Data());
+
+  // *) "eCorrelationsVsInteractionRate_vs_SigmaMeanPhi":
+  nBins_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_SigmaMeanPhi] = 200;
+  min_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_SigmaMeanPhi] = 0.;
+  max_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_SigmaMeanPhi] = 1.0;
+  title_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_SigmaMeanPhi] = TString::Format("#sigma_{%s}", FancyFormatting(ph.fParticleHistogramsName[ePhi].Data()));
+
+  // *) "eCorrelationsVsInteractionRate_vs_MeanPt":
+  nBins_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_MeanPt] = 200;
+  min_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_MeanPt] = 0.0;
+  max_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_MeanPt] = 2.0;
+  title_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_MeanPt] = FancyFormatting(ph.fParticleHistogramsName[ePt].Data());
+
+  // *) "eCorrelationsVsInteractionRate_vs_SigmaMeanPt":
+  nBins_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_SigmaMeanPt] = 200;
+  min_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_SigmaMeanPt] = 0.;
+  max_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_SigmaMeanPt] = 1.0;
+  title_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_SigmaMeanPt] = TString::Format("#sigma_{%s}", FancyFormatting(ph.fParticleHistogramsName[ePt].Data()));
+
+  // *) "eCorrelationsVsInteractionRate_vs_MeanEta":
+  nBins_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_MeanEta] = 600;
+  min_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_MeanEta] = -0.5;
+  max_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_MeanEta] = 0.5;
+  title_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_MeanEta] = FancyFormatting(ph.fParticleHistogramsName[eEta].Data());
+
+  // *) "eCorrelationsVsInteractionRate_vs_SigmaMeanEta":
+  nBins_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_SigmaMeanEta] = 200;
+  min_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_SigmaMeanEta] = 0.;
+  max_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_SigmaMeanEta] = 1.0;
+  title_y_CorrelationsVsInteractionRateVs[eCorrelationsVsInteractionRate_vs_SigmaMeanEta] = TString::Format("#sigma_{%s}", FancyFormatting(ph.fParticleHistogramsName[eEta].Data()));
+
+  // .....
+
+  // *) Quick insanity check on title_x_CorrelationsVsInteractionRateVs and title_y_CorrelationsVsInteractionRateVs:
+  if (title_x_CorrelationsVsInteractionRateVs.EqualTo("")) {
+    LOGF(fatal, "\033[1;31m%s at line %d : title_x_CorrelationsVsInteractionRateVs is not set, check corresponding enum \033[0m", __FUNCTION__, __LINE__);
+  }
+  for (int t = 0; t < eQACorrelationsVsInteractionRateVsProfiles2D_N; t++) {
+    if (title_y_CorrelationsVsInteractionRateVs[t].EqualTo("")) {
+      LOGF(fatal, "\033[1;31m%s at line %d : title_y_CorrelationsVsInteractionRateVs[%d] is not set, check corresponding enum  \033[0m", __FUNCTION__, __LINE__, t);
+    }
+  }
+
+  // Okay, let's book 'em all:
+  for (int t = 0; t < eQACorrelationsVsInteractionRateVsProfiles2D_N; t++) // type, see enum eQACorrelationsVsInteractionRateVsProfiles2D
+  {
+    if (!qa.fBookQACorrelationsVsInteractionRateVsProfiles2D[t]) {
+      continue;
+    }
+
+    for (int h = 0; h < gMaxHarmonic; h++) {
+
+      if (h + 1 < qa.fQACorrelationsVsInteractionRateVsProfilesMinMaxHarmonic[eMin] || h + 1 >= qa.fQACorrelationsVsInteractionRateVsProfilesMinMaxHarmonic[eMax]) {
+        continue;
+      }
+
+      for (int rs = 0; rs < 2; rs++) // reco/sim
+      {
+
+        if (Skip(rs)) {
+          continue;
+        }
+
+        // TBI 20250317 documet here the output of profiling using valgrind --tool=massif
+        qa.fQACorrVsIRVsProfiles2D[t][h][rs] = new TProfile2D(
+          TString::Format("fQACorrVsIRVsProfiles2D[%s][%d][%s]", qa.fQACorrelationsVsInteractionRateVsProfilesName2D[t].Data(), h, gc.srs[rs].Data()),
+          TString::Format("%s, %s", "__RUN_NUMBER__", gc.srs_long[rs].Data()), // __RUN_NUMBER__ is handled in PropagateRunNumber(...)
+          nBins_x_CorrelationsVsInteractionRateVs, min_x_CorrelationsVsInteractionRateVs, max_x_CorrelationsVsInteractionRateVs, nBins_y_CorrelationsVsInteractionRateVs[t], min_y_CorrelationsVsInteractionRateVs[t], max_y_CorrelationsVsInteractionRateVs[t]);
+
+        TString tmp = qa.fQACorrVsIRVsProfiles2D[t][h][rs]->GetTitle(); // translating e.g. "544114, reconstructed" into "<<2>> (harmonic = 2), 544114, reconstructed"
+        qa.fQACorrVsIRVsProfiles2D[t][h][rs]->SetTitle(TString::Format("#LT#LT2#GT#GT (harmonic = %d), %s", h + 1, tmp.Data()));
+        qa.fQACorrVsIRVsProfiles2D[t][h][rs]->GetXaxis()->SetTitle(title_x_CorrelationsVsInteractionRateVs.Data());
+        qa.fQACorrVsIRVsProfiles2D[t][h][rs]->GetYaxis()->SetTitle(title_y_CorrelationsVsInteractionRateVs[t].Data());
+        qa.fQACorrVsIRVsProfiles2D[t][h][rs]->SetLineColor(ec.fBeforeAfterColor[eAfter]);
+        qa.fQACorrVsIRVsProfiles2D[t][h][rs]->SetFillColor(ec.fBeforeAfterColor[eAfter] - 10);
+        qa.fQACorrVsIRVsProfiles2D[t][h][rs]->SetOption("col");
+        qa.fQACorrelationsVsInteractionRateVsList->Add(qa.fQACorrVsIRVsProfiles2D[t][h][rs]);
+      } // for(int rs=0;rs<2;rs++) // reco/sim
+
+    } // for (int h = 0; h < gMaxHarmonic; h++) {
+
+  } // for(int t=0;t<eQACorrelationsVsInteractionRateVsProfiles2D_N;t++) // type, see enum eCorrelationsVsInteractionRateVsProfiles2D
 
   // ...
 
@@ -3651,7 +3950,7 @@ void BookEventCutsHistograms()
         continue;
       }
 
-      ec.fEventCutCounterHist[rs][cc] = new TH1I(TString::Format("fEventCutCounterHist[%s][%s]", gc.srs[rs].Data(), gc.scc[cc].Data()), TString::Format("%s, %s, event cut counter (%s)", "__RUN_NUMBER__", gc.srs_long[rs].Data(), gc.scc_long[cc].Data()), eEventCuts_N, 0.5, static_cast<double>(eEventCuts_N) + 0.5); // I cast in double the last argument, because that's what this particular TH1I constructor expects. And yes, +0.5, because eEventCuts kicks off from 0
+      ec.fEventCutCounterHist[rs][cc] = new TH1F(TString::Format("fEventCutCounterHist[%s][%s]", gc.srs[rs].Data(), gc.scc[cc].Data()), TString::Format("%s, %s, event cut counter (%s)", "__RUN_NUMBER__", gc.srs_long[rs].Data(), gc.scc_long[cc].Data()), eEventCuts_N, 0.5, static_cast<double>(eEventCuts_N) + 0.5); // I cast in double the last argument, because that's what this particular TH1I constructor expects. And yes, +0.5, because eEventCuts kicks off from 0
       ec.fEventCutCounterHist[rs][cc]->SetStats(false);
       ec.fEventCutCounterHist[rs][cc]->SetLineColor(eColor);
       ec.fEventCutCounterHist[rs][cc]->SetFillColor(eFillColor);
@@ -4705,7 +5004,7 @@ void BookInternalValidationHistograms()
 
   // b) Book and fill container vn amplitudes:
   iv.fInternalValidationVnPsin[eVn] = new TArrayD(gMaxHarmonic);
-  auto lInternalValidationAmplitudes = (vector<float>)cf_iv.cfInternalValidationAmplitudes; // this is now the local version of that array from configurable
+  auto lInternalValidationAmplitudes = (std::vector<float>)cf_iv.cfInternalValidationAmplitudes; // this is now the local version of that array from configurable
   if (lInternalValidationAmplitudes.size() < 1) {
     LOGF(fatal, "\033[1;31m%s at line %d : set at least one vn amplitude in array cfInternalValidationAmplitudes\n \033[0m", __FUNCTION__, __LINE__);
   }
@@ -4718,7 +5017,7 @@ void BookInternalValidationHistograms()
 
   // c) Book and fill container for Psin planes:
   iv.fInternalValidationVnPsin[ePsin] = new TArrayD(gMaxHarmonic);
-  auto lInternalValidationPlanes = (vector<float>)cf_iv.cfInternalValidationPlanes;
+  auto lInternalValidationPlanes = (std::vector<float>)cf_iv.cfInternalValidationPlanes;
   if (lInternalValidationPlanes.size() < 1) {
     LOGF(fatal, "\033[1;31m%s at line : %d set at least one Psi plane in array cfInternalValidationPlanes\n \033[0m", __FUNCTION__, __LINE__);
   }
@@ -4733,7 +5032,7 @@ void BookInternalValidationHistograms()
   }
 
   // d) Handle multiplicity for internal validation:
-  auto lMultRangeInternalValidation = (vector<int>)cf_iv.cfMultRangeInternalValidation;
+  auto lMultRangeInternalValidation = (std::vector<int>)cf_iv.cfMultRangeInternalValidation;
   iv.fMultRangeInternalValidation[eMin] = lMultRangeInternalValidation[eMin];
   iv.fMultRangeInternalValidation[eMax] = lMultRangeInternalValidation[eMax];
   if (iv.fMultRangeInternalValidation[eMin] >= iv.fMultRangeInternalValidation[eMax]) {
@@ -5507,6 +5806,17 @@ void Preprocess(T1 const& collision, T2 const& bcs)
     CheckCurrentRunNumber<rs>(collision, bcs);
   }
 
+  // *) Check whether this run shall be skipped later from further processing in Steer():
+  if (!tc.fSkipTheseRuns.EqualTo("")) {
+    // If tc.fSkipTheseRuns is not empty, that means it holds comma-separated list of runs to be skipped. Let's check it out...
+    SkipThisRun(); // I set inside the data member tc.fSkipRun , which serves then as a switch later all over the place
+    if (tc.fSkipRun) {
+      return; // yes, I bail out immediately from Preprocess, so that I do not waste time on fetching weights for this run
+    }
+    // TBI 20250316 Same comment here: At the moment I can access run number info only in process(...), but not in init(...)
+    // Once I can access run number info in init(...), this function shall be called in init(...), not in process(...)
+  } // if (!tc.fSkipTheseRuns.EqualTo(""))
+
   // *) Fetch the weights for this particular run number. Do it only once.
   //    TBI 20231012 If eventualy I can access programatically run number in init(...) at run time, this shall go there.
   if (!pw.fParticleWeightsAreFetched) {
@@ -5591,8 +5901,12 @@ void DetermineRunNumber(T1 const& collision, T2 const&)
       LOGF(fatal, "\033[1;31m%s at line %d : tc.fRunTime[eDurationInSec] = %d is not positive\033[0m", __FUNCTION__, __LINE__, tc.fRunTime[eDurationInSec]);
     }
 
+  } else if constexpr (rs == eTest) {
+    LOGF(warning, "\033[1;33m%s at line %d : RunNumber cannot be determined for eTest mode, due to minimal subscription. Setting run number manually to some dummy value. If you do not like this, extend subscription to more tables.\033[0m", __FUNCTION__, __LINE__);
+    tc.fRunNumber = "123456";
   } else {
-    // b) Determine run number for the rest. TBI 20241126 differentiate this support as well, e.g. for eRecSim and eSim.
+    // b) Determine run number for the rest.
+    //    TBI 20241126 differentiate this support as well, e.g. for eRecSim and eSim.
     LOGF(fatal, "\033[1;31m%s at line %d : bc.runNumber() is not validated yet for this case\033[0m", __FUNCTION__, __LINE__);
   }
   tc.fRunNumberIsDetermined = true;
@@ -5750,6 +6064,24 @@ void PropagateRunNumber()
     } // for (int h = 0; h < gMaxHarmonic; h++)
   } // for (int t = 0; t < eQACorrelationsVsHistograms2D_N; t++) // type, see enum eCorrelationsVsHistograms2D
 
+  // *) "correlations vs. IR vs. " profiles 2D:
+  for (int t = 0; t < eQACorrelationsVsInteractionRateVsProfiles2D_N; t++) // type, see enum eCorrelationsVsInteractionRateVsProfiles2D
+  {
+    for (int h = 0; h < gMaxHarmonic; h++) {
+      for (int rs = 0; rs < 2; rs++) // reco/sim
+      {
+        if (!qa.fQACorrVsIRVsProfiles2D[t][h][rs]) {
+          continue;
+        }
+        histTitle = qa.fQACorrVsIRVsProfiles2D[t][h][rs]->GetTitle();
+        if (histTitle.Contains("__RUN_NUMBER__")) {
+          histTitle.ReplaceAll("__RUN_NUMBER__", tc.fRunNumber.Data()); // it replaces in-place
+          qa.fQACorrVsIRVsProfiles2D[t][h][rs]->SetTitle(histTitle.Data());
+        }
+      } // for(int rs=0;rs<2;rs++) // reco/sim
+    } // for (int h = 0; h < gMaxHarmonic; h++)
+  } // for (int t = 0; t < eQACorrelationsVsInteractionRateVsProfiles2D_N; t++) // type, see enum eCorrelationsVsInteractionRateVsProfiles2D
+
   // *) particle cuts:
   for (int rs = 0; rs < 2; rs++) // reco/sim
   {
@@ -5879,6 +6211,8 @@ void CheckCurrentRunNumber(T1 const& collision, T2 const&)
       LOGF(fatal, "tc.fRunTime[eDurationInSec] = %d, durationInSec = %d", tc.fRunTime[eDurationInSec], durationInSec);
     }
 
+  } else if constexpr (rs == eTest) {
+    LOGF(warning, "\033[1;33m%s at line %d : RunNumber cannot be checked in eTest mode, due to minimal subscription. Simply skipping this check. If you do not like this, extend subscription to more tables.\033[0m", __FUNCTION__, __LINE__);
   } else {
     // b) The rest:
 
@@ -6144,7 +6478,7 @@ bool EventCuts(T1 const& collision, T2 const& tracks, eCutModus cutModus)
   // d) Event cuts on simulated (Run 3 specific);
   // e) Event cuts on reconstructed, and corresponding MC truth simulated (Run 1 and 2 specific); // In case there is some corner case between Run 1 and Run 2, simply branch further this one
   // f) Event cuts on simulated (Run 1 and 2 specific); // In case there is some corner case between Run 1 and Run 2, simply branch further this one
-  // *) Event cuts on Test case.
+  // *) Event cuts for Test case.
 
   if (tc.fVerbose) {
     StartFunction(__FUNCTION__);
@@ -6720,9 +7054,9 @@ bool EventCuts(T1 const& collision, T2 const& tracks, eCutModus cutModus)
     //   *) Vertex_z:
     if (ec.fUseEventCuts[eVertex_z]) {
       if (cutModus == eCutCounterBinning) {
-        EventCut(eSim, eVertex_z, eCutCounterBinning);
+        EventCut(eRec, eVertex_z, eCutCounterBinning);
       } else if (collision.posZ() < ec.fdEventCuts[eVertex_z][eMin] || collision.posZ() > ec.fdEventCuts[eVertex_z][eMax] || TMath::Abs(collision.posZ() - ec.fdEventCuts[eVertex_z][eMax]) < tc.fFloatingPointPrecision) {
-        if (!EventCut(eSim, eVertex_z, cutModus)) {
+        if (!EventCut(eRec, eVertex_z, cutModus)) {
           return false;
         }
       }
@@ -6768,29 +7102,34 @@ bool EventCut(int rs, int eventCut, eCutModus cutModus)
 
   // *) Do the thing:
   switch (cutModus) {
-    case eCut:
+    case eCut: {
       if (tc.fVerboseEventCut) {
         LOGF(info, "\033[1;31mEvent didn't survive the cut: %s\033[0m", ec.fEventCutName[eventCut].Data());
       }
       return false;
       break;
-    case eCutCounterBinning:
+    }
+    case eCutCounterBinning: {
       ec.fEventCutCounterMap[rs]->Add(ec.fEventCutCounterBinNumber[rs], eventCut);
       ec.fEventCutCounterMapInverse[rs]->Add(eventCut, ec.fEventCutCounterBinNumber[rs]);
       ec.fEventCutCounterBinNumber[rs]++; // yes
       return true;
       break;
-    case eCutCounterAbsolute:
+    }
+    case eCutCounterAbsolute: {
       ec.fEventCutCounterHist[rs][eAbsolute]->Fill(ec.fEventCutCounterMapInverse[rs]->GetValue(eventCut));
       return true; // yes, so that I can proceed with another cut in EventCuts
       break;
-    case eCutCounterSequential:
+    }
+    case eCutCounterSequential: {
       ec.fEventCutCounterHist[rs][eSequential]->Fill(ec.fEventCutCounterMapInverse[rs]->GetValue(eventCut));
       return false; // yes, so that I bail out from EventCuts
       break;
-    default:
+    }
+    default: {
       LOGF(fatal, "\033[1;31m%s at line %d : This cutModus = %d is not supported yet. \033[0m", __FUNCTION__, __LINE__, static_cast<int>(cutModus));
       break;
+    }
   } // switch(cutModus)
 
   return false; // obsolete, but it suppresses the warning...
@@ -6953,9 +7292,9 @@ void FillEventHistograms(T1 const& collision, T2 const& tracks, eBeforeAfter ba)
         if (wTwo > 0.0) {
           twoC /= wTwo;
         } else {
-          LOGF(fatal, "In function \033[1;31m%s at line %d, wTwo = %f <=0. ebye.fSelectedTracks = %d\033[0m", __FUNCTION__, __LINE__, wTwo, ebye.fSelectedTracks);
+          LOGF(fatal, "In function \033[1;31m%s at line %d : wTwo = %f <=0. ebye.fSelectedTracks = %d.\nDid you forget to enable fCalculateQvectors = true?\033[0m", __FUNCTION__, __LINE__, wTwo, ebye.fSelectedTracks);
         }
-        !qa.fQACorrelationsVsHistograms2D[eCorrelations_vs_Multiplicity][h - 1][eRec] ? true : qa.fQACorrelationsVsHistograms2D[eCorrelations_vs_Multiplicity][h - 1][eRec]->Fill(twoC, ebye.fMultiplicity);
+        !qa.fQACorrelationsVsHistograms2D[eCorrelations_vs_Multiplicity][h - 1][eRec] ? true : qa.fQACorrelationsVsHistograms2D[eCorrelations_vs_Multiplicity][h - 1][eRec]->Fill(twoC, ebye.fMultiplicity); // Remark: I have exceptionally divided above already twoC /= wTwo , since I do not use here any particular weight
         !qa.fQACorrelationsVsHistograms2D[eCorrelations_vs_ReferenceMultiplicity][h - 1][eRec] ? true : qa.fQACorrelationsVsHistograms2D[eCorrelations_vs_ReferenceMultiplicity][h - 1][eRec]->Fill(twoC, ebye.fReferenceMultiplicity);
         !qa.fQACorrelationsVsHistograms2D[eCorrelations_vs_Centrality][h - 1][eRec] ? true : qa.fQACorrelationsVsHistograms2D[eCorrelations_vs_Centrality][h - 1][eRec]->Fill(twoC, ebye.fCentrality);
         // .....
@@ -6969,6 +7308,49 @@ void FillEventHistograms(T1 const& collision, T2 const& tracks, eBeforeAfter ba)
       ResetQ();
 
     } // if (qa.fFillQACorrelationsVsHistograms2D && qa.fQAParticleEventProEbyE[eRec][ba] && ba == eAfter) {
+
+    if (qa.fFillQACorrelationsVsInteractionRateVsProfiles2D && qa.fQAParticleEventProEbyE[eRec][ba] && ba == eAfter) { // fill only for eAfter, because I do not calculate Q-vectors before cuts
+
+      // Calculate quickly 2-p correlation in harmonic h for this event: TBI 20250114 shall I add this also to some EbyE variable? There is no really much of a code bloat for the time being...
+
+      // Flush 'n' fill the generic Q-vectors:
+      ResetQ();
+      int lMaxCorrelator = 2; // used only here locally
+      for (int h = 0; h < gMaxHarmonic * lMaxCorrelator + 1; h++) {
+        for (int wp = 0; wp < lMaxCorrelator + 1; wp++) // weight power
+        {
+          qv.fQ[h][wp] = qv.fQvector[h][wp];
+        }
+      }
+
+      for (int h = 1; h <= gMaxHarmonic; h++) {
+        TComplex two = Two(h, -h);
+        double twoC = two.Re(); // cos
+        // double twoS = two.Im(); // sin
+        double wTwo = Two(0, 0).Re(); // Weight is 'number of combinations' by default TBI
+                                      // 20220809 add support for other weights
+        if (!(wTwo > 0.0)) {
+          LOGF(fatal, "In function \033[1;31m%s at line %d : wTwo = %f <=0. ebye.fSelectedTracks = %d.\nDid you forget to enable fCalculateQvectors = true?\033[0m", __FUNCTION__, __LINE__, wTwo, ebye.fSelectedTracks);
+        }
+
+        !qa.fQACorrVsIRVsProfiles2D[eCorrelationsVsInteractionRate_vs_CurrentRunDuration][h - 1][eRec] ? true : qa.fQACorrVsIRVsProfiles2D[eCorrelationsVsInteractionRate_vs_CurrentRunDuration][h - 1][eRec]->Fill(ebye.fInteractionRate, ebye.fCurrentRunDuration, twoC / wTwo, wTwo);
+        !qa.fQACorrVsIRVsProfiles2D[eCorrelationsVsInteractionRate_vs_Multiplicity][h - 1][eRec] ? true : qa.fQACorrVsIRVsProfiles2D[eCorrelationsVsInteractionRate_vs_Multiplicity][h - 1][eRec]->Fill(ebye.fInteractionRate, ebye.fMultiplicity, twoC / wTwo, wTwo);
+        !qa.fQACorrVsIRVsProfiles2D[eCorrelationsVsInteractionRate_vs_ReferenceMultiplicity][h - 1][eRec] ? true : qa.fQACorrVsIRVsProfiles2D[eCorrelationsVsInteractionRate_vs_ReferenceMultiplicity][h - 1][eRec]->Fill(ebye.fInteractionRate, ebye.fReferenceMultiplicity, twoC / wTwo, wTwo);
+        !qa.fQACorrVsIRVsProfiles2D[eCorrelationsVsInteractionRate_vs_Centrality][h - 1][eRec] ? true : qa.fQACorrVsIRVsProfiles2D[eCorrelationsVsInteractionRate_vs_Centrality][h - 1][eRec]->Fill(ebye.fInteractionRate, ebye.fCentrality, twoC / wTwo, wTwo);
+        // .....
+        !qa.fQACorrVsIRVsProfiles2D[eCorrelationsVsInteractionRate_vs_MeanPhi][h - 1][eRec] ? true : qa.fQACorrVsIRVsProfiles2D[eCorrelationsVsInteractionRate_vs_MeanPhi][h - 1][eRec]->Fill(ebye.fInteractionRate, qa.fQAParticleEventProEbyE[eRec][ba]->GetBinContent(eMeanPhi), twoC / wTwo, wTwo);
+        !qa.fQACorrVsIRVsProfiles2D[eCorrelationsVsInteractionRate_vs_SigmaMeanPhi][h - 1][eRec] ? true : qa.fQACorrVsIRVsProfiles2D[eCorrelationsVsInteractionRate_vs_SigmaMeanPhi][h - 1][eRec]->Fill(ebye.fInteractionRate, qa.fQAParticleEventProEbyE[eRec][ba]->GetBinError(eMeanPhi), twoC / wTwo, wTwo);
+        !qa.fQACorrVsIRVsProfiles2D[eCorrelationsVsInteractionRate_vs_MeanPt][h - 1][eRec] ? true : qa.fQACorrVsIRVsProfiles2D[eCorrelationsVsInteractionRate_vs_MeanPt][h - 1][eRec]->Fill(ebye.fInteractionRate, qa.fQAParticleEventProEbyE[eRec][ba]->GetBinContent(eMeanPt), twoC / wTwo, wTwo);
+        !qa.fQACorrVsIRVsProfiles2D[eCorrelationsVsInteractionRate_vs_SigmaMeanPt][h - 1][eRec] ? true : qa.fQACorrVsIRVsProfiles2D[eCorrelationsVsInteractionRate_vs_SigmaMeanPt][h - 1][eRec]->Fill(ebye.fInteractionRate, qa.fQAParticleEventProEbyE[eRec][ba]->GetBinError(eMeanPt), twoC / wTwo, wTwo);
+        !qa.fQACorrVsIRVsProfiles2D[eCorrelationsVsInteractionRate_vs_MeanEta][h - 1][eRec] ? true : qa.fQACorrVsIRVsProfiles2D[eCorrelationsVsInteractionRate_vs_MeanEta][h - 1][eRec]->Fill(ebye.fInteractionRate, qa.fQAParticleEventProEbyE[eRec][ba]->GetBinContent(eMeanEta), twoC / wTwo, wTwo);
+        !qa.fQACorrVsIRVsProfiles2D[eCorrelationsVsInteractionRate_vs_SigmaMeanEta][h - 1][eRec] ? true : qa.fQACorrVsIRVsProfiles2D[eCorrelationsVsInteractionRate_vs_SigmaMeanEta][h - 1][eRec]->Fill(ebye.fInteractionRate, qa.fQAParticleEventProEbyE[eRec][ba]->GetBinError(eMeanEta), twoC / wTwo, wTwo);
+        // .....
+      }
+
+      // Flush the generic Q-vectors:
+      ResetQ();
+
+    } // if (qa.fFillQACorrelationsVsInteractionRateVsProfiles2D && qa.fQAParticleEventProEbyE[eRec][ba] && ba == eAfter) {
 
     // ... and corresponding MC truth simulated (common to Run 3, Run 2 and Run 1) ( see https://github.com/AliceO2Group/O2Physics/blob/master/Tutorials/src/mcHistograms.cxx ):
     if constexpr (rs == eRecAndSim || rs == eRecAndSim_Run2 || rs == eRecAndSim_Run1) {
@@ -7130,6 +7512,7 @@ void FillEventHistograms(T1 const& collision, T2 const& tracks, eBeforeAfter ba)
     // TBI 20240223 for the time being, eTest fills only eRec histos:
     // A few example histograms, just to check if I access corresponding tables:
     if (eh.fFillEventHistograms) {
+      !eh.fEventHistograms[eNumberOfEvents][eRec][ba] ? true : eh.fEventHistograms[eNumberOfEvents][eRec][ba]->Fill(0.5);
       !eh.fEventHistograms[eVertex_z][eRec][ba] ? true : eh.fEventHistograms[eVertex_z][eRec][ba]->Fill(collision.posZ());
       !eh.fEventHistograms[eTotalMultiplicity][eRec][ba] ? true : eh.fEventHistograms[eTotalMultiplicity][eRec][ba]->Fill(tracks.size());
       !eh.fEventHistograms[eCentrality][eRec][ba] ? true : eh.fEventHistograms[eCentrality][eRec][ba]->Fill(ebye.fCentrality);
@@ -8107,29 +8490,34 @@ bool ParticleCut(int rs, int particleCut, eCutModus cutModus)
   // Remark: Remember that as a second argument I cannot use enum eParticleCuts, because here in one go I take both enum eParticleCuts and enum eParticleHistograms .
 
   switch (cutModus) {
-    case eCut:
+    case eCut: {
       if (tc.fVerboseForEachParticle) {
         LOGF(info, "\033[1;31mParticle didn't pass the cut: %s\033[0m", pc.fParticleCutName[particleCut].Data());
       }
       return false;
       break;
-    case eCutCounterBinning:
+    }
+    case eCutCounterBinning: {
       pc.fParticleCutCounterMap[rs]->Add(pc.fParticleCutCounterBinNumber[rs], particleCut);
       pc.fParticleCutCounterMapInverse[rs]->Add(particleCut, pc.fParticleCutCounterBinNumber[rs]);
       pc.fParticleCutCounterBinNumber[rs]++; // yes
       return true;
       break;
-    case eCutCounterAbsolute:
+    }
+    case eCutCounterAbsolute: {
       pc.fParticleCutCounterHist[rs][eAbsolute]->Fill(pc.fParticleCutCounterMapInverse[rs]->GetValue(particleCut));
       return true; // yes, so that I can proceed with another cut in ParticleCuts
       break;
-    case eCutCounterSequential:
+    }
+    case eCutCounterSequential: {
       pc.fParticleCutCounterHist[rs][eSequential]->Fill(pc.fParticleCutCounterMapInverse[rs]->GetValue(particleCut));
       return false; // yes, so that I bail out from ParticleCuts
       break;
-    default:
+    }
+    default: {
       LOGF(fatal, "\033[1;31m%s at line %d : This cutModus = %d is not supported yet. \033[0m", __FUNCTION__, __LINE__, static_cast<int>(cutModus));
       break;
+    }
   } // switch(cutModus)
 
   return false; // obsolete, but it suppresses the warning...
@@ -8235,7 +8623,7 @@ void FillParticleHistograms(T const& track, eBeforeAfter ba, int weight = 1)
     if (qa.fFillQAParticleHistograms2D) {
       !qa.fQAParticleHistograms2D[ePt_vs_dcaXY][eRec][ba] ? true : qa.fQAParticleHistograms2D[ePt_vs_dcaXY][eRec][ba]->Fill(track.pt(), track.dcaXY(), weight);
     }
-    if ((qa.fFillQAParticleEventHistograms2D || qa.fFillQACorrelationsVsHistograms2D) && qa.fQAParticleEventProEbyE[eRec][ba]) {
+    if ((qa.fFillQAParticleEventHistograms2D || qa.fFillQACorrelationsVsHistograms2D || qa.fFillQACorrelationsVsInteractionRateVsProfiles2D) && qa.fQAParticleEventProEbyE[eRec][ba]) {
       // Here I only fill the helper profile to get average of requested particle variable for current event:
       qa.fQAParticleEventProEbyE[eRec][ba]->Fill(static_cast<float>(eitsNClsEbyE) - 0.5, track.itsNCls(), weight);
 
@@ -8777,17 +9165,20 @@ void CalculateKineCorrelations(eAsFunctionOf AFO_variable)
   // int nBins = -1; // TBI 20241111 temporarily commented out just to suppress warnings
 
   switch (AFO_variable) {
-    case AFO_PT:
+    case AFO_PT: {
       qvKine = PTq;
       // nBins = res.fResultsPro[AFO_PT]->GetNbinsX(); // TBI 20241111 temporarily commented out just to suppress warnings
       break;
-    case AFO_ETA:
+    }
+    case AFO_ETA: {
       qvKine = ETAq;
       // nBins = res.fResultsPro[AFO_ETA]->GetNbinsX(); // TBI 20241111 temporarily commented out just to suppress warnings
       break;
-    default:
+    }
+    default: {
       LOGF(fatal, "\033[1;31m%s at line %d : This AFO_variable = %d is not supported yet. \033[0m", __FUNCTION__, __LINE__, static_cast<int>(AFO_variable));
       break;
+    }
   } // switch(AFO_variable)
 
   // *) Insanity checks on above settings:
@@ -9058,17 +9449,20 @@ void CalculateKineTest0(eAsFunctionOf AFO_variable)
   int nBins = -1;
 
   switch (AFO_variable) {
-    case AFO_PT:
+    case AFO_PT: {
       qvKine = PTq;
       nBins = res.fResultsPro[AFO_PT]->GetNbinsX();
       break;
-    case AFO_ETA:
+    }
+    case AFO_ETA: {
       qvKine = ETAq;
       nBins = res.fResultsPro[AFO_ETA]->GetNbinsX();
       break;
-    default:
+    }
+    default: {
       LOGF(fatal, "\033[1;31m%s at line %d : This AFO_variable = %d is not supported yet. \033[0m", __FUNCTION__, __LINE__, static_cast<int>(AFO_variable));
       break;
+    }
   } // switch(AFO_variable)
 
   // *) Insanity checks on above settings:
@@ -9348,16 +9742,19 @@ void CalculateKineEtaSeparations(eAsFunctionOf AFO_variable)
   int nBins = -1;
 
   switch (AFO_variable) {
-    case AFO_PT:
+    case AFO_PT: {
       qvKine = PTq;
       nBins = res.fResultsPro[AFO_PT]->GetNbinsX();
       break;
-    case AFO_ETA:
+    }
+    case AFO_ETA: {
       LOGF(fatal, "\033[1;31m%s at line %d : It doesn't make sense (i.e. AFO_ETA cannot be used here). \033[0m", __FUNCTION__, __LINE__, static_cast<int>(AFO_variable));
       break; // obsolete, but it supresses the warning
-    default:
+    }
+    default: {
       LOGF(fatal, "\033[1;31m%s at line %d : This AFO_variable = %d is not supported yet. \033[0m", __FUNCTION__, __LINE__, static_cast<int>(AFO_variable));
       break;
+    }
   } // switch(AFO_variable)
 
   // *) Insanity checks on above settings:
@@ -10118,7 +10515,7 @@ void SetWeightsHist(TH1D* const hist, eWeights whichWeight)
 
   // Finally:
   hist->SetDirectory(0);
-  pw.fWeightsHist[whichWeight] = reinterpret_cast<TH1D*>(hist->Clone());
+  pw.fWeightsHist[whichWeight] = reinterpret_cast<TH1D*>(hist);
 
   if (!pw.fWeightsHist[whichWeight]) {
     LOGF(fatal, "\033[1;31m%s at line %d\033[0m", __FUNCTION__, __LINE__);
@@ -10163,7 +10560,7 @@ void SetDiffWeightsHist(TH1D* const hist, eDiffWeights whichDiffWeight, int bin)
 
   // Finally:
   hist->SetDirectory(0);
-  pw.fDiffWeightsHist[whichDiffWeight][bin] = reinterpret_cast<TH1D*>(hist->Clone());
+  pw.fDiffWeightsHist[whichDiffWeight][bin] = reinterpret_cast<TH1D*>(hist);
 
   if (!pw.fDiffWeightsHist[whichDiffWeight][bin]) {
     LOGF(fatal, "\033[1;31m%s at line %d\033[0m", __FUNCTION__, __LINE__);
@@ -10208,7 +10605,7 @@ void SetDiffWeightsSparse(THnSparseF* const sparse, eDiffWeightCategory dwc)
 
   // Finally:
   // sparse->SetDirectory(0); I cannot use this for sparse
-  pw.fDiffWeightsSparse[dwc] = reinterpret_cast<THnSparseF*>(sparse->Clone());
+  pw.fDiffWeightsSparse[dwc] = reinterpret_cast<THnSparseF*>(sparse);
 
   if (!pw.fDiffWeightsSparse[dwc]) {
     LOGF(fatal, "\033[1;31m%s at line %d\033[0m", __FUNCTION__, __LINE__);
@@ -10265,7 +10662,7 @@ void SetCentralityWeightsHist(TH1D* const hist)
 
   // Finally:
   hist->SetDirectory(0);
-  cw.fCentralityWeightsHist = reinterpret_cast<TH1D*>(hist->Clone());
+  cw.fCentralityWeightsHist = reinterpret_cast<TH1D*>(hist);
 
   if (!cw.fCentralityWeightsHist) {
     LOGF(fatal, "\033[1;31m%s at line %d\033[0m", __FUNCTION__, __LINE__);
@@ -10338,7 +10735,8 @@ TH1D* GetHistogramWithWeights(const char* filePath, const char* runNumber, const
   // d) Handle the AliEn case;
   // e) Handle the CCDB case;
   // f) Handle the local case;
-  // g) The final touch on histogram with weights.
+  // g) The final touch on histogram with weights;
+  // h) Clone histogram and delete baseList (realising back the memory).
 
   if (tc.fVerbose) {
     StartFunction(__FUNCTION__);
@@ -10555,7 +10953,7 @@ TH1D* GetHistogramWithWeights(const char* filePath, const char* runNumber, const
       AFO = AFO_ETA;
       lVariableName = FancyFormatting("Eta");
     } else {
-      LOGF(fatal, "\033[1;31m%s at line %d : name = %s is not supported yet. \033[0m", __FUNCTION__, __LINE__, static_cast<string>(variable));
+      LOGF(fatal, "\033[1;31m%s at line %d : name = %s is not supported yet. \033[0m", __FUNCTION__, __LINE__, static_cast<std::string>(variable));
     }
 
     // Get min and max value for bin, stored locally:
@@ -10585,11 +10983,16 @@ TH1D* GetHistogramWithWeights(const char* filePath, const char* runNumber, const
   // TBI 20241021 if I need to split hist title across two lines, use this technique:
   // hist->SetTitle(Form("#splitline{#scale[0.6]{%s}}{#scale[0.4]{%s}}",hist->GetTitle(),filePath));
 
+  // h) Clone histogram and delete baseList (realising back the memory):
+  //    Remark: Yes, I have to clone here.
+  TH1D* histClone = reinterpret_cast<TH1D*>(hist->Clone());
+  delete baseList; // release back the memory
+
   if (tc.fVerbose) {
     ExitFunction(__FUNCTION__);
   }
 
-  return hist;
+  return histClone;
 
 } // TH1D* GetHistogramWithWeights(const char* filePath, const char* runNumber, const char* variable, int bin = -1)
 
@@ -10623,7 +11026,8 @@ THnSparseF* GetSparseHistogramWithWeights(const char* filePath, const char* runN
   // d) Handle the AliEn case;
   // e) Handle the CCDB case;
   // f) Handle the local case;
-  // g) The final touch on histogram with weights.
+  // g) The final touch on sparse histogram with weights;
+  // h) Clone histogram and delete baseList (realising back the memory).
 
   if (tc.fVerbose) {
     StartFunction(__FUNCTION__);
@@ -10830,7 +11234,7 @@ THnSparseF* GetSparseHistogramWithWeights(const char* filePath, const char* runN
         AFO = AFO_ETA;
         lVariableName = FancyFormatting("Eta");
       } else {
-        LOGF(fatal, "\033[1;31m%s at line %d : name = %s is not supported yet. \033[0m", __FUNCTION__, __LINE__, static_cast<string>(variable));
+        LOGF(fatal, "\033[1;31m%s at line %d : name = %s is not supported yet. \033[0m", __FUNCTION__, __LINE__, static_cast<std::string>(variable));
       }
 
       // Get min and max value for bin, stored locally:
@@ -10859,11 +11263,16 @@ THnSparseF* GetSparseHistogramWithWeights(const char* filePath, const char* runN
   // TBI 20241021 if I need to split hist title across two lines, use this technique:
   // hist->SetTitle(Form("#splitline{#scale[0.6]{%s}}{#scale[0.4]{%s}}",hist->GetTitle(),filePath));
 
+  // h) Clone histogram and delete baseList (realising back the memory):
+  //    Remark: Yes, I have to clone here.
+  THnSparseF* sparseHistClone = reinterpret_cast<THnSparseF*>(sparseHist->Clone());
+  delete baseList; // release back the memory
+
   if (tc.fVerbose) {
     ExitFunction(__FUNCTION__);
   }
 
-  return sparseHist;
+  return sparseHistClone;
 
 } // THnSparseF* GetSparseHistogramWithWeights(const char* filePath, const char* runNumber, const char* whichCategory, const char* whichDimensions)
 
@@ -10884,7 +11293,8 @@ TH1D* GetHistogramWithCentralityWeights(const char* filePath, const char* runNum
   // d) Handle the AliEn case;
   // e) Handle the CCDB case;
   // f) Handle the local case;
-  // g) The final touch on histogram with centrality weights.
+  // g) The final touch on histogram with centrality weights;
+  // h) Clone histogram and delete baseList (realising back the memory).
 
   if (tc.fVerbose) {
     StartFunction(__FUNCTION__);
@@ -11079,7 +11489,12 @@ TH1D* GetHistogramWithCentralityWeights(const char* filePath, const char* runNum
     ExitFunction(__FUNCTION__);
   }
 
-  return hist;
+  // h) Clone histogram and delete baseList (realising back the memory):
+  //    Remark: Yes, I have to clone here.
+  TH1D* histClone = reinterpret_cast<TH1D*>(hist->Clone());
+  delete baseList; // release back the memory
+
+  return histClone;
 
 } // TH1D* GetHistogramWithCentralityWeights(const char* filePath, const char* runNumber)
 
@@ -11318,7 +11733,8 @@ void GetHistogramWithCustomNUA(const char* filePath, eNUAPDF variable)
   // d) Handle the AliEn case;
   // e) Handle the CCDB case;
   // f) Handle the local case;
-  // g) The final touch.
+  // g) The final touch;
+  // h) Clone histogram and delete baseList (realising back the memory).
 
   if (tc.fVerbose) {
     StartFunction(__FUNCTION__);
@@ -11428,9 +11844,14 @@ void GetHistogramWithCustomNUA(const char* filePath, eNUAPDF variable)
     LOGF(info, "\033[1;31m nua.fCustomNUAPDFHistNames[variable]->Data() = %s\033[0m", nua.fCustomNUAPDFHistNames[variable]->Data());
     LOGF(fatal, "\033[1;31m%s at line %d\033[0m", __FUNCTION__, __LINE__);
   }
+
+  // h) Clone histogram and delete baseList (realising back the memory).
+  //    TBI 20250315 here I did it a bit differently than e.g. in GetHistogramWithWeights or in GetSparseHistogramWithWeights .
+  //                 If it's failing here, redo it in exactly the same way as I did it there.
   hist->SetDirectory(0);
   nua.fCustomNUAPDF[variable] = reinterpret_cast<TH1D*>(hist->Clone());
   nua.fCustomNUAPDF[variable]->SetTitle(Form("%s", filePath));
+  delete baseList;
 
   // TBI 20240501 if additional cosmetics is needed, it can be implemented here
 
@@ -12138,20 +12559,23 @@ bool MaxNumberOfEvents(eBeforeAfter ba)
 
   // *) Okay, do the thing:
   switch (ba) {
-    case eBefore:
+    case eBefore: {
       if (eh.fEventHistograms[eNumberOfEvents][rs][eBefore] && eh.fEventHistograms[eNumberOfEvents][rs][eBefore]->GetBinContent(1) == ec.fdEventCuts[eNumberOfEvents][eMax]) {
         reachedMaxNumberOfEvents = true;
       }
       break;
-    case eAfter:
+    }
+    case eAfter: {
       if (eh.fEventHistograms[eNumberOfEvents][rs][eAfter] && eh.fEventHistograms[eNumberOfEvents][rs][eAfter]->GetBinContent(1) == ec.fdEventCuts[eSelectedEvents][eMax]) {
         reachedMaxNumberOfEvents = true;
       }
       break;
-    default:
+    }
+    default: {
       LOGF(fatal, "\033[1;31m%s at line %d : enum ba = %d is not supported yet. \033[0m", __FUNCTION__, __LINE__, static_cast<int>(ba));
       break;
-  }
+    }
+  } // switch (ba)
 
   // *) Hasta la vista:
   if (tc.fVerbose) {
@@ -12174,24 +12598,27 @@ void PrintEventCounter(eBeforeAfter ba)
 
   // *) Print or die:
   switch (ba) {
-    case eBefore:
+    case eBefore: {
       if (!tc.fPlainPrintout) {
         LOGF(info, "\033[1;32m%s : processing event %d ....\033[0m", __FUNCTION__, eh.fEventCounter[eTotal]);
       } else {
         LOGF(info, "%s : processing event %d ....", __FUNCTION__, eh.fEventCounter[eTotal]);
       }
       break;
-    case eAfter:
+    }
+    case eAfter: {
       if (!tc.fPlainPrintout) {
         LOGF(info, "\033[1;32m%s : event passed all cuts %d/%d\033[0m", __FUNCTION__, eh.fEventCounter[eProcessed], eh.fEventCounter[eTotal]);
       } else {
         LOGF(info, "%s : event passed all cuts %d/%d", __FUNCTION__, eh.fEventCounter[eProcessed], eh.fEventCounter[eTotal]);
       }
       break;
-    default:
+    }
+    default: {
       LOGF(fatal, "\033[1;31m%s at line %d : enum ba = %d is not supported yet. \033[0m", __FUNCTION__, __LINE__, static_cast<int>(ba));
       break;
-  }
+    }
+  } // switch (ba)
 
   if (tc.fVerbose) {
     ExitFunction(__FUNCTION__);
@@ -12216,12 +12643,13 @@ void EventCounterForDryRun(eEventCounterForDryRun eVar)
   }
 
   switch (eVar) {
-    case eFill:
+    case eFill: {
       // Fill event counter:
       !eh.fEventHistograms[eNumberOfEvents][eRec][eAfter] ? true : eh.fEventHistograms[eNumberOfEvents][eRec][eAfter]->Fill(0.5);
       !eh.fEventHistograms[eNumberOfEvents][eSim][eAfter] ? true : eh.fEventHistograms[eNumberOfEvents][eSim][eAfter]->Fill(0.5);
       break;
-    case ePrint:
+    }
+    case ePrint: {
       // Print current status of event counter:
       // Remark: if I am processing RecSim, the counter is corresponding to Rec.
       if (eh.fEventHistograms[eNumberOfEvents][eRec][eAfter]) {
@@ -12230,9 +12658,11 @@ void EventCounterForDryRun(eEventCounterForDryRun eVar)
         LOGF(info, "Processing event %d (dry run) ....", static_cast<int>(eh.fEventHistograms[eNumberOfEvents][eSim][eAfter]->GetBinContent(1)));
       }
       break;
-    default:
+    }
+    default: {
       LOGF(fatal, "\033[1;31m%s at line %d : enum eVar = %d is not supported yet in eEventCounter. \033[0m", __FUNCTION__, __LINE__, static_cast<int>(eVar));
       break;
+    }
   } // switch(eVar)
 
   if (tc.fVerbose) {
@@ -12547,17 +12977,20 @@ double CalculateKineCustomNestedLoops(TArrayI* harmonics, eAsFunctionOf AFO_vari
   eqvectorKine qvKine = eqvectorKine_N; // which component of q-vector
   TString kineVarName = "";
   switch (AFO_variable) {
-    case AFO_PT:
+    case AFO_PT: {
       qvKine = PTq;
       kineVarName = "pt";
       break;
-    case AFO_ETA:
+    }
+    case AFO_ETA: {
       qvKine = ETAq;
       kineVarName = "eta";
       break;
-    default:
+    }
+    default: {
       LOGF(fatal, "\033[1;31m%s at line %d : This AFO_variable = %d is not supported yet. \033[0m", __FUNCTION__, __LINE__, static_cast<int>(AFO_variable));
       break;
+    }
   } // switch(AFO_variable)
 
   // *) Insanity checks on above settings:
@@ -13258,7 +13691,7 @@ void BanishmentLoopOverParticles(T const& tracks)
 
   // *) Quick insanity checks (mandatory!):
   if (lSelectedTracks != ebye.fSelectedTracks) {
-    LOGF(fatal, "\033[1;31m%s at line %d : lSelectedTracks != ebye.fSelectedTracks , lSelectedTracks = %d, ebye.fSelectedTracks = %d \033[0m", __FUNCTION__, __LINE__, lSelectedTracks, ebye.fSelectedTracks);
+    LOGF(fatal, "\033[1;31m%s at line %d : lSelectedTracks != ebye.fSelectedTracks , lSelectedTracks = %d, ebye.fSelectedTracks = %d\nDid you accidentally enable Toy NUA? \033[0m", __FUNCTION__, __LINE__, lSelectedTracks, ebye.fSelectedTracks);
   }
 
   if (tc.fVerbose) {
@@ -13683,19 +14116,22 @@ void Fillqvector(const double& dPhi, const double& kineVarValue, eqvectorKine ki
   eWeights AFO_weight = eWeights_N;             // this local variable determines the enum "eWeights" which corresponds to enum "eqvectorKine"
   eDiffWeights AFO_diffWeight = eDiffWeights_N; // this local variable determines the enum "eDiffWeights" which corresponds to enum "eqvectorKine"
   switch (kineVarChoice) {
-    case PTq:
+    case PTq: {
       AFO_var = AFO_PT;
       AFO_weight = wPT;
       AFO_diffWeight = wPHIPT;
       break;
-    case ETAq:
+    }
+    case ETAq: {
       AFO_var = AFO_ETA;
       AFO_weight = wETA;
       AFO_diffWeight = wPHIETA;
       break;
-    default:
+    }
+    default: {
       LOGF(fatal, "\033[1;31m%s at line %d : this kineVarChoice = %d is not supported yet. \033[0m", __FUNCTION__, __LINE__, static_cast<int>(kineVarChoice));
       break;
+    }
   } // switch(kineVarChoice)
 
   // *) Insanity checks on above settings:
@@ -13868,6 +14304,40 @@ void CalculateEverything()
   }
 
 } // void CalculateEverything()
+
+//============================================================
+
+void SkipThisRun()
+{
+  // Skip or not the current run from furher processing.
+
+  // a) Insanity checks;
+  // b) Do the check.
+
+  if (tc.fVerbose) {
+    StartFunction(__FUNCTION__);
+  }
+  // a) Insanity checks:
+  if (tc.fRunNumber.EqualTo("")) {
+    LOGF(fatal, "\033[1;31m%s at line %d : tc.fRunNumber is empty. In case you are running something on-the-fly, empty the string fSkipTheseRuns .\033[0m", __FUNCTION__, __LINE__);
+  }
+
+  // TBI 20250516 Shall I implement some insanity check on fSkipTheseRuns? I commented in configurable that the format is comma-separated list of runs,
+  //              but I am nowhere really enforcing that...
+
+  // b) Do the check:
+  if (tc.fSkipTheseRuns.Contains(tc.fRunNumber.Data())) {
+    // TBI 20250316 I think this check is safe enough. If not, tokenize fSkipTheseRuns with respect to "," etc.
+    tc.fSkipRun = true;
+  } else {
+    tc.fSkipRun = false;
+  }
+
+  if (tc.fVerbose) {
+    ExitFunction(__FUNCTION__);
+  }
+
+} // void SkipThisRun()
 
 //============================================================
 
@@ -14060,6 +14530,12 @@ void Steer(T1 const& collision, T2 const& bcs, T3 const& tracks)
 
   // *) Do all thingies before starting to process data from this collision (e.g. cut on number of events (both total and selected), fetch the run number, etc.):
   Preprocess<rs>(collision, bcs);
+
+  // *) It was explicitly requested, skip this particular run:
+  if (tc.fSkipRun) {
+    LOGF(info, "\033[1;33mPer exlicit request via configurable cfSkipTheseRuns, skipping run %s from further processing.\033[0m", tc.fRunNumber.Data());
+    return;
+  }
 
   // *) Determine collision reference multiplicity:
   DetermineReferenceMultiplicity<rs>(collision);

--- a/PWGCF/MultiparticleCorrelations/Tasks/multiparticle-correlations-ab.cxx
+++ b/PWGCF/MultiparticleCorrelations/Tasks/multiparticle-correlations-ab.cxx
@@ -64,6 +64,7 @@ using CollisionRecSim_Run1 = soa::Join<aod::Collisions, aod::McCollisionLabels, 
 #include <TSystem.h>
 #include <TFile.h>
 #include <TH1D.h>
+#include <TProfile2D.h>
 #include <TGrid.h>
 #include <Riostream.h>
 #include <TRandom3.h>
@@ -274,6 +275,8 @@ struct MultiparticleCorrelationsAB // this name is used in lower-case format to 
   // -------------------------------------------
 
   // J) Process data with minimum subscription to the tables, for testing purposes:
+  //    Remark: To keep this branch as simple as possible, I do not subscribe to centrality table. Therefore, when running with "processTest": "true" in JSON,
+  //            I have to remove "| o2-analysis-centrality-table $JsonFile \" from workflow (yes, remove, not comment out!)
   void processTest(aod::Collision const& collision, aod::BCs const& bcs, aod::Tracks const& tracks)
   {
     Steer<eTest>(collision, bcs, tracks);


### PR DESCRIPTION
- support to skip bad runs from further processing
- prevent conflict between FixedNumberOfRandomlySelectedTracks and Toy NUA
- change TH1I to TH1F for CutCounter histos to prevent integer overshooting
- new series of QA profiles 2D (corr vs. ir vs. …, ir is always x-axis)
- fix for O2Linter, part 3 (prepending std:: all over the place)