### PR TITLE
[PWGHF] taskXic: Remove not needed PID from track tables

### DIFF
--- a/PWGHF/D2H/Tasks/taskXic.cxx
+++ b/PWGHF/D2H/Tasks/taskXic.cxx
@@ -67,7 +67,6 @@ struct HfTaskXic {
   float etaMaxAcceptance = 0.8;
   float ptMinAcceptance = 0.1;
 
-
   Filter filterSelectCandidates = (aod::hf_sel_candidate_xic::isSelXicToPKPi >= selectionFlagXic || aod::hf_sel_candidate_xic::isSelXicToPiKP >= selectionFlagXic);
 
   HistogramRegistry registry{


### PR DESCRIPTION
Updated removing the TracksWPid, which joined TrackWDca, with not needed PID tables.  I also deleted a non used partition.  