### PR TITLE
[PWGHF,Trigger] Revert to symmetric NsigmaDe cut for charm femto trigger

### DIFF
--- a/EventFiltering/PWGHF/HFFilterHelpers.h
+++ b/EventFiltering/PWGHF/HFFilterHelpers.h
@@ -278,7 +278,7 @@ constexpr float massJPsi = o2::constants::physics::MassJPsi;
 
 static const o2::framework::AxisSpec ptAxis{50, 0.f, 50.f};
 static const o2::framework::AxisSpec pAxis{50, 0.f, 10.f};
-static const o2::framework::AxisSpec kstarAxis{100, 0.f, 1.f};
+static const o2::framework::AxisSpec kstarAxis{200, 0.f, 2.f};
 static const o2::framework::AxisSpec etaAxis{30, -1.5f, 1.5f};
 static const o2::framework::AxisSpec nSigmaAxis{100, -10.f, 10.f};
 static const o2::framework::AxisSpec alphaAxis{100, -1.f, 1.f};
@@ -958,11 +958,11 @@ inline bool HfFilterHelper::isSelectedTrack4Femto(const T1& track, const T2& tra
     // Apply different PID strategy in different pt range
     // one side selection only
     if (pt <= ptThresholdPidStrategy) {
-      if (NSigmaTPC < -nSigmaCuts[0] || NSigmaITS < -nSigmaCuts[3]) { // Use TPC and ITS below the threshold, NSigmaITS for deuteron with a lower limit
+      if (std::fabs(NSigmaTPC) > nSigmaCuts[0] || NSigmaITS < -nSigmaCuts[3]) { // Use TPC and ITS below the threshold, NSigmaITS for deuteron with a lower limit
         return false;
       }
     } else {
-      if (NSigmaTOF < -nSigmaCuts[1] || NSigmaTPC < -nSigmaCuts[0]) { // Use combined TPC and TOF above the threshold
+      if (std::fabs(NSigmaTOF) > nSigmaCuts[1] || std::fabs(NSigmaTPC) > nSigmaCuts[0]) { // Use combined TPC and TOF above the threshold
         return false;
       }
     }
@@ -970,7 +970,7 @@ inline bool HfFilterHelper::isSelectedTrack4Femto(const T1& track, const T2& tra
 
   if (activateQA > 1) {
     hTPCPID->Fill(track.p(), NSigmaTPC);
-    if ((forceTof || track.hasTOF())) {
+    if ((!forceTof || track.hasTOF())) {
       if (trackSpecies == kProtonForFemto)
         hTOFPID->Fill(track.p(), NSigmaTOF);
       else if (trackSpecies == kDeuteronForFemto && pt > ptThresholdPidStrategy)


### PR DESCRIPTION
For some reason with an asymmetric cut (to keep everything compatible with deuteron and heavier) we select many tracks with very large `NsigmaTPC(de)`, which increase drastically the selectivity of the charm femto triggers, see e.g.
```
[3721435:hf-filter]: [19:35:58][INFO] ACCEPTED pT = 0.8474335, NSIGMATPC 1203.5966 (cut -3), NSIGMAITS -3.3222082 (cut -4), NSIGMATOF -999 (cut -3)
[3721435:hf-filter]: [19:33:58][INFO] ACCEPTED pT = 0.99228996, NSIGMATPC 147.07945 (cut -3), NSIGMAITS -2.176171 (cut -4), NSIGMATOF -999 (cut -3)
[3721435:hf-filter]: [19:33:58][INFO] ACCEPTED pT = 0.81965065, NSIGMATPC 319.33163 (cut -3), NSIGMAITS -3.2618442 (cut -4), NSIGMATOF -999 (cut -3)
[3721435:hf-filter]: [19:33:58][INFO] ACCEPTED pT = 0.81965065, NSIGMATPC 319.33163 (cut -3), NSIGMAITS -3.2618442 (cut -4), NSIGMATOF -999 (cut -3)
[3721435:hf-filter]: [19:34:09][INFO] ACCEPTED pT = 1.0035484, NSIGMATPC 131.13118 (cut -3), NSIGMAITS -3.3340607 (cut -4), NSIGMATOF -999 (cut -3)
[3721435:hf-filter]: [19:35:58][INFO] ACCEPTED pT = 1.0433966, NSIGMATPC 888.9518 (cut -3), NSIGMAITS -3.6788256 (cut -4), NSIGMATOF -999 (cut -3)
[3721435:hf-filter]: [19:36:03][INFO] ACCEPTED pT = 0.8597881, NSIGMATPC 72.977325 (cut -3), NSIGMAITS -2.5652158 (cut -4), NSIGMATOF -68.59817 (cut -3)
[3721435:hf-filter]: [19:36:04][INFO] ACCEPTED pT = 0.923919, NSIGMATPC 295.51266 (cut -3), NSIGMAITS -3.1370604 (cut -4), NSIGMATOF -64.92043 (cut -3)
```
Since heavier nuclei are very likely unfeasible and we have no time to study this further, I revert to the symmetric cut around 0 @zhangbiao-phy 
