### PR TITLE
[PWGLF] feat(kinkBuilder): use aod::BCs instead of aod::BCsWithTimestamps

### DIFF
--- a/PWGLF/TableProducer/Common/kinkBuilder.cxx
+++ b/PWGLF/TableProducer/Common/kinkBuilder.cxx
@@ -122,12 +122,9 @@ struct kinkBuilder {
   Configurable<bool> unlikeSignBkg{"unlikeSignBkg", false, "Use unlike sign background"};
 
   // CCDB options
-  Configurable<double> inputBz{"inputBz", -999, "bz field, -999 is automatic"};
   Configurable<std::string> ccdbPath{"ccdbPath", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
-  Configurable<std::string> grpPath{"grpPath", "GLO/GRP/GRP", "Path of the grp file"};
   Configurable<std::string> grpmagPath{"grpmagPath", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
   Configurable<std::string> lutPath{"lutPath", "GLO/Param/MatLUT", "Path of the Lut parametrization"};
-  Configurable<std::string> geoPath{"geoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
 
   // PDG codes
 
@@ -174,7 +171,6 @@ struct kinkBuilder {
     ccdb->setURL(ccdbPath);
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
-    ccdb->setFatalWhenNull(false);
     fitter.setPropagateToPCA(true);
     fitter.setMaxR(200.);
     fitter.setMinParamChange(1e-3);
@@ -182,10 +178,6 @@ struct kinkBuilder {
     fitter.setMaxDZIni(1e9);
     fitter.setMaxChi2(1e9);
     fitter.setUseAbsDCA(true);
-
-    lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(lutPath));
-    int mat{static_cast<int>(cfgMaterialCorrection)};
-    fitter.setMatCorrType(static_cast<o2::base::Propagator::MatCorrType>(mat));
 
     svCreator.setTimeMargin(customVertexerTimeMargin);
     if (skipAmbiTracks) {
@@ -210,6 +202,11 @@ struct kinkBuilder {
     h2MothMassPt = qaRegistry.add<TH2>("h2MothMassPt", "; p_{T} (GeV/#it{c}); m (GeV/#it{c}^{2})", HistType::kTH2F, {ptAxis, massAxis});
     h2ClsMapPtMoth = qaRegistry.add<TH2>("h2ClsMapPtMoth", "; p_{T} (GeV/#it{c}); ITS cluster map", HistType::kTH2F, {ptAxis, itsClusterMapAxis});
     h2ClsMapPtDaug = qaRegistry.add<TH2>("h2ClsMapPtDaug", "; p_{T} (GeV/#it{c}); ITS cluster map", HistType::kTH2F, {ptAxis, itsClusterMapAxis});
+
+    for (int i = 0; i < 5; i++) {
+      mBBparamsDaug[i] = cfgBetheBlochParams->get("Daughter", Form("p%i", i));
+    }
+    mBBparamsDaug[5] = cfgBetheBlochParams->get("Daughter", "resolution");
   }
 
   template <typename T>
@@ -283,9 +280,9 @@ struct kinkBuilder {
       kinkCand.primVtx = {primaryVertex.getX(), primaryVertex.getY(), primaryVertex.getZ()};
 
       o2::track::TrackParCov trackParCovMoth = getTrackParCov(trackMoth);
+      o2::track::TrackParCov trackParCovMothPV{trackParCovMoth};
       o2::base::Propagator::Instance()->PropagateToXBxByBz(trackParCovMoth, LayerRadii[trackMoth.itsNCls() - 1]);
 
-      o2::track::TrackParCov trackParCovMothPV = getTrackParCov(trackMoth);
       std::array<float, 2> dcaInfoMoth;
       o2::base::Propagator::Instance()->propagateToDCABxByBz({primaryVertex.getX(), primaryVertex.getY(), primaryVertex.getZ()}, trackParCovMothPV, 2.f, static_cast<o2::base::Propagator::MatCorrType>(cfgMaterialCorrection.value), &dcaInfoMoth);
 
@@ -407,39 +404,17 @@ struct kinkBuilder {
       return;
     }
     mRunNumber = bc.runNumber();
-
-    o2::parameters::GRPObject* grpo = ccdb->getForRun<o2::parameters::GRPObject>(grpPath, mRunNumber);
-    o2::parameters::GRPMagField* grpmag = 0x0;
-    if (grpo) {
-      o2::base::Propagator::initFieldFromGRP(grpo);
-      if (inputBz < -990) {
-        // Fetch magnetic field from ccdb for current collision
-        mBz = grpo->getNominalL3Field();
-        LOG(info) << "Retrieved GRP for run " << mRunNumber << " with magnetic field of " << mBz << " kZG";
-      } else {
-        mBz = inputBz;
-      }
-    } else {
-      grpmag = ccdb->getForRun<o2::parameters::GRPMagField>(grpmagPath, mRunNumber);
-      if (!grpmag) {
-        LOG(fatal) << "Got nullptr from CCDB for path " << grpmagPath << " of object GRPMagField and " << grpPath << " of object GRPObject for run " << mRunNumber;
-      }
-      o2::base::Propagator::initFieldFromGRP(grpmag);
-      if (inputBz < -990) {
-        // Fetch magnetic field from ccdb for current collision
-        mBz = std::lround(5.f * grpmag->getL3Current() / 30000.f);
-        LOG(info) << "Retrieved GRP for run " << mRunNumber << " with magnetic field of " << mBz << " kZG";
-      } else {
-        mBz = inputBz;
-      }
-    }
-
-    for (int i = 0; i < 5; i++) {
-      mBBparamsDaug[i] = cfgBetheBlochParams->get("Daughter", Form("p%i", i));
-    }
-    mBBparamsDaug[5] = cfgBetheBlochParams->get("Daughter", "resolution");
-
+    LOG(info) << "Initializing CCDB for run " << mRunNumber;
+    o2::parameters::GRPMagField* grpmag = ccdb->getForRun<o2::parameters::GRPMagField>(grpmagPath, mRunNumber);
+    o2::base::Propagator::initFieldFromGRP(grpmag);
+    mBz = grpmag->getNominalL3Field();
     fitter.setBz(mBz);
+
+    if (!lut) {
+      lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(lutPath));
+      int mat{static_cast<int>(cfgMaterialCorrection)};
+      fitter.setMatCorrType(static_cast<o2::base::Propagator::MatCorrType>(mat));
+    }
     o2::base::Propagator::Instance()->setMatLUT(lut);
     LOG(info) << "Task initialized for run " << mRunNumber << " with magnetic field " << mBz << " kZG";
   }


### PR DESCRIPTION
The changes in this commit update the usage of the aod::BCsWithTimestamps data
source to the more generic aod::BCs data source. This simplifies the code and
removes the need for the specific BCsWithTimestamps data source, which is no
longer required. The changes ensure that the kinkBuilder functionality
continues to work with the updated data source.