### PR TITLE
[PWGJE] modification of IP tagging method

### DIFF
--- a/PWGJE/TableProducer/jetTaggerHF.cxx
+++ b/PWGJE/TableProducer/jetTaggerHF.cxx
@@ -237,7 +237,6 @@ struct JetTaggerHFTask {
     }
     if (useJetProb) {
       if constexpr (isMC) {
-        std::cout << "before calculate Jet Probability .... " << std::endl;
         jetProb = calculateJetProbability(origin, jet, tracks, isMC);
         if (trackProbQA) {
           evaluateTrackProbQA(origin, jet, tracks, isMC);
@@ -290,14 +289,16 @@ struct JetTaggerHFTask {
     std::map<std::string, std::string> metadata;
     resoFuncMatch = resoFuncMatching;
 
+    const int IPmethod_resolution_function_size = 7;
+
     auto loadCCDBforIP = [&](const std::vector<std::string>& paths, std::vector<TF1*>& targetVec, const std::string& name) {
-      if (paths.size() != 7) {
+      if (paths.size() != IPmethod_resolution_function_size) {
         usepTcategorize.value = false;
         LOG(info) << name << " does not have 7 entries. Disabling pT categorization (usepTcategorize = false).";
         resoFuncMatch = 0;
         return;
       }
-      for (int i = 0; i < 7; i++) {
+      for (int i = 0; i < IPmethod_resolution_function_size; i++) {
         targetVec.push_back(ccdbApi.retrieveFromTFileAny<TF1>(paths[i], metadata, -1));
       }
     };
@@ -322,6 +323,7 @@ struct JetTaggerHFTask {
     }
 
     maxOrder = numCount + 1; // 0: untagged, >1 : N ordering
+    const int IPmethod_numOfParameters = 9;
 
     // Set up the resolution function
     switch (resoFuncMatch) {
@@ -387,7 +389,7 @@ struct JetTaggerHFTask {
         for (size_t j = 0; j < resoFuncBeautyCCDB.size(); j++) {
           std::vector<float> params;
           if (resoFuncBeautyCCDB[j]) {
-            for (int i = 0; i < 9; i++) {
+            for (int i = 0; i < IPmethod_numOfParameters; i++) {
               params.emplace_back(resoFuncBeautyCCDB[j]->GetParameter(i));
             }
           }
@@ -396,7 +398,7 @@ struct JetTaggerHFTask {
         for (size_t j = 0; j < resoFuncCharmCCDB.size(); j++) {
           std::vector<float> params;
           if (resoFuncCharmCCDB[j]) {
-            for (int i = 0; i < 9; i++) {
+            for (int i = 0; i < IPmethod_numOfParameters; i++) {
               params.emplace_back(resoFuncCharmCCDB[j]->GetParameter(i));
             }
           }
@@ -405,7 +407,7 @@ struct JetTaggerHFTask {
         for (size_t j = 0; j < resoFuncLfCCDB.size(); j++) {
           std::vector<float> params;
           if (resoFuncLfCCDB[j]) {
-            for (int i = 0; i < 9; i++) {
+            for (int i = 0; i < IPmethod_numOfParameters; i++) {
               params.emplace_back(resoFuncLfCCDB[j]->GetParameter(i));
             }
           }

--- a/PWGJE/TableProducer/jetTaggerHF.cxx
+++ b/PWGJE/TableProducer/jetTaggerHF.cxx
@@ -64,7 +64,10 @@ struct JetTaggerHFTask {
   Configurable<bool> trackProbQA{"trackProbQA", false, "fill track probability histograms separately for geometric positive and negative tracks for QA"};
   Configurable<int> numCount{"numCount", 3, "number of track counting"};
   Configurable<int> resoFuncMatching{"resoFuncMatching", 0, "matching parameters of resolution function as MC samble (0: custom, 1: custom & inc, 2: MB, 3: MB & inc, 4: JJ, 5: JJ & inc)"};
-  Configurable<std::vector<std::string>> pathsCCDBforIPparamer{"pathsCCDBforIPparamer", std::vector<std::string>{"Users/l/leehy/LHC24g4/f_inclusive_0"}, "Paths for fitting parameters of resolution functions for IP method on CCDB"};
+  Configurable<std::vector<std::string>> pathsCCDBforIPIncparameter{"pathsCCDBforIPIncparameter", std::vector<std::string>{"Users/l/leehy/LHC24g4/f_inclusive_0"}, "Paths for fitting parameters of resolution functions of inclusive for IP method on CCDB"};
+  Configurable<std::vector<std::string>> pathsCCDBforIPBeautyparameter{"pathsCCDBforIPBeautyparameter", std::vector<std::string>{"Users/l/leehy/LHC24g4/f_inclusive_0"}, "Paths for fitting parameters of resolution functions of beauty for IP method on CCDB"};
+  Configurable<std::vector<std::string>> pathsCCDBforIPCharmparameter{"pathsCCDBforIPCharmparameter", std::vector<std::string>{"Users/l/leehy/LHC24g4/f_inclusive_0"}, "Paths for fitting parameters of resolution functions of charm for IP method on CCDB"};
+  Configurable<std::vector<std::string>> pathsCCDBforIPLfparameter{"pathsCCDBforIPLfparameter", std::vector<std::string>{"Users/l/leehy/LHC24g4/f_inclusive_0"}, "Paths for fitting parameters of resolution functions of light flavour for IP method on CCDB"};
   Configurable<bool> usepTcategorize{"usepTcategorize", false, "p_T categorize TF1 function with Inclusive jet"};
   Configurable<std::vector<float>> paramsResoFuncData{"paramsResoFuncData", std::vector<float>{-1.0}, "parameters of gaus(0)+expo(3)+expo(5)+expo(7))"};
   Configurable<std::vector<float>> paramsResoFuncIncJetMC{"paramsResoFuncIncJetMC", std::vector<float>{-1.0}, "parameters of gaus(0)+expo(3)+expo(5)+expo(7)))"};
@@ -136,7 +139,14 @@ struct JetTaggerHFTask {
   std::unique_ptr<TF1> fSignImpXYSigLfJetMC = nullptr;
 
   std::vector<std::vector<float>> vecParamsIncJetMcCCDB;
+  std::vector<std::vector<float>> vecParamsBeautyJetMcCCDB;
+  std::vector<std::vector<float>> vecParamsCharmJetMcCCDB;
+  std::vector<std::vector<float>> vecParamsLfJetMcCCDB;
+
   std::vector<std::unique_ptr<TF1>> vecfSignImpXYSigIncJetMcCCDB;
+  std::vector<std::unique_ptr<TF1>> vecfSignImpXYSigCharmJetMcCCDB;
+  std::vector<std::unique_ptr<TF1>> vecfSignImpXYSigBeautyJetMcCCDB;
+  std::vector<std::unique_ptr<TF1>> vecfSignImpXYSigLfJetMcCCDB;
 
   std::vector<uint16_t> decisionNonML;
   std::vector<float> scoreML;
@@ -158,11 +168,23 @@ struct JetTaggerHFTask {
         }
       } else {
         if (origin == JetTaggingSpecies::charm) {
-          jetProb = jettaggingutilities::getJetProbability(fSignImpXYSigCharmJetMC, jet, tracks, trackDcaXYMax, trackDcaZMax, minSignImpXYSig);
+          if (usepTcategorize) {
+            jetProb = jettaggingutilities::getJetProbability(vecfSignImpXYSigCharmJetMcCCDB, jet, tracks, trackDcaXYMax, trackDcaZMax, minSignImpXYSig);
+          } else {
+            jetProb = jettaggingutilities::getJetProbability(fSignImpXYSigCharmJetMC, jet, tracks, trackDcaXYMax, trackDcaZMax, minSignImpXYSig);
+          }
         } else if (origin == JetTaggingSpecies::beauty) {
-          jetProb = jettaggingutilities::getJetProbability(fSignImpXYSigBeautyJetMC, jet, tracks, trackDcaXYMax, trackDcaZMax, minSignImpXYSig);
+          if (usepTcategorize) {
+            jetProb = jettaggingutilities::getJetProbability(vecfSignImpXYSigBeautyJetMcCCDB, jet, tracks, trackDcaXYMax, trackDcaZMax, minSignImpXYSig);
+          } else {
+            jetProb = jettaggingutilities::getJetProbability(fSignImpXYSigBeautyJetMC, jet, tracks, trackDcaXYMax, trackDcaZMax, minSignImpXYSig);
+          }
         } else {
-          jetProb = jettaggingutilities::getJetProbability(fSignImpXYSigLfJetMC, jet, tracks, trackDcaXYMax, trackDcaZMax, minSignImpXYSig);
+          if (usepTcategorize) {
+            jetProb = jettaggingutilities::getJetProbability(vecfSignImpXYSigLfJetMcCCDB, jet, tracks, trackDcaXYMax, trackDcaZMax, minSignImpXYSig);
+          } else {
+            jetProb = jettaggingutilities::getJetProbability(fSignImpXYSigLfJetMC, jet, tracks, trackDcaXYMax, trackDcaZMax, minSignImpXYSig);
+          }
         }
       }
     }
@@ -215,12 +237,13 @@ struct JetTaggerHFTask {
     }
     if (useJetProb) {
       if constexpr (isMC) {
-        jetProb = calculateJetProbability(origin, jet, tracks);
+        std::cout << "before calculate Jet Probability .... " << std::endl;
+        jetProb = calculateJetProbability(origin, jet, tracks, isMC);
         if (trackProbQA) {
           evaluateTrackProbQA(origin, jet, tracks, isMC);
         }
       } else {
-        jetProb = calculateJetProbability(0, jet, tracks);
+        jetProb = calculateJetProbability(0, jet, tracks, isMC);
         if (trackProbQA) {
           evaluateTrackProbQA(0, jet, tracks, isMC);
         }
@@ -256,21 +279,51 @@ struct JetTaggerHFTask {
     std::vector<float> vecParamsCharmJetMC;
     std::vector<float> vecParamsBeautyJetMC;
     std::vector<float> vecParamsLfJetMC;
-    std::vector<TF1*> resoFuncCCDB;
+
+    std::vector<TF1*> resoFuncIncCCDB;
+    std::vector<TF1*> resoFuncBeautyCCDB;
+    std::vector<TF1*> resoFuncCharmCCDB;
+    std::vector<TF1*> resoFuncLfCCDB;
 
     ccdbApi.init(ccdbUrl);
-    if (usepTcategorize) {
-      std::map<std::string, std::string> metadata; // dummy meta data (will be updated)
-                                                   // fill the timestamp directly of each TF1 according to p_T track range (0, 0.5, 1, 2, 4, 6, 9)
+
+    std::map<std::string, std::string> metadata;
+    resoFuncMatch = resoFuncMatching;
+
+    auto loadCCDBforIP = [&](const std::vector<std::string>& paths, std::vector<TF1*>& targetVec, const std::string& name) {
+      if (paths.size() != 7) {
+        usepTcategorize.value = false;
+        LOG(info) << name << " does not have 7 entries. Disabling pT categorization (usepTcategorize = false).";
+        resoFuncMatch = 0;
+        return;
+      }
       for (int i = 0; i < 7; i++) {
-        resoFuncCCDB.push_back(ccdbApi.retrieveFromTFileAny<TF1>(pathsCCDBforIPparamer->at(i), metadata, -1));
+        targetVec.push_back(ccdbApi.retrieveFromTFileAny<TF1>(paths[i], metadata, -1));
+      }
+    };
+
+    if (usepTcategorize) {
+      switch (resoFuncMatch) {
+        case 6:
+          loadCCDBforIP(pathsCCDBforIPIncparameter, resoFuncIncCCDB, "pathsCCDBforIPIncparameter");
+          break;
+
+        case 7:
+          loadCCDBforIP(pathsCCDBforIPBeautyparameter, resoFuncBeautyCCDB, "pathsCCDBforIPBeautyparameter");
+          loadCCDBforIP(pathsCCDBforIPCharmparameter, resoFuncCharmCCDB, "pathsCCDBforIPCharmparameter");
+          loadCCDBforIP(pathsCCDBforIPLfparameter, resoFuncLfCCDB, "pathsCCDBforIPLfparameter");
+          break;
+
+        default:
+          LOG(info) << "resoFuncMatching is neither 6 nor 7, although usepTcategorize is set to true. Resetting resoFuncMatching to 0.";
+          resoFuncMatch = 0;
+          break;
       }
     }
 
     maxOrder = numCount + 1; // 0: untagged, >1 : N ordering
 
     // Set up the resolution function
-    resoFuncMatch = resoFuncMatching;
     switch (resoFuncMatch) {
       case 0:
         vecParamsData = (std::vector<float>)paramsResoFuncData;
@@ -313,12 +366,12 @@ struct JetTaggerHFTask {
         break;
       case 6: // TODO
         vecParamsData = (std::vector<float>)paramsResoFuncData;
-        vecParamsIncJetMC = (std::vector<float>)paramsResoFuncData;
-        for (size_t j = 0; j < resoFuncCCDB.size(); j++) {
+        vecParamsIncJetMC = (std::vector<float>)paramsResoFuncIncJetMC;
+        for (size_t j = 0; j < resoFuncIncCCDB.size(); j++) {
           std::vector<float> params;
-          if (resoFuncCCDB[j]) {
+          if (resoFuncIncCCDB[j]) {
             for (int i = 0; i < 9; i++) {
-              params.emplace_back(resoFuncCCDB[j]->GetParameter(i));
+              params.emplace_back(resoFuncIncCCDB[j]->GetParameter(i));
             }
           }
           vecParamsIncJetMcCCDB.emplace_back(params);
@@ -326,6 +379,41 @@ struct JetTaggerHFTask {
         LOG(info) << "defined parameters of resolution function from CCDB";
         useResoFuncFromIncJet = true;
         break;
+      case 7: // TODO
+        vecParamsData = (std::vector<float>)paramsResoFuncData;
+        vecParamsBeautyJetMC = (std::vector<float>)paramsResoFuncBeautyJetMC;
+        vecParamsCharmJetMC = (std::vector<float>)paramsResoFuncCharmJetMC;
+        vecParamsLfJetMC = (std::vector<float>)paramsResoFuncLfJetMC;
+        for (size_t j = 0; j < resoFuncBeautyCCDB.size(); j++) {
+          std::vector<float> params;
+          if (resoFuncBeautyCCDB[j]) {
+            for (int i = 0; i < 9; i++) {
+              params.emplace_back(resoFuncBeautyCCDB[j]->GetParameter(i));
+            }
+          }
+          vecParamsBeautyJetMcCCDB.emplace_back(params);
+        }
+        for (size_t j = 0; j < resoFuncCharmCCDB.size(); j++) {
+          std::vector<float> params;
+          if (resoFuncCharmCCDB[j]) {
+            for (int i = 0; i < 9; i++) {
+              params.emplace_back(resoFuncCharmCCDB[j]->GetParameter(i));
+            }
+          }
+          vecParamsCharmJetMcCCDB.emplace_back(params);
+        }
+        for (size_t j = 0; j < resoFuncLfCCDB.size(); j++) {
+          std::vector<float> params;
+          if (resoFuncLfCCDB[j]) {
+            for (int i = 0; i < 9; i++) {
+              params.emplace_back(resoFuncLfCCDB[j]->GetParameter(i));
+            }
+          }
+          vecParamsLfJetMcCCDB.emplace_back(params);
+        }
+        LOG(info) << "defined parameters of resolution function from CCDB for each flavour";
+        break;
+
       default:
         LOG(fatal) << "undefined parameters of resolution function. Fix it!";
         break;
@@ -339,6 +427,15 @@ struct JetTaggerHFTask {
 
     for (const auto& params : vecParamsIncJetMcCCDB) {
       vecfSignImpXYSigIncJetMcCCDB.emplace_back(jettaggingutilities::setResolutionFunction(params));
+    }
+    for (const auto& params : vecParamsBeautyJetMcCCDB) {
+      vecfSignImpXYSigBeautyJetMcCCDB.emplace_back(jettaggingutilities::setResolutionFunction(params));
+    }
+    for (const auto& params : vecParamsCharmJetMcCCDB) {
+      vecfSignImpXYSigCharmJetMcCCDB.emplace_back(jettaggingutilities::setResolutionFunction(params));
+    }
+    for (const auto& params : vecParamsLfJetMcCCDB) {
+      vecfSignImpXYSigLfJetMcCCDB.emplace_back(jettaggingutilities::setResolutionFunction(params));
     }
 
     // Use QA for effectivness of track probability

--- a/PWGJE/TableProducer/jetTaggerHF.cxx
+++ b/PWGJE/TableProducer/jetTaggerHF.cxx
@@ -289,16 +289,16 @@ struct JetTaggerHFTask {
     std::map<std::string, std::string> metadata;
     resoFuncMatch = resoFuncMatching;
 
-    const int IPmethod_resolution_function_size = 7;
+    const int IPmethodResolutionFunctionSize = 7;
 
     auto loadCCDBforIP = [&](const std::vector<std::string>& paths, std::vector<TF1*>& targetVec, const std::string& name) {
-      if (paths.size() != IPmethod_resolution_function_size) {
+      if (paths.size() != IPmethodResolutionFunctionSize) {
         usepTcategorize.value = false;
         LOG(info) << name << " does not have 7 entries. Disabling pT categorization (usepTcategorize = false).";
         resoFuncMatch = 0;
         return;
       }
-      for (int i = 0; i < IPmethod_resolution_function_size; i++) {
+      for (int i = 0; i < IPmethodResolutionFunctionSize; i++) {
         targetVec.push_back(ccdbApi.retrieveFromTFileAny<TF1>(paths[i], metadata, -1));
       }
     };
@@ -323,7 +323,7 @@ struct JetTaggerHFTask {
     }
 
     maxOrder = numCount + 1; // 0: untagged, >1 : N ordering
-    const int IPmethod_numOfParameters = 9;
+    const int IPmethodNumOfParameters = 9;
 
     // Set up the resolution function
     switch (resoFuncMatch) {
@@ -372,7 +372,7 @@ struct JetTaggerHFTask {
         for (size_t j = 0; j < resoFuncIncCCDB.size(); j++) {
           std::vector<float> params;
           if (resoFuncIncCCDB[j]) {
-            for (int i = 0; i < 9; i++) {
+            for (int i = 0; i < IPmethodNumOfParameters; i++) {
               params.emplace_back(resoFuncIncCCDB[j]->GetParameter(i));
             }
           }
@@ -389,7 +389,7 @@ struct JetTaggerHFTask {
         for (size_t j = 0; j < resoFuncBeautyCCDB.size(); j++) {
           std::vector<float> params;
           if (resoFuncBeautyCCDB[j]) {
-            for (int i = 0; i < IPmethod_numOfParameters; i++) {
+            for (int i = 0; i < IPmethodNumOfParameters; i++) {
               params.emplace_back(resoFuncBeautyCCDB[j]->GetParameter(i));
             }
           }
@@ -398,7 +398,7 @@ struct JetTaggerHFTask {
         for (size_t j = 0; j < resoFuncCharmCCDB.size(); j++) {
           std::vector<float> params;
           if (resoFuncCharmCCDB[j]) {
-            for (int i = 0; i < IPmethod_numOfParameters; i++) {
+            for (int i = 0; i < IPmethodNumOfParameters; i++) {
               params.emplace_back(resoFuncCharmCCDB[j]->GetParameter(i));
             }
           }
@@ -407,7 +407,7 @@ struct JetTaggerHFTask {
         for (size_t j = 0; j < resoFuncLfCCDB.size(); j++) {
           std::vector<float> params;
           if (resoFuncLfCCDB[j]) {
-            for (int i = 0; i < IPmethod_numOfParameters; i++) {
+            for (int i = 0; i < IPmethodNumOfParameters; i++) {
               params.emplace_back(resoFuncLfCCDB[j]->GetParameter(i));
             }
           }

--- a/PWGJE/Tasks/jetTaggerHFQA.cxx
+++ b/PWGJE/Tasks/jetTaggerHFQA.cxx
@@ -149,12 +149,18 @@ struct JetTaggerHFQA {
     AxisSpec axisSigmaLxyz = {binSigmaLxyz, "#sigma_{L_{XYZ}} [cm]"};
 
     if (doprocessTracksDca) {
-      registry.add("h_impact_parameter_xy", "", {HistType::kTH1F, {{axisImpactParameterXY}}});
-      registry.add("h_impact_parameter_xy_significance", "", {HistType::kTH1F, {{axisImpactParameterXYSignificance}}});
-      registry.add("h_impact_parameter_z", "", {HistType::kTH1F, {{axisImpactParameterZ}}});
-      registry.add("h_impact_parameter_z_significance", "", {HistType::kTH1F, {{axisImpactParameterZSignificance}}});
-      registry.add("h_impact_parameter_xyz", "", {HistType::kTH1F, {{axisImpactParameterXYZ}}});
-      registry.add("h_impact_parameter_xyz_significance", "", {HistType::kTH1F, {{axisImpactParameterXYZSignificance}}});
+      if (fillIPxy) {
+        registry.add("h_impact_parameter_xy", "", {HistType::kTH1F, {{axisImpactParameterXY}}});
+        registry.add("h_impact_parameter_xy_significance", "", {HistType::kTH1F, {{axisImpactParameterXYSignificance}}});
+      }
+      if (fillIPz) {
+        registry.add("h_impact_parameter_z", "", {HistType::kTH1F, {{axisImpactParameterZ}}});
+        registry.add("h_impact_parameter_z_significance", "", {HistType::kTH1F, {{axisImpactParameterZSignificance}}});
+      }
+      if (fillIPxyz) {
+        registry.add("h_impact_parameter_xyz", "", {HistType::kTH1F, {{axisImpactParameterXYZ}}});
+        registry.add("h_impact_parameter_xyz_significance", "", {HistType::kTH1F, {{axisImpactParameterXYZSignificance}}});
+      }
     }
     if (doprocessValFlavourDefMCD) {
       registry.add("h2_flavour_dist_quark_flavour_dist_hadron", "", {HistType::kTH2F, {{axisJetFlavour}, {axisJetFlavour}}});
@@ -193,21 +199,27 @@ struct JetTaggerHFQA {
         registry.add("h3_jet_pt_track_pt_sign_impact_parameter_xyz_significance", "", {HistType::kTH3F, {{axisJetPt}, {axisTrackPt}, {axisImpactParameterXYZSignificance}}});
       }
       if (fillTrackCounting) {
-        registry.add("h2_jet_pt_sign_impact_parameter_xy_significance_N1", "", {HistType::kTH2F, {{axisJetPt}, {axisImpactParameterXYSignificance}}});
-        registry.add("h2_jet_pt_sign_impact_parameter_xy_significance_N2", "", {HistType::kTH2F, {{axisJetPt}, {axisImpactParameterXYSignificance}}});
-        registry.add("h2_jet_pt_sign_impact_parameter_xy_significance_N3", "", {HistType::kTH2F, {{axisJetPt}, {axisImpactParameterXYSignificance}}});
-        registry.add("h2_jet_pt_sign_impact_parameter_z_significance_N1", "", {HistType::kTH2F, {{axisJetPt}, {axisImpactParameterXYSignificance}}});
-        registry.add("h2_jet_pt_sign_impact_parameter_z_significance_N2", "", {HistType::kTH2F, {{axisJetPt}, {axisImpactParameterXYSignificance}}});
-        registry.add("h2_jet_pt_sign_impact_parameter_z_significance_N3", "", {HistType::kTH2F, {{axisJetPt}, {axisImpactParameterXYSignificance}}});
-        registry.add("h2_jet_pt_sign_impact_parameter_xyz_significance_N1", "", {HistType::kTH2F, {{axisJetPt}, {axisImpactParameterXYSignificance}}});
-        registry.add("h2_jet_pt_sign_impact_parameter_xyz_significance_N2", "", {HistType::kTH2F, {{axisJetPt}, {axisImpactParameterXYSignificance}}});
-        registry.add("h2_jet_pt_sign_impact_parameter_xyz_significance_N3", "", {HistType::kTH2F, {{axisJetPt}, {axisImpactParameterXYSignificance}}});
-        registry.add("h3_jet_pt_sign_impact_parameter_xy_significance_tc", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterXYSignificance}, {axisNumOrder}}});
-        registry.add("h3_jet_pt_sign_impact_parameter_z_significance_tc", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterZSignificance}, {axisNumOrder}}});
-        registry.add("h3_jet_pt_sign_impact_parameter_xyz_significance_tc", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterXYZSignificance}, {axisNumOrder}}});
-        registry.add("h3_track_pt_sign_impact_parameter_xy_significance_tc", "", {HistType::kTH3F, {{axisTrackPt}, {axisImpactParameterXYSignificance}, {axisNumOrder}}});
-        registry.add("h3_track_pt_sign_impact_parameter_z_significance_tc", "", {HistType::kTH3F, {{axisTrackPt}, {axisImpactParameterZSignificance}, {axisNumOrder}}});
-        registry.add("h3_track_pt_sign_impact_parameter_xyz_significance_tc", "", {HistType::kTH3F, {{axisTrackPt}, {axisImpactParameterXYZSignificance}, {axisNumOrder}}});
+        if (fillIPxy) {
+          registry.add("h2_jet_pt_sign_impact_parameter_xy_significance_N1", "", {HistType::kTH2F, {{axisJetPt}, {axisImpactParameterXYSignificance}}});
+          registry.add("h2_jet_pt_sign_impact_parameter_xy_significance_N2", "", {HistType::kTH2F, {{axisJetPt}, {axisImpactParameterXYSignificance}}});
+          registry.add("h2_jet_pt_sign_impact_parameter_xy_significance_N3", "", {HistType::kTH2F, {{axisJetPt}, {axisImpactParameterXYSignificance}}});
+          registry.add("h3_jet_pt_sign_impact_parameter_xy_significance_tc", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterXYSignificance}, {axisNumOrder}}});
+          registry.add("h3_track_pt_sign_impact_parameter_xy_significance_tc", "", {HistType::kTH3F, {{axisTrackPt}, {axisImpactParameterXYSignificance}, {axisNumOrder}}});
+        }
+        if (fillIPz) {
+          registry.add("h2_jet_pt_sign_impact_parameter_z_significance_N1", "", {HistType::kTH2F, {{axisJetPt}, {axisImpactParameterXYSignificance}}});
+          registry.add("h2_jet_pt_sign_impact_parameter_z_significance_N2", "", {HistType::kTH2F, {{axisJetPt}, {axisImpactParameterXYSignificance}}});
+          registry.add("h2_jet_pt_sign_impact_parameter_z_significance_N3", "", {HistType::kTH2F, {{axisJetPt}, {axisImpactParameterXYSignificance}}});
+          registry.add("h3_jet_pt_sign_impact_parameter_z_significance_tc", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterZSignificance}, {axisNumOrder}}});
+          registry.add("h3_track_pt_sign_impact_parameter_z_significance_tc", "", {HistType::kTH3F, {{axisTrackPt}, {axisImpactParameterZSignificance}, {axisNumOrder}}});
+        }
+        if (fillIPxyz) {
+          registry.add("h2_jet_pt_sign_impact_parameter_xyz_significance_N1", "", {HistType::kTH2F, {{axisJetPt}, {axisImpactParameterXYSignificance}}});
+          registry.add("h2_jet_pt_sign_impact_parameter_xyz_significance_N2", "", {HistType::kTH2F, {{axisJetPt}, {axisImpactParameterXYSignificance}}});
+          registry.add("h2_jet_pt_sign_impact_parameter_xyz_significance_N3", "", {HistType::kTH2F, {{axisJetPt}, {axisImpactParameterXYSignificance}}});
+          registry.add("h3_jet_pt_sign_impact_parameter_xyz_significance_tc", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterXYZSignificance}, {axisNumOrder}}});
+          registry.add("h3_track_pt_sign_impact_parameter_xyz_significance_tc", "", {HistType::kTH3F, {{axisTrackPt}, {axisImpactParameterXYZSignificance}, {axisNumOrder}}});
+        }
       }
     }
     if (doprocessIPsMCD || doprocessIPsMCDWeighted || doprocessIPsMCPMCDMatched || doprocessIPsMCPMCDMatchedWeighted) {
@@ -249,18 +261,24 @@ struct JetTaggerHFQA {
         registry.add("h3_track_pt_sign_impact_parameter_xyz_significance_flavour", "", {HistType::kTH3F, {{axisTrackPt}, {axisImpactParameterXYZSignificance}, {axisJetFlavour}}});
       }
       if (fillTrackCounting) {
-        registry.add("h3_jet_pt_sign_impact_parameter_xy_significance_flavour_N1", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterXYSignificance}, {axisJetFlavour}}});
-        registry.add("h3_jet_pt_sign_impact_parameter_xy_significance_flavour_N2", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterXYSignificance}, {axisJetFlavour}}});
-        registry.add("h3_jet_pt_sign_impact_parameter_xy_significance_flavour_N3", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterXYSignificance}, {axisJetFlavour}}});
-        registry.add("h3_jet_pt_sign_impact_parameter_z_significance_flavour_N1", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterZSignificance}, {axisJetFlavour}}});
-        registry.add("h3_jet_pt_sign_impact_parameter_z_significance_flavour_N2", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterZSignificance}, {axisJetFlavour}}});
-        registry.add("h3_jet_pt_sign_impact_parameter_z_significance_flavour_N3", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterZSignificance}, {axisJetFlavour}}});
-        registry.add("h3_jet_pt_sign_impact_parameter_xyz_significance_flavour_N1", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterXYZSignificance}, {axisJetFlavour}}});
-        registry.add("h3_jet_pt_sign_impact_parameter_xyz_significance_flavour_N2", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterXYZSignificance}, {axisJetFlavour}}});
-        registry.add("h3_jet_pt_sign_impact_parameter_xyz_significance_flavour_N3", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterXYZSignificance}, {axisJetFlavour}}});
-        registry.add("h3_sign_impact_parameter_xy_significance_tc_flavour", "", {HistType::kTH3F, {{axisImpactParameterXYSignificance}, {axisNumOrder}, {axisJetFlavour}}});
-        registry.add("h3_sign_impact_parameter_z_significance_tc_flavour", "", {HistType::kTH3F, {{axisImpactParameterZSignificance}, {axisNumOrder}, {axisJetFlavour}}});
-        registry.add("h3_sign_impact_parameter_xyz_significance_tc_flavour", "", {HistType::kTH3F, {{axisImpactParameterXYZSignificance}, {axisNumOrder}, {axisJetFlavour}}});
+        if (fillIPxy) {
+          registry.add("h3_jet_pt_sign_impact_parameter_xy_significance_flavour_N1", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterXYSignificance}, {axisJetFlavour}}});
+          registry.add("h3_jet_pt_sign_impact_parameter_xy_significance_flavour_N2", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterXYSignificance}, {axisJetFlavour}}});
+          registry.add("h3_jet_pt_sign_impact_parameter_xy_significance_flavour_N3", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterXYSignificance}, {axisJetFlavour}}});
+          registry.add("h3_sign_impact_parameter_xy_significance_tc_flavour", "", {HistType::kTH3F, {{axisImpactParameterXYSignificance}, {axisNumOrder}, {axisJetFlavour}}});
+        }
+        if (fillIPz) {
+          registry.add("h3_jet_pt_sign_impact_parameter_z_significance_flavour_N1", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterZSignificance}, {axisJetFlavour}}});
+          registry.add("h3_jet_pt_sign_impact_parameter_z_significance_flavour_N2", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterZSignificance}, {axisJetFlavour}}});
+          registry.add("h3_jet_pt_sign_impact_parameter_z_significance_flavour_N3", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterZSignificance}, {axisJetFlavour}}});
+          registry.add("h3_sign_impact_parameter_z_significance_tc_flavour", "", {HistType::kTH3F, {{axisImpactParameterZSignificance}, {axisNumOrder}, {axisJetFlavour}}});
+        }
+        if (fillIPxyz) {
+          registry.add("h3_jet_pt_sign_impact_parameter_xyz_significance_flavour_N1", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterXYZSignificance}, {axisJetFlavour}}});
+          registry.add("h3_jet_pt_sign_impact_parameter_xyz_significance_flavour_N2", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterXYZSignificance}, {axisJetFlavour}}});
+          registry.add("h3_jet_pt_sign_impact_parameter_xyz_significance_flavour_N3", "", {HistType::kTH3F, {{axisJetPt}, {axisImpactParameterXYZSignificance}, {axisJetFlavour}}});
+          registry.add("h3_sign_impact_parameter_xyz_significance_tc_flavour", "", {HistType::kTH3F, {{axisImpactParameterXYZSignificance}, {axisNumOrder}, {axisJetFlavour}}});
+        }
       }
     }
     if (doprocessIPsMCP || doprocessIPsMCPWeighted) {

--- a/PWGJE/Tasks/jetTaggerHFQA.cxx
+++ b/PWGJE/Tasks/jetTaggerHFQA.cxx
@@ -1075,12 +1075,18 @@ struct JetTaggerHFQA {
       varImpXYZ = dcaXYZ * jettaggingutilities::cmTomum;
       varImpXYZSig = dcaXYZ / sigmadcaXYZ;
 
-      registry.fill(HIST("h_impact_parameter_xy"), varImpXY);
-      registry.fill(HIST("h_impact_parameter_xy_significance"), varImpXYSig);
-      registry.fill(HIST("h_impact_parameter_z"), varImpZ);
-      registry.fill(HIST("h_impact_parameter_z_significance"), varImpZSig);
-      registry.fill(HIST("h_impact_parameter_xyz"), varImpXYZ);
-      registry.fill(HIST("h_impact_parameter_xyz_significance"), varImpXYZSig);
+      if (fillIPxy) {
+        registry.fill(HIST("h_impact_parameter_xy"), varImpXY);
+        registry.fill(HIST("h_impact_parameter_xy_significance"), varImpXYSig);
+      }
+      if (fillIPz) {
+        registry.fill(HIST("h_impact_parameter_z"), varImpZ);
+        registry.fill(HIST("h_impact_parameter_z_significance"), varImpZSig);
+      }
+      if (fillIPxyz) {
+        registry.fill(HIST("h_impact_parameter_xyz"), varImpXYZ);
+        registry.fill(HIST("h_impact_parameter_xyz_significance"), varImpXYZSig);
+      }
     }
   }
   PROCESS_SWITCH(JetTaggerHFQA, processTracksDca, "Fill inclusive tracks' imformation for data", false);


### PR DESCRIPTION
 jetTaggerHFQA.cxx
- To reduce unnecessary memory usage, the histograms filled by FillXY, FillZ, and FillXYZ are subdivided into finer bins.

jetTaggerHF.cxx :
- Modification of the IP tagging method
- IIf the number of resolution functions loaded from the CCDB is not 7 (since the pT range is divided into 7 bins), a constant value will be used as the parameter instead.
- Modified to load different resolution parameters from the CCDB depending on the jet flavour.