### PR TITLE
[PWGEM/PhotonMeson] Add pile-up and centrality dependence to pi0 task

### DIFF
--- a/PWGEM/PhotonMeson/TableProducer/CMakeLists.txt
+++ b/PWGEM/PhotonMeson/TableProducer/CMakeLists.txt
@@ -46,7 +46,7 @@ o2physics_add_dpl_workflow(skimmer-gamma-calo
 
 o2physics_add_dpl_workflow(bc-wise-cluster-skimmer
                     SOURCES bcWiseClusterSkimmer.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2::EMCALBase O2Physics::AnalysisCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2::EMCALBase O2Physics::AnalysisCCDB O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(skimmer-phos

--- a/PWGEM/PhotonMeson/TableProducer/bcWiseClusterSkimmer.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/bcWiseClusterSkimmer.cxx
@@ -28,6 +28,9 @@
 
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/Centrality.h"
+#include "Common/CCDB/ctpRateFetcher.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "DataFormatsParameters/GRPLHCIFData.h"
 #include "PWGJE/DataModel/EMCALClusters.h"
 #include "PWGEM/PhotonMeson/Utils/MCUtilities.h"
 #include "PWGEM/PhotonMeson/DataModel/bcWiseTables.h"
@@ -39,7 +42,7 @@ using namespace o2::framework::expressions;
 
 using MyCollisions = soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Ms>;
 using MyMCCollisions = soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Ms, aod::McCollisionLabels>;
-using MyBCs = soa::Join<aod::BCs, aod::BcSels>;
+using MyBCs = soa::Join<aod::BCs, aod::BcSels, aod::Timestamps>;
 
 using SelectedUniqueClusters = soa::Filtered<aod::EMCALClusters>;                                                         // Clusters from collisions with only one collision in the BC
 using SelectedUniqueMCClusters = soa::Filtered<soa::Join<aod::EMCALClusters, aod::EMCALMCClusters>>;                      // Clusters from collisions with only one collision in the BC
@@ -70,8 +73,12 @@ struct bcWiseClusterSkimmer {
 
   Configurable<bool> cfgRequirekTVXinEMC{"cfgRequirekTVXinEMC", false, "Only store kTVXinEMC triggered BCs"};
   Configurable<bool> cfgRequireGoodRCTQuality{"cfgRequireGoodRCTQuality", false, "Only store BCs with good quality of T0 and EMC in RCT"};
+  Configurable<bool> cfgStoreMu{"cfgStoreMu", false, "Calculate and store mu (probablity of a TVX collision in the BC) per BC. Otherwise fill with 0"};
 
   aod::rctsel::RCTFlagsChecker isFT0EMCGoodRCTChecker{aod::rctsel::kFT0Bad, aod::rctsel::kEMCBad};
+  parameters::GRPLHCIFData* mLHCIFdata = nullptr;
+  int mRunNumber = -1;
+  ctpRateFetcher mRateFetcher;
 
   Filter energyFilter = (aod::emcalcluster::energy > cfgMinClusterEnergy && aod::emcalcluster::energy < cfgMaxClusterEnergy);
   Filter m02Filter = (aod::emcalcluster::nCells == 1 || (aod::emcalcluster::m02 > cfgMinM02 && aod::emcalcluster::m02 < cfgMaxM02));
@@ -82,7 +89,7 @@ struct bcWiseClusterSkimmer {
 
   std::map<int32_t, int32_t> fMapPi0Index; // Map to connect the MC index of the pi0 to the one saved in the derived table
 
-  void init(framework::InitContext&)
+  void init(o2::framework::InitContext&)
   {
     const int nEventBins = 6;
     mHistManager.add("nBCs", "Number of BCs;;#bf{#it{N}_{BCs}}", HistType::kTH1F, {{nEventBins, -0.5, 5.5}});
@@ -105,9 +112,9 @@ struct bcWiseClusterSkimmer {
 
   /// \brief Process EMCAL clusters (either ambigous or unique)
   template <typename OutputType, typename InputType>
-  OutputType convertForStorage(InputType const& valueIn, Observables observable)
+  OutputType convertForStorage(InputType const& valueIn, Observable observable)
   {
-    double valueToBeChecked = std::round(valueIn * downscalingFactors[observable]);
+    double valueToBeChecked = valueIn * downscalingFactors[observable];
     if (valueToBeChecked < std::numeric_limits<OutputType>::lowest()) {
       LOG(warning) << "Value " << valueToBeChecked << " of observable " << observable << " below lowest possible value of " << typeid(OutputType).name() << ": " << static_cast<float>(std::numeric_limits<OutputType>::lowest());
       valueToBeChecked = static_cast<float>(std::numeric_limits<OutputType>::lowest());
@@ -173,6 +180,34 @@ struct bcWiseClusterSkimmer {
     return true;
   }
 
+  double calculateMu(const auto& bc)
+  {
+    auto& ccdbMgr = o2::ccdb::BasicCCDBManager::instance();
+    uint64_t timeStamp = bc.timestamp();
+
+    if (mRunNumber != bc.runNumber()) {
+      std::map<string, string> metadata;
+      mLHCIFdata = ccdbMgr.getSpecific<o2::parameters::GRPLHCIFData>("GLO/Config/GRPLHCIF", timeStamp, metadata);
+      if (mLHCIFdata == nullptr) {
+        LOG(fatal) << "GRPLHCIFData not in database, timestamp:" << timeStamp;
+      }
+      mRunNumber = bc.runNumber();
+      LOG(info) << "LHCIF data fetched for run " << mRunNumber << " and timestamp " << timeStamp;
+    }
+
+    auto bfilling = mLHCIFdata->getBunchFilling();
+    double nbc = bfilling.getFilledBCs().size();
+
+    double tvxRate = mRateFetcher.fetch(&ccdbMgr, timeStamp, bc.runNumber(), "T0VTX");
+
+    double nTriggersPerFilledBC = tvxRate / nbc / o2::constants::lhc::LHCRevFreq;
+    double mu = -std::log(1 - nTriggersPerFilledBC);
+
+    // LOG(info) << "Time stamp: " << timeStamp << " Run number: " << bc.runNumber() << " Number of filled BCs: " << nbc << " Trigger rate: " << tvxRate << " Mu: " << mu;
+
+    return mu;
+  }
+
   void processEventProperties(const auto& bc, const auto& collisionsInBC, const auto& cellsInBC)
   {
     bool hasFT0 = bc.has_foundFT0();
@@ -192,13 +227,16 @@ struct bcWiseClusterSkimmer {
     if (hasNoTFROFBorder)
       mHistManager.fill(HIST("nBCs"), 5);
 
+    double mu = cfgStoreMu ? calculateMu(bc) : 0.;
     float ft0Amp = hasFT0 ? bc.foundFT0().sumAmpA() + bc.foundFT0().sumAmpC() : 0.;
+    double centrality = 101.5;
+    if (collisionsInBC.size() > 0)
+      centrality = collisionsInBC.iteratorAt(0).centFT0M();
 
-    bcTable(hasFT0, hasTVX, haskTVXinEMC, hasEMCCell, hasNoTFROFBorder, convertForStorage<uint16_t>(ft0Amp, kFT0Amp));
+    bcTable(hasFT0, hasTVX, haskTVXinEMC, hasEMCCell, hasNoTFROFBorder, convertForStorage<uint8_t>(centrality, kFT0MCent), convertForStorage<uint16_t>(ft0Amp, kFT0Amp), convertForStorage<uint16_t>(mu, kMu));
 
-    for (const auto& collision : collisionsInBC) {
+    for (const auto& collision : collisionsInBC)
       collisionTable(bcTable.lastIndex(), convertForStorage<uint8_t>(collision.centFT0M(), kFT0MCent), convertForStorage<int16_t>(collision.posZ(), kZVtx));
-    }
   }
 
   template <typename TMCParticle, typename TMCParticles>

--- a/PWGEM/PhotonMeson/TableProducer/bcWiseClusterSkimmer.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/bcWiseClusterSkimmer.cxx
@@ -19,6 +19,7 @@
 #include <limits>
 #include <vector>
 #include <map>
+#include <string>
 
 #include "Framework/runDataProcessing.h"
 #include "Framework/AnalysisTask.h"
@@ -186,11 +187,10 @@ struct bcWiseClusterSkimmer {
     uint64_t timeStamp = bc.timestamp();
 
     if (mRunNumber != bc.runNumber()) {
-      std::map<string, string> metadata;
+      std::map<std::string, std::string> metadata;
       mLHCIFdata = ccdbMgr.getSpecific<o2::parameters::GRPLHCIFData>("GLO/Config/GRPLHCIF", timeStamp, metadata);
-      if (mLHCIFdata == nullptr) {
+      if (mLHCIFdata == nullptr)
         LOG(fatal) << "GRPLHCIFData not in database, timestamp:" << timeStamp;
-      }
       mRunNumber = bc.runNumber();
       LOG(info) << "LHCIF data fetched for run " << mRunNumber << " and timestamp " << timeStamp;
     }

--- a/PWGEM/PhotonMeson/Tasks/emcalBcWisePi0.cxx
+++ b/PWGEM/PhotonMeson/Tasks/emcalBcWisePi0.cxx
@@ -56,8 +56,7 @@ struct EmcalBcWisePi0 {
   Configurable<int> cfgDistanceToEdge{"cfgDistanceToEdge", 1, "Distance to edge in cells required for rotated cluster to be accepted"};
   Configurable<int> cfgBGEventDownsampling{"cfgBGEventDownsampling", 1, "Only calculate background for every n-th event (performance reasons in PbPb)"};
 
-  static constexpr float DefaultCentralityWindow[2] = {-1., 101.};
-  Configurable<LabeledArray<float>> cfgCentralityWindow{"cfgCentralityWindow", {DefaultCentralityWindow, 2, {"Min_Centrality", "Max_Centrality"}}, "Select centrality window (also requires unique collision)"};
+  ConfigurableAxis cfgCentralityBinning{"cfgCentralityBinning", {VARIABLE_WIDTH, 0.f, 5.f, 10.f, 20.f, 30.f, 40.f, 50.f, 60.f, 70.f, 80.f, 90.f, 100.f, 101.f, 102.f}, "FT0M centrality (%)"};
 
   Configurable<bool> cfgIsMC{"cfgIsMC", false, "Flag to indicate if the task is running on MC data and should fill MC histograms"};
 
@@ -71,40 +70,44 @@ struct EmcalBcWisePi0 {
   void init(InitContext const&)
   {
     emcalGeom = emcal::Geometry::GetInstanceFromRunNumber(300000);
-    const int nEventBins = 8;
-    mHistManager.add("Event/nBCs", "Number of BCs;;#bf{#it{N}_{BC}}", HistType::kTH1F, {{nEventBins, -0.5, 7.5}});
-    const TString binLabels[nEventBins] = {"All", "FT0", "TVX", "kTVXinEMC", "Cell", "Cluster", "NoBorder", "Collision"};
-    for (int iBin = 0; iBin < nEventBins; iBin++)
-      mHistManager.get<TH1>(HIST("Event/nBCs"))->GetXaxis()->SetBinLabel(iBin + 1, binLabels[iBin]);
+    const int nEventBins = 6;
+    mHistManager.add("Event/nBCs", "Number of BCs;;#bf{FT0M centrality (%)};#bf{#it{N}_{BC}}", HistType::kTH2F, {{nEventBins, -0.5, 5.5}, cfgCentralityBinning});
+    mHistManager.add("Event/nCollisions", "Number of Collisions (BCs x P(mu));;#bf{FT0M centrality (%)};#bf{#it{N}_{coll}}", HistType::kTH2F, {{nEventBins, -0.5, 5.5}, cfgCentralityBinning});
+    const TString binLabels[nEventBins] = {"All", "FT0", "TVX", "kTVXinEMC", "Cell", "Cluster"};
+    for (int iBin = 0; iBin < nEventBins; iBin++) {
+      mHistManager.get<TH2>(HIST("Event/nBCs"))->GetXaxis()->SetBinLabel(iBin + 1, binLabels[iBin]);
+      mHistManager.get<TH2>(HIST("Event/nCollisions"))->GetXaxis()->SetBinLabel(iBin + 1, binLabels[iBin]);
+    }
 
-    mHistManager.add("Event/nCollPerBC", "Number of collisions per BC;#bf{#it{N}_{coll}};#bf{#it{N}_{BC}}", HistType::kTH1F, {{5, -0.5, 4.5}});
+    mHistManager.add("Event/nCollPerBC", "Number of collisions per BC;#bf{#it{N}_{coll}};#bf{FT0M centrality (%)};#bf{#it{N}_{BC}}", HistType::kTH2F, {{5, -0.5, 4.5}, cfgCentralityBinning});
     mHistManager.add("Event/Z1VsZ2", "Z vertex positions for BCs with two collisions;#bf{#it{z}_{vtx}^{1} (cm)};#bf{#it{z}_{vtx}^{2} (cm)}", HistType::kTH2F, {{150, -15, 15}, {150, -15, 15}});
     mHistManager.add("Event/dZ", "Distance between vertices for BCs with two collisions;#bf{#Delta #it{z}_{vtx} (cm)};#bf{#it{N}_{BC}}", HistType::kTH1F, {{600, -30, 30}});
+    mHistManager.add("Event/Mu", "Probablity of a collision in the BC;#bf{#mu};#bf{#it{N}_{BC}}", HistType::kTH1F, {{1000, 0., 0.1}});
 
-    mHistManager.add("Event/Centrality", "FT0M centrality;FT0M centrality (%);#bf{#it{N}_{BC} (only BCs containing exactly 1 collision)}", HistType::kTH1F, {{100, 0., 100.}});
-    mHistManager.add("Event/CentralityVsAmplitude", "FT0M AmplitudeVsCentrality;FT0M Centrality;FT0M Amplitude", HistType::kTH2F, {{105, 0, 105}, {600, 0, 300000}});
+    mHistManager.add("Event/Centrality", "FT0M centrality;FT0M centrality (%);#bf{#it{N}_{BC}}", HistType::kTH1F, {cfgCentralityBinning});
+    mHistManager.add("Event/CentralityVsAmplitude", "FT0M AmplitudeVsCentrality;FT0M Centrality;FT0M Amplitude", HistType::kTH2F, {cfgCentralityBinning, {600, 0, 300000}});
 
-    mHistManager.add("Cluster/E", "Energy of cluster;#bf{#it{E} (GeV)};#bf{#it{N}_{clusters}}", HistType::kTH1F, {{200, 0, 20}});
-    mHistManager.add("Cluster/M02", "Shape of cluster;#bf{#it{M}_{02}};#bf{#it{N}_{clusters}}", HistType::kTH1F, {{200, 0, 2}});
-    mHistManager.add("Cluster/Time", "Time of cluster;#bf{#it{t} (ns)};#bf{#it{N}_{clusters}}", HistType::kTH1F, {{200, -100, 100}});
-    mHistManager.add("Cluster/NCells", "Number of cells per cluster;#bf{#it{N}_{cells}};#bf{#it{N}_{clusters}}", HistType::kTH1F, {{51, 0., 50.5}});
-    mHistManager.add("Cluster/Exotic", "Is cluster exotic?;#bf{Exotic?};#bf{#it{N}_{clusters}}", HistType::kTH1F, {{2, -0.5, 1.5}});
-    mHistManager.add("Cluster/EtaPhi", "Eta/Phi distribution of clusters;#eta;#phi", HistType::kTH2F, {{400, -0.8, 0.8}, {400, 0, constants::math::TwoPI}});
+    mHistManager.add("Cluster/E", "Energy of cluster;#bf{#it{E} (GeV)};#bf{FT0M centrality (%)};#bf{#it{N}_{clusters}}", HistType::kTH2F, {{200, 0, 20}, cfgCentralityBinning});
+    mHistManager.add("Cluster/M02", "Shape of cluster;#bf{#it{M}_{02}};#bf{FT0M centrality (%)};#bf{#it{N}_{clusters}}", HistType::kTH2F, {{200, 0, 2}, cfgCentralityBinning});
+    mHistManager.add("Cluster/Time", "Time of cluster;#bf{#it{t} (ns)};#bf{FT0M centrality (%)};#bf{#it{N}_{clusters}}", HistType::kTH2F, {{200, -100, 100}, cfgCentralityBinning});
+    mHistManager.add("Cluster/NCells", "Number of cells per cluster;#bf{#it{N}_{cells}};#bf{FT0M centrality (%)};#bf{#it{N}_{clusters}}", HistType::kTH2F, {{51, 0., 50.5}, cfgCentralityBinning});
+    mHistManager.add("Cluster/Exotic", "Is cluster exotic?;#bf{Exotic?};#bf{FT0M centrality (%)};#bf{#it{N}_{clusters}}", HistType::kTH2F, {{2, -0.5, 1.5}, cfgCentralityBinning});
+    mHistManager.add("Cluster/EtaPhi", "Eta/Phi distribution of clusters;#eta;#phi;#bf{FT0M centrality (%)};#bf{#it{N}_{clusters}}", HistType::kTH3F, {{400, -0.8, 0.8}, {400, 0, constants::math::TwoPI}, cfgCentralityBinning});
 
-    mHistManager.add("GG/invMassVsPt", "Invariant mass and pT of meson candidates;#bf{#it{M}^{#gamma#gamma} (GeV/#it{c}^{2})};#bf{#it{p}_{T}^{#gamma#gamma} (GeV/#it{c})}", HistType::kTH2F, {{200, 0., 0.4}, {200, 0., 20.}});
-    mHistManager.add("GG/invMassVsPtBackground", "Invariant mass and pT of background meson candidates;#bf{#it{M}^{#gamma#gamma} (GeV/#it{c}^{2})};#bf{#it{p}_{T}^{#gamma#gamma} (GeV/#it{c})}", HistType::kTH2F, {{200, 0., 0.4}, {200, 0., 20.}});
+    mHistManager.add("GG/invMassVsPt", "Invariant mass and pT of meson candidates;#bf{#it{M}^{#gamma#gamma} (GeV/#it{c}^{2})};#bf{#it{p}_{T}^{#gamma#gamma} (GeV/#it{c})};#bf{FT0M centrality (%)}", HistType::kTH3F, {{200, 0., 0.4}, {200, 0., 20.}, cfgCentralityBinning});
+    mHistManager.add("GG/invMassVsPtBackground", "Invariant mass and pT of background meson candidates;#bf{#it{M}^{#gamma#gamma} (GeV/#it{c}^{2})};#bf{#it{p}_{T}^{#gamma#gamma} (GeV/#it{c})};#bf{FT0M centrality (%)}", HistType::kTH3F, {{200, 0., 0.4}, {200, 0., 20.}, cfgCentralityBinning});
 
     if (cfgIsMC) {
-      mHistManager.add("True/clusterERecVsETrue", "True vs reconstructed energy of cluster inducing particle;#bf{#it{E}_{rec} (GeV)};#bf{#it{E}_{true}^{cls inducing part} (GeV)}", HistType::kTH2F, {{200, 0, 20}, {200, 0, 20}});
-      mHistManager.add("True/PtRecVsPtTrue", "True vs reconstructed pT of true pi0s;#bf{#it{p}_{T}^{rec} (GeV/#it{c})};#bf{#it{p}_{T}^{true} (GeV/#it{c})}", HistType::kTH2F, {{200, 0., 20.}, {200, 0., 20.}});
-      mHistManager.add("True/invMassVsPt_Primary", "Invariant mass and pT of meson candidates", HistType::kTH2F, {{200, 0., 0.4}, {200, 0., 20.}});
-      mHistManager.add("True/invMassVsPt_Secondary", "Invariant mass and pT of meson candidates", HistType::kTH2F, {{200, 0., 0.4}, {200, 0., 20.}});
-      mHistManager.add("True/invMassVsPt_HadronicShower", "Invariant mass and pT of meson candidates", HistType::kTH2F, {{200, 0., 0.4}, {200, 0., 20.}});
+      mHistManager.add("True/clusterERecVsETrue", "True vs reconstructed energy of cluster inducing particle;#bf{#it{E}_{rec} (GeV)};#bf{#it{E}_{true}^{cls inducing part} (GeV)};#bf{FT0M centrality (%)}", HistType::kTH3F, {{200, 0, 20}, {200, 0, 20}, cfgCentralityBinning});
+      mHistManager.add("True/PtRecVsPtTrue", "True vs reconstructed pT of true pi0s;#bf{#it{p}_{T}^{rec} (GeV/#it{c})};#bf{#it{p}_{T}^{true} (GeV/#it{c})};#bf{FT0M centrality (%)}", HistType::kTH3F, {{200, 0., 20.}, {200, 0., 20.}, cfgCentralityBinning});
+      mHistManager.add("True/invMassVsPt_Primary", "Reconstructed validated primary pi0;#bf{#it{M}^{#gamma#gamma} (GeV/#it{c}^{2})};#bf{#it{p}_{T}^{#gamma#gamma} (GeV/#it{c})};#bf{FT0M centrality (%)}", HistType::kTH3F, {{200, 0., 0.4}, {200, 0., 20.}, cfgCentralityBinning});
+      mHistManager.add("True/invMassVsPt_Secondary", "Reconstructed validated pi0 from secondary decay;#bf{#it{M}^{#gamma#gamma} (GeV/#it{c}^{2})};#bf{#it{p}_{T}^{#gamma#gamma} (GeV/#it{c})};#bf{FT0M centrality (%)}", HistType::kTH3F, {{200, 0., 0.4}, {200, 0., 20.}, cfgCentralityBinning});
+      mHistManager.add("True/invMassVsPt_HadronicShower", "Reconstructed validated pi0 from hadronic shower;#bf{#it{M}^{#gamma#gamma} (GeV/#it{c}^{2})};#bf{#it{p}_{T}^{#gamma#gamma} (GeV/#it{c})};#bf{FT0M centrality (%)}", HistType::kTH3F, {{200, 0., 0.4}, {200, 0., 20.}, cfgCentralityBinning});
 
-      mHistManager.add("Generated/pi0_AllBCs", "pT spectrum of generated pi0s in all BCs;#bf{#it{p}_{T} (GeV/#it{c})};#bf{#it{N}_{#pi^{0}}^{gen}}", HistType::kTH1F, {{200, 0, 20}});
-      mHistManager.add("Generated/pi0_TVX", "pT spectrum of generated pi0s in TVX triggered BCs;#bf{#it{p}_{T} (GeV/#it{c})};#bf{#it{N}_{#pi^{0}}^{gen}}", HistType::kTH1F, {{200, 0, 20}});
-      mHistManager.add("Generated/pi0_kTVXinEMC", "pT spectrum of generated pi0s in kTVXinEMC triggered BCs;#bf{#it{p}_{T} (GeV/#it{c})};#bf{#it{N}_{#pi^{0}}^{gen}}", HistType::kTH1F, {{200, 0, 20}});
-      mHistManager.add("Accepted/pi0_kTVXinEMC", "pT spectrum of accepted pi0s in kTVXinEMC triggered BCs;#bf{#it{p}_{T} (GeV/#it{c})};#bf{#it{N}_{#pi^{0}}^{acc}}", HistType::kTH1F, {{200, 0, 20}});
+      mHistManager.add("Generated/pi0_AllBCs", "pT spectrum of generated pi0s in all BCs;#bf{#it{p}_{T} (GeV/#it{c})};#bf{FT0M centrality (%)};#bf{#it{N}_{#pi^{0}}^{gen}}", HistType::kTH2F, {{200, 0, 20}, cfgCentralityBinning});
+      mHistManager.add("Generated/pi0_TVX", "pT spectrum of generated pi0s in TVX triggered BCs;#bf{#it{p}_{T} (GeV/#it{c})};#bf{FT0M centrality (%)};#bf{#it{N}_{#pi^{0}}^{gen}}", HistType::kTH2F, {{200, 0, 20}, cfgCentralityBinning});
+      mHistManager.add("Generated/pi0_kTVXinEMC", "pT spectrum of generated pi0s in kTVXinEMC triggered BCs;#bf{#it{p}_{T} (GeV/#it{c})};#bf{FT0M centrality (%)};#bf{#it{N}_{#pi^{0}}^{gen}}", HistType::kTH2F, {{200, 0, 20}, cfgCentralityBinning});
+      mHistManager.add("Accepted/pi0_kTVXinEMC", "pT spectrum of accepted pi0s in kTVXinEMC triggered BCs;#bf{#it{p}_{T} (GeV/#it{c})};#bf{FT0M centrality (%)};#bf{#it{N}_{#pi^{0}}^{acc}}", HistType::kTH2F, {{200, 0, 20}, cfgCentralityBinning});
     }
   }
 
@@ -126,49 +129,55 @@ struct EmcalBcWisePi0 {
 
   void fillEventHists(const auto& bc, const auto& collisions, const auto& clusters)
   {
-    mHistManager.fill(HIST("Event/nBCs"), 0);
-    if (bc.hasFT0())
-      mHistManager.fill(HIST("Event/nBCs"), 1);
-    if (bc.hasTVX())
-      mHistManager.fill(HIST("Event/nBCs"), 2);
-    if (bc.haskTVXinEMC())
-      mHistManager.fill(HIST("Event/nBCs"), 3);
-    if (bc.hasEMCCell())
-      mHistManager.fill(HIST("Event/nBCs"), 4);
-    if (clusters.size() > 0)
-      mHistManager.fill(HIST("Event/nBCs"), 5);
-    if (bc.hasNoTFROFBorder())
-      mHistManager.fill(HIST("Event/nBCs"), 6);
-    if (collisions.size() > 0)
-      mHistManager.fill(HIST("Event/nBCs"), 7);
-
-    if (collisions.size() == 1) {
-      mHistManager.fill(HIST("Event/Centrality"), collisions.iteratorAt(0).centrality());
-      mHistManager.fill(HIST("Event/CentralityVsAmplitude"), collisions.iteratorAt(0).centrality(), bc.ft0Amplitude());
-    } else {
-      mHistManager.fill(HIST("Event/CentralityVsAmplitude"), 103, bc.ft0Amplitude());
+    mHistManager.fill(HIST("Event/nBCs"), 0, bc.centrality());
+    float mu = bc.mu();
+    mHistManager.fill(HIST("Event/Mu"), mu);
+    double p = mu > 0.001 ? mu / (1 - std::exp(-mu)) : 1.; // No pile-up for small mu (protection against division by zero)
+    mHistManager.fill(HIST("Event/nCollisions"), 0, bc.centrality(), p);
+    if (bc.hasFT0()) {
+      mHistManager.fill(HIST("Event/nBCs"), 1, bc.centrality());
+      mHistManager.fill(HIST("Event/nCollisions"), 1, bc.centrality(), p);
+    }
+    if (bc.hasTVX()) {
+      mHistManager.fill(HIST("Event/nBCs"), 2, bc.centrality());
+      mHistManager.fill(HIST("Event/nCollisions"), 2, bc.centrality(), p);
+    }
+    if (bc.haskTVXinEMC()) {
+      mHistManager.fill(HIST("Event/nBCs"), 3, bc.centrality());
+      mHistManager.fill(HIST("Event/nCollisions"), 3, bc.centrality(), p);
+    }
+    if (bc.hasEMCCell()) {
+      mHistManager.fill(HIST("Event/nBCs"), 4, bc.centrality());
+      mHistManager.fill(HIST("Event/nCollisions"), 4, bc.centrality(), p);
+    }
+    if (clusters.size() > 0) {
+      mHistManager.fill(HIST("Event/nBCs"), 5, bc.centrality());
+      mHistManager.fill(HIST("Event/nCollisions"), 5, bc.centrality(), p);
     }
 
-    mHistManager.fill(HIST("Event/nCollPerBC"), collisions.size());
+    mHistManager.fill(HIST("Event/Centrality"), bc.centrality());
+    mHistManager.fill(HIST("Event/CentralityVsAmplitude"), bc.centrality(), bc.ft0Amplitude());
+
+    mHistManager.fill(HIST("Event/nCollPerBC"), collisions.size(), bc.centrality());
     if (collisions.size() == 2) {
       mHistManager.fill(HIST("Event/Z1VsZ2"), collisions.iteratorAt(0).zVtx(), collisions.iteratorAt(1).zVtx());
       mHistManager.fill(HIST("Event/dZ"), collisions.iteratorAt(0).zVtx() - collisions.iteratorAt(1).zVtx());
     }
   }
 
-  void fillClusterHists(const auto& clusters)
+  void fillClusterHists(const auto& clusters, float centrality)
   {
     for (const auto& cluster : clusters) {
-      mHistManager.fill(HIST("Cluster/E"), cluster.e());
-      mHistManager.fill(HIST("Cluster/M02"), cluster.m02());
-      mHistManager.fill(HIST("Cluster/Time"), cluster.time());
-      mHistManager.fill(HIST("Cluster/NCells"), cluster.nCells());
-      mHistManager.fill(HIST("Cluster/EtaPhi"), cluster.eta(), cluster.phi());
-      mHistManager.fill(HIST("Cluster/Exotic"), cluster.isExotic());
+      mHistManager.fill(HIST("Cluster/E"), cluster.e(), centrality);
+      mHistManager.fill(HIST("Cluster/M02"), cluster.m02(), centrality);
+      mHistManager.fill(HIST("Cluster/Time"), cluster.time(), centrality);
+      mHistManager.fill(HIST("Cluster/NCells"), cluster.nCells(), centrality);
+      mHistManager.fill(HIST("Cluster/EtaPhi"), cluster.eta(), cluster.phi(), centrality);
+      mHistManager.fill(HIST("Cluster/Exotic"), cluster.isExotic(), centrality);
     }
   }
 
-  void reconstructMesons(const auto& clusters, int bcId)
+  void reconstructMesons(const auto& clusters, const auto& bc)
   {
     for (const auto& [g1, g2] : soa::combinations(soa::CombinationsStrictlyUpperIndexPolicy(clusters, clusters))) {
       ROOT::Math::PtEtaPhiMVector v1(g1.pt(), g1.eta(), g1.phi(), 0.);
@@ -181,12 +190,12 @@ struct EmcalBcWisePi0 {
       if (openingAngle12 < cfgMinOpenAngle)
         continue;
 
-      mHistManager.fill(HIST("GG/invMassVsPt"), v12.M(), v12.Pt());
+      mHistManager.fill(HIST("GG/invMassVsPt"), v12.M(), v12.Pt(), bc.centrality());
 
       if (clusters.size() < 3)
         continue;
 
-      if (bcId % cfgBGEventDownsampling != 0)
+      if (bc.globalIndex() % cfgBGEventDownsampling != 0)
         continue;
 
       // "else: Calculate background"
@@ -217,12 +226,12 @@ struct EmcalBcWisePi0 {
 
           ROOT::Math::PtEtaPhiMVector vBG = v3 + vi;
 
-          mHistManager.fill(HIST("GG/invMassVsPtBackground"), vBG.M(), vBG.Pt());
+          mHistManager.fill(HIST("GG/invMassVsPtBackground"), vBG.M(), vBG.Pt(), bc.centrality());
         }
       }
     }
   }
-  void reconstructTrueMesons(const auto& clusters, const auto& mcPi0s)
+  void reconstructTrueMesons(const auto& clusters, const auto& mcPi0s, const auto& bc)
   {
     for (const auto& [g1, g2] : soa::combinations(soa::CombinationsStrictlyUpperIndexPolicy(clusters, clusters))) {
       if (g1.pi0ID() == -1 || g1.pi0ID() != g2.pi0ID())
@@ -240,14 +249,14 @@ struct EmcalBcWisePi0 {
 
       const auto& mcPi0 = mcPi0s.iteratorAt(g1.pi0ID() - mcPi0s.offset());
 
-      mHistManager.fill(HIST("True/PtRecVsPtTrue"), v12.Pt(), mcPi0.pt());
+      mHistManager.fill(HIST("True/PtRecVsPtTrue"), v12.Pt(), mcPi0.pt(), bc.centrality());
 
       if (mcPi0.isPrimary())
-        mHistManager.fill(HIST("True/invMassVsPt_Primary"), v12.M(), v12.Pt());
+        mHistManager.fill(HIST("True/invMassVsPt_Primary"), v12.M(), v12.Pt(), bc.centrality());
       else if (mcPi0.isFromWD())
-        mHistManager.fill(HIST("True/invMassVsPt_Secondary"), v12.M(), v12.Pt());
+        mHistManager.fill(HIST("True/invMassVsPt_Secondary"), v12.M(), v12.Pt(), bc.centrality());
       else
-        mHistManager.fill(HIST("True/invMassVsPt_HadronicShower"), v12.M(), v12.Pt());
+        mHistManager.fill(HIST("True/invMassVsPt_HadronicShower"), v12.M(), v12.Pt(), bc.centrality());
     }
   }
 
@@ -255,19 +264,10 @@ struct EmcalBcWisePi0 {
   {
     if (cfgRequirekTVXinEMC && !bc.haskTVXinEMC())
       return false;
-
-    if (cfgCentralityWindow->get("Min_Centrality") > -0.5 || cfgCentralityWindow->get("Max_Centrality") < 100.5) { // Centrality window is set
-      if (collisions.size() != 1)
-        return false;
-      if (collisions.iteratorAt(0).centrality() < cfgCentralityWindow->get("Min_Centrality") || collisions.iteratorAt(0).centrality() > cfgCentralityWindow->get("Max_Centrality"))
-        return false;
-    }
-
     if (cfgSelectOnlyUniqueAmbiguous == 1 && collisions.size() != 1)
       return false;
     if (cfgSelectOnlyUniqueAmbiguous == 2 && collisions.size() == 1)
       return false;
-
     return true;
   }
 
@@ -275,13 +275,13 @@ struct EmcalBcWisePi0 {
   {
     for (const auto& mcPi0 : mcPi0s) {
       if (mcPi0.isPrimary()) {
-        mHistManager.fill(HIST("Generated/pi0_AllBCs"), mcPi0.pt());
+        mHistManager.fill(HIST("Generated/pi0_AllBCs"), mcPi0.pt(), bc.centrality());
         if (bc.hasTVX())
-          mHistManager.fill(HIST("Generated/pi0_TVX"), mcPi0.pt());
+          mHistManager.fill(HIST("Generated/pi0_TVX"), mcPi0.pt(), bc.centrality());
         if (bc.haskTVXinEMC())
-          mHistManager.fill(HIST("Generated/pi0_kTVXinEMC"), mcPi0.pt());
+          mHistManager.fill(HIST("Generated/pi0_kTVXinEMC"), mcPi0.pt(), bc.centrality());
         if (mcPi0.isAccepted() && bc.haskTVXinEMC())
-          mHistManager.fill(HIST("Accepted/pi0_kTVXinEMC"), mcPi0.pt());
+          mHistManager.fill(HIST("Accepted/pi0_kTVXinEMC"), mcPi0.pt(), bc.centrality());
       }
     }
   }
@@ -293,17 +293,15 @@ struct EmcalBcWisePi0 {
 
     fillEventHists(bc, collisions, clusters);
 
-    fillClusterHists(clusters);
+    fillClusterHists(clusters, bc.centrality());
 
-    reconstructMesons(clusters, bc.globalIndex());
+    reconstructMesons(clusters, bc);
   }
 
   void processMCInfo(aod::BCWiseBCs::iterator const& bc, aod::BCWiseCollisions const& collisions, SelectedMCClusters const& clusters, aod::BCWiseMCPi0s const& mcPi0s)
   {
-    if (!cfgIsMC) {
+    if (!cfgIsMC)
       LOG(fatal) << "MC processing is not enabled, but the task is running on MC data. Please set cfgIsMC to true.";
-      return;
-    }
 
     fillGeneratedPi0Hists(mcPi0s, bc); // Fill before BC selection to also store pi0s in BCs that were not triggered
 
@@ -311,9 +309,9 @@ struct EmcalBcWisePi0 {
       return;
 
     for (const auto& cluster : clusters)
-      mHistManager.fill(HIST("True/clusterERecVsETrue"), cluster.e(), cluster.trueE());
+      mHistManager.fill(HIST("True/clusterERecVsETrue"), cluster.e(), cluster.trueE(), bc.centrality());
 
-    reconstructTrueMesons(clusters, mcPi0s);
+    reconstructTrueMesons(clusters, mcPi0s, bc);
   }
   PROCESS_SWITCH(EmcalBcWisePi0, processMCInfo, "Run true and gen", false);
 };


### PR DESCRIPTION
- Add centrality axis to most histograms in analysis task
- Add pile-up correction information (mu based on interaction rate)
- Fix rounding error from derived data -> nextafter instead of +epsilon