### PR TITLE
[Common,PWGDQ] Optimising muon realignment code

### DIFF
--- a/Common/DataModel/FwdTrackReAlignTables.h
+++ b/Common/DataModel/FwdTrackReAlignTables.h
@@ -22,129 +22,51 @@ namespace o2::aod
 {
 namespace fwdtrackrealign
 {
-// FwdTracksRealign Columns definitions
-DECLARE_SOA_INDEX_COLUMN(Collision, collision);    //!
-DECLARE_SOA_INDEX_COLUMN(FwdTrack, fwdtrack);      //! FwdTrack index
-DECLARE_SOA_COLUMN(TrackType, trackType, uint8_t); //! Type of track. See enum ForwardTrackTypeEnum
-DECLARE_SOA_COLUMN(X, x, float);                   //! TrackParFwd parameter x
-DECLARE_SOA_COLUMN(Y, y, float);                   //! TrackParFwd parameter y
-DECLARE_SOA_COLUMN(Z, z, float);                   //! TrackParFwd propagation parameter z
-DECLARE_SOA_COLUMN(Phi, phi, float);               //! TrackParFwd parameter phi; (i.e. pt pointing direction)
-DECLARE_SOA_COLUMN(Tgl, tgl, float);               //! TrackParFwd parameter tan(\lamba); (\lambda = 90 - \theta_{polar})
-DECLARE_SOA_COLUMN(Signed1Pt, signed1Pt, float);   //! TrackParFwd parameter: charged inverse transverse momentum; (q/pt)
-DECLARE_SOA_COLUMN(IsRemovable, isRemovable, int); //! flag to validate the re-aligned track
-DECLARE_SOA_COLUMN(Chi2, chi2, float);             //! Track chi^2
+DECLARE_SOA_COLUMN(IsRemovable, isRemovable, int); //! flag to check the refit status
+}
 
-// FwdTracksCovRealign columns definitions
-DECLARE_SOA_COLUMN(SigmaX, sigmaX, float);        //! Covariance matrix
-DECLARE_SOA_COLUMN(SigmaY, sigmaY, float);        //! Covariance matrix
-DECLARE_SOA_COLUMN(SigmaPhi, sigmaPhi, float);    //! Covariance matrix
-DECLARE_SOA_COLUMN(SigmaTgl, sigmaTgl, float);    //! Covariance matrix
-DECLARE_SOA_COLUMN(Sigma1Pt, sigma1Pt, float);    //! Covariance matrix
-DECLARE_SOA_COLUMN(RhoXY, rhoXY, int8_t);         //! Covariance matrix in compressed form
-DECLARE_SOA_COLUMN(RhoPhiX, rhoPhiX, int8_t);     //! Covariance matrix in compressed form
-DECLARE_SOA_COLUMN(RhoPhiY, rhoPhiY, int8_t);     //! Covariance matrix in compressed form
-DECLARE_SOA_COLUMN(RhoTglX, rhoTglX, int8_t);     //! Covariance matrix in compressed form
-DECLARE_SOA_COLUMN(RhoTglY, rhoTglY, int8_t);     //! Covariance matrix in compressed form
-DECLARE_SOA_COLUMN(RhoTglPhi, rhoTglPhi, int8_t); //! Covariance matrix in compressed form
-DECLARE_SOA_COLUMN(Rho1PtX, rho1PtX, int8_t);     //! Covariance matrix in compressed form
-DECLARE_SOA_COLUMN(Rho1PtY, rho1PtY, int8_t);     //! Covariance matrix in compressed form
-DECLARE_SOA_COLUMN(Rho1PtPhi, rho1PtPhi, int8_t); //! Covariance matrix in compressed form
-DECLARE_SOA_COLUMN(Rho1PtTgl, rho1PtTgl, int8_t); //! Covariance matrix in compressed form
-
-// Dynamic and expression columns
-DECLARE_SOA_DYNAMIC_COLUMN(Sign, sign, //! Sign of the track eletric charge
-                           [](float signed1Pt) -> short { return (signed1Pt > 0) ? 1 : -1; });
-DECLARE_SOA_DYNAMIC_COLUMN(Px, px, //!
-                           [](float pt, float phi) -> float {
-                             return pt * std::cos(phi);
-                           });
-DECLARE_SOA_DYNAMIC_COLUMN(Py, py, //!
-                           [](float pt, float phi) -> float {
-                             return pt * std::sin(phi);
-                           });
-DECLARE_SOA_DYNAMIC_COLUMN(Pz, pz, //!
-                           [](float pt, float tgl) -> float {
-                             return pt * tgl;
-                           });
-
-DECLARE_SOA_EXPRESSION_COLUMN(Eta, eta, float, //!
-                              -1.f * nlog(ntan(o2::constants::math::PIQuarter - 0.5f * natan(aod::fwdtrackrealign::tgl))));
-DECLARE_SOA_EXPRESSION_COLUMN(Pt, pt, float, //!
-                              ifnode(nabs(aod::fwdtrackrealign::signed1Pt) < o2::constants::math::Almost0, o2::constants::math::VeryBig, nabs(1.f / aod::fwdtrackrealign::signed1Pt)));
-DECLARE_SOA_EXPRESSION_COLUMN(P, p, float, //!
-                              ifnode((nabs(aod::fwdtrackrealign::signed1Pt) < o2::constants::math::Almost0) || (nabs(o2::constants::math::PIQuarter - 0.5f * natan(aod::fwdtrackrealign::tgl)) < o2::constants::math::Almost0), o2::constants::math::VeryBig, 0.5f * (ntan(o2::constants::math::PIQuarter - 0.5f * natan(aod::fwdtrackrealign::tgl)) + 1.f / ntan(o2::constants::math::PIQuarter - 0.5f * natan(aod::fwdtrackrealign::tgl))) / nabs(aod::fwdtrackrealign::signed1Pt)));
-DECLARE_SOA_EXPRESSION_COLUMN(CXX, cXX, float, //!
-                              aod::fwdtrackrealign::sigmaX* aod::fwdtrackrealign::sigmaX);
-DECLARE_SOA_EXPRESSION_COLUMN(CXY, cXY, float, //!
-                              (aod::fwdtrackrealign::rhoXY / 128.f) * (aod::fwdtrackrealign::sigmaX * aod::fwdtrackrealign::sigmaY));
-DECLARE_SOA_EXPRESSION_COLUMN(CYY, cYY, float, //!
-                              aod::fwdtrackrealign::sigmaY* aod::fwdtrackrealign::sigmaY);
-DECLARE_SOA_EXPRESSION_COLUMN(CPhiX, cPhiX, float, //!
-                              (aod::fwdtrackrealign::rhoPhiX / 128.f) * (aod::fwdtrackrealign::sigmaPhi * aod::fwdtrackrealign::sigmaX));
-DECLARE_SOA_EXPRESSION_COLUMN(CPhiY, cPhiY, float, //!
-                              (aod::fwdtrackrealign::rhoPhiY / 128.f) * (aod::fwdtrackrealign::sigmaPhi * aod::fwdtrackrealign::sigmaY));
-DECLARE_SOA_EXPRESSION_COLUMN(CPhiPhi, cPhiPhi, float, //!
-                              aod::fwdtrackrealign::sigmaPhi* aod::fwdtrackrealign::sigmaPhi);
-DECLARE_SOA_EXPRESSION_COLUMN(CTglX, cTglX, float, //!
-                              (aod::fwdtrackrealign::rhoTglX / 128.f) * (aod::fwdtrackrealign::sigmaTgl * aod::fwdtrackrealign::sigmaX));
-DECLARE_SOA_EXPRESSION_COLUMN(CTglY, cTglY, float, //!
-                              (aod::fwdtrackrealign::rhoTglY / 128.f) * (aod::fwdtrackrealign::sigmaTgl * aod::fwdtrackrealign::sigmaY));
-DECLARE_SOA_EXPRESSION_COLUMN(CTglPhi, cTglPhi, float, //!
-                              (aod::fwdtrackrealign::rhoTglPhi / 128.f) * (aod::fwdtrackrealign::sigmaTgl * aod::fwdtrackrealign::sigmaPhi));
-DECLARE_SOA_EXPRESSION_COLUMN(CTglTgl, cTglTgl, float, //!
-                              aod::fwdtrackrealign::sigmaTgl* aod::fwdtrackrealign::sigmaTgl);
-DECLARE_SOA_EXPRESSION_COLUMN(C1PtY, c1PtY, float, //!
-                              (aod::fwdtrackrealign::rho1PtY / 128.f) * (aod::fwdtrackrealign::sigma1Pt * aod::fwdtrackrealign::sigmaY));
-DECLARE_SOA_EXPRESSION_COLUMN(C1PtX, c1PtX, float, //!
-                              (aod::fwdtrackrealign::rho1PtX / 128.f) * (aod::fwdtrackrealign::sigma1Pt * aod::fwdtrackrealign::sigmaX));
-DECLARE_SOA_EXPRESSION_COLUMN(C1PtPhi, c1PtPhi, float, //!
-                              (aod::fwdtrackrealign::rho1PtPhi / 128.f) * (aod::fwdtrackrealign::sigma1Pt * aod::fwdtrackrealign::sigmaPhi));
-DECLARE_SOA_EXPRESSION_COLUMN(C1PtTgl, c1PtTgl, float, //!
-                              (aod::fwdtrackrealign::rho1PtTgl / 128.f) * (aod::fwdtrackrealign::sigma1Pt * aod::fwdtrackrealign::sigmaTgl));
-DECLARE_SOA_EXPRESSION_COLUMN(C1Pt21Pt2, c1Pt21Pt2, float, //!
-                              aod::fwdtrackrealign::sigma1Pt* aod::fwdtrackrealign::sigma1Pt);
-} // namespace fwdtrackrealign
-
-// Tracks including MCH and/or MCH (plus optionally MFT)          //!
 DECLARE_SOA_TABLE_FULL(StoredFwdTracksReAlign, "FwdTracksReAlign", "AOD", "FWDTRACKREALIGN",
-                       o2::soa::Index<>, fwdtrackrealign::CollisionId, fwdtrackrealign::FwdTrackId, fwdtrackrealign::TrackType, fwdtrackrealign::X, fwdtrackrealign::Y, fwdtrackrealign::Z, fwdtrackrealign::Phi, fwdtrackrealign::Tgl,
-                       fwdtrackrealign::Signed1Pt,
-                       fwdtrackrealign::Px<fwdtrackrealign::Pt, fwdtrackrealign::Phi>,
-                       fwdtrackrealign::Py<fwdtrackrealign::Pt, fwdtrackrealign::Phi>,
-                       fwdtrackrealign::Pz<fwdtrackrealign::Pt, fwdtrackrealign::Tgl>,
-                       fwdtrackrealign::Sign<fwdtrackrealign::Signed1Pt>,
-                       fwdtrackrealign::Chi2,
-                       fwdtrackrealign::IsRemovable);
-
-DECLARE_SOA_TABLE_FULL(StoredFwdTrksCovReAlign, "FwdCovsReAlign", "AOD", "FWDCOVREALIGN", //!
-                       fwdtrackrealign::SigmaX, fwdtrackrealign::SigmaY, fwdtrackrealign::SigmaPhi, fwdtrackrealign::SigmaTgl, fwdtrackrealign::Sigma1Pt,
-                       fwdtrackrealign::RhoXY, fwdtrackrealign::RhoPhiY, fwdtrackrealign::RhoPhiX, fwdtrackrealign::RhoTglX, fwdtrackrealign::RhoTglY,
-                       fwdtrackrealign::RhoTglPhi, fwdtrackrealign::Rho1PtX, fwdtrackrealign::Rho1PtY, fwdtrackrealign::Rho1PtPhi, fwdtrackrealign::Rho1PtTgl);
+                       o2::soa::Index<>, fwdtrack::CollisionId, fwdtrack::TrackType,
+                       fwdtrack::X, fwdtrack::Y, fwdtrack::Z, fwdtrack::Phi, fwdtrack::Tgl,
+                       fwdtrack::Signed1Pt, fwdtrack::NClusters, fwdtrack::PDca, fwdtrack::RAtAbsorberEnd,
+                       fwdtrackrealign::IsRemovable,
+                       fwdtrack::Px<fwdtrack::Pt, fwdtrack::Phi>,
+                       fwdtrack::Py<fwdtrack::Pt, fwdtrack::Phi>,
+                       fwdtrack::Pz<fwdtrack::Pt, fwdtrack::Tgl>,
+                       fwdtrack::Sign<fwdtrack::Signed1Pt>,
+                       fwdtrack::Chi2, fwdtrack::Chi2MatchMCHMID, fwdtrack::Chi2MatchMCHMFT,
+                       fwdtrack::MatchScoreMCHMFT, fwdtrack::MFTTrackId, fwdtrack::MCHTrackId,
+                       fwdtrack::MCHBitMap, fwdtrack::MIDBitMap, fwdtrack::MIDBoards,
+                       fwdtrack::TrackTime, fwdtrack::TrackTimeRes);
 
 // extended table with expression columns that can be used as arguments of dynamic columns
 DECLARE_SOA_EXTENDED_TABLE_USER(FwdTracksReAlign, StoredFwdTracksReAlign, "FWDTRKREALIGNEXT", //!
-                                fwdtrackrealign::Pt,
-                                fwdtrackrealign::Eta,
-                                fwdtrackrealign::P); // the table name has here to be the one with EXT which is not nice and under study
+                                fwdtrack::Pt,
+                                fwdtrack::Eta,
+                                fwdtrack::P);
+
+DECLARE_SOA_TABLE_FULL(StoredFwdTrksCovReAlign, "FwdCovsReAlign", "AOD", "FWDCOVREALIGN",
+                       fwdtrack::SigmaX, fwdtrack::SigmaY, fwdtrack::SigmaPhi, fwdtrack::SigmaTgl, fwdtrack::Sigma1Pt,
+                       fwdtrack::RhoXY, fwdtrack::RhoPhiY, fwdtrack::RhoPhiX, fwdtrack::RhoTglX, fwdtrack::RhoTglY,
+                       fwdtrack::RhoTglPhi, fwdtrack::Rho1PtX, fwdtrack::Rho1PtY, fwdtrack::Rho1PtPhi, fwdtrack::Rho1PtTgl);
 
 // extended table with expression columns that can be used as arguments of dynamic columns
 DECLARE_SOA_EXTENDED_TABLE_USER(FwdTrksCovReAlign, StoredFwdTrksCovReAlign, "FWDCOVREALIGNEXT", //!
-                                fwdtrackrealign::CXX,
-                                fwdtrackrealign::CXY,
-                                fwdtrackrealign::CYY,
-                                fwdtrackrealign::CPhiX,
-                                fwdtrackrealign::CPhiY,
-                                fwdtrackrealign::CPhiPhi,
-                                fwdtrackrealign::CTglX,
-                                fwdtrackrealign::CTglY,
-                                fwdtrackrealign::CTglPhi,
-                                fwdtrackrealign::CTglTgl,
-                                fwdtrackrealign::C1PtX,
-                                fwdtrackrealign::C1PtY,
-                                fwdtrackrealign::C1PtPhi,
-                                fwdtrackrealign::C1PtTgl,
-                                fwdtrackrealign::C1Pt21Pt2); // the table name has here to be the one with EXT which is not nice and under study
+                                fwdtrack::CXX,
+                                fwdtrack::CXY,
+                                fwdtrack::CYY,
+                                fwdtrack::CPhiX,
+                                fwdtrack::CPhiY,
+                                fwdtrack::CPhiPhi,
+                                fwdtrack::CTglX,
+                                fwdtrack::CTglY,
+                                fwdtrack::CTglPhi,
+                                fwdtrack::CTglTgl,
+                                fwdtrack::C1PtX,
+                                fwdtrack::C1PtY,
+                                fwdtrack::C1PtPhi,
+                                fwdtrack::C1PtTgl,
+                                fwdtrack::C1Pt21Pt2);
 
 using FwdTrackRealign = FwdTracksReAlign::iterator;
 using FwdTrkCovRealign = FwdTrksCovReAlign::iterator;

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -876,8 +876,8 @@ class VarManager : public TObject
     kToRabs
   };
 
-  static TString fgVariableNames[kNVars]; // variable names
-  static TString fgVariableUnits[kNVars]; // variable units
+  static TString fgVariableNames[kNVars];      // variable names
+  static TString fgVariableUnits[kNVars];      // variable units
   static std::map<TString, int> fgVarNamesMap; // key: variables short name, value: order in the Variables enum
   static void SetDefaultVarNames();
 
@@ -2180,11 +2180,6 @@ void VarManager::FillTrack(T const& track, float* values)
       }
     }
 
-    if constexpr ((fillMap & MuonRealign) > 0) {
-      values[kMuonChi2] = track.chi2();
-      values[kMuonTrackType] = track.trackType();
-    }
-
     if (fgUsedVars[kM11REFoverMpsingle]) {
       float m = o2::constants::physics::MassMuon;
       ROOT::Math::PtEtaPhiMVector v(track.pt(), track.eta(), track.phi(), m);
@@ -2518,7 +2513,7 @@ void VarManager::FillTrack(T const& track, float* values)
   }
 
   // Quantities based on the muon extra table
-  if constexpr ((fillMap & ReducedMuonExtra) > 0 || (fillMap & Muon) > 0) {
+  if constexpr ((fillMap & ReducedMuonExtra) > 0 || (fillMap & Muon) > 0 || (fillMap & MuonRealign) > 0) {
     values[kMuonNClusters] = track.nClusters();
     values[kMuonPDca] = track.pDca();
     values[kMCHBitMap] = track.mchBitMap();

--- a/PWGDQ/TableProducer/tableMaker.cxx
+++ b/PWGDQ/TableProducer/tableMaker.cxx
@@ -119,7 +119,7 @@ using MyMuons = soa::Join<aod::FwdTracks, aod::FwdTracksDCA>;
 using MyMuonsWithCov = soa::Join<aod::FwdTracks, aod::FwdTracksCov, aod::FwdTracksDCA>;
 using MyMuonsColl = soa::Join<aod::FwdTracks, aod::FwdTracksDCA, aod::FwdTrkCompColls>;
 using MyMuonsCollWithCov = soa::Join<aod::FwdTracks, aod::FwdTracksCov, aod::FwdTracksDCA, aod::FwdTrkCompColls>;
-using MyMuonsRealignWithCov = soa::Join<aod::FwdTracksReAlign, aod::FwdTrksCovReAlign>;
+using MyMuonsRealignCollWithCov = soa::Join<aod::FwdTracksReAlign, aod::FwdTrksCovReAlign, aod::FwdTracksDCA, aod::FwdTrkCompColls>;
 using ExtBCs = soa::Join<aod::BCs, aod::Timestamps, aod::MatchedBCCollisionsSparseMulti>;
 
 constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision;
@@ -139,7 +139,7 @@ constexpr static uint32_t gkTrackFillMapForElectronMuon = VarManager::ObjTypes::
 constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::Muon;
 constexpr static uint32_t gkMuonFillMapWithCov = VarManager::ObjTypes::Muon | VarManager::ObjTypes::MuonCov;
 constexpr static uint32_t gkMuonFillMapWithCovAmbi = VarManager::ObjTypes::Muon | VarManager::ObjTypes::MuonCov | VarManager::ObjTypes::AmbiMuon;
-constexpr static uint32_t gkMuonRealignFillMapWithCov = VarManager::ObjTypes::MuonRealign | VarManager::ObjTypes::MuonCovRealign;
+constexpr static uint32_t gkMuonRealignFillMapWithCovAmbi = VarManager::ObjTypes::MuonRealign | VarManager::ObjTypes::MuonCovRealign | VarManager::ObjTypes::AmbiMuon;
 constexpr static uint32_t gkTrackFillMapWithAmbi = VarManager::ObjTypes::Track | VarManager::ObjTypes::AmbiTrack;
 constexpr static uint32_t gkMFTFillMap = VarManager::ObjTypes::TrackMFT;
 
@@ -227,10 +227,8 @@ struct TableMaker {
 
   Preslice<MyBarrelTracks> perCollisionTracks = aod::track::collisionId;
   Preslice<MyMuons> perCollisionMuons = aod::fwdtrack::collisionId;
-  PresliceUnsorted<MyMuonsRealignWithCov> perCollisionMuonsRealign = aod::fwdtrackrealign::collisionId;
   Preslice<aod::TrackAssoc> trackIndicesPerCollision = aod::track_association::collisionId;
   Preslice<aod::FwdTrackAssoc> fwdtrackIndicesPerCollision = aod::track_association::collisionId;
-  PresliceUnsorted<MyMuonsRealignWithCov> fwdtrackRealignPerMuon = aod::fwdtrackrealign::fwdtrackId;
   bool fDoDetailedQA = false; // Bool to set detailed QA true, if QA is set true
   int fCurrentRun;            // needed to detect if the run changed and trigger update of calibrations etc.
 
@@ -845,8 +843,8 @@ struct TableMaker {
   } // end fullSkimming()
 
   // Templated function instantianed for all of the process functions
-  template <uint32_t TEventFillMap, uint32_t TTrackFillMap, uint32_t TMuonFillMap, uint32_t TMuonRealignFillMap, typename TEvent, typename TTracks, typename TMuons, typename TMuonsRealign, typename AssocTracks, typename AssocMuons>
-  void fullSkimmingIndices(TEvent const& collision, aod::BCsWithTimestamps const&, TTracks const& tracksBarrel, TMuons const& tracksMuon, TMuonsRealign const& tracksMuonRealign, AssocTracks const& trackIndices, AssocMuons const& fwdtrackIndices)
+  template <uint32_t TEventFillMap, uint32_t TTrackFillMap, uint32_t TMuonFillMap, typename TEvent, typename TTracks, typename TMuons, typename AssocTracks, typename AssocMuons>
+  void fullSkimmingIndices(TEvent const& collision, aod::BCsWithTimestamps const&, TTracks const& tracksBarrel, TMuons const& tracksMuon, AssocTracks const& trackIndices, AssocMuons const& fwdtrackIndices)
   {
     auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
     if (fCurrentRun != bc.runNumber()) {
@@ -1106,7 +1104,7 @@ struct TableMaker {
       muonBasic.reserve(tracksMuon.size());
       muonExtra.reserve(tracksMuon.size());
       muonInfo.reserve(tracksMuon.size());
-      if constexpr (static_cast<bool>((TMuonFillMap & VarManager::ObjTypes::MuonCov) || (TMuonRealignFillMap & VarManager::ObjTypes::MuonCovRealign))) {
+      if constexpr (static_cast<bool>((TMuonFillMap & VarManager::ObjTypes::MuonCov) || (TMuonFillMap & VarManager::ObjTypes::MuonCovRealign))) {
         muonCov.reserve(tracksMuon.size());
       }
       // loop over muons
@@ -1118,28 +1116,10 @@ struct TableMaker {
       std::map<int, int> newMatchIndex;
 
       for (const auto& muonId : fwdtrackIndices) { // start loop over tracks
-        auto muon = muonId.template fwdtrack_as<TMuons>();
+        auto muon = tracksMuon.rawIteratorAt(muonId.fwdtrackId());
         trackFilteringTag = static_cast<uint64_t>(0);
-        int realignRemoveFlag = 0;
-        if constexpr (static_cast<bool>(TMuonRealignFillMap)) {
-          // Update muon information using realigned tracks
-          if (static_cast<int>(muon.trackType()) > 2) {
-            // Update only MCH or MCH-MID tracks with realigned information
-            auto muonRealignSelected = tracksMuonRealign.sliceBy(fwdtrackRealignPerMuon, muonId.fwdtrackId());
-            if (muonRealignSelected.size() == 1) {
-              for (const auto& muonRealign : muonRealignSelected) {
-                VarManager::FillTrack<TMuonRealignFillMap>(muonRealign);
-                realignRemoveFlag = muonRealign.isRemovable();
-              }
-            } else {
-              LOGF(fatal, "Inconsistent size of realigned muon track candidates.");
-            }
-          } else {
-            VarManager::FillTrack<TMuonFillMap>(muon);
-          }
-        } else {
-          VarManager::FillTrack<TMuonFillMap>(muon);
-        }
+
+        VarManager::FillTrack<TMuonFillMap>(muon);
 
         if (muon.index() > idxPrev + 1) { // checks if some muons are filtered even before the skimming function
           nDel += muon.index() - (idxPrev + 1);
@@ -1153,7 +1133,7 @@ struct TableMaker {
             trackTempFilterMap |= (uint8_t(1) << i);
         }
 
-        if (!trackTempFilterMap || realignRemoveFlag) { // does not pass the cuts
+        if (!trackTempFilterMap) { // does not pass the cuts
           nDel++;
         } else { // it passes the cuts and will be saved in the tables
           newEntryNb[muon.index()] = muon.index() - nDel;
@@ -1162,7 +1142,7 @@ struct TableMaker {
 
       // now let's save the muons with the correct indices and matches
       for (const auto& muonId : fwdtrackIndices) { // start loop over tracks
-        auto muon = muonId.template fwdtrack_as<TMuons>();
+        auto muon = tracksMuon.rawIteratorAt(muonId.fwdtrackId());
         if constexpr ((TMuonFillMap & VarManager::ObjTypes::AmbiMuon) > 0) {
           if (fIsAmbiguous) {
             isAmbiguous = (muon.compatibleCollIds().size() != 1);
@@ -1171,55 +1151,19 @@ struct TableMaker {
         trackFilteringTag = static_cast<uint64_t>(0);
         trackTempFilterMap = uint8_t(0);
 
-        if constexpr (static_cast<bool>(TMuonRealignFillMap)) {
-          // Update muon information using realigned tracks
-          if (static_cast<int>(muon.trackType()) > 2) {
-            // Update only MCH or MCH-MID tracks with realigned information
-            auto muonRealignSelected = tracksMuonRealign.sliceBy(fwdtrackRealignPerMuon, muonId.fwdtrackId());
-            int realignRemoveFlag = 0;
-            if (muonRealignSelected.size() == 1) {
-              for (const auto& muonRealign : muonRealignSelected) {
-                LOGF(debug, "Muon original  - collisionId:%d x:%g y:%g z:%g phi:%g tgl:%g signed1pt:%g pt:%g p:%g eta:%g chi2:%g", muon.collisionId(), muon.x(), muon.y(), muon.z(), muon.phi(), muon.tgl(), muon.signed1Pt(), muon.pt(), muon.p(), muon.eta(), muon.chi2());
-                LOGF(debug, "Muon realigned - collisionId:%d x:%g y:%g z:%g phi:%g tgl:%g signed1pt:%g pt:%g p:%g eta:%g chi2:%g", muonRealign.collisionId(), muonRealign.x(), muonRealign.y(), muonRealign.z(), muonRealign.phi(), muonRealign.tgl(), muonRealign.signed1Pt(), muonRealign.pt(), muonRealign.p(), muonRealign.eta(), muonRealign.chi2());
-                VarManager::FillTrack<TMuonRealignFillMap>(muonRealign);
-                realignRemoveFlag = muonRealign.isRemovable();
-
-                // recalculte pDca for global muon tracks
-                VarManager::FillTrackCollision<TMuonRealignFillMap>(muonRealign, collision);
-
-                if (fPropMuon) {
-                  VarManager::FillPropagateMuon<TMuonRealignFillMap>(muonRealign, collision);
-                }
-              }
-
-              if (realignRemoveFlag) {
-                continue;
-              }
-
-            } else {
-              LOGF(fatal, "Inconsistent size of realigned muon track candidates.");
-            }
-          } else {
-            // For global tracks, their matched muon tracks should be updated already
-
-            VarManager::FillTrack<TMuonFillMap>(muon);
-
-            // recalculte pDca for global muon tracks
-            VarManager::FillTrackCollision<TMuonFillMap>(muon, collision);
-
-            if (fPropMuon) {
-              VarManager::FillPropagateMuon<TMuonFillMap>(muon, collision);
-            }
+        if constexpr (static_cast<bool>(TMuonFillMap & VarManager::ObjTypes::MuonRealign)) {
+          if (static_cast<bool>(muon.isRemovable())) {
+            continue;
           }
-        } else {
-          VarManager::FillTrack<TMuonFillMap>(muon);
+        }
 
-          // recalculte pDca for global muon tracks
-          VarManager::FillTrackCollision<TMuonFillMap>(muon, collision);
+        VarManager::FillTrack<TMuonFillMap>(muon);
 
-          if (fPropMuon) {
-            VarManager::FillPropagateMuon<TMuonFillMap>(muon, collision);
-          }
+        // recalculte pDca for global muon tracks
+        VarManager::FillTrackCollision<TMuonFillMap>(muon, collision);
+
+        if (fPropMuon) {
+          VarManager::FillPropagateMuon<TMuonFillMap>(muon, collision);
         }
 
         if (fDoDetailedQA) {
@@ -1274,7 +1218,7 @@ struct TableMaker {
 
         muonBasic(event.lastIndex(), newMatchIndex.find(muon.index())->second, -1, trackFilteringTag, VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], muon.sign(), isAmbiguous);
         muonInfo(muon.collisionId(), collision.posX(), collision.posY(), collision.posZ());
-        if constexpr (static_cast<bool>((TMuonFillMap & VarManager::ObjTypes::MuonCov))) {
+        if constexpr (static_cast<bool>((TMuonFillMap & VarManager::ObjTypes::MuonCov) || (TMuonFillMap & VarManager::ObjTypes::MuonCovRealign))) {
 
           if (fPropMuon) {
             muonExtra(muon.nClusters(), VarManager::fgValues[VarManager::kMuonPDca], VarManager::fgValues[VarManager::kMuonRAtAbsorberEnd],
@@ -1684,17 +1628,16 @@ struct TableMaker {
   {
     for (auto& collision : collisions) {
       auto muonIdsThisCollision = fwdtrackIndices.sliceBy(fwdtrackIndicesPerCollision, collision.globalIndex());
-      fullSkimmingIndices<gkEventFillMap, 0u, gkMuonFillMapWithCovAmbi, 0u>(collision, bcs, nullptr, tracksMuon, nullptr, nullptr, muonIdsThisCollision);
+      fullSkimmingIndices<gkEventFillMap, 0u, gkMuonFillMapWithCovAmbi>(collision, bcs, nullptr, tracksMuon, nullptr, muonIdsThisCollision);
     }
   }
 
   void processAssociatedRealignedMuonOnlyWithCov(MyEvents const& collisions, aod::BCsWithTimestamps const& bcs,
-                                                 soa::Filtered<MyMuonsCollWithCov> const& tracksMuon, MyMuonsRealignWithCov const& tracksMuonRealign, aod::AmbiguousFwdTracks const&, aod::FwdTrackAssoc const& fwdtrackIndices)
+                                                 soa::Filtered<MyMuonsRealignCollWithCov> const& tracksMuon, aod::AmbiguousFwdTracks const&, aod::FwdTrackAssoc const& fwdtrackIndices)
   {
     for (auto& collision : collisions) {
       auto muonIdsThisCollision = fwdtrackIndices.sliceBy(fwdtrackIndicesPerCollision, collision.globalIndex());
-      auto muonsRealignThisCollision = tracksMuonRealign.sliceBy(perCollisionMuonsRealign, collision.globalIndex());
-      fullSkimmingIndices<gkEventFillMap, 0u, gkMuonFillMapWithCovAmbi, gkMuonRealignFillMapWithCov>(collision, bcs, nullptr, tracksMuon, muonsRealignThisCollision, nullptr, muonIdsThisCollision);
+      fullSkimmingIndices<gkEventFillMap, 0u, gkMuonRealignFillMapWithCovAmbi>(collision, bcs, nullptr, tracksMuon, nullptr, muonIdsThisCollision);
     }
   }
 
@@ -1703,7 +1646,7 @@ struct TableMaker {
   {
     for (auto& collision : collisions) {
       auto muonIdsThisCollision = fwdtrackIndices.sliceBy(fwdtrackIndicesPerCollision, collision.globalIndex());
-      fullSkimmingIndices<gkEventFillMapWithCentAndMults, 0u, gkMuonFillMapWithCovAmbi, 0u>(collision, bcs, nullptr, tracksMuon, nullptr, nullptr, muonIdsThisCollision);
+      fullSkimmingIndices<gkEventFillMapWithCentAndMults, 0u, gkMuonFillMapWithCovAmbi>(collision, bcs, nullptr, tracksMuon, nullptr, muonIdsThisCollision);
     }
   }
 
@@ -1712,7 +1655,7 @@ struct TableMaker {
   {
     for (auto& collision : collisions) {
       auto muonIdsThisCollision = fwdtrackIndices.sliceBy(fwdtrackIndicesPerCollision, collision.globalIndex());
-      fullSkimmingIndices<gkEventFillMapWithMult, 0u, gkMuonFillMapWithCovAmbi, 0u>(collision, bcs, nullptr, tracksMuon, nullptr, nullptr, muonIdsThisCollision);
+      fullSkimmingIndices<gkEventFillMapWithMult, 0u, gkMuonFillMapWithCovAmbi>(collision, bcs, nullptr, tracksMuon, nullptr, muonIdsThisCollision);
     }
   }
 

--- a/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
+++ b/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
@@ -1492,7 +1492,7 @@ struct TableMaker {
                                   TrackAssoc const& trackAssocs)
   {
     computeOccupancyEstimators(collisions, tracksPosWithCovNoTOF, tracksNegWithCovNoTOF, presliceWithCovNoTOF, bcs);
-    fullSkimming<gkEventFillMapWithCentAndMults, gkTrackFillMapNoTOF, 0u, 0u, 0u>(collisions, bcs, nullptr, tracksBarrel, nullptr, nullptr, nullptr, trackAssocs, nullptr, nullptr);
+    fullSkimming<gkEventFillMapWithCentAndMults, gkTrackFillMapNoTOF, 0u, 0u>(collisions, bcs, nullptr, tracksBarrel, nullptr, nullptr, trackAssocs, nullptr, nullptr);
   }
 
   // produce the barrel-only DQ skimmed data model typically for UPC Pb-Pb (no centrality), subscribe to the DQ rapidity gap event filter (filter-PbPb)

--- a/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
+++ b/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
@@ -109,7 +109,7 @@ using MyEventsWithCentAndMults = soa::Join<aod::Collisions, aod::EvSels, aod::Ce
 using MyEventsWithMultsExtra = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::MultsExtra>;
 using MyMuons = soa::Join<aod::FwdTracks, aod::FwdTracksDCA>;
 using MyMuonsWithCov = soa::Join<aod::FwdTracks, aod::FwdTracksCov, aod::FwdTracksDCA>;
-using MyMuonsRealignWithCov = soa::Join<aod::FwdTracksReAlign, aod::FwdTrksCovReAlign>;
+using MyMuonsRealignWithCov = soa::Join<aod::FwdTracksReAlign, aod::FwdTrksCovReAlign, aod::FwdTracksDCA>;
 using MyMuonsColl = soa::Join<aod::FwdTracks, aod::FwdTracksDCA, aod::FwdTrkCompColls>;
 using MyMuonsCollWithCov = soa::Join<aod::FwdTracks, aod::FwdTracksCov, aod::FwdTracksDCA, aod::FwdTrkCompColls>;
 using MyBCs = soa::Join<aod::BCs, aod::Timestamps, aod::Run3MatchedToBCSparse>;
@@ -294,8 +294,6 @@ struct TableMaker {
   Preslice<aod::TrackAssoc> trackIndicesPerCollision = aod::track_association::collisionId;
   Preslice<aod::FwdTrackAssoc> fwdtrackIndicesPerCollision = aod::track_association::collisionId;
   Preslice<aod::MFTTrackAssoc> mfttrackIndicesPerCollision = aod::track_association::collisionId;
-  PresliceUnsorted<MyMuonsRealignWithCov> perCollisionMuonsRealign = aod::fwdtrackrealign::collisionId;
-  PresliceUnsorted<MyMuonsRealignWithCov> fwdtrackRealignPerMuon = aod::fwdtrackrealign::fwdtrackId;
 
   Preslice<MyBarrelTracksWithV0Bits> preslice = aod::track::collisionId;
   Partition<MyBarrelTracksWithV0Bits> tracksPos = (((aod::track::flags & static_cast<uint32_t>(o2::aod::track::PVContributor)) == static_cast<uint32_t>(o2::aod::track::PVContributor)) && (aod::track::tgl > static_cast<float>(0.05)));
@@ -1123,8 +1121,8 @@ struct TableMaker {
     }
   }
 
-  template <uint32_t TMuonFillMap, uint32_t TMuonRealignFillMap, uint32_t TMFTFillMap, typename TEvent, typename TBCs, typename TMuons, typename TMuonsRealign, typename TMFTTracks>
-  void skimMuons(TEvent const& collision, TBCs const& /*bcs*/, TMuons const& muons, TMuonsRealign const& muonsRealign, FwdTrackAssoc const& muonAssocs, TMFTTracks const& /*mftTracks*/)
+  template <uint32_t TMuonFillMap, uint32_t TMFTFillMap, typename TEvent, typename TBCs, typename TMuons, typename TMFTTracks>
+  void skimMuons(TEvent const& collision, TBCs const& /*bcs*/, TMuons const& muons, FwdTrackAssoc const& muonAssocs, TMFTTracks const& /*mftTracks*/)
   {
     // Skim the fwd-tracks (muons)
     // Loop over the collision-track associations, recompute track properties depending on the collision assigned, and apply track cuts for selection
@@ -1141,10 +1139,18 @@ struct TableMaker {
     uint32_t counter = 0;
     for (const auto& assoc : muonAssocs) {
       // get the muon
-      auto muon = assoc.template fwdtrack_as<TMuons>();
+      auto muon = muons.rawIteratorAt(assoc.fwdtrackId());
 
       trackFilteringTag = static_cast<uint8_t>(0);
       trackTempFilterMap = static_cast<uint8_t>(0);
+
+      if constexpr (static_cast<bool>(TMuonFillMap & VarManager::ObjTypes::MuonRealign)) {
+        // Check refit flag in case of realigned muons
+        if (static_cast<bool>(muon.isRemovable())) {
+          continue;
+        }
+      }
+
       VarManager::FillTrack<TMuonFillMap>(muon);
       // NOTE: Muons are propagated to the current associated collisions.
       //       So if a muon is associated to multiple collisions, depending on the selections,
@@ -1164,35 +1170,7 @@ struct TableMaker {
         auto mfttrack = muon.template matchMFTTrack_as<MFTTracks>();
         VarManager::FillGlobalMuonRefit<TMuonFillMap>(muontrack, mfttrack, collision);
       } else {
-        if constexpr ((static_cast<bool>(TMuonRealignFillMap))) {
-          if (static_cast<int>(muon.trackType()) > 2) {
-            // refill kinematic info and recalculate propagation in case of using realigned muons
-            auto muonRealignSelected = muonsRealign.sliceBy(fwdtrackRealignPerMuon, assoc.fwdtrackId());
-            int realignRemoveFlag = 0;
-            if (muonRealignSelected.size() == 1) {
-              for (const auto& muonRealign : muonRealignSelected) {
-                // refill muon information with realigned tracks
-                VarManager::FillTrack<TMuonRealignFillMap>(muonRealign);
-                realignRemoveFlag = muonRealign.isRemovable();
-
-                if (fConfigVariousOptions.fPropMuon) {
-                  VarManager::FillPropagateMuon<TMuonRealignFillMap>(muonRealign, collision);
-                }
-
-                VarManager::FillTrackCollision<TMuonRealignFillMap>(muonRealign, collision);
-              }
-
-              if (realignRemoveFlag) {
-                continue;
-              }
-
-            } else {
-              LOGF(fatal, "Inconsistent size of realigned muon track candidates.");
-            }
-          }
-        } else {
-          VarManager::FillTrackCollision<TMuonFillMap>(muon, collision);
-        }
+        VarManager::FillTrackCollision<TMuonFillMap>(muon, collision);
       }
 
       if (fDoDetailedQA) {
@@ -1258,6 +1236,14 @@ struct TableMaker {
           mftIdx = fMftIndexMap[muon.matchMFTTrackId()];
         }
       }
+
+      if constexpr (static_cast<bool>(TMuonFillMap & VarManager::ObjTypes::MuonRealign)) {
+        // Check refit flag in case of realigned muons
+        if (static_cast<bool>(muon.isRemovable())) {
+          continue;
+        }
+      }
+
       VarManager::FillTrack<TMuonFillMap>(muon);
       if (fConfigVariousOptions.fPropMuon) {
         VarManager::FillPropagateMuon<TMuonFillMap>(muon, collision);
@@ -1271,35 +1257,7 @@ struct TableMaker {
         VarManager::FillTrackCollision<TMuonFillMap>(muontrack, collision);
         VarManager::FillGlobalMuonRefit<TMuonFillMap>(muontrack, mfttrack, collision);
       } else {
-        if constexpr ((static_cast<bool>(TMuonRealignFillMap))) {
-          if (static_cast<int>(muon.trackType()) > 2) {
-            // refill kinematic info and recalculate propagation in case of using realigned muons
-            auto muonRealignSelected = muonsRealign.sliceBy(fwdtrackRealignPerMuon, muon.globalIndex());
-            int realignRemoveFlag = 0;
-            if (muonRealignSelected.size() == 1) {
-              for (const auto& muonRealign : muonRealignSelected) {
-                // refill muon information with realigned tracks
-                VarManager::FillTrack<TMuonRealignFillMap>(muonRealign);
-                realignRemoveFlag = muonRealign.isRemovable();
-
-                if (fConfigVariousOptions.fPropMuon) {
-                  VarManager::FillPropagateMuon<TMuonRealignFillMap>(muonRealign, collision);
-                }
-
-                VarManager::FillTrackCollision<TMuonRealignFillMap>(muonRealign, collision);
-              }
-
-              if (realignRemoveFlag) {
-                continue;
-              }
-
-            } else {
-              LOGF(fatal, "Inconsistent size of realigned muon track candidates.");
-            }
-          }
-        } else {
-          VarManager::FillTrackCollision<TMuonFillMap>(muon, collision);
-        }
+        VarManager::FillTrackCollision<TMuonFillMap>(muon, collision);
       }
       muonBasic(reducedEventIdx, mchIdx, mftIdx, fFwdTrackFilterMap[muon.globalIndex()], VarManager::fgValues[VarManager::kPt], VarManager::fgValues[VarManager::kEta], VarManager::fgValues[VarManager::kPhi], muon.sign(), 0);
       muonExtra(globalClusters, VarManager::fgValues[VarManager::kMuonPDca], VarManager::fgValues[VarManager::kMuonRAtAbsorberEnd],
@@ -1309,7 +1267,7 @@ struct TableMaker {
                 muon.midBoards(), muon.trackType(), VarManager::fgValues[VarManager::kMuonDCAx], VarManager::fgValues[VarManager::kMuonDCAy],
                 muon.trackTime(), muon.trackTimeRes());
       muonInfo(muon.collisionId(), collision.posX(), collision.posY(), collision.posZ());
-      if constexpr (static_cast<bool>(TMuonFillMap & VarManager::ObjTypes::MuonCov) || static_cast<bool>(TMuonRealignFillMap & VarManager::ObjTypes::MuonCovRealign)) {
+      if constexpr (static_cast<bool>(TMuonFillMap & VarManager::ObjTypes::MuonCov) || static_cast<bool>(TMuonFillMap & VarManager::ObjTypes::MuonCovRealign)) {
         muonCov(VarManager::fgValues[VarManager::kX], VarManager::fgValues[VarManager::kY], VarManager::fgValues[VarManager::kZ], VarManager::fgValues[VarManager::kPhi], VarManager::fgValues[VarManager::kTgl], muon.sign() / VarManager::fgValues[VarManager::kPt],
                 VarManager::fgValues[VarManager::kMuonCXX], VarManager::fgValues[VarManager::kMuonCXY], VarManager::fgValues[VarManager::kMuonCYY], VarManager::fgValues[VarManager::kMuonCPhiX], VarManager::fgValues[VarManager::kMuonCPhiY], VarManager::fgValues[VarManager::kMuonCPhiPhi],
                 VarManager::fgValues[VarManager::kMuonCTglX], VarManager::fgValues[VarManager::kMuonCTglY], VarManager::fgValues[VarManager::kMuonCTglPhi], VarManager::fgValues[VarManager::kMuonCTglTgl], VarManager::fgValues[VarManager::kMuonC1Pt2X], VarManager::fgValues[VarManager::kMuonC1Pt2Y],
@@ -1319,11 +1277,11 @@ struct TableMaker {
   } // end skimMuons
 
   // Produce standard barrel + muon tables with event filter (typically for pp and p-Pb) ------------------------------------------------------
-  template <uint32_t TEventFillMap, uint32_t TTrackFillMap, uint32_t TMuonFillMap, uint32_t TMuonRealignFillMap, uint32_t TMFTFillMap,
-            typename TEvents, typename TBCs, typename TZdcs, typename TTracks, typename TMuons, typename TMuonsRealign, typename TMFTTracks,
+  template <uint32_t TEventFillMap, uint32_t TTrackFillMap, uint32_t TMuonFillMap, uint32_t TMFTFillMap,
+            typename TEvents, typename TBCs, typename TZdcs, typename TTracks, typename TMuons, typename TMFTTracks,
             typename TTrackAssoc, typename TFwdTrackAssoc, typename TMFTTrackAssoc>
   void fullSkimming(TEvents const& collisions, TBCs const& bcs, TZdcs const& zdcs,
-                    TTracks const& tracksBarrel, TMuons const& muons, TMuonsRealign const& muonsRealign, TMFTTracks const& mftTracks,
+                    TTracks const& tracksBarrel, TMuons const& muons, TMFTTracks const& mftTracks,
                     TTrackAssoc const& trackAssocs, TFwdTrackAssoc const& fwdTrackAssocs, TMFTTrackAssoc const& mftAssocs)
   {
 
@@ -1418,16 +1376,10 @@ struct TableMaker {
       if constexpr (static_cast<bool>(TMuonFillMap)) {
         if constexpr (static_cast<bool>(TMFTFillMap)) {
           auto groupedMuonIndices = fwdTrackAssocs.sliceBy(fwdtrackIndicesPerCollision, origIdx);
-          skimMuons<TMuonFillMap, 0u, TMFTFillMap>(collision, bcs, muons, nullptr, groupedMuonIndices, mftTracks);
+          skimMuons<TMuonFillMap, TMFTFillMap>(collision, bcs, muons, groupedMuonIndices, mftTracks);
         } else {
-          if constexpr (static_cast<bool>(TMuonRealignFillMap)) {
-            auto groupedMuonIndices = fwdTrackAssocs.sliceBy(fwdtrackIndicesPerCollision, origIdx);
-            auto muonsRealignThisCollision = muonsRealign.sliceBy(perCollisionMuonsRealign, origIdx);
-            skimMuons<TMuonFillMap, TMuonRealignFillMap, 0u>(collision, bcs, muons, muonsRealignThisCollision, groupedMuonIndices, nullptr);
-          } else {
-            auto groupedMuonIndices = fwdTrackAssocs.sliceBy(fwdtrackIndicesPerCollision, origIdx);
-            skimMuons<TMuonFillMap, 0u, 0u>(collision, bcs, muons, nullptr, groupedMuonIndices, nullptr);
-          }
+          auto groupedMuonIndices = fwdTrackAssocs.sliceBy(fwdtrackIndicesPerCollision, origIdx);
+          skimMuons<TMuonFillMap, 0u>(collision, bcs, muons, groupedMuonIndices, nullptr);
         }
       }
     } // end loop over skimmed collisions
@@ -1444,7 +1396,7 @@ struct TableMaker {
                            TrackAssoc const& trackAssocs, FwdTrackAssoc const& fwdTrackAssocs,
                            MFTTrackAssoc const& mftAssocs)
   {
-    fullSkimming<gkEventFillMapWithMultsAndEventFilter, gkTrackFillMapWithCov, gkMuonFillMapWithCov, 0u, gkMFTFillMap>(collisions, bcs, nullptr, tracksBarrel, muons, nullptr, mftTracks, trackAssocs, fwdTrackAssocs, mftAssocs);
+    fullSkimming<gkEventFillMapWithMultsAndEventFilter, gkTrackFillMapWithCov, gkMuonFillMapWithCov, gkMFTFillMap>(collisions, bcs, nullptr, tracksBarrel, muons, mftTracks, trackAssocs, fwdTrackAssocs, mftAssocs);
   }
 
   // produce the barrel-only DQ skimmed data model typically for pp/p-Pb or UPC Pb-Pb (no centrality), subscribe to the DQ event filter (filter-pp or filter-PbPb)
@@ -1452,14 +1404,14 @@ struct TableMaker {
                                      MyBarrelTracksWithCov const& tracksBarrel,
                                      TrackAssoc const& trackAssocs)
   {
-    fullSkimming<gkEventFillMapWithMultsEventFilterZdc, gkTrackFillMapWithCov, 0u, 0u, 0u>(collisions, bcs, zdcs, tracksBarrel, nullptr, nullptr, nullptr, trackAssocs, nullptr, nullptr);
+    fullSkimming<gkEventFillMapWithMultsEventFilterZdc, gkTrackFillMapWithCov, 0u, 0u>(collisions, bcs, zdcs, tracksBarrel, nullptr, nullptr, trackAssocs, nullptr, nullptr);
   }
 
   // produce the muon-only DQ skimmed data model typically for pp/p-Pb or UPC Pb-Pb (no centrality), subscribe to the DQ event filter (filter-pp or filter-PbPb)
   void processPPWithFilterMuonOnly(MyEventsWithMultsAndFilter const& collisions, BCsWithTimestamps const& bcs,
                                    MyMuonsWithCov const& muons, FwdTrackAssoc const& fwdTrackAssocs)
   {
-    fullSkimming<gkEventFillMapWithMultsAndEventFilter, 0u, gkMuonFillMapWithCov, 0u, 0u>(collisions, bcs, nullptr, nullptr, muons, nullptr, nullptr, nullptr, fwdTrackAssocs, nullptr);
+    fullSkimming<gkEventFillMapWithMultsAndEventFilter, 0u, gkMuonFillMapWithCov, 0u>(collisions, bcs, nullptr, nullptr, muons, nullptr, nullptr, fwdTrackAssocs, nullptr);
   }
 
   // produce the muon+mft DQ skimmed data model typically for pp/p-Pb or UPC Pb-Pb (no centrality), subscribe to the DQ event filter (filter-pp or filter-PbPb)
@@ -1467,7 +1419,7 @@ struct TableMaker {
                                   MyMuonsWithCov const& muons, MFTTracks const& mftTracks,
                                   FwdTrackAssoc const& fwdTrackAssocs, MFTTrackAssoc const& mftAssocs)
   {
-    fullSkimming<gkEventFillMapWithMultsAndEventFilter, 0u, gkMuonFillMapWithCov, 0u, gkMFTFillMap>(collisions, bcs, nullptr, nullptr, muons, nullptr, mftTracks, nullptr, fwdTrackAssocs, mftAssocs);
+    fullSkimming<gkEventFillMapWithMultsAndEventFilter, 0u, gkMuonFillMapWithCov, gkMFTFillMap>(collisions, bcs, nullptr, nullptr, muons, mftTracks, nullptr, fwdTrackAssocs, mftAssocs);
   }
 
   // produce the barrel-only DQ skimmed data model typically for pp/p-Pb or UPC Pb-Pb (no centrality), meant to run on skimmed data
@@ -1475,7 +1427,7 @@ struct TableMaker {
                            MyBarrelTracksWithCov const& tracksBarrel,
                            TrackAssoc const& trackAssocs)
   {
-    fullSkimming<gkEventFillMapWithMultsZdc, gkTrackFillMapWithCov, 0u, 0u, 0u>(collisions, bcs, zdcs, tracksBarrel, nullptr, nullptr, nullptr, trackAssocs, nullptr, nullptr);
+    fullSkimming<gkEventFillMapWithMultsZdc, gkTrackFillMapWithCov, 0u, 0u>(collisions, bcs, zdcs, tracksBarrel, nullptr, nullptr, trackAssocs, nullptr, nullptr);
   }
 
   // produce the barrel-only DQ skimmed barrel data model, with V0 tagged tracks
@@ -1483,21 +1435,21 @@ struct TableMaker {
                                   MyBarrelTracksWithV0BitsNoTOF const& tracksBarrel,
                                   TrackAssoc const& trackAssocs)
   {
-    fullSkimming<gkEventFillMapWithMults, gkTrackFillMapWithV0BitsNoTOF, 0u, 0u, 0u>(collisions, bcs, nullptr, tracksBarrel, nullptr, nullptr, nullptr, trackAssocs, nullptr, nullptr);
+    fullSkimming<gkEventFillMapWithMults, gkTrackFillMapWithV0BitsNoTOF, 0u, 0u>(collisions, bcs, nullptr, tracksBarrel, nullptr, nullptr, trackAssocs, nullptr, nullptr);
   }
 
   // produce the muon-only DQ skimmed data model typically for pp/p-Pb or UPC Pb-Pb (no centrality), meant to run on skimmed data
   void processPPMuonOnly(MyEventsWithMults const& collisions, BCsWithTimestamps const& bcs,
                          MyMuonsWithCov const& muons, FwdTrackAssoc const& fwdTrackAssocs)
   {
-    fullSkimming<gkEventFillMapWithMults, 0u, gkMuonFillMapWithCov, 0u, 0u>(collisions, bcs, nullptr, nullptr, muons, nullptr, nullptr, nullptr, fwdTrackAssocs, nullptr);
+    fullSkimming<gkEventFillMapWithMults, 0u, gkMuonFillMapWithCov, 0u>(collisions, bcs, nullptr, nullptr, muons, nullptr, nullptr, fwdTrackAssocs, nullptr);
   }
 
   // produce the realigned muon-only DQ skimmed data model typically for pp/p-Pb or UPC Pb-Pb (no centrality), meant to run on skimmed data
   void processPPRealignedMuonOnly(MyEventsWithMults const& collisions, BCsWithTimestamps const& bcs,
-                                  MyMuonsWithCov const& muons, MyMuonsRealignWithCov const& muonsRealign, FwdTrackAssoc const& fwdTrackAssocs)
+                                  MyMuonsRealignWithCov const& muons, FwdTrackAssoc const& fwdTrackAssocs)
   {
-    fullSkimming<gkEventFillMapWithMults, 0u, gkMuonFillMapWithCov, gkMuonRealignFillMapWithCov, 0u>(collisions, bcs, nullptr, nullptr, muons, muonsRealign, nullptr, nullptr, fwdTrackAssocs, nullptr);
+    fullSkimming<gkEventFillMapWithMults, 0u, gkMuonRealignFillMapWithCov, 0u>(collisions, bcs, nullptr, nullptr, muons, nullptr, nullptr, fwdTrackAssocs, nullptr);
   }
 
   // produce the muon+mft DQ skimmed data model typically for pp/p-Pb or UPC Pb-Pb (no centrality), meant to run on skimmed data
@@ -1505,7 +1457,7 @@ struct TableMaker {
                         MyMuonsWithCov const& muons, MFTTracks const& mftTracks,
                         FwdTrackAssoc const& fwdTrackAssocs, MFTTrackAssoc const& mftAssocs)
   {
-    fullSkimming<gkEventFillMapWithMults, 0u, gkMuonFillMapWithCov, 0u, gkMFTFillMap>(collisions, bcs, nullptr, nullptr, muons, nullptr, mftTracks, nullptr, fwdTrackAssocs, mftAssocs);
+    fullSkimming<gkEventFillMapWithMults, 0u, gkMuonFillMapWithCov, gkMFTFillMap>(collisions, bcs, nullptr, nullptr, muons, mftTracks, nullptr, fwdTrackAssocs, mftAssocs);
   }
 
   // Central barrel multiplicity estimation
@@ -1513,7 +1465,7 @@ struct TableMaker {
                                       MyMuonsWithCov const& muons, MFTTracks const& mftTracks,
                                       FwdTrackAssoc const& fwdTrackAssocs, MFTTrackAssoc const& mftAssocs)
   {
-    fullSkimming<gkEventFillMapWithMultsExtra, 0u, gkMuonFillMapWithCov, 0u, gkMFTFillMap>(collisions, bcs, nullptr, nullptr, muons, nullptr, mftTracks, nullptr, fwdTrackAssocs, mftAssocs);
+    fullSkimming<gkEventFillMapWithMultsExtra, 0u, gkMuonFillMapWithCov, gkMFTFillMap>(collisions, bcs, nullptr, nullptr, muons, mftTracks, nullptr, fwdTrackAssocs, mftAssocs);
   }
 
   // produce the full DQ skimmed data model typically for Pb-Pb (with centrality), no subscribtion to the DQ event filter
@@ -1523,7 +1475,7 @@ struct TableMaker {
                    TrackAssoc const& trackAssocs, FwdTrackAssoc const& fwdTrackAssocs,
                    MFTTrackAssoc const& mftAssocs)
   {
-    fullSkimming<gkEventFillMapWithCentAndMults, gkTrackFillMapWithCov, gkMuonFillMapWithCov, 0u, gkMFTFillMap>(collisions, bcs, nullptr, tracksBarrel, muons, nullptr, mftTracks, trackAssocs, fwdTrackAssocs, mftAssocs);
+    fullSkimming<gkEventFillMapWithCentAndMults, gkTrackFillMapWithCov, gkMuonFillMapWithCov, gkMFTFillMap>(collisions, bcs, nullptr, tracksBarrel, muons, mftTracks, trackAssocs, fwdTrackAssocs, mftAssocs);
   }
 
   // produce the barrel only DQ skimmed data model typically for Pb-Pb (with centrality), no subscribtion to the DQ event filter
@@ -1531,7 +1483,7 @@ struct TableMaker {
                              MyBarrelTracksWithCov const& tracksBarrel,
                              TrackAssoc const& trackAssocs)
   {
-    fullSkimming<gkEventFillMapWithCentAndMults, gkTrackFillMapWithCov, 0u, 0u, 0u>(collisions, bcs, nullptr, tracksBarrel, nullptr, nullptr, nullptr, trackAssocs, nullptr, nullptr);
+    fullSkimming<gkEventFillMapWithCentAndMults, gkTrackFillMapWithCov, 0u, 0u>(collisions, bcs, nullptr, tracksBarrel, nullptr, nullptr, trackAssocs, nullptr, nullptr);
   }
 
   // produce the barrel only DQ skimmed data model typically for Pb-Pb (with centrality), no TOF
@@ -1548,7 +1500,7 @@ struct TableMaker {
                                        MyBarrelTracksWithCov const& tracksBarrel,
                                        TrackAssoc const& trackAssocs)
   {
-    fullSkimming<gkEventFillMapWithMultsRapidityGapFilterZdc, gkTrackFillMapWithCov, 0u, 0u, 0u>(collisions, bcs, zdcs, tracksBarrel, nullptr, nullptr, nullptr, trackAssocs, nullptr, nullptr);
+    fullSkimming<gkEventFillMapWithMultsRapidityGapFilterZdc, gkTrackFillMapWithCov, 0u, 0u>(collisions, bcs, zdcs, tracksBarrel, nullptr, nullptr, trackAssocs, nullptr, nullptr);
   }
 
   // produce the barrel only DQ skimmed data model typically for Pb-Pb (with centrality), no subscribtion to the DQ event filter
@@ -1557,7 +1509,7 @@ struct TableMaker {
                                        TrackAssoc const& trackAssocs)
   {
     computeOccupancyEstimators(collisions, tracksPos, tracksNeg, preslice, bcs);
-    fullSkimming<gkEventFillMapWithCentAndMults, gkTrackFillMapWithV0Bits, 0u, 0u, 0u>(collisions, bcs, nullptr, tracksBarrel, nullptr, nullptr, nullptr, trackAssocs, nullptr, nullptr);
+    fullSkimming<gkEventFillMapWithCentAndMults, gkTrackFillMapWithV0Bits, 0u, 0u>(collisions, bcs, nullptr, tracksBarrel, nullptr, nullptr, trackAssocs, nullptr, nullptr);
   }
 
   // produce the barrel only DQ skimmed data model typically for Pb-Pb (with centrality), no subscribtion to the DQ event filter
@@ -1566,21 +1518,21 @@ struct TableMaker {
                                             TrackAssoc const& trackAssocs)
   {
     computeOccupancyEstimators(collisions, tracksPosNoTOF, tracksNegNoTOF, presliceNoTOF, bcs);
-    fullSkimming<gkEventFillMapWithCentAndMults, gkTrackFillMapWithV0BitsNoTOF, 0u, 0u, 0u>(collisions, bcs, nullptr, tracksBarrel, nullptr, nullptr, nullptr, trackAssocs, nullptr, nullptr);
+    fullSkimming<gkEventFillMapWithCentAndMults, gkTrackFillMapWithV0BitsNoTOF, 0u, 0u>(collisions, bcs, nullptr, tracksBarrel, nullptr, nullptr, trackAssocs, nullptr, nullptr);
   }
 
   // produce the muon only DQ skimmed data model typically for Pb-Pb (with centrality), no subscribtion to the DQ event filter
   void processPbPbMuonOnly(MyEventsWithCentAndMults const& collisions, BCsWithTimestamps const& bcs,
                            MyMuonsWithCov const& muons, FwdTrackAssoc const& fwdTrackAssocs)
   {
-    fullSkimming<gkEventFillMapWithCentAndMults, 0u, gkMuonFillMapWithCov, 0u, 0u>(collisions, bcs, nullptr, nullptr, muons, nullptr, nullptr, nullptr, fwdTrackAssocs, nullptr);
+    fullSkimming<gkEventFillMapWithCentAndMults, 0u, gkMuonFillMapWithCov, 0u>(collisions, bcs, nullptr, nullptr, muons, nullptr, nullptr, fwdTrackAssocs, nullptr);
   }
 
   // produce the realigned muon only DQ skimmed data model typically for Pb-Pb (with centrality), no subscribtion to the DQ event filter
   void processPbPbRealignedMuonOnly(MyEventsWithCentAndMults const& collisions, BCsWithTimestamps const& bcs,
-                                    MyMuonsWithCov const& muons, MyMuonsRealignWithCov const& muonsRealign, FwdTrackAssoc const& fwdTrackAssocs)
+                                    MyMuonsRealignWithCov const& muons, FwdTrackAssoc const& fwdTrackAssocs)
   {
-    fullSkimming<gkEventFillMapWithCentAndMults, 0u, gkMuonFillMapWithCov, gkMuonRealignFillMapWithCov, 0u>(collisions, bcs, nullptr, nullptr, muons, muonsRealign, nullptr, nullptr, fwdTrackAssocs, nullptr);
+    fullSkimming<gkEventFillMapWithCentAndMults, 0u, gkMuonRealignFillMapWithCov, 0u>(collisions, bcs, nullptr, nullptr, muons, nullptr, nullptr, fwdTrackAssocs, nullptr);
   }
 
   // produce the muon+mft DQ skimmed data model typically for Pb-Pb (with centrality), no subscribtion to the DQ event filter
@@ -1588,7 +1540,7 @@ struct TableMaker {
                           MyMuonsWithCov const& muons, MFTTracks const& mftTracks,
                           FwdTrackAssoc const& fwdTrackAssocs, MFTTrackAssoc const& mftAssocs)
   {
-    fullSkimming<gkEventFillMapWithCentAndMults, 0u, gkMuonFillMapWithCov, 0u, gkMFTFillMap>(collisions, bcs, nullptr, nullptr, muons, nullptr, mftTracks, nullptr, fwdTrackAssocs, mftAssocs);
+    fullSkimming<gkEventFillMapWithCentAndMults, 0u, gkMuonFillMapWithCov, gkMFTFillMap>(collisions, bcs, nullptr, nullptr, muons, mftTracks, nullptr, fwdTrackAssocs, mftAssocs);
   }
 
   // Process the BCs and store stats for luminosity retrieval -----------------------------------------------------------------------------------


### PR DESCRIPTION
- Data model changed for realigned muons so they will take the same format as original fwdtrack tables with only necessary kinematics updated if requiring realignment. At DQ maker level, this new table will be treated in the same way as fwdtracks table.
- Only `fwdtrack_as` has to be replaced by `rawIteratorAt` to make use of `fwdtrackId` in `FwdTrackAssoc` in case of realigned muons which is not bounded to `FwdTrackAssoc` table. The later operation is safe in the sense that realigned muons table preserves the row-by-row correspondance with the orignal fwdtracks table.