### PR TITLE
[PWGLF] Improvements in sigma0 tasks

### DIFF
--- a/PWGLF/DataModel/LFSigmaTables.h
+++ b/PWGLF/DataModel/LFSigmaTables.h
@@ -81,6 +81,8 @@ DECLARE_SOA_COLUMN(PhotonPosITSCls, photonPosITSCls, int);
 DECLARE_SOA_COLUMN(PhotonNegITSCls, photonNegITSCls, int);
 DECLARE_SOA_COLUMN(PhotonPosITSChi2PerNcl, photonPosITSChi2PerNcl, float);
 DECLARE_SOA_COLUMN(PhotonNegITSChi2PerNcl, photonNegITSChi2PerNcl, float);
+DECLARE_SOA_COLUMN(PhotonPosTrackCode, photonPosTrackCode, uint8_t);
+DECLARE_SOA_COLUMN(PhotonNegTrackCode, photonNegTrackCode, uint8_t);
 DECLARE_SOA_COLUMN(PhotonV0Type, photonV0Type, uint8_t);
 DECLARE_SOA_COLUMN(GammaBDTScore, gammaBDTScore, float);
 
@@ -117,7 +119,9 @@ DECLARE_SOA_TABLE(SigmaPhotonExtras, "AOD", "SIGMA0PHOTON",
                   sigmaPhotonExtra::PhotonNegITSCls,
                   sigmaPhotonExtra::PhotonPosITSChi2PerNcl,
                   sigmaPhotonExtra::PhotonNegITSChi2PerNcl,
-                  sigmaPhotonExtra::PhotonV0Type,
+                  sigmaPhotonExtra::PhotonPosTrackCode,
+                  sigmaPhotonExtra::PhotonNegTrackCode,
+                  sigmaPhotonExtra::PhotonV0Type,            
                   sigmaPhotonExtra::GammaBDTScore);
 
 // For Lambda extra info
@@ -159,6 +163,8 @@ DECLARE_SOA_COLUMN(LambdaPosITSCls, lambdaPosITSCls, int);
 DECLARE_SOA_COLUMN(LambdaNegITSCls, lambdaNegITSCls, int);
 DECLARE_SOA_COLUMN(LambdaPosITSChi2PerNcl, lambdaPosChi2PerNcl, float);
 DECLARE_SOA_COLUMN(LambdaNegITSChi2PerNcl, lambdaNegChi2PerNcl, float);
+DECLARE_SOA_COLUMN(LambdaPosTrackCode, lambdaPosTrackCode, uint8_t);
+DECLARE_SOA_COLUMN(LambdaNegTrackCode, lambdaNegTrackCode, uint8_t);
 DECLARE_SOA_COLUMN(LambdaV0Type, lambdaV0Type, uint8_t);
 DECLARE_SOA_COLUMN(LambdaBDTScore, lambdaBDTScore, float);
 DECLARE_SOA_COLUMN(AntiLambdaBDTScore, antilambdaBDTScore, float);
@@ -202,6 +208,8 @@ DECLARE_SOA_TABLE(SigmaLambdaExtras, "AOD", "SIGMA0LAMBDA",
                   sigmaLambdaExtra::LambdaNegITSCls,
                   sigmaLambdaExtra::LambdaPosITSChi2PerNcl,
                   sigmaLambdaExtra::LambdaNegITSChi2PerNcl,
+                  sigmaLambdaExtra::LambdaPosTrackCode,
+                  sigmaLambdaExtra::LambdaNegTrackCode,
                   sigmaLambdaExtra::LambdaV0Type,
                   sigmaLambdaExtra::LambdaBDTScore,
                   sigmaLambdaExtra::AntiLambdaBDTScore);

--- a/PWGLF/DataModel/LFSigmaTables.h
+++ b/PWGLF/DataModel/LFSigmaTables.h
@@ -216,10 +216,12 @@ DECLARE_SOA_COLUMN(PhotonCandPDGCode, photonCandPDGCode, int);
 DECLARE_SOA_COLUMN(PhotonCandPDGCodeMother, photonCandPDGCodeMother, int);
 DECLARE_SOA_COLUMN(IsPhotonCandPrimary, isPhotonCandPrimary, bool);
 DECLARE_SOA_COLUMN(PhotonMCPt, photonMCPt, float);
+DECLARE_SOA_COLUMN(PhotonIsCorrectlyAssoc, photonIsCorrectlyAssoc, bool);
 DECLARE_SOA_COLUMN(LambdaCandPDGCode, lambdaCandPDGCode, int);
 DECLARE_SOA_COLUMN(LambdaCandPDGCodeMother, lambdaCandPDGCodeMother, int);
 DECLARE_SOA_COLUMN(IsLambdaCandPrimary, isLambdaCandPrimary, bool);
 DECLARE_SOA_COLUMN(LambdaMCPt, lambdaMCPt, float);
+DECLARE_SOA_COLUMN(LambdaIsCorrectlyAssoc, lambdaIsCorrectlyAssoc, bool);
 
 } // namespace sigmaMCCore
 
@@ -231,10 +233,12 @@ DECLARE_SOA_TABLE(SigmaMCCores, "AOD", "SIGMA0MCCORES",
                   sigmaMCCore::PhotonCandPDGCodeMother,
                   sigmaMCCore::IsPhotonCandPrimary,
                   sigmaMCCore::PhotonMCPt,
+                  sigmaMCCore::PhotonIsCorrectlyAssoc,
                   sigmaMCCore::LambdaCandPDGCode,
                   sigmaMCCore::LambdaCandPDGCodeMother,
                   sigmaMCCore::IsLambdaCandPrimary,
-                  sigmaMCCore::LambdaMCPt);
+                  sigmaMCCore::LambdaMCPt,
+                  sigmaMCCore::LambdaIsCorrectlyAssoc);
 } // namespace o2::aod
 
 #endif // PWGLF_DATAMODEL_LFSIGMATABLES_H_

--- a/PWGLF/DataModel/LFSigmaTables.h
+++ b/PWGLF/DataModel/LFSigmaTables.h
@@ -36,6 +36,7 @@ DECLARE_SOA_COLUMN(SigmaOPAngle, sigmaOPAngle, float);
 DECLARE_SOA_COLUMN(SigmaCentrality, sigmaCentrality, float);
 DECLARE_SOA_COLUMN(SigmaRunNumber, sigmaRunNumber, int);
 DECLARE_SOA_COLUMN(SigmaTimestamp, sigmaTimestamp, uint64_t);
+DECLARE_SOA_COLUMN(SigmaIR, sigmaIR, float);
 
 } // namespace sigma0Core
 
@@ -46,7 +47,8 @@ DECLARE_SOA_TABLE(Sigma0Cores, "AOD", "SIGMA0CORES",
                   sigma0Core::SigmaOPAngle,
                   sigma0Core::SigmaCentrality,
                   sigma0Core::SigmaRunNumber,
-                  sigma0Core::SigmaTimestamp);
+                  sigma0Core::SigmaTimestamp, 
+                  sigma0Core::SigmaIR);
 
 // For Photon extra info
 namespace sigmaPhotonExtra

--- a/PWGLF/TableProducer/Strangeness/CMakeLists.txt
+++ b/PWGLF/TableProducer/Strangeness/CMakeLists.txt
@@ -144,7 +144,7 @@ o2physics_add_dpl_workflow(cascademlselection
 
 o2physics_add_dpl_workflow(sigma0builder
     SOURCES sigma0builder.cxx
-    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::MLCore
+    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::MLCore O2Physics::AnalysisCCDB
     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(lambdajetpolarizationbuilder

--- a/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
@@ -289,6 +289,7 @@ struct sigma0builder {
     if (fGetIR){
       histos.add("GeneralQA/hRunNumberNegativeIR", "", kTH1D, {{1, 0., 1.}});
       histos.add("GeneralQA/hInteractionRate", "hInteractionRate", kTH1F, {axisIRBinning});
+      histos.add("GeneralQA/hCentralityVsInteractionRate", "hCentralityVsInteractionRate", kTH2F, {axisCentrality, axisIRBinning});
     }
 
     if (doAssocStudy && doprocessMonteCarlo){
@@ -922,7 +923,8 @@ struct sigma0builder {
       if (interactionRate<0)          
           histos.get<TH1>(HIST("GeneralQA/hRunNumberNegativeIR"))->Fill(Form("%d", coll.runNumber()), 1);
 
-      histos.fill(HIST("GeneralQA/hInteractionRate"), interactionRate);      
+      histos.fill(HIST("GeneralQA/hInteractionRate"), interactionRate);  
+      histos.fill(HIST("GeneralQA/hCentralityVsInteractionRate"), centrality, interactionRate);    
     }
     
     std::vector<int> bestGammasArray;
@@ -1112,7 +1114,8 @@ struct sigma0builder {
       if (interactionRate<0)          
           histos.get<TH1>(HIST("GeneralQA/hRunNumberNegativeIR"))->Fill(Form("%d", coll.runNumber()), 1);
 
-      histos.fill(HIST("GeneralQA/hInteractionRate"), interactionRate);      
+      histos.fill(HIST("GeneralQA/hInteractionRate"), interactionRate);
+      histos.fill(HIST("GeneralQA/hCentralityVsInteractionRate"), centrality, interactionRate);      
     }
     
     std::vector<int> bestGammasArray;

--- a/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
@@ -877,11 +877,15 @@ struct sigma0builder {
     float fSigmaRap = RecoDecay::y(std::array{gamma.px() + lambda.px(), gamma.py() + lambda.py(), gamma.pz() + lambda.pz()}, o2::constants::physics::MassSigma0);
     float fSigmaOPAngle = v1.Angle(v2);
     float fSigmaCentrality = coll.centFT0C();
-    float fSigmaTimeStamp = coll.timestamp();
-    float fSigmaRunNumber = coll.runNumber();
+    uint64_t fSigmaTimeStamp = coll.timestamp();
+    int fSigmaRunNumber = coll.runNumber();
+    float fSigmaIR = -1;
+
+    if (fGetIR)
+      fSigmaIR = rateFetcher.fetch(ccdb.service, coll.timestamp(), coll.runNumber(), irSource, fIRCrashOnNull) * 1.e-3;
 
     // Filling TTree for ML analysis
-    sigma0cores(fSigmapT, fSigmaMass, fSigmaRap, fSigmaOPAngle, fSigmaCentrality, fSigmaRunNumber, fSigmaTimeStamp);
+    sigma0cores(fSigmapT, fSigmaMass, fSigmaRap, fSigmaOPAngle, fSigmaCentrality, fSigmaRunNumber, fSigmaTimeStamp, fSigmaIR);
 
     sigmaPhotonExtras(fPhotonPt, fPhotonMass, fPhotonQt, fPhotonAlpha, fPhotonRadius,
                       fPhotonCosPA, fPhotonDCADau, fPhotonDCANegPV, fPhotonDCAPosPV, fPhotonZconv,
@@ -916,7 +920,7 @@ struct sigma0builder {
     
     //_______________________________________________
     // Retrieving IR info
-    double interactionRate = -1;
+    float interactionRate = -1;
     if (fGetIR){
       interactionRate = rateFetcher.fetch(ccdb.service, coll.timestamp(), coll.runNumber(), irSource, fIRCrashOnNull) * 1.e-3;
       
@@ -1107,7 +1111,8 @@ struct sigma0builder {
     histos.fill(HIST("hEventCentrality"), centrality);
 
     //_______________________________________________
-    // Retrieving IR info
+    // Retrieving IR info    
+    float interactionRate = -1;
     if (fGetIR){
       interactionRate = rateFetcher.fetch(ccdb.service, coll.timestamp(), coll.runNumber(), irSource, fIRCrashOnNull) * 1.e-3;
       

--- a/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
@@ -997,7 +997,7 @@ struct sigma0builder {
 
   PROCESS_SWITCH(sigma0builder, processMonteCarlo, "process as if MC data", false);
   PROCESS_SWITCH(sigma0builder, processRealData, "process as if real data", true);
-  PROCESS_SWITCH(sigma0builder, processGeneratedCollRun3, "process generated MC collisions", true);
+  PROCESS_SWITCH(sigma0builder, processGeneratedCollRun3, "process generated MC collisions", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
@@ -177,6 +177,7 @@ struct sigma0builder {
   ConfigurableAxis axisRadius{"axisRadius", {240, 0.0f, 120.0f}, "V0 radius (cm)"};
   ConfigurableAxis axisRapidity{"axisRapidity", {100, -2.0f, 2.0f}, "Rapidity"};
   ConfigurableAxis axisCandSel{"axisCandSel", {13, 0.5f, +13.5f}, "Candidate Selection"};
+  ConfigurableAxis axisMonteCarloNch{"axisMonteCarloNch", {300, 0.0f, 3000.0f}, "N_{ch} MC"};
 
   int nSigmaCandidates = 0;
   void init(InitContext const&)
@@ -294,6 +295,8 @@ struct sigma0builder {
 
     histos.add("h3dMassSigmasBeforeSel", "h3dMassSigmasBeforeSel", kTH3F, {axisCentrality, axisPt, axisSigmaMass});
     histos.add("h3dMassSigmasAfterSel", "h3dMassSigmasAfterSel", kTH3F, {axisCentrality, axisPt, axisSigmaMass});
+
+    histos.add("Gen/hNEventsNch", "hNEventsNch", kTH1D, {axisMonteCarloNch});
   }
 
   template <typename TCollision>
@@ -984,6 +987,12 @@ struct sigma0builder {
         }
       }
     }
+  }
+
+  // Simulated processing in Run 3 (subscribes to MC information too)
+  void processGeneratedCollRun3(soa::Join<aod::StraMCCollisions, aod::StraMCCollMults>::iterator const& mcCollision)
+  {
+    histos.fill(HIST("Gen/hNEventsNch"), mcCollision.multMCNParticlesEta05());
   }
 
   PROCESS_SWITCH(sigma0builder, processMonteCarlo, "process as if MC data", false);

--- a/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
@@ -997,6 +997,7 @@ struct sigma0builder {
 
   PROCESS_SWITCH(sigma0builder, processMonteCarlo, "process as if MC data", false);
   PROCESS_SWITCH(sigma0builder, processRealData, "process as if real data", true);
+  PROCESS_SWITCH(sigma0builder, processGeneratedCollRun3, "process generated MC collisions", true);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
@@ -55,7 +55,6 @@ using namespace o2::framework;
 using namespace o2::framework::expressions;
 using std::array;
 using dauTracks = soa::Join<aod::DauTrackExtras, aod::DauTrackTPCPIDs>;
-// using V0DerivedMCDatas = soa::Join<aod::V0Cores, aod::V0CollRefs, aod::V0Extras, aod::V0TOFPIDs, aod::V0TOFNSigmas, aod::V0MCDatas>;
 using V0DerivedMCDatas = soa::Join<aod::V0Cores, aod::V0CollRefs, aod::V0Extras, aod::V0TOFPIDs, aod::V0TOFNSigmas, aod::V0MCMothers, aod::V0CoreMCLabels, aod::V0LambdaMLScores, aod::V0AntiLambdaMLScores, aod::V0GammaMLScores>;
 using V0StandardDerivedDatas = soa::Join<aod::V0Cores, aod::V0CollRefs, aod::V0Extras, aod::V0TOFPIDs, aod::V0TOFNSigmas, aod::V0LambdaMLScores, aod::V0AntiLambdaMLScores, aod::V0GammaMLScores>;
 
@@ -182,7 +181,7 @@ struct sigma0builder {
   ConfigurableAxis axisDCAdau{"axisDCAdau", {50, 0.0f, 5.0f}, "DCA (cm)"};
   ConfigurableAxis axisRadius{"axisRadius", {240, 0.0f, 120.0f}, "V0 radius (cm)"};
   ConfigurableAxis axisRapidity{"axisRapidity", {100, -2.0f, 2.0f}, "Rapidity"};
-  ConfigurableAxis axisCandSel{"axisCandSel", {13, 0.5f, +13.5f}, "Candidate Selection"};
+  ConfigurableAxis axisCandSel{"axisCandSel", {7, 0.5f, +7.5f}, "Candidate Selection"};
   ConfigurableAxis axisMonteCarloNch{"axisMonteCarloNch", {300, 0.0f, 3000.0f}, "N_{ch} MC"};
 
   int nSigmaCandidates = 0;
@@ -215,41 +214,52 @@ struct sigma0builder {
     }
 
     histos.add("hEventCentrality", "hEventCentrality", kTH1D, {axisCentrality});
-    histos.add("hCandidateBuilderSelection", "hCandidateBuilderSelection", kTH1D, {axisCandSel});
-    histos.get<TH1>(HIST("hCandidateBuilderSelection"))->GetXaxis()->SetBinLabel(1, "No Sel");
-    histos.get<TH1>(HIST("hCandidateBuilderSelection"))->GetXaxis()->SetBinLabel(2, "Photon Mass Cut");
-    histos.get<TH1>(HIST("hCandidateBuilderSelection"))->GetXaxis()->SetBinLabel(3, "Photon DauEta Cut");
-    histos.get<TH1>(HIST("hCandidateBuilderSelection"))->GetXaxis()->SetBinLabel(4, "Photon DCAToPV Cut");
-    histos.get<TH1>(HIST("hCandidateBuilderSelection"))->GetXaxis()->SetBinLabel(5, "Photon DCADau Cut");
-    histos.get<TH1>(HIST("hCandidateBuilderSelection"))->GetXaxis()->SetBinLabel(6, "Photon Radius Cut");
-    histos.get<TH1>(HIST("hCandidateBuilderSelection"))->GetXaxis()->SetBinLabel(7, "Lambda Mass Cut");
-    histos.get<TH1>(HIST("hCandidateBuilderSelection"))->GetXaxis()->SetBinLabel(8, "Lambda DauEta Cut");
-    histos.get<TH1>(HIST("hCandidateBuilderSelection"))->GetXaxis()->SetBinLabel(9, "Lambda DCAToPV Cut");
-    histos.get<TH1>(HIST("hCandidateBuilderSelection"))->GetXaxis()->SetBinLabel(10, "Lambda Radius Cut");
-    histos.get<TH1>(HIST("hCandidateBuilderSelection"))->GetXaxis()->SetBinLabel(11, "Lambda DCADau Cut");
-    histos.get<TH1>(HIST("hCandidateBuilderSelection"))->GetXaxis()->SetBinLabel(12, "Sigma Mass Window");
-    histos.get<TH1>(HIST("hCandidateBuilderSelection"))->GetXaxis()->SetBinLabel(13, "Sigma Y Window");
+
+    histos.add("PhotonSel/hSelectionStatistics", "hSelectionStatistics", kTH1D, {axisCandSel});
+    histos.get<TH1>(HIST("PhotonSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(1, "No Sel");
+    histos.get<TH1>(HIST("PhotonSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(2, "Photon Mass Cut");
+    histos.get<TH1>(HIST("PhotonSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(3, "Photon DauEta Cut");
+    histos.get<TH1>(HIST("PhotonSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(4, "Photon DCAToPV Cut");
+    histos.get<TH1>(HIST("PhotonSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(5, "Photon DCADau Cut");
+    histos.get<TH1>(HIST("PhotonSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(6, "Photon Radius Cut");
+
+    histos.add("PhotonSel/hPhotonMass", "hPhotonMass", kTH1F, {axisPhotonMass});
+    histos.add("PhotonSel/hPhotonNegEta", "hPhotonNegEta", kTH1F, {axisRapidity});
+    histos.add("PhotonSel/hPhotonPosEta", "hPhotonPosEta", kTH1F, {axisRapidity});
+    histos.add("PhotonSel/hPhotonDCANegToPV", "hPhotonDCANegToPV", kTH1F, {axisDCAtoPV});
+    histos.add("PhotonSel/hPhotonDCAPosToPV", "hPhotonDCAPosToPV", kTH1F, {axisDCAtoPV});
+    histos.add("PhotonSel/hPhotonDCADau", "hPhotonDCADau", kTH1F, {axisDCAdau});
+    histos.add("PhotonSel/hPhotonRadius", "hPhotonRadius", kTH1F, {axisRadius});
+
+    histos.add("LambdaSel/hSelectionStatistics", "hSelectionStatistics", kTH1D, {axisCandSel});
+    histos.get<TH1>(HIST("LambdaSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(1, "No Sel");
+    histos.get<TH1>(HIST("LambdaSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(2, "Lambda Mass Cut");
+    histos.get<TH1>(HIST("LambdaSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(3, "Lambda DauEta Cut");
+    histos.get<TH1>(HIST("LambdaSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(4, "Lambda DCAToPV Cut");
+    histos.get<TH1>(HIST("LambdaSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(5, "Lambda Radius Cut");
+    histos.get<TH1>(HIST("LambdaSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(6, "Lambda DCADau Cut");
+
+    histos.add("LambdaSel/hLambdaMass", "hLambdaMass", kTH1F, {axisLambdaMass});
+    histos.add("LambdaSel/hAntiLambdaMass", "hAntiLambdaMass", kTH1F, {axisLambdaMass});
+    histos.add("LambdaSel/hLambdaNegEta", "hLambdaNegEta", kTH1F, {axisRapidity});
+    histos.add("LambdaSel/hLambdaPosEta", "hLambdaPosEta", kTH1F, {axisRapidity});
+    histos.add("LambdaSel/hLambdaDCANegToPV", "hLambdaDCANegToPV", kTH1F, {axisDCAtoPV});
+    histos.add("LambdaSel/hLambdaDCAPosToPV", "hLambdaDCAPosToPV", kTH1F, {axisDCAtoPV});
+    histos.add("LambdaSel/hLambdaDCADau", "hLambdaDCADau", kTH1F, {axisDCAdau});
+    histos.add("LambdaSel/hLambdaRadius", "hLambdaRadius", kTH1F, {axisRadius});
+
+    histos.add("SigmaSel/hSelectionStatistics", "hSelectionStatistics", kTH1D, {axisCandSel});
+    histos.get<TH1>(HIST("SigmaSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(1, "No Sel");
+    histos.get<TH1>(HIST("SigmaSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(2, "Sigma Mass Window");
+    histos.get<TH1>(HIST("SigmaSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(3, "Sigma Y Window");
 
     // For selection:
-    histos.add("Selection/hPhotonMass", "hPhotonMass", kTH1F, {axisPhotonMass});
-    histos.add("Selection/hPhotonNegEta", "hPhotonNegEta", kTH1F, {axisRapidity});
-    histos.add("Selection/hPhotonPosEta", "hPhotonPosEta", kTH1F, {axisRapidity});
-    histos.add("Selection/hPhotonDCANegToPV", "hPhotonDCANegToPV", kTH1F, {axisDCAtoPV});
-    histos.add("Selection/hPhotonDCAPosToPV", "hPhotonDCAPosToPV", kTH1F, {axisDCAtoPV});
-    histos.add("Selection/hPhotonDCADau", "hPhotonDCADau", kTH1F, {axisDCAdau});
-    histos.add("Selection/hPhotonRadius", "hPhotonRadius", kTH1F, {axisRadius});
-    histos.add("Selection/hLambdaMass", "hLambdaMass", kTH1F, {axisLambdaMass});
-    histos.add("Selection/hAntiLambdaMass", "hAntiLambdaMass", kTH1F, {axisLambdaMass});
-    histos.add("Selection/hLambdaNegEta", "hLambdaNegEta", kTH1F, {axisRapidity});
-    histos.add("Selection/hLambdaPosEta", "hLambdaPosEta", kTH1F, {axisRapidity});
-    histos.add("Selection/hLambdaDCANegToPV", "hLambdaDCANegToPV", kTH1F, {axisDCAtoPV});
-    histos.add("Selection/hLambdaDCAPosToPV", "hLambdaDCAPosToPV", kTH1F, {axisDCAtoPV});
-    histos.add("Selection/hLambdaDCADau", "hLambdaDCADau", kTH1F, {axisDCAdau});
-    histos.add("Selection/hLambdaRadius", "hLambdaRadius", kTH1F, {axisRadius});
-    histos.add("Selection/hSigmaMass", "hSigmaMass", kTH1F, {axisSigmaMass});
-    histos.add("Selection/hSigmaMassWindow", "hSigmaMassWindow", kTH1F, {{200, -0.09f, 0.11f}});
-    histos.add("Selection/hSigmaY", "hSigmaY", kTH1F, {axisRapidity});
-    histos.add("Selection/hSigmaMassSelected", "hSigmaMassSelected", kTH1F, {axisSigmaMass});
+    histos.add("SigmaSel/h3dMassSigma0BeforeSel", "h3dMassSigma0BeforeSel", kTH3F, {axisCentrality, axisPt, axisSigmaMass});
+    histos.add("SigmaSel/hSigmaMass", "hSigmaMass", kTH1F, {axisSigmaMass});
+    histos.add("SigmaSel/hSigmaMassWindow", "hSigmaMassWindow", kTH1F, {{200, -0.09f, 0.11f}});
+    histos.add("SigmaSel/hSigmaY", "hSigmaY", kTH1F, {axisRapidity});
+    histos.add("SigmaSel/hSigmaMassSelected", "hSigmaMassSelected", kTH1F, {axisSigmaMass});
+    histos.add("SigmaSel/h3dMassSigma0AfterSel", "h3dMassSigma0AfterSel", kTH3F, {axisCentrality, axisPt, axisSigmaMass});
 
     if (fillQAhistos){
       histos.add("GeneralQA/h2dMassGammaVsK0S", "h2dMassGammaVsK0S", kTH2D, {axisPhotonMass, axisK0SMass});
@@ -298,10 +308,8 @@ struct sigma0builder {
       histos.add("Pi0QA/h2dPtVsMassPi0AfterSel_Candidates", "h2dPtVsMassPi0AfterSel_Candidates", kTH2D, {axisPt, axisPi0Mass});
     }
     
-    histos.add("h3dMassSigma0BeforeSel", "h3dMassSigma0BeforeSel", kTH3F, {axisCentrality, axisPt, axisSigmaMass});
-    histos.add("h3dMassSigma0AfterSel", "h3dMassSigma0AfterSel", kTH3F, {axisCentrality, axisPt, axisSigmaMass});
-
-    histos.add("Gen/hNEventsNch", "hNEventsNch", kTH1D, {axisMonteCarloNch});
+    if (doprocessGeneratedCollRun3)
+      histos.add("Gen/hNEventsNch", "hNEventsNch", kTH1D, {axisMonteCarloNch});
   }
 
   template <typename TCollision>
@@ -443,7 +451,7 @@ struct sigma0builder {
 
   template <typename TV0Object>
   void runPi0QA(TV0Object const& gamma1, TV0Object const& gamma2)
-  {
+  {    
     // Check if both V0s are made of the same tracks
     if (gamma1.posTrackExtraId() == gamma2.posTrackExtraId() ||
         gamma1.negTrackExtraId() == gamma2.negTrackExtraId() ||
@@ -451,7 +459,7 @@ struct sigma0builder {
         gamma1.negTrackExtraId() == gamma2.posTrackExtraId()) {
       return;
     }
-
+    
     // Calculate pi0 properties
     std::array<float, 3> pVecGamma1{gamma1.px(), gamma1.py(), gamma1.pz()};
     std::array<float, 3> pVecGamma2{gamma2.px(), gamma2.py(), gamma2.pz()};
@@ -459,7 +467,7 @@ struct sigma0builder {
     float pi0Mass = RecoDecay::m(arrpi0, std::array{o2::constants::physics::MassPhoton, o2::constants::physics::MassPhoton});
     float pi0Pt = RecoDecay::pt(std::array{gamma1.px() + gamma2.px(), gamma1.py() + gamma2.py()});
     float pi0Y = RecoDecay::y(std::array{gamma1.px() + gamma2.px(), gamma1.py() + gamma2.py(), gamma1.pz() + gamma2.pz()}, o2::constants::physics::MassPi0);
-
+    
     // MC-specific variables
     bool fIsPi0 = false, fIsMC = false;
 
@@ -477,7 +485,7 @@ struct sigma0builder {
           histos.fill(HIST("Pi0QA/h2dPtVsMassPi0BeforeSel_MCAssoc"), pi0Pt, pi0Mass);
         }
       }
-    } 
+    }     
       
     histos.fill(HIST("Pi0QA/h2dPtVsMassPi0BeforeSel_Candidates"), pi0Pt, pi0Mass);
 
@@ -490,7 +498,7 @@ struct sigma0builder {
     // Gamma1 Selection
     bool passedTPCGamma1 = (posTrackGamma1.tpcNSigmaEl() == -999.f || TMath::Abs(posTrackGamma1.tpcNSigmaEl()) < Pi0PhotonMaxTPCNSigmas) &&
                            (negTrackGamma1.tpcNSigmaEl() == -999.f || TMath::Abs(negTrackGamma1.tpcNSigmaEl()) < Pi0PhotonMaxTPCNSigmas);
-
+    
     if (TMath::Abs(gamma1.mGamma()) > Pi0PhotonMaxMass ||
         gamma1.qtarm() >= Pi0PhotonMaxQt ||
         TMath::Abs(gamma1.alpha()) >= Pi0PhotonMaxAlpha ||
@@ -540,15 +548,11 @@ struct sigma0builder {
       histos.fill(HIST("Pi0QA/h2dPtVsMassPi0AfterSel_MCAssoc"), pi0Pt, pi0Mass);    
   }
 
-  // Process sigma candidate and store properties in object
+  // Process photon candidate
   template <typename TV0Object>
-  bool processSigmaCandidate(TV0Object const& lambda, TV0Object const& gamma)
+  bool processPhotonCandidate(TV0Object const& gamma)
   {
-    if ((lambda.v0Type() == 0) || (gamma.v0Type() == 0))
-      return false;
-
-    // Checking if both V0s are made of the very same tracks
-    if ((gamma.posTrackExtraId() == lambda.posTrackExtraId()) || (gamma.negTrackExtraId() == lambda.negTrackExtraId()) || (gamma.posTrackExtraId() == lambda.negTrackExtraId()) || (gamma.negTrackExtraId() == lambda.posTrackExtraId()) || (gamma.posTrackExtraId() == lambda.negTrackExtraId()))
+    if (gamma.v0Type() == 0)
       return false;
 
     if (useMLScores) {
@@ -556,62 +560,92 @@ struct sigma0builder {
       if (gamma.gammaBDTScore() <= Gamma_MLThreshold)
         return false;
 
-      // Lambda and AntiLambda selection
+    } 
+    else {
+      // Standard selection
+      // Gamma basic selection criteria:
+      histos.fill(HIST("PhotonSel/hSelectionStatistics"), 1.);
+      histos.fill(HIST("PhotonSel/hPhotonMass"), gamma.mGamma());
+      if ((gamma.mGamma() < 0) || (gamma.mGamma() > PhotonMaxMass))
+        return false;
+      histos.fill(HIST("PhotonSel/hPhotonNegEta"), gamma.negativeeta());
+      histos.fill(HIST("PhotonSel/hPhotonPosEta"), gamma.positiveeta());
+      histos.fill(HIST("PhotonSel/hSelectionStatistics"), 2.);
+      if ((TMath::Abs(gamma.negativeeta()) > PhotonMaxDauPseudoRap) || (TMath::Abs(gamma.positiveeta()) > PhotonMaxDauPseudoRap))
+        return false;
+      histos.fill(HIST("PhotonSel/hPhotonDCANegToPV"), TMath::Abs(gamma.dcanegtopv()));
+      histos.fill(HIST("PhotonSel/hPhotonDCAPosToPV"), TMath::Abs(gamma.dcapostopv()));
+      histos.fill(HIST("PhotonSel/hSelectionStatistics"), 3.);
+      if ((TMath::Abs(gamma.dcapostopv()) < PhotonMinDCAToPv) || (TMath::Abs(gamma.dcanegtopv()) < PhotonMinDCAToPv))
+        return false;
+      histos.fill(HIST("PhotonSel/hPhotonDCADau"), TMath::Abs(gamma.dcaV0daughters()));
+      histos.fill(HIST("PhotonSel/hSelectionStatistics"), 4.);
+      if (TMath::Abs(gamma.dcaV0daughters()) > PhotonMaxDCAV0Dau)
+        return false;
+      histos.fill(HIST("PhotonSel/hPhotonRadius"), gamma.v0radius());
+      histos.fill(HIST("PhotonSel/hSelectionStatistics"), 5.);
+      if ((gamma.v0radius() < PhotonMinRadius) || (gamma.v0radius() > PhotonMaxRadius))
+        return false;
+      histos.fill(HIST("PhotonSel/hSelectionStatistics"), 6.);
+    }   
+    return true;
+  }
+
+  // Process photon candidate
+  template <typename TV0Object>
+  bool processLambdaCandidate(TV0Object const& lambda)
+  {
+    if (lambda.v0Type() != 1)
+      return false;
+    
+    if (useMLScores) {
       if ((lambda.lambdaBDTScore() <= Lambda_MLThreshold) && (lambda.antiLambdaBDTScore() <= AntiLambda_MLThreshold))
         return false;
 
-    } else {
-      // Standard selection
-      // Gamma basic selection criteria:
-      histos.fill(HIST("hCandidateBuilderSelection"), 1.);
-      histos.fill(HIST("Selection/hPhotonMass"), gamma.mGamma());
-      if ((gamma.mGamma() < 0) || (gamma.mGamma() > PhotonMaxMass))
-        return false;
-      histos.fill(HIST("Selection/hPhotonNegEta"), gamma.negativeeta());
-      histos.fill(HIST("Selection/hPhotonPosEta"), gamma.positiveeta());
-      histos.fill(HIST("hCandidateBuilderSelection"), 2.);
-      if ((TMath::Abs(gamma.negativeeta()) > PhotonMaxDauPseudoRap) || (TMath::Abs(gamma.positiveeta()) > PhotonMaxDauPseudoRap))
-        return false;
-      histos.fill(HIST("Selection/hPhotonDCANegToPV"), TMath::Abs(gamma.dcanegtopv()));
-      histos.fill(HIST("Selection/hPhotonDCAPosToPV"), TMath::Abs(gamma.dcapostopv()));
-      histos.fill(HIST("hCandidateBuilderSelection"), 3.);
-      if ((TMath::Abs(gamma.dcapostopv()) < PhotonMinDCAToPv) || (TMath::Abs(gamma.dcanegtopv()) < PhotonMinDCAToPv))
-        return false;
-      histos.fill(HIST("Selection/hPhotonDCADau"), TMath::Abs(gamma.dcaV0daughters()));
-      histos.fill(HIST("hCandidateBuilderSelection"), 4.);
-      if (TMath::Abs(gamma.dcaV0daughters()) > PhotonMaxDCAV0Dau)
-        return false;
-      histos.fill(HIST("Selection/hPhotonRadius"), gamma.v0radius());
-      histos.fill(HIST("hCandidateBuilderSelection"), 5.);
-      if ((gamma.v0radius() < PhotonMinRadius) || (gamma.v0radius() > PhotonMaxRadius))
-        return false;
-
+    } 
+    else {
       // Lambda basic selection criteria:
-      histos.fill(HIST("hCandidateBuilderSelection"), 6.);
-      histos.fill(HIST("Selection/hLambdaMass"), lambda.mLambda());
-      histos.fill(HIST("Selection/hAntiLambdaMass"), lambda.mAntiLambda());
+      histos.fill(HIST("LambdaSel/hSelectionStatistics"), 1.);
+      histos.fill(HIST("LambdaSel/hLambdaMass"), lambda.mLambda());
+      histos.fill(HIST("LambdaSel/hAntiLambdaMass"), lambda.mAntiLambda());
       if ((TMath::Abs(lambda.mLambda() - o2::constants::physics::MassLambda0) > LambdaWindow) && (TMath::Abs(lambda.mAntiLambda() - o2::constants::physics::MassLambda0) > LambdaWindow))
         return false;
-      histos.fill(HIST("Selection/hLambdaNegEta"), lambda.negativeeta());
-      histos.fill(HIST("Selection/hLambdaPosEta"), lambda.positiveeta());
-      histos.fill(HIST("hCandidateBuilderSelection"), 7.);
+      histos.fill(HIST("LambdaSel/hLambdaNegEta"), lambda.negativeeta());
+      histos.fill(HIST("LambdaSel/hLambdaPosEta"), lambda.positiveeta());
+      histos.fill(HIST("LambdaSel/hSelectionStatistics"), 2.);
       if ((TMath::Abs(lambda.negativeeta()) > LambdaDauPseudoRap) || (TMath::Abs(lambda.positiveeta()) > LambdaDauPseudoRap))
         return false;
-      histos.fill(HIST("Selection/hLambdaDCANegToPV"), lambda.dcanegtopv());
-      histos.fill(HIST("Selection/hLambdaDCAPosToPV"), lambda.dcapostopv());
-      histos.fill(HIST("hCandidateBuilderSelection"), 8.);
+      histos.fill(HIST("LambdaSel/hLambdaDCANegToPV"), lambda.dcanegtopv());
+      histos.fill(HIST("LambdaSel/hLambdaDCAPosToPV"), lambda.dcapostopv());
+      histos.fill(HIST("LambdaSel/hSelectionStatistics"), 3.);
       if ((TMath::Abs(lambda.dcapostopv()) < LambdaMinDCAPosToPv) || (TMath::Abs(lambda.dcanegtopv()) < LambdaMinDCANegToPv))
         return false;
-      histos.fill(HIST("Selection/hLambdaRadius"), lambda.v0radius());
-      histos.fill(HIST("hCandidateBuilderSelection"), 9.);
+      histos.fill(HIST("LambdaSel/hLambdaRadius"), lambda.v0radius());
+      histos.fill(HIST("LambdaSel/hSelectionStatistics"), 4.);
       if ((lambda.v0radius() < LambdaMinv0radius) || (lambda.v0radius() > LambdaMaxv0radius))
         return false;
-      histos.fill(HIST("Selection/hLambdaDCADau"), lambda.dcaV0daughters());
-      histos.fill(HIST("hCandidateBuilderSelection"), 10.);
+      histos.fill(HIST("LambdaSel/hLambdaDCADau"), lambda.dcaV0daughters());
+      histos.fill(HIST("LambdaSel/hSelectionStatistics"), 5.);
       if (TMath::Abs(lambda.dcaV0daughters()) > LambdaMaxDCAV0Dau)
         return false;
-      histos.fill(HIST("hCandidateBuilderSelection"), 11.);
+      histos.fill(HIST("LambdaSel/hSelectionStatistics"), 6.);
     }
+
+    return true;
+  }
+  ///////////
+  // Process sigma candidate and store properties in object
+  template <typename TV0Object>
+  bool processSigmaCandidate(TV0Object const& lambda, TV0Object const& gamma)
+  {    
+    // Checking if both V0s are made of the very same tracks
+    if (gamma.posTrackExtraId() == lambda.posTrackExtraId() ||
+        gamma.negTrackExtraId() == lambda.negTrackExtraId() ||
+        gamma.posTrackExtraId() == lambda.negTrackExtraId() ||
+        gamma.negTrackExtraId() == lambda.posTrackExtraId()) {
+      return false;
+    }
+
     // Sigma0 candidate properties
     std::array<float, 3> pVecPhotons{gamma.px(), gamma.py(), gamma.pz()};
     std::array<float, 3> pVecLambda{lambda.px(), lambda.py(), lambda.pz()};
@@ -619,8 +653,9 @@ struct sigma0builder {
     float sigmamass = RecoDecay::m(arrMom, std::array{o2::constants::physics::MassPhoton, o2::constants::physics::MassLambda0});
     float sigmarap = RecoDecay::y(std::array{gamma.px() + lambda.px(), gamma.py() + lambda.py(), gamma.pz() + lambda.pz()}, o2::constants::physics::MassSigma0);
     
-    histos.fill(HIST("Selection/hSigmaMass"), sigmamass);
-    histos.fill(HIST("Selection/hSigmaMassWindow"), sigmamass - 1.192642);
+    histos.fill(HIST("SigmaSel/hSelectionStatistics"), 1.);
+    histos.fill(HIST("SigmaSel/hSigmaMass"), sigmamass);
+    histos.fill(HIST("SigmaSel/hSigmaMassWindow"), sigmamass - 1.192642);
     
     if (fillQAhistos){
       histos.fill(HIST("GeneralQA/h2dMassGammaVsK0S"), gamma.mGamma(), gamma.mK0Short());
@@ -633,14 +668,14 @@ struct sigma0builder {
     if (TMath::Abs(sigmamass - 1.192642) > Sigma0Window)
       return false;
 
-    histos.fill(HIST("Selection/hSigmaY"), sigmarap);
-    histos.fill(HIST("hCandidateBuilderSelection"), 12.);
+    histos.fill(HIST("SigmaSel/hSigmaY"), sigmarap);
+    histos.fill(HIST("SigmaSel/hSelectionStatistics"), 2.);
 
     if (TMath::Abs(sigmarap) > SigmaMaxRap)
       return false;
 
-    histos.fill(HIST("Selection/hSigmaMassSelected"), sigmamass);
-    histos.fill(HIST("hCandidateBuilderSelection"), 13.);
+    histos.fill(HIST("SigmaSel/hSigmaMassSelected"), sigmamass);
+    histos.fill(HIST("SigmaSel/hSelectionStatistics"), 3.);
     
     if (fillQAhistos){
       histos.fill(HIST("GeneralQA/h2dMassGammaVsK0SAfterMassSel"), gamma.mGamma(), gamma.mK0Short());
@@ -803,183 +838,257 @@ struct sigma0builder {
                       fLambdaV0Type, LambdaBDTScore, AntiLambdaBDTScore);
   }
 
-  void processMonteCarlo(soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraStamps, aod::StraCollLabels> const& collisions, V0DerivedMCDatas const& V0s, dauTracks const&, aod::MotherMCParts const&, soa::Join<aod::StraMCCollisions, aod::StraMCCollMults> const&, soa::Join<aod::V0MCCores, aod::V0MCCollRefs> const&)
+  void processMonteCarlo(soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraStamps, aod::StraCollLabels>::iterator const& coll, V0DerivedMCDatas const& V0s, dauTracks const&, aod::MotherMCParts const&, soa::Join<aod::StraMCCollisions, aod::StraMCCollMults> const&, soa::Join<aod::V0MCCores, aod::V0MCCollRefs> const&)
   {
-    for (const auto& coll : collisions) {
-      if (!IsEventAccepted(coll, true)) {
+    if (!IsEventAccepted(coll, true)) 
+      return;
+    
+    float centrality = coll.centFT0C();
+    histos.fill(HIST("hEventCentrality"), centrality);
+    
+    bool fhasMCColl=false;
+    if (coll.has_straMCCollision())
+      fhasMCColl=true;
+
+    std::vector<int> bestGammasArray;
+    std::vector<int> bestLambdasArray;
+    int v0TableOffset = V0s.offset();
+
+    //_______________________________________________
+    // Photon-only loop
+    for (auto& gamma : V0s) { // selecting photons from Sigma0
+      
+      if (!gamma.has_v0MCCore())
         continue;
+
+      auto gammaMC = gamma.v0MCCore_as<soa::Join<aod::V0MCCores, aod::V0MCCollRefs>>();
+
+      if (gammaMC.pdgCode() == 22) {
+        histos.fill(HIST("MC/h2dGammaXYConversion"), gamma.x(), gamma.y());
+        float GammaY = TMath::Abs(RecoDecay::y(std::array{gamma.px(), gamma.py(), gamma.pz()}, o2::constants::physics::MassGamma));
+        if (GammaY < 0.5) {                                                                                                                // rapidity selection
+          histos.fill(HIST("MC/h2dPtVsCentralityBeforeSel_MCAssocGamma"), centrality, gamma.pt());                                                // isgamma            
+        }
+      }
+
+      // basic photon selection
+      if (!processPhotonCandidate(gamma)) 
+        continue;
+
+      // Save indices of best gamma candidates
+      bestGammasArray.push_back(gamma.globalIndex() - v0TableOffset);
+    }
+    
+    //_______________________________________________
+    // Lambda-only loop
+    for (auto& lambda : V0s) { // selecting lambdas from Sigma0
+      if (!lambda.has_v0MCCore())
+        continue;
+
+      auto lambdaMC = lambda.v0MCCore_as<soa::Join<aod::V0MCCores, aod::V0MCCollRefs>>();
+      float lambdaY = TMath::Abs(RecoDecay::y(std::array{lambda.px(), lambda.py(), lambda.pz()}, o2::constants::physics::MassLambda));
+      
+      if (lambdaY < 0.5){
+        if (lambdaMC.pdgCode() == 3122) // Is Lambda          
+          histos.fill(HIST("MC/h2dPtVsCentralityBeforeSel_MCAssocLambda"), centrality, lambda.pt());          
+        if (lambdaMC.pdgCode() == -3122) // Is AntiLambda          
+          histos.fill(HIST("MC/h2dPtVsCentralityBeforeSel_MCAssocALambda"), centrality, lambda.pt());            
       }
       
+      // basic lambda selection
+      if (!processLambdaCandidate(lambda)) 
+        continue;
+
+      // Save indices of best lambda candidates
+      bestLambdasArray.push_back(lambda.globalIndex() - v0TableOffset); 
+    }
+    //_______________________________________________
+    // Pi0 optional loop
+    if (doPi0QA){      
+      for (size_t i = 0; i < bestGammasArray.size(); ++i) {
+        auto gamma1 = V0s.rawIteratorAt(bestGammasArray[i]);
+        for (size_t j = i + 1; j < bestGammasArray.size(); ++j) {            
+          auto gamma2 = V0s.rawIteratorAt(bestGammasArray[j]);          
+          runPi0QA(gamma1, gamma2);
+        }
+      }
+    }
+    
+    //_______________________________________________
+    // Sigma0 loop
+    for (size_t i = 0; i < bestGammasArray.size(); ++i) {
+      auto gamma = V0s.rawIteratorAt(bestGammasArray[i]);
+
+      if (!gamma.has_v0MCCore())
+        continue;
+
+      auto gammaMC = gamma.v0MCCore_as<soa::Join<aod::V0MCCores, aod::V0MCCollRefs>>();
+
       bool fIsPhotonCorrectlyAssign = false;
+      if (fhasMCColl) {
+        auto gammaMCCollision = coll.template straMCCollision_as<soa::Join<aod::StraMCCollisions, aod::StraMCCollMults>>();
+        fIsPhotonCorrectlyAssign = (gammaMC.straMCCollisionId() == gammaMCCollision.globalIndex());
+      }
 
-      // Do analysis with collision-grouped V0s, retain full collision information
-      const uint64_t collIdx = coll.globalIndex();
-      auto V0Table_thisCollision = V0s.sliceBy(perCollisionMCDerived, collIdx);
-
-      histos.fill(HIST("hEventCentrality"), coll.centFT0C());
-      // V0 table sliced
-      for (auto& gamma : V0Table_thisCollision) { // selecting photons from Sigma0
-        float centrality = coll.centFT0C();
-
-        if (!gamma.has_v0MCCore())
+      for (size_t j = 0; j < bestLambdasArray.size(); ++j){
+        auto lambda = V0s.iteratorAt(bestLambdasArray[j]);
+        
+        if (!lambda.has_v0MCCore())
           continue;
 
-        auto gammaMC = gamma.v0MCCore_as<soa::Join<aod::V0MCCores, aod::V0MCCollRefs>>();
+        auto lambdaMC = lambda.v0MCCore_as<soa::Join<aod::V0MCCores, aod::V0MCCollRefs>>();
+      
+        // Sigma0 candidate properties
+        std::array<float, 3> pVecPhotons{gamma.px(), gamma.py(), gamma.pz()};
+        std::array<float, 3> pVecLambda{lambda.px(), lambda.py(), lambda.pz()};
+        auto arrMom = std::array{pVecPhotons, pVecLambda};
+        float SigmaMass = RecoDecay::m(arrMom, std::array{o2::constants::physics::MassPhoton, o2::constants::physics::MassLambda0});
+        float SigmapT = RecoDecay::pt(array{gamma.px() + lambda.px(), gamma.py() + lambda.py()});
+        float SigmaY = TMath::Abs(RecoDecay::y(std::array{gamma.px() + lambda.px(), gamma.py() + lambda.py(), gamma.pz() + lambda.pz()}, o2::constants::physics::MassSigma0));
 
-        if (coll.has_straMCCollision()) {
-          auto gammaMCCollision = coll.template straMCCollision_as<soa::Join<aod::StraMCCollisions, aod::StraMCCollMults>>();
-          fIsPhotonCorrectlyAssign = (gammaMC.straMCCollisionId() == gammaMCCollision.globalIndex());
+        // MC properties
+        bool fIsSigma = false;
+        bool fIsAntiSigma = false;
+        bool fIsPhotonPrimary = gammaMC.isPhysicalPrimary();
+        bool fIsLambdaPrimary = lambdaMC.isPhysicalPrimary();     
+        bool fIsLambdaCorrectlyAssign = false;     
+
+        int PhotonCandPDGCode = gammaMC.pdgCode();
+        int PhotonCandPDGCodeMother = gammaMC.pdgCodeMother();
+        int LambdaCandPDGCode = lambdaMC.pdgCode();
+        int LambdaCandPDGCodeMother = lambdaMC.pdgCodeMother();
+
+        float SigmaMCpT = RecoDecay::pt(array{gammaMC.pxMC() + lambdaMC.pxMC(), gammaMC.pyMC() + lambdaMC.pyMC()});
+        float PhotonMCpT = RecoDecay::pt(array{gammaMC.pxMC(), gammaMC.pyMC()});
+        float LambdaMCpT = RecoDecay::pt(array{lambdaMC.pxMC(), lambdaMC.pyMC()});
+      
+        if (fhasMCColl) {
+          auto lambdaMCCollision = coll.template straMCCollision_as<soa::Join<aod::StraMCCollisions, aod::StraMCCollMults>>();
+          fIsLambdaCorrectlyAssign = (lambdaMC.straMCCollisionId() == lambdaMCCollision.globalIndex());
         }
 
-        // Auxiliary histograms:
-        if (gammaMC.pdgCode() == 22) {
-          histos.fill(HIST("MC/h2dGammaXYConversion"), gamma.x(), gamma.y());
-          float GammaY = TMath::Abs(RecoDecay::y(std::array{gamma.px(), gamma.py(), gamma.pz()}, o2::constants::physics::MassGamma));
-          if (GammaY < 0.5) {                                                                                                                // rapidity selection
-            histos.fill(HIST("MC/h2dPtVsCentralityBeforeSel_MCAssocGamma"), centrality, gamma.pt());                                                // isgamma            
+        if ((PhotonCandPDGCode == 22) && (PhotonCandPDGCodeMother == 3212) && (LambdaCandPDGCode == 3122) && (LambdaCandPDGCodeMother == 3212) && (gamma.motherMCPartId() == lambda.motherMCPartId()))
+          fIsSigma = true;
+        if ((PhotonCandPDGCode == 22) && (PhotonCandPDGCodeMother == -3212) && (LambdaCandPDGCode == -3122) && (LambdaCandPDGCodeMother == -3212) && (gamma.motherMCPartId() == lambda.motherMCPartId()))
+          fIsAntiSigma = true;
+
+        if (SigmaY < 0.5){
+          if (fIsSigma) {
+            histos.fill(HIST("MC/h2dPtVsCentralityBeforeSel_MCAssocSigma0"), centrality, SigmaMCpT);
+            histos.fill(HIST("MC/h2dSigma0PtVsLambdaPtBeforeSel_MCAssoc"), SigmaMCpT, LambdaMCpT);
+            histos.fill(HIST("MC/h2dSigma0PtVsGammaPtBeforeSel_MCAssoc"), SigmaMCpT, PhotonMCpT);
           }
-        }
-        if (gammaMC.pdgCode() == 3122) { // Is Lambda
-          float LambdaY = TMath::Abs(RecoDecay::y(std::array{gamma.px(), gamma.py(), gamma.pz()}, o2::constants::physics::MassLambda));
-          if (LambdaY < 0.5) { // rapidity selection
-            histos.fill(HIST("MC/h2dPtVsCentralityBeforeSel_MCAssocLambda"), centrality, gamma.pt());
-          }
-        }
-        if (gammaMC.pdgCode() == -3122) { // Is AntiLambda
-          float AntiLambdaY = TMath::Abs(RecoDecay::y(std::array{gamma.px(), gamma.py(), gamma.pz()}, o2::constants::physics::MassLambda));
-          if (AntiLambdaY < 0.5) { // rapidity selection
-            histos.fill(HIST("MC/h2dPtVsCentralityBeforeSel_MCAssocALambda"), centrality, gamma.pt());
-            
-          }
+          if (fIsAntiSigma)
+            histos.fill(HIST("MC/h2dPtVsCentralityBeforeSel_MCAssocASigma0"), centrality, SigmaMCpT);  
         }
 
-        for (auto& lambda : V0Table_thisCollision) { // selecting lambdas from Sigma0
-          if (!lambda.has_v0MCCore())
-            continue;
+        histos.fill(HIST("SigmaSel/h3dMassSigma0BeforeSel"), centrality, SigmapT, SigmaMass);
+        
+        // Selecting sigma0 candidate
+        if (!processSigmaCandidate(lambda, gamma)) 
+          continue;
 
-          if (doPi0QA) // Pi0 QA study
-            runPi0QA(gamma, lambda);
+        // Calculating properties and filling histos
+        histos.fill(HIST("SigmaSel/h3dMassSigma0AfterSel"), centrality, SigmapT, SigmaMass);
 
-          if (lambda.v0Type() != 1) { // safeguard to avoid TPC-only photons
-            continue;
-          }
-
-          bool fIsLambdaCorrectlyAssign = false;
-          auto lambdaMC = lambda.v0MCCore_as<soa::Join<aod::V0MCCores, aod::V0MCCollRefs>>();
-
-          if (coll.has_straMCCollision()) {
-            auto lambdaMCCollision = coll.template straMCCollision_as<soa::Join<aod::StraMCCollisions, aod::StraMCCollMults>>();
-            fIsLambdaCorrectlyAssign = (lambdaMC.straMCCollisionId() == lambdaMCCollision.globalIndex());
-          }
-
-          // Sigma0 candidate properties
-          std::array<float, 3> pVecPhotons{gamma.px(), gamma.py(), gamma.pz()};
-          std::array<float, 3> pVecLambda{lambda.px(), lambda.py(), lambda.pz()};
-          auto arrMom = std::array{pVecPhotons, pVecLambda};
-          float SigmaMass = RecoDecay::m(arrMom, std::array{o2::constants::physics::MassPhoton, o2::constants::physics::MassLambda0});
-          float SigmapT = RecoDecay::pt(array{gamma.px() + lambda.px(), gamma.py() + lambda.py()});
-          float SigmaY = TMath::Abs(RecoDecay::y(std::array{gamma.px() + lambda.px(), gamma.py() + lambda.py(), gamma.pz() + lambda.pz()}, o2::constants::physics::MassSigma0));
-
-          if ((gammaMC.pdgCode() == 22) && (gammaMC.pdgCodeMother() == 3212) && (lambdaMC.pdgCode() == 3122) && (lambdaMC.pdgCodeMother() == 3212) && (gamma.motherMCPartId() == lambda.motherMCPartId()) && (SigmaY < 0.5)) {
-            histos.fill(HIST("MC/h2dPtVsCentralityBeforeSel_MCAssocSigma0"), centrality, RecoDecay::pt(array{gamma.px() + lambda.px(), gamma.py() + lambda.py()}));
-            histos.fill(HIST("MC/h2dSigma0PtVsLambdaPtBeforeSel_MCAssoc"), SigmapT, lambda.pt());
-            histos.fill(HIST("MC/h2dSigma0PtVsGammaPtBeforeSel_MCAssoc"), SigmapT, gamma.pt());
-          }
-          if ((gammaMC.pdgCode() == 22) && (gammaMC.pdgCodeMother() == -3212) && (lambdaMC.pdgCode() == -3122) && (lambdaMC.pdgCodeMother() == -3212) && (gamma.motherMCPartId() == lambda.motherMCPartId()) && (SigmaY < 0.5))
-            histos.fill(HIST("MC/h2dPtVsCentralityBeforeSel_MCAssocASigma0"), centrality, SigmapT);
-
-          histos.fill(HIST("h3dMassSigma0BeforeSel"), coll.centFT0C(), SigmapT, SigmaMass);
-
-          if (!processSigmaCandidate(lambda, gamma)) // basic selection
-            continue;
-
-          // Calculating properties and filling histos
-          histos.fill(HIST("h3dMassSigma0AfterSel"), coll.centFT0C(), SigmapT, SigmaMass);
-
-          bool fIsSigma = false;
-          bool fIsAntiSigma = false;
-          float SigmaMCpT = RecoDecay::pt(array{gammaMC.pxMC() + lambdaMC.pxMC(), gammaMC.pyMC() + lambdaMC.pyMC()});
-          bool fIsPhotonPrimary = gammaMC.isPhysicalPrimary();
-          int PhotonCandPDGCode = gammaMC.pdgCode();
-          int PhotonCandPDGCodeMother = gammaMC.pdgCodeMother();
-          float PhotonMCpT = RecoDecay::pt(array{gammaMC.pxMC(), gammaMC.pyMC()});
-          
-          bool fIsLambdaPrimary = lambdaMC.isPhysicalPrimary();
-          int LambdaCandPDGCode = lambdaMC.pdgCode();
-          int LambdaCandPDGCodeMother = lambdaMC.pdgCodeMother();
-          float LambdaMCpT = RecoDecay::pt(array{lambdaMC.pxMC(), lambdaMC.pyMC()});
-          
-          if ((gammaMC.pdgCode() == 22) && (gammaMC.pdgCodeMother() == 3212) && (lambdaMC.pdgCode() == 3122) && (lambdaMC.pdgCodeMother() == 3212) && (gamma.motherMCPartId() == lambda.motherMCPartId())) {
-            fIsSigma = true;
-            histos.fill(HIST("MC/h2dPtVsCentralityAfterSel_MCAssocSigma0"), centrality, RecoDecay::pt(array{gamma.px() + lambda.px(), gamma.py() + lambda.py()}));
-          }
-          if ((gammaMC.pdgCode() == 22) && (gammaMC.pdgCodeMother() == -3212) && (lambdaMC.pdgCode() == -3122) && (lambdaMC.pdgCodeMother() == -3212) && (gamma.motherMCPartId() == lambda.motherMCPartId())) {
-            fIsAntiSigma = true;
-            histos.fill(HIST("MC/h2dPtVsCentralityAfterSel_MCAssocASigma0"), centrality, RecoDecay::pt(array{gamma.px() + lambda.px(), gamma.py() + lambda.py()}));
-          }
-          
-          if (fillBkgQAhistos) 
-            runBkgAnalysis(fIsSigma, fIsAntiSigma, PhotonCandPDGCode, PhotonCandPDGCodeMother, LambdaCandPDGCode, LambdaCandPDGCodeMother, SigmapT, SigmaMass);
-
-          // Fill Tables please
-          sigma0mccores(fIsSigma, fIsAntiSigma, SigmaMCpT,
-                        PhotonCandPDGCode, PhotonCandPDGCodeMother, fIsPhotonPrimary, PhotonMCpT, fIsPhotonCorrectlyAssign,
-                        LambdaCandPDGCode, LambdaCandPDGCodeMother, fIsLambdaPrimary, LambdaMCpT, fIsLambdaCorrectlyAssign);
-
-          fillTables(lambda, gamma, coll); // filling tables with accepted candidates
-
-          nSigmaCandidates++;
-          if (nSigmaCandidates % 10000 == 0) 
-            LOG(info) << "Sigma0 Candidates built: " << nSigmaCandidates;
+        if (SigmaY < 0.5){
+          if (fIsSigma) 
+            histos.fill(HIST("MC/h2dPtVsCentralityAfterSel_MCAssocSigma0"), centrality, SigmaMCpT);            
+          if (fIsAntiSigma) 
+            histos.fill(HIST("MC/h2dPtVsCentralityAfterSel_MCAssocASigma0"), centrality, SigmaMCpT);
         }
+                            
+        if (fillBkgQAhistos) 
+          runBkgAnalysis(fIsSigma, fIsAntiSigma, PhotonCandPDGCode, PhotonCandPDGCodeMother, LambdaCandPDGCode, LambdaCandPDGCodeMother, SigmapT, SigmaMass);
+
+        // Fill Tables please
+        sigma0mccores(fIsSigma, fIsAntiSigma, SigmaMCpT,
+                      PhotonCandPDGCode, PhotonCandPDGCodeMother, fIsPhotonPrimary, PhotonMCpT, fIsPhotonCorrectlyAssign,
+                      LambdaCandPDGCode, LambdaCandPDGCodeMother, fIsLambdaPrimary, LambdaMCpT, fIsLambdaCorrectlyAssign);
+
+        fillTables(lambda, gamma, coll); // filling tables with accepted candidates
+
+        nSigmaCandidates++;
+        if (nSigmaCandidates % 10000 == 0) 
+          LOG(info) << "Sigma0 Candidates built: " << nSigmaCandidates;
       }
-    }
+    }          
   }
 
-  void processRealData(soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraStamps> const& collisions, V0StandardDerivedDatas const& V0s, dauTracks const&)
-  {
-    for (const auto& coll : collisions) {
-      if (!IsEventAccepted(coll, true)) {
+  void processRealData(soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraStamps>::iterator const& coll, V0StandardDerivedDatas const& V0s, dauTracks const&)
+  {    
+    if (!IsEventAccepted(coll, true)) 
+      return;
+    
+    float centrality = coll.centFT0C();
+    histos.fill(HIST("hEventCentrality"), centrality);
+    
+    std::vector<int> bestGammasArray;
+    std::vector<int> bestLambdasArray;
+    int v0TableOffset = V0s.offset();
+
+    //_______________________________________________
+    // Photon-only loop
+    for (auto& gamma : V0s) { // selecting photons       
+      if (!processPhotonCandidate(gamma)) 
         continue;
-      }
-      // Do analysis with collision-grouped V0s, retain full collision information
-      const uint64_t collIdx = coll.globalIndex();
-      auto V0Table_thisCollision = V0s.sliceBy(perCollisionSTDDerived, collIdx);
 
-      histos.fill(HIST("hEventCentrality"), coll.centFT0C());
-      // V0 table sliced
-      for (auto& gamma : V0Table_thisCollision) {    // selecting photons from Sigma0
-        for (auto& lambda : V0Table_thisCollision) { // selecting lambdas from Sigma0
-          if (doPi0QA)                               // Pi0 QA study
-            runPi0QA(gamma, lambda);
+      // Save indices of best gamma candidates
+      bestGammasArray.push_back(gamma.globalIndex() - v0TableOffset);
+    }
 
-          if (lambda.v0Type() != 1) { // safeguard to avoid TPC-only photons
-            continue;
-          }
+    //_______________________________________________
+    // Lambda-only loop
+    for (auto& lambda : V0s) { // selecting lambdas 
+      if (!processLambdaCandidate(lambda))  
+        continue;
 
-          // Sigma0 candidate properties
-          std::array<float, 3> pVecPhotons{gamma.px(), gamma.py(), gamma.pz()};
-          std::array<float, 3> pVecLambda{lambda.px(), lambda.py(), lambda.pz()};
-          auto arrMom = std::array{pVecPhotons, pVecLambda};
-          float SigmaMass = RecoDecay::m(arrMom, std::array{o2::constants::physics::MassPhoton, o2::constants::physics::MassLambda0});
-          float SigmapT = RecoDecay::pt(array{gamma.px() + lambda.px(), gamma.py() + lambda.py()});
-          // float SigmaY = TMath::Abs(RecoDecay::y(std::array{gamma.px() + lambda.px(), gamma.py() + lambda.py(), gamma.pz() + lambda.pz()}, o2::constants::physics::MassSigma0));
-          histos.fill(HIST("h3dMassSigma0BeforeSel"), coll.centFT0C(), SigmapT, SigmaMass);
+      // Save indices of best lambda candidates
+      bestLambdasArray.push_back(lambda.globalIndex() - v0TableOffset);      
+    }
 
-          if (!processSigmaCandidate(lambda, gamma)) // applying selection for reconstruction
-            continue;
-
-          fillTables(lambda, gamma, coll); // filling tables with accepted candidates
-
-          histos.fill(HIST("h3dMassSigma0AfterSel"), coll.centFT0C(), SigmapT, SigmaMass);
-
-          nSigmaCandidates++;
-          if (nSigmaCandidates % 5000 == 0) {
-            LOG(info) << "Sigma0 Candidates built: " << nSigmaCandidates;
-          }
+    //_______________________________________________
+    // Pi0 optional loop
+    if (doPi0QA){      
+      for (size_t i = 0; i < bestGammasArray.size(); ++i) {
+        auto gamma1 = V0s.rawIteratorAt(bestGammasArray[i]);
+        for (size_t j = i + 1; j < bestGammasArray.size(); ++j) {            
+          auto gamma2 = V0s.rawIteratorAt(bestGammasArray[j]);          
+          runPi0QA(gamma1, gamma2);
         }
       }
     }
+
+    //_______________________________________________
+    // Sigma0 loop
+    for (size_t i = 0; i < bestGammasArray.size(); ++i) {
+      auto gamma = V0s.rawIteratorAt(bestGammasArray[i]);
+      
+      for (size_t j = 0; j < bestLambdasArray.size(); ++j){
+        auto lambda = V0s.iteratorAt(bestLambdasArray[j]);
+
+        // Sigma0 candidate properties
+        std::array<float, 3> pVecPhotons{gamma.px(), gamma.py(), gamma.pz()};
+        std::array<float, 3> pVecLambda{lambda.px(), lambda.py(), lambda.pz()};
+        auto arrMom = std::array{pVecPhotons, pVecLambda};
+        float SigmaMass = RecoDecay::m(arrMom, std::array{o2::constants::physics::MassPhoton, o2::constants::physics::MassLambda0});
+        float SigmapT = RecoDecay::pt(array{gamma.px() + lambda.px(), gamma.py() + lambda.py()});
+
+        histos.fill(HIST("SigmaSel/h3dMassSigma0BeforeSel"), centrality, SigmapT, SigmaMass);
+
+        // Selecting sigma0 candidate
+        if (!processSigmaCandidate(lambda, gamma)) 
+          continue;
+
+        fillTables(lambda, gamma, coll); // filling tables with accepted candidates
+
+        histos.fill(HIST("SigmaSel/h3dMassSigma0AfterSel"), centrality, SigmapT, SigmaMass);
+
+        nSigmaCandidates++;
+        if (nSigmaCandidates % 10000 == 0)
+          LOG(info) << "Sigma0 Candidates built: " << nSigmaCandidates;        
+      }
+    }    
   }
 
   // Simulated processing in Run 3 (subscribes to MC information too)

--- a/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
@@ -71,6 +71,14 @@ struct sigma0builder {
   Preslice<V0DerivedMCDatas> perCollisionMCDerived = o2::aod::v0data::straCollisionId;
   Preslice<V0StandardDerivedDatas> perCollisionSTDDerived = o2::aod::v0data::straCollisionId;
 
+  // pack track quality but separte also afterburner
+  // dynamic range: 0-31
+  enum selection : int { hasTPC = 0,
+    hasITSTracker,
+    hasITSAfterburner,
+    hasTRD,
+    hasTOF };
+
   // Histogram registry
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
 
@@ -678,6 +686,18 @@ struct sigma0builder {
     float fPhotonNegITSChi2PerNcl = negTrackGamma.itsChi2PerNcl();
     uint8_t fPhotonV0Type = gamma.v0Type();
 
+    uint8_t fPhotonPosTrackCode = ((uint8_t(posTrackGamma.hasTPC()) << hasTPC) |
+                                   (uint8_t(posTrackGamma.hasITSTracker()) << hasITSTracker) |
+                                   (uint8_t(posTrackGamma.hasITSAfterburner()) << hasITSAfterburner) |
+                                   (uint8_t(posTrackGamma.hasTRD()) << hasTRD) |
+                                   (uint8_t(posTrackGamma.hasTOF()) << hasTOF));
+
+    uint8_t fPhotonNegTrackCode = ((uint8_t(negTrackGamma.hasTPC()) << hasTPC) |
+                                  (uint8_t(negTrackGamma.hasITSTracker()) << hasITSTracker) |
+                                  (uint8_t(negTrackGamma.hasITSAfterburner()) << hasITSAfterburner) |
+                                  (uint8_t(negTrackGamma.hasTRD()) << hasTRD) |
+                                  (uint8_t(negTrackGamma.hasTOF()) << hasTOF));
+
     // Lambda
     auto posTrackLambda = lambda.template posTrackExtra_as<dauTracks>();
     auto negTrackLambda = lambda.template negTrackExtra_as<dauTracks>();
@@ -722,6 +742,18 @@ struct sigma0builder {
     float fLambdaNegITSChi2PerNcl = negTrackLambda.itsChi2PerNcl();
     uint8_t fLambdaV0Type = lambda.v0Type();
 
+    uint8_t fLambdaPosTrackCode = ((uint8_t(posTrackLambda.hasTPC()) << hasTPC) |
+                                   (uint8_t(posTrackLambda.hasITSTracker()) << hasITSTracker) |
+                                   (uint8_t(posTrackLambda.hasITSAfterburner()) << hasITSAfterburner) |
+                                   (uint8_t(posTrackLambda.hasTRD()) << hasTRD) |
+                                   (uint8_t(posTrackLambda.hasTOF()) << hasTOF));
+
+    uint8_t fLambdaNegTrackCode = ((uint8_t(negTrackLambda.hasTPC()) << hasTPC) |
+                                  (uint8_t(negTrackLambda.hasITSTracker()) << hasITSTracker) |
+                                  (uint8_t(negTrackLambda.hasITSAfterburner()) << hasITSAfterburner) |
+                                  (uint8_t(negTrackLambda.hasTRD()) << hasTRD) |
+                                  (uint8_t(negTrackLambda.hasTOF()) << hasTOF));
+
     // Sigma0 candidate properties
     std::array<float, 3> pVecPhotons{gamma.px(), gamma.py(), gamma.pz()};
     std::array<float, 3> pVecLambda{lambda.px(), lambda.py(), lambda.pz()};
@@ -746,7 +778,7 @@ struct sigma0builder {
                       fPhotonEta, fPhotonY, fPhotonPhi, fPhotonPosTPCNSigmaEl, fPhotonNegTPCNSigmaEl, fPhotonPosTPCNSigmaPi, fPhotonNegTPCNSigmaPi, fPhotonPosTPCCrossedRows,
                       fPhotonNegTPCCrossedRows, fPhotonPosPt, fPhotonNegPt, fPhotonPosEta,
                       fPhotonNegEta, fPhotonPosY, fPhotonNegY, fPhotonPsiPair,
-                      fPhotonPosITSCls, fPhotonNegITSCls, fPhotonPosITSChi2PerNcl, fPhotonNegITSChi2PerNcl,
+                      fPhotonPosITSCls, fPhotonNegITSCls, fPhotonPosITSChi2PerNcl, fPhotonNegITSChi2PerNcl, fPhotonPosTrackCode, fPhotonNegTrackCode,
                       fPhotonV0Type, GammaBDTScore);
 
     sigmaLambdaExtras(fLambdaPt, fLambdaMass, fAntiLambdaMass, fLambdaQt, fLambdaAlpha, fLambdaLifeTime,
@@ -756,7 +788,7 @@ struct sigma0builder {
                       fLambdaPrTOFNSigma, fLambdaPiTOFNSigma, fALambdaPrTOFNSigma, fALambdaPiTOFNSigma,
                       fLambdaPosTPCCrossedRows, fLambdaNegTPCCrossedRows, fLambdaPosPt, fLambdaNegPt, fLambdaPosEta,
                       fLambdaNegEta, fLambdaPosPrY, fLambdaPosPiY, fLambdaNegPrY, fLambdaNegPiY,
-                      fLambdaPosITSCls, fLambdaNegITSCls, fLambdaPosITSChi2PerNcl, fLambdaNegITSChi2PerNcl,
+                      fLambdaPosITSCls, fLambdaNegITSCls, fLambdaPosITSChi2PerNcl, fLambdaNegITSChi2PerNcl, fLambdaPosTrackCode, fLambdaNegTrackCode,
                       fLambdaV0Type, LambdaBDTScore, AntiLambdaBDTScore);
   }
 

--- a/PWGLF/Tasks/QC/strderivedGenQA.cxx
+++ b/PWGLF/Tasks/QC/strderivedGenQA.cxx
@@ -320,6 +320,7 @@ struct strderivedGenQA {
     histos.add("MCV0/Gamma/hdcaDau", "hdcaDau", kTH1F, {axisDCAdau});
     histos.add("MCV0/Gamma/hdcaNegtopv", "hdcaNegtopv", kTH1F, {axisDCAToPV});
     histos.add("MCV0/Gamma/hdcaPostopv", "hdcaPostopv", kTH1F, {axisDCAToPV});
+    histos.add("MCV0/Gamma/hZ", "hZ", kTH1F, {{240, -120.0f, 120.0f}});
 
     histos.add("MCV0/Lambda/h2dpTResolution", "h2dpTResolution", kTH2F, {axisPt, axisPtResolution});
     histos.add("MCV0/Lambda/h2dMass", "h2dMass", kTH2F, {axisPt, axisMassLambda});
@@ -804,6 +805,7 @@ struct strderivedGenQA {
         histos.fill(HIST("MCV0/Gamma/hdcaDau"), v0.dcaV0daughters());
         histos.fill(HIST("MCV0/Gamma/hdcaNegtopv"), v0.dcanegtopv());
         histos.fill(HIST("MCV0/Gamma/hdcaPostopv"), v0.dcapostopv());
+        histos.fill(HIST("MCV0/Gamma/hZ"), v0.z());
       }
       if (v0MC.pdgCode() == 3122) { // IsLambda
         histos.fill(HIST("MCV0/h2dArmenterosP"), v0.alpha(), v0.qtarm());

--- a/PWGLF/Tasks/Strangeness/sigmaanalysis.cxx
+++ b/PWGLF/Tasks/Strangeness/sigmaanalysis.cxx
@@ -64,38 +64,12 @@ struct sigmaanalysis {
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   // Interaction rate selection:
-  // Event selection
-  Configurable<bool> doPPAnalysis{"doPPAnalysis", true, "if in pp, set to true"};
+  // Event selection  
   Configurable<bool> fGetIR{"fGetIR", false, "Flag to retrieve the IR info."};
   Configurable<bool> fIRCrashOnNull{"fIRCrashOnNull", false, "Flag to avoid CTP RateFetcher crash."};
   Configurable<std::string> irSource{"irSource", "T0VTX", "Estimator of the interaction rate (Recommended: pp --> T0VTX, Pb-Pb --> ZNC hadronic)"};
   Configurable<float> minIR{"minIR", -1, "Min Interaction Rate (kHz). Leave -1 if no selection desired."};
   Configurable<float> maxIR{"maxIR", -1, "Max Interaction Rate (kHz). Leave -1 if no selection desired."};
-
-  struct : ConfigurableGroup {
-    Configurable<bool> requireSel8{"requireSel8", true, "require sel8 event selection"};
-    Configurable<bool> requireTriggerTVX{"requireTriggerTVX", true, "require FT0 vertex (acceptable FT0C-FT0A time difference) at trigger level"};
-    Configurable<bool> rejectITSROFBorder{"rejectITSROFBorder", true, "reject events at ITS ROF border"};
-    Configurable<bool> rejectTFBorder{"rejectTFBorder", true, "reject events at TF border"};
-    Configurable<bool> requireIsVertexITSTPC{"requireIsVertexITSTPC", true, "require events with at least one ITS-TPC track"};
-    Configurable<bool> requireIsGoodZvtxFT0VsPV{"requireIsGoodZvtxFT0VsPV", true, "require events with PV position along z consistent (within 1 cm) between PV reconstructed using tracks and PV using FT0 A-C time difference"};
-    Configurable<bool> requireIsVertexTOFmatched{"requireIsVertexTOFmatched", false, "require events with at least one of vertex contributors matched to TOF"};
-    Configurable<bool> requireIsVertexTRDmatched{"requireIsVertexTRDmatched", false, "require events with at least one of vertex contributors matched to TRD"};
-    Configurable<bool> rejectSameBunchPileup{"rejectSameBunchPileup", false, "reject collisions in case of pileup with another collision in the same foundBC"};
-    Configurable<bool> requireNoCollInTimeRangeStd{"requireNoCollInTimeRangeStd", false, "reject collisions corrupted by the cannibalism, with other collisions within +/- 2 microseconds or mult above a certain threshold in -4 - -2 microseconds"};
-    Configurable<bool> requireNoCollInTimeRangeStrict{"requireNoCollInTimeRangeStrict", false, "reject collisions corrupted by the cannibalism, with other collisions within +/- 10 microseconds"};
-    Configurable<bool> requireNoCollInTimeRangeNarrow{"requireNoCollInTimeRangeNarrow", false, "reject collisions corrupted by the cannibalism, with other collisions within +/- 2 microseconds"};
-    Configurable<bool> requireNoCollInTimeRangeVzDep{"requireNoCollInTimeRangeVzDep", false, "reject collisions corrupted by the cannibalism, with other collisions with pvZ of drifting TPC tracks from past/future collisions within 2.5 cm the current pvZ"};
-    Configurable<bool> requireNoCollInROFStd{"requireNoCollInROFStd", false, "reject collisions corrupted by the cannibalism, with other collisions within the same ITS ROF with mult. above a certain threshold"};
-    Configurable<bool> requireNoCollInROFStrict{"requireNoCollInROFStrict", false, "reject collisions corrupted by the cannibalism, with other collisions within the same ITS ROF"};
-    Configurable<bool> requireINEL0{"requireINEL0", false, "require INEL>0 event selection"};
-    Configurable<bool> requireINEL1{"requireINEL1", false, "require INEL>1 event selection"};
-    Configurable<float> maxZVtxPosition{"maxZVtxPosition", 10., "max Z vtx position"};
-    Configurable<bool> useFT0CbasedOccupancy{"useFT0CbasedOccupancy", false, "Use sum of FT0-C amplitudes for estimating occupancy? (if not, use track-based definition)"};
-    // fast check on occupancy
-    Configurable<float> minOccupancy{"minOccupancy", -1, "minimum occupancy from neighbouring collisions"};
-    Configurable<float> maxOccupancy{"maxOccupancy", -1, "maximum occupancy from neighbouring collisions"};
-  } eventSelections;
 
   // Analysis strategy:
   Configurable<bool> fUseMLSel{"fUseMLSel", false, "Flag to use ML selection. If False, the standard selection is applied."};
@@ -202,6 +176,7 @@ struct sigmaanalysis {
 
   // ML
   ConfigurableAxis MLProb{"MLOutput", {100, 0.0f, 1.0f}, ""};
+  
   int nSigmaCandidates = 0;
   void init(InitContext const&)
   {
@@ -210,38 +185,10 @@ struct sigmaanalysis {
     ccdb->setCaching(true);
     ccdb->setFatalWhenNull(false);
 
-    // Event Counters
-    histos.add("hEventSelection", "hEventSelection", kTH1F, {{20, -0.5f, +18.5f}});
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(1, "All collisions");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(2, "sel8 cut");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(3, "kIsTriggerTVX");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(4, "kNoITSROFrameBorder");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(5, "kNoTimeFrameBorder");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(6, "posZ cut");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(7, "kIsVertexITSTPC");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(8, "kIsGoodZvtxFT0vsPV");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(9, "kIsVertexTOFmatched");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(10, "kIsVertexTRDmatched");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(11, "kNoSameBunchPileup");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(12, "kNoCollInTimeRangeStd");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(13, "kNoCollInTimeRangeStrict");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(14, "kNoCollInTimeRangeNarrow");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(15, "kNoCollInRofStd");
-    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(16, "kNoCollInRofStrict");
-    if (doPPAnalysis) {
-      histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(17, "INEL>0");
-      histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(18, "INEL>1");
-    } else {
-      histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(17, "Below min occup.");
-      histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(18, "Above max occup.");
-    }
-
     // All candidates received
     histos.add("GeneralQA/hRunNumberNegativeIR", "", kTH1D, {{1, 0., 1.}});
-    histos.add("GeneralQA/hInteractionRate", "hInteractionRate", kTH1F, {axisIRBinning});
-    histos.add("GeneralQA/hInteractionRatePerColl", "hInteractionRatePerColl", kTH1F, {axisIRBinning});
-    histos.add("GeneralQA/hCentralityVsInteractionRate", "hCentralityVsInteractionRate", kTH2F, {axisCentrality, axisIRBinning});
-    histos.add("GeneralQA/hCentralityVsInteractionRatePerColl", "hCentralityVsInteractionRatePerColl", kTH2F, {axisCentrality, axisIRBinning});
+    histos.add("GeneralQA/hInteractionRate", "hInteractionRate", kTH1F, {axisIRBinning});    
+    histos.add("GeneralQA/hCentralityVsInteractionRate", "hCentralityVsInteractionRate", kTH2F, {axisCentrality, axisIRBinning});    
     histos.add("GeneralQA/h2dArmenterosBeforeSel", "h2dArmenterosBeforeSel", {HistType::kTH2F, {axisAPAlpha, axisAPQt}});
     histos.add("GeneralQA/h2dArmenterosAfterSel", "h2dArmenterosAfterSel", {HistType::kTH2F, {axisAPAlpha, axisAPQt}});
     histos.add("GeneralQA/hMassSigma0BeforeSel", "hMassSigma0BeforeSel", kTH1F, {axisSigmaMass});
@@ -521,94 +468,6 @@ struct sigmaanalysis {
       histos.add("MC/h2dSigmaMCPtVsLambdaMCPt", "h2dSigmaMCPtVsLambdaMCPt", kTH2D, {axisPt, axisPt});
       histos.add("MC/h2dSigmaMCPtVsGammaMCPt", "h2dSigmaMCPtVsGammaMCPt", kTH2D, {axisPt, axisPt});
     }
-  }
-
-  template <typename TCollision>
-  bool IsEventAccepted(TCollision collision)
-  // check whether the collision passes our collision selections
-  {
-    histos.fill(HIST("hEventSelection"), 0. /* all collisions */);
-    if (eventSelections.requireSel8 && !collision.sel8()) {
-      return false;
-    }
-    histos.fill(HIST("hEventSelection"), 1 /* sel8 collisions */);
-    if (eventSelections.requireTriggerTVX && !collision.selection_bit(aod::evsel::kIsTriggerTVX)) {
-      return false;
-    }
-    histos.fill(HIST("hEventSelection"), 2 /* FT0 vertex (acceptable FT0C-FT0A time difference) collisions */);
-    if (eventSelections.rejectITSROFBorder && !collision.selection_bit(o2::aod::evsel::kNoITSROFrameBorder)) {
-      return false;
-    }
-    histos.fill(HIST("hEventSelection"), 3 /* Not at ITS ROF border */);
-    if (eventSelections.rejectTFBorder && !collision.selection_bit(o2::aod::evsel::kNoTimeFrameBorder)) {
-      return false;
-    }
-    histos.fill(HIST("hEventSelection"), 4 /* Not at TF border */);
-    if (std::abs(collision.posZ()) > eventSelections.maxZVtxPosition) {
-      return false;
-    }
-    histos.fill(HIST("hEventSelection"), 5 /* vertex-Z selected */);
-    if (eventSelections.requireIsVertexITSTPC && !collision.selection_bit(o2::aod::evsel::kIsVertexITSTPC)) {
-      return false;
-    }
-    histos.fill(HIST("hEventSelection"), 6 /* Contains at least one ITS-TPC track */);
-    if (eventSelections.requireIsGoodZvtxFT0VsPV && !collision.selection_bit(o2::aod::evsel::kIsGoodZvtxFT0vsPV)) {
-      return false;
-    }
-    histos.fill(HIST("hEventSelection"), 7 /* PV position consistency check */);
-    if (eventSelections.requireIsVertexTOFmatched && !collision.selection_bit(o2::aod::evsel::kIsVertexTOFmatched)) {
-      return false;
-    }
-    histos.fill(HIST("hEventSelection"), 8 /* PV with at least one contributor matched with TOF */);
-    if (eventSelections.requireIsVertexTRDmatched && !collision.selection_bit(o2::aod::evsel::kIsVertexTRDmatched)) {
-      return false;
-    }
-    histos.fill(HIST("hEventSelection"), 9 /* PV with at least one contributor matched with TRD */);
-    if (eventSelections.rejectSameBunchPileup && !collision.selection_bit(o2::aod::evsel::kNoSameBunchPileup)) {
-      return false;
-    }
-    histos.fill(HIST("hEventSelection"), 10 /* Not at same bunch pile-up */);
-    if (eventSelections.requireNoCollInTimeRangeStd && !collision.selection_bit(o2::aod::evsel::kNoCollInTimeRangeStandard)) {
-      return false;
-    }
-    histos.fill(HIST("hEventSelection"), 11 /* No other collision within +/- 2 microseconds or mult above a certain threshold in -4 - -2 microseconds*/);
-    if (eventSelections.requireNoCollInTimeRangeStrict && !collision.selection_bit(o2::aod::evsel::kNoCollInTimeRangeStrict)) {
-      return false;
-    }
-    histos.fill(HIST("hEventSelection"), 12 /* No other collision within +/- 10 microseconds */);
-    if (eventSelections.requireNoCollInTimeRangeNarrow && !collision.selection_bit(o2::aod::evsel::kNoCollInTimeRangeNarrow)) {
-      return false;
-    }
-    histos.fill(HIST("hEventSelection"), 13 /* No other collision within +/- 2 microseconds */);
-    if (eventSelections.requireNoCollInROFStd && !collision.selection_bit(o2::aod::evsel::kNoCollInRofStandard)) {
-      return false;
-    }
-    histos.fill(HIST("hEventSelection"), 14 /* No other collision within the same ITS ROF with mult. above a certain threshold */);
-    if (eventSelections.requireNoCollInROFStrict && !collision.selection_bit(o2::aod::evsel::kNoCollInRofStrict)) {
-      return false;
-    }
-    histos.fill(HIST("hEventSelection"), 15 /* No other collision within the same ITS ROF */);
-    if (doPPAnalysis) { // we are in pp
-      if (eventSelections.requireINEL0 && collision.multNTracksPVeta1() < 1) {
-        return false;
-      }
-      histos.fill(HIST("hEventSelection"), 16 /* INEL > 0 */);
-      if (eventSelections.requireINEL1 && collision.multNTracksPVeta1() < 2) {
-        return false;
-      }
-      histos.fill(HIST("hEventSelection"), 17 /* INEL > 1 */);
-    } else { // we are in Pb-Pb
-      float collisionOccupancy = eventSelections.useFT0CbasedOccupancy ? collision.ft0cOccupancyInTimeRange() : collision.trackOccupancyInTimeRange();
-      if (eventSelections.minOccupancy >= 0 && collisionOccupancy < eventSelections.minOccupancy) {
-        return false;
-      }
-      histos.fill(HIST("hEventSelection"), 16 /* Below min occupancy */);
-      if (eventSelections.maxOccupancy >= 0 && collisionOccupancy > eventSelections.maxOccupancy) {
-        return false;
-      }
-      histos.fill(HIST("hEventSelection"), 17 /* Above max occupancy */);
-    }
-    return true;
   }
 
   // Apply selections in sigma candidates
@@ -1187,23 +1046,9 @@ struct sigmaanalysis {
       histos.fill(HIST("GeneralQA/hPhotonMassSelected"), sigma.photonMass());
     }
   }
-
-  void processCollisions(soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraStamps> const& collisions)
-  {
-    for (const auto& coll : collisions) {
-      if (!IsEventAccepted(coll)) {
-        continue;
-      }
-      double interactionRate = rateFetcher.fetch(ccdb.service, coll.timestamp(), coll.runNumber(), irSource) * 1.e-3;
-      histos.fill(HIST("GeneralQA/hInteractionRatePerColl"), interactionRate);
-      histos.fill(HIST("GeneralQA/hCentralityVsInteractionRatePerColl"), coll.centFT0C(), interactionRate);
-    }
-  }
-
-  // PROCESS_SWITCH(sigmaanalysis, processCounterQA, "Check standard counter correctness", true);
+  
   PROCESS_SWITCH(sigmaanalysis, processMonteCarlo, "Do Monte-Carlo-based analysis", false);
-  PROCESS_SWITCH(sigmaanalysis, processRealData, "Do real data analysis", true);
-  PROCESS_SWITCH(sigmaanalysis, processCollisions, "Process collisions to retrieve IR info", false);
+  PROCESS_SWITCH(sigmaanalysis, processRealData, "Do real data analysis", true);  
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGLF/Tasks/Strangeness/sigmaanalysis.cxx
+++ b/PWGLF/Tasks/Strangeness/sigmaanalysis.cxx
@@ -961,7 +961,7 @@ struct sigmaanalysis {
       histos.fill(HIST("BuilderQA/hPhotonAssociation"), sigma.photonIsCorrectlyAssoc());
       histos.fill(HIST("BuilderQA/hLambdaAssociation"), sigma.lambdaIsCorrectlyAssoc());
 
-      int GammaTrkCode = -10; // 1: TPC-only, 2: TPC+Something, 3: ITS-Only
+      int GammaTrkCode = -10; // 1: TPC-only, 2: TPC+Something, 3: ITS-Only, 4: ITS+TPC + Something
       int LambdaTrkCode = -10; // 1: TPC-only, 2: TPC+Something, 3: ITS-Only, 4: ITS+TPC + Something
       
       if (sigma.photonPosTrackCode()==1 && sigma.photonNegTrackCode()==1)
@@ -970,6 +970,8 @@ struct sigmaanalysis {
         GammaTrkCode = 2;
       if (sigma.photonPosTrackCode()==3 && sigma.photonNegTrackCode()==3)
         GammaTrkCode = 3;
+      if (sigma.photonPosTrackCode()==2 || sigma.photonNegTrackCode()==2)
+        GammaTrkCode = 4;
       if (sigma.lambdaPosTrackCode()==1 && sigma.lambdaNegTrackCode()==1)
         LambdaTrkCode = 1;
       if ((sigma.lambdaPosTrackCode()!=1 && sigma.lambdaNegTrackCode()==1) || (sigma.lambdaPosTrackCode()==1 && sigma.lambdaNegTrackCode()!=1))
@@ -979,8 +981,10 @@ struct sigmaanalysis {
       if (sigma.lambdaPosTrackCode()==2 || sigma.lambdaNegTrackCode()==2)
         LambdaTrkCode = 4;
 
-      histos.fill(HIST("BuilderQA/hPhotonTrackCode"), GammaTrkCode);
-      histos.fill(HIST("BuilderQA/hLambdaTrackCode"), LambdaTrkCode);
+      if (sigma.photonIsCorrectlyAssoc()){  
+        histos.fill(HIST("BuilderQA/hPhotonTrackCode"), GammaTrkCode);
+        histos.fill(HIST("BuilderQA/hLambdaTrackCode"), LambdaTrkCode);
+      }
 
       if ((GammaTrkCode==1) && (TMath::Abs(sigma.photonY()) <= 0.5) && (sigma.photonCandPDGCode() == 22)){
         histos.fill(HIST("BuilderQA/hPhotonZ"), sigma.photonZconv());

--- a/PWGLF/Tasks/Strangeness/sigmaanalysis.cxx
+++ b/PWGLF/Tasks/Strangeness/sigmaanalysis.cxx
@@ -126,9 +126,7 @@ struct sigmaanalysis {
   Configurable<float> PhotonMaxDCAV0Dau{"PhotonMaxDCAV0Dau", 3.5, "Max DCA V0 Daughters (cm)"};
   Configurable<int> PhotonMinTPCCrossedRows{"PhotonMinTPCCrossedRows", 30, "Min daughter TPC Crossed Rows"};
   Configurable<float> PhotonMinTPCNSigmas{"PhotonMinTPCNSigmas", -7, "Min TPC NSigmas for daughters"};
-  Configurable<float> PhotonMaxTPCNSigmas{"PhotonMaxTPCNSigmas", 7, "Max TPC NSigmas for daughters"};
-  Configurable<float> PiMaxTPCNSigmas{"PiMaxTPCNSigmas", 1, "Max TPC NSigmas for pi rejection"};
-  Configurable<float> piMaxpT{"piMaxpT", 3.5, "Max pT for pi rejection"};
+  Configurable<float> PhotonMaxTPCNSigmas{"PhotonMaxTPCNSigmas", 7, "Max TPC NSigmas for daughters"};  
   Configurable<float> PhotonMinPt{"PhotonMinPt", 0.0, "Min photon pT (GeV/c)"};
   Configurable<float> PhotonMaxPt{"PhotonMaxPt", 50.0, "Max photon pT (GeV/c)"};
   Configurable<float> PhotonMaxRap{"PhotonMaxRap", 0.5, "Max photon rapidity"};
@@ -142,10 +140,10 @@ struct sigmaanalysis {
   Configurable<float> PhotonPsiPairMax{"PhotonPsiPairMax", 1e+9, "maximum psi angle of the track pair"};
   Configurable<float> PhotonMaxDauEta{"PhotonMaxDauEta", 0.8, "Max pseudorapidity of daughter tracks"};
   Configurable<float> PhotonLineCutZ0{"PhotonLineCutZ0", 7.0, "The offset for the linecute used in the Z vs R plot"};
-  Configurable<float> PhotonPhiMin1{"PhotonPhiMin1", -1, "Phi min value for photons, region 1 (leave negative if no selection desired)"};
-  Configurable<float> PhotonPhiMax1{"PhotonPhiMax1", -1, "Phi max value for photons, region 1 (leave negative if no selection desired)"};
-  Configurable<float> PhotonPhiMin2{"PhotonPhiMin2", -1, "Phi max value for photons, region 2 (leave negative if no selection desired)"};
-  Configurable<float> PhotonPhiMax2{"PhotonPhiMax2", -1, "Phi min value for photons, region 2 (leave negative if no selection desired)"};
+  Configurable<float> PhotonPhiMin1{"PhotonPhiMin1", -1, "Phi min value to reject photons, region 1 (leave negative if no selection desired)"};
+  Configurable<float> PhotonPhiMax1{"PhotonPhiMax1", -1, "Phi max value to reject photons, region 1 (leave negative if no selection desired)"};
+  Configurable<float> PhotonPhiMin2{"PhotonPhiMin2", -1, "Phi max value to reject photons, region 2 (leave negative if no selection desired)"};
+  Configurable<float> PhotonPhiMax2{"PhotonPhiMax2", -1, "Phi min value to reject photons, region 2 (leave negative if no selection desired)"};
 
   Configurable<float> SigmaMaxRap{"SigmaMaxRap", 0.5, "Max sigma0 rapidity"};
 
@@ -156,12 +154,12 @@ struct sigmaanalysis {
   ConfigurableAxis axisInvPt{"axisInvPt", {VARIABLE_WIDTH, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 2.0, 5.0, 10.0, 20.0, 50.0}, ""};
   ConfigurableAxis axisDeltaPt{"axisDeltaPt", {400, -50.0, 50.0}, ""};
   ConfigurableAxis axisRapidity{"axisRapidity", {100, -2.0f, 2.0f}, "Rapidity"};
-  ConfigurableAxis axisIRBinning{"axisIRBinning", {5000, 0, 1500}, "Binning for the interaction rate (kHz)"};
+  ConfigurableAxis axisIRBinning{"axisIRBinning", {150, 0, 1500}, "Binning for the interaction rate (kHz)"};
 
   // Invariant Mass
-  ConfigurableAxis axisSigmaMass{"axisSigmaMass", {1000, 1.10f, 1.30f}, "M_{#Sigma^{0}} (GeV/c^{2})"};
+  ConfigurableAxis axisSigmaMass{"axisSigmaMass", {500, 1.10f, 1.30f}, "M_{#Sigma^{0}} (GeV/c^{2})"};
   ConfigurableAxis axisLambdaMass{"axisLambdaMass", {200, 1.05f, 1.151f}, "M_{#Lambda} (GeV/c^{2})"};
-  ConfigurableAxis axisPhotonMass{"axisPhotonMass", {600, -0.1f, 0.5f}, "M_{#Gamma}"};
+  ConfigurableAxis axisPhotonMass{"axisPhotonMass", {200, -0.1f, 0.5f}, "M_{#Gamma}"};
 
   // AP plot axes
   ConfigurableAxis axisAPAlpha{"axisAPAlpha", {220, -1.1f, 1.1f}, "V0 AP alpha"};
@@ -173,7 +171,7 @@ struct sigmaanalysis {
   ConfigurableAxis axisChi2PerNcl{"axisChi2PerNcl", {80, -40, 40}, "Chi2 Per Ncl"};
   ConfigurableAxis axisTPCNSigma{"axisTPCNSigma", {120, -30, 30}, "TPC NSigma"};
   ConfigurableAxis axisTOFNSigma{"axisTOFNSigma", {120, -30, 30}, "TOF NSigma"};
-  ConfigurableAxis axisLifetime{"axisLifetime", {200, 0, 200}, "Chi2 Per Ncl"};
+  ConfigurableAxis axisLifetime{"axisLifetime", {100, 0, 100}, "Chi2 Per Ncl"};
 
   // topological variable QA axes
   ConfigurableAxis axisRadius{"axisRadius", {240, 0.0f, 120.0f}, "V0 radius (cm)"};
@@ -181,7 +179,7 @@ struct sigmaanalysis {
   ConfigurableAxis axisDCAdau{"axisDCAdau", {50, 0.0f, 5.0f}, "DCA (cm)"};
   ConfigurableAxis axisCosPA{"axisCosPA", {200, 0.5f, 1.0f}, "Cosine of pointing angle"};
   ConfigurableAxis axisPA{"axisPA", {100, 0.0f, 1}, "Pointing angle"};
-  ConfigurableAxis axisPsiPair{"axisPsiPair", {500, -5.0f, 5.0f}, "Psipair for photons"};
+  ConfigurableAxis axisPsiPair{"axisPsiPair", {250, -5.0f, 5.0f}, "Psipair for photons"};
   ConfigurableAxis axisPhi{"axisPhi", {200, 0, 2 * o2::constants::math::PI}, "Phi for photons"};  
   ConfigurableAxis axisZ{"axisZ", {120, -120.0f, 120.0f}, "V0 Z position (cm)"};
 
@@ -190,7 +188,6 @@ struct sigmaanalysis {
   // ML
   ConfigurableAxis MLProb{"MLOutput", {100, 0.0f, 1.0f}, ""};
 
-  int nSigmaCandidates = 0;
   void init(InitContext const&)
   {        
 
@@ -345,7 +342,7 @@ struct sigmaanalysis {
       const auto& sel = PhotonSels[i];
     
       histos.add(Form("Selection/Photon/h2d%s", sel.c_str()), ("h2d" + sel).c_str(), kTH2F, {axisPt, axisPhotonMass});
-      histos.get<TH1>(HIST("Selection/Photon/hCandidateSel"))->GetXaxis()->SetBinLabel(i + 1, sel.c_str());
+      histos.get<TH1>(HIST("Selection/Photon/hCandidateSel"))->GetXaxis()->SetBinLabel(i+1, sel.c_str());
       histos.add(Form("Selection/Sigma0/h2dPhoton%s", sel.c_str()), ("h2dPhoton" + sel).c_str(), kTH2F, {axisPt, axisSigmaMass});
     }
 
@@ -353,7 +350,7 @@ struct sigmaanalysis {
       const auto& sel = LambdaSels[i];
     
       histos.add(Form("Selection/Lambda/h2d%s", sel.c_str()), ("h2d" + sel).c_str(), kTH2F, {axisPt, axisLambdaMass});
-      histos.get<TH1>(HIST("Selection/Lambda/hCandidateSel"))->GetXaxis()->SetBinLabel(i + 1, sel.c_str());
+      histos.get<TH1>(HIST("Selection/Lambda/hCandidateSel"))->GetXaxis()->SetBinLabel(i+1, sel.c_str());
       histos.add(Form("Selection/Sigma0/h2dLambda%s", sel.c_str()), ("h2dLambda" + sel).c_str(), kTH2F, {axisPt, axisSigmaMass});
     }
     
@@ -574,91 +571,91 @@ struct sigmaanalysis {
 
     //_______________________________________
     // MC specific              
-    //if (doprocessMonteCarlo && isMC) {
+    if (doprocessMonteCarlo) {
+      if constexpr (requires { sigma.lambdaCandPDGCode(); sigma.photonCandPDGCode(); }){
+        
+        //_______________________________________
+        // Gamma MC association
+        if (sigma.photonCandPDGCode()==22){        
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/hV0ToCollAssoc"), sigma.photonIsCorrectlyAssoc());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/hPt"), sigma.photonPt());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/hMCPt"), sigma.photonMCPt());
+        
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h2dPosTPCNSigmaEl"), sigma.photonPosPt(), sigma.photonPosTPCNSigmaEl());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h2dNegTPCNSigmaEl"), sigma.photonNegPt(), sigma.photonNegTPCNSigmaEl());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h2dPosTPCNSigmaPi"), sigma.photonPosPt(), sigma.photonPosTPCNSigmaPi());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h2dNegTPCNSigmaPi"), sigma.photonNegPt(), sigma.photonNegTPCNSigmaPi());
+                  
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h2dIRVsPt"), sigma.sigmaIR(), sigma.photonMCPt());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h3dPAVsIRVsPt"), TMath::ACos(sigma.photonCosPA()), sigma.sigmaIR(), sigma.photonMCPt());
 
-    if constexpr (requires { sigma.lambdaCandPDGCode(); sigma.photonCandPDGCode(); }){
-      
-      //_______________________________________
-      // Gamma MC association
-      if (sigma.photonCandPDGCode()==22){        
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/hV0ToCollAssoc"), sigma.photonIsCorrectlyAssoc());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/hPt"), sigma.photonPt());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/hMCPt"), sigma.photonMCPt());
-      
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h2dPosTPCNSigmaEl"), sigma.photonPosPt(), sigma.photonPosTPCNSigmaEl());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h2dNegTPCNSigmaEl"), sigma.photonNegPt(), sigma.photonNegTPCNSigmaEl());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h2dPosTPCNSigmaPi"), sigma.photonPosPt(), sigma.photonPosTPCNSigmaPi());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h2dNegTPCNSigmaPi"), sigma.photonNegPt(), sigma.photonNegTPCNSigmaPi());
-                
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h2dIRVsPt"), sigma.sigmaIR(), sigma.photonMCPt());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h3dPAVsIRVsPt"), TMath::ACos(sigma.photonCosPA()), sigma.sigmaIR(), sigma.photonMCPt());
-
-        if (!sigma.photonIsCorrectlyAssoc()){
-          histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h2dIRVsPt_BadCollAssig"), sigma.sigmaIR(), sigma.photonMCPt());
-          histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h3dPAVsIRVsPt_BadCollAssig"), TMath::ACos(sigma.photonCosPA()), sigma.sigmaIR(), sigma.photonMCPt());          
+          if (!sigma.photonIsCorrectlyAssoc()){
+            histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h2dIRVsPt_BadCollAssig"), sigma.sigmaIR(), sigma.photonMCPt());
+            histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h3dPAVsIRVsPt_BadCollAssig"), TMath::ACos(sigma.photonCosPA()), sigma.sigmaIR(), sigma.photonMCPt());          
+          }
         }
-      }
 
-      //_______________________________________
-      // Lambda MC association
-      if (sigma.lambdaCandPDGCode()==3122){
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/Lambda/hV0ToCollAssoc"), sigma.lambdaIsCorrectlyAssoc());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/Lambda/hPt"), sigma.lambdaPt());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/Lambda/hMCPt"), sigma.lambdaMCPt());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/Lambda/h3dTPCvsTOFNSigma_Pr"), sigma.lambdaPosPrTPCNSigma(), sigma.lambdaPrTOFNSigma(), sigma.lambdaPt());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/Lambda/h3dTPCvsTOFNSigma_Pi"), sigma.lambdaNegPiTPCNSigma(), sigma.lambdaPiTOFNSigma(), sigma.lambdaPt());
-      }
+        //_______________________________________
+        // Lambda MC association
+        if (sigma.lambdaCandPDGCode()==3122){
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Lambda/hV0ToCollAssoc"), sigma.lambdaIsCorrectlyAssoc());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Lambda/hPt"), sigma.lambdaPt());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Lambda/hMCPt"), sigma.lambdaMCPt());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Lambda/h3dTPCvsTOFNSigma_Pr"), sigma.lambdaPosPrTPCNSigma(), sigma.lambdaPrTOFNSigma(), sigma.lambdaPt());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Lambda/h3dTPCvsTOFNSigma_Pi"), sigma.lambdaNegPiTPCNSigma(), sigma.lambdaPiTOFNSigma(), sigma.lambdaPt());
+        }
 
-      //_______________________________________
-      // AntiLambda MC association
-      if (sigma.lambdaCandPDGCode() == -3122){
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/ALambda/hV0ToCollAssoc"), sigma.lambdaIsCorrectlyAssoc());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/ALambda/hPt"), sigma.lambdaPt());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/ALambda/hMCPt"), sigma.lambdaMCPt());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/ALambda/h3dTPCvsTOFNSigma_Pr"), sigma.lambdaNegPrTPCNSigma(), sigma.aLambdaPrTOFNSigma(), sigma.lambdaPt());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/ALambda/h3dTPCvsTOFNSigma_Pi"), sigma.lambdaPosPiTPCNSigma(), sigma.aLambdaPiTOFNSigma(), sigma.lambdaPt());
-      }
+        //_______________________________________
+        // AntiLambda MC association
+        if (sigma.lambdaCandPDGCode() == -3122){
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/ALambda/hV0ToCollAssoc"), sigma.lambdaIsCorrectlyAssoc());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/ALambda/hPt"), sigma.lambdaPt());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/ALambda/hMCPt"), sigma.lambdaMCPt());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/ALambda/h3dTPCvsTOFNSigma_Pr"), sigma.lambdaNegPrTPCNSigma(), sigma.aLambdaPrTOFNSigma(), sigma.lambdaPt());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/ALambda/h3dTPCvsTOFNSigma_Pi"), sigma.lambdaPosPiTPCNSigma(), sigma.aLambdaPiTOFNSigma(), sigma.lambdaPt());
+        }
 
-      //_______________________________________
-      // Sigma0 MC association
-      if (sigma.isSigma()){
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/h2dArmenteros"), sigma.photonAlpha(), sigma.photonQt());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/h2dArmenteros"), sigma.lambdaAlpha(), sigma.lambdaQt());
+        //_______________________________________
+        // Sigma0 MC association
+        if (sigma.isSigma()){
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/h2dArmenteros"), sigma.photonAlpha(), sigma.photonQt());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/h2dArmenteros"), sigma.lambdaAlpha(), sigma.lambdaQt());
 
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/Sigma0/hPt"), sigma.sigmapT());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/Sigma0/hMCPt"), sigma.sigmaMCPt());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/Sigma0/h2dMCPtVsLambdaMCPt"), sigma.sigmaMCPt(), sigma.lambdaMCPt());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/Sigma0/h2dMCPtVsGammaMCPt"), sigma.sigmaMCPt(), sigma.photonMCPt());                          
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/Sigma0/hMass"), sigma.sigmaMass());        
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/Sigma0/h3dMass"), sigma.sigmaCentrality(), sigma.sigmapT(), sigma.sigmaMass());          
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Sigma0/hPt"), sigma.sigmapT());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Sigma0/hMCPt"), sigma.sigmaMCPt());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Sigma0/h2dMCPtVsLambdaMCPt"), sigma.sigmaMCPt(), sigma.lambdaMCPt());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Sigma0/h2dMCPtVsGammaMCPt"), sigma.sigmaMCPt(), sigma.photonMCPt());                          
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Sigma0/hMass"), sigma.sigmaMass());        
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Sigma0/h3dMass"), sigma.sigmaCentrality(), sigma.sigmapT(), sigma.sigmaMass());          
 
-      }
+        }
 
-      //_______________________________________
-      // AntiSigma0 MC association
-      if (sigma.isAntiSigma()){
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/h2dArmenteros"), sigma.photonAlpha(), sigma.photonQt());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/h2dArmenteros"), sigma.lambdaAlpha(), sigma.lambdaQt());
+        //_______________________________________
+        // AntiSigma0 MC association
+        if (sigma.isAntiSigma()){
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/h2dArmenteros"), sigma.photonAlpha(), sigma.photonQt());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/h2dArmenteros"), sigma.lambdaAlpha(), sigma.lambdaQt());
 
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/ASigma0/hPt"), sigma.sigmapT());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/ASigma0/hMCPt"), sigma.sigmaMCPt());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/ASigma0/h2dMCPtVsLambdaMCPt"), sigma.sigmaMCPt(), sigma.lambdaMCPt());
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/ASigma0/h2dMCPtVsPhotonMCPt"), sigma.sigmaMCPt(), sigma.photonMCPt());                          
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/ASigma0/hMass"), sigma.sigmaMass());        
-        histos.fill(HIST(MainDir[mode])+HIST("/MC/ASigma0/h3dMass"), sigma.sigmaCentrality(), sigma.sigmapT(), sigma.sigmaMass());          
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/ASigma0/hPt"), sigma.sigmapT());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/ASigma0/hMCPt"), sigma.sigmaMCPt());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/ASigma0/h2dMCPtVsLambdaMCPt"), sigma.sigmaMCPt(), sigma.lambdaMCPt());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/ASigma0/h2dMCPtVsPhotonMCPt"), sigma.sigmaMCPt(), sigma.photonMCPt());                          
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/ASigma0/hMass"), sigma.sigmaMass());        
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/ASigma0/h3dMass"), sigma.sigmaCentrality(), sigma.sigmapT(), sigma.sigmaMass());          
 
-      }
-          
-      // For background studies:
-      if (fillBkgQAhistos) 
-        runBkgAnalysis<mode>(sigma); 
+        }
+            
+        // For background studies:
+        if (fillBkgQAhistos) 
+          runBkgAnalysis<mode>(sigma); 
 
-      //_______________________________________          
-      // pT resolution histos
-      if ((mode==0) && fillpTResoQAhistos)
-        getpTResolution(sigma);  
-      
-    }            
+        //_______________________________________          
+        // pT resolution histos
+        if ((mode==0) && fillpTResoQAhistos)
+          getpTResolution(sigma);  
+        
+      } 
+    }           
   }
 
   template <int selection_index, typename TV0Object>
@@ -673,20 +670,9 @@ struct sigmaanalysis {
                                                            "CosPA", "Y", "TPCCR", "DauITSCls", "Lifetime", 
                                                            "TPCTOFPID", "DCADauToPV", "Mass"};
       
-    bool isMCTruePhoton = false;
-    bool isMCTrueLambda = false;  
-
-    
-    if constexpr (requires { sigma.lambdaCandPDGCode(); sigma.photonCandPDGCode(); }){      
-      if (sigma.photonCandPDGCode() == 22)
-        isMCTruePhoton = true;
-      if (TMath::Abs(sigma.lambdaCandPDGCode()) == 3122)
-        isMCTrueLambda = true;      
-    }
-    
-            
-    if ((PDGRequired==22) || isMCTruePhoton){  
-      //if (selection_index < 0 || selection_index >= (int)PhotonSels.size()) return;  // safeguard  
+  
+          
+    if (PDGRequired==22){         
       if constexpr (selection_index >= 0 && selection_index < (int)std::size(PhotonSelsLocal)){
         histos.fill(HIST("Selection/Photon/hCandidateSel"), selection_index);
         histos.fill(HIST("Selection/Photon/h2d")+HIST(PhotonSelsLocal[selection_index]), sigma.photonPt(), sigma.photonMass());
@@ -695,8 +681,7 @@ struct sigmaanalysis {
       
     }
      
-    if ((TMath::Abs(PDGRequired)==3122) || isMCTrueLambda){
-      //if (selection_index < 0 || selection_index >= (int)LambdaSels.size()) return; // safeguard
+    if (PDGRequired==3122){      
       if constexpr (selection_index >= 0 && selection_index < (int)std::size(LambdaSelsLocal)){
         histos.fill(HIST("Selection/Lambda/hCandidateSel"), selection_index);
         histos.fill(HIST("Selection/Lambda/h2d")+HIST(LambdaSelsLocal[selection_index]), sigma.lambdaPt(), sigma.lambdaMass());
@@ -710,82 +695,74 @@ struct sigmaanalysis {
   template <typename TV0Object>
   bool selectPhoton(TV0Object const& cand)
   {
-    fillSelHistos<1>(cand, 22);      
+    fillSelHistos<0>(cand, 22);      
     if (cand.photonV0Type() != Photonv0TypeSel && Photonv0TypeSel > -1)
       return false;
 
-    fillSelHistos<2>(cand, 22);
+    fillSelHistos<1>(cand, 22);
     if ((cand.photonPosPt() < PhotonDauMinPt) || (cand.photonNegPt() < PhotonDauMinPt))
       return false;
 
-    fillSelHistos<3>(cand, 22);
+    fillSelHistos<2>(cand, 22);
     if ((TMath::Abs(cand.photonDCAPosPV()) < PhotonMinDCADauToPv) || (TMath::Abs(cand.photonDCANegPV()) < PhotonMinDCADauToPv))
       return false;
 
-    fillSelHistos<4>(cand, 22);
+    fillSelHistos<3>(cand, 22);
     if (TMath::Abs(cand.photonDCADau()) > PhotonMaxDCAV0Dau)
       return false;
 
-    fillSelHistos<5>(cand, 22);
+    fillSelHistos<4>(cand, 22);
     if ((cand.photonPosTPCCrossedRows() < PhotonMinTPCCrossedRows) || (cand.photonNegTPCCrossedRows() < PhotonMinTPCCrossedRows))
       return false;
     
-    fillSelHistos<6>(cand, 22);
+    fillSelHistos<5>(cand, 22);
     if (((cand.photonPosTPCNSigmaEl() < PhotonMinTPCNSigmas) || (cand.photonPosTPCNSigmaEl() > PhotonMaxTPCNSigmas)))
       return false;
     
-    fillSelHistos<7>(cand, 22);
     if (((cand.photonNegTPCNSigmaEl() < PhotonMinTPCNSigmas) || (cand.photonNegTPCNSigmaEl() > PhotonMaxTPCNSigmas)))
       return false;
     
-    fillSelHistos<8>(cand, 22);
-    if (((TMath::Abs(cand.photonPosTPCNSigmaPi()) < PiMaxTPCNSigmas) && cand.photonPosPt() <= piMaxpT))
-      return false;
-    
-    if (((TMath::Abs(cand.photonNegTPCNSigmaPi()) < PiMaxTPCNSigmas) && cand.photonNegPt() <= piMaxpT))
-      return false;
-  
-    fillSelHistos<9>(cand, 22);
+    fillSelHistos<6>(cand, 22);
     if ((cand.photonPt() < PhotonMinPt) || (cand.photonPt() > PhotonMaxPt))
       return false;
 
-    fillSelHistos<10>(cand, 22);
+    fillSelHistos<7>(cand, 22);
     if ((TMath::Abs(cand.photonY()) > PhotonMaxRap) || (TMath::Abs(cand.photonPosEta()) > PhotonMaxDauEta) || (TMath::Abs(cand.photonNegEta()) > PhotonMaxDauEta))
       return false;
 
-    fillSelHistos<11>(cand, 22);
+    fillSelHistos<8>(cand, 22);
     if ((cand.photonRadius() < PhotonMinRadius) || (cand.photonRadius() > PhotonMaxRadius))
       return false;
 
-    fillSelHistos<12>(cand, 22);
+    fillSelHistos<9>(cand, 22);
     float photonRZLineCut = TMath::Abs(cand.photonZconv()) * TMath::Tan(2 * TMath::ATan(TMath::Exp(-PhotonMaxDauEta))) - PhotonLineCutZ0;      
     if ((TMath::Abs(cand.photonRadius()) < photonRZLineCut) || (TMath::Abs(cand.photonZconv()) > PhotonMaxZ))
       return false;
 
-    fillSelHistos<13>(cand, 22);
+    fillSelHistos<10>(cand, 22);
     if (cand.photonQt() > PhotonMaxQt)
       return false;
     
     if (TMath::Abs(cand.photonAlpha()) > PhotonMaxAlpha)
       return false;
 
-    fillSelHistos<14>(cand, 22);
+    fillSelHistos<11>(cand, 22);
     if (cand.photonCosPA() < PhotonMinV0cospa)
       return false;
 
-    fillSelHistos<15>(cand, 22);
+    fillSelHistos<12>(cand, 22);
     if (TMath::Abs(cand.photonPsiPair()) > PhotonPsiPairMax)
       return false;
 
-    fillSelHistos<16>(cand, 22);
-    if (((cand.photonPhi() < PhotonPhiMin1) || ((cand.photonPhi() > PhotonPhiMax1) && (cand.photonPhi() < PhotonPhiMin2)) || ((cand.photonPhi() > PhotonPhiMax2) && (PhotonPhiMax2 != -1))))
+    fillSelHistos<13>(cand, 22);
+    if ((((cand.photonPhi() > PhotonPhiMin1) && (cand.photonPhi() < PhotonPhiMax1)) || ((cand.photonPhi() > PhotonPhiMin2) && (cand.photonPhi() < PhotonPhiMax2))) && ((PhotonPhiMin1!=-1) && (PhotonPhiMax1!=-1) && (PhotonPhiMin2!=-1) && (PhotonPhiMax2!=-1))) 
       return false;
 
-    fillSelHistos<17>(cand, 22);
+    fillSelHistos<14>(cand, 22);
     if (TMath::Abs(cand.photonMass()) > PhotonMaxMass)
       return false;
 
-    //fillSelHistos<18>(cand, 22);
+    fillSelHistos<15>(cand, 22);
     return true;
   }
 
@@ -793,34 +770,34 @@ struct sigmaanalysis {
   template <typename TV0Object>
   bool selectLambda(TV0Object const& cand)
   {    
-    fillSelHistos<1>(cand, 3122);      
+    fillSelHistos<0>(cand, 3122);      
     if ((cand.lambdaRadius() < LambdaMinv0radius) || (cand.lambdaRadius() > LambdaMaxv0radius))
       return false;
     
-    fillSelHistos<2>(cand, 3122);
+    fillSelHistos<1>(cand, 3122);
     if (TMath::Abs(cand.lambdaDCADau()) > LambdaMaxDCAV0Dau)
       return false;
 
-    fillSelHistos<3>(cand, 3122);
+    fillSelHistos<2>(cand, 3122);
     if ((cand.lambdaQt() < LambdaMinQt) || (cand.lambdaQt() > LambdaMaxQt))
       return false;
     
     if ((TMath::Abs(cand.lambdaAlpha()) < LambdaMinAlpha) || (TMath::Abs(cand.lambdaAlpha()) > LambdaMaxAlpha))
       return false;
 
-    fillSelHistos<4>(cand, 3122);
+    fillSelHistos<3>(cand, 3122);
     if (cand.lambdaCosPA() < LambdaMinv0cospa)
       return false;
 
-    fillSelHistos<5>(cand, 3122);
+    fillSelHistos<4>(cand, 3122);
     if ((TMath::Abs(cand.lambdaY()) > LambdaMaxRap) || (TMath::Abs(cand.lambdaPosEta()) > LambdaMaxDauEta) || (TMath::Abs(cand.lambdaNegEta()) > LambdaMaxDauEta))
       return false;
 
-    fillSelHistos<6>(cand, 3122);
+    fillSelHistos<5>(cand, 3122);
     if ((cand.lambdaPosTPCCrossedRows() < LambdaMinTPCCrossedRows) || (cand.lambdaNegTPCCrossedRows() < LambdaMinTPCCrossedRows))
       return false;
 
-    fillSelHistos<7>(cand, 3122);
+    fillSelHistos<6>(cand, 3122);
     // check minimum number of ITS clusters + reject ITS afterburner tracks if requested
     bool posIsFromAfterburner = cand.lambdaPosChi2PerNcl() < 0;
     bool negIsFromAfterburner = cand.lambdaNegChi2PerNcl() < 0;
@@ -829,12 +806,12 @@ struct sigmaanalysis {
     if (cand.lambdaNegITSCls() < LambdaMinITSclusters && (!LambdaRejectNegITSafterburner || negIsFromAfterburner))
       return false;
     
-    fillSelHistos<8>(cand, 3122);
+    fillSelHistos<7>(cand, 3122);
     if (cand.lambdaLifeTime() > LambdaMaxLifeTime)
       return false;
 
     // Separating lambda and antilambda selections:
-    fillSelHistos<9>(cand, 3122);    
+    fillSelHistos<8>(cand, 3122);    
     if (cand.lambdaAlpha() > 0) { // Lambda selection      
       // TPC Selection
       if (fselLambdaTPCPID && (TMath::Abs(cand.lambdaPosPrTPCNSigma()) > LambdaMaxTPCNSigmas))
@@ -849,16 +826,16 @@ struct sigmaanalysis {
         return false;
       
       // DCA Selection              
-      fillSelHistos<10>(cand, 3122);
+      fillSelHistos<9>(cand, 3122);
       if ((TMath::Abs(cand.lambdaDCAPosPV()) < LambdaMinDCAPosToPv) || (TMath::Abs(cand.lambdaDCANegPV()) < LambdaMinDCANegToPv))
         return false;
 
       // Mass Selection
-      fillSelHistos<11>(cand, 3122);
+      fillSelHistos<10>(cand, 3122);
       if (TMath::Abs(cand.lambdaMass() - o2::constants::physics::MassLambda0) > LambdaWindow)
         return false;
 
-      //fillSelHistos<12>(cand, 3122);
+      fillSelHistos<11>(cand, 3122);
 
     } else { // AntiLambda selection
       
@@ -875,16 +852,16 @@ struct sigmaanalysis {
         return false;
       
       // DCA Selection        
-      fillSelHistos<10>(cand, 3122);
+      fillSelHistos<9>(cand, 3122);
       if ((TMath::Abs(cand.lambdaDCAPosPV()) < ALambdaMinDCAPosToPv) || (TMath::Abs(cand.lambdaDCANegPV()) < ALambdaMinDCANegToPv))
         return false;
       
       // Mass Selection      
-      fillSelHistos<11>(cand, 3122);
+      fillSelHistos<10>(cand, 3122);
       if (TMath::Abs(cand.antilambdaMass() - o2::constants::physics::MassLambda0) > LambdaWindow)
         return false;
       
-      //fillSelHistos<12>(cand, 3122);
+      fillSelHistos<11>(cand, 3122);
     }
     
     return true;
@@ -953,11 +930,6 @@ struct sigmaanalysis {
                        
       // Fill histos after all selections
       fillQAHistos<1>(sigma);
-
-      nSigmaCandidates++;
-      if (nSigmaCandidates % 100000 == 0) {
-        LOG(info) << "Sigma0 Candidates processed: " << nSigmaCandidates;
-      }
     }
   }
 
@@ -973,12 +945,7 @@ struct sigmaanalysis {
         continue;
                        
       // Fill histos after all selections
-      fillQAHistos<1>(sigma);
-      
-      nSigmaCandidates++;
-      if (nSigmaCandidates % 100000 == 0) {
-        LOG(info) << "Sigma0 Candidates processed: " << nSigmaCandidates;
-      }
+      fillQAHistos<1>(sigma);          
     }
   }
   

--- a/PWGLF/Tasks/Strangeness/sigmaanalysis.cxx
+++ b/PWGLF/Tasks/Strangeness/sigmaanalysis.cxx
@@ -37,7 +37,6 @@
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/Centrality.h"
 #include "Common/DataModel/PIDResponse.h"
-#include "Common/CCDB/ctpRateFetcher.h"
 #include "PWGLF/DataModel/LFStrangenessTables.h"
 #include "PWGLF/DataModel/LFStrangenessPIDTables.h"
 #include "PWGLF/DataModel/LFStrangenessMLTables.h"
@@ -58,22 +57,32 @@ using std::array;
 using V0MCSigmas = soa::Join<aod::Sigma0Cores, aod::SigmaPhotonExtras, aod::SigmaLambdaExtras, aod::SigmaMCCores>;
 using V0Sigmas = soa::Join<aod::Sigma0Cores, aod::SigmaPhotonExtras, aod::SigmaLambdaExtras>;
 
-struct sigmaanalysis {
-  Service<o2::ccdb::BasicCCDBManager> ccdb;
-  ctpRateFetcher rateFetcher;
+static const std::vector<std::string> PhotonSels = {"NoSel", "V0Type", "DaupT", "DCADauToPV", 
+                                      "DCADau", "DauTPCCR", "TPCNSigmaEl", "V0pT", 
+                                      "Y", "V0Radius", "RZCut", "Armenteros", "CosPA", 
+                                      "PsiPair", "Phi", "Mass"};
+
+static const std::vector<std::string> LambdaSels = {"NoSel", "V0Radius", "DCADau", "Armenteros", 
+                                      "CosPA", "Y", "TPCCR", "DauITSCls", "Lifetime", 
+                                      "TPCTOFPID", "DCADauToPV", "Mass"};
+                                      
+
+static const  std::vector<std::string> DirList = {"BeforeSel", "AfterSel"};
+
+struct sigmaanalysis {  
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
 
-  // Interaction rate selection:
-  // Event selection  
-  Configurable<bool> fGetIR{"fGetIR", false, "Flag to retrieve the IR info."};
-  Configurable<bool> fIRCrashOnNull{"fIRCrashOnNull", false, "Flag to avoid CTP RateFetcher crash."};
-  Configurable<std::string> irSource{"irSource", "T0VTX", "Estimator of the interaction rate (Recommended: pp --> T0VTX, Pb-Pb --> ZNC hadronic)"};
+  Configurable<bool> fillQAhistos{"fillQAhistos", false, "if true, fill QA histograms"};
+  Configurable<bool> fillBkgQAhistos{"fillBkgQAhistos", false, "if true, fill MC QA histograms for Bkg study. Only works with MC."};
+  Configurable<bool> fillpTResoQAhistos{"fillpTResoQAhistos", false, "if true, fill MC QA histograms for pT resolution study. Only works with MC."};
+  
+  // Interaction rate selection:  
+  Configurable<bool> fGetIR{"fGetIR", false, "Flag to retrieve the IR info."};  
   Configurable<float> minIR{"minIR", -1, "Min Interaction Rate (kHz). Leave -1 if no selection desired."};
   Configurable<float> maxIR{"maxIR", -1, "Max Interaction Rate (kHz). Leave -1 if no selection desired."};
 
   // Analysis strategy:
-  Configurable<bool> fUseMLSel{"fUseMLSel", false, "Flag to use ML selection. If False, the standard selection is applied."};
-  Configurable<bool> fProcessMonteCarlo{"fProcessMonteCarlo", false, "Flag to process MC data."};
+  Configurable<bool> fUseMLSel{"fUseMLSel", false, "Flag to use ML selection. If False, the standard selection is applied."};  
   Configurable<bool> fselLambdaTPCPID{"fselLambdaTPCPID", true, "Flag to select lambda-like candidates using TPC NSigma."};
   Configurable<bool> fselLambdaTOFPID{"fselLambdaTOFPID", false, "Flag to select lambda-like candidates using TOF NSigma."};
   Configurable<bool> doMCAssociation{"doMCAssociation", false, "Flag to process only signal candidates. Use only with processMonteCarlo!"};
@@ -171,314 +180,731 @@ struct sigmaanalysis {
   ConfigurableAxis axisDCAtoPV{"axisDCAtoPV", {500, 0.0f, 50.0f}, "DCA (cm)"};
   ConfigurableAxis axisDCAdau{"axisDCAdau", {50, 0.0f, 5.0f}, "DCA (cm)"};
   ConfigurableAxis axisCosPA{"axisCosPA", {200, 0.5f, 1.0f}, "Cosine of pointing angle"};
+  ConfigurableAxis axisPA{"axisPA", {100, 0.0f, 1}, "Pointing angle"};
   ConfigurableAxis axisPsiPair{"axisPsiPair", {500, -5.0f, 5.0f}, "Psipair for photons"};
-  ConfigurableAxis axisCandSel{"axisCandSel", {32, 0.5f, +32.5f}, "Candidate Selection"};
+  ConfigurableAxis axisPhi{"axisPhi", {200, 0, 2 * o2::constants::math::PI}, "Phi for photons"};  
+  ConfigurableAxis axisZ{"axisZ", {120, -120.0f, 120.0f}, "V0 Z position (cm)"};
+
+  ConfigurableAxis axisCandSel{"axisCandSel", {20, 0.5f, +20.5f}, "Candidate Selection"};
 
   // ML
   ConfigurableAxis MLProb{"MLOutput", {100, 0.0f, 1.0f}, ""};
-  
+
   int nSigmaCandidates = 0;
   void init(InitContext const&)
-  {
-    // setting CCDB service
-    ccdb->setURL("http://alice-ccdb.cern.ch");
-    ccdb->setCaching(true);
-    ccdb->setFatalWhenNull(false);
+  {        
 
-    // All candidates received
-    histos.add("GeneralQA/hRunNumberNegativeIR", "", kTH1D, {{1, 0., 1.}});
-    histos.add("GeneralQA/hInteractionRate", "hInteractionRate", kTH1F, {axisIRBinning});    
-    histos.add("GeneralQA/hCentralityVsInteractionRate", "hCentralityVsInteractionRate", kTH2F, {axisCentrality, axisIRBinning});    
-    histos.add("GeneralQA/h2dArmenterosBeforeSel", "h2dArmenterosBeforeSel", {HistType::kTH2F, {axisAPAlpha, axisAPQt}});
-    histos.add("GeneralQA/h2dArmenterosAfterSel", "h2dArmenterosAfterSel", {HistType::kTH2F, {axisAPAlpha, axisAPQt}});
-    histos.add("GeneralQA/hMassSigma0BeforeSel", "hMassSigma0BeforeSel", kTH1F, {axisSigmaMass});
+    for (const auto& histodir : DirList) {
 
-    // Candidates Counters
-    histos.add("GeneralQA/hCandidateAnalysisSelection", "hCandidateAnalysisSelection", kTH1F, {axisCandSel});
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(1, "No Sel");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(2, "Photon V0Type");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(3, "Photon DauPt");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(4, "Photon DCAToPV");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(5, "Photon DCADau");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(6, "Photon TPCCrossedRows");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(7, "Photon TPCNSigmaEl");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(8, "Photon TPCNSigmaPi");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(9, "Photon Pt");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(10, "Photon Y/Eta");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(11, "Photon Radius");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(12, "Photon RZ line");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(13, "Photon QT");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(14, "Photon Alpha");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(15, "Photon CosPA");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(16, "Photon PsiPair");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(17, "Photon Phi");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(18, "Photon Mass");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(19, "Lambda Radius");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(20, "Lambda DCADau");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(21, "Lambda QT");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(22, "Lambda Alpha");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(23, "Lambda CosPA");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(24, "Lambda Y/Eta");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(25, "Lambda TPCCrossedRows");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(26, "Lambda ITSNCls");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(27, "Lambda Lifetime");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(28, "Lambda/ALambda PID");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(29, "Lambda/ALambda DCAToPV");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(30, "Lambda/ALambda Mass");
-    histos.get<TH1>(HIST("GeneralQA/hCandidateAnalysisSelection"))->GetXaxis()->SetBinLabel(31, "Sigma Y");
+      histos.add(histodir+"/Photon/hTrackCode", "hTrackCode", kTH1F, {{11, 0.5f, 11.5f}});
+      histos.add(histodir+"/Photon/hV0Type", "hV0Type", kTH1F, {{8, 0.5f, 8.5f}});
+      histos.add(histodir+"/Photon/hNegpT", "hNegpT", kTH1F, {axisPt});
+      histos.add(histodir+"/Photon/hPospT", "hPospT", kTH1F, {axisPt});
+      histos.add(histodir+"/Photon/hDCANegToPV", "hDCANegToPV", kTH1F, {axisDCAtoPV});
+      histos.add(histodir+"/Photon/hDCAPosToPV", "hDCAPosToPV", kTH1F, {axisDCAtoPV});
+      histos.add(histodir+"/Photon/hDCADau", "hDCADau", kTH1F, {axisDCAdau});
+      histos.add(histodir+"/Photon/hPosTPCCR", "hPosTPCCR", kTH1F, {axisTPCrows});
+      histos.add(histodir+"/Photon/hNegTPCCR", "hNegTPCCR", kTH1F, {axisTPCrows});
+      histos.add(histodir+"/Photon/h2dPosTPCNSigmaEl", "h2dPosTPCNSigmaEl", kTH2F, {axisPt, axisTPCNSigma});
+      histos.add(histodir+"/Photon/h2dNegTPCNSigmaEl", "h2dNegTPCNSigmaEl", kTH2F, {axisPt, axisTPCNSigma});
+      histos.add(histodir+"/Photon/h2dPosTPCNSigmaPi", "h2dPosTPCNSigmaPi", kTH2F, {axisPt, axisTPCNSigma});
+      histos.add(histodir+"/Photon/h2dNegTPCNSigmaPi", "h2dNegTPCNSigmaPi", kTH2F, {axisPt, axisTPCNSigma});
+      histos.add(histodir+"/Photon/hpT", "hpT", kTH1F, {axisPt});
+      histos.add(histodir+"/Photon/hY", "hY", kTH1F, {axisRapidity});
+      histos.add(histodir+"/Photon/hPosEta", "hPosEta", kTH1F, {axisRapidity});
+      histos.add(histodir+"/Photon/hNegEta", "hNegEta", kTH1F, {axisRapidity});
+      histos.add(histodir+"/Photon/hRadius", "hRadius", kTH1F, {axisRadius});
+      histos.add(histodir+"/Photon/hZ", "hZ", kTH1F, {axisZ});
+      histos.add(histodir+"/Photon/h2dRZCut", "h2dRZCut", kTH2F, {axisZ, axisRadius});
+      histos.add(histodir+"/Photon/h2dRZPlane", "h2dRZPlane", kTH2F, {axisZ, axisRadius});
+      histos.add(histodir+"/Photon/hCosPA", "hCosPA", kTH1F, {axisCosPA});
+      histos.add(histodir+"/Photon/hPsiPair", "hPsiPair", kTH1F, {axisPsiPair});
+      histos.add(histodir+"/Photon/hPhi", "hPhi", kTH1F, {axisPhi});
+      histos.add(histodir+"/Photon/h3dMass", "h3dMass", kTH3F, {axisCentrality, axisPt, axisPhotonMass});
+      histos.add(histodir+"/Photon/hMass", "hMass", kTH1F, {axisPhotonMass});
 
-    // Builder output QA
-    histos.add("BuilderQA/hPhotonAssociation", "hPhotonAssociation", kTH1F, {{2, 0.0f, 2.0f}});
-    histos.add("BuilderQA/hLambdaAssociation", "hLambdaAssociation", kTH1F, {{2, 0.0f, 2.0f}});
-    histos.add("BuilderQA/hPhotonTrackCode", "hPhotonTrackCode", kTH1F, {{8, 0.5f, 8.5f}});
-    histos.add("BuilderQA/hLambdaTrackCode", "hLambdaTrackCode", kTH1F, {{8, 0.5f, 8.5f}});
-    histos.add("BuilderQA/hPhotonZ", "hPhotonZ", kTH1D, {{240, -120.0f, 120.0f}});
-    histos.add("BuilderQA/hPhotonCosPA", "hPhotonCosPA", kTH1D, {axisCosPA});
-    histos.add("BuilderQA/hPhotonDCADau", "hPhotonDCADau", kTH1D, {axisDCAdau});
+      histos.add(histodir+"/Lambda/hTrackCode", "hTrackCode", kTH1F, {{11, 0.5f, 11.5f}});
+      histos.add(histodir+"/Lambda/hRadius", "hRadius", kTH1F, {axisRadius});
+      histos.add(histodir+"/Lambda/hDCADau", "hDCADau", kTH1F, {axisDCAdau});
+      histos.add(histodir+"/Lambda/hCosPA", "hCosPA", kTH1F, {axisCosPA});
+      histos.add(histodir+"/Lambda/hY", "hY", kTH1F, {axisRapidity});
+      histos.add(histodir+"/Lambda/hPosEta", "hPosEta", kTH1F, {axisRapidity});
+      histos.add(histodir+"/Lambda/hNegEta", "hNegEta", kTH1F, {axisRapidity});
+      histos.add(histodir+"/Lambda/hPosTPCCR", "hPosTPCCR", kTH1F, {axisTPCrows});
+      histos.add(histodir+"/Lambda/hNegTPCCR", "hNegTPCCR", kTH1F, {axisTPCrows});
+      histos.add(histodir+"/Lambda/hPosITSCls", "hPosITSCls", kTH1F, {axisNCls});
+      histos.add(histodir+"/Lambda/hNegITSCls", "hNegITSCls", kTH1F, {axisNCls});
+      histos.add(histodir+"/Lambda/hPosChi2PerNc", "hPosChi2PerNc", kTH1F, {axisChi2PerNcl});
+      histos.add(histodir+"/Lambda/hNegChi2PerNc", "hNegChi2PerNc", kTH1F, {axisChi2PerNcl});
+      histos.add(histodir+"/Lambda/hLifeTime", "hLifeTime", kTH1F, {axisLifetime});    
+      histos.add(histodir+"/Lambda/h2dTPCvsTOFNSigma_LambdaPr", "h2dTPCvsTOFNSigma_LambdaPr", kTH2F, {axisTPCNSigma, axisTOFNSigma});
+      histos.add(histodir+"/Lambda/h2dTPCvsTOFNSigma_LambdaPi", "h2dTPCvsTOFNSigma_LambdaPi", kTH2F, {axisTPCNSigma, axisTOFNSigma});
+      histos.add(histodir+"/Lambda/hLambdaDCANegToPV", "hLambdaDCANegToPV", kTH1F, {axisDCAtoPV});
+      histos.add(histodir+"/Lambda/hLambdaDCAPosToPV", "hLambdaDCAPosToPV", kTH1F, {axisDCAtoPV});
+      histos.add(histodir+"/Lambda/hLambdapT", "hLambdapT", kTH1F, {axisPt});
+      histos.add(histodir+"/Lambda/hLambdaMass", "hLambdaMass", kTH1F, {axisLambdaMass});
+      histos.add(histodir+"/Lambda/h3dLambdaMass", "h3dLambdaMass", kTH3F, {axisCentrality, axisPt, axisLambdaMass});
+      histos.add(histodir+"/Lambda/h2dTPCvsTOFNSigma_ALambdaPr", "h2dTPCvsTOFNSigma_ALambdaPr", kTH2F, {axisTPCNSigma, axisTOFNSigma});
+      histos.add(histodir+"/Lambda/h2dTPCvsTOFNSigma_ALambdaPi", "h2dTPCvsTOFNSigma_ALambdaPi", kTH2F, {axisTPCNSigma, axisTOFNSigma});
+      histos.add(histodir+"/Lambda/hALambdaDCANegToPV", "hALambdaDCANegToPV", kTH1F, {axisDCAtoPV});
+      histos.add(histodir+"/Lambda/hALambdaDCAPosToPV", "hALambdaDCAPosToPV", kTH1F, {axisDCAtoPV});
+      histos.add(histodir+"/Lambda/hALambdapT", "hALambdapT", kTH1F, {axisPt});
+      histos.add(histodir+"/Lambda/hAntiLambdaMass", "hAntiLambdaMass", kTH1F, {axisLambdaMass});
+      histos.add(histodir+"/Lambda/h3dAntiLambdaMass", "h3dAntiLambdaMass", kTH3F, {axisCentrality, axisPt, axisLambdaMass});
 
-    histos.add("BuilderQA/hPhotonZ_BadCollAssig", "hPhotonZ_BadCollAssig", kTH1D, {{240, -120.0f, 120.0f}});
-    histos.add("BuilderQA/hPhotonCosPA_BadCollAssig", "hPhotonCosPA_BadCollAssig", kTH1D, {axisCosPA});
-    histos.add("BuilderQA/hPhotonDCADau_BadCollAssig", "hPhotonDCADau_BadCollAssig", kTH1D, {axisDCAdau});
+      histos.add(histodir+"/h2dArmenteros", "h2dArmenteros", kTH2F, {axisAPAlpha, axisAPQt});    
 
-    // Photon Selection QA histos
-    histos.add("GeneralQA/hPhotonV0Type", "hPhotonV0Type", kTH1F, {{8, 0.5f, 8.5f}});
-    histos.add("GeneralQA/hPhotonNegpT", "hPhotonNegpT", kTH1F, {axisPt});
-    histos.add("GeneralQA/hPhotonPospT", "hPhotonPospT", kTH1F, {axisPt});
-    histos.add("GeneralQA/hPhotonDCANegToPV", "hPhotonDCANegToPV", kTH1F, {axisDCAtoPV});
-    histos.add("GeneralQA/hPhotonDCAPosToPV", "hPhotonDCAPosToPV", kTH1F, {axisDCAtoPV});
-    histos.add("GeneralQA/hPhotonDCADau", "hPhotonDCADau", kTH1F, {axisDCAdau});
-    histos.add("GeneralQA/hPhotonPosTPCCR", "hPhotonPosTPCCR", kTH1F, {axisTPCrows});
-    histos.add("GeneralQA/hPhotonNegTPCCR", "hPhotonNegTPCCR", kTH1F, {axisTPCrows});
-    histos.add("GeneralQA/h2dPhotonPosTPCNSigmaEl", "h2dPhotonPosTPCNSigmaEl", {HistType::kTH2F, {axisPt, {30, -15.0f, 15.0f}}});
-    histos.add("GeneralQA/h2dPhotonNegTPCNSigmaEl", "h2dPhotonNegTPCNSigmaEl", {HistType::kTH2F, {axisPt, {30, -15.0f, 15.0f}}});
-    histos.add("GeneralQA/h2dPhotonPosTPCNSigmaPi", "h2dPhotonPosTPCNSigmaPi", {HistType::kTH2F, {axisPt, {30, -15.0f, 15.0f}}});
-    histos.add("GeneralQA/h2dPhotonNegTPCNSigmaPi", "h2dPhotonNegTPCNSigmaPi", {HistType::kTH2F, {axisPt, {30, -15.0f, 15.0f}}});
-    histos.add("GeneralQA/hPhotonpT", "hPhotonpT", kTH1F, {axisPt});
-    histos.add("GeneralQA/hPhotonY", "hPhotonY", kTH1F, {axisRapidity});
-    histos.add("GeneralQA/hPhotonPosEta", "hPhotonPosEta", kTH1F, {axisRapidity});
-    histos.add("GeneralQA/hPhotonNegEta", "hPhotonNegEta", kTH1F, {axisRapidity});
-    histos.add("GeneralQA/hPhotonRadius", "hPhotonRadius", kTH1F, {axisRadius});
-    histos.add("GeneralQA/hPhotonZ", "hPhotonZ", kTH1F, {{240, 0.0f, 120.0f}});
-    histos.add("GeneralQA/h2dRZCut", "h2dRZCut", {HistType::kTH2F, {{240, -120.0f, 120.0f}, axisRadius}});
-    histos.add("GeneralQA/h2dRZPlane", "h2dRZPlane", {HistType::kTH2F, {{240, -120.0f, 120.0f}, axisRadius}});
-    histos.add("GeneralQA/h2dPhotonArmenteros", "h2dPhotonArmenteros", {HistType::kTH2F, {axisAPAlpha, axisAPQt}});
-    histos.add("GeneralQA/hPhotonCosPA", "hPhotonCosPA", kTH1F, {axisCosPA});
-    histos.add("GeneralQA/hPhotonPsiPair", "hPhotonPsiPair", kTH1F, {axisPsiPair});
-    histos.add("GeneralQA/hPhotonPhi", "hPhotonPhi", kTH1F, {{200, 0, 2 * o2::constants::math::PI}});
-    histos.add("GeneralQA/h3dPhotonMass", "h3dPhotonMass", kTH3F, {axisCentrality, axisPt, axisPhotonMass});
+      histos.add(histodir+"/Sigma0/hMass", "hMass", kTH1F, {axisSigmaMass});
+      histos.add(histodir+"/Sigma0/hPt", "hPt", kTH1F, {axisPt});
+      histos.add(histodir+"/Sigma0/hY", "hY", kTH1F, {axisRapidity});
+      histos.add(histodir+"/Sigma0/h3dMass", "h3dMass", kTH3F, {axisCentrality, axisPt, axisSigmaMass});
+      histos.add(histodir+"/Sigma0/h3dPhotonRadiusVsMassSigma", "h3dPhotonRadiusVsMassSigma", kTH3F, {axisCentrality, axisRadius, axisSigmaMass});
+      histos.add(histodir+"/Sigma0/h2dpTVsOPAngle", "h2dpTVsOPAngle", kTH2F, {axisPt, {140, 0.0f, +7.0f}});
+      
+      histos.add(histodir+"/ASigma0/hMass", "hMass", kTH1F, {axisSigmaMass});
+      histos.add(histodir+"/ASigma0/hPt", "hPt", kTH1F, {axisPt});
+      histos.add(histodir+"/ASigma0/hY", "hY", kTH1F, {axisRapidity});
+      histos.add(histodir+"/ASigma0/h3dMass", "h3dMass", kTH3F, {axisCentrality, axisPt, axisSigmaMass});
+      histos.add(histodir+"/ASigma0/h3dPhotonRadiusVsMassSigma", "h3dPhotonRadiusVsMassSigma", kTH3F, {axisCentrality, axisRadius, axisSigmaMass});
+      histos.add(histodir+"/ASigma0/h2dpTVsOPAngle", "h2dpTVsOPAngle", kTH2F, {axisPt, {140, 0.0f, +7.0f}});
 
-    // Lambda Selection QA histos
-    histos.add("GeneralQA/hLambdaRadius", "hLambdaRadius", kTH1F, {axisRadius});
-    histos.add("GeneralQA/hLambdaDCADau", "hLambdaDCADau", kTH1F, {axisDCAdau});
-    histos.add("GeneralQA/h2dLambdaArmenteros", "h2dLambdaArmenteros", {HistType::kTH2F, {axisAPAlpha, axisAPQt}});
-    histos.add("GeneralQA/hLambdaCosPA", "hLambdaCosPA", kTH1F, {axisCosPA});
-    histos.add("GeneralQA/hLambdaY", "hLambdaY", kTH1F, {axisRapidity});
-    histos.add("GeneralQA/hLambdaPosEta", "hLambdaPosEta", kTH1F, {axisRapidity});
-    histos.add("GeneralQA/hLambdaNegEta", "hLambdaNegEta", kTH1F, {axisRapidity});
-    histos.add("GeneralQA/hLambdaPosTPCCR", "hLambdaPosTPCCR", kTH1F, {axisTPCrows});
-    histos.add("GeneralQA/hLambdaNegTPCCR", "hLambdaNegTPCCR", kTH1F, {axisTPCrows});
-    histos.add("GeneralQA/hLambdaPosITSCls", "hLambdaPosITSCls", kTH1F, {axisNCls});
-    histos.add("GeneralQA/hLambdaNegITSCls", "hLambdaNegITSCls", kTH1F, {axisNCls});
-    histos.add("GeneralQA/hLambdaPosChi2PerNc", "hLambdaPosChi2PerNc", kTH1F, {axisChi2PerNcl});
-    histos.add("GeneralQA/hLambdaNegChi2PerNc", "hLambdaNegChi2PerNc", kTH1F, {axisChi2PerNcl});
-    histos.add("GeneralQA/hLambdaLifeTime", "hLambdaLifeTime", kTH1F, {axisLifetime});
+      // Process MC
+      if (doprocessMonteCarlo) {
+        histos.add(histodir+"/MC/Photon/hV0ToCollAssoc", "hV0ToCollAssoc", kTH1F, {{2, 0.0f, 2.0f}});
+        histos.add(histodir+"/MC/Photon/hPt", "hPt", kTH1F, {axisPt});
+        histos.add(histodir+"/MC/Photon/hMCPt", "hMCPt", kTH1F, {axisPt});
+        histos.add(histodir+"/MC/Photon/h2dPosTPCNSigmaEl", "h2dPosTPCNSigmaEl", kTH2F, {axisPt, axisTPCNSigma});
+        histos.add(histodir+"/MC/Photon/h2dNegTPCNSigmaEl", "h2dNegTPCNSigmaEl", kTH2F, {axisPt, axisTPCNSigma});
+        histos.add(histodir+"/MC/Photon/h2dPosTPCNSigmaPi", "h2dPosTPCNSigmaPi", kTH2F, {axisPt, axisTPCNSigma});
+        histos.add(histodir+"/MC/Photon/h2dNegTPCNSigmaPi", "h2dNegTPCNSigmaPi", kTH2F, {axisPt, axisTPCNSigma});
+        histos.add(histodir+"/MC/Photon/h2dIRVsPt", "h2dIRVsPt", kTH2F, {axisIRBinning, axisPt});
+        histos.add(histodir+"/MC/Photon/h3dPAVsIRVsPt", "h3dPAVsIRVsPt", kTH3F, {axisPA, axisIRBinning, axisPt});
+        histos.add(histodir+"/MC/Photon/h2dIRVsPt_BadCollAssig", "h2dIRVsPt_BadCollAssig", kTH2F, {axisIRBinning, axisPt});
+        histos.add(histodir+"/MC/Photon/h3dPAVsIRVsPt_BadCollAssig", "h3dPAVsIRVsPt_BadCollAssig", kTH3F, {axisPA, axisIRBinning, axisPt});
+        
+        histos.add(histodir+"/MC/Lambda/hV0ToCollAssoc", "hV0ToCollAssoc", kTH1F, {{2, 0.0f, 2.0f}});
+        histos.add(histodir+"/MC/Lambda/hPt", "hPt", kTH1F, {axisPt});
+        histos.add(histodir+"/MC/Lambda/hMCPt", "hMCPt", kTH1F, {axisPt});
+        histos.add(histodir+"/MC/Lambda/h3dTPCvsTOFNSigma_Pr", "h3dTPCvsTOFNSigma_Pr", kTH3F, {axisTPCNSigma, axisTOFNSigma, axisPt});
+        histos.add(histodir+"/MC/Lambda/h3dTPCvsTOFNSigma_Pi", "h3dTPCvsTOFNSigma_Pi", kTH3F, {axisTPCNSigma, axisTOFNSigma, axisPt});
+        
+        histos.add(histodir+"/MC/ALambda/hV0ToCollAssoc", "hV0ToCollAssoc", kTH1F, {{2, 0.0f, 2.0f}});
+        histos.add(histodir+"/MC/ALambda/hPt", "hPt", kTH1F, {axisPt});
+        histos.add(histodir+"/MC/ALambda/hMCPt", "hMCPt", kTH1F, {axisPt});
+        histos.add(histodir+"/MC/ALambda/h3dTPCvsTOFNSigma_Pr", "h3dTPCvsTOFNSigma_Pr", kTH3F, {axisTPCNSigma, axisTOFNSigma, axisPt});
+        histos.add(histodir+"/MC/ALambda/h3dTPCvsTOFNSigma_Pi", "h3dTPCvsTOFNSigma_Pi", kTH3F, {axisTPCNSigma, axisTOFNSigma, axisPt});
+        
+        histos.add(histodir+"/MC/h2dArmenteros", "h2dArmenteros", kTH2F, {axisAPAlpha, axisAPQt});    
 
-    histos.add("GeneralQA/h2dTPCvsTOFNSigma_LambdaPr", "h2dTPCvsTOFNSigma_LambdaPr", {HistType::kTH2F, {axisTPCNSigma, axisTOFNSigma}});
-    histos.add("GeneralQA/h2dTPCvsTOFNSigma_LambdaPi", "h2dTPCvsTOFNSigma_LambdaPi", {HistType::kTH2F, {axisTPCNSigma, axisTOFNSigma}});
-    histos.add("GeneralQA/hLambdaDCANegToPV", "hLambdaDCANegToPV", kTH1F, {axisDCAtoPV});
-    histos.add("GeneralQA/hLambdaDCAPosToPV", "hLambdaDCAPosToPV", kTH1F, {axisDCAtoPV});
-    histos.add("GeneralQA/h3dLambdaMass", "h3dLambdaMass", kTH3F, {axisCentrality, axisPt, axisLambdaMass});
-    histos.add("GeneralQA/h2dTPCvsTOFNSigma_ALambdaPr", "h2dTPCvsTOFNSigma_ALambdaPr", {HistType::kTH2F, {axisTPCNSigma, axisTOFNSigma}});
-    histos.add("GeneralQA/h2dTPCvsTOFNSigma_ALambdaPi", "h2dTPCvsTOFNSigma_ALambdaPi", {HistType::kTH2F, {axisTPCNSigma, axisTOFNSigma}});
-    histos.add("GeneralQA/hALambdaDCANegToPV", "hALambdaDCANegToPV", kTH1F, {axisDCAtoPV});
-    histos.add("GeneralQA/hALambdaDCAPosToPV", "hALambdaDCAPosToPV", kTH1F, {axisDCAtoPV});
-    histos.add("GeneralQA/h3dAntiLambdaMass", "h3dAntiLambdaMass", kTH3F, {axisCentrality, axisPt, axisLambdaMass});
+        histos.add(histodir+"/MC/Sigma0/hPt", "hPt", kTH1F, {axisPt});
+        histos.add(histodir+"/MC/Sigma0/hMCPt", "hMCPt", kTH1F, {axisPt});
+        histos.add(histodir+"/MC/Sigma0/h2dMCPtVsLambdaMCPt", "h2dMCPtVsLambdaMCPt", kTH2F, {axisPt, axisPt});
+        histos.add(histodir+"/MC/Sigma0/h2dMCPtVsGammaMCPt", "h2dMCPtVsGammaMCPt", kTH2F, {axisPt, axisPt});
+        histos.add(histodir+"/MC/Sigma0/hMass", "hMass", kTH1F, {axisSigmaMass});
+        histos.add(histodir+"/MC/Sigma0/h3dMass", "h3dMass", kTH3F, {axisCentrality, axisPt, axisSigmaMass});
+        
+        histos.add(histodir+"/MC/ASigma0/hPt", "hPt", kTH1F, {axisPt});
+        histos.add(histodir+"/MC/ASigma0/hMCPt", "hMCPt", kTH1F, {axisPt});
+        histos.add(histodir+"/MC/ASigma0/h2dMCPtVsLambdaMCPt", "h2dMCPtVsLambdaMCPt", kTH2F, {axisPt, axisPt});
+        histos.add(histodir+"/MC/ASigma0/h2dMCPtVsPhotonMCPt", "h2dMCPtVsPhotonMCPt", kTH2F, {axisPt, axisPt});
+        histos.add(histodir+"/MC/ASigma0/hMass", "hMass", kTH1F, {axisSigmaMass});
+        histos.add(histodir+"/MC/ASigma0/h3dMass", "h3dMass", kTH3F, {axisCentrality, axisPt, axisSigmaMass});
 
-    histos.add("GeneralQA/hPhotonMassSelected", "hPhotonMassSelected", kTH1F, {axisPhotonMass});
-    histos.add("GeneralQA/hLambdaMassSelected", "hLambdaMassSelected", kTH1F, {axisLambdaMass});
-    histos.add("GeneralQA/hAntiLambdaMassSelected", "hAntiLambdaMassSelected", kTH1F, {axisLambdaMass});
+        // 1/pT Resolution:
+        if (fillpTResoQAhistos && histodir=="BeforeSel"){
+          histos.add(histodir+"/MC/pTReso/h3dGammaPtResoVsTPCCR", "h3dGammaPtResoVsTPCCR", kTH3F, {axisInvPt, axisDeltaPt, axisTPCrows});
+          histos.add(histodir+"/MC/pTReso/h3dGammaPtResoVsTPCCR", "h3dGammaPtResoVsTPCCR", kTH3F, {axisInvPt, axisDeltaPt, axisTPCrows});
+          histos.add(histodir+"/MC/pTReso/h2dGammaPtResolution", "h2dGammaPtResolution", kTH2F, {axisInvPt, axisDeltaPt});
+          histos.add(histodir+"/MC/pTReso/h2dLambdaPtResolution", "h2dLambdaPtResolution", kTH2F, {axisInvPt, axisDeltaPt});
+          histos.add(histodir+"/MC/pTReso/h3dLambdaPtResoVsTPCCR", "h3dLambdaPtResoVsTPCCR", kTH3F, {axisInvPt, axisDeltaPt, axisTPCrows});
+          histos.add(histodir+"/MC/pTReso/h3dLambdaPtResoVsTPCCR", "h3dLambdaPtResoVsTPCCR", kTH3F, {axisInvPt, axisDeltaPt, axisTPCrows});
+          histos.add(histodir+"/MC/pTReso/h2dAntiLambdaPtResolution", "h2dAntiLambdaPtResolution", kTH2F, {axisInvPt, axisDeltaPt});
+          histos.add(histodir+"/MC/pTReso/h3dAntiLambdaPtResoVsTPCCR", "h3dAntiLambdaPtResoVsTPCCR", kTH3F, {axisInvPt, axisDeltaPt, axisTPCrows});
+          histos.add(histodir+"/MC/pTReso/h3dAntiLambdaPtResoVsTPCCR", "h3dAntiLambdaPtResoVsTPCCR", kTH3F, {axisInvPt, axisDeltaPt, axisTPCrows});
+          histos.add(histodir+"/MC/pTReso/h2dSigma0PtResolution", "h2dSigma0PtResolution", kTH2F, {axisInvPt, axisDeltaPt});
+          histos.add(histodir+"/MC/pTReso/h2dAntiSigma0PtResolution", "h2dAntiSigma0PtResolution", kTH2F, {axisInvPt, axisDeltaPt});
+        }
 
-    histos.add("GeneralQA/hSigmaY", "hSigmaY", kTH1F, {axisRapidity});
-    histos.add("GeneralQA/hSigmaOPAngle", "hSigmaOPAngle", kTH1F, {{140, 0.0f, +7.0f}});
-
-    // Specific sigma0 QA
-    histos.add("SigmaSelQA/h2dPhotonV0Type", "h2dPhotonV0Type", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dPhotonMass", "h2dPhotonMass", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dPhotonDaupT", "h2dPhotonDaupT", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dPhotonDCADauToPV", "h2dPhotonDCADauToPV", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dPhotonDCADau", "h2dPhotonDCADau", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dPhotonDauTPCCR", "h2dPhotonDauTPCCR", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dPhotonTPCNSigmaEl", "h2dPhotonTPCNSigmaEl", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dPhotonpT", "h2dPhotonpT", {HistType::kTH2F, {axisPt, axisSigmaMass}}); //
-    histos.add("SigmaSelQA/h2dPhotonY", "h2dPhotonY", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dPhotonRadius", "h2dPhotonRadius", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dRZCut", "h2dRZCut", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dPhotonArmenteros", "h2dPhotonArmenteros", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dPhotonCosPA", "h2dPhotonCosPA", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dPhotonPsiPair", "h2dPhotonPsiPair", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dLambdaRadius", "h2dLambdaRadius", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dLambdaDCADau", "h2dLambdaDCADau", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dLambdaArmenteros", "h2dLambdaArmenteros", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dLambdaCosPA", "h2dLambdaCosPA", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dLambdaY", "h2dLambdaY", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dLambdaDauTPCCR", "h2dLambdaDauTPCCR", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dLambdaDauITSCls", "h2dLambdaDauITSCls", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dLambdaLifeTime", "h2dLambdaLifeTime", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dTPCvsTOFNSigma_Lambda", "h2dTPCvsTOFNSigma_Lambda", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dLambdaDCADauToPV", "h2dLambdaDCADauToPV", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dLambdaMass", "h2dLambdaMass", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dTPCvsTOFNSigma_ALambda", "h2dTPCvsTOFNSigma_ALambda", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dALambdaDCADauToPV", "h2dALambdaDCADauToPV", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dAntiLambdaMass", "h2dAntiLambdaMass", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-    histos.add("SigmaSelQA/h2dSigmaY", "h2dSigmaY", {HistType::kTH2F, {axisPt, axisSigmaMass}});
-
-    // Specific photon QA
-    histos.add("PhotonSelQA/h2dPhotonBaseline", "h2dPhotonBaseline", {HistType::kTH2F, {axisPt, axisPhotonMass}});
-    histos.add("PhotonSelQA/h2dPhotonV0Type", "h2dPhotonV0Type", {HistType::kTH2F, {axisPt, axisPhotonMass}});
-    histos.add("PhotonSelQA/h2dPhotonMass", "h2dPhotonMass", {HistType::kTH2F, {axisPt, axisPhotonMass}});
-    histos.add("PhotonSelQA/h2dPhotonDaupT", "h2dPhotonDaupT", {HistType::kTH2F, {axisPt, axisPhotonMass}});
-    histos.add("PhotonSelQA/h2dPhotonDCADauToPV", "h2dPhotonDCADauToPV", {HistType::kTH2F, {axisPt, axisPhotonMass}});
-    histos.add("PhotonSelQA/h2dPhotonDCADau", "h2dPhotonDCADau", {HistType::kTH2F, {axisPt, axisPhotonMass}});
-    histos.add("PhotonSelQA/h2dPhotonDauTPCCR", "h2dPhotonDauTPCCR", {HistType::kTH2F, {axisPt, axisPhotonMass}});
-    histos.add("PhotonSelQA/h2dPhotonTPCNSigmaEl", "h2dPhotonTPCNSigmaEl", {HistType::kTH2F, {axisPt, axisPhotonMass}});
-    histos.add("PhotonSelQA/h2dPhotonpT", "h2dPhotonpT", {HistType::kTH2F, {axisPt, axisPhotonMass}}); //
-    histos.add("PhotonSelQA/h2dPhotonY", "h2dPhotonY", {HistType::kTH2F, {axisPt, axisPhotonMass}});
-    histos.add("PhotonSelQA/h2dPhotonRadius", "h2dPhotonRadius", {HistType::kTH2F, {axisPt, axisPhotonMass}});
-    histos.add("PhotonSelQA/h2dRZCut", "h2dRZCut", {HistType::kTH2F, {axisPt, axisPhotonMass}});
-    histos.add("PhotonSelQA/h2dPhotonArmenteros", "h2dPhotonArmenteros", {HistType::kTH2F, {axisPt, axisPhotonMass}});
-    histos.add("PhotonSelQA/h2dPhotonCosPA", "h2dPhotonCosPA", {HistType::kTH2F, {axisPt, axisPhotonMass}});
-    histos.add("PhotonSelQA/h2dPhotonPsiPair", "h2dPhotonPsiPair", {HistType::kTH2F, {axisPt, axisPhotonMass}});
-    histos.add("PhotonSelQA/h2dPhotonPhi", "h2dPhotonPhi", {HistType::kTH2F, {axisPt, axisPhotonMass}});
-
-    // Specific Lambda/ALambda QA
-    histos.add("LambdaSelQA/h2dLambdaBaseline", "h2dLambdaBaseline", {HistType::kTH2F, {axisPt, axisLambdaMass}});
-    histos.add("LambdaSelQA/h2dLambdaRadius", "h2dLambdaRadius", {HistType::kTH2F, {axisPt, axisLambdaMass}});
-    histos.add("LambdaSelQA/h2dLambdaDCADau", "h2dLambdaDCADau", {HistType::kTH2F, {axisPt, axisLambdaMass}});
-    histos.add("LambdaSelQA/h2dLambdaArmenteros", "h2dLambdaArmenteros", {HistType::kTH2F, {axisPt, axisLambdaMass}});
-    histos.add("LambdaSelQA/h2dLambdaCosPA", "h2dLambdaCosPA", {HistType::kTH2F, {axisPt, axisLambdaMass}});
-    histos.add("LambdaSelQA/h2dLambdaY", "h2dLambdaY", {HistType::kTH2F, {axisPt, axisLambdaMass}});
-    histos.add("LambdaSelQA/h2dLambdaDauTPCCR", "h2dLambdaDauTPCCR", {HistType::kTH2F, {axisPt, axisLambdaMass}});
-    histos.add("LambdaSelQA/h2dLambdaDauITSCls", "h2dLambdaDauITSCls", {HistType::kTH2F, {axisPt, axisLambdaMass}});
-    histos.add("LambdaSelQA/h2dLambdaLifeTime", "h2dLambdaLifeTime", {HistType::kTH2F, {axisPt, axisLambdaMass}});
-    histos.add("LambdaSelQA/h2dTPCvsTOFNSigma_Lambda", "h2dTPCvsTOFNSigma_Lambda", {HistType::kTH2F, {axisPt, axisLambdaMass}});
-    histos.add("LambdaSelQA/h2dLambdaDCADauToPV", "h2dLambdaDCADauToPV", {HistType::kTH2F, {axisPt, axisLambdaMass}});
-    histos.add("LambdaSelQA/h2dLambdaMass", "h2dLambdaMass", {HistType::kTH2F, {axisPt, axisLambdaMass}});
-
-    // For Signal Extraction
-
-    // Sigma0
-    histos.add("Sigma0/h3dMassSigma0", "h3dMassSigma0", kTH3F, {axisCentrality, axisPt, axisSigmaMass});
-    histos.add("Sigma0/h3dPhotonRadiusVsMassSigma0", "h3dPhotonRadiusVsMassSigma0", kTH3F, {axisCentrality, axisRadius, axisSigmaMass});
-    histos.add("Sigma0/hMassSigma0", "hMassSigma0", kTH1F, {axisSigmaMass});
-    histos.add("Sigma0/hPtSigma0", "hPtSigma0", kTH1F, {axisPt});
-    histos.add("Sigma0/hRapiditySigma0", "hRapiditySigma0", kTH1F, {axisRapidity});
-
-    // AntiSigma0
-    histos.add("AntiSigma0/h3dMassAntiSigma0", "h3dMassAntiSigma0", kTH3F, {axisCentrality, axisPt, axisSigmaMass});
-    histos.add("AntiSigma0/h3dPhotonRadiusVsMassAntiSigma0", "h3dPhotonRadiusVsMassAntiSigma0", kTH3F, {axisCentrality, axisRadius, axisSigmaMass});
-    histos.add("AntiSigma0/hMassAntiSigma0", "hMassAntiSigma0", kTH1F, {axisSigmaMass});
-    histos.add("AntiSigma0/hPtAntiSigma0", "hPtAntiSigma0", kTH1F, {axisPt});
-    histos.add("AntiSigma0/hRapidityAntiSigma0", "hRapidityAntiSigma0", kTH1F, {axisRapidity});
-
-    if (fProcessMonteCarlo) {
-
-      // Kinematic
-      histos.add("MC/h3dMassSigma0", "h3dMassSigma0", kTH3F, {axisCentrality, axisPt, axisSigmaMass});
-      histos.add("MC/h3dMassAntiSigma0", "h3dMassSigma0", kTH3F, {axisCentrality, axisPt, axisSigmaMass});
-      histos.add("MC/h3dMassAllSigma0sBeforesel", "h3dMassAllSigma0sBeforesel", kTH3F, {axisCentrality, axisPt, axisSigmaMass});
-      histos.add("MC/h2dArmenterosBeforeSel", "h2dArmenterosBeforeSel", {HistType::kTH2F, {axisAPAlpha, axisAPQt}});
-      histos.add("MC/h2dArmenterosAfterSel", "h2dArmenterosAfterSel", {HistType::kTH2F, {axisAPAlpha, axisAPQt}});
-
-      // Sigma0 QA
-      histos.add("MC/hMassSigma0BeforeSel", "hMassSigma0BeforeSel", kTH1F, {axisSigmaMass});
-      histos.add("MC/hPtSigma0BeforeSel", "hPtSigma0BeforeSel", kTH1F, {axisPt});
-      histos.add("MC/hMassSigma0", "hMassSigma0", kTH1F, {axisSigmaMass});
-      histos.add("MC/hPtSigma0", "hPtSigma0", kTH1F, {axisPt});
-      histos.add("MC/hMassAntiSigma0", "hMassAntiSigma0", kTH1F, {axisSigmaMass});
-      histos.add("MC/hPtAntiSigma0", "hPtAntiSigma0", kTH1F, {axisPt});
-
-      // For background decomposition
-      histos.add("MC/h2dPtVsMassSigma_SignalBkg", "h2dPtVsMassSigma_SignalBkg", kTH2D, {axisPt, axisSigmaMass});
-      histos.add("MC/h2dPtVsMassSigma_SignalOnly", "h2dPtVsMassSigma_SignalOnly", kTH2D, {axisPt, axisSigmaMass});
-      histos.add("MC/h2dPtVsMassSigma_TrueDaughters", "h2dPtVsMassSigma_TrueDaughters", kTH2D, {axisPt, axisSigmaMass});
-      histos.add("MC/h2dPtVsMassSigma_TrueGammaFakeLambda", "h2dPtVsMassSigma_TrueGammaFakeLambda", kTH2D, {axisPt, axisSigmaMass});
-      histos.add("MC/h2dPtVsMassSigma_FakeGammaTrueLambda", "h2dPtVsMassSigma_FakeGammaTrueLambda", kTH2D, {axisPt, axisSigmaMass});
-      histos.add("MC/h2dPtVsMassSigma_FakeDaughters", "h2dPtVsMassSigma_FakeDaughters", kTH2D, {axisPt, axisSigmaMass});
-      histos.add("MC/h2dTrueDaughtersMatrix", "h2dTrueDaughtersMatrix", kTHnSparseD, {{10001, -5000.5f, +5000.5f}, {10001, -5000.5f, +5000.5f}});
-
-      // For new selection studies:
-      //// Opening angle between daughters
-      histos.add("MC/h2dPtVsOPAngle_SignalOnly", "h2dPtVsOPAngle_SignalOnly", kTH2D, {axisPt, {140, 0.0f, +7.0f}});
-      histos.add("MC/h2dPtVsOPAngle_TrueDaughters", "h2dPtVsOPAngle_TrueDaughters", kTH2D, {axisPt, {140, 0.0f, +7.0f}});
-      histos.add("MC/h2dPtVsMassSigma_AfterOPAngleSel", "h2dPtVsMassSigma_AfterOPAngleSel", kTH2D, {axisPt, axisSigmaMass});
-
-      // For efficiency/Purity studies
-      // Before any selection
-      histos.add("MC/hPtTrueLambda_BeforeSel", "hPtTrueLambda_BeforeSel", kTH1F, {axisPt}); // Signal only
-      histos.add("MC/hPtTrueAntiLambda_BeforeSel", "hPtTrueAntiLambda_BeforeSel", kTH1F, {axisPt}); // Signal only
-      histos.add("MC/hPtTrueGamma_BeforeSel", "hPtTrueGamma_BeforeSel", kTH1F, {axisPt});   // Signal only
-      histos.add("MC/hPtTrueSigma_BeforeSel", "hPtTrueSigma_BeforeSel", kTH1F, {axisPt});   // Signal only
-      histos.add("MC/hPtTrueAntiSigma_BeforeSel", "hPtTrueAntiSigma_BeforeSel", kTH1F, {axisPt}); // Signal only
-      histos.add("MC/hPtLambdaCand_BeforeSel", "hPtLambdaCand_BeforeSel", kTH1F, {axisPt}); // Bkg + Signal
-      histos.add("MC/hPtGammaCand_BeforeSel", "hPtGammaCand_BeforeSel", kTH1F, {axisPt});   // Bkg + Signal
-      histos.add("MC/hPtSigmaCand_BeforeSel", "hPtGammaCand_BeforeSel", kTH1F, {axisPt});   // Bkg + Signal
-
-      // After analysis selections
-      histos.add("MC/hPtTrueLambda_AfterSel", "hPtTrueLambda_AfterSel", kTH1F, {axisPt}); // Signal only
-      histos.add("MC/hPtTrueAntiLambda_AfterSel", "hPtTrueAntiLambda_AfterSel", kTH1F, {axisPt}); // Signal only
-      histos.add("MC/hPtTrueGamma_AfterSel", "hPtTrueGamma_AfterSel", kTH1F, {axisPt});   // Signal only
-      histos.add("MC/hPtTrueSigma_AfterSel", "hPtTrueSigma_AfterSel", kTH1F, {axisPt});   // Signal only
-
-      histos.add("MC/hPtLambdaCand_AfterSel", "hPtLambdaCand_AfterSel", kTH1F, {axisPt});
-      histos.add("MC/hPtGammaCand_AfterSel", "hPtGammaCand_AfterSel", kTH1F, {axisPt});
-      histos.add("MC/hPtSigmaCand_AfterSel", "hPtSigmaCand_AfterSel", kTH1F, {axisPt});
-
-      // TPC vs TOF N Sigmas distributions
-      histos.add("MC/h3dTPCvsTOFNSigma_LambdaPr", "h3dTPCvsTOFNSigma_LambdaPr", kTH3F, {axisTPCNSigma, axisTOFNSigma, axisPt});
-      histos.add("MC/h3dTPCvsTOFNSigma_LambdaPi", "h3dTPCvsTOFNSigma_LambdaPi", kTH3F, {axisTPCNSigma, axisTOFNSigma, axisPt});
-      histos.add("MC/h3dTPCvsTOFNSigma_TrueLambdaPr", "h3dTPCvsTOFNSigma_TrueLambdaPr", kTH3F, {axisTPCNSigma, axisTOFNSigma, axisPt});
-      histos.add("MC/h3dTPCvsTOFNSigma_TrueLambdaPi", "h3dTPCvsTOFNSigma_TrueLambdaPi", kTH3F, {axisTPCNSigma, axisTOFNSigma, axisPt});
-      histos.add("MC/h3dTPCvsTOFNSigma_TrueALambdaPr", "h3dTPCvsTOFNSigma_TrueALambdaPr", kTH3F, {axisTPCNSigma, axisTOFNSigma, axisPt});
-      histos.add("MC/h3dTPCvsTOFNSigma_TrueALambdaPi", "h3dTPCvsTOFNSigma_TrueALambdaPi", kTH3F, {axisTPCNSigma, axisTOFNSigma, axisPt});
-
-      // QA of PID selections:
-      //// TPC PID
-      histos.add("MC/hPtTrueLambda_passedTPCPID", "hPtTrueLambda_passedTPCPID", kTH1F, {axisPt});
-      histos.add("MC/hPtLambdaCandidates_passedTPCPID", "hPtLambdaCandidates_passedTPCPID", kTH1F, {axisPt});
-
-      //// TOF PID
-      histos.add("MC/hPtTrueLambda_passedTOFPID", "hPtTrueLambda_passedTOFPID", kTH1F, {axisPt});
-      histos.add("MC/hPtLambdaCandidates_passedTOFPID", "hPtLambdaCandidates_passedTOFPID", kTH1F, {axisPt});
-
-      //// TPC+TOF PID
-      histos.add("MC/hPtTrueLambda_passedTPCTOFPID", "hPtTrueLambda_passedTPCTOFPID", kTH1F, {axisPt});
-      histos.add("MC/hPtLambdaCandidates_passedTPCTOFPID", "hPtLambdaCandidates_passedTPCTOFPID", kTH1F, {axisPt});
-
-      // 1/pT Resolution:
-      histos.add("MC/h2dLambdaPtResolution", "h2dLambdaPtResolution", kTH2D, {axisInvPt, axisDeltaPt});
-      histos.add("MC/h2dAntiLambdaPtResolution", "h2dAntiLambdaPtResolution", kTH2D, {axisInvPt, axisDeltaPt});
-      histos.add("MC/h2dGammaPtResolution", "h2dGammaPtResolution", kTH2D, {axisInvPt, axisDeltaPt});
-      histos.add("MC/h2dSigma0PtResolution", "h2dSigma0PtResolution", kTH2D, {axisInvPt, axisDeltaPt});
-      histos.add("MC/h2dAntiSigma0PtResolution", "h2dAntiSigma0PtResolution", kTH2D, {axisInvPt, axisDeltaPt});
-      histos.add("MC/h3dLambdaPtResoVsTPCCR", "h3dLambdaPtResoVsTPCCR", kTH3F, {axisInvPt, axisDeltaPt, {320, -160.0f, 160.0f}});
-      histos.add("MC/h3dAntiLambdaPtResoVsTPCCR", "h3dAntiLambdaPtResoVsTPCCR", kTH3F, {axisInvPt, axisDeltaPt, {320, -160.0f, 160.0f}});
-      histos.add("MC/h3dGammaPtResoVsTPCCR", "h3dGammaPtResoVsTPCCR", kTH3F, {axisInvPt, axisDeltaPt, {320, -160.0f, 160.0f}});
-
-      // pTMC info:
-      histos.add("MC/h2dSigmaMCPtVsLambdaMCPt", "h2dSigmaMCPtVsLambdaMCPt", kTH2D, {axisPt, axisPt});
-      histos.add("MC/h2dSigmaMCPtVsGammaMCPt", "h2dSigmaMCPtVsGammaMCPt", kTH2D, {axisPt, axisPt});
+        // For background decomposition study
+        if (fillBkgQAhistos){
+          histos.add(histodir+"/MC/BkgStudy/h2dPtVsMassSigma_All", "h2dPtVsMassSigma_All", kTH2F, {axisPt, axisSigmaMass});
+          histos.add(histodir+"/MC/BkgStudy/h2dPtVsMassSigma_TrueDaughters", "h2dPtVsMassSigma_TrueDaughters", kTH2F, {axisPt, axisSigmaMass});
+          histos.add(histodir+"/MC/BkgStudy/h2dTrueDaughtersMatrix", "h2dTrueDaughtersMatrix", kTHnSparseD, {{10001, -5000.5f, +5000.5f}, {10001, -5000.5f, +5000.5f}});
+          histos.add(histodir+"/MC/BkgStudy/h2dPtVsMassSigma_TrueGammaFakeLambda", "h2dPtVsMassSigma_TrueGammaFakeLambda", kTH2F, {axisPt, axisSigmaMass});
+          histos.add(histodir+"/MC/BkgStudy/h2dPtVsMassSigma_FakeGammaTrueLambda", "h2dPtVsMassSigma_FakeGammaTrueLambda", kTH2F, {axisPt, axisSigmaMass});
+          histos.add(histodir+"/MC/BkgStudy/h2dPtVsMassSigma_FakeDaughters", "h2dPtVsMassSigma_FakeDaughters", kTH2F, {axisPt, axisSigmaMass});
+        }
+      }
     }
+    
+    // Selections
+    histos.add("Selection/Photon/hCandidateSel", "hCandidateSel", kTH1F, {axisCandSel});
+    histos.add("Selection/Lambda/hCandidateSel", "hCandidateSel", kTH1F, {axisCandSel});
+    
+    for (size_t i = 0; i < PhotonSels.size(); ++i) {
+      const auto& sel = PhotonSels[i];
+    
+      histos.add(Form("Selection/Photon/h2d%s", sel.c_str()), ("h2d" + sel).c_str(), kTH2F, {axisPt, axisPhotonMass});
+      histos.get<TH1>(HIST("Selection/Photon/hCandidateSel"))->GetXaxis()->SetBinLabel(i + 1, sel.c_str());
+      histos.add(Form("Selection/Sigma0/h2dPhoton%s", sel.c_str()), ("h2dPhoton" + sel).c_str(), kTH2F, {axisPt, axisSigmaMass});
+    }
+
+    for (size_t i = 0; i < LambdaSels.size(); ++i) {
+      const auto& sel = LambdaSels[i];
+    
+      histos.add(Form("Selection/Lambda/h2d%s", sel.c_str()), ("h2d" + sel).c_str(), kTH2F, {axisPt, axisLambdaMass});
+      histos.get<TH1>(HIST("Selection/Lambda/hCandidateSel"))->GetXaxis()->SetBinLabel(i + 1, sel.c_str());
+      histos.add(Form("Selection/Sigma0/h2dLambda%s", sel.c_str()), ("h2dLambda" + sel).c_str(), kTH2F, {axisPt, axisSigmaMass});
+    }
+    
+  }
+  
+  //__________________________________________
+  template <bool isGamma, typename TV0Object>
+  int retrieveV0TrackCode(TV0Object const& sigma){
+    
+    int TrkCode = 10; // 1: TPC-only, 2: TPC+Something, 3: ITS-Only, 4: ITS+TPC + Something, 10: anything else
+    
+    if (isGamma){
+      if (sigma.photonPosTrackCode()==1 && sigma.photonNegTrackCode()==1)
+        TrkCode = 1;
+      if ((sigma.photonPosTrackCode()!=1 && sigma.photonNegTrackCode()==1) || (sigma.photonPosTrackCode()==1 && sigma.photonNegTrackCode()!=1))
+        TrkCode = 2;
+      if (sigma.photonPosTrackCode()==3 && sigma.photonNegTrackCode()==3)
+        TrkCode = 3;
+      if (sigma.photonPosTrackCode()==2 || sigma.photonNegTrackCode()==2)
+        TrkCode = 4;
+    }
+    else{
+      if (sigma.lambdaPosTrackCode()==1 && sigma.lambdaNegTrackCode()==1)
+      TrkCode = 1;
+      if ((sigma.lambdaPosTrackCode()!=1 && sigma.lambdaNegTrackCode()==1) || (sigma.lambdaPosTrackCode()==1 && sigma.lambdaNegTrackCode()!=1))
+        TrkCode = 2;
+      if (sigma.lambdaPosTrackCode()==3 && sigma.lambdaNegTrackCode()==3)
+        TrkCode = 3;
+      if (sigma.lambdaPosTrackCode()==2 || sigma.lambdaNegTrackCode()==2)
+        TrkCode = 4;
+    }
+    
+    return TrkCode;
+  }
+  
+  template <typename TV0Object>
+  void getpTResolution(TV0Object const& sigma){
+
+    //_______________________________________
+    // Gamma MC association
+    if (sigma.photonCandPDGCode() == 22) {      
+      if (sigma.photonMCPt() > 0) {
+        histos.fill(HIST("BeforeSel/MC/pTReso/h3dGammaPtResoVsTPCCR"), 1.f / sigma.lambdaMCPt(), 1.f / sigma.lambdaPt() - 1.f / sigma.lambdaMCPt(), -1 * sigma.photonNegTPCCrossedRows()); // 1/pT resolution
+        histos.fill(HIST("BeforeSel/MC/pTReso/h3dGammaPtResoVsTPCCR"), 1.f / sigma.lambdaMCPt(), 1.f / sigma.lambdaPt() - 1.f / sigma.lambdaMCPt(), sigma.photonPosTPCCrossedRows());      // 1/pT resolution
+        histos.fill(HIST("BeforeSel/MC/pTReso/h2dGammaPtResolution"), 1.f / sigma.photonMCPt(), 1.f / sigma.photonPt() - 1.f / sigma.photonMCPt());                                        // pT resolution
+      }
+    }
+
+    //_______________________________________
+    // Lambda MC association
+    if (sigma.lambdaCandPDGCode() == 3122) {      
+      if (sigma.lambdaMCPt() > 0) {
+        histos.fill(HIST("BeforeSel/MC/pTReso/h2dLambdaPtResolution"), 1.f / sigma.lambdaMCPt(), 1.f / sigma.lambdaPt() - 1.f / sigma.lambdaMCPt());                                        // 1/pT resolution
+        histos.fill(HIST("BeforeSel/MC/pTReso/h3dLambdaPtResoVsTPCCR"), 1.f / sigma.lambdaMCPt(), 1.f / sigma.lambdaPt() - 1.f / sigma.lambdaMCPt(), -1 * sigma.lambdaNegTPCCrossedRows()); // 1/pT resolution
+        histos.fill(HIST("BeforeSel/MC/pTReso/h3dLambdaPtResoVsTPCCR"), 1.f / sigma.lambdaMCPt(), 1.f / sigma.lambdaPt() - 1.f / sigma.lambdaMCPt(), sigma.lambdaPosTPCCrossedRows());      // 1/pT resolution
+      }
+    }
+
+    //_______________________________________
+    // AntiLambda MC association
+    if (sigma.lambdaCandPDGCode() == -3122) {
+      if (sigma.lambdaMCPt() > 0) {
+        histos.fill(HIST("BeforeSel/MC/pTReso/h2dAntiLambdaPtResolution"), 1.f / sigma.lambdaMCPt(), 1.f / sigma.lambdaPt() - 1.f / sigma.lambdaMCPt());                                        // pT resolution
+        histos.fill(HIST("BeforeSel/MC/pTReso/h3dAntiLambdaPtResoVsTPCCR"), 1.f / sigma.lambdaMCPt(), 1.f / sigma.lambdaPt() - 1.f / sigma.lambdaMCPt(), -1 * sigma.lambdaNegTPCCrossedRows()); // 1/pT resolution
+        histos.fill(HIST("BeforeSel/MC/pTReso/h3dAntiLambdaPtResoVsTPCCR"), 1.f / sigma.lambdaMCPt(), 1.f / sigma.lambdaPt() - 1.f / sigma.lambdaMCPt(), sigma.lambdaPosTPCCrossedRows());      // 1/pT resolution
+      }      
+    }
+
+    //_______________________________________
+    // Sigma and AntiSigma MC association
+    if (sigma.isSigma()) {
+      if (sigma.sigmaMCPt() > 0)
+        histos.fill(HIST("BeforeSel/MC/pTReso/h2dSigma0PtResolution"), 1.f / sigma.sigmaMCPt(), 1.f / sigma.sigmapT() - 1.f / sigma.sigmaMCPt()); // pT resolution
+    }
+    if (sigma.isAntiSigma()) {       
+      if (sigma.sigmaMCPt() > 0)
+        histos.fill(HIST("BeforeSel/MC/pTReso/h2dAntiSigma0PtResolution"), 1.f / sigma.sigmaMCPt(), 1.f / sigma.sigmapT() - 1.f / sigma.sigmaMCPt()); // pT resolution
+    }        
   }
 
-  // Apply selections in sigma candidates
-  template <typename TV0Object>
-  bool processSigmaCandidate(TV0Object const& cand, bool isLambdalike)
+  // To save histograms for background analysis
+  template <int mode, typename TV0Object>
+  void runBkgAnalysis(TV0Object const& sigma)
   {
-    if (fUseMLSel) {
+    // Check whether it is before or after selections        
+    static constexpr std::string_view MainDir[] = {"BeforeSel", "AfterSel"};
+    
+    bool fIsSigma = sigma.isSigma(); 
+    bool fIsAntiSigma = sigma.isAntiSigma();
+    int PhotonPDGCode = sigma.photonCandPDGCode(); 
+    int PhotonPDGCodeMother = sigma.photonCandPDGCodeMother(); 
+    int LambdaPDGCode = sigma.lambdaCandPDGCode(); 
+    int LambdaPDGCodeMother = sigma.lambdaCandPDGCodeMother(); 
+    float sigmapT = sigma.sigmapT();
+    float sigmaMass = sigma.sigmaMass();
+
+    histos.fill(HIST(MainDir[mode])+HIST("/MC/BkgStudy/h2dPtVsMassSigma_All"), sigmapT, sigmaMass);
+
+    //_______________________________________ 
+    // Real Gamma x Real Lambda - but not from the same sigma0/antisigma0!
+    if ((PhotonPDGCode == 22) && ((LambdaPDGCode == 3122) || (LambdaPDGCode == -3122)) && (!fIsSigma && !fIsAntiSigma)) {
+      histos.fill(HIST(MainDir[mode])+HIST("/MC/BkgStudy/h2dPtVsMassSigma_TrueDaughters"), sigmapT, sigmaMass);
+      histos.fill(HIST(MainDir[mode])+HIST("/MC/BkgStudy/h2dTrueDaughtersMatrix"), LambdaPDGCodeMother, PhotonPDGCodeMother);
+    }
+
+    //_______________________________________ 
+    // Real Gamma x fake Lambda
+    if ((PhotonPDGCode == 22) && (LambdaPDGCode != 3122) && (LambdaPDGCode != -3122)) 
+      histos.fill(HIST(MainDir[mode])+HIST("/MC/BkgStudy/h2dPtVsMassSigma_TrueGammaFakeLambda"), sigmapT, sigmaMass);        
+    
+      //_______________________________________ 
+    // Fake Gamma x Real Lambda
+    if ((PhotonPDGCode != 22) && ((LambdaPDGCode == 3122) || (LambdaPDGCode == -3122))) 
+      histos.fill(HIST(MainDir[mode])+HIST("/MC/BkgStudy/h2dPtVsMassSigma_FakeGammaTrueLambda"), sigmapT, sigmaMass);          
+
+    //_______________________________________ 
+    // Fake Gamma x Fake Lambda
+    if ((PhotonPDGCode != 22) && (LambdaPDGCode != 3122) && (LambdaPDGCode != -3122)) 
+      histos.fill(HIST(MainDir[mode])+HIST("/MC/BkgStudy/h2dPtVsMassSigma_FakeDaughters"), sigmapT, sigmaMass);             
+  }
+
+  template <int mode,typename TV0Object>
+  void fillQAHistos(TV0Object const& sigma){    
+    
+    // Check whether it is before or after selections
+    // static std::string main_dir;
+    // main_dir = IsBeforeSel ? "BeforeSel" : "AfterSel";
+    static constexpr std::string_view MainDir[] = {"BeforeSel", "AfterSel"};
+    
+    // Get V0trackCode    
+    int GammaTrkCode = retrieveV0TrackCode<true>(sigma);
+    int LambdaTrkCode = retrieveV0TrackCode<false>(sigma);
+    
+    float photonRZLineCut = TMath::Abs(sigma.photonZconv()) * TMath::Tan(2 * TMath::ATan(TMath::Exp(-PhotonMaxDauEta))) - PhotonLineCutZ0;
+    //_______________________________________    
+    // Photon    
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/hTrackCode"), GammaTrkCode);    
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/hV0Type"), sigma.photonV0Type());
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/hNegpT"), sigma.photonNegPt());
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/hPospT"), sigma.photonPosPt());
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/hDCANegToPV"), sigma.photonDCANegPV());
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/hDCAPosToPV"), sigma.photonDCAPosPV());
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/hDCADau"), sigma.photonDCADau());
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/hPosTPCCR"), sigma.photonPosTPCCrossedRows());
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/hNegTPCCR"), sigma.photonNegTPCCrossedRows());
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/h2dPosTPCNSigmaEl"), sigma.photonPosPt(), sigma.photonPosTPCNSigmaEl());
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/h2dNegTPCNSigmaEl"), sigma.photonNegPt(), sigma.photonNegTPCNSigmaEl());
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/h2dPosTPCNSigmaPi"), sigma.photonPosPt(), sigma.photonPosTPCNSigmaPi());
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/h2dNegTPCNSigmaPi"), sigma.photonNegPt(), sigma.photonNegTPCNSigmaPi());
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/hpT"), sigma.photonPt());
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/hY"), sigma.photonY());
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/hPosEta"), sigma.photonPosEta());
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/hNegEta"), sigma.photonNegEta());
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/hRadius"), sigma.photonRadius());
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/hZ"), sigma.photonZconv());      
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/h2dRZCut"), sigma.photonRadius(), photonRZLineCut);
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/h2dRZPlane"), sigma.photonZconv(), sigma.photonRadius());    
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/hCosPA"), sigma.photonCosPA());
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/hPsiPair"), sigma.photonPsiPair());
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/hPhi"), sigma.photonPhi());
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/h3dMass"), sigma.sigmaCentrality(), sigma.photonPt(), sigma.photonMass());
+    histos.fill(HIST(MainDir[mode])+HIST("/Photon/hMass"), sigma.photonMass());
+
+    //_______________________________________
+    // Lambdas 
+    histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hTrackCode"), LambdaTrkCode);
+    histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hRadius"), sigma.lambdaRadius());
+    histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hDCADau"), sigma.lambdaDCADau());    
+    histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hCosPA"), sigma.lambdaCosPA());
+    histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hY"), sigma.lambdaY());    
+    histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hPosEta"), sigma.lambdaPosEta());
+    histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hNegEta"), sigma.lambdaNegEta());
+    histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hPosTPCCR"), sigma.lambdaPosTPCCrossedRows());
+    histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hNegTPCCR"), sigma.lambdaNegTPCCrossedRows());
+    histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hPosITSCls"), sigma.lambdaPosITSCls());
+    histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hNegITSCls"), sigma.lambdaNegITSCls());
+    histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hPosChi2PerNc"), sigma.lambdaPosChi2PerNcl());
+    histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hNegChi2PerNc"), sigma.lambdaNegChi2PerNcl());
+    histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hLifeTime"), sigma.lambdaLifeTime());
+                
+    //_______________________________________
+    // Sigmas and Lambdas
+    histos.fill(HIST(MainDir[mode])+HIST("/h2dArmenteros"), sigma.photonAlpha(), sigma.photonQt());
+    histos.fill(HIST(MainDir[mode])+HIST("/h2dArmenteros"), sigma.lambdaAlpha(), sigma.lambdaQt());
+
+    if (sigma.lambdaAlpha() > 0) { 
+      histos.fill(HIST(MainDir[mode])+HIST("/Lambda/h2dTPCvsTOFNSigma_LambdaPr"), sigma.lambdaPosPrTPCNSigma(), sigma.lambdaPrTOFNSigma());
+      histos.fill(HIST(MainDir[mode])+HIST("/Lambda/h2dTPCvsTOFNSigma_LambdaPi"), sigma.lambdaNegPiTPCNSigma(), sigma.lambdaPiTOFNSigma());
+      histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hLambdaDCANegToPV"), sigma.lambdaDCANegPV());
+      histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hLambdaDCAPosToPV"), sigma.lambdaDCAPosPV());
+      histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hLambdapT"), sigma.lambdaPt());
+      histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hLambdaMass"), sigma.lambdaMass());     
+      histos.fill(HIST(MainDir[mode])+HIST("/Lambda/h3dLambdaMass"), sigma.sigmaCentrality(), sigma.lambdaPt(), sigma.lambdaMass());          
+      
+      histos.fill(HIST(MainDir[mode])+HIST("/Sigma0/hMass"), sigma.sigmaMass());
+      histos.fill(HIST(MainDir[mode])+HIST("/Sigma0/hPt"), sigma.sigmapT());
+      histos.fill(HIST(MainDir[mode])+HIST("/Sigma0/hY"), sigma.sigmaRapidity());
+      histos.fill(HIST(MainDir[mode])+HIST("/Sigma0/h3dMass"), sigma.sigmaCentrality(), sigma.sigmapT(), sigma.sigmaMass());
+      histos.fill(HIST(MainDir[mode])+HIST("/Sigma0/h3dPhotonRadiusVsMassSigma"), sigma.sigmaCentrality(), sigma.photonRadius(), sigma.sigmaMass());
+      histos.fill(HIST(MainDir[mode])+HIST("/Sigma0/h2dpTVsOPAngle"), sigma.sigmapT(), sigma.sigmaOPAngle());
+    }
+    else{
+      histos.fill(HIST(MainDir[mode])+HIST("/Lambda/h2dTPCvsTOFNSigma_ALambdaPr"), sigma.lambdaNegPrTPCNSigma(), sigma.aLambdaPrTOFNSigma());
+      histos.fill(HIST(MainDir[mode])+HIST("/Lambda/h2dTPCvsTOFNSigma_ALambdaPi"), sigma.lambdaPosPiTPCNSigma(), sigma.aLambdaPiTOFNSigma());
+      histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hALambdaDCANegToPV"), sigma.lambdaDCANegPV());
+      histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hALambdaDCAPosToPV"), sigma.lambdaDCAPosPV());
+      histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hALambdapT"), sigma.lambdaPt());
+      histos.fill(HIST(MainDir[mode])+HIST("/Lambda/hAntiLambdaMass"), sigma.antilambdaMass());
+      histos.fill(HIST(MainDir[mode])+HIST("/Lambda/h3dAntiLambdaMass"), sigma.sigmaCentrality(), sigma.lambdaPt(), sigma.antilambdaMass());
+      
+      histos.fill(HIST(MainDir[mode])+HIST("/ASigma0/hMass"), sigma.sigmaMass());
+      histos.fill(HIST(MainDir[mode])+HIST("/ASigma0/hPt"), sigma.sigmapT());
+      histos.fill(HIST(MainDir[mode])+HIST("/ASigma0/hY"), sigma.sigmaRapidity());
+      histos.fill(HIST(MainDir[mode])+HIST("/ASigma0/h3dMass"), sigma.sigmaCentrality(), sigma.sigmapT(), sigma.sigmaMass());
+      histos.fill(HIST(MainDir[mode])+HIST("/ASigma0/h3dPhotonRadiusVsMassSigma"), sigma.sigmaCentrality(), sigma.photonRadius(), sigma.sigmaMass());
+      histos.fill(HIST(MainDir[mode])+HIST("/ASigma0/h2dpTVsOPAngle"), sigma.sigmapT(), sigma.sigmaOPAngle());
+    }
+
+    //_______________________________________
+    // MC specific              
+    //if (doprocessMonteCarlo && isMC) {
+
+    if constexpr (requires { sigma.lambdaCandPDGCode(); sigma.photonCandPDGCode(); }){
+      
+      //_______________________________________
+      // Gamma MC association
+      if (sigma.photonCandPDGCode()==22){        
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/hV0ToCollAssoc"), sigma.photonIsCorrectlyAssoc());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/hPt"), sigma.photonPt());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/hMCPt"), sigma.photonMCPt());
+      
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h2dPosTPCNSigmaEl"), sigma.photonPosPt(), sigma.photonPosTPCNSigmaEl());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h2dNegTPCNSigmaEl"), sigma.photonNegPt(), sigma.photonNegTPCNSigmaEl());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h2dPosTPCNSigmaPi"), sigma.photonPosPt(), sigma.photonPosTPCNSigmaPi());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h2dNegTPCNSigmaPi"), sigma.photonNegPt(), sigma.photonNegTPCNSigmaPi());
+                
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h2dIRVsPt"), sigma.sigmaIR(), sigma.photonMCPt());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h3dPAVsIRVsPt"), TMath::ACos(sigma.photonCosPA()), sigma.sigmaIR(), sigma.photonMCPt());
+
+        if (!sigma.photonIsCorrectlyAssoc()){
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h2dIRVsPt_BadCollAssig"), sigma.sigmaIR(), sigma.photonMCPt());
+          histos.fill(HIST(MainDir[mode])+HIST("/MC/Photon/h3dPAVsIRVsPt_BadCollAssig"), TMath::ACos(sigma.photonCosPA()), sigma.sigmaIR(), sigma.photonMCPt());          
+        }
+      }
+
+      //_______________________________________
+      // Lambda MC association
+      if (sigma.lambdaCandPDGCode()==3122){
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/Lambda/hV0ToCollAssoc"), sigma.lambdaIsCorrectlyAssoc());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/Lambda/hPt"), sigma.lambdaPt());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/Lambda/hMCPt"), sigma.lambdaMCPt());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/Lambda/h3dTPCvsTOFNSigma_Pr"), sigma.lambdaPosPrTPCNSigma(), sigma.lambdaPrTOFNSigma(), sigma.lambdaPt());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/Lambda/h3dTPCvsTOFNSigma_Pi"), sigma.lambdaNegPiTPCNSigma(), sigma.lambdaPiTOFNSigma(), sigma.lambdaPt());
+      }
+
+      //_______________________________________
+      // AntiLambda MC association
+      if (sigma.lambdaCandPDGCode() == -3122){
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/ALambda/hV0ToCollAssoc"), sigma.lambdaIsCorrectlyAssoc());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/ALambda/hPt"), sigma.lambdaPt());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/ALambda/hMCPt"), sigma.lambdaMCPt());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/ALambda/h3dTPCvsTOFNSigma_Pr"), sigma.lambdaNegPrTPCNSigma(), sigma.aLambdaPrTOFNSigma(), sigma.lambdaPt());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/ALambda/h3dTPCvsTOFNSigma_Pi"), sigma.lambdaPosPiTPCNSigma(), sigma.aLambdaPiTOFNSigma(), sigma.lambdaPt());
+      }
+
+      //_______________________________________
+      // Sigma0 MC association
+      if (sigma.isSigma()){
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/h2dArmenteros"), sigma.photonAlpha(), sigma.photonQt());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/h2dArmenteros"), sigma.lambdaAlpha(), sigma.lambdaQt());
+
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/Sigma0/hPt"), sigma.sigmapT());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/Sigma0/hMCPt"), sigma.sigmaMCPt());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/Sigma0/h2dMCPtVsLambdaMCPt"), sigma.sigmaMCPt(), sigma.lambdaMCPt());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/Sigma0/h2dMCPtVsGammaMCPt"), sigma.sigmaMCPt(), sigma.photonMCPt());                          
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/Sigma0/hMass"), sigma.sigmaMass());        
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/Sigma0/h3dMass"), sigma.sigmaCentrality(), sigma.sigmapT(), sigma.sigmaMass());          
+
+      }
+
+      //_______________________________________
+      // AntiSigma0 MC association
+      if (sigma.isAntiSigma()){
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/h2dArmenteros"), sigma.photonAlpha(), sigma.photonQt());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/h2dArmenteros"), sigma.lambdaAlpha(), sigma.lambdaQt());
+
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/ASigma0/hPt"), sigma.sigmapT());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/ASigma0/hMCPt"), sigma.sigmaMCPt());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/ASigma0/h2dMCPtVsLambdaMCPt"), sigma.sigmaMCPt(), sigma.lambdaMCPt());
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/ASigma0/h2dMCPtVsPhotonMCPt"), sigma.sigmaMCPt(), sigma.photonMCPt());                          
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/ASigma0/hMass"), sigma.sigmaMass());        
+        histos.fill(HIST(MainDir[mode])+HIST("/MC/ASigma0/h3dMass"), sigma.sigmaCentrality(), sigma.sigmapT(), sigma.sigmaMass());          
+
+      }
+          
+      // For background studies:
+      if (fillBkgQAhistos) 
+        runBkgAnalysis<mode>(sigma); 
+
+      //_______________________________________          
+      // pT resolution histos
+      if ((mode==0) && fillpTResoQAhistos)
+        getpTResolution(sigma);  
+      
+    }            
+  }
+
+  template <int selection_index, typename TV0Object>
+  void fillSelHistos(TV0Object const& sigma, int PDGRequired){
+    
+    static constexpr std::string_view PhotonSelsLocal[] = {"NoSel", "V0Type", "DaupT", "DCADauToPV", 
+                                                          "DCADau", "DauTPCCR", "TPCNSigmaEl", "V0pT", 
+                                                          "Y", "V0Radius", "RZCut", "Armenteros", "CosPA", 
+                                                          "PsiPair", "Phi", "Mass"};
+
+    static constexpr std::string_view LambdaSelsLocal[] = {"NoSel", "V0Radius", "DCADau", "Armenteros", 
+                                                           "CosPA", "Y", "TPCCR", "DauITSCls", "Lifetime", 
+                                                           "TPCTOFPID", "DCADauToPV", "Mass"};
+      
+    bool isMCTruePhoton = false;
+    bool isMCTrueLambda = false;  
+
+    
+    if constexpr (requires { sigma.lambdaCandPDGCode(); sigma.photonCandPDGCode(); }){      
+      if (sigma.photonCandPDGCode() == 22)
+        isMCTruePhoton = true;
+      if (TMath::Abs(sigma.lambdaCandPDGCode()) == 3122)
+        isMCTrueLambda = true;      
+    }
+    
+            
+    if ((PDGRequired==22) || isMCTruePhoton){  
+      //if (selection_index < 0 || selection_index >= (int)PhotonSels.size()) return;  // safeguard  
+      if constexpr (selection_index >= 0 && selection_index < (int)std::size(PhotonSelsLocal)){
+        histos.fill(HIST("Selection/Photon/hCandidateSel"), selection_index);
+        histos.fill(HIST("Selection/Photon/h2d")+HIST(PhotonSelsLocal[selection_index]), sigma.photonPt(), sigma.photonMass());
+        histos.fill(HIST("Selection/Sigma0/h2dPhoton")+HIST(PhotonSelsLocal[selection_index]), sigma.sigmapT(), sigma.sigmaMass());
+      }
+      
+    }
+     
+    if ((TMath::Abs(PDGRequired)==3122) || isMCTrueLambda){
+      //if (selection_index < 0 || selection_index >= (int)LambdaSels.size()) return; // safeguard
+      if constexpr (selection_index >= 0 && selection_index < (int)std::size(LambdaSelsLocal)){
+        histos.fill(HIST("Selection/Lambda/hCandidateSel"), selection_index);
+        histos.fill(HIST("Selection/Lambda/h2d")+HIST(LambdaSelsLocal[selection_index]), sigma.lambdaPt(), sigma.lambdaMass());
+        histos.fill(HIST("Selection/Sigma0/h2dLambda")+HIST(LambdaSelsLocal[selection_index]), sigma.sigmapT(), sigma.sigmaMass());
+      }
+      
+    }         
+  }
+  
+  // Apply specific selections for photons
+  template <typename TV0Object>
+  bool selectPhoton(TV0Object const& cand)
+  {
+    fillSelHistos<1>(cand, 22);      
+    if (cand.photonV0Type() != Photonv0TypeSel && Photonv0TypeSel > -1)
+      return false;
+
+    fillSelHistos<2>(cand, 22);
+    if ((cand.photonPosPt() < PhotonDauMinPt) || (cand.photonNegPt() < PhotonDauMinPt))
+      return false;
+
+    fillSelHistos<3>(cand, 22);
+    if ((TMath::Abs(cand.photonDCAPosPV()) < PhotonMinDCADauToPv) || (TMath::Abs(cand.photonDCANegPV()) < PhotonMinDCADauToPv))
+      return false;
+
+    fillSelHistos<4>(cand, 22);
+    if (TMath::Abs(cand.photonDCADau()) > PhotonMaxDCAV0Dau)
+      return false;
+
+    fillSelHistos<5>(cand, 22);
+    if ((cand.photonPosTPCCrossedRows() < PhotonMinTPCCrossedRows) || (cand.photonNegTPCCrossedRows() < PhotonMinTPCCrossedRows))
+      return false;
+    
+    fillSelHistos<6>(cand, 22);
+    if (((cand.photonPosTPCNSigmaEl() < PhotonMinTPCNSigmas) || (cand.photonPosTPCNSigmaEl() > PhotonMaxTPCNSigmas)))
+      return false;
+    
+    fillSelHistos<7>(cand, 22);
+    if (((cand.photonNegTPCNSigmaEl() < PhotonMinTPCNSigmas) || (cand.photonNegTPCNSigmaEl() > PhotonMaxTPCNSigmas)))
+      return false;
+    
+    fillSelHistos<8>(cand, 22);
+    if (((TMath::Abs(cand.photonPosTPCNSigmaPi()) < PiMaxTPCNSigmas) && cand.photonPosPt() <= piMaxpT))
+      return false;
+    
+    if (((TMath::Abs(cand.photonNegTPCNSigmaPi()) < PiMaxTPCNSigmas) && cand.photonNegPt() <= piMaxpT))
+      return false;
+  
+    fillSelHistos<9>(cand, 22);
+    if ((cand.photonPt() < PhotonMinPt) || (cand.photonPt() > PhotonMaxPt))
+      return false;
+
+    fillSelHistos<10>(cand, 22);
+    if ((TMath::Abs(cand.photonY()) > PhotonMaxRap) || (TMath::Abs(cand.photonPosEta()) > PhotonMaxDauEta) || (TMath::Abs(cand.photonNegEta()) > PhotonMaxDauEta))
+      return false;
+
+    fillSelHistos<11>(cand, 22);
+    if ((cand.photonRadius() < PhotonMinRadius) || (cand.photonRadius() > PhotonMaxRadius))
+      return false;
+
+    fillSelHistos<12>(cand, 22);
+    float photonRZLineCut = TMath::Abs(cand.photonZconv()) * TMath::Tan(2 * TMath::ATan(TMath::Exp(-PhotonMaxDauEta))) - PhotonLineCutZ0;      
+    if ((TMath::Abs(cand.photonRadius()) < photonRZLineCut) || (TMath::Abs(cand.photonZconv()) > PhotonMaxZ))
+      return false;
+
+    fillSelHistos<13>(cand, 22);
+    if (cand.photonQt() > PhotonMaxQt)
+      return false;
+    
+    if (TMath::Abs(cand.photonAlpha()) > PhotonMaxAlpha)
+      return false;
+
+    fillSelHistos<14>(cand, 22);
+    if (cand.photonCosPA() < PhotonMinV0cospa)
+      return false;
+
+    fillSelHistos<15>(cand, 22);
+    if (TMath::Abs(cand.photonPsiPair()) > PhotonPsiPairMax)
+      return false;
+
+    fillSelHistos<16>(cand, 22);
+    if (((cand.photonPhi() < PhotonPhiMin1) || ((cand.photonPhi() > PhotonPhiMax1) && (cand.photonPhi() < PhotonPhiMin2)) || ((cand.photonPhi() > PhotonPhiMax2) && (PhotonPhiMax2 != -1))))
+      return false;
+
+    fillSelHistos<17>(cand, 22);
+    if (TMath::Abs(cand.photonMass()) > PhotonMaxMass)
+      return false;
+
+    //fillSelHistos<18>(cand, 22);
+    return true;
+  }
+
+  // Apply specific selections for lambdas
+  template <typename TV0Object>
+  bool selectLambda(TV0Object const& cand)
+  {    
+    fillSelHistos<1>(cand, 3122);      
+    if ((cand.lambdaRadius() < LambdaMinv0radius) || (cand.lambdaRadius() > LambdaMaxv0radius))
+      return false;
+    
+    fillSelHistos<2>(cand, 3122);
+    if (TMath::Abs(cand.lambdaDCADau()) > LambdaMaxDCAV0Dau)
+      return false;
+
+    fillSelHistos<3>(cand, 3122);
+    if ((cand.lambdaQt() < LambdaMinQt) || (cand.lambdaQt() > LambdaMaxQt))
+      return false;
+    
+    if ((TMath::Abs(cand.lambdaAlpha()) < LambdaMinAlpha) || (TMath::Abs(cand.lambdaAlpha()) > LambdaMaxAlpha))
+      return false;
+
+    fillSelHistos<4>(cand, 3122);
+    if (cand.lambdaCosPA() < LambdaMinv0cospa)
+      return false;
+
+    fillSelHistos<5>(cand, 3122);
+    if ((TMath::Abs(cand.lambdaY()) > LambdaMaxRap) || (TMath::Abs(cand.lambdaPosEta()) > LambdaMaxDauEta) || (TMath::Abs(cand.lambdaNegEta()) > LambdaMaxDauEta))
+      return false;
+
+    fillSelHistos<6>(cand, 3122);
+    if ((cand.lambdaPosTPCCrossedRows() < LambdaMinTPCCrossedRows) || (cand.lambdaNegTPCCrossedRows() < LambdaMinTPCCrossedRows))
+      return false;
+
+    fillSelHistos<7>(cand, 3122);
+    // check minimum number of ITS clusters + reject ITS afterburner tracks if requested
+    bool posIsFromAfterburner = cand.lambdaPosChi2PerNcl() < 0;
+    bool negIsFromAfterburner = cand.lambdaNegChi2PerNcl() < 0;
+    if (cand.lambdaPosITSCls() < LambdaMinITSclusters && (!LambdaRejectPosITSafterburner || posIsFromAfterburner))
+      return false;
+    if (cand.lambdaNegITSCls() < LambdaMinITSclusters && (!LambdaRejectNegITSafterburner || negIsFromAfterburner))
+      return false;
+    
+    fillSelHistos<8>(cand, 3122);
+    if (cand.lambdaLifeTime() > LambdaMaxLifeTime)
+      return false;
+
+    // Separating lambda and antilambda selections:
+    fillSelHistos<9>(cand, 3122);    
+    if (cand.lambdaAlpha() > 0) { // Lambda selection      
+      // TPC Selection
+      if (fselLambdaTPCPID && (TMath::Abs(cand.lambdaPosPrTPCNSigma()) > LambdaMaxTPCNSigmas))
+        return false;
+      if (fselLambdaTPCPID && (TMath::Abs(cand.lambdaNegPiTPCNSigma()) > LambdaMaxTPCNSigmas))
+        return false;
+
+      // TOF Selection
+      if (fselLambdaTOFPID && (TMath::Abs(cand.lambdaPrTOFNSigma()) > LambdaPrMaxTOFNSigmas))
+        return false;
+      if (fselLambdaTOFPID && (TMath::Abs(cand.lambdaPiTOFNSigma()) > LambdaPiMaxTOFNSigmas))
+        return false;
+      
+      // DCA Selection              
+      fillSelHistos<10>(cand, 3122);
+      if ((TMath::Abs(cand.lambdaDCAPosPV()) < LambdaMinDCAPosToPv) || (TMath::Abs(cand.lambdaDCANegPV()) < LambdaMinDCANegToPv))
+        return false;
+
+      // Mass Selection
+      fillSelHistos<11>(cand, 3122);
+      if (TMath::Abs(cand.lambdaMass() - o2::constants::physics::MassLambda0) > LambdaWindow)
+        return false;
+
+      //fillSelHistos<12>(cand, 3122);
+
+    } else { // AntiLambda selection
+      
+      // TPC Selection
+      if (fselLambdaTPCPID && (TMath::Abs(cand.lambdaPosPiTPCNSigma()) > LambdaMaxTPCNSigmas))
+        return false;
+      if (fselLambdaTPCPID && (TMath::Abs(cand.lambdaNegPrTPCNSigma()) > LambdaMaxTPCNSigmas))
+        return false;
+
+      // TOF Selection
+      if (fselLambdaTOFPID && (TMath::Abs(cand.aLambdaPrTOFNSigma()) > LambdaPrMaxTOFNSigmas))
+        return false;
+      if (fselLambdaTOFPID && (TMath::Abs(cand.aLambdaPiTOFNSigma()) > LambdaPiMaxTOFNSigmas))
+        return false;
+      
+      // DCA Selection        
+      fillSelHistos<10>(cand, 3122);
+      if ((TMath::Abs(cand.lambdaDCAPosPV()) < ALambdaMinDCAPosToPv) || (TMath::Abs(cand.lambdaDCANegPV()) < ALambdaMinDCANegToPv))
+        return false;
+      
+      // Mass Selection      
+      fillSelHistos<11>(cand, 3122);
+      if (TMath::Abs(cand.antilambdaMass() - o2::constants::physics::MassLambda0) > LambdaWindow)
+        return false;
+      
+      //fillSelHistos<12>(cand, 3122);
+    }
+    
+    return true;
+  }
+
+  // Apply selections in sigma0 candidates
+  template <typename TV0Object>
+  bool processSigmaCandidate(TV0Object const& cand)
+  {
+    // Optionally Select on Interaction Rate                          
+    if (fGetIR && (maxIR != -1) && (minIR != -1) && ((cand.sigmaIR() <= minIR) || (cand.sigmaIR() >= maxIR))) {
+      return false;
+    }
+  
+    // Do ML analysis
+    if (fUseMLSel) { 
       if ((cand.gammaBDTScore() == -1) || (cand.lambdaBDTScore() == -1) || (cand.antilambdaBDTScore() == -1)) {
         LOGF(fatal, "ML Score is not available! Please, enable gamma and lambda selection with ML in sigmabuilder!");
       }
-      // Gamma selection:
+      // Photon selection:
       if (cand.gammaBDTScore() <= Gamma_MLThreshold)
         return false;
 
@@ -489,311 +915,25 @@ struct sigmaanalysis {
       // AntiLambda selection:
       if (cand.antilambdaBDTScore() <= AntiLambda_MLThreshold)
         return false;
-    } else {
-
-      bool isMCTrueLambda = false;
-      bool isMCTruePhoton = false;
-      if constexpr (requires { cand.lambdaCandPDGCode(); cand.photonCandPDGCode(); }) {
-        if (cand.photonCandPDGCode() == 22)
-          isMCTruePhoton = true;
-        if (cand.lambdaCandPDGCode() == 3122)
-          isMCTrueLambda = true;
-      }
-
-      // Photon Selections
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 1.);
-      histos.fill(HIST("GeneralQA/hPhotonV0Type"), cand.photonV0Type());
-      if ((isMCTruePhoton || doPhotonLambdaSelQA) && (TMath::Abs(cand.photonMass()) <= PhotonMaxMass))
-        histos.fill(HIST("PhotonSelQA/h2dPhotonBaseline"), cand.photonPt(), cand.photonMass());
-      if (cand.photonV0Type() != Photonv0TypeSel && Photonv0TypeSel > -1)
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dPhotonV0Type"), cand.sigmapT(), cand.sigmaMass());
-      if ((isMCTruePhoton || doPhotonLambdaSelQA) && (TMath::Abs(cand.photonMass()) <= PhotonMaxMass))
-        histos.fill(HIST("PhotonSelQA/h2dPhotonV0Type"), cand.photonPt(), cand.photonMass());
-
-      // histos.fill(HIST("GeneralQA/h3dPhotonMass"), cand.sigmaCentrality(), cand.photonPt(), cand.photonMass());
-      // histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 2.);
-      // if (TMath::Abs(cand.photonMass()) > PhotonMaxMass)
-      //   return false;
-      // histos.fill(HIST("SigmaSelQA/h2dPhotonMass"), cand.sigmapT(), cand.sigmaMass());
-      // if (isMCTruePhoton || doPhotonLambdaSelQA) histos.fill(HIST("PhotonSelQA/h2dPhotonMass"), cand.photonPt(), cand.photonMass());
-
-      histos.fill(HIST("GeneralQA/hPhotonNegpT"), cand.photonNegPt());
-      histos.fill(HIST("GeneralQA/hPhotonPospT"), cand.photonPosPt());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 2.);
-      if ((cand.photonPosPt() < PhotonDauMinPt) || (cand.photonNegPt() < PhotonDauMinPt))
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dPhotonDaupT"), cand.sigmapT(), cand.sigmaMass());
-      if ((isMCTruePhoton || doPhotonLambdaSelQA) && (TMath::Abs(cand.photonMass()) <= PhotonMaxMass))
-        histos.fill(HIST("PhotonSelQA/h2dPhotonDaupT"), cand.photonPt(), cand.photonMass());
-      histos.fill(HIST("GeneralQA/hPhotonDCANegToPV"), cand.photonDCANegPV());
-      histos.fill(HIST("GeneralQA/hPhotonDCAPosToPV"), cand.photonDCAPosPV());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 3.);
-      if ((TMath::Abs(cand.photonDCAPosPV()) < PhotonMinDCADauToPv) || (TMath::Abs(cand.photonDCANegPV()) < PhotonMinDCADauToPv))
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dPhotonDCADauToPV"), cand.sigmapT(), cand.sigmaMass());
-      if ((isMCTruePhoton || doPhotonLambdaSelQA) && (TMath::Abs(cand.photonMass()) <= PhotonMaxMass))
-        histos.fill(HIST("PhotonSelQA/h2dPhotonDCADauToPV"), cand.photonPt(), cand.photonMass());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 4.);
-      histos.fill(HIST("GeneralQA/hPhotonDCADau"), cand.photonDCADau());
-      if (TMath::Abs(cand.photonDCADau()) > PhotonMaxDCAV0Dau)
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dPhotonDCADau"), cand.sigmapT(), cand.sigmaMass());
-      if ((isMCTruePhoton || doPhotonLambdaSelQA) && (TMath::Abs(cand.photonMass()) <= PhotonMaxMass))
-        histos.fill(HIST("PhotonSelQA/h2dPhotonDCADau"), cand.photonPt(), cand.photonMass());
-      histos.fill(HIST("GeneralQA/hPhotonPosTPCCR"), cand.photonPosTPCCrossedRows());
-      histos.fill(HIST("GeneralQA/hPhotonNegTPCCR"), cand.photonNegTPCCrossedRows());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 5.);
-      if ((cand.photonPosTPCCrossedRows() < PhotonMinTPCCrossedRows) || (cand.photonNegTPCCrossedRows() < PhotonMinTPCCrossedRows))
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dPhotonDauTPCCR"), cand.sigmapT(), cand.sigmaMass());
-      if ((isMCTruePhoton || doPhotonLambdaSelQA) && (TMath::Abs(cand.photonMass()) <= PhotonMaxMass))
-        histos.fill(HIST("PhotonSelQA/h2dPhotonDauTPCCR"), cand.photonPt(), cand.photonMass());
-      histos.fill(HIST("GeneralQA/h2dPhotonPosTPCNSigmaEl"), cand.photonPosPt(), cand.photonPosTPCNSigmaEl());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 6.);
-      if (((cand.photonPosTPCNSigmaEl() < PhotonMinTPCNSigmas) || (cand.photonPosTPCNSigmaEl() > PhotonMaxTPCNSigmas)))
-        return false;
-      histos.fill(HIST("GeneralQA/h2dPhotonNegTPCNSigmaEl"), cand.photonNegPt(), cand.photonNegTPCNSigmaEl());
-      if (((cand.photonNegTPCNSigmaEl() < PhotonMinTPCNSigmas) || (cand.photonNegTPCNSigmaEl() > PhotonMaxTPCNSigmas)))
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dPhotonTPCNSigmaEl"), cand.sigmapT(), cand.sigmaMass());
-      if ((isMCTruePhoton || doPhotonLambdaSelQA) && (TMath::Abs(cand.photonMass()) <= PhotonMaxMass))
-        histos.fill(HIST("PhotonSelQA/h2dPhotonTPCNSigmaEl"), cand.photonPt(), cand.photonMass());
-      histos.fill(HIST("GeneralQA/h2dPhotonPosTPCNSigmaPi"), cand.photonPosPt(), cand.photonPosTPCNSigmaPi());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 7.);
-      if (((TMath::Abs(cand.photonPosTPCNSigmaPi()) < PiMaxTPCNSigmas) && cand.photonPosPt() <= piMaxpT))
-        return false;
-      histos.fill(HIST("GeneralQA/h2dPhotonNegTPCNSigmaPi"), cand.photonNegPt(), cand.photonNegTPCNSigmaPi());
-      if (((TMath::Abs(cand.photonNegTPCNSigmaPi()) < PiMaxTPCNSigmas) && cand.photonNegPt() <= piMaxpT))
-        return false;
-      histos.fill(HIST("GeneralQA/hPhotonpT"), cand.photonPt());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 8.);
-      if ((cand.photonPt() < PhotonMinPt) || (cand.photonPt() > PhotonMaxPt))
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dPhotonpT"), cand.sigmapT(), cand.sigmaMass());
-      if ((isMCTruePhoton || doPhotonLambdaSelQA) && (TMath::Abs(cand.photonMass()) <= PhotonMaxMass))
-        histos.fill(HIST("PhotonSelQA/h2dPhotonpT"), cand.photonPt(), cand.photonMass());
-      histos.fill(HIST("GeneralQA/hPhotonY"), cand.photonY());
-      histos.fill(HIST("GeneralQA/hPhotonPosEta"), cand.photonPosEta());
-      histos.fill(HIST("GeneralQA/hPhotonNegEta"), cand.photonNegEta());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 9.);
-      if ((TMath::Abs(cand.photonY()) > PhotonMaxRap) || (TMath::Abs(cand.photonPosEta()) > PhotonMaxDauEta) || (TMath::Abs(cand.photonNegEta()) > PhotonMaxDauEta))
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dPhotonY"), cand.sigmapT(), cand.sigmaMass());
-      if ((isMCTruePhoton || doPhotonLambdaSelQA) && (TMath::Abs(cand.photonMass()) <= PhotonMaxMass))
-        histos.fill(HIST("PhotonSelQA/h2dPhotonY"), cand.photonPt(), cand.photonMass());
-      histos.fill(HIST("GeneralQA/hPhotonRadius"), cand.photonRadius());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 10.);
-      if ((cand.photonRadius() < PhotonMinRadius) || (cand.photonRadius() > PhotonMaxRadius))
-        return false;
-      float photonRZLineCut = TMath::Abs(cand.photonZconv()) * TMath::Tan(2 * TMath::ATan(TMath::Exp(-PhotonMaxDauEta))) - PhotonLineCutZ0;
-      histos.fill(HIST("SigmaSelQA/h2dPhotonRadius"), cand.sigmapT(), cand.sigmaMass());
-      if ((isMCTruePhoton || doPhotonLambdaSelQA) && (TMath::Abs(cand.photonMass()) <= PhotonMaxMass))
-        histos.fill(HIST("PhotonSelQA/h2dPhotonRadius"), cand.photonPt(), cand.photonMass());
-      histos.fill(HIST("GeneralQA/hPhotonZ"), cand.photonZconv());
-      histos.fill(HIST("GeneralQA/h2dRZCut"), cand.photonRadius(), photonRZLineCut);
-      histos.fill(HIST("GeneralQA/h2dRZPlane"), cand.photonZconv(), cand.photonRadius());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 11.);
-      if ((TMath::Abs(cand.photonRadius()) < photonRZLineCut) || (TMath::Abs(cand.photonZconv()) > PhotonMaxZ))
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dRZCut"), cand.sigmapT(), cand.sigmaMass());
-      if ((isMCTruePhoton || doPhotonLambdaSelQA) && (TMath::Abs(cand.photonMass()) <= PhotonMaxMass))
-        histos.fill(HIST("PhotonSelQA/h2dRZCut"), cand.photonPt(), cand.photonMass());
-      histos.fill(HIST("GeneralQA/h2dPhotonArmenteros"), cand.photonAlpha(), cand.photonQt());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 12.);
-      if (cand.photonQt() > PhotonMaxQt)
-        return false;
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 13.);
-      if (TMath::Abs(cand.photonAlpha()) > PhotonMaxAlpha)
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dPhotonArmenteros"), cand.sigmapT(), cand.sigmaMass());
-      if ((isMCTruePhoton || doPhotonLambdaSelQA) && (TMath::Abs(cand.photonMass()) <= PhotonMaxMass))
-        histos.fill(HIST("PhotonSelQA/h2dPhotonArmenteros"), cand.photonPt(), cand.photonMass());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 14.);
-      histos.fill(HIST("GeneralQA/hPhotonCosPA"), cand.photonCosPA());
-      if (cand.photonCosPA() < PhotonMinV0cospa)
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dPhotonCosPA"), cand.sigmapT(), cand.sigmaMass());
-      if ((isMCTruePhoton || doPhotonLambdaSelQA) && (TMath::Abs(cand.photonMass()) <= PhotonMaxMass))
-        histos.fill(HIST("PhotonSelQA/h2dPhotonCosPA"), cand.photonPt(), cand.photonMass());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 15.);
-      histos.fill(HIST("GeneralQA/hPhotonPsiPair"), cand.photonPsiPair());
-      if (TMath::Abs(cand.photonPsiPair()) > PhotonPsiPairMax)
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dPhotonPsiPair"), cand.sigmapT(), cand.sigmaMass());
-      if ((isMCTruePhoton || doPhotonLambdaSelQA) && (TMath::Abs(cand.photonMass()) <= PhotonMaxMass))
-        histos.fill(HIST("PhotonSelQA/h2dPhotonPsiPair"), cand.photonPt(), cand.photonMass());
-
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 16.);
-      histos.fill(HIST("GeneralQA/hPhotonPhi"), cand.photonPhi());
-      if (((cand.photonPhi() < PhotonPhiMin1) || ((cand.photonPhi() > PhotonPhiMax1) && (cand.photonPhi() < PhotonPhiMin2)) || ((cand.photonPhi() > PhotonPhiMax2) && (PhotonPhiMax2 != -1))))
-        return false;
-      if ((isMCTruePhoton || doPhotonLambdaSelQA) && (TMath::Abs(cand.photonMass()) <= PhotonMaxMass))
-        histos.fill(HIST("PhotonSelQA/h2dPhotonPhi"), cand.photonPt(), cand.photonMass());
-      histos.fill(HIST("GeneralQA/h3dPhotonMass"), cand.sigmaCentrality(), cand.photonPt(), cand.photonMass());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 17.);
-      if (TMath::Abs(cand.photonMass()) > PhotonMaxMass)
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dPhotonMass"), cand.sigmapT(), cand.sigmaMass());
-      if (isMCTruePhoton || doPhotonLambdaSelQA)
-        histos.fill(HIST("PhotonSelQA/h2dPhotonMass"), cand.photonPt(), cand.photonMass());
-
-      // ####
-      //  Lambda selections
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 18.);
-      histos.fill(HIST("GeneralQA/hLambdaRadius"), cand.lambdaRadius());
-      if ((isMCTrueLambda || doPhotonLambdaSelQA) && (TMath::Abs(cand.lambdaMass() - o2::constants::physics::MassLambda0) < LambdaWindow))
-        histos.fill(HIST("LambdaSelQA/h2dLambdaBaseline"), cand.lambdaPt(), cand.lambdaMass());
-      if ((cand.lambdaRadius() < LambdaMinv0radius) || (cand.lambdaRadius() > LambdaMaxv0radius))
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dLambdaRadius"), cand.sigmapT(), cand.sigmaMass());
-      if ((isMCTrueLambda || doPhotonLambdaSelQA) && (TMath::Abs(cand.lambdaMass() - o2::constants::physics::MassLambda0) < LambdaWindow))
-        histos.fill(HIST("LambdaSelQA/h2dLambdaRadius"), cand.lambdaPt(), cand.lambdaMass());
-      histos.fill(HIST("GeneralQA/hLambdaDCADau"), cand.lambdaDCADau());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 19.);
-      if (TMath::Abs(cand.lambdaDCADau()) > LambdaMaxDCAV0Dau)
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dLambdaDCADau"), cand.sigmapT(), cand.sigmaMass());
-      if ((isMCTrueLambda || doPhotonLambdaSelQA) && (TMath::Abs(cand.lambdaMass() - o2::constants::physics::MassLambda0) < LambdaWindow))
-        histos.fill(HIST("LambdaSelQA/h2dLambdaDCADau"), cand.lambdaPt(), cand.lambdaMass());
-      histos.fill(HIST("GeneralQA/h2dLambdaArmenteros"), cand.lambdaAlpha(), cand.lambdaQt());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 20.);
-      if ((cand.lambdaQt() < LambdaMinQt) || (cand.lambdaQt() > LambdaMaxQt))
-        return false;
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 21.);
-      if ((TMath::Abs(cand.lambdaAlpha()) < LambdaMinAlpha) || (TMath::Abs(cand.lambdaAlpha()) > LambdaMaxAlpha))
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dLambdaArmenteros"), cand.sigmapT(), cand.sigmaMass());
-      if ((isMCTrueLambda || doPhotonLambdaSelQA) && (TMath::Abs(cand.lambdaMass() - o2::constants::physics::MassLambda0) < LambdaWindow))
-        histos.fill(HIST("LambdaSelQA/h2dLambdaArmenteros"), cand.lambdaPt(), cand.lambdaMass());
-      histos.fill(HIST("GeneralQA/hLambdaCosPA"), cand.lambdaCosPA());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 22.);
-      if (cand.lambdaCosPA() < LambdaMinv0cospa)
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dLambdaCosPA"), cand.sigmapT(), cand.sigmaMass());
-      if ((isMCTrueLambda || doPhotonLambdaSelQA) && (TMath::Abs(cand.lambdaMass() - o2::constants::physics::MassLambda0) < LambdaWindow))
-        histos.fill(HIST("LambdaSelQA/h2dLambdaCosPA"), cand.lambdaPt(), cand.lambdaMass());
-      histos.fill(HIST("GeneralQA/hLambdaY"), cand.lambdaY());
-      histos.fill(HIST("GeneralQA/hLambdaPosEta"), cand.lambdaPosEta());
-      histos.fill(HIST("GeneralQA/hLambdaNegEta"), cand.lambdaNegEta());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 23.);
-      if ((TMath::Abs(cand.lambdaY()) > LambdaMaxRap) || (TMath::Abs(cand.lambdaPosEta()) > LambdaMaxDauEta) || (TMath::Abs(cand.lambdaNegEta()) > LambdaMaxDauEta))
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dLambdaY"), cand.sigmapT(), cand.sigmaMass());
-      if ((isMCTrueLambda || doPhotonLambdaSelQA) && (TMath::Abs(cand.lambdaMass() - o2::constants::physics::MassLambda0) < LambdaWindow))
-        histos.fill(HIST("LambdaSelQA/h2dLambdaY"), cand.lambdaPt(), cand.lambdaMass());
-      histos.fill(HIST("GeneralQA/hLambdaPosTPCCR"), cand.lambdaPosTPCCrossedRows());
-      histos.fill(HIST("GeneralQA/hLambdaNegTPCCR"), cand.lambdaNegTPCCrossedRows());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 24.);
-      if ((cand.lambdaPosTPCCrossedRows() < LambdaMinTPCCrossedRows) || (cand.lambdaNegTPCCrossedRows() < LambdaMinTPCCrossedRows))
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dLambdaDauTPCCR"), cand.sigmapT(), cand.sigmaMass());
-      if ((isMCTrueLambda || doPhotonLambdaSelQA) && (TMath::Abs(cand.lambdaMass() - o2::constants::physics::MassLambda0) < LambdaWindow))
-        histos.fill(HIST("LambdaSelQA/h2dLambdaDauTPCCR"), cand.lambdaPt(), cand.lambdaMass());
-      histos.fill(HIST("GeneralQA/hLambdaPosITSCls"), cand.lambdaPosITSCls());
-      histos.fill(HIST("GeneralQA/hLambdaNegITSCls"), cand.lambdaNegITSCls());
-      histos.fill(HIST("GeneralQA/hLambdaPosChi2PerNc"), cand.lambdaPosChi2PerNcl());
-      histos.fill(HIST("GeneralQA/hLambdaNegChi2PerNc"), cand.lambdaNegChi2PerNcl());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 25.);
-      // check minimum number of ITS clusters + reject ITS afterburner tracks if requested
-      bool posIsFromAfterburner = cand.lambdaPosChi2PerNcl() < 0;
-      bool negIsFromAfterburner = cand.lambdaNegChi2PerNcl() < 0;
-      if (cand.lambdaPosITSCls() < LambdaMinITSclusters && (!LambdaRejectPosITSafterburner || posIsFromAfterburner))
-        return false;
-      if (cand.lambdaNegITSCls() < LambdaMinITSclusters && (!LambdaRejectNegITSafterburner || negIsFromAfterburner))
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dLambdaDauITSCls"), cand.sigmapT(), cand.sigmaMass());
-      if ((isMCTrueLambda || doPhotonLambdaSelQA) && (TMath::Abs(cand.lambdaMass() - o2::constants::physics::MassLambda0) < LambdaWindow))
-        histos.fill(HIST("LambdaSelQA/h2dLambdaDauITSCls"), cand.lambdaPt(), cand.lambdaMass());
-      histos.fill(HIST("GeneralQA/hLambdaLifeTime"), cand.lambdaLifeTime());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 26.);
-      if (cand.lambdaLifeTime() > LambdaMaxLifeTime)
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dLambdaLifeTime"), cand.sigmapT(), cand.sigmaMass());
-      if ((isMCTrueLambda || doPhotonLambdaSelQA) && (TMath::Abs(cand.lambdaMass() - o2::constants::physics::MassLambda0) < LambdaWindow))
-        histos.fill(HIST("LambdaSelQA/h2dLambdaLifeTime"), cand.lambdaPt(), cand.lambdaMass());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 27.);
-      // Separating lambda and antilambda selections:
-      if (isLambdalike) { // Lambda selection
-        histos.fill(HIST("GeneralQA/h2dTPCvsTOFNSigma_LambdaPr"), cand.lambdaPosPrTPCNSigma(), cand.lambdaPrTOFNSigma());
-        histos.fill(HIST("GeneralQA/h2dTPCvsTOFNSigma_LambdaPi"), cand.lambdaNegPiTPCNSigma(), cand.lambdaPiTOFNSigma());
-
-        // TPC Selection
-        if (fselLambdaTPCPID && (TMath::Abs(cand.lambdaPosPrTPCNSigma()) > LambdaMaxTPCNSigmas))
-          return false;
-        if (fselLambdaTPCPID && (TMath::Abs(cand.lambdaNegPiTPCNSigma()) > LambdaMaxTPCNSigmas))
-          return false;
-
-        // TOF Selection
-        if (fselLambdaTOFPID && (TMath::Abs(cand.lambdaPrTOFNSigma()) > LambdaPrMaxTOFNSigmas))
-          return false;
-        if (fselLambdaTOFPID && (TMath::Abs(cand.lambdaPiTOFNSigma()) > LambdaPiMaxTOFNSigmas))
-          return false;
-
-        histos.fill(HIST("SigmaSelQA/h2dTPCvsTOFNSigma_Lambda"), cand.sigmapT(), cand.sigmaMass());
-        if ((isMCTrueLambda || doPhotonLambdaSelQA) && (TMath::Abs(cand.lambdaMass() - o2::constants::physics::MassLambda0) < LambdaWindow))
-          histos.fill(HIST("LambdaSelQA/h2dTPCvsTOFNSigma_Lambda"), cand.lambdaPt(), cand.lambdaMass());
-        // DCA Selection
-        histos.fill(HIST("GeneralQA/hLambdaDCANegToPV"), cand.lambdaDCANegPV());
-        histos.fill(HIST("GeneralQA/hLambdaDCAPosToPV"), cand.lambdaDCAPosPV());
-        histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 28.);
-        if ((TMath::Abs(cand.lambdaDCAPosPV()) < LambdaMinDCAPosToPv) || (TMath::Abs(cand.lambdaDCANegPV()) < LambdaMinDCANegToPv))
-          return false;
-        histos.fill(HIST("SigmaSelQA/h2dLambdaDCADauToPV"), cand.sigmapT(), cand.sigmaMass());
-        if ((isMCTrueLambda || doPhotonLambdaSelQA) && (TMath::Abs(cand.lambdaMass() - o2::constants::physics::MassLambda0) < LambdaWindow))
-          histos.fill(HIST("LambdaSelQA/h2dLambdaDCADauToPV"), cand.lambdaPt(), cand.lambdaMass());
-
-        // Mass Selection
-        histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 29.);
-        histos.fill(HIST("GeneralQA/h3dLambdaMass"), cand.sigmaCentrality(), cand.lambdaPt(), cand.lambdaMass());
-        if (TMath::Abs(cand.lambdaMass() - o2::constants::physics::MassLambda0) > LambdaWindow)
-          return false;
-        histos.fill(HIST("SigmaSelQA/h2dLambdaMass"), cand.sigmapT(), cand.sigmaMass());
-        if (isMCTrueLambda || doPhotonLambdaSelQA)
-          histos.fill(HIST("LambdaSelQA/h2dLambdaMass"), cand.lambdaPt(), cand.lambdaMass());
-
-      } else { // AntiLambda selection
-        histos.fill(HIST("GeneralQA/h2dTPCvsTOFNSigma_ALambdaPr"), cand.lambdaNegPrTPCNSigma(), cand.aLambdaPrTOFNSigma());
-        histos.fill(HIST("GeneralQA/h2dTPCvsTOFNSigma_ALambdaPi"), cand.lambdaPosPiTPCNSigma(), cand.aLambdaPiTOFNSigma());
-
-        // TPC Selection
-        if (fselLambdaTPCPID && (TMath::Abs(cand.lambdaPosPiTPCNSigma()) > LambdaMaxTPCNSigmas))
-          return false;
-        if (fselLambdaTPCPID && (TMath::Abs(cand.lambdaNegPrTPCNSigma()) > LambdaMaxTPCNSigmas))
-          return false;
-
-        // TOF Selection
-        if (fselLambdaTOFPID && (TMath::Abs(cand.aLambdaPrTOFNSigma()) > LambdaPrMaxTOFNSigmas))
-          return false;
-        if (fselLambdaTOFPID && (TMath::Abs(cand.aLambdaPiTOFNSigma()) > LambdaPiMaxTOFNSigmas))
-          return false;
-
-        histos.fill(HIST("SigmaSelQA/h2dTPCvsTOFNSigma_ALambda"), cand.sigmapT(), cand.sigmaMass());
-        // DCA Selection
-        histos.fill(HIST("GeneralQA/hALambdaDCANegToPV"), cand.lambdaDCANegPV());
-        histos.fill(HIST("GeneralQA/hALambdaDCAPosToPV"), cand.lambdaDCAPosPV());
-        histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 28.);
-        if ((TMath::Abs(cand.lambdaDCAPosPV()) < ALambdaMinDCAPosToPv) || (TMath::Abs(cand.lambdaDCANegPV()) < ALambdaMinDCANegToPv))
-          return false;
-
-        histos.fill(HIST("SigmaSelQA/h2dALambdaDCADauToPV"), cand.sigmapT(), cand.sigmaMass());
-        // Mass Selection
-        histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 29.);
-        histos.fill(HIST("GeneralQA/h3dAntiLambdaMass"), cand.sigmaCentrality(), cand.lambdaPt(), cand.antilambdaMass());
-        if (TMath::Abs(cand.antilambdaMass() - o2::constants::physics::MassLambda0) > LambdaWindow)
-          return false;
-        histos.fill(HIST("SigmaSelQA/h2dAntiLambdaMass"), cand.sigmapT(), cand.sigmaMass());
-      }
-
-      // Sigma0 selection
-      histos.fill(HIST("GeneralQA/hSigmaY"), cand.sigmaRapidity());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 30.);
-      if (TMath::Abs(cand.sigmaRapidity()) > SigmaMaxRap)
-        return false;
-      histos.fill(HIST("SigmaSelQA/h2dSigmaY"), cand.sigmapT(), cand.sigmaMass());
-      histos.fill(HIST("GeneralQA/hSigmaOPAngle"), cand.sigmaOPAngle());
-      histos.fill(HIST("GeneralQA/hCandidateAnalysisSelection"), 31.);
+    
     }
+
+    // Go for standard analysis
+    else { 
+
+      // Photon specific selections            
+      if (!selectPhoton(cand))
+        return false;
+      
+      // Lambda specific selections
+      if (!selectLambda(cand))
+        return false;
+
+      // Sigma0 specific selections      
+      if (TMath::Abs(cand.sigmaRapidity()) > SigmaMaxRap)
+        return false;      
+    }
+
     return true;
   }
 
@@ -803,247 +943,42 @@ struct sigmaanalysis {
       if (doMCAssociation && !(sigma.isSigma() || sigma.isAntiSigma())) {
         continue;
       }
-      if (fGetIR) {
-        double interactionRate = rateFetcher.fetch(ccdb.service, sigma.sigmaTimestamp(), sigma.sigmaRunNumber(), irSource, fIRCrashOnNull) * 1.e-3;
 
-        if (interactionRate<0)          
-          histos.get<TH1>(HIST("GeneralQA/hRunNumberNegativeIR"))->Fill(Form("%d", sigma.sigmaRunNumber()), 1);
-        
-        histos.fill(HIST("GeneralQA/hInteractionRate"), interactionRate);
-        histos.fill(HIST("GeneralQA/hCentralityVsInteractionRate"), sigma.sigmaCentrality(), interactionRate);
-        if ((maxIR != -1) && (minIR != -1) && ((interactionRate <= minIR) || (interactionRate >= maxIR))) {
-          continue;
-        }
-      }
-
-      // BuilderQA
-      histos.fill(HIST("BuilderQA/hPhotonAssociation"), sigma.photonIsCorrectlyAssoc());
-      histos.fill(HIST("BuilderQA/hLambdaAssociation"), sigma.lambdaIsCorrectlyAssoc());
-
-      int GammaTrkCode = -10; // 1: TPC-only, 2: TPC+Something, 3: ITS-Only, 4: ITS+TPC + Something
-      int LambdaTrkCode = -10; // 1: TPC-only, 2: TPC+Something, 3: ITS-Only, 4: ITS+TPC + Something
+      // Fill histos before any selection
+      fillQAHistos<0>(sigma);
       
-      if (sigma.photonPosTrackCode()==1 && sigma.photonNegTrackCode()==1)
-        GammaTrkCode = 1;
-      if ((sigma.photonPosTrackCode()!=1 && sigma.photonNegTrackCode()==1) || (sigma.photonPosTrackCode()==1 && sigma.photonNegTrackCode()!=1))
-        GammaTrkCode = 2;
-      if (sigma.photonPosTrackCode()==3 && sigma.photonNegTrackCode()==3)
-        GammaTrkCode = 3;
-      if (sigma.photonPosTrackCode()==2 || sigma.photonNegTrackCode()==2)
-        GammaTrkCode = 4;
-      if (sigma.lambdaPosTrackCode()==1 && sigma.lambdaNegTrackCode()==1)
-        LambdaTrkCode = 1;
-      if ((sigma.lambdaPosTrackCode()!=1 && sigma.lambdaNegTrackCode()==1) || (sigma.lambdaPosTrackCode()==1 && sigma.lambdaNegTrackCode()!=1))
-        LambdaTrkCode = 2;
-      if (sigma.lambdaPosTrackCode()==3 && sigma.lambdaNegTrackCode()==3)
-        LambdaTrkCode = 3;
-      if (sigma.lambdaPosTrackCode()==2 || sigma.lambdaNegTrackCode()==2)
-        LambdaTrkCode = 4;
+      // Select sigma0 candidates
+      if (!processSigmaCandidate(sigma))
+        continue;
+                       
+      // Fill histos after all selections
+      fillQAHistos<1>(sigma);
 
-      if (sigma.photonIsCorrectlyAssoc()){  
-        histos.fill(HIST("BuilderQA/hPhotonTrackCode"), GammaTrkCode);
-        histos.fill(HIST("BuilderQA/hLambdaTrackCode"), LambdaTrkCode);
+      nSigmaCandidates++;
+      if (nSigmaCandidates % 100000 == 0) {
+        LOG(info) << "Sigma0 Candidates processed: " << nSigmaCandidates;
       }
-
-      if ((GammaTrkCode==1) && (TMath::Abs(sigma.photonY()) <= 0.5) && (sigma.photonCandPDGCode() == 22)){
-        histos.fill(HIST("BuilderQA/hPhotonZ"), sigma.photonZconv());
-        histos.fill(HIST("BuilderQA/hPhotonCosPA"), sigma.photonCosPA());
-        histos.fill(HIST("BuilderQA/hPhotonDCADau"), sigma.photonDCADau());
-
-        if (!sigma.photonIsCorrectlyAssoc()){
-          histos.fill(HIST("BuilderQA/hPhotonZ_BadCollAssig"), sigma.photonZconv());
-          histos.fill(HIST("BuilderQA/hPhotonCosPA_BadCollAssig"), sigma.photonCosPA());
-          histos.fill(HIST("BuilderQA/hPhotonDCADau_BadCollAssig"), sigma.photonDCADau());
-        }
-      }
-           
-      // Filling histos before analysis selection
-      histos.fill(HIST("MC/h2dSigmaMCPtVsLambdaMCPt"), sigma.sigmaMCPt(), sigma.lambdaMCPt());
-      histos.fill(HIST("MC/h2dSigmaMCPtVsGammaMCPt"), sigma.sigmaMCPt(), sigma.photonMCPt());
-      histos.fill(HIST("MC/h3dMassAllSigma0sBeforesel"), sigma.sigmaCentrality(), sigma.sigmapT(), sigma.sigmaMass());
-      histos.fill(HIST("MC/h2dArmenterosBeforeSel"), sigma.photonAlpha(), sigma.photonQt());
-      histos.fill(HIST("MC/h2dArmenterosBeforeSel"), sigma.lambdaAlpha(), sigma.lambdaQt());
-      histos.fill(HIST("MC/hMassSigma0BeforeSel"), sigma.sigmaMass());
-      histos.fill(HIST("MC/hPtSigma0BeforeSel"), sigma.sigmapT());
-      histos.fill(HIST("MC/hPtGammaCand_BeforeSel"), sigma.photonPt());
-      histos.fill(HIST("MC/hPtLambdaCand_BeforeSel"), sigma.lambdaPt());
-      histos.fill(HIST("MC/hPtSigmaCand_BeforeSel"), sigma.sigmapT());
-
-      if (sigma.photonCandPDGCode() == 22) {
-        histos.fill(HIST("MC/hPtTrueGamma_BeforeSel"), sigma.photonPt());
-        if (sigma.photonMCPt() > 0) {
-          histos.fill(HIST("MC/h3dGammaPtResoVsTPCCR"), 1.f / sigma.lambdaMCPt(), 1.f / sigma.lambdaPt() - 1.f / sigma.lambdaMCPt(), -1 * sigma.photonNegTPCCrossedRows()); // 1/pT resolution
-          histos.fill(HIST("MC/h3dGammaPtResoVsTPCCR"), 1.f / sigma.lambdaMCPt(), 1.f / sigma.lambdaPt() - 1.f / sigma.lambdaMCPt(), sigma.photonPosTPCCrossedRows());      // 1/pT resolution
-          histos.fill(HIST("MC/h2dGammaPtResolution"), 1.f / sigma.photonMCPt(), 1.f / sigma.photonPt() - 1.f / sigma.photonMCPt());                                        // pT resolution
-        }
-      }
-      if (sigma.lambdaCandPDGCode() == 3122) {
-        histos.fill(HIST("MC/hPtTrueLambda_BeforeSel"), sigma.lambdaPt());
-        if (sigma.lambdaMCPt() > 0) {
-          histos.fill(HIST("MC/h2dLambdaPtResolution"), 1.f / sigma.lambdaMCPt(), 1.f / sigma.lambdaPt() - 1.f / sigma.lambdaMCPt());                                        // 1/pT resolution
-          histos.fill(HIST("MC/h3dLambdaPtResoVsTPCCR"), 1.f / sigma.lambdaMCPt(), 1.f / sigma.lambdaPt() - 1.f / sigma.lambdaMCPt(), -1 * sigma.lambdaNegTPCCrossedRows()); // 1/pT resolution
-          histos.fill(HIST("MC/h3dLambdaPtResoVsTPCCR"), 1.f / sigma.lambdaMCPt(), 1.f / sigma.lambdaPt() - 1.f / sigma.lambdaMCPt(), sigma.lambdaPosTPCCrossedRows());      // 1/pT resolution
-        }
-      }
-      if (sigma.lambdaCandPDGCode() == -3122) {
-        if (sigma.lambdaMCPt() > 0) {
-          histos.fill(HIST("MC/h2dAntiLambdaPtResolution"), 1.f / sigma.lambdaMCPt(), 1.f / sigma.lambdaPt() - 1.f / sigma.lambdaMCPt());                                        // pT resolution
-          histos.fill(HIST("MC/h3dAntiLambdaPtResoVsTPCCR"), 1.f / sigma.lambdaMCPt(), 1.f / sigma.lambdaPt() - 1.f / sigma.lambdaMCPt(), -1 * sigma.lambdaNegTPCCrossedRows()); // 1/pT resolution
-          histos.fill(HIST("MC/h3dAntiLambdaPtResoVsTPCCR"), 1.f / sigma.lambdaMCPt(), 1.f / sigma.lambdaPt() - 1.f / sigma.lambdaMCPt(), sigma.lambdaPosTPCCrossedRows());      // 1/pT resolution
-        }
-        histos.fill(HIST("MC/hPtTrueAntiLambda_BeforeSel"), sigma.lambdaPt());
-      }
-      if (sigma.isSigma()) {
-        histos.fill(HIST("MC/hPtTrueSigma_BeforeSel"), sigma.sigmapT());
-        if (sigma.sigmaMCPt() > 0)
-          histos.fill(HIST("MC/h2dSigma0PtResolution"), 1.f / sigma.sigmaMCPt(), 1.f / sigma.sigmapT() - 1.f / sigma.sigmaMCPt()); // pT resolution
-      }
-      if (sigma.isAntiSigma()) {
-        histos.fill(HIST("MC/hPtTrueAntiSigma_BeforeSel"), sigma.sigmapT());
-        if (sigma.sigmaMCPt() > 0)
-          histos.fill(HIST("MC/h2dAntiSigma0PtResolution"), 1.f / sigma.sigmaMCPt(), 1.f / sigma.sigmapT() - 1.f / sigma.sigmaMCPt()); // pT resolution
-      }
-
-      if (sigma.lambdaAlpha() > 0) { // Lambda Analysis
-        if (!processSigmaCandidate(sigma, true))
-          continue;
-
-        // For Lambda PID Studies
-        histos.fill(HIST("MC/hPtLambdaCand_AfterSel"), sigma.lambdaPt());
-        histos.fill(HIST("MC/h3dTPCvsTOFNSigma_LambdaPr"), sigma.lambdaPosPrTPCNSigma(), sigma.lambdaPrTOFNSigma(), sigma.lambdaPt());
-        histos.fill(HIST("MC/h3dTPCvsTOFNSigma_LambdaPi"), sigma.lambdaNegPiTPCNSigma(), sigma.lambdaPiTOFNSigma(), sigma.lambdaPt());
-
-        if (sigma.lambdaCandPDGCode() == 3122) {
-          histos.fill(HIST("MC/hPtTrueLambda_AfterSel"), sigma.lambdaPt());
-          histos.fill(HIST("MC/h3dTPCvsTOFNSigma_TrueLambdaPr"), sigma.lambdaPosPrTPCNSigma(), sigma.lambdaPrTOFNSigma(), sigma.lambdaPt());
-          histos.fill(HIST("MC/h3dTPCvsTOFNSigma_TrueLambdaPi"), sigma.lambdaNegPiTPCNSigma(), sigma.lambdaPiTOFNSigma(), sigma.lambdaPt());
-        }
-        histos.fill(HIST("GeneralQA/hLambdaMassSelected"), sigma.lambdaMass());
-        histos.fill(HIST("Sigma0/hMassSigma0"), sigma.sigmaMass());
-        histos.fill(HIST("Sigma0/hPtSigma0"), sigma.sigmapT());
-        histos.fill(HIST("Sigma0/hRapiditySigma0"), sigma.sigmaRapidity());
-        histos.fill(HIST("Sigma0/h3dMassSigma0"), sigma.sigmaCentrality(), sigma.sigmapT(), sigma.sigmaMass());
-        histos.fill(HIST("Sigma0/h3dPhotonRadiusVsMassSigma0"), sigma.sigmaCentrality(), sigma.photonRadius(), sigma.sigmaMass());
-
-        if (sigma.isSigma()) { // Signal study
-          histos.fill(HIST("MC/h2dArmenterosAfterSel"), sigma.photonAlpha(), sigma.photonQt());
-          histos.fill(HIST("MC/h2dArmenterosAfterSel"), sigma.lambdaAlpha(), sigma.lambdaQt());
-          histos.fill(HIST("MC/hMassSigma0"), sigma.sigmaMass());
-          histos.fill(HIST("MC/hPtSigma0"), sigma.sigmapT());
-          histos.fill(HIST("MC/h3dMassSigma0"), sigma.sigmaCentrality(), sigma.sigmapT(), sigma.sigmaMass());
-          histos.fill(HIST("MC/h2dPtVsMassSigma_SignalOnly"), sigma.sigmapT(), sigma.sigmaMass());
-          histos.fill(HIST("MC/hPtTrueSigma_AfterSel"), sigma.sigmapT());
-        }
-      } else { // AntiLambda Analysis
-        if (!processSigmaCandidate(sigma, false))
-          continue;
-
-        if (sigma.lambdaCandPDGCode() == -3122) {
-          histos.fill(HIST("MC/hPtTrueAntiLambda_AfterSel"), sigma.lambdaPt());
-          histos.fill(HIST("MC/h3dTPCvsTOFNSigma_TrueALambdaPr"), sigma.lambdaNegPrTPCNSigma(), sigma.aLambdaPrTOFNSigma(), sigma.lambdaPt());
-          histos.fill(HIST("MC/h3dTPCvsTOFNSigma_TrueALambdaPi"), sigma.lambdaPosPiTPCNSigma(), sigma.aLambdaPiTOFNSigma(), sigma.lambdaPt());
-        }
-        histos.fill(HIST("GeneralQA/hAntiLambdaMassSelected"), sigma.antilambdaMass());
-        histos.fill(HIST("AntiSigma0/hMassAntiSigma0"), sigma.sigmaMass());
-        histos.fill(HIST("AntiSigma0/hPtAntiSigma0"), sigma.sigmapT());
-        histos.fill(HIST("AntiSigma0/hRapidityAntiSigma0"), sigma.sigmaRapidity());
-        histos.fill(HIST("AntiSigma0/h3dMassAntiSigma0"), sigma.sigmaCentrality(), sigma.sigmapT(), sigma.sigmaMass());
-        histos.fill(HIST("AntiSigma0/h3dPhotonRadiusVsMassAntiSigma0"), sigma.sigmaCentrality(), sigma.photonRadius(), sigma.sigmaMass());
-        if (sigma.isAntiSigma()) { // Signal study
-          histos.fill(HIST("MC/h2dArmenterosAfterSel"), sigma.photonAlpha(), sigma.photonQt());
-          histos.fill(HIST("MC/h2dArmenterosAfterSel"), sigma.lambdaAlpha(), sigma.lambdaQt());
-          histos.fill(HIST("MC/hMassAntiSigma0"), sigma.sigmaMass());
-          histos.fill(HIST("MC/hPtAntiSigma0"), sigma.sigmapT());
-          histos.fill(HIST("MC/h3dMassAntiSigma0"), sigma.sigmaCentrality(), sigma.sigmapT(), sigma.sigmaMass());
-          histos.fill(HIST("MC/h2dPtVsMassSigma_SignalOnly"), sigma.sigmapT(), sigma.sigmaMass());
-          histos.fill(HIST("MC/hPtTrueSigma_AfterSel"), sigma.sigmapT());
-        }
-      }
-
-      // Fill histos after selection, please
-      histos.fill(HIST("MC/hPtGammaCand_AfterSel"), sigma.photonPt());
-      histos.fill(HIST("GeneralQA/hPhotonMassSelected"), sigma.photonMass());
-      histos.fill(HIST("MC/hPtSigmaCand_AfterSel"), sigma.sigmapT());
-
-      if (sigma.photonCandPDGCode() == 22) {
-        histos.fill(HIST("MC/hPtTrueGamma_AfterSel"), sigma.photonPt());
-      }
-
-      // For background studies:
-      histos.fill(HIST("MC/h2dPtVsMassSigma_SignalBkg"), sigma.sigmapT(), sigma.sigmaMass());
-      // Real Gamma x Real Lambda - but not from the same sigma0/antisigma0!
-      if ((sigma.photonCandPDGCode() == 22) && ((sigma.lambdaCandPDGCode() == 3122) || (sigma.lambdaCandPDGCode() == -3122)) && !(sigma.isSigma()) && !(sigma.isAntiSigma())) {
-        histos.fill(HIST("MC/h2dPtVsMassSigma_TrueDaughters"), sigma.sigmapT(), sigma.sigmaMass());
-        histos.fill(HIST("MC/h2dTrueDaughtersMatrix"), sigma.lambdaCandPDGCodeMother(), sigma.photonCandPDGCodeMother());
-        histos.fill(HIST("MC/h2dPtVsOPAngle_TrueDaughters"), sigma.sigmapT(), sigma.sigmaOPAngle());
-      }
-      // Real Gamma x fake Lambda
-      if ((sigma.photonCandPDGCode() == 22) && (sigma.lambdaCandPDGCode() != 3122) && (sigma.lambdaCandPDGCode() != -3122))
-        histos.fill(HIST("MC/h2dPtVsMassSigma_TrueGammaFakeLambda"), sigma.sigmapT(), sigma.sigmaMass());
-
-      // Fake Gamma x Real Lambda
-      if ((sigma.photonCandPDGCode() != 22) && ((sigma.lambdaCandPDGCode() == 3122) || (sigma.lambdaCandPDGCode() == -3122)))
-        histos.fill(HIST("MC/h2dPtVsMassSigma_FakeGammaTrueLambda"), sigma.sigmapT(), sigma.sigmaMass());
-
-      // Fake Gamma x Fake Lambda
-      if ((sigma.photonCandPDGCode() != 22) && (sigma.lambdaCandPDGCode() != 3122) && (sigma.lambdaCandPDGCode() != -3122))
-        histos.fill(HIST("MC/h2dPtVsMassSigma_FakeDaughters"), sigma.sigmapT(), sigma.sigmaMass());
     }
   }
 
   void processRealData(V0Sigmas const& sigmas)
   {
     for (auto& sigma : sigmas) { // selecting Sigma0-like candidates
-      if (fGetIR) {
-        double interactionRate = rateFetcher.fetch(ccdb.service, sigma.sigmaTimestamp(), sigma.sigmaRunNumber(), irSource, fIRCrashOnNull) * 1.e-3;
-
-        if (interactionRate<0)          
-          histos.get<TH1>(HIST("GeneralQA/hRunNumberNegativeIR"))->Fill(Form("%d", sigma.sigmaRunNumber()), 1);
-        histos.fill(HIST("GeneralQA/hInteractionRate"), interactionRate);
-        histos.fill(HIST("GeneralQA/hCentralityVsInteractionRate"), sigma.sigmaCentrality(), interactionRate);
-        if ((maxIR != -1) && (minIR != -1) && ((interactionRate <= minIR) || (interactionRate >= maxIR))) {
-          continue;
-        }
-      }
-      histos.fill(HIST("GeneralQA/h2dArmenterosBeforeSel"), sigma.photonAlpha(), sigma.photonQt());
-      histos.fill(HIST("GeneralQA/h2dArmenterosBeforeSel"), sigma.lambdaAlpha(), sigma.lambdaQt());
-      histos.fill(HIST("GeneralQA/hMassSigma0BeforeSel"), sigma.sigmaMass());
-
+                
+      // Fill histos before any selection
+      fillQAHistos<0>(sigma);
+      
+      // Select sigma0 candidates
+      if (!processSigmaCandidate(sigma))
+        continue;
+                       
+      // Fill histos after all selections
+      fillQAHistos<1>(sigma);
+      
       nSigmaCandidates++;
       if (nSigmaCandidates % 100000 == 0) {
-        LOG(info) << "Sigma0-like Candidates processed: " << nSigmaCandidates;
+        LOG(info) << "Sigma0 Candidates processed: " << nSigmaCandidates;
       }
-
-      if (sigma.lambdaAlpha() > 0) {
-        // Perform analysis selection for sigma0
-        if (!processSigmaCandidate(sigma, true))
-          continue;
-
-        histos.fill(HIST("GeneralQA/h2dArmenterosAfterSel"), sigma.photonAlpha(), sigma.photonQt());
-        histos.fill(HIST("GeneralQA/h2dArmenterosAfterSel"), sigma.lambdaAlpha(), sigma.lambdaQt());
-        histos.fill(HIST("GeneralQA/hLambdaMassSelected"), sigma.lambdaMass());
-        histos.fill(HIST("Sigma0/hMassSigma0"), sigma.sigmaMass());
-        histos.fill(HIST("Sigma0/hPtSigma0"), sigma.sigmapT());
-        histos.fill(HIST("Sigma0/hRapiditySigma0"), sigma.sigmaRapidity());
-        histos.fill(HIST("Sigma0/h3dMassSigma0"), sigma.sigmaCentrality(), sigma.sigmapT(), sigma.sigmaMass());
-        histos.fill(HIST("Sigma0/h3dPhotonRadiusVsMassSigma0"), sigma.sigmaCentrality(), sigma.photonRadius(), sigma.sigmaMass());
-
-      } else {
-
-        // Perform analysis selection for antisigma0
-        if (!processSigmaCandidate(sigma, false))
-          continue;
-
-        histos.fill(HIST("GeneralQA/h2dArmenterosAfterSel"), sigma.photonAlpha(), sigma.photonQt());
-        histos.fill(HIST("GeneralQA/h2dArmenterosAfterSel"), sigma.lambdaAlpha(), sigma.lambdaQt());
-        histos.fill(HIST("GeneralQA/hAntiLambdaMassSelected"), sigma.antilambdaMass());
-        histos.fill(HIST("AntiSigma0/hMassAntiSigma0"), sigma.sigmaMass());
-        histos.fill(HIST("AntiSigma0/hPtAntiSigma0"), sigma.sigmapT());
-        histos.fill(HIST("AntiSigma0/hRapidityAntiSigma0"), sigma.sigmaRapidity());
-        histos.fill(HIST("AntiSigma0/h3dMassAntiSigma0"), sigma.sigmaCentrality(), sigma.sigmapT(), sigma.sigmaMass());
-        histos.fill(HIST("AntiSigma0/h3dPhotonRadiusVsMassAntiSigma0"), sigma.sigmaCentrality(), sigma.photonRadius(), sigma.sigmaMass());
-      }
-      histos.fill(HIST("GeneralQA/hPhotonMassSelected"), sigma.photonMass());
     }
   }
   
@@ -1055,3 +990,4 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{adaptAnalysisTask<sigmaanalysis>(cfgc)};
 }
+


### PR DESCRIPTION
This PR introduces several improvements to the Sigma0-related tasks:

- The sigma0builder now pre-selects photons and lambdas separately before combining them in the nested loop. This significantly reduces the N² scaling and should improve CPU performance.

- In both sigma0builder and sigmaanalysis, histogram definitions and filling logic have been reorganized to improve memory efficiency and code readability.

- Photon and lambda selections have been encapsulated into dedicated functions for better modularity and maintainability, applied to both sigma0builder and sigmaanalysis.

- Other Changes:

  - Removed deprecated event selection.
  - Interaction rate (IR) info is now included in the Sigma0 data model.
  - A new module has been added to check V0-to-collision associations (QA purposes)
  
Tagging @ddobrigk 