### PR TITLE
[PWGHF] Add RCT selection in HF event selection utils

### DIFF
--- a/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
@@ -292,8 +292,8 @@ struct HfDataCreatorCharmHadPiReduced {
     setLabelHistoCands(hCandidatesDPlus);
     setLabelHistoCands(hCandidatesDs);
 
-    // init RCT checker
-    hfEvSel.initRctChecker();
+    // init HF event selection helper
+    hfEvSel.init(registry);
   }
 
   /// Pion selection (D Pi <-- B0)

--- a/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
@@ -291,6 +291,9 @@ struct HfDataCreatorCharmHadPiReduced {
     setLabelHistoCands(hCandidatesD0);
     setLabelHistoCands(hCandidatesDPlus);
     setLabelHistoCands(hCandidatesDs);
+
+    // init RCT checker
+    hfEvSel.initRctChecker();
   }
 
   /// Pion selection (D Pi <-- B0)

--- a/PWGHF/D2H/TableProducer/dataCreatorCharmResoReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorCharmResoReduced.cxx
@@ -303,8 +303,8 @@ struct HfDataCreatorCharmResoReduced {
     fitter.setUseAbsDCA(true);
     fitter.setWeightedFinalPCA(false);
 
-    // init RCT checker
-    hfEvSel.initRctChecker();
+    // init HF event selection helper
+    hfEvSel.init(registry);
   }
 
   /// Basic track quality selections for V0 daughters

--- a/PWGHF/D2H/TableProducer/dataCreatorCharmResoReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorCharmResoReduced.cxx
@@ -302,6 +302,9 @@ struct HfDataCreatorCharmResoReduced {
     fitter.setMaxChi2(1e9);
     fitter.setUseAbsDCA(true);
     fitter.setWeightedFinalPCA(false);
+
+    // init RCT checker
+    hfEvSel.initRctChecker();
   }
 
   /// Basic track quality selections for V0 daughters

--- a/PWGHF/TableProducer/candidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator2Prong.cxx
@@ -148,6 +148,7 @@ struct HfCandidateCreator2Prong {
     registry.add("hVertexerType", "Use KF or DCAFitterN;Vertexer type;entries", {HistType::kTH1D, {{2, -0.5, 1.5}}}); // See o2::aod::hf_cand::VertexerType
     hCandidates = registry.add<TH1>("hCandidates", "candidates counter", {HistType::kTH1D, {axisCands}});
     hfEvSel.addHistograms(registry); // collision monitoring
+    hfEvSel.initRctChecker();
 
     massPi = MassPiPlus;
     massK = MassKPlus;

--- a/PWGHF/TableProducer/candidateCreator2Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator2Prong.cxx
@@ -147,8 +147,9 @@ struct HfCandidateCreator2Prong {
     registry.add("hDcaZProngs", "DCAz of 2-prong candidate daughters;#it{p}_{T} (GeV/#it{c};#it{d}_{z}) (#mum);entries", {HistType::kTH2F, {{100, 0., 20.}, {200, -500., 500.}}});
     registry.add("hVertexerType", "Use KF or DCAFitterN;Vertexer type;entries", {HistType::kTH1D, {{2, -0.5, 1.5}}}); // See o2::aod::hf_cand::VertexerType
     hCandidates = registry.add<TH1>("hCandidates", "candidates counter", {HistType::kTH1D, {axisCands}});
-    hfEvSel.addHistograms(registry); // collision monitoring
-    hfEvSel.initRctChecker();
+
+    // init HF event selection helper
+    hfEvSel.init(registry);
 
     massPi = MassPiPlus;
     massK = MassKPlus;
@@ -714,11 +715,11 @@ struct HfCandidateCreator2ProngExpressions {
     const auto& workflows = initContext.services().get<RunningWorkflowInfo const>();
     for (const DeviceSpec& device : workflows.devices) {
       if (device.name.compare("hf-candidate-creator-2prong") == 0) {
-        hfEvSelMc.configureFromDevice(device);
+        // init HF event selection helper
+        hfEvSelMc.init(device, registry);
         break;
       }
     }
-    hfEvSelMc.addHistograms(registry); // particles monitoring
   }
 
   /// Performs MC matching.

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -175,8 +175,9 @@ struct HfCandidateCreator3Prong {
     registry.add("hDcaXYProngs", "DCAxy of 3-prong candidate daughters;#it{p}_{T} (GeV/#it{c};#it{d}_{xy}) (#mum);entries", {HistType::kTH2F, {{100, 0., 20.}, {200, -500., 500.}}});
     registry.add("hDcaZProngs", "DCAz of 3-prong candidate daughters;#it{p}_{T} (GeV/#it{c};#it{d}_{z}) (#mum);entries", {HistType::kTH2F, {{100, 0., 20.}, {200, -500., 500.}}});
     hCandidates = registry.add<TH1>("hCandidates", "candidates counter", {HistType::kTH1D, {axisCands}});
-    hfEvSel.addHistograms(registry); // collision monitoring
-    hfEvSel.initRctChecker();
+
+    // init HF event selection helper
+    hfEvSel.init(registry);
 
     massP = MassProton;
     massPi = MassPiPlus;
@@ -839,12 +840,11 @@ struct HfCandidateCreator3ProngExpressions {
     const auto& workflows = initContext.services().get<RunningWorkflowInfo const>();
     for (const DeviceSpec& device : workflows.devices) {
       if (device.name.compare("hf-candidate-creator-3prong") == 0) {
-        hfEvSelMc.configureFromDevice(device);
+        // init HF event selection helper
+        hfEvSelMc.init(device, registry);
         break;
       }
     }
-
-    hfEvSelMc.addHistograms(registry); // particles monitoring
   }
 
   /// Performs MC matching.

--- a/PWGHF/TableProducer/candidateCreator3Prong.cxx
+++ b/PWGHF/TableProducer/candidateCreator3Prong.cxx
@@ -176,6 +176,7 @@ struct HfCandidateCreator3Prong {
     registry.add("hDcaZProngs", "DCAz of 3-prong candidate daughters;#it{p}_{T} (GeV/#it{c};#it{d}_{z}) (#mum);entries", {HistType::kTH2F, {{100, 0., 20.}, {200, -500., 500.}}});
     hCandidates = registry.add<TH1>("hCandidates", "candidates counter", {HistType::kTH1D, {axisCands}});
     hfEvSel.addHistograms(registry); // collision monitoring
+    hfEvSel.initRctChecker();
 
     massP = MassProton;
     massPi = MassPiPlus;

--- a/PWGHF/TableProducer/candidateCreatorCascade.cxx
+++ b/PWGHF/TableProducer/candidateCreatorCascade.cxx
@@ -118,8 +118,9 @@ struct HfCandidateCreatorCascade {
     registry.add("hCovPVXX", "2-prong candidates;XX element of cov. matrix of prim. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 1.e-4}}});
     registry.add("hCovSVXX", "2-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 0.2}}});
     hCandidates = registry.add<TH1>("hCandidates", "candidates counter", {HistType::kTH1D, {axisCands}});
-    hfEvSel.addHistograms(registry); // collision monitoring
-    hfEvSel.initRctChecker();
+
+    // init HF event selection helper
+    hfEvSel.init(registry);
 
     massP = MassProton;
     massK0s = MassK0Short;
@@ -472,11 +473,11 @@ struct HfCandidateCreatorCascadeMc {
     const auto& workflows = initContext.services().get<RunningWorkflowInfo const>();
     for (const DeviceSpec& device : workflows.devices) {
       if (device.name.compare("hf-candidate-creator-cascade") == 0) {
-        hfEvSelMc.configureFromDevice(device);
+        // init HF event selection helper
+        hfEvSelMc.init(device, registry);
         break;
       }
     }
-    hfEvSelMc.addHistograms(registry); // particles monitoring
   }
 
   template <o2::hf_centrality::CentralityEstimator centEstimator, typename CCs, typename McCollisions>

--- a/PWGHF/TableProducer/candidateCreatorCascade.cxx
+++ b/PWGHF/TableProducer/candidateCreatorCascade.cxx
@@ -119,6 +119,7 @@ struct HfCandidateCreatorCascade {
     registry.add("hCovSVXX", "2-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 0.2}}});
     hCandidates = registry.add<TH1>("hCandidates", "candidates counter", {HistType::kTH1D, {axisCands}});
     hfEvSel.addHistograms(registry); // collision monitoring
+    hfEvSel.initRctChecker();
 
     massP = MassProton;
     massK0s = MassK0Short;

--- a/PWGHF/TableProducer/candidateCreatorDstar.cxx
+++ b/PWGHF/TableProducer/candidateCreatorDstar.cxx
@@ -137,6 +137,7 @@ struct HfCandidateCreatorDstar {
 
     hCandidates = registry.add<TH1>("hCandidates", "candidates counter", {HistType::kTH1D, {axisCands}});
     hfEvSel.addHistograms(registry); // collision monitoring
+    hfEvSel.initRctChecker();
 
     // LOG(info) << "Init Function Invoked";
     massPi = MassPiPlus;

--- a/PWGHF/TableProducer/candidateCreatorDstar.cxx
+++ b/PWGHF/TableProducer/candidateCreatorDstar.cxx
@@ -136,8 +136,9 @@ struct HfCandidateCreatorDstar {
     }
 
     hCandidates = registry.add<TH1>("hCandidates", "candidates counter", {HistType::kTH1D, {axisCands}});
-    hfEvSel.addHistograms(registry); // collision monitoring
-    hfEvSel.initRctChecker();
+
+    // init HF event selection helper
+    hfEvSel.init(registry);
 
     // LOG(info) << "Init Function Invoked";
     massPi = MassPiPlus;
@@ -535,11 +536,11 @@ struct HfCandidateCreatorDstarExpressions {
     const auto& workflows = initContext.services().get<RunningWorkflowInfo const>();
     for (const DeviceSpec& device : workflows.devices) {
       if (device.name.compare("hf-candidate-creator-dstar") == 0) {
-        hfEvSelMc.configureFromDevice(device);
+        // init HF event selection helper
+        hfEvSelMc.init(device, registry);
         break;
       }
     }
-    hfEvSelMc.addHistograms(registry); // particles monitoring
   }
 
   /// Perform MC Matching.

--- a/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
+++ b/PWGHF/TableProducer/candidateCreatorSigmac0plusplus.cxx
@@ -408,12 +408,11 @@ struct HfCandidateSigmac0plusplusMc {
       // here we assume that the hf-candidate-creator-3prong is in the workflow
       // configure the ev. sel from that workflow
       if (device.name.compare("hf-candidate-creator-3prong") == 0) {
-        hfEvSelMc.configureFromDevice(device);
+        // init HF event selection helper
+        hfEvSelMc.init(device, registry);
         break;
       }
     }
-
-    hfEvSelMc.addHistograms(registry); // particles monitoring
   }
 
   /// @brief dummy process function, to be run on data

--- a/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
@@ -342,6 +342,7 @@ struct HfCandidateCreatorXic0Omegac0 {
       registry.add("hKFcosPaCascToOmegac", "hKFcosPaCascToOmegac", kTH1D, {{5000, 0.8f, 1.1f}});
     }
     hfEvSel.addHistograms(registry); // collision monitoring
+    hfEvSel.initRctChecker();
 
     df.setPropagateToPCA(propagateToPCA);
     df.setMaxR(maxR);

--- a/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
@@ -341,8 +341,9 @@ struct HfCandidateCreatorXic0Omegac0 {
       registry.add("hKFcosPaV0ToCasc", "hKFcosPaV0ToCasc", kTH1D, {{5000, 0.8f, 1.1f}});
       registry.add("hKFcosPaCascToOmegac", "hKFcosPaCascToOmegac", kTH1D, {{5000, 0.8f, 1.1f}});
     }
-    hfEvSel.addHistograms(registry); // collision monitoring
-    hfEvSel.initRctChecker();
+
+    // init HF event selection helper
+    hfEvSel.init(registry);
 
     df.setPropagateToPCA(propagateToPCA);
     df.setMaxR(maxR);
@@ -1880,11 +1881,11 @@ struct HfCandidateCreatorXic0Omegac0Mc {
     const auto& workflows = initContext.services().get<RunningWorkflowInfo const>();
     for (const DeviceSpec& device : workflows.devices) {
       if (device.name.compare("hf-candidate-creator-xic0-omegac0") == 0) {
-        hfEvSelMc.configureFromDevice(device);
+        // init HF event selection helper
+        hfEvSelMc.init(device, registry);
         break;
       }
     }
-    hfEvSelMc.addHistograms(registry); // particles monitoring
 
     hGenCharmBaryonPtRapidityTightXicToXiPi = registry.add<TH1>("hGenCharmBaryonPtRapidityTightXicToXiPi", "Generated charm baryon #it{p}_{T};#it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1D, {{20, 0.0, 20.0}}}); // keep track of generated candidates pt when |y|<0.5
     hGenCharmBaryonPtRapidityLooseXicToXiPi = registry.add<TH1>("hGenCharmBaryonPtRapidityLooseXicToXiPi", "Generated charm baryon #it{p}_{T};#it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1D, {{20, 0.0, 20.0}}}); // keep track of generated candidates pt when |y|<0.8

--- a/PWGHF/Utils/utilsEvSelHf.h
+++ b/PWGHF/Utils/utilsEvSelHf.h
@@ -207,7 +207,8 @@ struct HfEventSelection : o2::framework::ConfigurableGroup {
     }
   }
 
-  void initRctChecker() {
+  void initRctChecker()
+  {
     rctChecker.init(rctLabel.value, rctCheckZDC.value, rctTreatLimitedAcceptanceAsBad.value);
   }
 

--- a/PWGHF/Utils/utilsEvSelHf.h
+++ b/PWGHF/Utils/utilsEvSelHf.h
@@ -207,7 +207,9 @@ struct HfEventSelection : o2::framework::ConfigurableGroup {
   void init(o2::framework::HistogramRegistry& registry)
   {
     // we initialise the RCT checker
-    rctChecker.init(rctLabel.value, rctCheckZDC.value, rctTreatLimitedAcceptanceAsBad.value);
+    if (requireGoodRct) {
+      rctChecker.init(rctLabel.value, rctCheckZDC.value, rctTreatLimitedAcceptanceAsBad.value);
+    }
 
     // we initialise the summary object
     if (softwareTrigger.value != "") {
@@ -439,7 +441,9 @@ struct HfEventSelectionMc {
     configureFromDevice(device);
 
     // we initialise the RCT checker
-    rctChecker.init(rctLabel, rctCheckZDC, rctTreatLimitedAcceptanceAsBad);
+    if (requireGoodRct) {
+      rctChecker.init(rctLabel, rctCheckZDC, rctTreatLimitedAcceptanceAsBad);
+    }
 
     // we initialise histograms
     addHistograms(registry);

--- a/PWGHF/Utils/utilsEvSelHf.h
+++ b/PWGHF/Utils/utilsEvSelHf.h
@@ -200,16 +200,22 @@ struct HfEventSelection : o2::framework::ConfigurableGroup {
     const o2::framework::AxisSpec th2AxisCent{th2ConfigAxisCent, "Centrality"};
     const o2::framework::AxisSpec th2AxisOccupancy{th2ConfigAxisOccupancy, "Occupancy"};
     hCollisionsCentOcc = registry.add<TH2>(NameHistCollisionsCentOcc, "selected events;Centrality; Occupancy", {o2::framework::HistType::kTH2D, {th2AxisCent, th2AxisOccupancy}});
+  }
+
+  /// \brief Inits the HF event selection object 
+  /// \param registry reference to the histogram registry
+  void init(o2::framework::HistogramRegistry& registry)
+  {
+    // we initialise the RCT checker
+    rctChecker.init(rctLabel.value, rctCheckZDC.value, rctTreatLimitedAcceptanceAsBad.value);
 
     // we initialise the summary object
     if (softwareTrigger.value != "") {
       zorroSummary.setObject(zorro.getZorroSummary());
     }
-  }
 
-  void initRctChecker()
-  {
-    rctChecker.init(rctLabel.value, rctCheckZDC.value, rctTreatLimitedAcceptanceAsBad.value);
+    // we initialise histograms
+    addHistograms(registry);
   }
 
   /// \brief Applies event selection.
@@ -390,6 +396,9 @@ struct HfEventSelectionMc {
     setEventRejectionLabels(hParticles);
   }
 
+  /// \brief Configures the object from the reco workflow 
+  /// \param registry reference to the histogram registry
+  /// \param device device spec to get the configs from the reco workflow
   void configureFromDevice(const o2::framework::DeviceSpec& device)
   {
     for (const auto& option : device.options) {
@@ -419,7 +428,21 @@ struct HfEventSelectionMc {
         rctTreatLimitedAcceptanceAsBad = option.defaultValue.get<bool>();
       }
     }
+  }
+
+  /// \brief Inits the HF event selection object 
+  /// \param device device spec to get the configs from the reco workflow
+  /// \param registry reference to the histogram registry
+  void init(const o2::framework::DeviceSpec& device, o2::framework::HistogramRegistry& registry)
+  {
+    // we get the configuration from the reco workflow
+    configureFromDevice(device);
+
+    // we initialise the RCT checker
     rctChecker.init(rctLabel, rctCheckZDC, rctTreatLimitedAcceptanceAsBad);
+
+    // we initialise histograms
+    addHistograms(registry);
   }
 
   /// \brief Function to apply event selections to generated MC collisions

--- a/PWGHF/Utils/utilsEvSelHf.h
+++ b/PWGHF/Utils/utilsEvSelHf.h
@@ -27,6 +27,7 @@
 #include "Framework/OutputObjHeader.h"
 
 #include "Common/CCDB/EventSelectionParams.h"
+#include "Common/CCDB/RCTSelectionFlags.h"
 #include "EventFiltering/Zorro.h"
 #include "EventFiltering/ZorroSummary.h"
 #include "PWGLF/DataModel/mcCentrality.h"
@@ -82,6 +83,7 @@ namespace o2::hf_evsel
 // event rejection types
 enum EventRejection {
   None = 0,
+  Rct,
   SoftwareTrigger,
   Centrality,
   Trigger,
@@ -110,6 +112,7 @@ void setEventRejectionLabels(Histo& hRejection, std::string softwareTriggerLabel
 {
   // Puts labels on the collision monitoring histogram.
   hRejection->GetXaxis()->SetBinLabel(EventRejection::None + 1, "All");
+  hRejection->GetXaxis()->SetBinLabel(EventRejection::Rct + 1, "RCT");
   hRejection->GetXaxis()->SetBinLabel(EventRejection::SoftwareTrigger + 1, softwareTriggerLabel.data());
   hRejection->GetXaxis()->SetBinLabel(EventRejection::Centrality + 1, "Centrality");
   hRejection->GetXaxis()->SetBinLabel(EventRejection::Trigger + 1, "Trigger");
@@ -155,6 +158,10 @@ struct HfEventSelection : o2::framework::ConfigurableGroup {
   o2::framework::Configurable<std::string> ccdbPathSoftwareTrigger{"ccdbPathSoftwareTrigger", "Users/m/mpuccio/EventFiltering/OTS/Chunked/", "ccdb path for ZORRO objects"};
   o2::framework::ConfigurableAxis th2ConfigAxisCent{"th2ConfigAxisCent", {100, 0., 100.}, ""};
   o2::framework::ConfigurableAxis th2ConfigAxisOccupancy{"th2ConfigAxisOccupancy", {14, 0, 14000}, ""};
+  o2::framework::Configurable<bool> requireGoodRct{"requireGoodRct", false, "Flag to require good RCT"};
+  o2::framework::Configurable<std::string> rctLabel{"rctLabel", "CBT_hadronPID", "RCT selection flag (CBT, CBT_hadronPID, CBT_electronPID, CCBT_calo, CBT_muon, CBT_muon_glo)"};
+  o2::framework::Configurable<bool> rctCheckZDC{"rctCheckZDC", false, "RCT flag to check whether the ZDC is present or not"};
+  o2::framework::Configurable<bool> rctTreatLimitedAcceptanceAsBad{"rctTreatLimitedAcceptanceAsBad", false, "RCT flag to reject events with limited acceptance for selected detectors"};
 
   // histogram names
   static constexpr char NameHistCollisions[] = "hCollisions";
@@ -168,6 +175,9 @@ struct HfEventSelection : o2::framework::ConfigurableGroup {
 
   std::shared_ptr<TH1> hCollisions, hSelCollisionsCent, hPosZBeforeEvSel, hPosZAfterEvSel, hPosXAfterEvSel, hPosYAfterEvSel, hNumPvContributorsAfterSel;
   std::shared_ptr<TH2> hCollisionsCentOcc;
+
+  // util to retrieve the RCT info from CCDB
+  o2::aod::rctsel::RCTFlagsChecker rctChecker;
 
   // util to retrieve trigger mask in case of software triggers
   Zorro zorro;
@@ -197,6 +207,10 @@ struct HfEventSelection : o2::framework::ConfigurableGroup {
     }
   }
 
+  void initRctChecker() {
+    rctChecker.init(rctLabel.value, rctCheckZDC.value, rctTreatLimitedAcceptanceAsBad.value);
+  }
+
   /// \brief Applies event selection.
   /// \tparam useEvSel use information from the EvSel table
   /// \tparam centEstimator centrality estimator
@@ -218,6 +232,10 @@ struct HfEventSelection : o2::framework::ConfigurableGroup {
     }
 
     if constexpr (useEvSel) {
+      /// RCT condition
+      if (requireGoodRct && !rctChecker.checkTable(collision)) {
+        SETBIT(rejectionMask, EventRejection::Rct);
+      }
       /// trigger condition
       if ((useSel8Trigger && !collision.sel8()) || (!useSel8Trigger && triggerClass > -1 && !collision.alias_bit(triggerClass))) {
         SETBIT(rejectionMask, EventRejection::Trigger);
@@ -333,14 +351,21 @@ struct HfEventSelection : o2::framework::ConfigurableGroup {
 
 struct HfEventSelectionMc {
   // event selection parameters (in chronological order of application)
-  bool useSel8Trigger{false};       // Apply the Sel8 selection
-  bool useTvxTrigger{false};        // Apply the TVX trigger
-  bool useTimeFrameBorderCut{true}; // Apply TF border cut
-  bool useItsRofBorderCut{false};   // Apply the ITS RO frame border cut
-  float zPvPosMin{-1000.f};         // Minimum PV posZ (cm)
-  float zPvPosMax{1000.f};          // Maximum PV posZ (cm)
-  float centralityMin{0.f};         // Minimum centrality
-  float centralityMax{100.f};       // Maximum centrality
+  bool useSel8Trigger{false};          // Apply the Sel8 selection
+  bool useTvxTrigger{false};           // Apply the TVX trigger
+  bool useTimeFrameBorderCut{true};    // Apply TF border cut
+  bool useItsRofBorderCut{false};      // Apply the ITS RO frame border cut
+  float zPvPosMin{-1000.f};            // Minimum PV posZ (cm)
+  float zPvPosMax{1000.f};             // Maximum PV posZ (cm)
+  float centralityMin{0.f};            // Minimum centrality
+  float centralityMax{100.f};          // Maximum centrality
+  bool requireGoodRct{false};          // Apply RCT selection
+  std::string rctLabel{""};            // RCT selection flag
+  bool rctCheckZDC;                    // require ZDC from RCT
+  bool rctTreatLimitedAcceptanceAsBad; // RCT flag to reject events with limited acceptance for selected detectors
+
+  // util to retrieve the RCT info from CCDB
+  o2::aod::rctsel::RCTFlagsChecker rctChecker;
 
   // histogram names
   static constexpr char NameHistGenCollisionsCent[] = "hGenCollisionsCent";
@@ -383,8 +408,17 @@ struct HfEventSelectionMc {
         centralityMin = option.defaultValue.get<float>();
       } else if (option.name.compare("hfEvSel.centralityMax") == 0) {
         centralityMax = option.defaultValue.get<float>();
+      } else if (option.name.compare("hfEvSel.requireGoodRct") == 0) {
+        requireGoodRct = option.defaultValue.get<bool>();
+      } else if (option.name.compare("hfEvSel.rctLabel") == 0) {
+        rctLabel = option.defaultValue.get<std::string>();
+      } else if (option.name.compare("hfEvSel.rctCheckZDC") == 0) {
+        rctCheckZDC = option.defaultValue.get<bool>();
+      } else if (option.name.compare("hfEvSel.rctTreatLimitedAcceptanceAsBad") == 0) {
+        rctTreatLimitedAcceptanceAsBad = option.defaultValue.get<bool>();
       }
     }
+    rctChecker.init(rctLabel, rctCheckZDC, rctTreatLimitedAcceptanceAsBad);
   }
 
   /// \brief Function to apply event selections to generated MC collisions
@@ -404,6 +438,16 @@ struct HfEventSelectionMc {
       /// centrality selection
       if (centrality < centralityMin || centrality > centralityMax) {
         SETBIT(rejectionMask, EventRejection::Centrality);
+      }
+    }
+
+    /// RCT condition
+    if (requireGoodRct) {
+      for (auto const& collision : collSlice) {
+        if (!rctChecker.checkTable(collision)) {
+          SETBIT(rejectionMask, EventRejection::Rct);
+          break;
+        }
       }
     }
     /// Sel8 trigger selection

--- a/PWGHF/Utils/utilsEvSelHf.h
+++ b/PWGHF/Utils/utilsEvSelHf.h
@@ -202,7 +202,7 @@ struct HfEventSelection : o2::framework::ConfigurableGroup {
     hCollisionsCentOcc = registry.add<TH2>(NameHistCollisionsCentOcc, "selected events;Centrality; Occupancy", {o2::framework::HistType::kTH2D, {th2AxisCent, th2AxisOccupancy}});
   }
 
-  /// \brief Inits the HF event selection object 
+  /// \brief Inits the HF event selection object
   /// \param registry reference to the histogram registry
   void init(o2::framework::HistogramRegistry& registry)
   {
@@ -396,7 +396,7 @@ struct HfEventSelectionMc {
     setEventRejectionLabels(hParticles);
   }
 
-  /// \brief Configures the object from the reco workflow 
+  /// \brief Configures the object from the reco workflow
   /// \param registry reference to the histogram registry
   /// \param device device spec to get the configs from the reco workflow
   void configureFromDevice(const o2::framework::DeviceSpec& device)
@@ -430,7 +430,7 @@ struct HfEventSelectionMc {
     }
   }
 
-  /// \brief Inits the HF event selection object 
+  /// \brief Inits the HF event selection object
   /// \param device device spec to get the configs from the reco workflow
   /// \param registry reference to the histogram registry
   void init(const o2::framework::DeviceSpec& device, o2::framework::HistogramRegistry& registry)


### PR DESCRIPTION
Hi @mfaggin @zhangbiao-phy, this PR adds the possibility to apply the RCT event selection in the HF code. 
I still keep it draft for the pending questions I asked to the experts in the mail thread.

@pstahlhu @creetz16 @JaeYoonCHO @sh-lim (I could not find Krista, please add her if you know her github account) while implementing this I noticed that there is no event selection applied at all for the Xic+ -> XiPiPi, could you please add it in a dedicated PR, or do you prefer me to do it?