### PR TITLE
[Common] Always initialize listCalib as it is serialized unconditionally

### DIFF
--- a/Common/TableProducer/centralityTable.cxx
+++ b/Common/TableProducer/centralityTable.cxx
@@ -238,6 +238,7 @@ struct CentralityTable {
     ccdb->setLocalObjectValidityChecking();
     ccdb->setFatalWhenNull(false);
     mRunNumber = 0;
+    listCalib.setObject(new TList);
     if (!produceHistograms.value) {
       return;
     }
@@ -259,7 +260,6 @@ struct CentralityTable {
     histos.addClone("FT0A/", "sel8FT0A/");
 
     histos.print();
-    listCalib.setObject(new TList);
   }
 
   using BCsWithTimestampsAndRun2Infos = soa::Join<aod::BCs, aod::Run2BCInfos, aod::Timestamps>;

--- a/Common/TableProducer/multiplicityTable.cxx
+++ b/Common/TableProducer/multiplicityTable.cxx
@@ -227,6 +227,7 @@ struct MultiplicityTable {
     ccdb->setLocalObjectValidityChecking();
     ccdb->setFatalWhenNull(false); // don't fatal, please - exception is caught explicitly (as it should)
 
+    listCalib.setObject(new TList);
     if (!produceHistograms.value) {
       return;
     }
@@ -234,8 +235,6 @@ struct MultiplicityTable {
     histos.add("FT0C", "FT0C vs FT0C eq.", HistType::kTH2D, {{1000, 0, 1000, "FT0C multiplicity"}, {1000, 0, 1000, "FT0C multiplicity eq."}});
     histos.add("FT0CMultvsPV", "FT0C vs mult.", HistType::kTH2D, {{1000, 0, 1000, "FT0C mult."}, {100, 0, 100, "PV mult."}});
     histos.add("FT0AMultvsPV", "FT0A vs mult.", HistType::kTH2D, {{1000, 0, 1000, "FT0A mult."}, {100, 0, 100, "PV mult."}});
-
-    listCalib.setObject(new TList);
   }
 
   /// Dummy process function for BCs, needed in case both Run2 and Run3 process functions are disabled


### PR DESCRIPTION
This fixes 
```
 Cannot read class info from buffer of ATSK/12c99cc07f5f____/0
 Cannot read class info from buffer of ATSK/12c99cc0863a____/0
 ```
errors that are the result of a `nullptr` being serialized. Now the empty list is always created, even if `produceHistograms` is `false`. I will add protection for `OutputObj` in a separate PR so we can avoid further issues like this. 

@njacazio @ktf @mhemmer-cern 