### PR TITLE
[PWGLF] Fix bug in to-build cascade list mapping

### DIFF
--- a/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
@@ -29,7 +29,7 @@
 //                           task will adapt algorithm to spare / spend CPU accordingly
 //  -- mc_findableMode ....: 0: only found (default), 1: add findable to found, 2: all findable
 //                           When using findables, refer to FoundTag bools for checking if found
-//  -- v0builderopts ......: V0-specific building options (topological, etc)
+//  -- v0builderopts ......: V0-specific building options (topological, deduplication, etc)
 //  -- cascadebuilderopts .: cascade-specific building options (topological, etc)
 
 #include <string>

--- a/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
@@ -1016,9 +1016,6 @@ struct StrangenessBuilder {
         // simple passthrough: copy existing cascades to build list
         for (const auto& cascade : cascades) {
           auto const& v0 = cascade.v0();
-          if (v0.v0Type() > 1) {
-            continue; // skip any unexpected stuff (FIXME: follow-up)
-          }
           currentCascadeEntry.globalId = cascade.globalIndex();
           currentCascadeEntry.collisionId = cascade.collisionId();
           currentCascadeEntry.v0Id = ao2dV0toV0List[v0.globalIndex()];


### PR DESCRIPTION
@fcatalan92 this fixes the bug that manifested itself in the omegaC when building in the KF path. 

The issue is that in a recent commit I introduced a check for TPC-only V0s being used in cascades in the first entry point of the builder and removed those cascades from the pool, which accidentally renders the joinability between `Cascades` and the `Cascades`-to-[]Data interlinks false because a tiny amount of candidates is rejected and the interlink tables are smaller. This is inadequately reported by the framework for some reason in the particular use case of the OmegaC building, since there was a segmentation fault instead of a message of "table size mismatch" (tagging also @aalkin - I suspect it may be because we are dealing with linked derived data here, not sure). I found out the table size mismatch by isolating the joined table combination that led to the crash manually.

In the fix, I simply don't filter out cascades that use tpc-only V0s; these are filtered from actual candidate generation anyhow a posteriori via a build call that includes the protection added by #10908, but by not removing the cascades from the build pool, the interlinks will have the same size as the original `Cascades` table. 

Tagging also @romainschotter @gianniliveraro; further tagging @f3sch - we should still find out why cascades seem to be using TPC-only V0s as this should not happen in the svertexer from what I remember. 