### PR TITLE
[PWGLF] Protect against accidental acceptance of TPC-only V0s

### DIFF
--- a/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
@@ -818,7 +818,7 @@ struct StrangenessBuilder {
             // process candidate with helper, generate properties for consulting
             // <false>: do not apply selections: do as much as possible to preserve
             // candidate at this level and do not select with topo selections
-            if (straHelper.buildV0Candidate<false>(v0tableGrouped[iV0].collisionIds[ic], collision.posX(), collision.posY(), collision.posZ(), pTrack, nTrack, posTrackPar, negTrackPar, true, false)) {
+            if (straHelper.buildV0Candidate<false>(v0tableGrouped[iV0].collisionIds[ic], collision.posX(), collision.posY(), collision.posZ(), pTrack, nTrack, posTrackPar, negTrackPar, true, false, true)) {
               // candidate built, check pointing angle
               if (straHelper.v0.pointingAngle < bestPointingAngle) {
                 bestPointingAngle = straHelper.v0.pointingAngle;
@@ -1294,7 +1294,7 @@ struct StrangenessBuilder {
         }
       }
 
-      if (!straHelper.buildV0Candidate(v0.collisionId, pvX, pvY, pvZ, posTrack, negTrack, posTrackPar, negTrackPar, v0.isCollinearV0, mEnabledTables[kV0Covs])) {
+      if (!straHelper.buildV0Candidate(v0.collisionId, pvX, pvY, pvZ, posTrack, negTrack, posTrackPar, negTrackPar, v0.isCollinearV0, mEnabledTables[kV0Covs], true)) {
         products.v0dataLink(-1, -1);
         continue;
       }

--- a/PWGLF/Utils/strangenessBuilderHelper.h
+++ b/PWGLF/Utils/strangenessBuilderHelper.h
@@ -294,12 +294,12 @@ class strangenessBuilderHelper
         v0 = {};
         return false;
       }
-      if(!acceptTPCOnly && !positiveTrack.hasITS()){ 
-        v0 = {}; 
+      if (!acceptTPCOnly && !positiveTrack.hasITS()) {
+        v0 = {};
         return false;
       }
-      if(!acceptTPCOnly && !negativeTrack.hasITS()){ 
-        v0 = {}; 
+      if (!acceptTPCOnly && !negativeTrack.hasITS()) {
+        v0 = {};
         return false;
       }
     }

--- a/PWGLF/Utils/strangenessBuilderHelper.h
+++ b/PWGLF/Utils/strangenessBuilderHelper.h
@@ -272,7 +272,8 @@ class strangenessBuilderHelper
                         TTrackParametrization& positiveTrackParam,
                         TTrackParametrization& negativeTrackParam,
                         bool useCollinearFit = false,
-                        bool calculateCovariance = false)
+                        bool calculateCovariance = false,
+                        bool acceptTPCOnly = false)
   {
     if constexpr (useSelections) {
       // verify track quality
@@ -291,6 +292,14 @@ class strangenessBuilderHelper
       }
       if (std::fabs(negativeTrack.eta()) > v0selections.maxDaughterEta) {
         v0 = {};
+        return false;
+      }
+      if(!acceptTPCOnly && !positiveTrack.hasITS()){ 
+        v0 = {}; 
+        return false;
+      }
+      if(!acceptTPCOnly && !negativeTrack.hasITS()){ 
+        v0 = {}; 
         return false;
       }
     }
@@ -624,7 +633,7 @@ class strangenessBuilderHelper
     auto posTrackPar = getTrackParCov(positiveTrack);
     auto negTrackPar = getTrackParCov(negativeTrack);
 
-    if (!buildV0Candidate(collisionIndex, pvX, pvY, pvZ, positiveTrack, negativeTrack, posTrackPar, negTrackPar, false, processCovariances)) {
+    if (!buildV0Candidate(collisionIndex, pvX, pvY, pvZ, positiveTrack, negativeTrack, posTrackPar, negTrackPar, false, processCovariances, false)) {
       return false;
     }
     if (!buildCascadeCandidate(collisionIndex, pvX, pvY, pvZ, v0, positiveTrack, negativeTrack, bachelorTrack, calculateBachelorBaryonVariables, useCascadeMomentumAtPV, processCovariances)) {


### PR DESCRIPTION
Adds a check to reject TPC-only tracks from V0 building via the strangeness builder helper. Controlled by the last `buildV0candidate` parameter, with default behaviour being reject. 

Crucially, this rejects 80-90% of `aod::V0s` in high-IR pp because of the way we store V0s with at least one TPC-only track: we duplicate V0s many times (up to 20x) in different collisions, and having this overlooked when doing traditional (K0/Lambda) building could introduce unwanted CPU usage and, in the worst case, spurious background in large quantity. 

Tagging also @mpuccio as this will directly impact current trigger code as well even if the change is not in the EventFiltering directory. Hope this helps and happy easter! 