### PR TITLE
[PWGDQ] Add loading of geometry to dilepton-track task

### DIFF
--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -2903,6 +2903,10 @@ struct AnalysisDileptonTrack {
   Configurable<std::string> fConfigGRPmagPath{"cfgGrpmagPath", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
   Configurable<float> fConfigMagField{"cfgMagField", 5.0f, "Manually set magnetic field"};
 
+  Configurable<string> fConfigCcdbUrl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+  Configurable<int64_t> fConfigNoLaterThan{"ccdb-no-later-than", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(), "latest acceptable timestamp of creation for the object"};
+  Configurable<std::string> fConfigGeoPath{"geoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
+
   int fCurrentRun; // needed to detect if the run changed and trigger update of calibrations etc.
   int fNCuts;      // number of dilepton leg cuts
   int fNLegCuts;
@@ -3152,6 +3156,16 @@ struct AnalysisDileptonTrack {
 
     VarManager::SetUseVars(fHistMan->GetUsedVars());
     fOutputList.setObject(fHistMan->GetMainHistogramList());
+
+    fCCDB->setURL(fConfigCcdbUrl.value);
+    fCCDB->setCaching(true);
+    fCCDB->setLocalObjectValidityChecking();
+    fCCDB->setCreatedNotAfter(fConfigNoLaterThan.value);
+    if (!o2::base::GeometryManager::isGeometryLoaded()) {
+      LOG(info) << "Loading geometry from CCDB in dilepton-track task";
+      fCCDB->get<TGeoManager>(fConfigGeoPath);
+    }
+
     LOG(info) << "Initialization of AnalysisDileptonTrack finished (idstoreh)";
   }
 


### PR DESCRIPTION
At the moment, the AnalysisDileptonTrack fails for muon tracks, due to the geometry not being loaded. This PR adds a check for the geometry similar to the ones in AnalysisMuonSelection and AnalysisSameEventPairing tasks, along with the required configurables. 

A from hyperloop of the error produces is here: [stdout.log](https://github.com/user-attachments/files/20611510/stdout.log)
