### PR TITLE
[PWGJE,EMCAL-1154] emcalCorrectionTask: fix include headers

### DIFF
--- a/PWGJE/TableProducer/emcalCorrectionTask.cxx
+++ b/PWGJE/TableProducer/emcalCorrectionTask.cxx
@@ -18,28 +18,42 @@
 /// \author Raymond Ehlers (raymond.ehlers@cern.ch) ORNL, Florian Jonas (florian.jonas@cern.ch)
 ///
 
-#include <algorithm>
+#include <gsl/span>
+#include <fairlogger/Logger.h>
+#include <cstdint>
+#include <cstddef>
 #include <memory>
+#include <sstream>
 #include <unordered_map>
 #include <cmath>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 #include <random>
 
 #include "CCDB/BasicCCDBManager.h"
 #include "Framework/runDataProcessing.h"
-#include "Framework/AnalysisTask.h"
 #include "Framework/AnalysisDataModel.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisHelpers.h"
 #include "Framework/ASoA.h"
+#include "Framework/Configurable.h"
+#include "Framework/Expressions.h"
+#include "Framework/HistogramSpec.h"
+#include "Framework/HistogramRegistry.h"
+#include "Framework/InitContext.h"
+#include "Framework/WorkflowSpec.h"
 
 #include "DetectorsBase/GeometryManager.h"
 
+#include "PWGJE/DataModel/EMCALClusterDefinition.h"
 #include "PWGJE/DataModel/EMCALClusters.h"
 #include "PWGJE/DataModel/EMCALMatchedCollisions.h"
 
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/TrackSelectionTables.h"
+#include "DataFormatsEMCAL/ClusterLabel.h"
 #include "DataFormatsEMCAL/Cell.h"
 #include "DataFormatsEMCAL/CellLabel.h"
 #include "DataFormatsEMCAL/Constants.h"
@@ -49,7 +63,9 @@
 #include "EMCALBase/NonlinearityHandler.h"
 #include "EMCALReconstruction/Clusterizer.h"
 #include "PWGJE/Core/JetUtilities.h"
+#include "GPUROOTCartesianFwd.h"
 #include "TVector2.h"
+#include "TH1.h"
 
 using namespace o2;
 using namespace o2::framework;


### PR DESCRIPTION
Used clang-tidy to:
- Remove headers that where not needed
- Add headers that were needed and missing