### PR TITLE
[PWGJE,EMCAL-689] Implementation of EMCal cell-track-matcher

### DIFF
--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -1366,7 +1366,7 @@ struct LumiTask {
     const char* srun = Form("%d", run);
 
     for (const auto& bc : bcs) {
-      auto selection = bc.selection_raw();
+      auto& selection = bc.selection_raw();
       if (bcPatternB[bc.globalBC() % nBCsPerOrbit] == 0) // skip non-colliding bcs
         continue;
 

--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -14,34 +14,37 @@
 ///
 /// \author Evgeny Kryshen <evgeny.kryshen@cern.ch> and Igor Altsybeev <Igor.Altsybeev@cern.ch>
 
-#include <vector>
-#include <map>
-#include <string>
-#include <limits>
-
-#include "Framework/ConfigParamSpec.h"
-#include "Framework/runDataProcessing.h"
-#include "Framework/AnalysisTask.h"
-#include "Framework/AnalysisDataModel.h"
 #include "Common/DataModel/EventSelection.h"
+
+#include "MetadataHelper.h"
+
 #include "Common/CCDB/EventSelectionParams.h"
 #include "Common/CCDB/TriggerAliases.h"
+
 #include "CCDB/BasicCCDBManager.h"
 #include "CommonConstants/LHCConstants.h"
-#include "Framework/HistogramRegistry.h"
-#include "DataFormatsFT0/Digit.h"
-#include "DataFormatsParameters/GRPLHCIFData.h"
-#include "DataFormatsParameters/GRPECSObject.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
-#include "MetadataHelper.h"
-#include "DataFormatsParameters/AggregatedRunInfo.h"
-#include "DataFormatsITSMFT/NoiseMap.h" // missing include in TimeDeadMap.h
-#include "DataFormatsITSMFT/TimeDeadMap.h"
-#include "ITSMFTReconstruction/ChipMappingITS.h"
 #include "DataFormatsCTP/Configuration.h"
 #include "DataFormatsCTP/Scalers.h"
+#include "DataFormatsFT0/Digit.h"
+#include "DataFormatsITSMFT/NoiseMap.h" // missing include in TimeDeadMap.h
+#include "DataFormatsITSMFT/TimeDeadMap.h"
+#include "DataFormatsParameters/AggregatedRunInfo.h"
+#include "DataFormatsParameters/GRPECSObject.h"
+#include "DataFormatsParameters/GRPLHCIFData.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/ConfigParamSpec.h"
+#include "Framework/HistogramRegistry.h"
+#include "Framework/runDataProcessing.h"
+#include "ITSMFTBase/DPLAlpideParam.h"
+#include "ITSMFTReconstruction/ChipMappingITS.h"
 
 #include "TH1D.h"
+
+#include <limits>
+#include <map>
+#include <string>
+#include <vector>
 
 using namespace o2;
 using namespace o2::framework;
@@ -1363,7 +1366,7 @@ struct LumiTask {
     const char* srun = Form("%d", run);
 
     for (const auto& bc : bcs) {
-      auto& selection = bc.selection_raw();
+      auto selection = bc.selection_raw();
       if (bcPatternB[bc.globalBC() % nBCsPerOrbit] == 0) // skip non-colliding bcs
         continue;
 

--- a/PWGEM/PhotonMeson/Tasks/emcalPi0QC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/emcalPi0QC.cxx
@@ -12,6 +12,7 @@
 #include <climits>
 #include <cstdlib>
 #include <map>
+#include <unordered_map>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -359,7 +360,7 @@ struct Pi0QCTask {
       FillClusterQAHistos<decltype(cluster), 1>(cluster);
 
       // put clusters in photon vector
-      mPhotons.push_back(Photon(cluster.eta(), cluster.phi(), cluster.energy(), cluster.id()));
+      mPhotons.push_back(Photon(cluster.eta(), cluster.phi(), cluster.energy(), cluster.globalIndex()));
     }
   }
 
@@ -382,7 +383,7 @@ struct Pi0QCTask {
       FillClusterQAHistos<decltype(cluster), 1>(cluster);
 
       // put clusters in photon vector
-      mPhotons.push_back(Photon(cluster.eta(), cluster.phi(), cluster.energy(), cluster.id()));
+      mPhotons.push_back(Photon(cluster.eta(), cluster.phi(), cluster.energy(), cluster.globalIndex()));
     }
   }
 

--- a/PWGJE/Core/JetUtilities.h
+++ b/PWGJE/Core/JetUtilities.h
@@ -20,6 +20,8 @@
 
 #include "Common/Core/RecoDecay.h"
 
+#include "CommonConstants/MathConstants.h"
+
 #include <TKDTree.h>
 
 #include <algorithm>
@@ -29,10 +31,6 @@
 #include <stdexcept>
 #include <tuple>
 #include <vector>
-
-#include "Framework/Logger.h"
-#include "CommonConstants/MathConstants.h"
-#include "Common/Core/RecoDecay.h"
 
 namespace jetutilities
 {

--- a/PWGJE/TableProducer/CMakeLists.txt
+++ b/PWGJE/TableProducer/CMakeLists.txt
@@ -100,3 +100,13 @@ o2physics_add_dpl_workflow(emcal-cluster-hadronic-correction-task
                     SOURCES emcalClusterHadronicCorrectionTask.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2::EMCALBase O2::EMCALReconstruction
                     COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(emcal-cell-track-matching-task
+                    SOURCES emcalCellTrackMatcher.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase O2::EMCALBase O2::EMCALReconstruction
+                    COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(emcal-track-sorting-task
+                    SOURCES emcalTrackSorter.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::DetectorsBase
+                    COMPONENT_NAME Analysis)

--- a/PWGJE/TableProducer/derivedDataProducer.cxx
+++ b/PWGJE/TableProducer/derivedDataProducer.cxx
@@ -428,7 +428,7 @@ struct JetDerivedDataProducerTask {
         }
       }
 
-      products.jClustersTable(cluster.collisionId(), cluster.id(), cluster.energy(), cluster.coreEnergy(), cluster.rawEnergy(), cluster.eta(), cluster.phi(), cluster.m02(), cluster.m20(), cluster.nCells(), cluster.time(), cluster.isExotic(), cluster.distanceToBadChannel(), cluster.nlm(), cluster.definition(), leadingCellEnergy, subleadingCellEnergy, leadingCellNumber, subleadingCellNumber);
+      products.jClustersTable(cluster.collisionId(), cluster.globalIndex(), cluster.energy(), cluster.coreEnergy(), cluster.rawEnergy(), cluster.eta(), cluster.phi(), cluster.m02(), cluster.m20(), cluster.nCells(), cluster.time(), cluster.isExotic(), cluster.distanceToBadChannel(), cluster.nlm(), cluster.definition(), leadingCellEnergy, subleadingCellEnergy, leadingCellNumber, subleadingCellNumber);
       products.jClustersParentIndexTable(cluster.globalIndex());
 
       auto const clusterTracks = matchedTracks.sliceBy(perClusterTracks, cluster.globalIndex());

--- a/PWGJE/TableProducer/emcalCellTrackMatcher.cxx
+++ b/PWGJE/TableProducer/emcalCellTrackMatcher.cxx
@@ -664,212 +664,212 @@ struct EmcalCellTrackMatcher {
         cellMatchedTracks(emptySpan);
       }
       return;
-      // } else {
-      //   for (int64_t iCell = 0; iCell < cells.size(); ++iCell){
-      //     cellMatchedTracks(emptySpan);
-      //   }
+    } else {
+      for (int64_t iCell = 0; iCell < cells.size(); ++iCell) {
+        cellMatchedTracks(emptySpan);
+      }
     }
 
     // outer vector is size as number of ALL calo cells in current DF, inside vector will store trackIDs
-    std::vector<std::vector<int>> vecCellToTracks(cells.size(), std::vector<int>());
-    std::vector<int> vecTrackIDs;
-    vecTrackIDs.reserve(cells.size());
-    std::vector<int> vecNTrackIDs(cells.size(), 0);
+    // std::vector<std::vector<int>> vecCellToTracks(cells.size(), std::vector<int>());
+    // std::vector<int> vecTrackIDs;
+    // vecTrackIDs.reserve(cells.size());
+    // std::vector<int> vecNTrackIDs(cells.size(), 0);
 
-    std::array<size_t, NCellsTotal> matchedTrackCounts;
-    std::vector<size_t> matchedTrackOffsets;
-    matchedTrackOffsets.reserve(NCellsTotal + 1);
-    std::vector<int> matchedTrackCountsOrdered;
-    matchedTrackCountsOrdered.reserve(NCellsTotal);
+    // std::array<size_t, NCellsTotal> matchedTrackCounts;
+    // std::vector<size_t> matchedTrackOffsets;
+    // matchedTrackOffsets.reserve(NCellsTotal + 1);
+    // std::vector<int> matchedTrackCountsOrdered;
+    // matchedTrackCountsOrdered.reserve(NCellsTotal);
 
-    auto track = tracks.begin();
-    auto cell = emcalCells.begin();
+    // auto track = tracks.begin();
+    // auto cell = emcalCells.begin();
 
-    const auto cellEnd = emcalCells.end();
-    const auto trackEnd = tracks.end();
+    // const auto cellEnd = emcalCells.end();
+    // const auto trackEnd = tracks.end();
 
-    std::vector<int> matchIndexCell;
-    matchIndexCell.reserve(maxNumberTracks); // reserve enough space for better performance
-    std::vector<int> matchIndexTower;
-    matchIndexTower.reserve(maxNumberTracks); // reserve enough space for better performance
+    // std::vector<int> matchIndexCell;
+    // matchIndexCell.reserve(maxNumberTracks); // reserve enough space for better performance
+    // std::vector<int> matchIndexTower;
+    // matchIndexTower.reserve(maxNumberTracks); // reserve enough space for better performance
 
-    // For the matching of a track to a cell we will use a KDTree approach from emcmatchingutilities
-    // where cells are matched to tracks. For this we need vectors of cell and track eta and phi.
-    std::vector<float> vTrackPhi;
-    std::vector<float> vTrackEta;
-    std::vector<int> vTrackIndex;
-    std::vector<float> vCellPhi;
-    std::vector<float> vCellEta;
-    std::vector<int> vCellIndex;
-    std::vector<int16_t> vTowerIndex;
-    std::vector<int> vSMIndex;
-    std::vector<std::tuple<float, float, float, float>> cellBounds;
-    vTrackPhi.reserve(maxNumberTracks);
-    vTrackEta.reserve(maxNumberTracks);
-    vTrackIndex.reserve(maxNumberTracks);
-    vCellPhi.reserve(NCellsTotal);
-    vCellEta.reserve(NCellsTotal);
-    vCellIndex.reserve(NCellsTotal);
-    vTowerIndex.reserve(NCellsTotal);
-    vSMIndex.reserve(NCellsTotal);
-    cellBounds.reserve(NCellsTotal);
-    while (cell != cellEnd && track != trackEnd) {
-      auto cellBC = cell.bcId();
-      auto trackBC = track.bcId();
+    // // For the matching of a track to a cell we will use a KDTree approach from emcmatchingutilities
+    // // where cells are matched to tracks. For this we need vectors of cell and track eta and phi.
+    // std::vector<float> vTrackPhi;
+    // std::vector<float> vTrackEta;
+    // std::vector<int> vTrackIndex;
+    // std::vector<float> vCellPhi;
+    // std::vector<float> vCellEta;
+    // std::vector<int> vCellIndex;
+    // std::vector<int16_t> vTowerIndex;
+    // std::vector<int> vSMIndex;
+    // std::vector<std::tuple<float, float, float, float>> cellBounds;
+    // vTrackPhi.reserve(maxNumberTracks);
+    // vTrackEta.reserve(maxNumberTracks);
+    // vTrackIndex.reserve(maxNumberTracks);
+    // vCellPhi.reserve(NCellsTotal);
+    // vCellEta.reserve(NCellsTotal);
+    // vCellIndex.reserve(NCellsTotal);
+    // vTowerIndex.reserve(NCellsTotal);
+    // vSMIndex.reserve(NCellsTotal);
+    // cellBounds.reserve(NCellsTotal);
+    // while (cell != cellEnd && track != trackEnd) {
+    //   auto cellBC = cell.bcId();
+    //   auto trackBC = track.bcId();
 
-      if (cellBC == trackBC) {
-        auto currentBCID = cellBC;
+    //   if (cellBC == trackBC) {
+    //     auto currentBCID = cellBC;
 
-        while (cell != cellEnd && cellBC == currentBCID) {
-          int16_t cellNumber = cell.cellNumber();
-          if (cellNumber < 0 || cellNumber >= NCellsTotal) {
-            LOG(info) << "cell number " << cellNumber << " not within EMCal!";
-            continue;
-          }
-          vCellEta.emplace_back(arrEta[cellNumber]);
-          vCellPhi.emplace_back(arrPhi[cellNumber]);
-          vCellIndex.emplace_back(cell.globalIndex());
-          vTowerIndex.emplace_back(cellNumber);
-          vSMIndex.emplace_back(geometry->GetSuperModuleNumber(cellNumber));
-          // cell bounds (etaMin, etaMax, phiMin, phiMax)
-          cellBounds.emplace_back(std::tuple<float, float, float, float>(arrLowEta[cellNumber], arrUpEta[cellNumber], arrLowPhi[cellNumber], arrUpPhi[cellNumber]));
-          if (++cell != cellEnd) {
-            cellBC = cell.bcId();
-          }
-        }
+    //     while (cell != cellEnd && cellBC == currentBCID) {
+    //       int16_t cellNumber = cell.cellNumber();
+    //       if (cellNumber < 0 || cellNumber >= NCellsTotal) {
+    //         LOG(info) << "cell number " << cellNumber << " not within EMCal!";
+    //         continue;
+    //       }
+    //       vCellEta.emplace_back(arrEta[cellNumber]);
+    //       vCellPhi.emplace_back(arrPhi[cellNumber]);
+    //       vCellIndex.emplace_back(cell.globalIndex());
+    //       vTowerIndex.emplace_back(cellNumber);
+    //       vSMIndex.emplace_back(geometry->GetSuperModuleNumber(cellNumber));
+    //       // cell bounds (etaMin, etaMax, phiMin, phiMax)
+    //       cellBounds.emplace_back(std::tuple<float, float, float, float>(arrLowEta[cellNumber], arrUpEta[cellNumber], arrLowPhi[cellNumber], arrUpPhi[cellNumber]));
+    //       if (++cell != cellEnd) {
+    //         cellBC = cell.bcId();
+    //       }
+    //     }
 
-        while (track != trackEnd && trackBC == currentBCID) {
-          vTrackPhi.emplace_back(track.phi());
-          vTrackEta.emplace_back(track.eta());
-          vTrackIndex.emplace_back(track.trackId());
-          if (++track != trackEnd) {
-            trackBC = track.bcId();
-          }
-        }
-        // build the current RTree
-        auto cellRTree = buildCellRTree(cellBounds);
+    //     while (track != trackEnd && trackBC == currentBCID) {
+    //       vTrackPhi.emplace_back(track.phi());
+    //       vTrackEta.emplace_back(track.eta());
+    //       vTrackIndex.emplace_back(track.trackId());
+    //       if (++track != trackEnd) {
+    //         trackBC = track.bcId();
+    //       }
+    //     }
+    //     // build the current RTree
+    //     auto cellRTree = buildCellRTree(cellBounds);
 
-        // loop over tracks to find matching cell
-        for (size_t iTrack = 0; iTrack < vTrackIndex.size(); ++iTrack) {
-          point p(vTrackEta[iTrack], vTrackPhi[iTrack]);
-          std::vector<value> result;
-          cellRTree.query(bgi::contains(p), std::back_inserter(result));
+    //     // loop over tracks to find matching cell
+    //     for (size_t iTrack = 0; iTrack < vTrackIndex.size(); ++iTrack) {
+    //       point p(vTrackEta[iTrack], vTrackPhi[iTrack]);
+    //       std::vector<value> result;
+    //       cellRTree.query(bgi::contains(p), std::back_inserter(result));
 
-          if (!result.empty()) {
-            // Choose best match if multiple
-            auto best = std::min_element(result.begin(), result.end(),
-                                         [&](const value& a, const value& b) {
-                                           auto center = [](const value& v) {
-                                             float etaC = 0.5f * (v.first.min_corner().get<0>() + v.first.max_corner().get<0>());
-                                             float phiC = 0.5f * (v.first.min_corner().get<1>() + v.first.max_corner().get<1>());
-                                             return std::make_pair(etaC, phiC);
-                                           };
-                                           auto [etaA, phiA] = center(a);
-                                           auto [etaB, phiB] = center(b);
-                                           float dA = std::hypot(vTrackEta[iTrack] - etaA, vTrackPhi[iTrack] - phiA);
-                                           float dB = std::hypot(vTrackEta[iTrack] - etaB, vTrackPhi[iTrack] - phiB);
-                                           return dA < dB;
-                                         });
+    //       if (!result.empty()) {
+    //         // Choose best match if multiple
+    //         auto best = std::min_element(result.begin(), result.end(),
+    //                                      [&](const value& a, const value& b) {
+    //                                        auto center = [](const value& v) {
+    //                                          float etaC = 0.5f * (v.first.min_corner().get<0>() + v.first.max_corner().get<0>());
+    //                                          float phiC = 0.5f * (v.first.min_corner().get<1>() + v.first.max_corner().get<1>());
+    //                                          return std::make_pair(etaC, phiC);
+    //                                        };
+    //                                        auto [etaA, phiA] = center(a);
+    //                                        auto [etaB, phiB] = center(b);
+    //                                        float dA = std::hypot(vTrackEta[iTrack] - etaA, vTrackPhi[iTrack] - phiA);
+    //                                        float dB = std::hypot(vTrackEta[iTrack] - etaB, vTrackPhi[iTrack] - phiB);
+    //                                        return dA < dB;
+    //                                      });
 
-            int localCellIdx = best->second;        // Index in vCellIndex
-            int cellID = vTowerIndex[localCellIdx]; // towerID of the matched cell
-            LOG(info) << "localCellIdx = " << localCellIdx << "\t cellID = " << cellID;
-            matchIndexCell.emplace_back(localCellIdx);
-            matchIndexTower.emplace_back(cellID);
+    //         int localCellIdx = best->second;        // Index in vCellIndex
+    //         int cellID = vTowerIndex[localCellIdx]; // towerID of the matched cell
+    //         LOG(info) << "localCellIdx = " << localCellIdx << "\t cellID = " << cellID;
+    //         matchIndexCell.emplace_back(localCellIdx);
+    //         matchIndexTower.emplace_back(cellID);
 
-            // Fill histograms
-            mHistManager.fill(HIST("hvTrackEtaPhiEMCal"), vTrackEta[iTrack], vTrackPhi[iTrack]);
-            float dEta = vTrackEta[iTrack] - vCellEta[localCellIdx];
-            float dPhi = vTrackPhi[iTrack] - vCellPhi[localCellIdx];
+    //         // Fill histograms
+    //         mHistManager.fill(HIST("hvTrackEtaPhiEMCal"), vTrackEta[iTrack], vTrackPhi[iTrack]);
+    //         float dEta = vTrackEta[iTrack] - vCellEta[localCellIdx];
+    //         float dPhi = vTrackPhi[iTrack] - vCellPhi[localCellIdx];
 
-            if (NCellsInEMCal > vTowerIndex[localCellIdx]) {
-              mHistManager.fill(HIST("hTrackCellDiffEMCal"), dEta, dPhi);
-            } else {
-              mHistManager.fill(HIST("hTrackCellDiffDCal"), dEta, dPhi);
-            }
+    //         if (NCellsInEMCal > vTowerIndex[localCellIdx]) {
+    //           mHistManager.fill(HIST("hTrackCellDiffEMCal"), dEta, dPhi);
+    //         } else {
+    //           mHistManager.fill(HIST("hTrackCellDiffDCal"), dEta, dPhi);
+    //         }
 
-            auto [iRow, iCol] = geometry->GlobalRowColFromIndex(vTowerIndex[localCellIdx]);
-            mHistManager.fill(HIST("hNTracksPerCell"), iCol, iRow);
-            fillSupermoduleHistograms(vSMIndex[localCellIdx], dEta, dPhi);
+    //         auto [iRow, iCol] = geometry->GlobalRowColFromIndex(vTowerIndex[localCellIdx]);
+    //         mHistManager.fill(HIST("hNTracksPerCell"), iCol, iRow);
+    //         fillSupermoduleHistograms(vSMIndex[localCellIdx], dEta, dPhi);
 
-          } else {
-            matchIndexCell.emplace_back(-1);
-            matchIndexTower.emplace_back(-1);
-          } // if (!result.empty())
-        } // end of loop over tracks
+    //       } else {
+    //         matchIndexCell.emplace_back(-1);
+    //         matchIndexTower.emplace_back(-1);
+    //       } // if (!result.empty())
+    //     } // end of loop over tracks
 
-        // count how many tracks a single cell is matched to
-        for (size_t iTrack = 0; iTrack < matchIndexTower.size(); ++iTrack) {
-          int towerID = matchIndexTower[iTrack];
-          if (towerID != -1) {
-            matchedTrackCounts[towerID]++;
-          }
-        }
-        matchedTrackOffsets.assign(vTowerIndex.size() + 1, 0);
-        matchedTrackCountsOrdered.assign(vTowerIndex.size(), 0);
-        // make adjustments for the offset for the flat vector later
-        for (size_t iCell = 0; iCell < vTowerIndex.size(); ++iCell) {
-          matchedTrackOffsets[iCell + 1] = matchedTrackOffsets[iCell] + matchedTrackCounts[vTowerIndex[iCell]];
-          matchedTrackCountsOrdered[iCell] = matchedTrackCounts[vTowerIndex[iCell]];
-        }
+    //     // count how many tracks a single cell is matched to
+    //     for (size_t iTrack = 0; iTrack < matchIndexTower.size(); ++iTrack) {
+    //       int towerID = matchIndexTower[iTrack];
+    //       if (towerID != -1) {
+    //         matchedTrackCounts[towerID]++;
+    //       }
+    //     }
+    //     matchedTrackOffsets.assign(vTowerIndex.size() + 1, 0);
+    //     matchedTrackCountsOrdered.assign(vTowerIndex.size(), 0);
+    //     // make adjustments for the offset for the flat vector later
+    //     for (size_t iCell = 0; iCell < vTowerIndex.size(); ++iCell) {
+    //       matchedTrackOffsets[iCell + 1] = matchedTrackOffsets[iCell] + matchedTrackCounts[vTowerIndex[iCell]];
+    //       matchedTrackCountsOrdered[iCell] = matchedTrackCounts[vTowerIndex[iCell]];
+    //     }
 
-        // making a flat vector order by the appearance of the cells
-        std::vector<int> matchedTrackIDsFlat(matchedTrackOffsets.back());
-        matchedTrackIDsFlat.assign(matchedTrackOffsets.back(), -1);
-        std::vector<size_t> cellFillPos = matchedTrackOffsets; // working positions
-        if (!matchedTrackIDsFlat.empty()) {
-          for (size_t iTrack = 0; iTrack < matchIndexCell.size(); ++iTrack) {
-            int localCellID = matchIndexCell[iTrack];
-            if (localCellID != -1) {
-              size_t pos = cellFillPos[localCellID]++;
-              matchedTrackIDsFlat[pos] = vTrackIndex[iTrack];
-            }
-          }
-        }
-        auto it = matchedTrackIDsFlat.begin();
-        LOG(info) << "matchedTrackCountsOrdered.size() = " << matchedTrackCountsOrdered.size();
-        for (auto& size : matchedTrackCountsOrdered) {
-          auto sp = std::span(it, size);
-          // fill sp
-          cellMatchedTracks(sp);
-          it += size;
-        }
+    //     // making a flat vector order by the appearance of the cells
+    //     std::vector<int> matchedTrackIDsFlat(matchedTrackOffsets.back());
+    //     matchedTrackIDsFlat.assign(matchedTrackOffsets.back(), -1);
+    //     std::vector<size_t> cellFillPos = matchedTrackOffsets; // working positions
+    //     if (!matchedTrackIDsFlat.empty()) {
+    //       for (size_t iTrack = 0; iTrack < matchIndexCell.size(); ++iTrack) {
+    //         int localCellID = matchIndexCell[iTrack];
+    //         if (localCellID != -1) {
+    //           size_t pos = cellFillPos[localCellID]++;
+    //           matchedTrackIDsFlat[pos] = vTrackIndex[iTrack];
+    //         }
+    //       }
+    //     }
+    //     auto it = matchedTrackIDsFlat.begin();
+    //     LOG(info) << "matchedTrackCountsOrdered.size() = " << matchedTrackCountsOrdered.size();
+    //     for (auto& size : matchedTrackCountsOrdered) {
+    //       auto sp = std::span(it, size);
+    //       // fill sp
+    //       cellMatchedTracks(sp);
+    //       it += size;
+    //     }
 
-        matchedTrackCounts.fill(0);
-        matchedTrackCountsOrdered.clear();
-        cellBounds.clear();
-        matchedTrackOffsets.clear();
-        vTrackPhi.clear();
-        vTrackEta.clear();
-        vTrackIndex.clear();
-        vCellPhi.clear();
-        vCellEta.clear();
-        vCellIndex.clear();
-        vTowerIndex.clear();
-        vSMIndex.clear();
-        matchIndexCell.clear();
-        matchIndexTower.clear();
-      } else if (cellBC < trackBC) {
-        LOG(info) << "filling empty spans";
-        while (cell != cellEnd && cellBC < trackBC) {
-          if (++cell != cellEnd) {
-            cellMatchedTracks(std::span<const int>());
-            cellBC = cell.bcId();
-          }
-        }
-      } else {
-        while (track != trackEnd && trackBC < cellBC) {
-          if (++track != trackEnd) {
-            trackBC = track.bcId();
-          }
-        }
-      }
-      if (cell == cellEnd || track == trackEnd) {
-        break;
-      }
-    } // while (cell != cellEnd && track != trackEnd)
+    //     matchedTrackCounts.fill(0);
+    //     matchedTrackCountsOrdered.clear();
+    //     cellBounds.clear();
+    //     matchedTrackOffsets.clear();
+    //     vTrackPhi.clear();
+    //     vTrackEta.clear();
+    //     vTrackIndex.clear();
+    //     vCellPhi.clear();
+    //     vCellEta.clear();
+    //     vCellIndex.clear();
+    //     vTowerIndex.clear();
+    //     vSMIndex.clear();
+    //     matchIndexCell.clear();
+    //     matchIndexTower.clear();
+    //   } else if (cellBC < trackBC) {
+    //     LOG(info) << "filling empty spans";
+    //     while (cell != cellEnd && cellBC < trackBC) {
+    //       if (++cell != cellEnd) {
+    //         cellMatchedTracks(std::span<const int>());
+    //         cellBC = cell.bcId();
+    //       }
+    //     }
+    //   } else {
+    //     while (track != trackEnd && trackBC < cellBC) {
+    //       if (++track != trackEnd) {
+    //         trackBC = track.bcId();
+    //       }
+    //     }
+    //   }
+    //   if (cell == cellEnd || track == trackEnd) {
+    //     break;
+    //   }
+    // } // while (cell != cellEnd && track != trackEnd)
 
-    LOG(info) << "number of entries in new matched tracks table " << cellMatchedTracks.lastIndex() + 1 << "\t number of inital cell table entries " << cells.size();
+    // LOG(info) << "number of entries in new matched tracks table " << cellMatchedTracks.lastIndex() + 1 << "\t number of inital cell table entries " << cells.size();
   }
   PROCESS_SWITCH(EmcalCellTrackMatcher, processSortedRTree, "run analysis with tracks sorted according to BCId", false);
 

--- a/PWGJE/TableProducer/emcalCellTrackMatcher.cxx
+++ b/PWGJE/TableProducer/emcalCellTrackMatcher.cxx
@@ -1,0 +1,571 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+///
+/// EMCAL cell track matching task
+///
+/// \file emcalCellTrackMatcher.cxx
+/// \brief Task that matches EMCal cells and tracks
+/// \author Marvin Hemmer (marvin.hemmer@cern.ch) Goethe-University
+///
+
+#include <algorithm>
+#include <memory>
+#include <unordered_map>
+#include <cmath>
+#include <string>
+#include <tuple>
+#include <vector>
+#include <random>
+
+#include "CCDB/BasicCCDBManager.h"
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoA.h"
+
+#include "DetectorsBase/GeometryManager.h"
+
+#include "PWGJE/DataModel/EMCALClusters.h"
+#include "PWGJE/DataModel/EMCALMatchedCollisions.h"
+
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+#include "DataFormatsEMCAL/Cell.h"
+#include "DataFormatsEMCAL/CellLabel.h"
+#include "DataFormatsEMCAL/Constants.h"
+#include "DataFormatsEMCAL/AnalysisCluster.h"
+#include "EMCALBase/Geometry.h"
+#include "EMCALBase/ClusterFactory.h"
+#include "EMCALBase/NonlinearityHandler.h"
+#include "EMCALReconstruction/Clusterizer.h"
+#include "PWGJE/Core/EmcalMatchingUtilities.h"
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using MyGlobTracks = o2::soa::Join<o2::aod::Tracks, o2::aod::TracksExtra, o2::aod::TrackSelection, o2::aod::TracksDCA, o2::aod::TracksCov>;
+using BcEvSels = o2::soa::Join<o2::aod::BCs, o2::aod::BcSels>;
+using CollEventSels = o2::soa::Join<o2::aod::Collisions, o2::aod::EvSels>;
+using FilteredTracks = o2::soa::Filtered<MyGlobTracks>;
+using McCells = o2::soa::Join<aod::Calos, aod::McCaloLabels_001>;
+using FilteredCells = o2::soa::Filtered<aod::Calos>;
+
+struct EmcalCellTrackMatcher {
+  Produces<o2::aod::EMCALCellTracks> cellMatchedTracks;
+
+  // Options for the clusterization
+  // 1 corresponds to EMCAL cells based on the Run2 definition.
+  Configurable<int> selectedCellType{"selectedCellType", 1, "EMCAL Cell type"};
+  Configurable<float> trackMinPt{"trackMinPt", 0.3f, "Minimum pT for tracks to perform track matching, to reduce computing time. Tracks below a certain pT will be loopers anyway."};
+  Configurable<float> trackDCAz{"trackDCAz", 5.f, "Maximum DCAz of a track to to be considered primary and perform the track matching."};
+  Configurable<float> trackDCAxy{"trackDCAxy", 5.f, "Maximum DCAxy of a track to to be considered primary and perform the track matching."};
+  Configurable<float> maxMatchingDistance{"maxMatchingDistance", 0.01011162697, "Max matching distance track-cell. Default value is equal to half a cell diagonal."};
+  Configurable<int> maxNumberTracks{"maxNumberTracks", 1000, "Number of tracks we expect per BC that point to EMCal. This is for optimization."};
+  Configurable<bool> useAlignmentFromCCDB{"useAlignmentFromCCDB", true, "States if alignment objects should be used from CCDB"};
+
+  // Require EMCAL cells (CALO type 1)
+  Partition<aod::Calos> emcalCells = aod::calo::caloType == selectedCellType;
+  Filter emccellfilter = aod::calo::caloType == selectedCellType;
+
+  // Filter for the tracks
+  const float trackNotOnEMCal = -900;
+  Filter trackFilter = (aod::track::pt >= trackMinPt) && (aod::track::trackEtaEmcal > trackNotOnEMCal) && (aod::track::trackPhiEmcal > trackNotOnEMCal) && ((requireGlobalTrackInFilter()) || (aod::track::isGlobalTrackSDD == (uint8_t) true)) && (nabs(aod::track::dcaXY) < trackDCAxy) && (nabs(aod::track::dcaZ) < trackDCAz);
+
+  // CDB service (for geometry)
+  Service<o2::ccdb::BasicCCDBManager> mCcdbManager;
+
+  // QA
+  o2::framework::HistogramRegistry mHistManager{"EmcalCellTrackMatcherQAHistograms"};
+
+  // EMCal geometry
+  o2::emcal::Geometry* geometry;
+  const int16_t nCellsInEMCal = 12288;
+  int nCellsTotal;
+  std::vector<std::vector<float>> vecLookUpCellPosition;
+
+  // Preslices
+  Preslice<MyGlobTracks> perCollision = o2::aod::track::collisionId;
+  PresliceUnsorted<CollEventSels> collisionsPerFoundBC = aod::evsel::foundBCId;
+  Preslice<aod::Calos> cellsPerFoundBC = aod::calo::bcId;
+  Preslice<aod::SortedTracks> tracksPerFoundBC = aod::emcalcluster::bcId;
+
+  void init(InitContext const&)
+  {
+    LOG(debug) << "Start init!";
+    // NOTE: The geometry manager isn't necessary just to load the EMCAL geometry.
+    //       However, it _is_ necessary for loading the misalignment matrices as of September 2020
+    //       Eventually, those matrices will be moved to the CCDB, but it's not yet ready.
+
+    // The geomatrices from the CCDB are needed in order to calculate the cluster kinematics
+    const char* ccdburl = "http://alice-ccdb.cern.ch"; // Possibly the parameter might become configurable, in order to be able to load new EMCAL calibration objects
+    mCcdbManager->setURL(ccdburl);
+    mCcdbManager->setCaching(true);
+    mCcdbManager->setLocalObjectValidityChecking();
+    if (!o2::base::GeometryManager::isGeometryLoaded()) {
+      mCcdbManager->get<TGeoManager>("GLO/Config/Geometry");
+    }
+    LOG(debug) << "After load geometry!";
+    const int runNumberForGeom = 223409;
+    geometry = o2::emcal::Geometry::GetInstanceFromRunNumber(runNumberForGeom);
+    nCellsTotal = geometry->GetNCells();
+    LOG(debug) << "Completed init!";
+
+    // Setup QA hists.
+    using O2HistType = o2::framework::HistType;
+    o2::framework::AxisSpec etaAxis{1000, -0.8, 0.8, "#it{#eta}"},
+      phiAxis{1000, 0, 2 * 3.14159, "#it{#varphi} (rad)"},
+      dEtaAxis{100, -0.015, 0.015, "#Delta#it{#eta}"},
+      dPhiAxis{100, -0.015, 0.015, "#Delta#it{#varphi} (rad)"},
+      cellAxis{nCellsTotal, -0.5, nCellsTotal - 0.5, "cellID"},
+      etaIndexAxis{96, -0.5, 95.5, "#it{#eta} ID"},
+      phiIndexAxis{208, -0.5, 207.5, "#it{#varphi} ID"},
+      smAxis{20, -0.5, 19.5, "SM"};
+
+    mHistManager.add("hvTrackEtaPhiEMCal", "hvTrackEtaPhiEMCal", O2HistType::kTH2D, {etaAxis, phiAxis});
+    mHistManager.add("hTrackCellDiffEMCal", "hTrackCellDiffEMCal", O2HistType::kTH2D, {dEtaAxis, dPhiAxis});
+    mHistManager.add("hTrackCellDiffDCal", "hTrackCellDiffDCal", O2HistType::kTH2D, {dEtaAxis, dPhiAxis});
+    mHistManager.add("hNTracksPerCell", "hNTracksPerCell", O2HistType::kTH2D, {etaIndexAxis, phiIndexAxis});
+    mHistManager.add("hEMCalEtaPhi3DMap", "hEMCalEtaPhi3DMap", O2HistType::kTH2D, {etaIndexAxis, phiIndexAxis});
+    mHistManager.add("pEMCalRadiusSM", "pEMCalRadiusSM", O2HistType::kTProfile, {smAxis});
+    mHistManager.add("pEMCalRadiusEta", "pEMCalRadiusEta", O2HistType::kTProfile, {etaIndexAxis});
+    mHistManager.add("pEMCalRadiusPhi", "pEMCalRadiusPhi", O2HistType::kTProfile, {phiIndexAxis});
+    const int nSM = 20; // we have 20 SM
+    for (int ism = 0; ism < nSM; ++ism) {
+      mHistManager.add(Form("SMwise/h2TrackCellDiffSM%d", ism), Form("#Delta#it{#eta} and #Delta#it{#varphi} between tracks and cells for SM %d", ism), O2HistType::kTH2D, {dEtaAxis, dPhiAxis});
+    }
+
+    if (useAlignmentFromCCDB.value) {
+      geometry->SetMisalMatrixFromCcdb("Users/m/mhemmer/EMCAL/Config/GeometryAligned", 10000);
+    }
+    double dist = 0; // we will check the position on the surface of the cell
+    double lxyzi[3] = {0., 0., 0.}, xyzi[3] = {0., 0., 0.};
+    vecLookUpCellPosition = std::vector<std::vector<float>>(nCellsTotal, std::vector<float>(2, -999.f));
+    for (int iCell = 0; iCell < nCellsTotal; ++iCell) {
+      // get the local coordinates of the cell
+      try {
+        geometry->RelPosCellInSModule(iCell, dist).GetCoordinates(lxyzi[0], lxyzi[1], lxyzi[2]);
+      } catch (o2::emcal::InvalidCellIDException& e) {
+        LOG(error) << e.what();
+        continue;
+      }
+      // Now get the global coordinate
+      int SM = geometry->GetSuperModuleNumber(iCell);
+      geometry->GetGlobal(lxyzi, xyzi, SM);
+      auto [iRow, iCol] = geometry->GlobalRowColFromIndex(iCell);
+      math_utils::Point3D<float> pos(xyzi[0], xyzi[1], xyzi[2]);
+      vecLookUpCellPosition[iCell][0] = pos.Eta();
+      vecLookUpCellPosition[iCell][1] = RecoDecay::constrainAngle(pos.Phi());
+      mHistManager.fill(HIST("hEMCalEtaPhi3DMap"), iCol, iRow, std::sqrt(pos.X() * pos.X() + pos.Y() * pos.Y()));
+      mHistManager.fill(HIST("pEMCalRadiusSM"), SM, std::sqrt(pos.X() * pos.X() + pos.Y() * pos.Y()));
+      mHistManager.fill(HIST("pEMCalRadiusEta"), iCol, std::sqrt(pos.X() * pos.X() + pos.Y() * pos.Y()));
+      mHistManager.fill(HIST("pEMCalRadiusPhi"), iRow, std::sqrt(pos.X() * pos.X() + pos.Y() * pos.Y()));
+    }
+  }
+
+  template <int supermoduleID>
+  void supermoduleHistHelper(double dEta, double dPhi)
+  {
+    static constexpr std::string_view CellTrackDiffHistSM[20] = {"SMwise/h2TrackCellDiffSM0", "SMwise/h2TrackCellDiffSM1", "SMwise/h2TrackCellDiffSM2", "SMwise/h2TrackCellDiffSM3", "SMwise/h2TrackCellDiffSM4", "SMwise/h2TrackCellDiffSM5", "SMwise/h2TrackCellDiffSM6", "SMwise/h2TrackCellDiffSM7", "SMwise/h2TrackCellDiffSM8", "SMwise/h2TrackCellDiffSM9", "SMwise/h2TrackCellDiffSM10", "SMwise/h2TrackCellDiffSM11", "SMwise/h2TrackCellDiffSM12", "SMwise/h2TrackCellDiffSM13", "SMwise/h2TrackCellDiffSM14", "SMwise/h2TrackCellDiffSM15", "SMwise/h2TrackCellDiffSM16", "SMwise/h2TrackCellDiffSM17", "SMwise/h2TrackCellDiffSM18", "SMwise/h2TrackCellDiffSM19"};
+    mHistManager.fill(HIST(CellTrackDiffHistSM[supermoduleID]), dEta, dPhi);
+  }
+
+  void fillSupermoduleHistograms(int supermoduleID, double dEta, double dPhi)
+  {
+    // workaround to have the histogram names per supermodule
+    // handled as constexpr
+    switch (supermoduleID) {
+      case 0:
+        supermoduleHistHelper<0>(dEta, dPhi);
+        break;
+      case 1:
+        supermoduleHistHelper<1>(dEta, dPhi);
+        break;
+      case 2:
+        supermoduleHistHelper<2>(dEta, dPhi);
+        break;
+      case 3:
+        supermoduleHistHelper<3>(dEta, dPhi);
+        break;
+      case 4:
+        supermoduleHistHelper<4>(dEta, dPhi);
+        break;
+      case 5:
+        supermoduleHistHelper<5>(dEta, dPhi);
+        break;
+      case 6:
+        supermoduleHistHelper<6>(dEta, dPhi);
+        break;
+      case 7:
+        supermoduleHistHelper<7>(dEta, dPhi);
+        break;
+      case 8:
+        supermoduleHistHelper<8>(dEta, dPhi);
+        break;
+      case 9:
+        supermoduleHistHelper<9>(dEta, dPhi);
+        break;
+      case 10:
+        supermoduleHistHelper<10>(dEta, dPhi);
+        break;
+      case 11:
+        supermoduleHistHelper<11>(dEta, dPhi);
+        break;
+      case 12:
+        supermoduleHistHelper<12>(dEta, dPhi);
+        break;
+      case 13:
+        supermoduleHistHelper<13>(dEta, dPhi);
+        break;
+      case 14:
+        supermoduleHistHelper<14>(dEta, dPhi);
+        break;
+      case 15:
+        supermoduleHistHelper<15>(dEta, dPhi);
+        break;
+      case 16:
+        supermoduleHistHelper<16>(dEta, dPhi);
+        break;
+      case 17:
+        supermoduleHistHelper<17>(dEta, dPhi);
+        break;
+      case 18:
+        supermoduleHistHelper<18>(dEta, dPhi);
+        break;
+      case 19:
+        supermoduleHistHelper<19>(dEta, dPhi);
+        break;
+      default:
+        LOG(info) << "Case Supermodule " << supermoduleID;
+        break;
+    }
+  }
+
+  //  Appears to need the BC to be accessed to be available in the collision table...
+  void processFull(BcEvSels const& bcs, CollEventSels const& collisions, FilteredTracks const& tracks, aod::Calos const& cells)
+  {
+    LOG(debug) << "Starting process full.";
+    int previousCollisionId = 0; // Collision ID of the last unique BC. Needed to skip unordered collisions to ensure ordered collisionIds in the cluster table
+    int nBCsProcessed = 0;
+    int nCellsProcessed = 0;
+
+    std::vector<int> matchIndexCell;
+    matchIndexCell.reserve(maxNumberTracks); // reserve enough space for better performance
+
+    // outer vector is size as number of ALL calocells in current DF, inside vector will store trackIDs
+    std::vector<std::vector<int>> vecCellToTracks(cells.size(), std::vector<int>());
+    for (const auto& bc : bcs) {
+      LOG(debug) << "Next BC";
+
+      // Get the collisions matched to the BC using foundBCId of the collision
+      auto collisionsInFoundBC = collisions.sliceBy(collisionsPerFoundBC, bc.globalIndex());
+      auto cellsInBC = emcalCells.sliceBy(cellsPerFoundBC, bc.globalIndex());
+
+      if (!cellsInBC.size()) {
+        LOG(debug) << "No cells found for BC";
+        continue;
+      }
+      // We need bcs which only have a single collision matched to them,
+      // so that we can get the tracks from that collision
+      if (collisionsInFoundBC.size() == 1) {
+        // For the matching of a track to a cell we will use a KDTree approach from emcmatchingutilities
+        // where cells are matched to tracks. For this we need vectors of cell and track eta and phi.
+        std::vector<float> vTrackPhi;
+        std::vector<float> vTrackEta;
+        std::vector<int> vTrackIndex;
+        std::vector<float> vCellPhi;
+        std::vector<float> vCellEta;
+        std::vector<int> vCellIndex;
+        std::vector<int16_t> vTowerIndex;
+        LOG(detail) << "Number of cells for BC (CF): " << cellsInBC.size();
+        nCellsProcessed += cellsInBC.size();
+        // dummy loop to get the first collision
+        for (const auto& col : collisionsInFoundBC) {
+          if (previousCollisionId > col.globalIndex()) {
+            continue;
+          }
+          previousCollisionId = col.globalIndex();
+          if (col.foundBCId() == bc.globalIndex()) {
+            // loop over cells and fill cell information
+            vCellPhi.reserve(cellsInBC.size());
+            vCellEta.reserve(cellsInBC.size());
+            vCellIndex.reserve(cellsInBC.size());
+            vTowerIndex.reserve(cellsInBC.size());
+            for (const auto& cell : cellsInBC) {
+              int16_t cellNumber = cell.cellNumber();
+              if (cellNumber < 0 || cellNumber >= nCellsTotal) {
+                continue;
+              }
+              vCellEta.emplace_back(vecLookUpCellPosition[cellNumber][0]);
+              vCellPhi.emplace_back(vecLookUpCellPosition[cellNumber][1]);
+              vCellIndex.emplace_back(cell.globalIndex());
+              vTowerIndex.emplace_back(cellNumber);
+            }
+
+            // loop over tracks and fill track info
+            auto groupedTracks = tracks.sliceBy(perCollision, col.globalIndex());
+            vTrackPhi.reserve(groupedTracks.size());
+            vTrackEta.reserve(groupedTracks.size());
+            vTrackIndex.reserve(groupedTracks.size());
+            for (const auto& track : groupedTracks) {
+              if (!track.isGlobalTrack()) {
+                LOG(info) << "Track is not global and was not filtered!";
+                continue;
+              }
+              vTrackPhi.emplace_back(RecoDecay::constrainAngle(track.trackPhiEmcal()));
+              vTrackEta.emplace_back(track.trackEtaEmcal());
+              vTrackIndex.emplace_back(track.globalIndex());
+            } // end of loop over track
+
+            matchIndexCell.clear();
+            emcmatchingutilities::matchCellsAndTracks(vCellPhi, vCellEta, vTrackPhi, vTrackEta, maxMatchingDistance, matchIndexCell);
+            for (size_t iTrack = 0; iTrack < matchIndexCell.size(); iTrack++) {
+              int cellIDLocal = matchIndexCell[iTrack];
+              if (cellIDLocal != -1) {
+                int trackID = vTrackIndex[iTrack];
+                int cellID = vCellIndex[cellIDLocal];
+                vecCellToTracks[cellID].emplace_back(trackID);
+                mHistManager.fill(HIST("hvTrackEtaPhiEMCal"), vTrackEta[iTrack], vTrackPhi[iTrack]);
+                double dEta = vTrackEta[iTrack] - vCellEta[cellIDLocal];
+                double dPhi = vTrackPhi[iTrack] - vCellPhi[cellIDLocal];
+                if (nCellsInEMCal > vTowerIndex[cellIDLocal]) {
+                  mHistManager.fill(HIST("hTrackCellDiffEMCal"), dEta, dPhi);
+                } else {
+                  mHistManager.fill(HIST("hTrackCellDiffDCal"), dEta, dPhi);
+                }
+                auto [iRow, iCol] = geometry->GlobalRowColFromIndex(vTowerIndex[cellIDLocal]);
+                mHistManager.fill(HIST("hNTracksPerCell"), iCol, iRow);
+                fillSupermoduleHistograms(geometry->GetSuperModuleNumber(vTowerIndex[cellIDLocal]), dEta, dPhi);
+              }
+            }
+          }
+        } // end of loop over current collision mathed to the BC
+      } // if (collisionsInFoundBC.size() == 1) {
+      LOG(debug) << "Done with process BC.";
+      nBCsProcessed++;
+    } // end of bc loop
+    for (const auto& trackIDs : vecCellToTracks) {
+      cellMatchedTracks(trackIDs);
+    }
+    LOG(detail) << "Processed " << nBCsProcessed << " BCs with " << nCellsProcessed << " cells";
+  }
+  PROCESS_SWITCH(EmcalCellTrackMatcher, processFull, "run full analysis", true);
+
+  //  Appears to need the BC to be accessed to be available in the collision table...
+  void processSorted(o2::aod::SortedTracks const& tracks, aod::Calos const& cells)
+  {
+    LOG(debug) << "Starting process sorted tracks.";
+
+    // outer vector is size as number of ALL calo cells in current DF, inside vector will store trackIDs
+    std::vector<std::vector<int>> vecCellToTracks(cells.size(), std::vector<int>());
+
+    auto track = tracks.begin();
+    auto cell = emcalCells.begin();
+
+    const auto cellEnd = emcalCells.end();
+    const auto trackEnd = tracks.end();
+
+    std::vector<int> matchIndexCell;
+    matchIndexCell.reserve(maxNumberTracks); // reserve enough space for better performance
+
+    // For the matching of a track to a cell we will use a KDTree approach from emcmatchingutilities
+    // where cells are matched to tracks. For this we need vectors of cell and track eta and phi.
+    std::vector<float> vTrackPhi;
+    std::vector<float> vTrackEta;
+    std::vector<int> vTrackIndex;
+    std::vector<float> vCellPhi;
+    std::vector<float> vCellEta;
+    std::vector<int> vCellIndex;
+    std::vector<int16_t> vTowerIndex;
+    std::vector<int> vSMIndex;
+    vTrackPhi.reserve(maxNumberTracks);
+    vTrackEta.reserve(maxNumberTracks);
+    vTrackIndex.reserve(maxNumberTracks);
+    vCellPhi.reserve(nCellsTotal);
+    vCellEta.reserve(nCellsTotal);
+    vCellIndex.reserve(nCellsTotal);
+    vTowerIndex.reserve(nCellsTotal);
+    vSMIndex.reserve(nCellsTotal);
+    while (cell != cellEnd && track != trackEnd) {
+      auto cellBC = cell.bcId();
+      auto trackBC = track.bcId();
+
+      if (cellBC == trackBC) {
+        auto currentBCID = cellBC;
+
+        while (cell != cellEnd && cellBC == currentBCID) {
+          int16_t cellNumber = cell.cellNumber();
+          if (cellNumber < 0 || cellNumber >= nCellsTotal) {
+            LOG(info) << "cell number " << cellNumber << " not within EMCal!";
+            continue;
+          }
+          vCellEta.emplace_back(vecLookUpCellPosition[cellNumber][0]);
+          vCellPhi.emplace_back(vecLookUpCellPosition[cellNumber][1]);
+          vCellIndex.emplace_back(cell.globalIndex());
+          vTowerIndex.emplace_back(cellNumber);
+          vSMIndex.emplace_back(geometry->GetSuperModuleNumber(cellNumber));
+          if (++cell != cellEnd) {
+            cellBC = cell.bcId();
+          }
+        }
+
+        while (track != trackEnd && trackBC == currentBCID) {
+          vTrackPhi.emplace_back(track.phi());
+          vTrackEta.emplace_back(track.eta());
+          vTrackIndex.emplace_back(track.trackId());
+          if (++track != trackEnd) {
+            trackBC = track.bcId();
+          }
+        }
+        matchIndexCell.clear();
+        emcmatchingutilities::matchCellsAndTracks(vCellPhi, vCellEta, vTrackPhi, vTrackEta, maxMatchingDistance, matchIndexCell);
+        for (size_t iTrack = 0; iTrack < matchIndexCell.size(); ++iTrack) {
+          float trackPhi = vTrackPhi[iTrack];
+          float trackEta = vTrackEta[iTrack];
+          int cellIDLocal = matchIndexCell[iTrack];
+          if (cellIDLocal != -1) {
+            int trackID = vTrackIndex[iTrack];
+            int cellID = vCellIndex[cellIDLocal];
+            vecCellToTracks[cellID].emplace_back(trackID);
+            mHistManager.fill(HIST("hvTrackEtaPhiEMCal"), trackEta, trackPhi);
+            double dEta = trackEta - vCellEta[cellIDLocal];
+            double dPhi = trackPhi - vCellPhi[cellIDLocal];
+            if (nCellsInEMCal > vTowerIndex[cellIDLocal]) {
+              mHistManager.fill(HIST("hTrackCellDiffEMCal"), dEta, dPhi);
+            } else {
+              mHistManager.fill(HIST("hTrackCellDiffDCal"), dEta, dPhi);
+            }
+            auto [iRow, iCol] = geometry->GlobalRowColFromIndex(vTowerIndex[cellIDLocal]);
+            mHistManager.fill(HIST("hNTracksPerCell"), iCol, iRow);
+            fillSupermoduleHistograms(vSMIndex[cellIDLocal], dEta, dPhi);
+          }
+        }
+        vTrackPhi.clear();
+        vTrackEta.clear();
+        vTrackIndex.clear();
+        vCellPhi.clear();
+        vCellEta.clear();
+        vCellIndex.clear();
+        vTowerIndex.clear();
+        vSMIndex.clear();
+      } else if (cellBC < trackBC) {
+        while (cell != cellEnd && cellBC < trackBC) {
+          if (++cell != cellEnd) {
+            cellBC = cell.bcId();
+          }
+        }
+      } else {
+        while (track != trackEnd && trackBC < cellBC) {
+          if (++track != trackEnd) {
+            trackBC = track.bcId();
+          }
+        }
+      }
+      if (cell == cellEnd || track == trackEnd) {
+        break;
+      }
+    } // while (cell != cellEnd && track != trackEnd)
+
+    for (const auto& trackIDs : vecCellToTracks) {
+      cellMatchedTracks(trackIDs);
+    }
+  }
+  PROCESS_SWITCH(EmcalCellTrackMatcher, processSorted, "run analysis with tracks sorted according to BCId", false);
+
+  //  Appears to need the BC to be accessed to be available in the collision table...
+  void processSortedWithSlices(BcEvSels const& bcs, o2::aod::SortedTracks const& tracks, aod::Calos const& cells)
+  {
+    LOG(debug) << "Starting process sorted with slices.";
+
+    std::vector<int> matchIndexCell;
+    matchIndexCell.reserve(maxNumberTracks); // reserve enough space for better performance
+
+    // outer vector is size as number of ALL calocells in current DF, inside vector will store trackIDs
+    std::vector<std::vector<int>> vecCellToTracks(cells.size(), std::vector<int>());
+    for (const auto& bc : bcs) {
+
+      // Get the collisions matched to the BC using foundBCId of the collision
+      auto cellsInBC = emcalCells.sliceBy(cellsPerFoundBC, bc.globalIndex());
+      auto tracksInBc = tracks.sliceBy(tracksPerFoundBC, bc.globalIndex());
+
+      if (!cellsInBC.size()) {
+        LOG(debug) << "No cells found for current BC";
+        continue;
+      }
+      if (!tracksInBc.size()) {
+        LOG(debug) << "No tracks found for current BC";
+        continue;
+      }
+      // For the matching of a track to a cell we will use a KDTree approach from emcmatchingutilities
+      // where cells are matched to tracks. For this we need vectors of cell and track eta and phi.
+      std::vector<float> vTrackPhi;
+      std::vector<float> vTrackEta;
+      std::vector<int> vTrackIndex;
+      std::vector<float> vCellPhi;
+      std::vector<float> vCellEta;
+      std::vector<int> vCellIndex;
+      std::vector<int16_t> vTowerIndex;
+
+      // loop over cells and fill cell information
+      vCellPhi.reserve(cellsInBC.size());
+      vCellEta.reserve(cellsInBC.size());
+      vCellIndex.reserve(cellsInBC.size());
+      vTowerIndex.reserve(cellsInBC.size());
+      for (const auto& cell : cellsInBC) {
+        int16_t cellNumber = cell.cellNumber();
+        vCellEta.emplace_back(vecLookUpCellPosition[cellNumber][0]);
+        vCellPhi.emplace_back(vecLookUpCellPosition[cellNumber][1]);
+        vCellIndex.emplace_back(cell.globalIndex());
+        vTowerIndex.emplace_back(cellNumber);
+      }
+
+      vTrackPhi.reserve(tracksInBc.size());
+      vTrackEta.reserve(tracksInBc.size());
+      vTrackIndex.reserve(tracksInBc.size());
+      for (const auto& track : tracksInBc) {
+        vTrackPhi.emplace_back(track.phi());
+        vTrackEta.emplace_back(track.eta());
+        vTrackIndex.emplace_back(track.globalIndex());
+      } // end of loop over track
+
+      matchIndexCell.clear();
+      emcmatchingutilities::matchCellsAndTracks(vCellPhi, vCellEta, vTrackPhi, vTrackEta, maxMatchingDistance, matchIndexCell);
+      for (size_t iTrack = 0; iTrack < matchIndexCell.size(); iTrack++) {
+        int cellIDLocal = matchIndexCell[iTrack];
+        if (cellIDLocal != -1) {
+          int trackID = vTrackIndex[iTrack];
+          int cellID = vCellIndex[cellIDLocal];
+          vecCellToTracks[cellID].emplace_back(trackID);
+          mHistManager.fill(HIST("hvTrackEtaPhiEMCal"), vTrackEta[iTrack], vTrackPhi[iTrack]);
+          double dEta = vTrackEta[iTrack] - vCellEta[cellIDLocal];
+          double dPhi = vTrackPhi[iTrack] - vCellPhi[cellIDLocal];
+          if (nCellsInEMCal > vTowerIndex[cellIDLocal]) {
+            mHistManager.fill(HIST("hTrackCellDiffEMCal"), dEta, dPhi);
+          } else {
+            mHistManager.fill(HIST("hTrackCellDiffDCal"), dEta, dPhi);
+          }
+          auto [iRow, iCol] = geometry->GlobalRowColFromIndex(vTowerIndex[cellIDLocal]);
+          mHistManager.fill(HIST("hNTracksPerCell"), iCol, iRow);
+          fillSupermoduleHistograms(geometry->GetSuperModuleNumber(vTowerIndex[cellIDLocal]), dEta, dPhi);
+        }
+      }
+    } // end of bc loop
+    for (const auto& trackIDs : vecCellToTracks) {
+      cellMatchedTracks(trackIDs);
+    }
+  }
+  PROCESS_SWITCH(EmcalCellTrackMatcher, processSortedWithSlices, "run analysis with sorted tracks utilizing preslices", false);
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<EmcalCellTrackMatcher>(cfgc)};
+}

--- a/PWGJE/TableProducer/emcalCellTrackMatcher.cxx
+++ b/PWGJE/TableProducer/emcalCellTrackMatcher.cxx
@@ -42,6 +42,7 @@
 #include <boost/geometry.hpp>
 #include <boost/geometry/index/rtree.hpp>
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstddef>
@@ -645,236 +646,228 @@ struct EmcalCellTrackMatcher {
   }
   PROCESS_SWITCH(EmcalCellTrackMatcher, processSorted, "run analysis with tracks sorted according to BCId", false);
 
-  void processSortedRTree(o2::aod::SortedTracks const&, aod::Calos const& cells)
+  void processSortedRTree(o2::aod::SortedTracks const& tracks, aod::Calos const& cells)
   {
     LOG(debug) << "Starting process sorted tracks.";
 
     // if we have no cells, just skip this DF
-    // if(!cells.size()) {
-    //   return;
-    // }
+    if (cells.size() == 0) {
+      return;
+    }
 
     auto emptyVec = std::vector<int>({});
     auto emptySpan = std::span(emptyVec.begin(), 0);
     // if we have no tracks fill the table with empty spans
     cellMatchedTracks.reserve(cells.size());
-    for (int64_t iCell = 0; iCell < cells.size(); ++iCell) {
-      cellMatchedTracks(emptySpan);
+    if (tracks.size() == 0) {
+      for (int64_t iCell = 0; iCell < cells.size(); ++iCell) {
+        cellMatchedTracks(emptySpan);
+      }
+      return;
+      // } else {
+      //   for (int64_t iCell = 0; iCell < cells.size(); ++iCell){
+      //     cellMatchedTracks(emptySpan);
+      //   }
     }
-    // if(tracks.size() == 0){
-    //   for (int64_t iCell = 0; iCell < cells.size(); ++iCell){
-    //     cellMatchedTracks(emptySpan);
-    //   }
-    //   return;
-    // } else {
-    //   for (int64_t iCell = 0; iCell < cells.size(); ++iCell){
-    //     cellMatchedTracks(emptySpan);
-    //   }
-    // }
 
-    // // outer vector is size as number of ALL calo cells in current DF, inside vector will store trackIDs
-    // std::vector<std::vector<int>> vecCellToTracks(cells.size(), std::vector<int>());
-    // std::vector<int> vecTrackIDs;
-    // vecTrackIDs.reserve(cells.size());
-    // std::vector<int> vecNTrackIDs(cells.size(), 0);
+    // outer vector is size as number of ALL calo cells in current DF, inside vector will store trackIDs
+    std::vector<std::vector<int>> vecCellToTracks(cells.size(), std::vector<int>());
+    std::vector<int> vecTrackIDs;
+    vecTrackIDs.reserve(cells.size());
+    std::vector<int> vecNTrackIDs(cells.size(), 0);
 
-    // std::array<size_t, NCellsTotal> matchedTrackCounts;
-    // std::vector<size_t> matchedTrackOffsets;
-    // matchedTrackOffsets.reserve(NCellsTotal + 1);
-    // std::vector<int> matchedTrackCountsOrdered;
-    // matchedTrackCountsOrdered.reserve(NCellsTotal);
+    std::array<size_t, NCellsTotal> matchedTrackCounts;
+    std::vector<size_t> matchedTrackOffsets;
+    matchedTrackOffsets.reserve(NCellsTotal + 1);
+    std::vector<int> matchedTrackCountsOrdered;
+    matchedTrackCountsOrdered.reserve(NCellsTotal);
 
-    // auto track = tracks.begin();
-    // auto cell = emcalCells.begin();
+    auto track = tracks.begin();
+    auto cell = emcalCells.begin();
 
-    // const auto cellEnd = emcalCells.end();
-    // const auto trackEnd = tracks.end();
+    const auto cellEnd = emcalCells.end();
+    const auto trackEnd = tracks.end();
 
-    // std::vector<int> matchIndexCell;
-    // matchIndexCell.reserve(maxNumberTracks); // reserve enough space for better performance
-    // std::vector<int> matchIndexTower;
-    // matchIndexTower.reserve(maxNumberTracks); // reserve enough space for better performance
+    std::vector<int> matchIndexCell;
+    matchIndexCell.reserve(maxNumberTracks); // reserve enough space for better performance
+    std::vector<int> matchIndexTower;
+    matchIndexTower.reserve(maxNumberTracks); // reserve enough space for better performance
 
-    // // For the matching of a track to a cell we will use a KDTree approach from emcmatchingutilities
-    // // where cells are matched to tracks. For this we need vectors of cell and track eta and phi.
-    // std::vector<float> vTrackPhi;
-    // std::vector<float> vTrackEta;
-    // std::vector<int> vTrackIndex;
-    // std::vector<float> vCellPhi;
-    // std::vector<float> vCellEta;
-    // std::vector<int> vCellIndex;
-    // std::vector<int16_t> vTowerIndex;
-    // std::vector<int> vSMIndex;
-    // std::vector<std::tuple<float, float, float, float>> cellBounds;
-    // vTrackPhi.reserve(maxNumberTracks);
-    // vTrackEta.reserve(maxNumberTracks);
-    // vTrackIndex.reserve(maxNumberTracks);
-    // vCellPhi.reserve(NCellsTotal);
-    // vCellEta.reserve(NCellsTotal);
-    // vCellIndex.reserve(NCellsTotal);
-    // vTowerIndex.reserve(NCellsTotal);
-    // vSMIndex.reserve(NCellsTotal);
-    // cellBounds.reserve(NCellsTotal);
-    // while (cell != cellEnd && track != trackEnd) {
-    //   auto cellBC = cell.bcId();
-    //   auto trackBC = track.bcId();
+    // For the matching of a track to a cell we will use a KDTree approach from emcmatchingutilities
+    // where cells are matched to tracks. For this we need vectors of cell and track eta and phi.
+    std::vector<float> vTrackPhi;
+    std::vector<float> vTrackEta;
+    std::vector<int> vTrackIndex;
+    std::vector<float> vCellPhi;
+    std::vector<float> vCellEta;
+    std::vector<int> vCellIndex;
+    std::vector<int16_t> vTowerIndex;
+    std::vector<int> vSMIndex;
+    std::vector<std::tuple<float, float, float, float>> cellBounds;
+    vTrackPhi.reserve(maxNumberTracks);
+    vTrackEta.reserve(maxNumberTracks);
+    vTrackIndex.reserve(maxNumberTracks);
+    vCellPhi.reserve(NCellsTotal);
+    vCellEta.reserve(NCellsTotal);
+    vCellIndex.reserve(NCellsTotal);
+    vTowerIndex.reserve(NCellsTotal);
+    vSMIndex.reserve(NCellsTotal);
+    cellBounds.reserve(NCellsTotal);
+    while (cell != cellEnd && track != trackEnd) {
+      auto cellBC = cell.bcId();
+      auto trackBC = track.bcId();
 
-    //   if (cellBC == trackBC) {
-    //     auto currentBCID = cellBC;
+      if (cellBC == trackBC) {
+        auto currentBCID = cellBC;
 
-    //     while (cell != cellEnd && cellBC == currentBCID) {
-    //       int16_t cellNumber = cell.cellNumber();
-    //       if (cellNumber < 0 || cellNumber >= NCellsTotal) {
-    //         LOG(info) << "cell number " << cellNumber << " not within EMCal!";
-    //         continue;
-    //       }
-    //       vCellEta.emplace_back(arrEta[cellNumber]);
-    //       vCellPhi.emplace_back(arrPhi[cellNumber]);
-    //       vCellIndex.emplace_back(cell.globalIndex());
-    //       vTowerIndex.emplace_back(cellNumber);
-    //       vSMIndex.emplace_back(geometry->GetSuperModuleNumber(cellNumber));
-    //       // cell bounds (etaMin, etaMax, phiMin, phiMax)
-    //       cellBounds.emplace_back(std::tuple<float, float, float, float>(arrLowEta[cellNumber], arrUpEta[cellNumber], arrLowPhi[cellNumber], arrUpPhi[cellNumber]));
-    //       if (++cell != cellEnd) {
-    //         cellBC = cell.bcId();
-    //       }
-    //     }
+        while (cell != cellEnd && cellBC == currentBCID) {
+          int16_t cellNumber = cell.cellNumber();
+          if (cellNumber < 0 || cellNumber >= NCellsTotal) {
+            LOG(info) << "cell number " << cellNumber << " not within EMCal!";
+            continue;
+          }
+          vCellEta.emplace_back(arrEta[cellNumber]);
+          vCellPhi.emplace_back(arrPhi[cellNumber]);
+          vCellIndex.emplace_back(cell.globalIndex());
+          vTowerIndex.emplace_back(cellNumber);
+          vSMIndex.emplace_back(geometry->GetSuperModuleNumber(cellNumber));
+          // cell bounds (etaMin, etaMax, phiMin, phiMax)
+          cellBounds.emplace_back(std::tuple<float, float, float, float>(arrLowEta[cellNumber], arrUpEta[cellNumber], arrLowPhi[cellNumber], arrUpPhi[cellNumber]));
+          if (++cell != cellEnd) {
+            cellBC = cell.bcId();
+          }
+        }
 
-    //     while (track != trackEnd && trackBC == currentBCID) {
-    //       vTrackPhi.emplace_back(track.phi());
-    //       vTrackEta.emplace_back(track.eta());
-    //       vTrackIndex.emplace_back(track.trackId());
-    //       if (++track != trackEnd) {
-    //         trackBC = track.bcId();
-    //       }
-    //     }
-    //     // build the current RTree
-    //     auto cellRTree = buildCellRTree(cellBounds);
+        while (track != trackEnd && trackBC == currentBCID) {
+          vTrackPhi.emplace_back(track.phi());
+          vTrackEta.emplace_back(track.eta());
+          vTrackIndex.emplace_back(track.trackId());
+          if (++track != trackEnd) {
+            trackBC = track.bcId();
+          }
+        }
+        // build the current RTree
+        auto cellRTree = buildCellRTree(cellBounds);
 
-    //     // loop over tracks to find matching cell
-    //     for (size_t iTrack = 0; iTrack < vTrackIndex.size(); ++iTrack) {
-    //       point p(vTrackEta[iTrack], vTrackPhi[iTrack]);
-    //       std::vector<value> result;
-    //       cellRTree.query(bgi::contains(p), std::back_inserter(result));
+        // loop over tracks to find matching cell
+        for (size_t iTrack = 0; iTrack < vTrackIndex.size(); ++iTrack) {
+          point p(vTrackEta[iTrack], vTrackPhi[iTrack]);
+          std::vector<value> result;
+          cellRTree.query(bgi::contains(p), std::back_inserter(result));
 
-    //       if (!result.empty()) {
-    //         // Choose best match if multiple
-    //         auto best = std::min_element(result.begin(), result.end(),
-    //             [&](const value& a, const value& b) {
-    //                 auto center = [](const value& v) {
-    //                     float etaC = 0.5f * (v.first.min_corner().get<0>() + v.first.max_corner().get<0>());
-    //                     float phiC = 0.5f * (v.first.min_corner().get<1>() + v.first.max_corner().get<1>());
-    //                     return std::make_pair(etaC, phiC);
-    //                 };
-    //                 auto [etaA, phiA] = center(a);
-    //                 auto [etaB, phiB] = center(b);
-    //                 float dA = std::hypot(vTrackEta[iTrack] - etaA, vTrackPhi[iTrack] - phiA);
-    //                 float dB = std::hypot(vTrackEta[iTrack] - etaB, vTrackPhi[iTrack] - phiB);
-    //                 return dA < dB;
-    //             });
+          if (!result.empty()) {
+            // Choose best match if multiple
+            auto best = std::min_element(result.begin(), result.end(),
+                                         [&](const value& a, const value& b) {
+                                           auto center = [](const value& v) {
+                                             float etaC = 0.5f * (v.first.min_corner().get<0>() + v.first.max_corner().get<0>());
+                                             float phiC = 0.5f * (v.first.min_corner().get<1>() + v.first.max_corner().get<1>());
+                                             return std::make_pair(etaC, phiC);
+                                           };
+                                           auto [etaA, phiA] = center(a);
+                                           auto [etaB, phiB] = center(b);
+                                           float dA = std::hypot(vTrackEta[iTrack] - etaA, vTrackPhi[iTrack] - phiA);
+                                           float dB = std::hypot(vTrackEta[iTrack] - etaB, vTrackPhi[iTrack] - phiB);
+                                           return dA < dB;
+                                         });
 
-    //         int localCellIdx = best->second; // Index in vCellIndex
-    //         int cellID = vTowerIndex[localCellIdx];  // towerID of the matched cell
-    //         LOG(info) << "localCellIdx = " << localCellIdx << "\t cellID = " << cellID;
-    //         matchIndexCell.emplace_back(localCellIdx);
-    //         matchIndexTower.emplace_back(cellID);
+            int localCellIdx = best->second;        // Index in vCellIndex
+            int cellID = vTowerIndex[localCellIdx]; // towerID of the matched cell
+            LOG(info) << "localCellIdx = " << localCellIdx << "\t cellID = " << cellID;
+            matchIndexCell.emplace_back(localCellIdx);
+            matchIndexTower.emplace_back(cellID);
 
-    //         // Fill histograms
-    //         mHistManager.fill(HIST("hvTrackEtaPhiEMCal"), vTrackEta[iTrack], vTrackPhi[iTrack]);
-    //         float dEta = vTrackEta[iTrack] - vCellEta[localCellIdx];
-    //         float dPhi = vTrackPhi[iTrack] - vCellPhi[localCellIdx];
+            // Fill histograms
+            mHistManager.fill(HIST("hvTrackEtaPhiEMCal"), vTrackEta[iTrack], vTrackPhi[iTrack]);
+            float dEta = vTrackEta[iTrack] - vCellEta[localCellIdx];
+            float dPhi = vTrackPhi[iTrack] - vCellPhi[localCellIdx];
 
-    //         if (NCellsInEMCal > vTowerIndex[localCellIdx]) {
-    //           mHistManager.fill(HIST("hTrackCellDiffEMCal"), dEta, dPhi);
-    //         } else {
-    //           mHistManager.fill(HIST("hTrackCellDiffDCal"), dEta, dPhi);
-    //         }
+            if (NCellsInEMCal > vTowerIndex[localCellIdx]) {
+              mHistManager.fill(HIST("hTrackCellDiffEMCal"), dEta, dPhi);
+            } else {
+              mHistManager.fill(HIST("hTrackCellDiffDCal"), dEta, dPhi);
+            }
 
-    //         auto [iRow, iCol] = geometry->GlobalRowColFromIndex(vTowerIndex[localCellIdx]);
-    //         mHistManager.fill(HIST("hNTracksPerCell"), iCol, iRow);
-    //         fillSupermoduleHistograms(vSMIndex[localCellIdx], dEta, dPhi);
+            auto [iRow, iCol] = geometry->GlobalRowColFromIndex(vTowerIndex[localCellIdx]);
+            mHistManager.fill(HIST("hNTracksPerCell"), iCol, iRow);
+            fillSupermoduleHistograms(vSMIndex[localCellIdx], dEta, dPhi);
 
-    //       } else {
-    //         matchIndexCell.emplace_back(-1);
-    //         matchIndexTower.emplace_back(-1);
-    //       } // if (!result.empty())
-    //     } // end of loop over tracks
+          } else {
+            matchIndexCell.emplace_back(-1);
+            matchIndexTower.emplace_back(-1);
+          } // if (!result.empty())
+        } // end of loop over tracks
 
-    //     // count how many tracks a single cell is matched to
-    //     for (size_t iTrack = 0; iTrack < matchIndexTower.size(); ++iTrack) {
-    //       int towerID = matchIndexTower[iTrack];
-    //       if (towerID != -1) {
-    //         matchedTrackCounts[towerID]++;
-    //       }
-    //     }
-    //     matchedTrackOffsets.assign(vTowerIndex.size() + 1, 0);
-    //     matchedTrackCountsOrdered.assign(vTowerIndex.size(), 0);
-    //     // make adjustments for the offset for the flat vector later
-    //     for (size_t iCell = 0; iCell < vTowerIndex.size(); ++iCell) {
-    //       matchedTrackOffsets[iCell + 1] = matchedTrackOffsets[iCell] + matchedTrackCounts[vTowerIndex[iCell]];
-    //       matchedTrackCountsOrdered[iCell] = matchedTrackCounts[vTowerIndex[iCell]];
-    //     }
+        // count how many tracks a single cell is matched to
+        for (size_t iTrack = 0; iTrack < matchIndexTower.size(); ++iTrack) {
+          int towerID = matchIndexTower[iTrack];
+          if (towerID != -1) {
+            matchedTrackCounts[towerID]++;
+          }
+        }
+        matchedTrackOffsets.assign(vTowerIndex.size() + 1, 0);
+        matchedTrackCountsOrdered.assign(vTowerIndex.size(), 0);
+        // make adjustments for the offset for the flat vector later
+        for (size_t iCell = 0; iCell < vTowerIndex.size(); ++iCell) {
+          matchedTrackOffsets[iCell + 1] = matchedTrackOffsets[iCell] + matchedTrackCounts[vTowerIndex[iCell]];
+          matchedTrackCountsOrdered[iCell] = matchedTrackCounts[vTowerIndex[iCell]];
+        }
 
-    //     // making a flat vector order by the appearance of the cells
-    //     std::vector<int> matchedTrackIDsFlat(matchedTrackOffsets.back());
-    //     matchedTrackIDsFlat.assign(matchedTrackOffsets.back(), -1);
-    //     std::vector<size_t> cellFillPos = matchedTrackOffsets;  // working positions
-    //     if (!matchedTrackIDsFlat.empty()) {
-    //       for (size_t iTrack = 0; iTrack < matchIndexCell.size(); ++iTrack) {
-    //         int localCellID = matchIndexCell[iTrack];
-    //         if (localCellID != -1) {
-    //           size_t pos = cellFillPos[localCellID]++;
-    //           matchedTrackIDsFlat[pos] = vTrackIndex[iTrack];
-    //         }
-    //       }
-    //     }
-    //     auto it = matchedTrackIDsFlat.begin();
-    //     LOG(info) << "matchedTrackCountsOrdered.size() = " << matchedTrackCountsOrdered.size();
-    //     int nFilled2 = 0;
-    //     for (auto& size : matchedTrackCountsOrdered) {
-    //       auto sp = std::span(it, size);
-    //       //fill sp
-    //       ++nFilled;
-    //       ++nFilled2;
-    //       cellMatchedTracks(sp);
-    //       it += size;
-    //     }
-    //     LOG(info) << "nFilled2 = " << nFilled2;
+        // making a flat vector order by the appearance of the cells
+        std::vector<int> matchedTrackIDsFlat(matchedTrackOffsets.back());
+        matchedTrackIDsFlat.assign(matchedTrackOffsets.back(), -1);
+        std::vector<size_t> cellFillPos = matchedTrackOffsets; // working positions
+        if (!matchedTrackIDsFlat.empty()) {
+          for (size_t iTrack = 0; iTrack < matchIndexCell.size(); ++iTrack) {
+            int localCellID = matchIndexCell[iTrack];
+            if (localCellID != -1) {
+              size_t pos = cellFillPos[localCellID]++;
+              matchedTrackIDsFlat[pos] = vTrackIndex[iTrack];
+            }
+          }
+        }
+        auto it = matchedTrackIDsFlat.begin();
+        LOG(info) << "matchedTrackCountsOrdered.size() = " << matchedTrackCountsOrdered.size();
+        for (auto& size : matchedTrackCountsOrdered) {
+          auto sp = std::span(it, size);
+          // fill sp
+          cellMatchedTracks(sp);
+          it += size;
+        }
 
-    //     matchedTrackCounts.fill(0);
-    //     matchedTrackCountsOrdered.clear();
-    //     cellBounds.clear();
-    //     matchedTrackOffsets.clear();
-    //     vTrackPhi.clear();
-    //     vTrackEta.clear();
-    //     vTrackIndex.clear();
-    //     vCellPhi.clear();
-    //     vCellEta.clear();
-    //     vCellIndex.clear();
-    //     vTowerIndex.clear();
-    //     vSMIndex.clear();
-    //     matchIndexCell.clear();
-    //     matchIndexTower.clear();
-    //   } else if (cellBC < trackBC) {
-    //     LOG(info) << "filling empty spans";
-    //     while (cell != cellEnd && cellBC < trackBC) {
-    //       if (++cell != cellEnd) {
-    //         cellMatchedTracks(std::span<const int>());
-    //         ++nFilled;
-    //         cellBC = cell.bcId();
-    //       }
-    //     }
-    //   } else {
-    //     while (track != trackEnd && trackBC < cellBC) {
-    //       if (++track != trackEnd) {
-    //         trackBC = track.bcId();
-    //       }
-    //     }
-    //   }
-    //   if (cell == cellEnd || track == trackEnd) {
-    //     break;
-    //   }
-    // } // while (cell != cellEnd && track != trackEnd)
+        matchedTrackCounts.fill(0);
+        matchedTrackCountsOrdered.clear();
+        cellBounds.clear();
+        matchedTrackOffsets.clear();
+        vTrackPhi.clear();
+        vTrackEta.clear();
+        vTrackIndex.clear();
+        vCellPhi.clear();
+        vCellEta.clear();
+        vCellIndex.clear();
+        vTowerIndex.clear();
+        vSMIndex.clear();
+        matchIndexCell.clear();
+        matchIndexTower.clear();
+      } else if (cellBC < trackBC) {
+        LOG(info) << "filling empty spans";
+        while (cell != cellEnd && cellBC < trackBC) {
+          if (++cell != cellEnd) {
+            cellMatchedTracks(std::span<const int>());
+            cellBC = cell.bcId();
+          }
+        }
+      } else {
+        while (track != trackEnd && trackBC < cellBC) {
+          if (++track != trackEnd) {
+            trackBC = track.bcId();
+          }
+        }
+      }
+      if (cell == cellEnd || track == trackEnd) {
+        break;
+      }
+    } // while (cell != cellEnd && track != trackEnd)
 
     LOG(info) << "number of entries in new matched tracks table " << cellMatchedTracks.lastIndex() + 1 << "\t number of inital cell table entries " << cells.size();
   }

--- a/PWGJE/TableProducer/emcalTrackSorter.cxx
+++ b/PWGJE/TableProducer/emcalTrackSorter.cxx
@@ -1,0 +1,120 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+///
+/// EMCAL track sorting and selection task
+///
+/// \file emcalTrackSorter.cxx
+/// \brief Task that selects tracks and sorts them to BCid to be later used in track matching
+/// \author Marvin Hemmer (marvin.hemmer@cern.ch) Goethe-University
+///
+
+#include <algorithm>
+#include <vector>
+
+#include "CCDB/BasicCCDBManager.h"
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoA.h"
+
+#include "PWGJE/DataModel/EMCALClusters.h"
+
+#include "Common/Core/RecoDecay.h"
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using MyGlobTracks = o2::soa::Join<o2::aod::Tracks, o2::aod::TracksExtra, o2::aod::TrackSelection, o2::aod::TracksDCA, o2::aod::TracksCov>;
+using CollEventSels = o2::soa::Join<o2::aod::Collisions, o2::aod::EvSels>;
+using FilteredTracks = o2::soa::Filtered<MyGlobTracks>;
+using FilteredCollisions = o2::soa::Filtered<CollEventSels>;
+
+struct EmcalTrackSorter {
+  Produces<o2::aod::SortedTracks> sortedTracks;
+
+  // Options for the track selection
+  Configurable<float> trackMinPt{"trackMinPt", 0.3f, "Minimum pT for tracks to be selected."};
+  Configurable<float> trackDCAz{"trackDCAz", 1.f, "Maximum DCAz of a track to be selected."};
+  Configurable<float> trackDCAxy{"trackDCAxy", 1.f, "Maximum DCAxy of a track to be selected."};
+  Configurable<bool> useOnlyGlobal{"useOnlyGlobal", true, "Select only global tracks."};
+
+  // Filter for the tracks
+  const float trackNotOnEMCal = -900;
+  Filter trackFilter = (aod::track::pt >= trackMinPt) && ((requireGlobalTrackInFilter()) || (aod::track::isGlobalTrackSDD == (uint8_t) true)) && (aod::track::trackEtaEmcal > trackNotOnEMCal) && (aod::track::trackPhiEmcal > trackNotOnEMCal) && (nabs(aod::track::dcaXY) < trackDCAxy) && (nabs(aod::track::dcaZ) < trackDCAz);
+  Filter collisionFilter = aod::evsel::foundBCId != -1;
+
+  // QA
+  o2::framework::HistogramRegistry mHistManager{"EmcalTrackSorterQAHistograms"};
+
+  // Preslice
+  Preslice<o2::aod::Tracks> perCollision = o2::aod::track::collisionId;
+
+  struct MySortedTracks {
+    int bcID;
+    int trackID;
+    float eta;
+    float phi;
+  };
+
+  void init(InitContext const&)
+  {
+    LOG(debug) << "Start init!";
+
+    // Setup QA hists.
+    // using O2HistType = o2::framework::HistType;
+    // o2::framework::AxisSpec etaAxis{160, -0.8, 0.8, "#it{#eta}"};
+    // o2::framework::AxisSpec phiAxis{72, 0, 2 * 3.14159, "#it{#varphi} (rad)"};
+
+    // mHistManager.add("hTrackEtaPhiEMCal", "hTrackEtaPhiEMCal", O2HistType::kTH2D, {etaAxis, phiAxis});
+    LOG(debug) << "Completed init!";
+  }
+
+  //  Appears to need the BC to be accessed to be available in the collision table...
+  void processFull(FilteredCollisions const& cols, FilteredTracks const& tracks)
+  {
+    LOG(debug) << "Starting process full.";
+
+    // outer vector is size as number of ALL calocells in current DF, inside vector will store trackIDs
+    std::vector<MySortedTracks> vecSortedTracks;
+    vecSortedTracks.reserve(tracks.size());
+
+    for (const auto& col : cols) {
+      if (!col.selection_bit(o2::aod::evsel::kNoSameBunchPileup)) {
+        continue;
+      }
+      auto groupedTracks = tracks.sliceBy(perCollision, col.globalIndex());
+      auto foundBC = col.foundBCId();
+      // loop over all selected tracks
+      for (const auto& track : groupedTracks) {
+        // fill the bcID, trackID, eta and phi values at EMCal surface to the vector
+        vecSortedTracks.emplace_back(foundBC, track.globalIndex(), track.trackEtaEmcal(), RecoDecay::constrainAngle(track.trackPhiEmcal()));
+      } // end of loop over tracks
+    } // end of loop over collisions
+    // sort the tracks of this DF according to their bcID
+    std::sort(vecSortedTracks.begin(), vecSortedTracks.end(), [](const MySortedTracks& a, const MySortedTracks& b) {
+      return a.bcID < b.bcID;
+    });
+    for (const auto& vecSortedTracksIter : vecSortedTracks) {
+      // mHistManager.fill(HIST("hTrackEtaPhiEMCal"), vecSortedTracksIter.eta, vecSortedTracksIter.phi);
+      sortedTracks(vecSortedTracksIter.bcID, vecSortedTracksIter.trackID, vecSortedTracksIter.eta, vecSortedTracksIter.phi);
+    }
+    LOG(debug) << "Ending process full.";
+  }
+  PROCESS_SWITCH(EmcalTrackSorter, processFull, "run full track sorting analysis", true);
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<EmcalTrackSorter>(cfgc)};
+}

--- a/PWGJE/Tasks/CMakeLists.txt
+++ b/PWGJE/Tasks/CMakeLists.txt
@@ -38,6 +38,10 @@ o2physics_add_dpl_workflow(emc-tmmonitor
                     SOURCES emcTmMonitor.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::EMCALBase O2::EMCALCalib O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
+o2physics_add_dpl_workflow(emc-mc-tm
+                    SOURCES emcMCTmMonitor.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::EMCALBase O2::EMCALCalib O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
 o2physics_add_dpl_workflow(hadron-photon-correlation
                     SOURCES hadronPhotonCorrelation.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore

--- a/PWGJE/Tasks/emcClusterMonitor.cxx
+++ b/PWGJE/Tasks/emcClusterMonitor.cxx
@@ -230,7 +230,6 @@ struct ClusterMonitor {
       LOG(debug) << "Cluster energy: " << cluster.energy();
       LOG(debug) << "Cluster index: " << cluster.index();
       LOG(debug) << "ncells in cluster: " << cluster.nCells();
-      LOG(debug) << "real cluster id" << cluster.id();
 
       // monitor observables per supermodule
       try {

--- a/PWGJE/Tasks/emcMCTmMonitor.cxx
+++ b/PWGJE/Tasks/emcMCTmMonitor.cxx
@@ -1,0 +1,516 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file emcMCTmMonitor.cxx
+/// \brief Simple monitoring task for EMCal clusters
+/// \author Marvin Hemmer <marvin.hemmer@cern.ch>
+/// \since 13.06.2025
+///
+/// This task is meant to be used for monitoring the matching between global tracks and EMCal clusters
+/// properties, such as:
+/// - cluster energy over track momentum
+/// - difference in eta
+/// - difference in phi
+/// Simple event selection using the flag doEventSel is provided, which selects INT7 events if set to 1
+/// For pilot beam data, instead of relying on the event selection, one can veto specific BC IDS using the flag
+/// fDoVetoBCID.
+
+#include <climits>
+#include <cstdlib>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <algorithm>
+#include <vector>
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/ASoA.h"
+#include "Framework/HistogramRegistry.h"
+
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/Centrality.h"
+#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+#include "CommonConstants/MathConstants.h"
+
+#include "EMCALBase/Geometry.h"
+#include "EMCALCalib/BadChannelMap.h"
+#include "PWGJE/DataModel/EMCALClusters.h"
+#include "DataFormatsEMCAL/Cell.h"
+#include "DataFormatsEMCAL/Constants.h"
+#include "DataFormatsEMCAL/AnalysisCluster.h"
+
+#include "CommonDataFormat/InteractionRecord.h"
+
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using CollisionEvSel = o2::soa::Join<o2::aod::Collisions, o2::aod::EvSels, o2::aod::McCollisionLabel>;
+using CollisionEvSelIt = o2::soa::Join<o2::aod::Collisions, o2::aod::EvSels, o2::aod::McCollisionLabel>::iterator;
+using SelectedClusters = o2::soa::Filtered<o2::soa::Join<o2::aod::EMCALClusters, o2::aod::EMCALMCClusters>>;
+using McTracks = o2::soa::Join<o2::aod::Tracks, o2::aod::TracksExtra, o2::aod::McTrackLabels>;
+
+/// \brief Function to put labels on monitoring histogram
+/// \param hRejection monitoring histogram
+/// \param softwareTriggerLabel bin label for software trigger rejection
+template <typename Histo>
+void setParticleLabels(Histo& hParticle)
+{
+  auto axis = hParticle->GetAxis(0);
+  axis->SetBinLabel(1, "e^{#pm}");
+  axis->SetBinLabel(2, "#mu^{#pm}");
+  axis->SetBinLabel(3, "#tau^{#pm}");
+  axis->SetBinLabel(4, "#gamma");
+  axis->SetBinLabel(5, "#pi^{0}");
+  axis->SetBinLabel(6, "#pi^{#pm}");
+  axis->SetBinLabel(7, "#eta");
+  axis->SetBinLabel(8, "K");
+  axis->SetBinLabel(9, "#eta\'");
+  axis->SetBinLabel(10, "p");
+  axis->SetBinLabel(11, "n");
+  axis->SetBinLabel(12, "d");
+  axis->SetBinLabel(13, "t");
+  axis->SetBinLabel(14, "other");
+}
+
+template <typename Histo>
+void setParticleLabels1D(Histo& hParticle)
+{
+  auto axis = hParticle->GetXaxis();
+  axis->SetBinLabel(1, "e^{#pm}");
+  axis->SetBinLabel(2, "#mu^{#pm}");
+  axis->SetBinLabel(3, "#tau^{#pm}");
+  axis->SetBinLabel(4, "#gamma");
+  axis->SetBinLabel(5, "#pi^{0}");
+  axis->SetBinLabel(6, "#pi^{#pm}");
+  axis->SetBinLabel(7, "#eta");
+  axis->SetBinLabel(8, "K");
+  axis->SetBinLabel(9, "#eta\'");
+  axis->SetBinLabel(10, "p");
+  axis->SetBinLabel(11, "n");
+  axis->SetBinLabel(12, "d");
+  axis->SetBinLabel(13, "t");
+  axis->SetBinLabel(14, "other");
+}
+
+bool isInEMCal(float eta, float phi)
+{
+  // Acceptable eta range for EMCal
+  if (std::fabs(eta) >= 0.7f) {
+    return false;
+  }
+
+  // Wrap phi into [0, 2π)
+  float phiWrapped = RecoDecay::constrainAngle(phi);
+
+  // Convert degrees to radians for cuts
+  constexpr float phiMin = 80.f * o2::constants::math::Deg2Rad;
+  constexpr float phiMax = 187.f * o2::constants::math::Deg2Rad;
+  constexpr float dcalMin = 260.f * o2::constants::math::Deg2Rad;
+  constexpr float dcalMax = 327.f * o2::constants::math::Deg2Rad;
+  constexpr float transitionMin = 260.f * o2::constants::math::Deg2Rad;
+  constexpr float transitionMax = 320.f * o2::constants::math::Deg2Rad;
+
+  // Exclude phi outside EMCal sector (80° < φ < 187°)
+  if (phiWrapped <= phiMin || phiWrapped >= dcalMax || (phiWrapped >= phiMax && phiWrapped <= dcalMin)) {
+    return false;
+  }
+
+  // Exclude transition region with limited acceptance due to PHOS gap
+  if ((phiWrapped > transitionMin && phiWrapped < transitionMax) && std::fabs(eta) <= 0.22f) {
+    return false;
+  }
+
+  return true;
+}
+
+// calculate ratio of cluster energy to track momentum
+double calcRcorr(double Eclus, double P)
+{
+  if (Eclus < P) {
+    return Eclus / P;
+  } else {
+    // if we have more track momentum than energy in the cluster we "choose" to just output 1
+    return 1.f;
+  }
+}
+
+struct EmcMCTmMonitor {
+  HistogramRegistry mHistManager{"TrackMatchingMonitorHistograms", {}, OutputObjHandlingPolicy::AnalysisObject};
+  o2::emcal::Geometry* mGeometry = nullptr;
+
+  Preslice<o2::aod::EMCALMatchedTracks> perClusterMatchedTracks = o2::aod::emcalclustercell::emcalclusterId;
+  Preslice<o2::aod::McParticles> perCollision = o2::aod::mcparticle::mcCollisionId;
+  // configurable parameters
+  Configurable<bool> doEventSel{"doEventSel", 0, "demand kINT7"};
+  Configurable<double> vertexCut{"vertexCut", -1, "apply z-vertex cut with value in cm"};
+  Configurable<int> clusterDefinition{"clusterDefinition", 10, "cluster definition to be selected, e.g. 10=kV3Default"};
+  ConfigurableAxis clustertimeBinning{"clustertimeBinning", {1500, -600, 900}, ""};
+  Configurable<float> minTime{"minTime", -25., "Minimum cluster time for time cut"};
+  Configurable<float> maxTime{"maxTime", +20., "Maximum cluster time for time cut"};
+  Configurable<float> minDEta{"minDEta", 0.015, "Minimum dEta between track and cluster"};
+  Configurable<float> minDPhi{"minDPhi", 0.03, "Minimum dPhi between track and cluster"};
+  Configurable<std::vector<float>> eOverPRange{"eOverPRange", {0.9, 1.2}, "E/p range where one would search for electrons (first <= E/p <= second)"};
+  Configurable<bool> useAlignmentFromCCDB{"useAlignmentFromCCDB", false, "States if alignment objects should be used from CCDB"};
+  Configurable<bool> doFindFirst{"doFindFirst", false, "States if one wants to search and find the first appearance of a MCParticle that might have scattered multiple times. Heavy on CPU time!"};
+
+  // vector to store important PDG Codes
+  std::vector<int> mPDGCodes;
+
+  /// \brief Create output histograms and initialize geometry
+  void init(InitContext const&)
+  {
+
+    //           e,  mu, tau, y, pi0,  pi,  eta, K,  eta', p,    n,       d,          t
+    mPDGCodes = {11, 13, 15, 22, 111, 211, 221, 321, 331, 2212, 2112, 1000010020, 1000010030};
+    // create histograms
+    using O2HistType = HistType;
+    using O2Axis = AxisSpec;
+
+    // load geometry just in case we need it
+    const int runNumberForGeom = 300000;
+    mGeometry = o2::emcal::Geometry::GetInstanceFromRunNumber(runNumberForGeom);
+    if (useAlignmentFromCCDB.value) {
+      mGeometry->SetMisalMatrixFromCcdb("Users/m/mhemmer/EMCAL/Config/GeometryAligned", 10000);
+    }
+
+    // create common axes
+    LOG(info) << "Creating histograms";
+    const O2Axis bcAxis{3501, -0.5, 3500.5};
+    const O2Axis clusterEnergyAxis{makeEnergyBinningAliPhysics(), "#it{E}_{clus} (GeV)"};
+    const O2Axis energyAxis{makeEnergyBinningAliPhysics(), "#it{E} (GeV)"};
+    const O2Axis energyFractionAxis{110, 0., 1.1, "#it{E}/#it{E}_{clus}"};
+    const O2Axis energyFractionParticleAxis{500, 0., 5., "#it{E}_{part}/(#it{E}_{clus}*frac)"};
+    const O2Axis energyParticle{200, 0., 20., "#it{E}_{part} (GeV)"};
+    const O2Axis energyCluster{200, 0., 20., "#it{E}_{clus} (GeV)"};
+    const O2Axis energyParticleCluster{200, 0., 20., "#it{E}_{clus}*frac (GeV)"};
+    const O2Axis productionRadius{1000, 0., 500., "#it{R} (cm)"};
+    const O2Axis amplitudeAxisLarge{1000, 0., 100., "amplitudeLarge", "Amplitude (GeV)"};
+    const O2Axis dEtaAxis{100, -1.f * minDEta, minDEta, "d#it{#eta}"};
+    const O2Axis dPhiAxis{100, -1.f * minDPhi, minDPhi, "d#it{#varphi} (rad)"};
+    const O2Axis dRAxis{150, 0.0, 0.015, "d#it{R}"};
+    const O2Axis eoverpAxis{500, 0, 10, "#it{E}_{cluster}/#it{p}_{track}"};
+    const O2Axis nSigmaAxis{400, -10., +30., "N#sigma"};
+    const O2Axis trackptAxis{makePtBinning(), "#it{p}_{T,track}"};
+    const O2Axis trackpAxis{200, 0, 100, "#it{p}_{track}"};
+    const O2Axis clusterptAxis{makePtBinning(), "#it{p}_{T}"};
+    const O2Axis etaAxis{160, -0.8, 0.8, "#eta"};
+    const O2Axis phiAxis{72, 0, 2 * 3.14159, "#varphi (rad)"};
+    const O2Axis smAxis{20, -0.5, 19.5, "SM"};
+    const O2Axis ptParticle{200, 0., 20., "#it{p}_{T,track} (GeV)"};
+    const O2Axis momentumParticle{200, 0., 20., "#it{p}_{part} (GeV/#it{c})"};
+    const O2Axis particleSpecies{static_cast<int>(mPDGCodes.size()) + 1, -0.5, static_cast<float>(mPDGCodes.size()) + 0.5, "species"};
+    const O2Axis rCorrAxis{100, 0.01f, 1.01f, "#it{R}_{corr}"};
+    const O2Axis matchAxis{2, -0.5, 1.5, ""};
+    const O2Axis mcProcessAxis{50, -0.5, 49.5, "MC process"};
+    O2Axis timeAxis{clustertimeBinning, "t_{cl} (ns)"};
+
+    int maxMatched = 20; // maximum number of matched tracks, hardcoded in emcalCorrectionTask.cxx!
+    const O2Axis nmatchedtrack{maxMatched, -0.5, maxMatched + 0.5};
+
+    // event properties
+    mHistManager.add("eventsAll", "Number of events", O2HistType::kTH1F, {{1, 0.5, 1.5}});
+    mHistManager.add("eventsSelected", "Number of events", O2HistType::kTH1F, {{1, 0.5, 1.5}});
+    mHistManager.add("eventVertexZAll", "z-vertex of event (all events)", O2HistType::kTH1F, {{200, -20, 20}});
+    mHistManager.add("eventVertexZSelected", "z-vertex of event (selected events)", O2HistType::kTH1F, {{200, -20, 20}});
+
+    mHistManager.add("hContributors", "hContributors;contributor per cluster;#it{counts}", O2HistType::kTH1I, {{100, 0, 100}});
+
+    mHistManager.add("hClusterEnergyParticleEnergy", "hClusterEnergyParticleEnergy", O2HistType::kTH2D, {{energyParticle, energyParticleCluster}});
+
+    mHistManager.add("hRCorrNeutronTrue", "hRCorrNeutronTrue", O2HistType::kTH2D, {{rCorrAxis, momentumParticle}});
+    mHistManager.add("hRCorrChargedReco", "hRCorrChargedReco", O2HistType::kTH2D, {{rCorrAxis, momentumParticle}});
+    mHistManager.add("hRCorrChargedTrue", "hRCorrChargedTrue", O2HistType::kTH2D, {{rCorrAxis, momentumParticle}});
+
+    auto hMatchType = mHistManager.add<TH2>("hMatchType", ";;counts", kTH2D, {{matchAxis, ptParticle}}, false);
+    hMatchType->GetXaxis()->SetBinLabel(1, "match");
+    hMatchType->GetXaxis()->SetBinLabel(2, "Miss match");
+
+    // cluster properties (matched clusters)
+    auto hFractionVsParticle = mHistManager.add<THnSparse>("hFractionVsParticle", ";;#it{E}/#it{E}_{clus}", O2HistType::kTHnSparseF, {{particleSpecies, energyFractionAxis, energyParticle, energyCluster}}, false);
+    auto hParticleFractionVsParticle = mHistManager.add<THnSparse>("hParticleFractionVsParticle", ";;#it{E}/#it{E}_{clus}", O2HistType::kTHnSparseF, {{particleSpecies, energyFractionParticleAxis, energyParticle, energyCluster}}, false);
+    auto hRadiusVsParticle = mHistManager.add<THnSparse>("hRadiusVsParticle", ";;#it{E} (GeV)", O2HistType::kTHnSparseF, {{particleSpecies, productionRadius, energyParticle, energyCluster}}, false);
+    // cluster properties (matched clusters)
+    auto hFractionVsParticleSingleCell = mHistManager.add<THnSparse>("hFractionVsParticleSingleCell", ";;#it{E}/#it{E}_{clus}", O2HistType::kTHnSparseF, {{particleSpecies, energyFractionAxis, energyParticle, energyCluster}}, false);
+    auto hParticleFractionVsParticleSingleCell = mHistManager.add<THnSparse>("hParticleFractionVsParticleSingleCell", ";;#it{E}/#it{E}_{clus}", O2HistType::kTHnSparseF, {{particleSpecies, energyFractionParticleAxis, energyParticle, energyCluster}}, false);
+    auto hEnergyVsAllParticle = mHistManager.add<TH2>("hEnergyVsAllParticle", ";;#it{E} (GeV)", kTH2D, {{particleSpecies, energyAxis}}, false);
+    auto hRadiusVsAllParticle = mHistManager.add<TH2>("hRadiusVsAllParticle", ";;#it{E} (GeV)", kTH2D, {{particleSpecies, productionRadius}}, false);
+    auto hEnergyVsOnEMCParticle = mHistManager.add<TH2>("hEnergyVsOnEMCParticle", ";;#it{E} (GeV)", kTH2D, {{particleSpecies, energyAxis}}, false);
+    auto hParticleVsProcess = mHistManager.add<TH3>("hParticleVsProcess", ";;;#it{E} (GeV)", kTH3D, {{particleSpecies, mcProcessAxis, energyAxis}}, false);
+
+    setParticleLabels(hFractionVsParticle);
+    setParticleLabels(hParticleFractionVsParticle);
+    setParticleLabels(hRadiusVsParticle);
+    setParticleLabels(hFractionVsParticleSingleCell);
+    setParticleLabels(hParticleFractionVsParticleSingleCell);
+    setParticleLabels1D(hEnergyVsAllParticle);
+    setParticleLabels1D(hRadiusVsAllParticle);
+    setParticleLabels1D(hEnergyVsOnEMCParticle);
+    setParticleLabels1D(hParticleVsProcess);
+  }
+
+  // define cluster filter. It selects only those clusters which are of the type
+  // sadly passing of the string at runtime is not possible for technical region so cluster definition is
+  // an integer instead
+  Filter clusterDefinitionSelection = (o2::aod::emcalcluster::definition == clusterDefinition) && (o2::aod::emcalcluster::time >= minTime) && (o2::aod::emcalcluster::time <= maxTime);
+
+  /// \brief Process EMCAL clusters that are matched to a collisions
+  void processCollisions(CollisionEvSelIt const& theCollision, SelectedClusters const& clusters, o2::aod::EMCALMatchedTracks const& matchedtracks, McTracks const& /* alltracks */, o2::aod::McParticles const& mcParticles)
+  {
+    mHistManager.fill(HIST("eventsAll"), 1);
+
+    // do event selection if doEventSel is specified
+    // currently the event selection is hard coded to kINT7
+    // but other selections are possible that are defined in TriggerAliases.h
+    bool isSelected = true;
+    int minimumRun3Number = 300000;
+    if (doEventSel) {
+      if (theCollision.bc().runNumber() < minimumRun3Number) {
+        if (!theCollision.alias_bit(kINT7)) {
+          isSelected = false;
+        }
+      } else {
+        if (!theCollision.alias_bit(kTVXinEMC)) {
+          isSelected = false;
+        }
+      }
+    }
+    if (!isSelected) {
+      LOG(debug) << "Event not selected because it is not kINT7 or does not have EMCAL in readout, skipping";
+      return;
+    }
+    mHistManager.fill(HIST("eventVertexZAll"), theCollision.posZ());
+    if (vertexCut > 0 && std::abs(theCollision.posZ()) > vertexCut) {
+      LOG(debug) << "Event not selected because of z-vertex cut z= " << theCollision.posZ() << " > " << vertexCut << " cm, skipping";
+      return;
+    }
+    mHistManager.fill(HIST("eventsSelected"), 1);
+    mHistManager.fill(HIST("eventVertexZSelected"), theCollision.posZ());
+
+    auto mcParticlesInColl = mcParticles.sliceBy(perCollision, theCollision.mcCollisionId());
+    for (const auto& mcParticle : mcParticlesInColl) {
+      int pdgCode = std::abs(mcParticle.pdgCode());
+      auto pdgIter = std::find(mPDGCodes.begin(), mPDGCodes.end(), pdgCode);
+      int pdgIndex = pdgIter - mPDGCodes.begin();
+      mHistManager.fill(HIST("hEnergyVsAllParticle"), pdgIndex, mcParticle.e());
+      mHistManager.fill(HIST("hRadiusVsAllParticle"), pdgIndex, std::sqrt(mcParticle.vx() * mcParticle.vx() + mcParticle.vy() * mcParticle.vy()));
+
+      if (isInEMCal(mcParticle.eta(), mcParticle.phi())) {
+        mHistManager.fill(HIST("hEnergyVsOnEMCParticle"), pdgIndex, mcParticle.e());
+      }
+    }
+
+    // loop over all clusters from accepted collision
+    for (const auto& cluster : clusters) {
+      // TODO:
+      // check anti neutron is a thing?
+      // 2D Radius vs Z (p, n) with antis
+      // Check MCType
+      // Sandro: Haben wir Material Interaction Maps? (X0 Verteilung und lambda Verteilung),
+      // Gibt es ein Macro, was uns die Materialverteilung in radiation und interaction length geben kann für bestimmte eta/phi bei bestimmten R
+      // F+ Verteilung vs cluster E (Figure 17 EMCal paper)
+      // Figure 16 und 15
+      // match / miss match vs track pT
+      // E_cluster * frac vs E_cluster für E_part < 500 MeV (e + gamma vs rest)
+      // E_cluster * frac vs E_part für leading particle (vs frac)
+      double dEta, dPhi, trackEta, trackPhi;
+      // int supermoduleID;
+      std::vector<int> clusterPDG;
+      std::vector<int> clusterMCId;
+      std::vector<int> clusterUniqueMCId;
+      clusterPDG.reserve(cluster.mcParticleIds().size());
+      clusterMCId.reserve(cluster.mcParticleIds().size());
+      clusterUniqueMCId.reserve(cluster.mcParticleIds().size());
+      if (cluster.mcParticleIds().size() != cluster.amplitudeA().size()) {
+        LOG(info) << "Number of mc particles " << cluster.mcParticleIds().size() << " does not match number of amplitude fractions " << cluster.amplitudeA().size();
+      }
+      mHistManager.fill(HIST("hContributors"), cluster.mcParticleIds().size());
+
+      float pNeutron = 0.f;
+      float pCharged = 0.f;
+      for (size_t iParticle = 0; iParticle < cluster.amplitudeA().size(); ++iParticle) {
+        auto mcParticle = mcParticles.iteratorAt(cluster.mcParticleIds()[iParticle]);
+        float fraction = cluster.amplitudeA()[iParticle];
+        int pdgCode = std::abs(mcParticle.pdgCode());
+        clusterPDG.emplace_back(pdgCode);
+        clusterMCId.emplace_back(cluster.mcParticleIds()[iParticle]);
+
+        if (pdgCode == 2112) {
+          pNeutron += mcParticle.p();
+        } else if (pdgCode == 11 || pdgCode == 211 || pdgCode == 321 || pdgCode == 2212 || pdgCode == 13 || pdgCode == 1000010020 || pdgCode == 1000010030) {
+          pCharged += mcParticle.p();
+        }
+
+        // Trying to figure out if the particle was scattered, if so, get the original particle:
+        auto current = mcParticle;
+        while (doFindFirst) {
+          auto mothers = current.mothers_as<o2::aod::McParticles>();
+          if (mothers.size() != 1) {
+            break;
+          }
+
+          auto& mother = *mothers.begin(); // only one, so safe
+          if (std::abs(mother.pdgCode()) != pdgCode) {
+            break;
+          }
+          current = mother; // continue walking up
+        }
+        // use the current particle to obtain the production radius instead of the scattered particle
+
+        auto uniqueIdIter = std::find(clusterUniqueMCId.begin(), clusterUniqueMCId.end(), current.globalIndex());
+        if (uniqueIdIter == clusterUniqueMCId.end()) {
+          clusterUniqueMCId.push_back(current.globalIndex());
+        } else {
+          LOG(info) << "MCParticle " << mcParticle.globalIndex() << " is just a rescatter of particle " << current.globalIndex() << " which already has another hit in the same cluster!";
+        }
+
+        auto pdgIter = std::find(mPDGCodes.begin(), mPDGCodes.end(), pdgCode);
+        int pdgIndex = pdgIter - mPDGCodes.begin();
+
+        mHistManager.fill(HIST("hFractionVsParticle"), pdgIndex, fraction, mcParticle.e(), cluster.energy());
+        mHistManager.fill(HIST("hParticleFractionVsParticle"), pdgIndex, mcParticle.e() / (cluster.energy() * fraction), mcParticle.e(), cluster.energy());
+
+        mHistManager.fill(HIST("hClusterEnergyParticleEnergy"), mcParticle.e(), (cluster.energy() * fraction));
+        mHistManager.fill(HIST("hRadiusVsParticle"), pdgIndex, std::sqrt(current.vx() * current.vx() + current.vy() * current.vy()), mcParticle.e(), cluster.energy());
+
+        if (cluster.nCells() == 1) {
+          mHistManager.fill(HIST("hFractionVsParticleSingleCell"), pdgIndex, fraction, mcParticle.e(), cluster.energy());
+          mHistManager.fill(HIST("hParticleFractionVsParticleSingleCell"), pdgIndex, mcParticle.e() / (cluster.energy() * fraction), mcParticle.e(), cluster.energy());
+        }
+
+        mHistManager.fill(HIST("hParticleVsProcess"), pdgIndex, current.statusCode(), mcParticle.e());
+      } // end of loop over mcParticles in cluster
+
+      mHistManager.fill(HIST("hRCorrNeutronTrue"), calcRcorr(cluster.energy(), pNeutron), pNeutron);
+      mHistManager.fill(HIST("hRCorrChargedTrue"), calcRcorr(cluster.energy(), pCharged), pCharged);
+
+      auto tracksofcluster = matchedtracks.sliceBy(perClusterMatchedTracks, cluster.globalIndex());
+      float pChargedReco = 0.f;
+      for (const auto& match : tracksofcluster) {
+        // only consider closest match
+        trackEta = match.track_as<McTracks>().trackEtaEmcal();
+        trackPhi = match.track_as<McTracks>().trackPhiEmcal();
+        dPhi = trackPhi - cluster.phi();
+        dEta = trackEta - cluster.eta();
+        if (std::fabs(dEta) >= minDEta || std::fabs(dPhi) >= minDPhi) { // dEta and dPhi cut
+          continue;
+        }
+        pChargedReco += match.track_as<McTracks>().p();
+        // Get the MC Particle coresponding to the track that was just matched
+        // auto trackMCParticle = mcParticles.iteratorAt(match.track_as<McTracks>().mcParticleId());
+        // int trackPdgCode = std::abs(trackMCParticle.pdgCode());
+
+        // try to find the particle in the cluster
+        auto trackPdgIter = std::find(clusterMCId.begin(), clusterMCId.end(), match.track_as<McTracks>().mcParticleId());
+
+        if (trackPdgIter != clusterMCId.end()) {
+          // track deposit energy into cluster
+          mHistManager.fill(HIST("hMatchType"), 0, match.track_as<McTracks>().pt());
+        } else {
+          // track did not deposit energy into cluster
+          mHistManager.fill(HIST("hMatchType"), 1, match.track_as<McTracks>().pt());
+        }
+      } // end of loop pver tracks of clusters
+      mHistManager.fill(HIST("hRCorrChargedReco"), calcRcorr(cluster.energy(), pChargedReco), pChargedReco);
+    } // end of loop over cluster
+  }
+  PROCESS_SWITCH(EmcMCTmMonitor, processCollisions, "Process clusters from collision", true);
+
+  /// \brief Create binning for cluster energy axis (variable bin size)
+  /// \return vector with bin limits
+  std::vector<double>
+    makeEnergyBinning() const
+  {
+    auto fillBinLimits = [](std::vector<double>& binlimits, double max, double binwidth) {
+      auto current = *binlimits.rbegin();
+      while (current < max) {
+        current += binwidth;
+        binlimits.emplace_back(current);
+      }
+    };
+    std::vector<double> result = {0.};
+    fillBinLimits(result, 2., 0.1);
+    fillBinLimits(result, 5., 0.2);
+    fillBinLimits(result, 10., 0.5);
+    fillBinLimits(result, 20., 1.);
+    fillBinLimits(result, 50., 2.);
+    fillBinLimits(result, 100., 5.);
+    fillBinLimits(result, 200., 10.);
+    return result;
+  }
+
+  /// \brief Create binning for cluster energy axis (variable bin size)
+  /// direct port from binning often used in AliPhysics for debugging
+  /// \return vector with bin limits
+  std::vector<double> makeEnergyBinningAliPhysics() const
+  {
+
+    std::vector<double> result;
+    int nBinsClusterE = 235;
+    for (int i = 0; i < nBinsClusterE + 1; i++) {
+      if (i < 1)
+        result.emplace_back(0.3 * i);
+      else if (i < 55)
+        result.emplace_back(0.3 + 0.05 * (i - 1));
+      else if (i < 105)
+        result.emplace_back(3. + 0.1 * (i - 55));
+      else if (i < 140)
+        result.emplace_back(8. + 0.2 * (i - 105));
+      else if (i < 170)
+        result.emplace_back(15. + 0.5 * (i - 140));
+      else if (i < 190)
+        result.emplace_back(30. + 1.0 * (i - 170));
+      else if (i < 215)
+        result.emplace_back(50. + 2.0 * (i - 190));
+      else if (i < 235)
+        result.emplace_back(100. + 5.0 * (i - 215));
+      else if (i < 245)
+        result.emplace_back(200. + 10.0 * (i - 235));
+    }
+    return result;
+  }
+
+  /// \brief Create binning for pT axis (variable bin size)
+  /// direct port from binning often used in AliPhysics for debugging
+  /// \return vector with bin limits
+  std::vector<double> makePtBinning() const
+  {
+    std::vector<double> result;
+    result.reserve(1000);
+    double epsilon = 1e-6;
+    double valGammaPt = 0;
+    for (int i = 0; i < 1000; ++i) {
+      result.push_back(valGammaPt);
+      if (valGammaPt < 1.0 - epsilon)
+        valGammaPt += 0.1;
+      else if (valGammaPt < 5 - epsilon)
+        valGammaPt += 0.2;
+      else if (valGammaPt < 10 - epsilon)
+        valGammaPt += 0.5;
+      else if (valGammaPt < 50 - epsilon)
+        valGammaPt += 1;
+      else if (valGammaPt < 100 - epsilon)
+        valGammaPt += 5;
+      else
+        break;
+    }
+    return result;
+  }
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  WorkflowSpec workflow{
+    adaptAnalysisTask<EmcMCTmMonitor>(cfgc)};
+  return workflow;
+}

--- a/PWGJE/Tasks/emcMCTmMonitor.cxx
+++ b/PWGJE/Tasks/emcMCTmMonitor.cxx
@@ -23,35 +23,34 @@
 /// For pilot beam data, instead of relying on the event selection, one can veto specific BC IDS using the flag
 /// fDoVetoBCID.
 
-#include <climits>
-#include <cstdlib>
-#include <map>
-#include <memory>
-#include <sstream>
-#include <string>
-#include <algorithm>
-#include <vector>
+#include "PWGJE/DataModel/EMCALClusters.h"
 
-#include "Framework/runDataProcessing.h"
-#include "Framework/AnalysisTask.h"
-#include "Framework/AnalysisDataModel.h"
-#include "Framework/ASoA.h"
-#include "Framework/HistogramRegistry.h"
-
+#include "Common/CCDB/TriggerAliases.h"
+#include "Common/Core/RecoDecay.h"
 #include "Common/DataModel/EventSelection.h"
-#include "Common/DataModel/Centrality.h"
-#include "Common/DataModel/PIDResponse.h"
-#include "Common/DataModel/TrackSelectionTables.h"
-#include "CommonConstants/MathConstants.h"
 
+#include "CommonConstants/MathConstants.h"
 #include "EMCALBase/Geometry.h"
 #include "EMCALCalib/BadChannelMap.h"
-#include "PWGJE/DataModel/EMCALClusters.h"
-#include "DataFormatsEMCAL/Cell.h"
-#include "DataFormatsEMCAL/Constants.h"
-#include "DataFormatsEMCAL/AnalysisCluster.h"
+#include "Framework/ASoA.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/HistogramRegistry.h"
+#include "Framework/runDataProcessing.h"
+#include <Framework/Configurable.h>
+#include <Framework/HistogramSpec.h>
+#include <Framework/InitContext.h>
+#include <Framework/OutputObjHeader.h>
 
-#include "CommonDataFormat/InteractionRecord.h"
+#include <TH3.h>
+#include <THnSparse.h>
+
+#include <algorithm>
+#include <climits>
+#include <cmath>
+#include <cstdlib>
+#include <string>
+#include <vector>
 
 using namespace o2::framework;
 using namespace o2::framework::expressions;

--- a/PWGJE/Tasks/emcTmMonitor.cxx
+++ b/PWGJE/Tasks/emcTmMonitor.cxx
@@ -285,7 +285,6 @@ struct TrackMatchingMonitor {
       LOG(debug) << "Cluster energy: " << cluster.energy();
       LOG(debug) << "Cluster index: " << cluster.index();
       LOG(debug) << "ncells in cluster: " << cluster.nCells();
-      LOG(debug) << "real cluster id" << cluster.id();
 
       // Example of loop over tracks matched to cluster within dR=0.4, where only the
       // 20 most closest tracks are stored. If needed the number of tracks can be later

--- a/PWGJE/Tasks/emcalPi0EnergyScaleCalib.cxx
+++ b/PWGJE/Tasks/emcalPi0EnergyScaleCalib.cxx
@@ -352,7 +352,7 @@ struct Pi0EnergyScaleCalibTask {
       FillClusterQAHistos(cluster, cellid);
 
       // put clusters in photon vector
-      mPhotons.push_back(Photon(cluster.eta(), cluster.phi(), cluster.energy(), cluster.id(), cellid));
+      mPhotons.push_back(Photon(cluster.eta(), cluster.phi(), cluster.energy(), cluster.globalIndex(), cellid));
     }
   }
 


### PR DESCRIPTION
- Add `emcal-cell-track-matcher` task `emcalCellTrackMatcher.cxx`
In this task we loop over all BCs since cells are mapped to BCs. Then we check that there is only a single collision associated to that BC since we need tracks which are only mapped to collisions not to BCs.
From the BC we get the all the EMCal cells and from the collision all the tracks. We store the IDs and eta and phi values to vectors and perform the matching with a KDTree.

- First simple options include `trackMinPt`, `trackDCAzSigma` and `trackDCAxySigma`. The first is to reduce the computing time since low pT tracks will never reach EMCal. The last two cuts are sigma based DCA cuts to select primary tracks.

- Add new table `SortedTracks` with four column: BCID, TrackID, trackEtaOnEMCal, trackPhiOnEMCal

- Add `emcal-track-sorting-task` which sorts selected tracks on the BCID instead of the collisionID, removing the need for the collision table in later EMCal tasks.

- Add `processSorted` to `emcal-cell-track-matcher-task` which utilizes the new sorted track table. This allows to just loop over the new sorted track table and the cell table simultaneously without the need to loop over BCs or Collisions.

- Open:
  - Do we want sigma or cm based DCA cuts?
  - Configurable to check if we want to select primary cuts
  - Further QA histograms
  - Investigate different results between `processSorted` and `processFull` from `emcal-cell-track-matcher-task`