### PR TITLE
[PWGDQ] Fixing the initialization of histograms of reconstructed dimuons matched to MC signals

### DIFF
--- a/PWGDQ/Tasks/dqEfficiency_withAssoc.cxx
+++ b/PWGDQ/Tasks/dqEfficiency_withAssoc.cxx
@@ -1507,7 +1507,8 @@ struct AnalysisSameEventPairing {
 
             // assign hist directories for pairs matched to MC signals for each (muon cut, MCrec signal) combination
             if (!sigNamesStr.IsNull()) {
-              for (auto& sig : fRecMCSignals) {
+              for (unsigned int isig = 0; isig < fRecMCSignals.size(); isig++) {
+                auto sig = fRecMCSignals.at(isig);
                 names = {
                   Form("PairsMuonSEPM_%s_%s", objArray->At(icut)->GetName(), sig->GetName()),
                   Form("PairsMuonSEPP_%s_%s", objArray->At(icut)->GetName(), sig->GetName()),
@@ -1526,9 +1527,9 @@ struct AnalysisSameEventPairing {
                 for (auto& n : names) {
                   histNames += Form("%s;", n.Data());
                 }
+                fMuonHistNamesMCmatched.try_emplace(icut * fRecMCSignals.size() + isig, names);
               } // end loop over MC signals
             }
-            fMuonHistNamesMCmatched[icut] = names;
           }
         }
       } // end loop over cuts


### PR DESCRIPTION
The initialisation of dimuon reconstructed histograms matched to MC signals is now handled in the same way as dielectron histograms. The task no longer breaks when running with multiple MC signals in "cfgBarrelMCRecSignals".