### PR TITLE
Fix -Wmissing-template-arg-list-after-template-kw

### DIFF
--- a/PWGEM/Dilepton/Core/Dilepton.h
+++ b/PWGEM/Dilepton/Core/Dilepton.h
@@ -817,11 +817,11 @@ struct Dilepton {
     }
 
     if constexpr (pairtype == o2::aod::pwgem::dilepton::utils::pairutil::DileptonPairType::kDielectron) {
-      if (!cut.template IsSelectedPair(t1, t2, d_bz)) {
+      if (!cut.IsSelectedPair(t1, t2, d_bz)) {
         return false;
       }
     } else if constexpr (pairtype == o2::aod::pwgem::dilepton::utils::pairutil::DileptonPairType::kDimuon) {
-      if (!cut.template IsSelectedPair(t1, t2)) {
+      if (!cut.IsSelectedPair(t1, t2)) {
         return false;
       }
     }
@@ -1329,17 +1329,17 @@ struct Dilepton {
         }
       }
     } else if constexpr (pairtype == o2::aod::pwgem::dilepton::utils::pairutil::DileptonPairType::kDimuon) {
-      if (!cut.template IsSelectedTrack(t1) || !cut.template IsSelectedTrack(t2)) {
+      if (!cut.IsSelectedTrack(t1) || !cut.IsSelectedTrack(t2)) {
         return false;
       }
     }
 
     if constexpr (pairtype == o2::aod::pwgem::dilepton::utils::pairutil::DileptonPairType::kDielectron) {
-      if (!cut.template IsSelectedPair(t1, t2, d_bz)) {
+      if (!cut.IsSelectedPair(t1, t2, d_bz)) {
         return false;
       }
     } else if constexpr (pairtype == o2::aod::pwgem::dilepton::utils::pairutil::DileptonPairType::kDimuon) {
-      if (!cut.template IsSelectedPair(t1, t2)) {
+      if (!cut.IsSelectedPair(t1, t2)) {
         return false;
       }
     }

--- a/PWGEM/Dilepton/Core/DileptonMC.h
+++ b/PWGEM/Dilepton/Core/DileptonMC.h
@@ -782,14 +782,14 @@ struct DileptonMC {
           return false;
         }
       }
-      if (!cut.template IsSelectedPair(t1, t2, d_bz)) {
+      if (!cut.IsSelectedPair(t1, t2, d_bz)) {
         return false;
       }
     } else if constexpr (pairtype == o2::aod::pwgem::dilepton::utils::pairutil::DileptonPairType::kDimuon) {
       if (!cut.template IsSelectedTrack<false>(t1) || !cut.template IsSelectedTrack<false>(t2)) {
         return false;
       }
-      if (!cut.template IsSelectedPair(t1, t2)) {
+      if (!cut.IsSelectedPair(t1, t2)) {
         return false;
       }
     }

--- a/PWGEM/PhotonMeson/Core/Pi0EtaToGammaGammaMC.h
+++ b/PWGEM/PhotonMeson/Core/Pi0EtaToGammaGammaMC.h
@@ -563,7 +563,7 @@ struct Pi0EtaToGammaGammaMC {
               continue;
             }
 
-            if (!cut2.template IsSelectedPair(pos2, ele2, d_bz)) {
+            if (!cut2.IsSelectedPair(pos2, ele2, d_bz)) {
               continue;
             }
 

--- a/PWGEM/PhotonMeson/Core/TaggingPi0MC.h
+++ b/PWGEM/PhotonMeson/Core/TaggingPi0MC.h
@@ -511,7 +511,7 @@ struct TaggingPi0MC {
               continue;
             }
 
-            if (!cut2.template IsSelectedPair(pos2, ele2, d_bz)) {
+            if (!cut2.IsSelectedPair(pos2, ele2, d_bz)) {
               continue;
             }
 


### PR DESCRIPTION
I suspect that this might break the CI, as I don't think people put template keywords around out of whimsical creativity. But either this works, or we will have to disable that warning from the list of -Wall