### PR TITLE
Configure clang-format to sort and group includes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -39,7 +39,60 @@ PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
-SortIncludes: false
+SortIncludes: CaseSensitive
+IncludeBlocks: Regroup
+IncludeCategories:
+  # O2Physics, PWG
+  - Regex: ^(<|")PWG[A-Z]{2}/.*\.h
+    Priority: 2
+    CaseSensitive: true
+  # O2Physics, non-PWG
+  - Regex: ^(<|")(Common|ALICE3|DPG|EventFiltering|Tools|Tutorials)/.*\.h
+    Priority: 3
+    CaseSensitive: true
+  # O2
+  - Regex: ^(<|")(Algorithm|CCDB|Common[A-Z]|DataFormats|DCAFitter|Detectors|EMCAL|Field|Framework|FT0|FV0|GlobalTracking|ITS|MathUtils|MFT|MCH|MID|PHOS|PID|ReconstructionDataFormats|SimulationDataFormat|TOF|TPC|ZDC).*/.*\.h
+    Priority: 4
+    CaseSensitive: true
+  # ROOT
+  - Regex: ^(<|")(T[A-Z]|Math/|Roo[A-Z])[[:alnum:]/]+\.h
+    Priority: 5
+    CaseSensitive: true
+  # known third-party: KFParticle
+  - Regex: ^(<|")KF[A-Z][[:alnum:]]+\.h
+    Priority: 6
+    CaseSensitive: true
+  # known third-party: FastJet
+  - Regex: ^(<|")fastjet/
+    Priority: 6
+    CaseSensitive: true
+  # known third-party: ONNX runtime
+  - Regex: ^(<|")onnxruntime
+    Priority: 6
+    CaseSensitive: true
+  # incomplete path to DataModel
+  - Regex: ^(<|").*DataModel/
+    Priority: 1
+    CaseSensitive: true
+  # other third-party
+  - Regex: ^(<|")([[:alnum:]_]+/)+[[:alnum:]_]+\.h
+    Priority: 6
+    CaseSensitive: true
+  # other local-looking file
+  - Regex: ^".*\.
+    Priority: 1
+    CaseSensitive: true
+  # C system
+  - Regex: ^(<|")[[:lower:]_]+\.h(>|")
+    Priority: 102
+    CaseSensitive: true
+  # C++ system
+  - Regex: ^(<|")[[:lower:]_/]+(>|")
+    Priority: 101
+    CaseSensitive: true
+  # rest
+  - Regex: .*
+    Priority: 100
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
 SpaceInEmptyParentheses: false

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,1 +1,1 @@
-filter=-build/c++11,-build/namespaces,-readability/fn_size,-readability/todo,-runtime/references,-whitespace/blank_line,-whitespace/braces,-whitespace/comments,-whitespace/indent_namespace,-whitespace/line_length,-whitespace/semicolon,-whitespace/todo
+filter=-build/c++11,-build/include_order,-build/namespaces,-readability/fn_size,-readability/todo,-runtime/references,-whitespace/blank_line,-whitespace/braces,-whitespace/comments,-whitespace/indent_namespace,-whitespace/line_length,-whitespace/semicolon,-whitespace/todo


### PR DESCRIPTION
Implements the sorting and grouping of header `#include`s from the most specific to the least specific,
as proposed in the [WP4 + WP14 Meeting](https://indico.cern.ch/event/1513750/#29-management-of-header-depend), in the following order:

0. Main module
1. Local-like file
1. Project (O2Physics)
   - PWG
   - Other
1. Third-party
   - O2
   - ROOT
   - Other non-system (FastJet, ONNX, KFParticle,...)
   - Anything else
1. System
   - C++ standard library
   - C standard library
