### PR TITLE
[PWGHF] HF invariant mass fitter: code cleaning and minor enhancement

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,7 +38,7 @@
 /PWGEM @alibuild @feisenhu @dsekihat @ivorobye
 /PWGEM/Dilepton @alibuild @mikesas @rbailhac @dsekihat @ivorobye @feisenhu
 /PWGEM/PhotonMeson @alibuild @mikesas @rbailhac @m-c-danisch @novitzky @mhemmer-cern @dsekihat
-/PWGHF @alibuild @vkucera @fcolamar @fgrosa @fcatalan92 @mfaggin @mmazzilli @deepathoms @NicoleBastid @hahassan7 @jpxrk @apalasciano @zhangbiao-phy
+/PWGHF @alibuild @vkucera @fcolamar @fgrosa @fcatalan92 @mfaggin @mmazzilli @deepathoms @NicoleBastid @hahassan7 @jpxrk @apalasciano @zhangbiao-phy @gluparel
 # PWG-LF
 /PWGLF @alibuild @sustripathy @skundu692
 /PWGLF/Tasks/GlobalEventProperties         @alibuild @sustripathy @skundu692 @gbencedi @abmodak
@@ -63,7 +63,7 @@
 /Tutorials/PWGCF @alibuild @jgrosseo @saganatt @victor-gonzalez @zchochul
 /Tutorials/PWGDQ @alibuild @iarsene @dsekihat @feisenhu @lucamicheletti93
 /Tutorials/PWGEM @alibuild @mikesas @rbailhac @dsekihat @ivorobye @feisenhu
-/Tutorials/PWGHF @alibuild @vkucera @fcolamar @fgrosa
+/Tutorials/PWGHF @alibuild @vkucera @fcolamar @fgrosa @gluparel
 /Tutorials/PWGJE @alibuild @lhavener @maoyx @nzardosh @mfasDa @fjonasALICE
 /Tutorials/PWGLF @alibuild @alcaliva @lbariogl @chiarapinto @BongHwi @lbarnby @ercolessi @iravasen @njacazio @romainschotter @skundu692
 /Tutorials/PWGMM @alibuild @aalkin @ddobrigk

--- a/PWGHF/D2H/Macros/HFInvMassFitter.cxx
+++ b/PWGHF/D2H/Macros/HFInvMassFitter.cxx
@@ -372,18 +372,18 @@ void HFInvMassFitter::fillWorkspace(RooWorkspace& workspace) const
   workspace.import(*bkgFuncPoly3);
   delete bkgFuncPoly3;
   // bkg power law
-  RooRealVar PowParam1("PowParam1", "Parameter of Pow function", TDatabasePDG::Instance()->GetParticle("pi+")->Mass());
-  RooRealVar PowParam2("PowParam2", "Parameter of Pow function", 1., -10, 10);
-  RooAbsPdf* bkgFuncPow = new RooGenericPdf("bkgFuncPow", "bkgFuncPow", "(mass-PowParam1)^PowParam2", RooArgSet(mass, PowParam1, PowParam2));
+  RooRealVar powParam1("powParam1", "Parameter of Pow function", TDatabasePDG::Instance()->GetParticle("pi+")->Mass());
+  RooRealVar powParam2("powParam2", "Parameter of Pow function", 1., -10, 10);
+  RooAbsPdf* bkgFuncPow = new RooGenericPdf("bkgFuncPow", "bkgFuncPow", "(mass-powParam1)^powParam2", RooArgSet(mass, powParam1, powParam2));
   workspace.import(*bkgFuncPow);
   delete bkgFuncPow;
   // pow * exp
-  RooRealVar PowExpoParam1("PowExpoParam1", "Parameter of PowExpo function", 1 / 2);
-  RooRealVar PowExpoParam2("PowExpoParam2", "Parameter of PowExpo function", 1, -10, 10);
+  RooRealVar powExpoParam1("powExpoParam1", "Parameter of PowExpo function", 1 / 2);
+  RooRealVar powExpoParam2("powExpoParam2", "Parameter of PowExpo function", 1, -10, 10);
   RooRealVar massPi("massPi", "mass of pion", TDatabasePDG::Instance()->GetParticle("pi+")->Mass());
-  RooFormulaVar PowExpoParam3("PowExpoParam3", "PowExpoParam1 + 1", RooArgList(PowExpoParam1));
-  RooFormulaVar PowExpoParam4("PowExpoParam4", "1./PowExpoParam2", RooArgList(PowExpoParam2));
-  RooAbsPdf* bkgFuncPowExpo = new RooGamma("bkgFuncPowExpo", "background pdf", mass, PowExpoParam3, PowExpoParam4, massPi);
+  RooFormulaVar powExpoParam3("powExpoParam3", "powExpoParam1 + 1", RooArgList(powExpoParam1));
+  RooFormulaVar powExpoParam4("powExpoParam4", "1./powExpoParam2", RooArgList(powExpoParam2));
+  RooAbsPdf* bkgFuncPowExpo = new RooGamma("bkgFuncPowExpo", "background pdf", mass, powExpoParam3, powExpoParam4, massPi);
   workspace.import(*bkgFuncPowExpo);
   delete bkgFuncPowExpo;
 

--- a/PWGHF/D2H/Macros/HFInvMassFitter.cxx
+++ b/PWGHF/D2H/Macros/HFInvMassFitter.cxx
@@ -19,17 +19,23 @@
 
 #include "HFInvMassFitter.h"
 
+#include <TLine.h>
+
 #include <RooRealVar.h>
-#include <RooDataSet.h>
 #include <RooWorkspace.h>
 #include <RooAddPdf.h>
-#include <RooExtendPdf.h>
 #include <RooPlot.h>
 #include <RooHist.h>
 #include <RooDataHist.h>
+#include <RooExponential.h>
+#include <RooGamma.h>
+#include <RooPolynomial.h>
+#include <RooGenericPdf.h>
+#include <RooGaussian.h>
+#include <RooFormulaVar.h>
+#include <RooFitResult.h>
 
 using namespace RooFit;
-using namespace std;
 
 ClassImp(HFInvMassFitter);
 
@@ -44,7 +50,6 @@ HFInvMassFitter::HFInvMassFitter() : TNamed(),
                                      mTypeOfReflPdf(1),
                                      mMass(1.865),
                                      mSecMass(1.969),
-                                     mMassErr(0.),
                                      mSigmaSgn(0.012),
                                      mSecSigma(0.006),
                                      mNSigmaForSidebands(4.),
@@ -94,76 +99,79 @@ HFInvMassFitter::HFInvMassFitter() : TNamed(),
                                      mReflOnlyFrame(0x0),
                                      mResidualFrame(0x0),
                                      mWorkspace(0x0),
-                                     mHistoTemplateRefl(0x0)
+                                     mHistoTemplateRefl(0x0),
+                                     mDrawBgPrefit(kFALSE),
+                                     mHighlightPeakRegion(kFALSE)
 {
   // default constructor
 }
 
-HFInvMassFitter::HFInvMassFitter(const TH1F* histoToFit, Double_t minValue, Double_t maxValue, Int_t fitTypeBkg, Int_t fitTypeSgn) : TNamed(),
-                                                                                                                                     mHistoInvMass(0x0),
-                                                                                                                                     mFitOption("L,E"),
-                                                                                                                                     mMinMass(minValue),
-                                                                                                                                     mMaxMass(maxValue),
-                                                                                                                                     mTypeOfBkgPdf(fitTypeBkg),
-                                                                                                                                     mMassParticle(1.864),
-                                                                                                                                     mTypeOfSgnPdf(fitTypeSgn),
-                                                                                                                                     mTypeOfReflPdf(1),
-                                                                                                                                     mMass(1.865),
-                                                                                                                                     mSecMass(1.969),
-                                                                                                                                     mMassErr(0.),
-                                                                                                                                     mSigmaSgn(0.012),
-                                                                                                                                     mSecSigma(0.006),
-                                                                                                                                     mNSigmaForSidebands(3.),
-                                                                                                                                     mNSigmaForSgn(3.),
-                                                                                                                                     mSigmaSgnErr(0.),
-                                                                                                                                     mSigmaSgnDoubleGaus(0.012),
-                                                                                                                                     mFixedMean(kFALSE),
-                                                                                                                                     mBoundMean(kFALSE),
-                                                                                                                                     mBoundReflMean(kFALSE),
-                                                                                                                                     mRooMeanSgn(0x0),
-                                                                                                                                     mRooSigmaSgn(0x0),
-                                                                                                                                     mMassLowLimit(0),
-                                                                                                                                     mMassUpLimit(0),
-                                                                                                                                     mMassReflLowLimit(0),
-                                                                                                                                     mMassReflUpLimit(0),
-                                                                                                                                     mFixedSigma(kFALSE),
-                                                                                                                                     mFixedSigmaDoubleGaus(kFALSE),
-                                                                                                                                     mBoundSigma(kFALSE),
-                                                                                                                                     mSigmaValue(0.012),
-                                                                                                                                     mParamSgn(0.1),
-                                                                                                                                     mFracDoubleGaus(0.2),
-                                                                                                                                     mFixedRawYield(-1.),
-                                                                                                                                     mFixedFracDoubleGaus(kFALSE),
-                                                                                                                                     mRatioDoubleGausSigma(0.),
-                                                                                                                                     mFixedRatioDoubleGausSigma(kFALSE),
-                                                                                                                                     mReflOverSgn(0),
-                                                                                                                                     mEnableReflections(kFALSE),
-                                                                                                                                     mRawYield(0),
-                                                                                                                                     mRawYieldErr(0),
-                                                                                                                                     mBkgYield(0),
-                                                                                                                                     mBkgYieldErr(0),
-                                                                                                                                     mSignificance(0),
-                                                                                                                                     mSignificanceErr(0),
-                                                                                                                                     mChiSquareOverNdf(0),
-                                                                                                                                     mSgnPdf(0x0),
-                                                                                                                                     mBkgPdf(0x0),
-                                                                                                                                     mReflPdf(0x0),
-                                                                                                                                     mIntegralHisto(0),
-                                                                                                                                     mIntegralBkg(0),
-                                                                                                                                     mIntegralSgn(0),
-                                                                                                                                     mRooNSgn(0x0),
-                                                                                                                                     mRooNBkg(0x0),
-                                                                                                                                     mRooNRefl(0x0),
-                                                                                                                                     mTotalPdf(0x0),
-                                                                                                                                     mInvMassFrame(0x0),
-                                                                                                                                     mReflFrame(0x0),
-                                                                                                                                     mReflOnlyFrame(0x0),
-                                                                                                                                     mResidualFrame(0x0),
-                                                                                                                                     mWorkspace(0x0),
-                                                                                                                                     mHistoTemplateRefl(0x0)
+HFInvMassFitter::HFInvMassFitter(const TH1* histoToFit, Double_t minValue, Double_t maxValue, Int_t fitTypeBkg, Int_t fitTypeSgn) : TNamed(),
+                                                                                                                                    mHistoInvMass(0x0),
+                                                                                                                                    mFitOption("L,E"),
+                                                                                                                                    mMinMass(minValue),
+                                                                                                                                    mMaxMass(maxValue),
+                                                                                                                                    mTypeOfBkgPdf(fitTypeBkg),
+                                                                                                                                    mMassParticle(1.864),
+                                                                                                                                    mTypeOfSgnPdf(fitTypeSgn),
+                                                                                                                                    mTypeOfReflPdf(1),
+                                                                                                                                    mMass(1.865),
+                                                                                                                                    mSecMass(1.969),
+                                                                                                                                    mSigmaSgn(0.012),
+                                                                                                                                    mSecSigma(0.006),
+                                                                                                                                    mNSigmaForSidebands(3.),
+                                                                                                                                    mNSigmaForSgn(3.),
+                                                                                                                                    mSigmaSgnErr(0.),
+                                                                                                                                    mSigmaSgnDoubleGaus(0.012),
+                                                                                                                                    mFixedMean(kFALSE),
+                                                                                                                                    mBoundMean(kFALSE),
+                                                                                                                                    mBoundReflMean(kFALSE),
+                                                                                                                                    mRooMeanSgn(0x0),
+                                                                                                                                    mRooSigmaSgn(0x0),
+                                                                                                                                    mMassLowLimit(0),
+                                                                                                                                    mMassUpLimit(0),
+                                                                                                                                    mMassReflLowLimit(0),
+                                                                                                                                    mMassReflUpLimit(0),
+                                                                                                                                    mFixedSigma(kFALSE),
+                                                                                                                                    mFixedSigmaDoubleGaus(kFALSE),
+                                                                                                                                    mBoundSigma(kFALSE),
+                                                                                                                                    mSigmaValue(0.012),
+                                                                                                                                    mParamSgn(0.1),
+                                                                                                                                    mFracDoubleGaus(0.2),
+                                                                                                                                    mFixedRawYield(-1.),
+                                                                                                                                    mFixedFracDoubleGaus(kFALSE),
+                                                                                                                                    mRatioDoubleGausSigma(0.),
+                                                                                                                                    mFixedRatioDoubleGausSigma(kFALSE),
+                                                                                                                                    mReflOverSgn(0),
+                                                                                                                                    mEnableReflections(kFALSE),
+                                                                                                                                    mRawYield(0),
+                                                                                                                                    mRawYieldErr(0),
+                                                                                                                                    mBkgYield(0),
+                                                                                                                                    mBkgYieldErr(0),
+                                                                                                                                    mSignificance(0),
+                                                                                                                                    mSignificanceErr(0),
+                                                                                                                                    mChiSquareOverNdf(0),
+                                                                                                                                    mSgnPdf(0x0),
+                                                                                                                                    mBkgPdf(0x0),
+                                                                                                                                    mReflPdf(0x0),
+                                                                                                                                    mIntegralHisto(0),
+                                                                                                                                    mIntegralBkg(0),
+                                                                                                                                    mIntegralSgn(0),
+                                                                                                                                    mRooNSgn(0x0),
+                                                                                                                                    mRooNBkg(0x0),
+                                                                                                                                    mRooNRefl(0x0),
+                                                                                                                                    mTotalPdf(0x0),
+                                                                                                                                    mInvMassFrame(0x0),
+                                                                                                                                    mReflFrame(0x0),
+                                                                                                                                    mReflOnlyFrame(0x0),
+                                                                                                                                    mResidualFrame(0x0),
+                                                                                                                                    mWorkspace(0x0),
+                                                                                                                                    mHistoTemplateRefl(0x0),
+                                                                                                                                    mDrawBgPrefit(kFALSE),
+                                                                                                                                    mHighlightPeakRegion(kFALSE)
 {
   // standard constructor
-  mHistoInvMass = reinterpret_cast<TH1F*>(histoToFit->Clone(histoToFit->GetTitle()));
+  mHistoInvMass = dynamic_cast<TH1*>(histoToFit->Clone(histoToFit->GetTitle()));
   mHistoInvMass->SetDirectory(0);
 }
 
@@ -189,7 +197,7 @@ HFInvMassFitter::~HFInvMassFitter()
   delete mWorkspace;
 }
 
-void HFInvMassFitter::doFit(Bool_t draw)
+void HFInvMassFitter::doFit()
 {
   mIntegralHisto = mHistoInvMass->Integral(mHistoInvMass->FindBin(mMinMass), mHistoInvMass->FindBin(mMaxMass));
   mWorkspace = new RooWorkspace("mWorkspace");
@@ -221,7 +229,7 @@ void HFInvMassFitter::doFit(Bool_t draw)
   RooAbsPdf* bkgPdf = createBackgroundFitFunction(mWorkspace);                                                   // Create background pdf
   RooAbsPdf* sgnPdf = createSignalFitFunction(mWorkspace);                                                       // Create signal pdf
 
-  // fir MC or Data
+  // fit MC or Data
   if (mTypeOfBkgPdf == 6) {                                                                                    // MC
     mRooNSgn = new RooRealVar("mRooNSig", "number of signal", 0.3 * mIntegralHisto, 0., 1.2 * mIntegralHisto); // signal yield
     mTotalPdf = new RooAddPdf("mMCFunc", "MC fit function", RooArgList(*sgnPdf), RooArgList(*mRooNSgn));       // create total pdf
@@ -230,8 +238,8 @@ void HFInvMassFitter::doFit(Bool_t draw)
     } else {
       mTotalPdf->fitTo(dataHistogram, Range("signal"));
     }
-    RooAbsReal* signalIntergralMc = mTotalPdf->createIntegral(*mass, NormSet(*mass), Range("signal")); // sig yield from fit
-    mIntegralSgn = signalIntergralMc->getValV();
+    RooAbsReal* signalIntegralMc = mTotalPdf->createIntegral(*mass, NormSet(*mass), Range("signal")); // sig yield from fit
+    mIntegralSgn = signalIntegralMc->getValV();
     calculateSignal(mRawYield, mRawYieldErr);        // calculate signal and signal error
     mTotalPdf->plotOn(mInvMassFrame, Name("Tot_c")); // plot total function
   } else {                                           // data
@@ -249,13 +257,19 @@ void HFInvMassFitter::doFit(Bool_t draw)
         mBkgPdf->fitTo(dataHistogram, Range("SBL,SBR"), Save());
       }
     }
+    RooAbsPdf* mBkgPdfPrefit{nullptr};
+    if (mDrawBgPrefit) {
+      mBkgPdfPrefit = dynamic_cast<RooAbsPdf*>(mBkgPdf->Clone());
+      mBkgPdfPrefit->plotOn(mInvMassFrame, Range("full"), Name("Bkg_c_prefit"), LineColor(kGray));
+      delete mBkgPdfPrefit;
+    }
 
     // estimate signal yield
     RooAbsReal* bkgIntegral = mBkgPdf->createIntegral(*mass, NormSet(*mass), Range("bkg")); // bkg integral
-    mIntegralBkg = bkgIntegral->getValV();
+    mIntegralBkg = bkgIntegral->getValV();                                                  // fraction of BG's integral in "bkg" range out of that in "full" range (which is 1 by construction). Not an absolute value.
     Double_t estimatedSignal;
-    checkForSignal(estimatedSignal);
-    calculateBackground(mBkgYield, mBkgYieldErr);
+    checkForSignal(estimatedSignal);              // SIG's absolute integral in "bkg" range
+    calculateBackground(mBkgYield, mBkgYieldErr); // BG's absolute integral in "bkg" range
 
     mRooNSgn = new RooRealVar("mNSgn", "number of signal", 0.3 * estimatedSignal, 0., 1.2 * estimatedSignal); // estimated signal yield
     if (mFixedRawYield > 0) {
@@ -309,15 +323,14 @@ void HFInvMassFitter::doFit(Bool_t draw)
         mTotalPdf->fitTo(dataHistogram);
       }
       plotBkg(mTotalPdf);
-      mTotalPdf->plotOn(mInvMassFrame, Components("mReflFuncDoubleGaus"), Name("refl_c"), LineColor(kGreen));
       mTotalPdf->plotOn(mInvMassFrame, Name("Tot_c"), LineColor(kBlue));
-      mChiSquareOverNdf = mInvMassFrame->chiSquare("Tot_c", "data_c"); // calculate refuced chi2 / DNF
+      mSgnPdf->plotOn(mInvMassFrame, Normalization(1.0, RooAbsReal::RelativeExpected), DrawOption("F"), FillColor(TColor::GetColorTransparent(kBlue, 0.2)), VLines());
+      mChiSquareOverNdf = mInvMassFrame->chiSquare("Tot_c", "data_c"); // calculate reduced chi2 / DNF
       // plot residual distribution
       mResidualFrame = mass->frame(Title("Residual Distribution"));
       RooHist* residualHistogram = mInvMassFrame->residHist("data_c", "Bkg_c");
       mResidualFrame->addPlotable(residualHistogram, "P");
       mSgnPdf->plotOn(mResidualFrame, Normalization(1.0, RooAbsReal::RelativeExpected), LineColor(kBlue));
-      mTotalPdf->plotOn(mResidualFrame, Components(*mSgnPdf), Normalization(1.0, RooAbsReal::RelativeExpected), LineColor(kBlue));
     }
     mass->setRange("bkgForSignificance", mRooMeanSgn->getVal() - mNSigmaForSgn * mRooSigmaSgn->getVal(), mRooMeanSgn->getVal() + mNSigmaForSgn * mRooSigmaSgn->getVal());
     bkgIntegral = mBkgPdf->createIntegral(*mass, NormSet(*mass), Range("bkgForSignificance"));
@@ -327,36 +340,42 @@ void HFInvMassFitter::doFit(Bool_t draw)
     RooAbsReal* sgnIntegral = mSgnPdf->createIntegral(*mass, NormSet(*mass), Range("signal"));
     mIntegralSgn = sgnIntegral->getValV();
     calculateSignal(mRawYield, mRawYieldErr);
+    countSignal(mRawYieldCounted, mRawYieldCountedErr);
     calculateSignificance(mSignificance, mSignificanceErr);
   }
 }
 
-void HFInvMassFitter::fillWorkspace(RooWorkspace& workspace)
+void HFInvMassFitter::fillWorkspace(RooWorkspace& workspace) const
 {
   // Declare observable variable
-  RooRealVar mass("mass", "mass", mMinMass, mMaxMass, "GeV/c");
+  RooRealVar mass("mass", "mass", mMinMass, mMaxMass, "GeV/c^{2}");
   // bkg expo
   RooRealVar tau("tau", "tau", -1, -5., 5.);
   RooAbsPdf* bkgFuncExpo = new RooExponential("bkgFuncExpo", "background fit function", mass, tau);
   workspace.import(*bkgFuncExpo);
+  delete bkgFuncExpo;
   // bkg poly1
   RooRealVar PolyParam0("PolyParam0", "Parameter of Poly function", 0.5, -5., 5.);
   RooRealVar PolyParam1("PolyParam1", "Parameter of Poly function", 0.2, -5., 5.);
   RooAbsPdf* bkgFuncPoly1 = new RooPolynomial("bkgFuncPoly1", "background fit function", mass, RooArgSet(PolyParam0, PolyParam1));
   workspace.import(*bkgFuncPoly1);
+  delete bkgFuncPoly1;
   // bkg poly2
   RooRealVar PolyParam2("PolyParam2", "Parameter of Poly function", 0.2, -5., 5.);
   RooAbsPdf* bkgFuncPoly2 = new RooPolynomial("bkgFuncPoly2", "background fit function", mass, RooArgSet(PolyParam0, PolyParam1, PolyParam2));
   workspace.import(*bkgFuncPoly2);
+  delete bkgFuncPoly2;
   // bkg poly3
   RooRealVar PolyParam3("PolyParam3", "Parameter of Poly function", 0.2, -1., 1.);
   RooAbsPdf* bkgFuncPoly3 = new RooPolynomial("bkgFuncPoly3", "background pdf", mass, RooArgSet(PolyParam0, PolyParam1, PolyParam2, PolyParam3));
   workspace.import(*bkgFuncPoly3);
+  delete bkgFuncPoly3;
   // bkg power law
   RooRealVar PowParam1("PowParam1", "Parameter of Pow function", 0.13957);
   RooRealVar PowParam2("PowParam2", "Parameter of Pow function", 1., -10, 10);
   RooAbsPdf* bkgFuncPow = new RooGenericPdf("bkgFuncPow", "bkgFuncPow", "(mass-PowParam1)^PowParam2", RooArgSet(mass, PowParam1, PowParam2));
   workspace.import(*bkgFuncPow);
+  delete bkgFuncPow;
   // pow * exp
   RooRealVar PowExpoParam1("PowExpoParam1", "Parameter of PowExpo function", 1 / 2);
   RooRealVar PowExpoParam2("PowExpoParam2", "Parameter of PowExpo function", 1, -10, 10);
@@ -365,13 +384,15 @@ void HFInvMassFitter::fillWorkspace(RooWorkspace& workspace)
   RooFormulaVar PowExpoParam4("PowExpoParam4", "1./PowExpoParam2", RooArgList(PowExpoParam2));
   RooAbsPdf* bkgFuncPowExpo = new RooGamma("bkgFuncPowExpo", "background pdf", mass, PowExpoParam3, PowExpoParam4, massPi);
   workspace.import(*bkgFuncPowExpo);
+  delete bkgFuncPowExpo;
+
   // signal pdf
-  RooRealVar mean("mean", "mean for signal fit", mMass, 1.86, 1.87);
+  RooRealVar mean("mean", "mean for signal fit", mMass, 0, 5);
   if (mBoundMean) {
     mean.setMax(mMassUpLimit);
     mean.setMin(mMassLowLimit);
   }
-  // signal Guassian
+  // signal Gaussian
   if (mFixedMean) {
     mean.setVal(mMass);
     mean.setConstant(kTRUE);
@@ -387,7 +408,8 @@ void HFInvMassFitter::fillWorkspace(RooWorkspace& workspace)
   }
   RooAbsPdf* sgnFuncGaus = new RooGaussian("sgnFuncGaus", "signal pdf", mass, mean, sigma);
   workspace.import(*sgnFuncGaus);
-  // signal double Gaussianaa
+  delete sgnFuncGaus;
+  // signal double Gaussian
   RooRealVar sigmaDoubleGaus("sigmaDoubleGaus", "sigma2Gaus", mSigmaSgn, mSigmaSgn - 0.01, mSigmaSgn + 0.01);
   if (mBoundSigma) {
     sigmaDoubleGaus.setMax(mSigmaSgn * (1 + mParamSgn));
@@ -410,6 +432,7 @@ void HFInvMassFitter::fillWorkspace(RooWorkspace& workspace)
   }
   RooAbsPdf* sgnFuncDoubleGaus = new RooAddPdf("sgnFuncDoubleGaus", "signal pdf", RooArgList(gaus1, gaus2), fracDoubleGaus);
   workspace.import(*sgnFuncDoubleGaus);
+  delete sgnFuncDoubleGaus;
   // double Gaussian ratio
   RooRealVar ratio("ratio", "ratio of sigma12", mRatioDoubleGausSigma, 0, 10);
   if (mFixedSigma) {
@@ -434,6 +457,7 @@ void HFInvMassFitter::fillWorkspace(RooWorkspace& workspace)
   }
   RooAbsPdf* sgnFuncGausRatio = new RooAddPdf("sgnFuncGausRatio", "signal pdf", RooArgList(gausRatio1, gausRatio2), fracDoubleGausRatio);
   workspace.import(*sgnFuncGausRatio);
+  delete sgnFuncGausRatio;
   // double peak for Ds
   RooRealVar meanSec("meanSec", "mean for second peak fit", mSecMass, mMinMass, mMaxMass);
   RooRealVar sigmaSec("sigmaSec", "sigmaSec", mSecSigma, mSecSigma - 0.005, mSecSigma + 0.01);
@@ -458,6 +482,7 @@ void HFInvMassFitter::fillWorkspace(RooWorkspace& workspace)
   RooRealVar fracSec("fracSec", "frac of two peak", 0.5, 0, 1.);
   RooAbsPdf* sgnFuncDoublePeak = new RooAddPdf("sgnFuncDoublePeak", "signal pdf", RooArgList(gausSec1, gausSec2), fracSec);
   workspace.import(*sgnFuncDoublePeak);
+  delete sgnFuncDoublePeak;
   // reflection Gaussian
   RooRealVar meanRefl("meanRefl", "mean for reflection", mMass, 0.0, mMass + 0.05);
   if (mBoundReflMean) {
@@ -467,6 +492,7 @@ void HFInvMassFitter::fillWorkspace(RooWorkspace& workspace)
   RooRealVar sigmaRefl("sigmaRefl", "sigma for reflection", 0.012, 0, 0.25);
   RooAbsPdf* reflFuncGaus = new RooGaussian("reflFuncGaus", "reflection pdf", mass, meanRefl, sigmaRefl);
   workspace.import(*reflFuncGaus);
+  delete reflFuncGaus;
   // reflection double Gaussian
   RooRealVar meanReflDoubleGaus("meanReflDoubleGaus", "mean for reflection double gaussian", mMass, 0.0, mMass + 0.05);
   if (mBoundReflMean) {
@@ -479,6 +505,7 @@ void HFInvMassFitter::fillWorkspace(RooWorkspace& workspace)
   RooRealVar fracRefl("fracRefl", "frac of two gauss", 0.5, 0, 1.);
   RooAbsPdf* reflFuncDoubleGaus = new RooAddPdf("reflFuncDoubleGaus", "reflection pdf", RooArgList(gausRefl1, gausRefl2), fracRefl);
   workspace.import(*reflFuncDoubleGaus);
+  delete reflFuncDoubleGaus;
   // reflection poly3
   RooRealVar PolyReflParam0("PolyReflParam0", "PolyReflParam0", 0.5, -1., 1.);
   RooRealVar PolyReflParam1("PolyReflParam1", "PolyReflParam1", 0.2, -1., 1.);
@@ -486,12 +513,14 @@ void HFInvMassFitter::fillWorkspace(RooWorkspace& workspace)
   RooRealVar PolyReflParam3("PolyReflParam3", "PolyReflParam3", 0.2, -1., 1.);
   RooAbsPdf* reflFuncPoly3 = new RooPolynomial("reflFuncPoly3", "reflection PDF", mass, RooArgSet(PolyReflParam0, PolyReflParam1, PolyReflParam2, PolyReflParam3));
   workspace.import(*reflFuncPoly3);
+  delete reflFuncPoly3;
   // reflection poly6
   RooRealVar PolyReflParam4("PolyReflParam4", "PolyReflParam4", 0.2, -1., 1.);
   RooRealVar PolyReflParam5("PolyReflParam5", "PolyReflParam5", 0.2, -1., 1.);
   RooRealVar PolyReflParam6("PolyReflParam6", "PolyReflParam6", 0.2, -1., 1.);
   RooAbsPdf* reflFuncPoly6 = new RooPolynomial("reflFuncPoly6", "reflection pdf", mass, RooArgSet(PolyReflParam0, PolyReflParam1, PolyReflParam2, PolyReflParam3, PolyReflParam4, PolyReflParam5, PolyReflParam6));
   workspace.import(*reflFuncPoly6);
+  delete reflFuncPoly6;
 }
 // draw fit output
 void HFInvMassFitter::drawFit(TVirtualPad* pad, Int_t writeFitInfo)
@@ -509,6 +538,7 @@ void HFInvMassFitter::drawFit(TVirtualPad* pad, Int_t writeFitInfo)
     textInfoRight->SetFillStyle(0);
     textInfoRight->SetTextColor(kBlue);
     textInfoLeft->AddText(Form("S = %.0f #pm %.0f ", mRawYield, mRawYieldErr));
+    textInfoLeft->AddText(Form("S_{count} = %.0f #pm %.0f ", mRawYieldCounted, mRawYieldCountedErr));
     if (mTypeOfBkgPdf != 6) {
       textInfoLeft->AddText(Form("B (%d#sigma) = %.0f #pm %.0f", mNSigmaForSidebands, mBkgYield, mBkgYieldErr));
       textInfoLeft->AddText(Form("S/B (%d#sigma) = %.4g ", mNSigmaForSidebands, mRawYield / mBkgYield));
@@ -537,13 +567,14 @@ void HFInvMassFitter::drawFit(TVirtualPad* pad, Int_t writeFitInfo)
     mInvMassFrame->GetYaxis()->SetTitle(Form("%s", mHistoInvMass->GetYaxis()->GetTitle()));
     mInvMassFrame->GetXaxis()->SetTitle(Form("%s", mHistoInvMass->GetXaxis()->GetTitle()));
     mInvMassFrame->Draw();
+    highlightPeakRegion(mInvMassFrame);
     if (mHistoTemplateRefl) {
       mReflFrame->Draw("same");
     }
   }
 }
 
-// draw redisual distribution on canvas
+// draw residual distribution on canvas
 void HFInvMassFitter::drawResidual(TVirtualPad* pad)
 {
   pad->cd();
@@ -553,10 +584,33 @@ void HFInvMassFitter::drawResidual(TVirtualPad* pad)
   textInfo->SetFillStyle(0);
   textInfo->SetTextColor(kBlue);
   textInfo->AddText(Form("S = %.0f #pm %.0f ", mRawYield, mRawYieldErr));
+  textInfo->AddText(Form("S_{count} = %.0f #pm %.0f ", mRawYieldCounted, mRawYieldCountedErr));
   textInfo->AddText(Form("mean = %.3f #pm %.3f", mRooMeanSgn->getVal(), mRooMeanSgn->getError()));
   textInfo->AddText(Form("sigma = %.3f #pm %.3f", mRooSigmaSgn->getVal(), mRooSigmaSgn->getError()));
   mResidualFrame->addObject(textInfo);
   mResidualFrame->Draw();
+  highlightPeakRegion(mResidualFrame);
+}
+
+// draw peak region with vertical lines
+void HFInvMassFitter::highlightPeakRegion(const RooPlot* plot, Color_t color, Width_t width, Style_t style) const
+{
+  if (!mHighlightPeakRegion)
+    return;
+  double yMin = plot->GetMinimum();
+  double yMax = plot->GetMaximum();
+  const Double_t mean = mRooMeanSgn->getVal();
+  const Double_t sigma = mRooSigmaSgn->getVal();
+  const Double_t minForSgn = mean - mNSigmaForSidebands * sigma;
+  const Double_t maxForSgn = mean + mNSigmaForSidebands * sigma;
+  TLine* leftLine = new TLine(minForSgn, yMin, minForSgn, yMax);
+  TLine* rightLine = new TLine(maxForSgn, yMin, maxForSgn, yMax);
+  for (const auto& line : std::array<TLine*, 2>{leftLine, rightLine}) {
+    line->SetLineColor(color);
+    line->SetLineWidth(width);
+    line->SetLineStyle(style);
+    line->Draw();
+  }
 }
 
 // draw reflection distribution on canvas
@@ -565,6 +619,34 @@ void HFInvMassFitter::drawReflection(TVirtualPad* pad)
   pad->cd();
   mReflOnlyFrame->GetYaxis()->SetTitle("");
   mReflOnlyFrame->Draw();
+}
+
+// calculate signal yield via bin counting
+void HFInvMassFitter::countSignal(Double_t& signal, Double_t& signalErr) const
+{
+  const Double_t mean = mRooMeanSgn->getVal();
+  const Double_t sigma = mRooSigmaSgn->getVal();
+  const Double_t minForSgn = mean - mNSigmaForSidebands * sigma;
+  const Double_t maxForSgn = mean + mNSigmaForSidebands * sigma;
+  const Int_t binForMinSgn = mHistoInvMass->FindBin(minForSgn);
+  const Int_t binForMaxSgn = mHistoInvMass->FindBin(maxForSgn);
+  const Double_t binForMinSgnUpperEdge = mHistoInvMass->GetBinLowEdge(binForMinSgn + 1);
+  const Double_t binForMaxSgnLowerEdge = mHistoInvMass->GetBinLowEdge(binForMaxSgn);
+  const Double_t binForMinSgnFraction = (binForMinSgnUpperEdge - minForSgn) / mHistoInvMass->GetBinWidth(binForMinSgn);
+  const Double_t binForMaxSgnFraction = (maxForSgn - binForMaxSgnLowerEdge) / mHistoInvMass->GetBinWidth(binForMaxSgn);
+
+  Double_t sum = 0;
+  sum += mHistoInvMass->GetBinContent(binForMinSgn) * binForMinSgnFraction;
+  for (Int_t iBin = binForMinSgn + 1; iBin <= binForMaxSgn - 1; iBin++) {
+    sum += mHistoInvMass->GetBinContent(iBin);
+  }
+  sum += mHistoInvMass->GetBinContent(binForMaxSgn) * binForMaxSgnFraction;
+
+  Double_t bkg, errBkg;
+  calculateBackground(bkg, errBkg);
+
+  signal = sum - bkg;
+  signalErr = std::sqrt(sum + errBkg * errBkg); // sum error squared is equal to sum
 }
 
 // calculate signal yield
@@ -595,7 +677,7 @@ void HFInvMassFitter::calculateSignificance(Double_t& significance, Double_t& er
   errSignificance = significance * std::sqrt((sgnErrSquare + bkgErrSquare) / (mNSigmaForSidebands * totalSgnBkg * totalSgnBkg) + (bkg / totalSgnBkg) * (sgnErrSquare / signal / signal));
 }
 
-// estimate Signnal
+// estimate Signal
 void HFInvMassFitter::checkForSignal(Double_t& estimatedSignal)
 {
   Double_t minForSgn = mMass - 4 * mSigmaSgn;
@@ -613,7 +695,7 @@ void HFInvMassFitter::checkForSignal(Double_t& estimatedSignal)
 }
 
 // Create Background Fit Function
-RooAbsPdf* HFInvMassFitter::createBackgroundFitFunction(RooWorkspace* workspace)
+RooAbsPdf* HFInvMassFitter::createBackgroundFitFunction(RooWorkspace* workspace) const
 {
   RooAbsPdf* bkgPdf;
   switch (mTypeOfBkgPdf) {
@@ -677,7 +759,7 @@ RooAbsPdf* HFInvMassFitter::createSignalFitFunction(RooWorkspace* workspace)
 }
 
 // Create Reflection Fit Function
-RooAbsPdf* HFInvMassFitter::createReflectionFitFunction(RooWorkspace* workspace)
+RooAbsPdf* HFInvMassFitter::createReflectionFitFunction(RooWorkspace* workspace) const
 {
   RooAbsPdf* reflPdf;
   switch (mTypeOfReflPdf) {
@@ -700,26 +782,26 @@ RooAbsPdf* HFInvMassFitter::createReflectionFitFunction(RooWorkspace* workspace)
 }
 
 // Plot Bkg components of fTotFunction
-void HFInvMassFitter::plotBkg(RooAbsPdf* pdf)
+void HFInvMassFitter::plotBkg(RooAbsPdf* pdf, Color_t color)
 {
   switch (mTypeOfBkgPdf) {
     case 0:
-      pdf->plotOn(mInvMassFrame, Components("bkgFuncExpo"), Name("Bkg_c"), LineColor(kRed));
+      pdf->plotOn(mInvMassFrame, Components("bkgFuncExpo"), Name("Bkg_c"), LineColor(color));
       break;
     case 1:
-      pdf->plotOn(mInvMassFrame, Components("bkgFuncPoly1"), Name("Bkg_c"), LineColor(kRed));
+      pdf->plotOn(mInvMassFrame, Components("bkgFuncPoly1"), Name("Bkg_c"), LineColor(color));
       break;
     case 2:
-      pdf->plotOn(mInvMassFrame, Components("bkgFuncPoly2"), Name("Bkg_c"), LineColor(kRed));
+      pdf->plotOn(mInvMassFrame, Components("bkgFuncPoly2"), Name("Bkg_c"), LineColor(color));
       break;
     case 3:
-      pdf->plotOn(mInvMassFrame, Components("bkgFuncPow"), Name("Bkg_c"), LineColor(kRed));
+      pdf->plotOn(mInvMassFrame, Components("bkgFuncPow"), Name("Bkg_c"), LineColor(color));
       break;
     case 4:
-      pdf->plotOn(mInvMassFrame, Components("bkgFuncPowExp"), Name("Bkg_c"), LineColor(kRed));
+      pdf->plotOn(mInvMassFrame, Components("bkgFuncPowExp"), Name("Bkg_c"), LineColor(color));
       break;
     case 5:
-      pdf->plotOn(mInvMassFrame, Components("bkgFuncPoly3"), Name("Bkg_c"), LineColor(kRed));
+      pdf->plotOn(mInvMassFrame, Components("bkgFuncPoly3"), Name("Bkg_c"), LineColor(color));
       break;
     case 6:
       break;

--- a/PWGHF/D2H/Macros/HFInvMassFitter.h
+++ b/PWGHF/D2H/Macros/HFInvMassFitter.h
@@ -20,7 +20,7 @@
 #ifndef PWGHF_D2H_MACROS_HFINVMASSFITTER_H_
 #define PWGHF_D2H_MACROS_HFINVMASSFITTER_H_
 
-#include <iostream> // std::cout
+#include <cstdio>
 
 #include <RooPlot.h>
 #include <RooRealVar.h>
@@ -116,7 +116,7 @@ class HFInvMassFitter : public TNamed
   {
     if (mean < meanLowLimit ||
         mean > meanUpLimit) {
-      std::cout << "Invalid Gaussian mean limit!" << std::endl;
+      printf("Invalid Gaussian mean limit!\n");
     }
     setInitialGaussianMean(mean);
     mMassLowLimit = meanLowLimit;
@@ -127,7 +127,7 @@ class HFInvMassFitter : public TNamed
   {
     if (mean < meanLowLimit ||
         mean > meanUpLimit) {
-      std::cout << "Invalid Gaussian mean limit for reflection!" << std::endl;
+      printf("Invalid Gaussian mean limit for reflection!\n");
     }
     setInitialGaussianMean(mean);
     mMassReflLowLimit = meanLowLimit;
@@ -148,7 +148,7 @@ class HFInvMassFitter : public TNamed
   void setFixSecondGaussianSigma(Double_t sigma)
   {
     if (mTypeOfSgnPdf != DoubleGaus) {
-      std::cout << "Fit type should be 2Gaus!" << std::endl;
+      printf("Fit type should be 2Gaus!\n");
     }
     setInitialSecondGaussianSigma(sigma);
     mFixedSigmaDoubleGaus = kTRUE;
@@ -157,7 +157,7 @@ class HFInvMassFitter : public TNamed
   {
     if (mTypeOfSgnPdf != DoubleGaus &&
         mTypeOfSgnPdf != DoubleGausSigmaRatioPar) {
-      std::cout << "Fit type should be 2Gaus or 2GausSigmaRatio!" << std::endl;
+      printf("Fit type should be 2Gaus or 2GausSigmaRatio!\n");
     }
     setInitialFracDoubleGaus(frac);
     mFixedFracDoubleGaus = kTRUE;
@@ -165,7 +165,7 @@ class HFInvMassFitter : public TNamed
   void setFixRatioToGausSigma(Double_t sigmaFrac)
   {
     if (mTypeOfSgnPdf != DoubleGausSigmaRatioPar) {
-      std::cout << "Fit type should be set to k2GausSigmaRatioPar!" << std::endl;
+      printf("Fit type should be set to k2GausSigmaRatioPar!\n");
     }
     setInitialRatioDoubleGausSigma(sigmaFrac);
     mFixedRatioDoubleGausSigma = kTRUE;

--- a/PWGHF/D2H/Macros/HFInvMassFitter.h
+++ b/PWGHF/D2H/Macros/HFInvMassFitter.h
@@ -21,25 +21,19 @@
 #define PWGHF_D2H_MACROS_HFINVMASSFITTER_H_
 
 #include <iostream> // std::cout
-#include <string>   // std::string
 
+#include <RooPlot.h>
+#include <RooRealVar.h>
 #include <RooWorkspace.h>
-#include <TCanvas.h>
 #include <TCanvas.h>
 #include <TDatabasePDG.h>
 #include <TF1.h>
 #include <TFitResult.h>
 #include <TH1.h>
-#include <TH1F.h>
 #include <TNamed.h>
 #include <TPaveText.h>
 #include <TStyle.h>
 #include <TVirtualFitter.h>
-
-using namespace RooFit;
-
-class TF1;
-class TH1F;
 
 class HFInvMassFitter : public TNamed
 {
@@ -66,22 +60,22 @@ class HFInvMassFitter : public TNamed
     Poly6Refl = 3
   };
   HFInvMassFitter();
-  HFInvMassFitter(const TH1F* histoToFit, Double_t minValue, Double_t maxValue, Int_t fitTypeBkg = Expo, Int_t fitTypeSgn = SingleGaus);
+  HFInvMassFitter(const TH1* histoToFit, Double_t minValue, Double_t maxValue, Int_t fitTypeBkg = Expo, Int_t fitTypeSgn = SingleGaus);
   ~HFInvMassFitter();
-  void setHistogramForFit(const TH1F* histoToFit)
+  void setHistogramForFit(const TH1* histoToFit)
   {
     if (mHistoInvMass) {
       delete mHistoInvMass;
     }
-    mHistoInvMass = reinterpret_cast<TH1F*>(histoToFit->Clone("mHistoInvMass"));
+    mHistoInvMass = static_cast<TH1*>(histoToFit->Clone("mHistoInvMass"));
     mHistoInvMass->SetDirectory(0);
   }
   void setUseLikelihoodFit() { mFitOption = "L,E"; }
   void setUseChi2Fit() { mFitOption = "Chi2"; }
   void setFitOption(TString opt) { mFitOption = opt.Data(); }
-  RooAbsPdf* createBackgroundFitFunction(RooWorkspace* w1);
+  RooAbsPdf* createBackgroundFitFunction(RooWorkspace* w1) const;
   RooAbsPdf* createSignalFitFunction(RooWorkspace* w1);
-  RooAbsPdf* createReflectionFitFunction(RooWorkspace* w1);
+  RooAbsPdf* createReflectionFitFunction(RooWorkspace* w1) const;
 
   void setFitRange(Double_t minValue, Double_t maxValue)
   {
@@ -122,7 +116,7 @@ class HFInvMassFitter : public TNamed
   {
     if (mean < meanLowLimit ||
         mean > meanUpLimit) {
-      std::cout << "Invalid Gaussian mean limmit!" << std::endl;
+      std::cout << "Invalid Gaussian mean limit!" << std::endl;
     }
     setInitialGaussianMean(mean);
     mMassLowLimit = meanLowLimit;
@@ -133,7 +127,7 @@ class HFInvMassFitter : public TNamed
   {
     if (mean < meanLowLimit ||
         mean > meanUpLimit) {
-      std::cout << "Invalid Gaussian mean limmit for reflection!" << std::endl;
+      std::cout << "Invalid Gaussian mean limit for reflection!" << std::endl;
     }
     setInitialGaussianMean(mean);
     mMassReflLowLimit = meanLowLimit;
@@ -178,10 +172,10 @@ class HFInvMassFitter : public TNamed
   }
   void setFixSignalYield(Double_t yield) { mFixedRawYield = yield; }
   void setNumberOfSigmaForSidebands(Double_t numberOfSigma) { mNSigmaForSidebands = numberOfSigma; }
-  void plotBkg(RooAbsPdf* mFunc);
+  void plotBkg(RooAbsPdf* mFunc, Color_t color = kRed);
   void plotRefl(RooAbsPdf* mFunc);
   void setReflFuncFixed();
-  void doFit(Bool_t draw = kTRUE);
+  void doFit();
   void setInitialReflOverSgn(Double_t reflOverSgn) { mReflOverSgn = reflOverSgn; }
   void setFixReflOverSgn(Double_t reflOverSgn)
   {
@@ -193,11 +187,15 @@ class HFInvMassFitter : public TNamed
     if (!histoRefl) {
       mEnableReflections = kFALSE;
     }
-    mHistoTemplateRefl = reinterpret_cast<TH1F*>(histoRefl->Clone("mHistoTemplateRefl"));
+    mHistoTemplateRefl = static_cast<TH1*>(histoRefl->Clone("mHistoTemplateRefl"));
   }
+  void setDrawBgPrefit(Bool_t value = true) { mDrawBgPrefit = value; }
+  void setHighlightPeakRegion(Bool_t value = true) { mHighlightPeakRegion = value; }
   Double_t getChiSquareOverNDF() const { return mChiSquareOverNdf; }
   Double_t getRawYield() const { return mRawYield; }
   Double_t getRawYieldError() const { return mRawYieldErr; }
+  Double_t getRawYieldCounted() const { return mRawYieldCounted; }
+  Double_t getRawYieldCountedError() const { return mRawYieldCountedErr; }
   Double_t getBkgYield() const { return mBkgYield; }
   Double_t getBkgYieldError() const { return mBkgYieldErr; }
   Double_t getSignificance() const { return mSignificance; }
@@ -215,6 +213,7 @@ class HFInvMassFitter : public TNamed
     }
   }
   void calculateSignal(Double_t& signal, Double_t& signalErr) const;
+  void countSignal(Double_t& signal, Double_t& signalErr) const;
   void calculateBackground(Double_t& bkg, Double_t& bkgErr) const;
   void calculateSignificance(Double_t& significance, Double_t& significanceErr) const;
   void checkForSignal(Double_t& estimatedSignal);
@@ -225,9 +224,10 @@ class HFInvMassFitter : public TNamed
  private:
   HFInvMassFitter(const HFInvMassFitter& source);
   HFInvMassFitter& operator=(const HFInvMassFitter& source);
-  void fillWorkspace(RooWorkspace& w);
+  void fillWorkspace(RooWorkspace& w) const;
+  void highlightPeakRegion(const RooPlot* plot, Color_t color = kGray + 1, Width_t width = 1, Style_t style = 2) const;
 
-  TH1F* mHistoInvMass; // histogram to fit
+  TH1* mHistoInvMass; // histogram to fit
   TString mFitOption;
   Double_t mMinMass;                 // lower mass limit
   Double_t mMaxMass;                 // upper mass limit
@@ -241,14 +241,13 @@ class HFInvMassFitter : public TNamed
   Double_t mMassReflLowLimit;        /// lower limit of the allowed mass range for reflection
   Double_t mMassReflUpLimit;         /// upper limit of the allowed mass range for reflection
   Double_t mSecMass;                 /// Second peak mean value
-  Double_t mMassErr;                 /// uncertainty on signal gaussian mean value
   Double_t mSigmaSgn;                /// signal gaussian sigma
   Double_t mSecSigma;                /// Second peak gaussian sigma
   Int_t mNSigmaForSidebands;         /// number of sigmas to veto the signal peak
   Int_t mNSigmaForSgn;               /// number of sigmas to veto the signal peak
   Double_t mSigmaSgnErr;             /// uncertainty on signal gaussian sigma
   Double_t mSigmaSgnDoubleGaus;      /// signal 2gaussian sigma
-  Double_t mFixedMean;               /// switch for fix mean of gaussian
+  Bool_t mFixedMean;                 /// switch for fix mean of gaussian
   Bool_t mBoundMean;                 /// switch for bound mean of guassian
   Bool_t mBoundReflMean;             /// switch for bound mean of guassian for reflection
   Bool_t mFixedSigma;                /// fix sigma or not
@@ -265,6 +264,8 @@ class HFInvMassFitter : public TNamed
   Bool_t mEnableReflections;         /// flag use/not use reflections
   Double_t mRawYield;                /// signal gaussian integral
   Double_t mRawYieldErr;             /// err on signal gaussian integral
+  Double_t mRawYieldCounted;         /// signal gaussian integral evaluated via bin counting
+  Double_t mRawYieldCountedErr;      /// err on signal gaussian integral evaluated via bin counting
   Double_t mBkgYield;                /// background
   Double_t mBkgYieldErr;             /// err on background
   Double_t mSignificance;            /// significance
@@ -284,13 +285,14 @@ class HFInvMassFitter : public TNamed
   RooPlot* mReflFrame;               /// reflection frame
   RooPlot* mReflOnlyFrame;           /// reflection frame plot on reflection only
   RooPlot* mResidualFrame;           /// residual frame
-  RooPlot* mResidualFrameForCalulation;
-  RooRealVar* mass;         /// mass
-  RooWorkspace* mWorkspace; /// workspace
-  Double_t mIntegralHisto;  /// integral of histogram to fit
-  Double_t mIntegralBkg;    /// integral of background fit function
-  Double_t mIntegralSgn;    /// integral of signal fit function
-  TH1F* mHistoTemplateRefl; /// reflection histogram
+  RooPlot* mResidualFrameForCalculation;
+  RooWorkspace* mWorkspace;    /// workspace
+  Double_t mIntegralHisto;     /// integral of histogram to fit
+  Double_t mIntegralBkg;       /// integral of background fit function
+  Double_t mIntegralSgn;       /// integral of signal fit function
+  TH1* mHistoTemplateRefl;     /// reflection histogram
+  Bool_t mDrawBgPrefit;        /// draw background after fitting the sidebands
+  Bool_t mHighlightPeakRegion; /// draw vertical lines showing the peak region (usually +- 3 sigma)
 
   ClassDef(HFInvMassFitter, 1);
 };

--- a/PWGHF/D2H/Macros/config_massfitter.json
+++ b/PWGHF/D2H/Macros/config_massfitter.json
@@ -1,12 +1,15 @@
 {
   "IsMC": false,
-  "InFileName": "input file directory ",
-  "ReflFileName": "input reflection file directory",
-  "OutFileName": "output file directory",
+  "InFileName": "hMasses.root",
+  "_InFileName": "download example file here https://cernbox.cern.ch/s/uoWicuRAVGArDsV",
+  "ReflFileName": "",
+  "OutFileName": "mInvFits.root",
   "InputHistoName": [
-    "name array of the input data histogram for fit",
-    "once the projection macro is ready",
-    "these names will no longer need to be input manually"
+    "hMass_T_0.20_0.35",
+    "hMass_T_0.35_0.50",
+    "hMass_T_0.50_0.70",
+    "hMass_T_0.70_0.90",
+    "hMass_T_0.90_1.60"
   ],
   "PromptHistoName": [
     "MC prompt histogram name array"
@@ -23,7 +26,7 @@
   "FDSecPeakHistoName": [
     "MC FD second peak histogram name array"
   ],
-  "Particle": "D0",
+  "Particle": "LcToPKPi",
   "_Particles": [
     "Dplus",
     "Ds",
@@ -31,79 +34,71 @@
     "LcToPK0s",
     "Dstar"
   ],
-  "EnableRefl": true,
+  "EnableRefl": false,
   "FixSigma": false,
   "SigmaFile": "",
   "_SigmaFile": "fix sigma from file",
   "FixSigmaManual": [
-    0.012,
-    0.012,
-    0.013,
-    0.015,
-    0.017,
-    0.02
-  ],
-  "_FixSigmaManual": "fix sigma mannually",
-  "FixMean": false,
-  "MeanFile": "",
-  "_MeanFile": "fix mean from file",
-  "PtMin": [
-    1.0,
-    2.0,
-    4.0,
-    6.0,
-    8.0,
-    12.0
-  ],
-  "PtMax": [
-    2.0,
-    4.0,
-    6.0,
-    8.0,
-    12.0,
-    24.0
-  ],
-  "MassMin": [
-    1.72,
-    1.72,
-    1.72,
-    1.72,
-    1.72,
-    1.72
-  ],
-  "MassMax": [
-    2.03,
-    2.03,
-    2.03,
-    2.03,
-    2.03,
-    2.03
-  ],
-  "Rebin": [
-    6,
-    6,
-    6,
-    6,
-    6,
-    6
-  ],
-  "InclSecPeak": false,
-  "SigmaSecPeak": "",
-  "SigmaFileSecPeak": "",
-  "SigmaMultFactorSecPeak": 1.0,
-  "FixSigmaToFirstPeak": false,
-  "UseLikelihood": true,
-  "_UseLikelihood": [
-    "true: likelihood fit",
-    "false: chi2 fit"
-  ],
-  "BkgFunc": [
-    0,
     0,
     0,
     0,
     0,
     0
+  ],
+  "_FixSigmaManual": "fix sigma manually",
+  "FixMean": false,
+  "MeanFile": "",
+  "_MeanFile": "fix mean from file",
+  "SliceVarName": "T",
+  "SliceVarUnit": "ps",
+  "_SliceVarName, _SliceVarUnit": "e.g. pT, GeV/c or something else depending on user's needs",
+  "SliceVarMin": [
+    0.2,
+    0.35,
+    0.5,
+    0.7,
+    0.9
+  ],
+  "SliceVarMax": [
+    0.35,
+    0.5,
+    0.7,
+    0.9,
+    1.6
+  ],
+  "MassMin": [
+    2.12,
+    2.12,
+    2.12,
+    2.12,
+    2.12
+  ],
+  "MassMax": [
+    2.42,
+    2.42,
+    2.42,
+    2.42,
+    2.42
+  ],
+  "Rebin": [
+    4,
+    4,
+    4,
+    4,
+    4
+  ],
+  "InclSecPeak": false,
+  "UseLikelihood": false,
+  "_UseLikelihood": [
+    "true: likelihood fit",
+    "false: chi2 fit"
+  ],
+  "BkgFunc": [
+    2,
+    2,
+    2,
+    2,
+    2
   ],
   "_BkgFuncs": [
     "0 for Expo",
@@ -119,7 +114,6 @@
     0,
     0,
     0,
-    0,
     0
   ],
   "_SgnFuncs": [
@@ -128,9 +122,6 @@
     "2 for DoubleGausSigmaRatioPar",
     "3 for GausSec"
   ],
-  "BoundMean": false,
-  "_BoundMean": [
-    "false: Do not set limits on mean range",
-    "true: the mean is set to be between MassMin[i] and MassMax[i]"
-  ]
+  "drawBgPrefit": true,
+  "highlightPeakRegion": true
 }

--- a/PWGHF/D2H/Macros/runMassFitter.C
+++ b/PWGHF/D2H/Macros/runMassFitter.C
@@ -280,74 +280,74 @@ int runMassFitter(const TString& configFileName)
 
   // define output histos
   auto hRawYields = new TH1D("hRawYields", ";" + sliceVarName + "(" + sliceVarUnit + ");raw yield",
-                             nSliceVarBins, sliceVarLimits);
+                             nSliceVarBins, sliceVarLimits.data());
   auto hRawYieldsCounted = new TH1D("hRawYieldsCounted", ";" + sliceVarName + "(" + sliceVarUnit + ");raw yield via bin count",
-                                    nSliceVarBins, sliceVarLimits);
+                                    nSliceVarBins, sliceVarLimits.data());
   auto hRawYieldsSigma = new TH1D(
     "hRawYieldsSigma", ";" + sliceVarName + "(" + sliceVarUnit + ");width (GeV/#it{c}^{2})",
-    nSliceVarBins, sliceVarLimits);
+    nSliceVarBins, sliceVarLimits.data());
   auto hRawYieldsSigmaRatio = new TH1D(
     "hRawYieldsSigmaRatio",
-    ";" + sliceVarName + "(" + sliceVarUnit + ");ratio #sigma_{1}/#sigma_{2}", nSliceVarBins, sliceVarLimits);
+    ";" + sliceVarName + "(" + sliceVarUnit + ");ratio #sigma_{1}/#sigma_{2}", nSliceVarBins, sliceVarLimits.data());
   auto hRawYieldsSigma2 = new TH1D(
     "hRawYieldsSigma2", ";" + sliceVarName + "(" + sliceVarUnit + ");width (GeV/#it{c}^{2})",
-    nSliceVarBins, sliceVarLimits);
+    nSliceVarBins, sliceVarLimits.data());
   auto hRawYieldsMean = new TH1D(
     "hRawYieldsMean", ";" + sliceVarName + "(" + sliceVarUnit + ");mean (GeV/#it{c}^{2})",
-    nSliceVarBins, sliceVarLimits);
+    nSliceVarBins, sliceVarLimits.data());
   auto hRawYieldsFracGaus2 = new TH1D(
     "hRawYieldsFracGaus2",
-    ";" + sliceVarName + "(" + sliceVarUnit + ");second-gaussian fraction", nSliceVarBins, sliceVarLimits);
+    ";" + sliceVarName + "(" + sliceVarUnit + ");second-gaussian fraction", nSliceVarBins, sliceVarLimits.data());
   auto hRawYieldsSignificance = new TH1D(
     "hRawYieldsSignificance",
-    ";" + sliceVarName + "(" + sliceVarUnit + ");significance (3#sigma)", nSliceVarBins, sliceVarLimits);
+    ";" + sliceVarName + "(" + sliceVarUnit + ");significance (3#sigma)", nSliceVarBins, sliceVarLimits.data());
   auto hRawYieldsSgnOverBkg =
     new TH1D("hRawYieldsSgnOverBkg", ";" + sliceVarName + "(" + sliceVarUnit + ");S/B (3#sigma)",
-             nSliceVarBins, sliceVarLimits);
+             nSliceVarBins, sliceVarLimits.data());
   auto hRawYieldsSignal =
     new TH1D("hRawYieldsSignal", ";" + sliceVarName + "(" + sliceVarUnit + ");Signal (3#sigma)",
-             nSliceVarBins, sliceVarLimits);
+             nSliceVarBins, sliceVarLimits.data());
   auto hRawYieldsBkg =
     new TH1D("hRawYieldsBkg", ";" + sliceVarName + "(" + sliceVarUnit + ");Background (3#sigma)",
-             nSliceVarBins, sliceVarLimits);
+             nSliceVarBins, sliceVarLimits.data());
   auto hRawYieldsChiSquare =
     new TH1D("hRawYieldsChiSquare",
-             ";" + sliceVarName + "(" + sliceVarUnit + ");#chi^{2}/#it{ndf}", nSliceVarBins, sliceVarLimits);
+             ";" + sliceVarName + "(" + sliceVarUnit + ");#chi^{2}/#it{ndf}", nSliceVarBins, sliceVarLimits.data());
   auto hRawYieldsSecondPeak = new TH1D(
     "hRawYieldsSecondPeak", ";" + sliceVarName + "(" + sliceVarUnit + ");raw yield second peak",
-    nSliceVarBins, sliceVarLimits);
+    nSliceVarBins, sliceVarLimits.data());
   auto hRawYieldsMeanSecondPeak =
     new TH1D("hRawYieldsMeanSecondPeak",
              ";" + sliceVarName + "(" + sliceVarUnit + ");mean second peak (GeV/#it{c}^{2})",
-             nSliceVarBins, sliceVarLimits);
+             nSliceVarBins, sliceVarLimits.data());
   auto hRawYieldsSigmaSecondPeak =
     new TH1D("hRawYieldsSigmaSecondPeak",
              ";" + sliceVarName + "(" + sliceVarUnit + ");width second peak (GeV/#it{c}^{2})",
-             nSliceVarBins, sliceVarLimits);
+             nSliceVarBins, sliceVarLimits.data());
   auto hRawYieldsSignificanceSecondPeak =
     new TH1D("hRawYieldsSignificanceSecondPeak",
              ";" + sliceVarName + "(" + sliceVarUnit + ");signficance second peak (3#sigma)",
-             nSliceVarBins, sliceVarLimits);
+             nSliceVarBins, sliceVarLimits.data());
   auto hRawYieldsSigmaRatioSecondFirstPeak =
     new TH1D("hRawYieldsSigmaRatioSecondFirstPeak",
              ";" + sliceVarName + "(" + sliceVarUnit + ");width second peak / width first peak",
-             nSliceVarBins, sliceVarLimits);
+             nSliceVarBins, sliceVarLimits.data());
   auto hRawYieldsSoverBSecondPeak = new TH1D(
     "hRawYieldsSoverBSecondPeak",
-    ";" + sliceVarName + "(" + sliceVarUnit + ");S/B second peak (3#sigma)", nSliceVarBins, sliceVarLimits);
+    ";" + sliceVarName + "(" + sliceVarUnit + ");S/B second peak (3#sigma)", nSliceVarBins, sliceVarLimits.data());
   auto hRawYieldsSignalSecondPeak = new TH1D(
     "hRawYieldsSignalSecondPeak",
-    ";" + sliceVarName + "(" + sliceVarUnit + ");Signal second peak (3#sigma)", nSliceVarBins, sliceVarLimits);
+    ";" + sliceVarName + "(" + sliceVarUnit + ");Signal second peak (3#sigma)", nSliceVarBins, sliceVarLimits.data());
   auto hRawYieldsBkgSecondPeak =
     new TH1D("hRawYieldsBkgSecondPeak",
              ";" + sliceVarName + "(" + sliceVarUnit + ");Background second peak (3#sigma)",
-             nSliceVarBins, sliceVarLimits);
+             nSliceVarBins, sliceVarLimits.data());
   auto hReflectionOverSignal =
     new TH1D("hReflectionOverSignal", ";" + sliceVarName + "(" + sliceVarUnit + ");Refl/Signal",
-             nSliceVarBins, sliceVarLimits);
+             nSliceVarBins, sliceVarLimits.data());
 
   const Int_t nConfigsToSave = 6;
-  auto hFitConfig = new TH2F("hfitConfig", "Fit Configurations", nConfigsToSave, 0, 6, nSliceVarBins, sliceVarLimits);
+  auto hFitConfig = new TH2F("hfitConfig", "Fit Configurations", nConfigsToSave, 0, 6, nSliceVarBins, sliceVarLimits.data());
   const char* hFitConfigXLabel[nConfigsToSave] = {"mass min", "mass max", "rebin num", "fix sigma", "bkg func", "sgn func"};
   hFitConfig->SetStats(0);
   hFitConfig->LabelsDeflate("X");

--- a/PWGHF/D2H/Macros/runMassFitter.C
+++ b/PWGHF/D2H/Macros/runMassFitter.C
@@ -439,7 +439,7 @@ int runMassFitter(const TString& configFileName)
 
     Double_t reflOverSgn = 0;
     double markerSize = 1.;
-    const int NSliceVarBinsLarge = 15;
+    constexpr int NSliceVarBinsLarge = 15;
     if (nSliceVarBins > NSliceVarBinsLarge) {
       markerSize = 0.5;
     }
@@ -678,8 +678,8 @@ void setHistoStyle(TH1* histo, Color_t color, Size_t markerSize)
 void divideCanvas(TCanvas* canvas, int nSliceVarBins)
 {
   const int rectangularSideMin = std::floor(std::sqrt(nSliceVarBins));
-  constexpr int rectangularSidesDiffMax = 2;
-  for (int rectangularSidesDiff = 0; rectangularSidesDiff < rectangularSidesDiffMax; ++rectangularSidesDiff) {
+  constexpr int RectangularSidesDiffMax = 2;
+  for (int rectangularSidesDiff = 0; rectangularSidesDiff < RectangularSidesDiffMax; ++rectangularSidesDiff) {
     if (rectangularSideMin * (rectangularSideMin + rectangularSidesDiff) >= nSliceVarBins) {
       canvas->Divide(rectangularSideMin + rectangularSidesDiff, rectangularSideMin);
     }

--- a/PWGHF/D2H/Macros/runMassFitter.C
+++ b/PWGHF/D2H/Macros/runMassFitter.C
@@ -168,39 +168,21 @@ int runMassFitter(const TString& configFileName)
     sliceVarLimits[iSliceVar] = sliceVarMin[iSliceVar];
     sliceVarLimits[iSliceVar + 1] = sliceVarMax[iSliceVar];
 
-    if (bkgFuncConfig[iSliceVar] == 0) {
-      bkgFunc[iSliceVar] = HFInvMassFitter::Expo;
-    } else if (bkgFuncConfig[iSliceVar] == 1) {
-      bkgFunc[iSliceVar] = HFInvMassFitter::Poly1;
-    } else if (bkgFuncConfig[iSliceVar] == 2) {
-      bkgFunc[iSliceVar] = HFInvMassFitter::Poly2;
-    } else if (bkgFuncConfig[iSliceVar] == 3) {
-      bkgFunc[iSliceVar] = HFInvMassFitter::Pow;
-    } else if (bkgFuncConfig[iSliceVar] == 4) {
-      bkgFunc[iSliceVar] = HFInvMassFitter::PowExpo;
-    } else if (bkgFuncConfig[iSliceVar] == 5) {
-      bkgFunc[iSliceVar] = HFInvMassFitter::Poly3;
-    } else if (bkgFuncConfig[iSliceVar] == 6) {
-      bkgFunc[iSliceVar] = HFInvMassFitter::NoBkg;
-    } else {
+    if (bkgFuncConfig[iSliceVar] < HFInvMassFitter::Expo || bkgFuncConfig[iSliceVar] > HFInvMassFitter::NoBkg) {
       std::cerr << "ERROR: only Expo, Poly1, Poly2, Pow and PowEx background "
                    "functions supported! Exit"
                 << std::endl;
       return -1;
     }
+    bkgFunc[iSliceVar] = bkgFuncConfig[iSliceVar];
 
-    if (sgnFuncConfig[iSliceVar] == 0) {
-      sgnFunc[iSliceVar] = HFInvMassFitter::SingleGaus;
-    } else if (sgnFuncConfig[iSliceVar] == 1) {
-      sgnFunc[iSliceVar] = HFInvMassFitter::DoubleGaus;
-    } else if (sgnFuncConfig[iSliceVar] == 2) {
-      sgnFunc[iSliceVar] = HFInvMassFitter::DoubleGausSigmaRatioPar;
-    } else {
+    if (sgnFuncConfig[iSliceVar] < HFInvMassFitter::SingleGaus || sgnFuncConfig[iSliceVar] > HFInvMassFitter::DoubleGausSigmaRatioPar) {
       std::cerr << "ERROR: only SingleGaus, DoubleGaus and DoubleGausSigmaRatioPar signal "
                    "functions supported! Exit"
                 << std::endl;
       return -1;
     }
+    sgnFunc[iSliceVar] = sgnFuncConfig[iSliceVar];
   }
 
   TString massAxisTitle = "";
@@ -457,7 +439,8 @@ int runMassFitter(const TString& configFileName)
 
     Double_t reflOverSgn = 0;
     double markerSize = 1.;
-    if (nSliceVarBins > 15) {
+    const int NSliceVarBinsLarge = 15;
+    if (nSliceVarBins > NSliceVarBinsLarge) {
       markerSize = 0.5;
     }
 
@@ -694,31 +677,11 @@ void setHistoStyle(TH1* histo, Color_t color, Size_t markerSize)
 
 void divideCanvas(TCanvas* canvas, int nSliceVarBins)
 {
-  if (nSliceVarBins < 2) {
-    canvas->cd();
-  } else if (nSliceVarBins == 2 || nSliceVarBins == 3) {
-    canvas->Divide(nSliceVarBins, 1);
-  } else if (nSliceVarBins == 4 || nSliceVarBins == 6 || nSliceVarBins == 8) {
-    canvas->Divide(nSliceVarBins / 2, 2);
-  } else if (nSliceVarBins == 5 || nSliceVarBins == 7) {
-    canvas->Divide((nSliceVarBins + 1) / 2, 2);
-  } else if (nSliceVarBins == 9 || nSliceVarBins == 12 || nSliceVarBins == 15) {
-    canvas->Divide(nSliceVarBins / 3, 3);
-  } else if (nSliceVarBins == 10 || nSliceVarBins == 11) {
-    canvas->Divide(4, 3);
-  } else if (nSliceVarBins == 13 || nSliceVarBins == 14) {
-    canvas->Divide(5, 3);
-  } else if (nSliceVarBins > 15 && nSliceVarBins <= 20 && nSliceVarBins % 4 == 0) {
-    canvas->Divide(nSliceVarBins / 4, 4);
-  } else if (nSliceVarBins > 15 && nSliceVarBins <= 20 && nSliceVarBins % 4 != 0) {
-    canvas->Divide(5, 4);
-  } else if (nSliceVarBins == 21) {
-    canvas->Divide(7, 3);
-  } else if (nSliceVarBins > 21 && nSliceVarBins <= 25) {
-    canvas->Divide(5, 5);
-  } else if (nSliceVarBins > 25 && nSliceVarBins % 2 == 0) {
-    canvas->Divide(nSliceVarBins / 2, 2);
-  } else {
-    canvas->Divide((nSliceVarBins + 1) / 2, 2);
+  const int rectangularSideMin = std::floor(std::sqrt(nSliceVarBins));
+  constexpr int rectangularSidesDiffMax = 2;
+  for (int rectangularSidesDiff = 0; rectangularSidesDiff < rectangularSidesDiffMax; ++rectangularSidesDiff) {
+    if (rectangularSideMin * (rectangularSideMin + rectangularSidesDiff) >= nSliceVarBins) {
+      canvas->Divide(rectangularSideMin + rectangularSidesDiff, rectangularSideMin);
+    }
   }
 }

--- a/PWGHF/D2H/Macros/runMassFitter.C
+++ b/PWGHF/D2H/Macros/runMassFitter.C
@@ -25,8 +25,9 @@
 #include <string>   // std::string
 #include <vector>   // std::vector
 
-#include <Riostream.h>
-#include <TROOT.h>
+#include <TDatabasePDG.h>
+#include <TFile.h>
+#include <TH2F.h>
 
 // if .h file not found, please include your local rapidjson/document.h and rapidjson/filereadstream.h here
 #include <rapidjson/document.h>
@@ -34,10 +35,9 @@
 
 #endif
 
-using namespace std;
 using namespace rapidjson;
 
-int runMassFitter(TString configFileName = "config_massfitter.json");
+int runMassFitter(const TString& configFileName = "config_massfitter.json");
 
 template <typename ValueType>
 void readArray(const Value& jsonArray, std::vector<ValueType>& output)
@@ -48,7 +48,7 @@ void readArray(const Value& jsonArray, std::vector<ValueType>& output)
   }
 }
 
-void parseStringArray(const Value& jsonArray, std::vector<string>& output)
+void parseStringArray(const Value& jsonArray, std::vector<std::string>& output)
 {
   size_t arrayLength = jsonArray.Size();
   for (size_t i = 0; i < arrayLength; i++) {
@@ -58,15 +58,15 @@ void parseStringArray(const Value& jsonArray, std::vector<string>& output)
   }
 }
 
-void divideCanvas(TCanvas* c, int nPtBins);
-void setHistoStyle(TH1* histo, int color = kBlack, double markerSize = 1.);
+void divideCanvas(TCanvas* c, int nSliceVarBins);
+void setHistoStyle(TH1* histo, Color_t color = kBlack, Size_t markerSize = 1);
 
-int runMassFitter(TString configFileName)
+int runMassFitter(const TString& configFileName)
 {
   // load config
   FILE* configFile = fopen(configFileName.Data(), "r");
   if (!configFile) {
-    cerr << "ERROR: Missing configuration json file: " << configFileName << endl;
+    std::cerr << "ERROR: Missing configuration json file: " << configFileName << std::endl;
     return -1;
   }
 
@@ -82,20 +82,22 @@ int runMassFitter(TString configFileName)
   TString outputFileName = config["OutFileName"].GetString();
   TString particleName = config["Particle"].GetString();
 
-  vector<string> inputHistoName;
-  vector<string> promptHistoName;
-  vector<string> fdHistoName;
-  vector<string> reflHistoName;
-  vector<string> promptSecPeakHistoName;
-  vector<string> fdSecPeakHistoName;
-  vector<double> ptMin;
-  vector<double> ptMax;
-  vector<double> massMin;
-  vector<double> massMax;
-  vector<double> fixSigmaManual;
-  vector<int> nRebin;
-  vector<int> bkgFuncConfig;
-  vector<int> sgnFuncConfig;
+  std::vector<std::string> inputHistoName;
+  std::vector<std::string> promptHistoName;
+  std::vector<std::string> fdHistoName;
+  std::vector<std::string> reflHistoName;
+  std::vector<std::string> promptSecPeakHistoName;
+  std::vector<std::string> fdSecPeakHistoName;
+  TString sliceVarName;
+  TString sliceVarUnit;
+  std::vector<double> sliceVarMin;
+  std::vector<double> sliceVarMax;
+  std::vector<double> massMin;
+  std::vector<double> massMax;
+  std::vector<double> fixSigmaManual;
+  std::vector<int> nRebin;
+  std::vector<int> bkgFuncConfig;
+  std::vector<int> sgnFuncConfig;
 
   const Value& inputHistoNameValue = config["InputHistoName"];
   parseStringArray(inputHistoNameValue, inputHistoName);
@@ -113,23 +115,25 @@ int runMassFitter(TString configFileName)
   parseStringArray(promptSecPeakHistoNameValue, promptSecPeakHistoName);
 
   const Value& fdSecPeakHistoNameValue = config["FDSecPeakHistoName"];
-  parseStringArray(promptSecPeakHistoNameValue, promptSecPeakHistoName);
+  parseStringArray(fdSecPeakHistoNameValue, fdSecPeakHistoName);
 
   bool fixSigma = config["FixSigma"].GetBool();
-  string sigmaFile = config["SigmaFile"].GetString();
-  double sigmaMultFactor =
-    config["SigmaMultFactor"].GetDouble();
+  std::string sigmaFile = config["SigmaFile"].GetString();
+
   bool fixMean = config["FixMean"].GetBool();
-  string meanFile = config["MeanFile"].GetString();
+  std::string meanFile = config["MeanFile"].GetString();
 
   const Value& fixSigmaManualValue = config["FixSigmaManual"];
   readArray(fixSigmaManualValue, fixSigmaManual);
 
-  const Value& ptMinValue = config["PtMin"];
-  readArray(ptMinValue, ptMin);
+  sliceVarName = config["SliceVarName"].GetString();
+  sliceVarUnit = config["SliceVarUnit"].GetString();
 
-  const Value& ptMaxValue = config["PtMax"];
-  readArray(ptMaxValue, ptMax);
+  const Value& sliceVarMinValue = config["SliceVarMin"];
+  readArray(sliceVarMinValue, sliceVarMin);
+
+  const Value& sliceVarMaxValue = config["SliceVarMax"];
+  readArray(sliceVarMaxValue, sliceVarMax);
 
   const Value& massMinValue = config["MassMin"];
   readArray(massMinValue, massMin);
@@ -141,13 +145,6 @@ int runMassFitter(TString configFileName)
   readArray(rebinValue, nRebin);
 
   bool includeSecPeak = config["InclSecPeak"].GetBool();
-  string sigmaSecPeak = config["SigmaSecPeak"].GetString();
-  string sigmaFileSecPeak =
-    config["SigmaFileSecPeak"].GetString();
-  double sigmaMultFactorSecPeak =
-    config["SigmaMultFactorSecPeak"].GetDouble();
-  bool fixSigmaToFirstPeak =
-    config["FixSigmaToFirstPeak"].GetBool();
   bool useLikelihood = config["UseLikelihood"].GetBool();
 
   const Value& bkgFuncValue = config["BkgFunc"];
@@ -156,69 +153,76 @@ int runMassFitter(TString configFileName)
   const Value& sgnFuncValue = config["SgnFunc"];
   readArray(sgnFuncValue, sgnFuncConfig);
 
-  bool fixSigmaRatio = config["FixSigmaRatio"].GetBool();
-  TString sigmaRatioFile = config["SigmaRatioFile"].GetString();
-  bool boundMean = config["BoundMean"].GetBool();
   bool enableRefl = config["EnableRefl"].GetBool();
 
-  const unsigned int nPtBins = ptMin.size();
-  int bkgFunc[nPtBins], sgnFunc[nPtBins];
-  double ptLimits[nPtBins + 1];
+  bool drawBgPrefit = config["drawBgPrefit"].GetBool();
+  bool highlightPeakRegion = config["highlightPeakRegion"].GetBool();
 
-  for (unsigned int iPt = 0; iPt < nPtBins; iPt++) {
-    ptLimits[iPt] = ptMin[iPt];
-    ptLimits[iPt + 1] = ptMax[iPt];
+  const unsigned int nSliceVarBins = sliceVarMin.size();
+  int bkgFunc[nSliceVarBins], sgnFunc[nSliceVarBins];
+  double sliceVarLimits[nSliceVarBins + 1];
 
-    if (bkgFuncConfig[iPt] == 0) {
-      bkgFunc[iPt] = HFInvMassFitter::Expo;
-    } else if (bkgFuncConfig[iPt] == 1) {
-      bkgFunc[iPt] = HFInvMassFitter::Poly1;
-    } else if (bkgFuncConfig[iPt] == 2) {
-      bkgFunc[iPt] = HFInvMassFitter::Poly2;
-    } else if (bkgFuncConfig[iPt] == 3) {
-      bkgFunc[iPt] = HFInvMassFitter::Pow;
-    } else if (bkgFuncConfig[iPt] == 4) {
-      bkgFunc[iPt] = HFInvMassFitter::PowExpo;
-    } else if (bkgFuncConfig[iPt] == 5) {
-      bkgFunc[iPt] = HFInvMassFitter::Poly3;
-    } else if (bkgFuncConfig[iPt] == 6) {
-      bkgFunc[iPt] = HFInvMassFitter::NoBkg;
+  for (unsigned int iSliceVar = 0; iSliceVar < nSliceVarBins; iSliceVar++) {
+    sliceVarLimits[iSliceVar] = sliceVarMin[iSliceVar];
+    sliceVarLimits[iSliceVar + 1] = sliceVarMax[iSliceVar];
+
+    if (bkgFuncConfig[iSliceVar] == 0) {
+      bkgFunc[iSliceVar] = HFInvMassFitter::Expo;
+    } else if (bkgFuncConfig[iSliceVar] == 1) {
+      bkgFunc[iSliceVar] = HFInvMassFitter::Poly1;
+    } else if (bkgFuncConfig[iSliceVar] == 2) {
+      bkgFunc[iSliceVar] = HFInvMassFitter::Poly2;
+    } else if (bkgFuncConfig[iSliceVar] == 3) {
+      bkgFunc[iSliceVar] = HFInvMassFitter::Pow;
+    } else if (bkgFuncConfig[iSliceVar] == 4) {
+      bkgFunc[iSliceVar] = HFInvMassFitter::PowExpo;
+    } else if (bkgFuncConfig[iSliceVar] == 5) {
+      bkgFunc[iSliceVar] = HFInvMassFitter::Poly3;
+    } else if (bkgFuncConfig[iSliceVar] == 6) {
+      bkgFunc[iSliceVar] = HFInvMassFitter::NoBkg;
     } else {
-      cerr << "ERROR: only Expo, Poly1, Poly2, Pow and PowEx background "
-              "functions supported! Exit"
-           << endl;
+      std::cerr << "ERROR: only Expo, Poly1, Poly2, Pow and PowEx background "
+                   "functions supported! Exit"
+                << std::endl;
       return -1;
     }
 
-    if (sgnFuncConfig[iPt] == 0) {
-      sgnFunc[iPt] = HFInvMassFitter::SingleGaus;
-    } else if (sgnFuncConfig[iPt] == 1) {
-      sgnFunc[iPt] = HFInvMassFitter::DoubleGaus;
-    } else if (sgnFuncConfig[iPt] == 2) {
-      sgnFunc[iPt] = HFInvMassFitter::DoubleGausSigmaRatioPar;
+    if (sgnFuncConfig[iSliceVar] == 0) {
+      sgnFunc[iSliceVar] = HFInvMassFitter::SingleGaus;
+    } else if (sgnFuncConfig[iSliceVar] == 1) {
+      sgnFunc[iSliceVar] = HFInvMassFitter::DoubleGaus;
+    } else if (sgnFuncConfig[iSliceVar] == 2) {
+      sgnFunc[iSliceVar] = HFInvMassFitter::DoubleGausSigmaRatioPar;
     } else {
-      cerr << "ERROR: only SingleGaus, DoubleGaus and DoubleGausSigmaRatioPar signal "
-              "functions supported! Exit"
-           << endl;
+      std::cerr << "ERROR: only SingleGaus, DoubleGaus and DoubleGausSigmaRatioPar signal "
+                   "functions supported! Exit"
+                << std::endl;
       return -1;
     }
   }
 
   TString massAxisTitle = "";
+  double massPDG;
   if (particleName == "Dplus") {
     massAxisTitle = "#it{M}(K#pi#pi) (GeV/#it{c}^{2})";
+    massPDG = TDatabasePDG::Instance()->GetParticle("D+")->Mass();
   } else if (particleName == "D0") {
     massAxisTitle = "#it{M}(K#pi) (GeV/#it{c}^{2})";
+    massPDG = TDatabasePDG::Instance()->GetParticle("D0")->Mass();
   } else if (particleName == "Ds") {
     massAxisTitle = "#it{M}(KK#pi) (GeV/#it{c}^{2})";
+    massPDG = TDatabasePDG::Instance()->GetParticle("D_s+")->Mass();
   } else if (particleName == "LcToPKPi") {
     massAxisTitle = "#it{M}(pK#pi) (GeV/#it{c}^{2})";
+    massPDG = TDatabasePDG::Instance()->GetParticle("Lambda_c+")->Mass();
   } else if (particleName == "LcToPK0s") {
     massAxisTitle = "#it{M}(pK^{0}_{s}) (GeV/#it{c}^{2})";
+    massPDG = TDatabasePDG::Instance()->GetParticle("Lambda_c+")->Mass();
   } else if (particleName == "Dstar") {
     massAxisTitle = "#it{M}(pi^{+}) (GeV/#it{c}^{2})";
+    massPDG = TDatabasePDG::Instance()->GetParticle("D*+")->Mass();
   } else {
-    cerr << "ERROR: only Dplus, D0, Ds, LcToPKPi, LcToPK0s and Dstar particles supported! Exit" << endl;
+    std::cerr << "ERROR: only Dplus, D0, Ds, LcToPKPi, LcToPK0s and Dstar particles supported! Exit" << std::endl;
     return -1;
   }
 
@@ -228,7 +232,7 @@ int runMassFitter(TString configFileName)
     return -1;
   }
 
-  TFile* inputFileRefl = NULL;
+  TFile* inputFileRefl = nullptr;
   if (enableRefl) {
     inputFileRefl = TFile::Open(reflFileName.Data());
     if (!inputFileRefl || !inputFileRefl->IsOpen()) {
@@ -236,110 +240,112 @@ int runMassFitter(TString configFileName)
     }
   }
 
-  TH1F* hMassSgn[nPtBins];
-  TH1F* hMassRefl[nPtBins];
-  TH1F* hMass[nPtBins];
+  TH1* hMassSgn[nSliceVarBins];
+  TH1* hMassRefl[nSliceVarBins];
+  TH1* hMass[nSliceVarBins];
 
-  for (unsigned int iPt = 0; iPt < nPtBins; iPt++) {
+  for (unsigned int iSliceVar = 0; iSliceVar < nSliceVarBins; iSliceVar++) {
     if (!isMc) {
-      hMass[iPt] = static_cast<TH1F*>(inputFile->Get(inputHistoName[iPt].data()));
+      hMass[iSliceVar] = inputFile->Get<TH1>(inputHistoName[iSliceVar].data());
       if (enableRefl) {
-        hMassRefl[iPt] = static_cast<TH1F*>(inputFileRefl->Get(reflHistoName[iPt].data()));
-        hMassSgn[iPt] = static_cast<TH1F*>(inputFileRefl->Get(fdHistoName[iPt].data()));
-        hMassSgn[iPt]->Add(static_cast<TH1F*>(inputFileRefl->Get(promptHistoName[iPt].data())));
-        if (!hMassRefl[iPt]) {
-          cerr << "ERROR: MC reflection histogram not found! Exit!" << endl;
+        hMassRefl[iSliceVar] = inputFileRefl->Get<TH1>(reflHistoName[iSliceVar].data());
+        hMassSgn[iSliceVar] = inputFileRefl->Get<TH1>(fdHistoName[iSliceVar].data());
+        hMassSgn[iSliceVar]->Add(inputFileRefl->Get<TH1>(promptHistoName[iSliceVar].data()));
+        if (!hMassRefl[iSliceVar]) {
+          std::cerr << "ERROR: MC reflection histogram not found! Exit!" << std::endl;
           return -1;
         }
-        if (!hMassSgn[iPt]) {
-          cerr << "ERROR: MC prompt or FD histogram not found! Exit!" << endl;
+        if (!hMassSgn[iSliceVar]) {
+          std::cerr << "ERROR: MC prompt or FD histogram not found! Exit!" << std::endl;
           return -1;
         }
       }
     } else {
-      hMass[iPt] = static_cast<TH1F*>(inputFile->Get(promptHistoName[iPt].data()));
-      hMass[iPt]->Add(static_cast<TH1F*>(inputFile->Get(fdHistoName[iPt].data())));
+      hMass[iSliceVar] = inputFile->Get<TH1>(promptHistoName[iSliceVar].data());
+      hMass[iSliceVar]->Add(inputFile->Get<TH1>(fdHistoName[iSliceVar].data()));
       if (includeSecPeak) {
-        hMass[iPt]->Add(static_cast<TH1F*>(inputFile->Get(promptSecPeakHistoName[iPt].data())));
-        hMass[iPt]->Add(static_cast<TH1F*>(inputFile->Get(fdSecPeakHistoName[iPt].data())));
+        hMass[iSliceVar]->Add(inputFile->Get<TH1>(promptSecPeakHistoName[iSliceVar].data()));
+        hMass[iSliceVar]->Add(inputFile->Get<TH1>(fdSecPeakHistoName[iSliceVar].data()));
       }
     }
-    if (!hMass[iPt]) {
-      cerr << "ERROR: input histogram for fit not found! Exit!" << endl;
+    if (!hMass[iSliceVar]) {
+      std::cerr << "ERROR: input histogram for fit not found! Exit!" << std::endl;
       return -1;
     }
-    hMass[iPt]->SetDirectory(0);
+    hMass[iSliceVar]->SetDirectory(nullptr);
   }
   inputFile->Close();
 
   // define output histos
-  auto hRawYields = new TH1D("hRawYields", ";#it{p}_{T} (GeV/#it{c});raw yield",
-                             nPtBins, ptLimits);
+  auto hRawYields = new TH1D("hRawYields", ";" + sliceVarName + "(" + sliceVarUnit + ");raw yield",
+                             nSliceVarBins, sliceVarLimits);
+  auto hRawYieldsCounted = new TH1D("hRawYieldsCounted", ";" + sliceVarName + "(" + sliceVarUnit + ");raw yield via bin count",
+                                    nSliceVarBins, sliceVarLimits);
   auto hRawYieldsSigma = new TH1D(
-    "hRawYieldsSigma", ";#it{p}_{T} (GeV/#it{c});width (GeV/#it{c}^{2})",
-    nPtBins, ptLimits);
+    "hRawYieldsSigma", ";" + sliceVarName + "(" + sliceVarUnit + ");width (GeV/#it{c}^{2})",
+    nSliceVarBins, sliceVarLimits);
   auto hRawYieldsSigmaRatio = new TH1D(
     "hRawYieldsSigmaRatio",
-    ";#it{p}_{T} (GeV/#it{c});ratio #sigma_{1}/#sigma_{2}", nPtBins, ptLimits);
+    ";" + sliceVarName + "(" + sliceVarUnit + ");ratio #sigma_{1}/#sigma_{2}", nSliceVarBins, sliceVarLimits);
   auto hRawYieldsSigma2 = new TH1D(
-    "hRawYieldsSigma2", ";#it{p}_{T} (GeV/#it{c});width (GeV/#it{c}^{2})",
-    nPtBins, ptLimits);
+    "hRawYieldsSigma2", ";" + sliceVarName + "(" + sliceVarUnit + ");width (GeV/#it{c}^{2})",
+    nSliceVarBins, sliceVarLimits);
   auto hRawYieldsMean = new TH1D(
-    "hRawYieldsMean", ";#it{p}_{T} (GeV/#it{c});mean (GeV/#it{c}^{2})",
-    nPtBins, ptLimits);
+    "hRawYieldsMean", ";" + sliceVarName + "(" + sliceVarUnit + ");mean (GeV/#it{c}^{2})",
+    nSliceVarBins, sliceVarLimits);
   auto hRawYieldsFracGaus2 = new TH1D(
     "hRawYieldsFracGaus2",
-    ";#it{p}_{T} (GeV/#it{c});second-gaussian fraction", nPtBins, ptLimits);
+    ";" + sliceVarName + "(" + sliceVarUnit + ");second-gaussian fraction", nSliceVarBins, sliceVarLimits);
   auto hRawYieldsSignificance = new TH1D(
     "hRawYieldsSignificance",
-    ";#it{p}_{T} (GeV/#it{c});significance (3#sigma)", nPtBins, ptLimits);
+    ";" + sliceVarName + "(" + sliceVarUnit + ");significance (3#sigma)", nSliceVarBins, sliceVarLimits);
   auto hRawYieldsSgnOverBkg =
-    new TH1D("hRawYieldsSgnOverBkg", ";#it{p}_{T} (GeV/#it{c});S/B (3#sigma)",
-             nPtBins, ptLimits);
+    new TH1D("hRawYieldsSgnOverBkg", ";" + sliceVarName + "(" + sliceVarUnit + ");S/B (3#sigma)",
+             nSliceVarBins, sliceVarLimits);
   auto hRawYieldsSignal =
-    new TH1D("hRawYieldsSignal", ";#it{p}_{T} (GeV/#it{c});Signal (3#sigma)",
-             nPtBins, ptLimits);
+    new TH1D("hRawYieldsSignal", ";" + sliceVarName + "(" + sliceVarUnit + ");Signal (3#sigma)",
+             nSliceVarBins, sliceVarLimits);
   auto hRawYieldsBkg =
-    new TH1D("hRawYieldsBkg", ";#it{p}_{T} (GeV/#it{c});Background (3#sigma)",
-             nPtBins, ptLimits);
+    new TH1D("hRawYieldsBkg", ";" + sliceVarName + "(" + sliceVarUnit + ");Background (3#sigma)",
+             nSliceVarBins, sliceVarLimits);
   auto hRawYieldsChiSquare =
     new TH1D("hRawYieldsChiSquare",
-             ";#it{p}_{T} (GeV/#it{c});#chi^{2}/#it{ndf}", nPtBins, ptLimits);
+             ";" + sliceVarName + "(" + sliceVarUnit + ");#chi^{2}/#it{ndf}", nSliceVarBins, sliceVarLimits);
   auto hRawYieldsSecondPeak = new TH1D(
-    "hRawYieldsSecondPeak", ";#it{p}_{T} (GeV/#it{c});raw yield second peak",
-    nPtBins, ptLimits);
+    "hRawYieldsSecondPeak", ";" + sliceVarName + "(" + sliceVarUnit + ");raw yield second peak",
+    nSliceVarBins, sliceVarLimits);
   auto hRawYieldsMeanSecondPeak =
     new TH1D("hRawYieldsMeanSecondPeak",
-             ";#it{p}_{T} (GeV/#it{c});mean second peak (GeV/#it{c}^{2})",
-             nPtBins, ptLimits);
+             ";" + sliceVarName + "(" + sliceVarUnit + ");mean second peak (GeV/#it{c}^{2})",
+             nSliceVarBins, sliceVarLimits);
   auto hRawYieldsSigmaSecondPeak =
     new TH1D("hRawYieldsSigmaSecondPeak",
-             ";#it{p}_{T} (GeV/#it{c});width second peak (GeV/#it{c}^{2})",
-             nPtBins, ptLimits);
+             ";" + sliceVarName + "(" + sliceVarUnit + ");width second peak (GeV/#it{c}^{2})",
+             nSliceVarBins, sliceVarLimits);
   auto hRawYieldsSignificanceSecondPeak =
     new TH1D("hRawYieldsSignificanceSecondPeak",
-             ";#it{p}_{T} (GeV/#it{c});signficance second peak (3#sigma)",
-             nPtBins, ptLimits);
+             ";" + sliceVarName + "(" + sliceVarUnit + ");signficance second peak (3#sigma)",
+             nSliceVarBins, sliceVarLimits);
   auto hRawYieldsSigmaRatioSecondFirstPeak =
     new TH1D("hRawYieldsSigmaRatioSecondFirstPeak",
-             ";#it{p}_{T} (GeV/#it{c});width second peak / width first peak",
-             nPtBins, ptLimits);
+             ";" + sliceVarName + "(" + sliceVarUnit + ");width second peak / width first peak",
+             nSliceVarBins, sliceVarLimits);
   auto hRawYieldsSoverBSecondPeak = new TH1D(
     "hRawYieldsSoverBSecondPeak",
-    ";#it{p}_{T} (GeV/#it{c});S/B second peak (3#sigma)", nPtBins, ptLimits);
+    ";" + sliceVarName + "(" + sliceVarUnit + ");S/B second peak (3#sigma)", nSliceVarBins, sliceVarLimits);
   auto hRawYieldsSignalSecondPeak = new TH1D(
     "hRawYieldsSignalSecondPeak",
-    ";#it{p}_{T} (GeV/#it{c});Signal second peak (3#sigma)", nPtBins, ptLimits);
+    ";" + sliceVarName + "(" + sliceVarUnit + ");Signal second peak (3#sigma)", nSliceVarBins, sliceVarLimits);
   auto hRawYieldsBkgSecondPeak =
     new TH1D("hRawYieldsBkgSecondPeak",
-             ";#it{p}_{T} (GeV/#it{c});Background second peak (3#sigma)",
-             nPtBins, ptLimits);
+             ";" + sliceVarName + "(" + sliceVarUnit + ");Background second peak (3#sigma)",
+             nSliceVarBins, sliceVarLimits);
   auto hReflectionOverSignal =
-    new TH1D("hReflectionOverSignal", ";#it{p}_{T} (GeV/#it{c});Refl/Signal",
-             nPtBins, ptLimits);
+    new TH1D("hReflectionOverSignal", ";" + sliceVarName + "(" + sliceVarUnit + ");Refl/Signal",
+             nSliceVarBins, sliceVarLimits);
 
   const Int_t nConfigsToSave = 6;
-  auto hFitConfig = new TH2F("hfitConfig", "Fit Configurations", nConfigsToSave, 0, 6, nPtBins, ptLimits);
+  auto hFitConfig = new TH2F("hfitConfig", "Fit Configurations", nConfigsToSave, 0, 6, nSliceVarBins, sliceVarLimits);
   const char* hFitConfigXLabel[nConfigsToSave] = {"mass min", "mass max", "rebin num", "fix sigma", "bkg func", "sgn func"};
   hFitConfig->SetStats(0);
   hFitConfig->LabelsDeflate("X");
@@ -350,6 +356,7 @@ int runMassFitter(TString configFileName)
   }
 
   setHistoStyle(hRawYields);
+  setHistoStyle(hRawYieldsCounted);
   setHistoStyle(hRawYieldsSigma);
   setHistoStyle(hRawYieldsSigma2);
   setHistoStyle(hRawYieldsMean);
@@ -369,53 +376,53 @@ int runMassFitter(TString configFileName)
   setHistoStyle(hRawYieldsBkgSecondPeak, kRed + 1);
   setHistoStyle(hReflectionOverSignal, kRed + 1);
 
-  TH1D* hSigmaToFix = NULL;
+  TH1* hSigmaToFix = nullptr;
   if (fixSigma) {
     if (fixSigmaManual.empty()) {
       auto inputFileSigma = TFile::Open(sigmaFile.data());
       if (!inputFileSigma) {
         return -2;
       }
-      hSigmaToFix = static_cast<TH1D*>(inputFileSigma->Get("hRawYieldsSigma"));
+      hSigmaToFix = inputFileSigma->Get<TH1>("hRawYieldsSigma");
       hSigmaToFix->SetDirectory(0);
-      if (static_cast<unsigned int>(hSigmaToFix->GetNbinsX()) != nPtBins) {
-        cout << "WARNING: Different number of bins for this analysis and histo for fix sigma!" << endl;
+      if (static_cast<unsigned int>(hSigmaToFix->GetNbinsX()) != nSliceVarBins) {
+        std::cout << "WARNING: Different number of bins for this analysis and histo for fix sigma!" << std::endl;
       }
       inputFileSigma->Close();
     }
   }
 
-  TH1D* hMeanToFix = NULL;
+  TH1* hMeanToFix = nullptr;
   if (fixMean) {
     auto inputFileMean = TFile::Open(meanFile.data());
     if (!inputFileMean) {
       return -3;
     }
-    hMeanToFix = static_cast<TH1D*>(inputFileMean->Get("hRawYieldsMean"));
+    hMeanToFix = inputFileMean->Get<TH1>("hRawYieldsMean");
     hMeanToFix->SetDirectory(0);
-    if (static_cast<unsigned int>(hMeanToFix->GetNbinsX()) != nPtBins) {
-      cout << "WARNING: Different number of bins for this analysis and histo for fix mean" << endl;
+    if (static_cast<unsigned int>(hMeanToFix->GetNbinsX()) != nSliceVarBins) {
+      std::cout << "WARNING: Different number of bins for this analysis and histo for fix mean" << std::endl;
     }
     inputFileMean->Close();
   }
 
   // fit histograms
 
-  TH1F* hMassForFit[nPtBins];
-  TH1F* hMassForRefl[nPtBins];
-  TH1F* hMassForSgn[nPtBins];
+  TH1* hMassForFit[nSliceVarBins];
+  TH1* hMassForRefl[nSliceVarBins];
+  TH1* hMassForSgn[nSliceVarBins];
 
   Int_t canvasSize[2] = {1920, 1080};
-  if (nPtBins == 1) {
+  if (nSliceVarBins == 1) {
     canvasSize[0] = 500;
     canvasSize[1] = 500;
   }
 
   Int_t nCanvasesMax = 20; // do not put more than 20 bins per canvas to make them visible
-  const Int_t nCanvases = ceil((float)nPtBins / nCanvasesMax);
+  const Int_t nCanvases = ceil(static_cast<float>(nSliceVarBins) / nCanvasesMax);
   TCanvas *canvasMass[nCanvases], *canvasResiduals[nCanvases], *canvasRefl[nCanvases];
   for (int iCanvas = 0; iCanvas < nCanvases; iCanvas++) {
-    int nPads = (nCanvases == 1) ? nPtBins : nCanvasesMax;
+    int nPads = (nCanvases == 1) ? nSliceVarBins : nCanvasesMax;
     canvasMass[iCanvas] = new TCanvas(Form("canvasMass%d", iCanvas), Form("canvasMass%d", iCanvas),
                                       canvasSize[0], canvasSize[1]);
     divideCanvas(canvasMass[iCanvas], nPads);
@@ -428,37 +435,40 @@ int runMassFitter(TString configFileName)
     divideCanvas(canvasRefl[iCanvas], nPads);
   }
 
-  for (unsigned int iPt = 0; iPt < nPtBins; iPt++) {
-    Int_t iCanvas = floor((float)iPt / nCanvasesMax);
+  for (unsigned int iSliceVar = 0; iSliceVar < nSliceVarBins; iSliceVar++) {
+    Int_t iCanvas = floor(static_cast<float>(iSliceVar) / nCanvasesMax);
 
-    hMassForFit[iPt] = reinterpret_cast<TH1F*>(hMass[iPt]->Rebin(nRebin[iPt]));
+    hMassForFit[iSliceVar] = static_cast<TH1*>(hMass[iSliceVar]->Rebin(nRebin[iSliceVar]));
     TString ptTitle =
-      Form("%0.1f < #it{p}_{T} < %0.1f GeV/#it{c}", ptMin[iPt], ptMax[iPt]);
-    hMassForFit[iPt]->SetTitle(Form("%s;%s;Counts per %0.f MeV/#it{c}^{2}",
-                                    ptTitle.Data(), massAxisTitle.Data(),
-                                    hMassForFit[iPt]->GetBinWidth(1) * 1000));
-    hMassForFit[iPt]->SetName(Form("MassForFit%d", iPt));
+      Form("%0.2f < " + sliceVarName + " < %0.2f " + sliceVarUnit, sliceVarMin[iSliceVar], sliceVarMax[iSliceVar]);
+    hMassForFit[iSliceVar]->SetTitle(Form("%s;%s;Counts per %0.1f MeV/#it{c}^{2}",
+                                          ptTitle.Data(), massAxisTitle.Data(),
+                                          hMassForFit[iSliceVar]->GetBinWidth(1) * 1000));
+    hMassForFit[iSliceVar]->SetName(Form("MassForFit%d", iSliceVar));
 
     if (enableRefl) {
-      hMassForRefl[iPt] =
-        reinterpret_cast<TH1F*>(hMassRefl[iPt]->Rebin(nRebin[iPt]));
-      hMassForSgn[iPt] =
-        reinterpret_cast<TH1F*>(hMassSgn[iPt]->Rebin(nRebin[iPt]));
+      hMassForRefl[iSliceVar] = static_cast<TH1*>(hMassRefl[iSliceVar]->Rebin(nRebin[iSliceVar]));
+      hMassForSgn[iSliceVar] = static_cast<TH1*>(hMassSgn[iSliceVar]->Rebin(nRebin[iSliceVar]));
     }
 
     Double_t reflOverSgn = 0;
     double markerSize = 1.;
-    if (nPtBins > 15) {
+    if (nSliceVarBins > 15) {
       markerSize = 0.5;
     }
 
     if (isMc) {
       HFInvMassFitter* massFitter;
-      massFitter = new HFInvMassFitter(hMassForFit[iPt], massMin[iPt], massMax[iPt], HFInvMassFitter::NoBkg, sgnFunc[iPt]);
-      massFitter->doFit(false);
+      massFitter = new HFInvMassFitter(hMassForFit[iSliceVar], massMin[iSliceVar], massMax[iSliceVar], HFInvMassFitter::NoBkg, sgnFunc[iSliceVar]);
+      massFitter->setDrawBgPrefit(drawBgPrefit);
+      massFitter->setHighlightPeakRegion(highlightPeakRegion);
+      massFitter->setInitialGaussianMean(massPDG);
+      massFitter->setParticlePdgMass(massPDG);
+      massFitter->setBoundGaussianMean(massPDG, 0.8 * massPDG, 1.2 * massPDG);
+      massFitter->doFit();
 
-      if (nPtBins > 1) {
-        canvasMass[iCanvas]->cd(iPt - nCanvasesMax * iCanvas + 1);
+      if (nSliceVarBins > 1) {
+        canvasMass[iCanvas]->cd(iSliceVar - nCanvasesMax * iCanvas + 1);
       } else {
         canvasMass[iCanvas]->cd();
       }
@@ -467,6 +477,8 @@ int runMassFitter(TString configFileName)
 
       Double_t rawYield = massFitter->getRawYield();
       Double_t rawYieldErr = massFitter->getRawYieldError();
+      Double_t rawYieldCounted = massFitter->getRawYieldCounted();
+      Double_t rawYieldCountedErr = massFitter->getRawYieldCountedError();
 
       Double_t sigma = massFitter->getSigma();
       Double_t sigmaErr = massFitter->getSigmaUncertainty();
@@ -474,53 +486,62 @@ int runMassFitter(TString configFileName)
       Double_t meanErr = massFitter->getMeanUncertainty();
       Double_t reducedChiSquare = massFitter->getChiSquareOverNDF();
 
-      hRawYields->SetBinContent(iPt + 1, rawYield);
-      hRawYields->SetBinError(iPt + 1, rawYieldErr);
-      hRawYieldsSigma->SetBinContent(iPt + 1, sigma);
-      hRawYieldsSigma->SetBinError(iPt + 1, sigmaErr);
-      hRawYieldsMean->SetBinContent(iPt + 1, mean);
-      hRawYieldsMean->SetBinError(iPt + 1, meanErr);
-      hRawYieldsChiSquare->SetBinContent(iPt + 1, reducedChiSquare);
-      hRawYieldsChiSquare->SetBinError(iPt + 1, 0.);
+      hRawYields->SetBinContent(iSliceVar + 1, rawYield);
+      hRawYields->SetBinError(iSliceVar + 1, rawYieldErr);
+      hRawYieldsCounted->SetBinContent(iSliceVar + 1, rawYieldCounted);
+      hRawYieldsCounted->SetBinError(iSliceVar + 1, rawYieldCountedErr);
+      hRawYieldsSigma->SetBinContent(iSliceVar + 1, sigma);
+      hRawYieldsSigma->SetBinError(iSliceVar + 1, sigmaErr);
+      hRawYieldsMean->SetBinContent(iSliceVar + 1, mean);
+      hRawYieldsMean->SetBinError(iSliceVar + 1, meanErr);
+      hRawYieldsChiSquare->SetBinContent(iSliceVar + 1, reducedChiSquare);
+      hRawYieldsChiSquare->SetBinError(iSliceVar + 1, 0.);
     } else {
       HFInvMassFitter* massFitter;
-      massFitter = new HFInvMassFitter(hMassForFit[iPt], massMin[iPt], massMax[iPt],
-                                       bkgFunc[iPt], sgnFunc[iPt]);
+      massFitter = new HFInvMassFitter(hMassForFit[iSliceVar], massMin[iSliceVar], massMax[iSliceVar],
+                                       bkgFunc[iSliceVar], sgnFunc[iSliceVar]);
+      massFitter->setDrawBgPrefit(drawBgPrefit);
+      massFitter->setHighlightPeakRegion(highlightPeakRegion);
+      massFitter->setInitialGaussianMean(massPDG);
+      massFitter->setParticlePdgMass(massPDG);
+      massFitter->setBoundGaussianMean(massPDG, 0.8 * massPDG, 1.2 * massPDG);
       if (useLikelihood) {
         massFitter->setUseLikelihoodFit();
       }
       if (fixMean) {
-        massFitter->setFixGaussianMean(hMeanToFix->GetBinContent(iPt + 1));
+        massFitter->setFixGaussianMean(hMeanToFix->GetBinContent(iSliceVar + 1));
       }
       if (fixSigma) {
         if (fixSigmaManual.empty()) {
-          massFitter->setFixGaussianSigma(hSigmaToFix->GetBinContent(iPt + 1));
-          cout << "*****************************"
-               << "\n"
-               << "FIXED SIGMA: " << hSigmaToFix->GetBinContent(iPt + 1) << "\n"
-               << "*****************************" << endl;
+          massFitter->setFixGaussianSigma(hSigmaToFix->GetBinContent(iSliceVar + 1));
+          std::cout << "*****************************"
+                    << "\n"
+                    << "FIXED SIGMA: " << hSigmaToFix->GetBinContent(iSliceVar + 1) << "\n"
+                    << "*****************************" << std::endl;
         } else if (!fixSigmaManual.empty()) {
-          massFitter->setFixGaussianSigma(fixSigmaManual[iPt]);
-          cout << "*****************************"
-               << "\n"
-               << "FIXED SIGMA: " << fixSigmaManual[iPt] << "\n"
-               << "*****************************" << endl;
+          massFitter->setFixGaussianSigma(fixSigmaManual[iSliceVar]);
+          std::cout << "*****************************"
+                    << "\n"
+                    << "FIXED SIGMA: " << fixSigmaManual[iSliceVar] << "\n"
+                    << "*****************************" << std::endl;
         } else {
-          cout << "WARNING: impossible to fix sigma! Wrong fix sigma file or value!" << endl;
+          std::cout << "WARNING: impossible to fix sigma! Wrong fix sigma file or value!" << std::endl;
         }
       }
 
       if (enableRefl) {
-        reflOverSgn = hMassForSgn[iPt]->Integral(hMassForSgn[iPt]->FindBin(massMin[iPt] * 1.0001), hMassForSgn[iPt]->FindBin(massMax[iPt] * 0.999));
-        reflOverSgn = hMassForRefl[iPt]->Integral(hMassForRefl[iPt]->FindBin(massMin[iPt] * 1.0001), hMassForRefl[iPt]->FindBin(massMax[iPt] * 0.999)) / reflOverSgn;
+        reflOverSgn = hMassForSgn[iSliceVar]->Integral(hMassForSgn[iSliceVar]->FindBin(massMin[iSliceVar] * 1.0001), hMassForSgn[iSliceVar]->FindBin(massMax[iSliceVar] * 0.999));
+        reflOverSgn = hMassForRefl[iSliceVar]->Integral(hMassForRefl[iSliceVar]->FindBin(massMin[iSliceVar] * 1.0001), hMassForRefl[iSliceVar]->FindBin(massMax[iSliceVar] * 0.999)) / reflOverSgn;
         massFitter->setFixReflOverSgn(reflOverSgn);
-        massFitter->setTemplateReflections(hMassRefl[iPt], HFInvMassFitter::DoubleGaus);
+        massFitter->setTemplateReflections(hMassRefl[iSliceVar], HFInvMassFitter::DoubleGaus);
       }
 
-      massFitter->doFit(false);
+      massFitter->doFit();
 
       double rawYield = massFitter->getRawYield();
       double rawYieldErr = massFitter->getRawYieldError();
+      double rawYieldCounted = massFitter->getRawYieldCounted();
+      double rawYieldCountedErr = massFitter->getRawYieldCountedError();
       double sigma = massFitter->getSigma();
       double sigmaErr = massFitter->getSigmaUncertainty();
       double mean = massFitter->getMean();
@@ -531,29 +552,31 @@ int runMassFitter(TString configFileName)
       double bkg = massFitter->getBkgYield();
       double bkgErr = massFitter->getBkgYieldError();
 
-      hRawYields->SetBinContent(iPt + 1, rawYield);
-      hRawYields->SetBinError(iPt + 1, rawYieldErr);
-      hRawYieldsSigma->SetBinContent(iPt + 1, sigma);
-      hRawYieldsSigma->SetBinError(iPt + 1, sigmaErr);
-      hRawYieldsMean->SetBinContent(iPt + 1, mean);
-      hRawYieldsMean->SetBinError(iPt + 1, meanErr);
-      hRawYieldsSignificance->SetBinContent(iPt + 1, significance);
-      hRawYieldsSignificance->SetBinError(iPt + 1, significanceErr);
-      hRawYieldsSgnOverBkg->SetBinContent(iPt + 1, rawYield / bkg);
-      hRawYieldsSgnOverBkg->SetBinError(iPt + 1, rawYield / bkg * std::sqrt(rawYieldErr / rawYield * rawYieldErr / rawYield + bkgErr / bkg * bkgErr / bkg));
-      hRawYieldsSignal->SetBinContent(iPt + 1, rawYield);
-      hRawYieldsSignal->SetBinError(iPt + 1, rawYieldErr);
-      hRawYieldsBkg->SetBinContent(iPt + 1, bkg);
-      hRawYieldsBkg->SetBinError(iPt + 1, bkgErr);
-      hRawYieldsChiSquare->SetBinContent(iPt + 1, reducedChiSquare);
-      hRawYieldsChiSquare->SetBinError(iPt + 1, 1.e-20);
+      hRawYields->SetBinContent(iSliceVar + 1, rawYield);
+      hRawYields->SetBinError(iSliceVar + 1, rawYieldErr);
+      hRawYieldsCounted->SetBinContent(iSliceVar + 1, rawYieldCounted);
+      hRawYieldsCounted->SetBinError(iSliceVar + 1, rawYieldCountedErr);
+      hRawYieldsSigma->SetBinContent(iSliceVar + 1, sigma);
+      hRawYieldsSigma->SetBinError(iSliceVar + 1, sigmaErr);
+      hRawYieldsMean->SetBinContent(iSliceVar + 1, mean);
+      hRawYieldsMean->SetBinError(iSliceVar + 1, meanErr);
+      hRawYieldsSignificance->SetBinContent(iSliceVar + 1, significance);
+      hRawYieldsSignificance->SetBinError(iSliceVar + 1, significanceErr);
+      hRawYieldsSgnOverBkg->SetBinContent(iSliceVar + 1, rawYield / bkg);
+      hRawYieldsSgnOverBkg->SetBinError(iSliceVar + 1, rawYield / bkg * std::sqrt(rawYieldErr / rawYield * rawYieldErr / rawYield + bkgErr / bkg * bkgErr / bkg));
+      hRawYieldsSignal->SetBinContent(iSliceVar + 1, rawYield);
+      hRawYieldsSignal->SetBinError(iSliceVar + 1, rawYieldErr);
+      hRawYieldsBkg->SetBinContent(iSliceVar + 1, bkg);
+      hRawYieldsBkg->SetBinError(iSliceVar + 1, bkgErr);
+      hRawYieldsChiSquare->SetBinContent(iSliceVar + 1, reducedChiSquare);
+      hRawYieldsChiSquare->SetBinError(iSliceVar + 1, 1.e-20);
       if (enableRefl) {
-        hReflectionOverSignal->SetBinContent(iPt + 1, reflOverSgn);
+        hReflectionOverSignal->SetBinContent(iSliceVar + 1, reflOverSgn);
       }
 
       if (enableRefl) {
-        if (nPtBins > 1) {
-          canvasRefl[iCanvas]->cd(iPt - nCanvasesMax * iCanvas + 1);
+        if (nSliceVarBins > 1) {
+          canvasRefl[iCanvas]->cd(iSliceVar - nCanvasesMax * iCanvas + 1);
         } else {
           canvasRefl[iCanvas]->cd();
         }
@@ -562,8 +585,8 @@ int runMassFitter(TString configFileName)
         canvasRefl[iCanvas]->Update();
       }
 
-      if (nPtBins > 1) {
-        canvasMass[iCanvas]->cd(iPt - nCanvasesMax * iCanvas + 1);
+      if (nSliceVarBins > 1) {
+        canvasMass[iCanvas]->cd(iSliceVar - nCanvasesMax * iCanvas + 1);
       } else {
         canvasMass[iCanvas]->cd();
       }
@@ -571,8 +594,8 @@ int runMassFitter(TString configFileName)
       canvasMass[iCanvas]->Modified();
       canvasMass[iCanvas]->Update();
 
-      if (nPtBins > 1) {
-        canvasResiduals[iCanvas]->cd(iPt - nCanvasesMax * iCanvas + 1);
+      if (nSliceVarBins > 1) {
+        canvasResiduals[iCanvas]->cd(iSliceVar - nCanvasesMax * iCanvas + 1);
       } else {
         canvasResiduals[iCanvas]->cd();
       }
@@ -581,18 +604,18 @@ int runMassFitter(TString configFileName)
       canvasResiduals[iCanvas]->Update();
     }
 
-    hFitConfig->SetBinContent(1, iPt + 1, massMin[iPt]);
-    hFitConfig->SetBinContent(2, iPt + 1, massMax[iPt]);
-    hFitConfig->SetBinContent(3, iPt + 1, nRebin[iPt]);
+    hFitConfig->SetBinContent(1, iSliceVar + 1, massMin[iSliceVar]);
+    hFitConfig->SetBinContent(2, iSliceVar + 1, massMax[iSliceVar]);
+    hFitConfig->SetBinContent(3, iSliceVar + 1, nRebin[iSliceVar]);
     if (fixSigma) {
       if (fixSigmaManual.empty()) {
-        hFitConfig->SetBinContent(4, iPt + 1, hSigmaToFix->GetBinContent(iPt + 1));
+        hFitConfig->SetBinContent(4, iSliceVar + 1, hSigmaToFix->GetBinContent(iSliceVar + 1));
       } else {
-        hFitConfig->SetBinContent(4, iPt + 1, fixSigmaManual[iPt]);
+        hFitConfig->SetBinContent(4, iSliceVar + 1, fixSigmaManual[iSliceVar]);
       }
     }
-    hFitConfig->SetBinContent(5, iPt + 1, bkgFuncConfig[iPt]);
-    hFitConfig->SetBinContent(6, iPt + 1, sgnFuncConfig[iPt]);
+    hFitConfig->SetBinContent(5, iSliceVar + 1, bkgFuncConfig[iSliceVar]);
+    hFitConfig->SetBinContent(6, iSliceVar + 1, sgnFuncConfig[iSliceVar]);
   }
 
   // save output histograms
@@ -605,10 +628,11 @@ int runMassFitter(TString configFileName)
     }
   }
 
-  for (unsigned int iPt = 0; iPt < nPtBins; iPt++) {
-    hMass[iPt]->Write();
+  for (unsigned int iSliceVar = 0; iSliceVar < nSliceVarBins; iSliceVar++) {
+    hMass[iSliceVar]->Write();
   }
   hRawYields->Write();
+  hRawYieldsCounted->Write();
   hRawYieldsSigma->Write();
   hRawYieldsMean->Write();
   hRawYieldsSignificance->Write();
@@ -654,7 +678,7 @@ int runMassFitter(TString configFileName)
   return 0;
 }
 
-void setHistoStyle(TH1* histo, int color, double markerSize)
+void setHistoStyle(TH1* histo, Color_t color, Size_t markerSize)
 {
   histo->SetStats(kFALSE);
   histo->SetMarkerSize(markerSize);
@@ -664,33 +688,33 @@ void setHistoStyle(TH1* histo, int color, double markerSize)
   histo->SetLineColor(color);
 }
 
-void divideCanvas(TCanvas* canvas, int nPtBins)
+void divideCanvas(TCanvas* canvas, int nSliceVarBins)
 {
-  if (nPtBins < 2) {
+  if (nSliceVarBins < 2) {
     canvas->cd();
-  } else if (nPtBins == 2 || nPtBins == 3) {
-    canvas->Divide(nPtBins, 1);
-  } else if (nPtBins == 4 || nPtBins == 6 || nPtBins == 8) {
-    canvas->Divide(nPtBins / 2, 2);
-  } else if (nPtBins == 5 || nPtBins == 7) {
-    canvas->Divide((nPtBins + 1) / 2, 2);
-  } else if (nPtBins == 9 || nPtBins == 12 || nPtBins == 15) {
-    canvas->Divide(nPtBins / 3, 3);
-  } else if (nPtBins == 10 || nPtBins == 11) {
+  } else if (nSliceVarBins == 2 || nSliceVarBins == 3) {
+    canvas->Divide(nSliceVarBins, 1);
+  } else if (nSliceVarBins == 4 || nSliceVarBins == 6 || nSliceVarBins == 8) {
+    canvas->Divide(nSliceVarBins / 2, 2);
+  } else if (nSliceVarBins == 5 || nSliceVarBins == 7) {
+    canvas->Divide((nSliceVarBins + 1) / 2, 2);
+  } else if (nSliceVarBins == 9 || nSliceVarBins == 12 || nSliceVarBins == 15) {
+    canvas->Divide(nSliceVarBins / 3, 3);
+  } else if (nSliceVarBins == 10 || nSliceVarBins == 11) {
     canvas->Divide(4, 3);
-  } else if (nPtBins == 13 || nPtBins == 14) {
+  } else if (nSliceVarBins == 13 || nSliceVarBins == 14) {
     canvas->Divide(5, 3);
-  } else if (nPtBins > 15 && nPtBins <= 20 && nPtBins % 4 == 0) {
-    canvas->Divide(nPtBins / 4, 4);
-  } else if (nPtBins > 15 && nPtBins <= 20 && nPtBins % 4 != 0) {
+  } else if (nSliceVarBins > 15 && nSliceVarBins <= 20 && nSliceVarBins % 4 == 0) {
+    canvas->Divide(nSliceVarBins / 4, 4);
+  } else if (nSliceVarBins > 15 && nSliceVarBins <= 20 && nSliceVarBins % 4 != 0) {
     canvas->Divide(5, 4);
-  } else if (nPtBins == 21) {
+  } else if (nSliceVarBins == 21) {
     canvas->Divide(7, 3);
-  } else if (nPtBins > 21 && nPtBins <= 25) {
+  } else if (nSliceVarBins > 21 && nSliceVarBins <= 25) {
     canvas->Divide(5, 5);
-  } else if (nPtBins > 25 && nPtBins % 2 == 0) {
-    canvas->Divide(nPtBins / 2, 2);
+  } else if (nSliceVarBins > 25 && nSliceVarBins % 2 == 0) {
+    canvas->Divide(nSliceVarBins / 2, 2);
   } else {
-    canvas->Divide((nPtBins + 1) / 2, 2);
+    canvas->Divide((nSliceVarBins + 1) / 2, 2);
   }
 }

--- a/PWGHF/D2H/Macros/runMassFitter.C
+++ b/PWGHF/D2H/Macros/runMassFitter.C
@@ -21,6 +21,11 @@
 
 #include "HFInvMassFitter.h"
 
+// if .h file not found, please include your local rapidjson/document.h and rapidjson/filereadstream.h here
+#include <rapidjson/document.h>
+#include <rapidjson/filereadstream.h>
+
+#include <cstdio>   // for fclose
 #include <iostream> // std::cout
 #include <string>   // std::string
 #include <vector>   // std::vector
@@ -28,10 +33,6 @@
 #include <TDatabasePDG.h>
 #include <TFile.h>
 #include <TH2F.h>
-
-// if .h file not found, please include your local rapidjson/document.h and rapidjson/filereadstream.h here
-#include <rapidjson/document.h>
-#include <rapidjson/filereadstream.h>
 
 #endif
 
@@ -159,8 +160,9 @@ int runMassFitter(const TString& configFileName)
   bool highlightPeakRegion = config["highlightPeakRegion"].GetBool();
 
   const unsigned int nSliceVarBins = sliceVarMin.size();
-  int bkgFunc[nSliceVarBins], sgnFunc[nSliceVarBins];
-  double sliceVarLimits[nSliceVarBins + 1];
+  std::vector<int> bkgFunc(nSliceVarBins);
+  std::vector<int> sgnFunc(nSliceVarBins);
+  std::vector<double> sliceVarLimits(nSliceVarBins + 1);
 
   for (unsigned int iSliceVar = 0; iSliceVar < nSliceVarBins; iSliceVar++) {
     sliceVarLimits[iSliceVar] = sliceVarMin[iSliceVar];
@@ -240,9 +242,9 @@ int runMassFitter(const TString& configFileName)
     }
   }
 
-  TH1* hMassSgn[nSliceVarBins];
-  TH1* hMassRefl[nSliceVarBins];
-  TH1* hMass[nSliceVarBins];
+  std::vector<TH1*> hMassSgn(nSliceVarBins);
+  std::vector<TH1*> hMassRefl(nSliceVarBins);
+  std::vector<TH1*> hMass(nSliceVarBins);
 
   for (unsigned int iSliceVar = 0; iSliceVar < nSliceVarBins; iSliceVar++) {
     if (!isMc) {
@@ -408,9 +410,9 @@ int runMassFitter(const TString& configFileName)
 
   // fit histograms
 
-  TH1* hMassForFit[nSliceVarBins];
-  TH1* hMassForRefl[nSliceVarBins];
-  TH1* hMassForSgn[nSliceVarBins];
+  std::vector<TH1*> hMassForFit(nSliceVarBins);
+  std::vector<TH1*> hMassForRefl(nSliceVarBins);
+  std::vector<TH1*> hMassForSgn(nSliceVarBins);
 
   Int_t canvasSize[2] = {1920, 1080};
   if (nSliceVarBins == 1) {
@@ -420,7 +422,9 @@ int runMassFitter(const TString& configFileName)
 
   Int_t nCanvasesMax = 20; // do not put more than 20 bins per canvas to make them visible
   const Int_t nCanvases = ceil(static_cast<float>(nSliceVarBins) / nCanvasesMax);
-  TCanvas *canvasMass[nCanvases], *canvasResiduals[nCanvases], *canvasRefl[nCanvases];
+  std::vector<TCanvas*> canvasMass(nCanvases);
+  std::vector<TCanvas*> canvasResiduals(nCanvases);
+  std::vector<TCanvas*> canvasRefl(nCanvases);
   for (int iCanvas = 0; iCanvas < nCanvases; iCanvas++) {
     int nPads = (nCanvases == 1) ? nSliceVarBins : nCanvasesMax;
     canvasMass[iCanvas] = new TCanvas(Form("canvasMass%d", iCanvas), Form("canvasMass%d", iCanvas),


### PR DESCRIPTION
**Code cleaning:**
* obsolete headers, variables and pieces of code removed;
* use `TH1` instead of `TH1F` to be more general with possible input histogram type;
* more safe type castings employed (e.g. avoid `reinterpret_cast` and use `Get<TH1>()` instead of `Get()` before `static_cast`);
* instances from the standard library (`string`, `vector`, `cout`, etc.) prepended with `std::`;
* removed **using** directive from header;
* the code is made less D0-hardcoded;
* fixed typos in comments and variable names.

**Enhancement:**
* added signal evaluation via bin counting (in addition to integral);
* added plotting features:
  * semi-opaque pure signal plot
  * background pre-fit function
  * highlight peak region (which is usually 3 sigma) with vertical lines.
  
The json config file is updated accordingly to mentioned changes, a link to CernBox with an example of input file is provided.