### PR TITLE
[Common] [Common]::CCDB:: add RCTSelectionFlags.h as header only library

### DIFF
--- a/Common/CCDB/CMakeLists.txt
+++ b/Common/CCDB/CMakeLists.txt
@@ -21,3 +21,6 @@ o2physics_target_root_dictionary(AnalysisCCDB
               HEADERS ctpRateFetcher.h
               HEADERS RCTSelectionFlags.h
               LINKDEF AnalysisCCDBLinkDef.h)
+
+o2physics_add_header_only_library(RCTSelectionFlags
+                                  HEADERS RCTSelectionFlags.h)


### PR DESCRIPTION
to be added into $O2PHYSICS_ROOT/include (and solve the compilation of O2OpenAccess application)