### PR TITLE
[PWGDQ] Small fix for computing the TPC nSigmas when running the table-maker …

### DIFF
--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -2483,7 +2483,7 @@ void VarManager::FillTrack(T const& track, float* values)
         values[kTPCnSigmaPr_Corr] = track.tpcNSigmaPr();
       }
     }
-    
+
     if constexpr ((fillMap & TrackPID) > 0 || (fillMap & ReducedTrackBarrelPID) > 0) {
       values[kTOFnSigmaEl] = track.tofNSigmaEl();
       values[kTOFnSigmaPi] = track.tofNSigmaPi();


### PR DESCRIPTION
…with postcalibration and VarManager::ObjTypes::TrackTPCPID is enabled