### PR TITLE
[Common] Add option to prevent fatal error in ctpRateFetcher::fetch()

### DIFF
--- a/Common/CCDB/ctpRateFetcher.cxx
+++ b/Common/CCDB/ctpRateFetcher.cxx
@@ -22,7 +22,7 @@
 
 namespace o2
 {
-double ctpRateFetcher::fetch(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber, std::string sourceName)
+double ctpRateFetcher::fetch(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber, std::string sourceName, bool fCrashOnNull)
 {
   setupRun(runNumber, ccdb, timeStamp);
   if (sourceName.find("ZNC") != std::string::npos) {
@@ -43,7 +43,7 @@ double ctpRateFetcher::fetch(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStam
       if (ret < 0.) {
         LOG(info) << "Trying different class";
         ret = fetchCTPratesClasses(ccdb, timeStamp, runNumber, "CMTVX-NONE");
-        if (ret < 0) {
+        if ((ret < 0) && fCrashOnNull) {
           LOG(fatal) << "None of the classes used for lumi found";
         }
       }

--- a/Common/CCDB/ctpRateFetcher.h
+++ b/Common/CCDB/ctpRateFetcher.h
@@ -34,7 +34,7 @@ class ctpRateFetcher
 {
  public:
   ctpRateFetcher() = default;
-  double fetch(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber, std::string sourceName);
+  double fetch(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber, std::string sourceName, bool fCrashOnNull = true);
 
   void setManualCleanup(bool manualCleanup = true) { mManualCleanup = manualCleanup; }
 


### PR DESCRIPTION
This PR adds an optional boolean argument (`fCrashOnNull`) to `ctpRateFetcher::fetch()`, controlling whether a fatal error is triggered when the CCDB file for a given RunNumber is missing.

`fCrashOnNull` is true by default, keeping the current behavior unchanged - and ensuring no impact on other tasks.

Tagging @mpuccio, @ddobrigk, @romainschotter and @lhusova for completeness. 