### PR TITLE
[PWGHF] Update MC matching in XicToXiPiPi workflow

### DIFF
--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -1735,7 +1735,6 @@ DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t); // reconstruction le
 DECLARE_SOA_COLUMN(FlagMcMatchGen, flagMcMatchGen, int8_t); // generator level
 DECLARE_SOA_COLUMN(OriginRec, originRec, int8_t);
 DECLARE_SOA_COLUMN(OriginGen, originGen, int8_t);
-DECLARE_SOA_COLUMN(NPionsDecayed, nPionsDecayed, int8_t);
 // Dynamic columns
 DECLARE_SOA_DYNAMIC_COLUMN(PProng0, pProng0, //!
                            [](float px, float py, float pz) -> float { return RecoDecay::p(px, py, pz); });
@@ -1820,15 +1819,12 @@ DECLARE_SOA_TABLE(HfCandXicKF, "AOD", "HFCANDXICKF",
 // table with results of reconstruction level MC matching
 DECLARE_SOA_TABLE(HfCandXicMcRec, "AOD", "HFCANDXICMCREC", //!
                   hf_cand_xic_to_xi_pi_pi::FlagMcMatchRec,
-                  hf_cand_xic_to_xi_pi_pi::OriginRec,
-                  hf_cand_xic_to_xi_pi_pi::NPionsDecayed,
-                  hf_cand::NInteractionsWithMaterial);
+                  hf_cand_xic_to_xi_pi_pi::OriginRec);
 // table with results of generator level MC matching
 DECLARE_SOA_TABLE(HfCandXicMcGen, "AOD", "HFCANDXICMCGEN", //!
                   hf_cand_xic_to_xi_pi_pi::FlagMcMatchGen,
                   hf_cand_xic_to_xi_pi_pi::OriginGen,
-                  hf_cand::PdgBhadMotherPart,
-                  hf_cand::PtBhadMotherPart);
+                  hf_cand::PdgBhadMotherPart);
 
 // specific chic candidate properties
 namespace hf_cand_chic

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -1733,10 +1733,9 @@ DECLARE_SOA_COLUMN(NSigTofPrFromLambda, nSigTofPrFromLambda, float);
 // MC matching result:
 DECLARE_SOA_COLUMN(FlagMcMatchRec, flagMcMatchRec, int8_t); // reconstruction level
 DECLARE_SOA_COLUMN(FlagMcMatchGen, flagMcMatchGen, int8_t); // generator level
-DECLARE_SOA_COLUMN(DebugMcRec, debugMcRec, int8_t);         // debug flag for mis-association reconstruction level
-DECLARE_SOA_COLUMN(DebugMcGen, debugMcGen, int8_t);
 DECLARE_SOA_COLUMN(OriginRec, originRec, int8_t);
 DECLARE_SOA_COLUMN(OriginGen, originGen, int8_t);
+DECLARE_SOA_COLUMN(NPionsDecayed, nPionsDecayed, int8_t);
 // Dynamic columns
 DECLARE_SOA_DYNAMIC_COLUMN(PProng0, pProng0, //!
                            [](float px, float py, float pz) -> float { return RecoDecay::p(px, py, pz); });
@@ -1821,14 +1820,15 @@ DECLARE_SOA_TABLE(HfCandXicKF, "AOD", "HFCANDXICKF",
 // table with results of reconstruction level MC matching
 DECLARE_SOA_TABLE(HfCandXicMcRec, "AOD", "HFCANDXICMCREC", //!
                   hf_cand_xic_to_xi_pi_pi::FlagMcMatchRec,
-                  hf_cand_xic_to_xi_pi_pi::DebugMcRec,
-                  hf_cand_xic_to_xi_pi_pi::OriginRec);
-
+                  hf_cand_xic_to_xi_pi_pi::OriginRec,
+                  hf_cand_xic_to_xi_pi_pi::NPionsDecayed,
+                  hf_cand::NInteractionsWithMaterial);
 // table with results of generator level MC matching
 DECLARE_SOA_TABLE(HfCandXicMcGen, "AOD", "HFCANDXICMCGEN", //!
                   hf_cand_xic_to_xi_pi_pi::FlagMcMatchGen,
-                  hf_cand_xic_to_xi_pi_pi::DebugMcGen,
-                  hf_cand_xic_to_xi_pi_pi::OriginGen);
+                  hf_cand_xic_to_xi_pi_pi::OriginGen,
+                  hf_cand::PdgBhadMotherPart,
+                  hf_cand::PtBhadMotherPart);
 
 // specific chic candidate properties
 namespace hf_cand_chic

--- a/PWGHF/TableProducer/candidateCreatorXicToXiPiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXicToXiPiPi.cxx
@@ -934,36 +934,36 @@ struct HfCandidateCreatorXicToXiPiPiExpressions {
 
       // Xic → pi pi pi pi p
       if (matchDecayedPions && matchInteractionsWithMaterial) {
-        indexRec = RecoDecay::getMatchedMCRec<false, false, false, true, true>(mcParticles, arrayDaughters, Pdg::kXiCPlus, std::array{+kPiPlus, +kPiPlus, +kPiMinus, +kProton, +kPiMinus}, true, &sign, 4, &nPionsDecayed, nullptr, &nInteractionsWithMaterial);
+        indexRec = RecoDecay::getMatchedMCRec<false, true, false, true, true>(mcParticles, arrayDaughters, Pdg::kXiCPlus, std::array{+kPiPlus, +kPiPlus, +kPiMinus, +kProton, +kPiMinus}, true, &sign, 4, &nPionsDecayed, nullptr, &nInteractionsWithMaterial);
       } else if (matchDecayedPions && !matchInteractionsWithMaterial) {
-        indexRec = RecoDecay::getMatchedMCRec<false, false, false, true, false>(mcParticles, arrayDaughters, Pdg::kXiCPlus, std::array{+kPiPlus, +kPiPlus, +kPiMinus, +kProton, +kPiMinus}, true, &sign, 4, &nPionsDecayed, nullptr, &nInteractionsWithMaterial);
+        indexRec = RecoDecay::getMatchedMCRec<false, true, false, true, false>(mcParticles, arrayDaughters, Pdg::kXiCPlus, std::array{+kPiPlus, +kPiPlus, +kPiMinus, +kProton, +kPiMinus}, true, &sign, 4, &nPionsDecayed, nullptr, &nInteractionsWithMaterial);
       } else if (!matchDecayedPions && matchInteractionsWithMaterial) {
-        indexRec = RecoDecay::getMatchedMCRec<false, false, false, false, true>(mcParticles, arrayDaughters, Pdg::kXiCPlus, std::array{+kPiPlus, +kPiPlus, +kPiMinus, +kProton, +kPiMinus}, true, &sign, 4, &nPionsDecayed, nullptr, &nInteractionsWithMaterial);
+        indexRec = RecoDecay::getMatchedMCRec<false, true, false, false, true>(mcParticles, arrayDaughters, Pdg::kXiCPlus, std::array{+kPiPlus, +kPiPlus, +kPiMinus, +kProton, +kPiMinus}, true, &sign, 4, &nPionsDecayed, nullptr, &nInteractionsWithMaterial);
       } else {
-        indexRec = RecoDecay::getMatchedMCRec<false, false, false, false, false>(mcParticles, arrayDaughters, Pdg::kXiCPlus, std::array{+kPiPlus, +kPiPlus, +kPiMinus, +kProton, +kPiMinus}, true, &sign, 4, &nPionsDecayed, nullptr, &nInteractionsWithMaterial);
+        indexRec = RecoDecay::getMatchedMCRec<false, true, false, false, false>(mcParticles, arrayDaughters, Pdg::kXiCPlus, std::array{+kPiPlus, +kPiPlus, +kPiMinus, +kProton, +kPiMinus}, true, &sign, 4, &nPionsDecayed, nullptr, &nInteractionsWithMaterial);
       }
       indexRecXicPlus = indexRec;
       if (indexRec > -1) {
         // Xi- → pi pi p
         if (matchDecayedPions && matchInteractionsWithMaterial) {
-          indexRec = RecoDecay::getMatchedMCRec<false, false, false, true, true>(mcParticles, arrayDaughtersCasc, +kXiMinus, std::array{+kPiMinus, +kProton, +kPiMinus}, true, nullptr, 2);
+          indexRec = RecoDecay::getMatchedMCRec<false, true, false, true, true>(mcParticles, arrayDaughtersCasc, +kXiMinus, std::array{+kPiMinus, +kProton, +kPiMinus}, true, nullptr, 2);
         } else if (matchDecayedPions && !matchInteractionsWithMaterial) {
-          indexRec = RecoDecay::getMatchedMCRec<false, false, false, true, false>(mcParticles, arrayDaughtersCasc, +kXiMinus, std::array{+kPiMinus, +kProton, +kPiMinus}, true, nullptr, 2);
+          indexRec = RecoDecay::getMatchedMCRec<false, true, false, true, false>(mcParticles, arrayDaughtersCasc, +kXiMinus, std::array{+kPiMinus, +kProton, +kPiMinus}, true, nullptr, 2);
         } else if (!matchDecayedPions && matchInteractionsWithMaterial) {
-          indexRec = RecoDecay::getMatchedMCRec<false, false, false, false, true>(mcParticles, arrayDaughtersCasc, +kXiMinus, std::array{+kPiMinus, +kProton, +kPiMinus}, true, nullptr, 2);
+          indexRec = RecoDecay::getMatchedMCRec<false, true, false, false, true>(mcParticles, arrayDaughtersCasc, +kXiMinus, std::array{+kPiMinus, +kProton, +kPiMinus}, true, nullptr, 2);
         } else {
-          indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughtersCasc, +kXiMinus, std::array{+kPiMinus, +kProton, +kPiMinus}, true, nullptr, 2);
+          indexRec = RecoDecay::getMatchedMCRec<false, true, false, false, false>(mcParticles, arrayDaughtersCasc, +kXiMinus, std::array{+kPiMinus, +kProton, +kPiMinus}, true, nullptr, 2);
         }
         if (indexRec > -1) {
           // Lambda → p pi
           if (matchDecayedPions && matchInteractionsWithMaterial) {
-            indexRec = RecoDecay::getMatchedMCRec<false, false, false, true, true>(mcParticles, arrayDaughtersV0, +kLambda0, std::array{+kProton, +kPiMinus}, true);
+            indexRec = RecoDecay::getMatchedMCRec<false, true, false, true, true>(mcParticles, arrayDaughtersV0, +kLambda0, std::array{+kProton, +kPiMinus}, true);
           } else if (matchDecayedPions && !matchInteractionsWithMaterial) {
-            indexRec = RecoDecay::getMatchedMCRec<false, false, false, true, false>(mcParticles, arrayDaughtersV0, +kLambda0, std::array{+kProton, +kPiMinus}, true);
+            indexRec = RecoDecay::getMatchedMCRec<false, true, false, true, false>(mcParticles, arrayDaughtersV0, +kLambda0, std::array{+kProton, +kPiMinus}, true);
           } else if (!matchDecayedPions && matchInteractionsWithMaterial) {
-            indexRec = RecoDecay::getMatchedMCRec<false, false, false, false, true>(mcParticles, arrayDaughtersV0, +kLambda0, std::array{+kProton, +kPiMinus}, true);
+            indexRec = RecoDecay::getMatchedMCRec<false, true, false, false, true>(mcParticles, arrayDaughtersV0, +kLambda0, std::array{+kProton, +kPiMinus}, true);
           } else {
-            indexRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughtersV0, +kLambda0, std::array{+kProton, +kPiMinus}, true);
+            indexRec = RecoDecay::getMatchedMCRec<false, true, false, false, false>(mcParticles, arrayDaughtersV0, +kLambda0, std::array{+kProton, +kPiMinus}, true);
           }
           if (indexRec > -1) {
             RecoDecay::getDaughters(mcParticles.rawIteratorAt(indexRecXicPlus), &arrDaughIndex, std::array{0}, 1);
@@ -1027,21 +1027,21 @@ struct HfCandidateCreatorXicToXiPiPiExpressions {
         idxBhadMothers.clear();
 
         //  Xic → Xi pi pi
-        if (RecoDecay::isMatchedMCGen(mcParticles, particle, Pdg::kXiCPlus, std::array{+kXiMinus, +kPiPlus, +kPiPlus}, true, &sign, 2)) {
+        if (RecoDecay::isMatchedMCGen<false, true>(mcParticles, particle, Pdg::kXiCPlus, std::array{+kXiMinus, +kPiPlus, +kPiPlus}, true, &sign, 2)) {
           // Xi- -> Lambda pi
           auto cascMC = mcParticles.rawIteratorAt(particle.daughtersIds().front());
           // Find Xi- from Xi(1530) -> Xi pi in case of resonant decay
           RecoDecay::getDaughters(particle, &arrDaughIndex, std::array{0}, 1);
           if (arrDaughIndex.size() == NDaughtersResonant) {
             auto cascStarMC = mcParticles.rawIteratorAt(particle.daughtersIds().front());
-            if (RecoDecay::isMatchedMCGen(mcParticles, cascStarMC, +3324, std::array{+kXiMinus, +kPiPlus}, true)) {
+            if (RecoDecay::isMatchedMCGen<false, true>(mcParticles, cascStarMC, +3324, std::array{+kXiMinus, +kPiPlus}, true)) {
               cascMC = mcParticles.rawIteratorAt(cascStarMC.daughtersIds().front());
             }
           }
-          if (RecoDecay::isMatchedMCGen(mcParticles, cascMC, +kXiMinus, std::array{+kLambda0, +kPiMinus}, true)) {
+          if (RecoDecay::isMatchedMCGen<false, true>(mcParticles, cascMC, +kXiMinus, std::array{+kLambda0, +kPiMinus}, true)) {
             // Lambda -> p pi
             auto v0MC = mcParticles.rawIteratorAt(cascMC.daughtersIds().front());
-            if (RecoDecay::isMatchedMCGen(mcParticles, v0MC, +kLambda0, std::array{+kProton, +kPiMinus}, true)) {
+            if (RecoDecay::isMatchedMCGen<false, true>(mcParticles, v0MC, +kLambda0, std::array{+kProton, +kPiMinus}, true)) {
               if (arrDaughIndex.size() == NDaughtersResonant) {
                 for (auto iProng = 0u; iProng < NDaughtersResonant; ++iProng) {
                   auto daughI = mcParticles.rawIteratorAt(arrDaughIndex[iProng]);

--- a/PWGHF/TableProducer/treeCreatorXicToXiPiPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorXicToXiPiPi.cxx
@@ -110,7 +110,6 @@ DECLARE_SOA_COLUMN(ZSvPull, zSvPull, float);
 
 DECLARE_SOA_TABLE(HfCandXicToXiPiPiLites, "AOD", "HFXICXI2PILITE",
                   hf_cand_xic_to_xi_pi_pi::FlagMcMatchRec,
-                  hf_cand_xic_to_xi_pi_pi::DebugMcRec,
                   hf_cand_xic_to_xi_pi_pi::OriginRec,
                   full::CandidateSelFlag,
                   full::Sign,
@@ -149,7 +148,6 @@ DECLARE_SOA_TABLE(HfCandXicToXiPiPiLites, "AOD", "HFXICXI2PILITE",
 
 DECLARE_SOA_TABLE(HfCandXicToXiPiPiLiteKfs, "AOD", "HFXICXI2PILITKF",
                   hf_cand_xic_to_xi_pi_pi::FlagMcMatchRec,
-                  hf_cand_xic_to_xi_pi_pi::DebugMcRec,
                   hf_cand_xic_to_xi_pi_pi::OriginRec,
                   full::CandidateSelFlag,
                   full::Sign,
@@ -201,8 +199,9 @@ DECLARE_SOA_TABLE(HfCandXicToXiPiPiLiteKfs, "AOD", "HFXICXI2PILITKF",
 
 DECLARE_SOA_TABLE(HfCandXicToXiPiPiFulls, "AOD", "HFXICXI2PIFULL",
                   hf_cand_xic_to_xi_pi_pi::FlagMcMatchRec,
-                  hf_cand_xic_to_xi_pi_pi::DebugMcRec,
                   hf_cand_xic_to_xi_pi_pi::OriginRec,
+                  hf_cand_xic_to_xi_pi_pi::NPionsDecayed,
+                  hf_cand::NInteractionsWithMaterial,
                   full::CandidateSelFlag,
                   full::Sign,
                   full::Y,
@@ -265,8 +264,9 @@ DECLARE_SOA_TABLE(HfCandXicToXiPiPiFulls, "AOD", "HFXICXI2PIFULL",
 
 DECLARE_SOA_TABLE(HfCandXicToXiPiPiFullKfs, "AOD", "HFXICXI2PIFULKF",
                   hf_cand_xic_to_xi_pi_pi::FlagMcMatchRec,
-                  hf_cand_xic_to_xi_pi_pi::DebugMcRec,
                   hf_cand_xic_to_xi_pi_pi::OriginRec,
+                  hf_cand_xic_to_xi_pi_pi::NPionsDecayed,
+                  hf_cand::NInteractionsWithMaterial,
                   full::CandidateSelFlag,
                   full::Sign,
                   full::Y,
@@ -342,8 +342,9 @@ DECLARE_SOA_TABLE(HfCandXicToXiPiPiFullKfs, "AOD", "HFXICXI2PIFULKF",
 
 DECLARE_SOA_TABLE(HfCandXicToXiPiPiFullPs, "AOD", "HFXICXI2PIFULLP",
                   hf_cand_xic_to_xi_pi_pi::FlagMcMatchGen,
-                  hf_cand_xic_to_xi_pi_pi::DebugMcGen,
                   hf_cand_xic_to_xi_pi_pi::OriginGen,
+                  hf_cand::PtBhadMotherPart,
+                  hf_cand::PdgBhadMotherPart,
                   full::Pt,
                   full::Eta,
                   full::Phi,
@@ -384,6 +385,9 @@ struct HfTreeCreatorXicToXiPiPi {
   Configurable<bool> fillOnlyBackground{"fillOnlyBackground", false, "Flag to fill derived tables with background for ML trainings"};
   Configurable<float> downSampleBkgFactor{"downSampleBkgFactor", 1., "Fraction of background candidates to keep for ML trainings"};
   Configurable<float> ptMaxForDownSample{"ptMaxForDownSample", 10., "Maximum pt for the application of the downsampling factor"};
+  // parameters for MC matching in residual process function
+  Configurable<bool> matchDecayedPions{"matchDecayedPions", true, "Match also candidates with daughter pion tracks that decay with kinked topology"};
+  Configurable<bool> matchInteractionsWithMaterial{"matchInteractionsWithMaterial", true, "Match also candidates with daughter tracks that interact with material"};
 
   using SelectedCandidates = soa::Filtered<soa::Join<aod::HfCandXic, aod::HfSelXicToXiPiPi>>;
   using SelectedCandidatesKf = soa::Filtered<soa::Join<aod::HfCandXic, aod::HfCandXicKF, aod::HfSelXicToXiPiPi>>;
@@ -405,18 +409,19 @@ struct HfTreeCreatorXicToXiPiPi {
   void fillCandidateTable(const T& candidate)
   {
     int8_t flagMc = 0;
-    int8_t debugMc = 0;
     int8_t originMc = 0;
+    int8_t nPionsDecayed = 0;
+    int8_t nInteractionsWithMaterial = 0;
     if constexpr (doMc) {
       flagMc = candidate.flagMcMatchRec();
-      debugMc = candidate.debugMcRec();
       originMc = candidate.originRec();
+      nPionsDecayed = candidate.nPionsDecayed();
+      nInteractionsWithMaterial = candidate.nInteractionsWithMaterial();
     }
     if constexpr (!doKf) {
       if (fillCandidateLiteTable) {
         rowCandidateLite(
           flagMc,
-          debugMc,
           originMc,
           candidate.isSelXicToXiPiPi(),
           candidate.sign(),
@@ -455,8 +460,9 @@ struct HfTreeCreatorXicToXiPiPi {
       } else {
         rowCandidateFull(
           flagMc,
-          debugMc,
           originMc,
+          nPionsDecayed,
+          nInteractionsWithMaterial,
           candidate.isSelXicToXiPiPi(),
           candidate.sign(),
           candidate.y(o2::constants::physics::MassXiCPlus),
@@ -521,7 +527,6 @@ struct HfTreeCreatorXicToXiPiPi {
       if (fillCandidateLiteTable) {
         rowCandidateLiteKf(
           flagMc,
-          debugMc,
           originMc,
           candidate.isSelXicToXiPiPi(),
           candidate.sign(),
@@ -573,8 +578,9 @@ struct HfTreeCreatorXicToXiPiPi {
       } else {
         rowCandidateFullKf(
           flagMc,
-          debugMc,
           originMc,
+          nPionsDecayed,
+          nInteractionsWithMaterial,
           candidate.isSelXicToXiPiPi(),
           candidate.sign(),
           candidate.y(o2::constants::physics::MassXiCPlus),
@@ -649,6 +655,24 @@ struct HfTreeCreatorXicToXiPiPi {
           candidate.dcaPi1Xi());
       }
     }
+  }
+
+  void fillGeneratedParticleTable(soa::Join<aod::McParticles, aod::HfCandXicMcGen> const& particles)
+  {
+    rowCandidateFullParticles.reserve(particles.size());
+    for (const auto& particle : particles) {
+      if (TESTBIT(std::abs(particle.flagMcMatchGen()), aod::hf_cand_xic_to_xi_pi_pi::DecayType::XicToXiPiPi) || TESTBIT(std::abs(particle.flagMcMatchGen()), aod::hf_cand_xic_to_xi_pi_pi::DecayType::XicToXiResPiToXiPiPi)) {
+        rowCandidateFullParticles(
+          particle.flagMcMatchGen(),
+          particle.originGen(),
+          particle.pdgBhadMotherPart(),
+          particle.ptBhadMotherPart(),
+          particle.pt(),
+          particle.eta(),
+          particle.phi(),
+          RecoDecay::y(particle.pVector(), o2::constants::physics::MassXiCPlus));
+      }
+    } // loop over generated particles
   }
 
   void processData(SelectedCandidates const& candidates)
@@ -729,20 +753,7 @@ struct HfTreeCreatorXicToXiPiPi {
     }
 
     if (fillGenParticleTable) {
-      rowCandidateFullParticles.reserve(particles.size());
-
-      for (const auto& particle : particles) {
-        if (TESTBIT(std::abs(particle.flagMcMatchGen()), aod::hf_cand_xic_to_xi_pi_pi::DecayType::XicToXiPiPi) || TESTBIT(std::abs(particle.flagMcMatchGen()), aod::hf_cand_xic_to_xi_pi_pi::DecayType::XicToXiResPiToXiPiPi)) {
-          rowCandidateFullParticles(
-            particle.flagMcMatchGen(),
-            particle.debugMcGen(),
-            particle.originGen(),
-            particle.pt(),
-            particle.eta(),
-            particle.phi(),
-            RecoDecay::y(particle.pVector(), o2::constants::physics::MassXiCPlus));
-        }
-      } // loop over generated particles
+      fillGeneratedParticleTable(particles);
     }
   }
   PROCESS_SWITCH(HfTreeCreatorXicToXiPiPi, processMc, "Process MC with DCAFitter reconstruction", false);
@@ -785,19 +796,7 @@ struct HfTreeCreatorXicToXiPiPi {
     }
 
     if (fillGenParticleTable) {
-      rowCandidateFullParticles.reserve(particles.size());
-      for (const auto& particle : particles) {
-        if (TESTBIT(std::abs(particle.flagMcMatchGen()), aod::hf_cand_xic_to_xi_pi_pi::DecayType::XicToXiPiPi) || TESTBIT(std::abs(particle.flagMcMatchGen()), aod::hf_cand_xic_to_xi_pi_pi::DecayType::XicToXiResPiToXiPiPi)) {
-          rowCandidateFullParticles(
-            particle.flagMcMatchGen(),
-            particle.debugMcGen(),
-            particle.originGen(),
-            particle.pt(),
-            particle.eta(),
-            particle.phi(),
-            RecoDecay::y(particle.pVector(), o2::constants::physics::MassXiCPlus));
-        }
-      } // loop over generated particles
+      fillGeneratedParticleTable(particles);
     }
   }
   PROCESS_SWITCH(HfTreeCreatorXicToXiPiPi, processMcKf, "Process MC with KF Particle reconstruction", false);
@@ -813,8 +812,7 @@ struct HfTreeCreatorXicToXiPiPi {
 
     std::vector<int> arrDaughIndex;
     int indexRecXicPlus;
-    int8_t sign;
-    int8_t origin;
+    int origin;
     std::array<float, 3> pvResiduals;
     std::array<float, 3> svResiduals;
     std::array<float, 3> pvPulls;
@@ -823,8 +821,7 @@ struct HfTreeCreatorXicToXiPiPi {
     for (const auto& candidate : recSig) {
       arrDaughIndex.clear();
       indexRecXicPlus = -1;
-      sign = 0;
-      origin = 0;
+      origin = RecoDecay::OriginType::None;
       pvResiduals = {-9999.9};
       svResiduals = {-9999.9};
       pvPulls = {-9999.9};
@@ -837,12 +834,20 @@ struct HfTreeCreatorXicToXiPiPi {
                                        candidate.negTrack_as<aod::TracksWMc>()}; // pi <- lambda
 
       // get XicPlus as MC particle
-      indexRecXicPlus = RecoDecay::getMatchedMCRec(particles, arrayDaughters, Pdg::kXiCPlus, std::array{+kPiPlus, +kPiPlus, +kPiMinus, +kProton, +kPiMinus}, true, &sign, 4);
+      if (matchDecayedPions && matchInteractionsWithMaterial) {
+        indexRecXicPlus = RecoDecay::getMatchedMCRec<false, false, false, true, true>(particles, arrayDaughters, Pdg::kXiCPlus, std::array{+kPiPlus, +kPiPlus, +kPiMinus, +kProton, +kPiMinus}, true, nullptr, 4);
+      } else if (matchDecayedPions && !matchInteractionsWithMaterial) {
+        indexRecXicPlus = RecoDecay::getMatchedMCRec<false, false, false, true, false>(particles, arrayDaughters, Pdg::kXiCPlus, std::array{+kPiPlus, +kPiPlus, +kPiMinus, +kProton, +kPiMinus}, true, nullptr, 4);
+      } else if (!matchDecayedPions && matchInteractionsWithMaterial) {
+        indexRecXicPlus = RecoDecay::getMatchedMCRec<false, false, false, false, true>(particles, arrayDaughters, Pdg::kXiCPlus, std::array{+kPiPlus, +kPiPlus, +kPiMinus, +kProton, +kPiMinus}, true, nullptr, 4);
+      } else {
+        indexRecXicPlus = RecoDecay::getMatchedMCRec<false, false, false, false, false>(particles, arrayDaughters, Pdg::kXiCPlus, std::array{+kPiPlus, +kPiPlus, +kPiMinus, +kProton, +kPiMinus}, true, nullptr, 4);
+      }
       if (indexRecXicPlus == -1) {
         continue;
       }
       auto particleXicPlusGen = particles.rawIteratorAt(indexRecXicPlus);
-      origin = RecoDecay::getCharmHadronOrigin(particles, particleXicPlusGen, true);
+      origin = RecoDecay::getCharmHadronOrigin(particles, particleXicPlusGen, false);
 
       // get MC collision
       auto mcCollision = particleXicPlusGen.mcCollision_as<aod::McCollisions>();


### PR DESCRIPTION
@JaeYoonCHO @sh-lim @klsmith15k

- Update MC matching to include the latest updates to RecoDecay functions from recent PRs
- remove debug flags from the output trees (unnecessary memory consumption, different logic between reconstructed + generated), instead add counter histogram for the matching of the reconstructed candidates
- add histograms for the number of decayed pions and number of material interactions of daughter particles from matched $\Xi_{\rm{c}}^{+} \rightarrow \Xi^{-} \pi^{+} \pi^{+}$ decays
- Use a filter for filling of generated particle tables in the tree creator