### PR TITLE
[PWGUD] Remove BCsWithTimestamps, and define the run number

### DIFF
--- a/PWGUD/Tasks/flowCumulantsUpc.cxx
+++ b/PWGUD/Tasks/flowCumulantsUpc.cxx
@@ -706,8 +706,24 @@ struct FlowCumulantsUpc {
   }
 
   // void process(AodCollisions::iterator const& collision, aod::BCsWithTimestamps const&, AodTracks const& tracks)
-  void process(UDCollisionsFull::iterator const& collision, aod::BCsWithTimestamps const&, UdTracksFull const& tracks)
+  void process(UDCollisionsFull::iterator const& collision, UdTracksFull const& tracks)
   {
+
+    // Runnumber loading test
+    // accept only selected run numbers
+    int run = collision.runNumber();
+
+    // extract bc pattern from CCDB for data or anchored MC only
+    // if (run != lastRun && run >= 500000) {
+    //   LOGF(info, "Updating bcPattern %d ...", run);
+    //   auto tss = ccdb->getRunDuration(run);
+    //   auto grplhcif = ccdb->getForTimeStamp<o2::parameters::GRPLHCIFData>("GLO/Config/GRPLHCIF", tss.first);
+    //   bcPatternB = grplhcif->getBunchFilling().getBCPattern();
+    //   lastRun = run;
+    //   LOGF(info, "done!");
+    // }
+
+    // auto bcnum = collision.globalBC();
 
     registry.fill(HIST("hEventCount"), 0.5);
     int gapSide = collision.gapSide();

--- a/PWGUD/Tasks/flowCumulantsUpc.cxx
+++ b/PWGUD/Tasks/flowCumulantsUpc.cxx
@@ -711,7 +711,7 @@ struct FlowCumulantsUpc {
 
     // Runnumber loading test
     // accept only selected run numbers
-    int run = collision.runNumber();
+    // int run = collision.runNumber();
 
     // extract bc pattern from CCDB for data or anchored MC only
     // if (run != lastRun && run >= 500000) {


### PR DESCRIPTION
Remove BCsWithTimestamps, and define the run number directly from collision (for future use)