### PR TITLE
Add reduced workflow for B+, B0s -> J/Psi X analyses

### DIFF
--- a/PWGHF/Core/HfHelper.h
+++ b/PWGHF/Core/HfHelper.h
@@ -664,6 +664,12 @@ class HfHelper
   }
 
   template <typename T>
+  auto invMassBsToJPsiPhi(const T& candidate)
+  {
+    return candidate.m(std::array{o2::constants::physics::MassJPsi, o2::constants::physics::MassKPlus});
+  }
+
+  template <typename T>
   auto cosThetaStarBs(const T& candidate)
   {
     return candidate.cosThetaStar(std::array{o2::constants::physics::MassDSBar, o2::constants::physics::MassPiPlus}, o2::constants::physics::MassBS, 1);
@@ -879,7 +885,7 @@ class HfHelper
 
   // Apply topological cuts as defined in SelectorCuts.h
   /// \param candBp B+ candidate
-  /// \param cuts B+ candidate selection per pT bin"
+  /// \param cuts B+ candidate selection per pT bin
   /// \param binsPt pT bin limits
   /// \return true if candidate passes all selections
   template <typename T1, typename T2, typename T3>
@@ -1058,6 +1064,114 @@ class HfHelper
       return false;
     }
     if (acceptPIDNotApplicable && pidTrackPi == TrackSelectorPID::Rejected) {
+      return false;
+    }
+
+    return true;
+  }
+
+  // Apply topological cuts as defined in SelectorCuts.h
+  /// \param candBs Bs candidate
+  /// \param cuts Bs candidate selection per pT bin
+  /// \param binsPt pT bin limits
+  /// \return true if candidate passes all selections
+  template <typename T1, typename T2, typename T3, typename T4, typename T5>
+  bool selectionBsToJPsiPhiTopol(const T1& candBs, const T2& candKa0, const T3& candKa1, const T4& cuts, const T5& binsPt)
+  {
+    auto ptcandBs = candBs.pt();
+    auto mcandBs = invMassBsToJPsiPhi(candBs);
+    std::array<float, 3> pVecKa0 = {candKa0.px(), candKa0.py(), candKa0.pz()};
+    std::array<float, 3> pVecKa1 = {candKa1.px(), candKa1.py(), candKa1.pz()};
+    auto mcandPhi = RecoDecay::m(std::array{pVecKa0, pVecKa1}, std::array{o2::constants::physics::MassKPlus, o2::constants::physics::MassKPlus});
+    auto ptJPsi = RecoDecay::pt(candBs.pxProng0(), candBs.pyProng0());
+    auto candJPsi = candBs.jPsi();
+    float pseudoPropDecLen = candBs.decayLengthXY() * mcandBs / ptcandBs;
+
+    int pTBin = o2::analysis::findBin(binsPt, ptcandBs);
+    if (pTBin == -1) {
+      return false;
+    }
+
+    // Bs mass cut
+    if (std::abs(mcandBs - o2::constants::physics::MassBPlus) > cuts->get(pTBin, "m")) {
+      return false;
+    }
+
+    // kaon pt
+    if (candKa0.pt() < cuts->get(pTBin, "pT K") &&
+        candKa1.pt() < cuts->get(pTBin, "pT K")) {
+      return false;
+    }
+
+    // J/Psi pt
+    if (ptJPsi < cuts->get(pTBin, "pT J/Psi")) {
+      return false;
+    }
+
+    // phi mass
+    if (std::abs(mcandPhi - o2::constants::physics::MassPhi) < cuts->get(pTBin, "DeltaM phi")) {
+      return false;
+    }
+
+    // J/Psi mass
+    if (std::abs(candJPsi.m() - o2::constants::physics::MassJPsi) < cuts->get(pTBin, "DeltaM J/Psi")) {
+      return false;
+    }
+
+    // d0(J/Psi)xd0(phi)
+    if (candBs.impactParameterProduct() > cuts->get(pTBin, "B Imp. Par. Product")) {
+      return false;
+    }
+
+    // Bs Decay length
+    if (candBs.decayLength() < cuts->get(pTBin, "B decLen")) {
+      return false;
+    }
+
+    // Bs Decay length XY
+    if (candBs.decayLengthXY() < cuts->get(pTBin, "B decLenXY")) {
+      return false;
+    }
+
+    // Bs CPA cut
+    if (candBs.cpa() < cuts->get(pTBin, "CPA")) {
+      return false;
+    }
+
+    // Bs CPAXY cut
+    if (candBs.cpaXY() < cuts->get(pTBin, "CPAXY")) {
+      return false;
+    }
+
+    // d0 of phi
+    if (std::abs(candBs.impactParameter1()) < cuts->get(pTBin, "d0 phi")) {
+      return false;
+    }
+
+    // d0 of J/Psi
+    if (std::abs(candBs.impactParameter0()) < cuts->get(pTBin, "d0 J/Psi")) {
+      return false;
+    }
+
+    // B pseudoproper decay length
+    if (pseudoPropDecLen < cuts->get(pTBin, "B pseudoprop. decLen")) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /// Apply PID selection
+  /// \param pidTrackKa PID status of trackKa (prong1 of B+ candidate)
+  /// \param acceptPIDNotApplicable switch to accept Status::NotApplicable
+  /// \return true if prong1 of B+ candidate passes all selections
+  template <typename T1 = int, typename T2 = bool>
+  bool selectionBsToJPsiPhiPid(const T1& pidTrackKa, const T2& acceptPIDNotApplicable)
+  {
+    if (!acceptPIDNotApplicable && pidTrackKa != TrackSelectorPID::Accepted) {
+      return false;
+    }
+    if (acceptPIDNotApplicable && pidTrackKa == TrackSelectorPID::Rejected) {
       return false;
     }
 

--- a/PWGHF/Core/HfHelper.h
+++ b/PWGHF/Core/HfHelper.h
@@ -172,6 +172,12 @@ class HfHelper
   }
 
   template <typename T>
+  auto invMassBplusToJPsiK(const T& candidate)
+  {
+    return candidate.m(std::array{o2::constants::physics::MassJPsi, o2::constants::physics::MassKPlus});
+  }
+
+  template <typename T>
   auto cosThetaStarBplus(const T& candidate)
   {
     return candidate.cosThetaStar(std::array{o2::constants::physics::MassD0, o2::constants::physics::MassPiPlus}, o2::constants::physics::MassBPlus, 1);

--- a/PWGHF/Core/HfHelper.h
+++ b/PWGHF/Core/HfHelper.h
@@ -877,6 +877,106 @@ class HfHelper
     return true;
   }
 
+  // Apply topological cuts as defined in SelectorCuts.h
+  /// \param candBp B+ candidate
+  /// \param cuts B+ candidate selection per pT bin"
+  /// \param binsPt pT bin limits
+  /// \return true if candidate passes all selections
+  template <typename T1, typename T2, typename T3>
+  bool selectionBplusToJPsiKTopol(const T1& candBp, const T2& cuts, const T3& binsPt)
+  {
+    auto ptcandBp = candBp.pt();
+    auto mcandBp = invMassBplusToJPsiK(candBp);
+    auto ptJPsi = RecoDecay::pt(candBp.pxProng0(), candBp.pyProng0());
+    auto ptKa = RecoDecay::pt(candBp.pxProng1(), candBp.pyProng1());
+    auto candJPsi = candBp.jPsi();
+    float pseudoPropDecLen = candBp.decayLengthXY() * mcandBp / ptcandBp;
+
+    int pTBin = o2::analysis::findBin(binsPt, ptcandBp);
+    if (pTBin == -1) {
+      return false;
+    }
+
+    // B+ mass cut
+    if (std::abs(mcandBp - o2::constants::physics::MassBPlus) > cuts->get(pTBin, "m")) {
+      return false;
+    }
+
+    // kaon pt
+    if (ptKa < cuts->get(pTBin, "pT K")) {
+      return false;
+    }
+
+    // J/Psi pt
+    if (ptJPsi < cuts->get(pTBin, "pT J/Psi")) {
+      return false;
+    }
+
+    // J/Psi mass
+    if (std::abs(candJPsi.m() - o2::constants::physics::MassJPsi) < cuts->get(pTBin, "DeltaM J/Psi")) {
+      return false;
+    }
+
+    // d0(J/Psi)xd0(K)
+    if (candBp.impactParameterProduct() > cuts->get(pTBin, "B Imp. Par. Product")) {
+      return false;
+    }
+
+    // B+ Decay length
+    if (candBp.decayLength() < cuts->get(pTBin, "B decLen")) {
+      return false;
+    }
+
+    // B+ Decay length XY
+    if (candBp.decayLengthXY() < cuts->get(pTBin, "B decLenXY")) {
+      return false;
+    }
+
+    // B+ CPA cut
+    if (candBp.cpa() < cuts->get(pTBin, "CPA")) {
+      return false;
+    }
+
+    // B+ CPAXY cut
+    if (candBp.cpaXY() < cuts->get(pTBin, "CPAXY")) {
+      return false;
+    }
+
+    // d0 of K
+    if (std::abs(candBp.impactParameter1()) < cuts->get(pTBin, "d0 K")) {
+      return false;
+    }
+
+    // d0 of J/Psi
+    if (std::abs(candBp.impactParameter0()) < cuts->get(pTBin, "d0 J/Psi")) {
+      return false;
+    }
+
+    // B pseudoproper decay length
+    if (pseudoPropDecLen < cuts->get(pTBin, "B pseudoprop. decLen")) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /// Apply PID selection
+  /// \param pidTrackKa PID status of trackKa (prong1 of B+ candidate)
+  /// \param acceptPIDNotApplicable switch to accept Status::NotApplicable
+  /// \return true if prong1 of B+ candidate passes all selections
+  template <typename T1 = int, typename T2 = bool>
+  bool selectionBplusToJPsiKPid(const T1& pidTrackKa, const T2& acceptPIDNotApplicable)
+  {
+    if (!acceptPIDNotApplicable && pidTrackKa != TrackSelectorPID::Accepted) {
+      return false;
+    }
+    if (acceptPIDNotApplicable && pidTrackKa == TrackSelectorPID::Rejected) {
+      return false;
+    }
+
+    return true;
+  }
+
   /// Apply topological cuts as defined in SelectorCuts.h
   /// \param candBs Bs candidate
   /// \param cuts Bs candidate selections

--- a/PWGHF/Core/HfMlResponseBplusToJPsiKReduced.h
+++ b/PWGHF/Core/HfMlResponseBplusToJPsiKReduced.h
@@ -1,0 +1,164 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file HfMlResponseBplusToJPsiKReduced.h
+/// \brief Class to compute the ML response for B± → J/Psi K± analysis selections in the reduced format
+/// \author Fabrizio Chinu <fabrizio.chinu@cern.ch>, Università degli Studi and INFN Torino
+
+#ifndef PWGHF_CORE_HFMLRESPONSEBPLUSTOJPSIKREDUCED_H_
+#define PWGHF_CORE_HFMLRESPONSEBPLUSTOJPSIKREDUCED_H_
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "PWGHF/Core/HfMlResponse.h"
+#include "PWGHF/D2H/Utils/utilsRedDataFormat.h"
+
+// Fill the map of available input features
+// the key is the feature's name (std::string)
+// the value is the corresponding value in EnumInputFeatures
+#define FILL_MAP_BPLUS(FEATURE)                                               \
+  {                                                                           \
+    #FEATURE, static_cast<uint8_t>(InputFeaturesBplusToJPsiKReduced::FEATURE) \
+  }
+
+// Check if the index of mCachedIndices (index associated to a FEATURE)
+// matches the entry in EnumInputFeatures associated to this FEATURE
+// if so, the inputFeatures vector is filled with the FEATURE's value
+// by calling the corresponding GETTER from OBJECT
+#define CHECK_AND_FILL_VEC_BPLUS_FULL(OBJECT, FEATURE, GETTER)            \
+  case static_cast<uint8_t>(InputFeaturesBplusToJPsiKReduced::FEATURE): { \
+    inputFeatures.emplace_back(OBJECT.GETTER());                          \
+    break;                                                                \
+  }
+
+// Check if the index of mCachedIndices (index associated to a FEATURE)
+// matches the entry in EnumInputFeatures associated to this FEATURE
+// if so, the inputFeatures vector is filled with the FEATURE's value
+// by calling the GETTER function taking OBJECT in argument
+#define CHECK_AND_FILL_VEC_BPLUS_FUNC(OBJECT, FEATURE, GETTER)            \
+  case static_cast<uint8_t>(InputFeaturesBplusToJPsiKReduced::FEATURE): { \
+    inputFeatures.emplace_back(GETTER(OBJECT));                           \
+    break;                                                                \
+  }
+
+// Specific case of CHECK_AND_FILL_VEC_BPLUS_FULL(OBJECT, FEATURE, GETTER)
+// where OBJECT is named candidate and FEATURE = GETTER
+#define CHECK_AND_FILL_VEC_BPLUS(GETTER)                                 \
+  case static_cast<uint8_t>(InputFeaturesBplusToJPsiKReduced::GETTER): { \
+    inputFeatures.emplace_back(candidate.GETTER());                      \
+    break;                                                               \
+  }
+
+namespace o2::analysis
+{
+
+enum class InputFeaturesBplusToJPsiKReduced : uint8_t {
+  ptProng0 = 0,
+  ptProng1,
+  impactParameter0,
+  impactParameter1,
+  impactParameterProduct,
+  chi2PCA,
+  decayLength,
+  decayLengthXY,
+  decayLengthNormalised,
+  decayLengthXYNormalised,
+  cpa,
+  cpaXY,
+  maxNormalisedDeltaIP,
+  tpcNSigmaKa1,
+  tofNSigmaKa1,
+  tpcTofNSigmaKa1
+};
+
+template <typename TypeOutputScore = float>
+class HfMlResponseBplusToJPsiKReduced : public HfMlResponse<TypeOutputScore>
+{
+ public:
+  /// Default constructor
+  HfMlResponseBplusToJPsiKReduced() = default;
+  /// Default destructor
+  virtual ~HfMlResponseBplusToJPsiKReduced() = default;
+
+  /// Method to get the input features vector needed for ML inference
+  /// \param candidate is the B+ candidate
+  /// \param prong1 is the candidate's prong1
+  /// \return inputFeatures vector
+  template <typename T1, typename T2>
+  std::vector<float> getInputFeatures(T1 const& candidate,
+                                      T2 const& prong1)
+  {
+    std::vector<float> inputFeatures;
+
+    for (const auto& idx : MlResponse<TypeOutputScore>::mCachedIndices) {
+      switch (idx) {
+        CHECK_AND_FILL_VEC_BPLUS(ptProng0);
+        CHECK_AND_FILL_VEC_BPLUS(ptProng1);
+        CHECK_AND_FILL_VEC_BPLUS(impactParameter0);
+        CHECK_AND_FILL_VEC_BPLUS(impactParameter1);
+        CHECK_AND_FILL_VEC_BPLUS(impactParameterProduct);
+        CHECK_AND_FILL_VEC_BPLUS(chi2PCA);
+        CHECK_AND_FILL_VEC_BPLUS(decayLength);
+        CHECK_AND_FILL_VEC_BPLUS(decayLengthXY);
+        CHECK_AND_FILL_VEC_BPLUS(decayLengthNormalised);
+        CHECK_AND_FILL_VEC_BPLUS(decayLengthXYNormalised);
+        CHECK_AND_FILL_VEC_BPLUS(cpa);
+        CHECK_AND_FILL_VEC_BPLUS(cpaXY);
+        CHECK_AND_FILL_VEC_BPLUS(maxNormalisedDeltaIP);
+        // TPC PID variable
+        CHECK_AND_FILL_VEC_BPLUS_FULL(prong1, tpcNSigmaKa1, tpcNSigmaKa);
+        // TOF PID variable
+        CHECK_AND_FILL_VEC_BPLUS_FULL(prong1, tofNSigmaKa1, tofNSigmaKa);
+        // Combined PID variables
+        CHECK_AND_FILL_VEC_BPLUS_FUNC(prong1, tpcTofNSigmaKa1, o2::pid_tpc_tof_utils::getTpcTofNSigmaKa1);
+      }
+    }
+
+    return inputFeatures;
+  }
+
+ protected:
+  /// Method to fill the map of available input features
+  void setAvailableInputFeatures()
+  {
+    MlResponse<TypeOutputScore>::mAvailableInputFeatures = {
+      FILL_MAP_BPLUS(ptProng0),
+      FILL_MAP_BPLUS(ptProng1),
+      FILL_MAP_BPLUS(impactParameter0),
+      FILL_MAP_BPLUS(impactParameter1),
+      FILL_MAP_BPLUS(impactParameterProduct),
+      FILL_MAP_BPLUS(chi2PCA),
+      FILL_MAP_BPLUS(decayLength),
+      FILL_MAP_BPLUS(decayLengthXY),
+      FILL_MAP_BPLUS(decayLengthNormalised),
+      FILL_MAP_BPLUS(decayLengthXYNormalised),
+      FILL_MAP_BPLUS(cpa),
+      FILL_MAP_BPLUS(cpaXY),
+      FILL_MAP_BPLUS(maxNormalisedDeltaIP),
+      // TPC PID variable
+      FILL_MAP_BPLUS(tpcNSigmaKa1),
+      // TOF PID variable
+      FILL_MAP_BPLUS(tofNSigmaKa1),
+      // Combined PID variable
+      FILL_MAP_BPLUS(tpcTofNSigmaKa1)};
+  }
+};
+
+} // namespace o2::analysis
+
+#undef FILL_MAP_BPLUS
+#undef CHECK_AND_FILL_VEC_BPLUS_FULL
+#undef CHECK_AND_FILL_VEC_BPLUS_FUNC
+#undef CHECK_AND_FILL_VEC_BPLUS
+
+#endif // PWGHF_CORE_HFMLRESPONSEBPLUSTOJPSIKREDUCED_H_

--- a/PWGHF/Core/HfMlResponseBsToJPsiPhiReduced.h
+++ b/PWGHF/Core/HfMlResponseBsToJPsiPhiReduced.h
@@ -1,0 +1,180 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file HfMlResponseBsToJPsiPhiReduced.h
+/// \brief Class to compute the ML response for Bs0 → J/Psi phi analysis selections in the reduced format
+/// \author Fabrizio Chinu <fabrizio.chinu@cern.ch>, Università degli Studi and INFN Torino
+
+#ifndef PWGHF_CORE_HFMLRESPONSEBSTOJPSIPHIREDUCED_H_
+#define PWGHF_CORE_HFMLRESPONSEBSTOJPSIPHIREDUCED_H_
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "PWGHF/Core/HfMlResponse.h"
+#include "PWGHF/D2H/Utils/utilsRedDataFormat.h"
+
+// Fill the map of available input features
+// the key is the feature's name (std::string)
+// the value is the corresponding value in EnumInputFeatures
+#define FILL_MAP_BS(FEATURE)                                                 \
+  {                                                                          \
+    #FEATURE, static_cast<uint8_t>(InputFeaturesBsToJPsiPhiReduced::FEATURE) \
+  }
+
+// Check if the index of mCachedIndices (index associated to a FEATURE)
+// matches the entry in EnumInputFeatures associated to this FEATURE
+// if so, the inputFeatures vector is filled with the FEATURE's value
+// by calling the corresponding GETTER from OBJECT
+#define CHECK_AND_FILL_VEC_BS_FULL(OBJECT, FEATURE, GETTER)              \
+  case static_cast<uint8_t>(InputFeaturesBsToJPsiPhiReduced::FEATURE): { \
+    inputFeatures.emplace_back(OBJECT.GETTER());                         \
+    break;                                                               \
+  }
+
+// Check if the index of mCachedIndices (index associated to a FEATURE)
+// matches the entry in EnumInputFeatures associated to this FEATURE
+// if so, the inputFeatures vector is filled with the FEATURE's value
+// by calling the GETTER function taking OBJECT in argument
+#define CHECK_AND_FILL_VEC_BS_FUNC(OBJECT, FEATURE, GETTER)              \
+  case static_cast<uint8_t>(InputFeaturesBsToJPsiPhiReduced::FEATURE): { \
+    inputFeatures.emplace_back(GETTER(OBJECT));                          \
+    break;                                                               \
+  }
+
+// Specific case of CHECK_AND_FILL_VEC_BS_FULL(OBJECT, FEATURE, GETTER)
+// where OBJECT is named candidate and FEATURE = GETTER
+#define CHECK_AND_FILL_VEC_BS(GETTER)                                   \
+  case static_cast<uint8_t>(InputFeaturesBsToJPsiPhiReduced::GETTER): { \
+    inputFeatures.emplace_back(candidate.GETTER());                     \
+    break;                                                              \
+  }
+
+namespace o2::analysis
+{
+
+enum class InputFeaturesBsToJPsiPhiReduced : uint8_t {
+  ptProng0 = 0,
+  ptProng1,
+  impactParameter0,
+  impactParameter1,
+  impactParameterProduct,
+  chi2PCA,
+  decayLength,
+  decayLengthXY,
+  decayLengthNormalised,
+  decayLengthXYNormalised,
+  cpa,
+  cpaXY,
+  maxNormalisedDeltaIP,
+  tpcNSigmaKa0,
+  tofNSigmaKa0,
+  tpcTofNSigmaKa0,
+  tpcNSigmaKa1,
+  tofNSigmaKa1,
+  tpcTofNSigmaKa1
+};
+
+template <typename TypeOutputScore = float>
+class HfMlResponseBsToJPsiPhiReduced : public HfMlResponse<TypeOutputScore>
+{
+ public:
+  /// Default constructor
+  HfMlResponseBsToJPsiPhiReduced() = default;
+  /// Default destructor
+  virtual ~HfMlResponseBsToJPsiPhiReduced() = default;
+
+  /// Method to get the input features vector needed for ML inference
+  /// \param candidate is the Bs candidate
+  /// \param prong1 is the candidate's prong1
+  /// \return inputFeatures vector
+  template <typename T1, typename T2, typename T3>
+  std::vector<float> getInputFeatures(T1 const& candidate,
+                                      T2 const& prong1,
+                                      T3 const& prong2)
+  {
+    std::vector<float> inputFeatures;
+
+    for (const auto& idx : MlResponse<TypeOutputScore>::mCachedIndices) {
+      switch (idx) {
+        CHECK_AND_FILL_VEC_BS(ptProng0);
+        CHECK_AND_FILL_VEC_BS(ptProng1);
+        CHECK_AND_FILL_VEC_BS(impactParameter0);
+        CHECK_AND_FILL_VEC_BS(impactParameter1);
+        CHECK_AND_FILL_VEC_BS(impactParameterProduct);
+        CHECK_AND_FILL_VEC_BS(chi2PCA);
+        CHECK_AND_FILL_VEC_BS(decayLength);
+        CHECK_AND_FILL_VEC_BS(decayLengthXY);
+        CHECK_AND_FILL_VEC_BS(decayLengthNormalised);
+        CHECK_AND_FILL_VEC_BS(decayLengthXYNormalised);
+        CHECK_AND_FILL_VEC_BS(cpa);
+        CHECK_AND_FILL_VEC_BS(cpaXY);
+        CHECK_AND_FILL_VEC_BS(maxNormalisedDeltaIP);
+        // TPC PID variable
+        CHECK_AND_FILL_VEC_BS_FULL(prong1, tpcNSigmaKa0, tpcNSigmaKa);
+        // TOF PID variable
+        CHECK_AND_FILL_VEC_BS_FULL(prong1, tofNSigmaKa0, tofNSigmaKa);
+        // Combined PID variables
+        CHECK_AND_FILL_VEC_BS_FUNC(prong1, tpcTofNSigmaKa0, o2::pid_tpc_tof_utils::getTpcTofNSigmaKa1);
+        // TPC PID variable
+        CHECK_AND_FILL_VEC_BS_FULL(prong2, tpcNSigmaKa1, tpcNSigmaKa);
+        // TOF PID variable
+        CHECK_AND_FILL_VEC_BS_FULL(prong2, tofNSigmaKa1, tofNSigmaKa);
+        // Combined PID variables
+        CHECK_AND_FILL_VEC_BS_FUNC(prong2, tpcTofNSigmaKa1, o2::pid_tpc_tof_utils::getTpcTofNSigmaKa1);
+      }
+    }
+
+    return inputFeatures;
+  }
+
+ protected:
+  /// Method to fill the map of available input features
+  void setAvailableInputFeatures()
+  {
+    MlResponse<TypeOutputScore>::mAvailableInputFeatures = {
+      FILL_MAP_BS(ptProng0),
+      FILL_MAP_BS(ptProng1),
+      FILL_MAP_BS(impactParameter0),
+      FILL_MAP_BS(impactParameter1),
+      FILL_MAP_BS(impactParameterProduct),
+      FILL_MAP_BS(chi2PCA),
+      FILL_MAP_BS(decayLength),
+      FILL_MAP_BS(decayLengthXY),
+      FILL_MAP_BS(decayLengthNormalised),
+      FILL_MAP_BS(decayLengthXYNormalised),
+      FILL_MAP_BS(cpa),
+      FILL_MAP_BS(cpaXY),
+      FILL_MAP_BS(maxNormalisedDeltaIP),
+      // TPC PID variable
+      FILL_MAP_BS(tpcNSigmaKa0),
+      // TOF PID variable
+      FILL_MAP_BS(tofNSigmaKa0),
+      // Combined PID variable
+      FILL_MAP_BS(tpcTofNSigmaKa0),
+      // TPC PID variable
+      FILL_MAP_BS(tpcNSigmaKa1),
+      // TOF PID variable
+      FILL_MAP_BS(tofNSigmaKa1),
+      // Combined PID variable
+      FILL_MAP_BS(tpcTofNSigmaKa1)};
+  }
+};
+
+} // namespace o2::analysis
+
+#undef FILL_MAP_BS
+#undef CHECK_AND_FILL_VEC_BS_FULL
+#undef CHECK_AND_FILL_VEC_BS_FUNC
+#undef CHECK_AND_FILL_VEC_BS
+
+#endif // PWGHF_CORE_HFMLRESPONSEBSTOJPSIPHIREDUCED_H_

--- a/PWGHF/Core/SelectorCuts.h
+++ b/PWGHF/Core/SelectorCuts.h
@@ -896,6 +896,53 @@ static const std::vector<std::string> labelsPt = {
 static const std::vector<std::string> labelsCutVar = {"m", "DCA_xy", "DCA_z", "pT El", "chi2PCA"};
 } // namespace hf_cuts_jpsi_to_e_e
 
+namespace hf_cuts_jpsi_to_mu_mu
+{
+static constexpr int NBinsPt = 9;
+static constexpr int NCutVars = 7;
+// default values for the pT bin edges (can be used to configure histogram axis)
+// offset by 1 from the bin numbers in cuts array
+constexpr double BinsPt[NBinsPt + 1] = {
+  0,
+  0.5,
+  1.0,
+  2.0,
+  3.0,
+  4.0,
+  5.0,
+  6.0,
+  10.0,
+  16.0,
+};
+auto vecBinsPt = std::vector<double>{BinsPt, BinsPt + NBinsPt + 1};
+
+// default values for the cuts
+constexpr double Cuts[NBinsPt][NCutVars] = {{0.6, 1.0, 0.2, 0.2, 0.9, 0.9, 0.},  /* 0   < pT < 0.5 */
+                                            {0.6, 1.0, 0.2, 0.2, 0.9, 0.9, 0.},  /* 0.5 < pT < 1   */
+                                            {0.6, 1.0, 0.2, 0.2, 0.9, 0.9, 0.},  /* 1   < pT < 2   */
+                                            {0.6, 1.0, 0.2, 0.2, 0.9, 0.9, 0.},  /* 2   < pT < 3   */
+                                            {0.6, 1.0, 0.2, 0.2, 0.9, 0.9, 0.},  /* 3   < pT < 4   */
+                                            {0.6, 1.0, 0.2, 0.2, 0.9, 0.9, 0.},  /* 4   < pT < 5   */
+                                            {0.8, 1.0, 0.3, 0.3, 0.9, 0.9, 0.},  /* 5   < pT < 6   */
+                                            {0.8, 1.0, 0.3, 0.3, 0.9, 0.9, 1.},  /* 6   < pT < 10  */
+                                            {0.8, 1.0, 0.3, 0.3, 0.9, 0.9, 1.}}; /* 10  < pT < 16  */
+
+// row labels
+static const std::vector<std::string> labelsPt = {
+  "pT bin 0",
+  "pT bin 1",
+  "pT bin 2",
+  "pT bin 3",
+  "pT bin 4",
+  "pT bin 5",
+  "pT bin 6",
+  "pT bin 7",
+  "pT bin 8"};
+
+// column labels
+static const std::vector<std::string> labelsCutVar = {"m", "pT mu", "decay length", "decay length xy", "cpa", "cpa xy", "d0xd0"};
+} // namespace hf_cuts_jpsi_to_mu_mu
+
 namespace hf_cuts_b0_to_d_pi
 {
 static constexpr int NBinsPt = 12;

--- a/PWGHF/Core/SelectorCuts.h
+++ b/PWGHF/Core/SelectorCuts.h
@@ -1050,6 +1050,62 @@ static const std::vector<std::string> labelsPt = {
 static const std::vector<std::string> labelsCutVar = {"m", "CPA", "Chi2PCA", "d0 Ds", "d0 Pi", "pT Ds", "pT Pi", "Bs decLen", "Bs decLenXY", "Imp. Par. Product"};
 } // namespace hf_cuts_bs_to_ds_pi
 
+namespace hf_cuts_bs_to_jpsi_phi
+{
+static constexpr int NBinsPt = 12;
+static constexpr int NCutVars = 13;
+// default values for the pT bin edges (can be used to configure histogram axis)
+// offset by 1 from the bin numbers in cuts array
+constexpr double BinsPt[NBinsPt + 1] = {
+  0,
+  0.5,
+  1.0,
+  2.0,
+  3.0,
+  4.0,
+  5.0,
+  7.0,
+  10.0,
+  13.0,
+  16.0,
+  20.0,
+  24.0};
+
+auto vecBinsPt = std::vector<double>{BinsPt, BinsPt + NBinsPt + 1};
+
+// default values for the cuts
+// DeltaM CPA d0JPsi d0K pTJPsi pTK BDecayLength BDecayLengthXY BIPProd DeltaMJPsi JPsiIPProd
+constexpr double Cuts[NBinsPt][NCutVars] = {{1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.02, 0.},  /* 0 < pt < 0.5 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.02, 0.},  /* 0.5 < pt < 1 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.02, 0.},  /* 1 < pt < 2 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.02, 0.},  /* 2 < pt < 3 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.02, 0.},  /* 3 < pt < 4 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.02, 0.},  /* 4 < pt < 5 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.02, 0.},  /* 5 < pt < 7 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.02, 0.},  /* 7 < pt < 10 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.02, 0.},  /* 10 < pt < 13 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.02, 0.},  /* 13 < pt < 16 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.02, 0.},  /* 16 < pt < 20 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.02, 0.}}; /* 20 < pt < 24 */
+// row labels
+static const std::vector<std::string> labelsPt = {
+  "pT bin 0",
+  "pT bin 1",
+  "pT bin 2",
+  "pT bin 3",
+  "pT bin 4",
+  "pT bin 5",
+  "pT bin 6",
+  "pT bin 7",
+  "pT bin 8",
+  "pT bin 9",
+  "pT bin 10",
+  "pT bin 11"};
+
+// column labels
+static const std::vector<std::string> labelsCutVar = {"m", "CPA", "CPAXY", "d0 J/Psi", "d0 phi", "pT J/Psi", "pT K", "B decLen", "B decLenXY", "B Imp. Par. Product", "DeltaM J/Psi", "DeltaM phi", "B pseudoprop. decLen"};
+} // namespace hf_cuts_bs_to_jpsi_phi
+
 namespace hf_cuts_bplus_to_d0_pi
 {
 static constexpr int NBinsPt = 12;

--- a/PWGHF/Core/SelectorCuts.h
+++ b/PWGHF/Core/SelectorCuts.h
@@ -1106,6 +1106,62 @@ static const std::vector<std::string> labelsPt = {
 static const std::vector<std::string> labelsCutVar = {"m", "CPA", "d0 D0", "d0 Pi", "pT D0", "pT Pi", "B decLen", "B decLenXY", "Imp. Par. Product", "DeltaMD0", "Cos ThetaStar"};
 } // namespace hf_cuts_bplus_to_d0_pi
 
+namespace hf_cuts_bplus_to_jpsi_k
+{
+static constexpr int NBinsPt = 12;
+static constexpr int NCutVars = 12;
+// default values for the pT bin edges (can be used to configure histogram axis)
+// offset by 1 from the bin numbers in cuts array
+constexpr double BinsPt[NBinsPt + 1] = {
+  0,
+  0.5,
+  1.0,
+  2.0,
+  3.0,
+  4.0,
+  5.0,
+  7.0,
+  10.0,
+  13.0,
+  16.0,
+  20.0,
+  24.0};
+
+auto vecBinsPt = std::vector<double>{BinsPt, BinsPt + NBinsPt + 1};
+
+// default values for the cuts
+// DeltaM CPA d0JPsi d0K pTJPsi pTK BDecayLength BDecayLengthXY BIPProd DeltaMJPsi JPsiIPProd
+constexpr double Cuts[NBinsPt][NCutVars] = {{1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.},  /* 0 < pt < 0.5 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.},  /* 0.5 < pt < 1 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.},  /* 1 < pt < 2 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.},  /* 2 < pt < 3 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.},  /* 3 < pt < 4 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.},  /* 4 < pt < 5 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.},  /* 5 < pt < 7 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.},  /* 7 < pt < 10 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.},  /* 10 < pt < 13 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.},  /* 13 < pt < 16 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.},  /* 16 < pt < 20 */
+                                            {1., 0.8, 0.8, 0.01, 0.01, 1.0, 0.15, 0.05, 0.05, 0., 0.1, 0.}}; /* 20 < pt < 24 */
+// row labels
+static const std::vector<std::string> labelsPt = {
+  "pT bin 0",
+  "pT bin 1",
+  "pT bin 2",
+  "pT bin 3",
+  "pT bin 4",
+  "pT bin 5",
+  "pT bin 6",
+  "pT bin 7",
+  "pT bin 8",
+  "pT bin 9",
+  "pT bin 10",
+  "pT bin 11"};
+
+// column labels
+static const std::vector<std::string> labelsCutVar = {"m", "CPA", "CPAXY", "d0 J/Psi", "d0 K", "pT J/Psi", "pT K", "B decLen", "B decLenXY", "B Imp. Par. Product", "DeltaM J/Psi", "B pseudoprop. decLen"};
+} // namespace hf_cuts_bplus_to_jpsi_k
+
 namespace hf_cuts_lb_to_lc_pi
 {
 static constexpr int NBinsPt = 12;

--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -699,15 +699,21 @@ using HfRedCandBplusToJPsiK = soa::Join<HfCandBplusExt, HfRedBplus2JPsiDaus>;
 
 namespace hf_cand_bs_reduced
 {
-DECLARE_SOA_INDEX_COLUMN_FULL(Prong0, prong0, int, HfRed3Prongs, "_0");    //! Prong0 index
-DECLARE_SOA_INDEX_COLUMN_FULL(Prong1, prong1, int, HfRedTrackBases, "_1"); //! Prong1 index
-DECLARE_SOA_COLUMN(Prong0MlScoreBkg, prong0MlScoreBkg, float);             //! Bkg ML score of the D daughter
-DECLARE_SOA_COLUMN(Prong0MlScorePrompt, prong0MlScorePrompt, float);       //! Prompt ML score of the D daughter
-DECLARE_SOA_COLUMN(Prong0MlScoreNonprompt, prong0MlScoreNonprompt, float); //! Nonprompt ML score of the D daughter
+DECLARE_SOA_INDEX_COLUMN_FULL(Prong0, prong0, int, HfRed3Prongs, "_0");               //! Prong0 index
+DECLARE_SOA_INDEX_COLUMN_FULL(Prong1, prong1, int, HfRedTrackBases, "_1");            //! Prong1 index
+DECLARE_SOA_INDEX_COLUMN_FULL(JPsi, jPsi, int, HfRedJPsis, "_0");                     //! J/Psi index
+DECLARE_SOA_INDEX_COLUMN_FULL(Prong0Phi, prong0Phi, int, HfRedBachProng0Bases, "_0"); //! J/Psi index
+DECLARE_SOA_INDEX_COLUMN_FULL(Prong1Phi, prong1Phi, int, HfRedBachProng1Bases, "_0"); //! J/Psi index
+DECLARE_SOA_COLUMN(Prong0MlScoreBkg, prong0MlScoreBkg, float);                        //! Bkg ML score of the D daughter
+DECLARE_SOA_COLUMN(Prong0MlScorePrompt, prong0MlScorePrompt, float);                  //! Prompt ML score of the D daughter
+DECLARE_SOA_COLUMN(Prong0MlScoreNonprompt, prong0MlScoreNonprompt, float);            //! Nonprompt ML score of the D daughter
 } // namespace hf_cand_bs_reduced
 
 DECLARE_SOA_TABLE(HfRedBsProngs, "AOD", "HFREDBSPRONG", //! Table with Bs daughter indices
                   hf_cand_bs_reduced::Prong0Id, hf_cand_bs_reduced::Prong1Id);
+
+DECLARE_SOA_TABLE(HfRedBs2JPsiDaus, "AOD", "HFREDBS2JPSIDAU",
+                  hf_cand_bs_reduced::JPsiId, hf_cand_bs_reduced::Prong0PhiId, hf_cand_bs_reduced::Prong1PhiId);
 
 DECLARE_SOA_TABLE(HfRedBsDsMls, "AOD", "HFREDBSDSML", //! Table with ML scores for the Ds daughter
                   hf_cand_bs_reduced::Prong0MlScoreBkg,
@@ -719,11 +725,11 @@ using HfRedCandBs = soa::Join<HfCandBsExt, HfRedBsProngs>;
 
 namespace hf_cand_lb_reduced
 {
-DECLARE_SOA_INDEX_COLUMN_FULL(Prong0, prong0, int, HfRed3Prongs, "_0");              //! Prong0 index
-DECLARE_SOA_INDEX_COLUMN_FULL(Prong1, prong1, int, HfRedTrackBases, "_1");           //! Prong1 index
-DECLARE_SOA_COLUMN(Prong0MlScoreBkg, prong0MlScoreBkg, float);                       //! Bkg ML score of the Lc daughter
-DECLARE_SOA_COLUMN(Prong0MlScorePrompt, prong0MlScorePrompt, float);                 //! Prompt ML score of the Lc daughter
-DECLARE_SOA_COLUMN(Prong0MlScoreNonprompt, prong0MlScoreNonprompt, float);           //! Nonprompt ML score of the Lc daughter
+DECLARE_SOA_INDEX_COLUMN_FULL(Prong0, prong0, int, HfRed3Prongs, "_0");    //! Prong0 index
+DECLARE_SOA_INDEX_COLUMN_FULL(Prong1, prong1, int, HfRedTrackBases, "_1"); //! Prong1 index
+DECLARE_SOA_COLUMN(Prong0MlScoreBkg, prong0MlScoreBkg, float);             //! Bkg ML score of the Lc daughter
+DECLARE_SOA_COLUMN(Prong0MlScorePrompt, prong0MlScorePrompt, float);       //! Prompt ML score of the Lc daughter
+DECLARE_SOA_COLUMN(Prong0MlScoreNonprompt, prong0MlScoreNonprompt, float); //! Nonprompt ML score of the Lc daughter
 } // namespace hf_cand_lb_reduced
 
 DECLARE_SOA_TABLE(HfRedLbProngs, "AOD", "HFREDLBPRONG", //! Table with Lb daughter indices
@@ -851,6 +857,15 @@ DECLARE_SOA_TABLE(HfMcRecRedD0Pis, "AOD", "HFMCRECREDD0PI", //! Table with recon
                   hf_cand_bplus::DebugMcRec,
                   hf_bplus_mc::PtMother);
 
+// table with results of reconstruction level MC matching
+DECLARE_SOA_TABLE(HfMcRecRedJPsiKs, "AOD", "HFMCRECREDJPSIK", //! Table with reconstructed MC information on J/PsiK(<-B+) pairs for reduced workflow
+                  hf_cand_bplus_reduced::JPsiId,
+                  hf_cand_bplus_reduced::Prong1Id,
+                  hf_cand_bplus::FlagMcMatchRec,
+                  hf_cand_bplus::FlagWrongCollision,
+                  hf_cand_bplus::DebugMcRec,
+                  hf_bplus_mc::PtMother);
+
 // DECLARE_SOA_EXTENDED_TABLE_USER(ExTable, Tracks, "EXTABLE",
 DECLARE_SOA_TABLE(HfMcCheckD0Pis, "AOD", "HFMCCHECKD0PI", //! Table with reconstructed MC information on D0Pi(<-B0) pairs for MC checks in reduced workflow
                   hf_bplus_mc::PdgCodeBeautyMother,
@@ -902,7 +917,7 @@ DECLARE_SOA_TABLE(HfCandBpConfigs, "AOD", "HFCANDBPCONFIG", //! Table with confi
                   hf_cand_bplus_config::MySelectionFlagD0bar,
                   hf_cand_bplus_config::MyInvMassWindowD0Pi);
 
-DECLARE_SOA_TABLE(HfCandBpToJPsiKConfigs, "AOD", "HFCANDBPTOJPSIKCONFIG", //! Table with configurables information for reduced workflow
+DECLARE_SOA_TABLE(HfCfgBpToJPsi, "AOD", "HFCFGBPTOJPSI", //! Table with configurables information for reduced workflow
                   hf_cand_bplus_config::MyInvMassWindowJPsiK);
 
 namespace hf_bs_mc
@@ -932,6 +947,16 @@ DECLARE_SOA_COLUMN(PdgCodeProng3, pdgCodeProng3, int);             //! Pdg code 
 DECLARE_SOA_TABLE(HfMcRecRedDsPis, "AOD", "HFMCRECREDDSPI", //! Table with reconstructed MC information on DsPi(<-Bs) pairs for reduced workflow
                   hf_cand_bs_reduced::Prong0Id,
                   hf_cand_bs_reduced::Prong1Id,
+                  hf_cand_bs::FlagMcMatchRec,
+                  hf_cand_bs::FlagWrongCollision,
+                  hf_cand_bs::DebugMcRec,
+                  hf_bs_mc::PtMother);
+
+// table with results of reconstruction level MC matching
+DECLARE_SOA_TABLE(HfMcRecRedJPsiPhis, "AOD", "HFMCRECREDJPSIPHI", //! Table with reconstructed MC information on DsPi(<-Bs) pairs for reduced workflow
+                  hf_cand_bs_reduced::JPsiId,
+                  hf_cand_bs_reduced::Prong0PhiId,
+                  hf_cand_bs_reduced::Prong1PhiId,
                   hf_cand_bs::FlagMcMatchRec,
                   hf_cand_bs::FlagWrongCollision,
                   hf_cand_bs::DebugMcRec,
@@ -980,14 +1005,17 @@ DECLARE_SOA_TABLE(HfMcGenRedBss, "AOD", "HFMCGENREDBS", //! Generation-level MC 
 // so we can use them in the Bs part
 namespace hf_cand_bs_config
 {
-DECLARE_SOA_COLUMN(MySelectionFlagD, mySelectionFlagD, int8_t);    //! Flag to filter selected Ds mesons
-DECLARE_SOA_COLUMN(MyInvMassWindowDPi, myInvMassWindowDPi, float); //! Half-width of the Bs invariant-mass window in GeV/c2
+DECLARE_SOA_COLUMN(MySelectionFlagD, mySelectionFlagD, int8_t);            //! Flag to filter selected Ds mesons
+DECLARE_SOA_COLUMN(MyInvMassWindowDPi, myInvMassWindowDPi, float);         //! Half-width of the Bs invariant-mass window in GeV/c2
+DECLARE_SOA_COLUMN(MyInvMassWindowJPsiPhi, myInvMassWindowJPsiPhi, float); //! Half-width of the Bs invariant-mass window in GeV/c2
 } // namespace hf_cand_bs_config
 
 DECLARE_SOA_TABLE(HfCandBsConfigs, "AOD", "HFCANDBSCONFIG", //! Table with configurables information for reduced workflow
                   hf_cand_bs_config::MySelectionFlagD,
                   hf_cand_bs_config::MyInvMassWindowDPi);
 
+DECLARE_SOA_TABLE(HfCfgBsToJPsi, "AOD", "HFCFGBSTOJPSI", //! Table with configurables information for reduced workflow
+                  hf_cand_bs_config::MyInvMassWindowJPsiPhi);
 namespace hf_lb_mc
 {
 // MC Rec

--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -19,6 +19,7 @@
 /// \author Fabrizio Grosa <fabrizio.grosa@cern.ch>, CERN
 /// \author Luca Aglietta <luca.aglietta@cern.ch>, Università degli Studi di Torino (UniTO)
 /// \author Biao Zhang <biao.zhang@cern.ch>, Heidelberg University
+/// \author Fabrizio Chinu <fabrizio.chinu@cern.ch>, Università degli Studi di Torino (UniTO)
 
 #ifndef PWGHF_D2H_DATAMODEL_REDUCEDDATAMODEL_H_
 #define PWGHF_D2H_DATAMODEL_REDUCEDDATAMODEL_H_
@@ -272,6 +273,66 @@ DECLARE_SOA_TABLE(HfRedTracksCov, "AOD", "HFREDTRACKCOV", //! Table with track c
                   soa::Index<>,
                   HFTRACKPARCOV_COLUMNS);
 
+// CAREFUL: need to follow convention [Name = Description + 's'] in DECLARE_SOA_TABLE(Name, "AOD", Description)
+// to call DECLARE_SOA_INDEX_COLUMN_FULL later on
+DECLARE_SOA_TABLE(HfRedBachProng0Bases, "AOD", "HFREDTRK0BASE", //! Table with track information for reduced workflow
+                  soa::Index<>,
+                  hf_track_index_reduced::TrackId,
+                  hf_track_index_reduced::HfRedCollisionId,
+                  HFTRACKPAR_COLUMNS,
+                  hf_track_vars_reduced::ItsNCls,
+                  hf_track_vars_reduced::TpcNClsCrossedRows,
+                  hf_track_vars_reduced::TpcChi2NCl,
+                  hf_track_vars_reduced::HasTPC,
+                  hf_track_vars_reduced::HasTOF,
+                  pidtpc::TPCNSigmaPi,
+                  pidtof::TOFNSigmaPi,
+                  pidtpc::TPCNSigmaKa,
+                  pidtof::TOFNSigmaKa,
+                  pidtpc::TPCNSigmaPr,
+                  pidtof::TOFNSigmaPr,
+                  hf_track_pid_reduced::TPCTOFNSigmaPi<pidtpc::TPCNSigmaPi, pidtof::TOFNSigmaPi>,
+                  hf_track_pid_reduced::TPCTOFNSigmaKa<pidtpc::TPCNSigmaKa, pidtof::TOFNSigmaKa>,
+                  hf_track_pid_reduced::TPCTOFNSigmaPr<pidtpc::TPCNSigmaPr, pidtof::TOFNSigmaPr>,
+                  aod::track::Px<aod::track::Signed1Pt, aod::track::Snp, aod::track::Alpha>,
+                  aod::track::Py<aod::track::Signed1Pt, aod::track::Snp, aod::track::Alpha>,
+                  aod::track::Pz<aod::track::Signed1Pt, track::Tgl>,
+                  aod::track::PVector<aod::track::Signed1Pt, aod::track::Snp, aod::track::Alpha, aod::track::Tgl>);
+
+DECLARE_SOA_TABLE(HfRedBachProng0Cov, "AOD", "HFREDTRK0COV", //! Table with track covariance information for reduced workflow
+                  soa::Index<>,
+                  HFTRACKPARCOV_COLUMNS);
+
+// CAREFUL: need to follow convention [Name = Description + 's'] in DECLARE_SOA_TABLE(Name, "AOD", Description)
+// to call DECLARE_SOA_INDEX_COLUMN_FULL later on
+DECLARE_SOA_TABLE(HfRedBachProng1Bases, "AOD", "HFREDTRK1BASE", //! Table with track information for reduced workflow
+                  soa::Index<>,
+                  hf_track_index_reduced::TrackId,
+                  hf_track_index_reduced::HfRedCollisionId,
+                  HFTRACKPAR_COLUMNS,
+                  hf_track_vars_reduced::ItsNCls,
+                  hf_track_vars_reduced::TpcNClsCrossedRows,
+                  hf_track_vars_reduced::TpcChi2NCl,
+                  hf_track_vars_reduced::HasTPC,
+                  hf_track_vars_reduced::HasTOF,
+                  pidtpc::TPCNSigmaPi,
+                  pidtof::TOFNSigmaPi,
+                  pidtpc::TPCNSigmaKa,
+                  pidtof::TOFNSigmaKa,
+                  pidtpc::TPCNSigmaPr,
+                  pidtof::TOFNSigmaPr,
+                  hf_track_pid_reduced::TPCTOFNSigmaPi<pidtpc::TPCNSigmaPi, pidtof::TOFNSigmaPi>,
+                  hf_track_pid_reduced::TPCTOFNSigmaKa<pidtpc::TPCNSigmaKa, pidtof::TOFNSigmaKa>,
+                  hf_track_pid_reduced::TPCTOFNSigmaPr<pidtpc::TPCNSigmaPr, pidtof::TOFNSigmaPr>,
+                  aod::track::Px<aod::track::Signed1Pt, aod::track::Snp, aod::track::Alpha>,
+                  aod::track::Py<aod::track::Signed1Pt, aod::track::Snp, aod::track::Alpha>,
+                  aod::track::Pz<aod::track::Signed1Pt, track::Tgl>,
+                  aod::track::PVector<aod::track::Signed1Pt, aod::track::Snp, aod::track::Alpha, aod::track::Tgl>);
+
+DECLARE_SOA_TABLE(HfRedBachProng1Cov, "AOD", "HFREDTRK1COV", //! Table with track covariance information for reduced workflow
+                  soa::Index<>,
+                  HFTRACKPARCOV_COLUMNS);
+
 // table with all attributes needed to call statusTpcAndTof() in the selector task
 DECLARE_SOA_TABLE(HfRedTracksPid, "AOD", "HFREDTRACKPID", //! Table with PID track information for reduced workflow
                   o2::soa::Index<>,
@@ -283,8 +344,14 @@ DECLARE_SOA_TABLE(HfRedTracksPid, "AOD", "HFREDTRACKPID", //! Table with PID tra
 
 DECLARE_SOA_EXTENDED_TABLE_USER(HfRedTracksExt, HfRedTrackBases, "HFREDTRACKEXT", //! Track parameters at collision vertex
                                 aod::track::Pt);
+DECLARE_SOA_EXTENDED_TABLE_USER(HfRedBachProng0Ext, HfRedBachProng0Bases, "HFREDTRK0EXT", //! Track parameters at collision vertex
+                                aod::track::Pt);
+DECLARE_SOA_EXTENDED_TABLE_USER(HfRedBachProng1Ext, HfRedBachProng1Bases, "HFREDTRK1EXT", //! Track parameters at collision vertex
+                                aod::track::Pt);
 
 using HfRedTracks = HfRedTracksExt;
+using HfRedBachProng0Tracks = HfRedBachProng0Ext;
+using HfRedBachProng1Tracks = HfRedBachProng1Ext;
 
 namespace hf_charm_cand_reduced
 {
@@ -297,6 +364,105 @@ DECLARE_SOA_COLUMN(MlScoreBkgMassHypo1, mlScoreBkgMassHypo1, float);            
 DECLARE_SOA_COLUMN(MlScorePromptMassHypo1, mlScorePromptMassHypo1, float);       //! ML score for prompt class (mass hypothesis 1)
 DECLARE_SOA_COLUMN(MlScoreNonpromptMassHypo1, mlScoreNonpromptMassHypo1, float); //! ML score for non-prompt class (mass hypothesis 1)
 } // namespace hf_charm_cand_reduced
+
+namespace hf_jpsi_cand_reduced
+{
+DECLARE_SOA_COLUMN(ProngPosId, prongPosId, int);             //! Original track index
+DECLARE_SOA_COLUMN(ProngNegId, prongNegId, int);             //! Original track index
+DECLARE_SOA_COLUMN(HfRedCollisionId, hfRedCollisionId, int); //! Collision index
+DECLARE_SOA_COLUMN(M, m, float);                             //! Invariant mass of candidate in GeV/c2
+DECLARE_SOA_COLUMN(XDauPos, xDauPos, float);                 //! x
+DECLARE_SOA_COLUMN(XDauNeg, xDauNeg, float);                 //! x
+DECLARE_SOA_COLUMN(YDauPos, yDauPos, float);                 //! y
+DECLARE_SOA_COLUMN(YDauNeg, yDauNeg, float);                 //! y
+DECLARE_SOA_COLUMN(ZDauPos, zDauPos, float);                 //! z
+DECLARE_SOA_COLUMN(ZDauNeg, zDauNeg, float);                 //! z
+DECLARE_SOA_COLUMN(AlphaDauPos, alphaDauPos, float);         //! alpha of the J/Psi positive decay daughter
+DECLARE_SOA_COLUMN(AlphaDauNeg, alphaDauNeg, float);         //! alpha of the J/Psi negative decay daughter
+DECLARE_SOA_COLUMN(SnpDauPos, snpDauPos, float);             //! snp of the J/Psi positive decay daughter
+DECLARE_SOA_COLUMN(SnpDauNeg, snpDauNeg, float);             //! snp of the J/Psi negative decay daughter
+DECLARE_SOA_COLUMN(TglDauPos, tglDauPos, float);             //! tgl of the J/Psi positive decay daughter
+DECLARE_SOA_COLUMN(TglDauNeg, tglDauNeg, float);             //! tgl of the J/Psi negative decay daughter
+DECLARE_SOA_COLUMN(Signed1PtDauPos, signed1PtDauPos, float); //! signed1Pt of the J/Psi positive decay daughter
+DECLARE_SOA_COLUMN(Signed1PtDauNeg, signed1PtDauNeg, float); //! signed1Pt of the J/Psi negative decay daughter
+
+DECLARE_SOA_DYNAMIC_COLUMN(PxDauPos, pxDauPos, //! Momentum in x-direction in GeV/c
+                           [](float signed1Pt, float snp, float alpha) -> float {
+                             auto pt = 1.f / std::abs(signed1Pt);
+                             // FIXME: GCC & clang should optimize to sincosf
+                             float cs = cosf(alpha), sn = sinf(alpha);
+                             auto r = std::sqrt((1.f - snp) * (1.f + snp));
+                             return pt * (r * cs - snp * sn);
+                           });
+DECLARE_SOA_DYNAMIC_COLUMN(PyDauPos, pyDauPos, //! Momentum in y-direction in GeV/c
+                           [](float signed1Pt, float snp, float alpha) -> float {
+                             auto pt = 1.f / std::abs(signed1Pt);
+                             // FIXME: GCC & clang should optimize to sincosf
+                             float cs = cosf(alpha), sn = sinf(alpha);
+                             auto r = std::sqrt((1.f - snp) * (1.f + snp));
+                             return pt * (snp * cs + r * sn);
+                           });
+DECLARE_SOA_DYNAMIC_COLUMN(PzDauPos, pzDauPos, //! Momentum in z-direction in GeV/c
+                           [](float signed1Pt, float tgl) -> float {
+                             auto pt = 1.f / std::abs(signed1Pt);
+                             return pt * tgl;
+                           });
+DECLARE_SOA_DYNAMIC_COLUMN(PxDauNeg, pxDauNeg, //! Momentum in x-direction in GeV/c
+                           [](float signed1Pt, float snp, float alpha) -> float {
+                             auto pt = 1.f / std::abs(signed1Pt);
+                             // FIXME: GCC & clang should optimize to sincosf
+                             float cs = cosf(alpha), sn = sinf(alpha);
+                             auto r = std::sqrt((1.f - snp) * (1.f + snp));
+                             return pt * (r * cs - snp * sn);
+                           });
+DECLARE_SOA_DYNAMIC_COLUMN(PyDauNeg, pyDauNeg, //! Momentum in y-direction in GeV/c
+                           [](float signed1Pt, float snp, float alpha) -> float {
+                             auto pt = 1.f / std::abs(signed1Pt);
+                             // FIXME: GCC & clang should optimize to sincosf
+                             float cs = cosf(alpha), sn = sinf(alpha);
+                             auto r = std::sqrt((1.f - snp) * (1.f + snp));
+                             return pt * (snp * cs + r * sn);
+                           });
+DECLARE_SOA_DYNAMIC_COLUMN(PzDauNeg, pzDauNeg, //! Momentum in z-direction in GeV/c
+                           [](float signed1Pt, float tgl) -> float {
+                             auto pt = 1.f / std::abs(signed1Pt);
+                             return pt * tgl;
+                           });
+
+// Covariance matrix of the J/Psi positive decay daughter
+DECLARE_SOA_COLUMN(CYYDauPos, cYYDauPos, float);             //! Covariance matrix
+DECLARE_SOA_COLUMN(CZYDauPos, cZYDauPos, float);             //! Covariance matrix
+DECLARE_SOA_COLUMN(CZZDauPos, cZZDauPos, float);             //! Covariance matrix
+DECLARE_SOA_COLUMN(CSnpYDauPos, cSnpYDauPos, float);         //! Covariance matrix
+DECLARE_SOA_COLUMN(CSnpZDauPos, cSnpZDauPos, float);         //! Covariance matrix
+DECLARE_SOA_COLUMN(CSnpSnpDauPos, cSnpSnpDauPos, float);     //! Covariance matrix
+DECLARE_SOA_COLUMN(CTglYDauPos, cTglYDauPos, float);         //! Covariance matrix
+DECLARE_SOA_COLUMN(CTglZDauPos, cTglZDauPos, float);         //! Covariance matrix
+DECLARE_SOA_COLUMN(CTglSnpDauPos, cTglSnpDauPos, float);     //! Covariance matrix
+DECLARE_SOA_COLUMN(CTglTglDauPos, cTglTglDauPos, float);     //! Covariance matrix
+DECLARE_SOA_COLUMN(C1PtYDauPos, c1PtYDauPos, float);         //! Covariance matrix
+DECLARE_SOA_COLUMN(C1PtZDauPos, c1PtZDauPos, float);         //! Covariance matrix
+DECLARE_SOA_COLUMN(C1PtSnpDauPos, c1PtSnpDauPos, float);     //! Covariance matrix
+DECLARE_SOA_COLUMN(C1PtTglDauPos, c1PtTglDauPos, float);     //! Covariance matrix
+DECLARE_SOA_COLUMN(C1Pt21Pt2DauPos, c1Pt21Pt2DauPos, float); //! Covariance matrix
+
+// Covariance matrix of the J/Psi negative decay daughter
+DECLARE_SOA_COLUMN(CYYDauNeg, cYYDauNeg, float);             //! Covariance matrix
+DECLARE_SOA_COLUMN(CZYDauNeg, cZYDauNeg, float);             //! Covariance matrix
+DECLARE_SOA_COLUMN(CZZDauNeg, cZZDauNeg, float);             //! Covariance matrix
+DECLARE_SOA_COLUMN(CSnpYDauNeg, cSnpYDauNeg, float);         //! Covariance matrix
+DECLARE_SOA_COLUMN(CSnpZDauNeg, cSnpZDauNeg, float);         //! Covariance matrix
+DECLARE_SOA_COLUMN(CSnpSnpDauNeg, cSnpSnpDauNeg, float);     //! Covariance matrix
+DECLARE_SOA_COLUMN(CTglYDauNeg, cTglYDauNeg, float);         //! Covariance matrix
+DECLARE_SOA_COLUMN(CTglZDauNeg, cTglZDauNeg, float);         //! Covariance matrix
+DECLARE_SOA_COLUMN(CTglSnpDauNeg, cTglSnpDauNeg, float);     //! Covariance matrix
+DECLARE_SOA_COLUMN(CTglTglDauNeg, cTglTglDauNeg, float);     //! Covariance matrix
+DECLARE_SOA_COLUMN(C1PtYDauNeg, c1PtYDauNeg, float);         //! Covariance matrix
+DECLARE_SOA_COLUMN(C1PtZDauNeg, c1PtZDauNeg, float);         //! Covariance matrix
+DECLARE_SOA_COLUMN(C1PtSnpDauNeg, c1PtSnpDauNeg, float);     //! Covariance matrix
+DECLARE_SOA_COLUMN(C1PtTglDauNeg, c1PtTglDauNeg, float);     //! Covariance matrix
+DECLARE_SOA_COLUMN(C1Pt21Pt2DauNeg, c1Pt21Pt2DauNeg, float); //! Covariance matrix
+} // namespace hf_jpsi_cand_reduced
 
 // CAREFUL: need to follow convention [Name = Description + 's'] in DECLARE_SOA_TABLE(Name, "AOD", Description)
 // to call DECLARE_SOA_INDEX_COLUMN_FULL later on
@@ -363,6 +529,47 @@ DECLARE_SOA_TABLE_VERSIONED(HfRed3ProngsMl_001, "AOD", "HFRED3PRONGML", 1, //! T
                             o2::soa::Marker<1>);
 
 using HfRed3ProngsMl = HfRed3ProngsMl_001;
+
+// CAREFUL: need to follow convention [Name = Description + 's'] in DECLARE_SOA_TABLE(Name, "AOD", Description)
+// to call DECLARE_SOA_INDEX_COLUMN_FULL later on
+DECLARE_SOA_TABLE(HfRedJPsis, "AOD", "HFREDJPSI", //! Table with J/Psi candidate information for reduced workflow
+                  o2::soa::Index<>,
+                  hf_jpsi_cand_reduced::ProngPosId,
+                  hf_jpsi_cand_reduced::ProngNegId,
+                  hf_track_index_reduced::HfRedCollisionId,
+                  hf_cand::XSecondaryVertex, hf_cand::YSecondaryVertex, hf_cand::ZSecondaryVertex,
+                  hf_jpsi_cand_reduced::M,
+                  hf_jpsi_cand_reduced::XDauPos, hf_jpsi_cand_reduced::XDauNeg,
+                  hf_jpsi_cand_reduced::YDauPos, hf_jpsi_cand_reduced::YDauNeg,
+                  hf_jpsi_cand_reduced::ZDauPos, hf_jpsi_cand_reduced::ZDauNeg,
+                  hf_jpsi_cand_reduced::AlphaDauPos, hf_jpsi_cand_reduced::AlphaDauNeg,
+                  hf_jpsi_cand_reduced::SnpDauPos, hf_jpsi_cand_reduced::SnpDauNeg,
+                  hf_jpsi_cand_reduced::TglDauPos, hf_jpsi_cand_reduced::TglDauNeg,
+                  hf_jpsi_cand_reduced::Signed1PtDauPos, hf_jpsi_cand_reduced::Signed1PtDauNeg,
+                  hf_jpsi_cand_reduced::PxDauPos<hf_jpsi_cand_reduced::Signed1PtDauPos, hf_jpsi_cand_reduced::SnpDauPos, hf_jpsi_cand_reduced::AlphaDauPos>,
+                  hf_jpsi_cand_reduced::PxDauNeg<hf_jpsi_cand_reduced::Signed1PtDauNeg, hf_jpsi_cand_reduced::SnpDauNeg, hf_jpsi_cand_reduced::AlphaDauNeg>,
+                  hf_jpsi_cand_reduced::PyDauPos<hf_jpsi_cand_reduced::Signed1PtDauPos, hf_jpsi_cand_reduced::SnpDauPos, hf_jpsi_cand_reduced::AlphaDauPos>,
+                  hf_jpsi_cand_reduced::PyDauNeg<hf_jpsi_cand_reduced::Signed1PtDauNeg, hf_jpsi_cand_reduced::SnpDauNeg, hf_jpsi_cand_reduced::AlphaDauNeg>,
+                  hf_jpsi_cand_reduced::PzDauPos<hf_jpsi_cand_reduced::Signed1PtDauPos, hf_jpsi_cand_reduced::TglDauPos>,
+                  hf_jpsi_cand_reduced::PzDauNeg<hf_jpsi_cand_reduced::Signed1PtDauNeg, hf_jpsi_cand_reduced::TglDauNeg>);
+
+DECLARE_SOA_TABLE(HfRedJPsiCov, "AOD", "HFREDJPSICOV", //! Table with J/Psi candidate covariance for reduced workflow
+                  o2::soa::Index<>,
+                  hf_jpsi_cand_reduced::CYYDauPos, hf_jpsi_cand_reduced::CYYDauNeg,
+                  hf_jpsi_cand_reduced::CZYDauPos, hf_jpsi_cand_reduced::CZYDauNeg,
+                  hf_jpsi_cand_reduced::CZZDauPos, hf_jpsi_cand_reduced::CZZDauNeg,
+                  hf_jpsi_cand_reduced::CSnpYDauPos, hf_jpsi_cand_reduced::CSnpYDauNeg,
+                  hf_jpsi_cand_reduced::CSnpZDauPos, hf_jpsi_cand_reduced::CSnpZDauNeg,
+                  hf_jpsi_cand_reduced::CSnpSnpDauPos, hf_jpsi_cand_reduced::CSnpSnpDauNeg,
+                  hf_jpsi_cand_reduced::CTglYDauPos, hf_jpsi_cand_reduced::CTglYDauNeg,
+                  hf_jpsi_cand_reduced::CTglZDauPos, hf_jpsi_cand_reduced::CTglZDauNeg,
+                  hf_jpsi_cand_reduced::CTglSnpDauPos, hf_jpsi_cand_reduced::CTglSnpDauNeg,
+                  hf_jpsi_cand_reduced::CTglTglDauPos, hf_jpsi_cand_reduced::CTglTglDauNeg,
+                  hf_jpsi_cand_reduced::C1PtYDauPos, hf_jpsi_cand_reduced::C1PtYDauNeg,
+                  hf_jpsi_cand_reduced::C1PtZDauPos, hf_jpsi_cand_reduced::C1PtZDauNeg,
+                  hf_jpsi_cand_reduced::C1PtSnpDauPos, hf_jpsi_cand_reduced::C1PtSnpDauNeg,
+                  hf_jpsi_cand_reduced::C1PtTglDauPos, hf_jpsi_cand_reduced::C1PtTglDauNeg,
+                  hf_jpsi_cand_reduced::C1Pt21Pt2DauPos, hf_jpsi_cand_reduced::C1Pt21Pt2DauNeg);
 
 DECLARE_SOA_TABLE(HfRedPidDau0s_000, "AOD", "HFREDPIDDAU0", //!
                   hf_track_pid_reduced::TPCNSigmaPiProng0,
@@ -466,15 +673,20 @@ using HfRedCandB0 = soa::Join<HfCandB0Ext, HfRedB0Prongs>;
 
 namespace hf_cand_bplus_reduced
 {
-DECLARE_SOA_INDEX_COLUMN_FULL(Prong0, prong0, int, HfRed2Prongs, "_0");    //! Prong0 index
-DECLARE_SOA_INDEX_COLUMN_FULL(Prong1, prong1, int, HfRedTrackBases, "_1"); //! Prong1 index
-DECLARE_SOA_COLUMN(Prong0MlScoreBkg, prong0MlScoreBkg, float);             //! Bkg ML score of the D daughter
-DECLARE_SOA_COLUMN(Prong0MlScorePrompt, prong0MlScorePrompt, float);       //! Prompt ML score of the D daughter
-DECLARE_SOA_COLUMN(Prong0MlScoreNonprompt, prong0MlScoreNonprompt, float); //! Nonprompt ML score of the D daughter
+DECLARE_SOA_INDEX_COLUMN_FULL(Prong0, prong0, int, HfRed2Prongs, "_0");         //! Prong0 index
+DECLARE_SOA_INDEX_COLUMN_FULL(Prong1, prong1, int, HfRedTrackBases, "_1");      //! Prong1 index
+DECLARE_SOA_INDEX_COLUMN_FULL(JPsi, jPsi, int, HfRedJPsis, "_0");               //! J/Psi index
+DECLARE_SOA_INDEX_COLUMN_FULL(BachKa, bachKa, int, HfRedBachProng0Bases, "_0"); //! J/Psi index
+DECLARE_SOA_COLUMN(Prong0MlScoreBkg, prong0MlScoreBkg, float);                  //! Bkg ML score of the D daughter
+DECLARE_SOA_COLUMN(Prong0MlScorePrompt, prong0MlScorePrompt, float);            //! Prompt ML score of the D daughter
+DECLARE_SOA_COLUMN(Prong0MlScoreNonprompt, prong0MlScoreNonprompt, float);      //! Nonprompt ML score of the D daughter
 } // namespace hf_cand_bplus_reduced
 
 DECLARE_SOA_TABLE(HfRedBplusProngs, "AOD", "HFREDBPPRONG",
                   hf_cand_bplus_reduced::Prong0Id, hf_cand_bplus_reduced::Prong1Id);
+
+DECLARE_SOA_TABLE(HfRedBplus2JPsiDaus, "AOD", "HFREDBP2JPSIDAU",
+                  hf_cand_bplus_reduced::JPsiId, hf_cand_bplus_reduced::BachKaId);
 
 DECLARE_SOA_TABLE(HfRedBplusD0Mls, "AOD", "HFREDBPLUSD0ML", //! Table with ML scores for the D0 daughter
                   hf_cand_bplus_reduced::Prong0MlScoreBkg,
@@ -483,6 +695,7 @@ DECLARE_SOA_TABLE(HfRedBplusD0Mls, "AOD", "HFREDBPLUSD0ML", //! Table with ML sc
                   o2::soa::Marker<1>);
 
 using HfRedCandBplus = soa::Join<HfCandBplusExt, HfRedBplusProngs>;
+using HfRedCandBplusToJPsiK = soa::Join<HfCandBplusExt, HfRedBplus2JPsiDaus>;
 
 namespace hf_cand_bs_reduced
 {
@@ -681,12 +894,16 @@ namespace hf_cand_bplus_config
 DECLARE_SOA_COLUMN(MySelectionFlagD0, mySelectionFlagD0, int8_t);       //! Flag to filter selected D0 mesons
 DECLARE_SOA_COLUMN(MySelectionFlagD0bar, mySelectionFlagD0bar, int8_t); //! Flag to filter selected D0 mesons
 DECLARE_SOA_COLUMN(MyInvMassWindowD0Pi, myInvMassWindowD0Pi, float);    //! Half-width of the Bplus invariant-mass window in GeV/c2
+DECLARE_SOA_COLUMN(MyInvMassWindowJPsiK, myInvMassWindowJPsiK, float);  //! Half-width of the Bplus invariant-mass window in GeV/c2
 } // namespace hf_cand_bplus_config
 
 DECLARE_SOA_TABLE(HfCandBpConfigs, "AOD", "HFCANDBPCONFIG", //! Table with configurables information for reduced workflow
                   hf_cand_bplus_config::MySelectionFlagD0,
                   hf_cand_bplus_config::MySelectionFlagD0bar,
                   hf_cand_bplus_config::MyInvMassWindowD0Pi);
+
+DECLARE_SOA_TABLE(HfCandBpToJPsiKConfigs, "AOD", "HFCANDBPTOJPSIKCONFIG", //! Table with configurables information for reduced workflow
+                  hf_cand_bplus_config::MyInvMassWindowJPsiK);
 
 namespace hf_bs_mc
 {

--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -722,6 +722,7 @@ DECLARE_SOA_TABLE(HfRedBsDsMls, "AOD", "HFREDBSDSML", //! Table with ML scores f
                   o2::soa::Marker<1>);
 
 using HfRedCandBs = soa::Join<HfCandBsExt, HfRedBsProngs>;
+using HfRedCandBsToJPsiPhi = soa::Join<HfCandBsExt, HfRedBs2JPsiDaus>;
 
 namespace hf_cand_lb_reduced
 {

--- a/PWGHF/D2H/TableProducer/CMakeLists.txt
+++ b/PWGHF/D2H/TableProducer/CMakeLists.txt
@@ -11,6 +11,11 @@
 
 # Candidate creators
 
+o2physics_add_dpl_workflow(candidate-creator-b-to-j-psi-reduced
+                    SOURCES candidateCreatorBToJPsiReduced.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::MLCore
+                    COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(candidate-creator-b0-reduced
                     SOURCES candidateCreatorB0Reduced.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::DCAFitter
@@ -67,6 +72,11 @@ o2physics_add_dpl_workflow(data-creator-charm-had-pi-reduced
 
 o2physics_add_dpl_workflow(data-creator-charm-reso-reduced
                     SOURCES dataCreatorCharmResoReduced.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::EventFilteringUtils
+                    COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(data-creator-j-psi-had-reduced
+                    SOURCES dataCreatorJPsiHadReduced.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::EventFilteringUtils
                     COMPONENT_NAME Analysis)
 

--- a/PWGHF/D2H/TableProducer/candidateCreatorBToJPsiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorBToJPsiReduced.cxx
@@ -1,0 +1,313 @@
+
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file candidateCreatorBToJPsiReduced.cxx
+/// \brief Reconstruction of B->J/Psi hadron candidates
+///
+/// \author Fabrizio Chinu <fabrizio.chinu@cern.ch>, Università degli Studi and INFN Torino
+/// \author Fabrizio Grosa <fabrizio.grosa@cern.ch>, CERN
+
+#include <memory>
+
+#include "CommonConstants/PhysicsConstants.h"
+#include "DCAFitter/DCAFitterN.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/runDataProcessing.h"
+#include "ReconstructionDataFormats/DCA.h"
+#include "ReconstructionDataFormats/V0.h"
+
+#include "Common/Core/trackUtilities.h"
+#include "Common/DataModel/CollisionAssociationTables.h"
+
+#include "PWGHF/DataModel/CandidateReconstructionTables.h"
+#include "PWGHF/DataModel/CandidateSelectionTables.h"
+#include "PWGHF/D2H/DataModel/ReducedDataModel.h"
+#include "PWGHF/Utils/utilsTrkCandHf.h"
+
+using namespace o2;
+using namespace o2::aod;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using namespace o2::hf_trkcandsel;
+
+/// Reconstruction of B+ candidates
+struct HfCandidateCreatorBToJPsiReduced {
+  Produces<aod::HfCandBplusBase> rowCandidateBase;       // table defined in CandidateReconstructionTables.h
+  Produces<aod::HfRedBplus2JPsiDaus> rowCandidateProngs; // table defined in ReducedDataModel.h
+
+  // vertexing
+  Configurable<bool> propagateToPCA{"propagateToPCA", true, "create tracks version propagated to PCA"};
+  Configurable<bool> useAbsDCA{"useAbsDCA", true, "Minimise abs. distance rather than chi2"};
+  Configurable<bool> useWeightedFinalPCA{"useWeightedFinalPCA", false, "Recalculate vertex position using track covariances, effective only if useAbsDCA is true"};
+  Configurable<double> maxR{"maxR", 200., "reject PCA's above this radius"};
+  Configurable<double> maxDZIni{"maxDZIni", 4., "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
+  Configurable<double> minParamChange{"minParamChange", 1.e-3, "stop iterations if largest change of any B+ is smaller than this"};
+  Configurable<double> minRelChi2Change{"minRelChi2Change", 0.9, "stop iterations is chi2/chi2old > this"};
+
+  Configurable<bool> runJPsiToee{"runJPsiToee", false, "Run analysis for J/Psi to ee (debug)"};
+  // selection
+  Configurable<double> invMassWindowJPsiKTolerance{"invMassWindowJPsiKTolerance", 0.01, "invariant-mass window tolerance for J/Psi K pair preselections (GeV/c2)"};
+
+  float myInvMassWindowJPsiK{1.}; // variable that will store the value of invMassWindowJPsiK (defined in dataCreatorJPsiKReduced.cxx)
+  double massBplus{0.};
+  double bz{0.};
+  o2::vertexing::DCAFitterN<2> df2; // fitter for B vertex (2-prong vertex fitter)
+
+  using HfRedCollisionsWithExtras = soa::Join<aod::HfRedCollisions, aod::HfRedCollExtras>;
+
+  Preslice<soa::Join<aod::HfRedJPsis, aod::HfRedJPsiCov>> candsJPsiPerCollision = hf_track_index_reduced::hfRedCollisionId;
+  Preslice<soa::Join<aod::HfRedBachProng0Bases, aod::HfRedBachProng0Cov>> tracksKaonPerCollision = hf_track_index_reduced::hfRedCollisionId;
+
+  std::shared_ptr<TH1> hCandidates;
+  o2::base::Propagator::MatCorrType noMatCorr = o2::base::Propagator::MatCorrType::USEMatCorrNONE;
+  HistogramRegistry registry{"registry"};
+
+  void init(InitContext const&)
+  {
+    // invariant-mass window cut
+    massBplus = o2::constants::physics::MassBPlus;
+
+    // Initialize fitter
+    df2.setPropagateToPCA(propagateToPCA);
+    df2.setMaxR(maxR);
+    df2.setMaxDZIni(maxDZIni);
+    df2.setMinParamChange(minParamChange);
+    df2.setMinRelChi2Change(minRelChi2Change);
+    df2.setUseAbsDCA(useAbsDCA);
+    df2.setWeightedFinalPCA(useWeightedFinalPCA);
+    df2.setMatCorrType(noMatCorr);
+
+    // histograms
+    registry.add("hMassJPsi", "J/Psi mass;#it{M}_{#mu#mu} (GeV/#it{c}^{2});Counts", {HistType::kTH1F, {{600, 2.5, 3.7, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hMassBplusToJPsiK", "2-prong candidates;inv. mass (B^{+} #rightarrow #overline{D^{0}}#pi^{#plus} #rightarrow #pi^{#minus}K^{#plus}#pi^{#plus}) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {{500, 3., 8.}}});
+    registry.add("hCovPVXX", "2-prong candidates;XX element of cov. matrix of prim. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 1.e-4}}});
+    registry.add("hCovSVXX", "2-prong candidates;XX element of cov. matrix of sec. vtx. position (cm^{2});entries", {HistType::kTH1F, {{100, 0., 0.2}}});
+    registry.add("hEvents", "Events;;entries", HistType::kTH1F, {{1, 0.5, 1.5}});
+
+    /// candidate monitoring
+    hCandidates = registry.add<TH1>("hFitCandidatesJPsi", "candidates counter", {HistType::kTH1D, {axisCands}});
+    setLabelHistoCands(hCandidates);
+  }
+
+  /// Main function to perform B+ candidate creation
+  /// \param collision the collision
+  /// \param candsJPsiThisColl J/Psi candidates in this collision
+  /// \param tracksKaonThisCollision kaon tracks in this collision
+  /// \param invMass2JPsiKMin minimum B+ invariant-mass
+  /// \param invMass2JPsiKMax maximum B+ invariant-mass
+  template <typename Cands, typename Kaons, typename Coll>
+  void runCandidateCreation(Coll const& collision,
+                            Cands const& candsJPsiThisColl,
+                            Kaons const& tracksKaonThisCollision,
+                            const float& invMass2JPsiKMin,
+                            const float& invMass2JPsiKMax)
+  {
+    auto primaryVertex = getPrimaryVertex(collision);
+    auto covMatrixPV = primaryVertex.getCov();
+
+    // Set the magnetic field from ccdb
+    bz = collision.bz();
+    df2.setBz(bz);
+
+    for (const auto& candJPsi : candsJPsiThisColl) {
+      o2::track::TrackParametrizationWithError<float> trackPosParCov(
+        candJPsi.xDauPos(), candJPsi.alphaDauPos(), {candJPsi.yDauPos(), candJPsi.zDauPos(), candJPsi.snpDauPos(), candJPsi.tglDauPos(), candJPsi.signed1PtDauPos()}, 1 /*Charge*/, 1 /*Muon*/);
+      o2::track::TrackParametrizationWithError<float> trackNegParCov(
+        candJPsi.xDauNeg(), candJPsi.alphaDauNeg(), {candJPsi.yDauNeg(), candJPsi.zDauNeg(), candJPsi.snpDauNeg(), candJPsi.tglDauNeg(), candJPsi.signed1PtDauNeg()}, -1 /*Charge*/, 1 /*Muon*/);
+
+      // ---------------------------------
+      // reconstruct J/Psi candidate
+      o2::track::TrackParCov trackParCovJPsi{};
+      std::array<float, 3> pVecJPsi{};
+      registry.fill(HIST("hFitCandidatesJPsi"), SVFitting::BeforeFit);
+      try {
+        if (df2.process(trackPosParCov, trackNegParCov) == 0) {
+          LOG(info) << "DCAFitterN failed to reconstruct J/Psi candidate, skipping the candidate.";
+          continue;
+        }
+      } catch (const std::runtime_error& error) {
+        LOG(info) << "Run time error found: " << error.what() << ". DCAFitterN cannot work, skipping the candidate.";
+        registry.fill(HIST("hFitCandidatesJPsi"), SVFitting::Fail);
+        continue;
+      }
+      registry.fill(HIST("hFitCandidatesJPsi"), SVFitting::FitOk);
+
+      std::array<float, 3> pVecDauPos{candJPsi.pxDauPos(), candJPsi.pyDauPos(), candJPsi.pzDauPos()};
+      std::array<float, 3> pVecDauNeg{candJPsi.pxDauNeg(), candJPsi.pyDauNeg(), candJPsi.pzDauNeg()};
+      LOG(info) << "pVecDauPos before: " << pVecDauPos[0] << " " << pVecDauPos[1] << " " << pVecDauPos[2];
+
+      // df2.getTrack(0).getPxPyPzGlo(pVecDauPos);
+      // df2.getTrack(1).getPxPyPzGlo(pVecDauNeg);
+      LOG(info) << "pVecDauPos: " << pVecDauPos[0] << " " << pVecDauPos[1] << " " << pVecDauPos[2];
+      LOG(info) << "pVecDauPos from table: " << candJPsi.pxDauPos() << " " << candJPsi.pyDauPos() << " " << candJPsi.pzDauPos();
+      pVecJPsi = RecoDecay::pVec(pVecDauPos, pVecDauNeg);
+      trackParCovJPsi = df2.createParentTrackParCov();
+      trackParCovJPsi.setAbsCharge(0); // to be sure
+
+      float invMassJPsi{0.f};
+      if (runJPsiToee) {
+        invMassJPsi = RecoDecay::m2(std::array{pVecDauPos, pVecDauNeg}, std::array{o2::constants::physics::MassElectron, o2::constants::physics::MassElectron});
+      } else {
+        invMassJPsi = RecoDecay::m2(std::array{pVecDauPos, pVecDauNeg}, std::array{o2::constants::physics::MassMuon, o2::constants::physics::MassMuon});
+      }
+      invMassJPsi = std::sqrt(invMassJPsi);
+      registry.fill(HIST("hMassJPsi"), invMassJPsi);
+
+      for (const auto& trackKaon : tracksKaonThisCollision) {
+        // this track is among daughters
+        if (trackKaon.trackId() == candJPsi.prongPosId() || trackKaon.trackId() == candJPsi.prongNegId()) {
+          continue;
+        }
+        auto trackParCovKa = getTrackParCov(trackKaon);
+        std::array<float, 3> pVecKaon = trackKaon.pVector();
+
+        // compute invariant mass square and apply selection
+        auto invMass2JPsiK = RecoDecay::m2(std::array{pVecJPsi, pVecKaon}, std::array{o2::constants::physics::MassJPsi, o2::constants::physics::MassKPlus});
+        if ((invMass2JPsiK < invMass2JPsiKMin) || (invMass2JPsiK > invMass2JPsiKMax)) {
+          continue;
+        }
+        // ---------------------------------
+        // reconstruct the 2-prong B+ vertex
+        hCandidates->Fill(SVFitting::BeforeFit);
+        try {
+          if (df2.process(trackParCovJPsi, trackParCovKa) == 0) {
+            continue;
+          }
+        } catch (const std::runtime_error& error) {
+          LOG(info) << "Run time error found: " << error.what() << ". DCAFitterN cannot work, skipping the candidate.";
+          hCandidates->Fill(SVFitting::Fail);
+          continue;
+        }
+        hCandidates->Fill(SVFitting::FitOk);
+        // JPsiK passed B+ reconstruction
+
+        // calculate relevant properties
+        const auto& secondaryVertexBplus = df2.getPCACandidate();
+        auto chi2PCA = df2.getChi2AtPCACandidate();
+        auto covMatrixPCA = df2.calcPCACovMatrixFlat();
+        registry.fill(HIST("hCovSVXX"), covMatrixPCA[0]);
+        registry.fill(HIST("hCovPVXX"), covMatrixPV[0]);
+
+        // propagate JPsi and K to the B+ vertex
+        df2.propagateTracksToVertex();
+        // track.getPxPyPzGlo(pVec) modifies pVec of track
+        df2.getTrack(0).getPxPyPzGlo(pVecJPsi); // momentum of JPsi at the B+ vertex
+        df2.getTrack(1).getPxPyPzGlo(pVecKaon); // momentum of K at the B+ vertex
+
+        registry.fill(HIST("hMassBplusToJPsiK"), std::sqrt(invMass2JPsiK));
+
+        // compute impact parameters of JPsi and K
+        o2::dataformats::DCA dcaJPsi;
+        o2::dataformats::DCA dcaKaon;
+        trackParCovJPsi.propagateToDCA(primaryVertex, bz, &dcaJPsi);
+        trackParCovKa.propagateToDCA(primaryVertex, bz, &dcaKaon);
+
+        // get uncertainty of the decay length
+        double phi, theta;
+        // getPointDirection modifies phi and theta
+        getPointDirection(std::array{collision.posX(), collision.posY(), collision.posZ()}, secondaryVertexBplus, phi, theta);
+        auto errorDecayLength = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, theta) + getRotatedCovMatrixXX(covMatrixPCA, phi, theta));
+        auto errorDecayLengthXY = std::sqrt(getRotatedCovMatrixXX(covMatrixPV, phi, 0.) + getRotatedCovMatrixXX(covMatrixPCA, phi, 0.));
+
+        // fill the candidate table for the B+ here:
+        rowCandidateBase(collision.globalIndex(),
+                         collision.posX(), collision.posY(), collision.posZ(),
+                         secondaryVertexBplus[0], secondaryVertexBplus[1], secondaryVertexBplus[2],
+                         errorDecayLength, errorDecayLengthXY,
+                         chi2PCA,
+                         pVecJPsi[0], pVecJPsi[1], pVecJPsi[2],
+                         pVecKaon[0], pVecKaon[1], pVecKaon[2],
+                         dcaJPsi.getY(), dcaKaon.getY(),
+                         std::sqrt(dcaJPsi.getSigmaY2()), std::sqrt(dcaKaon.getSigmaY2()));
+
+        rowCandidateProngs(candJPsi.globalIndex(), trackKaon.globalIndex());
+
+      } // kaon loop
+    } // J/Psi loop
+  } // end runCandidateCreation
+
+  void processData(HfRedCollisionsWithExtras const& collisions,
+                   soa::Join<aod::HfRedJPsis, aod::HfRedJPsiCov> const& candsJPsi,
+                   soa::Join<aod::HfRedBachProng0Bases, aod::HfRedBachProng0Cov> const& tracksKaon,
+                   aod::HfOrigColCounts const& collisionsCounter,
+                   aod::HfCandBpToJPsiKConfigs const& configs)
+  {
+    // JPsi K invariant-mass window cut
+    for (const auto& config : configs) {
+      myInvMassWindowJPsiK = config.myInvMassWindowJPsiK();
+    }
+    // invMassWindowJPsiKTolerance is used to apply a slightly tighter cut than in JPsiK pair preselection
+    // to avoid accepting JPsiK pairs that were not formed in JPsiK pair creator
+    double invMass2JPsiKMin = (massBplus - myInvMassWindowJPsiK + invMassWindowJPsiKTolerance) * (massBplus - myInvMassWindowJPsiK + invMassWindowJPsiKTolerance);
+    double invMass2JPsiKMax = (massBplus + myInvMassWindowJPsiK - invMassWindowJPsiKTolerance) * (massBplus + myInvMassWindowJPsiK - invMassWindowJPsiKTolerance);
+
+    for (const auto& collisionCounter : collisionsCounter) {
+      registry.fill(HIST("hEvents"), 1, collisionCounter.originalCollisionCount());
+    }
+
+    static int ncol = 0;
+
+    for (const auto& collision : collisions) {
+      auto thisCollId = collision.globalIndex();
+      auto candsJPsiThisColl = candsJPsi.sliceBy(candsJPsiPerCollision, thisCollId);
+      auto tracksKaonThisCollision = tracksKaon.sliceBy(tracksKaonPerCollision, thisCollId);
+      runCandidateCreation(collision, candsJPsiThisColl, tracksKaonThisCollision, invMass2JPsiKMin, invMass2JPsiKMax);
+      if (ncol % 10000 == 0) {
+        LOG(debug) << ncol << " collisions parsed";
+      }
+      ncol++;
+    }
+  } // processData
+
+  PROCESS_SWITCH(HfCandidateCreatorBToJPsiReduced, processData, "Process data", true);
+}; // struct
+
+/// Extends the table base with expression columns and performs MC matching.
+struct HfCandidateCreatorBplusToJPsiReducedExpressions {
+  Spawns<aod::HfCandBplusExt> rowCandidateBPlus;
+  Spawns<aod::HfRedBachProng0Ext> rowTracksExt;
+  Produces<aod::HfMcRecRedBps> rowBplusMcRec;
+
+  /// Fill candidate information at MC reconstruction level
+  /// \param rowsJPsiKMcRec MC reco information on JPsiK pairs
+  /// \param candsBplus prong global indices of B+ candidates
+  template <typename McRec>
+  void fillBplusMcRec(McRec const& rowsJPsiKMcRec, HfRedBplus2JPsiDaus const& candsBplus)
+  {
+    for (const auto& candBplus : candsBplus) {
+      bool filledMcInfo{false};
+      for (const auto& rowJPsiKMcRec : rowsJPsiKMcRec) {
+        if ((rowJPsiKMcRec.prong0Id() != candBplus.jPsiId()) || (rowJPsiKMcRec.prong1Id() != candBplus.bachKaId())) {
+          continue;
+        }
+        rowBplusMcRec(rowJPsiKMcRec.flagMcMatchRec(), rowJPsiKMcRec.flagWrongCollision(), rowJPsiKMcRec.debugMcRec(), rowJPsiKMcRec.ptMother());
+        filledMcInfo = true;
+        break;
+      }
+      if (!filledMcInfo) { // protection to get same size tables in case something went wrong: we created a candidate that was not preselected in the JPsi-K creator
+        rowBplusMcRec(0, -1, -1, -1.f);
+      }
+    }
+  }
+
+  void processMc(HfMcRecRedD0Pis const& rowsJPsiKMcRec, HfRedBplus2JPsiDaus const& candsBplus)
+  {
+    fillBplusMcRec(rowsJPsiKMcRec, candsBplus);
+  }
+  PROCESS_SWITCH(HfCandidateCreatorBplusToJPsiReducedExpressions, processMc, "Process MC", false);
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{adaptAnalysisTask<HfCandidateCreatorBToJPsiReduced>(cfgc),
+                      adaptAnalysisTask<HfCandidateCreatorBplusToJPsiReducedExpressions>(cfgc)};
+}

--- a/PWGHF/D2H/TableProducer/dataCreatorJPsiHadReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorJPsiHadReduced.cxx
@@ -1,0 +1,801 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file dataCreatorJPsiHadReduced.cxx
+/// \brief Creation of J/Psi-LF hadron pairs for Beauty hadron analyses
+///
+/// \author Fabrizio Chinu <fabrizio.chinu@cern.ch>, Università degli Studi and INFN Torino
+/// \author Fabrizio Grosa <fabrizio.grosa@cern.ch>, CERN
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "CommonConstants/PhysicsConstants.h"
+#include "DCAFitter/DCAFitterN.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/O2DatabasePDGPlugin.h"
+#include "Framework/runDataProcessing.h"
+#include "ReconstructionDataFormats/DCA.h"
+
+#include "Common/Core/trackUtilities.h"
+#include "Common/DataModel/CollisionAssociationTables.h"
+#include "Common/DataModel/Centrality.h"
+#include "Common/DataModel/Qvectors.h"
+
+#include "PWGHF/Core/HfHelper.h"
+#include "PWGHF/DataModel/CandidateReconstructionTables.h"
+#include "PWGHF/DataModel/CandidateSelectionTables.h"
+#include "PWGHF/Utils/utilsBfieldCCDB.h"
+#include "PWGHF/Utils/utilsEvSelHf.h"
+#include "PWGHF/D2H/DataModel/ReducedDataModel.h"
+#include "PWGHF/Utils/utilsTrkCandHf.h"
+#include "PWGHF/D2H/Utils/utilsRedDataFormat.h"
+
+using namespace o2;
+using namespace o2::analysis;
+using namespace o2::aod;
+using namespace o2::constants::physics;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using namespace o2::hf_trkcandsel;
+
+enum Event : uint8_t {
+  Processed = 0,
+  NoCharmHadPiSelected,
+  CharmHadPiSelected,
+  kNEvent
+};
+
+enum DecayChannel : uint8_t {
+  B0ToJPsiK0Star = 0,
+  BplusToJPsiK,
+  BsToJPsiPhi
+};
+
+enum WrongCollisionType : uint8_t {
+  None = 0,
+  WrongAssociation,
+  SplitCollision,
+};
+
+/// Creation of JPsi-Had pairs for Beauty hadrons
+struct HfDataCreatorJPsiHadReduced {
+  // Produces AOD tables to store track information
+  // collision related tables
+  Produces<aod::HfRedCollisions> hfReducedCollision;
+  Produces<aod::HfRedCollCents> hfReducedCollCentrality;
+  Produces<aod::HfRedQvectors> hfReducedQvector;
+  Produces<aod::HfRedCollExtras> hfReducedCollExtra;
+  Produces<aod::HfOrigColCounts> hfCollisionCounter;
+  // J/Psi related tables
+  Produces<aod::HfRedJPsis> hfJPsi;
+  Produces<aod::HfRedJPsiCov> hfRedJPsiCov;
+  // Ka bachelor related tables
+  Produces<aod::HfRedBachProng0Bases> hfTrackKaon;
+  Produces<aod::HfRedBachProng0Cov> hfTrackCovKaon;
+  // MC related tables
+  Produces<aod::HfMcRecRedD0Pis> rowHfJPsiKMcRecReduced;
+  Produces<aod::HfMcGenRedBps> rowHfBpMcGenReduced;
+
+  Produces<aod::HfCandBpToJPsiKConfigs> rowCandidateConfigBplus;
+
+  Configurable<bool> propagateToPCA{"propagateToPCA", true, "create tracks version propagated to PCA"};
+  Configurable<bool> useAbsDCA{"useAbsDCA", false, "Minimise abs. distance rather than chi2"};
+  Configurable<bool> useWeightedFinalPCA{"useWeightedFinalPCA", false, "Recalculate vertex position using track covariances, effective only if useAbsDCA is true"};
+  Configurable<double> maxR{"maxR", 200., "reject PCA's above this radius"};
+  Configurable<double> maxDZIni{"maxDZIni", 4., "reject (if>0) PCA candidate if tracks DZ exceeds threshold"};
+  Configurable<double> minParamChange{"minParamChange", 1.e-3, "stop iterations if largest change of any B0 is smaller than this"};
+  Configurable<double> minRelChi2Change{"minRelChi2Change", 0.9, "stop iterations is chi2/chi2old > this"};
+
+  Configurable<bool> runJPsiToee{"runJPsiToee", false, "Run analysis for J/Psi to ee (debug)"};
+  Configurable<double> ptJpsiMin{"ptJpsiMin", 0., "Lower bound of J/Psi pT"};
+  Configurable<double> ptJpsiMax{"ptJpsiMax", 50., "Upper bound of J/Psi pT"};
+  Configurable<bool> useKaonIsGlobalTrackWoDCA{"useKaonIsGlobalTrackWoDCA", true, "check isGlobalTrackWoDCA status for kaons, for Run3 studies"};
+  Configurable<double> ptKaonMin{"ptKaonMin", 0.5, "minimum kaon pT threshold (GeV/c)"};
+  Configurable<double> absEtaKaonMax{"etaKaonMax", 0.8, "maximum kaon absolute eta threshold"};
+  Configurable<std::vector<double>> binsPtKaon{"binsPtKaon", std::vector<double>{hf_cuts_single_track::vecBinsPtTrack}, "track pT bin limits for kaon DCA XY pT-dependent cut"};
+  Configurable<LabeledArray<double>> cutsTrackKaonDCA{"cutsTrackKaonDCA", {hf_cuts_single_track::CutsTrack[0], hf_cuts_single_track::NBinsPtTrack, hf_cuts_single_track::NCutVarsTrack, hf_cuts_single_track::labelsPtTrack, hf_cuts_single_track::labelsCutVarTrack}, "Single-track selections per pT bin for kaons"};
+  // topological cuts
+  Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_jpsi_to_mu_mu::vecBinsPt}, "J/Psi pT bin limits"};
+  Configurable<LabeledArray<double>> cuts{"cuts", {hf_cuts_jpsi_to_mu_mu::Cuts[0], hf_cuts_jpsi_to_mu_mu::NBinsPt, hf_cuts_jpsi_to_mu_mu::NCutVars, hf_cuts_jpsi_to_mu_mu::labelsPt, hf_cuts_jpsi_to_mu_mu::labelsCutVar}, "J/Psi candidate selection per pT bin"};
+
+  Configurable<double> invMassWindowJPsiKa{"invMassWindowJPsiKa", 0.3, "invariant-mass window for JPsi-Ka pair preselections (GeV/c2)"};
+  // magnetic field setting from CCDB
+  Configurable<std::string> ccdbUrl{"ccdbUrl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+  Configurable<std::string> ccdbPathGrpMag{"ccdbPathGrpMag", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object (Run 3)"};
+
+  using TracksPid = soa::Join<aod::pidTPCFullPi, aod::pidTOFFullPi, aod::pidTPCFullKa, aod::pidTOFFullKa, aod::pidTPCFullPr, aod::pidTOFFullPr>;
+  using TracksPidWithSel = soa::Join<aod::TracksWCovDcaExtra, TracksPid, aod::TrackSelection>;
+  using TracksSel = soa::Join<aod::TracksWDcaExtra, aod::TracksPidPi, aod::PidTpcTofFullPi, aod::TracksPidKa, aod::PidTpcTofFullKa>;
+  using TracksPidWithSelAndMc = soa::Join<TracksPidWithSel, aod::McTrackLabels>;
+  using CollisionsWCMcLabels = soa::Join<aod::Collisions, aod::McCollisionLabels, aod::EvSels>;
+
+  Preslice<aod::HfCand2ProngWPid> candsJPsiPerCollision = aod::track_association::collisionId;
+  Preslice<aod::TrackAssoc> trackIndicesPerCollision = aod::track_association::collisionId;
+  PresliceUnsorted<CollisionsWCMcLabels> colPerMcCollision = aod::mccollisionlabel::mcCollisionId;
+
+  HistogramRegistry registry{"registry"};
+
+  // CCDB service
+  Service<o2::ccdb::BasicCCDBManager> ccdb;
+  o2::base::Propagator::MatCorrType noMatCorr = o2::base::Propagator::MatCorrType::USEMatCorrNONE;
+  int runNumber;
+  double bz{0.};
+
+  // O2DatabasePDG service
+  Service<o2::framework::O2DatabasePDG> pdg;
+
+  double invMass2JPsiKaMin, invMass2JPsiKaMax;
+  HfHelper hfHelper;
+  o2::hf_evsel::HfEventSelection hfEvSel;
+  o2::vertexing::DCAFitterN<2> df2;
+
+  bool isHfCandBhadConfigFilled = false;
+
+  void init(InitContext const&)
+  {
+    std::array<int, 2> doProcess = {doprocessJPsiKData, doprocessJPsiKMc};
+    if (std::accumulate(doProcess.begin(), doProcess.end(), 0) != 1) {
+      LOGP(fatal, "One and only one process function can be enabled at a time, please fix your configuration!");
+    }
+
+    // Set up the histogram registry
+    constexpr int kNBinsSelections = 2 + aod::SelectionStep::RecoTopol;
+    std::string labels[kNBinsSelections];
+    labels[0] = "No selection";
+    labels[1 + aod::SelectionStep::RecoSkims] = "Skims selection";
+    labels[1 + aod::SelectionStep::RecoTopol] = "Skims & Topological selections";
+    static const AxisSpec axisSelections = {kNBinsSelections, 0.5, kNBinsSelections + 0.5, ""};
+    registry.add("hSelectionsJPsi", "J/Psi selection;;#it{p}_{T} (GeV/#it{c})", {HistType::kTH2F, {axisSelections, {(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    for (int iBin = 0; iBin < kNBinsSelections; ++iBin) {
+      registry.get<TH2>(HIST("hSelectionsJPsi"))->GetXaxis()->SetBinLabel(iBin + 1, labels[iBin].data());
+    }
+
+    constexpr int kNBinsEvents = kNEvent;
+    std::string labelsEvents[kNBinsEvents];
+    labelsEvents[Event::Processed] = "processed";
+    labelsEvents[Event::NoCharmHadPiSelected] = "without CharmHad-Pi pairs";
+    labelsEvents[Event::CharmHadPiSelected] = "with CharmHad-Pi pairs";
+    static const AxisSpec axisEvents = {kNBinsEvents, 0.5, kNBinsEvents + 0.5, ""};
+    registry.add("hEvents", "Events;;entries", HistType::kTH1F, {axisEvents});
+    for (int iBin = 0; iBin < kNBinsEvents; iBin++) {
+      registry.get<TH1>(HIST("hEvents"))->GetXaxis()->SetBinLabel(iBin + 1, labelsEvents[iBin].data());
+    }
+
+    registry.add("hMassJPsi", "J/Psi mass;#it{M}_{#mu#mu} (GeV/#it{c}^{2});Counts", {HistType::kTH1F, {{600, 2.8, 3.4, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hPtJPsi", "J/Psi #it{p}_{T};#it{p}_{T} (GeV/#it{c});Counts", {HistType::kTH1F, {{(std::vector<double>)binsPt, "#it{p}_{T} (GeV/#it{c})"}}});
+    registry.add("hCpaJPsi", "J/Psi cos#theta_{p};J/Psi cos#theta_{p};Counts", {HistType::kTH1F, {{200, -1., 1, "J/Psi cos#theta_{p}"}}});
+    std::shared_ptr<TH1> hFitCandidatesJPsi = registry.add<TH1>("hFitCandidatesJPsi", "JPsi candidate counter", {HistType::kTH1D, {axisCands}});
+    registry.add("hPtKaon", "Kaon #it{p}_{T};#it{p}_{T} (GeV/#it{c});Counts", {HistType::kTH1F, {{100, 0., 10.}}});
+    registry.add("hMassJPsiKaon", "J/Psi Kaon mass;#it{M}_{J/#PsiK} (GeV/#it{c}^{2});Counts", {HistType::kTH1F, {{800, 4.9, 5.7}}});
+
+    setLabelHistoCands(hFitCandidatesJPsi);
+
+    df2.setPropagateToPCA(propagateToPCA);
+    df2.setMaxR(maxR);
+    df2.setMaxDZIni(maxDZIni);
+    df2.setMinParamChange(minParamChange);
+    df2.setMinRelChi2Change(minRelChi2Change);
+    df2.setUseAbsDCA(useAbsDCA);
+    df2.setWeightedFinalPCA(useWeightedFinalPCA);
+    df2.setMatCorrType(noMatCorr);
+
+    // Configure CCDB access
+    ccdb->setURL(ccdbUrl);
+    ccdb->setCaching(true);
+    ccdb->setLocalObjectValidityChecking();
+    runNumber = 0;
+
+    invMass2JPsiKaMin = (MassBPlus - invMassWindowJPsiKa) * (MassBPlus - invMassWindowJPsiKa); // TODO: change mass bplus for other species
+    invMass2JPsiKaMax = (MassBPlus + invMassWindowJPsiKa) * (MassBPlus + invMassWindowJPsiKa); // TODO: change mass bplus for other species
+  }
+
+  /// Topological cuts
+  /// \param candidate is candidate
+  /// \param trackPos is the positive track
+  /// \param trackNeg is the negative track
+  /// \return true if candidate passes all cuts
+  template <typename T1, typename T2>
+  bool selectionTopol(const T1& candidate, const T2& trackPos, const T2& trackNeg)
+  {
+    auto candpT = candidate.pt();
+    auto pTBin = findBin(binsPt, candpT);
+    if (pTBin == -1) {
+      return false;
+    }
+
+    // check that the candidate pT is within the analysis range
+    if (candpT < ptJpsiMin || candpT >= ptJpsiMax) {
+      return false;
+    }
+
+    // cut on μ+ μ− (e+e−) invariant mass
+    if (runJPsiToee && std::abs(hfHelper.invMassJpsiToEE(candidate) - o2::constants::physics::MassJPsi) > cuts->get(pTBin, "m")) {
+      return false;
+    } else if (!runJPsiToee && std::abs(hfHelper.invMassJpsiToMuMu(candidate) - o2::constants::physics::MassJPsi) > cuts->get(pTBin, "m")) {
+      return false;
+    }
+
+    // cut on daughter pT (same cut used for both channels)
+    if (trackNeg.pt() < cuts->get(pTBin, "pT mu") || trackPos.pt() < cuts->get(pTBin, "pT mu")) {
+      return false;
+    }
+
+    // decay length
+    if (candidate.decayLength() < cuts->get(pTBin, "decay length")) {
+      return false;
+    }
+
+    // decay length in XY plane
+    if (candidate.decayLengthXY() < cuts->get(pTBin, "decay length xy")) {
+      return false;
+    }
+
+    // cosine of pointing angle
+    if (candidate.cpa() < cuts->get(pTBin, "cpa")) {
+      return false;
+    }
+
+    // cosine of pointing angle XY
+    if (candidate.cpaXY() < cuts->get(pTBin, "cpa xy")) {
+      return false;
+    }
+
+    // product of daughter impact parameters
+    if (candidate.impactParameterProduct() > cuts->get(pTBin, "d0xd0")) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /// Single-track cuts for kaons on dcaXY
+  /// \param trackPar is the track parametrisation
+  /// \param dca is the 2-D array with track DCAs
+  /// \return true if track passes all cuts
+  template <typename T1, typename T2>
+  bool isSelectedTrackDCA(const T1& trackPar, const T2& dca)
+  {
+    auto pTBinTrack = findBin(binsPtKaon, trackPar.getPt());
+    if (pTBinTrack == -1) {
+      return false;
+    }
+
+    if (std::abs(dca[0]) < cutsTrackKaonDCA->get(pTBinTrack, "min_dcaxytoprimary")) {
+      return false; // minimum DCAxy
+    }
+    if (std::abs(dca[0]) > cutsTrackKaonDCA->get(pTBinTrack, "max_dcaxytoprimary")) {
+      return false; // maximum DCAxy
+    }
+    return true;
+  }
+
+  /// Kaon selection (J/Psi K+ <-- B+)
+  /// \param trackKaon is a track with the kaon hypothesis
+  /// \param trackParCovKaon is the track parametrisation of the kaon
+  /// \param dcaKaon is the 2-D array with track DCAs of the kaon
+  /// \param jPsiDautracks J/Psi daughter tracks
+  /// \return true if trackKaon passes all cuts
+  template <typename T1, typename T2, typename T3>
+  bool isKaonSelected(const T1& trackKaon, const T2& trackParCovKaon, const T3& dcaKaon, const std::vector<T1>& jPsiDautracks)
+  {
+    // check isGlobalTrackWoDCA status for kaons if wanted
+    if (useKaonIsGlobalTrackWoDCA && !trackKaon.isGlobalTrackWoDCA()) {
+      return false;
+    }
+    // minimum pT, eta, and DCA selection
+    if (trackParCovKaon.getPt() < ptKaonMin || std::abs(trackParCovKaon.getEta()) > absEtaKaonMax || !isSelectedTrackDCA(trackParCovKaon, dcaKaon)) {
+      return false;
+    }
+    // reject kaons that are J/Psi daughters
+    for (const auto& track : jPsiDautracks) {
+      if (trackKaon.globalIndex() == track.globalIndex()) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /// Checks if the B meson is associated with a different collision than the one it was generated in
+  /// \param particleMother is the mother particle
+  /// \param collision is the reconstructed collision
+  /// \param indexCollisionMaxNumContrib is the index of the collision associated with a given MC collision with the largest number of contributors.
+  /// \param flagWrongCollision is the flag indicating if whether the associated collision is incorrect.
+  template <typename PParticle, typename CColl>
+  void checkWrongCollision(const PParticle& particleMother,
+                           const CColl& collision,
+                           const int64_t& indexCollisionMaxNumContrib,
+                           int8_t& flagWrongCollision)
+  {
+
+    if (particleMother.mcCollision().globalIndex() != collision.mcCollisionId()) {
+      flagWrongCollision = WrongCollisionType::WrongAssociation;
+    } else {
+      if (collision.globalIndex() != indexCollisionMaxNumContrib) {
+        flagWrongCollision = WrongCollisionType::SplitCollision;
+      }
+    }
+  }
+
+  /// Function for filling MC reco information in the tables
+  /// \param particlesMc is the table with MC particles
+  /// \param vecDaughtersB is the vector with all daughter tracks (JPsi daughters in first position)
+  /// \param indexHfCandJPsi is the index of the JPsi candidate
+  /// \param selectedTracksKaon is the map with the indices of selected bachelor pion tracks
+  template <uint8_t decChannel, typename CColl, typename PParticles, typename TTrack>
+  void fillMcRecoInfo(const CColl& collision,
+                      const PParticles& particlesMc,
+                      const std::vector<TTrack>& vecDaughtersB,
+                      int& indexHfCandJPsi,
+                      std::map<int64_t, int64_t> selectedTracksKaon,
+                      const int64_t indexCollisionMaxNumContrib)
+  {
+
+    // we check the MC matching to be stored
+    int8_t sign{0};
+    int8_t flag{0};
+    int8_t flagWrongCollision{WrongCollisionType::None};
+    int8_t debug{0};
+    float motherPt{-1.f};
+
+    if constexpr (decChannel == DecayChannel::BplusToJPsiK) {
+      // B+ → J/Psi K+ → (µ+µ-) K+
+      int indexRec = -1;
+      if (!runJPsiToee) {
+        indexRec = RecoDecay::getMatchedMCRec<true, false, false, true, true>(particlesMc, std::array{vecDaughtersB[0], vecDaughtersB[1], vecDaughtersB[2]}, Pdg::kBPlus, std::array{-kMuonMinus, +kMuonMinus, +kKPlus}, true, &sign, 3);
+      } else {
+        LOG(info) << "JPsiToee";
+        indexRec = RecoDecay::getMatchedMCRec<true, false, false, true, true>(particlesMc, std::array{vecDaughtersB[0], vecDaughtersB[1], vecDaughtersB[2]}, Pdg::kBPlus, std::array{-kElectron, +kElectron, +kKPlus}, true, &sign, 3);
+        if (indexRec > -1) {
+          LOG(info) << "JPsiToee from B found";
+        }
+        if (RecoDecay::getMatchedMCRec<false, false, false, true, true>(particlesMc, std::array{vecDaughtersB[0], vecDaughtersB[1]}, Pdg::kJPsi, std::array{-kElectron, +kElectron}, true, &sign, 1) > -1) {
+          LOG(info) << "JPsiToee found";
+        }
+      }
+      if (indexRec > -1) {
+        // J/Psi → µ+µ-
+        if (!runJPsiToee) {
+          indexRec = RecoDecay::getMatchedMCRec<false, false, false, true, true>(particlesMc, std::array{vecDaughtersB[0], vecDaughtersB[1]}, Pdg::kJPsi, std::array{-kMuonMinus, +kMuonMinus}, true, &sign, 1);
+        } else {
+          indexRec = RecoDecay::getMatchedMCRec<false, false, false, true, true>(particlesMc, std::array{vecDaughtersB[0], vecDaughtersB[1]}, Pdg::kJPsi, std::array{-kElectron, +kElectron}, true, &sign, 1);
+        }
+        if (indexRec > -1) {
+          flag = sign * BIT(static_cast<uint8_t>(hf_cand_bplus::DecayTypeBToJPsiMc::BplusToJPsiKToMuMuK));
+        } else {
+          debug = 1;
+          LOGF(debug, "B+ decays in the expected final state but the condition on the intermediate state is not fulfilled");
+        }
+
+        auto indexMother = RecoDecay::getMother(particlesMc, vecDaughtersB.back().template mcParticle_as<PParticles>(), Pdg::kBPlus, true);
+        if (indexMother >= 0) {
+          auto particleMother = particlesMc.rawIteratorAt(indexMother);
+          motherPt = particleMother.pt();
+          checkWrongCollision(particleMother, collision, indexCollisionMaxNumContrib, flagWrongCollision);
+        }
+      }
+      rowHfJPsiKMcRecReduced(indexHfCandJPsi, selectedTracksKaon[vecDaughtersB.back().globalIndex()], flag, flagWrongCollision, debug, motherPt);
+    }
+  }
+
+  /// Calculates the index of the collision with the maximum number of contributions.
+  ///\param collisions are the collisions to search through.
+  ///\return The index of the collision with the maximum number of contributions.
+  template <typename CColl>
+  int64_t getIndexCollisionMaxNumContrib(const CColl& collisions)
+  {
+    unsigned maxNumContrib = 0;
+    int64_t indexCollisionMaxNumContrib = -1;
+    for (const auto& collision : collisions) {
+      if (collision.numContrib() > maxNumContrib) {
+        maxNumContrib = collision.numContrib();
+        indexCollisionMaxNumContrib = collision.globalIndex();
+      }
+    }
+    return indexCollisionMaxNumContrib;
+  }
+
+  template <uint8_t decChannel>
+  void runMcGen(aod::McParticles const& particlesMc)
+  {
+    // Match generated particles.
+    for (const auto& particle : particlesMc) {
+      int8_t sign{0};
+      int8_t flag{0};
+      if constexpr (decChannel == DecayChannel::BplusToJPsiK) {
+        // B+ → J/Psi K+ → (µ+µ-) K+
+        if (RecoDecay::isMatchedMCGen<true>(particlesMc, particle, Pdg::kBPlus, std::array{static_cast<int>(Pdg::kJPsi), +kKPlus}, true)) {
+          // Match J/Psi -> µ+µ-
+          auto candJPsiMC = particlesMc.rawIteratorAt(particle.daughtersIds().front());
+          // Printf("Checking J/Psi -> µ+µ-");
+          if (!runJPsiToee) {
+            if (RecoDecay::isMatchedMCGen(particlesMc, candJPsiMC, static_cast<int>(Pdg::kJPsi), std::array{-kMuonMinus, +kMuonMinus}, true, &sign, 2)) {
+              flag = sign * BIT(hf_cand_bplus::DecayType::BplusToJPsiK);
+            }
+          } else {
+            // Printf("Checking J/Psi -> e+e-");
+            if (RecoDecay::isMatchedMCGen(particlesMc, candJPsiMC, static_cast<int>(Pdg::kJPsi), std::array{-kElectron, +kElectron}, true, &sign, 2)) {
+              flag = sign * BIT(hf_cand_bplus::DecayType::BplusToJPsiK);
+            }
+          }
+        }
+
+        // save information for B+ task
+        if (!TESTBIT(std::abs(flag), hf_cand_bplus::DecayType::BplusToJPsiK)) {
+          continue;
+        }
+
+        auto ptParticle = particle.pt();
+        auto yParticle = RecoDecay::y(particle.pVector(), MassBPlus);
+        auto etaParticle = particle.eta();
+
+        std::array<float, 2> ptProngs;
+        std::array<float, 2> yProngs;
+        std::array<float, 2> etaProngs;
+        int counter = 0;
+        for (const auto& daught : particle.daughters_as<aod::McParticles>()) {
+          ptProngs[counter] = daught.pt();
+          etaProngs[counter] = daught.eta();
+          yProngs[counter] = RecoDecay::y(daught.pVector(), pdg->Mass(daught.pdgCode()));
+          counter++;
+        }
+        rowHfBpMcGenReduced(flag, ptParticle, yParticle, etaParticle,
+                            ptProngs[0], yProngs[0], etaProngs[0],
+                            ptProngs[1], yProngs[1], etaProngs[1]);
+      }
+    } // gen
+  }
+
+  // JPsi candidate selection
+  template <bool doMc, uint8_t decChannel, typename Coll, typename JPsiCands, typename TTracks, typename PParticles>
+  void runDataCreation(Coll const& collision,
+                       JPsiCands const& candsJPsi,
+                       aod::TrackAssoc const& trackIndices,
+                       TTracks const&,
+                       PParticles const& particlesMc,
+                       uint64_t const& indexCollisionMaxNumContrib,
+                       aod::BCsWithTimestamps const&)
+  {
+
+    // helpers for ReducedTables filling
+    int indexHfReducedCollision = hfReducedCollision.lastIndex() + 1;
+    // std::map where the key is the track.globalIndex() and
+    // the value is the track index in the table of the selected pions
+    std::map<int64_t, int64_t> selectedTracksKaon;
+
+    bool fillHfReducedCollision = false;
+
+    auto primaryVertex = getPrimaryVertex(collision);
+
+    // Set the magnetic field from ccdb.
+    // The static instance of the propagator was already modified in the HFTrackIndexSkimCreator,
+    // but this is not true when running on Run2 data/MC already converted into AO2Ds.
+    auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
+    if (runNumber != bc.runNumber()) {
+      LOG(info) << ">>>>>>>>>>>> Current run number: " << runNumber;
+      o2::parameters::GRPMagField* grpo = ccdb->getForTimeStamp<o2::parameters::GRPMagField>(ccdbPathGrpMag, bc.timestamp());
+      if (grpo == nullptr) {
+        LOGF(fatal, "Run 3 GRP object (type o2::parameters::GRPMagField) is not available in CCDB for run=%d at timestamp=%llu", bc.runNumber(), bc.timestamp());
+      }
+      o2::base::Propagator::initFieldFromGRP(grpo);
+      bz = o2::base::Propagator::Instance()->getNominalBz();
+      LOG(info) << ">>>>>>>>>>>> Magnetic field: " << bz;
+      runNumber = bc.runNumber();
+    }
+    df2.setBz(bz);
+
+    auto thisCollId = collision.globalIndex();
+    // looping over 2-prong candidates
+    for (const auto& candidate : candsJPsi) {
+
+      // Apply the selections on the J/Psi candidates
+      registry.fill(HIST("hSelectionsJPsi"), 1, candidate.pt());
+
+      if (!(candidate.hfflag() & 1 << aod::hf_cand_2prong::DecayType::JpsiToMuMu)) {
+        continue;
+      }
+      registry.fill(HIST("hSelectionsJPsi"), 2 + aod::SelectionStep::RecoSkims, candidate.pt());
+
+      auto trackPos = candidate.template prong0_as<TTracks>(); // positive daughter
+      auto trackNeg = candidate.template prong1_as<TTracks>(); // negative daughter
+
+      auto trackPosParCov = getTrackParCov(trackPos);
+      auto trackNegParCov = getTrackParCov(trackNeg);
+
+      // topological selection
+      if (!selectionTopol(candidate, trackPos, trackNeg)) {
+        continue;
+      }
+      registry.fill(HIST("hSelectionsJPsi"), 2 + aod::SelectionStep::RecoTopol, candidate.pt());
+
+      int indexHfCandJPsi = hfJPsi.lastIndex() + 1;
+      float invMassJPsi{0.f};
+      if (runJPsiToee) {
+        invMassJPsi = hfHelper.invMassJpsiToEE(candidate);
+      } else {
+        invMassJPsi = hfHelper.invMassJpsiToMuMu(candidate);
+      }
+      registry.fill(HIST("hMassJPsi"), invMassJPsi);
+      LOG(info) << "J/Psi mass: " << invMassJPsi;
+      registry.fill(HIST("hPtJPsi"), candidate.pt());
+      registry.fill(HIST("hCpaJPsi"), candidate.cpa());
+
+      bool fillHfCandJPsi = false;
+
+      std::vector<typename TTracks::iterator> jPsiDauTracks{trackPos, trackNeg};
+
+      std::array<float, 3> pVec0 = jPsiDauTracks[0].pVector();
+      LOG(info) << "pVec0: " << pVec0[0] << " " << pVec0[1] << " " << pVec0[2];
+      std::array<float, 3> pVec1 = jPsiDauTracks[1].pVector();
+
+      auto dca0 = o2::dataformats::DCA(jPsiDauTracks[0].dcaXY(), jPsiDauTracks[0].dcaZ(), jPsiDauTracks[0].cYY(), jPsiDauTracks[0].cZY(), jPsiDauTracks[0].cZZ());
+      auto dca1 = o2::dataformats::DCA(jPsiDauTracks[1].dcaXY(), jPsiDauTracks[1].dcaZ(), jPsiDauTracks[1].cYY(), jPsiDauTracks[1].cZY(), jPsiDauTracks[1].cZZ());
+
+      // repropagate tracks to this collision if needed
+      if (jPsiDauTracks[0].collisionId() != thisCollId) {
+        trackPosParCov.propagateToDCA(primaryVertex, bz, &dca0);
+      }
+
+      if (jPsiDauTracks[1].collisionId() != thisCollId) {
+        trackNegParCov.propagateToDCA(primaryVertex, bz, &dca1);
+      }
+
+      // ---------------------------------
+      // reconstruct J/Psi candidate secondary vertex
+      o2::track::TrackParCov trackParCovJPsi{};
+      std::array<float, 3> pVecJPsi{};
+      registry.fill(HIST("hFitCandidatesJPsi"), SVFitting::BeforeFit);
+      try {
+        if (df2.process(trackPosParCov, trackNegParCov) == 0) {
+          continue;
+        }
+      } catch (const std::runtime_error& error) {
+        LOG(info) << "Run time error found: " << error.what() << ". DCAFitterN cannot work, skipping the candidate.";
+        registry.fill(HIST("hFitCandidatesJPsi"), SVFitting::Fail);
+        continue;
+      }
+      registry.fill(HIST("hFitCandidatesJPsi"), SVFitting::FitOk);
+
+      auto secondaryVertexJPsi = df2.getPCACandidate();
+      trackPosParCov.propagateTo(secondaryVertexJPsi[0], bz);
+      trackNegParCov.propagateTo(secondaryVertexJPsi[0], bz);
+      LOG(info) << "pVec0 after: " << pVec0[0] << " " << pVec0[1] << " " << pVec0[2];
+      df2.getTrack(0).getPxPyPzGlo(pVec0);
+      LOG(info) << "pVec0 after2: " << pVec0[0] << " " << pVec0[1] << " " << pVec0[2];
+      df2.getTrack(1).getPxPyPzGlo(pVec1);
+      pVecJPsi = RecoDecay::pVec(pVec0, pVec1);
+      trackParCovJPsi = df2.createParentTrackParCov();
+      trackParCovJPsi.setAbsCharge(0); // to be sure
+
+      // TODO: add single track information (min eta, min ITS/TPC clusters, etc.)
+      double invMass2JPsiKa{0.f};
+      for (const auto& trackId : trackIndices) {
+        auto trackKaon = trackId.template track_as<TTracks>();
+
+        // apply selections on kaon tracks
+        auto trackParCovKaon = getTrackParCov(trackKaon);
+        o2::gpu::gpustd::array<float, 2> dcaKaon{trackKaon.dcaXY(), trackKaon.dcaZ()};
+        std::array<float, 3> pVecKaon = trackKaon.pVector();
+        if (trackKaon.collisionId() != thisCollId) {
+          o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParCovKaon, 2.f, noMatCorr, &dcaKaon);
+          getPxPyPz(trackParCovKaon, pVecKaon);
+        }
+
+        // apply selections on kaon tracks
+        if (!isKaonSelected(trackKaon, trackParCovKaon, dcaKaon, jPsiDauTracks)) {
+          continue;
+        }
+
+        registry.fill(HIST("hPtKaon"), trackParCovKaon.getPt());
+        // compute invariant mass square and apply selection
+        invMass2JPsiKa = RecoDecay::m2(std::array{pVecJPsi, pVecKaon}, std::array{MassJPsi, MassKPlus});
+        if ((invMass2JPsiKa < invMass2JPsiKaMin) || (invMass2JPsiKa > invMass2JPsiKaMax)) {
+          continue;
+        }
+        registry.fill(HIST("hMassJPsiKaon"), std::sqrt(invMass2JPsiKa));
+
+        // fill Kaon tracks table
+        // if information on track already stored, go to next track
+        if (!selectedTracksKaon.count(trackKaon.globalIndex())) {
+          hfTrackKaon(trackKaon.globalIndex(), indexHfReducedCollision,
+                      trackParCovKaon.getX(), trackParCovKaon.getAlpha(),
+                      trackParCovKaon.getY(), trackParCovKaon.getZ(), trackParCovKaon.getSnp(),
+                      trackParCovKaon.getTgl(), trackParCovKaon.getQ2Pt(),
+                      trackKaon.itsNCls(), trackKaon.tpcNClsCrossedRows(), trackKaon.tpcChi2NCl(),
+                      trackKaon.hasTPC(), trackKaon.hasTOF(),
+                      trackKaon.tpcNSigmaPi(), trackKaon.tofNSigmaPi(),
+                      trackKaon.tpcNSigmaKa(), trackKaon.tofNSigmaKa(),
+                      trackKaon.tpcNSigmaPr(), trackKaon.tofNSigmaPr());
+          hfTrackCovKaon(trackParCovKaon.getSigmaY2(), trackParCovKaon.getSigmaZY(), trackParCovKaon.getSigmaZ2(),
+                         trackParCovKaon.getSigmaSnpY(), trackParCovKaon.getSigmaSnpZ(),
+                         trackParCovKaon.getSigmaSnp2(), trackParCovKaon.getSigmaTglY(), trackParCovKaon.getSigmaTglZ(),
+                         trackParCovKaon.getSigmaTglSnp(), trackParCovKaon.getSigmaTgl2(),
+                         trackParCovKaon.getSigma1PtY(), trackParCovKaon.getSigma1PtZ(), trackParCovKaon.getSigma1PtSnp(),
+                         trackParCovKaon.getSigma1PtTgl(), trackParCovKaon.getSigma1Pt2());
+          // add trackKaon.globalIndex() to a list
+          // to keep memory of the pions filled in the table and avoid refilling them if they are paired to another JPsi candidate
+          // and keep track of their index in hfTrackKaon for McRec purposes
+          selectedTracksKaon[trackKaon.globalIndex()] = hfTrackKaon.lastIndex();
+        }
+
+        if constexpr (doMc) {
+          std::vector<typename TTracks::iterator> beautyHadDauTracks{};
+          for (const auto& track : jPsiDauTracks) {
+            beautyHadDauTracks.push_back(track);
+          }
+          beautyHadDauTracks.push_back(trackKaon);
+          fillMcRecoInfo<DecayChannel::BplusToJPsiK>(collision, particlesMc, beautyHadDauTracks, indexHfCandJPsi, selectedTracksKaon, indexCollisionMaxNumContrib);
+        }
+        fillHfCandJPsi = true;
+      } // kaon loop
+      if (!fillHfCandJPsi) {
+        LOG(info) << "No kaon found for this JPsi candidate";
+      }
+      if (fillHfCandJPsi) {                                       // fill JPsi table only once per JPsi candidate
+        if constexpr (decChannel == DecayChannel::BplusToJPsiK) { // J/Psi → µ+µ-
+          hfJPsi(trackPos.globalIndex(), trackNeg.globalIndex(),
+                 indexHfReducedCollision,
+                 candidate.xSecondaryVertex(), candidate.ySecondaryVertex(), candidate.zSecondaryVertex(),
+                 std::sqrt(invMass2JPsiKa),
+                 trackPosParCov.getX(), trackNegParCov.getX(),
+                 trackPosParCov.getY(), trackNegParCov.getY(),
+                 trackPosParCov.getZ(), trackNegParCov.getZ(),
+                 trackPosParCov.getAlpha(), trackNegParCov.getAlpha(),
+                 trackPosParCov.getSnp(), trackNegParCov.getSnp(),
+                 trackPosParCov.getTgl(), trackNegParCov.getTgl(),
+                 trackPosParCov.getQ2Pt(), trackNegParCov.getQ2Pt()); // Q/pT
+          hfRedJPsiCov(trackPosParCov.getSigmaY2(), trackNegParCov.getSigmaY2(),
+                       trackPosParCov.getSigmaZY(), trackNegParCov.getSigmaZY(),
+                       trackPosParCov.getSigmaZ2(), trackNegParCov.getSigmaZ2(),
+                       trackPosParCov.getSigmaSnpY(), trackNegParCov.getSigmaSnpY(),
+                       trackPosParCov.getSigmaSnpZ(), trackNegParCov.getSigmaSnpZ(),
+                       trackPosParCov.getSigmaSnp2(), trackNegParCov.getSigmaSnp2(),
+                       trackPosParCov.getSigmaTglY(), trackNegParCov.getSigmaTglY(),
+                       trackPosParCov.getSigmaTglZ(), trackNegParCov.getSigmaTglZ(),
+                       trackPosParCov.getSigmaTglSnp(), trackNegParCov.getSigmaTglSnp(),
+                       trackPosParCov.getSigmaTgl2(), trackNegParCov.getSigmaTgl2(),
+                       trackPosParCov.getSigma1PtY(), trackNegParCov.getSigma1PtY(),
+                       trackPosParCov.getSigma1PtZ(), trackNegParCov.getSigma1PtZ(),
+                       trackPosParCov.getSigma1PtSnp(), trackNegParCov.getSigma1PtSnp(),
+                       trackPosParCov.getSigma1PtTgl(), trackNegParCov.getSigma1PtTgl(),
+                       trackPosParCov.getSigma1Pt2(), trackNegParCov.getSigma1Pt2());
+        }
+        fillHfReducedCollision = true;
+      }
+    } // candsJPsi loop
+
+    registry.fill(HIST("hEvents"), 1 + Event::Processed);
+    if (!fillHfReducedCollision) {
+      registry.fill(HIST("hEvents"), 1 + Event::NoCharmHadPiSelected);
+      return;
+    }
+    registry.fill(HIST("hEvents"), 1 + Event::CharmHadPiSelected);
+    float centrality = -1.f;
+    uint16_t hfRejMap = hfEvSel.getHfCollisionRejectionMask<true, o2::hf_centrality::CentralityEstimator::None, aod::BCsWithTimestamps>(collision, centrality, ccdb, registry);
+    // fill collision table if it contains a J/Psi K pair at minimum
+    hfReducedCollision(collision.posX(), collision.posY(), collision.posZ(), collision.numContrib(), hfRejMap, bz);
+    hfReducedCollExtra(collision.covXX(), collision.covXY(), collision.covYY(),
+                       collision.covXZ(), collision.covYZ(), collision.covZZ());
+    // hfReducedCollCentrality(collision.centFT0C(), collision.centFT0M(), collision.trackOccupancyInTimeRange(), collision.ft0cOccupancyInTimeRange()); // TODO: add
+    // if constexpr (withQvec) {
+    //   hfReducedQvector(collision.qvecFT0CRe(), collision.qvecFT0CIm(), collision.sumAmplFT0C(),
+    //                    collision.qvecFT0ARe(), collision.qvecFT0AIm(), collision.sumAmplFT0A(),
+    //                    collision.qvecFT0MRe(), collision.qvecFT0MIm(), collision.sumAmplFT0M(),
+    //                    collision.qvecTPCposRe(), collision.qvecTPCposIm(), collision.nTrkTPCpos(),
+    //                    collision.qvecTPCnegRe(), collision.qvecTPCnegIm(), collision.nTrkTPCneg(),
+    //                    collision.qvecTPCallRe(), collision.qvecTPCallIm(), collision.nTrkTPCall());
+    // }
+  }
+
+  void processJPsiKData(soa::Join<aod::Collisions, aod::EvSels> const& collisions,
+                        aod::HfCand2ProngWPid const& candsJPsi,
+                        aod::TrackAssoc const& trackIndices,
+                        TracksPidWithSel const& tracks,
+                        aod::BCsWithTimestamps const& bcs)
+  {
+    // store configurables needed for B0 workflow
+    if (!isHfCandBhadConfigFilled) {
+      rowCandidateConfigBplus(invMassWindowJPsiKa.value);
+      isHfCandBhadConfigFilled = true;
+    }
+
+    int zvtxColl{0};
+    int sel8Coll{0};
+    int zvtxAndSel8Coll{0};
+    int zvtxAndSel8CollAndSoftTrig{0};
+    int allSelColl{0};
+    for (const auto& collision : collisions) {
+      o2::hf_evsel::checkEvSel<true, o2::hf_centrality::CentralityEstimator::None, aod::BCsWithTimestamps>(collision, hfEvSel, zvtxColl, sel8Coll, zvtxAndSel8Coll, zvtxAndSel8CollAndSoftTrig, allSelColl, ccdb, registry);
+
+      auto thisCollId = collision.globalIndex();
+      auto candsJPsiThisColl = candsJPsi.sliceBy(candsJPsiPerCollision, thisCollId);
+      auto trackIdsThisCollision = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
+      runDataCreation<false, DecayChannel::BplusToJPsiK>(collision, candsJPsiThisColl, trackIdsThisCollision, tracks, tracks, -1, bcs);
+    }
+    // handle normalization by the right number of collisions
+    hfCollisionCounter(collisions.tableSize(), zvtxColl, sel8Coll, zvtxAndSel8Coll, zvtxAndSel8CollAndSoftTrig, allSelColl);
+  }
+  PROCESS_SWITCH(HfDataCreatorJPsiHadReduced, processJPsiKData, "Process DplusPi without MC info", true);
+
+  void processJPsiKMc(CollisionsWCMcLabels const& collisions,
+                      aod::HfCand2ProngWPid const& candsJPsi,
+                      aod::TrackAssoc const& trackIndices,
+                      TracksPidWithSelAndMc const& tracks,
+                      aod::McParticles const& particlesMc,
+                      aod::BCsWithTimestamps const& bcs,
+                      McCollisions const&)
+  {
+    // store configurables needed for B+ workflow
+    if (!isHfCandBhadConfigFilled) {
+      rowCandidateConfigBplus(invMassWindowJPsiKa.value);
+      isHfCandBhadConfigFilled = true;
+    }
+
+    int zvtxColl{0};
+    int sel8Coll{0};
+    int zvtxAndSel8Coll{0};
+    int zvtxAndSel8CollAndSoftTrig{0};
+    int allSelColl{0};
+    for (const auto& collision : collisions) {
+      o2::hf_evsel::checkEvSel<true, o2::hf_centrality::CentralityEstimator::None, aod::BCsWithTimestamps>(collision, hfEvSel, zvtxColl, sel8Coll, zvtxAndSel8Coll, zvtxAndSel8CollAndSoftTrig, allSelColl, ccdb, registry);
+
+      auto thisCollId = collision.globalIndex();
+      auto candsJPsiThisColl = candsJPsi.sliceBy(candsJPsiPerCollision, thisCollId);
+      auto trackIdsThisCollision = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
+      auto collsSameMcCollision = collisions.sliceBy(colPerMcCollision, collision.mcCollisionId());
+      int64_t indexCollisionMaxNumContrib = getIndexCollisionMaxNumContrib(collsSameMcCollision);
+      runDataCreation<true, DecayChannel::BplusToJPsiK>(collision, candsJPsiThisColl, trackIdsThisCollision, tracks, particlesMc, indexCollisionMaxNumContrib, bcs);
+    }
+    // handle normalization by the right number of collisions
+    hfCollisionCounter(collisions.tableSize(), zvtxColl, sel8Coll, zvtxAndSel8Coll, zvtxAndSel8CollAndSoftTrig, allSelColl);
+    runMcGen<DecayChannel::BplusToJPsiK>(particlesMc);
+  }
+  PROCESS_SWITCH(HfDataCreatorJPsiHadReduced, processJPsiKMc, "Process DplusPi with MC info", false);
+
+  // void processJPsiPhiData(aod::Collisions const& collisions,
+  //                         aod::HfCand2ProngWPid const& candsJPsi,
+  //                         aod::TrackAssoc const& trackIndices,
+  //                         TracksPidWithSel const& tracks,
+  //                         aod::BCsWithTimestamps const& bcs)
+  // {
+  //   // store configurables needed for B0 workflow
+  //   if (!isHfCandBhadConfigFilled) {
+  //     rowCandidateConfigB0(selectionFlagDplus.value, invMassWindowCharmHadPi.value);
+  //     isHfCandBhadConfigFilled = true;
+  //   }
+
+  //   int zvtxColl{0};
+  //   int sel8Coll{0};
+  //   int zvtxAndSel8Coll{0};
+  //   int zvtxAndSel8CollAndSoftTrig{0};
+  //   int allSelColl{0};
+  //   for (const auto& collision : collisions) {
+  //     o2::hf_evsel::checkEvSel<true, o2::hf_centrality::CentralityEstimator::None, aod::BCsWithTimestamps>(collision, hfEvSel, zvtxColl, sel8Coll, zvtxAndSel8Coll, zvtxAndSel8CollAndSoftTrig, allSelColl, ccdb, registry);
+
+  //     auto thisCollId = collision.globalIndex();
+  //     auto candsJPsiThisColl = candsJPsi.sliceBy(candsJPsiPerCollision, thisCollId);
+  //     auto trackIdsThisCollision = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
+  //     runDataCreation(collision, candsJPsiThisColl, trackIdsThisCollision, tracks, bcs);
+  //   }
+  //   // handle normalization by the right number of collisions
+  //   hfCollisionCounter(collisions.tableSize(), zvtxColl, sel8Coll, zvtxAndSel8Coll, zvtxAndSel8CollAndSoftTrig, allSelColl);
+  // }
+  // PROCESS_SWITCH(HfDataCreatorCharmHadPiReduced, processDplusPiData, "Process DplusPi without MC info and without ML info", true);
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{adaptAnalysisTask<HfDataCreatorJPsiHadReduced>(cfgc)};
+}

--- a/PWGHF/D2H/Tasks/CMakeLists.txt
+++ b/PWGHF/D2H/Tasks/CMakeLists.txt
@@ -31,7 +31,7 @@ o2physics_add_dpl_workflow(task-bplus-reduced
 
 o2physics_add_dpl_workflow(task-bplus-to-j-psi-k-reduced
                     SOURCES taskBplusToJPsiKReduced.cxx
-                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::MLCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(task-bs-reduced

--- a/PWGHF/D2H/Tasks/CMakeLists.txt
+++ b/PWGHF/D2H/Tasks/CMakeLists.txt
@@ -39,6 +39,11 @@ o2physics_add_dpl_workflow(task-bs-reduced
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(task-bs-to-j-psi-phi-reduced
+                    SOURCES taskBsToJPsiPhiReduced.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::MLCore
+                    COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(task-bs
                     SOURCES taskBs.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore

--- a/PWGHF/D2H/Tasks/CMakeLists.txt
+++ b/PWGHF/D2H/Tasks/CMakeLists.txt
@@ -29,6 +29,11 @@ o2physics_add_dpl_workflow(task-bplus-reduced
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(task-bplus-to-j-psi-k-reduced
+                    SOURCES taskBplusToJPsiKReduced.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(task-bs-reduced
                     SOURCES taskBsReduced.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore

--- a/PWGHF/D2H/Tasks/taskBplusToJPsiKReduced.cxx
+++ b/PWGHF/D2H/Tasks/taskBplusToJPsiKReduced.cxx
@@ -1,0 +1,413 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file taskBplusToJPsiKReduced.cxx
+/// \brief B+ → JPsi K+ → (µ+ µ-) K+ analysis task
+///
+/// \author Fabrizio Chinu <fabrizio.chinu@cern.ch>, Università degli Studi and INFN Torino
+/// \author Fabrizio Grosa <fabrizio.grosa@cern.ch>, CERN
+
+#include <vector>
+
+#include "Framework/AnalysisTask.h"
+#include "Framework/HistogramRegistry.h"
+#include "Framework/runDataProcessing.h"
+#include "Common/Core/RecoDecay.h"
+
+#include "PWGHF/Core/HfHelper.h"
+#include "PWGHF/Core/SelectorCuts.h"
+#include "PWGHF/DataModel/CandidateReconstructionTables.h"
+#include "PWGHF/DataModel/CandidateSelectionTables.h"
+#include "PWGHF/D2H/DataModel/ReducedDataModel.h"
+
+using namespace o2;
+using namespace o2::aod;
+using namespace o2::analysis;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+namespace o2::aod
+{
+namespace hf_cand_bplustojpsik_lite
+{
+DECLARE_SOA_COLUMN(PtJPsi, ptD, float);    //! Transverse momentum of JPsi daughter candidate (GeV/c)
+DECLARE_SOA_COLUMN(PtBach, ptBach, float); //! Transverse momentum of bachelor pion (GeV/c)
+// DECLARE_SOA_COLUMN(AbsEtaBach, absEtaBach, float);                                       //! Absolute pseudorapidity of bachelor pion
+// DECLARE_SOA_COLUMN(ItsNClsBach, itsNClsBach, int);                                       //! Number of ITS clusters of bachelor pion
+// DECLARE_SOA_COLUMN(TpcNClsCrossedRowsBach, tpcNClsCrossedRowsBach, int);                 //! Number of TPC crossed rows of prongs of bachelor pion
+// DECLARE_SOA_COLUMN(TpcChi2NClBach, tpcChi2NClBach, float);                               //! Maximum TPC chi2 of prongs of JPsi-meson daughter candidate
+// DECLARE_SOA_COLUMN(PtJPsiProngMin, ptJPsiProngMin, float);                               //! Minimum pT of prongs of JPsi daughter candidate (GeV/c)
+// DECLARE_SOA_COLUMN(AbsEtaJPsiProngMin, absEtaJPsiProngMin, float);                       //! Minimum absolute pseudorapidity of prongs of JPsi daughter candidate
+// DECLARE_SOA_COLUMN(ItsNClsJPsiProngMin, itsNClsJPsiProngMin, int);                       //! Minimum number of ITS clusters of prongs of JPsi daughter candidate
+// DECLARE_SOA_COLUMN(TpcNClsCrossedRowsJPsiProngMin, tpcNClsCrossedRowsJPsiProngMin, int); //! Minimum number of TPC crossed rows of prongs of JPsi daughter candidate
+// DECLARE_SOA_COLUMN(TpcChi2NClJPsiProngMax, tpcChi2NClJPsiProngMax, float);               //! Maximum TPC chi2 of prongs of JPsi daughter candidate
+DECLARE_SOA_COLUMN(MJPsi, mJPsi, float);                                     //! Invariant mass of JPsi daughter candidates (GeV/c)
+DECLARE_SOA_COLUMN(M, m, float);                                             //! Invariant mass of candidate (GeV/c2)
+DECLARE_SOA_COLUMN(Pt, pt, float);                                           //! Transverse momentum of candidate (GeV/c)
+DECLARE_SOA_COLUMN(PtGen, ptGen, float);                                     //! Transverse momentum of candidate (GeV/c)
+DECLARE_SOA_COLUMN(P, p, float);                                             //! Momentum of candidate (GeV/c)
+DECLARE_SOA_COLUMN(Y, y, float);                                             //! Rapidity of candidate
+DECLARE_SOA_COLUMN(Eta, eta, float);                                         //! Pseudorapidity of candidate
+DECLARE_SOA_COLUMN(Phi, phi, float);                                         //! Azimuth angle of candidate
+DECLARE_SOA_COLUMN(E, e, float);                                             //! Energy of candidate (GeV)
+DECLARE_SOA_COLUMN(NSigTpcKaBachelor, nSigTpcKaBachelor, float);             //! TPC Nsigma separation for bachelor with kaon mass hypothesis
+DECLARE_SOA_COLUMN(NSigTofKaBachelor, nSigTofKaBachelor, float);             //! TOF Nsigma separation for bachelor with kaon mass hypothesis
+DECLARE_SOA_COLUMN(NSigTpcTofKaBachelor, nSigTpcTofKaBachelor, float);       //! Combined TPC and TOF Nsigma separation for bachelor with kaon mass hypothesis
+DECLARE_SOA_COLUMN(NSigTpcMuJPsiDauPos, nSigTpcMuJPsiDauPos, float);         //! TPC Nsigma separation for JPsi DauPos with muon mass hypothesis
+DECLARE_SOA_COLUMN(NSigTofMuJPsiDauPos, nSigTofMuJPsiDauPos, float);         //! TOF Nsigma separation for JPsi DauPos with muon mass hypothesis
+DECLARE_SOA_COLUMN(NSigTpcTofMuJPsiDauPos, nSigTpcTofMuJPsiDauPos, float);   //! Combined TPC and TOF Nsigma separation for JPsi prong0 with muon mass hypothesis
+DECLARE_SOA_COLUMN(NSigTpcMuJPsiDauNeg, nSigTpcMuJPsiDauNeg, float);         //! TPC Nsigma separation for JPsi DauNeg with muon mass hypothesis
+DECLARE_SOA_COLUMN(NSigTofMuJPsiDauNeg, nSigTofMuJPsiDauNeg, float);         //! TOF Nsigma separation for JPsi DauNeg with muon mass hypothesis
+DECLARE_SOA_COLUMN(NSigTpcTofMuJPsiDauNeg, nSigTpcTofMuJPsiDauNeg, float);   //! Combined TPC and TOF Nsigma separation for JPsi prong1 with muon mass hypothesis
+DECLARE_SOA_COLUMN(DecayLength, decayLength, float);                         //! Decay length of candidate (cm)
+DECLARE_SOA_COLUMN(DecayLengthXY, decayLengthXY, float);                     //! Transverse decay length of candidate (cm)
+DECLARE_SOA_COLUMN(DecayLengthNormalised, decayLengthNormalised, float);     //! Normalised decay length of candidate
+DECLARE_SOA_COLUMN(DecayLengthXYNormalised, decayLengthXYNormalised, float); //! Normalised transverse decay length of candidate
+DECLARE_SOA_COLUMN(ImpactParameterJPsi, impactParameterJPsi, float);         //! Impact parameter product of JPsi daughter candidate
+DECLARE_SOA_COLUMN(ImpactParameterBach, impactParameterBach, float);         //! Impact parameter product of bachelor kaon
+DECLARE_SOA_COLUMN(ImpactParameterProduct, impactParameterProduct, float);   //! Impact parameter product of daughters
+DECLARE_SOA_COLUMN(Cpa, cpa, float);                                         //! Cosine pointing angle of candidate
+DECLARE_SOA_COLUMN(CpaXY, cpaXY, float);                                     //! Cosine pointing angle of candidate in transverse plane
+DECLARE_SOA_COLUMN(CpaJPsi, cpaJPsi, float);                                 //! Cosine pointing angle of JPsi daughter candidate
+DECLARE_SOA_COLUMN(CpaXYJPsi, cpaXYJPsi, float);                             //! Cosine pointing angle in transverse plane of JPsi daughter candidate
+DECLARE_SOA_COLUMN(MaxNormalisedDeltaIP, maxNormalisedDeltaIP, float);       //! Maximum normalized difference between measured and expected impact parameter of candidate prongs
+DECLARE_SOA_COLUMN(MlScoreSig, mlScoreSig, float);                           //! ML score for signal class
+DECLARE_SOA_COLUMN(FlagWrongCollision, flagWrongCollision, int8_t);          //! Flag for association with wrong collision
+} // namespace hf_cand_bplustojpsik_lite
+
+DECLARE_SOA_TABLE(HfRedCandBpLites, "AOD", "HFREDCANDBPLITE", //! Table with some B+ properties
+                  hf_cand_bplustojpsik_lite::M,
+                  hf_cand_bplustojpsik_lite::Pt,
+                  hf_cand_bplustojpsik_lite::Eta,
+                  hf_cand_bplustojpsik_lite::Phi,
+                  hf_cand_bplustojpsik_lite::Y,
+                  hf_cand_bplustojpsik_lite::Cpa,
+                  hf_cand_bplustojpsik_lite::CpaXY,
+                  hf_cand::Chi2PCA,
+                  hf_cand_bplustojpsik_lite::DecayLength,
+                  hf_cand_bplustojpsik_lite::DecayLengthXY,
+                  hf_cand_bplustojpsik_lite::DecayLengthNormalised,
+                  hf_cand_bplustojpsik_lite::DecayLengthXYNormalised,
+                  hf_cand_bplustojpsik_lite::ImpactParameterProduct,
+                  hf_cand_bplustojpsik_lite::MaxNormalisedDeltaIP,
+                  hf_cand_bplustojpsik_lite::MlScoreSig,
+                  // hf_sel_candidate_bplus::IsSelBplusToJPsiPi,
+                  //  JPsi meson features
+                  hf_cand_bplustojpsik_lite::MJPsi,
+                  hf_cand_bplustojpsik_lite::PtJPsi,
+                  hf_cand_bplustojpsik_lite::ImpactParameterJPsi,
+                  // hf_cand_bplustojpsik_lite::PtJPsiProngMin,
+                  // hf_cand_bplustojpsik_lite::AbsEtaJPsiProngMin,
+                  // hf_cand_bplustojpsik_lite::ItsNClsJPsiProngMin,
+                  // hf_cand_bplustojpsik_lite::TpcNClsCrossedRowsJPsiProngMin,
+                  // hf_cand_bplustojpsik_lite::TpcChi2NClJPsiProngMax,
+                  // kaon features
+                  hf_cand_bplustojpsik_lite::PtBach,
+                  // hf_cand_bplustojpsik_lite::AbsEtaBach,
+                  // hf_cand_bplustojpsik_lite::ItsNClsBach,
+                  // hf_cand_bplustojpsik_lite::TpcNClsCrossedRowsBach,
+                  // hf_cand_bplustojpsik_lite::TpcChi2NClBach,
+                  hf_cand_bplustojpsik_lite::ImpactParameterBach,
+                  hf_cand_bplustojpsik_lite::NSigTpcKaBachelor,
+                  hf_cand_bplustojpsik_lite::NSigTofKaBachelor,
+                  hf_cand_bplustojpsik_lite::NSigTpcTofKaBachelor,
+                  // MC truth
+                  hf_cand_2prong::FlagMcMatchRec,
+                  hf_cand_2prong::OriginMcRec,
+                  hf_cand_bplustojpsik_lite::FlagWrongCollision,
+                  hf_cand_bplustojpsik_lite::PtGen);
+
+// DECLARE_SOA_TABLE(HfRedBpMcCheck, "AOD", "HFREDBPMCCHECK", //! Table with MC decay type check
+//                   hf_cand_2prong::FlagMcMatchRec,
+//                   hf_cand_bplustojpsik_lite::FlagWrongCollision,
+//                   hf_cand_bplustojpsik_lite::MJPsi,
+//                   hf_cand_bplustojpsik_lite::PtJPsi,
+//                   hf_cand_bplustojpsik_lite::M,
+//                   hf_cand_bplustojpsik_lite::Pt,
+//                   // hf_cand_bplustojpsik_lite::MlScoreSig,
+//                   hf_bplus_mc::PdgCodeBeautyMother,
+//                   hf_bplus_mc::PdgCodeCharmMother,
+//                   hf_bplus_mc::PdgCodeDauPos,
+//                   hf_bplus_mc::PdgCodeDauNeg,
+//                   hf_bplus_mc::PdgCodeProng2);
+} // namespace o2::aod
+
+// string definitions, used for histogram axis labels
+const TString stringPt = "#it{p}_{T} (GeV/#it{c})";
+const TString stringPtJPsi = "#it{p}_{T}(JPsi) (GeV/#it{c});";
+const TString bPlusCandTitle = "B+ candidates;";
+const TString entries = "entries";
+const TString bPlusCandMatch = "B+ candidates (matched);";
+const TString bPlusCandUnmatch = "B+ candidates (unmatched);";
+const TString mcParticleMatched = "MC particles (matched);";
+
+/// B+ analysis task
+struct HfTaskBplusToJPsiKReduced {
+  Produces<aod::HfRedCandBpLites> hfRedCandBpLite;
+  // Produces<aod::HfRedBpMcCheck> hfRedBpMcCheck;
+
+  Configurable<int> selectionFlagBplus{"selectionFlagBplus", 1, "Selection Flag for Bplus"};
+  Configurable<double> yCandGenMax{"yCandGenMax", 0.5, "max. gen particle rapidity"};
+  Configurable<double> yCandRecoMax{"yCandRecoMax", 0.8, "max. cand. rapidity"};
+  Configurable<float> etaTrackMax{"etaTrackMax", 0.8, "max. track pseudo-rapidity"};
+  Configurable<float> ptTrackMin{"ptTrackMin", 0.1, "min. track transverse momentum"};
+  Configurable<bool> fillBackground{"fillBackground", false, "Flag to enable filling of background histograms/sparses/tree (only MC)"};
+  Configurable<float> downSampleBkgFactor{"downSampleBkgFactor", 1., "Fraction of background candidates to keep for ML trainings"};
+  Configurable<float> ptMaxForDownSample{"ptMaxForDownSample", 10., "Maximum pt for the application of the downsampling factor"};
+  Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_bplus_to_d0_pi::vecBinsPt}, "pT bin limits"};
+
+  HfHelper hfHelper;
+
+  using TracksKaon = soa::Join<HfRedTracks, HfRedTracksPid>;
+
+  // Filter filterSelectCandidates = (aod::hf_sel_candidate_bplus::isSelBplusToJPsiPi >= selectionFlagBplus);
+
+  HistogramRegistry registry{"registry"};
+
+  void init(InitContext&)
+  {
+    std::array<bool, 2> processFuncData{doprocessData, doprocessDataWithBplusMl};
+    if ((std::accumulate(processFuncData.begin(), processFuncData.end(), 0)) > 1) {
+      LOGP(fatal, "Only one process function for data can be enabled at a time.");
+    }
+    std::array<bool, 2> processFuncMc{doprocessMc, doprocessMcWithBplusMl};
+    if ((std::accumulate(processFuncMc.begin(), processFuncMc.end(), 0)) > 1) {
+      LOGP(fatal, "Only one process function for MC can be enabled at a time.");
+    }
+
+    const AxisSpec axisMassBplus{150, 4.5, 6.0};
+    const AxisSpec axisMassJPsi{600, 2.8f, 3.4f};
+    const AxisSpec axisPtProng{100, 0., 10.};
+    const AxisSpec axisImpactPar{200, -0.05, 0.05};
+    const AxisSpec axisPtJPsi{100, 0., 50.};
+    const AxisSpec axisRapidity{100, -2., 2.};
+    const AxisSpec axisPtB{(std::vector<double>)binsPt, "#it{p}_{T}^{B^{+}} (GeV/#it{c})"};
+    const AxisSpec axisPtKa{100, 0.f, 10.f};
+
+    registry.add("hMass", bPlusCandTitle + "inv. mass J/#Psi K^{+} (GeV/#it{c}^{2});" + stringPt, {HistType::kTH2F, {axisMassBplus, axisPtB}});
+    registry.add("hMassJPsi", bPlusCandTitle + "inv. mass #mu^{+}#mu^{#minus} (GeV/#it{c}^{2});" + stringPt, {HistType::kTH2F, {axisMassJPsi, axisPtJPsi}});
+    registry.add("hd0K", bPlusCandTitle + "Kaon DCAxy to prim. vertex (cm);" + stringPt, {HistType::kTH2F, {axisImpactPar, axisPtKa}});
+
+    // histograms processMC
+    if (doprocessMc || doprocessMcWithBplusMl) {
+      registry.add("hPtJPsiGen", mcParticleMatched + "J/#Psi #it{p}_{T}^{gen} (GeV/#it{c}); B^{+} " + stringPt, {HistType::kTH2F, {axisPtProng, axisPtB}});
+      registry.add("hPtKGen", mcParticleMatched + "Kaon #it{p}_{T}^{gen} (GeV/#it{c}); B^{+} " + stringPt, {HistType::kTH2F, {axisPtProng, axisPtB}});
+      registry.add("hYGenWithProngsInAcceptance", mcParticleMatched + "Kaon #it{p}_{T}^{gen} (GeV/#it{c}); B^{+} " + stringPt, {HistType::kTH2F, {axisPtProng, axisRapidity}});
+      registry.add("hMassRecSig", bPlusCandMatch + "inv. mass J/#Psi K^{+} (GeV/#it{c}^{2}); B^{+} " + stringPt, {HistType::kTH2F, {axisMassBplus, axisPtB}});
+      registry.add("hMassJPsiRecSig", bPlusCandMatch + "inv. mass #mu^{+}#mu^{#minus} (GeV/#it{c}^{2}); J/#Psi " + stringPt, {HistType::kTH2F, {axisMassJPsi, axisPtJPsi}});
+      registry.add("hd0KRecSig", bPlusCandMatch + "Kaon DCAxy to prim. vertex (cm); K^{+} " + stringPt, {HistType::kTH2F, {axisImpactPar, axisPtKa}});
+      registry.add("hMassRecBg", bPlusCandUnmatch + "inv. mass J/#Psi K^{+} (GeV/#it{c}^{2}); B^{+} " + stringPt, {HistType::kTH2F, {axisMassBplus, axisPtB}});
+      registry.add("hMassJPsiRecBg", bPlusCandUnmatch + "nv. mass #mu^{+}#mu^{#minus} (GeV/#it{c}^{2}); J/#Psi " + stringPt, {HistType::kTH2F, {axisMassJPsi, axisPtJPsi}});
+      registry.add("hd0KRecBg", bPlusCandMatch + "Kaon DCAxy to prim. vertex (cm); K^{+} " + stringPt, {HistType::kTH2F, {axisImpactPar, axisPtKa}});
+    }
+  }
+
+  /// Selection of B+ daughter in geometrical acceptance
+  /// \param etaProng is the pseudorapidity of B+ prong
+  /// \param ptProng is the pT of B+ prong
+  /// \return true if prong is in geometrical acceptance
+  template <typename T = float>
+  bool isProngInAcceptance(const T& etaProng, const T& ptProng)
+  {
+    return std::abs(etaProng) <= etaTrackMax && ptProng >= ptTrackMin;
+  }
+
+  /// Fill candidate information at reconstruction level
+  /// \param doMc is the flag to enable the filling with MC information
+  /// \param withBplusMl is the flag to enable the filling with ML scores for the B+ candidate
+  /// \param candidate is the B+ candidate
+  /// \param candidatesJPsi is the table with JPsi candidates
+  template <bool doMc, bool withBplusMl, typename Cand>
+  void fillCand(Cand const& candidate,
+                aod::HfRedJPsis const& /*candidatesJPsi*/,
+                aod::HfRedBachProng0Tracks const&)
+  {
+    auto ptCandBplus = candidate.pt();
+    auto invMassBplus = hfHelper.invMassBplusToJPsiK(candidate);
+    auto candJPsi = candidate.template jPsi_as<aod::HfRedJPsis>();
+    auto candKa = candidate.template bachKa_as<aod::HfRedBachProng0Tracks>();
+    auto ptJPsi = candidate.ptProng0();
+    auto invMassJPsi = candJPsi.m();
+
+    int8_t flagMcMatchRec = 0;
+    int8_t flagWrongCollision = 0;
+    bool isSignal = false;
+    if constexpr (doMc) {
+      flagMcMatchRec = candidate.flagMcMatchRec();
+      flagWrongCollision = candidate.flagWrongCollision();
+      isSignal = TESTBIT(std::abs(flagMcMatchRec), static_cast<int>(hf_cand_bplus::DecayTypeBToJPsiMc::BplusToJPsiKToMuMuK));
+    }
+
+    registry.fill(HIST("hMass"), invMassBplus, ptCandBplus);
+    registry.fill(HIST("hMassJPsi"), invMassJPsi, candidate.ptProng0());
+    registry.fill(HIST("hd0K"), candidate.impactParameter1(), candidate.ptProng1());
+    if constexpr (doMc) {
+      if (isSignal) {
+        registry.fill(HIST("hMassRecSig"), invMassBplus, ptCandBplus);
+        registry.fill(HIST("hMassJPsiRecSig"), invMassJPsi, candidate.ptProng0());
+        registry.fill(HIST("hd0KRecSig"), candidate.impactParameter1(), candidate.ptProng1());
+      } else if (fillBackground) {
+        registry.fill(HIST("hMassRecBg"), invMassBplus, ptCandBplus);
+        registry.fill(HIST("hMassJPsiRecBg"), invMassJPsi, candidate.ptProng0());
+        registry.fill(HIST("hd0KRecBg"), candidate.impactParameter1(), candidate.ptProng1());
+      }
+    }
+
+    float pseudoRndm = ptJPsi * 1000. - static_cast<int64_t>(ptJPsi * 1000);
+    if (ptCandBplus >= ptMaxForDownSample || pseudoRndm < downSampleBkgFactor) {
+      float candidateMlScoreSig = -1;
+      if constexpr (withBplusMl) {
+        candidateMlScoreSig = candidate.mlProbBplusToJPsiK();
+      }
+      auto prong1 = candidate.template bachKa_as<aod::HfRedBachProng0Tracks>();
+      float ptMother = -1.;
+      if constexpr (doMc) {
+        ptMother = candidate.ptMother();
+      }
+
+      hfRedCandBpLite(
+        // B+ - meson features
+        invMassBplus,
+        ptCandBplus,
+        candidate.eta(),
+        candidate.phi(),
+        hfHelper.yBplus(candidate),
+        candidate.cpa(),
+        candidate.cpaXY(),
+        candidate.chi2PCA(),
+        candidate.decayLength(),
+        candidate.decayLengthXY(),
+        candidate.decayLengthNormalised(),
+        candidate.decayLengthXYNormalised(),
+        candidate.impactParameterProduct(),
+        candidate.maxNormalisedDeltaIP(),
+        candidateMlScoreSig,
+        // J/Psi features
+        invMassJPsi,
+        ptJPsi,
+        candidate.impactParameter0(),
+        // candJPsi.ptProngMin(),
+        // candJPsi.absEtaProngMin(),
+        // candJPsi.itsNClsProngMin(),
+        // candJPsi.tpcNClsCrossedRowsProngMin(),
+        // candJPsi.tpcChi2NClProngMax(),
+        // pion features
+        candidate.ptProng1(),
+        // std::abs(RecoDecay::eta(prong1.pVector())),
+        // prong1.itsNCls(),
+        // prong1.tpcNClsCrossedRows(),
+        // prong1.tpcChi2NCl(),
+        candidate.impactParameter1(),
+        prong1.tpcNSigmaKa(),
+        prong1.tofNSigmaKa(),
+        prong1.tpcTofNSigmaKa(),
+        // MC truth
+        flagMcMatchRec,
+        isSignal,
+        flagWrongCollision,
+        ptMother);
+    }
+  }
+
+  /// Fill particle histograms (gen MC truth)
+  void fillCandMcGen(aod::HfMcGenRedBps::iterator const& particle)
+  {
+    auto ptParticle = particle.ptTrack();
+    auto yParticle = particle.yTrack();
+    if (yCandGenMax >= 0. && std::abs(yParticle) > yCandGenMax) {
+      return;
+    }
+    std::array<float, 2> ptProngs = {particle.ptProng0(), particle.ptProng1()};
+    std::array<float, 2> etaProngs = {particle.etaProng0(), particle.etaProng1()};
+    bool prongsInAcc = isProngInAcceptance(etaProngs[0], ptProngs[0]) && isProngInAcceptance(etaProngs[1], ptProngs[1]);
+
+    registry.fill(HIST("hPtJPsiGen"), ptProngs[0], ptParticle);
+    registry.fill(HIST("hPtKGen"), ptProngs[1], ptParticle);
+
+    // generated B+ with daughters in geometrical acceptance
+    if (prongsInAcc) {
+      registry.fill(HIST("hYGenWithProngsInAcceptance"), ptParticle, yParticle);
+    }
+  }
+
+  // Process functions
+  void processData(aod::HfRedCandBplusToJPsiK const& candidates,
+                   aod::HfRedJPsis const& candidatesJPsi,
+                   aod::HfRedBachProng0Tracks const& kaonTracks)
+  {
+    for (const auto& candidate : candidates) {
+      if (yCandRecoMax >= 0. && std::abs(hfHelper.yBplus(candidate)) > yCandRecoMax) {
+        continue;
+      }
+      fillCand<false, false>(candidate, candidatesJPsi, kaonTracks);
+    } // candidate loop
+  } // processData
+  PROCESS_SWITCH(HfTaskBplusToJPsiKReduced, processData, "Process data without ML scores for JPsi daughter", true);
+
+  void processDataWithBplusMl(soa::Join<aod::HfRedCandBplusToJPsiK, aod::HfMlBplusToJPsiK> const& candidates,
+                              aod::HfRedJPsis const& candidatesJPsi,
+                              aod::HfRedBachProng0Tracks const& kaonTracks)
+  {
+    for (const auto& candidate : candidates) {
+      if (yCandRecoMax >= 0. && std::abs(hfHelper.yBplus(candidate)) > yCandRecoMax) {
+        continue;
+      }
+      fillCand<false, true>(candidate, candidatesJPsi, kaonTracks);
+    } // candidate loop
+  } // processDataWithBplusMl
+  PROCESS_SWITCH(HfTaskBplusToJPsiKReduced, processDataWithBplusMl, "Process data with(out) ML scores for B+ (JPsi daughter)", false);
+
+  void processMc(soa::Join<aod::HfRedCandBplusToJPsiK, aod::HfMcRecRedBps> const& candidates,
+                 aod::HfMcGenRedBps const& mcParticles,
+                 aod::HfRedJPsis const& candidatesJPsi,
+                 aod::HfRedBachProng0Tracks const& kaonTracks)
+  {
+    // MC rec
+    for (const auto& candidate : candidates) {
+      if (yCandRecoMax >= 0. && std::abs(hfHelper.yBplus(candidate)) > yCandRecoMax) {
+        continue;
+      }
+      fillCand<true, false>(candidate, candidatesJPsi, kaonTracks);
+    } // rec
+
+    // MC gen. level
+    for (const auto& particle : mcParticles) {
+      fillCandMcGen(particle);
+    } // gen
+  } // processMc
+  PROCESS_SWITCH(HfTaskBplusToJPsiKReduced, processMc, "Process MC without ML scores for B+ and JPsi daughter", false);
+
+  void processMcWithBplusMl(soa::Join<aod::HfRedCandBplusToJPsiK, aod::HfMlBplusToJPsiK, aod::HfMcRecRedBps> const& candidates,
+                            aod::HfMcGenRedBps const& mcParticles,
+                            aod::HfRedJPsis const& candidatesJPsi,
+                            aod::HfRedBachProng0Tracks const& kaonTracks)
+  {
+    // MC rec
+    for (const auto& candidate : candidates) {
+      if (yCandRecoMax >= 0. && std::abs(hfHelper.yBplus(candidate)) > yCandRecoMax) {
+        continue;
+      }
+      fillCand<true, true>(candidate, candidatesJPsi, kaonTracks);
+    } // rec
+
+    // MC gen. level
+    for (const auto& particle : mcParticles) {
+      fillCandMcGen(particle);
+    } // gen
+  } // processMcWithBplusMl
+  PROCESS_SWITCH(HfTaskBplusToJPsiKReduced, processMcWithBplusMl, "Process MC with(out) ML scores for B+ (JPsi daughter)", false);
+
+}; // struct
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{adaptAnalysisTask<HfTaskBplusToJPsiKReduced>(cfgc)};
+}

--- a/PWGHF/D2H/Utils/utilsRedDataFormat.h
+++ b/PWGHF/D2H/Utils/utilsRedDataFormat.h
@@ -76,6 +76,30 @@ float getTpcTofNSigmaPi1(const T1& prong1)
   }
   return defaultNSigma;
 }
+
+/// Helper function to retrive PID information of bachelor kaon from b-hadron decay
+/// \param prong1 kaon track from reduced data format, aod::HfRedBachProng0Tracks
+template <typename T1>
+float getTpcTofNSigmaKa1(const T1& prong1)
+{
+  float defaultNSigma = -999.f; // -999.f is the default value set in TPCPIDResponse.h and PIDTOF.h
+
+  bool hasTpc = prong1.hasTPC();
+  bool hasTof = prong1.hasTOF();
+
+  if (hasTpc && hasTof) {
+    float tpcNSigma = prong1.tpcNSigmaKa();
+    float tofNSigma = prong1.tofNSigmaKa();
+    return std::sqrt(.5f * tpcNSigma * tpcNSigma + .5f * tofNSigma * tofNSigma);
+  }
+  if (hasTpc) {
+    return std::abs(prong1.tpcNSigmaKa());
+  }
+  if (hasTof) {
+    return std::abs(prong1.tofNSigmaKa());
+  }
+  return defaultNSigma;
+}
 } // namespace o2::pid_tpc_tof_utils
 
 #endif // PWGHF_D2H_UTILS_UTILSREDDATAFORMAT_H_

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -857,13 +857,19 @@ DECLARE_SOA_COLUMN(OriginMcRec, originMcRec, int8_t);               // particle 
 DECLARE_SOA_COLUMN(OriginMcGen, originMcGen, int8_t);               // particle origin, generator level
 DECLARE_SOA_COLUMN(DebugMcRec, debugMcRec, int8_t);                 // debug flag for mis-association reconstruction level
 
-enum DecayType { BplusToD0Pi = 0 };
+enum DecayType { BplusToD0Pi = 0,
+                 BplusToJPsiK };
 
 enum DecayTypeMc : uint8_t { BplusToD0PiToKPiPi = 0,
                              BplusToD0KToKPiK,
                              PartlyRecoDecay,
                              OtherDecay,
                              NDecayTypeMc };
+
+enum class DecayTypeBToJPsiMc : uint8_t { BplusToJPsiKToMuMuK = 0,
+                                          PartlyRecoDecay,
+                                          OtherDecay,
+                                          NDecayTypeMc };
 } // namespace hf_cand_bplus
 
 // declare dedicated BPlus decay candidate table
@@ -1985,7 +1991,8 @@ DECLARE_SOA_COLUMN(OriginMcGen, originMcGen, int8_t);               // particle 
 DECLARE_SOA_COLUMN(DebugMcRec, debugMcRec, int8_t);                 // debug flag for mis-association reconstruction level
 
 // mapping of decay types
-enum DecayType { B0ToDPi };
+enum DecayType { B0ToDPi = 0,
+                 B0ToJPsiK0Star };
 
 enum DecayTypeMc : uint8_t { B0ToDplusPiToPiKPiPi = 0,
                              B0ToDsPiToKKPiPi,
@@ -2061,7 +2068,8 @@ DECLARE_SOA_COLUMN(OriginMcGen, originMcGen, int8_t);               // particle 
 DECLARE_SOA_COLUMN(DebugMcRec, debugMcRec, int8_t);                 // debug flag for mis-association reconstruction level
 
 // mapping of decay types
-enum DecayType { BsToDsPi };
+enum DecayType { BsToDsPi = 0,
+                 BsToJPsiPhi };
 
 enum DecayTypeMc : uint8_t { BsToDsPiToPhiPiPiToKKPiPi = 0, // Bs(bar) → Ds∓ π± → (Phi π∓) π± → (K- K+ π∓) π±
                              BsToDsPiToK0starKPiToKKPiPi,   // Bs(bar) → Ds∓ π± → (K0* K∓) π± → (K- K+ π∓) π±

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -2081,6 +2081,11 @@ enum DecayTypeMc : uint8_t { BsToDsPiToPhiPiPiToKKPiPi = 0, // Bs(bar) → Ds∓
                              OtherDecay,
                              NDecayTypeMc }; // counter of differentiated MC decay types
 
+enum class DecayTypeBToJPsiMc : uint8_t { BsToJPsiPhiToMuMuKK = 0, // Bs(bar) → J/Psi Phi → (µ+ µ-) (K- K+)
+                                          PartlyRecoDecay,         // 4 final state particles have another common b-hadron ancestor
+                                          OtherDecay,
+                                          NDecayTypeMc }; // counter of differentiated MC decay types
+
 } // namespace hf_cand_bs
 
 // declare dedicated Bs decay candidate table

--- a/PWGHF/DataModel/CandidateSelectionTables.h
+++ b/PWGHF/DataModel/CandidateSelectionTables.h
@@ -265,8 +265,9 @@ DECLARE_SOA_TABLE(HfMlBsToDsPi, "AOD", "HFMLBS", //!
 
 namespace hf_sel_candidate_bplus
 {
-DECLARE_SOA_COLUMN(IsSelBplusToD0Pi, isSelBplusToD0Pi, int);     //! selection flag on B+ candidate
-DECLARE_SOA_COLUMN(MlProbBplusToD0Pi, mlProbBplusToD0Pi, float); //! ML score of B+ candidate for signal class
+DECLARE_SOA_COLUMN(IsSelBplusToD0Pi, isSelBplusToD0Pi, int);       //! selection flag on B+ candidate
+DECLARE_SOA_COLUMN(MlProbBplusToD0Pi, mlProbBplusToD0Pi, float);   //! ML score of B+ candidate for signal class
+DECLARE_SOA_COLUMN(MlProbBplusToJPsiK, mlProbBplusToJPsiK, float); //! ML score of B+ candidate for signal class
 } // namespace hf_sel_candidate_bplus
 
 DECLARE_SOA_TABLE(HfSelBplusToD0Pi, "AOD", "HFSELBPLUS", //!
@@ -275,6 +276,8 @@ DECLARE_SOA_TABLE(HfSelBplusToD0Pi, "AOD", "HFSELBPLUS", //!
 DECLARE_SOA_TABLE(HfMlBplusToD0Pi, "AOD", "HFMLBPLUS", //!
                   hf_sel_candidate_bplus::MlProbBplusToD0Pi);
 
+DECLARE_SOA_TABLE(HfMlBplusToJPsiK, "AOD", "HFMLBPLUSTOJPSIK", //!
+                  hf_sel_candidate_bplus::MlProbBplusToJPsiK);
 namespace hf_sel_candidate_lb
 {
 DECLARE_SOA_COLUMN(IsSelLbToLcPi, isSelLbToLcPi, int);     //! selection flag on Lb candidate

--- a/PWGHF/DataModel/CandidateSelectionTables.h
+++ b/PWGHF/DataModel/CandidateSelectionTables.h
@@ -254,13 +254,16 @@ DECLARE_SOA_TABLE(HfMlB0ToDPi, "AOD", "HFMLB0", //!
 
 namespace hf_sel_candidate_bs
 {
-DECLARE_SOA_COLUMN(IsSelBsToDsPi, isSelBsToDsPi, int);                  //!
-DECLARE_SOA_COLUMN(MlProbBsToDsPi, mlProbBsToDsPi, std::vector<float>); //!
+DECLARE_SOA_COLUMN(IsSelBsToDsPi, isSelBsToDsPi, int);                        //!
+DECLARE_SOA_COLUMN(MlProbBsToDsPi, mlProbBsToDsPi, std::vector<float>);       //!
+DECLARE_SOA_COLUMN(MlProbBsToJPsiPhi, mlProbBsToJPsiPhi, std::vector<float>); //!
 } // namespace hf_sel_candidate_bs
 
 DECLARE_SOA_TABLE(HfSelBsToDsPi, "AOD", "HFSELBS", //!
                   hf_sel_candidate_bs::IsSelBsToDsPi);
 DECLARE_SOA_TABLE(HfMlBsToDsPi, "AOD", "HFMLBS", //!
+                  hf_sel_candidate_bs::MlProbBsToDsPi);
+DECLARE_SOA_TABLE(HfMlBsToJPsiPhi, "AOD", "HFMLBSTOJPSIPHI", //!
                   hf_sel_candidate_bs::MlProbBsToDsPi);
 
 namespace hf_sel_candidate_bplus


### PR DESCRIPTION
This PR adds the reduced workflows for the B+ and B0s meson analyses for their decays into a J/Psi and a K+ and phi, respectively. The considered decay of the J/Psi is that into a muon pair at midrapidity, and this workflow is meant to be used for the newly-developed HF software triggers for 2025 pp data taking. A `runJPsiToee` is also available in order to validate the workflow using the already existing MC simulations of B -> J/Psi X -> ee X.
In a following PR the workflow of B0 -> J/psi K*(892)0 -> (µµ) (Kpi) will be added, following what was done for the B0s -> J/Psi phi -> (µµ)(KK) workflow.