### PR TITLE
[Infrastructure] MegaLinter: Configure cppcheck

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -39,4 +39,5 @@ PYTHON_PYRIGHT_CONFIG_FILE: pyproject.toml
 PYTHON_RUFF_CONFIG_FILE: pyproject.toml
 CPP_CPPLINT_FILE_EXTENSIONS: [".C", ".c", ".c++", ".cc", ".cl", ".cpp", ".cu", ".cuh", ".cxx", ".cxx.in", ".h", ".h++", ".hh", ".h.in", ".hpp", ".hxx", ".inc", ".inl", ".macro"]
 CPP_CLANG_FORMAT_FILE_EXTENSIONS: [".C", ".c", ".c++", ".cc", ".cl", ".cpp", ".cu", ".cuh", ".cxx", ".cxx.in", ".h", ".h++", ".hh", ".h.in", ".hpp", ".hxx", ".inc", ".inl", ".macro"]
+CPP_CPPCHECK_ARGUMENTS: --language=c++ --std=c++20 --check-level=exhaustive
 REPOSITORY_GITLEAKS_PR_COMMITS_SCAN: true


### PR DESCRIPTION
The current default configuration confuses the C++ code with C.