### PR TITLE
[PWGLF] Function to process generated V0s in sigma0 tasks + minor fixes

### DIFF
--- a/PWGJE/Tasks/fullJetTriggerQATask.cxx
+++ b/PWGJE/Tasks/fullJetTriggerQATask.cxx
@@ -88,6 +88,7 @@ struct JetTriggerQA {
   Configurable<bool> b_DoFiducialCut{"b_DoFiducialCut", false, "do a fiducial cut on jets to check if they are in the emcal"};
   Configurable<bool> b_RejectExoticClusters{"b_RejectExoticClusters", true, "Reject exotic clusters"};
   Configurable<int> f_GammaObservable{"f_gammaObservable", 0, "Observable for gamma trigger (0 - energy, 1 - pt)"};
+  Configurable<bool> b_doLightOutput{"b_doLightOutput", true, "do light output (disables most histograms not needed for QA)"};
 
   Configurable<float> cfgVertexCut{"cfgVertexCut", 10.0f, "Accepted z-vertex range"};
   Configurable<std::string> mClusterDefinition{"clusterDefinition", "kV3Default", "cluster definition to be selected, e.g. V3Default"};
@@ -103,18 +104,18 @@ struct JetTriggerQA {
     jetReclusterer.algorithm = fastjet::JetAlgorithm::cambridge_algorithm;
     jetReclusterer.jetR = f_jetR * 2.5; // Use larger R for CA reclustering to prevent losing particles
 
-    Int_t nPtBins = 200;
-    Float_t kMinPt = 0.;
-    Float_t kMaxPt = 201.;
-    Int_t nPhiBins = 18 * 8;
-    Float_t kMinPhi = 0.;
-    Float_t kMaxPhi = 2. * TMath::Pi();
-    Int_t nEtaBins = 100;
-    Float_t kMinEta = -1.;
-    Float_t kMaxEta = 1.;
-    Int_t nRBins = 6;
-    Float_t kMinR = 0.05;
-    Float_t kMaxR = 0.65;
+    int nPtBins = 200;
+    float kMinPt = 0.;
+    float kMaxPt = 201.;
+    int nPhiBins = 18 * 8;
+    float kMinPhi = 0.;
+    float kMaxPhi = o2::constants::math::TwoPI;
+    int nEtaBins = 100;
+    float kMinEta = -1.;
+    float kMaxEta = 1.;
+    int nRBins = 6;
+    float kMinR = 0.05;
+    float kMaxR = 0.65;
 
     // EMCAL gamma observables (for histogram and axis title)
     std::string observableName = (f_GammaObservable == 0) ? "Energy" : "#it{p}_{T}",
@@ -137,9 +138,11 @@ struct JetTriggerQA {
     HistogramConfigSpec hJetRMaxPtEtaPhiNoFiducial({HistType::kTHnF, {rAxis, jetPtAxis, etaAxis, phiAxis}});
 
     registry.add("jetRPtEtaPhi", "JetRPtEtaPhi", hJetRPtEtaPhi);
-    registry.add("jetRMaxPtEtaPhi", "JetRMaxPtEtaPhi", hJetRMaxPtEtaPhi);
+    if (!b_doLightOutput)
+      registry.add("jetRMaxPtEtaPhi", "JetRMaxPtEtaPhi", hJetRMaxPtEtaPhi);
     registry.add("jetRPtEtaPhiNoFiducial", "JetRPtEtaPhiNoFiducial", hJetRPtEtaPhiNoFiducial);
-    registry.add("jetRMaxPtEtaPhiNoFiducial", "JetRMaxPtEtaPhiNoFiducial", hJetRMaxPtEtaPhiNoFiducial);
+    if (!b_doLightOutput)
+      registry.add("jetRMaxPtEtaPhiNoFiducial", "JetRMaxPtEtaPhiNoFiducial", hJetRMaxPtEtaPhiNoFiducial);
 
     registry.add("hProcessedEvents", "Processed events", HistType::kTH1D, {{15, -0.5, 14.5, "Trigger type"}});
     auto histProcessed = registry.get<TH1>(HIST("hProcessedEvents"));
@@ -170,156 +173,192 @@ struct JetTriggerQA {
     // Histograms for events where the EMCAL is live
     registry.add("hJetRPtEta", "Jets #it{p}_{T} and #eta", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
     registry.add("hJetRPtPhi", "Jets #it{p}_{T} and #phi", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
-    registry.add("hJetRMaxPtEta", "Leading jets #it{p}_{T} and #eta", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
-    registry.add("hJetRMaxPtPhi", "Leading jets #it{p}_{T} and #phi", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
-    registry.add("hJetRMaxPtEtaMinBias", "Leading jets #it{p}_{T} and #eta (min. bias)", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
-    registry.add("hJetRMaxPtPhiMinBias", "Leading jets #it{p}_{T} and #phi (min. bias)", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
-    registry.add("hJetRMaxPtEtaLevel0", "Leading jets #it{p}_{T} and #eta (level0)", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
-    registry.add("hJetRMaxPtPhiLevel0", "Leading jets #it{p}_{T} and #phi (level0)", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
+    if (!b_doLightOutput) {
+      registry.add("hJetRMaxPtEta", "Leading jets #it{p}_{T} and #eta", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
+      registry.add("hJetRMaxPtPhi", "Leading jets #it{p}_{T} and #phi", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
+      registry.add("hJetRMaxPtEtaMinBias", "Leading jets #it{p}_{T} and #eta (min. bias)", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
+      registry.add("hJetRMaxPtPhiMinBias", "Leading jets #it{p}_{T} and #phi (min. bias)", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
+      registry.add("hJetRMaxPtEtaLevel0", "Leading jets #it{p}_{T} and #eta (level0)", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
+      registry.add("hJetRMaxPtPhiLevel0", "Leading jets #it{p}_{T} and #phi (level0)", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
+    }
     registry.add("hClusterPtEtaPhi", Form("Cluster %s, #eta and #phi", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
     registry.add("hClusterPtEtaPhiMinBias", Form("Cluster %s (Min. bias trigger), #eta and #phi", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
     registry.add("hClusterPtEtaPhiLevel0", Form("Cluster %s (Level-0 trigger), #eta and #phi", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
-    registry.add("hClusterEMCALMaxPtEtaPhi", Form("Leading cluster %s, #eta and #phi (EMCAL)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
-    registry.add("hClusterEMCALMaxPtEtaPhiMinBias", Form("Leading cluster %s, #eta and #phi (EMCAL, min. bias trigger)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
-    registry.add("hClusterEMCALMaxPtEtaPhiLevel0", Form("Leading cluster %s, #eta and #phi (EMCAL, Level-0 trigger)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
-    registry.add("hClusterDCALMaxPtEtaPhi", Form("Leading cluster %s, #eta and #phi (DCAL)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
-    registry.add("hClusterDCALMaxPtEtaPhiMinBias", Form("Leading cluster %s, #eta and #phi (DCAL, min, bias trigger)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
-    registry.add("hClusterDCALMaxPtEtaPhiLevel0", Form("Leading cluster %s, #eta and #phi (DCAL, Level-0 trigger)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
-    registry.add("hEventsNoMaxClusterEMCAL", "Events with no max. cluster in EMCAL", HistType::kTH1D, {{1, 0.5, 1.5}});
-    registry.add("hEventsNoMaxClusterEMCALMinBias", "Events with no max. cluster in EMCAL (min. bias trigger)", HistType::kTH1D, {{1, 0.5, 1.5}});
-    registry.add("hEventsNoMaxClusterEMCALLevel0", "Events with no max. cluster in EMCAL (level0 trigger)", HistType::kTH1D, {{1, 0.5, 1.5}});
-    registry.add("hEventsNoMaxClusterDCAL", ("Events with no max. cluster in DCAL"), HistType::kTH1D, {{1, 0.5, 1.5}});
-    registry.add("hEventsNoMaxClusterDCALMinBias", "Events with no max. cluster in DCAL (min. bias trigger)", HistType::kTH1D, {{1, 0.5, 1.5}});
-    registry.add("hEventsNoMaxClusterDCALLevel0", "Events with no max. cluster in DCAL (level0 trigger)", HistType::kTH1D, {{1, 0.5, 1.5}});
-    registry.add("hEventsNoMaxJet", "Events with no max. jet", HistType::kTH1D, {{rAxis}});
-    registry.add("hEventsNoMaxJetMinBias", "Events with no max. jet (min. bias trigger)", HistType::kTH1D, {{rAxis}});
-    registry.add("hEventsNoMaxJetLevel0", "Events with no max. jet (level0 trigger)", HistType::kTH1D, {{rAxis}});
-    registry.add("hJetRPtTrackPt", "Jets", HistType::kTH3F, {rAxis, jetPtAxis, ptAxisTrackInJet});
-    registry.add("hJetRPtClusterPt", "Jets", HistType::kTH3F, {rAxis, jetPtAxis, ptAxisClusterInJet});
-    registry.add("hJetRPtPtd", "Jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "p_{t,D}"}});
-    registry.add("hJetRPtChargeFrag", "Jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z"}});
-    registry.add("hJetRPtNEF", "Jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "NEF"}});
-    registry.add("hJetRPtZTheta", "Jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z#theta"}});
-    registry.add("hJetRPtZSqTheta", "Jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z^{2} #theta"}});
-    registry.add("hJetRPtZThetaSq", "Jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z #theta^{2}"}});
-    registry.add("hJetRMaxPtClusterMaxPt", "Leading jets and clusters", HistType::kTH3F, {rAxis, jetPtAxis, observableAxisCluster});
+
+    if (!b_doLightOutput) {
+      registry.add("hClusterEMCALMaxPtEtaPhi", Form("Leading cluster %s, #eta and #phi (EMCAL)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+      registry.add("hClusterEMCALMaxPtEtaPhiMinBias", Form("Leading cluster %s, #eta and #phi (EMCAL, min. bias trigger)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+      registry.add("hClusterEMCALMaxPtEtaPhiLevel0", Form("Leading cluster %s, #eta and #phi (EMCAL, Level-0 trigger)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+      registry.add("hClusterDCALMaxPtEtaPhi", Form("Leading cluster %s, #eta and #phi (DCAL)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+      registry.add("hClusterDCALMaxPtEtaPhiMinBias", Form("Leading cluster %s, #eta and #phi (DCAL, min, bias trigger)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+      registry.add("hClusterDCALMaxPtEtaPhiLevel0", Form("Leading cluster %s, #eta and #phi (DCAL, Level-0 trigger)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+      registry.add("hEventsNoMaxClusterEMCAL", "Events with no max. cluster in EMCAL", HistType::kTH1D, {{1, 0.5, 1.5}});
+      registry.add("hEventsNoMaxClusterEMCALMinBias", "Events with no max. cluster in EMCAL (min. bias trigger)", HistType::kTH1D, {{1, 0.5, 1.5}});
+      registry.add("hEventsNoMaxClusterEMCALLevel0", "Events with no max. cluster in EMCAL (level0 trigger)", HistType::kTH1D, {{1, 0.5, 1.5}});
+      registry.add("hEventsNoMaxClusterDCAL", ("Events with no max. cluster in DCAL"), HistType::kTH1D, {{1, 0.5, 1.5}});
+      registry.add("hEventsNoMaxClusterDCALMinBias", "Events with no max. cluster in DCAL (min. bias trigger)", HistType::kTH1D, {{1, 0.5, 1.5}});
+      registry.add("hEventsNoMaxClusterDCALLevel0", "Events with no max. cluster in DCAL (level0 trigger)", HistType::kTH1D, {{1, 0.5, 1.5}});
+      registry.add("hEventsNoMaxJet", "Events with no max. jet", HistType::kTH1D, {{rAxis}});
+      registry.add("hEventsNoMaxJetMinBias", "Events with no max. jet (min. bias trigger)", HistType::kTH1D, {{rAxis}});
+      registry.add("hEventsNoMaxJetLevel0", "Events with no max. jet (level0 trigger)", HistType::kTH1D, {{rAxis}});
+
+      registry.add("hJetRPtTrackPt", "Jets", HistType::kTH3F, {rAxis, jetPtAxis, ptAxisTrackInJet});
+      registry.add("hJetRPtClusterPt", "Jets", HistType::kTH3F, {rAxis, jetPtAxis, ptAxisClusterInJet});
+      registry.add("hJetRPtPtd", "Jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "p_{t,D}"}});
+      registry.add("hJetRPtChargeFrag", "Jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z"}});
+      registry.add("hJetRPtNEF", "Jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "NEF"}});
+      registry.add("hJetRPtZTheta", "Jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z#theta"}});
+      registry.add("hJetRPtZSqTheta", "Jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z^{2} #theta"}});
+      registry.add("hJetRPtZThetaSq", "Jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z #theta^{2}"}});
+
+      registry.add("hJetRMaxPtClusterMaxPt", "Leading jets and clusters", HistType::kTH3F, {rAxis, jetPtAxis, observableAxisCluster});
+    }
 
     // Histograms for triggered events
     registry.add("hSelectedClusterPtEtaPhi", Form("Selected cluster %s, #eta and #phi", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
-    registry.add("hSelectedClusterMaxPtEtaPhi", Form("Leading Selected cluster %s, #eta and #phi", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+
+    if (!b_doLightOutput) {
+      registry.add("hSelectedClusterMaxPtEtaPhi", Form("Leading Selected cluster %s, #eta and #phi", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+    }
 
     // Jet high trigger
-    registry.add("hSelectedJetRMaxPtEta", "Leading selected jets #it{p}_{T} and #eta", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
-    registry.add("hSelectedJetRMaxPtPhi", "Leading selected jets #it{p}_{T} and #phi", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
+    if (!b_doLightOutput) {
+      registry.add("hSelectedJetRMaxPtEta", "Leading selected jets #it{p}_{T} and #eta", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
+      registry.add("hSelectedJetRMaxPtPhi", "Leading selected jets #it{p}_{T} and #phi", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
+    }
     registry.add("hSelectedJetRPtEta", "Selected jets #it{p}_{T} and #eta", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
     registry.add("hSelectedJetRPtPhi", "Selected jets #it{p}_{T} and #phi", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
-    registry.add("hSelectedJetRPtTrackPt", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, ptAxisTrackInJet});
-    registry.add("hSelectedJetRPtClusterPt", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, ptAxisClusterInJet});
-    registry.add("hSelectedJetRPtPtd", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "p_{t,D}"}});
-    registry.add("hSelectedJetRPtChargeFrag", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z"}});
-    registry.add("hSelectedJetRPtNEF", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "NEF"}});
-    registry.add("hSelectedJetRPtZTheta", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z#theta"}});
-    registry.add("hSelectedJetRPtZSqTheta", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z^{2} #theta"}});
-    registry.add("hSelectedJetRPtZThetaSq", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z #theta^{2}"}});
+    if (!b_doLightOutput) {
+      registry.add("hSelectedJetRPtTrackPt", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, ptAxisTrackInJet});
+      registry.add("hSelectedJetRPtClusterPt", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, ptAxisClusterInJet});
+      registry.add("hSelectedJetRPtPtd", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "p_{t,D}"}});
+      registry.add("hSelectedJetRPtChargeFrag", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z"}});
+      registry.add("hSelectedJetRPtNEF", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "NEF"}});
+      registry.add("hSelectedJetRPtZTheta", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z#theta"}});
+      registry.add("hSelectedJetRPtZSqTheta", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z^{2} #theta"}});
+      registry.add("hSelectedJetRPtZThetaSq", "Selected jets", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z #theta^{2}"}});
+    }
 
     // Jet low trigger
-    registry.add("hSelectedJetLowRMaxPtEta", "Leading selected jets (low threshold) #it{p}_{T} and #eta", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
-    registry.add("hSelectedJetLowRMaxPtPhi", "Leading selected jets (low threshold) #it{p}_{T} and #phi", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
+    if (!b_doLightOutput) {
+      registry.add("hSelectedJetLowRMaxPtEta", "Leading selected jets (low threshold) #it{p}_{T} and #eta", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
+      registry.add("hSelectedJetLowRMaxPtPhi", "Leading selected jets (low threshold) #it{p}_{T} and #phi", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
+    }
     registry.add("hSelectedJetLowRPtEta", "Selected jets (low threshold) #it{p}_{T} and #eta", HistType::kTH3F, {rAxis, jetPtAxis, etaAxis});
     registry.add("hSelectedJetLowRPtPhi", "Selected jets (low threshold) #it{p}_{T} and #phi", HistType::kTH3F, {rAxis, jetPtAxis, phiAxis});
-    registry.add("hSelectedJetLowRPtTrackPt", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, ptAxisTrackInJet});
-    registry.add("hSelectedJetLowRPtClusterPt", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, ptAxisClusterInJet});
-    registry.add("hSelectedJetLowRPtPtd", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "p_{t,D}"}});
-    registry.add("hSelectedJetLowRPtChargeFrag", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z"}});
-    registry.add("hSelectedJetLowRPtNEF", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "NEF"}});
-    registry.add("hSelectedJetLowRPtZTheta", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z#theta"}});
-    registry.add("hSelectedJetLowRPtZSqTheta", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z^{2} #theta"}});
-    registry.add("hSelectedJetLowRPtZThetaSq", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z #theta^{2}"}});
+
+    if (!b_doLightOutput) {
+      registry.add("hSelectedJetLowRPtTrackPt", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, ptAxisTrackInJet});
+      registry.add("hSelectedJetLowRPtClusterPt", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, ptAxisClusterInJet});
+      registry.add("hSelectedJetLowRPtPtd", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "p_{t,D}"}});
+      registry.add("hSelectedJetLowRPtChargeFrag", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z"}});
+      registry.add("hSelectedJetLowRPtNEF", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "NEF"}});
+      registry.add("hSelectedJetLowRPtZTheta", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z#theta"}});
+      registry.add("hSelectedJetLowRPtZSqTheta", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z^{2} #theta"}});
+      registry.add("hSelectedJetLowRPtZThetaSq", "Selected jets (low threshold)", HistType::kTH3F, {rAxis, jetPtAxis, {nPtBins / 2, 0., 1., "z #theta^{2}"}});
+    }
 
     // EMCAL gamma very-high trigger
     registry.add("hSelectedGammaEMCALPtEtaPhiVeryHigh", Form("Selected Gamma %s, #eta and #phi (EMCAL, very high threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
-    registry.add("hSelectedGammaEMCALMaxPtEtaPhiVeryHigh", Form("Leading selected gamma %s, #eta and #phi (EMCAL, very high treshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+    if (!b_doLightOutput)
+      registry.add("hSelectedGammaEMCALMaxPtEtaPhiVeryHigh", Form("Leading selected gamma %s, #eta and #phi (EMCAL, very high treshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
 
     // DCAL gamma very-high trigger
     registry.add("hSelectedGammaDCALPtEtaPhiVeryHigh", Form("Selected gamma %s, #eta and #phi (DCAL, very high treshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
-    registry.add("hSelectedGammaDCALMaxPtEtaPhiVeryHigh", Form("Leading selected gamma %s, #eta and #phi (DCAL, very high treshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+    if (!b_doLightOutput)
+      registry.add("hSelectedGammaDCALMaxPtEtaPhiVeryHigh", Form("Leading selected gamma %s, #eta and #phi (DCAL, very high treshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
 
     // EG1 trigger
     registry.add("hSelectedGammaEMCALPtEtaPhi", Form("Selected Gamma %s, #eta and #phi (EMCAL, high threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
-    registry.add("hSelectedGammaEMCALMaxPtEtaPhi", Form("Leading selected gamma %s, #eta and #phi (EMCAL, high treshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+    if (!b_doLightOutput)
+      registry.add("hSelectedGammaEMCALMaxPtEtaPhi", Form("Leading selected gamma %s, #eta and #phi (EMCAL, high treshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
 
     // DG1 trigger
     registry.add("hSelectedGammaDCALPtEtaPhi", Form("Selected gamma %s, #eta and #phi (DCAL, high treshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
-    registry.add("hSelectedGammaDCALMaxPtEtaPhi", Form("Leading selected gamma %s, #eta and #phi (DCAL, high treshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+    if (!b_doLightOutput)
+      registry.add("hSelectedGammaDCALMaxPtEtaPhi", Form("Leading selected gamma %s, #eta and #phi (DCAL, high treshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
 
     // EG2 trigger
     registry.add("hSelectedGammaEMCALPtEtaPhiLow", Form("Selected gamma %s, #eta and #phi (EMCAL, low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
-    registry.add("hSelectedGammaEMCALMaxPtEtaPhiLow", Form("Leading selected gamma %s, #eta and #phi (EMCAL, low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+    if (!b_doLightOutput)
+      registry.add("hSelectedGammaEMCALMaxPtEtaPhiLow", Form("Leading selected gamma %s, #eta and #phi (EMCAL, low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
 
     // DG2 trigger
     registry.add("hSelectedGammaDCALPtEtaPhiLow", Form("Selected gamma %s, #eta and #phi (DCAL, low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
-    registry.add("hSelectedGammaDCALMaxPtEtaPhiLow", Form("Leading selected gamma %s, #eta and #phi (DCAL, low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+    if (!b_doLightOutput)
+      registry.add("hSelectedGammaDCALMaxPtEtaPhiLow", Form("Leading selected gamma %s, #eta and #phi (DCAL, low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
 
     // EMCAL gamma very-low trigger
     registry.add("hSelectedGammaEMCALPtEtaPhiVeryLow", Form("Selected gamma %s, #eta and #phi (EMCAL, very low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
-    registry.add("hSelectedGammaEMCALMaxPtEtaPhiVeryLow", Form("Leading selected gamma %s, #eta and #phi (EMCAL, very low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+    if (!b_doLightOutput)
+      registry.add("hSelectedGammaEMCALMaxPtEtaPhiVeryLow", Form("Leading selected gamma %s, #eta and #phi (EMCAL, very low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
 
     //  DCAL gamma very-low trigger
     registry.add("hSelectedGammaDCALPtEtaPhiVeryLow", Form("Selected gamma %s, #eta and #phi (DCAL, low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
-    registry.add("hSelectedGammaDCALMaxPtEtaPhiVeryLow", Form("Leading selected gamma %s, #eta and #phi (DCAL, low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
+    if (!b_doLightOutput)
+      registry.add("hSelectedGammaDCALMaxPtEtaPhiVeryLow", Form("Leading selected gamma %s, #eta and #phi (DCAL, low threshold)", observableName.data()), HistType::kTH3F, {observableAxisCluster, etaAxis, phiAxis});
 
-    registry.add("hSelectedJetRMaxPtClusterMaxPt", "Leading selected jets and clusters", HistType::kTH3F, {rAxis, jetPtAxis, observableAxisCluster});
-    registry.add("hJetRMaxPtJetPt", "Leading jet #it{p}_{T} vs jet #it{p}_{T}", HistType::kTH3F, {rAxis, jetMaxPtAxis, jetPtAxis});
-    registry.add("hJetRMaxPtJetPtNoFiducial", "Leading jet #it{p}_{T} vs jet #it{p}_{T} (no fiducial cut)", HistType::kTH3F, {rAxis, jetMaxPtAxis, jetPtAxis});
-    registry.add("hClusterEMCALMaxPtClusterEMCALPt", Form("Leading clusterEMCAL %s vs clusterEMCAL %s", observableName.data(), observableName.data()), HistType::kTH2F, {observableAxisMaxCluster, observableAxisCluster});
-    registry.add("hClusterDCALMaxPtClusterDCALPt", Form("Leading clusterDCAL %s vs clusterDCAL %s", observableName.data(), observableName.data()), HistType::kTH2F, {observableAxisMaxCluster, observableAxisCluster});
+    if (!b_doLightOutput) {
+      registry.add("hSelectedJetRMaxPtClusterMaxPt", "Leading selected jets and clusters", HistType::kTH3F, {rAxis, jetPtAxis, observableAxisCluster});
+      registry.add("hJetRMaxPtJetPt", "Leading jet #it{p}_{T} vs jet #it{p}_{T}", HistType::kTH3F, {rAxis, jetMaxPtAxis, jetPtAxis});
+      registry.add("hJetRMaxPtJetPtNoFiducial", "Leading jet #it{p}_{T} vs jet #it{p}_{T} (no fiducial cut)", HistType::kTH3F, {rAxis, jetMaxPtAxis, jetPtAxis});
+      registry.add("hClusterEMCALMaxPtClusterEMCALPt", Form("Leading clusterEMCAL %s vs clusterEMCAL %s", observableName.data(), observableName.data()), HistType::kTH2F, {observableAxisMaxCluster, observableAxisCluster});
+      registry.add("hClusterDCALMaxPtClusterDCALPt", Form("Leading clusterDCAL %s vs clusterDCAL %s", observableName.data(), observableName.data()), HistType::kTH2F, {observableAxisMaxCluster, observableAxisCluster});
+    }
 
     if (b_JetsInEmcalOnly) {
       registry.get<TH3>(HIST("hJetRPtEta"))->SetTitle("Jets (in emcal only) #it{p}_{T} and #eta");
       registry.get<TH3>(HIST("hJetRPtPhi"))->SetTitle("Jets (in emcal only) #it{p}_{T} and #phi");
-      registry.get<TH3>(HIST("hJetRPtTrackPt"))->SetTitle("Jets (in emcal only)");
-      registry.get<TH3>(HIST("hJetRPtClusterPt"))->SetTitle("Jets (in emcal only)");
-      registry.get<TH3>(HIST("hJetRPtPtd"))->SetTitle("Jets (in emcal only)");
-      registry.get<TH3>(HIST("hJetRPtChargeFrag"))->SetTitle("Jets (in emcal only)");
-      registry.get<TH3>(HIST("hJetRPtNEF"))->SetTitle("Jets (in emcal only)");
-      registry.get<TH3>(HIST("hJetRPtZTheta"))->SetTitle("Jets (in emcal only)");
-      registry.get<TH3>(HIST("hJetRPtZSqTheta"))->SetTitle("Jets (in emcal only)");
-      registry.get<TH3>(HIST("hJetRPtZThetaSq"))->SetTitle("Jets (in emcal only)");
-      registry.get<TH3>(HIST("hJetRMaxPtEta"))->SetTitle("Leading jets (in emcal only) #it{p}_{T} and #eta");
-      registry.get<TH3>(HIST("hJetRMaxPtPhi"))->SetTitle("Leading jets (in emcal only) #it{p}_{T} and #phi");
-      registry.get<TH3>(HIST("hJetRMaxPtEtaMinBias"))->SetTitle("Leading jets (in emcal only, min. bias) #it{p}_{T} and #eta");
-      registry.get<TH3>(HIST("hJetRMaxPtPhiMinBias"))->SetTitle("Leading jets (in emcal only, min. bias) #it{p}_{T} and #phi");
-      registry.get<TH3>(HIST("hJetRMaxPtEtaLevel0"))->SetTitle("Leading jets (in emcal only, level-0) #it{p}_{T} and #eta");
-      registry.get<TH3>(HIST("hJetRMaxPtPhiLevel0"))->SetTitle("Leading jets (in emcal only, level-0) #it{p}_{T} and #phi");
-      registry.get<TH3>(HIST("hJetRMaxPtClusterMaxPt"))->SetTitle("Leading jets (in emcal only) and clusters");
+      if (!b_doLightOutput) {
+        registry.get<TH3>(HIST("hJetRPtTrackPt"))->SetTitle("Jets (in emcal only)");
+        registry.get<TH3>(HIST("hJetRPtClusterPt"))->SetTitle("Jets (in emcal only)");
+        registry.get<TH3>(HIST("hJetRPtPtd"))->SetTitle("Jets (in emcal only)");
+        registry.get<TH3>(HIST("hJetRPtChargeFrag"))->SetTitle("Jets (in emcal only)");
+        registry.get<TH3>(HIST("hJetRPtNEF"))->SetTitle("Jets (in emcal only)");
+        registry.get<TH3>(HIST("hJetRPtZTheta"))->SetTitle("Jets (in emcal only)");
+        registry.get<TH3>(HIST("hJetRPtZSqTheta"))->SetTitle("Jets (in emcal only)");
+        registry.get<TH3>(HIST("hJetRPtZThetaSq"))->SetTitle("Jets (in emcal only)");
+
+        registry.get<TH3>(HIST("hJetRMaxPtEta"))->SetTitle("Leading jets (in emcal only) #it{p}_{T} and #eta");
+        registry.get<TH3>(HIST("hJetRMaxPtPhi"))->SetTitle("Leading jets (in emcal only) #it{p}_{T} and #phi");
+        registry.get<TH3>(HIST("hJetRMaxPtEtaMinBias"))->SetTitle("Leading jets (in emcal only, min. bias) #it{p}_{T} and #eta");
+        registry.get<TH3>(HIST("hJetRMaxPtPhiMinBias"))->SetTitle("Leading jets (in emcal only, min. bias) #it{p}_{T} and #phi");
+        registry.get<TH3>(HIST("hJetRMaxPtEtaLevel0"))->SetTitle("Leading jets (in emcal only, level-0) #it{p}_{T} and #eta");
+        registry.get<TH3>(HIST("hJetRMaxPtPhiLevel0"))->SetTitle("Leading jets (in emcal only, level-0) #it{p}_{T} and #phi");
+        registry.get<TH3>(HIST("hJetRMaxPtClusterMaxPt"))->SetTitle("Leading jets (in emcal only) and clusters");
+      }
 
       registry.get<TH3>(HIST("hSelectedJetRPtEta"))->SetTitle("Selected jets (in emcal only) #it{p}_{T} and #eta");
       registry.get<TH3>(HIST("hSelectedJetRPtPhi"))->SetTitle("Selected jets (in emcal only) #it{p}_{T} and #phi");
-      registry.get<TH3>(HIST("hSelectedJetRPtTrackPt"))->SetTitle("Selected jets (in emcal only)");
-      registry.get<TH3>(HIST("hSelectedJetRPtClusterPt"))->SetTitle("Selected jets (in emcal only)");
-      registry.get<TH3>(HIST("hSelectedJetRPtPtd"))->SetTitle("Selected jets (in emcal only)");
-      registry.get<TH3>(HIST("hSelectedJetRPtChargeFrag"))->SetTitle("Selected jets (in emcal only)");
-      registry.get<TH3>(HIST("hSelectedJetRPtNEF"))->SetTitle("Selected jets (in emcal only)");
-      registry.get<TH3>(HIST("hSelectedJetRPtZTheta"))->SetTitle("Selected jets (in emcal only)");
-      registry.get<TH3>(HIST("hSelectedJetRPtZSqTheta"))->SetTitle("Selected jets (in emcal only)");
-      registry.get<TH3>(HIST("hSelectedJetRPtZThetaSq"))->SetTitle("Selected jets (in emcal only)");
+      if (!b_doLightOutput) {
+        registry.get<TH3>(HIST("hSelectedJetRPtTrackPt"))->SetTitle("Selected jets (in emcal only)");
+        registry.get<TH3>(HIST("hSelectedJetRPtClusterPt"))->SetTitle("Selected jets (in emcal only)");
+        registry.get<TH3>(HIST("hSelectedJetRPtPtd"))->SetTitle("Selected jets (in emcal only)");
+        registry.get<TH3>(HIST("hSelectedJetRPtChargeFrag"))->SetTitle("Selected jets (in emcal only)");
+        registry.get<TH3>(HIST("hSelectedJetRPtNEF"))->SetTitle("Selected jets (in emcal only)");
+        registry.get<TH3>(HIST("hSelectedJetRPtZTheta"))->SetTitle("Selected jets (in emcal only)");
+        registry.get<TH3>(HIST("hSelectedJetRPtZSqTheta"))->SetTitle("Selected jets (in emcal only)");
+        registry.get<TH3>(HIST("hSelectedJetRPtZThetaSq"))->SetTitle("Selected jets (in emcal only)");
+      }
 
       registry.get<TH3>(HIST("hSelectedJetLowRPtEta"))->SetTitle("Selected jets (low threshold, in emcal only) #it{p}_{T} and #eta");
       registry.get<TH3>(HIST("hSelectedJetLowRPtPhi"))->SetTitle("Selected jets (low threshold, in emcal only) #it{p}_{T} and #phi");
-      registry.get<TH3>(HIST("hSelectedJetLowRPtTrackPt"))->SetTitle("Selected jets (low threshold, in emcal only)");
-      registry.get<TH3>(HIST("hSelectedJetLowRPtClusterPt"))->SetTitle("Selected jets (low threshold, in emcal only)");
-      registry.get<TH3>(HIST("hSelectedJetLowRPtPtd"))->SetTitle("Selected jets (low threshold, in emcal only)");
-      registry.get<TH3>(HIST("hSelectedJetLowRPtChargeFrag"))->SetTitle("Selected jets (low threshold, in emcal only)");
-      registry.get<TH3>(HIST("hSelectedJetLowRPtNEF"))->SetTitle("Selected jets (low threshold, in emcal only)");
-      registry.get<TH3>(HIST("hSelectedJetLowRPtZTheta"))->SetTitle("Selected jets (low threshold, in emcal only)");
-      registry.get<TH3>(HIST("hSelectedJetLowRPtZSqTheta"))->SetTitle("Selected jets (low threshold, in emcal only)");
-      registry.get<TH3>(HIST("hSelectedJetLowRPtZThetaSq"))->SetTitle("Selected jets (low threshold, in emcal only)");
+      if (!b_doLightOutput) {
+        registry.get<TH3>(HIST("hSelectedJetLowRPtTrackPt"))->SetTitle("Selected jets (low threshold, in emcal only)");
+        registry.get<TH3>(HIST("hSelectedJetLowRPtClusterPt"))->SetTitle("Selected jets (low threshold, in emcal only)");
+        registry.get<TH3>(HIST("hSelectedJetLowRPtPtd"))->SetTitle("Selected jets (low threshold, in emcal only)");
+        registry.get<TH3>(HIST("hSelectedJetLowRPtChargeFrag"))->SetTitle("Selected jets (low threshold, in emcal only)");
+        registry.get<TH3>(HIST("hSelectedJetLowRPtNEF"))->SetTitle("Selected jets (low threshold, in emcal only)");
+        registry.get<TH3>(HIST("hSelectedJetLowRPtZTheta"))->SetTitle("Selected jets (low threshold, in emcal only)");
+        registry.get<TH3>(HIST("hSelectedJetLowRPtZSqTheta"))->SetTitle("Selected jets (low threshold, in emcal only)");
+        registry.get<TH3>(HIST("hSelectedJetLowRPtZThetaSq"))->SetTitle("Selected jets (low threshold, in emcal only)");
 
-      registry.get<TH3>(HIST("hSelectedJetRMaxPtEta"))->SetTitle("Leading selected jets (in emcal only) #it{p}_{T} and #eta");
-      registry.get<TH3>(HIST("hSelectedJetRMaxPtPhi"))->SetTitle("Leading selected jets (in emcal only) #it{p}_{T} and #phi");
-      registry.get<TH3>(HIST("hSelectedJetRMaxPtClusterMaxPt"))->SetTitle("Leading selected jets (in emcal only) and clusters");
+        registry.get<TH3>(HIST("hSelectedJetRMaxPtEta"))->SetTitle("Leading selected jets (in emcal only) #it{p}_{T} and #eta");
+        registry.get<TH3>(HIST("hSelectedJetRMaxPtPhi"))->SetTitle("Leading selected jets (in emcal only) #it{p}_{T} and #phi");
+        registry.get<TH3>(HIST("hSelectedJetRMaxPtClusterMaxPt"))->SetTitle("Leading selected jets (in emcal only) and clusters");
 
-      registry.get<TH3>(HIST("hJetRMaxPtJetPt"))->SetTitle("Leading jet #it{p}_{T} vs jet #it{p}_{T} (in emcal only)");
+        registry.get<TH3>(HIST("hJetRMaxPtJetPt"))->SetTitle("Leading jet #it{p}_{T} vs jet #it{p}_{T} (in emcal only)");
+      }
     }
   } // init
 
@@ -328,16 +367,16 @@ struct JetTriggerQA {
 
   double check_dphi(double dphi) const
   {
-    if (dphi > TMath::Pi()) {
-      dphi -= TMath::Pi();
-    } else if (dphi <= -1 * TMath::Pi()) {
-      dphi += TMath::Pi();
+    if (dphi > o2::constants::math::PI) {
+      dphi -= o2::constants::math::PI;
+    } else if (dphi <= -1 * o2::constants::math::PI) {
+      dphi += o2::constants::math::PI;
     }
     return dphi;
   }
 
   template <typename T>
-  Bool_t isJetInEmcal(T const& jet)
+  bool isJetInEmcal(T const& jet)
   {
     double emcalEtaMin = -0.7, emcalEtaMax = 0.7, emcalPhiMin = 1.40, emcalPhiMax = 3.26; // Phi: 80 - 187 deg
     double R = jet.r() * 1e-2;                                                            // Jet R is saved as round(100*R)
@@ -351,7 +390,7 @@ struct JetTriggerQA {
   {
     std::array<triggerAliases, 11> selectAliases = {{triggerAliases::kTVXinEMC, triggerAliases::kEMC7, triggerAliases::kDMC7, triggerAliases::kEG1, triggerAliases::kEG2, triggerAliases::kDG1, triggerAliases::kDG2, triggerAliases::kEJ1, triggerAliases::kEJ2, triggerAliases::kDJ1, triggerAliases::kDJ2}};
     bool found = false;
-    for (auto alias : selectAliases) {
+    for (const auto& alias : selectAliases) {
       if (collision.alias_bit(alias)) {
         found = true;
         break;
@@ -360,7 +399,7 @@ struct JetTriggerQA {
     return found;
   }
 
-  Bool_t isClusterInEmcal(selectedClusters::iterator const& cluster)
+  bool isClusterInEmcal(selectedClusters::iterator const& cluster)
   {
     if (cluster.phi() < f_PhiEmcalOrDcal) {
       return true;
@@ -466,78 +505,79 @@ struct JetTriggerQA {
         registry.fill(HIST("hSelectedGammaDCALPtEtaPhiVeryLow"), clusterObservable, cluster.eta(), cluster.phi());
       }
     } // for clusters
-
-    if (maxClusterObservableEMCAL > 0) {
-      registry.fill(HIST("hClusterEMCALMaxPtEtaPhi"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
-      if (hwtrg.test(EMCALHardwareTrigger::TRG_MB)) {
-        registry.fill(HIST("hClusterEMCALMaxPtEtaPhiMinBias"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
-      }
-      if (hwtrg.test(EMCALHardwareTrigger::TRG_EMC7)) {
-        registry.fill(HIST("hClusterEMCALMaxPtEtaPhiLevel0"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
-      }
-      for (const auto& cluster : analysedClusters) {
-        if (cluster.mEMCALcluster) {
-          registry.fill(HIST("hClusterEMCALMaxPtClusterEMCALPt"), maxClusterObservableEMCAL, cluster.mTriggerObservable);
+    if (!b_doLightOutput) {
+      if (maxClusterObservableEMCAL > 0) {
+        registry.fill(HIST("hClusterEMCALMaxPtEtaPhi"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
+        if (hwtrg.test(EMCALHardwareTrigger::TRG_MB)) {
+          registry.fill(HIST("hClusterEMCALMaxPtEtaPhiMinBias"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
+        }
+        if (hwtrg.test(EMCALHardwareTrigger::TRG_EMC7)) {
+          registry.fill(HIST("hClusterEMCALMaxPtEtaPhiLevel0"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
+        }
+        for (const auto& cluster : analysedClusters) {
+          if (cluster.mEMCALcluster) {
+            registry.fill(HIST("hClusterEMCALMaxPtClusterEMCALPt"), maxClusterObservableEMCAL, cluster.mTriggerObservable);
+          }
+        }
+        if (isTrigger(TriggerType_t::kEmcalJetFull) || isTrigger(TriggerType_t::kEmcalJetNeutral)) {
+          registry.fill(HIST("hSelectedClusterMaxPtEtaPhi"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
+        }
+        if (isTrigger(TriggerType_t::kEmcalGammaVeryHigh)) {
+          registry.fill(HIST("hSelectedGammaEMCALMaxPtEtaPhiVeryHigh"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
+        }
+        if (isTrigger(TriggerType_t::kEmcalGammaHigh)) {
+          registry.fill(HIST("hSelectedGammaEMCALMaxPtEtaPhi"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
+        }
+        if (isTrigger(TriggerType_t::kEmcalGammaLow)) {
+          registry.fill(HIST("hSelectedGammaEMCALMaxPtEtaPhiLow"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
+        }
+        if (isTrigger(TriggerType_t::kEmcalGammaVeryLow)) {
+          registry.fill(HIST("hSelectedGammaEMCALMaxPtEtaPhiVeryLow"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
+        }
+      } else {
+        // count events where max. cluster has not been found
+        registry.fill(HIST("hEventsNoMaxClusterEMCAL"), 1.);
+        if (hwtrg.test(EMCALHardwareTrigger::TRG_MB)) {
+          registry.fill(HIST("hEventsNoMaxClusterEMCALMinBias"), 1.);
+        }
+        if (hwtrg.test(EMCALHardwareTrigger::TRG_EMC7)) {
+          registry.fill(HIST("hEventsNoMaxClusterEMCALLevel0"), 1.);
         }
       }
-      if (isTrigger(TriggerType_t::kEmcalJetFull) || isTrigger(TriggerType_t::kEmcalJetNeutral)) {
-        registry.fill(HIST("hSelectedClusterMaxPtEtaPhi"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
-      }
-      if (isTrigger(TriggerType_t::kEmcalGammaVeryHigh)) {
-        registry.fill(HIST("hSelectedGammaEMCALMaxPtEtaPhiVeryHigh"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
-      }
-      if (isTrigger(TriggerType_t::kEmcalGammaHigh)) {
-        registry.fill(HIST("hSelectedGammaEMCALMaxPtEtaPhi"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
-      }
-      if (isTrigger(TriggerType_t::kEmcalGammaLow)) {
-        registry.fill(HIST("hSelectedGammaEMCALMaxPtEtaPhiLow"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
-      }
-      if (isTrigger(TriggerType_t::kEmcalGammaVeryLow)) {
-        registry.fill(HIST("hSelectedGammaEMCALMaxPtEtaPhiVeryLow"), maxClusterObservableEMCAL, maxClusterEMCAL.eta(), maxClusterEMCAL.phi());
-      }
-    } else {
-      // count events where max. cluster has not been found
-      registry.fill(HIST("hEventsNoMaxClusterEMCAL"), 1.);
-      if (hwtrg.test(EMCALHardwareTrigger::TRG_MB)) {
-        registry.fill(HIST("hEventsNoMaxClusterEMCALMinBias"), 1.);
-      }
-      if (hwtrg.test(EMCALHardwareTrigger::TRG_EMC7)) {
-        registry.fill(HIST("hEventsNoMaxClusterEMCALLevel0"), 1.);
-      }
-    }
-    if (maxClusterObservableDCAL > 0) {
-      registry.fill(HIST("hClusterDCALMaxPtEtaPhi"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
-      if (hwtrg.test(EMCALHardwareTrigger::TRG_MB)) {
-        registry.fill(HIST("hClusterDCALMaxPtEtaPhiMinBias"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
-      }
-      if (hwtrg.test(EMCALHardwareTrigger::TRG_DMC7)) {
-        registry.fill(HIST("hClusterDCALMaxPtEtaPhiLevel0"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
-      }
-      for (const auto& cluster : analysedClusters) {
-        if (!cluster.mEMCALcluster) {
-          registry.fill(HIST("hClusterDCALMaxPtClusterDCALPt"), maxClusterObservableDCAL, cluster.mTriggerObservable);
+      if (maxClusterObservableDCAL > 0) {
+        registry.fill(HIST("hClusterDCALMaxPtEtaPhi"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
+        if (hwtrg.test(EMCALHardwareTrigger::TRG_MB)) {
+          registry.fill(HIST("hClusterDCALMaxPtEtaPhiMinBias"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
         }
-      }
-      if (isTrigger(TriggerType_t::kDcalGammaVeryHigh)) {
-        registry.fill(HIST("hSelectedGammaDCALMaxPtEtaPhiVeryHigh"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
-      }
-      if (isTrigger(TriggerType_t::kDcalGammaHigh)) {
-        registry.fill(HIST("hSelectedGammaDCALMaxPtEtaPhi"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
-      }
-      if (isTrigger(TriggerType_t::kDcalGammaLow)) {
-        registry.fill(HIST("hSelectedGammaDCALMaxPtEtaPhiLow"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
-      }
-      if (isTrigger(TriggerType_t::kDcalGammaVeryLow)) {
-        registry.fill(HIST("hSelectedGammaDCALMaxPtEtaPhiVeryLow"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
-      }
-    } else {
-      registry.fill(HIST("hEventsNoMaxClusterDCAL"), 1.);
-      // count events where max. cluster has not been found
-      if (hwtrg.test(EMCALHardwareTrigger::TRG_MB)) {
-        registry.fill(HIST("hEventsNoMaxClusterDCALMinBias"), 1.);
-      }
-      if (hwtrg.test(EMCALHardwareTrigger::TRG_DMC7)) {
-        registry.fill(HIST("hEventsNoMaxClusterDCALLevel0"), 1.);
+        if (hwtrg.test(EMCALHardwareTrigger::TRG_DMC7)) {
+          registry.fill(HIST("hClusterDCALMaxPtEtaPhiLevel0"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
+        }
+        for (const auto& cluster : analysedClusters) {
+          if (!cluster.mEMCALcluster) {
+            registry.fill(HIST("hClusterDCALMaxPtClusterDCALPt"), maxClusterObservableDCAL, cluster.mTriggerObservable);
+          }
+        }
+        if (isTrigger(TriggerType_t::kDcalGammaVeryHigh)) {
+          registry.fill(HIST("hSelectedGammaDCALMaxPtEtaPhiVeryHigh"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
+        }
+        if (isTrigger(TriggerType_t::kDcalGammaHigh)) {
+          registry.fill(HIST("hSelectedGammaDCALMaxPtEtaPhi"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
+        }
+        if (isTrigger(TriggerType_t::kDcalGammaLow)) {
+          registry.fill(HIST("hSelectedGammaDCALMaxPtEtaPhiLow"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
+        }
+        if (isTrigger(TriggerType_t::kDcalGammaVeryLow)) {
+          registry.fill(HIST("hSelectedGammaDCALMaxPtEtaPhiVeryLow"), maxClusterObservableDCAL, maxClusterDCAL.eta(), maxClusterDCAL.phi());
+        }
+      } else {
+        registry.fill(HIST("hEventsNoMaxClusterDCAL"), 1.);
+        // count events where max. cluster has not been found
+        if (hwtrg.test(EMCALHardwareTrigger::TRG_MB)) {
+          registry.fill(HIST("hEventsNoMaxClusterDCALMinBias"), 1.);
+        }
+        if (hwtrg.test(EMCALHardwareTrigger::TRG_DMC7)) {
+          registry.fill(HIST("hEventsNoMaxClusterDCALLevel0"), 1.);
+        }
       }
     }
     return std::make_pair(maxClusterObservableEMCAL, maxClusterObservableDCAL);
@@ -568,80 +608,90 @@ struct JetTriggerQA {
       // This gives us access to all jet substructure information
       // auto tracksInJet = jetTrackConstituents.sliceBy(perJetTrackConstituents, jet.globalIndex());
       // for (const auto& trackList : tracksInJet) {
-      for (auto& track : jet.template tracks_as<aod::JetTracks>()) {
-        auto trackPt = track.pt();
-        auto chargeFrag = track.px() * jet.px() + track.py() * jet.py() + track.pz() * jet.pz();
-        chargeFrag /= (jet.p() * jet.p());
-        auto z = trackPt / jetPt;
-        auto dphi = jet.phi() - track.phi();
-        dphi = check_dphi(dphi);
-        auto dR = TMath::Sqrt(dphi * dphi + TMath::Power(jet.eta() - track.eta(), 2));
-        zTheta += z * dR / jetR;
-        zSqTheta += z * z * dR / jetR;
-        zThetaSq += z * dR * dR / (jetR * jetR);
-        ptD += z * z;
-        registry.fill(HIST("hJetRPtTrackPt"), jetR, jetPt, trackPt);
-        registry.fill(HIST("hJetRPtChargeFrag"), jetR, jetPt, chargeFrag);
-        if (isTrigger(TriggerType_t::kEmcalJetFull) || isTrigger(TriggerType_t::kEmcalJetNeutral)) {
-          registry.fill(HIST("hSelectedJetRPtTrackPt"), jetR, jetPt, trackPt);
-          registry.fill(HIST("hSelectedJetRPtChargeFrag"), jetR, jetPt, chargeFrag);
-        }
-        if (isTrigger(TriggerType_t::kEmcalJetFullLow) || isTrigger(TriggerType_t::kEmcalJetNeutralLow)) {
-          registry.fill(HIST("hSelectedJetLowRPtTrackPt"), jetR, jetPt, trackPt);
-          registry.fill(HIST("hSelectedJetLowRPtChargeFrag"), jetR, jetPt, chargeFrag);
-        }
-      } // for tracks in jet
+      if (!b_doLightOutput) {
+        for (const auto& track : jet.template tracks_as<aod::JetTracks>()) {
+          auto trackPt = track.pt();
+          auto chargeFrag = track.px() * jet.px() + track.py() * jet.py() + track.pz() * jet.pz();
+          chargeFrag /= (jet.p() * jet.p());
+          auto z = trackPt / jetPt;
+          auto dphi = jet.phi() - track.phi();
+          dphi = check_dphi(dphi);
+          auto dR = std::sqrt(dphi * dphi + std::pow(jet.eta() - track.eta(), 2));
+          zTheta += z * dR / jetR;
+          zSqTheta += z * z * dR / jetR;
+          zThetaSq += z * dR * dR / (jetR * jetR);
+          ptD += z * z;
+          registry.fill(HIST("hJetRPtTrackPt"), jetR, jetPt, trackPt);
+          registry.fill(HIST("hJetRPtChargeFrag"), jetR, jetPt, chargeFrag);
+          if (isTrigger(TriggerType_t::kEmcalJetFull) || isTrigger(TriggerType_t::kEmcalJetNeutral)) {
+            registry.fill(HIST("hSelectedJetRPtTrackPt"), jetR, jetPt, trackPt);
+            registry.fill(HIST("hSelectedJetRPtChargeFrag"), jetR, jetPt, chargeFrag);
+          }
+          if (isTrigger(TriggerType_t::kEmcalJetFullLow) || isTrigger(TriggerType_t::kEmcalJetNeutralLow)) {
+            registry.fill(HIST("hSelectedJetLowRPtTrackPt"), jetR, jetPt, trackPt);
+            registry.fill(HIST("hSelectedJetLowRPtChargeFrag"), jetR, jetPt, chargeFrag);
+          }
+        } // for tracks in jet
+      }
 
       // auto clustersInJet = jetClusterConstituents.sliceBy(perJetClusterConstituents, jet.globalIndex());
       // for (const auto& clusterList : clustersInJet) {
-      for (auto& cluster : jet.template clusters_as<selectedClusters>()) {
-        auto clusterPt = cluster.energy() / std::cosh(cluster.eta());
-        neutralEnergyFraction += cluster.energy();
-        auto z = clusterPt / jetPt;
-        auto dphi = jet.phi() - cluster.phi();
-        dphi = check_dphi(dphi);
-        auto dR = TMath::Sqrt(dphi * dphi + TMath::Power(jet.eta() - cluster.eta(), 2));
-        zTheta += z * dR / jetR;
-        zSqTheta += z * z * dR / jetR;
-        zThetaSq += z * dR * dR / (jetR * jetR);
-        ptD += z * z;
-        registry.fill(HIST("hJetRPtClusterPt"), jetR, jetPt, clusterPt);
-        if (isTrigger(TriggerType_t::kEmcalJetFull) || isTrigger(TriggerType_t::kEmcalJetNeutral)) {
-          registry.fill(HIST("hSelectedJetRPtClusterPt"), jetR, jetPt, clusterPt);
-        }
-        if (isTrigger(TriggerType_t::kEmcalJetFullLow) || isTrigger(TriggerType_t::kEmcalJetNeutralLow)) {
-          registry.fill(HIST("hSelectedJetLowRPtClusterPt"), jetR, jetPt, clusterPt);
-        }
-      } // for clusters in jet
+      if (!b_doLightOutput) {
+        for (const auto& cluster : jet.template clusters_as<selectedClusters>()) {
+          auto clusterPt = cluster.energy() / std::cosh(cluster.eta());
+          neutralEnergyFraction += cluster.energy();
+          auto z = clusterPt / jetPt;
+          auto dphi = jet.phi() - cluster.phi();
+          dphi = check_dphi(dphi);
+          auto dR = std::sqrt(dphi * dphi + std::pow(jet.eta() - cluster.eta(), 2));
+          zTheta += z * dR / jetR;
+          zSqTheta += z * z * dR / jetR;
+          zThetaSq += z * dR * dR / (jetR * jetR);
+          ptD += z * z;
+          registry.fill(HIST("hJetRPtClusterPt"), jetR, jetPt, clusterPt);
+          if (isTrigger(TriggerType_t::kEmcalJetFull) || isTrigger(TriggerType_t::kEmcalJetNeutral)) {
+            registry.fill(HIST("hSelectedJetRPtClusterPt"), jetR, jetPt, clusterPt);
+          }
+          if (isTrigger(TriggerType_t::kEmcalJetFullLow) || isTrigger(TriggerType_t::kEmcalJetNeutralLow)) {
+            registry.fill(HIST("hSelectedJetLowRPtClusterPt"), jetR, jetPt, clusterPt);
+          }
+        } // for clusters in jet
+      }
       neutralEnergyFraction /= jet.energy();
-      ptD = TMath::Sqrt(ptD);
+      ptD = std::sqrt(ptD);
 
       // Fillng histograms
       registry.fill(HIST("hJetRPtEta"), jetR, jetPt, jet.eta());
       registry.fill(HIST("hJetRPtPhi"), jetR, jetPt, jet.phi());
-      registry.fill(HIST("hJetRPtPtd"), jetR, jetPt, ptD);
-      registry.fill(HIST("hJetRPtNEF"), jetR, jetPt, neutralEnergyFraction);
-      registry.fill(HIST("hJetRPtZTheta"), jetR, jetPt, zTheta);
-      registry.fill(HIST("hJetRPtZSqTheta"), jetR, jetPt, zSqTheta);
-      registry.fill(HIST("hJetRPtZThetaSq"), jetR, jetPt, zThetaSq);
+      if (!b_doLightOutput) {
+        registry.fill(HIST("hJetRPtPtd"), jetR, jetPt, ptD);
+        registry.fill(HIST("hJetRPtNEF"), jetR, jetPt, neutralEnergyFraction);
+        registry.fill(HIST("hJetRPtZTheta"), jetR, jetPt, zTheta);
+        registry.fill(HIST("hJetRPtZSqTheta"), jetR, jetPt, zSqTheta);
+        registry.fill(HIST("hJetRPtZThetaSq"), jetR, jetPt, zThetaSq);
+      }
       registry.get<THn>(HIST("jetRPtEtaPhi"))->Fill(jetR, jetPt, jet.eta(), jet.phi());
       if (isTrigger(TriggerType_t::kEmcalJetFull) || isTrigger(TriggerType_t::kEmcalJetNeutral)) {
         registry.fill(HIST("hSelectedJetRPtEta"), jetR, jetPt, jet.eta());
         registry.fill(HIST("hSelectedJetRPtPhi"), jetR, jetPt, jet.phi());
-        registry.fill(HIST("hSelectedJetRPtPtd"), jetR, jetPt, ptD);
-        registry.fill(HIST("hSelectedJetRPtNEF"), jetR, jetPt, neutralEnergyFraction);
-        registry.fill(HIST("hSelectedJetRPtZTheta"), jetR, jetPt, zTheta);
-        registry.fill(HIST("hSelectedJetRPtZSqTheta"), jetR, jetPt, zSqTheta);
-        registry.fill(HIST("hSelectedJetRPtZThetaSq"), jetR, jetPt, zThetaSq);
+        if (!b_doLightOutput) {
+          registry.fill(HIST("hSelectedJetRPtPtd"), jetR, jetPt, ptD);
+          registry.fill(HIST("hSelectedJetRPtNEF"), jetR, jetPt, neutralEnergyFraction);
+          registry.fill(HIST("hSelectedJetRPtZTheta"), jetR, jetPt, zTheta);
+          registry.fill(HIST("hSelectedJetRPtZSqTheta"), jetR, jetPt, zSqTheta);
+          registry.fill(HIST("hSelectedJetRPtZThetaSq"), jetR, jetPt, zThetaSq);
+        }
       }
       if (isTrigger(TriggerType_t::kEmcalJetFullLow) || isTrigger(TriggerType_t::kEmcalJetNeutralLow)) {
         registry.fill(HIST("hSelectedJetLowRPtEta"), jetR, jetPt, jet.eta());
         registry.fill(HIST("hSelectedJetLowRPtPhi"), jetR, jetPt, jet.phi());
-        registry.fill(HIST("hSelectedJetLowRPtPtd"), jetR, jetPt, ptD);
-        registry.fill(HIST("hSelectedJetLowRPtNEF"), jetR, jetPt, neutralEnergyFraction);
-        registry.fill(HIST("hSelectedJetLowRPtZTheta"), jetR, jetPt, zTheta);
-        registry.fill(HIST("hSelectedJetLowRPtZSqTheta"), jetR, jetPt, zSqTheta);
-        registry.fill(HIST("hSelectedJetLowRPtZThetaSq"), jetR, jetPt, zThetaSq);
+        if (!b_doLightOutput) {
+          registry.fill(HIST("hSelectedJetLowRPtPtd"), jetR, jetPt, ptD);
+          registry.fill(HIST("hSelectedJetLowRPtNEF"), jetR, jetPt, neutralEnergyFraction);
+          registry.fill(HIST("hSelectedJetLowRPtZTheta"), jetR, jetPt, zTheta);
+          registry.fill(HIST("hSelectedJetLowRPtZSqTheta"), jetR, jetPt, zSqTheta);
+          registry.fill(HIST("hSelectedJetLowRPtZThetaSq"), jetR, jetPt, zThetaSq);
+        }
       }
     } // for jets
     return std::make_pair(vecMaxJet, vecMaxJetNoFiducial);
@@ -761,67 +811,74 @@ struct JetTriggerQA {
 
     std::array<bool, 5> foundMaxJet;
     std::fill(foundMaxJet.begin(), foundMaxJet.end(), false);
-    for (auto maxJet : vecMaxJet) {
-      double jetR = maxJet.r() * 1e-2, jetPt = maxJet.pt(), jetEta = maxJet.eta(), jetPhi = maxJet.phi();
-      foundMaxJet[static_cast<int>(maxJet.r() * 1e-1) - 2] = true;
-      registry.fill(HIST("hJetRMaxPtEta"), jetR, jetPt, jetEta);
-      registry.fill(HIST("hJetRMaxPtPhi"), jetR, jetPt, jetPhi);
-      if (hardwaretriggers.test(EMCALHardwareTrigger::TRG_MB)) {
-        registry.fill(HIST("hJetRMaxPtEtaMinBias"), jetR, jetPt, jetEta);
-        registry.fill(HIST("hJetRMaxPtPhiMinBias"), jetR, jetPt, jetPhi);
-      }
-      if (hardwaretriggers.test(EMCALHardwareTrigger::TRG_EMC7)) {
-        registry.fill(HIST("hJetRMaxPtEtaLevel0"), jetR, jetPt, jetEta);
-        registry.fill(HIST("hJetRMaxPtPhiLevel0"), jetR, jetPt, jetPhi);
-      }
-      // hJetRMaxPtEtaPhi->Fill(jetR, jetPt, jetEta, jetPhi);
-      registry.get<THn>(HIST("jetRMaxPtEtaPhi"))->Fill(jetR, jetPt, jetEta, jetPhi);
-      if (isTrigger(TriggerType_t::kEmcalJetFull) || isTrigger(TriggerType_t::kEmcalJetNeutral)) {
-        registry.fill(HIST("hSelectedJetRMaxPtEta"), jetR, jetPt, jetEta);
-        registry.fill(HIST("hSelectedJetRMaxPtPhi"), jetR, jetPt, jetPhi);
-      }
-      if (isTrigger(TriggerType_t::kEmcalJetFullLow) || isTrigger(TriggerType_t::kEmcalJetNeutralLow)) {
-        registry.fill(HIST("hSelectedJetLowRMaxPtEta"), jetR, jetPt, jetEta);
-        registry.fill(HIST("hSelectedJetLowRMaxPtPhi"), jetR, jetPt, jetPhi);
-      }
-      if (maxClusterObservableEMCAL > 0) {
-        registry.fill(HIST("hJetRMaxPtClusterMaxPt"), jetR, jetPt, maxClusterObservableEMCAL);
-        if (isTrigger(TriggerType_t::kEmcalJetFull) || isTrigger(TriggerType_t::kEmcalJetNeutral)) {
-          registry.fill(HIST("hSelectedJetRMaxPtClusterMaxPt"), jetR, jetPt, maxClusterObservableEMCAL);
-        }
-      } // if maxClusterPt
-      if (maxJet.r() == std::round(f_jetR * 100)) {
-        for (const auto& jet : jets) {
-          if (isJetInEmcal(jet)) {
-            registry.fill(HIST("hJetRMaxPtJetPt"), jet.r() * 1e-2, jetPt, jet.pt());
-          }
-        } // for jets
-      } // if maxJet.r() == std::round(f_jetR * 100)
-    } // for maxJet
-    // Fill counters for events without max jets
-    for (std::size_t ir = 0; ir < foundMaxJet.size(); ir++) {
-      if (!foundMaxJet[ir]) {
-        double rval = static_cast<double>(ir) / 10.;
-        registry.fill(HIST("hEventsNoMaxJet"), rval);
+    if (!b_doLightOutput) {
+      for (const auto& maxJet : vecMaxJet) {
+        double jetR = maxJet.r() * 1e-2, jetPt = maxJet.pt(), jetEta = maxJet.eta(), jetPhi = maxJet.phi();
+        foundMaxJet[static_cast<int>(maxJet.r() * 1e-1) - 2] = true;
+        registry.fill(HIST("hJetRMaxPtEta"), jetR, jetPt, jetEta);
+        registry.fill(HIST("hJetRMaxPtPhi"), jetR, jetPt, jetPhi);
         if (hardwaretriggers.test(EMCALHardwareTrigger::TRG_MB)) {
-          registry.fill(HIST("hEventsNoMaxJetMinBias"), rval);
+          registry.fill(HIST("hJetRMaxPtEtaMinBias"), jetR, jetPt, jetEta);
+          registry.fill(HIST("hJetRMaxPtPhiMinBias"), jetR, jetPt, jetPhi);
         }
         if (hardwaretriggers.test(EMCALHardwareTrigger::TRG_EMC7)) {
-          registry.fill(HIST("hEventsNoMaxJetLevel0"), rval);
+          registry.fill(HIST("hJetRMaxPtEtaLevel0"), jetR, jetPt, jetEta);
+          registry.fill(HIST("hJetRMaxPtPhiLevel0"), jetR, jetPt, jetPhi);
+        }
+        // hJetRMaxPtEtaPhi->Fill(jetR, jetPt, jetEta, jetPhi);
+        registry.get<THn>(HIST("jetRMaxPtEtaPhi"))->Fill(jetR, jetPt, jetEta, jetPhi);
+        if (isTrigger(TriggerType_t::kEmcalJetFull) || isTrigger(TriggerType_t::kEmcalJetNeutral)) {
+          registry.fill(HIST("hSelectedJetRMaxPtEta"), jetR, jetPt, jetEta);
+          registry.fill(HIST("hSelectedJetRMaxPtPhi"), jetR, jetPt, jetPhi);
+        }
+        if (isTrigger(TriggerType_t::kEmcalJetFullLow) || isTrigger(TriggerType_t::kEmcalJetNeutralLow)) {
+          registry.fill(HIST("hSelectedJetLowRMaxPtEta"), jetR, jetPt, jetEta);
+          registry.fill(HIST("hSelectedJetLowRMaxPtPhi"), jetR, jetPt, jetPhi);
+        }
+        if (maxClusterObservableEMCAL > 0) {
+          registry.fill(HIST("hJetRMaxPtClusterMaxPt"), jetR, jetPt, maxClusterObservableEMCAL);
+          if (isTrigger(TriggerType_t::kEmcalJetFull) || isTrigger(TriggerType_t::kEmcalJetNeutral)) {
+            registry.fill(HIST("hSelectedJetRMaxPtClusterMaxPt"), jetR, jetPt, maxClusterObservableEMCAL);
+          }
+        } // if maxClusterPt
+        if (maxJet.r() == std::round(f_jetR * 100)) {
+          for (const auto& jet : jets) {
+            if (isJetInEmcal(jet)) {
+              registry.fill(HIST("hJetRMaxPtJetPt"), jet.r() * 1e-2, jetPt, jet.pt());
+            }
+          } // for jets
+        } // if maxJet.r() == std::round(f_jetR * 100)
+      } // for maxJet
+    }
+    // Fill counters for events without max jets
+    if (!b_doLightOutput) {
+      for (std::size_t ir = 0; ir < foundMaxJet.size(); ir++) {
+        if (!foundMaxJet[ir]) {
+          double rval = static_cast<double>(ir) / 10.;
+          registry.fill(HIST("hEventsNoMaxJet"), rval);
+          if (hardwaretriggers.test(EMCALHardwareTrigger::TRG_MB)) {
+            registry.fill(HIST("hEventsNoMaxJetMinBias"), rval);
+          }
+          if (hardwaretriggers.test(EMCALHardwareTrigger::TRG_EMC7)) {
+            registry.fill(HIST("hEventsNoMaxJetLevel0"), rval);
+          }
         }
       }
     }
-    for (auto maxJet : vecMaxJetNoFiducial) {
-      double jetR = maxJet.r() * 1e-2, jetPt = maxJet.pt(), jetEta = maxJet.eta(), jetPhi = maxJet.phi();
-      // hJetRMaxPtEtaPhiNoFiducial->Fill(jetR, jetPt, jetEta, jetPhi);
-      registry.get<THn>(HIST("jetRMaxPtEtaPhiNoFiducial"))->Fill(jetR, jetPt, jetEta, jetPhi);
-      if (maxJet.r() == std::round(f_jetR * 100)) {
-        for (const auto& jet : jets) {
-          registry.fill(HIST("hJetRMaxPtJetPtNoFiducial"), jet.r() * 1e-2, jetPt, jet.pt());
-        } // for jets
-      } // if maxJet.r() == std::round(f_jetR * 100)
-    } // for maxjet no fiducial
 
+    if (!b_doLightOutput) {
+      for (const auto& maxJet : vecMaxJetNoFiducial) {
+        double jetR = maxJet.r() * 1e-2, jetPt = maxJet.pt(), jetEta = maxJet.eta(), jetPhi = maxJet.phi();
+        // hJetRMaxPtEtaPhiNoFiducial->Fill(jetR, jetPt, jetEta, jetPhi);
+        registry.get<THn>(HIST("jetRMaxPtEtaPhiNoFiducial"))->Fill(jetR, jetPt, jetEta, jetPhi);
+        if (maxJet.r() == std::round(f_jetR * 100)) {
+          for (const auto& jet : jets) {
+            if (!b_doLightOutput)
+              registry.fill(HIST("hJetRMaxPtJetPtNoFiducial"), jet.r() * 1e-2, jetPt, jet.pt());
+          } // for jets
+        } // if maxJet.r() == std::round(f_jetR * 100)
+      } // for maxjet no fiducial
+    }
   } // process
 
   void processFullJets(collisionWithTrigger const& collision,

--- a/PWGLF/DataModel/LFSigmaTables.h
+++ b/PWGLF/DataModel/LFSigmaTables.h
@@ -36,7 +36,6 @@ DECLARE_SOA_COLUMN(SigmaOPAngle, sigmaOPAngle, float);
 DECLARE_SOA_COLUMN(SigmaCentrality, sigmaCentrality, float);
 DECLARE_SOA_COLUMN(SigmaRunNumber, sigmaRunNumber, int);
 DECLARE_SOA_COLUMN(SigmaTimestamp, sigmaTimestamp, uint64_t);
-DECLARE_SOA_COLUMN(SigmaIR, sigmaIR, float);
 
 } // namespace sigma0Core
 
@@ -47,8 +46,7 @@ DECLARE_SOA_TABLE(Sigma0Cores, "AOD", "SIGMA0CORES",
                   sigma0Core::SigmaOPAngle,
                   sigma0Core::SigmaCentrality,
                   sigma0Core::SigmaRunNumber,
-                  sigma0Core::SigmaTimestamp,
-                  sigma0Core::SigmaIR);
+                  sigma0Core::SigmaTimestamp);
 
 // For Photon extra info
 namespace sigmaPhotonExtra

--- a/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
@@ -1389,7 +1389,7 @@ struct sigma0builder {
   }
 
   // Simulated processing in Run 3 (subscribes to MC information too)
-  void processGeneratedRun3(soa::Join<aod::StraMCCollisions, aod::StraMCCollMults> const& mcCollisions, soa::Join<aod::V0MCCores, aod::V0MCCollRefs> const& V0MCCores, soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraStamps, aod::StraCollLabels> const& collisions, aod::MotherMCParts const& mcmothers)
+  void processGeneratedRun3(soa::Join<aod::StraMCCollisions, aod::StraMCCollMults> const& mcCollisions, soa::Join<aod::V0MCCores, aod::V0MCCollRefs> const& V0MCCores, soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraStamps, aod::StraCollLabels> const& collisions)
   {
     analyzeGeneratedV0s(mcCollisions, V0MCCores, collisions);
   }

--- a/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
@@ -73,7 +73,8 @@ struct sigma0builder {
   // For manual sliceBy
   Preslice<V0DerivedMCDatas> perCollisionMCDerived = o2::aod::v0data::straCollisionId;
   Preslice<V0StandardDerivedDatas> perCollisionSTDDerived = o2::aod::v0data::straCollisionId;
-
+  PresliceUnsorted<soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraCollLabels>> perMcCollision = aod::v0data::straMCCollisionId;
+  
   // pack track quality but separte also afterburner
   // dynamic range: 0-31
   enum selection : int { hasTPC = 0,
@@ -115,10 +116,17 @@ struct sigma0builder {
     Configurable<bool> requireINEL0{"requireINEL0", false, "require INEL>0 event selection"};
     Configurable<bool> requireINEL1{"requireINEL1", false, "require INEL>1 event selection"};
     Configurable<float> maxZVtxPosition{"maxZVtxPosition", 10., "max Z vtx position"};
+    Configurable<bool> useEvtSelInDenomEff{"useEvtSelInDenomEff", false, "Consider event selections in the recoed <-> gen collision association for the denominator (or numerator) of the acc. x eff. (or signal loss)?"};
+    Configurable<bool> applyZVtxSelOnMCPV{"applyZVtxSelOnMCPV", false, "Apply Z-vtx cut on the PV of the generated collision?"};
     Configurable<bool> useFT0CbasedOccupancy{"useFT0CbasedOccupancy", false, "Use sum of FT0-C amplitudes for estimating occupancy? (if not, use track-based definition)"};
     // fast check on occupancy
     Configurable<float> minOccupancy{"minOccupancy", -1, "minimum occupancy from neighbouring collisions"};
     Configurable<float> maxOccupancy{"maxOccupancy", -1, "maximum occupancy from neighbouring collisions"};
+
+    // fast check on interaction rate
+    Configurable<float> minIR{"minIR", -1, "minimum IR collisions"};
+    Configurable<float> maxIR{"maxIR", -1, "maximum IR collisions"};
+
   } eventSelections;
 
   // For ML Selection
@@ -129,6 +137,8 @@ struct sigma0builder {
 
   // For standard approach:
   //// Lambda criteria:
+  Configurable<float> V0Rapidity{"V0Rapidity", 0.8, "v0 rapidity"};
+
   Configurable<float> LambdaDauPseudoRap{"LambdaDauPseudoRap", 1.5, "Max pseudorapidity of daughter tracks"};
   Configurable<float> LambdaMinDCANegToPv{"LambdaMinDCANegToPv", 0.0, "min DCA Neg To PV (cm)"};
   Configurable<float> LambdaMinDCAPosToPv{"LambdaMinDCAPosToPv", 0.0, "min DCA Pos To PV (cm)"};
@@ -137,7 +147,7 @@ struct sigma0builder {
   Configurable<float> LambdaMaxv0radius{"LambdaMaxv0radius", 60, "Max V0 radius (cm)"};
   Configurable<float> LambdaWindow{"LambdaWindow", 0.05, "Mass window around expected (in GeV/c2)"};
 
-  //// Photon criteria:
+  //// Photon criteria:  
   Configurable<float> PhotonMaxDauPseudoRap{"PhotonMaxDauPseudoRap", 1.5, "Max pseudorapidity of daughter tracks"};
   Configurable<float> PhotonMinDCAToPv{"PhotonMinDCAToPv", 0.0, "Min DCA daughter To PV (cm)"};
   Configurable<float> PhotonMaxDCAV0Dau{"PhotonMaxDCAV0Dau", 3.5, "Max DCA V0 Daughters (cm)"};
@@ -189,7 +199,7 @@ struct sigma0builder {
   ConfigurableAxis axisPA{"axisPA", {100, 0.0f, 1}, "Pointing angle"};
   ConfigurableAxis axisRapidity{"axisRapidity", {100, -2.0f, 2.0f}, "Rapidity"};
   ConfigurableAxis axisCandSel{"axisCandSel", {7, 0.5f, +7.5f}, "Candidate Selection"};
-  ConfigurableAxis axisMonteCarloNch{"axisMonteCarloNch", {300, 0.0f, 3000.0f}, "N_{ch} MC"};
+  ConfigurableAxis axisNch{"axisNch", {300, 0.0f, 3000.0f}, "N_{ch}"};
   ConfigurableAxis axisIRBinning{"axisIRBinning", {150, 0, 1500}, "Binning for the interaction rate (kHz)"};
 
   int nSigmaCandidates = 0;
@@ -201,7 +211,7 @@ struct sigma0builder {
     ccdb->setFatalWhenNull(false);
 
     // Event Counters
-    histos.add("hEventSelection", "hEventSelection", kTH1D, {{19, -0.5f, +18.5f}});
+    histos.add("hEventSelection", "hEventSelection", kTH1D, {{21, -0.5f, +20.5f}});
     histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(1, "All collisions");
     histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(2, "sel8 cut");
     histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(3, "kIsTriggerTVX");
@@ -225,13 +235,15 @@ struct sigma0builder {
       histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(17, "Below min occup.");
       histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(18, "Above max occup.");
     }
+    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(19, "Below min IR");
+    histos.get<TH1>(HIST("hEventSelection"))->GetXaxis()->SetBinLabel(20, "Above max IR");
 
     histos.add("hEventCentrality", "hEventCentrality", kTH1D, {axisCentrality});
 
     histos.add("PhotonSel/hSelectionStatistics", "hSelectionStatistics", kTH1D, {axisCandSel});
     histos.get<TH1>(HIST("PhotonSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(1, "No Sel");
     histos.get<TH1>(HIST("PhotonSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(2, "Photon Mass Cut");
-    histos.get<TH1>(HIST("PhotonSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(3, "Photon DauEta Cut");
+    histos.get<TH1>(HIST("PhotonSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(3, "Photon Eta/Y Cut");
     histos.get<TH1>(HIST("PhotonSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(4, "Photon DCAToPV Cut");
     histos.get<TH1>(HIST("PhotonSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(5, "Photon DCADau Cut");
     histos.get<TH1>(HIST("PhotonSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(6, "Photon Radius Cut");
@@ -239,6 +251,7 @@ struct sigma0builder {
     histos.add("PhotonSel/hPhotonMass", "hPhotonMass", kTH1F, {axisPhotonMass});
     histos.add("PhotonSel/hPhotonNegEta", "hPhotonNegEta", kTH1F, {axisRapidity});
     histos.add("PhotonSel/hPhotonPosEta", "hPhotonPosEta", kTH1F, {axisRapidity});
+    histos.add("PhotonSel/hPhotonY", "hPhotonY", kTH1F, {axisRapidity});
     histos.add("PhotonSel/hPhotonDCANegToPV", "hPhotonDCANegToPV", kTH1F, {axisDCAtoPV});
     histos.add("PhotonSel/hPhotonDCAPosToPV", "hPhotonDCAPosToPV", kTH1F, {axisDCAtoPV});
     histos.add("PhotonSel/hPhotonDCADau", "hPhotonDCADau", kTH1F, {axisDCAdau});
@@ -247,7 +260,7 @@ struct sigma0builder {
     histos.add("LambdaSel/hSelectionStatistics", "hSelectionStatistics", kTH1D, {axisCandSel});
     histos.get<TH1>(HIST("LambdaSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(1, "No Sel");
     histos.get<TH1>(HIST("LambdaSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(2, "Lambda Mass Cut");
-    histos.get<TH1>(HIST("LambdaSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(3, "Lambda DauEta Cut");
+    histos.get<TH1>(HIST("LambdaSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(3, "Lambda Eta/Y Cut");
     histos.get<TH1>(HIST("LambdaSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(4, "Lambda DCAToPV Cut");
     histos.get<TH1>(HIST("LambdaSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(5, "Lambda Radius Cut");
     histos.get<TH1>(HIST("LambdaSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(6, "Lambda DCADau Cut");
@@ -256,6 +269,7 @@ struct sigma0builder {
     histos.add("LambdaSel/hAntiLambdaMass", "hAntiLambdaMass", kTH1F, {axisLambdaMass});
     histos.add("LambdaSel/hLambdaNegEta", "hLambdaNegEta", kTH1F, {axisRapidity});
     histos.add("LambdaSel/hLambdaPosEta", "hLambdaPosEta", kTH1F, {axisRapidity});
+    histos.add("LambdaSel/hLambdaY", "hLambdaY", kTH1F, {axisRapidity});
     histos.add("LambdaSel/hLambdaDCANegToPV", "hLambdaDCANegToPV", kTH1F, {axisDCAtoPV});
     histos.add("LambdaSel/hLambdaDCAPosToPV", "hLambdaDCAPosToPV", kTH1F, {axisDCAtoPV});
     histos.add("LambdaSel/hLambdaDCADau", "hLambdaDCADau", kTH1F, {axisDCAdau});
@@ -339,8 +353,32 @@ struct sigma0builder {
       histos.add("Pi0QA/h2dPtVsMassPi0AfterSel_Candidates", "h2dPtVsMassPi0AfterSel_Candidates", kTH2D, {axisPt, axisPi0Mass});
     }
 
-    if (doprocessGeneratedCollRun3)
-      histos.add("Gen/hNEventsNch", "hNEventsNch", kTH1D, {axisMonteCarloNch});
+    if (doprocessGeneratedRun3){
+      
+      histos.add("Gen/hGenEvents", "hGenEvents", kTH2F, {{axisNch}, {2, -0.5f, +1.5f}});
+      histos.get<TH2>(HIST("Gen/hGenEvents"))->GetYaxis()->SetBinLabel(1, "All gen. events");
+      histos.get<TH2>(HIST("Gen/hGenEvents"))->GetYaxis()->SetBinLabel(2, "Gen. with at least 1 rec. events");
+      
+      histos.add("Gen/hGenEventCentrality", "hGenEventCentrality", kTH1F, {{101, 0.0f, 101.0f}});
+      histos.add("Gen/hCentralityVsNcoll_beforeEvSel", "hCentralityVsNcoll_beforeEvSel", kTH2F, {axisCentrality, {50, -0.5f, 49.5f}});
+      histos.add("Gen/hCentralityVsNcoll_afterEvSel", "hCentralityVsNcoll_afterEvSel", kTH2F, {axisCentrality, {50, -0.5f, 49.5f}});
+      histos.add("Gen/hCentralityVsMultMC", "hCentralityVsMultMC", kTH2F, {{101, 0.0f, 101.0f}, axisNch});
+      histos.add("Gen/h2dGenGamma", "h2dGenGamma", kTH2D, {axisCentrality, axisPt});
+      histos.add("Gen/h2dGenLambda", "h2dGenLambda", kTH2D, {axisCentrality, axisPt});
+      histos.add("Gen/h2dGenAntiLambda", "h2dGenAntiLambda", kTH2D, {axisCentrality, axisPt});      
+      histos.add("Gen/h2dGenGammaVsMultMC_RecoedEvt", "h2dGenGammaVsMultMC_RecoedEvt", kTH2D, {axisNch, axisPt});
+      histos.add("Gen/h2dGenLambdaVsMultMC_RecoedEvt", "h2dGenLambdaVsMultMC_RecoedEvt", kTH2D, {axisNch, axisPt});
+      histos.add("Gen/h2dGenAntiLambdaVsMultMC_RecoedEvt", "h2dGenAntiLambdaVsMultMC_RecoedEvt", kTH2D, {axisNch, axisPt});  
+      histos.add("Gen/h2dGenGammaVsMultMC", "h2dGenGammaVsMultMC", kTH2D, {axisNch, axisPt});
+      histos.add("Gen/h2dGenLambdaVsMultMC", "h2dGenLambdaVsMultMC", kTH2D, {axisNch, axisPt});
+      histos.add("Gen/h2dGenAntiLambdaVsMultMC", "h2dGenAntiLambdaVsMultMC", kTH2D, {axisNch, axisPt});      
+      histos.add("Gen/hEventPVzMC", "hEventPVzMC", kTH1F, {{100, -20.0f, +20.0f}});
+      histos.add("Gen/hCentralityVsPVzMC", "hCentralityVsPVzMC", kTH2F, {{101, 0.0f, 101.0f}, {100, -20.0f, +20.0f}});
+            
+      auto hPrimaryV0s = histos.add<TH1>("Gen/hPrimaryV0s", "hPrimaryV0s", kTH1D, {{2, -0.5f, 1.5f}});
+      hPrimaryV0s->GetXaxis()->SetBinLabel(1, "All V0s");
+      hPrimaryV0s->GetXaxis()->SetBinLabel(2, "Primary V0s");
+    }
   }
 
   template <typename TCollision>
@@ -448,6 +486,20 @@ struct sigma0builder {
       if (fillHists)
         histos.fill(HIST("hEventSelection"), 17 /* Above max occupancy */);
     }
+    // Fetch interaction rate only if required (in order to limit ccdb calls)
+    double interactionRate = (eventSelections.minIR >= 0 || eventSelections.maxIR >= 0) ? rateFetcher.fetch(ccdb.service, collision.timestamp(), collision.runNumber(), irSource, fIRCrashOnNull) * 1.e-3 : -1;
+    if (eventSelections.minIR >= 0 && interactionRate < eventSelections.minIR) {
+      return false;
+    }
+    if (fillHists)
+      histos.fill(HIST("hEventSelection"), 18 /* Below min IR */);
+
+    if (eventSelections.maxIR >= 0 && interactionRate > eventSelections.maxIR) {
+      return false;
+    }
+    if (fillHists)
+      histos.fill(HIST("hEventSelection"), 19 /* Above max IR */);
+
     return true;
   }
 
@@ -481,7 +533,7 @@ struct sigma0builder {
   }
 
   template <typename TCollision, typename TV0Object>
-  void analyzeV0CollAssoc(TCollision const& collision, TV0Object const& fullv0s, std::vector<int> selV0Indices, float IR)
+  void analyzeV0CollAssoc(TCollision const& collision, TV0Object const& fullv0s, std::vector<int> selV0Indices, float IR, bool isPhotonAnalysis)
   {
     auto v0MCCollision = collision.template straMCCollision_as<soa::Join<aod::StraMCCollisions, aod::StraMCCollMults>>();
 
@@ -492,8 +544,9 @@ struct sigma0builder {
       float V0MCpT = RecoDecay::pt(array<float, 2>{v0MC.pxMC(), v0MC.pyMC()});
       float V0PA = TMath::ACos(v0.v0cosPA());
       bool fIsV0CorrectlyAssigned = (v0MC.straMCCollisionId() == v0MCCollision.globalIndex());
+      bool isPrimary = v0MC.isPhysicalPrimary();
 
-      if (v0MC.pdgCode() == 22) { // True Gamma
+      if ((v0MC.pdgCode() == 22) && isPhotonAnalysis && isPrimary) { // True Gamma
         histos.fill(HIST("V0AssoQA/h2dIRVsPt_TrueGamma"), IR, V0MCpT);
         histos.fill(HIST("V0AssoQA/h3dPAVsIRVsPt_TrueGamma"), V0PA, IR, V0MCpT);
 
@@ -502,7 +555,7 @@ struct sigma0builder {
           histos.fill(HIST("V0AssoQA/h3dPAVsIRVsPt_TrueGamma_BadCollAssig"), V0PA, IR, V0MCpT);
         }
       }
-      if (v0MC.pdgCode() == 3122) { // True Lambda
+      if ((v0MC.pdgCode() == 3122) && !isPhotonAnalysis && isPrimary) { // True Lambda
         histos.fill(HIST("V0AssoQA/h2dIRVsPt_TrueLambda"), IR, V0MCpT);
         histos.fill(HIST("V0AssoQA/h3dPAVsIRVsPt_TrueLambda"), V0PA, IR, V0MCpT);
 
@@ -513,6 +566,171 @@ struct sigma0builder {
       }
     }
   }
+
+    // ______________________________________________________
+  // Simulated processing
+  // Return the list of indices to the recoed collision associated to a given MC collision.
+  template <typename TMCollisions, typename TCollisions>
+  std::vector<int> getListOfRecoCollIndices(TMCollisions const& mcCollisions, TCollisions const& collisions)
+  {
+    std::vector<int> listBestCollisionIdx(mcCollisions.size());
+    for (auto const& mcCollision : mcCollisions) {
+      auto groupedCollisions = collisions.sliceBy(perMcCollision, mcCollision.globalIndex()); 
+      int biggestNContribs = -1;
+      int bestCollisionIndex = -1;
+      for (auto const& collision : groupedCollisions) {
+        // consider event selections in the recoed <-> gen collision association, for the denominator (or numerator) of the efficiency (or signal loss)?
+        if (eventSelections.useEvtSelInDenomEff) {
+          if (!IsEventAccepted(collision, false)) {
+            continue;
+          }
+        }
+        // Find the collision with the biggest nbr of PV contributors
+        // Follows what was done here: https://github.com/AliceO2Group/O2Physics/blob/master/Common/TableProducer/mcCollsExtra.cxx#L93
+        if (biggestNContribs < collision.multPVTotalContributors()) {
+          biggestNContribs = collision.multPVTotalContributors();
+          bestCollisionIndex = collision.globalIndex();
+        }        
+      }
+      listBestCollisionIdx[mcCollision.globalIndex()] = bestCollisionIndex;
+    }
+    return listBestCollisionIdx;
+  }
+
+  // ______________________________________________________
+  // Simulated processing
+  // Fill generated event information (for event loss/splitting estimation)
+  template <typename TMCCollisions, typename TCollisions>
+  void fillGeneratedEventProperties(TMCCollisions const& mcCollisions, TCollisions const& collisions)
+  {
+    std::vector<int> listBestCollisionIdx(mcCollisions.size());
+    for (auto const& mcCollision : mcCollisions) {
+      // Apply selections on MC collisions
+      if (eventSelections.applyZVtxSelOnMCPV && std::abs(mcCollision.posZ()) > eventSelections.maxZVtxPosition) {
+        continue;
+      }
+      if (doPPAnalysis) { // we are in pp
+        if (eventSelections.requireINEL0 && mcCollision.multMCNParticlesEta10() < 1) {
+          continue;
+        }
+
+        if (eventSelections.requireINEL1 && mcCollision.multMCNParticlesEta10() < 2) {
+          continue;
+        }
+      }
+
+      histos.fill(HIST("Gen/hGenEvents"), mcCollision.multMCNParticlesEta05(), 0 /* all gen. events*/);
+
+      auto groupedCollisions = collisions.sliceBy(perMcCollision, mcCollision.globalIndex()); 
+      // Check if there is at least one of the reconstructed collisions associated to this MC collision
+      // If so, we consider it
+      bool atLeastOne = false;
+      int biggestNContribs = -1;
+      float centrality = 100.5f;
+      int nCollisions = 0;
+      for (auto const& collision : groupedCollisions) {
+
+        if (!IsEventAccepted(collision, false)) {
+          continue;
+        }
+        
+        if (biggestNContribs < collision.multPVTotalContributors()) {
+          biggestNContribs = collision.multPVTotalContributors();
+          centrality = doPPAnalysis ? collision.centFT0M() : collision.centFT0C();
+        }
+      
+        nCollisions++;
+        atLeastOne = true;
+      }
+
+      histos.fill(HIST("Gen/hCentralityVsNcoll_beforeEvSel"), centrality, groupedCollisions.size());
+      histos.fill(HIST("Gen/hCentralityVsNcoll_afterEvSel"), centrality, nCollisions);
+      histos.fill(HIST("Gen/hCentralityVsMultMC"), centrality, mcCollision.multMCNParticlesEta05());
+      histos.fill(HIST("Gen/hCentralityVsPVzMC"), centrality, mcCollision.posZ());
+      histos.fill(HIST("Gen/hEventPVzMC"), mcCollision.posZ());
+
+      if (atLeastOne) {
+        histos.fill(HIST("Gen/hGenEvents"), mcCollision.multMCNParticlesEta05(), 1 /* at least 1 rec. event*/);
+        histos.fill(HIST("Gen/hGenEventCentrality"), centrality);
+      }
+    }
+    return;
+  }
+  
+  // ______________________________________________________
+  // Simulated processing (subscribes to MC information too)
+  template <typename TMCCollisions, typename TV0MCs, typename TCollisions>
+  void analyzeGeneratedV0s(TMCCollisions const& mcCollisions, TV0MCs const& V0MCCores, TCollisions const& collisions)
+  {
+    fillGeneratedEventProperties(mcCollisions, collisions);
+    std::vector<int> listBestCollisionIdx = getListOfRecoCollIndices(mcCollisions, collisions);
+    for (auto const& v0MC : V0MCCores) {
+      if (!v0MC.has_straMCCollision())
+        continue;
+
+      histos.fill(HIST("Gen/hPrimaryV0s"), 0);
+      if (!v0MC.isPhysicalPrimary())
+        continue;
+
+      histos.fill(HIST("Gen/hPrimaryV0s"), 1);
+
+      // TODO: get generated sigma0s      
+
+      float ptmc = v0MC.ptMC();
+      float ymc = 1e3;
+      if (v0MC.pdgCode() == 22)
+        ymc = RecoDecay::y(std::array{v0MC.pxMC(), v0MC.pyMC(), v0MC.pzMC()}, o2::constants::physics::MassGamma);         
+           
+      else if (std::abs(v0MC.pdgCode()) == 3122)
+        ymc = v0MC.rapidityMC(1);
+
+      if (std::abs(ymc) > V0Rapidity) 
+        continue;
+
+      auto mcCollision = v0MC.template straMCCollision_as<soa::Join<aod::StraMCCollisions, aod::StraMCCollMults>>();
+      if (eventSelections.applyZVtxSelOnMCPV && std::abs(mcCollision.posZ()) > eventSelections.maxZVtxPosition) {
+        continue;
+      }
+      if (doPPAnalysis) { // we are in pp
+        if (eventSelections.requireINEL0 && mcCollision.multMCNParticlesEta10() < 1) {
+          continue;
+        }
+
+        if (eventSelections.requireINEL1 && mcCollision.multMCNParticlesEta10() < 2) {
+          continue;
+        }
+      }
+
+      float centrality = 100.5f;
+      if (listBestCollisionIdx[mcCollision.globalIndex()] > -1) {
+        auto collision = collisions.iteratorAt(listBestCollisionIdx[mcCollision.globalIndex()]);        
+        centrality = doPPAnalysis ? collision.centFT0M() : collision.centFT0C();
+         
+        if (v0MC.pdgCode() == 22) {
+          histos.fill(HIST("Gen/h2dGenGammaVsMultMC_RecoedEvt"), mcCollision.multMCNParticlesEta05(), ptmc);
+        }
+        if (v0MC.pdgCode() == 3122) {
+          histos.fill(HIST("Gen/h2dGenLambdaVsMultMC_RecoedEvt"), mcCollision.multMCNParticlesEta05(), ptmc);
+        }
+        if (v0MC.pdgCode() == -3122) {
+          histos.fill(HIST("Gen/h2dGenAntiLambdaVsMultMC_RecoedEvt"), mcCollision.multMCNParticlesEta05(), ptmc);
+        }
+      }
+      if (v0MC.pdgCode() == 22) {
+        histos.fill(HIST("Gen/h2dGenGamma"), centrality, ptmc);
+        histos.fill(HIST("Gen/h2dGenGammaVsMultMC"), mcCollision.multMCNParticlesEta05(), ptmc);
+      }
+      if (v0MC.pdgCode() == 3122) {
+        histos.fill(HIST("Gen/h2dGenLambda"), centrality, ptmc);
+        histos.fill(HIST("Gen/h2dGenLambdaVsMultMC"), mcCollision.multMCNParticlesEta05(), ptmc);
+      }
+      if (v0MC.pdgCode() == -3122) {
+        histos.fill(HIST("Gen/h2dGenAntiLambda"), centrality, ptmc);
+        histos.fill(HIST("Gen/h2dGenAntiLambdaVsMultMC"), mcCollision.multMCNParticlesEta05(), ptmc);
+      }
+    }    
+  }
+
   template <typename TV0Object>
   void runPi0QA(TV0Object const& gamma1, TV0Object const& gamma2)
   {
@@ -629,10 +847,12 @@ struct sigma0builder {
       histos.fill(HIST("PhotonSel/hPhotonMass"), gamma.mGamma());
       if ((gamma.mGamma() < 0) || (gamma.mGamma() > PhotonMaxMass))
         return false;
+      float PhotonY = RecoDecay::y(std::array{gamma.px(), gamma.py(), gamma.pz()}, o2::constants::physics::MassGamma);
       histos.fill(HIST("PhotonSel/hPhotonNegEta"), gamma.negativeeta());
       histos.fill(HIST("PhotonSel/hPhotonPosEta"), gamma.positiveeta());
+      histos.fill(HIST("PhotonSel/hPhotonY"), PhotonY);
       histos.fill(HIST("PhotonSel/hSelectionStatistics"), 2.);
-      if ((TMath::Abs(gamma.negativeeta()) > PhotonMaxDauPseudoRap) || (TMath::Abs(gamma.positiveeta()) > PhotonMaxDauPseudoRap))
+      if ((TMath::Abs(PhotonY) > V0Rapidity) || (TMath::Abs(gamma.negativeeta()) > PhotonMaxDauPseudoRap) || (TMath::Abs(gamma.positiveeta()) > PhotonMaxDauPseudoRap))
         return false;
       histos.fill(HIST("PhotonSel/hPhotonDCANegToPV"), TMath::Abs(gamma.dcanegtopv()));
       histos.fill(HIST("PhotonSel/hPhotonDCAPosToPV"), TMath::Abs(gamma.dcapostopv()));
@@ -672,8 +892,9 @@ struct sigma0builder {
         return false;
       histos.fill(HIST("LambdaSel/hLambdaNegEta"), lambda.negativeeta());
       histos.fill(HIST("LambdaSel/hLambdaPosEta"), lambda.positiveeta());
+      histos.fill(HIST("LambdaSel/hLambdaY"), lambda.yLambda());
       histos.fill(HIST("LambdaSel/hSelectionStatistics"), 2.);
-      if ((TMath::Abs(lambda.negativeeta()) > LambdaDauPseudoRap) || (TMath::Abs(lambda.positiveeta()) > LambdaDauPseudoRap))
+      if ((TMath::Abs(lambda.yLambda()) > V0Rapidity) || (TMath::Abs(lambda.negativeeta()) > LambdaDauPseudoRap) || (TMath::Abs(lambda.positiveeta()) > LambdaDauPseudoRap))
         return false;
       histos.fill(HIST("LambdaSel/hLambdaDCANegToPV"), lambda.dcanegtopv());
       histos.fill(HIST("LambdaSel/hLambdaDCAPosToPV"), lambda.dcapostopv());
@@ -870,16 +1091,12 @@ struct sigma0builder {
     float fSigmaMass = RecoDecay::m(arrMom, std::array{o2::constants::physics::MassPhoton, o2::constants::physics::MassLambda0});
     float fSigmaRap = RecoDecay::y(std::array{gamma.px() + lambda.px(), gamma.py() + lambda.py(), gamma.pz() + lambda.pz()}, o2::constants::physics::MassSigma0);
     float fSigmaOPAngle = v1.Angle(v2);
-    float fSigmaCentrality = coll.centFT0C();
+    float fSigmaCentrality = doPPAnalysis ? coll.centFT0M() : coll.centFT0C(); 
     uint64_t fSigmaTimeStamp = coll.timestamp();
     int fSigmaRunNumber = coll.runNumber();
-    float fSigmaIR = -1;
-
-    if (fGetIR)
-      fSigmaIR = rateFetcher.fetch(ccdb.service, coll.timestamp(), coll.runNumber(), irSource, fIRCrashOnNull) * 1.e-3;
 
     // Filling TTree for ML analysis
-    sigma0cores(fSigmapT, fSigmaMass, fSigmaRap, fSigmaOPAngle, fSigmaCentrality, fSigmaRunNumber, fSigmaTimeStamp, fSigmaIR);
+    sigma0cores(fSigmapT, fSigmaMass, fSigmaRap, fSigmaOPAngle, fSigmaCentrality, fSigmaRunNumber, fSigmaTimeStamp);
 
     sigmaPhotonExtras(fPhotonPt, fPhotonMass, fPhotonQt, fPhotonAlpha, fPhotonRadius,
                       fPhotonCosPA, fPhotonDCADau, fPhotonDCANegPV, fPhotonDCAPosPV, fPhotonZconv,
@@ -980,8 +1197,8 @@ struct sigma0builder {
       //_______________________________________________
       // Wrongly collision association study
       if (doAssocStudy && fhasMCColl) {
-        analyzeV0CollAssoc(coll, fullV0s, bestGammasArray, interactionRate);  // Gamma
-        analyzeV0CollAssoc(coll, fullV0s, bestLambdasArray, interactionRate); // Lambda
+        analyzeV0CollAssoc(coll, fullV0s, bestGammasArray, interactionRate, true);  // Gamma
+        analyzeV0CollAssoc(coll, fullV0s, bestLambdasArray, interactionRate, false); // Lambda
       }
 
       //_______________________________________________
@@ -1172,14 +1389,14 @@ struct sigma0builder {
   }
 
   // Simulated processing in Run 3 (subscribes to MC information too)
-  void processGeneratedCollRun3(soa::Join<aod::StraMCCollisions, aod::StraMCCollMults>::iterator const& mcCollision)
-  {
-    histos.fill(HIST("Gen/hNEventsNch"), mcCollision.multMCNParticlesEta05());
+  void processGeneratedRun3(soa::Join<aod::StraMCCollisions, aod::StraMCCollMults> const& mcCollisions, soa::Join<aod::V0MCCores, aod::V0MCCollRefs> const& V0MCCores, soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraStamps, aod::StraCollLabels> const& collisions, aod::MotherMCParts const& mcmothers)
+  {    
+    analyzeGeneratedV0s(mcCollisions, V0MCCores, collisions);    
   }
 
   PROCESS_SWITCH(sigma0builder, processMonteCarlo, "process as if MC data", false);
   PROCESS_SWITCH(sigma0builder, processRealData, "process as if real data", true);
-  PROCESS_SWITCH(sigma0builder, processGeneratedCollRun3, "process generated MC collisions", false);
+  PROCESS_SWITCH(sigma0builder, processGeneratedRun3, "process generated MC collisions", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
@@ -73,7 +73,7 @@ struct sigma0builder {
   // For manual sliceBy
   Preslice<V0DerivedMCDatas> perCollisionMCDerived = o2::aod::v0data::straCollisionId;
   Preslice<V0StandardDerivedDatas> perCollisionSTDDerived = o2::aod::v0data::straCollisionId;
-  Preslice<soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraCollLabels>> perMcCollision = aod::v0data::straMCCollisionId;
+  PresliceUnsorted<soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraCollLabels>> perMcCollision = aod::v0data::straMCCollisionId;
 
   // pack track quality but separte also afterburner
   // dynamic range: 0-31

--- a/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
@@ -73,7 +73,7 @@ struct sigma0builder {
   // For manual sliceBy
   Preslice<V0DerivedMCDatas> perCollisionMCDerived = o2::aod::v0data::straCollisionId;
   Preslice<V0StandardDerivedDatas> perCollisionSTDDerived = o2::aod::v0data::straCollisionId;
-  PresliceUnsorted<soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraCollLabels>> perMcCollision = aod::v0data::straMCCollisionId;
+  Preslice<soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraCollLabels>> perMcCollision = aod::v0data::straMCCollisionId;
 
   // pack track quality but separte also afterburner
   // dynamic range: 0-31


### PR DESCRIPTION
This PR includes the following updates:

- New functions for processing generated photons and Lambdas, taking event selection into account. These are intended for use in efficiency calculations and follow the implementation used in derivedlambdakzeroanalysis. A similar approach for Sigma0s is planned for a future update;

- Removal of IR information from the Sigma0 data model;.

- Safeguard added to the analyzeV0CollAssoc function to prevent double-counting of V0s. A check to ensure that only primary particles are considered has also been introduced.