### PR TITLE
[Common] Track propagation tester changed to modular test

### DIFF
--- a/Common/TableProducer/CMakeLists.txt
+++ b/Common/TableProducer/CMakeLists.txt
@@ -62,11 +62,6 @@ o2physics_add_dpl_workflow(track-propagation
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(track-propagation-tester
-                    SOURCES trackPropagationTester.cxx
-                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::trackSelectionRequest
-                    COMPONENT_NAME Analysis)
-
 o2physics_add_dpl_workflow(calo-clusters
                     SOURCES caloClusterProducer.cxx
                     PUBLIC_LINK_LIBRARIES O2::DataFormatsPHOS O2::PHOSBase O2::PHOSReconstruction O2Physics::DataModel
@@ -155,3 +150,7 @@ o2physics_add_dpl_workflow(fwdtrack-propagation
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::GlobalTracking
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(track-propagation-tester
+                    SOURCES trackPropagationTester.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::trackSelectionRequest
+                    COMPONENT_NAME Analysis)

--- a/Common/TableProducer/trackPropagationTester.cxx
+++ b/Common/TableProducer/trackPropagationTester.cxx
@@ -118,4 +118,3 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   WorkflowSpec workflow{adaptAnalysisTask<TrackPropagationTester>(cfgc)};
   return workflow;
 }
- 

--- a/Common/TableProducer/trackPropagationTester.cxx
+++ b/Common/TableProducer/trackPropagationTester.cxx
@@ -11,10 +11,10 @@
 
 //===============================================================
 //
-// Experimental version of the track propagation task 
+// Experimental version of the track propagation task
 // this utilizes an analysis task module that can be employed elsewhere
-// and allows for the re-utilization of a material LUT 
-// 
+// and allows for the re-utilization of a material LUT
+//
 // candidate approach for core service approach
 //
 //===============================================================
@@ -75,12 +75,12 @@ struct TrackPropagationTester {
   StandardCCDBLoader ccdbLoader;
   TrackPropagationModule trackPropagationMod;
 
-  // registry 
+  // registry
   HistogramRegistry registry{"registry"};
 
   void init(o2::framework::InitContext& initContext)
   {
-    // configure ccdb 
+    // configure ccdb
     ccdb->setURL(ccdbConfigurables.ccdburl);
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
@@ -90,7 +90,7 @@ struct TrackPropagationTester {
     trackPropagationMod.initHistograms(registry, trackPropagationConfigurables);
   }
 
-  void processReal(soa::Join<aod::StoredTracksIU, aod::TracksCovIU, aod::TracksExtra>  const& tracks, aod::Collisions const&, aod::BCs const& bcs)
+  void processReal(soa::Join<aod::StoredTracksIU, aod::TracksCovIU, aod::TracksExtra> const& tracks, aod::Collisions const&, aod::BCs const& bcs)
   {
     ccdbLoader.initCCDBfromBCs(ccdb, bcs);
     trackPropagationMod.getFromCCDBLoader(ccdbLoader);
@@ -118,3 +118,4 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   WorkflowSpec workflow{adaptAnalysisTask<TrackPropagationTester>(cfgc)};
   return workflow;
 }
+ 

--- a/Common/TableProducer/trackPropagationTester.cxx
+++ b/Common/TableProducer/trackPropagationTester.cxx
@@ -9,31 +9,20 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+//===============================================================
 //
-// Task to add a table of track parameters propagated to the primary vertex
+// Experimental version of the track propagation task 
+// this utilizes an analysis task module that can be employed elsewhere
+// and allows for the re-utilization of a material LUT 
+// 
+// candidate approach for core service approach
 //
-// FIXME: THIS IS AN EXPERIMENTAL TASK, MEANT ONLY FOR EXPLORATORY PURPOSES.
-// FIXME: PLEASE ONLY USE IT WITH EXTREME CARE. IF IN DOUBT, STICK WITH THE DEFAULT
-// FIXME: TRACKPROPAGATION
+//===============================================================
 
-#include "Framework/AnalysisDataModel.h"
-#include "Framework/AnalysisTask.h"
-#include "Framework/runDataProcessing.h"
-#include "Framework/RunningWorkflowInfo.h"
-#include "Common/DataModel/TrackSelectionTables.h"
-#include "Common/Core/trackUtilities.h"
-#include "ReconstructionDataFormats/DCA.h"
-#include "DetectorsBase/Propagator.h"
-#include "DetectorsBase/GeometryManager.h"
-#include "CommonUtils/NameConf.h"
-#include "CCDB/CcdbApi.h"
-#include "DataFormatsParameters/GRPMagField.h"
-#include "CCDB/BasicCCDBManager.h"
-#include "Framework/HistogramRegistry.h"
-#include "Framework/runDataProcessing.h"
-#include "DataFormatsCalibration/MeanVertexObject.h"
-#include "CommonConstants/GeomConstants.h"
-#include "trackSelectionRequest.h"
+#include "TableHelper.h"
+#include "Common/Tools/TrackTuner.h"
+#include "Common/Tools/TrackPropagationModule.h"
+#include "Common/Tools/StandardCCDBLoader.h"
 
 // The Run 3 AO2D stores the tracks at the point of innermost update. For a track with ITS this is the innermost (or second innermost)
 // ITS layer. For a track without ITS, this is the TPC inner wall or for loopers in the TPC even a radius beyond that.
@@ -48,294 +37,75 @@ using namespace o2::framework;
 // using namespace o2::framework::expressions;
 
 struct TrackPropagationTester {
-  Produces<aod::StoredTracks> tracksParPropagated;
-  Produces<aod::TracksExtension> tracksParExtensionPropagated;
+  // produces group to be passed to track propagation module
+  struct : ProducesGroup {
+    Produces<aod::StoredTracks> tracksParPropagated;
+    Produces<aod::TracksExtension> tracksParExtensionPropagated;
+    Produces<aod::StoredTracksCov> tracksParCovPropagated;
+    Produces<aod::TracksCovExtension> tracksParCovExtensionPropagated;
+    Produces<aod::TracksDCA> tracksDCA;
+    Produces<aod::TracksDCACov> tracksDCACov;
+    Produces<aod::TrackTunerTable> tunertable;
+  } trackPropagationProducts;
 
-  Produces<aod::StoredTracksCov> tracksParCovPropagated;
-  Produces<aod::TracksCovExtension> tracksParCovExtensionPropagated;
+  // Configurables
+  struct : ConfigurableGroup {
+    std::string prefix = "ccdb";
+    Configurable<std::string> ccdburl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+    Configurable<std::string> lutPath{"lutPath", "GLO/Param/MatLUT", "Path of the Lut parametrization"};
+    Configurable<std::string> geoPath{"geoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
+    Configurable<std::string> grpmagPath{"grpmagPath", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
+    Configurable<std::string> mVtxPath{"mVtxPath", "GLO/Calib/MeanVertex", "Path of the mean vertex file"};
+  } ccdbConfigurables;
 
-  Produces<aod::TracksDCA> tracksDCA;
+  struct : ConfigurableGroup {
+    std::string prefix = "trackPropagation";
+    Configurable<float> minPropagationRadius{"minPropagationDistance", o2::constants::geom::XTPCInnerRef + 0.1, "Only tracks which are at a smaller radius will be propagated, defaults to TPC inner wall"};
+    // for TrackTuner only (MC smearing)
+    Configurable<bool> useTrackTuner{"useTrackTuner", false, "Apply track tuner corrections to MC"};
+    Configurable<bool> useTrkPid{"useTrkPid", false, "use pid in tracking"};
+    Configurable<bool> fillTrackTunerTable{"fillTrackTunerTable", false, "flag to fill track tuner table"};
+    Configurable<int> trackTunerConfigSource{"trackTunerConfigSource", aod::track_tuner::InputString, "1: input string; 2: TrackTuner Configurables"};
+    Configurable<std::string> trackTunerParams{"trackTunerParams", "debugInfo=0|updateTrackDCAs=1|updateTrackCovMat=1|updateCurvature=0|updateCurvatureIU=0|updatePulls=0|isInputFileFromCCDB=1|pathInputFile=Users/m/mfaggin/test/inputsTrackTuner/PbPb2022|nameInputFile=trackTuner_DataLHC22sPass5_McLHC22l1b2_run529397.root|pathFileQoverPt=Users/h/hsharma/qOverPtGraphs|nameFileQoverPt=D0sigma_Data_removal_itstps_MC_LHC22b1b.root|usePvRefitCorrections=0|qOverPtMC=-1.|qOverPtData=-1.", "TrackTuner parameter initialization (format: <name>=<value>|<name>=<value>)"};
+    ConfigurableAxis axisPtQA{"axisPtQA", {VARIABLE_WIDTH, 0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f, 1.8f, 1.9f, 2.0f, 2.2f, 2.4f, 2.6f, 2.8f, 3.0f, 3.2f, 3.4f, 3.6f, 3.8f, 4.0f, 4.4f, 4.8f, 5.2f, 5.6f, 6.0f, 6.5f, 7.0f, 7.5f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 17.0f, 19.0f, 21.0f, 23.0f, 25.0f, 30.0f, 35.0f, 40.0f, 50.0f}, "pt axis for QA histograms"};
+  } trackPropagationConfigurables;
 
   Service<o2::ccdb::BasicCCDBManager> ccdb;
 
-  HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
+  StandardCCDBLoader ccdbLoader;
+  TrackPropagationModule trackPropagationMod;
 
-  bool fillTracksDCA = false;
-  int runNumber = -1;
-
-  o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
-
-  const o2::dataformats::MeanVertexObject* mVtx = nullptr;
-  o2::parameters::GRPMagField* grpmag = nullptr;
-  o2::base::MatLayerCylSet* lut = nullptr;
-
-  // Track selection object in this scope: not necessarily a configurable
-  trackSelectionRequest trackSels;
-  // Configurable based on a struct
-  // Configurable<trackSelectionRequest> trackSels{"trackSels", {}, "track selections"};
-
-  Configurable<std::string> ccdburl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
-  Configurable<std::string> lutPath{"lutPath", "GLO/Param/MatLUT", "Path of the Lut parametrization"};
-  Configurable<std::string> geoPath{"geoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
-  Configurable<std::string> grpmagPath{"grpmagPath", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
-  Configurable<std::string> mVtxPath{"mVtxPath", "GLO/Calib/MeanVertex", "Path of the mean vertex file"};
-  Configurable<float> minPropagationRadius{"minPropagationDistance", o2::constants::geom::XTPCInnerRef + 0.1, "Only tracks which are at a smaller radius will be propagated, defaults to TPC inner wall"};
-
-  // Configurables regarding what to propagate
-  //  FIXME: This is dangerous and error prone for general purpose use. It is meant ONLY for testing.
-  Configurable<bool> propagateUnassociated{"propagateUnassociated", false, "propagate tracks with no collision assoc"};
-  Configurable<bool> propagateTPConly{"propagateTPConly", false, "propagate tracks with only TPC (no ITS, TRD, TOF)"};
-  Configurable<int> minTPCClusters{"minTPCClusters", 70, "min number of TPC clusters to propagate"};
-  Configurable<float> maxPropagStep{"maxPropagStep", 2.0, "max propag step"}; // to be checked systematically
-                                                                              // use auto-detect configuration
-  Configurable<bool> d_UseAutodetectMode{"d_UseAutodetectMode", false, "Autodetect requested track criteria"};
-
-  bool hasEnding(std::string const& fullString, std::string const& ending)
-  {
-    if (fullString.length() >= ending.length()) {
-      return (0 == fullString.compare(fullString.length() - ending.length(), ending.length(), ending));
-    } else {
-      return false;
-    }
-  }
+  // registry 
+  HistogramRegistry registry{"registry"};
 
   void init(o2::framework::InitContext& initContext)
   {
-    const AxisSpec axisX{(int)4, 0.0f, +4.0f, "Track counter"};
-    histos.add("hTrackCounter", "hTrackCounter", kTH1F, {axisX});
-
-    if (doprocessCovariance == true && doprocessStandard == true) {
-      LOGF(fatal, "Cannot enable processStandard and processCovariance at the same time. Please choose one.");
-    }
-
-    // Checking if the tables are requested in the workflow and enabling them
-    auto& workflows = initContext.services().get<RunningWorkflowInfo const>();
-    for (DeviceSpec const& device : workflows.devices) {
-      for (auto const& input : device.inputs) {
-        if (input.matcher.binding == "TracksDCA") {
-          fillTracksDCA = true;
-        }
-      }
-    }
-
-    ccdb->setURL(ccdburl);
+    // configure ccdb 
+    ccdb->setURL(ccdbConfigurables.ccdburl);
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
 
-    lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(lutPath));
-
-    if (d_UseAutodetectMode) {
-      LOGF(info, "*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*");
-      LOGF(info, "    Track propagator self-configuration");
-      LOGF(info, "*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*+-+*");
-      trackSels.SetTightSelections(); // Only loosen from this point forward
-      for (DeviceSpec const& device : workflows.devices) {
-        // Loop over options to find track selection
-        for (auto const& option : device.options) {
-          if (hasEnding(option.name, ".requireTPC")) {
-            bool lVal = option.defaultValue.get<bool>();
-            LOGF(info, "Device %s, request TPC: %i", device.name, lVal);
-            if (trackSels.getRequireTPC() == false)
-              trackSels.setRequireTPC(lVal);
-          }
-          if (hasEnding(option.name, ".minTPCclusters")) {
-            int lVal = option.defaultValue.get<int>();
-            LOGF(info, "Device %s, min TPC clusters: %i", device.name, lVal);
-            if (trackSels.getMinTPCClusters() > lVal)
-              trackSels.setMinTPCClusters(lVal);
-          }
-          if (hasEnding(option.name, ".minTPCcrossedrows")) {
-            int lVal = option.defaultValue.get<int>();
-            LOGF(info, "Device %s, min TPC crossed rows: %i", device.name, lVal);
-            if (trackSels.getMinTPCCrossedRows() > lVal)
-              trackSels.setMinTPCCrossedRows(lVal);
-          }
-          if (hasEnding(option.name, ".minTPCcrossedrowsoverfindable")) {
-            float lVal = option.defaultValue.get<float>();
-            LOGF(info, "Device %s, min TPC crossed rows over findable: %.3f", device.name, lVal);
-            if (trackSels.getMinTPCCrossedRowsOverFindable() > lVal)
-              trackSels.setMinTPCCrossedRowsOverFindable(lVal);
-          }
-          if (hasEnding(option.name, ".requireITS")) {
-            bool lVal = option.defaultValue.get<bool>();
-            LOGF(info, "Device %s, request ITS: %i", device.name, lVal);
-            if (trackSels.getRequireITS() == false)
-              trackSels.setRequireITS(lVal);
-          }
-          if (hasEnding(option.name, ".minITSclusters")) {
-            int lVal = option.defaultValue.get<int>();
-            LOGF(info, "Device %s, minimum ITS clusters: %i", device.name, lVal);
-            if (trackSels.getMinITSClusters() > lVal)
-              trackSels.setMinITSClusters(lVal);
-          }
-          if (hasEnding(option.name, ".maxITSChi2percluster")) {
-            float lVal = option.defaultValue.get<float>();
-            LOGF(info, "Device %s, max ITS chi2/clu: %.3f", device.name, lVal);
-            if (trackSels.getMaxITSChi2PerCluster() < lVal)
-              trackSels.setMaxITSChi2PerCluster(lVal);
-          }
-        }
-      }
-      LOGF(info, "-+*> Automatic self-config ended. Final settings:");
-      trackSels.PrintSelections();
-    }
+    ccdbLoader.readConfiguration(ccdbConfigurables);
+    trackPropagationMod.init(initContext);
+    trackPropagationMod.initHistograms(registry, trackPropagationConfigurables);
   }
 
-  void initCCDB(aod::BCsWithTimestamps::iterator const& bc)
+  void processReal(soa::Join<aod::StoredTracksIU, aod::TracksCovIU, aod::TracksExtra>  const& tracks, aod::Collisions const&, aod::BCs const& bcs)
   {
-    if (runNumber == bc.runNumber()) {
-      return;
-    }
-    grpmag = ccdb->getForTimeStamp<o2::parameters::GRPMagField>(grpmagPath, bc.timestamp());
-    LOG(info) << "Setting magnetic field to current " << grpmag->getL3Current() << " A for run " << bc.runNumber() << " from its GRPMagField CCDB object";
-    o2::base::Propagator::initFieldFromGRP(grpmag);
-    o2::base::Propagator::Instance()->setMatLUT(lut);
-    if (propagateUnassociated)
-      mVtx = ccdb->getForTimeStamp<o2::dataformats::MeanVertexObject>(mVtxPath, bc.timestamp());
-    runNumber = bc.runNumber();
+    ccdbLoader.initCCDBfromBCs(ccdb, bcs);
+    trackPropagationMod.getFromCCDBLoader(ccdbLoader);
+    trackPropagationMod.fillTrackTables<false>(tracks, trackPropagationProducts, registry);
   }
+  PROCESS_SWITCH(TrackPropagationTester, processReal, "Process Real Data", true);
 
-  template <typename TTrack, typename TTrackPar>
-  void FillTracksPar(TTrack& track, aod::track::TrackTypeEnum trackType, TTrackPar& trackPar)
+  // -----------------------
+  void processMc(soa::Join<aod::StoredTracksIU, aod::McTrackLabels, aod::TracksCovIU, aod::TracksExtra> const& tracks, aod::McParticles const&, aod::Collisions const&, aod::BCs const& bcs)
   {
-    tracksParPropagated(track.collisionId(), trackType, trackPar.getX(), trackPar.getAlpha(), trackPar.getY(), trackPar.getZ(), trackPar.getSnp(), trackPar.getTgl(), trackPar.getQ2Pt());
-    tracksParExtensionPropagated(trackPar.getPt(), trackPar.getP(), trackPar.getEta(), trackPar.getPhi());
+    ccdbLoader.initCCDBfromBCs(ccdb, bcs);
+    trackPropagationMod.getFromCCDBLoader(ccdbLoader);
+    trackPropagationMod.fillTrackTables<true>(tracks, trackPropagationProducts, registry);
   }
-
-  void processStandard(soa::Join<aod::TracksIU, aod::TracksExtra> const& tracks, aod::Collisions const&, aod::BCsWithTimestamps const& bcs)
-  {
-    if (bcs.size() == 0) {
-      return;
-    }
-    initCCDB(bcs.begin());
-
-    gpu::gpustd::array<float, 2> dcaInfo;
-
-    int lNAll = 0;
-    int lNaccTPC = 0;
-    int lNaccNotTPCOnly = 0;
-    int lNPropagated = 0;
-    bool passTPCclu = kFALSE;
-    bool passNotTPCOnly = kFALSE;
-
-    for (auto& track : tracks) {
-      // Selection criteria
-      passTPCclu = kFALSE;
-      passNotTPCOnly = kFALSE;
-      lNAll++;
-      if (track.tpcNClsFound() >= minTPCClusters) {
-        passTPCclu = kTRUE;
-        lNaccTPC++;
-      }
-      if ((track.hasTPC() && !track.hasITS() && !track.hasTRD() && !track.hasTOF()) || propagateTPConly) {
-        passNotTPCOnly = kTRUE;
-        lNaccNotTPCOnly++;
-      }
-
-      dcaInfo[0] = 999;
-      dcaInfo[1] = 999;
-      aod::track::TrackTypeEnum trackType = (aod::track::TrackTypeEnum)track.trackType();
-      auto trackPar = getTrackPar(track);
-      // Only propagate tracks which have passed the innermost wall of the TPC (e.g. skipping loopers etc). Others fill unpropagated.
-      if (track.trackType() == aod::track::TrackIU && track.x() < minPropagationRadius && passTPCclu && passNotTPCOnly) {
-        if (track.has_collision()) {
-          auto const& collision = track.collision();
-          o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackPar, maxPropagStep, matCorr, &dcaInfo);
-          trackType = aod::track::Track;
-          lNPropagated++;
-        } else {
-          if (propagateUnassociated) {
-            o2::base::Propagator::Instance()->propagateToDCABxByBz({mVtx->getX(), mVtx->getY(), mVtx->getZ()}, trackPar, maxPropagStep, matCorr, &dcaInfo);
-            trackType = aod::track::Track;
-            lNPropagated++;
-          }
-        }
-      }
-      FillTracksPar(track, trackType, trackPar);
-      if (fillTracksDCA) {
-        tracksDCA(dcaInfo[0], dcaInfo[1]);
-      }
-    }
-    // Fill only per table (not per track). ROOT FindBin is slow
-    histos.fill(HIST("hTrackCounter"), 0.5, lNAll);
-    histos.fill(HIST("hTrackCounter"), 1.5, lNaccTPC);
-    histos.fill(HIST("hTrackCounter"), 2.5, lNaccNotTPCOnly);
-    histos.fill(HIST("hTrackCounter"), 3.5, lNPropagated);
-  }
-  PROCESS_SWITCH(TrackPropagationTester, processStandard, "Process without covariance", true);
-
-  void processCovariance(soa::Join<aod::TracksIU, aod::TracksCovIU, aod::TracksExtra> const& tracks, aod::Collisions const&, aod::BCsWithTimestamps const& bcs)
-  {
-    if (bcs.size() == 0) {
-      return;
-    }
-    initCCDB(bcs.begin());
-
-    o2::dataformats::DCA dcaInfoCov;
-    o2::dataformats::VertexBase vtx;
-
-    int lNAll = 0;
-    int lNaccTPC = 0;
-    int lNaccNotTPCOnly = 0;
-    int lNPropagated = 0;
-    bool passTPCclu = kFALSE;
-    bool passNotTPCOnly = kFALSE;
-
-    for (auto& track : tracks) {
-      // Selection criteria
-      passTPCclu = kFALSE;
-      passNotTPCOnly = kFALSE;
-      lNAll++;
-      if (track.tpcNClsFound() >= minTPCClusters) {
-        passTPCclu = kTRUE;
-        lNaccTPC++;
-      }
-      if ((track.hasTPC() && !track.hasITS() && !track.hasTRD() && !track.hasTOF()) || propagateTPConly) {
-        passNotTPCOnly = kTRUE;
-        lNaccNotTPCOnly++;
-      }
-
-      dcaInfoCov.set(999, 999, 999, 999, 999);
-      auto trackParCov = getTrackParCov(track);
-      aod::track::TrackTypeEnum trackType = (aod::track::TrackTypeEnum)track.trackType();
-      // Only propagate tracks which have passed the innermost wall of the TPC (e.g. skipping loopers etc). Others fill unpropagated.
-      if (track.trackType() == aod::track::TrackIU && track.x() < minPropagationRadius && passTPCclu && passNotTPCOnly) {
-        if (track.has_collision()) {
-          auto const& collision = track.collision();
-          vtx.setPos({collision.posX(), collision.posY(), collision.posZ()});
-          vtx.setCov(collision.covXX(), collision.covXY(), collision.covYY(), collision.covXZ(), collision.covYZ(), collision.covZZ());
-          o2::base::Propagator::Instance()->propagateToDCABxByBz(vtx, trackParCov, maxPropagStep, matCorr, &dcaInfoCov);
-          trackType = aod::track::Track;
-          lNPropagated++;
-        } else {
-          if (propagateUnassociated) {
-            vtx.setPos({mVtx->getX(), mVtx->getY(), mVtx->getZ()});
-            vtx.setCov(mVtx->getSigmaX() * mVtx->getSigmaX(), 0.0f, mVtx->getSigmaY() * mVtx->getSigmaY(), 0.0f, 0.0f, mVtx->getSigmaZ() * mVtx->getSigmaZ());
-            o2::base::Propagator::Instance()->propagateToDCABxByBz(vtx, trackParCov, maxPropagStep, matCorr, &dcaInfoCov);
-            trackType = aod::track::Track;
-            lNPropagated++;
-          }
-        }
-      }
-      FillTracksPar(track, trackType, trackParCov);
-      if (fillTracksDCA) {
-        tracksDCA(dcaInfoCov.getY(), dcaInfoCov.getZ());
-      }
-      // TODO do we keep the rho as 0? Also the sigma's are duplicated information
-      tracksParCovPropagated(std::sqrt(trackParCov.getSigmaY2()), std::sqrt(trackParCov.getSigmaZ2()), std::sqrt(trackParCov.getSigmaSnp2()),
-                             std::sqrt(trackParCov.getSigmaTgl2()), std::sqrt(trackParCov.getSigma1Pt2()), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-      tracksParCovExtensionPropagated(trackParCov.getSigmaY2(), trackParCov.getSigmaZY(), trackParCov.getSigmaZ2(), trackParCov.getSigmaSnpY(),
-                                      trackParCov.getSigmaSnpZ(), trackParCov.getSigmaSnp2(), trackParCov.getSigmaTglY(), trackParCov.getSigmaTglZ(), trackParCov.getSigmaTglSnp(),
-                                      trackParCov.getSigmaTgl2(), trackParCov.getSigma1PtY(), trackParCov.getSigma1PtZ(), trackParCov.getSigma1PtSnp(), trackParCov.getSigma1PtTgl(),
-                                      trackParCov.getSigma1Pt2());
-    }
-    // Fill only per table (not per track). ROOT FindBin is slow
-    histos.fill(HIST("hTrackCounter"), 0.5, lNAll);
-    histos.fill(HIST("hTrackCounter"), 1.5, lNaccTPC);
-    histos.fill(HIST("hTrackCounter"), 2.5, lNaccNotTPCOnly);
-    histos.fill(HIST("hTrackCounter"), 3.5, lNPropagated);
-  }
-  PROCESS_SWITCH(TrackPropagationTester, processCovariance, "Process with covariance", false);
+  PROCESS_SWITCH(TrackPropagationTester, processMc, "Process Monte Carlo", false);
 };
 
 //****************************************************************************************

--- a/Common/Tools/StandardCCDBLoader.h
+++ b/Common/Tools/StandardCCDBLoader.h
@@ -18,9 +18,9 @@
 #include "Framework/AnalysisDataModel.h"
 
 //__________________________________________
-// Standard class to load stuff  
+// Standard class to load stuff
 // such as matLUT, B and mean Vertex
-// partial requests possible. 
+// partial requests possible.
 
 class StandardCCDBLoader
 {
@@ -53,7 +53,8 @@ class StandardCCDBLoader
 
   // takes a configurableGroup and reads in necessary configs
   template <typename TConfigurableGroup>
-  void readConfiguration(TConfigurableGroup const& cGroup){ 
+  void readConfiguration(TConfigurableGroup const& cGroup)
+  {
     ccdburl = cGroup.ccdburl.value;
     lutPath = cGroup.lutPath.value;
     geoPath = cGroup.geoPath.value;
@@ -65,11 +66,11 @@ class StandardCCDBLoader
   template <typename TCCDB, typename TBCs>
   void initCCDBfromBCs(TCCDB& ccdb, TBCs& bcs, bool getMeanVertex = true)
   {
-    // instant load from BCs table. Bonus: protect also against empty bcs 
+    // instant load from BCs table. Bonus: protect also against empty bcs
     if (bcs.size() == 0) {
       return;
     }
-    auto bc = bcs.begin(); 
+    auto bc = bcs.begin();
     initCCDB(ccdb, bc.runNumber(), getMeanVertex);
   }
 
@@ -93,10 +94,10 @@ class StandardCCDBLoader
     o2::base::Propagator::initFieldFromGRP(grpmag);
     LOG(info) << "Setting global propagator material propagation LUT";
     o2::base::Propagator::Instance()->setMatLUT(lut);
-    if(getMeanVertex){
+    if (getMeanVertex) {
       // only try this if explicitly requested
       mMeanVtx = ccdb->template getForRun<o2::dataformats::MeanVertexObject>(mVtxPath, currentRunNumber);
-    }else{ 
+    } else {
       mMeanVtx = nullptr;
     }
 

--- a/Common/Tools/StandardCCDBLoader.h
+++ b/Common/Tools/StandardCCDBLoader.h
@@ -1,0 +1,107 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef COMMON_TOOLS_STANDARDCCDBLOADER_H_
+#define COMMON_TOOLS_STANDARDCCDBLOADER_H_
+
+#include <cstdlib>
+#include <cmath>
+#include <array>
+#include "Framework/AnalysisDataModel.h"
+
+//__________________________________________
+// Standard class to load stuff  
+// such as matLUT, B and mean Vertex
+// partial requests possible. 
+
+class StandardCCDBLoader
+{
+ public:
+  StandardCCDBLoader()
+  {
+    // constructor - sets standard locations
+    ccdburl = "http://alice-ccdb.cern.ch";
+    lutPath = "GLO/Param/MatLUT";
+    geoPath = "GLO/Config/GeometryAligned";
+    grpmagPath = "GLO/Config/GRPMagField";
+    mVtxPath = "GLO/Calib/MeanVertex";
+
+    mMeanVtx = nullptr;
+    grpmag = nullptr;
+    lut = nullptr;
+  };
+
+  // commonly needed objects
+  const o2::dataformats::MeanVertexObject* mMeanVtx = nullptr;
+  o2::parameters::GRPMagField* grpmag = nullptr;
+  o2::base::MatLayerCylSet* lut = nullptr;
+
+  std::string ccdburl;
+  std::string lutPath;
+  std::string geoPath;
+  std::string grpmagPath;
+  std::string mVtxPath;
+  int runNumber = -1;
+
+  // takes a configurableGroup and reads in necessary configs
+  template <typename TConfigurableGroup>
+  void readConfiguration(TConfigurableGroup const& cGroup){ 
+    ccdburl = cGroup.ccdburl.value;
+    lutPath = cGroup.lutPath.value;
+    geoPath = cGroup.geoPath.value;
+    grpmagPath = cGroup.grpmagPath.value;
+    mVtxPath = cGroup.mVtxPath.value;
+    LOGF(info, "Standard CCDB loader configuration acquired.");
+  }
+
+  template <typename TCCDB, typename TBCs>
+  void initCCDBfromBCs(TCCDB& ccdb, TBCs& bcs, bool getMeanVertex = true)
+  {
+    // instant load from BCs table. Bonus: protect also against empty bcs 
+    if (bcs.size() == 0) {
+      return;
+    }
+    auto bc = bcs.begin(); 
+    initCCDB(ccdb, bc.runNumber(), getMeanVertex);
+  }
+
+  template <typename TCCDB>
+  void initCCDB(TCCDB& ccdb, int currentRunNumber, bool getMeanVertex = true)
+  {
+    if (runNumber == currentRunNumber) {
+      return;
+    }
+
+    // load matLUT for this timestamp
+    if (!lut) {
+      LOG(info) << "Loading material look-up table for timestamp: " << currentRunNumber;
+      lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->template getForRun<o2::base::MatLayerCylSet>(lutPath, currentRunNumber));
+    } else {
+      LOG(info) << "Material look-up table already in place. Not reloading.";
+    }
+
+    grpmag = ccdb->template getForRun<o2::parameters::GRPMagField>(grpmagPath, currentRunNumber);
+    LOG(info) << "Setting global propagator magnetic field to current " << grpmag->getL3Current() << " A for run " << currentRunNumber << " from its GRPMagField CCDB object";
+    o2::base::Propagator::initFieldFromGRP(grpmag);
+    LOG(info) << "Setting global propagator material propagation LUT";
+    o2::base::Propagator::Instance()->setMatLUT(lut);
+    if(getMeanVertex){
+      // only try this if explicitly requested
+      mMeanVtx = ccdb->template getForRun<o2::dataformats::MeanVertexObject>(mVtxPath, currentRunNumber);
+    }else{ 
+      mMeanVtx = nullptr;
+    }
+
+    runNumber = currentRunNumber;
+  }
+};
+
+#endif // COMMON_TOOLS_STANDARDCCDBLOADER_H_

--- a/Common/Tools/TrackPropagationModule.h
+++ b/Common/Tools/TrackPropagationModule.h
@@ -21,13 +21,13 @@
 #include "Common/Tools/TrackTuner.h"
 
 //__________________________________________
-// track propagation module 
-// 
+// track propagation module
+//
 // this class is capable of performing the usual track propagation
-// and table creation it is a demonstration of core service 
-// plug-in functionality that could be used to reduce the number of 
-// heavyweight (e.g. mat-LUT-using, propagating) core services to 
-// reduce overhead and make it easier to pipeline / parallelize 
+// and table creation it is a demonstration of core service
+// plug-in functionality that could be used to reduce the number of
+// heavyweight (e.g. mat-LUT-using, propagating) core services to
+// reduce overhead and make it easier to pipeline / parallelize
 // bottlenecks in core services
 
 class TrackPropagationModule
@@ -36,19 +36,19 @@ class TrackPropagationModule
   TrackPropagationModule()
   {
     // constructor: set defaults
-    minPropagationRadius = o2::constants::geom::XTPCInnerRef + 0.1; 
+    minPropagationRadius = o2::constants::geom::XTPCInnerRef + 0.1;
     useTrackTuner = false;
-    useTrkPid = false; 
-    fillTrackTunerTable = false;  
+    useTrkPid = false;
+    fillTrackTunerTable = false;
     trackTunerConfigSource = o2::aod::track_tuner::InputString;
     std::string trackTunerParams = "debugInfo=0|updateTrackDCAs=1|updateTrackCovMat=1|updateCurvature=0|updateCurvatureIU=0|updatePulls=0|isInputFileFromCCDB=1|pathInputFile=Users/m/mfaggin/test/inputsTrackTuner/PbPb2022|nameInputFile=trackTuner_DataLHC22sPass5_McLHC22l1b2_run529397.root|pathFileQoverPt=Users/h/hsharma/qOverPtGraphs|nameFileQoverPt=D0sigma_Data_removal_itstps_MC_LHC22b1b.root|usePvRefitCorrections=0|qOverPtMC=-1.|qOverPtData=-1.";
   };
 
-  float minPropagationRadius; 
-  bool useTrackTuner; 
+  float minPropagationRadius;
+  bool useTrackTuner;
   bool useTrkPid;
-  bool fillTrackTunerTable; 
-  int trackTunerConfigSource; 
+  bool fillTrackTunerTable;
+  int trackTunerConfigSource;
   std::string trackTunerParams;
 
   // controls behaviour
@@ -74,7 +74,8 @@ class TrackPropagationModule
 
   // takes a configurableGroup and reads in necessary configs
   template <typename TConfigurableGroup>
-  void readConfiguration(TConfigurableGroup const& cGroup){ 
+  void readConfiguration(TConfigurableGroup const& cGroup)
+  {
     minPropagationRadius = cGroup.minPropagationRadius.value;
     useTrackTuner = cGroup.minPropagationRadius.value;
     useTrkPid = cGroup.useTrkPid.value;
@@ -84,14 +85,16 @@ class TrackPropagationModule
     LOGF(info, "Track propagation module configuration done.");
   }
   template <typename TCCDBLoader>
-  void getFromCCDBLoader(TCCDBLoader const& loader){ 
+  void getFromCCDBLoader(TCCDBLoader const& loader)
+  {
     lut = loader.lut;
     mMeanVtx = loader.mMeanVtx;
     grpmag = loader.grpmag;
   }
 
   template <typename TInitContext>
-  void init(TInitContext& initContext){ 
+  void init(TInitContext& initContext)
+  {
     // Checking if the tables are requested in the workflow and enabling them
     fillTracksCov = isTableRequiredInWorkflow(initContext, "TracksCov");
     fillTracksDCA = isTableRequiredInWorkflow(initContext, "TracksDCA");
@@ -118,15 +121,16 @@ class TrackPropagationModule
   }
 
   template <typename THistoRegistry, typename TConfigurableGroup>
-  void initHistograms(THistoRegistry& registry, TConfigurableGroup& cGroup){ 
+  void initHistograms(THistoRegistry& registry, TConfigurableGroup& cGroup)
+  {
     trackTunedTracks = registry.template add<TH1>("trackTunedTracks", "trackTunedTracks", o2::framework::kTH1D, {{1, 0.5f, 1.5f}});
-    
+
     // Histograms for track tuner
     o2::framework::AxisSpec axisBinsDCA = {600, -0.15f, 0.15f, "#it{dca}_{xy} (cm)"};
     registry.template add("hDCAxyVsPtRec", "hDCAxyVsPtRec", o2::framework::kTH2F, {axisBinsDCA, cGroup.axisPtQA});
     registry.template add("hDCAxyVsPtMC", "hDCAxyVsPtMC", o2::framework::kTH2F, {axisBinsDCA, cGroup.axisPtQA});
     registry.template add("hDCAzVsPtRec", "hDCAzVsPtRec", o2::framework::kTH2F, {axisBinsDCA, cGroup.axisPtQA});
-    registry.template add("hDCAzVsPtMC", "hDCAzVsPtMC", o2::framework::kTH2F, {axisBinsDCA, cGroup.axisPtQA});  
+    registry.template add("hDCAzVsPtMC", "hDCAzVsPtMC", o2::framework::kTH2F, {axisBinsDCA, cGroup.axisPtQA});
   }
 
   template <bool isMc, typename TTracks, typename TOutputGroup, typename THistoRegistry>
@@ -172,7 +176,7 @@ class TrackPropagationModule
       double q2OverPtNew = -9999.;
       // Only propagate tracks which have passed the innermost wall of the TPC (e.g. skipping loopers etc). Others fill unpropagated.
       if (track.trackType() == o2::aod::track::TrackIU && track.x() < minPropagationRadius) {
-        if(fillTracksCov){
+        if (fillTracksCov) {
           if constexpr (isMc) { // checking MC and fillCovMat block begins
             // bool hasMcParticle = track.has_mcParticle();
             if (useTrackTuner) {
@@ -210,7 +214,7 @@ class TrackPropagationModule
           trackType = o2::aod::track::Track;
         }
         // filling some QA histograms for track tuner test purpose
-        if(fillTracksCov){ 
+        if (fillTracksCov) {
           if constexpr (isMc) { // checking MC and fillCovMat block begins
             if (track.has_mcParticle() && isPropagationOK) {
               auto mcParticle1 = track.mcParticle();
@@ -235,11 +239,11 @@ class TrackPropagationModule
         cursors.tracksParExtensionPropagated(mTrackParCov.getPt(), mTrackParCov.getP(), mTrackParCov.getEta(), mTrackParCov.getPhi());
         // TODO do we keep the rho as 0? Also the sigma's are duplicated information
         cursors.tracksParCovPropagated(std::sqrt(mTrackParCov.getSigmaY2()), std::sqrt(mTrackParCov.getSigmaZ2()), std::sqrt(mTrackParCov.getSigmaSnp2()),
-                               std::sqrt(mTrackParCov.getSigmaTgl2()), std::sqrt(mTrackParCov.getSigma1Pt2()), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+                                       std::sqrt(mTrackParCov.getSigmaTgl2()), std::sqrt(mTrackParCov.getSigma1Pt2()), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         cursors.tracksParCovExtensionPropagated(mTrackParCov.getSigmaY2(), mTrackParCov.getSigmaZY(), mTrackParCov.getSigmaZ2(), mTrackParCov.getSigmaSnpY(),
-                                        mTrackParCov.getSigmaSnpZ(), mTrackParCov.getSigmaSnp2(), mTrackParCov.getSigmaTglY(), mTrackParCov.getSigmaTglZ(), mTrackParCov.getSigmaTglSnp(),
-                                        mTrackParCov.getSigmaTgl2(), mTrackParCov.getSigma1PtY(), mTrackParCov.getSigma1PtZ(), mTrackParCov.getSigma1PtSnp(), mTrackParCov.getSigma1PtTgl(),
-                                        mTrackParCov.getSigma1Pt2());
+                                                mTrackParCov.getSigmaSnpZ(), mTrackParCov.getSigmaSnp2(), mTrackParCov.getSigmaTglY(), mTrackParCov.getSigmaTglZ(), mTrackParCov.getSigmaTglSnp(),
+                                                mTrackParCov.getSigmaTgl2(), mTrackParCov.getSigma1PtY(), mTrackParCov.getSigma1PtZ(), mTrackParCov.getSigma1PtSnp(), mTrackParCov.getSigma1PtTgl(),
+                                                mTrackParCov.getSigma1Pt2());
         if (fillTracksDCA) {
           cursors.tracksDCA(mDcaInfoCov.getY(), mDcaInfoCov.getZ());
         }

--- a/Common/Tools/TrackPropagationModule.h
+++ b/Common/Tools/TrackPropagationModule.h
@@ -1,0 +1,260 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#ifndef COMMON_TOOLS_TRACKPROPAGATIONMODULE_H_
+#define COMMON_TOOLS_TRACKPROPAGATIONMODULE_H_
+
+#include <cstdlib>
+#include <cmath>
+#include <array>
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/Configurable.h"
+#include "Framework/HistogramSpec.h"
+#include "Common/Tools/TrackTuner.h"
+
+//__________________________________________
+// track propagation module 
+// 
+// this class is capable of performing the usual track propagation
+// and table creation it is a demonstration of core service 
+// plug-in functionality that could be used to reduce the number of 
+// heavyweight (e.g. mat-LUT-using, propagating) core services to 
+// reduce overhead and make it easier to pipeline / parallelize 
+// bottlenecks in core services
+
+class TrackPropagationModule
+{
+ public:
+  TrackPropagationModule()
+  {
+    // constructor: set defaults
+    minPropagationRadius = o2::constants::geom::XTPCInnerRef + 0.1; 
+    useTrackTuner = false;
+    useTrkPid = false; 
+    fillTrackTunerTable = false;  
+    trackTunerConfigSource = o2::aod::track_tuner::InputString;
+    std::string trackTunerParams = "debugInfo=0|updateTrackDCAs=1|updateTrackCovMat=1|updateCurvature=0|updateCurvatureIU=0|updatePulls=0|isInputFileFromCCDB=1|pathInputFile=Users/m/mfaggin/test/inputsTrackTuner/PbPb2022|nameInputFile=trackTuner_DataLHC22sPass5_McLHC22l1b2_run529397.root|pathFileQoverPt=Users/h/hsharma/qOverPtGraphs|nameFileQoverPt=D0sigma_Data_removal_itstps_MC_LHC22b1b.root|usePvRefitCorrections=0|qOverPtMC=-1.|qOverPtData=-1.";
+  };
+
+  float minPropagationRadius; 
+  bool useTrackTuner; 
+  bool useTrkPid;
+  bool fillTrackTunerTable; 
+  int trackTunerConfigSource; 
+  std::string trackTunerParams;
+
+  // controls behaviour
+  bool fillTracksCov = false;
+  bool fillTracksDCA = false;
+  bool fillTracksDCACov = false;
+  int runNumber = -1;
+
+  // pointers to objs needed for operation
+  o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
+  const o2::dataformats::MeanVertexObject* mMeanVtx = nullptr;
+  o2::parameters::GRPMagField* grpmag = nullptr;
+  o2::base::MatLayerCylSet* lut = nullptr;
+  std::shared_ptr<TH1> trackTunedTracks;
+  TrackTuner trackTunerObj;
+
+  // Running variables
+  o2::gpu::gpustd::array<float, 2> mDcaInfo;
+  o2::dataformats::DCA mDcaInfoCov;
+  o2::dataformats::VertexBase mVtx;
+  o2::track::TrackParametrization<float> mTrackPar;
+  o2::track::TrackParametrizationWithError<float> mTrackParCov;
+
+  // takes a configurableGroup and reads in necessary configs
+  template <typename TConfigurableGroup>
+  void readConfiguration(TConfigurableGroup const& cGroup){ 
+    minPropagationRadius = cGroup.minPropagationRadius.value;
+    useTrackTuner = cGroup.minPropagationRadius.value;
+    useTrkPid = cGroup.useTrkPid.value;
+    fillTrackTunerTable = cGroup.fillTrackTunerTable.value;
+    trackTunerConfigSource = cGroup.trackTunerConfigSource.value;
+    trackTunerParams = cGroup.trackTunerParams.value;
+    LOGF(info, "Track propagation module configuration done.");
+  }
+  template <typename TCCDBLoader>
+  void getFromCCDBLoader(TCCDBLoader const& loader){ 
+    lut = loader.lut;
+    mMeanVtx = loader.mMeanVtx;
+    grpmag = loader.grpmag;
+  }
+
+  template <typename TInitContext>
+  void init(TInitContext& initContext){ 
+    // Checking if the tables are requested in the workflow and enabling them
+    fillTracksCov = isTableRequiredInWorkflow(initContext, "TracksCov");
+    fillTracksDCA = isTableRequiredInWorkflow(initContext, "TracksDCA");
+    fillTracksDCACov = isTableRequiredInWorkflow(initContext, "TracksDCACov");
+
+    /// TrackTuner initialization
+    if (useTrackTuner) {
+      std::string outputStringParams = "";
+      switch (trackTunerConfigSource) {
+        case o2::aod::track_tuner::InputString:
+          outputStringParams = trackTunerObj.configParams(trackTunerParams);
+          break;
+        case o2::aod::track_tuner::Configurables:
+          outputStringParams = trackTunerObj.configParams();
+          break;
+
+        default:
+          LOG(fatal) << "TrackTuner configuration source not defined. Fix it! (Supported options: input string (1); Configurables (2))";
+          break;
+      }
+
+      trackTunerObj.getDcaGraphs();
+    }
+  }
+
+  template <typename THistoRegistry, typename TConfigurableGroup>
+  void initHistograms(THistoRegistry& registry, TConfigurableGroup& cGroup){ 
+    trackTunedTracks = registry.template add<TH1>("trackTunedTracks", "trackTunedTracks", o2::framework::kTH1D, {{1, 0.5f, 1.5f}});
+    
+    // Histograms for track tuner
+    o2::framework::AxisSpec axisBinsDCA = {600, -0.15f, 0.15f, "#it{dca}_{xy} (cm)"};
+    registry.template add("hDCAxyVsPtRec", "hDCAxyVsPtRec", o2::framework::kTH2F, {axisBinsDCA, cGroup.axisPtQA});
+    registry.template add("hDCAxyVsPtMC", "hDCAxyVsPtMC", o2::framework::kTH2F, {axisBinsDCA, cGroup.axisPtQA});
+    registry.template add("hDCAzVsPtRec", "hDCAzVsPtRec", o2::framework::kTH2F, {axisBinsDCA, cGroup.axisPtQA});
+    registry.template add("hDCAzVsPtMC", "hDCAzVsPtMC", o2::framework::kTH2F, {axisBinsDCA, cGroup.axisPtQA});  
+  }
+
+  template <bool isMc, typename TTracks, typename TOutputGroup, typename THistoRegistry>
+  void fillTrackTables(TTracks const& tracks, TOutputGroup& cursors, THistoRegistry& registry)
+  {
+    if (fillTracksCov) {
+      cursors.tracksParCovPropagated.reserve(tracks.size());
+      cursors.tracksParCovExtensionPropagated.reserve(tracks.size());
+      if (fillTracksDCACov) {
+        cursors.tracksDCACov.reserve(tracks.size());
+      }
+    } else {
+      cursors.tracksParPropagated.reserve(tracks.size());
+      cursors.tracksParExtensionPropagated.reserve(tracks.size());
+      if (fillTracksDCA) {
+        cursors.tracksDCA.reserve(tracks.size());
+      }
+    }
+
+    for (auto& track : tracks) {
+      if (fillTracksCov) {
+        if (fillTracksDCA || fillTracksDCACov) {
+          mDcaInfoCov.set(999, 999, 999, 999, 999);
+        }
+        setTrackParCov(track, mTrackParCov);
+        if (useTrkPid) {
+          mTrackParCov.setPID(track.pidForTracking());
+        }
+      } else {
+        if (fillTracksDCA) {
+          mDcaInfo[0] = 999;
+          mDcaInfo[1] = 999;
+        }
+        setTrackPar(track, mTrackPar);
+        if (useTrkPid) {
+          mTrackPar.setPID(track.pidForTracking());
+        }
+      }
+      // auto trackParCov = getTrackParCov(track);
+      o2::aod::track::TrackTypeEnum trackType = (o2::aod::track::TrackTypeEnum)track.trackType();
+      // std::array<float, 3> trackPxPyPz;
+      // std::array<float, 3> trackPxPyPzTuned = {0.0, 0.0, 0.0};
+      double q2OverPtNew = -9999.;
+      // Only propagate tracks which have passed the innermost wall of the TPC (e.g. skipping loopers etc). Others fill unpropagated.
+      if (track.trackType() == o2::aod::track::TrackIU && track.x() < minPropagationRadius) {
+        if(fillTracksCov){
+          if constexpr (isMc) { // checking MC and fillCovMat block begins
+            // bool hasMcParticle = track.has_mcParticle();
+            if (useTrackTuner) {
+              trackTunedTracks->Fill(1); // all tracks
+              bool hasMcParticle = track.has_mcParticle();
+              if (hasMcParticle) {
+                auto mcParticle = track.mcParticle();
+                trackTunerObj.tuneTrackParams(mcParticle, mTrackParCov, matCorr, &mDcaInfoCov, trackTunedTracks);
+                q2OverPtNew = mTrackParCov.getQ2Pt();
+              }
+            }
+          } // MC and fillCovMat block ends
+        }
+        bool isPropagationOK = true;
+
+        if (track.has_collision()) {
+          auto const& collision = track.collision();
+          if (fillTracksCov) {
+            mVtx.setPos({collision.posX(), collision.posY(), collision.posZ()});
+            mVtx.setCov(collision.covXX(), collision.covXY(), collision.covYY(), collision.covXZ(), collision.covYZ(), collision.covZZ());
+            isPropagationOK = o2::base::Propagator::Instance()->propagateToDCABxByBz(mVtx, mTrackParCov, 2.f, matCorr, &mDcaInfoCov);
+          } else {
+            isPropagationOK = o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, mTrackPar, 2.f, matCorr, &mDcaInfo);
+          }
+        } else {
+          if (fillTracksCov) {
+            mVtx.setPos({mMeanVtx->getX(), mMeanVtx->getY(), mMeanVtx->getZ()});
+            mVtx.setCov(mMeanVtx->getSigmaX() * mMeanVtx->getSigmaX(), 0.0f, mMeanVtx->getSigmaY() * mMeanVtx->getSigmaY(), 0.0f, 0.0f, mMeanVtx->getSigmaZ() * mMeanVtx->getSigmaZ());
+            isPropagationOK = o2::base::Propagator::Instance()->propagateToDCABxByBz(mVtx, mTrackParCov, 2.f, matCorr, &mDcaInfoCov);
+          } else {
+            isPropagationOK = o2::base::Propagator::Instance()->propagateToDCABxByBz({mMeanVtx->getX(), mMeanVtx->getY(), mMeanVtx->getZ()}, mTrackPar, 2.f, matCorr, &mDcaInfo);
+          }
+        }
+        if (isPropagationOK) {
+          trackType = o2::aod::track::Track;
+        }
+        // filling some QA histograms for track tuner test purpose
+        if(fillTracksCov){ 
+          if constexpr (isMc) { // checking MC and fillCovMat block begins
+            if (track.has_mcParticle() && isPropagationOK) {
+              auto mcParticle1 = track.mcParticle();
+              // && abs(mcParticle1.pdgCode())==211
+              if (mcParticle1.isPhysicalPrimary()) {
+                registry.fill(HIST("hDCAxyVsPtRec"), mDcaInfoCov.getY(), mTrackParCov.getPt());
+                registry.fill(HIST("hDCAxyVsPtMC"), mDcaInfoCov.getY(), mcParticle1.pt());
+                registry.fill(HIST("hDCAzVsPtRec"), mDcaInfoCov.getZ(), mTrackParCov.getPt());
+                registry.fill(HIST("hDCAzVsPtMC"), mDcaInfoCov.getZ(), mcParticle1.pt());
+              }
+            }
+          } // MC and fillCovMat block ends
+        }
+      }
+      // Filling modified Q/Pt values at IU/production point by track tuner in track tuner table
+      if (useTrackTuner && fillTrackTunerTable) {
+        cursors.tunertable(q2OverPtNew);
+      }
+      // LOG(info) <<  " trackPropagation (this value filled in tuner table)--> "  << q2OverPtNew;
+      if (fillTracksCov) {
+        cursors.tracksParPropagated(track.collisionId(), trackType, mTrackParCov.getX(), mTrackParCov.getAlpha(), mTrackParCov.getY(), mTrackParCov.getZ(), mTrackParCov.getSnp(), mTrackParCov.getTgl(), mTrackParCov.getQ2Pt());
+        cursors.tracksParExtensionPropagated(mTrackParCov.getPt(), mTrackParCov.getP(), mTrackParCov.getEta(), mTrackParCov.getPhi());
+        // TODO do we keep the rho as 0? Also the sigma's are duplicated information
+        cursors.tracksParCovPropagated(std::sqrt(mTrackParCov.getSigmaY2()), std::sqrt(mTrackParCov.getSigmaZ2()), std::sqrt(mTrackParCov.getSigmaSnp2()),
+                               std::sqrt(mTrackParCov.getSigmaTgl2()), std::sqrt(mTrackParCov.getSigma1Pt2()), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        cursors.tracksParCovExtensionPropagated(mTrackParCov.getSigmaY2(), mTrackParCov.getSigmaZY(), mTrackParCov.getSigmaZ2(), mTrackParCov.getSigmaSnpY(),
+                                        mTrackParCov.getSigmaSnpZ(), mTrackParCov.getSigmaSnp2(), mTrackParCov.getSigmaTglY(), mTrackParCov.getSigmaTglZ(), mTrackParCov.getSigmaTglSnp(),
+                                        mTrackParCov.getSigmaTgl2(), mTrackParCov.getSigma1PtY(), mTrackParCov.getSigma1PtZ(), mTrackParCov.getSigma1PtSnp(), mTrackParCov.getSigma1PtTgl(),
+                                        mTrackParCov.getSigma1Pt2());
+        if (fillTracksDCA) {
+          cursors.tracksDCA(mDcaInfoCov.getY(), mDcaInfoCov.getZ());
+        }
+        if (fillTracksDCACov) {
+          cursors.tracksDCACov(mDcaInfoCov.getSigmaY2(), mDcaInfoCov.getSigmaZ2());
+        }
+      } else {
+        cursors.tracksParPropagated(track.collisionId(), trackType, mTrackPar.getX(), mTrackPar.getAlpha(), mTrackPar.getY(), mTrackPar.getZ(), mTrackPar.getSnp(), mTrackPar.getTgl(), mTrackPar.getQ2Pt());
+        cursors.tracksParExtensionPropagated(mTrackPar.getPt(), mTrackPar.getP(), mTrackPar.getEta(), mTrackPar.getPhi());
+        if (fillTracksDCA) {
+          cursors.tracksDCA(mDcaInfo[0], mDcaInfo[1]);
+        }
+      }
+    }
+  }
+};
+
+#endif // COMMON_TOOLS_TRACKPROPAGATIONMODULE_H_

--- a/Common/Tools/TrackPropagationModule.h
+++ b/Common/Tools/TrackPropagationModule.h
@@ -127,10 +127,10 @@ class TrackPropagationModule
 
     // Histograms for track tuner
     o2::framework::AxisSpec axisBinsDCA = {600, -0.15f, 0.15f, "#it{dca}_{xy} (cm)"};
-    registry.template add("hDCAxyVsPtRec", "hDCAxyVsPtRec", o2::framework::kTH2F, {axisBinsDCA, cGroup.axisPtQA});
-    registry.template add("hDCAxyVsPtMC", "hDCAxyVsPtMC", o2::framework::kTH2F, {axisBinsDCA, cGroup.axisPtQA});
-    registry.template add("hDCAzVsPtRec", "hDCAzVsPtRec", o2::framework::kTH2F, {axisBinsDCA, cGroup.axisPtQA});
-    registry.template add("hDCAzVsPtMC", "hDCAzVsPtMC", o2::framework::kTH2F, {axisBinsDCA, cGroup.axisPtQA});
+    registry.template add<TH2>("hDCAxyVsPtRec", "hDCAxyVsPtRec", o2::framework::kTH2F, {axisBinsDCA, cGroup.axisPtQA});
+    registry.template add<TH2>("hDCAxyVsPtMC", "hDCAxyVsPtMC", o2::framework::kTH2F, {axisBinsDCA, cGroup.axisPtQA});
+    registry.template add<TH2>("hDCAzVsPtRec", "hDCAzVsPtRec", o2::framework::kTH2F, {axisBinsDCA, cGroup.axisPtQA});
+    registry.template add<TH2>("hDCAzVsPtMC", "hDCAzVsPtMC", o2::framework::kTH2F, {axisBinsDCA, cGroup.axisPtQA});
   }
 
   template <bool isMc, typename TTracks, typename TOutputGroup, typename THistoRegistry>


### PR DESCRIPTION
Adds a track propagation module as a first "plugin-like" step towards an optional merged use of heavy matLUT-containing core services. First used in the (already existing) track propagation tester such as to not interfere with standard operations for now. 