### PR TITLE
[PWGLF] Improved treatment of photons in strangeness builder

### DIFF
--- a/PWGLF/TableProducer/Strangeness/CMakeLists.txt
+++ b/PWGLF/TableProducer/Strangeness/CMakeLists.txt
@@ -108,7 +108,7 @@ o2physics_add_dpl_workflow(strangederivedbuilder
 
 o2physics_add_dpl_workflow(strangenessbuilder
     SOURCES strangenessbuilder.cxx
-    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::DCAFitter KFParticle::KFParticle
+    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::DCAFitter KFParticle::KFParticle O2Physics::TPCDriftManager
     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(v0-selector

--- a/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
@@ -630,7 +630,7 @@ struct StrangenessBuilder {
     // mmark this run as configured
     mRunNumber = bc.runNumber();
 
-    if(v0BuilderOpts.generatePhotonCandidates.value && v0BuilderOpts.moveTPCOnlyTracks.value){
+    if (v0BuilderOpts.generatePhotonCandidates.value && v0BuilderOpts.moveTPCOnlyTracks.value) {
       // initialize only if needed, avoid unnecessary CCDB calls
       mVDriftMgr.init(&ccdb->instance());
       mVDriftMgr.update(timestamp);
@@ -1150,27 +1150,27 @@ struct StrangenessBuilder {
       auto negTrackPar = getTrackParCov(negTrack);
 
       // handle TPC-only tracks properly (photon conversions)
-      if(v0BuilderOpts.moveTPCOnlyTracks){ 
+      if (v0BuilderOpts.moveTPCOnlyTracks) {
         bool isPosTPCOnly = (posTrack.hasTPC() && !posTrack.hasITS() && !posTrack.hasTRD() && !posTrack.hasTOF());
-        if(isPosTPCOnly){ 
-          // Nota bene: positive is TPC-only -> this entire V0 merits treatment as photon candidate 
+        if (isPosTPCOnly) {
+          // Nota bene: positive is TPC-only -> this entire V0 merits treatment as photon candidate
           posTrackPar.setPID(o2::track::PID::Electron);
           negTrackPar.setPID(o2::track::PID::Electron);
 
           auto const& collision = collisions.rawIteratorAt(v0.collisionId);
-          if(!mVDriftMgr.moveTPCTrack<TBCs, TCollisions>(collision, posTrack, posTrackPar)){
+          if (!mVDriftMgr.moveTPCTrack<TBCs, TCollisions>(collision, posTrack, posTrackPar)) {
             return;
           }
         }
 
         bool isNegTPCOnly = (negTrack.hasTPC() && !negTrack.hasITS() && !negTrack.hasTRD() && !negTrack.hasTOF());
-        if(isNegTPCOnly){ 
-          // Nota bene: negative is TPC-only -> this entire V0 merits treatment as photon candidate 
+        if (isNegTPCOnly) {
+          // Nota bene: negative is TPC-only -> this entire V0 merits treatment as photon candidate
           posTrackPar.setPID(o2::track::PID::Electron);
           negTrackPar.setPID(o2::track::PID::Electron);
 
           auto const& collision = collisions.rawIteratorAt(v0.collisionId);
-          if(!mVDriftMgr.moveTPCTrack<TBCs, TCollisions>(collision, negTrack, negTrackPar)){
+          if (!mVDriftMgr.moveTPCTrack<TBCs, TCollisions>(collision, negTrack, negTrackPar)) {
             return;
           }
         }

--- a/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
@@ -46,6 +46,7 @@
 #include "CCDB/BasicCCDBManager.h"
 #include "DataFormatsParameters/GRPObject.h"
 #include "DataFormatsParameters/GRPMagField.h"
+#include "Common/Core/TPCVDriftManager.h"
 
 using namespace o2;
 using namespace o2::framework;
@@ -278,6 +279,7 @@ struct StrangenessBuilder {
   struct : ConfigurableGroup {
     std::string prefix = "v0BuilderOpts";
     Configurable<bool> generatePhotonCandidates{"generatePhotonCandidates", false, "generate gamma conversion candidates (V0s using TPC-only tracks)"};
+    Configurable<bool> moveTPCOnlyTracks{"moveTPCOnlyTracks", true, "if dealing with TPC-only tracks, move them according to TPC drift / time info"};
 
     // baseline conditionals of V0 building
     Configurable<int> minCrossedRows{"minCrossedRows", 50, "minimum TPC crossed rows for daughter tracks"};
@@ -340,6 +342,9 @@ struct StrangenessBuilder {
 
   int mRunNumber;
   o2::base::MatLayerCylSet* lut = nullptr;
+
+  // for handling TPC-only tracks (photons)
+  o2::aod::common::TPCVDriftManager mVDriftMgr;
 
   // for tagging V0s used in cascades
   std::vector<o2::pwglf::v0candidate> v0sFromCascades; // Vector of v0 candidates used in cascades
@@ -624,6 +629,12 @@ struct StrangenessBuilder {
     LOG(info) << "Fully configured for run: " << bc.runNumber();
     // mmark this run as configured
     mRunNumber = bc.runNumber();
+
+    if(v0BuilderOpts.generatePhotonCandidates.value && v0BuilderOpts.moveTPCOnlyTracks.value){
+      // initialize only if needed, avoid unnecessary CCDB calls
+      mVDriftMgr.init(&ccdb->instance());
+      mVDriftMgr.update(timestamp);
+    }
 
     return true;
   }
@@ -1098,7 +1109,7 @@ struct StrangenessBuilder {
   }
 
   //__________________________________________________
-  template <typename TCollisions, typename TTracks, typename TV0s, typename TMCParticles>
+  template <class TBCs, typename TCollisions, typename TTracks, typename TV0s, typename TMCParticles>
   void buildV0s(TCollisions const& collisions, TV0s const& v0s, TTracks const& tracks, TMCParticles const& mcParticles)
   {
     // prepare MC containers (not necessarily used)
@@ -1134,7 +1145,38 @@ struct StrangenessBuilder {
       }
       auto const& posTrack = tracks.rawIteratorAt(v0.posTrackId);
       auto const& negTrack = tracks.rawIteratorAt(v0.negTrackId);
-      if (!straHelper.buildV0Candidate(v0.collisionId, pvX, pvY, pvZ, posTrack, negTrack, v0.isCollinearV0, mEnabledTables[kV0Covs])) {
+
+      auto posTrackPar = getTrackParCov(posTrack);
+      auto negTrackPar = getTrackParCov(negTrack);
+
+      // handle TPC-only tracks properly (photon conversions)
+      if(v0BuilderOpts.moveTPCOnlyTracks){ 
+        bool isPosTPCOnly = (posTrack.hasTPC() && !posTrack.hasITS() && !posTrack.hasTRD() && !posTrack.hasTOF());
+        if(isPosTPCOnly){ 
+          // Nota bene: positive is TPC-only -> this entire V0 merits treatment as photon candidate 
+          posTrackPar.setPID(o2::track::PID::Electron);
+          negTrackPar.setPID(o2::track::PID::Electron);
+
+          auto const& collision = collisions.rawIteratorAt(v0.collisionId);
+          if(!mVDriftMgr.moveTPCTrack<TBCs, TCollisions>(collision, posTrack, posTrackPar)){
+            return;
+          }
+        }
+
+        bool isNegTPCOnly = (negTrack.hasTPC() && !negTrack.hasITS() && !negTrack.hasTRD() && !negTrack.hasTOF());
+        if(isNegTPCOnly){ 
+          // Nota bene: negative is TPC-only -> this entire V0 merits treatment as photon candidate 
+          posTrackPar.setPID(o2::track::PID::Electron);
+          negTrackPar.setPID(o2::track::PID::Electron);
+
+          auto const& collision = collisions.rawIteratorAt(v0.collisionId);
+          if(!mVDriftMgr.moveTPCTrack<TBCs, TCollisions>(collision, negTrack, negTrackPar)){
+            return;
+          }
+        }
+      }
+
+      if (!straHelper.buildV0Candidate(v0.collisionId, pvX, pvY, pvZ, posTrack, negTrack, posTrackPar, negTrackPar, v0.isCollinearV0, mEnabledTables[kV0Covs])) {
         products.v0dataLink(-1, -1);
         continue;
       }
@@ -2107,7 +2149,7 @@ struct StrangenessBuilder {
     markV0sUsedInCascades(v0List, cascadeList, trackedCascades);
 
     // build V0s
-    buildV0s(collisions, v0List, tracks, mcParticles);
+    buildV0s<TBCs>(collisions, v0List, tracks, mcParticles);
 
     // build cascades
     buildCascades(collisions, cascadeList, tracks, mcParticles);
@@ -2121,22 +2163,22 @@ struct StrangenessBuilder {
     populateCascadeInterlinks();
   }
 
-  void processRealData(aod::Collisions const& collisions, aod::V0s const& v0s, aod::Cascades const& cascades, aod::TrackedCascades const& trackedCascades, FullTracksExtIU const& tracks, aod::BCsWithTimestamps const& bcs)
+  void processRealData(soa::Join<aod::Collisions, aod::EvSels> const& collisions, aod::V0s const& v0s, aod::Cascades const& cascades, aod::TrackedCascades const& trackedCascades, FullTracksExtIU const& tracks, aod::BCsWithTimestamps const& bcs)
   {
     dataProcess(collisions, static_cast<TObject*>(nullptr), v0s, cascades, trackedCascades, tracks, bcs, static_cast<TObject*>(nullptr));
   }
 
-  void processRealDataRun2(aod::Collisions const& collisions, aod::V0s const& v0s, aod::Cascades const& cascades, FullTracksExt const& tracks, aod::BCsWithTimestamps const& bcs)
+  void processRealDataRun2(soa::Join<aod::Collisions, aod::EvSels> const& collisions, aod::V0s const& v0s, aod::Cascades const& cascades, FullTracksExt const& tracks, aod::BCsWithTimestamps const& bcs)
   {
     dataProcess(collisions, static_cast<TObject*>(nullptr), v0s, cascades, static_cast<TObject*>(nullptr), tracks, bcs, static_cast<TObject*>(nullptr));
   }
 
-  void processMonteCarlo(soa::Join<aod::Collisions, aod::McCollisionLabels> const& collisions, aod::McCollisions const& mccollisions, aod::V0s const& v0s, aod::Cascades const& cascades, aod::TrackedCascades const& trackedCascades, FullTracksExtLabeledIU const& tracks, aod::BCsWithTimestamps const& bcs, aod::McParticles const& mcParticles)
+  void processMonteCarlo(soa::Join<aod::Collisions, aod::EvSels, aod::McCollisionLabels> const& collisions, aod::McCollisions const& mccollisions, aod::V0s const& v0s, aod::Cascades const& cascades, aod::TrackedCascades const& trackedCascades, FullTracksExtLabeledIU const& tracks, aod::BCsWithTimestamps const& bcs, aod::McParticles const& mcParticles)
   {
     dataProcess(collisions, mccollisions, v0s, cascades, trackedCascades, tracks, bcs, mcParticles);
   }
 
-  void processMonteCarloRun2(soa::Join<aod::Collisions, aod::McCollisionLabels> const& collisions, aod::McCollisions const& mccollisions, aod::V0s const& v0s, aod::Cascades const& cascades, FullTracksExtLabeled const& tracks, aod::BCsWithTimestamps const& bcs, aod::McParticles const& mcParticles)
+  void processMonteCarloRun2(soa::Join<aod::Collisions, aod::EvSels, aod::McCollisionLabels> const& collisions, aod::McCollisions const& mccollisions, aod::V0s const& v0s, aod::Cascades const& cascades, FullTracksExtLabeled const& tracks, aod::BCsWithTimestamps const& bcs, aod::McParticles const& mcParticles)
   {
     dataProcess(collisions, mccollisions, v0s, cascades, static_cast<TObject*>(nullptr), tracks, bcs, mcParticles);
   }

--- a/PWGLF/Utils/strangenessBuilderHelper.h
+++ b/PWGLF/Utils/strangenessBuilderHelper.h
@@ -168,8 +168,8 @@ class strangenessBuilderHelper
                         float pvX, float pvY, float pvZ,
                         TTrack const& positiveTrack,
                         TTrack const& negativeTrack,
-                        TTrackParametrization& positiveTrackParam, 
-                        TTrackParametrization& negativeTrackParam, 
+                        TTrackParametrization& positiveTrackParam,
+                        TTrackParametrization& negativeTrackParam,
                         bool useCollinearFit = false,
                         bool calculateCovariance = false)
   {
@@ -195,7 +195,7 @@ class strangenessBuilderHelper
     // do DCA to PV on copies instead of originals
     auto positiveTrackParamCopy = positiveTrackParam;
     auto negativeTrackParamCopy = negativeTrackParam;
-    
+
     o2::base::Propagator::Instance()->propagateToDCABxByBz({pvX, pvY, pvZ}, positiveTrackParamCopy, 2.f, fitter.getMatCorrType(), &dcaInfo);
     v0.positiveDCAxy = dcaInfo[0];
 
@@ -235,7 +235,7 @@ class strangenessBuilderHelper
       // avoids misuse if mixed with KF particle use
       v0.momentum[i] = v0.positiveMomentum[i] + v0.negativeMomentum[i];
     }
-    
+
     // get decay vertex coordinates
     const auto& vtx = fitter.getPCACandidate();
     for (int i = 0; i < 3; i++) {
@@ -315,17 +315,16 @@ class strangenessBuilderHelper
   }
 
   template <typename TCollision, typename TTrack, typename TTrackParametrization>
-  bool buildV0CandidateWithKF(TCollision const& collision, 
+  bool buildV0CandidateWithKF(TCollision const& collision,
                               TTrack const& positiveTrack,
                               TTrack const& negativeTrack,
-                              TTrackParametrization& positiveTrackParam, 
-                              TTrackParametrization& negativeTrackParam, 
-                              int kfConstructMethod = 2, // the typical used
+                              TTrackParametrization& positiveTrackParam,
+                              TTrackParametrization& negativeTrackParam,
+                              int kfConstructMethod = 2,           // the typical used
                               float kfConstrainedMassValue = 0.0f, // negative: no constraint
-                              bool kfConstrainToPrimaryVertex = true
-                              )
+                              bool kfConstrainToPrimaryVertex = true)
   {
-    int collisionIndex = collision.globalIndex(); 
+    int collisionIndex = collision.globalIndex();
     float pvX = collision.posX();
     float pvY = collision.posY();
     float pvZ = collision.posZ();
@@ -352,7 +351,7 @@ class strangenessBuilderHelper
     // do DCA to PV on copies instead of originals
     auto positiveTrackParamCopy = positiveTrackParam;
     auto negativeTrackParamCopy = negativeTrackParam;
-    
+
     o2::base::Propagator::Instance()->propagateToDCABxByBz({pvX, pvY, pvZ}, positiveTrackParamCopy, 2.f, fitter.getMatCorrType(), &dcaInfo);
     v0.positiveDCAxy = dcaInfo[0];
 
@@ -387,7 +386,7 @@ class strangenessBuilderHelper
       return false;
     }
 
-    if (kfConstrainedMassValue>-1e-4) { 
+    if (kfConstrainedMassValue > -1e-4) {
       // photon constraint: this one's got no mass
       KFV0.SetNonlinearMassConstraint(kfConstrainedMassValue);
     }
@@ -406,10 +405,9 @@ class strangenessBuilderHelper
     v0.negativeMomentum = {kfpNeg_DecayVtx.GetPx(), kfpNeg_DecayVtx.GetPy(), kfpNeg_DecayVtx.GetPz()};
 
     v0.daughterDCA = std::hypot(
-      kfpPos_DecayVtx.GetX()-kfpNeg_DecayVtx.GetX(),
-      kfpPos_DecayVtx.GetY()-kfpNeg_DecayVtx.GetY(),
-      kfpPos_DecayVtx.GetZ()-kfpNeg_DecayVtx.GetZ()
-      );
+      kfpPos_DecayVtx.GetX() - kfpNeg_DecayVtx.GetX(),
+      kfpPos_DecayVtx.GetY() - kfpNeg_DecayVtx.GetY(),
+      kfpPos_DecayVtx.GetZ() - kfpNeg_DecayVtx.GetZ());
 
     if (v0.daughterDCA > v0selections.dcav0dau) {
       return false;
@@ -434,14 +432,14 @@ class strangenessBuilderHelper
     v0.pointingAngle = TMath::ACos(cosPA);
 
     v0.dcaXY = CalculateDCAStraightToPV(
-    v0.position[0], v0.position[1], v0.position[2],
-    v0.momentum[0], v0.momentum[1], v0.momentum[2],
-    pvX, pvY, pvZ);
+      v0.position[0], v0.position[1], v0.position[2],
+      v0.momentum[0], v0.momentum[1], v0.momentum[2],
+      pvX, pvY, pvZ);
 
-    // apply topological constraint to PV if requested 
-    // might adjust px py pz 
+    // apply topological constraint to PV if requested
+    // might adjust px py pz
     KFParticle KFV0_PV = KFV0;
-    if(kfConstrainToPrimaryVertex){
+    if (kfConstrainToPrimaryVertex) {
       KFV0_PV.SetProductionVertex(KFPV);
     }
     v0.momentum = {KFV0_PV.GetPx(), KFV0_PV.GetPy(), KFV0_PV.GetPz()};

--- a/PWGLF/Utils/strangenessBuilderHelper.h
+++ b/PWGLF/Utils/strangenessBuilderHelper.h
@@ -21,6 +21,7 @@
 #include "DetectorsBase/GeometryManager.h"
 #include "CommonConstants/PhysicsConstants.h"
 #include "Common/Core/trackUtilities.h"
+#include "Tools/KFparticle/KFUtilities.h"
 
 #ifndef HomogeneousField
 #define HomogeneousField
@@ -56,6 +57,7 @@ struct v0candidate {
   float negativeDCAxy = 0.0f;
 
   // V0 properties
+  std::array<float, 3> momentum = {0.0f, 0.0f, 0.0f}; // necessary for KF
   std::array<float, 3> position = {0.0f, 0.0f, 0.0f};
   float daughterDCA = 1000.0f;
   float pointingAngle = 0.0f;
@@ -229,7 +231,11 @@ class strangenessBuilderHelper
     negativeTrackParam.getPxPyPzGlo(v0.negativeMomentum);
     positiveTrackParam.getXYZGlo(v0.positivePosition);
     negativeTrackParam.getXYZGlo(v0.negativePosition);
-
+    for (int i = 0; i < 3; i++) {
+      // avoids misuse if mixed with KF particle use
+      v0.momentum[i] = v0.positiveMomentum[i] + v0.negativeMomentum[i];
+    }
+    
     // get decay vertex coordinates
     const auto& vtx = fitter.getPCACandidate();
     for (int i = 0; i < 3; i++) {
@@ -303,6 +309,163 @@ class strangenessBuilderHelper
 
     // set collision Id correctly
     v0.collisionId = collisionIndex;
+
+    // information validated, V0 built successfully. Signal OK
+    return true;
+  }
+
+  template <typename TCollision, typename TTrack, typename TTrackParametrization>
+  bool buildV0CandidateWithKF(TCollision const& collision, 
+                              TTrack const& positiveTrack,
+                              TTrack const& negativeTrack,
+                              TTrackParametrization& positiveTrackParam, 
+                              TTrackParametrization& negativeTrackParam, 
+                              int kfConstructMethod = 2, // the typical used
+                              float kfConstrainedMassValue = 0.0f, // negative: no constraint
+                              bool kfConstrainToPrimaryVertex = true
+                              )
+  {
+    int collisionIndex = collision.globalIndex(); 
+    float pvX = collision.posX();
+    float pvY = collision.posY();
+    float pvZ = collision.posZ();
+
+    // verify track quality
+    if (positiveTrack.tpcNClsCrossedRows() < v0selections.minCrossedRows) {
+      return false;
+    }
+    if (negativeTrack.tpcNClsCrossedRows() < v0selections.minCrossedRows) {
+      return false;
+    }
+
+    // verify eta
+    if (std::fabs(positiveTrack.eta()) > v0selections.maxDaughterEta) {
+      return false;
+    }
+    if (std::fabs(negativeTrack.eta()) > v0selections.maxDaughterEta) {
+      return false;
+    }
+
+    // Calculate DCA with respect to the collision associated to the V0
+    gpu::gpustd::array<float, 2> dcaInfo;
+
+    // do DCA to PV on copies instead of originals
+    auto positiveTrackParamCopy = positiveTrackParam;
+    auto negativeTrackParamCopy = negativeTrackParam;
+    
+    o2::base::Propagator::Instance()->propagateToDCABxByBz({pvX, pvY, pvZ}, positiveTrackParamCopy, 2.f, fitter.getMatCorrType(), &dcaInfo);
+    v0.positiveDCAxy = dcaInfo[0];
+
+    if (std::fabs(v0.positiveDCAxy) < v0selections.dcanegtopv) {
+      return false;
+    }
+
+    o2::base::Propagator::Instance()->propagateToDCABxByBz({pvX, pvY, pvZ}, negativeTrackParamCopy, 2.f, fitter.getMatCorrType(), &dcaInfo);
+    v0.negativeDCAxy = dcaInfo[0];
+
+    if (std::fabs(v0.negativeDCAxy) < v0selections.dcanegtopv) {
+      return false;
+    }
+
+    //__________________________________________
+    //*>~<* do V0 with KF
+    // create KFParticle objects from trackParCovs
+    KFParticle kfpPos = createKFParticleFromTrackParCov(positiveTrackParam, positiveTrackParam.getCharge(), o2::constants::physics::MassElectron);
+    KFParticle kfpNeg = createKFParticleFromTrackParCov(negativeTrackParam, negativeTrackParam.getCharge(), o2::constants::physics::MassElectron);
+
+    KFParticle kfpPos_DecayVtx = kfpPos;
+    KFParticle kfpNeg_DecayVtx = kfpNeg;
+    const KFParticle* V0Daughters[2] = {&kfpPos, &kfpNeg};
+
+    // construct V0
+    KFParticle KFV0;
+    KFV0.SetConstructMethod(kfConstructMethod);
+    try {
+      KFV0.Construct(V0Daughters, 2);
+    } catch (std::runtime_error& e) {
+      LOG(debug) << "Failed to construct cascade V0 from daughter tracks: " << e.what();
+      return false;
+    }
+
+    if (kfConstrainedMassValue>-1e-4) { 
+      // photon constraint: this one's got no mass
+      KFV0.SetNonlinearMassConstraint(kfConstrainedMassValue);
+    }
+
+    // V0 constructed, now recovering TrackParCov for dca fitter minimization (with material correction)
+    KFV0.TransportToDecayVertex();
+    o2::track::TrackParCov v0TrackParCov = getTrackParCovFromKFP(KFV0, o2::track::PID::Lambda, 0);
+    v0TrackParCov.setAbsCharge(0); // to be sure
+
+    // estimate momentum of daughters (since KFParticle does not allow us to retrieve it directly...)
+    float xyz_decay[3] = {KFV0.GetX(), KFV0.GetY(), KFV0.GetZ()};
+    kfpPos_DecayVtx.TransportToPoint(xyz_decay);
+    kfpNeg_DecayVtx.TransportToPoint(xyz_decay);
+
+    v0.positiveMomentum = {kfpPos_DecayVtx.GetPx(), kfpPos_DecayVtx.GetPy(), kfpPos_DecayVtx.GetPz()};
+    v0.negativeMomentum = {kfpNeg_DecayVtx.GetPx(), kfpNeg_DecayVtx.GetPy(), kfpNeg_DecayVtx.GetPz()};
+
+    v0.daughterDCA = std::hypot(
+      kfpPos_DecayVtx.GetX()-kfpNeg_DecayVtx.GetX(),
+      kfpPos_DecayVtx.GetY()-kfpNeg_DecayVtx.GetY(),
+      kfpPos_DecayVtx.GetZ()-kfpNeg_DecayVtx.GetZ()
+      );
+
+    if (v0.daughterDCA > v0selections.dcav0dau) {
+      return false;
+    }
+
+    // check radius
+    for (int i = 0; i < 3; i++) {
+      v0.position[i] = xyz_decay[i];
+    }
+    if (std::hypot(v0.position[0], v0.position[1]) < v0selections.v0radius) {
+      return false;
+    }
+
+    KFPVertex kfpVertex = createKFPVertexFromCollision(collision);
+    KFParticle KFPV(kfpVertex);
+
+    // deal with pointing angle
+    float cosPA = cpaFromKF(KFV0, KFPV);
+    if (cosPA < v0selections.v0cospa) {
+      return false;
+    }
+    v0.pointingAngle = TMath::ACos(cosPA);
+
+    v0.dcaXY = CalculateDCAStraightToPV(
+    v0.position[0], v0.position[1], v0.position[2],
+    v0.momentum[0], v0.momentum[1], v0.momentum[2],
+    pvX, pvY, pvZ);
+
+    // apply topological constraint to PV if requested 
+    // might adjust px py pz 
+    KFParticle KFV0_PV = KFV0;
+    if(kfConstrainToPrimaryVertex){
+      KFV0_PV.SetProductionVertex(KFPV);
+    }
+    v0.momentum = {KFV0_PV.GetPx(), KFV0_PV.GetPy(), KFV0_PV.GetPz()};
+
+    // set collision Id correctly
+    v0.collisionId = collisionIndex;
+
+    // Calculate masses
+    v0.massGamma = RecoDecay::m(std::array{
+                                  std::array{v0.positiveMomentum[0], v0.positiveMomentum[1], v0.positiveMomentum[2]},
+                                  std::array{v0.negativeMomentum[0], v0.negativeMomentum[1], v0.negativeMomentum[2]}},
+                                std::array{o2::constants::physics::MassElectron, o2::constants::physics::MassElectron});
+    v0.massK0Short = RecoDecay::m(std::array{
+                                    std::array{v0.positiveMomentum[0], v0.positiveMomentum[1], v0.positiveMomentum[2]},
+                                    std::array{v0.negativeMomentum[0], v0.negativeMomentum[1], v0.negativeMomentum[2]}},
+                                  std::array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassPionCharged});
+    v0.massLambda = RecoDecay::m(std::array{
+                                   std::array{v0.positiveMomentum[0], v0.positiveMomentum[1], v0.positiveMomentum[2]},
+                                   std::array{v0.negativeMomentum[0], v0.negativeMomentum[1], v0.negativeMomentum[2]}},
+                                 std::array{o2::constants::physics::MassProton, o2::constants::physics::MassPionCharged});
+    v0.massAntiLambda = RecoDecay::m(std::array{
+                                       std::array{v0.positiveMomentum[0], v0.positiveMomentum[1], v0.positiveMomentum[2]},
+                                       std::array{v0.negativeMomentum[0], v0.negativeMomentum[1], v0.negativeMomentum[2]}},
+                                     std::array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassProton});
 
     // information validated, V0 built successfully. Signal OK
     return true;
@@ -933,70 +1096,6 @@ class strangenessBuilderHelper
 
     // Potentially also to be considered: bachelor-baryon DCA (between the two tracks)
     // to be added here as complementary information in the future
-  }
-
-  // TrackParCov to KF converter
-  // FIXME: could be an utility somewhere else
-  // from Carolina Reetz (thank you!)
-  template <typename T>
-  KFParticle createKFParticleFromTrackParCov(const o2::track::TrackParametrizationWithError<T>& trackparCov, int charge, float mass)
-  {
-    std::array<T, 3> xyz, pxpypz;
-    float xyzpxpypz[6];
-    trackparCov.getPxPyPzGlo(pxpypz);
-    trackparCov.getXYZGlo(xyz);
-    for (int i{0}; i < 3; ++i) {
-      xyzpxpypz[i] = xyz[i];
-      xyzpxpypz[i + 3] = pxpypz[i];
-    }
-
-    std::array<float, 21> cv;
-    try {
-      trackparCov.getCovXYZPxPyPzGlo(cv);
-    } catch (std::runtime_error& e) {
-      LOG(debug) << "Failed to get cov matrix from TrackParCov" << e.what();
-    }
-
-    KFParticle kfPart;
-    float Mini, SigmaMini, M, SigmaM;
-    kfPart.GetMass(Mini, SigmaMini);
-    LOG(debug) << "Daughter KFParticle mass before creation: " << Mini << " +- " << SigmaMini;
-
-    try {
-      kfPart.Create(xyzpxpypz, cv.data(), charge, mass);
-    } catch (std::runtime_error& e) {
-      LOG(debug) << "Failed to create KFParticle from daughter TrackParCov" << e.what();
-    }
-
-    kfPart.GetMass(M, SigmaM);
-    LOG(debug) << "Daughter KFParticle mass after creation: " << M << " +- " << SigmaM;
-    return kfPart;
-  }
-
-  // KF to TrackParCov converter
-  // FIXME: could be an utility somewhere else
-  // from Carolina Reetz (thank you!)
-  o2::track::TrackParCov getTrackParCovFromKFP(const KFParticle& kfParticle, const o2::track::PID pid, const int sign)
-  {
-    o2::gpu::gpustd::array<float, 3> xyz, pxpypz;
-    o2::gpu::gpustd::array<float, 21> cv;
-
-    // get parameters from kfParticle
-    xyz[0] = kfParticle.GetX();
-    xyz[1] = kfParticle.GetY();
-    xyz[2] = kfParticle.GetZ();
-    pxpypz[0] = kfParticle.GetPx();
-    pxpypz[1] = kfParticle.GetPy();
-    pxpypz[2] = kfParticle.GetPz();
-
-    // set covariance matrix elements (lower triangle)
-    for (int i = 0; i < 21; i++) {
-      cv[i] = kfParticle.GetCovariance(i);
-    }
-
-    // create TrackParCov track
-    o2::track::TrackParCov track = o2::track::TrackParCov(xyz, pxpypz, cv, sign, true, pid);
-    return track;
   }
 };
 


### PR DESCRIPTION
This PR: 

* adds an option `moveTPCOnlyTracks` to the strangenessBuilder whenever dealing with PCM candidates (using the TPC drift manager from @f3sch - thanks!) 
* moves all KF helper calls to the KFUtilities by @creetz16 - thanks a lot for modularizing! 
* adds a `buildV0CandidateWithKF` helper to the `strangenessBuilderHelper` for direct studies of DCAFitter with collinear option versus KFParticle fits. The `buildV0CandidateWithKF` has relevant options to be tested - mainly mass constraint and PV constraint. Similarly to what is done with the KF fit to cascades, a pre-minimization step with material corrections could also be added (since KFParticle fits do not consider material LUTs and such). 

@gianniliveraro pending some cross-checks from your side, this could go I guess... thanks! 