### PR TITLE
[PWGLF] feat: Add nuclei pair table to data model

### DIFF
--- a/PWGLF/DataModel/LFSlimNucleiTables.h
+++ b/PWGLF/DataModel/LFSlimNucleiTables.h
@@ -53,6 +53,29 @@ DECLARE_SOA_COLUMN(SurvivedEventSelection, survivedEventSelection, bool);
 DECLARE_SOA_COLUMN(AbsoDecL, absoDecL, float);
 
 } // namespace NucleiTableNS
+
+namespace NucleiPairTableNS
+{
+DECLARE_SOA_COLUMN(Pt1, pt1, float);                              // first particle pt
+DECLARE_SOA_COLUMN(Eta1, eta1, float);                            // first particle eta
+DECLARE_SOA_COLUMN(Phi1, phi1, float);                            // first particle phi
+DECLARE_SOA_COLUMN(TPCInnerParam1, tpcInnerParam1, float);        // first particle TPC inner param
+DECLARE_SOA_COLUMN(TPCsignal1, tpcSignal1, float);                // first particle TPC signal
+DECLARE_SOA_COLUMN(DCAxy1, dcaxy1, float);                        // first particle DCA xy
+DECLARE_SOA_COLUMN(DCAz1, dcaz1, float);                          // first particle DCA z
+DECLARE_SOA_COLUMN(ClusterSizesITS1, clusterSizesITS1, uint32_t); // first particle ITS cluster sizes
+DECLARE_SOA_COLUMN(Flags1, flags1, uint16_t);                     // first particle flags
+DECLARE_SOA_COLUMN(Pt2, pt2, float);                              // second particle pt
+DECLARE_SOA_COLUMN(Eta2, eta2, float);                            // second particle eta
+DECLARE_SOA_COLUMN(Phi2, phi2, float);                            // second particle phi
+DECLARE_SOA_COLUMN(TPCInnerParam2, tpcInnerParam2, float);        // second particle TPC inner param
+DECLARE_SOA_COLUMN(TPCsignal2, tpcSignal2, float);                // second particle TPC signal
+DECLARE_SOA_COLUMN(DCAxy2, dcaxy2, float);                        // second particle DCA xy
+DECLARE_SOA_COLUMN(DCAz2, dcaz2, float);                          // second particle DCA z
+DECLARE_SOA_COLUMN(ClusterSizesITS2, clusterSizesITS2, uint32_t); // second particle ITS cluster sizes
+DECLARE_SOA_COLUMN(Flags2, flags2, uint16_t);                     // second particle flags
+} // namespace NucleiPairTableNS
+
 namespace NucleiFlowTableNS
 {
 DECLARE_SOA_COLUMN(CentFV0A, centFV0A, float); // centrality with FT0A estimator
@@ -135,6 +158,26 @@ DECLARE_SOA_TABLE(NucleiTableMC, "AOD", "NUCLEITABLEMC",
                   NucleiTableNS::MotherPDGcode,
                   NucleiTableNS::SurvivedEventSelection,
                   NucleiTableNS::AbsoDecL);
+
+DECLARE_SOA_TABLE(NucleiPairTable, "AOD", "NUCLEIPAIRTABLE",
+                  NucleiPairTableNS::Pt1,
+                  NucleiPairTableNS::Eta1,
+                  NucleiPairTableNS::Phi1,
+                  NucleiPairTableNS::TPCInnerParam1,
+                  NucleiPairTableNS::TPCsignal1,
+                  NucleiPairTableNS::DCAxy1,
+                  NucleiPairTableNS::DCAz1,
+                  NucleiPairTableNS::ClusterSizesITS1,
+                  NucleiPairTableNS::Flags1,
+                  NucleiPairTableNS::Pt2,
+                  NucleiPairTableNS::Eta2,
+                  NucleiPairTableNS::Phi2,
+                  NucleiPairTableNS::TPCInnerParam2,
+                  NucleiPairTableNS::TPCsignal2,
+                  NucleiPairTableNS::DCAxy2,
+                  NucleiPairTableNS::DCAz2,
+                  NucleiPairTableNS::ClusterSizesITS2,
+                  NucleiPairTableNS::Flags2);
 
 } // namespace o2::aod
 


### PR DESCRIPTION
This commit adds a new table called `NucleiPairTable` to the data model. The new table contains information about pairs of light nuclei, including their kinematic properties, detector signals, and quality flags.

The changes include:

- Defining a new namespace `NucleiPairTableNS` with columns for the first and second particles in the pair.
- Declaring a new table `NucleiPairTable` in the `o2::aod` namespace, which includes the columns from `NucleiPairTableNS`.
- Modifying the `nucleiSpectra.cxx` file to produce the new `NucleiPairTable` in addition to the existing `NucleiTable`.
- Adding a new configurable `cfgFillPairTree` to control whether the pair table should be filled.

These changes will enable the analysis of light nuclei pairs.