### PR TITLE
[PWGUD] Added new Process function and modified the tables

### DIFF
--- a/PWGUD/Tasks/exclusiveRhoTo4Pi.cxx
+++ b/PWGUD/Tasks/exclusiveRhoTo4Pi.cxx
@@ -33,6 +33,7 @@
 #include "Math/Vector3D.h"
 #include "Math/GenVector/Boost.h"
 #include "CommonConstants/PhysicsConstants.h"
+#include "TPDGCode.h"
 
 using namespace std;
 using namespace o2;
@@ -250,9 +251,7 @@ DECLARE_SOA_TABLE(SignalMCreco, "AOD", "SignalMCreco",
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 struct ExclusiveRhoTo4Pi {
   SGSelector sgSelector;
-  int kPiPlus = 211;
-  int kPiMinus = -211;
-  int kRhoPrime1700 = 30113;
+  int rhoPrime = 30113;
   uint16_t numPVContrib = 4;
   Produces<aod::SignalData> sigFromData;
   Produces<aod::BkgroundData> bkgFromData;
@@ -402,30 +401,34 @@ struct ExclusiveRhoTo4Pi {
     histosMCgen.add("rhoPrimeCounts", "Total Rho prime Events; Events", kTH1F, {{10, 0, 10}});
 
     // Track Stuff
-    histosMCgen.add("MCgen_particle_pT", "Generated pT; pT [GeV/c]; Events", kTH1F, {{nBinsPt, 0, 10}});
-    histosMCgen.add("MCgen_particle_pT_contributed", "Generated pT; pT [GeV/c]; Events", kTH1F, {{nBinsPt, 0, 10}});
-    histosMCgen.add("MCgen_particle_rapidity", "Generated Rapidity; y; Events", kTH1F, {{nBinsRapidity, -2.5, 2.5}});
-    histosMCgen.add("MCgen_particle_rapidity_contributed", "Generated Rapidity; y; Events", kTH1F, {{nBinsRapidity, -2.5, 2.5}});
+    histosMCgen.add("pion_pT", "Generated pT; pT [GeV/c]; Events", kTH1F, {{nBinsPt, 0, 10}});
+    histosMCgen.add("pion_eta", "Generated Pseudorapidity; #eta; Events", kTH1F, {{1000, -2.5, 2.5}});
+    histosMCgen.add("pion_rapidity", "Generated Rapidity; y; Events", kTH1F, {{nBinsRapidity, -2.5, 2.5}});
 
     // Pair Invariant Mass
-    histosMCgen.add("MCgen_invMass_pair_1", "Invariant Mass Distribution of 2 pions 1 ; m(#pi^{+}#pi^{-}) [GeV/c]", kTH1F, {{5000, 0, 5}});
-    histosMCgen.add("MCgen_invMass_pair_2", "Invariant Mass Distribution of 2 pions 2 ; m(#pi^{+}#pi^{-}) [GeV/c]", kTH1F, {{5000, 0, 5}});
-    histosMCgen.add("MCgen_invMass_pair_3", "Invariant Mass Distribution of 2 pions 3 ; m(#pi^{+}#pi^{-}) [GeV/c]", kTH1F, {{5000, 0, 5}});
-    histosMCgen.add("MCgen_invMass_pair_4", "Invariant Mass Distribution of 2 pions 4 ; m(#pi^{+}#pi^{-}) [GeV/c]", kTH1F, {{5000, 0, 5}});
+    histosMCgen.add("twoPion_invMass_pair_1", "Invariant Mass Distribution of 2 pions 1 ; m(#pi^{+}#pi^{-}) [GeV/c]", kTH1F, {{5000, 0, 5}});
+    histosMCgen.add("twoPion_invMass_pair_2", "Invariant Mass Distribution of 2 pions 2 ; m(#pi^{+}#pi^{-}) [GeV/c]", kTH1F, {{5000, 0, 5}});
+    histosMCgen.add("twoPion_invMass_pair_3", "Invariant Mass Distribution of 2 pions 3 ; m(#pi^{+}#pi^{-}) [GeV/c]", kTH1F, {{5000, 0, 5}});
+    histosMCgen.add("twoPion_invMass_pair_4", "Invariant Mass Distribution of 2 pions 4 ; m(#pi^{+}#pi^{-}) [GeV/c]", kTH1F, {{5000, 0, 5}});
 
     // Generated Transverse Momentum, Rapidty and Invariant Mass
-    histosMCgen.add("MCgen_rhoPrime_pT", "Generated pT; pT [GeV/c]; Events", kTH1F, {{nBinsPt, 0, 2}});
-    histosMCgen.add("MCgen_4pion_pT", "Generated pT; pT [GeV/c]; Events", kTH1F, {{nBinsPt, 0, 2}});
-    histosMCgen.add("MCgen_4pion_rapidity", "Generated Rapidity; y; Events", kTH1F, {{nBinsRapidity, -2.5, 2.5}});
-    histosMCgen.add("MCgen_4pion_invmass", "Invariant Mass of 4-Pions; m(4-pion); Events", kTH1F, {{nBinsInvariantMass, invariantMassMin, invariantMassMax}});
+    histosMCgen.add("rhoPrime_pT", "Generated pT; pT [GeV/c]; Events", kTH1F, {{nBinsPt, 0, 2}});
+    histosMCgen.add("rhoPrime_eta", "Generated pT; pT [GeV/c]; Events", kTH1F, {{nBinsPt, 0, 2}});
+    histosMCgen.add("rhoPrime_rapidity", "Generated pT; pT [GeV/c]; Events", kTH1F, {{nBinsPt, 0, 2}});
+    histosMCgen.add("rhoPrime_invmass", "Generated pT; pT [GeV/c]; Events", kTH1F, {{nBinsPt, 0, 2}});
+
+    histosMCgen.add("fourPion_pT", "Generated pT; pT [GeV/c]; Events", kTH1F, {{nBinsPt, 0, 2}});
+    histosMCgen.add("fourPion_eta", "Generated Pseudorapidity; #eta; Events", kTH1F, {{1000, -2.5, 2.5}});
+    histosMCgen.add("fourPion_rapidity", "Generated Rapidity; y; Events", kTH1F, {{nBinsRapidity, -2.5, 2.5}});
+    histosMCgen.add("fourPion_invmass", "Invariant Mass of 4-Pions; m(4-pion); Events", kTH1F, {{nBinsInvariantMass, invariantMassMin, invariantMassMax}});
 
     // Collin Soper Theta and Phi
-    histosMCgen.add("MCgen_CS_phi_pair_1", "#phi Distribution; #phi; Events", kTH1F, {{nBinsPhi, -3.2, 3.2}});
-    histosMCgen.add("MCgen_CS_phi_pair_2", "#phi Distribution; #phi; Events", kTH1F, {{nBinsPhi, -3.2, 3.2}});
-    histosMCgen.add("MCgen_CS_costheta_pair_1", "#theta Distribution;cos(#theta); Events", kTH1F, {{nBinsCosTheta, -1, 1}});
-    histosMCgen.add("MCgen_CS_costheta_pair_2", "#theta Distribution;cos(#theta); Events", kTH1F, {{nBinsCosTheta, -1, 1}});
-    histosMCgen.add("MCgen_phi_cosTheta_pair_1", "Phi vs cosTheta; #phi; cos(#theta)", kTH2F, {{nBinsPhi, -3.2, 3.2}, {nBinsCosTheta, -1, 1}});
-    histosMCgen.add("MCgen_phi_cosTheta_pair_2", "Phi vs cosTheta; #phi; cos(#theta)", kTH2F, {{nBinsPhi, -3.2, 3.2}, {nBinsCosTheta, -1, 1}});
+    histosMCgen.add("fourPion_phi_pair_1", "#phi Distribution; #phi; Events", kTH1F, {{nBinsPhi, -3.2, 3.2}});
+    histosMCgen.add("fourPion_phi_pair_2", "#phi Distribution; #phi; Events", kTH1F, {{nBinsPhi, -3.2, 3.2}});
+    histosMCgen.add("fourPion_costheta_pair_1", "#theta Distribution;cos(#theta); Events", kTH1F, {{nBinsCosTheta, -1, 1}});
+    histosMCgen.add("fourPion_costheta_pair_2", "#theta Distribution;cos(#theta); Events", kTH1F, {{nBinsCosTheta, -1, 1}});
+    histosMCgen.add("phi_cosTheta_pair_1", "Phi vs cosTheta; #phi; cos(#theta)", kTH2F, {{nBinsPhi, -3.2, 3.2}, {nBinsCosTheta, -1, 1}});
+    histosMCgen.add("phi_cosTheta_pair_2", "Phi vs cosTheta; #phi; cos(#theta)", kTH2F, {{nBinsPhi, -3.2, 3.2}, {nBinsCosTheta, -1, 1}});
 
     // MC Reco Stuff
 
@@ -619,6 +622,7 @@ struct ExclusiveRhoTo4Pi {
     if ((gapSide != 2)) {
       return;
     }
+
     histosData.fill(HIST("vertexZ"), collision.posZ());
     histosData.fill(HIST("V0A"), collision.totalFV0AmplitudeA());
     histosData.fill(HIST("FT0A"), collision.totalFT0AmplitudeA());
@@ -1386,39 +1390,30 @@ struct ExclusiveRhoTo4Pi {
   {
     std::vector<TLorentzVector> piPlusvectors;
     std::vector<TLorentzVector> piMinusvectors;
-    TLorentzVector motherVector, tempVector, p1, p2, p3, p4;
-    TLorentzVector p1234;
-
-    bool flag = false;
+    TLorentzVector daughterVector;
+    TVector3 particleVector;
 
     for (const auto& particle : mcParts) {
-      tempVector.SetXYZM(particle.px(), particle.py(), particle.pz(), o2::constants::physics::MassPionCharged);
 
-      if (!particle.has_mothers()) {
+      if ((particle.pdgCode() != rhoPrime) || (particle.daughters_as<aod::UDMcParticles>().size() != 4)) {
         continue;
       }
 
-      for (const auto& mother : particle.mothers_as<aod::UDMcParticles>()) {
-        if (mother.pdgCode() == kRhoPrime1700) {
-          motherVector.SetXYZM(mother.px(), mother.py(), mother.pz(), o2::constants::physics::MassPionCharged);
-          histosMCgen.fill(HIST("MCgen_rhoPrime_pT"), motherVector.Pt());
+      particleVector.SetXYZ(particle.px(), particle.py(), particle.pz());
+      histosMCgen.fill(HIST("rhoPrimeCounts"), 1);
+      histosMCgen.fill(HIST("rhoPrime_pT"), particleVector.Pt());
+      histosMCgen.fill(HIST("rhoPrime_eta"), particleVector.Eta());
 
-          if (flag == false) {
-            histosMCgen.fill(HIST("rhoPrimeCounts"), 5);
-          }
-          flag = true;
-          if (particle.pdgCode() == kPiPlus) {
-            histosMCgen.fill(HIST("MCgen_particle_pT"), tempVector.Pt());
-            histosMCgen.fill(HIST("MCgen_particle_rapidity"), tempVector.Rapidity());
-            piPlusvectors.push_back(tempVector);
-          }
-          if (particle.pdgCode() == kPiMinus) {
-            histosMCgen.fill(HIST("MCgen_particle_pT"), tempVector.Pt());
-            histosMCgen.fill(HIST("MCgen_particle_rapidity"), tempVector.Rapidity());
-            piMinusvectors.push_back(tempVector);
-          }
-        } // End of Mother ID 30113 rho prime
-      } // End of loop over mothers
+      for (const auto& daughter : particle.daughters_as<aod::UDMcParticles>()) {
+        daughterVector.SetXYZM(daughter.px(), daughter.py(), daughter.pz(), o2::constants::physics::MassPionCharged);
+        if (daughter.pdgCode() == PDG_t::kPiPlus) {
+          piPlusvectors.push_back(daughterVector);
+        }
+        if (daughter.pdgCode() == PDG_t::kPiMinus) {
+          piMinusvectors.push_back(daughterVector);
+        }
+      } // End of loop over daughters
+
     } // End of loop over MC particles
 
     if (piPlusvectors.size() != 2 || piMinusvectors.size() != 2) {
@@ -1450,26 +1445,32 @@ struct ExclusiveRhoTo4Pi {
     pirapidity.push_back(piMinusvectors[0].Rapidity());
     pirapidity.push_back(piMinusvectors[1].Rapidity());
 
-    p1234 = piPlusvectors[0] + piPlusvectors[1] + piMinusvectors[0] + piMinusvectors[1];
+    TLorentzVector p1234 = piPlusvectors[0] + piPlusvectors[1] + piMinusvectors[0] + piMinusvectors[1];
 
-    histosMCgen.fill(HIST("MCgen_particle_pT_contributed"), piPlusvectors[0].Pt());
-    histosMCgen.fill(HIST("MCgen_particle_pT_contributed"), piPlusvectors[1].Pt());
-    histosMCgen.fill(HIST("MCgen_particle_pT_contributed"), piMinusvectors[0].Pt());
-    histosMCgen.fill(HIST("MCgen_particle_pT_contributed"), piMinusvectors[1].Pt());
+    histosMCgen.fill(HIST("pion_pT"), piPlusvectors[0].Pt());
+    histosMCgen.fill(HIST("pion_pT"), piPlusvectors[1].Pt());
+    histosMCgen.fill(HIST("pion_pT"), piMinusvectors[0].Pt());
+    histosMCgen.fill(HIST("pion_pT"), piMinusvectors[1].Pt());
 
-    histosMCgen.fill(HIST("MCgen_particle_rapidity_contributed"), piPlusvectors[0].Rapidity());
-    histosMCgen.fill(HIST("MCgen_particle_rapidity_contributed"), piPlusvectors[1].Rapidity());
-    histosMCgen.fill(HIST("MCgen_particle_rapidity_contributed"), piMinusvectors[0].Rapidity());
-    histosMCgen.fill(HIST("MCgen_particle_rapidity_contributed"), piMinusvectors[1].Rapidity());
+    histosMCgen.fill(HIST("pion_eta"), piPlusvectors[0].Eta());
+    histosMCgen.fill(HIST("pion_eta"), piPlusvectors[1].Eta());
+    histosMCgen.fill(HIST("pion_eta"), piMinusvectors[0].Eta());
+    histosMCgen.fill(HIST("pion_eta"), piMinusvectors[1].Eta());
 
-    histosMCgen.fill(HIST("MCgen_4pion_pT"), p1234.Pt());
-    histosMCgen.fill(HIST("MCgen_4pion_rapidity"), p1234.Rapidity());
-    histosMCgen.fill(HIST("MCgen_4pion_invmass"), p1234.M());
+    histosMCgen.fill(HIST("pion_rapidity"), piPlusvectors[0].Rapidity());
+    histosMCgen.fill(HIST("pion_rapidity"), piPlusvectors[1].Rapidity());
+    histosMCgen.fill(HIST("pion_rapidity"), piMinusvectors[0].Rapidity());
+    histosMCgen.fill(HIST("pion_rapidity"), piMinusvectors[1].Rapidity());
 
-    histosMCgen.fill(HIST("MCgen_invMass_pair_1"), (piPlusvectors[0] + piMinusvectors[0]).M());
-    histosMCgen.fill(HIST("MCgen_invMass_pair_2"), (piPlusvectors[0] + piMinusvectors[1]).M());
-    histosMCgen.fill(HIST("MCgen_invMass_pair_3"), (piPlusvectors[1] + piMinusvectors[0]).M());
-    histosMCgen.fill(HIST("MCgen_invMass_pair_4"), (piPlusvectors[1] + piMinusvectors[1]).M());
+    histosMCgen.fill(HIST("fourPion_pT"), p1234.Pt());
+    histosMCgen.fill(HIST("fourPion_eta"), p1234.Eta());
+    histosMCgen.fill(HIST("fourPion_rapidity"), p1234.Rapidity());
+    histosMCgen.fill(HIST("fourPion_invmass"), p1234.M());
+
+    histosMCgen.fill(HIST("twoPion_invMass_pair_1"), (piPlusvectors[0] + piMinusvectors[0]).M());
+    histosMCgen.fill(HIST("twoPion_invMass_pair_2"), (piPlusvectors[0] + piMinusvectors[1]).M());
+    histosMCgen.fill(HIST("twoPion_invMass_pair_3"), (piPlusvectors[1] + piMinusvectors[0]).M());
+    histosMCgen.fill(HIST("twoPion_invMass_pair_4"), (piPlusvectors[1] + piMinusvectors[1]).M());
 
     ROOT::Math::PtEtaPhiMVector k1, k2, k3, k4, k1234, k13, k14, k23, k24;
 
@@ -1490,16 +1491,17 @@ struct ExclusiveRhoTo4Pi {
     auto cosThetaPair1 = cosThetaCollinsSoperFrame(k13, k24, k1234);
     auto cosThetaPair2 = cosThetaCollinsSoperFrame(k14, k23, k1234);
 
-    generatedMC(pipt, pieta, piphi, pirapidity,
-                p1234.Pt(), p1234.Eta(), p1234.Phi(), p1234.Rapidity(), p1234.M(),
-                phiPair1, phiPair2, cosThetaPair1, cosThetaPair2);
+    generatedMC(
+      pipt, pieta, piphi, pirapidity,
+      p1234.Pt(), p1234.Eta(), p1234.Phi(), p1234.Rapidity(), p1234.M(),
+      phiPair1, phiPair2, cosThetaPair1, cosThetaPair2);
 
-    histosMCgen.fill(HIST("MCgen_CS_phi_pair_1"), phiPair1);
-    histosMCgen.fill(HIST("MCgen_CS_phi_pair_2"), phiPair2);
-    histosMCgen.fill(HIST("MCgen_CS_costheta_pair_1"), cosThetaPair1);
-    histosMCgen.fill(HIST("MCgen_CS_costheta_pair_2"), cosThetaPair2);
-    histosMCgen.fill(HIST("MCgen_phi_cosTheta_pair_1"), phiPair1, cosThetaPair1);
-    histosMCgen.fill(HIST("MCgen_phi_cosTheta_pair_2"), phiPair2, cosThetaPair2);
+    histosMCgen.fill(HIST("fourPion_phi_pair_1"), phiPair1);
+    histosMCgen.fill(HIST("fourPion_phi_pair_2"), phiPair2);
+    histosMCgen.fill(HIST("fourPion_costheta_pair_1"), cosThetaPair1);
+    histosMCgen.fill(HIST("fourPion_costheta_pair_2"), cosThetaPair2);
+    histosMCgen.fill(HIST("phi_cosTheta_pair_1"), phiPair1, cosThetaPair1);
+    histosMCgen.fill(HIST("phi_cosTheta_pair_2"), phiPair2, cosThetaPair2);
 
   } // End of 4 Pion MC Generation Process function
   PROCESS_SWITCH(ExclusiveRhoTo4Pi, processMCgen, "The Process for 4 Pion Analysis from MC Generation", false);
@@ -1863,6 +1865,208 @@ struct ExclusiveRhoTo4Pi {
 
   } // End of 4 Pion Analysis Process function for MC Reconstruction
   PROCESS_SWITCH(ExclusiveRhoTo4Pi, processMCrec, "The Process for 4 Pion Analysis from MC Reconstruction", false);
+
+  using FilteredTrackStuff = soa::Filtered<soa::Join<aod::UDTracks, aod::UDTracksPID, aod::UDTracksExtra, aod::UDTracksFlags, aod::UDTracksDCA, aod::UDMcTrackLabels>>;
+  using FilteredCollisionStuff = soa::Filtered<soa::Join<aod::UDCollisions_001, aod::SGCollisions, aod::UDCollisionsSels, aod::UDZdcsReduced, aod::UDMcCollsLabels>>;
+  using FilteredCollisionTotal = FilteredCollisionStuff::iterator;
+
+  void processMCrecFast(FilteredCollisionTotal const& collision, FilteredTrackStuff const& tracks)
+  {
+
+    if ((tracks.size() != 4) || (!collision.has_udMcCollision())) {
+      return;
+    }
+
+    std::vector<decltype(tracks.begin())> pionPlusTracks;
+    std::vector<decltype(tracks.begin())> pionMinusTracks;
+
+    for (const auto& track : tracks) {
+      if ((!selectionPIDPion(track, true, nSigmaTPCcut, nSigmaTOFcut)) || (!track.has_udMcParticle())) {
+        continue;
+      }
+      if (track.sign() == 1) {
+        pionPlusTracks.push_back(track);
+      }
+      if (track.sign() == -1) {
+        pionMinusTracks.push_back(track);
+      }
+    } // end of loop over tracks
+
+    if ((pionPlusTracks.size() + pionMinusTracks.size()) != 4) {
+      return;
+    }
+
+    if (pionPlusTracks.size() == 2 || pionMinusTracks.size() == 2) {
+
+      std::vector<double> dcaxy;
+      std::vector<double> dcaz;
+
+      std::vector<double> tpcnsigPi;
+      std::vector<double> tpcnsigKa;
+      std::vector<double> tpcnsigPr;
+      std::vector<double> tpcnsigEl;
+      std::vector<double> tpcnsigMu;
+
+      std::vector<double> tofnsigPi;
+      std::vector<double> tofnsigKa;
+      std::vector<double> tofnsigPr;
+      std::vector<double> tofnsigEl;
+      std::vector<double> tofnsigMu;
+
+      std::vector<double> tpcchi2;
+      std::vector<double> tpcnclsfindable;
+      std::vector<double> itschi2;
+
+      std::vector<double> pipt;
+      std::vector<double> pieta;
+      std::vector<double> piphi;
+      std::vector<double> pirapidity;
+
+      TLorentzVector p1, p2, p3, p4, p1234;
+      ROOT::Math::PtEtaPhiMVector k1, k2, k3, k4, k1234, k13, k14, k23, k24;
+
+      p1.SetXYZM(pionPlusTracks[0].px(), pionPlusTracks[0].py(), pionPlusTracks[0].pz(), o2::constants::physics::MassPionCharged);
+      p2.SetXYZM(pionPlusTracks[1].px(), pionPlusTracks[1].py(), pionPlusTracks[1].pz(), o2::constants::physics::MassPionCharged);
+      p3.SetXYZM(pionMinusTracks[0].px(), pionMinusTracks[0].py(), pionMinusTracks[0].pz(), o2::constants::physics::MassPionCharged);
+      p4.SetXYZM(pionMinusTracks[1].px(), pionMinusTracks[1].py(), pionMinusTracks[1].pz(), o2::constants::physics::MassPionCharged);
+
+      k1.SetCoordinates(p1.Pt(), p1.Eta(), p1.Phi(), o2::constants::physics::MassPionCharged);
+      k2.SetCoordinates(p2.Pt(), p2.Eta(), p2.Phi(), o2::constants::physics::MassPionCharged);
+      k3.SetCoordinates(p3.Pt(), p3.Eta(), p3.Phi(), o2::constants::physics::MassPionCharged);
+      k4.SetCoordinates(p4.Pt(), p4.Eta(), p4.Phi(), o2::constants::physics::MassPionCharged);
+
+      dcaxy.push_back(pionPlusTracks[0].dcaXY());
+      dcaxy.push_back(pionPlusTracks[1].dcaXY());
+      dcaxy.push_back(pionMinusTracks[0].dcaXY());
+      dcaxy.push_back(pionMinusTracks[1].dcaXY());
+
+      dcaz.push_back(pionPlusTracks[0].dcaZ());
+      dcaz.push_back(pionPlusTracks[1].dcaZ());
+      dcaz.push_back(pionMinusTracks[0].dcaZ());
+      dcaz.push_back(pionMinusTracks[1].dcaZ());
+
+      tpcnsigPi.push_back(pionPlusTracks[0].tpcNSigmaPi());
+      tpcnsigPi.push_back(pionPlusTracks[1].tpcNSigmaPi());
+      tpcnsigPi.push_back(pionMinusTracks[0].tpcNSigmaPi());
+      tpcnsigPi.push_back(pionMinusTracks[1].tpcNSigmaPi());
+
+      tpcnsigKa.push_back(pionPlusTracks[0].tpcNSigmaKa());
+      tpcnsigKa.push_back(pionPlusTracks[1].tpcNSigmaKa());
+      tpcnsigKa.push_back(pionMinusTracks[0].tpcNSigmaKa());
+      tpcnsigKa.push_back(pionMinusTracks[1].tpcNSigmaKa());
+
+      tpcnsigPr.push_back(pionPlusTracks[0].tpcNSigmaPr());
+      tpcnsigPr.push_back(pionPlusTracks[1].tpcNSigmaPr());
+      tpcnsigPr.push_back(pionMinusTracks[0].tpcNSigmaPr());
+      tpcnsigPr.push_back(pionMinusTracks[1].tpcNSigmaPr());
+
+      tpcnsigEl.push_back(pionPlusTracks[0].tpcNSigmaEl());
+      tpcnsigEl.push_back(pionPlusTracks[1].tpcNSigmaEl());
+      tpcnsigEl.push_back(pionMinusTracks[0].tpcNSigmaEl());
+      tpcnsigEl.push_back(pionMinusTracks[1].tpcNSigmaEl());
+
+      tpcnsigMu.push_back(pionPlusTracks[0].tpcNSigmaMu());
+      tpcnsigMu.push_back(pionPlusTracks[1].tpcNSigmaMu());
+      tpcnsigMu.push_back(pionMinusTracks[0].tpcNSigmaMu());
+      tpcnsigMu.push_back(pionMinusTracks[1].tpcNSigmaMu());
+
+      tofnsigPi.push_back(pionPlusTracks[0].tofNSigmaPi());
+      tofnsigPi.push_back(pionPlusTracks[1].tofNSigmaPi());
+      tofnsigPi.push_back(pionMinusTracks[0].tofNSigmaPi());
+      tofnsigPi.push_back(pionMinusTracks[1].tofNSigmaPi());
+
+      tofnsigKa.push_back(pionPlusTracks[0].tofNSigmaKa());
+      tofnsigKa.push_back(pionPlusTracks[1].tofNSigmaKa());
+      tofnsigKa.push_back(pionMinusTracks[0].tofNSigmaKa());
+      tofnsigKa.push_back(pionMinusTracks[1].tofNSigmaKa());
+
+      tofnsigPr.push_back(pionPlusTracks[0].tofNSigmaPr());
+      tofnsigPr.push_back(pionPlusTracks[1].tofNSigmaPr());
+      tofnsigPr.push_back(pionMinusTracks[0].tofNSigmaPr());
+      tofnsigPr.push_back(pionMinusTracks[1].tofNSigmaPr());
+
+      tofnsigEl.push_back(pionPlusTracks[0].tofNSigmaEl());
+      tofnsigEl.push_back(pionPlusTracks[1].tofNSigmaEl());
+      tofnsigEl.push_back(pionMinusTracks[0].tofNSigmaEl());
+      tofnsigEl.push_back(pionMinusTracks[1].tofNSigmaEl());
+
+      tofnsigMu.push_back(pionPlusTracks[0].tofNSigmaMu());
+      tofnsigMu.push_back(pionPlusTracks[1].tofNSigmaMu());
+      tofnsigMu.push_back(pionMinusTracks[0].tofNSigmaMu());
+      tofnsigMu.push_back(pionMinusTracks[1].tofNSigmaMu());
+
+      tpcchi2.push_back(pionPlusTracks[0].tpcChi2NCl());
+      tpcchi2.push_back(pionPlusTracks[1].tpcChi2NCl());
+      tpcchi2.push_back(pionMinusTracks[0].tpcChi2NCl());
+      tpcchi2.push_back(pionMinusTracks[1].tpcChi2NCl());
+
+      tpcnclsfindable.push_back(pionPlusTracks[0].tpcNClsFindable());
+      tpcnclsfindable.push_back(pionPlusTracks[1].tpcNClsFindable());
+      tpcnclsfindable.push_back(pionMinusTracks[0].tpcNClsFindable());
+      tpcnclsfindable.push_back(pionMinusTracks[1].tpcNClsFindable());
+
+      itschi2.push_back(pionPlusTracks[0].itsChi2NCl());
+      itschi2.push_back(pionPlusTracks[1].itsChi2NCl());
+      itschi2.push_back(pionMinusTracks[0].itsChi2NCl());
+      itschi2.push_back(pionMinusTracks[1].itsChi2NCl());
+
+      pipt.push_back(p1.Pt());
+      pipt.push_back(p2.Pt());
+      pipt.push_back(p3.Pt());
+      pipt.push_back(p4.Pt());
+
+      pieta.push_back(p1.Eta());
+      pieta.push_back(p2.Eta());
+      pieta.push_back(p3.Eta());
+      pieta.push_back(p4.Eta());
+
+      piphi.push_back(p1.Phi());
+      piphi.push_back(p2.Phi());
+      piphi.push_back(p3.Phi());
+      piphi.push_back(p4.Phi());
+
+      pirapidity.push_back(p1.Rapidity());
+      pirapidity.push_back(p2.Rapidity());
+      pirapidity.push_back(p3.Rapidity());
+      pirapidity.push_back(p4.Rapidity());
+
+      p1234 = p1 + p2 + p3 + p4;
+      k1234 = k1 + k2 + k3 + k4;
+
+      k13 = k1 + k3;
+      k14 = k1 + k4;
+      k23 = k2 + k3;
+      k24 = k2 + k4;
+
+      double fourPiPhiPair1 = phiCollinsSoperFrame(k13, k24, k1234);
+      double fourPiPhiPair2 = phiCollinsSoperFrame(k14, k23, k1234);
+      double fourPiCosThetaPair1 = cosThetaCollinsSoperFrame(k13, k24, k1234);
+      double fourPiCosThetaPair2 = cosThetaCollinsSoperFrame(k14, k23, k1234);
+
+      sigFromMC(
+        collision.posX(), collision.posY(), collision.posZ(),
+        collision.totalFV0AmplitudeA(), collision.totalFT0AmplitudeA(), collision.totalFT0AmplitudeC(), collision.totalFDDAmplitudeA(), collision.totalFDDAmplitudeC(),
+        collision.timeFV0A(), collision.timeFT0A(), collision.timeFT0C(), collision.timeFDDA(), collision.timeFDDC(),
+        collision.timeZNA(), collision.timeZNC(),
+        dcaxy, dcaz,
+        tpcnsigPi, tpcnsigKa, tpcnsigPr, tpcnsigEl, tpcnsigMu,
+        tofnsigPi, tofnsigKa, tofnsigPr, tofnsigEl, tofnsigMu,
+        tpcchi2, tpcnclsfindable, itschi2,
+        pipt, pieta, piphi, pirapidity,
+        p1234.Pt(), p1234.Eta(), p1234.Phi(), p1234.Rapidity(), p1234.M(),
+        fourPiPhiPair1, fourPiPhiPair2, fourPiCosThetaPair1, fourPiCosThetaPair2);
+
+      histosFast.fill(HIST("4PionPt"), p1234.Pt());
+      histosFast.fill(HIST("4PionRapidity"), p1234.Rapidity());
+      histosFast.fill(HIST("4PionMassFull"), p1234.M());
+
+      if ((p1234.Pt() < 0.15) && (std::abs(p1234.Rapidity()) < 0.5)) {
+        histosFast.fill(HIST("4PionMassWithCut"), p1234.M());
+      }
+    } // End 0 charge event
+  } // End of 4 Pion Analysis Process function for Fast MC Reconstruction
+
+  PROCESS_SWITCH(ExclusiveRhoTo4Pi, processMCrecFast, "The Process for 4 Pion Analysis from Fast MC Reconstruction", false);
 
 }; // End of Struct exclusiveRhoTo4Pi
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/PWGUD/Tasks/exclusiveRhoTo4Pi.cxx
+++ b/PWGUD/Tasks/exclusiveRhoTo4Pi.cxx
@@ -44,24 +44,40 @@ namespace o2::aod
 {
 namespace branch
 {
+
+DECLARE_SOA_COLUMN(PosX, posX, double);
+DECLARE_SOA_COLUMN(PosY, posY, double);
+DECLARE_SOA_COLUMN(PosZ, posZ, double);
+
 DECLARE_SOA_COLUMN(Fv0signal, fv0signal, double);
 DECLARE_SOA_COLUMN(Ft0asignal, ft0asignal, double);
 DECLARE_SOA_COLUMN(Ft0csignal, ft0csignal, double);
 DECLARE_SOA_COLUMN(Fddasignal, fddasignal, double);
 DECLARE_SOA_COLUMN(Fddcsignal, fddcsignal, double);
 
+DECLARE_SOA_COLUMN(TimeFv0, timeFv0, double);
+DECLARE_SOA_COLUMN(TimeFt0a, timeFt0a, double);
+DECLARE_SOA_COLUMN(TimeFt0c, timeFt0c, double);
+DECLARE_SOA_COLUMN(TimeFdda, timeFdda, double);
+DECLARE_SOA_COLUMN(TimeFddc, timeFddc, double);
+
+DECLARE_SOA_COLUMN(TimeZna, timeZna, double);
+DECLARE_SOA_COLUMN(TimeZnc, timeZnc, double);
+
 DECLARE_SOA_COLUMN(Dcaxy, dcaxy, std::vector<double>);
 DECLARE_SOA_COLUMN(Dcaz, dcaz, std::vector<double>);
 
+DECLARE_SOA_COLUMN(TpcNsigmaPi, tpcNsigmaPi, std::vector<double>);
 DECLARE_SOA_COLUMN(TpcNsigmaKa, tpcNsigmaKa, std::vector<double>);
 DECLARE_SOA_COLUMN(TpcNsigmaPr, tpcNsigmaPr, std::vector<double>);
-DECLARE_SOA_COLUMN(TpcNsigmaMu, tpcNsigmaMu, std::vector<double>);
 DECLARE_SOA_COLUMN(TpcNsigmaEl, tpcNsigmaEl, std::vector<double>);
+DECLARE_SOA_COLUMN(TpcNsigmaMu, tpcNsigmaMu, std::vector<double>);
 
+DECLARE_SOA_COLUMN(TofNsigmaPi, tofNsigmaPi, std::vector<double>);
 DECLARE_SOA_COLUMN(TofNsigmaKa, tofNsigmaKa, std::vector<double>);
 DECLARE_SOA_COLUMN(TofNsigmaPr, tofNsigmaPr, std::vector<double>);
-DECLARE_SOA_COLUMN(TofNsigmaMu, tofNsigmaMu, std::vector<double>);
 DECLARE_SOA_COLUMN(TofNsigmaEl, tofNsigmaEl, std::vector<double>);
+DECLARE_SOA_COLUMN(TofNsigmaMu, tofNsigmaMu, std::vector<double>);
 
 DECLARE_SOA_COLUMN(TpcChi2, tpcChi2, std::vector<double>);
 DECLARE_SOA_COLUMN(TpcNClsFindable, tpcNClsFindable, std::vector<double>);
@@ -69,84 +85,59 @@ DECLARE_SOA_COLUMN(ItsChi2, itsChi2, std::vector<double>);
 
 DECLARE_SOA_COLUMN(PionPt, pionPt, std::vector<double>);
 DECLARE_SOA_COLUMN(PionEta, pionEta, std::vector<double>);
+DECLARE_SOA_COLUMN(PionPhi, pionPhi, std::vector<double>);
 DECLARE_SOA_COLUMN(PionRapidity, pionRapidity, std::vector<double>);
 
 DECLARE_SOA_COLUMN(FourPionPt, fourPionPt, double);
 DECLARE_SOA_COLUMN(FourPionEta, fourPionEta, double);
-DECLARE_SOA_COLUMN(FourPionRapidity, fourPionRapidity, double);
-DECLARE_SOA_COLUMN(FourPionMass, fourPionMass, double);
 DECLARE_SOA_COLUMN(FourPionPhi, fourPionPhi, double);
+DECLARE_SOA_COLUMN(FourPionRapidity, fourPionRapidity, double);
+
+DECLARE_SOA_COLUMN(FourPionMass, fourPionMass, double);
 DECLARE_SOA_COLUMN(FourPionPhiPair1, fourPionPhiPair1, double);
 DECLARE_SOA_COLUMN(FourPionPhiPair2, fourPionPhiPair2, double);
 DECLARE_SOA_COLUMN(FourPionCosThetaPair1, fourPionCosThetaPair1, double);
 DECLARE_SOA_COLUMN(FourPionCosThetaPair2, fourPionCosThetaPair2, double);
 } // namespace branch
-DECLARE_SOA_TABLE(UDTree0c, "AOD", "UD0Charge",
+
+DECLARE_SOA_TABLE(SignalData, "AOD", "signalData",
+                  branch::PosX,
+                  branch::PosY,
+                  branch::PosZ,
                   branch::Fv0signal,
                   branch::Ft0asignal,
                   branch::Ft0csignal,
                   branch::Fddasignal,
                   branch::Fddcsignal,
+                  branch::TimeFv0,
+                  branch::TimeFt0a,
+                  branch::TimeFt0c,
+                  branch::TimeFdda,
+                  branch::TimeFddc,
+                  branch::TimeZna,
+                  branch::TimeZnc,
                   branch::Dcaxy,
                   branch::Dcaz,
+                  branch::TpcNsigmaPi,
                   branch::TpcNsigmaKa,
                   branch::TpcNsigmaPr,
-                  branch::TpcNsigmaMu,
                   branch::TpcNsigmaEl,
+                  branch::TpcNsigmaMu,
+                  branch::TofNsigmaPi,
                   branch::TofNsigmaKa,
                   branch::TofNsigmaPr,
-                  branch::TofNsigmaMu,
                   branch::TofNsigmaEl,
+                  branch::TofNsigmaMu,
                   branch::TpcChi2,
                   branch::TpcNClsFindable,
                   branch::ItsChi2,
                   branch::PionPt,
                   branch::PionEta,
+                  branch::PionPhi,
                   branch::PionRapidity,
                   branch::FourPionPt,
                   branch::FourPionEta,
-                  branch::FourPionRapidity,
-                  branch::FourPionMass,
                   branch::FourPionPhi,
-                  branch::FourPionPhiPair1,
-                  branch::FourPionPhiPair2,
-                  branch::FourPionCosThetaPair1,
-                  branch::FourPionCosThetaPair2);
-
-DECLARE_SOA_TABLE(UDTreen0c, "AOD", "UDn0Charge",
-                  branch::Fv0signal,
-                  branch::Ft0asignal,
-                  branch::Ft0csignal,
-                  branch::Fddasignal,
-                  branch::Fddcsignal,
-                  branch::Dcaxy,
-                  branch::Dcaz,
-                  branch::TpcNsigmaKa,
-                  branch::TpcNsigmaPr,
-                  branch::TpcNsigmaMu,
-                  branch::TpcNsigmaEl,
-                  branch::TofNsigmaKa,
-                  branch::TofNsigmaPr,
-                  branch::TofNsigmaMu,
-                  branch::TofNsigmaEl,
-                  branch::TpcChi2,
-                  branch::TpcNClsFindable,
-                  branch::ItsChi2,
-                  branch::PionPt,
-                  branch::PionEta,
-                  branch::PionRapidity,
-                  branch::FourPionPt,
-                  branch::FourPionEta,
-                  branch::FourPionRapidity,
-                  branch::FourPionMass,
-                  branch::FourPionPhi);
-
-DECLARE_SOA_TABLE(MCTree, "AOD", "MC0Charge",
-                  branch::PionPt,
-                  branch::PionEta,
-                  branch::PionRapidity,
-                  branch::FourPionPt,
-                  branch::FourPionEta,
                   branch::FourPionRapidity,
                   branch::FourPionMass,
                   branch::FourPionPhiPair1,
@@ -154,33 +145,102 @@ DECLARE_SOA_TABLE(MCTree, "AOD", "MC0Charge",
                   branch::FourPionCosThetaPair1,
                   branch::FourPionCosThetaPair2);
 
-DECLARE_SOA_TABLE(MCUDTree, "AOD", "UDMC0Charge",
+DECLARE_SOA_TABLE(BkgroundData, "AOD", "bkgroundData",
+                  branch::PosX,
+                  branch::PosY,
+                  branch::PosZ,
                   branch::Fv0signal,
                   branch::Ft0asignal,
                   branch::Ft0csignal,
                   branch::Fddasignal,
                   branch::Fddcsignal,
+                  branch::TimeFv0,
+                  branch::TimeFt0a,
+                  branch::TimeFt0c,
+                  branch::TimeFdda,
+                  branch::TimeFddc,
+                  branch::TimeZna,
+                  branch::TimeZnc,
                   branch::Dcaxy,
                   branch::Dcaz,
+                  branch::TpcNsigmaPi,
                   branch::TpcNsigmaKa,
                   branch::TpcNsigmaPr,
-                  branch::TpcNsigmaMu,
                   branch::TpcNsigmaEl,
+                  branch::TpcNsigmaMu,
+                  branch::TofNsigmaPi,
                   branch::TofNsigmaKa,
                   branch::TofNsigmaPr,
-                  branch::TofNsigmaMu,
                   branch::TofNsigmaEl,
+                  branch::TofNsigmaMu,
                   branch::TpcChi2,
                   branch::TpcNClsFindable,
                   branch::ItsChi2,
                   branch::PionPt,
                   branch::PionEta,
+                  branch::PionPhi,
                   branch::PionRapidity,
                   branch::FourPionPt,
                   branch::FourPionEta,
+                  branch::FourPionPhi,
+                  branch::FourPionRapidity,
+                  branch::FourPionMass);
+
+DECLARE_SOA_TABLE(MCgen, "AOD", "MCgen",
+                  branch::PionPt,
+                  branch::PionEta,
+                  branch::PionPhi,
+                  branch::PionRapidity,
+                  branch::FourPionPt,
+                  branch::FourPionEta,
+                  branch::FourPionPhi,
                   branch::FourPionRapidity,
                   branch::FourPionMass,
+                  branch::FourPionPhiPair1,
+                  branch::FourPionPhiPair2,
+                  branch::FourPionCosThetaPair1,
+                  branch::FourPionCosThetaPair2);
+
+DECLARE_SOA_TABLE(SignalMCreco, "AOD", "SignalMCreco",
+                  branch::PosX,
+                  branch::PosY,
+                  branch::PosZ,
+                  branch::Fv0signal,
+                  branch::Ft0asignal,
+                  branch::Ft0csignal,
+                  branch::Fddasignal,
+                  branch::Fddcsignal,
+                  branch::TimeFv0,
+                  branch::TimeFt0a,
+                  branch::TimeFt0c,
+                  branch::TimeFdda,
+                  branch::TimeFddc,
+                  branch::TimeZna,
+                  branch::TimeZnc,
+                  branch::Dcaxy,
+                  branch::Dcaz,
+                  branch::TpcNsigmaPi,
+                  branch::TpcNsigmaKa,
+                  branch::TpcNsigmaPr,
+                  branch::TpcNsigmaEl,
+                  branch::TpcNsigmaMu,
+                  branch::TofNsigmaPi,
+                  branch::TofNsigmaKa,
+                  branch::TofNsigmaPr,
+                  branch::TofNsigmaEl,
+                  branch::TofNsigmaMu,
+                  branch::TpcChi2,
+                  branch::TpcNClsFindable,
+                  branch::ItsChi2,
+                  branch::PionPt,
+                  branch::PionEta,
+                  branch::PionPhi,
+                  branch::PionRapidity,
+                  branch::FourPionPt,
+                  branch::FourPionEta,
                   branch::FourPionPhi,
+                  branch::FourPionRapidity,
+                  branch::FourPionMass,
                   branch::FourPionPhiPair1,
                   branch::FourPionPhiPair2,
                   branch::FourPionCosThetaPair1,
@@ -193,26 +253,26 @@ struct ExclusiveRhoTo4Pi {
   int kPiPlus = 211;
   int kPiMinus = -211;
   int kRhoPrime1700 = 30113;
-  Produces<aod::UDTree0c> zeroChargeEventsData;
-  Produces<aod::UDTreen0c> nonzeroChargeEventsData;
-  Produces<aod::MCTree> zeroChargeEventsMCgen;
-  Produces<aod::MCUDTree> zeroChargeEventsMCreco;
+  uint16_t numPVContrib = 4;
+  Produces<aod::SignalData> sigFromData;
+  Produces<aod::BkgroundData> bkgFromData;
+  Produces<aod::MCgen> generatedMC;
+  Produces<aod::SignalMCreco> sigFromMC;
 
   HistogramRegistry histosData{"histosData", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
   HistogramRegistry histosMCgen{"histosMCgen", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
   HistogramRegistry histosMCreco{"histosMCreco", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
+  HistogramRegistry histosFast{"histosFast", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
 
   //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   Configurable<float> fv0Cut{"fv0Cut", 50., "FV0A threshold"};
   Configurable<float> ft0aCut{"ft0aCut", 150., "FT0A threshold"};
   Configurable<float> ft0cCut{"ft0cCut", 50., "FT0C threshold"};
-  Configurable<float> fddaCut{"fddaCut", 10000., "FDDA threshold"};
-  Configurable<float> fddcCut{"fddcCut", 10000., "FDDC threshold"};
   Configurable<float> zdcCut{"zdcCut", 1., "ZDC threshold"};
 
   Configurable<float> pvCut{"pvCut", 1.0, "Use Only PV tracks"};
   Configurable<float> dcaZcut{"dcaZcut", 2, "dcaZ cut"};
-  Configurable<float> dcaXYcut{"dcaXYcut", 0, "dcaXY cut (0 for Pt-function)"};
+  Configurable<float> dcaXYcut{"dcaXYcut", 0, "dcaXY cut"};
   Configurable<float> tpcChi2Cut{"tpcChi2Cut", 4, "Max tpcChi2NCl"};
   Configurable<float> tpcNClsFindableCut{"tpcNClsFindableCut", 70, "Min tpcNClsFindable"};
   Configurable<float> itsChi2Cut{"itsChi2Cut", 36, "Max itsChi2NCl"};
@@ -221,7 +281,6 @@ struct ExclusiveRhoTo4Pi {
 
   Configurable<float> nSigmaTPCcut{"nSigmaTPCcut", 3, "TPC cut"};
   Configurable<float> nSigmaTOFcut{"nSigmaTOFcut", 3, "TOF cut"};
-  Configurable<bool> strictEventSelection{"strictEventSelection", true, "Event Selection"};
 
   Configurable<int> nBinsPt{"nBinsPt", 1000, "Number of bins for pT"};
   Configurable<int> nBinsInvariantMass{"nBinsInvariantMass", 1000, "Number of bins for Invariant Mass"};
@@ -470,6 +529,11 @@ struct ExclusiveRhoTo4Pi {
     histosMCreco.add("phi_cosTheta_pair_1", "Phi vs cosTheta; #phi; cos(#theta)", kTH2F, {{nBinsPhi, -3.2, 3.2}, {nBinsCosTheta, -1, 1}});
     histosMCreco.add("phi_cosTheta_pair_2", "Phi vs cosTheta; #phi; cos(#theta)", kTH2F, {{nBinsPhi, -3.2, 3.2}, {nBinsCosTheta, -1, 1}});
 
+    histosFast.add("4PionMassWithCut", "", kTH1F, {{nBinsInvariantMass, invariantMassMin, invariantMassMax}});
+    histosFast.add("4PionMassFull", "", kTH1F, {{nBinsInvariantMass, invariantMassMin, invariantMassMax}});
+    histosFast.add("4PionPt", "", kTH1F, {{nBinsPt, 0, 10}});
+    histosFast.add("4PionRapidity", "", kTH1F, {{nBinsRapidity, -1, 1}});
+
   } // End of init function
   //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -545,9 +609,8 @@ struct ExclusiveRhoTo4Pi {
     }
 
     int gapSide = collision.gapSide();
-    float fitCuts[5] = {fv0Cut, ft0aCut, ft0cCut, fddaCut, fddcCut};
     std::vector<float> parameters = {pvCut, dcaZcut, dcaXYcut, tpcChi2Cut, tpcNClsFindableCut, itsChi2Cut, etaCut, pTcut};
-    int truegapSide = sgSelector.trueGap(collision, fitCuts[0], fitCuts[1], fitCuts[2], zdcCut);
+    int truegapSide = sgSelector.trueGap(collision, fv0Cut, ft0aCut, ft0cCut, zdcCut);
     histosData.fill(HIST("GapSide"), gapSide);
     histosData.fill(HIST("TrueGapSide"), truegapSide);
     histosData.fill(HIST("EventCounts"), 1);
@@ -563,14 +626,8 @@ struct ExclusiveRhoTo4Pi {
     histosData.fill(HIST("ZDC_A"), collision.energyCommonZNA());
     histosData.fill(HIST("ZDC_C"), collision.energyCommonZNC());
 
-    if (strictEventSelection) {
-      if (collision.numContrib() != 4) {
-        return;
-      }
-    } else {
-      if (collision.numContrib() >= 10) {
-        return;
-      }
+    if (collision.numContrib() != 4) {
+      return;
     }
 
     std::vector<decltype(tracks.begin())> WOTS_tracks;
@@ -661,34 +718,32 @@ struct ExclusiveRhoTo4Pi {
       return;
     }
 
-    std::vector<double> pidcaXY;
-    std::vector<double> pidcaZ;
-
-    std::vector<double> tpcNsigKa;
-    std::vector<double> tpcNsigPr;
-    std::vector<double> tpcNsigEl;
-    std::vector<double> tpcNsigMu;
-
-    std::vector<double> tofNsigKa;
-    std::vector<double> tofNsigPr;
-    std::vector<double> tofNsigEl;
-    std::vector<double> tofNsigMu;
-
-    std::vector<double> tpcchi2;
-    std::vector<double> itschi2;
-    std::vector<double> tpcNFindableCls;
-
-    std::vector<double> piPt;
-    std::vector<double> piEta;
-    std::vector<double> piRapidity;
-
-    double fourPiPhiPair1 = 0;
-    double fourPiPhiPair2 = 0;
-    double fourPiCosThetaPair1 = 0;
-    double fourPiCosThetaPair2 = 0;
-
     // Selecting Events with net charge = 0
     if (numPionMinusTRacks == 2 && numPiPlusTracks == 2) {
+
+      std::vector<double> dcaxy;
+      std::vector<double> dcaz;
+
+      std::vector<double> tpcnsigPi;
+      std::vector<double> tpcnsigKa;
+      std::vector<double> tpcnsigPr;
+      std::vector<double> tpcnsigEl;
+      std::vector<double> tpcnsigMu;
+
+      std::vector<double> tofnsigPi;
+      std::vector<double> tofnsigKa;
+      std::vector<double> tofnsigPr;
+      std::vector<double> tofnsigEl;
+      std::vector<double> tofnsigMu;
+
+      std::vector<double> tpcchi2;
+      std::vector<double> tpcnclsfindable;
+      std::vector<double> itschi2;
+
+      std::vector<double> pipt;
+      std::vector<double> pieta;
+      std::vector<double> piphi;
+      std::vector<double> pirapidity;
 
       TLorentzVector p1, p2, p3, p4, p1234;
       ROOT::Math::PtEtaPhiMVector k1, k2, k3, k4, k1234, k13, k14, k23, k24;
@@ -697,86 +752,6 @@ struct ExclusiveRhoTo4Pi {
       p2.SetXYZM(Pi_plus_tracks[1].px(), Pi_plus_tracks[1].py(), Pi_plus_tracks[1].pz(), o2::constants::physics::MassPionCharged);
       p3.SetXYZM(Pi_minus_tracks[0].px(), Pi_minus_tracks[0].py(), Pi_minus_tracks[0].pz(), o2::constants::physics::MassPionCharged);
       p4.SetXYZM(Pi_minus_tracks[1].px(), Pi_minus_tracks[1].py(), Pi_minus_tracks[1].pz(), o2::constants::physics::MassPionCharged);
-
-      pidcaXY.push_back(Pi_plus_tracks[0].dcaXY());
-      pidcaXY.push_back(Pi_plus_tracks[1].dcaXY());
-      pidcaXY.push_back(Pi_minus_tracks[0].dcaXY());
-      pidcaXY.push_back(Pi_minus_tracks[1].dcaXY());
-
-      pidcaZ.push_back(Pi_plus_tracks[0].dcaZ());
-      pidcaZ.push_back(Pi_plus_tracks[1].dcaZ());
-      pidcaZ.push_back(Pi_minus_tracks[0].dcaZ());
-      pidcaZ.push_back(Pi_minus_tracks[1].dcaZ());
-
-      tpcNsigKa.push_back(Pi_plus_tracks[0].tpcNSigmaKa());
-      tpcNsigKa.push_back(Pi_plus_tracks[1].tpcNSigmaKa());
-      tpcNsigKa.push_back(Pi_minus_tracks[0].tpcNSigmaKa());
-      tpcNsigKa.push_back(Pi_minus_tracks[1].tpcNSigmaKa());
-
-      tpcNsigPr.push_back(Pi_plus_tracks[0].tpcNSigmaPr());
-      tpcNsigPr.push_back(Pi_plus_tracks[1].tpcNSigmaPr());
-      tpcNsigPr.push_back(Pi_minus_tracks[0].tpcNSigmaPr());
-      tpcNsigPr.push_back(Pi_minus_tracks[1].tpcNSigmaPr());
-
-      tpcNsigEl.push_back(Pi_plus_tracks[0].tpcNSigmaEl());
-      tpcNsigEl.push_back(Pi_plus_tracks[1].tpcNSigmaEl());
-      tpcNsigEl.push_back(Pi_minus_tracks[0].tpcNSigmaEl());
-      tpcNsigEl.push_back(Pi_minus_tracks[1].tpcNSigmaEl());
-
-      tpcNsigMu.push_back(Pi_plus_tracks[0].tpcNSigmaMu());
-      tpcNsigMu.push_back(Pi_plus_tracks[1].tpcNSigmaMu());
-      tpcNsigMu.push_back(Pi_minus_tracks[0].tpcNSigmaMu());
-      tpcNsigMu.push_back(Pi_minus_tracks[1].tpcNSigmaMu());
-
-      tofNsigKa.push_back(Pi_plus_tracks[0].tofNSigmaKa());
-      tofNsigKa.push_back(Pi_plus_tracks[1].tofNSigmaKa());
-      tofNsigKa.push_back(Pi_minus_tracks[0].tofNSigmaKa());
-      tofNsigKa.push_back(Pi_minus_tracks[1].tofNSigmaKa());
-
-      tofNsigPr.push_back(Pi_plus_tracks[0].tofNSigmaPr());
-      tofNsigPr.push_back(Pi_plus_tracks[1].tofNSigmaPr());
-      tofNsigPr.push_back(Pi_minus_tracks[0].tofNSigmaPr());
-      tofNsigPr.push_back(Pi_minus_tracks[1].tofNSigmaPr());
-
-      tofNsigEl.push_back(Pi_plus_tracks[0].tofNSigmaEl());
-      tofNsigEl.push_back(Pi_plus_tracks[1].tofNSigmaEl());
-      tofNsigEl.push_back(Pi_minus_tracks[0].tofNSigmaEl());
-      tofNsigEl.push_back(Pi_minus_tracks[1].tofNSigmaEl());
-
-      tofNsigMu.push_back(Pi_plus_tracks[0].tofNSigmaMu());
-      tofNsigMu.push_back(Pi_plus_tracks[1].tofNSigmaMu());
-      tofNsigMu.push_back(Pi_minus_tracks[0].tofNSigmaMu());
-      tofNsigMu.push_back(Pi_minus_tracks[1].tofNSigmaMu());
-
-      tpcchi2.push_back(Pi_plus_tracks[0].tpcChi2NCl());
-      tpcchi2.push_back(Pi_plus_tracks[1].tpcChi2NCl());
-      tpcchi2.push_back(Pi_minus_tracks[0].tpcChi2NCl());
-      tpcchi2.push_back(Pi_minus_tracks[1].tpcChi2NCl());
-
-      tpcNFindableCls.push_back(Pi_plus_tracks[0].tpcNClsFindable());
-      tpcNFindableCls.push_back(Pi_plus_tracks[1].tpcNClsFindable());
-      tpcNFindableCls.push_back(Pi_minus_tracks[0].tpcNClsFindable());
-      tpcNFindableCls.push_back(Pi_minus_tracks[1].tpcNClsFindable());
-
-      itschi2.push_back(Pi_plus_tracks[0].itsChi2NCl());
-      itschi2.push_back(Pi_plus_tracks[1].itsChi2NCl());
-      itschi2.push_back(Pi_minus_tracks[0].itsChi2NCl());
-      itschi2.push_back(Pi_minus_tracks[1].itsChi2NCl());
-
-      piPt.push_back(p1.Pt());
-      piPt.push_back(p2.Pt());
-      piPt.push_back(p3.Pt());
-      piPt.push_back(p4.Pt());
-
-      piEta.push_back(p1.Eta());
-      piEta.push_back(p2.Eta());
-      piEta.push_back(p3.Eta());
-      piEta.push_back(p4.Eta());
-
-      piRapidity.push_back(p1.Rapidity());
-      piRapidity.push_back(p2.Rapidity());
-      piRapidity.push_back(p3.Rapidity());
-      piRapidity.push_back(p4.Rapidity());
 
       histosData.fill(HIST("pT_track_WTS_PID_Pi_contributed"), p1.Pt());
       histosData.fill(HIST("pT_track_WTS_PID_Pi_contributed"), p2.Pt());
@@ -793,6 +768,101 @@ struct ExclusiveRhoTo4Pi {
       k3.SetCoordinates(p3.Pt(), p3.Eta(), p3.Phi(), o2::constants::physics::MassPionCharged);
       k4.SetCoordinates(p4.Pt(), p4.Eta(), p4.Phi(), o2::constants::physics::MassPionCharged);
 
+      dcaxy.push_back(Pi_plus_tracks[0].dcaXY());
+      dcaxy.push_back(Pi_plus_tracks[1].dcaXY());
+      dcaxy.push_back(Pi_minus_tracks[0].dcaXY());
+      dcaxy.push_back(Pi_minus_tracks[1].dcaXY());
+
+      dcaz.push_back(Pi_plus_tracks[0].dcaZ());
+      dcaz.push_back(Pi_plus_tracks[1].dcaZ());
+      dcaz.push_back(Pi_minus_tracks[0].dcaZ());
+      dcaz.push_back(Pi_minus_tracks[1].dcaZ());
+
+      tpcnsigPi.push_back(Pi_plus_tracks[0].tpcNSigmaPi());
+      tpcnsigPi.push_back(Pi_plus_tracks[1].tpcNSigmaPi());
+      tpcnsigPi.push_back(Pi_minus_tracks[0].tpcNSigmaPi());
+      tpcnsigPi.push_back(Pi_minus_tracks[1].tpcNSigmaPi());
+
+      tpcnsigKa.push_back(Pi_plus_tracks[0].tpcNSigmaKa());
+      tpcnsigKa.push_back(Pi_plus_tracks[1].tpcNSigmaKa());
+      tpcnsigKa.push_back(Pi_minus_tracks[0].tpcNSigmaKa());
+      tpcnsigKa.push_back(Pi_minus_tracks[1].tpcNSigmaKa());
+
+      tpcnsigPr.push_back(Pi_plus_tracks[0].tpcNSigmaPr());
+      tpcnsigPr.push_back(Pi_plus_tracks[1].tpcNSigmaPr());
+      tpcnsigPr.push_back(Pi_minus_tracks[0].tpcNSigmaPr());
+      tpcnsigPr.push_back(Pi_minus_tracks[1].tpcNSigmaPr());
+
+      tpcnsigEl.push_back(Pi_plus_tracks[0].tpcNSigmaEl());
+      tpcnsigEl.push_back(Pi_plus_tracks[1].tpcNSigmaEl());
+      tpcnsigEl.push_back(Pi_minus_tracks[0].tpcNSigmaEl());
+      tpcnsigEl.push_back(Pi_minus_tracks[1].tpcNSigmaEl());
+
+      tpcnsigMu.push_back(Pi_plus_tracks[0].tpcNSigmaMu());
+      tpcnsigMu.push_back(Pi_plus_tracks[1].tpcNSigmaMu());
+      tpcnsigMu.push_back(Pi_minus_tracks[0].tpcNSigmaMu());
+      tpcnsigMu.push_back(Pi_minus_tracks[1].tpcNSigmaMu());
+
+      tofnsigPi.push_back(Pi_plus_tracks[0].tofNSigmaPi());
+      tofnsigPi.push_back(Pi_plus_tracks[1].tofNSigmaPi());
+      tofnsigPi.push_back(Pi_minus_tracks[0].tofNSigmaPi());
+      tofnsigPi.push_back(Pi_minus_tracks[1].tofNSigmaPi());
+
+      tofnsigKa.push_back(Pi_plus_tracks[0].tofNSigmaKa());
+      tofnsigKa.push_back(Pi_plus_tracks[1].tofNSigmaKa());
+      tofnsigKa.push_back(Pi_minus_tracks[0].tofNSigmaKa());
+      tofnsigKa.push_back(Pi_minus_tracks[1].tofNSigmaKa());
+
+      tofnsigPr.push_back(Pi_plus_tracks[0].tofNSigmaPr());
+      tofnsigPr.push_back(Pi_plus_tracks[1].tofNSigmaPr());
+      tofnsigPr.push_back(Pi_minus_tracks[0].tofNSigmaPr());
+      tofnsigPr.push_back(Pi_minus_tracks[1].tofNSigmaPr());
+
+      tofnsigEl.push_back(Pi_plus_tracks[0].tofNSigmaEl());
+      tofnsigEl.push_back(Pi_plus_tracks[1].tofNSigmaEl());
+      tofnsigEl.push_back(Pi_minus_tracks[0].tofNSigmaEl());
+      tofnsigEl.push_back(Pi_minus_tracks[1].tofNSigmaEl());
+
+      tofnsigMu.push_back(Pi_plus_tracks[0].tofNSigmaMu());
+      tofnsigMu.push_back(Pi_plus_tracks[1].tofNSigmaMu());
+      tofnsigMu.push_back(Pi_minus_tracks[0].tofNSigmaMu());
+      tofnsigMu.push_back(Pi_minus_tracks[1].tofNSigmaMu());
+
+      tpcchi2.push_back(Pi_plus_tracks[0].tpcChi2NCl());
+      tpcchi2.push_back(Pi_plus_tracks[1].tpcChi2NCl());
+      tpcchi2.push_back(Pi_minus_tracks[0].tpcChi2NCl());
+      tpcchi2.push_back(Pi_minus_tracks[1].tpcChi2NCl());
+
+      tpcnclsfindable.push_back(Pi_plus_tracks[0].tpcNClsFindable());
+      tpcnclsfindable.push_back(Pi_plus_tracks[1].tpcNClsFindable());
+      tpcnclsfindable.push_back(Pi_minus_tracks[0].tpcNClsFindable());
+      tpcnclsfindable.push_back(Pi_minus_tracks[1].tpcNClsFindable());
+
+      itschi2.push_back(Pi_plus_tracks[0].itsChi2NCl());
+      itschi2.push_back(Pi_plus_tracks[1].itsChi2NCl());
+      itschi2.push_back(Pi_minus_tracks[0].itsChi2NCl());
+      itschi2.push_back(Pi_minus_tracks[1].itsChi2NCl());
+
+      pipt.push_back(p1.Pt());
+      pipt.push_back(p2.Pt());
+      pipt.push_back(p3.Pt());
+      pipt.push_back(p4.Pt());
+
+      pieta.push_back(p1.Eta());
+      pieta.push_back(p2.Eta());
+      pieta.push_back(p3.Eta());
+      pieta.push_back(p4.Eta());
+
+      piphi.push_back(p1.Phi());
+      piphi.push_back(p2.Phi());
+      piphi.push_back(p3.Phi());
+      piphi.push_back(p4.Phi());
+
+      pirapidity.push_back(p1.Rapidity());
+      pirapidity.push_back(p2.Rapidity());
+      pirapidity.push_back(p3.Rapidity());
+      pirapidity.push_back(p4.Rapidity());
+
       p1234 = p1 + p2 + p3 + p4;
       k1234 = k1 + k2 + k3 + k4;
 
@@ -801,19 +871,22 @@ struct ExclusiveRhoTo4Pi {
       k23 = k2 + k3;
       k24 = k2 + k4;
 
-      fourPiPhiPair1 = phiCollinsSoperFrame(k13, k24, k1234);
-      fourPiPhiPair2 = phiCollinsSoperFrame(k14, k23, k1234);
-      fourPiCosThetaPair1 = cosThetaCollinsSoperFrame(k13, k24, k1234);
-      fourPiCosThetaPair2 = cosThetaCollinsSoperFrame(k14, k23, k1234);
+      double fourPiPhiPair1 = phiCollinsSoperFrame(k13, k24, k1234);
+      double fourPiPhiPair2 = phiCollinsSoperFrame(k14, k23, k1234);
+      double fourPiCosThetaPair1 = cosThetaCollinsSoperFrame(k13, k24, k1234);
+      double fourPiCosThetaPair2 = cosThetaCollinsSoperFrame(k14, k23, k1234);
 
-      zeroChargeEventsData(
+      sigFromData(
+        collision.posX(), collision.posY(), collision.posZ(),
         collision.totalFV0AmplitudeA(), collision.totalFT0AmplitudeA(), collision.totalFT0AmplitudeC(), collision.totalFDDAmplitudeA(), collision.totalFDDAmplitudeC(),
-        pidcaXY, pidcaZ,
-        tpcNsigKa, tpcNsigPr, tpcNsigEl, tpcNsigMu,
-        tofNsigKa, tofNsigPr, tofNsigEl, tofNsigMu,
-        tpcchi2, tpcNFindableCls, itschi2,
-        piPt, piEta, piRapidity,
-        p1234.Pt(), p1234.Eta(), p1234.Rapidity(), p1234.M(), p1234.Phi(),
+        collision.timeFV0A(), collision.timeFT0A(), collision.timeFT0C(), collision.timeFDDA(), collision.timeFDDC(),
+        collision.timeZNA(), collision.timeZNC(),
+        dcaxy, dcaz,
+        tpcnsigPi, tpcnsigKa, tpcnsigPr, tpcnsigEl, tpcnsigMu,
+        tofnsigPi, tofnsigKa, tofnsigPr, tofnsigEl, tofnsigMu,
+        tpcchi2, tpcnclsfindable, itschi2,
+        pipt, pieta, piphi, pirapidity,
+        p1234.Pt(), p1234.Eta(), p1234.Phi(), p1234.Rapidity(), p1234.M(),
         fourPiPhiPair1, fourPiPhiPair2, fourPiCosThetaPair1, fourPiCosThetaPair2);
 
       if (std::fabs(p1234.Rapidity()) < 0.5) {
@@ -850,22 +923,30 @@ struct ExclusiveRhoTo4Pi {
     // Selecting Events with net charge != 0 for estimation of background
     if (numPionMinusTRacks != 2 && numPiPlusTracks != 2) {
 
-      std::vector<double> pidcaXY;
-      std::vector<double> pidcaZ;
-      std::vector<double> tpcNsigKa;
-      std::vector<double> tpcNsigPr;
-      std::vector<double> tpcNsigEl;
-      std::vector<double> tpcNsigMu;
-      std::vector<double> tofNsigKa;
-      std::vector<double> tofNsigPr;
-      std::vector<double> tofNsigEl;
-      std::vector<double> tofNsigMu;
+      std::vector<double> dcaxy;
+      std::vector<double> dcaz;
+
+      std::vector<double> tpcnsigPi;
+      std::vector<double> tpcnsigKa;
+      std::vector<double> tpcnsigPr;
+      std::vector<double> tpcnsigEl;
+      std::vector<double> tpcnsigMu;
+
+      std::vector<double> tofnsigPi;
+      std::vector<double> tofnsigKa;
+      std::vector<double> tofnsigPr;
+      std::vector<double> tofnsigEl;
+      std::vector<double> tofnsigMu;
+
       std::vector<double> tpcchi2;
+      std::vector<double> tpcnclsfindable;
       std::vector<double> itschi2;
-      std::vector<double> tpcNFindableCls;
-      std::vector<double> piPt;
-      std::vector<double> piEta;
-      std::vector<double> piRapidity;
+
+      std::vector<double> pipt;
+      std::vector<double> pieta;
+      std::vector<double> piphi;
+      std::vector<double> pirapidity;
+
       TLorentzVector p1, p2, p3, p4, p1234;
       TLorentzVector tempVec;
       p1.SetXYZM(WTS_PID_Pi_tracks[0].px(), WTS_PID_Pi_tracks[0].py(), WTS_PID_Pi_tracks[0].pz(), o2::constants::physics::MassPionCharged);
@@ -873,36 +954,114 @@ struct ExclusiveRhoTo4Pi {
       p3.SetXYZM(WTS_PID_Pi_tracks[2].px(), WTS_PID_Pi_tracks[2].py(), WTS_PID_Pi_tracks[2].pz(), o2::constants::physics::MassPionCharged);
       p4.SetXYZM(WTS_PID_Pi_tracks[3].px(), WTS_PID_Pi_tracks[3].py(), WTS_PID_Pi_tracks[3].pz(), o2::constants::physics::MassPionCharged);
 
+      dcaxy.push_back(WTS_PID_Pi_tracks[0].dcaXY());
+      dcaxy.push_back(WTS_PID_Pi_tracks[1].dcaXY());
+      dcaxy.push_back(WTS_PID_Pi_tracks[2].dcaXY());
+      dcaxy.push_back(WTS_PID_Pi_tracks[3].dcaXY());
+
+      dcaz.push_back(WTS_PID_Pi_tracks[0].dcaZ());
+      dcaz.push_back(WTS_PID_Pi_tracks[1].dcaZ());
+      dcaz.push_back(WTS_PID_Pi_tracks[2].dcaZ());
+      dcaz.push_back(WTS_PID_Pi_tracks[3].dcaZ());
+
+      tpcnsigPi.push_back(WTS_PID_Pi_tracks[0].tpcNSigmaPi());
+      tpcnsigPi.push_back(WTS_PID_Pi_tracks[1].tpcNSigmaPi());
+      tpcnsigPi.push_back(WTS_PID_Pi_tracks[2].tpcNSigmaPi());
+      tpcnsigPi.push_back(WTS_PID_Pi_tracks[3].tpcNSigmaPi());
+
+      tpcnsigKa.push_back(WTS_PID_Pi_tracks[0].tpcNSigmaKa());
+      tpcnsigKa.push_back(WTS_PID_Pi_tracks[1].tpcNSigmaKa());
+      tpcnsigKa.push_back(WTS_PID_Pi_tracks[2].tpcNSigmaKa());
+      tpcnsigKa.push_back(WTS_PID_Pi_tracks[3].tpcNSigmaKa());
+
+      tpcnsigPr.push_back(WTS_PID_Pi_tracks[0].tpcNSigmaPr());
+      tpcnsigPr.push_back(WTS_PID_Pi_tracks[1].tpcNSigmaPr());
+      tpcnsigPr.push_back(WTS_PID_Pi_tracks[2].tpcNSigmaPr());
+      tpcnsigPr.push_back(WTS_PID_Pi_tracks[3].tpcNSigmaPr());
+
+      tpcnsigEl.push_back(WTS_PID_Pi_tracks[0].tpcNSigmaEl());
+      tpcnsigEl.push_back(WTS_PID_Pi_tracks[1].tpcNSigmaEl());
+      tpcnsigEl.push_back(WTS_PID_Pi_tracks[2].tpcNSigmaEl());
+      tpcnsigEl.push_back(WTS_PID_Pi_tracks[3].tpcNSigmaEl());
+
+      tpcnsigMu.push_back(WTS_PID_Pi_tracks[0].tpcNSigmaMu());
+      tpcnsigMu.push_back(WTS_PID_Pi_tracks[1].tpcNSigmaMu());
+      tpcnsigMu.push_back(WTS_PID_Pi_tracks[2].tpcNSigmaMu());
+      tpcnsigMu.push_back(WTS_PID_Pi_tracks[3].tpcNSigmaMu());
+
+      tofnsigPi.push_back(WTS_PID_Pi_tracks[0].tofNSigmaPi());
+      tofnsigPi.push_back(WTS_PID_Pi_tracks[1].tofNSigmaPi());
+      tofnsigPi.push_back(WTS_PID_Pi_tracks[2].tofNSigmaPi());
+      tofnsigPi.push_back(WTS_PID_Pi_tracks[3].tofNSigmaPi());
+
+      tofnsigKa.push_back(WTS_PID_Pi_tracks[0].tofNSigmaKa());
+      tofnsigKa.push_back(WTS_PID_Pi_tracks[1].tofNSigmaKa());
+      tofnsigKa.push_back(WTS_PID_Pi_tracks[2].tofNSigmaKa());
+      tofnsigKa.push_back(WTS_PID_Pi_tracks[3].tofNSigmaKa());
+
+      tofnsigPr.push_back(WTS_PID_Pi_tracks[0].tofNSigmaPr());
+      tofnsigPr.push_back(WTS_PID_Pi_tracks[1].tofNSigmaPr());
+      tofnsigPr.push_back(WTS_PID_Pi_tracks[2].tofNSigmaPr());
+      tofnsigPr.push_back(WTS_PID_Pi_tracks[3].tofNSigmaPr());
+
+      tofnsigEl.push_back(WTS_PID_Pi_tracks[0].tofNSigmaEl());
+      tofnsigEl.push_back(WTS_PID_Pi_tracks[1].tofNSigmaEl());
+      tofnsigEl.push_back(WTS_PID_Pi_tracks[2].tofNSigmaEl());
+      tofnsigEl.push_back(WTS_PID_Pi_tracks[3].tofNSigmaEl());
+
+      tofnsigMu.push_back(WTS_PID_Pi_tracks[0].tofNSigmaMu());
+      tofnsigMu.push_back(WTS_PID_Pi_tracks[1].tofNSigmaMu());
+      tofnsigMu.push_back(WTS_PID_Pi_tracks[2].tofNSigmaMu());
+      tofnsigMu.push_back(WTS_PID_Pi_tracks[3].tofNSigmaMu());
+
+      tpcchi2.push_back(WTS_PID_Pi_tracks[0].tpcChi2NCl());
+      tpcchi2.push_back(WTS_PID_Pi_tracks[1].tpcChi2NCl());
+      tpcchi2.push_back(WTS_PID_Pi_tracks[2].tpcChi2NCl());
+      tpcchi2.push_back(WTS_PID_Pi_tracks[3].tpcChi2NCl());
+
+      tpcnclsfindable.push_back(WTS_PID_Pi_tracks[0].tpcNClsFindable());
+      tpcnclsfindable.push_back(WTS_PID_Pi_tracks[1].tpcNClsFindable());
+      tpcnclsfindable.push_back(WTS_PID_Pi_tracks[2].tpcNClsFindable());
+      tpcnclsfindable.push_back(WTS_PID_Pi_tracks[3].tpcNClsFindable());
+
+      itschi2.push_back(WTS_PID_Pi_tracks[0].itsChi2NCl());
+      itschi2.push_back(WTS_PID_Pi_tracks[1].itsChi2NCl());
+      itschi2.push_back(WTS_PID_Pi_tracks[2].itsChi2NCl());
+      itschi2.push_back(WTS_PID_Pi_tracks[3].itsChi2NCl());
+
+      pipt.push_back(p1.Pt());
+      pipt.push_back(p2.Pt());
+      pipt.push_back(p3.Pt());
+      pipt.push_back(p4.Pt());
+
+      pieta.push_back(p1.Eta());
+      pieta.push_back(p2.Eta());
+      pieta.push_back(p3.Eta());
+      pieta.push_back(p4.Eta());
+
+      piphi.push_back(p1.Phi());
+      piphi.push_back(p2.Phi());
+      piphi.push_back(p3.Phi());
+      piphi.push_back(p4.Phi());
+
+      pirapidity.push_back(p1.Rapidity());
+      pirapidity.push_back(p2.Rapidity());
+      pirapidity.push_back(p3.Rapidity());
+      pirapidity.push_back(p4.Rapidity());
+
       p1234 = p1 + p2 + p3 + p4;
 
-      for (int i = 0; i < 4; i++) {
-        tempVec.SetXYZM(WTS_PID_Pi_tracks[i].px(), WTS_PID_Pi_tracks[i].py(), WTS_PID_Pi_tracks[i].pz(), o2::constants::physics::MassPionCharged);
-        pidcaXY.push_back(WTS_PID_Pi_tracks[i].dcaXY());
-        pidcaZ.push_back(WTS_PID_Pi_tracks[i].dcaZ());
-        tpcNsigKa.push_back(WTS_PID_Pi_tracks[i].tpcNSigmaKa());
-        tpcNsigPr.push_back(WTS_PID_Pi_tracks[i].tpcNSigmaPr());
-        tpcNsigEl.push_back(WTS_PID_Pi_tracks[i].tpcNSigmaEl());
-        tpcNsigMu.push_back(WTS_PID_Pi_tracks[i].tpcNSigmaMu());
-        tofNsigKa.push_back(WTS_PID_Pi_tracks[i].tofNSigmaKa());
-        tofNsigPr.push_back(WTS_PID_Pi_tracks[i].tofNSigmaPr());
-        tofNsigEl.push_back(WTS_PID_Pi_tracks[i].tofNSigmaEl());
-        tofNsigMu.push_back(WTS_PID_Pi_tracks[i].tofNSigmaMu());
-        tpcchi2.push_back(WTS_PID_Pi_tracks[i].tpcChi2NCl());
-        itschi2.push_back(WTS_PID_Pi_tracks[i].itsChi2NCl());
-        tpcNFindableCls.push_back(WTS_PID_Pi_tracks[i].tpcNClsFindable());
-        piPt.push_back(tempVec.Pt());
-        piEta.push_back(tempVec.Eta());
-        piRapidity.push_back(tempVec.Rapidity());
-      }
-
-      nonzeroChargeEventsData(
+      bkgFromData(
+        collision.posX(), collision.posY(), collision.posZ(),
         collision.totalFV0AmplitudeA(), collision.totalFT0AmplitudeA(), collision.totalFT0AmplitudeC(), collision.totalFDDAmplitudeA(), collision.totalFDDAmplitudeC(),
-        pidcaXY, pidcaZ,
-        tpcNsigKa, tpcNsigPr, tpcNsigMu, tpcNsigEl,
-        tofNsigKa, tofNsigPr, tofNsigMu, tofNsigEl,
-        tpcchi2, tpcNFindableCls, itschi2,
-        piPt, piEta, piRapidity,
-        p1234.Pt(), p1234.Eta(), p1234.Rapidity(), p1234.M(), p1234.Phi());
+        collision.timeFV0A(), collision.timeFT0A(), collision.timeFT0C(), collision.timeFDDA(), collision.timeFDDC(),
+        collision.timeZNA(), collision.timeZNC(),
+        dcaxy, dcaz,
+        tpcnsigPi, tpcnsigKa, tpcnsigPr, tpcnsigEl, tpcnsigMu,
+        tofnsigPi, tofnsigKa, tofnsigPr, tofnsigEl, tofnsigMu,
+        tpcchi2, tpcnclsfindable, itschi2,
+        pipt, pieta, piphi, pirapidity,
+        p1234.Pt(), p1234.Eta(), p1234.Phi(), p1234.Rapidity(), p1234.M());
 
       if (std::fabs(p1234.Rapidity()) < 0.5) {
         histosData.fill(HIST("pT_event_non0charge_WTS_PID_Pi"), p1234.Pt());
@@ -927,6 +1086,296 @@ struct ExclusiveRhoTo4Pi {
   PROCESS_SWITCH(ExclusiveRhoTo4Pi, processData, "The Process for 4 Pion Analysis from data", true);
   //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
+  Filter collCuts = (nabs(o2::aod::collision::posZ) < 10.0f) && (o2::aod::collision::numContrib == numPVContrib);
+  Filter fitCuts = (o2::aod::udcollision::totalFT0AmplitudeA < ft0aCut) && (o2::aod::udcollision::totalFT0AmplitudeC < ft0cCut) && (o2::aod::udcollision::totalFV0AmplitudeA < fv0Cut);
+  Filter zdcCuts = (o2::aod::udzdc::energyCommonZNA < zdcCut) && (o2::aod::udzdc::energyCommonZNC < zdcCut);
+  Filter trackCuts = (o2::aod::track::tpcChi2NCl < tpcChi2Cut) && (o2::aod::track::tpcNClsFindable > tpcNClsFindableCut) && (o2::aod::track::itsChi2NCl < itsChi2Cut) && (nabs(o2::aod::track::eta) < etaCut) && (o2::aod::track::pt > pTcut) && (nabs(o2::aod::track::dcaZ) < dcaZcut) && (nabs(o2::aod::track::dcaXY) < dcaXYcut);
+  Filter udtrackCuts = (o2::aod::udtrack::isPVContributor == true);
+  Filter pidCuts = (nabs(o2::aod::pidtpc::tpcNSigmaPi) < nSigmaTPCcut);
+  using FilteredTracks = soa::Filtered<soa::Join<aod::UDTracks, aod::UDTracksPID, aod::UDTracksExtra, aod::UDTracksFlags, aod::UDTracksDCA>>;
+  using FilteredCollisions = soa::Filtered<soa::Join<aod::UDCollisions, aod::SGCollisions, aod::UDCollisionsSels, aod::UDZdcsReduced>>;
+  using FilteredCollisionsFull = FilteredCollisions::iterator;
+
+  // // Begin of FAST Process function--------------------------------------------------------------------------------------------------------------------------------------------------
+  void processDataFast(FilteredCollisionsFull const& collision, FilteredTracks const& tracks)
+  {
+
+    if (tracks.size() != 4) {
+      return;
+    }
+
+    std::vector<decltype(tracks.begin())> pionPlusTracks;
+    std::vector<decltype(tracks.begin())> pionMinusTracks;
+
+    for (const auto& track : tracks) {
+      if ((!selectionPIDPion(track, true, nSigmaTPCcut, nSigmaTOFcut))) {
+        continue;
+      }
+      if (track.sign() == 1) {
+        pionPlusTracks.push_back(track);
+      }
+      if (track.sign() == -1) {
+        pionMinusTracks.push_back(track);
+      }
+    } // end of loop over tracks
+
+    if ((pionPlusTracks.size() + pionMinusTracks.size()) != 4) {
+      return;
+    }
+
+    if (pionPlusTracks.size() == 2 || pionMinusTracks.size() == 2) {
+
+      std::vector<double> dcaxy;
+      std::vector<double> dcaz;
+
+      std::vector<double> tpcnsigPi;
+      std::vector<double> tpcnsigKa;
+      std::vector<double> tpcnsigPr;
+      std::vector<double> tpcnsigEl;
+      std::vector<double> tpcnsigMu;
+
+      std::vector<double> tofnsigPi;
+      std::vector<double> tofnsigKa;
+      std::vector<double> tofnsigPr;
+      std::vector<double> tofnsigEl;
+      std::vector<double> tofnsigMu;
+
+      std::vector<double> tpcchi2;
+      std::vector<double> tpcnclsfindable;
+      std::vector<double> itschi2;
+
+      std::vector<double> pipt;
+      std::vector<double> pieta;
+      std::vector<double> piphi;
+      std::vector<double> pirapidity;
+
+      TLorentzVector p1, p2, p3, p4, p1234;
+      ROOT::Math::PtEtaPhiMVector k1, k2, k3, k4, k1234, k13, k14, k23, k24;
+
+      p1.SetXYZM(pionPlusTracks[0].px(), pionPlusTracks[0].py(), pionPlusTracks[0].pz(), o2::constants::physics::MassPionCharged);
+      p2.SetXYZM(pionPlusTracks[1].px(), pionPlusTracks[1].py(), pionPlusTracks[1].pz(), o2::constants::physics::MassPionCharged);
+      p3.SetXYZM(pionMinusTracks[0].px(), pionMinusTracks[0].py(), pionMinusTracks[0].pz(), o2::constants::physics::MassPionCharged);
+      p4.SetXYZM(pionMinusTracks[1].px(), pionMinusTracks[1].py(), pionMinusTracks[1].pz(), o2::constants::physics::MassPionCharged);
+
+      k1.SetCoordinates(p1.Pt(), p1.Eta(), p1.Phi(), o2::constants::physics::MassPionCharged);
+      k2.SetCoordinates(p2.Pt(), p2.Eta(), p2.Phi(), o2::constants::physics::MassPionCharged);
+      k3.SetCoordinates(p3.Pt(), p3.Eta(), p3.Phi(), o2::constants::physics::MassPionCharged);
+      k4.SetCoordinates(p4.Pt(), p4.Eta(), p4.Phi(), o2::constants::physics::MassPionCharged);
+
+      dcaxy.push_back(pionPlusTracks[0].dcaXY());
+      dcaxy.push_back(pionPlusTracks[1].dcaXY());
+      dcaxy.push_back(pionMinusTracks[0].dcaXY());
+      dcaxy.push_back(pionMinusTracks[1].dcaXY());
+
+      dcaz.push_back(pionPlusTracks[0].dcaZ());
+      dcaz.push_back(pionPlusTracks[1].dcaZ());
+      dcaz.push_back(pionMinusTracks[0].dcaZ());
+      dcaz.push_back(pionMinusTracks[1].dcaZ());
+
+      tpcnsigPi.push_back(pionPlusTracks[0].tpcNSigmaPi());
+      tpcnsigPi.push_back(pionPlusTracks[1].tpcNSigmaPi());
+      tpcnsigPi.push_back(pionMinusTracks[0].tpcNSigmaPi());
+      tpcnsigPi.push_back(pionMinusTracks[1].tpcNSigmaPi());
+
+      tpcnsigKa.push_back(pionPlusTracks[0].tpcNSigmaKa());
+      tpcnsigKa.push_back(pionPlusTracks[1].tpcNSigmaKa());
+      tpcnsigKa.push_back(pionMinusTracks[0].tpcNSigmaKa());
+      tpcnsigKa.push_back(pionMinusTracks[1].tpcNSigmaKa());
+
+      tpcnsigPr.push_back(pionPlusTracks[0].tpcNSigmaPr());
+      tpcnsigPr.push_back(pionPlusTracks[1].tpcNSigmaPr());
+      tpcnsigPr.push_back(pionMinusTracks[0].tpcNSigmaPr());
+      tpcnsigPr.push_back(pionMinusTracks[1].tpcNSigmaPr());
+
+      tpcnsigEl.push_back(pionPlusTracks[0].tpcNSigmaEl());
+      tpcnsigEl.push_back(pionPlusTracks[1].tpcNSigmaEl());
+      tpcnsigEl.push_back(pionMinusTracks[0].tpcNSigmaEl());
+      tpcnsigEl.push_back(pionMinusTracks[1].tpcNSigmaEl());
+
+      tpcnsigMu.push_back(pionPlusTracks[0].tpcNSigmaMu());
+      tpcnsigMu.push_back(pionPlusTracks[1].tpcNSigmaMu());
+      tpcnsigMu.push_back(pionMinusTracks[0].tpcNSigmaMu());
+      tpcnsigMu.push_back(pionMinusTracks[1].tpcNSigmaMu());
+
+      tofnsigPi.push_back(pionPlusTracks[0].tofNSigmaPi());
+      tofnsigPi.push_back(pionPlusTracks[1].tofNSigmaPi());
+      tofnsigPi.push_back(pionMinusTracks[0].tofNSigmaPi());
+      tofnsigPi.push_back(pionMinusTracks[1].tofNSigmaPi());
+
+      tofnsigKa.push_back(pionPlusTracks[0].tofNSigmaKa());
+      tofnsigKa.push_back(pionPlusTracks[1].tofNSigmaKa());
+      tofnsigKa.push_back(pionMinusTracks[0].tofNSigmaKa());
+      tofnsigKa.push_back(pionMinusTracks[1].tofNSigmaKa());
+
+      tofnsigPr.push_back(pionPlusTracks[0].tofNSigmaPr());
+      tofnsigPr.push_back(pionPlusTracks[1].tofNSigmaPr());
+      tofnsigPr.push_back(pionMinusTracks[0].tofNSigmaPr());
+      tofnsigPr.push_back(pionMinusTracks[1].tofNSigmaPr());
+
+      tofnsigEl.push_back(pionPlusTracks[0].tofNSigmaEl());
+      tofnsigEl.push_back(pionPlusTracks[1].tofNSigmaEl());
+      tofnsigEl.push_back(pionMinusTracks[0].tofNSigmaEl());
+      tofnsigEl.push_back(pionMinusTracks[1].tofNSigmaEl());
+
+      tofnsigMu.push_back(pionPlusTracks[0].tofNSigmaMu());
+      tofnsigMu.push_back(pionPlusTracks[1].tofNSigmaMu());
+      tofnsigMu.push_back(pionMinusTracks[0].tofNSigmaMu());
+      tofnsigMu.push_back(pionMinusTracks[1].tofNSigmaMu());
+
+      tpcchi2.push_back(pionPlusTracks[0].tpcChi2NCl());
+      tpcchi2.push_back(pionPlusTracks[1].tpcChi2NCl());
+      tpcchi2.push_back(pionMinusTracks[0].tpcChi2NCl());
+      tpcchi2.push_back(pionMinusTracks[1].tpcChi2NCl());
+
+      tpcnclsfindable.push_back(pionPlusTracks[0].tpcNClsFindable());
+      tpcnclsfindable.push_back(pionPlusTracks[1].tpcNClsFindable());
+      tpcnclsfindable.push_back(pionMinusTracks[0].tpcNClsFindable());
+      tpcnclsfindable.push_back(pionMinusTracks[1].tpcNClsFindable());
+
+      itschi2.push_back(pionPlusTracks[0].itsChi2NCl());
+      itschi2.push_back(pionPlusTracks[1].itsChi2NCl());
+      itschi2.push_back(pionMinusTracks[0].itsChi2NCl());
+      itschi2.push_back(pionMinusTracks[1].itsChi2NCl());
+
+      pipt.push_back(p1.Pt());
+      pipt.push_back(p2.Pt());
+      pipt.push_back(p3.Pt());
+      pipt.push_back(p4.Pt());
+
+      pieta.push_back(p1.Eta());
+      pieta.push_back(p2.Eta());
+      pieta.push_back(p3.Eta());
+      pieta.push_back(p4.Eta());
+
+      piphi.push_back(p1.Phi());
+      piphi.push_back(p2.Phi());
+      piphi.push_back(p3.Phi());
+      piphi.push_back(p4.Phi());
+
+      pirapidity.push_back(p1.Rapidity());
+      pirapidity.push_back(p2.Rapidity());
+      pirapidity.push_back(p3.Rapidity());
+      pirapidity.push_back(p4.Rapidity());
+
+      p1234 = p1 + p2 + p3 + p4;
+      k1234 = k1 + k2 + k3 + k4;
+
+      k13 = k1 + k3;
+      k14 = k1 + k4;
+      k23 = k2 + k3;
+      k24 = k2 + k4;
+
+      double fourPiPhiPair1 = phiCollinsSoperFrame(k13, k24, k1234);
+      double fourPiPhiPair2 = phiCollinsSoperFrame(k14, k23, k1234);
+      double fourPiCosThetaPair1 = cosThetaCollinsSoperFrame(k13, k24, k1234);
+      double fourPiCosThetaPair2 = cosThetaCollinsSoperFrame(k14, k23, k1234);
+
+      sigFromData(
+        collision.posX(), collision.posY(), collision.posZ(),
+        collision.totalFV0AmplitudeA(), collision.totalFT0AmplitudeA(), collision.totalFT0AmplitudeC(), collision.totalFDDAmplitudeA(), collision.totalFDDAmplitudeC(),
+        collision.timeFV0A(), collision.timeFT0A(), collision.timeFT0C(), collision.timeFDDA(), collision.timeFDDC(),
+        collision.timeZNA(), collision.timeZNC(),
+        dcaxy, dcaz,
+        tpcnsigPi, tpcnsigKa, tpcnsigPr, tpcnsigEl, tpcnsigMu,
+        tofnsigPi, tofnsigKa, tofnsigPr, tofnsigEl, tofnsigMu,
+        tpcchi2, tpcnclsfindable, itschi2,
+        pipt, pieta, piphi, pirapidity,
+        p1234.Pt(), p1234.Eta(), p1234.Phi(), p1234.Rapidity(), p1234.M(),
+        fourPiPhiPair1, fourPiPhiPair2, fourPiCosThetaPair1, fourPiCosThetaPair2);
+
+      histosFast.fill(HIST("4PionPt"), p1234.Pt());
+      histosFast.fill(HIST("4PionRapidity"), p1234.Rapidity());
+      histosFast.fill(HIST("4PionMassFull"), p1234.M());
+
+      if ((p1234.Pt() < 0.15) && (std::abs(p1234.Rapidity()) < 0.5)) {
+        histosFast.fill(HIST("4PionMassWithCut"), p1234.M());
+      }
+    } // End 0 charge event
+
+    if (pionPlusTracks.size() != 2 && pionMinusTracks.size() != 2) {
+      std::vector<decltype(tracks.begin())> allTracks;
+      for (int i = 0; i < pionPlusTracks.size(); i++) {
+        allTracks.push_back(pionPlusTracks[i]);
+      }
+      for (int i = 0; i < pionMinusTracks.size(); i++) {
+        allTracks.push_back(pionMinusTracks[i]);
+      }
+
+      TLorentzVector p1, p2, p3, p4, p1234;
+
+      p1.SetXYZM(allTracks[0].px(), allTracks[0].py(), allTracks[0].pz(), o2::constants::physics::MassPionCharged);
+      p2.SetXYZM(allTracks[1].px(), allTracks[1].py(), allTracks[1].pz(), o2::constants::physics::MassPionCharged);
+      p3.SetXYZM(allTracks[2].px(), allTracks[2].py(), allTracks[2].pz(), o2::constants::physics::MassPionCharged);
+      p4.SetXYZM(allTracks[3].px(), allTracks[3].py(), allTracks[3].pz(), o2::constants::physics::MassPionCharged);
+
+      std::vector<double> dcaxy;
+      std::vector<double> dcaz;
+
+      std::vector<double> tpcnsigPi;
+      std::vector<double> tpcnsigKa;
+      std::vector<double> tpcnsigPr;
+      std::vector<double> tpcnsigEl;
+      std::vector<double> tpcnsigMu;
+
+      std::vector<double> tofnsigPi;
+      std::vector<double> tofnsigKa;
+      std::vector<double> tofnsigPr;
+      std::vector<double> tofnsigEl;
+      std::vector<double> tofnsigMu;
+
+      std::vector<double> tpcchi2;
+      std::vector<double> tpcnclsfindable;
+      std::vector<double> itschi2;
+
+      std::vector<double> pipt;
+      std::vector<double> pieta;
+      std::vector<double> piphi;
+      std::vector<double> pirapidity;
+
+      TLorentzVector tempPionVect;
+      for (int i = 0; i < allTracks.size(); i++) {
+        tempPionVect.SetXYZM(allTracks[i].px(), allTracks[i].py(), allTracks[i].pz(), o2::constants::physics::MassPionCharged);
+        dcaxy.push_back(allTracks[i].dcaXY());
+        dcaz.push_back(allTracks[i].dcaZ());
+        tpcnsigPi.push_back(allTracks[i].tpcNSigmaPi());
+        tpcnsigKa.push_back(allTracks[i].tpcNSigmaKa());
+        tpcnsigPr.push_back(allTracks[i].tpcNSigmaPr());
+        tpcnsigEl.push_back(allTracks[i].tpcNSigmaEl());
+        tpcnsigMu.push_back(allTracks[i].tpcNSigmaMu());
+        tofnsigPi.push_back(allTracks[i].tofNSigmaPi());
+        tofnsigKa.push_back(allTracks[i].tofNSigmaKa());
+        tofnsigPr.push_back(allTracks[i].tofNSigmaPr());
+        tofnsigEl.push_back(allTracks[i].tofNSigmaEl());
+        tofnsigMu.push_back(allTracks[i].tofNSigmaMu());
+        tpcchi2.push_back(allTracks[i].tpcChi2NCl());
+        tpcnclsfindable.push_back(allTracks[i].tpcNClsFindable());
+        itschi2.push_back(allTracks[i].itsChi2NCl());
+        pipt.push_back(tempPionVect.Pt());
+        pieta.push_back(tempPionVect.Eta());
+        piphi.push_back(tempPionVect.Phi());
+        pirapidity.push_back(tempPionVect.Rapidity());
+      }
+
+      p1234 = p1 + p2 + p3 + p4;
+
+      bkgFromData(
+        collision.posX(), collision.posY(), collision.posZ(),
+        collision.totalFV0AmplitudeA(), collision.totalFT0AmplitudeA(), collision.totalFT0AmplitudeC(), collision.totalFDDAmplitudeA(), collision.totalFDDAmplitudeC(),
+        collision.timeFV0A(), collision.timeFT0A(), collision.timeFT0C(), collision.timeFDDA(), collision.timeFDDC(),
+        collision.timeZNA(), collision.timeZNC(),
+        dcaxy, dcaz,
+        tpcnsigPi, tpcnsigKa, tpcnsigPr, tpcnsigEl, tpcnsigMu,
+        tofnsigPi, tofnsigKa, tofnsigPr, tofnsigEl, tofnsigMu,
+        tpcchi2, tpcnclsfindable, itschi2,
+        pipt, pieta, piphi, pirapidity,
+        p1234.Pt(), p1234.Eta(), p1234.Phi(), p1234.Rapidity(), p1234.M());
+
+    } // end of non 0 charge event
+
+  } // End of 4 Pion Analysis Process function for Fast Data
+  PROCESS_SWITCH(ExclusiveRhoTo4Pi, processDataFast, "The Process for 4 Pion Analysis from data fast", true);
+  // //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
   // Begin of MC Generation function-----------------------------------------------------------------------------------------------------------------------------------------------
   void processMCgen(aod::UDMcCollisions::iterator const&, aod::UDMcParticles const& mcParts)
   {
@@ -934,10 +1383,6 @@ struct ExclusiveRhoTo4Pi {
     std::vector<TLorentzVector> piMinusvectors;
     TLorentzVector motherVector, tempVector, p1, p2, p3, p4;
     TLorentzVector p1234;
-
-    std::vector<double> piPt;
-    std::vector<double> piEta;
-    std::vector<double> piRapidity;
 
     bool flag = false;
 
@@ -961,17 +1406,11 @@ struct ExclusiveRhoTo4Pi {
             histosMCgen.fill(HIST("MCgen_particle_pT"), tempVector.Pt());
             histosMCgen.fill(HIST("MCgen_particle_rapidity"), tempVector.Rapidity());
             piPlusvectors.push_back(tempVector);
-            piPt.push_back(tempVector.Pt());
-            piEta.push_back(tempVector.Eta());
-            piRapidity.push_back(tempVector.Rapidity());
           }
           if (particle.pdgCode() == kPiMinus) {
             histosMCgen.fill(HIST("MCgen_particle_pT"), tempVector.Pt());
             histosMCgen.fill(HIST("MCgen_particle_rapidity"), tempVector.Rapidity());
             piMinusvectors.push_back(tempVector);
-            piPt.push_back(tempVector.Pt());
-            piEta.push_back(tempVector.Eta());
-            piRapidity.push_back(tempVector.Rapidity());
           }
         } // End of Mother ID 30113 rho prime
       } // End of loop over mothers
@@ -980,6 +1419,31 @@ struct ExclusiveRhoTo4Pi {
     if (piPlusvectors.size() != 2 || piMinusvectors.size() != 2) {
       return;
     }
+
+    std::vector<double> pipt;
+    std::vector<double> pieta;
+    std::vector<double> piphi;
+    std::vector<double> pirapidity;
+
+    pipt.push_back(piPlusvectors[0].Pt());
+    pipt.push_back(piPlusvectors[1].Pt());
+    pipt.push_back(piMinusvectors[0].Pt());
+    pipt.push_back(piMinusvectors[1].Pt());
+
+    pieta.push_back(piPlusvectors[0].Eta());
+    pieta.push_back(piPlusvectors[1].Eta());
+    pieta.push_back(piMinusvectors[0].Eta());
+    pieta.push_back(piMinusvectors[1].Eta());
+
+    piphi.push_back(piPlusvectors[0].Phi());
+    piphi.push_back(piPlusvectors[1].Phi());
+    piphi.push_back(piMinusvectors[0].Phi());
+    piphi.push_back(piMinusvectors[1].Phi());
+
+    pirapidity.push_back(piPlusvectors[0].Rapidity());
+    pirapidity.push_back(piPlusvectors[1].Rapidity());
+    pirapidity.push_back(piMinusvectors[0].Rapidity());
+    pirapidity.push_back(piMinusvectors[1].Rapidity());
 
     p1234 = piPlusvectors[0] + piPlusvectors[1] + piMinusvectors[0] + piMinusvectors[1];
 
@@ -1021,16 +1485,16 @@ struct ExclusiveRhoTo4Pi {
     auto cosThetaPair1 = cosThetaCollinsSoperFrame(k13, k24, k1234);
     auto cosThetaPair2 = cosThetaCollinsSoperFrame(k14, k23, k1234);
 
+    generatedMC(pipt, pieta, piphi, pirapidity,
+                p1234.Pt(), p1234.Eta(), p1234.Phi(), p1234.Rapidity(), p1234.M(),
+                phiPair1, phiPair2, cosThetaPair1, cosThetaPair2);
+
     histosMCgen.fill(HIST("MCgen_CS_phi_pair_1"), phiPair1);
     histosMCgen.fill(HIST("MCgen_CS_phi_pair_2"), phiPair2);
     histosMCgen.fill(HIST("MCgen_CS_costheta_pair_1"), cosThetaPair1);
     histosMCgen.fill(HIST("MCgen_CS_costheta_pair_2"), cosThetaPair2);
     histosMCgen.fill(HIST("MCgen_phi_cosTheta_pair_1"), phiPair1, cosThetaPair1);
     histosMCgen.fill(HIST("MCgen_phi_cosTheta_pair_2"), phiPair2, cosThetaPair2);
-
-    zeroChargeEventsMCgen(piPt, piEta, piRapidity,
-                          p1234.Pt(), p1234.Eta(), p1234.Rapidity(), p1234.M(),
-                          phiPair1, phiPair2, cosThetaPair1, cosThetaPair2);
 
   } // End of 4 Pion MC Generation Process function
   PROCESS_SWITCH(ExclusiveRhoTo4Pi, processMCgen, "The Process for 4 Pion Analysis from MC Generation", false);
@@ -1051,9 +1515,8 @@ struct ExclusiveRhoTo4Pi {
     }
 
     int gapSide = collision.gapSide();
-    float fitCuts[5] = {fv0Cut, ft0aCut, ft0cCut, fddaCut, fddcCut};
     std::vector<float> parameters = {pvCut, dcaZcut, dcaXYcut, tpcChi2Cut, tpcNClsFindableCut, itsChi2Cut, etaCut, pTcut};
-    int truegapSide = sgSelector.trueGap(collision, fitCuts[0], fitCuts[1], fitCuts[2], zdcCut);
+    int truegapSide = sgSelector.trueGap(collision, fv0Cut, ft0aCut, ft0cCut, zdcCut);
     histosMCreco.fill(HIST("GapSide"), gapSide);
     histosMCreco.fill(HIST("TrueGapSide"), truegapSide);
     histosMCreco.fill(HIST("EventCounts"), 1);
@@ -1070,14 +1533,8 @@ struct ExclusiveRhoTo4Pi {
     histosMCreco.fill(HIST("ZDC_A"), collision.energyCommonZNA());
     histosMCreco.fill(HIST("ZDC_C"), collision.energyCommonZNC());
 
-    if (strictEventSelection) {
-      if (collision.numContrib() != 4) {
-        return;
-      }
-    } else {
-      if (collision.numContrib() >= 10) {
-        return;
-      }
+    if (collision.numContrib() != 4) {
+      return;
     }
 
     std::vector<decltype(tracks.begin())> WOTS_tracks;
@@ -1171,6 +1628,30 @@ struct ExclusiveRhoTo4Pi {
     // Selecting Events with net charge = 0
     if (numPionMinusTRacks == 2 && numPiPlusTracks == 2) {
 
+      std::vector<double> dcaxy;
+      std::vector<double> dcaz;
+
+      std::vector<double> tpcnsigPi;
+      std::vector<double> tpcnsigKa;
+      std::vector<double> tpcnsigPr;
+      std::vector<double> tpcnsigEl;
+      std::vector<double> tpcnsigMu;
+
+      std::vector<double> tofnsigPi;
+      std::vector<double> tofnsigKa;
+      std::vector<double> tofnsigPr;
+      std::vector<double> tofnsigEl;
+      std::vector<double> tofnsigMu;
+
+      std::vector<double> tpcchi2;
+      std::vector<double> tpcnclsfindable;
+      std::vector<double> itschi2;
+
+      std::vector<double> pipt;
+      std::vector<double> pieta;
+      std::vector<double> piphi;
+      std::vector<double> pirapidity;
+
       TLorentzVector p1, p2, p3, p4, p1234;
       ROOT::Math::PtEtaPhiMVector k1, k2, k3, k4, k1234, k13, k14, k23, k24;
 
@@ -1194,38 +1675,6 @@ struct ExclusiveRhoTo4Pi {
       k3.SetCoordinates(p3.Pt(), p3.Eta(), p3.Phi(), o2::constants::physics::MassPionCharged);
       k4.SetCoordinates(p4.Pt(), p4.Eta(), p4.Phi(), o2::constants::physics::MassPionCharged);
 
-      p1234 = p1 + p2 + p3 + p4;
-      k1234 = k1 + k2 + k3 + k4;
-
-      k13 = k1 + k3;
-      k14 = k1 + k4;
-      k23 = k2 + k3;
-      k24 = k2 + k4;
-
-      auto phiPair1 = phiCollinsSoperFrame(k13, k24, k1234);
-      auto phiPair2 = phiCollinsSoperFrame(k14, k23, k1234);
-      auto cosThetaPair1 = cosThetaCollinsSoperFrame(k13, k24, k1234);
-      auto cosThetaPair2 = cosThetaCollinsSoperFrame(k14, k23, k1234);
-
-      std::vector<double> dcaxy;
-      std::vector<double> dcaz;
-
-      std::vector<double> tpcNsigKa;
-      std::vector<double> tpcNsigPr;
-      std::vector<double> tpcNsigEl;
-      std::vector<double> tpcNsigMu;
-      std::vector<double> tofNsigKa;
-      std::vector<double> tofNsigPr;
-      std::vector<double> tofNsigEl;
-      std::vector<double> tofNsigMu;
-      std::vector<double> tpcchi2;
-      std::vector<double> itschi2;
-      std::vector<double> tpcNFindableCls;
-
-      std::vector<double> piPt;
-      std::vector<double> piEta;
-      std::vector<double> piRapidity;
-
       dcaxy.push_back(Pi_plus_tracks[0].dcaXY());
       dcaxy.push_back(Pi_plus_tracks[1].dcaXY());
       dcaxy.push_back(Pi_minus_tracks[0].dcaXY());
@@ -1236,84 +1685,115 @@ struct ExclusiveRhoTo4Pi {
       dcaz.push_back(Pi_minus_tracks[0].dcaZ());
       dcaz.push_back(Pi_minus_tracks[1].dcaZ());
 
-      tpcNsigKa.push_back(Pi_plus_tracks[0].tpcNSigmaKa());
-      tpcNsigKa.push_back(Pi_plus_tracks[1].tpcNSigmaKa());
-      tpcNsigKa.push_back(Pi_minus_tracks[0].tpcNSigmaKa());
-      tpcNsigKa.push_back(Pi_minus_tracks[1].tpcNSigmaKa());
+      tpcnsigPi.push_back(Pi_plus_tracks[0].tpcNSigmaPi());
+      tpcnsigPi.push_back(Pi_plus_tracks[1].tpcNSigmaPi());
+      tpcnsigPi.push_back(Pi_minus_tracks[0].tpcNSigmaPi());
+      tpcnsigPi.push_back(Pi_minus_tracks[1].tpcNSigmaPi());
 
-      tpcNsigPr.push_back(Pi_plus_tracks[0].tpcNSigmaPr());
-      tpcNsigPr.push_back(Pi_plus_tracks[1].tpcNSigmaPr());
-      tpcNsigPr.push_back(Pi_minus_tracks[0].tpcNSigmaPr());
-      tpcNsigPr.push_back(Pi_minus_tracks[1].tpcNSigmaPr());
+      tpcnsigKa.push_back(Pi_plus_tracks[0].tpcNSigmaKa());
+      tpcnsigKa.push_back(Pi_plus_tracks[1].tpcNSigmaKa());
+      tpcnsigKa.push_back(Pi_minus_tracks[0].tpcNSigmaKa());
+      tpcnsigKa.push_back(Pi_minus_tracks[1].tpcNSigmaKa());
 
-      tpcNsigEl.push_back(Pi_plus_tracks[0].tpcNSigmaEl());
-      tpcNsigEl.push_back(Pi_plus_tracks[1].tpcNSigmaEl());
-      tpcNsigEl.push_back(Pi_minus_tracks[0].tpcNSigmaEl());
-      tpcNsigEl.push_back(Pi_minus_tracks[1].tpcNSigmaEl());
+      tpcnsigPr.push_back(Pi_plus_tracks[0].tpcNSigmaPr());
+      tpcnsigPr.push_back(Pi_plus_tracks[1].tpcNSigmaPr());
+      tpcnsigPr.push_back(Pi_minus_tracks[0].tpcNSigmaPr());
+      tpcnsigPr.push_back(Pi_minus_tracks[1].tpcNSigmaPr());
 
-      tpcNsigMu.push_back(Pi_plus_tracks[0].tpcNSigmaMu());
-      tpcNsigMu.push_back(Pi_plus_tracks[1].tpcNSigmaMu());
-      tpcNsigMu.push_back(Pi_minus_tracks[0].tpcNSigmaMu());
-      tpcNsigMu.push_back(Pi_minus_tracks[1].tpcNSigmaMu());
+      tpcnsigEl.push_back(Pi_plus_tracks[0].tpcNSigmaEl());
+      tpcnsigEl.push_back(Pi_plus_tracks[1].tpcNSigmaEl());
+      tpcnsigEl.push_back(Pi_minus_tracks[0].tpcNSigmaEl());
+      tpcnsigEl.push_back(Pi_minus_tracks[1].tpcNSigmaEl());
 
-      tofNsigKa.push_back(Pi_plus_tracks[0].tofNSigmaKa());
-      tofNsigKa.push_back(Pi_plus_tracks[1].tofNSigmaKa());
-      tofNsigKa.push_back(Pi_minus_tracks[0].tofNSigmaKa());
-      tofNsigKa.push_back(Pi_minus_tracks[1].tofNSigmaKa());
+      tpcnsigMu.push_back(Pi_plus_tracks[0].tpcNSigmaMu());
+      tpcnsigMu.push_back(Pi_plus_tracks[1].tpcNSigmaMu());
+      tpcnsigMu.push_back(Pi_minus_tracks[0].tpcNSigmaMu());
+      tpcnsigMu.push_back(Pi_minus_tracks[1].tpcNSigmaMu());
 
-      tofNsigPr.push_back(Pi_plus_tracks[0].tofNSigmaPr());
-      tofNsigPr.push_back(Pi_plus_tracks[1].tofNSigmaPr());
-      tofNsigPr.push_back(Pi_minus_tracks[0].tofNSigmaPr());
-      tofNsigPr.push_back(Pi_minus_tracks[1].tofNSigmaPr());
+      tofnsigPi.push_back(Pi_plus_tracks[0].tofNSigmaPi());
+      tofnsigPi.push_back(Pi_plus_tracks[1].tofNSigmaPi());
+      tofnsigPi.push_back(Pi_minus_tracks[0].tofNSigmaPi());
+      tofnsigPi.push_back(Pi_minus_tracks[1].tofNSigmaPi());
 
-      tofNsigEl.push_back(Pi_plus_tracks[0].tofNSigmaEl());
-      tofNsigEl.push_back(Pi_plus_tracks[1].tofNSigmaEl());
-      tofNsigEl.push_back(Pi_minus_tracks[0].tofNSigmaEl());
-      tofNsigEl.push_back(Pi_minus_tracks[1].tofNSigmaEl());
+      tofnsigKa.push_back(Pi_plus_tracks[0].tofNSigmaKa());
+      tofnsigKa.push_back(Pi_plus_tracks[1].tofNSigmaKa());
+      tofnsigKa.push_back(Pi_minus_tracks[0].tofNSigmaKa());
+      tofnsigKa.push_back(Pi_minus_tracks[1].tofNSigmaKa());
 
-      tofNsigMu.push_back(Pi_plus_tracks[0].tofNSigmaMu());
-      tofNsigMu.push_back(Pi_plus_tracks[1].tofNSigmaMu());
-      tofNsigMu.push_back(Pi_minus_tracks[0].tofNSigmaMu());
-      tofNsigMu.push_back(Pi_minus_tracks[1].tofNSigmaMu());
+      tofnsigPr.push_back(Pi_plus_tracks[0].tofNSigmaPr());
+      tofnsigPr.push_back(Pi_plus_tracks[1].tofNSigmaPr());
+      tofnsigPr.push_back(Pi_minus_tracks[0].tofNSigmaPr());
+      tofnsigPr.push_back(Pi_minus_tracks[1].tofNSigmaPr());
+
+      tofnsigEl.push_back(Pi_plus_tracks[0].tofNSigmaEl());
+      tofnsigEl.push_back(Pi_plus_tracks[1].tofNSigmaEl());
+      tofnsigEl.push_back(Pi_minus_tracks[0].tofNSigmaEl());
+      tofnsigEl.push_back(Pi_minus_tracks[1].tofNSigmaEl());
+
+      tofnsigMu.push_back(Pi_plus_tracks[0].tofNSigmaMu());
+      tofnsigMu.push_back(Pi_plus_tracks[1].tofNSigmaMu());
+      tofnsigMu.push_back(Pi_minus_tracks[0].tofNSigmaMu());
+      tofnsigMu.push_back(Pi_minus_tracks[1].tofNSigmaMu());
 
       tpcchi2.push_back(Pi_plus_tracks[0].tpcChi2NCl());
       tpcchi2.push_back(Pi_plus_tracks[1].tpcChi2NCl());
       tpcchi2.push_back(Pi_minus_tracks[0].tpcChi2NCl());
       tpcchi2.push_back(Pi_minus_tracks[1].tpcChi2NCl());
 
-      tpcNFindableCls.push_back(Pi_plus_tracks[0].tpcNClsFindable());
-      tpcNFindableCls.push_back(Pi_plus_tracks[1].tpcNClsFindable());
-      tpcNFindableCls.push_back(Pi_minus_tracks[0].tpcNClsFindable());
-      tpcNFindableCls.push_back(Pi_minus_tracks[1].tpcNClsFindable());
+      tpcnclsfindable.push_back(Pi_plus_tracks[0].tpcNClsFindable());
+      tpcnclsfindable.push_back(Pi_plus_tracks[1].tpcNClsFindable());
+      tpcnclsfindable.push_back(Pi_minus_tracks[0].tpcNClsFindable());
+      tpcnclsfindable.push_back(Pi_minus_tracks[1].tpcNClsFindable());
 
       itschi2.push_back(Pi_plus_tracks[0].itsChi2NCl());
       itschi2.push_back(Pi_plus_tracks[1].itsChi2NCl());
       itschi2.push_back(Pi_minus_tracks[0].itsChi2NCl());
       itschi2.push_back(Pi_minus_tracks[1].itsChi2NCl());
 
-      piPt.push_back(p1.Pt());
-      piPt.push_back(p2.Pt());
-      piPt.push_back(p3.Pt());
-      piPt.push_back(p4.Pt());
+      pipt.push_back(p1.Pt());
+      pipt.push_back(p2.Pt());
+      pipt.push_back(p3.Pt());
+      pipt.push_back(p4.Pt());
 
-      piEta.push_back(p1.Eta());
-      piEta.push_back(p2.Eta());
-      piEta.push_back(p3.Eta());
-      piEta.push_back(p4.Eta());
+      pieta.push_back(p1.Eta());
+      pieta.push_back(p2.Eta());
+      pieta.push_back(p3.Eta());
+      pieta.push_back(p4.Eta());
 
-      piRapidity.push_back(p1.Rapidity());
-      piRapidity.push_back(p2.Rapidity());
-      piRapidity.push_back(p3.Rapidity());
-      piRapidity.push_back(p4.Rapidity());
+      piphi.push_back(p1.Phi());
+      piphi.push_back(p2.Phi());
+      piphi.push_back(p3.Phi());
+      piphi.push_back(p4.Phi());
 
-      zeroChargeEventsMCreco(
+      pirapidity.push_back(p1.Rapidity());
+      pirapidity.push_back(p2.Rapidity());
+      pirapidity.push_back(p3.Rapidity());
+      pirapidity.push_back(p4.Rapidity());
+
+      p1234 = p1 + p2 + p3 + p4;
+      k1234 = k1 + k2 + k3 + k4;
+
+      k13 = k1 + k3;
+      k14 = k1 + k4;
+      k23 = k2 + k3;
+      k24 = k2 + k4;
+
+      double phiPair1 = phiCollinsSoperFrame(k13, k24, k1234);
+      double phiPair2 = phiCollinsSoperFrame(k14, k23, k1234);
+      double cosThetaPair1 = cosThetaCollinsSoperFrame(k13, k24, k1234);
+      double cosThetaPair2 = cosThetaCollinsSoperFrame(k14, k23, k1234);
+
+      sigFromMC(
+        collision.posX(), collision.posY(), collision.posZ(),
         collision.totalFV0AmplitudeA(), collision.totalFT0AmplitudeA(), collision.totalFT0AmplitudeC(), collision.totalFDDAmplitudeA(), collision.totalFDDAmplitudeC(),
+        collision.timeFV0A(), collision.timeFT0A(), collision.timeFT0C(), collision.timeFDDA(), collision.timeFDDC(),
+        collision.timeZNA(), collision.timeZNC(),
         dcaxy, dcaz,
-        tpcNsigKa, tpcNsigPr, tpcNsigMu, tpcNsigEl,
-        tofNsigKa, tofNsigPr, tofNsigMu, tofNsigEl,
-        tpcchi2, tpcNFindableCls, itschi2,
-        piPt, piEta, piRapidity,
-        p1234.Pt(), p1234.Eta(), p1234.Rapidity(), p1234.M(), p1234.Phi(),
+        tpcnsigPi, tpcnsigKa, tpcnsigPr, tpcnsigEl, tpcnsigMu,
+        tofnsigPi, tofnsigKa, tofnsigPr, tofnsigEl, tofnsigMu,
+        tpcchi2, tpcnclsfindable, itschi2,
+        pipt, pieta, piphi, pirapidity,
+        p1234.Pt(), p1234.Eta(), p1234.Phi(), p1234.Rapidity(), p1234.M(),
         phiPair1, phiPair2, cosThetaPair1, cosThetaPair2);
 
       if (std::fabs(p1234.Rapidity()) < 0.5) {

--- a/PWGUD/Tasks/exclusiveRhoTo4Pi.cxx
+++ b/PWGUD/Tasks/exclusiveRhoTo4Pi.cxx
@@ -1294,12 +1294,17 @@ struct ExclusiveRhoTo4Pi {
 
     if (pionPlusTracks.size() != 2 && pionMinusTracks.size() != 2) {
       std::vector<decltype(tracks.begin())> allTracks;
-      for (int i = 0; i < pionPlusTracks.size(); i++) {
+      int piPlussize = static_cast<int>(pionPlusTracks.size());
+      int piMinussize = static_cast<int>(pionMinusTracks.size());
+
+      for (int i = 0; i < piPlussize; i++) {
         allTracks.push_back(pionPlusTracks[i]);
       }
-      for (int i = 0; i < pionMinusTracks.size(); i++) {
+      for (int i = 0; i < piMinussize; i++) {
         allTracks.push_back(pionMinusTracks[i]);
       }
+
+      int allTRackSize = static_cast<int>(allTracks.size());
 
       TLorentzVector p1, p2, p3, p4, p1234;
 
@@ -1333,7 +1338,7 @@ struct ExclusiveRhoTo4Pi {
       std::vector<double> pirapidity;
 
       TLorentzVector tempPionVect;
-      for (int i = 0; i < allTracks.size(); i++) {
+      for (int i = 0; i < allTRackSize; i++) {
         tempPionVect.SetXYZM(allTracks[i].px(), allTracks[i].py(), allTracks[i].pz(), o2::constants::physics::MassPionCharged);
         dcaxy.push_back(allTracks[i].dcaXY());
         dcaz.push_back(allTracks[i].dcaZ());


### PR DESCRIPTION
- Added a new Process function `processDataFast` which uses Filtered UD tables instead of the full ones, and it only produces derived data except 2-3 histograms. 
-  Removed the configurables `fddaCut`, `fddcCut` and `StrictEventSelection ` which is not required any more
- Small modifications in code