### PR TITLE
[PWGEM/PhotonMeson,PWGJE/EMCal] Add bc wise skimming and analysis task

### DIFF
--- a/PWGEM/PhotonMeson/DataModel/bcWiseTables.h
+++ b/PWGEM/PhotonMeson/DataModel/bcWiseTables.h
@@ -1,0 +1,146 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+///
+/// \file bcWiseTables.h
+///
+/// \brief This header provides the table definitions to store very lightweight EMCal clusters per BC
+///
+/// \author Nicolas Strangmann (nicolas.strangmann@cern.ch) - Goethe University Frankfurt
+///
+
+#ifndef PWGEM_PHOTONMESON_DATAMODEL_BCWISETABLES_H_
+#define PWGEM_PHOTONMESON_DATAMODEL_BCWISETABLES_H_
+
+#include "Framework/AnalysisDataModel.h"
+
+namespace o2::aod
+{
+
+namespace emdownscaling
+{
+enum Observables {
+  kDefinition,
+  kEnergy,
+  kEta,
+  kPhi,
+  kNCells,
+  kM02,
+  kTime,
+  kFT0MCent,
+  kZVtx,
+  kFT0Amp,
+  kCellAmpSum,
+  kpT,
+  nObservables
+};
+
+// Values in tables are stored in downscaled format to save disk space
+const float downscalingFactors[nObservables]{
+  1E0,  // Cluster definition
+  1E3,  // Cluster energy
+  1E4,  // Cluster eta
+  1E4,  // Cluster phi
+  1E0,  // Number of cells
+  1E4,  // M02
+  1E2,  // Cluster time
+  2E0,  // FT0M centrality
+  1E3,  // Z-vertex position
+  1E0,  // FT0M amplitude
+  1E0,  // Cell energy
+  1E3}; // MC pi0 pt
+} // namespace emdownscaling
+
+namespace bcwisebc
+{
+DECLARE_SOA_COLUMN(HasFT0, hasFT0, bool);                                   //! has_foundFT0()
+DECLARE_SOA_COLUMN(HasTVX, hasTVX, bool);                                   //! has the TVX trigger flag
+DECLARE_SOA_COLUMN(HaskTVXinEMC, haskTVXinEMC, bool);                       //! kTVXinEMC
+DECLARE_SOA_COLUMN(HasEMCCell, hasEMCCell, bool);                           //! at least one EMCal cell in the BC
+DECLARE_SOA_COLUMN(HasNoTFROFBorder, hasNoTFROFBorder, bool);               //! not in the TF border or ITS ROF border region
+DECLARE_SOA_COLUMN(StoredFT0MAmplitude, storedFT0MAmplitude, unsigned int); //! ft0a+c amplitude
+DECLARE_SOA_COLUMN(StoredEMCalnCells, storedEMCalnCells, unsigned int);     //! number of emcal cells
+DECLARE_SOA_COLUMN(StoredEMCalCellEnergy, storedEMCalCellEnergy, float);    //! sum of energy in emcal cells
+} // namespace bcwisebc
+DECLARE_SOA_TABLE(BCWiseBCs, "AOD", "BCWISEBCS", //! table of bc wise centrality estimation and event selection input
+                  o2::soa::Index<>, bcwisebc::HasFT0, bcwisebc::HasTVX, bcwisebc::HaskTVXinEMC, bcwisebc::HasEMCCell, bcwisebc::HasNoTFROFBorder,
+                  bcwisebc::StoredFT0MAmplitude, bcwisebc::StoredEMCalnCells, bcwisebc::StoredEMCalCellEnergy);
+
+DECLARE_SOA_INDEX_COLUMN(BCWiseBC, bcWiseBC); //! bunch crossing ID used as index
+
+namespace bcwisecollision
+{
+DECLARE_SOA_COLUMN(StoredCentrality, storedCentrality, uint8_t); //! FT0M centrality (0-100) (x2)
+DECLARE_SOA_COLUMN(StoredZVtx, storedZVtx, int16_t);             //! Z-vertex position (x1000)
+
+DECLARE_SOA_DYNAMIC_COLUMN(Centrality, centrality, [](uint8_t storedcentrality) -> float { return storedcentrality / emdownscaling::downscalingFactors[emdownscaling::kFT0MCent]; }); //! Centrality (0-100)
+DECLARE_SOA_DYNAMIC_COLUMN(ZVtx, zVtx, [](uint8_t storedzvtx) -> float { return storedzvtx / emdownscaling::downscalingFactors[emdownscaling::kZVtx]; });                             //! Centrality (0-100)
+} // namespace bcwisecollision
+DECLARE_SOA_TABLE(BCWiseCollisions, "AOD", "BCWISECOLLS", //! table of skimmed EMCal clusters
+                  o2::soa::Index<>, BCWiseBCId, bcwisecollision::StoredCentrality, bcwisecollision::StoredZVtx,
+                  bcwisecollision::Centrality<bcwisecollision::StoredCentrality>, bcwisecollision::ZVtx<bcwisecollision::StoredZVtx>);
+
+namespace bcwisecluster
+{
+DECLARE_SOA_COLUMN(StoredDefinition, storedDefinition, uint8_t); //! cluster definition, see EMCALClusterDefinition.h
+DECLARE_SOA_COLUMN(StoredE, storedE, uint16_t);                  //! cluster energy (1 MeV -> Maximum cluster energy of ~65 GeV)
+DECLARE_SOA_COLUMN(StoredEta, storedEta, int16_t);               //! cluster pseudorapidity (x10,000)
+DECLARE_SOA_COLUMN(StoredPhi, storedPhi, uint16_t);              //! cluster azimuthal angle (x10 000) from 0 to 2pi
+DECLARE_SOA_COLUMN(StoredNCells, storedNCells, uint8_t);         //! number of cells in cluster
+DECLARE_SOA_COLUMN(StoredM02, storedM02, uint16_t);              //! shower shape long axis (x10 000)
+DECLARE_SOA_COLUMN(StoredTime, storedTime, int16_t);             //! cluster time (10 ps resolution)
+DECLARE_SOA_COLUMN(StoredIsExotic, storedIsExotic, bool);        //! flag to mark cluster as exotic
+
+DECLARE_SOA_DYNAMIC_COLUMN(Definition, definition, [](uint8_t storedDefinition) -> uint8_t { return storedDefinition; });                                 //! cluster definition, see EMCALClusterDefinition.h
+DECLARE_SOA_DYNAMIC_COLUMN(E, e, [](uint16_t storedE) -> float { return storedE / emdownscaling::downscalingFactors[emdownscaling::kEnergy]; });          //! cluster energy (GeV)
+DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta, [](int16_t storedEta) -> float { return storedEta / emdownscaling::downscalingFactors[emdownscaling::kEta]; });      //! cluster pseudorapidity
+DECLARE_SOA_DYNAMIC_COLUMN(Phi, phi, [](uint16_t storedPhi) -> float { return storedPhi / emdownscaling::downscalingFactors[emdownscaling::kPhi]; });     //! cluster azimuthal angle (0 to 2pi)
+DECLARE_SOA_DYNAMIC_COLUMN(NCells, nCells, [](uint16_t storedNCells) -> uint16_t { return storedNCells; });                                               //! number of cells in cluster
+DECLARE_SOA_DYNAMIC_COLUMN(M02, m02, [](uint16_t storedM02) -> float { return storedM02 / emdownscaling::downscalingFactors[emdownscaling::kM02]; });     //! shower shape long axis
+DECLARE_SOA_DYNAMIC_COLUMN(Time, time, [](int16_t storedTime) -> float { return storedTime / emdownscaling::downscalingFactors[emdownscaling::kTime]; }); //! cluster time (ns)
+DECLARE_SOA_DYNAMIC_COLUMN(IsExotic, isExotic, [](bool storedIsExotic) -> bool { return storedIsExotic; });                                               //! flag to mark cluster as exotic
+
+DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, [](float storedE, float storedEta) -> float { return storedE / emdownscaling::downscalingFactors[emdownscaling::kEnergy] / std::cosh(storedEta / emdownscaling::downscalingFactors[emdownscaling::kEta]); }); //! cluster pt, assuming m=0 (photons)
+} // namespace bcwisecluster
+
+DECLARE_SOA_TABLE(BCWiseClusters, "AOD", "BCWISECLUSTERS", //! table of skimmed EMCal clusters
+                  o2::soa::Index<>, BCWiseBCId, bcwisecluster::StoredDefinition, bcwisecluster::StoredE, bcwisecluster::StoredEta, bcwisecluster::StoredPhi, bcwisecluster::StoredNCells, bcwisecluster::StoredM02, bcwisecluster::StoredTime, bcwisecluster::StoredIsExotic,
+                  bcwisecluster::Definition<bcwisecluster::StoredDefinition>, bcwisecluster::E<bcwisecluster::StoredE>, bcwisecluster::Eta<bcwisecluster::StoredEta>, bcwisecluster::Phi<bcwisecluster::StoredPhi>, bcwisecluster::NCells<bcwisecluster::StoredNCells>, bcwisecluster::M02<bcwisecluster::StoredM02>, bcwisecluster::Time<bcwisecluster::StoredTime>, bcwisecluster::IsExotic<bcwisecluster::StoredIsExotic>,
+                  bcwisecluster::Pt<bcwisecluster::StoredE, bcwisecluster::StoredEta>);
+
+namespace bcwisemcpi0s
+{
+DECLARE_SOA_COLUMN(ParticleIdPi0, particleIdPi0, int); //! ID of the pi0 in the MC stack
+DECLARE_SOA_COLUMN(StoredPt, storedPt, uint16_t);      //! Transverse momentum of generated pi0 (10 MeV)
+DECLARE_SOA_COLUMN(IsAccepted, isAccepted, bool);      //! Both decay photons are within the EMCal acceptance
+DECLARE_SOA_COLUMN(IsPrimary, isPrimary, bool);        //! mcParticle.isPhysicalPrimary() || mcParticle.producedByGenerator()
+DECLARE_SOA_COLUMN(IsFromWD, isFromWD, bool);          //! Pi0 from a weak decay according to pwgem::photonmeson::utils::mcutil::IsFromWD
+
+DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, [](uint16_t storedpt) -> float { return storedpt / emdownscaling::downscalingFactors[emdownscaling::kpT]; }); //! pT of pi0 (GeV)
+} // namespace bcwisemcpi0s
+
+DECLARE_SOA_TABLE(BCWiseMCPi0s, "AOD", "BCWISEMCPI0S", //! table of pi0s on MC level
+                  o2::soa::Index<>, BCWiseBCId, bcwisemcpi0s::ParticleIdPi0, bcwisemcpi0s::StoredPt, bcwisemcpi0s::IsAccepted, bcwisemcpi0s::IsPrimary, bcwisemcpi0s::IsFromWD,
+                  bcwisemcpi0s::Pt<bcwisemcpi0s::StoredPt>);
+
+namespace bcwisemccluster
+{
+DECLARE_SOA_COLUMN(StoredE, storedE, uint16_t); //! energy of cluster inducing particle (1 MeV precision)
+
+DECLARE_SOA_DYNAMIC_COLUMN(E, e, [](uint16_t storedE) -> float { return storedE / emdownscaling::downscalingFactors[emdownscaling::kEnergy]; }); //! energy of cluster inducing particle (GeV)
+} // namespace bcwisemccluster
+
+DECLARE_SOA_TABLE(BCWiseMCClusters, "AOD", "BCWISEMCCLS", //! table of MC information for clusters -> To be joined with the cluster table
+                  o2::soa::Index<>, BCWiseBCId, bcwisemccluster::StoredE, bcwisemcpi0s::ParticleIdPi0,
+                  bcwisemccluster::E<bcwisemccluster::StoredE>);
+
+} // namespace o2::aod
+
+#endif // PWGEM_PHOTONMESON_DATAMODEL_BCWISETABLES_H_

--- a/PWGEM/PhotonMeson/TableProducer/CMakeLists.txt
+++ b/PWGEM/PhotonMeson/TableProducer/CMakeLists.txt
@@ -44,6 +44,11 @@ o2physics_add_dpl_workflow(skimmer-gamma-calo
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(bc-wise-cluster-skimmer
+                    SOURCES bcWiseClusterSkimmer.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::EMCALBase O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(skimmer-phos
                     SOURCES skimmerPHOS.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::PHOSBase

--- a/PWGEM/PhotonMeson/TableProducer/bcWiseClusterSkimmer.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/bcWiseClusterSkimmer.cxx
@@ -1,0 +1,271 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+///
+/// \file bcWiseClusterSkimmer.cxx
+///
+/// \brief This task creates minimalistic skimmed tables containing EMC clusters and centrality information
+///
+/// \author Nicolas Strangmann (nicolas.strangmann@cern.ch) - Goethe University Frankfurt
+///
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+
+#include "DetectorsBase/GeometryManager.h"
+#include "EMCALBase/Geometry.h"
+
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/Centrality.h"
+#include "PWGJE/DataModel/EMCALClusters.h"
+#include "PWGEM/PhotonMeson/Utils/MCUtilities.h"
+#include "PWGEM/PhotonMeson/DataModel/bcWiseTables.h"
+
+using namespace o2;
+using namespace o2::aod::emdownscaling;
+using namespace o2::framework;
+
+using MyCollisions = soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Ms>;
+using MyMCCollisions = soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Ms, aod::McCollisionLabels>;
+using MyBCs = soa::Join<aod::BCs, aod::BcSels>;
+
+using SelectedUniqueClusters = soa::Filtered<aod::EMCALClusters>;                                                         // Clusters from collisions with only one collision in the BC
+using SelectedUniqueMCClusters = soa::Filtered<soa::Join<aod::EMCALClusters, aod::EMCALMCClusters>>;                      // Clusters from collisions with only one collision in the BC
+using SelectedAmbiguousClusters = soa::Filtered<aod::EMCALAmbiguousClusters>;                                             // Clusters from BCs with multiple collisions (no vertex assignment possible)
+using SelectedAmbiguousMCClusters = soa::Filtered<soa::Join<aod::EMCALAmbiguousClusters, aod::EMCALAmbiguousMCClusters>>; // Clusters from BCs with multiple collisions (no vertex assignment possible)
+using SelectedCells = o2::soa::Filtered<aod::Calos>;
+
+struct bcWiseClusterSkimmer {
+  Produces<aod::BCWiseBCs> bcTable;
+  Produces<aod::BCWiseClusters> clusterTable;
+  Produces<aod::BCWiseCollisions> collisionTable;
+  Produces<aod::BCWiseMCPi0s> mcpi0Table;
+  Produces<aod::BCWiseMCClusters> mcclusterTable;
+
+  PresliceUnsorted<MyCollisions> perFoundBC = aod::evsel::foundBCId;
+  Preslice<SelectedUniqueClusters> perCol = aod::emcalcluster::collisionId;
+  Preslice<SelectedAmbiguousClusters> perBC = aod::emcalcluster::bcId;
+  Preslice<SelectedCells> cellsPerBC = aod::calo::bcId;
+
+  Configurable<float> cfgMinClusterEnergy{"cfgMinClusterEnergy", 0.5, "Minimum energy of selected clusters (GeV)"};
+  Configurable<float> cfgMinM02{"cfgMinM02", -1., "Minimum M02 of selected clusters"};
+  Configurable<float> cfgMaxM02{"cfgMaxM02", 5., "Maximum M02 of selected clusters"};
+  Configurable<float> cfgMinTime{"cfgMinTime", -25, "Minimum time of selected clusters (ns)"};
+  Configurable<float> cfgMaxTime{"cfgMaxTime", 25, "Maximum time of selected clusters (ns)"};
+  Configurable<float> cfgRapidityCut{"cfgRapidityCut", 0.8f, "Maximum absolute rapidity of counted generated particles"};
+
+  expressions::Filter energyFilter = aod::emcalcluster::energy > cfgMinClusterEnergy;
+  expressions::Filter m02Filter = (aod::emcalcluster::nCells == 1 || (aod::emcalcluster::m02 > cfgMinM02 && aod::emcalcluster::m02 < cfgMaxM02));
+  expressions::Filter timeFilter = (aod::emcalcluster::time > cfgMinTime && aod::emcalcluster::time < cfgMaxTime);
+  expressions::Filter emccellfilter = aod::calo::caloType == 1;
+
+  HistogramRegistry mHistManager{"output", {}, OutputObjHandlingPolicy::AnalysisObject, false, false};
+
+  void init(framework::InitContext&)
+  {
+    const int nEventBins = 6;
+    mHistManager.add("nBCs", "Number of BCs;;#bf{#it{N}_{BCs}}", HistType::kTH1F, {{nEventBins, -0.5, 5.5}});
+    const TString binLabels[nEventBins] = {"All", "FT0", "TVX", "kTVXinEMC", "Cell", "NoBorder"};
+    for (int iBin = 0; iBin < nEventBins; iBin++)
+      mHistManager.get<TH1>(HIST("nBCs"))->GetXaxis()->SetBinLabel(iBin + 1, binLabels[iBin]);
+
+    mHistManager.add("hAmplitudeVsCentrality", "FT0M AmplitudeVsCentrality;FT0M Centrality;FT0M Amplitude", HistType::kTH2F, {{105, 0, 105}, {400, 0, 200000}});
+    mHistManager.add("sumAmp", "Sum Amplitude", HistType::kTH1F, {{1000, 0., 10.}});
+    mHistManager.add("nCells", "Number of EMCal cells", HistType::kTH1F, {{5000, -0.5, 5000.5}});
+
+    LOG(info) << "| Timing cut: " << cfgMinTime << " < t < " << cfgMaxTime;
+    LOG(info) << "| M02 cut: " << cfgMinM02 << " < M02 < " << cfgMaxM02;
+    LOG(info) << "| E cut: E > " << cfgMinClusterEnergy;
+
+    o2::emcal::Geometry::GetInstanceFromRunNumber(300000);
+  }
+
+  /// \brief Process EMCAL clusters (either ambigous or unique)
+  template <typename OutputType, typename InputType>
+  OutputType convertForStorage(InputType const& valueIn, Observables observable)
+  {
+    double valueToBeChecked = valueIn * downscalingFactors[observable];
+    if (valueToBeChecked < std::numeric_limits<OutputType>::lowest()) {
+      LOG(warning) << "Value " << valueToBeChecked << " of observable " << observable << " below lowest possible value of " << typeid(OutputType).name() << ": " << static_cast<float>(std::numeric_limits<OutputType>::lowest());
+      valueToBeChecked = static_cast<float>(std::numeric_limits<OutputType>::lowest());
+    }
+    if (valueToBeChecked > std::numeric_limits<OutputType>::max()) {
+      LOG(warning) << "Value " << valueToBeChecked << " of observable " << observable << " obove highest possible value of " << typeid(OutputType).name() << ": " << static_cast<float>(std::numeric_limits<OutputType>::max());
+      valueToBeChecked = static_cast<float>(std::numeric_limits<OutputType>::max());
+    }
+
+    return static_cast<OutputType>(valueToBeChecked);
+  }
+
+  /// \brief Process EMCAL clusters (either ambigous or unique)
+  template <typename Clusters>
+  void processClusters(Clusters const& clusters, const int bcID)
+  {
+    for (const auto& cluster : clusters) {
+      clusterTable(bcID,
+                   convertForStorage<uint8_t>(cluster.definition(), kDefinition),
+                   convertForStorage<uint16_t>(cluster.energy(), kEnergy),
+                   convertForStorage<int16_t>(cluster.eta(), kEta),
+                   convertForStorage<uint16_t>(cluster.phi(), kPhi),
+                   convertForStorage<uint8_t>(cluster.nCells(), kNCells),
+                   convertForStorage<uint16_t>(cluster.m02(), kM02),
+                   convertForStorage<int16_t>(cluster.time(), kTime),
+                   cluster.isExotic());
+    }
+  }
+
+  template <typename Clusters>
+  void processClusterMCInfo(Clusters const& clusters, const int bcID, aod::McParticles const& mcParticles)
+  {
+    for (const auto& cluster : clusters) {
+      float clusterInducerEnergy = 0.;
+      int pi0MCIndex = -1;
+      if (cluster.amplitudeA().size() > 0) {
+        int clusterInducerId = cluster.mcParticleIds()[0];
+        auto clusterInducer = mcParticles.iteratorAt(clusterInducerId);
+        clusterInducerEnergy = clusterInducer.e();
+        int daughterId = aod::pwgem::photonmeson::utils::mcutil::FindMotherInChain(clusterInducer, mcParticles, std::vector<int>{111});
+        if (daughterId > 0) {
+          pi0MCIndex = mcParticles.iteratorAt(daughterId).mothersIds()[0];
+        }
+      }
+      mcclusterTable(bcID, convertForStorage<uint16_t>(clusterInducerEnergy, kEnergy), pi0MCIndex);
+    }
+  }
+
+  void processEventProperties(const auto& bc, const auto& collisionsInBC, const auto& cellsInBC)
+  {
+    float sumAmp = 0.;
+    for (const auto& cell : cellsInBC)
+      sumAmp += cell.amplitude();
+    mHistManager.fill(HIST("sumAmp"), sumAmp);
+    mHistManager.fill(HIST("nCells"), cellsInBC.size());
+
+    bool hasFT0 = bc.has_foundFT0();
+    bool hasTVX = bc.selection_bit(aod::evsel::kIsTriggerTVX);
+    bool haskTVXinEMC = bc.alias_bit(kTVXinEMC);
+    bool hasEMCCell = cellsInBC.size() > 0;
+    bool hasNoTFROFBorder = bc.selection_bit(aod::evsel::kNoTimeFrameBorder) && bc.selection_bit(aod::evsel::kNoITSROFrameBorder);
+    mHistManager.fill(HIST("nBCs"), 0);
+    if (hasFT0)
+      mHistManager.fill(HIST("nBCs"), 1);
+    if (hasTVX)
+      mHistManager.fill(HIST("nBCs"), 2);
+    if (haskTVXinEMC)
+      mHistManager.fill(HIST("nBCs"), 3);
+    if (hasEMCCell)
+      mHistManager.fill(HIST("nBCs"), 4);
+    if (hasNoTFROFBorder)
+      mHistManager.fill(HIST("nBCs"), 5);
+
+    float ft0Amp = hasFT0 ? bc.foundFT0().sumAmpA() + bc.foundFT0().sumAmpC() : 0.;
+
+    bcTable(hasFT0, hasTVX, haskTVXinEMC, hasEMCCell, hasNoTFROFBorder, convertForStorage<unsigned int>(ft0Amp, kFT0Amp), convertForStorage<unsigned int>(cellsInBC.size(), kNCells), convertForStorage<float>(sumAmp, kCellAmpSum));
+
+    for (const auto& collision : collisionsInBC) {
+      collisionTable(bcTable.lastIndex(), convertForStorage<uint8_t>(collision.centFT0M(), kFT0MCent), convertForStorage<int16_t>(collision.posZ(), kZVtx));
+      mHistManager.fill(HIST("hAmplitudeVsCentrality"), collision.centFT0M(), ft0Amp);
+    }
+
+    if (collisionsInBC.size() == 0)
+      mHistManager.fill(HIST("hAmplitudeVsCentrality"), 103, ft0Amp);
+  }
+
+  template <typename TMCParticle, typename TMCParticles>
+  bool isGammaGammaDecay(TMCParticle mcParticle, TMCParticles mcParticles)
+  {
+    auto daughtersIds = mcParticle.daughtersIds();
+    if (daughtersIds.size() != 2)
+      return false;
+    for (const auto& daughterId : daughtersIds) {
+      if (mcParticles.iteratorAt(daughterId).pdgCode() != 22)
+        return false;
+    }
+    return true;
+  }
+
+  template <typename TMCParticle, typename TMCParticles>
+  bool isAccepted(TMCParticle mcParticle, TMCParticles mcParticles)
+  {
+    auto daughtersIds = mcParticle.daughtersIds();
+    if (daughtersIds.size() != 2)
+      return false;
+    for (const auto& daughterId : daughtersIds) {
+      if (mcParticles.iteratorAt(daughterId).pdgCode() != 22)
+        return false;
+      int iCellID = -1;
+      try {
+        iCellID = emcal::Geometry::GetInstance()->GetAbsCellIdFromEtaPhi(mcParticles.iteratorAt(daughterId).eta(), mcParticles.iteratorAt(daughterId).phi());
+      } catch (emcal::InvalidPositionException& e) {
+        iCellID = -1;
+      }
+      if (iCellID == -1)
+        return false;
+    }
+    return true;
+  }
+
+  void processData(MyBCs const& bcs, MyCollisions const& collisions, aod::FT0s const&, SelectedCells const& cells, SelectedUniqueClusters const& uClusters, SelectedAmbiguousClusters const& aClusters)
+  {
+    for (const auto& bc : bcs) {
+      auto collisionsInBC = collisions.sliceBy(perFoundBC, bc.globalIndex());
+      auto cellsInBC = cells.sliceBy(cellsPerBC, bc.globalIndex());
+
+      processEventProperties(bc, collisionsInBC, cellsInBC);
+
+      if (collisionsInBC.size() == 1) {
+        auto clustersInBC = uClusters.sliceBy(perCol, collisionsInBC.begin().globalIndex());
+        processClusters(clustersInBC, bcTable.lastIndex());
+      } else {
+        auto clustersInBC = aClusters.sliceBy(perBC, bc.globalIndex());
+        processClusters(clustersInBC, bcTable.lastIndex());
+      }
+    }
+  }
+  PROCESS_SWITCH(bcWiseClusterSkimmer, processData, "Run skimming for data", true);
+
+  Preslice<aod::McCollisions> mcCollperBC = aod::mccollision::bcId;
+  Preslice<aod::McParticles> perMcCollision = aod::mcparticle::mcCollisionId;
+
+  void processMC(MyBCs const& bcs, MyMCCollisions const& collisions, aod::McCollisions const& mcCollisions, aod::FT0s const&, SelectedCells const& cells, SelectedUniqueMCClusters const& uClusters, SelectedAmbiguousMCClusters const& aClusters, aod::McParticles const& mcParticles)
+  {
+    for (const auto& bc : bcs) {
+      auto collisionsInBC = collisions.sliceBy(perFoundBC, bc.globalIndex());
+      auto cellsInBC = cells.sliceBy(cellsPerBC, bc.globalIndex());
+
+      processEventProperties(bc, collisionsInBC, cellsInBC);
+
+      auto mcCollisionsBC = mcCollisions.sliceBy(mcCollperBC, bc.globalIndex());
+      for (const auto& mcCollision : mcCollisionsBC) {
+        auto mcParticlesInColl = mcParticles.sliceBy(perMcCollision, mcCollision.globalIndex());
+        for (const auto& mcParticle : mcParticlesInColl) {
+          if (mcParticle.pdgCode() != 111 || fabs(mcParticle.y()) > cfgRapidityCut || !isGammaGammaDecay(mcParticle, mcParticles))
+            continue;
+          bool isPrimary = mcParticle.isPhysicalPrimary() || mcParticle.producedByGenerator();
+          bool isFromWD = (aod::pwgem::photonmeson::utils::mcutil::IsFromWD(mcCollision, mcParticle, mcParticles)) > 0;
+          mcpi0Table(bc.globalIndex(), mcParticle.globalIndex(), convertForStorage<uint16_t>(mcParticle.pt(), kpT), isAccepted(mcParticle, mcParticles), isPrimary, isFromWD);
+        }
+      }
+
+      if (collisionsInBC.size() == 1) {
+        auto clustersInBC = uClusters.sliceBy(perCol, collisionsInBC.begin().globalIndex());
+        processClusters(clustersInBC, bcTable.lastIndex());
+        processClusterMCInfo(clustersInBC, bc.globalIndex(), mcParticles);
+      } else {
+        auto clustersInBC = aClusters.sliceBy(perBC, bc.globalIndex());
+        processClusters(clustersInBC, bcTable.lastIndex());
+        processClusterMCInfo(clustersInBC, bc.globalIndex(), mcParticles);
+      }
+    }
+  }
+  PROCESS_SWITCH(bcWiseClusterSkimmer, processMC, "Run skimming for MC", false);
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc) { return WorkflowSpec{adaptAnalysisTask<bcWiseClusterSkimmer>(cfgc)}; }

--- a/PWGEM/PhotonMeson/TableProducer/bcWiseClusterSkimmer.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/bcWiseClusterSkimmer.cxx
@@ -16,6 +16,9 @@
 /// \author Nicolas Strangmann (nicolas.strangmann@cern.ch) - Goethe University Frankfurt
 ///
 
+#include <limits>
+#include <vector>
+
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
 

--- a/PWGEM/PhotonMeson/Tasks/CMakeLists.txt
+++ b/PWGEM/PhotonMeson/Tasks/CMakeLists.txt
@@ -24,6 +24,11 @@ o2physics_add_dpl_workflow(emc-pi0-qc
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::EMCALBase O2::EMCALCalib O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(emc-bc-wise-pi0
+                    SOURCES emcalBcWisePi0.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::EMCALBase O2::EMCALCalib O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(pcm-qc
                     SOURCES pcmQC.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore O2Physics::PWGEMPhotonMesonCore

--- a/PWGEM/PhotonMeson/Tasks/emcalBcWisePi0.cxx
+++ b/PWGEM/PhotonMeson/Tasks/emcalBcWisePi0.cxx
@@ -1,0 +1,218 @@
+// Copyright 2019-2024 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+///
+/// \file emcalBcWisePi0.cxx
+///
+/// \brief Task that extracts pi0s from BC wise derived data of EMCal clusters
+///
+/// \author Nicolas Strangmann (nicolas.strangmann@cern.ch) Goethe University Frankfurt
+///
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/HistogramRegistry.h"
+
+#include "TString.h"
+#include "Math/Vector4D.h"
+#include "Math/Vector3D.h"
+#include "Math/LorentzRotation.h"
+#include "Math/Rotation3D.h"
+#include "Math/AxisAngle.h"
+
+#include "CommonConstants/MathConstants.h"
+#include "EMCALBase/Geometry.h"
+#include "PWGEM/PhotonMeson/DataModel/bcWiseTables.h"
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+struct EmcalBcWisePi0 {
+  HistogramRegistry mHistManager{"EmcalGammaGammaBcWiseHistograms"};
+
+  Configurable<int> cfgClusterDefinition{"cfgClusterDefinition", 10, "Clusterizer to be selected, e.g. 13 for kV3MostSplitLowSeed"};
+  Configurable<float> cfgMinClusterEnergy{"cfgMinClusterEnergy", 0.7, "Minimum energy of selected clusters (GeV)"};
+  Configurable<float> cfgMinM02{"cfgMinM02", 0.1, "Minimum M02 of selected clusters"};
+  Configurable<float> cfgMaxM02{"cfgMaxM02", 0.7, "Maximum M02 of selected clusters"};
+  Configurable<float> cfgMinTime{"cfgMinTime", -15, "Minimum time of selected clusters (ns)"};
+  Configurable<float> cfgMaxTime{"cfgMaxTime", 15, "Maximum time of selected clusters (ns)"};
+  Configurable<float> cfgRapidityCut{"cfgRapidityCut", 0.8f, "Maximum absolute rapidity of counted particles"};
+  Configurable<float> cfgMinOpenAngle{"cfgMinOpenAngle", 0.0202, "Minimum opening angle between photons"};
+  Configurable<int> cfgDistanceToEdge{"cfgDistanceToEdge", 1, "Distance to edge in cells required for rotated cluster to be accepted"};
+  Configurable<int> cfgBGEventDownsampling{"cfgBGEventDownsampling", 1, "Only calculate background for every n-th event (performance reasons in PbPb)"};
+
+  static constexpr float DefaultCentralityWindow[2] = {-1., 101.};
+  Configurable<LabeledArray<float>> cfgCentralityWindow{"cfgCentralityWindow", {DefaultCentralityWindow, 2, {"Min_Centrality", "Max_Centrality"}}, "Select centrality window (also requires unique collision)"};
+
+  Filter clusterDefinitionFilter = aod::bcwisecluster::storedDefinition == static_cast<uint8_t>(cfgClusterDefinition);
+  Filter energyFilter = aod::bcwisecluster::storedE > static_cast<uint16_t>(cfgMinClusterEnergy* aod::emdownscaling::downscalingFactors[aod::emdownscaling::kEnergy]);
+  Filter m02Filter = (aod::bcwisecluster::storedNCells == static_cast<uint8_t>(1) || (aod::bcwisecluster::storedM02 > static_cast<uint16_t>(cfgMinM02 * aod::emdownscaling::downscalingFactors[aod::emdownscaling::kM02]) && aod::bcwisecluster::storedM02 < static_cast<uint16_t>(cfgMaxM02 * aod::emdownscaling::downscalingFactors[aod::emdownscaling::kM02])));
+  Filter timeFilter = (aod::bcwisecluster::storedTime > static_cast<int16_t>(cfgMinTime * aod::emdownscaling::downscalingFactors[aod::emdownscaling::kTime]) && aod::bcwisecluster::storedTime < static_cast<int16_t>(cfgMaxTime * aod::emdownscaling::downscalingFactors[aod::emdownscaling::kTime]));
+
+  emcal::Geometry* emcalGeom;
+
+  void init(InitContext const&)
+  {
+    emcalGeom = emcal::Geometry::GetInstanceFromRunNumber(300000);
+    const int nEventBins = 8;
+    mHistManager.add("nBCs", "Number of BCs;;#bf{#it{N}_{BC}}", HistType::kTH1F, {{nEventBins, -0.5, 7.5}});
+    const TString binLabels[nEventBins] = {"All", "FT0", "TVX", "kTVXinEMC", "Cell", "Cluster", "NoBorder", "Collision"};
+    for (int iBin = 0; iBin < nEventBins; iBin++)
+      mHistManager.get<TH1>(HIST("nBCs"))->GetXaxis()->SetBinLabel(iBin + 1, binLabels[iBin]);
+
+    mHistManager.add("Centrality", "FT0M centrality;FT0M centrality (%);#bf{#it{N}_{BC} (only BCs containing exactly 1 collision)}", HistType::kTH1F, {{100, 0., 100.}});
+
+    mHistManager.add("clusterE", "Energy of cluster;#bf{#it{E} (GeV)};#bf{#it{N}_{clusters}}", HistType::kTH1F, {{200, 0, 20}});
+    mHistManager.add("clusterM02", "Shape of cluster;#bf{#it{M}_{02}};#bf{#it{N}_{clusters}}", HistType::kTH1F, {{200, 0, 2}});
+    mHistManager.add("clusterTime", "Time of cluster;#bf{#it{t} (ns)};#bf{#it{N}_{clusters}}", HistType::kTH1F, {{200, -100, 100}});
+    mHistManager.add("clusterNCells", "Number of cells per cluster;#bf{#it{N}_{cells}};#bf{#it{N}_{clusters}}", HistType::kTH1F, {{51, 0., 50.5}});
+    mHistManager.add("clusterExotic", "Is cluster exotic?;#bf{Exotic?};#bf{#it{N}_{clusters}}", HistType::kTH1F, {{2, -0.5, 1.5}});
+    mHistManager.add("clusterEtaPhi", "Eta/Phi distribution of clusters;#eta;#phi", HistType::kTH2F, {{400, -0.8, 0.8}, {400, 0, constants::math::TwoPI}});
+
+    mHistManager.add("invMassVsPt", "Invariant mass and pT of meson candidates", HistType::kTH2F, {{400, 0., 0.8}, {200, 0., 20.}});
+    mHistManager.add("invMassVsPtBackground", "Invariant mass and pT of background meson candidates", HistType::kTH2F, {{400, 0., 0.8}, {200, 0., 20.}});
+  }
+
+  /// \brief returns if cluster is too close to edge of EMCal
+  bool isTooCloseToEdge(const int cellID, const int DistanceToBorder = 1)
+  {
+    if (DistanceToBorder <= 0)
+      return false;
+    if (cellID < 0)
+      return true;
+
+    // check distance to border in case the cell is okay
+    auto [iSupMod, iMod, iPhi, iEta] = emcalGeom->GetCellIndex(cellID);
+    auto [irow, icol] = emcalGeom->GetCellPhiEtaIndexInSModule(iSupMod, iMod, iPhi, iEta);
+    int iRowLast = (emcalGeom->GetSMType(iSupMod) == o2::emcal::EMCALSMType::EMCAL_THIRD || emcalGeom->GetSMType(iSupMod) == o2::emcal::EMCALSMType::DCAL_EXT) ? 8 : 24;
+
+    return (irow < DistanceToBorder || (iRowLast - irow) <= DistanceToBorder);
+  }
+
+  void fillEventHists(const auto& bc, const auto& collisions, const auto& clusters)
+  {
+    mHistManager.fill(HIST("nBCs"), 0);
+    if (bc.hasFT0())
+      mHistManager.fill(HIST("nBCs"), 1);
+    if (bc.hasTVX())
+      mHistManager.fill(HIST("nBCs"), 2);
+    if (bc.haskTVXinEMC())
+      mHistManager.fill(HIST("nBCs"), 3);
+    if (bc.hasEMCCell())
+      mHistManager.fill(HIST("nBCs"), 4);
+    if (clusters.size() > 0)
+      mHistManager.fill(HIST("nBCs"), 5);
+    if (bc.hasNoTFROFBorder())
+      mHistManager.fill(HIST("nBCs"), 6);
+    if (collisions.size() > 0)
+      mHistManager.fill(HIST("nBCs"), 7);
+
+    if (collisions.size() == 1) {
+      for (const auto& collision : collisions)
+        mHistManager.fill(HIST("Centrality"), collision.centrality());
+    }
+  }
+
+  void fillClusterHists(const auto& clusters)
+  {
+    for (const auto& cluster : clusters) {
+      mHistManager.fill(HIST("clusterE"), cluster.e());
+      mHistManager.fill(HIST("clusterM02"), cluster.m02());
+      mHistManager.fill(HIST("clusterTime"), cluster.time());
+      mHistManager.fill(HIST("clusterNCells"), cluster.nCells());
+      mHistManager.fill(HIST("clusterEtaPhi"), cluster.eta(), cluster.phi());
+      mHistManager.fill(HIST("clusterExotic"), cluster.isExotic());
+    }
+  }
+
+  void reconstructMesons(const auto& clusters, int bcId)
+  {
+    for (const auto& [g1, g2] : soa::combinations(soa::CombinationsStrictlyUpperIndexPolicy(clusters, clusters))) {
+      ROOT::Math::PtEtaPhiMVector v1(g1.pt(), g1.eta(), g1.phi(), 0.);
+      ROOT::Math::PtEtaPhiMVector v2(g2.pt(), g2.eta(), g2.phi(), 0.);
+      ROOT::Math::PtEtaPhiMVector v12 = v1 + v2;
+      if (std::fabs(v12.Rapidity()) > cfgRapidityCut)
+        continue;
+
+      float openingAngle12 = std::acos(v1.Vect().Dot(v2.Vect()) / (v1.P() * v2.P()));
+      if (openingAngle12 < cfgMinOpenAngle)
+        continue;
+
+      mHistManager.fill(HIST("invMassVsPt"), v12.M(), v12.Pt());
+
+      if (clusters.size() < 3)
+        continue;
+
+      if (bcId % cfgBGEventDownsampling != 0)
+        continue;
+
+      // "else: Calculate background"
+
+      ROOT::Math::AxisAngle rotationAxis(v12.Vect(), constants::math::PIHalf);
+      ROOT::Math::Rotation3D rotationMatrix(rotationAxis);
+      for (ROOT::Math::PtEtaPhiMVector vi : {v1, v2}) {
+
+        vi = rotationMatrix * vi;
+
+        try {
+          int iCellID = emcalGeom->GetAbsCellIdFromEtaPhi(vi.Eta(), vi.Phi());
+          if (isTooCloseToEdge(iCellID, cfgDistanceToEdge))
+            continue;
+        } catch (o2::emcal::InvalidPositionException& e) {
+          continue;
+        }
+
+        for (const auto& g3 : clusters) {
+          if (g3.globalIndex() == g1.globalIndex() || g3.globalIndex() == g2.globalIndex())
+            continue;
+
+          ROOT::Math::PtEtaPhiMVector v3(g3.pt(), g3.eta(), g3.phi(), 0.);
+
+          float openingAnglei3 = std::acos(vi.Vect().Dot(v3.Vect()) / (vi.P() * v3.P()));
+          if (openingAnglei3 < cfgMinOpenAngle)
+            continue;
+
+          ROOT::Math::PtEtaPhiMVector vBG = v3 + vi;
+
+          mHistManager.fill(HIST("invMassVsPtBackground"), vBG.M(), vBG.Pt());
+        }
+      }
+    }
+  }
+
+  bool isCentralitySelected(const auto& collisions)
+  {
+    if (cfgCentralityWindow->get("Min_Centrality") > -0.5 || cfgCentralityWindow->get("Max_Centrality") < 100.5) { // Centrality window is set
+      if (collisions.size() != 1)
+        return false;
+      for (const auto& collision : collisions) {
+        if (collision.centrality() < cfgCentralityWindow->get("Min_Centrality") || collision.centrality() > cfgCentralityWindow->get("Max_Centrality"))
+          return false;
+      }
+    }
+    return true;
+  }
+
+  void process(aod::BCWiseBCs::iterator const& bc, aod::BCWiseCollisions const& collisions, soa::Filtered<aod::BCWiseClusters> const& clusters)
+  {
+    if (!isCentralitySelected(collisions))
+      return;
+
+    fillEventHists(bc, collisions, clusters);
+
+    fillClusterHists(clusters);
+
+    reconstructMesons(clusters, bc.globalIndex());
+  }
+};
+
+WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc) { return WorkflowSpec{adaptAnalysisTask<EmcalBcWisePi0>(cfgc)}; }

--- a/PWGJE/DataModel/EMCALClusters.h
+++ b/PWGJE/DataModel/EMCALClusters.h
@@ -135,6 +135,12 @@ DECLARE_SOA_TABLE(EMCALMCClusters, "AOD", "EMCALMCCLUSTERS", //!
 
 using EMCALMCCluster = EMCALMCClusters::iterator;
 
+// table of cluster MC info that could not be matched to a collision
+DECLARE_SOA_TABLE(EMCALAmbiguousMCClusters, "AOD", "EMCALAMBMCCLS", //!
+                  emcalclustermc::McParticleIds, emcalclustermc::AmplitudeA);
+
+using EMCALAmbiguousMCCluster = EMCALAmbiguousMCClusters::iterator;
+
 namespace emcalclustercell
 {
 // declare index column pointing to cluster table

--- a/PWGJE/TableProducer/emcalCorrectionTask.cxx
+++ b/PWGJE/TableProducer/emcalCorrectionTask.cxx
@@ -65,6 +65,7 @@ struct EmcalCorrectionTask {
   Produces<o2::aod::EMCALClusters> clusters;
   Produces<o2::aod::EMCALMCClusters> mcclusters;
   Produces<o2::aod::EMCALAmbiguousClusters> clustersAmbiguous;
+  Produces<o2::aod::EMCALAmbiguousMCClusters> mcclustersAmbiguous;
   Produces<o2::aod::EMCALClusterCells> clustercells; // cells belonging to given cluster
   Produces<o2::aod::EMCALAmbiguousClusterCells> clustercellsambiguous;
   Produces<o2::aod::EMCALMatchedTracks> matchedTracks;
@@ -702,6 +703,10 @@ struct EmcalCorrectionTask {
   {
     int cellindex = -1;
     clustersAmbiguous.reserve(mAnalysisClusters.size());
+    if (mClusterLabels.size() > 0) {
+      mcclustersAmbiguous.reserve(mClusterLabels.size());
+    }
+    unsigned int iCluster = 0;
     for (const auto& cluster : mAnalysisClusters) {
       auto pos = cluster.getGlobalPosition();
       pos = pos - math_utils::Point3D<float>{0., 0., 0.};
@@ -730,12 +735,16 @@ struct EmcalCorrectionTask {
         cluster.getM20(), cluster.getNCells(), cluster.getClusterTime(),
         cluster.getIsExotic(), cluster.getDistanceToBadChannel(),
         cluster.getNExMax(), static_cast<int>(mClusterDefinitions.at(iClusterizer)));
+      if (mClusterLabels.size() > 0) {
+        mcclustersAmbiguous(mClusterLabels[iCluster].getLabels(), mClusterLabels[iCluster].getEnergyFractions());
+      }
       clustercellsambiguous.reserve(cluster.getNCells());
       for (int ncell = 0; ncell < cluster.getNCells(); ncell++) {
         cellindex = cluster.getCellIndex(ncell);
         clustercellsambiguous(clustersAmbiguous.lastIndex(),
                               cellIndicesBC[cellindex]);
       } // end of cells of cluster loop
+      iCluster++;
     } // end of cluster loop
   }
 


### PR DESCRIPTION
- Add BC wise skimming tables for 
   - BCs
   - Collisions within the BC
   - (MC) clusters in the BC
   - Generated pi0s in the BC
- Add skimming task to fill these tables
- Add analysis task that produces invmass-pT distributions from the derived data tables
- Add MC labels to ambiguous clusters in JE EMCal correction task 