### PR TITLE
[PWGHF] Patches for first Xic autoencoder study

### DIFF
--- a/PWGHF/Core/HfAeToMseXicToPKPi.h
+++ b/PWGHF/Core/HfAeToMseXicToPKPi.h
@@ -21,93 +21,97 @@
 #include "PWGHF/Core/HfMlResponse.h"
 namespace o2::analysis
 {
-	template <typename TypeOutputScore = float>
-	class HfAeToMseXicToPKPi : public HfMlResponse<TypeOutputScore>
-	{
-		public:
-		/// Default constructor
-		HfAeToMseXicToPKPi() = default;
-		/// Default destructor
-		virtual ~HfAeToMseXicToPKPi() = default;
-		
-		std::vector<float> yScaled, yOutRescaled;
-		//private :
-		void setMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
-		{	yOut.clear();//initial clear to avoid multiple filling if setMinMax o setScaling are called more than once				
-			for (size_t j = 0; j < yIn.size(); ++j)
-			{ //for over the features 
-					//MinMax scaling of the input features
-					LOG(debug)<<"--------------> MinMax scaling Debug \t"<<scaleMin.at(j)<<"\t"<<scaleMax.at(j);
-					yOut.push_back((yIn.at(j) - scaleMin.at(j))/(scaleMax.at(j)- scaleMin.at(j)));
-					LOG(debug)<<"Feature = "<<j<<" ----> input = "<<yIn.at(j)<<" scaled feature = "<< yOut.at(j); 					
-			}
-		}	  		
-  		//----  External preprocessing scaling
-  		void setScaling(bool scaleFlag, int scaleType, /*input features of a candidate*/ std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax){ //it takes the bool flag and scaling parameters configurables in taskXic
-  			yScaled.clear();
-  		  	if( scaleFlag == false){ LOG(debug)<<"No external preprocessing transformation will be applied"; 
-  		  		yScaled.assign(yIn.begin(), yIn.end());
-  		  	} else{
-				  		if(scaleType == 1){
-				  			LOG(debug)<<"MinMax scaling will be applied"; 
-				  			setMinMaxScaling(yScaled, yIn, scaleMin, scaleMax);
-				  		}//... with scaleType > 1 we could add other preprocessing trasformations	  	
-  		  	}
-  		}
-  		std::vector<float> getPreprocessedFeatures(){ 
-  		  for (size_t j = 0; j < yScaled.size(); ++j) LOG(debug)<<"Global scaled feature = "<< yScaled.at(j); 
-  			return  yScaled; 			
-  		}
-  		//Reverse preprocessing - output postprocessing
-  		void unsetMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
-		{	yOut.clear();//initial clear to avoid multiple filling if setMinMax o setScaling are called more than once				
-			for (size_t j = 0; j < yIn.size(); ++j)
-			{ //for over the features 
-					//MinMax scaling of the input features
-					LOG(debug)<<"--------------> MinMax unscaling Debug \t"<<scaleMin.at(j)<<"\t"<<scaleMax.at(j);
-					yOut.push_back(yIn.at(j)*(scaleMax.at(j)- scaleMin.at(j))+ scaleMin.at(j));
-					LOG(debug)<<"Unscaling output = "<<j<<" ----> input = "<<yIn.at(j)<<" rescaled output = "<< yOut.at(j); 					
-			}
-		}	  		
+   template <typename TypeOutputScore = float>
+   class HfAeToMseXicToPKPi : public HfMlResponse<TypeOutputScore>
+   {
+     public:
+     /// Default constructor
+     HfAeToMseXicToPKPi() = default;
+     /// Default destructor
+     virtual ~HfAeToMseXicToPKPi() = default;
 
-		void unsetScaling(bool scaleFlag, int scaleType, /*AE output*/ std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax){ //it takes the bool flag and scaling parameters configurables in taskXic
-  			yOutRescaled.clear();
-  		  	if( scaleFlag == false){ LOG(debug)<<"No external preprocessing transformation will be applied"; 
-  		  		yOutRescaled.assign(yIn.begin(), yIn.end());
-  		  	} else{
-				  		if(scaleType == 1){
-				  			LOG(debug)<<"MinMax unscaling will be applied"; 
-				  			unsetMinMaxScaling(yOutRescaled, yIn, scaleMin, scaleMax);
-				  		}//... with scaleType > 1 we could add other preprocessing trasformations	  	
-  		  	}
-  		}
-  		std::vector<float> getPostprocessedOutput(){ 
-  		  for (size_t j = 0; j < yOutRescaled.size(); ++j) LOG(debug)<<"Global rescaled AE output = "<< yOutRescaled.at(j); 
-  			return  yOutRescaled; 			
-  		}		
-		//---- MSE function
-		float getMse(std::vector<float> yTrue, std::vector<float> yPred){
-				  LOG(debug)<<"Inside getMse sizes "<<yTrue.size()<<"\t"<<yPred.size();
-				  float mse= 0.0f;
-				  float sum = 0.0f;    
-				  for (size_t j = 0; j < yTrue.size(); ++j) LOG(debug)<<"Local Feature = "<<j<<" ----> input = "<<yTrue.at(j)<<" scaled feature = "<< yPred.at(j);
-				  std::vector<float> yTrueScaled = getPreprocessedFeatures();
-				  if( yTrue.size() != yPred.size()){  
-				  	LOG(debug)<< "size of input vector ="<<yTrue.size();
-				  	LOG(debug)<< "size of AE output vector ="<< yPred.size();
-				  	LOG(fatal) << "vectors of input and predictions don't have the same size";    	
-				  }
-				  else{//MSE    
-						for (size_t j = 0; j < yPred.size(); ++j) { //for over the features 
-								sum += std::pow(((yTrueScaled).at(j) - (yPred).at(j)), 2); //has dimensions
-								LOG(debug)<<"getMse Local feature = "<<j<<" ----> input = "<<yTrueScaled.at(j)<<" AE prediction = "<< yPred.at(j);           
-						}
-						mse = sum/yPred.size(); //MSE of a candidate 
-						LOG(debug)<<"Local mse "<<mse;
-				  }
-				  return mse;
-			}
-	}; //end of the class 
+     std::vector<float> yScaled, yOutRescaled;
+     //private :
+     void setMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
+     { yOut.clear(); // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once				
+       for (size_t j = 0; j < yIn.size(); ++j)
+       { // loop for over the features 
+         // MinMax scaling of the input features
+         LOG(debug)<<"--------------> MinMax scaling Debug \t"<<scaleMin.at(j)<<"\t"<<scaleMax.at(j);
+         yOut.push_back((yIn.at(j) - scaleMin.at(j))/(scaleMax.at(j)- scaleMin.at(j)));
+         LOG(debug)<<"Feature = "<<j<<" ----> input = "<<yIn.at(j)<<" scaled feature = "<< yOut.at(j); 		
+       }
+     }	  		
+     // ---- External preprocessing scaling
+     void setScaling(bool scaleFlag, int scaleType, /* input features of a candidate */ std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
+     { // it takes the bool flag and scaling parameters configurables in taskXic
+       yScaled.clear();
+       if( scaleFlag == false){ 
+         LOG(debug)<<"No external preprocessing transformation will be applied"; 
+         yScaled.assign(yIn.begin(), yIn.end());
+       } else{
+           if(scaleType == 1){
+             LOG(debug)<<"MinMax scaling will be applied"; 
+             setMinMaxScaling(yScaled, yIn, scaleMin, scaleMax);
+           } // ... with scaleType > 1 we could add other preprocessing trasformations	  	
+       }
+     }
+     std::vector<float> getPreprocessedFeatures(){ 
+       for (size_t j = 0; j < yScaled.size(); ++j) LOG(debug)<<"Global scaled feature = "<< yScaled.at(j); 
+         return  yScaled; 			
+     }
+     // Reverse preprocessing - output postprocessing
+     void unsetMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
+     { yOut.clear(); // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once				
+       for (size_t j = 0; j < yIn.size(); ++j)
+       { // loop for over the features 
+         // MinMax scaling of the input features
+         LOG(debug)<<"--------------> MinMax unscaling Debug \t"<<scaleMin.at(j)<<"\t"<<scaleMax.at(j);
+         yOut.push_back(yIn.at(j)*(scaleMax.at(j)- scaleMin.at(j))+ scaleMin.at(j));
+         LOG(debug)<<"Unscaling output = "<<j<<" ----> input = "<<yIn.at(j)<<" rescaled output = "<< yOut.at(j); 					
+       }
+     }	  		
+
+     void unsetScaling(bool scaleFlag, int scaleType, /*AE output*/ std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
+     { // it takes the bool flag and scaling parameters configurables in taskXic
+       yOutRescaled.clear();
+       if( scaleFlag == false){ 
+         LOG(debug)<<"No external preprocessing transformation will be applied"; 
+         yOutRescaled.assign(yIn.begin(), yIn.end());
+       } else{
+           if(scaleType == 1){
+             LOG(debug)<<"MinMax unscaling will be applied"; 
+             unsetMinMaxScaling(yOutRescaled, yIn, scaleMin, scaleMax);
+           }//... with scaleType > 1 we could add other preprocessing trasformations	  	
+       }
+     }
+     
+     std::vector<float> getPostprocessedOutput(){ 
+       for (size_t j = 0; j < yOutRescaled.size(); ++j) LOG(debug)<<"Global rescaled AE output = "<< yOutRescaled.at(j); 
+         return  yOutRescaled; 			
+     }		
+     //---- MSE function
+     float getMse(std::vector<float> yTrue, std::vector<float> yPred){
+       LOG(debug)<<"Inside getMse sizes "<<yTrue.size()<<"\t"<<yPred.size();
+       float mse= 0.0f;
+       float sum = 0.0f;    
+       for (size_t j = 0; j < yTrue.size(); ++j) LOG(debug)<<"Local Feature = "<<j<<" ----> input = "<<yTrue.at(j)<<" scaled feature = "<< yPred.at(j);
+       std::vector<float> yTrueScaled = getPreprocessedFeatures(); // to make the input features adimensional
+       if( yTrue.size() != yPred.size()){  
+         LOG(debug)<< "size of input vector ="<<yTrue.size();
+         LOG(debug)<< "size of AE output vector ="<< yPred.size();
+         LOG(fatal) << "vectors of input and predictions don't have the same size";    	
+       } else{ //MSE    
+           for (size_t j = 0; j < yPred.size(); ++j) { 
+             sum += std::pow(((yTrueScaled).at(j) - (yPred).at(j)), 2); //AE model gives adimensional predictions by design choice
+             LOG(debug)<<"getMse Local feature = "<<j<<" ----> input = "<<yTrueScaled.at(j)<<" AE prediction = "<< yPred.at(j);           
+           }
+           mse = sum/yPred.size(); // MSE of a candidate 
+           LOG(debug)<<"Local mse "<<mse;
+       }
+       return mse;
+     }
+   }; // end of the class 
 	
 
 } // namespace o2::analysis

--- a/PWGHF/Core/HfAeToMseXicToPKPi.h
+++ b/PWGHF/Core/HfAeToMseXicToPKPi.h
@@ -24,21 +24,21 @@ namespace o2::analysis
 template <typename TypeOutputScore = float>
 class HfAeToMseXicToPKPi : public HfMlResponse<TypeOutputScore>
 {
-public:
+ public:
   /// Default constructor
   HfAeToMseXicToPKPi() = default;
   /// Default destructor
   virtual ~HfAeToMseXicToPKPi() = default;
 
   std::vector<float> yScaled, yOutRescaled;
-  //private :
+
   void setMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
-  {  
+  {
     yOut.clear();                            // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once
     for (size_t j = 0; j < yIn.size(); ++j){ // loop for over the features
       // MinMax scaling of the input features
       LOG(debug) << "--------------> MinMax scaling Debug \t" << scaleMin.at(j) << "\t" << scaleMax.at(j);
-      yOut.push_back((yIn.at(j) - scaleMin.at(j))/(scaleMax.at(j)- scaleMin.at(j)));
+      yOut.push_back((yIn.at(j) - scaleMin.at(j)) / (scaleMax.at(j)- scaleMin.at(j)));
       LOG(debug) << "Feature = " << j << " ----> input = " << yIn.at(j) << " scaled feature = " << yOut.at(j);
     }
   }
@@ -50,76 +50,76 @@ public:
       LOG(debug) << "No external preprocessing transformation will be applied";
       yScaled.assign(yIn.begin(), yIn.end());
     } else {
-      if (scaleType == 1) {
-        LOG(debug) << "MinMax scaling will be applied";
-        setMinMaxScaling(yScaled, yIn, scaleMin, scaleMax);
+        if (scaleType == 1) {
+          LOG(debug) << "MinMax scaling will be applied";
+          setMinMaxScaling(yScaled, yIn, scaleMin, scaleMax);
         } // ... with scaleType > 1 we could add other preprocessing trasformations
       }
-    }
-    std::vector<float> getPreprocessedFeatures()
-    {
-      for (size_t j = 0; j < yScaled.size(); ++j)
-        LOG(debug) << "Global scaled feature = " << yScaled.at(j);
-      return  yScaled;
-    }
-    // Reverse preprocessing - output postprocessing
-    void unsetMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
-    { 
-      yOut.clear();                            // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once
-      for (size_t j = 0; j < yIn.size(); ++j){ // loop for over the features
-         // MinMax scaling of the input features
-         LOG(debug) << "--------------> MinMax unscaling Debug \t" << scaleMin.at(j) << "\t" << scaleMax.at(j);
-         yOut.push_back(yIn.at(j)*(scaleMax.at(j)- scaleMin.at(j))+ scaleMin.at(j));
-         LOG(debug) << "Unscaling output = " << j << " ----> input = " << yIn.at(j) << " rescaled output = " << yOut.at(j);
-       }
+  }
+  std::vector<float> getPreprocessedFeatures()
+  {
+    for (size_t j = 0; j < yScaled.size(); ++j)
+      LOG(debug) << "Global scaled feature = " << yScaled.at(j);
+    return  yScaled;
+  }
+  // Reverse preprocessing - output postprocessing
+  void unsetMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
+  {
+    yOut.clear();                            // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once
+    for (size_t j = 0; j < yIn.size(); ++j){ // loop for over the features
+       // MinMax scaling of the input features
+       LOG(debug) << "--------------> MinMax unscaling Debug \t" << scaleMin.at(j) << "\t" << scaleMax.at(j);
+       yOut.push_back(yIn.at(j)*(scaleMax.at(j)- scaleMin.at(j))+ scaleMin.at(j));
+       LOG(debug) << "Unscaling output = " << j << " ----> input = " << yIn.at(j) << " rescaled output = " << yOut.at(j);
      }
+   }
 
-     void unsetScaling(bool scaleFlag, int scaleType, /*AE output*/ std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
-     { // it takes the bool flag and scaling parameters configurables in taskXic
-       yOutRescaled.clear();
-       if (scaleFlag == false) {
-         LOG(debug) << "No external preprocessing transformation will be applied";
-         yOutRescaled.assign(yIn.begin(), yIn.end());
-       } else {
+   void unsetScaling(bool scaleFlag, int scaleType, /*AE output*/ std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
+   { // it takes the bool flag and scaling parameters configurables in taskXic
+     yOutRescaled.clear();
+     if (scaleFlag == false) {
+       LOG(debug) << "No external preprocessing transformation will be applied";
+       yOutRescaled.assign(yIn.begin(), yIn.end());
+     } else {
          if (scaleType == 1) {
             LOG(debug) << "MinMax unscaling will be applied";
             unsetMinMaxScaling(yOutRescaled, yIn, scaleMin, scaleMax);
          }  //... with scaleType > 1 we could add other preprocessing trasformations
        }
-     }
+   }
 
-     std::vector<float> getPostprocessedOutput()
+   std::vector<float> getPostprocessedOutput()
+   {
+     for (size_t j = 0; j < yOutRescaled.size(); ++j)
+       LOG(debug)<<"Global rescaled AE output = "<< yOutRescaled.at(j);
+     return yOutRescaled;
+   }
+   //---- MSE function
+   float getMse(std::vector<float> yTrue, std::vector<float> yPred)
+   {
+     LOG(debug) << "Inside getMse sizes " << yTrue.size() << "\t" << yPred.size();
+     float mse= 0.0f;
+     float sum = 0.0f;
+     for (size_t j = 0; j < yTrue.size(); ++j)
+       LOG(debug) << "Local Feature = " << j << " ----> input = " << yTrue.at(j) << " scaled feature = " << yPred.at(j);
+     std::vector<float> yTrueScaled = getPreprocessedFeatures(); // to make the input features adimensional
+     if (yTrue.size() != yPred.size())
      {
-       for (size_t j = 0; j < yOutRescaled.size(); ++j) 
-         LOG(debug)<<"Global rescaled AE output = "<< yOutRescaled.at(j);
-       return yOutRescaled;
+       LOG(debug) << "size of input vector =" << yTrue.size();
+       LOG(debug) << "size of AE output vector =" << yPred.size();
+       LOG(fatal) << "vectors of input and predictions don't have the same size";
      }
-     //---- MSE function
-     float getMse(std::vector<float> yTrue, std::vector<float> yPred)
-     {
-       LOG(debug) << "Inside getMse sizes " << yTrue.size() << "\t" << yPred.size();
-       float mse= 0.0f;
-       float sum = 0.0f;
-       for (size_t j = 0; j < yTrue.size(); ++j) 
-         LOG(debug) << "Local Feature = " << j << " ----> input = " << yTrue.at(j) << " scaled feature = " << yPred.at(j);
-       std::vector<float> yTrueScaled = getPreprocessedFeatures(); // to make the input features adimensional
-       if (yTrue.size() != yPred.size())
-       {
-         LOG(debug) << "size of input vector =" << yTrue.size();
-         LOG(debug) << "size of AE output vector =" << yPred.size();
-         LOG(fatal) << "vectors of input and predictions don't have the same size";
-       } 
-       else 
-       { //MSE
-         for (size_t j = 0; j < yPred.size(); ++j) {
-           sum += std::pow(((yTrueScaled).at(j) - (yPred).at(j)), 2); //AE model gives adimensional predictions by design choice
-           LOG(debug) << "getMse Local feature = " << j << " ----> input = " << yTrueScaled.at(j) << " AE prediction = " << yPred.at(j);
-         }
-         mse = sum/yPred.size(); // MSE of a candidate
-         LOG(debug) << "Local mse " << mse;
+     else
+     { //MSE
+       for (size_t j = 0; j < yPred.size(); ++j) {
+         sum += std::pow(((yTrueScaled).at(j) - (yPred).at(j)), 2); //AE model gives adimensional predictions by design choice
+         LOG(debug) << "getMse Local feature = " << j << " ----> input = " << yTrueScaled.at(j) << " AE prediction = " << yPred.at(j);
        }
-       return mse;
+       mse = sum/yPred.size(); // MSE of a candidate
+       LOG(debug) << "Local mse " << mse;
      }
+     return mse;
+   }
 }; // end of the class
 
 } // namespace o2::analysis

--- a/PWGHF/Core/HfAeToMseXicToPKPi.h
+++ b/PWGHF/Core/HfAeToMseXicToPKPi.h
@@ -16,59 +16,61 @@
 #ifndef PWGHF_CORE_HFAETOMSEXICTOPKPI_H_
 #define PWGHF_CORE_HFAETOMSEXICTOPKPI_H_
 
-#include <vector>
-
 #include "PWGHF/Core/HfMlResponse.h"
+
+#include <vector>
 namespace o2::analysis
 {
-   template <typename TypeOutputScore = float>
-   class HfAeToMseXicToPKPi : public HfMlResponse<TypeOutputScore>
-   {
-     public:
-     /// Default constructor
-     HfAeToMseXicToPKPi() = default;
-     /// Default destructor
-     virtual ~HfAeToMseXicToPKPi() = default;
+template <typename TypeOutputScore = float>
+class HfAeToMseXicToPKPi : public HfMlResponse<TypeOutputScore>
+{
+public:
+  /// Default constructor
+  HfAeToMseXicToPKPi() = default;
+  /// Default destructor
+  virtual ~HfAeToMseXicToPKPi() = default;
 
-     std::vector<float> yScaled, yOutRescaled;
-     //private :
-     void setMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
-     {  yOut.clear(); // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once
-        for (size_t j = 0; j < yIn.size(); ++j)
-        { // loop for over the features
-          // MinMax scaling of the input features
-          LOG(debug)<<"--------------> MinMax scaling Debug \t"<<scaleMin.at(j)<<"\t"<<scaleMax.at(j);
-          yOut.push_back((yIn.at(j) - scaleMin.at(j))/(scaleMax.at(j)- scaleMin.at(j)));
-          LOG(debug)<<"Feature = "<<j<<" ----> input = "<<yIn.at(j)<<" scaled feature = "<< yOut.at(j);
-        }
-     }
-     // ---- External preprocessing scaling
-     void setScaling(bool scaleFlag, int scaleType, /* input features of a candidate */ std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
-     { // it takes the bool flag and scaling parameters configurables in taskXic
-       yScaled.clear();
-       if (scaleFlag == false) {
-         LOG(debug)<<"No external preprocessing transformation will be applied";
-         yScaled.assign(yIn.begin(), yIn.end());
-       } else {
-           if (scaleType == 1) {
-             LOG(debug)<<"MinMax scaling will be applied";
-             setMinMaxScaling(yScaled, yIn, scaleMin, scaleMax);
-           } // ... with scaleType > 1 we could add other preprocessing trasformations
-         }
-     }
-     std::vector<float> getPreprocessedFeatures(){
-     for (size_t j = 0; j < yScaled.size(); ++j) LOG(debug)<<"Global scaled feature = "<< yScaled.at(j);
-       return  yScaled;
-     }
-     // Reverse preprocessing - output postprocessing
-     void unsetMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
-     { yOut.clear(); // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once
-       for (size_t j = 0; j < yIn.size(); ++j)
-       { // loop for over the features
+  std::vector<float> yScaled, yOutRescaled;
+  //private :
+  void setMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
+  {  
+    yOut.clear();                            // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once
+    for (size_t j = 0; j < yIn.size(); ++j){ // loop for over the features
+      // MinMax scaling of the input features
+      LOG(debug) << "--------------> MinMax scaling Debug \t" << scaleMin.at(j) << "\t" << scaleMax.at(j);
+      yOut.push_back((yIn.at(j) - scaleMin.at(j))/(scaleMax.at(j)- scaleMin.at(j)));
+      LOG(debug) << "Feature = " << j << " ----> input = " << yIn.at(j) << " scaled feature = " << yOut.at(j);
+    }
+  }
+  // ---- External preprocessing scaling
+  void setScaling(bool scaleFlag, int scaleType, /* input features of a candidate */ std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
+  { // it takes the bool flag and scaling parameters configurables in taskXic
+    yScaled.clear();
+    if (scaleFlag == false) {
+      LOG(debug) << "No external preprocessing transformation will be applied";
+      yScaled.assign(yIn.begin(), yIn.end());
+    } else {
+      if (scaleType == 1) {
+        LOG(debug) << "MinMax scaling will be applied";
+        setMinMaxScaling(yScaled, yIn, scaleMin, scaleMax);
+        } // ... with scaleType > 1 we could add other preprocessing trasformations
+      }
+    }
+    std::vector<float> getPreprocessedFeatures()
+    {
+      for (size_t j = 0; j < yScaled.size(); ++j)
+        LOG(debug) << "Global scaled feature = " << yScaled.at(j);
+      return  yScaled;
+    }
+    // Reverse preprocessing - output postprocessing
+    void unsetMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
+    { 
+      yOut.clear();                            // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once
+      for (size_t j = 0; j < yIn.size(); ++j){ // loop for over the features
          // MinMax scaling of the input features
-         LOG(debug)<<"--------------> MinMax unscaling Debug \t"<<scaleMin.at(j)<<"\t"<<scaleMax.at(j);
+         LOG(debug) << "--------------> MinMax unscaling Debug \t" << scaleMin.at(j) << "\t" << scaleMax.at(j);
          yOut.push_back(yIn.at(j)*(scaleMax.at(j)- scaleMin.at(j))+ scaleMin.at(j));
-         LOG(debug)<<"Unscaling output = "<<j<<" ----> input = "<<yIn.at(j)<<" rescaled output = "<< yOut.at(j);
+         LOG(debug) << "Unscaling output = " << j << " ----> input = " << yIn.at(j) << " rescaled output = " << yOut.at(j);
        }
      }
 
@@ -76,42 +78,49 @@ namespace o2::analysis
      { // it takes the bool flag and scaling parameters configurables in taskXic
        yOutRescaled.clear();
        if (scaleFlag == false) {
-         LOG(debug)<<"No external preprocessing transformation will be applied";
+         LOG(debug) << "No external preprocessing transformation will be applied";
          yOutRescaled.assign(yIn.begin(), yIn.end());
        } else {
-           if (scaleType == 1) {
-             LOG(debug)<<"MinMax unscaling will be applied";
-             unsetMinMaxScaling(yOutRescaled, yIn, scaleMin, scaleMax);
-           } //... with scaleType > 1 we could add other preprocessing trasformations
-         }
+         if (scaleType == 1) {
+            LOG(debug) << "MinMax unscaling will be applied";
+            unsetMinMaxScaling(yOutRescaled, yIn, scaleMin, scaleMax);
+         }  //... with scaleType > 1 we could add other preprocessing trasformations
+       }
      }
 
-     std::vector<float> getPostprocessedOutput() {
-       for (size_t j = 0; j < yOutRescaled.size(); ++j) LOG(debug)<<"Global rescaled AE output = "<< yOutRescaled.at(j);
-         return yOutRescaled;
+     std::vector<float> getPostprocessedOutput()
+     {
+       for (size_t j = 0; j < yOutRescaled.size(); ++j) 
+         LOG(debug)<<"Global rescaled AE output = "<< yOutRescaled.at(j);
+       return yOutRescaled;
      }
      //---- MSE function
-     float getMse(std::vector<float> yTrue, std::vector<float> yPred){
-       LOG(debug)<<"Inside getMse sizes "<<yTrue.size()<<"\t"<<yPred.size();
+     float getMse(std::vector<float> yTrue, std::vector<float> yPred)
+     {
+       LOG(debug) << "Inside getMse sizes " << yTrue.size() << "\t" << yPred.size();
        float mse= 0.0f;
        float sum = 0.0f;
-       for (size_t j = 0; j < yTrue.size(); ++j) LOG(debug)<<"Local Feature = "<<j<<" ----> input = "<<yTrue.at(j)<<" scaled feature = "<< yPred.at(j);
+       for (size_t j = 0; j < yTrue.size(); ++j) 
+         LOG(debug) << "Local Feature = " << j << " ----> input = " << yTrue.at(j) << " scaled feature = " << yPred.at(j);
        std::vector<float> yTrueScaled = getPreprocessedFeatures(); // to make the input features adimensional
-       i f(yTrue.size() != yPred.size()){
-         LOG(debug)<< "size of input vector ="<<yTrue.size();
-         LOG(debug)<< "size of AE output vector ="<< yPred.size();
+       if (yTrue.size() != yPred.size())
+       {
+         LOG(debug) << "size of input vector =" << yTrue.size();
+         LOG(debug) << "size of AE output vector =" << yPred.size();
          LOG(fatal) << "vectors of input and predictions don't have the same size";
-         } else { //MSE
-             for (size_t j = 0; j < yPred.size(); ++j) {
-               sum += std::pow(((yTrueScaled).at(j) - (yPred).at(j)), 2); //AE model gives adimensional predictions by design choice
-               LOG(debug)<<"getMse Local feature = "<<j<<" ----> input = "<<yTrueScaled.at(j)<<" AE prediction = "<< yPred.at(j);
-             }
-           mse = sum/yPred.size(); // MSE of a candidate
-           LOG(debug)<<"Local mse "<<mse;
+       } 
+       else 
+       { //MSE
+         for (size_t j = 0; j < yPred.size(); ++j) {
+           sum += std::pow(((yTrueScaled).at(j) - (yPred).at(j)), 2); //AE model gives adimensional predictions by design choice
+           LOG(debug) << "getMse Local feature = " << j << " ----> input = " << yTrueScaled.at(j) << " AE prediction = " << yPred.at(j);
+         }
+         mse = sum/yPred.size(); // MSE of a candidate
+         LOG(debug) << "Local mse " << mse;
        }
        return mse;
      }
-   }; // end of the class
+}; // end of the class
 
 } // namespace o2::analysis
 #endif // PWGHF_CORE_HFAETOMSEXICTOPKPI_H_

--- a/PWGHF/Core/HfAeToMseXicToPKPi.h
+++ b/PWGHF/Core/HfAeToMseXicToPKPi.h
@@ -66,7 +66,7 @@ class HfAeToMseXicToPKPi : public HfMlResponse<TypeOutputScore>
   void unsetMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
   {
     yOut.clear();                             // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once
-    for (size_t j = 0; j < yIn.size(); ++j ) { // loop for over the features
+    for (size_t j = 0; j < yIn.size(); ++j) { // loop for over the features
       // MinMax scaling of the input features
       LOG(debug) << "--------------> MinMax unscaling Debug \t" << scaleMin.at(j) << "\t" << scaleMax.at(j);
       yOut.push_back(yIn.at(j) * (scaleMax.at(j) - scaleMin.at(j)) + scaleMin.at(j));
@@ -84,36 +84,35 @@ class HfAeToMseXicToPKPi : public HfMlResponse<TypeOutputScore>
       if (scaleType == 1) {
         LOG(debug) << "MinMax unscaling will be applied";
         unsetMinMaxScaling(yOutRescaled, yIn, scaleMin, scaleMax);
-      }  //... with scaleType > 1 we could add other preprocessing trasformations
+      } //... with scaleType > 1 we could add other preprocessing trasformations
     }
   }
 
   std::vector<float> getPostprocessedOutput()
   {
     for (size_t j = 0; j < yOutRescaled.size(); ++j)
-      LOG(debug)<<"Global rescaled AE output = "<< yOutRescaled.at(j);
+      LOG(debug) << "Global rescaled AE output = " << yOutRescaled.at(j);
     return yOutRescaled;
   }
   //---- MSE function
   float getMse(std::vector<float> yTrue, std::vector<float> yPred)
   {
     LOG(debug) << "Inside getMse sizes " << yTrue.size() << "\t" << yPred.size();
-    float mse= 0.0f;
+    float mse = 0.0f;
     float sum = 0.0f;
     for (size_t j = 0; j < yTrue.size(); ++j)
       LOG(debug) << "Local Feature = " << j << " ----> input = " << yTrue.at(j) << " scaled feature = " << yPred.at(j);
     std::vector<float> yTrueScaled = getPreprocessedFeatures(); // to make the input features adimensional
-    if (yTrue.size() != yPred.size())
-    {
+    if (yTrue.size() != yPred.size()) {
       LOG(debug) << "size of input vector =" << yTrue.size();
       LOG(debug) << "size of AE output vector =" << yPred.size();
       LOG(fatal) << "vectors of input and predictions don't have the same size";
-    } else { //MSE
+    } else { // MSE
       for (size_t j = 0; j < yPred.size(); ++j) {
-        sum += std::pow(((yTrueScaled).at(j) - (yPred).at(j)), 2); //AE model gives adimensional predictions by design choice
+        sum += std::pow(((yTrueScaled).at(j) - (yPred).at(j)), 2); // AE model gives adimensional predictions by design choice
         LOG(debug) << "getMse Local feature = " << j << " ----> input = " << yTrueScaled.at(j) << " AE prediction = " << yPred.at(j);
       }
-      mse = sum/yPred.size(); // MSE of a candidate
+      mse = sum / yPred.size(); // MSE of a candidate
       LOG(debug) << "Local mse " << mse;
     }
     return mse;

--- a/PWGHF/Core/HfAeToMseXicToPKPi.h
+++ b/PWGHF/Core/HfAeToMseXicToPKPi.h
@@ -33,86 +33,85 @@ namespace o2::analysis
      std::vector<float> yScaled, yOutRescaled;
      //private :
      void setMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
-     { yOut.clear(); // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once				
-       for (size_t j = 0; j < yIn.size(); ++j)
-       { // loop for over the features 
-         // MinMax scaling of the input features
-         LOG(debug)<<"--------------> MinMax scaling Debug \t"<<scaleMin.at(j)<<"\t"<<scaleMax.at(j);
-         yOut.push_back((yIn.at(j) - scaleMin.at(j))/(scaleMax.at(j)- scaleMin.at(j)));
-         LOG(debug)<<"Feature = "<<j<<" ----> input = "<<yIn.at(j)<<" scaled feature = "<< yOut.at(j); 		
-       }
-     }	  		
+     {  yOut.clear(); // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once				
+        for (size_t j = 0; j < yIn.size(); ++j)
+        { // loop for over the features
+          // MinMax scaling of the input features
+          LOG(debug)<<"--------------> MinMax scaling Debug \t"<<scaleMin.at(j)<<"\t"<<scaleMax.at(j);
+          yOut.push_back((yIn.at(j) - scaleMin.at(j))/(scaleMax.at(j)- scaleMin.at(j)));
+          LOG(debug)<<"Feature = "<<j<<" ----> input = "<<yIn.at(j)<<" scaled feature = "<< yOut.at(j);		
+        }
+     }
      // ---- External preprocessing scaling
      void setScaling(bool scaleFlag, int scaleType, /* input features of a candidate */ std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
      { // it takes the bool flag and scaling parameters configurables in taskXic
        yScaled.clear();
-       if( scaleFlag == false){ 
-         LOG(debug)<<"No external preprocessing transformation will be applied"; 
+       if( scaleFlag == false){
+         LOG(debug)<<"No external preprocessing transformation will be applied";
          yScaled.assign(yIn.begin(), yIn.end());
        } else{
            if(scaleType == 1){
-             LOG(debug)<<"MinMax scaling will be applied"; 
+             LOG(debug)<<"MinMax scaling will be applied";
              setMinMaxScaling(yScaled, yIn, scaleMin, scaleMax);
            } // ... with scaleType > 1 we could add other preprocessing trasformations	  	
        }
      }
-     std::vector<float> getPreprocessedFeatures(){ 
-       for (size_t j = 0; j < yScaled.size(); ++j) LOG(debug)<<"Global scaled feature = "<< yScaled.at(j); 
-         return  yScaled; 			
+     std::vector<float> getPreprocessedFeatures(){
+     for (size_t j = 0; j < yScaled.size(); ++j) LOG(debug)<<"Global scaled feature = "<< yScaled.at(j);
+       return  yScaled;
      }
      // Reverse preprocessing - output postprocessing
      void unsetMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
      { yOut.clear(); // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once				
        for (size_t j = 0; j < yIn.size(); ++j)
-       { // loop for over the features 
+       { // loop for over the features
          // MinMax scaling of the input features
          LOG(debug)<<"--------------> MinMax unscaling Debug \t"<<scaleMin.at(j)<<"\t"<<scaleMax.at(j);
          yOut.push_back(yIn.at(j)*(scaleMax.at(j)- scaleMin.at(j))+ scaleMin.at(j));
          LOG(debug)<<"Unscaling output = "<<j<<" ----> input = "<<yIn.at(j)<<" rescaled output = "<< yOut.at(j); 					
        }
-     }	  		
+     }
 
      void unsetScaling(bool scaleFlag, int scaleType, /*AE output*/ std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
      { // it takes the bool flag and scaling parameters configurables in taskXic
        yOutRescaled.clear();
-       if( scaleFlag == false){ 
-         LOG(debug)<<"No external preprocessing transformation will be applied"; 
+       if( scaleFlag == false){
+         LOG(debug)<<"No external preprocessing transformation will be applied";
          yOutRescaled.assign(yIn.begin(), yIn.end());
        } else{
            if(scaleType == 1){
-             LOG(debug)<<"MinMax unscaling will be applied"; 
+             LOG(debug)<<"MinMax unscaling will be applied";
              unsetMinMaxScaling(yOutRescaled, yIn, scaleMin, scaleMax);
-           }//... with scaleType > 1 we could add other preprocessing trasformations	  	
+           } //... with scaleType > 1 we could add other preprocessing trasformations	  	
        }
      }
-     
-     std::vector<float> getPostprocessedOutput(){ 
-       for (size_t j = 0; j < yOutRescaled.size(); ++j) LOG(debug)<<"Global rescaled AE output = "<< yOutRescaled.at(j); 
-         return  yOutRescaled; 			
-     }		
+
+     std::vector<float> getPostprocessedOutput(){
+       for (size_t j = 0; j < yOutRescaled.size(); ++j) LOG(debug)<<"Global rescaled AE output = "<< yOutRescaled.at(j);
+         return yOutRescaled;
+     }
      //---- MSE function
      float getMse(std::vector<float> yTrue, std::vector<float> yPred){
        LOG(debug)<<"Inside getMse sizes "<<yTrue.size()<<"\t"<<yPred.size();
        float mse= 0.0f;
-       float sum = 0.0f;    
+       float sum = 0.0f;  
        for (size_t j = 0; j < yTrue.size(); ++j) LOG(debug)<<"Local Feature = "<<j<<" ----> input = "<<yTrue.at(j)<<" scaled feature = "<< yPred.at(j);
        std::vector<float> yTrueScaled = getPreprocessedFeatures(); // to make the input features adimensional
-       if( yTrue.size() != yPred.size()){  
+       if( yTrue.size() != yPred.size()){
          LOG(debug)<< "size of input vector ="<<yTrue.size();
          LOG(debug)<< "size of AE output vector ="<< yPred.size();
          LOG(fatal) << "vectors of input and predictions don't have the same size";    	
-       } else{ //MSE    
-           for (size_t j = 0; j < yPred.size(); ++j) { 
+       } else{ //MSE  
+           for (size_t j = 0; j < yPred.size(); ++j) {
              sum += std::pow(((yTrueScaled).at(j) - (yPred).at(j)), 2); //AE model gives adimensional predictions by design choice
-             LOG(debug)<<"getMse Local feature = "<<j<<" ----> input = "<<yTrueScaled.at(j)<<" AE prediction = "<< yPred.at(j);           
+             LOG(debug)<<"getMse Local feature = "<<j<<" ----> input = "<<yTrueScaled.at(j)<<" AE prediction = "<< yPred.at(j); 
            }
-           mse = sum/yPred.size(); // MSE of a candidate 
+           mse = sum/yPred.size(); // MSE of a candidate
            LOG(debug)<<"Local mse "<<mse;
        }
        return mse;
      }
-   }; // end of the class 
-	
+   }; // end of the class
 
 } // namespace o2::analysis
 #endif // PWGHF_CORE_HFAETOMSEXICTOPKPI_H_

--- a/PWGHF/Core/HfAeToMseXicToPKPi.h
+++ b/PWGHF/Core/HfAeToMseXicToPKPi.h
@@ -33,28 +33,28 @@ namespace o2::analysis
      std::vector<float> yScaled, yOutRescaled;
      //private :
      void setMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
-     {  yOut.clear(); // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once				
+     {  yOut.clear(); // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once
         for (size_t j = 0; j < yIn.size(); ++j)
         { // loop for over the features
           // MinMax scaling of the input features
           LOG(debug)<<"--------------> MinMax scaling Debug \t"<<scaleMin.at(j)<<"\t"<<scaleMax.at(j);
           yOut.push_back((yIn.at(j) - scaleMin.at(j))/(scaleMax.at(j)- scaleMin.at(j)));
-          LOG(debug)<<"Feature = "<<j<<" ----> input = "<<yIn.at(j)<<" scaled feature = "<< yOut.at(j);		
+          LOG(debug)<<"Feature = "<<j<<" ----> input = "<<yIn.at(j)<<" scaled feature = "<< yOut.at(j);
         }
      }
      // ---- External preprocessing scaling
      void setScaling(bool scaleFlag, int scaleType, /* input features of a candidate */ std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
      { // it takes the bool flag and scaling parameters configurables in taskXic
        yScaled.clear();
-       if( scaleFlag == false){
+       if (scaleFlag == false) {
          LOG(debug)<<"No external preprocessing transformation will be applied";
          yScaled.assign(yIn.begin(), yIn.end());
-       } else{
-           if(scaleType == 1){
+       } else {
+           if (scaleType == 1) {
              LOG(debug)<<"MinMax scaling will be applied";
              setMinMaxScaling(yScaled, yIn, scaleMin, scaleMax);
-           } // ... with scaleType > 1 we could add other preprocessing trasformations	  	
-       }
+           } // ... with scaleType > 1 we could add other preprocessing trasformations
+         }
      }
      std::vector<float> getPreprocessedFeatures(){
      for (size_t j = 0; j < yScaled.size(); ++j) LOG(debug)<<"Global scaled feature = "<< yScaled.at(j);
@@ -62,31 +62,31 @@ namespace o2::analysis
      }
      // Reverse preprocessing - output postprocessing
      void unsetMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
-     { yOut.clear(); // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once				
+     { yOut.clear(); // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once
        for (size_t j = 0; j < yIn.size(); ++j)
        { // loop for over the features
          // MinMax scaling of the input features
          LOG(debug)<<"--------------> MinMax unscaling Debug \t"<<scaleMin.at(j)<<"\t"<<scaleMax.at(j);
          yOut.push_back(yIn.at(j)*(scaleMax.at(j)- scaleMin.at(j))+ scaleMin.at(j));
-         LOG(debug)<<"Unscaling output = "<<j<<" ----> input = "<<yIn.at(j)<<" rescaled output = "<< yOut.at(j); 					
+         LOG(debug)<<"Unscaling output = "<<j<<" ----> input = "<<yIn.at(j)<<" rescaled output = "<< yOut.at(j);
        }
      }
 
      void unsetScaling(bool scaleFlag, int scaleType, /*AE output*/ std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
      { // it takes the bool flag and scaling parameters configurables in taskXic
        yOutRescaled.clear();
-       if( scaleFlag == false){
+       if (scaleFlag == false) {
          LOG(debug)<<"No external preprocessing transformation will be applied";
          yOutRescaled.assign(yIn.begin(), yIn.end());
-       } else{
-           if(scaleType == 1){
+       } else {
+           if (scaleType == 1) {
              LOG(debug)<<"MinMax unscaling will be applied";
              unsetMinMaxScaling(yOutRescaled, yIn, scaleMin, scaleMax);
-           } //... with scaleType > 1 we could add other preprocessing trasformations	  	
-       }
+           } //... with scaleType > 1 we could add other preprocessing trasformations
+         }
      }
 
-     std::vector<float> getPostprocessedOutput(){
+     std::vector<float> getPostprocessedOutput() {
        for (size_t j = 0; j < yOutRescaled.size(); ++j) LOG(debug)<<"Global rescaled AE output = "<< yOutRescaled.at(j);
          return yOutRescaled;
      }
@@ -94,18 +94,18 @@ namespace o2::analysis
      float getMse(std::vector<float> yTrue, std::vector<float> yPred){
        LOG(debug)<<"Inside getMse sizes "<<yTrue.size()<<"\t"<<yPred.size();
        float mse= 0.0f;
-       float sum = 0.0f;  
+       float sum = 0.0f;
        for (size_t j = 0; j < yTrue.size(); ++j) LOG(debug)<<"Local Feature = "<<j<<" ----> input = "<<yTrue.at(j)<<" scaled feature = "<< yPred.at(j);
        std::vector<float> yTrueScaled = getPreprocessedFeatures(); // to make the input features adimensional
-       if( yTrue.size() != yPred.size()){
+       i f(yTrue.size() != yPred.size()){
          LOG(debug)<< "size of input vector ="<<yTrue.size();
          LOG(debug)<< "size of AE output vector ="<< yPred.size();
-         LOG(fatal) << "vectors of input and predictions don't have the same size";    	
-       } else{ //MSE  
-           for (size_t j = 0; j < yPred.size(); ++j) {
-             sum += std::pow(((yTrueScaled).at(j) - (yPred).at(j)), 2); //AE model gives adimensional predictions by design choice
-             LOG(debug)<<"getMse Local feature = "<<j<<" ----> input = "<<yTrueScaled.at(j)<<" AE prediction = "<< yPred.at(j); 
-           }
+         LOG(fatal) << "vectors of input and predictions don't have the same size";
+         } else { //MSE
+             for (size_t j = 0; j < yPred.size(); ++j) {
+               sum += std::pow(((yTrueScaled).at(j) - (yPred).at(j)), 2); //AE model gives adimensional predictions by design choice
+               LOG(debug)<<"getMse Local feature = "<<j<<" ----> input = "<<yTrueScaled.at(j)<<" AE prediction = "<< yPred.at(j);
+             }
            mse = sum/yPred.size(); // MSE of a candidate
            LOG(debug)<<"Local mse "<<mse;
        }

--- a/PWGHF/Core/HfAeToMseXicToPKPi.h
+++ b/PWGHF/Core/HfAeToMseXicToPKPi.h
@@ -34,11 +34,11 @@ class HfAeToMseXicToPKPi : public HfMlResponse<TypeOutputScore>
 
   void setMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
   {
-    yOut.clear();                            // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once
-    for (size_t j = 0; j < yIn.size(); ++j){ // loop for over the features
+    yOut.clear();                             // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once
+    for (size_t j = 0; j < yIn.size(); ++j) { // loop for over the features
       // MinMax scaling of the input features
       LOG(debug) << "--------------> MinMax scaling Debug \t" << scaleMin.at(j) << "\t" << scaleMax.at(j);
-      yOut.push_back((yIn.at(j) - scaleMin.at(j)) / (scaleMax.at(j)- scaleMin.at(j)));
+      yOut.push_back((yIn.at(j) - scaleMin.at(j)) / (scaleMax.at(j) - scaleMin.at(j)));
       LOG(debug) << "Feature = " << j << " ----> input = " << yIn.at(j) << " scaled feature = " << yOut.at(j);
     }
   }
@@ -50,76 +50,74 @@ class HfAeToMseXicToPKPi : public HfMlResponse<TypeOutputScore>
       LOG(debug) << "No external preprocessing transformation will be applied";
       yScaled.assign(yIn.begin(), yIn.end());
     } else {
-        if (scaleType == 1) {
-          LOG(debug) << "MinMax scaling will be applied";
-          setMinMaxScaling(yScaled, yIn, scaleMin, scaleMax);
-        } // ... with scaleType > 1 we could add other preprocessing trasformations
-      }
+      if (scaleType == 1) {
+        LOG(debug) << "MinMax scaling will be applied";
+        setMinMaxScaling(yScaled, yIn, scaleMin, scaleMax);
+      } // ... with scaleType > 1 we could add other preprocessing trasformations
+    }
   }
   std::vector<float> getPreprocessedFeatures()
   {
     for (size_t j = 0; j < yScaled.size(); ++j)
       LOG(debug) << "Global scaled feature = " << yScaled.at(j);
-    return  yScaled;
+    return yScaled;
   }
   // Reverse preprocessing - output postprocessing
   void unsetMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
   {
-    yOut.clear();                            // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once
-    for (size_t j = 0; j < yIn.size(); ++j){ // loop for over the features
-       // MinMax scaling of the input features
-       LOG(debug) << "--------------> MinMax unscaling Debug \t" << scaleMin.at(j) << "\t" << scaleMax.at(j);
-       yOut.push_back(yIn.at(j)*(scaleMax.at(j)- scaleMin.at(j))+ scaleMin.at(j));
-       LOG(debug) << "Unscaling output = " << j << " ----> input = " << yIn.at(j) << " rescaled output = " << yOut.at(j);
-     }
-   }
+    yOut.clear();                             // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once
+    for (size_t j = 0; j < yIn.size(); ++j ){ // loop for over the features
+      // MinMax scaling of the input features
+      LOG(debug) << "--------------> MinMax unscaling Debug \t" << scaleMin.at(j) << "\t" << scaleMax.at(j);
+      yOut.push_back(yIn.at(j) * (scaleMax.at(j) - scaleMin.at(j)) + scaleMin.at(j));
+      LOG(debug) << "Unscaling output = " << j << " ----> input = " << yIn.at(j) << " rescaled output = " << yOut.at(j);
+    }
+  }
 
-   void unsetScaling(bool scaleFlag, int scaleType, /*AE output*/ std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
-   { // it takes the bool flag and scaling parameters configurables in taskXic
-     yOutRescaled.clear();
-     if (scaleFlag == false) {
-       LOG(debug) << "No external preprocessing transformation will be applied";
-       yOutRescaled.assign(yIn.begin(), yIn.end());
-     } else {
-         if (scaleType == 1) {
-            LOG(debug) << "MinMax unscaling will be applied";
-            unsetMinMaxScaling(yOutRescaled, yIn, scaleMin, scaleMax);
-         }  //... with scaleType > 1 we could add other preprocessing trasformations
-       }
-   }
+  void unsetScaling(bool scaleFlag, int scaleType, /*AE output*/ std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
+  { // it takes the bool flag and scaling parameters configurables in taskXic
+    yOutRescaled.clear();
+    if (scaleFlag == false) {
+      LOG(debug) << "No external preprocessing transformation will be applied";
+      yOutRescaled.assign(yIn.begin(), yIn.end());
+    } else {
+      if (scaleType == 1) {
+        LOG(debug) << "MinMax unscaling will be applied";
+        unsetMinMaxScaling(yOutRescaled, yIn, scaleMin, scaleMax);
+      }  //... with scaleType > 1 we could add other preprocessing trasformations
+    }
+  }
 
-   std::vector<float> getPostprocessedOutput()
-   {
-     for (size_t j = 0; j < yOutRescaled.size(); ++j)
-       LOG(debug)<<"Global rescaled AE output = "<< yOutRescaled.at(j);
-     return yOutRescaled;
-   }
-   //---- MSE function
-   float getMse(std::vector<float> yTrue, std::vector<float> yPred)
-   {
-     LOG(debug) << "Inside getMse sizes " << yTrue.size() << "\t" << yPred.size();
-     float mse= 0.0f;
-     float sum = 0.0f;
-     for (size_t j = 0; j < yTrue.size(); ++j)
-       LOG(debug) << "Local Feature = " << j << " ----> input = " << yTrue.at(j) << " scaled feature = " << yPred.at(j);
-     std::vector<float> yTrueScaled = getPreprocessedFeatures(); // to make the input features adimensional
-     if (yTrue.size() != yPred.size())
-     {
-       LOG(debug) << "size of input vector =" << yTrue.size();
-       LOG(debug) << "size of AE output vector =" << yPred.size();
-       LOG(fatal) << "vectors of input and predictions don't have the same size";
-     }
-     else
-     { //MSE
-       for (size_t j = 0; j < yPred.size(); ++j) {
-         sum += std::pow(((yTrueScaled).at(j) - (yPred).at(j)), 2); //AE model gives adimensional predictions by design choice
-         LOG(debug) << "getMse Local feature = " << j << " ----> input = " << yTrueScaled.at(j) << " AE prediction = " << yPred.at(j);
-       }
-       mse = sum/yPred.size(); // MSE of a candidate
-       LOG(debug) << "Local mse " << mse;
-     }
-     return mse;
-   }
+  std::vector<float> getPostprocessedOutput()
+  {
+    for (size_t j = 0; j < yOutRescaled.size(); ++j)
+      LOG(debug)<<"Global rescaled AE output = "<< yOutRescaled.at(j);
+    return yOutRescaled;
+  }
+  //---- MSE function
+  float getMse(std::vector<float> yTrue, std::vector<float> yPred)
+  {
+    LOG(debug) << "Inside getMse sizes " << yTrue.size() << "\t" << yPred.size();
+    float mse= 0.0f;
+    float sum = 0.0f;
+    for (size_t j = 0; j < yTrue.size(); ++j)
+      LOG(debug) << "Local Feature = " << j << " ----> input = " << yTrue.at(j) << " scaled feature = " << yPred.at(j);
+    std::vector<float> yTrueScaled = getPreprocessedFeatures(); // to make the input features adimensional
+    if (yTrue.size() != yPred.size())
+    {
+      LOG(debug) << "size of input vector =" << yTrue.size();
+      LOG(debug) << "size of AE output vector =" << yPred.size();
+      LOG(fatal) << "vectors of input and predictions don't have the same size";
+    } else { //MSE
+      for (size_t j = 0; j < yPred.size(); ++j) {
+        sum += std::pow(((yTrueScaled).at(j) - (yPred).at(j)), 2); //AE model gives adimensional predictions by design choice
+        LOG(debug) << "getMse Local feature = " << j << " ----> input = " << yTrueScaled.at(j) << " AE prediction = " << yPred.at(j);
+      }
+      mse = sum/yPred.size(); // MSE of a candidate
+      LOG(debug) << "Local mse " << mse;
+    }
+    return mse;
+  }
 }; // end of the class
 
 } // namespace o2::analysis

--- a/PWGHF/Core/HfAeToMseXicToPKPi.h
+++ b/PWGHF/Core/HfAeToMseXicToPKPi.h
@@ -1,3 +1,14 @@
+// Copyright 2020-2022 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 /// \file HfAeToMseXicToPKPi.h
 /// \brief Class to compute the mse for the Autoencoder for Xic+ → p K- π+ analysis selections
 /// \author Maria Teresa Camerlingo
@@ -13,13 +24,13 @@ namespace o2::analysis
 	template <typename TypeOutputScore = float>
 	class HfAeToMseXicToPKPi : public HfMlResponse<TypeOutputScore>
 	{
-	  public:
+		public:
 		/// Default constructor
-  		HfAeToMseXicToPKPi() = default;
-  		/// Default destructor
-  		virtual ~HfAeToMseXicToPKPi() = default;
-  		
-  		std::vector<float> yScaled, yOutRescaled;
+		HfAeToMseXicToPKPi() = default;
+		/// Default destructor
+		virtual ~HfAeToMseXicToPKPi() = default;
+		
+		std::vector<float> yScaled, yOutRescaled;
 		//private :
 		void setMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
 		{	yOut.clear();//initial clear to avoid multiple filling if setMinMax o setScaling are called more than once				
@@ -88,7 +99,7 @@ namespace o2::analysis
 				  }
 				  else{//MSE    
 						for (size_t j = 0; j < yPred.size(); ++j) { //for over the features 
-								sum += pow(((yTrueScaled).at(j) - (yPred).at(j)), 2); //has dimensions
+								sum += std::pow(((yTrueScaled).at(j) - (yPred).at(j)), 2); //has dimensions
 								LOG(debug)<<"getMse Local feature = "<<j<<" ----> input = "<<yTrueScaled.at(j)<<" AE prediction = "<< yPred.at(j);           
 						}
 						mse = sum/yPred.size(); //MSE of a candidate 

--- a/PWGHF/Core/HfAeToMseXicToPKPi.h
+++ b/PWGHF/Core/HfAeToMseXicToPKPi.h
@@ -1,0 +1,103 @@
+/// \file HfAeToMseXicToPKPi.h
+/// \brief Class to compute the mse for the Autoencoder for Xic+ → p K- π+ analysis selections
+/// \author Maria Teresa Camerlingo
+
+#ifndef PWGHF_CORE_HFAETOMSEXICTOPKPI_H_
+#define PWGHF_CORE_HFAETOMSEXICTOPKPI_H_
+
+#include <vector>
+
+#include "PWGHF/Core/HfMlResponse.h"
+namespace o2::analysis
+{
+	template <typename TypeOutputScore = float>
+	class HfAeToMseXicToPKPi : public HfMlResponse<TypeOutputScore>
+	{
+	  public:
+		/// Default constructor
+  		HfAeToMseXicToPKPi() = default;
+  		/// Default destructor
+  		virtual ~HfAeToMseXicToPKPi() = default;
+  		
+  		std::vector<float> yScaled, yOutRescaled;
+		//private :
+		void setMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
+		{	yOut.clear();//initial clear to avoid multiple filling if setMinMax o setScaling are called more than once				
+			for (size_t j = 0; j < yIn.size(); ++j)
+			{ //for over the features 
+					//MinMax scaling of the input features
+					LOG(debug)<<"--------------> MinMax scaling Debug \t"<<scaleMin.at(j)<<"\t"<<scaleMax.at(j);
+					yOut.push_back((yIn.at(j) - scaleMin.at(j))/(scaleMax.at(j)- scaleMin.at(j)));
+					LOG(debug)<<"Feature = "<<j<<" ----> input = "<<yIn.at(j)<<" scaled feature = "<< yOut.at(j); 					
+			}
+		}	  		
+  		//----  External preprocessing scaling
+  		void setScaling(bool scaleFlag, int scaleType, /*input features of a candidate*/ std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax){ //it takes the bool flag and scaling parameters configurables in taskXic
+  			yScaled.clear();
+  		  	if( scaleFlag == false){ LOG(debug)<<"No external preprocessing transformation will be applied"; 
+  		  		yScaled.assign(yIn.begin(), yIn.end());
+  		  	} else{
+				  		if(scaleType == 1){
+				  			LOG(debug)<<"MinMax scaling will be applied"; 
+				  			setMinMaxScaling(yScaled, yIn, scaleMin, scaleMax);
+				  		}//... with scaleType > 1 we could add other preprocessing trasformations	  	
+  		  	}
+  		}
+  		std::vector<float> getPreprocessedFeatures(){ 
+  		  for (size_t j = 0; j < yScaled.size(); ++j) LOG(debug)<<"Global scaled feature = "<< yScaled.at(j); 
+  			return  yScaled; 			
+  		}
+  		//Reverse preprocessing - output postprocessing
+  		void unsetMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
+		{	yOut.clear();//initial clear to avoid multiple filling if setMinMax o setScaling are called more than once				
+			for (size_t j = 0; j < yIn.size(); ++j)
+			{ //for over the features 
+					//MinMax scaling of the input features
+					LOG(debug)<<"--------------> MinMax unscaling Debug \t"<<scaleMin.at(j)<<"\t"<<scaleMax.at(j);
+					yOut.push_back(yIn.at(j)*(scaleMax.at(j)- scaleMin.at(j))+ scaleMin.at(j));
+					LOG(debug)<<"Unscaling output = "<<j<<" ----> input = "<<yIn.at(j)<<" rescaled output = "<< yOut.at(j); 					
+			}
+		}	  		
+
+		void unsetScaling(bool scaleFlag, int scaleType, /*AE output*/ std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax){ //it takes the bool flag and scaling parameters configurables in taskXic
+  			yOutRescaled.clear();
+  		  	if( scaleFlag == false){ LOG(debug)<<"No external preprocessing transformation will be applied"; 
+  		  		yOutRescaled.assign(yIn.begin(), yIn.end());
+  		  	} else{
+				  		if(scaleType == 1){
+				  			LOG(debug)<<"MinMax unscaling will be applied"; 
+				  			unsetMinMaxScaling(yOutRescaled, yIn, scaleMin, scaleMax);
+				  		}//... with scaleType > 1 we could add other preprocessing trasformations	  	
+  		  	}
+  		}
+  		std::vector<float> getPostprocessedOutput(){ 
+  		  for (size_t j = 0; j < yOutRescaled.size(); ++j) LOG(debug)<<"Global rescaled AE output = "<< yOutRescaled.at(j); 
+  			return  yOutRescaled; 			
+  		}		
+		//---- MSE function
+		float getMse(std::vector<float> yTrue, std::vector<float> yPred){
+				  LOG(debug)<<"Inside getMse sizes "<<yTrue.size()<<"\t"<<yPred.size();
+				  float mse= 0.0f;
+				  float sum = 0.0f;    
+				  for (size_t j = 0; j < yTrue.size(); ++j) LOG(debug)<<"Local Feature = "<<j<<" ----> input = "<<yTrue.at(j)<<" scaled feature = "<< yPred.at(j);
+				  std::vector<float> yTrueScaled = getPreprocessedFeatures();
+				  if( yTrue.size() != yPred.size()){  
+				  	LOG(debug)<< "size of input vector ="<<yTrue.size();
+				  	LOG(debug)<< "size of AE output vector ="<< yPred.size();
+				  	LOG(fatal) << "vectors of input and predictions don't have the same size";    	
+				  }
+				  else{//MSE    
+						for (size_t j = 0; j < yPred.size(); ++j) { //for over the features 
+								sum += pow(((yTrueScaled).at(j) - (yPred).at(j)), 2); //has dimensions
+								LOG(debug)<<"getMse Local feature = "<<j<<" ----> input = "<<yTrueScaled.at(j)<<" AE prediction = "<< yPred.at(j);           
+						}
+						mse = sum/yPred.size(); //MSE of a candidate 
+						LOG(debug)<<"Local mse "<<mse;
+				  }
+				  return mse;
+			}
+	}; //end of the class 
+	
+
+} // namespace o2::analysis
+#endif // PWGHF_CORE_HFAETOMSEXICTOPKPI_H_

--- a/PWGHF/Core/HfAeToMseXicToPKPi.h
+++ b/PWGHF/Core/HfAeToMseXicToPKPi.h
@@ -66,7 +66,7 @@ class HfAeToMseXicToPKPi : public HfMlResponse<TypeOutputScore>
   void unsetMinMaxScaling(std::vector<float>& yOut, std::vector<float> yIn, std::vector<float> scaleMin, std::vector<float> scaleMax)
   {
     yOut.clear();                             // initial clear to avoid multiple filling if setMinMax o setScaling are called more than once
-    for (size_t j = 0; j < yIn.size(); ++j ){ // loop for over the features
+    for (size_t j = 0; j < yIn.size(); ++j ) { // loop for over the features
       // MinMax scaling of the input features
       LOG(debug) << "--------------> MinMax unscaling Debug \t" << scaleMin.at(j) << "\t" << scaleMax.at(j);
       yOut.push_back(yIn.at(j) * (scaleMax.at(j) - scaleMin.at(j)) + scaleMin.at(j));

--- a/PWGHF/D2H/Tasks/taskXic.cxx
+++ b/PWGHF/D2H/Tasks/taskXic.cxx
@@ -81,8 +81,8 @@ struct HfTaskXic {
   ConfigurableAxis thnConfigAxisBdtScoreBkg{"thnConfigAxisBdtScoreBkg", {100, 0., 1.}, ""};
   ConfigurableAxis thnConfigAxisBdtScoreSignal{"thnConfigAxisBdtScoreSignal", {100, 0., 1.}, ""};
   ConfigurableAxis thnConfigAxisYMC{"thnConfigAxisYMC", {100, -2., 2.}, ""};
-  ConfigurableAxis thnConfigAxisMseXic{"thnConfigAxisMseXic", {502, -0.0002, 1}, ""};     // MSE axis
-  ConfigurableAxis thnConfigAxisAeOutputXic{"thnConfigAxisAeOutputXic", {20, 0.8, 1},""}; // an AE output axis
+  ConfigurableAxis thnConfigAxisMseXic{"thnConfigAxisMseXic", {502, -0.0002, 1}, ""};      // MSE axis
+  ConfigurableAxis thnConfigAxisAeOutputXic{"thnConfigAxisAeOutputXic", {20, 0.8, 1}, ""}; // an AE output axis
   //
 
   float etaMaxAcceptance = 0.8;
@@ -547,8 +547,8 @@ struct HfTaskXic {
                 // add here the pT_Mother, y_Mother, level (reco, Gen, Gen + Acc)
                 registry.get<THnSparse>(HIST("hnXicVarsWithBdt"))->Fill(massXicToPiKP, ptCandidate, outputBkg, outputPrompt, outputFD, origin);
               } else {
-                outputAE = candidate.aeOutputXicToPiKP()[0];  /// AE output of feature 0
-                outputMSE = candidate.mseXicToPiKP()[0];      /// MSE
+                outputAE = candidate.aeOutputXicToPiKP()[0]; /// AE output of feature 0
+                outputMSE = candidate.mseXicToPiKP()[0];     /// MSE
                 registry.get<THnSparse>(HIST("hnXicVarsWithMse"))->Fill(massXicToPiKP, ptCandidate, candidate.decayLength(), candidate.cpa(), outputAE, origin, outputMSE);
               }
             } else {

--- a/PWGHF/D2H/Tasks/taskXic.cxx
+++ b/PWGHF/D2H/Tasks/taskXic.cxx
@@ -532,7 +532,7 @@ struct HfTaskXic {
                  outputAE = candidate.aeOutputXicToPKPi()[0]; /// AE output of feature 0
                  outputMSE = candidate.mseXicToPKPi()[0];     /// MSE
                  registry.get<THnSparse>(HIST("hnXicVarsWithMse"))->Fill(massXicToPKPi, ptCandidate, candidate.decayLength(), candidate.cpa(), outputAE, origin, outputMSE);
-              }         
+              }
             } else {
               registry.get<THnSparse>(HIST("hnXicVars"))->Fill(massXicToPKPi, ptCandidate, candidate.chi2PCA(), candidate.decayLength(), candidate.decayLengthXY(), candidate.cpa(), origin);
             }
@@ -550,7 +550,7 @@ struct HfTaskXic {
                  outputAE = candidate.aeOutputXicToPiKP()[0];  /// AE output of feature 0
                  outputMSE = candidate.mseXicToPiKP()[0];      /// MSE
                  registry.get<THnSparse>(HIST("hnXicVarsWithMse"))->Fill(massXicToPiKP, ptCandidate, candidate.decayLength(), candidate.cpa(), outputAE, origin, outputMSE);
-              }         
+              }
             } else {
               registry.get<THnSparse>(HIST("hnXicVars"))->Fill(massXicToPiKP, ptCandidate, candidate.chi2PCA(), candidate.decayLength(), candidate.decayLengthXY(), candidate.cpa(), origin);
             }

--- a/PWGHF/D2H/Tasks/taskXic.cxx
+++ b/PWGHF/D2H/Tasks/taskXic.cxx
@@ -387,7 +387,7 @@ struct HfTaskXic {
               outputMSE = candidate.mseXicToPKPi()[0];        /// MSE
               LOG(debug)<<"Global mse in taskXic for PKPi Data "<<outputMSE;
               registry.get<THnSparse>(HIST("hnXicVarsWithMse"))->Fill(massXic, ptCandidate, candidate.decayLength(), candidate.cpa(), outputAE, 0, 0.0, 0.0, false, outputMSE);
-            }   
+            }
           } else {
             registry.get<THnSparse>(HIST("hnXicVars"))->Fill(massXic, ptCandidate, candidate.chi2PCA(), candidate.decayLength(), candidate.decayLengthXY(), candidate.cpa(), false);
           }
@@ -406,7 +406,7 @@ struct HfTaskXic {
               outputMSE = candidate.mseXicToPiKP()[0];        /// MSE
               LOG(debug)<<"Global mse in taskXic for PiKP Data "<<outputMSE;
               registry.get<THnSparse>(HIST("hnXicVarsWithMse"))->Fill(massXic, ptCandidate, candidate.decayLength(), candidate.cpa(), outputAE, false, outputMSE);
-            }               
+            }
           } else {
             registry.get<THnSparse>(HIST("hnXicVars"))->Fill(massXic, ptCandidate, candidate.chi2PCA(), candidate.decayLength(), candidate.decayLengthXY(), candidate.cpa(), false);
           }
@@ -532,7 +532,7 @@ struct HfTaskXic {
                  outputAE = candidate.aeOutputXicToPKPi()[0]; /// AE output of feature 0
                  outputMSE = candidate.mseXicToPKPi()[0];     /// MSE
                  registry.get<THnSparse>(HIST("hnXicVarsWithMse"))->Fill(massXicToPKPi, ptCandidate, candidate.decayLength(), candidate.cpa(), outputAE, origin, outputMSE);
-              }               
+              }         
             } else {
               registry.get<THnSparse>(HIST("hnXicVars"))->Fill(massXicToPKPi, ptCandidate, candidate.chi2PCA(), candidate.decayLength(), candidate.decayLengthXY(), candidate.cpa(), origin);
             }
@@ -550,7 +550,7 @@ struct HfTaskXic {
                  outputAE = candidate.aeOutputXicToPiKP()[0];  /// AE output of feature 0
                  outputMSE = candidate.mseXicToPiKP()[0];      /// MSE
                  registry.get<THnSparse>(HIST("hnXicVarsWithMse"))->Fill(massXicToPiKP, ptCandidate, candidate.decayLength(), candidate.cpa(), outputAE, origin, outputMSE);
-              }             
+              }         
             } else {
               registry.get<THnSparse>(HIST("hnXicVars"))->Fill(massXicToPiKP, ptCandidate, candidate.chi2PCA(), candidate.decayLength(), candidate.decayLengthXY(), candidate.cpa(), origin);
             }

--- a/PWGHF/D2H/Tasks/taskXic.cxx
+++ b/PWGHF/D2H/Tasks/taskXic.cxx
@@ -255,7 +255,7 @@ struct HfTaskXic {
 
       if (doprocessDataWithMl || doprocessMcWithMl) { // with ML
         registry.add("hnXicVarsWithBdt", "THn for Xic candidates with BDT scores", HistType::kTHnSparseF, {thnAxisMass, thnAxisPt, thnAxisBdtScoreXicBkg, thnAxisBdtScoreXicPrompt, thnAxisBdtScoreXicNonPrompt, thnAxisMcOrigin});
-        registry.add("hnXicVarsWithMse", "THn for Xic candidates with MSE using AD", HistType::kTHnSparseF, {thnAxisMass, thnAxisPt, thnAxisDecLength, thnAxisCPA, thnAxisAeOutputXic, thnAxisMcOrigin, thnAxisMseXic}); 
+        registry.add("hnXicVarsWithMse", "THn for Xic candidates with MSE using AD", HistType::kTHnSparseF, {thnAxisMass, thnAxisPt, thnAxisDecLength, thnAxisCPA, thnAxisAeOutputXic, thnAxisMcOrigin, thnAxisMseXic});
       } else {
         registry.add("hnXicVars", "THn for Xic candidates", HistType::kTHnSparseF, {thnAxisMass, thnAxisPt, thnAxisChi2PCA, thnAxisDecLength, thnAxisDecLengthXY, thnAxisCPA, thnAxisMcOrigin});
       }
@@ -387,7 +387,7 @@ struct HfTaskXic {
               outputMSE = candidate.mseXicToPKPi()[0];        /// MSE
               LOG(debug)<<"Global mse in taskXic for PKPi Data "<<outputMSE;
               registry.get<THnSparse>(HIST("hnXicVarsWithMse"))->Fill(massXic, ptCandidate, candidate.decayLength(), candidate.cpa(), outputAE, 0, 0.0, 0.0, false, outputMSE);
-            }    
+            }   
           } else {
             registry.get<THnSparse>(HIST("hnXicVars"))->Fill(massXic, ptCandidate, candidate.chi2PCA(), candidate.decayLength(), candidate.decayLengthXY(), candidate.cpa(), false);
           }
@@ -406,7 +406,7 @@ struct HfTaskXic {
               outputMSE = candidate.mseXicToPiKP()[0];        /// MSE
               LOG(debug)<<"Global mse in taskXic for PiKP Data "<<outputMSE;
               registry.get<THnSparse>(HIST("hnXicVarsWithMse"))->Fill(massXic, ptCandidate, candidate.decayLength(), candidate.cpa(), outputAE, false, outputMSE);
-            }                
+            }               
           } else {
             registry.get<THnSparse>(HIST("hnXicVars"))->Fill(massXic, ptCandidate, candidate.chi2PCA(), candidate.decayLength(), candidate.decayLengthXY(), candidate.cpa(), false);
           }
@@ -529,10 +529,10 @@ struct HfTaskXic {
                 /// Fill the ML outputScores and variables of candidate (todo: add multiplicity)
                 registry.get<THnSparse>(HIST("hnXicVarsWithBdt"))->Fill(massXicToPKPi, ptCandidate, outputBkg, outputPrompt, outputFD, origin);
               } else {
-		 outputAE =  candidate.aeOutputXicToPKPi()[0]; /// AE output of feature 0
-		 outputMSE = candidate.mseXicToPKPi()[0];      /// MSE
-		 registry.get<THnSparse>(HIST("hnXicVarsWithMse"))->Fill(massXicToPKPi, ptCandidate, candidate.decayLength(), candidate.cpa(), outputAE, origin, outputMSE);
-              }                
+                 outputAE = candidate.aeOutputXicToPKPi()[0]; /// AE output of feature 0
+                 outputMSE = candidate.mseXicToPKPi()[0];     /// MSE
+                 registry.get<THnSparse>(HIST("hnXicVarsWithMse"))->Fill(massXicToPKPi, ptCandidate, candidate.decayLength(), candidate.cpa(), outputAE, origin, outputMSE);
+              }               
             } else {
               registry.get<THnSparse>(HIST("hnXicVars"))->Fill(massXicToPKPi, ptCandidate, candidate.chi2PCA(), candidate.decayLength(), candidate.decayLengthXY(), candidate.cpa(), origin);
             }
@@ -547,10 +547,10 @@ struct HfTaskXic {
                 // add here the pT_Mother, y_Mother, level (reco, Gen, Gen + Acc)
                 registry.get<THnSparse>(HIST("hnXicVarsWithBdt"))->Fill(massXicToPiKP, ptCandidate, outputBkg, outputPrompt, outputFD, origin);
               } else {
-		outputAE = candidate.aeOutputXicToPiKP()[0];  /// AE output of feature 0
-		outputMSE = candidate.mseXicToPiKP()[0];      /// MSE
-		registry.get<THnSparse>(HIST("hnXicVarsWithMse"))->Fill(massXicToPiKP, ptCandidate, candidate.decayLength(), candidate.cpa(), outputAE, origin, outputMSE);
-              }              
+                 outputAE = candidate.aeOutputXicToPiKP()[0];  /// AE output of feature 0
+                 outputMSE = candidate.mseXicToPiKP()[0];      /// MSE
+                 registry.get<THnSparse>(HIST("hnXicVarsWithMse"))->Fill(massXicToPiKP, ptCandidate, candidate.decayLength(), candidate.cpa(), outputAE, origin, outputMSE);
+              }             
             } else {
               registry.get<THnSparse>(HIST("hnXicVars"))->Fill(massXicToPiKP, ptCandidate, candidate.chi2PCA(), candidate.decayLength(), candidate.decayLengthXY(), candidate.cpa(), origin);
             }

--- a/PWGHF/D2H/Tasks/taskXic.cxx
+++ b/PWGHF/D2H/Tasks/taskXic.cxx
@@ -81,7 +81,7 @@ struct HfTaskXic {
   ConfigurableAxis thnConfigAxisBdtScoreBkg{"thnConfigAxisBdtScoreBkg", {100, 0., 1.}, ""};
   ConfigurableAxis thnConfigAxisBdtScoreSignal{"thnConfigAxisBdtScoreSignal", {100, 0., 1.}, ""};
   ConfigurableAxis thnConfigAxisYMC{"thnConfigAxisYMC", {100, -2., 2.}, ""};
-  ConfigurableAxis thnConfigAxisMseXic{"thnConfigAxisMseXic", {502, -0.0002, 1}, ""}; // MSE axis
+  ConfigurableAxis thnConfigAxisMseXic{"thnConfigAxisMseXic", {502, -0.0002, 1}, ""};     // MSE axis
   ConfigurableAxis thnConfigAxisAeOutputXic{"thnConfigAxisAeOutputXic", {20, 0.8, 1},""}; // an AE output axis
   //
 
@@ -383,10 +383,10 @@ struct HfTaskXic {
               /// Fill the ML outputScores and variables of candidate Xic
               registry.get<THnSparse>(HIST("hnXicVarsWithBdt"))->Fill(massXic, ptCandidate, outputBkg, outputPrompt, outputFD, false);
             } else {
-              outputAE = candidate.aeOutputXicToPKPi()[0];    /// AE output of feature 0
-              outputMSE = candidate.mseXicToPKPi()[0];        /// MSE
-              LOG(debug)<<"Global mse in taskXic for PKPi Data "<<outputMSE;
-              registry.get<THnSparse>(HIST("hnXicVarsWithMse"))->Fill(massXic, ptCandidate, candidate.decayLength(), candidate.cpa(), outputAE, 0, 0.0, 0.0, false, outputMSE);
+              outputAE = candidate.aeOutputXicToPKPi()[0]; /// AE output of feature 0
+              outputMSE = candidate.mseXicToPKPi()[0];     /// MSE
+              LOG(debug) << "Global mse in taskXic for PKPi Data " << outputMSE;
+              registry.get<THnSparse>(HIST("hnXicVarsWithMse"))->Fill(massXic, ptCandidate, candidate.decayLength(), candidate.cpa(), outputAE, false, outputMSE);
             }
           } else {
             registry.get<THnSparse>(HIST("hnXicVars"))->Fill(massXic, ptCandidate, candidate.chi2PCA(), candidate.decayLength(), candidate.decayLengthXY(), candidate.cpa(), false);
@@ -402,9 +402,9 @@ struct HfTaskXic {
               /// Fill the ML outputScores and variables of candidate
               registry.get<THnSparse>(HIST("hnXicVarsWithBdt"))->Fill(massXic, ptCandidate, outputBkg, outputPrompt, outputFD, false);
             } else {
-              outputAE = candidate.aeOutputXicToPiKP()[0];    /// AE output of feature 0
-              outputMSE = candidate.mseXicToPiKP()[0];        /// MSE
-              LOG(debug)<<"Global mse in taskXic for PiKP Data "<<outputMSE;
+              outputAE = candidate.aeOutputXicToPiKP()[0]; /// AE output of feature 0
+              outputMSE = candidate.mseXicToPiKP()[0];     /// MSE
+              LOG(debug) << "Global mse in taskXic for PiKP Data " << outputMSE;
               registry.get<THnSparse>(HIST("hnXicVarsWithMse"))->Fill(massXic, ptCandidate, candidate.decayLength(), candidate.cpa(), outputAE, false, outputMSE);
             }
           } else {
@@ -529,9 +529,9 @@ struct HfTaskXic {
                 /// Fill the ML outputScores and variables of candidate (todo: add multiplicity)
                 registry.get<THnSparse>(HIST("hnXicVarsWithBdt"))->Fill(massXicToPKPi, ptCandidate, outputBkg, outputPrompt, outputFD, origin);
               } else {
-                 outputAE = candidate.aeOutputXicToPKPi()[0]; /// AE output of feature 0
-                 outputMSE = candidate.mseXicToPKPi()[0];     /// MSE
-                 registry.get<THnSparse>(HIST("hnXicVarsWithMse"))->Fill(massXicToPKPi, ptCandidate, candidate.decayLength(), candidate.cpa(), outputAE, origin, outputMSE);
+                outputAE = candidate.aeOutputXicToPKPi()[0]; /// AE output of feature 0
+                outputMSE = candidate.mseXicToPKPi()[0];     /// MSE
+                registry.get<THnSparse>(HIST("hnXicVarsWithMse"))->Fill(massXicToPKPi, ptCandidate, candidate.decayLength(), candidate.cpa(), outputAE, origin, outputMSE);
               }
             } else {
               registry.get<THnSparse>(HIST("hnXicVars"))->Fill(massXicToPKPi, ptCandidate, candidate.chi2PCA(), candidate.decayLength(), candidate.decayLengthXY(), candidate.cpa(), origin);
@@ -547,9 +547,9 @@ struct HfTaskXic {
                 // add here the pT_Mother, y_Mother, level (reco, Gen, Gen + Acc)
                 registry.get<THnSparse>(HIST("hnXicVarsWithBdt"))->Fill(massXicToPiKP, ptCandidate, outputBkg, outputPrompt, outputFD, origin);
               } else {
-                 outputAE = candidate.aeOutputXicToPiKP()[0];  /// AE output of feature 0
-                 outputMSE = candidate.mseXicToPiKP()[0];      /// MSE
-                 registry.get<THnSparse>(HIST("hnXicVarsWithMse"))->Fill(massXicToPiKP, ptCandidate, candidate.decayLength(), candidate.cpa(), outputAE, origin, outputMSE);
+                outputAE = candidate.aeOutputXicToPiKP()[0];  /// AE output of feature 0
+                outputMSE = candidate.mseXicToPiKP()[0];      /// MSE
+                registry.get<THnSparse>(HIST("hnXicVarsWithMse"))->Fill(massXicToPiKP, ptCandidate, candidate.decayLength(), candidate.cpa(), outputAE, origin, outputMSE);
               }
             } else {
               registry.get<THnSparse>(HIST("hnXicVars"))->Fill(massXicToPiKP, ptCandidate, candidate.chi2PCA(), candidate.decayLength(), candidate.decayLengthXY(), candidate.cpa(), origin);

--- a/PWGHF/DataModel/CandidateSelectionTables.h
+++ b/PWGHF/DataModel/CandidateSelectionTables.h
@@ -336,9 +336,9 @@ DECLARE_SOA_TABLE(HfSelXicToPKPi, "AOD", "HFSELXIC", //!
 DECLARE_SOA_TABLE(HfMlXicToPKPi, "AOD", "HFMLXIC", //!
                   hf_sel_candidate_xic::MlProbXicToPKPi, hf_sel_candidate_xic::MlProbXicToPiKP);
 DECLARE_SOA_TABLE(HfMseXicToPKPi, "AOD", "HFMSEXIC", //! new table for MSE
-                  hf_sel_candidate_xic::MseXicToPKPi, hf_sel_candidate_xic::MseXicToPiKP); 
+                  hf_sel_candidate_xic::MseXicToPKPi, hf_sel_candidate_xic::MseXicToPiKP);
 DECLARE_SOA_TABLE(HfAeOutXicToPKPi, "AOD", "HFAEXIC", //! new table for AE output
-                  hf_sel_candidate_xic::AeOutputXicToPKPi, hf_sel_candidate_xic::AeOutputXicToPiKP); 
+                  hf_sel_candidate_xic::AeOutputXicToPKPi, hf_sel_candidate_xic::AeOutputXicToPiKP);
 // XicPlus to Xi Pi Pi
 DECLARE_SOA_TABLE(HfSelXicToXiPiPi, "AOD", "HFSELXICTOXI2PI", //!
                   hf_sel_candidate_xic::IsSelXicToXiPiPi);

--- a/PWGHF/DataModel/CandidateSelectionTables.h
+++ b/PWGHF/DataModel/CandidateSelectionTables.h
@@ -314,8 +314,8 @@ DECLARE_SOA_COLUMN(IsSelXicToPKPi, isSelXicToPKPi, int);                  //!
 DECLARE_SOA_COLUMN(IsSelXicToPiKP, isSelXicToPiKP, int);                  //!
 DECLARE_SOA_COLUMN(MlProbXicToPKPi, mlProbXicToPKPi, std::vector<float>); //!
 DECLARE_SOA_COLUMN(MlProbXicToPiKP, mlProbXicToPiKP, std::vector<float>); //!
-DECLARE_SOA_COLUMN(MseXicToPKPi, mseXicToPKPi, std::vector<float>); //! new column for MSE
-DECLARE_SOA_COLUMN(MseXicToPiKP, mseXicToPiKP, std::vector<float>); //! new column for MSE
+DECLARE_SOA_COLUMN(MseXicToPKPi, mseXicToPKPi, std::vector<float>);       //! new column for MSE
+DECLARE_SOA_COLUMN(MseXicToPiKP, mseXicToPiKP, std::vector<float>);       //! new column for MSE
 DECLARE_SOA_COLUMN(AeOutputXicToPKPi, aeOutputXicToPKPi, std::vector<float>); //! new column for AE output
 DECLARE_SOA_COLUMN(AeOutputXicToPiKP, aeOutputXicToPiKP, std::vector<float>); //! new column for AE output
 // XicPlus to Xi Pi Pi

--- a/PWGHF/DataModel/CandidateSelectionTables.h
+++ b/PWGHF/DataModel/CandidateSelectionTables.h
@@ -314,6 +314,10 @@ DECLARE_SOA_COLUMN(IsSelXicToPKPi, isSelXicToPKPi, int);                  //!
 DECLARE_SOA_COLUMN(IsSelXicToPiKP, isSelXicToPiKP, int);                  //!
 DECLARE_SOA_COLUMN(MlProbXicToPKPi, mlProbXicToPKPi, std::vector<float>); //!
 DECLARE_SOA_COLUMN(MlProbXicToPiKP, mlProbXicToPiKP, std::vector<float>); //!
+DECLARE_SOA_COLUMN(MseXicToPKPi, mseXicToPKPi, std::vector<float>); //! new column for MSE
+DECLARE_SOA_COLUMN(MseXicToPiKP, mseXicToPiKP, std::vector<float>); //! new column for MSE
+DECLARE_SOA_COLUMN(AeOutputXicToPKPi, aeOutputXicToPKPi, std::vector<float>); //! new column for AE output
+DECLARE_SOA_COLUMN(AeOutputXicToPiKP, aeOutputXicToPiKP, std::vector<float>); //! new column for AE output
 // XicPlus to Xi Pi Pi
 DECLARE_SOA_COLUMN(IsSelXicToXiPiPi, isSelXicToXiPiPi, int);                  //!
 DECLARE_SOA_COLUMN(MlProbXicToXiPiPi, mlProbXicToXiPiPi, std::vector<float>); //!
@@ -331,6 +335,10 @@ DECLARE_SOA_TABLE(HfSelXicToPKPi, "AOD", "HFSELXIC", //!
                   hf_sel_candidate_xic::IsSelXicToPKPi, hf_sel_candidate_xic::IsSelXicToPiKP);
 DECLARE_SOA_TABLE(HfMlXicToPKPi, "AOD", "HFMLXIC", //!
                   hf_sel_candidate_xic::MlProbXicToPKPi, hf_sel_candidate_xic::MlProbXicToPiKP);
+DECLARE_SOA_TABLE(HfMseXicToPKPi, "AOD", "HFMSEXIC", //! new table for MSE
+                  hf_sel_candidate_xic::MseXicToPKPi, hf_sel_candidate_xic::MseXicToPiKP); 
+DECLARE_SOA_TABLE(HfAeOutXicToPKPi, "AOD", "HFAEXIC", //! new table for AE output
+                  hf_sel_candidate_xic::AeOutputXicToPKPi, hf_sel_candidate_xic::AeOutputXicToPiKP); 
 // XicPlus to Xi Pi Pi
 DECLARE_SOA_TABLE(HfSelXicToXiPiPi, "AOD", "HFSELXICTOXI2PI", //!
                   hf_sel_candidate_xic::IsSelXicToXiPiPi);

--- a/PWGHF/TableProducer/candidateSelectorXicToPKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorXicToPKPi.cxx
@@ -54,7 +54,7 @@ using namespace o2::framework;
 struct HfCandidateSelectorXicToPKPi {
   Produces<aod::HfSelXicToPKPi> hfSelXicToPKPiCandidate;
   Produces<aod::HfMlXicToPKPi> hfMlXicToPKPiCandidate;
-  Produces<aod::HfMseXicToPKPi> hfMseXicToPKPiCandidate; 
+  Produces<aod::HfMseXicToPKPi> hfMseXicToPKPiCandidate;
   Produces<aod::HfAeOutXicToPKPi> hfAeXicToPKPiCandidate;
 
   Configurable<double> ptCandMin{"ptCandMin", 0., "Lower bound of candidate pT"};
@@ -87,7 +87,7 @@ struct HfCandidateSelectorXicToPKPi {
   Configurable<bool> applyMSE{"applyMSE", false, "Flag to calculate MSE for autoencoders"};
   Configurable<bool> applyMinMax{"applyMinMax", false, "Flag to MinMax feature preprocessing"};
   /// Parameter vectors for feature preprocessing - external scaling
-  Configurable<std::vector<float>> scaleMin{"scaleMin", {0.,0.,0.}, "vector of scaling parameter min"};  
+  Configurable<std::vector<float>> scaleMin{"scaleMin", {0.,0.,0.}, "vector of scaling parameter min"};
   Configurable<std::vector<float>> scaleMax{"scaleMax", {1.,1.,1.}, "vector of scaling parameter max"};
   // CCDB configuration
   Configurable<std::string> ccdbUrl{"ccdbUrl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
@@ -104,10 +104,10 @@ struct HfCandidateSelectorXicToPKPi {
   o2::analysis::HfAeToMseXicToPKPi<float> hfAeResponse; // new class for AE
   std::vector<float> outputMseXicToPKPi = {};
   std::vector<float> outputMseXicToPiKP = {};
-  std::vector<float> outputAeXicToPKPi = {}; 
-  std::vector<float> outputAeXicToPiKP = {}; 
+  std::vector<float> outputAeXicToPKPi = {};
+  std::vector<float> outputAeXicToPiKP = {};
   int scaleType = 0; // 0 indicates no scaling application
-  
+
   o2::ccdb::CcdbApi ccdbApi;
   TrackSelectorPi selectorPion;
   TrackSelectorKa selectorKaon;
@@ -154,11 +154,11 @@ struct HfCandidateSelectorXicToPKPi {
       }
       hfMlResponse.cacheInputFeaturesIndices(namesInputFeatures);
       hfMlResponse.init();
-      /// AE feature preprocessing - MinMax scaling initialization 
+      /// AE feature preprocessing - MinMax scaling initialization
       if(applyMinMax == 1) {
-      	LOG(info)<<"MinMax scaling will be applied"; 
+        LOG(info)<<"MinMax scaling will be applied";
       	scaleType = 1;
-      } else LOG(info)<<"No external preprocessing transformation will be applied"; 
+      } else LOG(info)<<"No external preprocessing transformation will be applied";
     }
   }
 
@@ -272,7 +272,7 @@ struct HfCandidateSelectorXicToPKPi {
       outputMseXicToPiKP.clear();
       outputAeXicToPKPi.clear();
       outputAeXicToPiKP.clear();
-      
+
       auto ptCand = candidate.pt();
 
       if (!TESTBIT(candidate.hfflag(), aod::hf_cand_3prong::DecayType::XicToPKPi)) {
@@ -412,32 +412,32 @@ struct HfCandidateSelectorXicToPKPi {
         if (topolXicToPKPi && pidXicToPKPi) {
           std::vector<float> inputFeaturesXicToPKPi = hfMlResponse.getInputFeatures(candidate, true);
           isSelectedMlXicToPKPi = hfMlResponse.isSelectedMl(inputFeaturesXicToPKPi, ptCand, outputMlXicToPKPi);
-          if(applyMSE){ 
-						/// fill outputAeXicToPKPi with rescaled AE output since ML output is automatically scaled
-          	hfAeResponse.unsetScaling(applyMSE, scaleType, outputMlXicToPKPi, scaleMin, scaleMax);      	       	
-          	outputAeXicToPKPi = hfAeResponse.getPostprocessedOutput(); 
-          	/// fill outputMSEXicToPKPi vector with MSE
-          	hfAeResponse.setScaling(applyMSE, scaleType, inputFeaturesXicToPKPi, scaleMin, scaleMax);         	
-          	float msePKPi = hfAeResponse.getMse(inputFeaturesXicToPKPi, outputMlXicToPKPi); /// args are not-scaled input, automatically scaled ML output 
-          	outputMseXicToPKPi.push_back(msePKPi);          	
+          if(applyMSE){
+            /// fill outputAeXicToPKPi with rescaled AE output since ML output is automatically scaled
+            hfAeResponse.unsetScaling(applyMSE, scaleType, outputMlXicToPKPi, scaleMin, scaleMax);  	       	
+            outputAeXicToPKPi = hfAeResponse.getPostprocessedOutput();
+            /// fill outputMSEXicToPKPi vector with MSE
+            hfAeResponse.setScaling(applyMSE, scaleType, inputFeaturesXicToPKPi, scaleMin, scaleMax);
+            float msePKPi = hfAeResponse.getMse(inputFeaturesXicToPKPi, outputMlXicToPKPi); /// args are not-scaled input, automatically scaled ML output 
+            outputMseXicToPKPi.push_back(msePKPi);
           }
         }
         if (topolXicToPiKP && pidXicToPiKP) {
           std::vector<float> inputFeaturesXicToPiKP = hfMlResponse.getInputFeatures(candidate, false);
           isSelectedMlXicToPiKP = hfMlResponse.isSelectedMl(inputFeaturesXicToPiKP, ptCand, outputMlXicToPiKP);
-					if(applyMSE){ 
-						/// fill outputAeXicToPiKP with rescaled AE output since ML output is automatically scaled
-          	hfAeResponse.unsetScaling(applyMSE, scaleType, outputMlXicToPiKP, scaleMin, scaleMax); 
-          	outputAeXicToPiKP = hfAeResponse.getPostprocessedOutput();
-          	/// fill outputMSEXicToPiKP vector with MSE	
-          	hfAeResponse.setScaling(applyMSE, scaleType, inputFeaturesXicToPiKP, scaleMin, scaleMax); 
-          	float msePiKP = hfAeResponse.getMse(inputFeaturesXicToPiKP, outputMlXicToPiKP); /// args are not-scaled input, automatically scaled ML output 
-          	outputMseXicToPiKP.push_back(msePiKP);	          	
+          if(applyMSE){
+            /// fill outputAeXicToPiKP with rescaled AE output since ML output is automatically scaled
+            hfAeResponse.unsetScaling(applyMSE, scaleType, outputMlXicToPiKP, scaleMin, scaleMax);
+            outputAeXicToPiKP = hfAeResponse.getPostprocessedOutput();
+            /// fill outputMSEXicToPiKP vector with MSE
+            hfAeResponse.setScaling(applyMSE, scaleType, inputFeaturesXicToPiKP, scaleMin, scaleMax); 
+            float msePiKP = hfAeResponse.getMse(inputFeaturesXicToPiKP, outputMlXicToPiKP); /// args are not-scaled input, automatically scaled ML output 
+            outputMseXicToPiKP.push_back(msePiKP);	          	
           }
         }
 
         hfMlXicToPKPiCandidate(outputMlXicToPKPi, outputMlXicToPiKP);
-				hfMseXicToPKPiCandidate(outputMseXicToPKPi, outputMseXicToPiKP);
+        hfMseXicToPKPiCandidate(outputMseXicToPKPi, outputMseXicToPiKP);
         hfAeXicToPKPiCandidate(outputAeXicToPKPi, outputAeXicToPiKP);
 
         if (!isSelectedMlXicToPKPi && !isSelectedMlXicToPiKP) {

--- a/PWGHF/TableProducer/candidateSelectorXicToPKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorXicToPKPi.cxx
@@ -87,8 +87,8 @@ struct HfCandidateSelectorXicToPKPi {
   Configurable<bool> applyMSE{"applyMSE", false, "Flag to calculate MSE for autoencoders"};
   Configurable<bool> applyMinMax{"applyMinMax", false, "Flag to MinMax feature preprocessing"};
   /// Parameter vectors for feature preprocessing - external scaling
-  Configurable<std::vector<float>> scaleMin{"scaleMin", {0.,0.,0.}, "vector of scaling parameter min"};
-  Configurable<std::vector<float>> scaleMax{"scaleMax", {1.,1.,1.}, "vector of scaling parameter max"};
+  Configurable<std::vector<float>> scaleMin{"scaleMin", {0., 0., 0.}, "vector of scaling parameter min"};
+  Configurable<std::vector<float>> scaleMax{"scaleMax", {1., 1., 1.}, "vector of scaling parameter max"};
   // CCDB configuration
   Configurable<std::string> ccdbUrl{"ccdbUrl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::vector<std::string>> modelPathsCCDB{"modelPathsCCDB", std::vector<std::string>{"EventFiltering/PWGHF/BDTXic"}, "Paths of models on CCDB"};
@@ -155,10 +155,11 @@ struct HfCandidateSelectorXicToPKPi {
       hfMlResponse.cacheInputFeaturesIndices(namesInputFeatures);
       hfMlResponse.init();
       /// AE feature preprocessing - MinMax scaling initialization
-      if(applyMinMax == 1) {
+      if (applyMinMax == 1) {
         LOG(info)<<"MinMax scaling will be applied";
         scaleType = 1;
-      } else LOG(info)<<"No external preprocessing transformation will be applied";
+      } else 
+        LOG(info) << "No external preprocessing transformation will be applied";
     }
   }
 
@@ -280,7 +281,7 @@ struct HfCandidateSelectorXicToPKPi {
         if (applyMl) {
           hfMlXicToPKPiCandidate(outputMlXicToPKPi, outputMlXicToPiKP);
           hfMseXicToPKPiCandidate(outputMseXicToPKPi, outputMseXicToPiKP); // MSE
-          hfAeXicToPKPiCandidate(outputAeXicToPKPi, outputAeXicToPiKP); // autoencoder outputs
+          hfAeXicToPKPiCandidate(outputAeXicToPKPi, outputAeXicToPiKP);    // autoencoder outputs
         }
         if (activateQA) {
           registry.fill(HIST("hSelections"), 1, ptCand);
@@ -305,7 +306,7 @@ struct HfCandidateSelectorXicToPKPi {
         if (applyMl) {
           hfMlXicToPKPiCandidate(outputMlXicToPKPi, outputMlXicToPiKP);
           hfMseXicToPKPiCandidate(outputMseXicToPKPi, outputMseXicToPiKP); // MSE
-          hfAeXicToPKPiCandidate(outputAeXicToPKPi, outputAeXicToPiKP); // autoencoder outputs
+          hfAeXicToPKPiCandidate(outputAeXicToPKPi, outputAeXicToPiKP);    // autoencoder outputs
         }
         continue;
       }
@@ -320,7 +321,7 @@ struct HfCandidateSelectorXicToPKPi {
         if (applyMl) {
           hfMlXicToPKPiCandidate(outputMlXicToPKPi, outputMlXicToPiKP);
           hfMseXicToPKPiCandidate(outputMseXicToPKPi, outputMseXicToPiKP); // MSE
-          hfAeXicToPKPiCandidate(outputAeXicToPKPi, outputAeXicToPiKP); // autoencoder outputs
+          hfAeXicToPKPiCandidate(outputAeXicToPKPi, outputAeXicToPiKP);    // autoencoder outputs
         }
         continue;
       }
@@ -389,7 +390,7 @@ struct HfCandidateSelectorXicToPKPi {
         if (applyMl) {
           hfMlXicToPKPiCandidate(outputMlXicToPKPi, outputMlXicToPiKP);
           hfMseXicToPKPiCandidate(outputMseXicToPKPi, outputMseXicToPiKP); // MSE
-          hfAeXicToPKPiCandidate(outputAeXicToPKPi, outputAeXicToPiKP); // autoencoder outputs
+          hfAeXicToPKPiCandidate(outputAeXicToPKPi, outputAeXicToPiKP);    // autoencoder outputs
         }
         continue;
       }
@@ -412,7 +413,7 @@ struct HfCandidateSelectorXicToPKPi {
         if (topolXicToPKPi && pidXicToPKPi) {
           std::vector<float> inputFeaturesXicToPKPi = hfMlResponse.getInputFeatures(candidate, true);
           isSelectedMlXicToPKPi = hfMlResponse.isSelectedMl(inputFeaturesXicToPKPi, ptCand, outputMlXicToPKPi);
-          if(applyMSE){
+          if (applyMSE) {
             /// fill outputAeXicToPKPi with rescaled AE output since ML output is automatically scaled
             hfAeResponse.unsetScaling(applyMSE, scaleType, outputMlXicToPKPi, scaleMin, scaleMax);
             outputAeXicToPKPi = hfAeResponse.getPostprocessedOutput();
@@ -425,7 +426,7 @@ struct HfCandidateSelectorXicToPKPi {
         if (topolXicToPiKP && pidXicToPiKP) {
           std::vector<float> inputFeaturesXicToPiKP = hfMlResponse.getInputFeatures(candidate, false);
           isSelectedMlXicToPiKP = hfMlResponse.isSelectedMl(inputFeaturesXicToPiKP, ptCand, outputMlXicToPiKP);
-          if(applyMSE){
+          if (applyMSE) {
             /// fill outputAeXicToPiKP with rescaled AE output since ML output is automatically scaled
             hfAeResponse.unsetScaling(applyMSE, scaleType, outputMlXicToPiKP, scaleMin, scaleMax);
             outputAeXicToPiKP = hfAeResponse.getPostprocessedOutput();

--- a/PWGHF/TableProducer/candidateSelectorXicToPKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorXicToPKPi.cxx
@@ -87,8 +87,8 @@ struct HfCandidateSelectorXicToPKPi {
   Configurable<bool> applyMSE{"applyMSE", false, "Flag to calculate MSE for autoencoders"};
   Configurable<bool> applyMinMax{"applyMinMax", false, "Flag to MinMax feature preprocessing"};
   /// Parameter vectors for feature preprocessing - external scaling
-  Configurable<std::vector<float>> ScaleMin{"ScaleMin", {0.,0.,0.}, "vector of scaling parameter min"};  
-  Configurable<std::vector<float>> ScaleMax{"ScaleMax", {1.,1.,1.}, "vector of scaling parameter max"};
+  Configurable<std::vector<float>> scaleMin{"scaleMin", {0.,0.,0.}, "vector of scaling parameter min"};  
+  Configurable<std::vector<float>> scaleMax{"scaleMax", {1.,1.,1.}, "vector of scaling parameter max"};
   // CCDB configuration
   Configurable<std::string> ccdbUrl{"ccdbUrl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::vector<std::string>> modelPathsCCDB{"modelPathsCCDB", std::vector<std::string>{"EventFiltering/PWGHF/BDTXic"}, "Paths of models on CCDB"};
@@ -414,12 +414,12 @@ struct HfCandidateSelectorXicToPKPi {
           isSelectedMlXicToPKPi = hfMlResponse.isSelectedMl(inputFeaturesXicToPKPi, ptCand, outputMlXicToPKPi);
           if(applyMSE){ 
 						/// fill outputAeXicToPKPi with rescaled AE output since ML output is automatically scaled
-          	hfAeResponse.unsetScaling(applyMSE, scaleType, outputMlXicToPKPi, ScaleMin, ScaleMax);      	       	
+          	hfAeResponse.unsetScaling(applyMSE, scaleType, outputMlXicToPKPi, scaleMin, scaleMax);      	       	
           	outputAeXicToPKPi = hfAeResponse.getPostprocessedOutput(); 
           	/// fill outputMSEXicToPKPi vector with MSE
-          	hfAeResponse.setScaling(applyMSE, scaleType, inputFeaturesXicToPKPi, ScaleMin, ScaleMax);         	
-          	float MsePKPi = hfAeResponse.getMse(inputFeaturesXicToPKPi, outputMlXicToPKPi); /// args are not-scaled input, automatically scaled ML output 
-          	outputMseXicToPKPi.push_back(MsePKPi);          	
+          	hfAeResponse.setScaling(applyMSE, scaleType, inputFeaturesXicToPKPi, scaleMin, scaleMax);         	
+          	float msePKPi = hfAeResponse.getMse(inputFeaturesXicToPKPi, outputMlXicToPKPi); /// args are not-scaled input, automatically scaled ML output 
+          	outputMseXicToPKPi.push_back(msePKPi);          	
           }
         }
         if (topolXicToPiKP && pidXicToPiKP) {
@@ -427,12 +427,12 @@ struct HfCandidateSelectorXicToPKPi {
           isSelectedMlXicToPiKP = hfMlResponse.isSelectedMl(inputFeaturesXicToPiKP, ptCand, outputMlXicToPiKP);
 					if(applyMSE){ 
 						/// fill outputAeXicToPiKP with rescaled AE output since ML output is automatically scaled
-          	hfAeResponse.unsetScaling(applyMSE, scaleType, outputMlXicToPiKP, ScaleMin, ScaleMax); 
+          	hfAeResponse.unsetScaling(applyMSE, scaleType, outputMlXicToPiKP, scaleMin, scaleMax); 
           	outputAeXicToPiKP = hfAeResponse.getPostprocessedOutput();
           	/// fill outputMSEXicToPiKP vector with MSE	
-          	hfAeResponse.setScaling(applyMSE, scaleType, inputFeaturesXicToPiKP, ScaleMin, ScaleMax); 
-          	float MsePiKP = hfAeResponse.getMse(inputFeaturesXicToPiKP, outputMlXicToPiKP); /// args are not-scaled input, automatically scaled ML output 
-          	outputMseXicToPiKP.push_back(MsePiKP);	          	
+          	hfAeResponse.setScaling(applyMSE, scaleType, inputFeaturesXicToPiKP, scaleMin, scaleMax); 
+          	float msePiKP = hfAeResponse.getMse(inputFeaturesXicToPiKP, outputMlXicToPiKP); /// args are not-scaled input, automatically scaled ML output 
+          	outputMseXicToPiKP.push_back(msePiKP);	          	
           }
         }
 

--- a/PWGHF/TableProducer/candidateSelectorXicToPKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorXicToPKPi.cxx
@@ -157,7 +157,7 @@ struct HfCandidateSelectorXicToPKPi {
       /// AE feature preprocessing - MinMax scaling initialization
       if(applyMinMax == 1) {
         LOG(info)<<"MinMax scaling will be applied";
-      	scaleType = 1;
+        scaleType = 1;
       } else LOG(info)<<"No external preprocessing transformation will be applied";
     }
   }
@@ -418,7 +418,7 @@ struct HfCandidateSelectorXicToPKPi {
             outputAeXicToPKPi = hfAeResponse.getPostprocessedOutput();
             /// fill outputMSEXicToPKPi vector with MSE
             hfAeResponse.setScaling(applyMSE, scaleType, inputFeaturesXicToPKPi, scaleMin, scaleMax);
-            float msePKPi = hfAeResponse.getMse(inputFeaturesXicToPKPi, outputMlXicToPKPi); /// args are not-scaled input, automatically scaled ML output 
+            float msePKPi = hfAeResponse.getMse(inputFeaturesXicToPKPi, outputMlXicToPKPi); /// args are not-scaled input, automatically scaled ML output
             outputMseXicToPKPi.push_back(msePKPi);
           }
         }
@@ -430,8 +430,8 @@ struct HfCandidateSelectorXicToPKPi {
             hfAeResponse.unsetScaling(applyMSE, scaleType, outputMlXicToPiKP, scaleMin, scaleMax);
             outputAeXicToPiKP = hfAeResponse.getPostprocessedOutput();
             /// fill outputMSEXicToPiKP vector with MSE
-            hfAeResponse.setScaling(applyMSE, scaleType, inputFeaturesXicToPiKP, scaleMin, scaleMax); 
-            float msePiKP = hfAeResponse.getMse(inputFeaturesXicToPiKP, outputMlXicToPiKP); /// args are not-scaled input, automatically scaled ML output 
+            hfAeResponse.setScaling(applyMSE, scaleType, inputFeaturesXicToPiKP, scaleMin, scaleMax);
+            float msePiKP = hfAeResponse.getMse(inputFeaturesXicToPiKP, outputMlXicToPiKP); /// args are not-scaled input, automatically scaled ML output
             outputMseXicToPiKP.push_back(msePiKP);	          	
           }
         }

--- a/PWGHF/TableProducer/candidateSelectorXicToPKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorXicToPKPi.cxx
@@ -158,8 +158,9 @@ struct HfCandidateSelectorXicToPKPi {
       if (applyMinMax == 1) {
         LOG(info) << "MinMax scaling will be applied";
         scaleType = 1;
-      } else
+      } else {
         LOG(info) << "No external preprocessing transformation will be applied";
+      }
     }
   }
 

--- a/PWGHF/TableProducer/candidateSelectorXicToPKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorXicToPKPi.cxx
@@ -17,10 +17,10 @@
 /// \author Vít Kučera <vit.kucera@cern.ch>, CERN
 /// \author Cristina Terrevoli <cristina.terrevoli@cern.ch>, INFN BARI
 
+#include "PWGHF/Core/HfAeToMseXicToPKPi.h"
 #include "PWGHF/Core/HfHelper.h"
 #include "PWGHF/Core/HfMlResponseXicToPKPi.h"
 #include "PWGHF/Core/SelectorCuts.h"
-#include "PWGHF/Core/HfAeToMseXicToPKPi.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
 
@@ -156,9 +156,9 @@ struct HfCandidateSelectorXicToPKPi {
       hfMlResponse.init();
       /// AE feature preprocessing - MinMax scaling initialization
       if (applyMinMax == 1) {
-        LOG(info)<<"MinMax scaling will be applied";
+        LOG(info) << "MinMax scaling will be applied";
         scaleType = 1;
-      } else 
+      } else
         LOG(info) << "No external preprocessing transformation will be applied";
     }
   }

--- a/PWGHF/TableProducer/candidateSelectorXicToPKPi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorXicToPKPi.cxx
@@ -414,7 +414,7 @@ struct HfCandidateSelectorXicToPKPi {
           isSelectedMlXicToPKPi = hfMlResponse.isSelectedMl(inputFeaturesXicToPKPi, ptCand, outputMlXicToPKPi);
           if(applyMSE){
             /// fill outputAeXicToPKPi with rescaled AE output since ML output is automatically scaled
-            hfAeResponse.unsetScaling(applyMSE, scaleType, outputMlXicToPKPi, scaleMin, scaleMax);  	       	
+            hfAeResponse.unsetScaling(applyMSE, scaleType, outputMlXicToPKPi, scaleMin, scaleMax);
             outputAeXicToPKPi = hfAeResponse.getPostprocessedOutput();
             /// fill outputMSEXicToPKPi vector with MSE
             hfAeResponse.setScaling(applyMSE, scaleType, inputFeaturesXicToPKPi, scaleMin, scaleMax);
@@ -432,7 +432,7 @@ struct HfCandidateSelectorXicToPKPi {
             /// fill outputMSEXicToPiKP vector with MSE
             hfAeResponse.setScaling(applyMSE, scaleType, inputFeaturesXicToPiKP, scaleMin, scaleMax);
             float msePiKP = hfAeResponse.getMse(inputFeaturesXicToPiKP, outputMlXicToPiKP); /// args are not-scaled input, automatically scaled ML output
-            outputMseXicToPiKP.push_back(msePiKP);	          	
+            outputMseXicToPiKP.push_back(msePiKP);
           }
         }
 


### PR DESCRIPTION
Minimal changes in XicToPKPi specific files (task and selector) to evaluate the MSE between input (externally scaled) and internal scaled output of autoencoder. At moment, one can not run Autoencoder and BDT at the same time since they competitively fill candidate.mlProbXicToPKPi()[0].