### PR TITLE
[PWGHF,Trigger] Add the possibility to use TPC PID in BDT for HFfilters + minor changes to selections

### DIFF
--- a/EventFiltering/PWGHF/HFFilter.cxx
+++ b/EventFiltering/PWGHF/HFFilter.cxx
@@ -946,6 +946,11 @@ struct HfFilter { // Main struct for HF triggers
             if (trackProton.globalIndex() == trackPos.globalIndex() || trackProton.globalIndex() == trackNeg.globalIndex()) {
               continue;
             }
+            // minimal track selections
+            if (!trackProton.isGlobalTrackWoDCA() || std::fabs(trackProton.pt()) < 0.3f) {
+              continue;
+            }
+            // PID selection
             bool isProton = helper.isSelectedProton4CharmOrBeautyBaryons(trackProton);
             if (isProton) {
               if (!keepEvent[kPrCharm2P]) {

--- a/EventFiltering/PWGHF/HFFilter.cxx
+++ b/EventFiltering/PWGHF/HFFilter.cxx
@@ -104,7 +104,7 @@ struct HfFilter { // Main struct for HF triggers
   Configurable<bool> forceTofDeuteronForFemto{"forceTofDeuteronForFemto", false, "flag to force TOF PID for deuterons"};
 
   // double charm
-  Configurable<LabeledArray<int>> enableDoubleCharmChannels{"enableDoubleCharmChannels", {activeDoubleCharmChannels[0], 1, 3, labelsEmpty, labelsColumnsDoubleCharmChannels}, "Flags to enable/disable double charm channels"};
+  Configurable<LabeledArray<int>> enableDoubleCharmChannels{"enableDoubleCharmChannels", {activeDoubleCharmChannels[0], 2, 3, labelsRowsDoubleCharmChannels, labelsColumnsDoubleCharmChannels}, "Flags to enable/disable double charm channels"};
   Configurable<bool> keepOnlyDplusForDouble3Prongs{"keepOnlyDplusForDouble3Prongs", false, "Flag to enable/disable to keep only D+ in double charm 3-prongs trigger"};
 
   // parameters for resonance triggers
@@ -425,7 +425,7 @@ struct HfFilter { // Main struct for HF triggers
 
       hProcessedEvents->Fill(0);
 
-      std::vector<std::vector<int64_t>> indicesDau2Prong{};
+      std::vector<std::vector<int64_t>> indicesDau2Prong{}, indicesDau2ProngPrompt{};
 
       auto cand2ProngsThisColl = cand2Prongs.sliceBy(hf2ProngPerCollision, thisCollId);
       for (const auto& cand2Prong : cand2ProngsThisColl) { // start loop over 2 prongs
@@ -516,8 +516,9 @@ struct HfFilter { // Main struct for HF triggers
             }
           }
           // multi-charm selection
+          indicesDau2Prong.push_back(std::vector<int64_t>{trackPos.globalIndex(), trackNeg.globalIndex()});
           if (isD0CharmTagged) {
-            indicesDau2Prong.push_back(std::vector<int64_t>{trackPos.globalIndex(), trackNeg.globalIndex()});
+            indicesDau2ProngPrompt.push_back(std::vector<int64_t>{trackPos.globalIndex(), trackNeg.globalIndex()});
           }
 
           if (applyOptimisation) {
@@ -1079,7 +1080,7 @@ struct HfFilter { // Main struct for HF triggers
 
       } // end loop over 2-prong candidates
 
-      std::vector<std::vector<int64_t>> indicesDau3Prong{};
+      std::vector<std::vector<int64_t>> indicesDau3Prong{}, indicesDau3ProngPrompt{};
       auto cand3ProngsThisColl = cand3Prongs.sliceBy(hf3ProngPerCollision, thisCollId);
       for (const auto& cand3Prong : cand3ProngsThisColl) { // start loop over 3 prongs
         std::array<int8_t, kNCharmParticles - 1> is3Prong = {
@@ -1176,8 +1177,18 @@ struct HfFilter { // Main struct for HF triggers
           keepEvent[kSingleNonPromptCharm3P] = true;
         }
 
-        if ((!keepOnlyDplusForDouble3Prongs && std::accumulate(isCharmTagged.begin(), isCharmTagged.end(), 0)) || (keepOnlyDplusForDouble3Prongs && isCharmTagged[kDplus - 1])) {
+        if (!keepOnlyDplusForDouble3Prongs) {
           indicesDau3Prong.push_back(std::vector<int64_t>{trackFirst.globalIndex(), trackSecond.globalIndex(), trackThird.globalIndex()});
+          if (std::accumulate(isCharmTagged.begin(), isCharmTagged.end(), 0)) {
+            indicesDau3ProngPrompt.push_back(std::vector<int64_t>{trackFirst.globalIndex(), trackSecond.globalIndex(), trackThird.globalIndex()});
+          }
+        } else {
+          if (isSignalTagged[kDplus - 1]) {
+            indicesDau3Prong.push_back(std::vector<int64_t>{trackFirst.globalIndex(), trackSecond.globalIndex(), trackThird.globalIndex()});
+            if (isCharmTagged[kDplus - 1]) {
+              indicesDau3ProngPrompt.push_back(std::vector<int64_t>{trackFirst.globalIndex(), trackSecond.globalIndex(), trackThird.globalIndex()});
+            }
+          }
         } // end multiple 3-prong selection
 
         auto pVec3Prong = RecoDecay::pVec(pVecFirst, pVecSecond, pVecThird);
@@ -1783,9 +1794,13 @@ struct HfFilter { // Main struct for HF triggers
       }
 
       auto n2Prongs = helper.computeNumberOfCandidates(indicesDau2Prong);
+      auto n2ProngsPrompt = helper.computeNumberOfCandidates(indicesDau2ProngPrompt);
       auto n3Prongs = helper.computeNumberOfCandidates(indicesDau3Prong);
+      auto n3ProngsPrompt = helper.computeNumberOfCandidates(indicesDau3ProngPrompt);
       indicesDau2Prong.insert(indicesDau2Prong.end(), indicesDau3Prong.begin(), indicesDau3Prong.end());
       auto n23Prongs = helper.computeNumberOfCandidates(indicesDau2Prong);
+      indicesDau2ProngPrompt.insert(indicesDau2ProngPrompt.end(), indicesDau3ProngPrompt.begin(), indicesDau3ProngPrompt.end());
+      auto n23ProngsPrompt = helper.computeNumberOfCandidates(indicesDau2ProngPrompt);
 
       if (activateQA) {
         hN2ProngCharmCand->Fill(n2Prongs);
@@ -1793,13 +1808,31 @@ struct HfFilter { // Main struct for HF triggers
       }
 
       if (n2Prongs > 1 && enableDoubleCharmChannels->get(0u, 0u)) {
-        keepEvent[kDoubleCharm2P] = true;
+        if (enableDoubleCharmChannels->get(1u, 0u)) {
+          keepEvent[kDoubleCharm2P] = true;
+        } else {
+          if (n2ProngsPrompt > 1) {
+            keepEvent[kDoubleCharm2P] = true;
+          }
+        }
       }
       if (n3Prongs > 1 && enableDoubleCharmChannels->get(0u, 1u)) {
-        keepEvent[kDoubleCharm3P] = true;
+        if (enableDoubleCharmChannels->get(1u, 1u)) {
+          keepEvent[kDoubleCharm3P] = true;
+        } else {
+          if (n3ProngsPrompt > 1) {
+            keepEvent[kDoubleCharm3P] = true;
+          }
+        }
       }
       if (n23Prongs > 1 && enableDoubleCharmChannels->get(0u, 2u)) {
-        keepEvent[kDoubleCharmMix] = true;
+        if (enableDoubleCharmChannels->get(1u, 2u)) {
+          keepEvent[kDoubleCharmMix] = true;
+        } else {
+          if (n23ProngsPrompt > 1) {
+            keepEvent[kDoubleCharmMix] = true;
+          }
+        }
       }
 
       // apply downscale factors, if required

--- a/EventFiltering/PWGHF/HFFilterHelpers.h
+++ b/EventFiltering/PWGHF/HFFilterHelpers.h
@@ -343,8 +343,9 @@ static const std::vector<std::string> labelsColumnsCutsBeautyToJPsi = {"minPtMuo
 } // namespace hf_trigger_cuts_presel_beauty
 
 // double charm
-constexpr int activeDoubleCharmChannels[1][3] = {{1, 1, 1}}; // kDoubleCharm2P, kDoubleCharm3P, kDoubleCharmMix
+constexpr int activeDoubleCharmChannels[2][3] = {{1, 1, 1}, {1, 1, 0}}; // kDoubleCharm2P, kDoubleCharm3P, kDoubleCharmMix (second column to keep non-prompt)
 static const std::vector<std::string> labelsColumnsDoubleCharmChannels = {"DoubleCharm2Prong", "DoubleCharm3Prong", "DoubleCharmMix"};
+static const std::vector<std::string> labelsRowsDoubleCharmChannels = {"", "KeepNonprompt"};
 
 // charm resonances
 constexpr float cutsCharmReso[3][13] = {{0.0, 0.0, 0.0, 0.0, 0.4, 0., 0.0, 0.00, 0.21, 0.21, 0.0, 0.7, 0.7},

--- a/EventFiltering/PWGHF/HFFilterHelpers.h
+++ b/EventFiltering/PWGHF/HFFilterHelpers.h
@@ -932,12 +932,13 @@ inline bool HfFilterHelper::isSelectedTrack4Femto(const T1& track, const T2& tra
   // For deuterons: Determine whether to apply TOF based on pt threshold
   if (trackSpecies == kDeuteronForFemto) {
     // Apply different PID strategy in different pt range
+    // one side selection only
     if (pt <= ptThresholdPidStrategy) {
-      if (std::fabs(NSigmaTPC) > nSigmaCuts[0] || NSigmaITS < nSigmaCuts[3]) { // Use TPC and ITS below the threshold, NSigmaITS for deuteron with a lower limit
+      if (NSigmaTPC < -nSigmaCuts[0] || NSigmaITS < -nSigmaCuts[3]) { // Use TPC and ITS below the threshold, NSigmaITS for deuteron with a lower limit
         return false;
       }
     } else {
-      if (NSigma > nSigmaCuts[2]) { // Use combined TPC and TOF above the threshold
+      if (NSigmaTOF > nSigmaCuts[2] || NSigmaTPC < -nSigmaCuts[0]) { // Use combined TPC and TOF above the threshold
         return false;
       }
     }

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1766,9 +1766,12 @@ struct HfTrackIndexSkimCreator {
 
   /// Method to perform ML selections for 2-prong candidates after the rectangular selections
   /// \param featuresCand is the vector with the candidate features
+  /// \param featuresCandPid is the vector with the candidate PID features
   /// \param outputScores is the array of vectors with the output scores to be filled
   /// \param isSelected ia s bitmap with selection outcome
-  void applyMlSelectionForHfFilters3Prong(std::vector<float> featuresCand, std::array<std::vector<float>, kN3ProngDecays>& outputScores, int& isSelected)
+  /// \param usePidForHfFiltersBdt is the flag to determine whether to use also the PID features for the Lc BDT
+  template <bool usePidForHfFiltersBdt = false>
+  void applyMlSelectionForHfFilters3Prong(std::vector<float> featuresCand, std::vector<float> featuresCandPid, std::array<std::vector<float>, kN3ProngDecays>& outputScores, int& isSelected)
   {
     if (isSelected == 0) {
       return;
@@ -1777,7 +1780,18 @@ struct HfTrackIndexSkimCreator {
     const float ptDummy = 1.; // dummy pT value (only one pT bin)
     for (int iDecay3P{0}; iDecay3P < kN3ProngDecays; ++iDecay3P) {
       if (TESTBIT(isSelected, iDecay3P) && hasMlModel3Prong[iDecay3P]) {
-        bool isMlSel = hfMlResponse3Prongs[iDecay3P].isSelectedMl(featuresCand, ptDummy, outputScores[iDecay3P]);
+        bool isMlSel = false;
+        if constexpr (usePidForHfFiltersBdt) {
+          if (iDecay3P != hf_cand_3prong::DecayType::LcToPKPi && iDecay3P != hf_cand_3prong::DecayType::XicToPKPi) {
+            hfMlResponse3Prongs[iDecay3P].isSelectedMl(featuresCand, ptDummy, outputScores[iDecay3P]);
+          } else {
+            std::vector<float> featuresCandWithPid = featuresCand;
+            featuresCandWithPid.insert(featuresCandWithPid.begin(), featuresCandPid.begin(), featuresCandPid.end());
+            hfMlResponse3Prongs[iDecay3P].isSelectedMl(featuresCandWithPid, ptDummy, outputScores[iDecay3P]);
+          }
+        } else {
+          isMlSel = hfMlResponse3Prongs[iDecay3P].isSelectedMl(featuresCand, ptDummy, outputScores[iDecay3P]);
+        }
         if (config.fillHistograms) {
           switch (iDecay3P) {
             case hf_cand_3prong::DecayType::DplusToPiKPi: {
@@ -2002,7 +2016,7 @@ struct HfTrackIndexSkimCreator {
     return;
   } /// end of performPvRefitCandProngs function
 
-  template <bool doPvRefit = false, typename TTracks>
+  template <bool doPvRefit = false, bool usePidForHfFiltersBdt = false, typename TTracks>
   void run2And3Prongs(SelectedCollisions const& collisions,
                       aod::BCsWithTimestamps const& bcWithTimeStamps,
                       FilteredTrackAssocSel const&,
@@ -2506,7 +2520,15 @@ struct HfTrackIndexSkimCreator {
               std::array<std::vector<float>, kN3ProngDecays> mlScores3Prongs;
               if (config.applyMlForHfFilters) {
                 std::vector<float> inputFeatures{trackParVarPcaPos1.getPt(), dcaInfoPos1[0], dcaInfoPos1[1], trackParVarPcaNeg1.getPt(), dcaInfoNeg1[0], dcaInfoNeg1[1], trackParVarPcaPos2.getPt(), dcaInfoPos2[0], dcaInfoPos2[1]};
-                applyMlSelectionForHfFilters3Prong(inputFeatures, mlScores3Prongs, isSelected3ProngCand);
+                std::vector<float> inputFeaturesLcPid{};
+                if constexpr (usePidForHfFiltersBdt) {
+                  inputFeaturesLcPid.push_back(trackPos1.tpcNSigmaPr());
+                  inputFeaturesLcPid.push_back(trackPos2.tpcNSigmaPr());
+                  inputFeaturesLcPid.push_back(trackPos1.tpcNSigmaPi());
+                  inputFeaturesLcPid.push_back(trackPos2.tpcNSigmaPi());
+                  inputFeaturesLcPid.push_back(trackNeg1.tpcNSigmaKa());
+                }
+                applyMlSelectionForHfFilters3Prong<usePidForHfFiltersBdt>(inputFeatures, inputFeaturesLcPid, mlScores3Prongs, isSelected3ProngCand);
               }
 
               if (!config.debug && isSelected3ProngCand == 0) {
@@ -2751,7 +2773,15 @@ struct HfTrackIndexSkimCreator {
               std::array<std::vector<float>, kN3ProngDecays> mlScores3Prongs;
               if (config.applyMlForHfFilters) {
                 std::vector<float> inputFeatures{trackParVarPcaNeg1.getPt(), dcaInfoNeg1[0], dcaInfoNeg1[1], trackParVarPcaPos1.getPt(), dcaInfoPos1[0], dcaInfoPos1[1], trackParVarPcaNeg2.getPt(), dcaInfoNeg2[0], dcaInfoNeg2[1]};
-                applyMlSelectionForHfFilters3Prong(inputFeatures, mlScores3Prongs, isSelected3ProngCand);
+                std::vector<float> inputFeaturesLcPid{};
+                if constexpr (usePidForHfFiltersBdt) {
+                  inputFeaturesLcPid.push_back(trackNeg1.tpcNSigmaPr());
+                  inputFeaturesLcPid.push_back(trackNeg2.tpcNSigmaPr());
+                  inputFeaturesLcPid.push_back(trackNeg1.tpcNSigmaPi());
+                  inputFeaturesLcPid.push_back(trackNeg2.tpcNSigmaPi());
+                  inputFeaturesLcPid.push_back(trackPos1.tpcNSigmaKa());
+                }
+                applyMlSelectionForHfFilters3Prong<usePidForHfFiltersBdt>(inputFeatures, inputFeaturesLcPid, mlScores3Prongs, isSelected3ProngCand);
               }
 
               if (!config.debug && isSelected3ProngCand == 0) {
@@ -2945,6 +2975,26 @@ struct HfTrackIndexSkimCreator {
     run2And3Prongs(collisions, bcWithTimeStamps, trackIndices, tracks);
   }
   PROCESS_SWITCH(HfTrackIndexSkimCreator, process2And3ProngsNoPvRefit, "Process 2-prong and 3-prong skim without PV refit", true);
+
+  void process2And3ProngsWithPvRefitWithPidForHfFiltersBdt( // soa::Join<aod::Collisions, aod::CentV0Ms>::iterator const& collision, //FIXME add centrality when option for variations to the process function appears
+    SelectedCollisions const& collisions,
+    aod::BCsWithTimestamps const& bcWithTimeStamps,
+    FilteredTrackAssocSel const& trackIndices,
+    soa::Join<TracksWithPVRefitAndDCA, aod::pidTPCFullPi, aod::pidTPCFullKa, aod::pidTPCFullPr> const& tracks)
+  {
+    run2And3Prongs<true, true>(collisions, bcWithTimeStamps, trackIndices, tracks);
+  }
+  PROCESS_SWITCH(HfTrackIndexSkimCreator, process2And3ProngsWithPvRefitWithPidForHfFiltersBdt, "Process 2-prong and 3-prong skim with PV refit and PID for software trigger BDTs (Lc and Xic only)", false);
+
+  void process2And3ProngsNoPvRefitWithPidForHfFiltersBdt( // soa::Join<aod::Collisions, aod::CentV0Ms>::iterator const& collision, //FIXME add centrality when option for variations to the process function appears
+    SelectedCollisions const& collisions,
+    aod::BCsWithTimestamps const& bcWithTimeStamps,
+    FilteredTrackAssocSel const& trackIndices,
+    soa::Join<aod::TracksWCovDcaExtra, aod::pidTPCFullPi, aod::pidTPCFullKa, aod::pidTPCFullPr> const& tracks)
+  {
+    run2And3Prongs<false, true>(collisions, bcWithTimeStamps, trackIndices, tracks);
+  }
+  PROCESS_SWITCH(HfTrackIndexSkimCreator, process2And3ProngsNoPvRefitWithPidForHfFiltersBdt, "Process 2-prong and 3-prong skim without PV refit and PID for software trigger BDTs (Lc and Xic only)", false);
 };
 
 //________________________________________________________________________________________________________________________

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1786,7 +1786,7 @@ struct HfTrackIndexSkimCreator {
             hfMlResponse3Prongs[iDecay3P].isSelectedMl(featuresCand, ptDummy, outputScores[iDecay3P]);
           } else {
             std::vector<float> featuresCandWithPid = featuresCand;
-            featuresCandWithPid.insert(featuresCandWithPid.begin(), featuresCandPid.begin(), featuresCandPid.end());
+            featuresCandWithPid.insert(featuresCandWithPid.end(), featuresCandPid.begin(), featuresCandPid.end());
             hfMlResponse3Prongs[iDecay3P].isSelectedMl(featuresCandWithPid, ptDummy, outputScores[iDecay3P]);
           }
         } else {


### PR DESCRIPTION
@zhangbiao-phy @apalasciano in this PR I:
1) added the possibility to use TPC PID variables in the BDTs for Lc (and possibly Xic) in the software triggers
2) slightly modified some selections: for D0Pr and D*+Pr I added minimal track selections for the proton, while for the femto I modified the deuteron PID selections in order to be one sided only (for ITS or TPC we only keep > -Nsigma, while for TOF we only keep < Nsigma). Please note the signs, that imply that in the configurable the values should always be **without sign**