### PR TITLE
[Infrastructure] O2 linter: Support severity levels and tolerated tests per directory

### DIFF
--- a/.github/workflows/o2-linter.yml
+++ b/.github/workflows/o2-linter.yml
@@ -2,10 +2,10 @@
 # Find issues in O2 code
 name: O2 linter
 
-'on': [pull_request, push]
+"on": [pull_request_target, push]
 permissions: {}
 env:
-  MAIN_BRANCH: master
+  BRANCH_MAIN: master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
@@ -15,20 +15,47 @@ jobs:
   o2-linter:
     name: O2 linter
     runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
     steps:
+      - name: Set branches
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            branch_head="${{ github.ref }}"
+            branch_base="${{ env.BRANCH_MAIN }}"
+          else
+            branch_head="refs/pull/${{ github.event.pull_request.number }}/merge"
+            branch_base="${{ github.event.pull_request.base.ref }}"
+          fi
+          echo BRANCH_HEAD="$branch_head" >> "$GITHUB_ENV"
+          echo BRANCH_BASE="$branch_base" >> "$GITHUB_ENV"
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
+          ref: ${{ env.BRANCH_HEAD }}
           fetch-depth: 0 # needed to get the full history
       - name: Run tests
+        id: linter
         run: |
-          # Diff against the common ancestor of the source branch and the main branch.
-          readarray -t files < <(git diff --diff-filter d --name-only origin/${{ env.MAIN_BRANCH }}...)
+          # Diff against the common ancestor of the source (head) branch and the target (base) branch.
+          echo "Diffing ${{ env.BRANCH_HEAD }} against ${{ env.BRANCH_BASE }}."
+          readarray -t files < <(git diff --diff-filter d --name-only origin/${{ env.BRANCH_BASE }}...)
           if [ ${#files[@]} -eq 0 ]; then
               echo "::notice::No files to lint."
+              echo "linter_ran=0" >> "$GITHUB_OUTPUT"
               exit 0
           fi
-          [ ${{ github.event_name }} == 'pull_request' ] && options="-g"
+          echo "linter_ran=1" >> "$GITHUB_OUTPUT"
+          [[ "${{ github.event_name }}" == "pull_request_target" ]] && options="-g"
           # shellcheck disable=SC2086 # Ignore unquoted options.
           python3 Scripts/o2_linter.py $options "${files[@]}"
           echo "Tip: If you allow actions in your fork repository, O2 linter will run when you push commits."
+      - name: Comment PR
+        if: (success() || failure()) && (github.event_name == 'pull_request_target' && steps.linter.outputs.linter_ran == 1)
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          comment-tag: o2-linter
+          message: "O2 linter results:
+            ${{ steps.linter.outputs.n_issues }} errors,
+            ${{ steps.linter.outputs.n_tolerated }} warnings,
+            ${{ steps.linter.outputs.n_disabled }} disabled"

--- a/.github/workflows/o2-linter.yml
+++ b/.github/workflows/o2-linter.yml
@@ -58,4 +58,4 @@ jobs:
           message: "**O2 linter results:**
             ❌ ${{ steps.linter.outputs.n_issues }} errors,
             ⚠️ ${{ steps.linter.outputs.n_tolerated }} warnings,
-            🔇🔕🙊🤐🤫 ${{ steps.linter.outputs.n_disabled }} disabled"
+            🔕 ${{ steps.linter.outputs.n_disabled }} disabled"

--- a/.github/workflows/o2-linter.yml
+++ b/.github/workflows/o2-linter.yml
@@ -55,7 +55,7 @@ jobs:
         uses: thollander/actions-comment-pull-request@v3
         with:
           comment-tag: o2-linter
-          message: "O2 linter results:
-            ${{ steps.linter.outputs.n_issues }} errors,
-            ${{ steps.linter.outputs.n_tolerated }} warnings,
-            ${{ steps.linter.outputs.n_disabled }} disabled"
+          message: "**O2 linter results:**
+            ❌ ${{ steps.linter.outputs.n_issues }} errors,
+            ⚠️ ${{ steps.linter.outputs.n_tolerated }} warnings,
+            🔇🔕🙊🤐🤫 ${{ steps.linter.outputs.n_disabled }} disabled"

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1780,9 +1780,7 @@ def main():
             f'Exceptionally, you can disable a test for a line by adding a comment with "{prefix_disable}"'
             " followed by the name of the test and parentheses with a reason for the exception."
         )
-        msg_tolerate = (
-            f'To tolerate certain issues in a directory, add a line with the test name in "{file_config}".'
-        )
+        msg_tolerate = f'To tolerate certain issues in a directory, add a line with the test name in "{file_config}".'
         if github_mode:
             print(f"\n::error title={title_result}::{msg_result}")
             print(f"::notice::{msg_disable}")

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1794,10 +1794,13 @@ def main():
 
     # Make results available to the GitHub actions.
     if github_mode:
-        with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
-            print(f"n_issues={n_issues}", file=fh)
-            print(f"n_disabled={n_disabled}", file=fh)
-            print(f"n_tolerated={n_tolerated}", file=fh)
+        try:
+            with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+                print(f"n_issues={n_issues}", file=fh)
+                print(f"n_disabled={n_disabled}", file=fh)
+                print(f"n_tolerated={n_tolerated}", file=fh)
+        except KeyError:
+            print("Skipping writing in GITHUB_OUTPUT.")
 
     # Print tips.
     print("\nTip: You can run the O2 linter locally with: python3 Scripts/o2_linter.py <files>")

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -22,21 +22,24 @@ import os
 import re
 import sys
 from enum import Enum
-from typing import Union
 from pathlib import Path
+from typing import Union
 
 github_mode = False  # GitHub mode
 prefix_disable = "o2-linter: disable="  # prefix for disabling tests
 file_tolerated_tests = "o2linter"  # name of file with a list of tests whose failures should be tolerated
-# If this file exists in the path of the tested file, failures of tests listed in this file will not make the linter fail.
+# If this file exists in the path of the tested file,
+# failures of tests listed in this file will not make the linter fail.
 
 
+# issue severity levels
 class Severity(Enum):
     WARNING = 1
     ERROR = 2
     DEFAULT = ERROR
 
 
+# strings for error messages
 message_levels = {
     Severity.WARNING: "warning",
     Severity.ERROR: "error",
@@ -200,8 +203,8 @@ def get_tolerated_tests(path: str) -> "list[str]":
     Starts in the test file directory and iterates through parents.
     """
     tests: list[str] = []
-    for dir in Path(path).resolve().parents:
-        path_tests = dir / file_tolerated_tests
+    for directory in Path(path).resolve().parents:
+        path_tests = directory / file_tolerated_tests
         if path_tests.is_file():
             with path_tests.open() as content:
                 tests = [line.strip() for line in content.readlines() if line.strip()]
@@ -252,7 +255,8 @@ class TestSpec:
         if github_mode and not self.tolerated:  # Annotate only not tolerated issues.
             # GitHub annotation format
             print(
-                f"::{message_levels[self.severity_current]} file={path},line={line},title=[{self.name}]::{message} [{self.name}]"
+                f"::{message_levels[self.severity_current]} "
+                f"file={path},line={line},title=[{self.name}]::{message} [{self.name}]"
             )
 
     def test_line(self, line: str) -> bool:
@@ -736,7 +740,7 @@ class TestWorkflowOptions(TestSpec):
 
     def test_file(self, path: str, content) -> bool:
         is_inside_define = False  # Are we inside defineDataProcessing?
-        for i, line in enumerate(content):  # pylint: disable=unused-variable
+        for _i, line in enumerate(content):  # pylint: disable=unused-variable
             if not line.strip():
                 continue
             if self.is_disabled(line):
@@ -1746,8 +1750,8 @@ def main():
                 ref_ids = [ref.value for ref in test.references]
                 ref_names += test.references
                 print(
-                    f"{test.name}{' ' * (len_max - len(test.name))}\t{test.n_issues}\t{test.n_disabled}\t\t{test.n_tolerated}"
-                    f"\t\t{n_files_bad[test.name]}\t\t{test.rationale} {ref_ids}"
+                    f"{test.name}{' ' * (len_max - len(test.name))}\t{test.n_issues}\t{test.n_disabled}"
+                    f"\t\t{test.n_tolerated}\t\t{n_files_bad[test.name]}\t\t{test.rationale} {ref_ids}"
                 )
         # Print list of references for listed tests.
         print("\nReferences")

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -27,7 +27,7 @@ from typing import Union
 
 github_mode = False  # GitHub mode
 prefix_disable = "o2-linter: disable="  # prefix for disabling tests
-file_tolerated_tests = "o2linter"  # name of file with a list of tests whose failures should be tolerated
+file_config = "o2linter_config"  # name of the configuration file (applied per directory)
 # If this file exists in the path of the tested file,
 # failures of tests listed in this file will not make the linter fail.
 
@@ -199,12 +199,12 @@ def block_ranges(line: str, char_open: str, char_close: str) -> "list[list[int]]
 def get_tolerated_tests(path: str) -> "list[str]":
     """Get the list of tolerated tests.
 
-    Looks for file_tolerated_tests.
+    Looks for the configuration file.
     Starts in the test file directory and iterates through parents.
     """
     tests: list[str] = []
     for directory in Path(path).resolve().parents:
-        path_tests = directory / file_tolerated_tests
+        path_tests = directory / file_config
         if path_tests.is_file():
             with path_tests.open() as content:
                 tests = [line.strip() for line in content.readlines() if line.strip()]
@@ -1781,7 +1781,7 @@ def main():
             " followed by the name of the test and parentheses with a reason for the exception."
         )
         msg_tolerate = (
-            f'To tolerate certain issues in a directory, add a line with the test name in "{file_tolerated_tests}".'
+            f'To tolerate certain issues in a directory, add a line with the test name in "{file_config}".'
         )
         if github_mode:
             print(f"\n::error title={title_result}::{msg_result}")

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1742,6 +1742,7 @@ def main():
         print("\nResults for failed, disabled and tolerated tests")
         len_max = max(len(name) for name in test_names)
         print(f"test{' ' * (len_max - len('test'))}\tissues\tdisabled\ttolerated\tbad files\trationale")
+        print("-" * len_max)
         ref_names = []
         for test in tests:
             if any(n > 0 for n in (test.n_issues, test.n_disabled, test.n_tolerated, n_files_bad[test.name])):
@@ -1754,8 +1755,8 @@ def main():
             n_issues += test.n_issues
             n_disabled += test.n_disabled
             n_tolerated += test.n_tolerated
-        # Print the totals.
         print("-" * len_max)
+        # Print the totals.
         name_total = "total"
         print(f"{name_total}{' ' * (len_max - len(name_total))}\t{n_issues}\t{n_disabled}\t\t{n_tolerated}")
         # Print list of references for listed tests.

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1737,6 +1737,7 @@ def main():
             sys.exit(1)
 
     # Report results for tests that failed or were disabled or were tolerated.
+    n_issues, n_disabled, n_tolerated = 0, 0, 0  # global counters
     if not passed or any(n > 0 for n in (test.n_disabled + test.n_tolerated for test in tests)):
         print("\nResults for failed, disabled and tolerated tests")
         len_max = max(len(name) for name in test_names)
@@ -1750,6 +1751,13 @@ def main():
                     f"{test.name}{' ' * (len_max - len(test.name))}\t{test.n_issues}\t{test.n_disabled}"
                     f"\t\t{test.n_tolerated}\t\t{n_files_bad[test.name]}\t\t{test.rationale} {ref_ids}"
                 )
+            n_issues += test.n_issues
+            n_disabled += test.n_disabled
+            n_tolerated += test.n_tolerated
+        # Print the totals.
+        print("-" * len_max)
+        name_total = "total"
+        print(f"{name_total}{' ' * (len_max - len(name_total))}\t{n_issues}\t{n_disabled}\t\t{n_tolerated}")
         # Print list of references for listed tests.
         print("\nReferences")
         ref_names = list(dict.fromkeys(ref_names))
@@ -1782,8 +1790,17 @@ def main():
             print(f"\n{title_result}: {msg_result}")
             print(msg_disable)
             print(msg_tolerate)
+
+    # Make results available to the GitHub actions.
+    if github_mode:
+        with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+            print(f"n_issues={n_issues}", file=fh)
+            print(f"n_disabled={n_disabled}", file=fh)
+            print(f"n_tolerated={n_tolerated}", file=fh)
+
     # Print tips.
     print("\nTip: You can run the O2 linter locally with: python3 Scripts/o2_linter.py <files>")
+
     if not passed:
         sys.exit(1)
 

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -221,7 +221,7 @@ class TestSpec:
     severity_current: Severity = Severity.DEFAULT
     suffixes: "list[str]" = []  # suffixes of files to test
     per_line: bool = True  # Test lines separately one by one.
-    tolerated: bool = False  # Flag for tolerating issues.
+    tolerated: bool = False  # flag for tolerating issues
     n_issues: int = 0  # issue counter
     n_disabled: int = 0  # counter of disabled issues
     n_tolerated: int = 0  # counter of tolerated issues

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -254,10 +254,7 @@ class TestSpec:
         print(f"{path}:{line}: {message_levels[self.severity_current]}: {message} [{self.name}]")
         if github_mode and not self.tolerated:  # Annotate only not tolerated issues.
             # GitHub annotation format
-            print(
-                f"::{message_levels[self.severity_current]} "
-                f"file={path},line={line},title=[{self.name}]::{message} [{self.name}]"
-            )
+            print(f"::{message_levels[self.severity_current]} file={path},line={line},title=[{self.name}]::{message}")
 
     def test_line(self, line: str) -> bool:
         """Test a line."""

--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -1739,9 +1739,9 @@ def main():
     # Report results for tests that failed or were disabled or were tolerated.
     n_issues, n_disabled, n_tolerated = 0, 0, 0  # global counters
     if not passed or any(n > 0 for n in (test.n_disabled + test.n_tolerated for test in tests)):
-        print("\nResults for failed, disabled and tolerated tests")
+        print("\nResults for failed, tolerated and disabled tests")
         len_max = max(len(name) for name in test_names)
-        print(f"test{' ' * (len_max - len('test'))}\tissues\tdisabled\ttolerated\tbad files\trationale")
+        print(f"test{' ' * (len_max - len('test'))}\tissues\ttolerated\tdisabled\tbad files\trationale")
         print("-" * len_max)
         ref_names = []
         for test in tests:
@@ -1749,8 +1749,8 @@ def main():
                 ref_ids = [ref.value for ref in test.references]
                 ref_names += test.references
                 print(
-                    f"{test.name}{' ' * (len_max - len(test.name))}\t{test.n_issues}\t{test.n_disabled}"
-                    f"\t\t{test.n_tolerated}\t\t{n_files_bad[test.name]}\t\t{test.rationale} {ref_ids}"
+                    f"{test.name}{' ' * (len_max - len(test.name))}\t{test.n_issues}\t{test.n_tolerated}"
+                    f"\t\t{test.n_disabled}\t\t{n_files_bad[test.name]}\t\t{test.rationale} {ref_ids}"
                 )
             n_issues += test.n_issues
             n_disabled += test.n_disabled
@@ -1758,7 +1758,7 @@ def main():
         print("-" * len_max)
         # Print the totals.
         name_total = "total"
-        print(f"{name_total}{' ' * (len_max - len(name_total))}\t{n_issues}\t{n_disabled}\t\t{n_tolerated}")
+        print(f"{name_total}{' ' * (len_max - len(name_total))}\t{n_issues}\t{n_tolerated}\t\t{n_disabled}")
         # Print list of references for listed tests.
         print("\nReferences")
         ref_names = list(dict.fromkeys(ref_names))


### PR DESCRIPTION
- Support severity levels and tolerated tests per directory
- Unify error message format.

Summary of the new features:

- Introduce two levels of severity (warning, error) which are distinguished with a "tolerated" flag.
- Both levels are reported in the terminal log but only errors make the linter fail and only errors show up in the PR as GitHub annotations.
- The total numbers of errors (issues), warnings (tolerated), and disabled issues are reported as a comment in the PR.
  - Example: "**O2 linter results:** ❌ 41 errors, ⚠️ 13 warnings, 🔕 0 disabled"
- The default level for all tests is "error" and the "tolerated" flag is set per test and per file based on the list of tolerated tests listed in a special file `o2linter_config` in one of the parent directories.
- Configs in a deeper directory (closer to the tested file) override configs in a shallower directory (further from the tested file).

This will give the code owners the flexibility to define which tests are mandatory in which directory without hiding issues from people who want to fix them.

FYI: @mpuccio @ddobrigk 