### PR TITLE
[PWGHF,PWGCF] Split same-event table and add the collision infos into lcp femto task 

### DIFF
--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -312,7 +312,7 @@ DECLARE_SOA_TABLE(FDHfCand, "AOD", "FDHFCAND", //! Table to store the derived da
                   fdhf::Phi<fdhf::Prong0Pt, fdhf::Prong0Phi, fdhf::Prong0Eta, fdhf::Prong1Pt, fdhf::Prong1Phi, fdhf::Prong1Eta, fdhf::Prong2Pt, fdhf::Prong2Phi, fdhf::Prong2Eta>,
                   fdhf::Pt<fdhf::Prong0Pt, fdhf::Prong0Phi, fdhf::Prong0Eta, fdhf::Prong1Pt, fdhf::Prong1Phi, fdhf::Prong1Eta, fdhf::Prong2Pt, fdhf::Prong2Phi, fdhf::Prong2Eta>);
 
-DECLARE_SOA_TABLE(FDResultsHFCharm, "AOD", "FDRESULTSHFCHARM", //! table to store results for HF femtoscopy
+DECLARE_SOA_TABLE(FDResultsCharm, "AOD", "FDRESULTSCHARM", //! table to store results for HF femtoscopy
                   fdhf::GIndexCol,
                   fdhf::TimeStamp,
                   fdhf::CharmM,
@@ -326,7 +326,7 @@ DECLARE_SOA_TABLE(FDResultsHFCharm, "AOD", "FDRESULTSHFCHARM", //! table to stor
                   fdhf::FlagMc,
                   fdhf::OriginMcRec);
 
-DECLARE_SOA_TABLE(FDResultsHFTrk, "AOD", "FDRESULTSHFTRK", //! table to store results for HF femtoscopy
+DECLARE_SOA_TABLE(FDResultsTrk, "AOD", "FDRESULTSTRK", //! table to store results for HF femtoscopy
                   fdhf::GIndexCol,
                   fdhf::TimeStamp,
                   fdhf::TrkPt,
@@ -339,7 +339,7 @@ DECLARE_SOA_TABLE(FDResultsHFTrk, "AOD", "FDRESULTSHFTRK", //! table to store re
                   femtodreamparticle::TPCNSigmaPr,
                   femtodreamparticle::TOFNSigmaPr);
 
-DECLARE_SOA_TABLE(FDResultsHFColl, "AOD", "FDRESULTSHFCOLL", //! table to store results for HF femtoscopy
+DECLARE_SOA_TABLE(FDResultsColl, "AOD", "FDRESULTSCOLL", //! table to store results for HF femtoscopy
                   fdhf::GIndexCol,
                   fdhf::TimeStamp,
                   fdhf::VertexZ,

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -312,7 +312,7 @@ DECLARE_SOA_TABLE(FDHfCand, "AOD", "FDHFCAND", //! Table to store the derived da
                   fdhf::Phi<fdhf::Prong0Pt, fdhf::Prong0Phi, fdhf::Prong0Eta, fdhf::Prong1Pt, fdhf::Prong1Phi, fdhf::Prong1Eta, fdhf::Prong2Pt, fdhf::Prong2Phi, fdhf::Prong2Eta>,
                   fdhf::Pt<fdhf::Prong0Pt, fdhf::Prong0Phi, fdhf::Prong0Eta, fdhf::Prong1Pt, fdhf::Prong1Phi, fdhf::Prong1Eta, fdhf::Prong2Pt, fdhf::Prong2Phi, fdhf::Prong2Eta>);
 
-DECLARE_SOA_TABLE(FDResultsCharm, "AOD", "FDRESULTSCHARM", //! table to store results for HF femtoscopy
+DECLARE_SOA_TABLE(FDHfCharm, "AOD", "FDHFCHARM", //! table to store results for HF femtoscopy
                   fdhf::GIndexCol,
                   fdhf::TimeStamp,
                   fdhf::CharmM,
@@ -326,7 +326,7 @@ DECLARE_SOA_TABLE(FDResultsCharm, "AOD", "FDRESULTSCHARM", //! table to store re
                   fdhf::FlagMc,
                   fdhf::OriginMcRec);
 
-DECLARE_SOA_TABLE(FDResultsTrk, "AOD", "FDRESULTSTRK", //! table to store results for HF femtoscopy
+DECLARE_SOA_TABLE(FDHfTrk, "AOD", "FDHFTRK", //! table to store results for HF femtoscopy
                   fdhf::GIndexCol,
                   fdhf::TimeStamp,
                   fdhf::TrkPt,
@@ -339,7 +339,7 @@ DECLARE_SOA_TABLE(FDResultsTrk, "AOD", "FDRESULTSTRK", //! table to store result
                   femtodreamparticle::TPCNSigmaPr,
                   femtodreamparticle::TOFNSigmaPr);
 
-DECLARE_SOA_TABLE(FDResultsColl, "AOD", "FDRESULTSCOLL", //! table to store results for HF femtoscopy
+DECLARE_SOA_TABLE(FDHfColl, "AOD", "FDHFCOLL", //! table to store results for HF femtoscopy
                   fdhf::GIndexCol,
                   fdhf::TimeStamp,
                   fdhf::VertexZ,

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -235,9 +235,9 @@ DECLARE_SOA_COLUMN(FlagMc, flagMc, int8_t);                         //! To selec
 DECLARE_SOA_COLUMN(OriginMcRec, originMcRec, int8_t);               //! flag for reconstruction level matching (1 for prompt, 2 for non-prompt)
 DECLARE_SOA_COLUMN(OriginMcGen, originMcGen, int8_t);               //! flag for generator level matching (1 for prompt, 2 for non-prompt)
 DECLARE_SOA_COLUMN(IsCandidateSwapped, isCandidateSwapped, int8_t); //! swapping of the prongs order (0 for Lc -> pkpi, 1 for Lc -> pikp)
-DECLARE_SOA_COLUMN(PtAssoc, ptAssoc, float);                        //! Transverse momentum of associate femto particle
-DECLARE_SOA_COLUMN(EtaAssoc, etaAssoc, float);                      //! Eta of associate femto particle
-DECLARE_SOA_COLUMN(PhiAssoc, phiAssoc, float);                      //! Phi of associate femto particle
+DECLARE_SOA_COLUMN(TrkPt, trkPt, float);                            //! Transverse momentum of associate femto particle
+DECLARE_SOA_COLUMN(TrkEta, trkEta, float);                          //! Eta of associate femto particle
+DECLARE_SOA_COLUMN(TrkPhi, trkPhi, float);                          //! Phi of associate femto particle
 DECLARE_SOA_COLUMN(Kstar, kstar, float);                            //! Relative momentum in particles pair frame
 DECLARE_SOA_COLUMN(KT, kT, float);                                  //! kT distribution of particle pairs
 DECLARE_SOA_COLUMN(MT, mT, float);                                  //! Transverse mass distribution
@@ -312,36 +312,38 @@ DECLARE_SOA_TABLE(FDHfCand, "AOD", "FDHFCAND", //! Table to store the derived da
                   fdhf::Phi<fdhf::Prong0Pt, fdhf::Prong0Phi, fdhf::Prong0Eta, fdhf::Prong1Pt, fdhf::Prong1Phi, fdhf::Prong1Eta, fdhf::Prong2Pt, fdhf::Prong2Phi, fdhf::Prong2Eta>,
                   fdhf::Pt<fdhf::Prong0Pt, fdhf::Prong0Phi, fdhf::Prong0Eta, fdhf::Prong1Pt, fdhf::Prong1Phi, fdhf::Prong1Eta, fdhf::Prong2Pt, fdhf::Prong2Phi, fdhf::Prong2Eta>);
 
-DECLARE_SOA_TABLE(FDResultsHF, "AOD", "FDRESULTSHF", //! table to store results for HF femtoscopy
+DECLARE_SOA_TABLE(FDResultsHFCharm, "AOD", "FDRESULTSHFCHARM", //! table to store results for HF femtoscopy
                   fdhf::GIndexCol,
                   fdhf::TimeStamp,
-                  fdhf::VertexZ,
                   fdhf::CharmM,
                   fdhf::CharmPt,
-                  fdhf::PtAssoc,
                   fdhf::CharmEta,
-                  fdhf::EtaAssoc,
                   fdhf::CharmPhi,
-                  fdhf::PhiAssoc,
+                  fdhf::Charge,
                   fdhf::BDTBkg,
                   fdhf::BDTPrompt,
                   fdhf::BDTFD,
-                  fdhf::Kstar,
-                  fdhf::KT,
-                  fdhf::MT,
-                  fdhf::Mult,
-                  fdhf::Charge,
-                  fdhf::PairSign,
-                  fdhf::ProcessType,
                   fdhf::FlagMc,
                   fdhf::OriginMcRec);
 
-DECLARE_SOA_TABLE(FDResultsHFTrkInfo, "AOD", "FDRESULTSHFTRKINFO", //! table to store results for HF femtoscopy
+DECLARE_SOA_TABLE(FDResultsHFTrk, "AOD", "FDRESULTSHFTRK", //! table to store results for HF femtoscopy
+                  fdhf::GIndexCol,
+                  fdhf::TimeStamp,
+                  fdhf::TrkPt,
+                  fdhf::TrkEta,
+                  fdhf::TrkPhi,
+                  femtodreamparticle::Sign,
                   femtodreamparticle::TPCNClsFound,
                   track::TPCNClsFindable,
                   femtodreamparticle::TPCNClsCrossedRows,
                   femtodreamparticle::TPCNSigmaPr,
                   femtodreamparticle::TOFNSigmaPr);
+
+DECLARE_SOA_TABLE(FDResultsHFColl, "AOD", "FDRESULTSHFCOLL", //! table to store results for HF femtoscopy
+                  fdhf::GIndexCol,
+                  fdhf::TimeStamp,
+                  fdhf::VertexZ,
+                  fdhf::Mult);
 
 DECLARE_SOA_TABLE(FDHfCandMC, "AOD", "FDHFCANDMC", //! Table for reconstructed MC charm hadron candidates
                   o2::soa::Index<>,

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -211,6 +211,7 @@ enum CharmHadronMassHypo {
   lcToPiKP = 2
 };
 DECLARE_SOA_COLUMN(GIndexCol, gIndexCol, int);                      //! Global index for the collision
+DECLARE_SOA_COLUMN(TimeStamp, timeStamp, int64_t);                  //! Timestamp for the collision
 DECLARE_SOA_COLUMN(TrackId, trackId, int);                          //! track id to match associate particle with charm hadron prongs
 DECLARE_SOA_COLUMN(Charge, charge, int8_t);                         //! Charge of charm hadron
 DECLARE_SOA_COLUMN(Prong0Id, prong0Id, int);                        //! Track id of charm hadron prong0
@@ -307,6 +308,7 @@ DECLARE_SOA_TABLE(FDHfCand, "AOD", "FDHFCAND", //! Table to store the derived da
 
 DECLARE_SOA_TABLE(FDResultsHF, "AOD", "FDRESULTSHF", //! table to store results for HF femtoscopy
                   fdhf::GIndexCol,
+                  fdhf::TimeStamp,
                   fdhf::CharmM,
                   fdhf::CharmPt,
                   fdhf::PtAssoc,

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -306,6 +306,8 @@ DECLARE_SOA_TABLE(FDHfCand, "AOD", "FDHFCAND", //! Table to store the derived da
                   fdhf::Pt<fdhf::Prong0Pt, fdhf::Prong0Phi, fdhf::Prong0Eta, fdhf::Prong1Pt, fdhf::Prong1Phi, fdhf::Prong1Eta, fdhf::Prong2Pt, fdhf::Prong2Phi, fdhf::Prong2Eta>);
 
 DECLARE_SOA_TABLE(FDResultsHF, "AOD", "FDRESULTSHF", //! table to store results for HF femtoscopy
+                  o2::soa::Index<>,
+                  femtodreamparticle::FDCollisionId,
                   fdhf::CharmM,
                   fdhf::CharmPt,
                   fdhf::PtAssoc,

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -210,7 +210,7 @@ enum CharmHadronMassHypo {
   lcToPKPi = 1,
   lcToPiKP = 2
 };
-
+DECLARE_SOA_COLUMN(GIndexCol, gIndexCol, int);                      //! Global index for the collision
 DECLARE_SOA_COLUMN(TrackId, trackId, int);                          //! track id to match associate particle with charm hadron prongs
 DECLARE_SOA_COLUMN(Charge, charge, int8_t);                         //! Charge of charm hadron
 DECLARE_SOA_COLUMN(Prong0Id, prong0Id, int);                        //! Track id of charm hadron prong0
@@ -306,8 +306,7 @@ DECLARE_SOA_TABLE(FDHfCand, "AOD", "FDHFCAND", //! Table to store the derived da
                   fdhf::Pt<fdhf::Prong0Pt, fdhf::Prong0Phi, fdhf::Prong0Eta, fdhf::Prong1Pt, fdhf::Prong1Phi, fdhf::Prong1Eta, fdhf::Prong2Pt, fdhf::Prong2Phi, fdhf::Prong2Eta>);
 
 DECLARE_SOA_TABLE(FDResultsHF, "AOD", "FDRESULTSHF", //! table to store results for HF femtoscopy
-                  o2::soa::Index<>,
-                  femtodreamparticle::FDCollisionId,
+                  fdhf::GIndexCol,
                   fdhf::CharmM,
                   fdhf::CharmPt,
                   fdhf::PtAssoc,

--- a/PWGCF/DataModel/FemtoDerived.h
+++ b/PWGCF/DataModel/FemtoDerived.h
@@ -212,6 +212,7 @@ enum CharmHadronMassHypo {
 };
 DECLARE_SOA_COLUMN(GIndexCol, gIndexCol, int);                      //! Global index for the collision
 DECLARE_SOA_COLUMN(TimeStamp, timeStamp, int64_t);                  //! Timestamp for the collision
+DECLARE_SOA_COLUMN(VertexZ, vertexZ, float);                        //! VertexZ for the collision
 DECLARE_SOA_COLUMN(TrackId, trackId, int);                          //! track id to match associate particle with charm hadron prongs
 DECLARE_SOA_COLUMN(Charge, charge, int8_t);                         //! Charge of charm hadron
 DECLARE_SOA_COLUMN(Prong0Id, prong0Id, int);                        //! Track id of charm hadron prong0
@@ -235,11 +236,15 @@ DECLARE_SOA_COLUMN(OriginMcRec, originMcRec, int8_t);               //! flag for
 DECLARE_SOA_COLUMN(OriginMcGen, originMcGen, int8_t);               //! flag for generator level matching (1 for prompt, 2 for non-prompt)
 DECLARE_SOA_COLUMN(IsCandidateSwapped, isCandidateSwapped, int8_t); //! swapping of the prongs order (0 for Lc -> pkpi, 1 for Lc -> pikp)
 DECLARE_SOA_COLUMN(PtAssoc, ptAssoc, float);                        //! Transverse momentum of associate femto particle
+DECLARE_SOA_COLUMN(EtaAssoc, etaAssoc, float);                      //! Eta of associate femto particle
+DECLARE_SOA_COLUMN(PhiAssoc, phiAssoc, float);                      //! Phi of associate femto particle
 DECLARE_SOA_COLUMN(Kstar, kstar, float);                            //! Relative momentum in particles pair frame
 DECLARE_SOA_COLUMN(KT, kT, float);                                  //! kT distribution of particle pairs
 DECLARE_SOA_COLUMN(MT, mT, float);                                  //! Transverse mass distribution
 DECLARE_SOA_COLUMN(CharmM, charmM, float);                          //! Charm hadron mass
 DECLARE_SOA_COLUMN(CharmPt, charmPt, float);                        //! Transverse momentum of charm hadron for result task
+DECLARE_SOA_COLUMN(CharmEta, charmEta, float);                      //! Eta of charm hadron for result task
+DECLARE_SOA_COLUMN(CharmPhi, charmPhi, float);                      //! Phi of charm hadron for result task
 DECLARE_SOA_COLUMN(Mult, mult, int);                                //! Charge particle multiplicity
 DECLARE_SOA_COLUMN(MultPercentile, multPercentile, float);          //! Multiplicity precentile
 DECLARE_SOA_COLUMN(PairSign, pairSign, int8_t);                     //! Selection between like sign (1) and unlike sign pair (2)
@@ -282,6 +287,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta,                                            
 DECLARE_SOA_TABLE(FDHfCand, "AOD", "FDHFCAND", //! Table to store the derived data for charm hadron candidates
                   o2::soa::Index<>,
                   femtodreamparticle::FDCollisionId,
+                  fdhf::TimeStamp,
                   fdhf::Charge,
                   fdhf::Prong0Id,
                   fdhf::Prong1Id,
@@ -309,9 +315,14 @@ DECLARE_SOA_TABLE(FDHfCand, "AOD", "FDHFCAND", //! Table to store the derived da
 DECLARE_SOA_TABLE(FDResultsHF, "AOD", "FDRESULTSHF", //! table to store results for HF femtoscopy
                   fdhf::GIndexCol,
                   fdhf::TimeStamp,
+                  fdhf::VertexZ,
                   fdhf::CharmM,
                   fdhf::CharmPt,
                   fdhf::PtAssoc,
+                  fdhf::CharmEta,
+                  fdhf::EtaAssoc,
+                  fdhf::CharmPhi,
+                  fdhf::PhiAssoc,
                   fdhf::BDTBkg,
                   fdhf::BDTPrompt,
                   fdhf::BDTFD,
@@ -319,7 +330,6 @@ DECLARE_SOA_TABLE(FDResultsHF, "AOD", "FDRESULTSHF", //! table to store results 
                   fdhf::KT,
                   fdhf::MT,
                   fdhf::Mult,
-                  fdhf::MultPercentile,
                   fdhf::Charge,
                   fdhf::PairSign,
                   fdhf::ProcessType,

--- a/PWGHF/HFC/TableProducer/femtoDreamProducer.cxx
+++ b/PWGHF/HFC/TableProducer/femtoDreamProducer.cxx
@@ -475,6 +475,8 @@ struct HfFemtoDreamProducer {
           LOGF(fatal, "Please check your Ml configuration!!");
         }
       }
+      auto bc = col.template bc_as<aod::BCsWithTimestamps>();
+      int64_t timeStamp = bc.timestamp();
       auto fillTable = [&](int CandFlag,
                            int FunctionSelection,
                            float BDTScoreBkg,
@@ -483,6 +485,7 @@ struct HfFemtoDreamProducer {
         if (FunctionSelection >= 1){
                 rowCandCharmHad(
                     outputCollision.lastIndex(),
+                    timeStamp,
                     trackPos1.sign() + trackNeg.sign() + trackPos2.sign(),
                     trackPos1.globalIndex(),
                     trackNeg.globalIndex(),

--- a/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
+++ b/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
@@ -385,13 +385,6 @@ struct HfTaskCharmHadronsFemtoDream {
           continue;
         }
 
-        int charmHadMc = 0;
-        int originType = 0;
-        if constexpr (isMc) {
-          charmHadMc = p2.flagMc();
-          originType = p2.originMcRec();
-        }
-
         // if constexpr (!isMc) mixedEventCont.setPair<isMc, true>(p1, p2, collision1.multNtr(), collision1.multV0M(), use4D, extendedPlots, smearingByOrigin);
         mixedEventCont.setPair<isMc, true>(p1, p2, collision1.multNtr(), collision1.multV0M(), use4D, extendedPlots, smearingByOrigin);
       }

--- a/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
+++ b/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
@@ -47,12 +47,6 @@ struct HfTaskCharmHadronsFemtoDream {
     NegativeCharge = -1
   };
 
-  enum PairSign {
-    PairNotDefined = 0,
-    LikeSignPair = 1,
-    UnLikeSignPair = 2
-  };
-
   /// Binning configurables
   ConfigurableAxis bin4Dkstar{"bin4Dkstar", {1500, 0., 6.}, "binning kstar for the 4Dimensional plot: k* vs multiplicity vs multiplicity percentile vs mT (set <<Confuse4D>> to true in order to use)"};
   ConfigurableAxis bin4DMult{"bin4Dmult", {VARIABLE_WIDTH, 0.0f, 4.0f, 8.0f, 12.0f, 16.0f, 20.0f, 24.0f, 28.0f, 32.0f, 36.0f, 40.0f, 44.0f, 48.0f, 52.0f, 56.0f, 60.0f, 64.0f, 68.0f, 72.0f, 76.0f, 80.0f, 84.0f, 88.0f, 92.0f, 96.0f, 100.0f, 200.0f}, "multiplicity Binning for the 4Dimensional plot: k* vs multiplicity vs multiplicity percentile vs mT (set <<Confuse4D>> to true in order to use)"};
@@ -195,9 +189,9 @@ struct HfTaskCharmHadronsFemtoDream {
 
   SliceCache cache;
   Preslice<aod::FDParticles> perCol = aod::femtodreamparticle::fdCollisionId;
-  Produces<o2::aod::FDResultsHFCharm> fillFemtoResultCharm;
-  Produces<o2::aod::FDResultsHFTrk> fillFemtoResultTrk;
-  Produces<o2::aod::FDResultsHFColl> fillFemtoResultColl;
+  Produces<o2::aod::FDResultsCharm> fillFemtoResultCharm;
+  Produces<o2::aod::FDResultsTrk> fillFemtoResultTrk;
+  Produces<o2::aod::FDResultsColl> fillFemtoResultColl;
 
   void init(InitContext& /*context*/)
   {
@@ -273,12 +267,6 @@ struct HfTaskCharmHadronsFemtoDream {
         chargeTrack = NegativeCharge;
       }
 
-      int pairSign = 0;
-      if (chargeTrack == p2.charge()) {
-        pairSign = LikeSignPair;
-      } else {
-        pairSign = UnLikeSignPair;
-      }
 
       float kstar = FemtoDreamMath::getkstar(p1, massOne, p2, massTwo);
       if (kstar > highkstarCut) {
@@ -351,8 +339,6 @@ struct HfTaskCharmHadronsFemtoDream {
   {
 
     // Mixed events that contain the pair of interest
-    processType = 2; // for mixed event
-
     Partition<CollisionType> PartitionMaskedCol1 = (aod::femtodreamcollision::bitmaskTrackOne & BitMask) == BitMask;
     PartitionMaskedCol1.bindTable(cols);
 
@@ -386,13 +372,6 @@ struct HfTaskCharmHadronsFemtoDream {
           chargeTrack = PositiveCharge;
         } else {
           chargeTrack = NegativeCharge;
-        }
-
-        int pairSign = 0;
-        if (chargeTrack == p2.charge()) {
-          pairSign = LikeSignPair;
-        } else {
-          pairSign = UnLikeSignPair;
         }
 
         float kstar = FemtoDreamMath::getkstar(p1, massOne, p2, massTwo);

--- a/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
+++ b/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
@@ -366,13 +366,6 @@ struct HfTaskCharmHadronsFemtoDream {
           continue;
         }
 
-        float chargeTrack = 0.;
-        if ((p1.cut() & 2) == 2) {
-          chargeTrack = PositiveCharge;
-        } else {
-          chargeTrack = NegativeCharge;
-        }
-
         float kstar = FemtoDreamMath::getkstar(p1, massOne, p2, massTwo);
         if (kstar > highkstarCut) {
           continue;

--- a/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
+++ b/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
@@ -327,6 +327,7 @@ struct HfTaskCharmHadronsFemtoDream {
         originType = p2.originMcRec();
       }
       fillFemtoResult(
+        col.globalIndex(),
         invMass,
         p2.pt(),
         p1.pt(),
@@ -424,6 +425,7 @@ struct HfTaskCharmHadronsFemtoDream {
           originType = p2.originMcRec();
         }
         fillFemtoResult(
+          -999., // no need to store the index in the mix-event
           invMass,
           p2.pt(),
           p1.pt(),

--- a/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
+++ b/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
@@ -189,9 +189,9 @@ struct HfTaskCharmHadronsFemtoDream {
 
   SliceCache cache;
   Preslice<aod::FDParticles> perCol = aod::femtodreamparticle::fdCollisionId;
-  Produces<o2::aod::FDResultsCharm> fillFemtoResultCharm;
-  Produces<o2::aod::FDResultsTrk> fillFemtoResultTrk;
-  Produces<o2::aod::FDResultsColl> fillFemtoResultColl;
+  Produces<o2::aod::FDHfCharm> fillFemtoResultCharm;
+  Produces<o2::aod::FDHfTrk> fillFemtoResultTrk;
+  Produces<o2::aod::FDHfColl> fillFemtoResultColl;
 
   void init(InitContext& /*context*/)
   {

--- a/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
+++ b/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
@@ -328,9 +328,15 @@ struct HfTaskCharmHadronsFemtoDream {
       }
       fillFemtoResult(
         col.globalIndex(),
+        p2.timeStamp(),
+        col.posZ(),
         invMass,
         p2.pt(),
         p1.pt(),
+        p2.eta(),
+        p1.eta(),
+        p2.phi(),
+        p1.phi(),
         p2.bdtBkg(),
         p2.bdtPrompt(),
         p2.bdtFD(),
@@ -338,7 +344,6 @@ struct HfTaskCharmHadronsFemtoDream {
         FemtoDreamMath::getkT(p1, massOne, p2, massTwo),
         FemtoDreamMath::getmT(p1, massOne, p2, massTwo),
         col.multNtr(),
-        col.multV0M(),
         p2.charge(),
         pairSign,
         processType,
@@ -426,9 +431,15 @@ struct HfTaskCharmHadronsFemtoDream {
         }
         fillFemtoResult(
           -999., // no need to store the index in the mix-event
+          -999., // no need to store the index in the mix-event
+          -999.,
           invMass,
           p2.pt(),
           p1.pt(),
+          -999.,
+          -999.,
+          -999.,
+          -999.,
           p2.bdtBkg(),
           p2.bdtPrompt(),
           p2.bdtFD(),
@@ -436,7 +447,6 @@ struct HfTaskCharmHadronsFemtoDream {
           FemtoDreamMath::getkT(p1, massOne, p2, massTwo),
           FemtoDreamMath::getmT(p1, massOne, p2, massTwo),
           collision1.multNtr(),
-          collision1.multV0M(),
           p2.charge(),
           pairSign,
           processType,

--- a/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
+++ b/PWGHF/HFC/Tasks/taskCharmHadronsFemtoDream.cxx
@@ -189,9 +189,9 @@ struct HfTaskCharmHadronsFemtoDream {
 
   SliceCache cache;
   Preslice<aod::FDParticles> perCol = aod::femtodreamparticle::fdCollisionId;
-  Produces<o2::aod::FDHfCharm> fillFemtoResultCharm;
-  Produces<o2::aod::FDHfTrk> fillFemtoResultTrk;
-  Produces<o2::aod::FDHfColl> fillFemtoResultColl;
+  Produces<o2::aod::FDHfCharm> rowFemtoResultCharm;
+  Produces<o2::aod::FDHfTrk> rowFemtoResultTrk;
+  Produces<o2::aod::FDHfColl> rowFemtoResultColl;
 
   void init(InitContext& /*context*/)
   {
@@ -296,7 +296,7 @@ struct HfTaskCharmHadronsFemtoDream {
         originType = p2.originMcRec();
       }
 
-      fillFemtoResultCharm(
+      rowFemtoResultCharm(
         col.globalIndex(),
         p2.timeStamp(),
         invMass,
@@ -310,7 +310,7 @@ struct HfTaskCharmHadronsFemtoDream {
         charmHadMc,
         originType);
 
-      fillFemtoResultTrk(
+      rowFemtoResultTrk(
         col.globalIndex(),
         p2.timeStamp(),
         p1.pt(),
@@ -323,7 +323,7 @@ struct HfTaskCharmHadronsFemtoDream {
         p1.tpcNSigmaPr(),
         p1.tofNSigmaPr());
 
-      fillFemtoResultColl(
+      rowFemtoResultColl(
         col.globalIndex(),
         p2.timeStamp(),
         col.posZ(),


### PR DESCRIPTION
For convenience in doing the mixed event locally, I added the collision index to the table 

- Separate into 3 tables: charm, track, and collision
- Add eta and phi into the table --> calculate k*, kT, mT locally
- Remove table filling in the mix-event function (if the test is smooth, this part will be deleted later)

