### PR TITLE
[PWGHF] Enable ML selection in KF-based LcToPKPi reconstruction

### DIFF
--- a/PWGHF/Core/HfMlResponseLcToPKPi.h
+++ b/PWGHF/Core/HfMlResponseLcToPKPi.h
@@ -139,7 +139,13 @@ enum class InputFeaturesLcToPKPi : uint8_t {
   kfChi2PrimPion,
   kfChi2GeoKaonPion,
   kfChi2GeoProtonPion,
-  kfChi2GeoProtonKaon
+  kfChi2GeoProtonKaon,
+  kfDcaKaonPion,
+  kfDcaProtonPion,
+  kfDcaProtonKaon,
+  kfChi2Geo,
+  kfChi2Topo,
+  kfDecayLengthNormalised
 };
 
 template <typename TypeOutputScore = float, aod::hf_cand::VertexerType reconstructionType = aod::hf_cand::VertexerType::DCAFitter>
@@ -227,6 +233,15 @@ class HfMlResponseLcToPKPi : public HfMlResponse<TypeOutputScore>
           CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, kfChi2GeoKaonPion, kfChi2GeoProng1Prong2, kfChi2GeoProng0Prong1);
           CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, kfChi2GeoProtonPion, kfChi2GeoProng0Prong2);
           CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, kfChi2GeoProtonKaon, kfChi2GeoProng0Prong1, kfChi2GeoProng1Prong2);
+          CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, kfDcaKaonPion, kfDcaProng1Prong2, kfDcaProng0Prong1);
+          CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, kfDcaProtonPion, kfDcaProng0Prong2);
+          CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, kfDcaProtonKaon, kfDcaProng0Prong1, kfDcaProng1Prong2);
+          CHECK_AND_FILL_VEC_LCTOPKPI(kfChi2Geo);
+          CHECK_AND_FILL_VEC_LCTOPKPI(kfChi2Topo);
+          case static_cast<uint8_t>(InputFeaturesLcToPKPi::kfDecayLengthNormalised): {
+            inputFeatures.emplace_back(candidate.kfDecayLength() / candidate.kfDecayLengthError());
+            break;
+          }
         }
       }
     }
@@ -297,7 +312,13 @@ class HfMlResponseLcToPKPi : public HfMlResponse<TypeOutputScore>
         FILL_MAP_LCTOPKPI(kfChi2PrimPion),
         FILL_MAP_LCTOPKPI(kfChi2GeoKaonPion),
         FILL_MAP_LCTOPKPI(kfChi2GeoProtonPion),
-        FILL_MAP_LCTOPKPI(kfChi2GeoProtonKaon)};
+        FILL_MAP_LCTOPKPI(kfChi2GeoProtonKaon),
+        FILL_MAP_LCTOPKPI(kfDcaKaonPion),
+        FILL_MAP_LCTOPKPI(kfDcaProtonPion),
+        FILL_MAP_LCTOPKPI(kfDcaProtonKaon),
+        FILL_MAP_LCTOPKPI(kfChi2Geo),
+        FILL_MAP_LCTOPKPI(kfChi2Topo),
+        FILL_MAP_LCTOPKPI(kfDecayLengthNormalised)};
       MlResponse<TypeOutputScore>::mAvailableInputFeatures.insert(mapKfFeatures.begin(), mapKfFeatures.end());
     }
   }

--- a/PWGHF/Core/HfMlResponseLcToPKPi.h
+++ b/PWGHF/Core/HfMlResponseLcToPKPi.h
@@ -222,10 +222,7 @@ class HfMlResponseLcToPKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, tpcTofNSigmaPrExpPr0, tpcTofNSigmaPr0, tpcTofNSigmaPr2);
         CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, tpcTofNSigmaPiExpPi2, tpcTofNSigmaPi2, tpcTofNSigmaPi0);
       }
-    }
-    // KFParticle variables
-    if constexpr (reconstructionType == aod::hf_cand::VertexerType::KfParticle) {
-      for (const auto& idx : MlResponse<TypeOutputScore>::mCachedIndices) {
+      if constexpr (reconstructionType == aod::hf_cand::VertexerType::KfParticle) {
         switch (idx) {
           CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, kfChi2PrimProton, kfChi2PrimProng0, kfChi2PrimProng2);
           CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, kfChi2PrimKaon, kfChi2PrimProng1);

--- a/PWGHF/Core/HfMlResponseLcToPKPi.h
+++ b/PWGHF/Core/HfMlResponseLcToPKPi.h
@@ -16,7 +16,11 @@
 #ifndef PWGHF_CORE_HFMLRESPONSELCTOPKPI_H_
 #define PWGHF_CORE_HFMLRESPONSELCTOPKPI_H_
 
+#include <map>
+#include <string>
 #include <vector>
+
+#include "PWGHF/DataModel/CandidateReconstructionTables.h"
 
 #include "PWGHF/Core/HfMlResponse.h"
 
@@ -129,10 +133,16 @@ enum class InputFeaturesLcToPKPi : uint8_t {
   tofNSigmaPrExpPr0,
   tofNSigmaPiExpPi2,
   tpcTofNSigmaPrExpPr0,
-  tpcTofNSigmaPiExpPi2
+  tpcTofNSigmaPiExpPi2,
+  kfChi2PrimProton,
+  kfChi2PrimKaon,
+  kfChi2PrimPion,
+  kfChi2GeoKaonPion,
+  kfChi2GeoProtonPion,
+  kfChi2GeoProtonKaon
 };
 
-template <typename TypeOutputScore = float>
+template <typename TypeOutputScore = float, aod::hf_cand::VertexerType reconstructionType = aod::hf_cand::VertexerType::DCAFitter>
 class HfMlResponseLcToPKPi : public HfMlResponse<TypeOutputScore>
 {
  public:
@@ -179,8 +189,6 @@ class HfMlResponseLcToPKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tpcNSigmaPr2, nSigTpcPr2);
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tpcNSigmaKa2, nSigTpcKa2);
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tpcNSigmaPi2, nSigTpcPi2);
-        // CHECK_AND_FILL_VEC_LCTOPKPI_OBJECT_SIGNED(prong0, prong2, tpcNSigmaPrExpPr0, tpcNSigmaPr);
-        // CHECK_AND_FILL_VEC_LCTOPKPI_OBJECT_SIGNED(prong2, prong0, tpcNSigmaPiExpPi2, tpcNSigmaPi);
         CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, tpcNSigmaPrExpPr0, nSigTpcPr0, nSigTpcPr2);
         CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, tpcNSigmaPiExpPi2, nSigTpcPi2, nSigTpcPi0);
         // TOF PID variables
@@ -193,8 +201,6 @@ class HfMlResponseLcToPKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tofNSigmaPr2, nSigTofPr2);
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tofNSigmaKa2, nSigTofKa2);
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tofNSigmaPi2, nSigTofPi2);
-        // CHECK_AND_FILL_VEC_LCTOPKPI_OBJECT_SIGNED(prong0, prong2, tofNSigmaPrExpPr0, tofNSigmaPr);
-        // CHECK_AND_FILL_VEC_LCTOPKPI_OBJECT_SIGNED(prong2, prong0, tofNSigmaPiExpPi2, tofNSigmaPi);
         CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, tofNSigmaPrExpPr0, nSigTofPr0, nSigTofPr2);
         CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, tofNSigmaPiExpPi2, nSigTofPi2, nSigTofPi0);
         // Combined PID variables
@@ -207,13 +213,23 @@ class HfMlResponseLcToPKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tpcTofNSigmaPr0, tpcTofNSigmaPr0);
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tpcTofNSigmaPr1, tpcTofNSigmaPr1);
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tpcTofNSigmaPr2, tpcTofNSigmaPr2);
-        // CHECK_AND_FILL_VEC_LCTOPKPI_OBJECT_SIGNED(prong0, prong2, tpcTofNSigmaPrExpPr0, tpcTofNSigmaPr);
-        // CHECK_AND_FILL_VEC_LCTOPKPI_OBJECT_SIGNED(prong2, prong0, tpcTofNSigmaPiExpPi2, tpcTofNSigmaPi);
         CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, tpcTofNSigmaPrExpPr0, tpcTofNSigmaPr0, tpcTofNSigmaPr2);
         CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, tpcTofNSigmaPiExpPi2, tpcTofNSigmaPi2, tpcTofNSigmaPi0);
       }
     }
-
+    // KFParticle variables
+    if constexpr (reconstructionType == aod::hf_cand::VertexerType::KfParticle) {
+      for (const auto& idx : MlResponse<TypeOutputScore>::mCachedIndices) {
+        switch (idx) {
+          CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, kfChi2PrimProton, kfChi2PrimProng0, kfChi2PrimProng2);
+          CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, kfChi2PrimKaon, kfChi2PrimProng1);
+          CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, kfChi2PrimPion, kfChi2PrimProng2, kfChi2PrimProng0);
+          CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, kfChi2GeoKaonPion, kfChi2GeoProng1Prong2, kfChi2GeoProng0Prong1);
+          CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, kfChi2GeoProtonPion, kfChi2GeoProng0Prong2);
+          CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, kfChi2GeoProtonKaon, kfChi2GeoProng0Prong1, kfChi2GeoProng1Prong2);
+        }
+      }
+    }
     return inputFeatures;
   }
 
@@ -273,6 +289,17 @@ class HfMlResponseLcToPKPi : public HfMlResponse<TypeOutputScore>
       FILL_MAP_LCTOPKPI(tpcTofNSigmaPr2),
       FILL_MAP_LCTOPKPI(tpcTofNSigmaPrExpPr0),
       FILL_MAP_LCTOPKPI(tpcTofNSigmaPiExpPi2)};
+    if constexpr (reconstructionType == aod::hf_cand::VertexerType::KfParticle) {
+      std::map<std::string, uint8_t> mapKfFeatures{
+        // KFParticle variables
+        FILL_MAP_LCTOPKPI(kfChi2PrimProton),
+        FILL_MAP_LCTOPKPI(kfChi2PrimKaon),
+        FILL_MAP_LCTOPKPI(kfChi2PrimPion),
+        FILL_MAP_LCTOPKPI(kfChi2GeoKaonPion),
+        FILL_MAP_LCTOPKPI(kfChi2GeoProtonPion),
+        FILL_MAP_LCTOPKPI(kfChi2GeoProtonKaon)};
+      MlResponse<TypeOutputScore>::mAvailableInputFeatures.insert(mapKfFeatures.begin(), mapKfFeatures.end());
+    }
   }
 };
 

--- a/PWGHF/TableProducer/candidateSelectorLc.cxx
+++ b/PWGHF/TableProducer/candidateSelectorLc.cxx
@@ -287,7 +287,7 @@ struct HfCandidateSelectorLc {
         return false;
       }
 
-      float massLc, massKPi;
+      float massLc{0.f}, massKPi{0.f};
       if constexpr (reconstructionType == aod::hf_cand::VertexerType::DCAFitter) {
         if (trackProton.globalIndex() == candidate.prong0Id()) {
           massLc = hfHelper.invMassLcToPKPi(candidate);

--- a/PWGHF/TableProducer/candidateSelectorLc.cxx
+++ b/PWGHF/TableProducer/candidateSelectorLc.cxx
@@ -93,7 +93,8 @@ struct HfCandidateSelectorLc {
   Configurable<bool> loadModelsFromCCDB{"loadModelsFromCCDB", false, "Flag to enable or disable the loading of models from CCDB"};
 
   HfHelper hfHelper;
-  o2::analysis::HfMlResponseLcToPKPi<float> hfMlResponse;
+  o2::analysis::HfMlResponseLcToPKPi<float, aod::hf_cand::VertexerType::DCAFitter> hfMlResponseDCA;
+  o2::analysis::HfMlResponseLcToPKPi<float, aod::hf_cand::VertexerType::KfParticle> hfMlResponseKF;
   std::vector<float> outputMlLcToPKPi = {};
   std::vector<float> outputMlLcToPiKP = {};
   o2::ccdb::CcdbApi ccdbApi;
@@ -142,15 +143,20 @@ struct HfCandidateSelectorLc {
     }
 
     if (applyMl) {
-      hfMlResponse.configure(binsPtMl, cutsMl, cutDirMl, nClassesMl);
+      hfMlResponseDCA.configure(binsPtMl, cutsMl, cutDirMl, nClassesMl);
+      hfMlResponseKF.configure(binsPtMl, cutsMl, cutDirMl, nClassesMl);
       if (loadModelsFromCCDB) {
         ccdbApi.init(ccdbUrl);
-        hfMlResponse.setModelPathsCCDB(onnxFileNames, ccdbApi, modelPathsCCDB, timestampCCDB);
+        hfMlResponseDCA.setModelPathsCCDB(onnxFileNames, ccdbApi, modelPathsCCDB, timestampCCDB);
+        hfMlResponseKF.setModelPathsCCDB(onnxFileNames, ccdbApi, modelPathsCCDB, timestampCCDB);
       } else {
-        hfMlResponse.setModelPathsLocal(onnxFileNames);
+        hfMlResponseDCA.setModelPathsLocal(onnxFileNames);
+        hfMlResponseKF.setModelPathsLocal(onnxFileNames);
       }
-      hfMlResponse.cacheInputFeaturesIndices(namesInputFeatures);
-      hfMlResponse.init();
+      hfMlResponseDCA.cacheInputFeaturesIndices(namesInputFeatures);
+      hfMlResponseKF.init();
+      hfMlResponseDCA.cacheInputFeaturesIndices(namesInputFeatures);
+      hfMlResponseKF.init();
     }
 
     massK0Star892 = o2::constants::physics::MassK0Star892;
@@ -553,13 +559,24 @@ struct HfCandidateSelectorLc {
         isSelectedMlLcToPKPi = false;
         isSelectedMlLcToPiKP = false;
 
-        if (pidLcToPKPi == 1 && pidBayesLcToPKPi == 1 && topolLcToPKPi) {
-          std::vector<float> inputFeaturesLcToPKPi = hfMlResponse.getInputFeatures(candidate, true);
-          isSelectedMlLcToPKPi = hfMlResponse.isSelectedMl(inputFeaturesLcToPKPi, candidate.pt(), outputMlLcToPKPi);
-        }
-        if (pidLcToPiKP == 1 && pidBayesLcToPiKP == 1 && topolLcToPiKP) {
-          std::vector<float> inputFeaturesLcToPiKP = hfMlResponse.getInputFeatures(candidate, false);
-          isSelectedMlLcToPiKP = hfMlResponse.isSelectedMl(inputFeaturesLcToPiKP, candidate.pt(), outputMlLcToPiKP);
+        if constexpr (reconstructionType == aod::hf_cand::VertexerType::DCAFitter) {
+          if (pidLcToPKPi == 1 && pidBayesLcToPKPi == 1 && topolLcToPKPi) {
+            std::vector<float> inputFeaturesLcToPKPi = hfMlResponseDCA.getInputFeatures(candidate, true);
+            isSelectedMlLcToPKPi = hfMlResponseDCA.isSelectedMl(inputFeaturesLcToPKPi, candidate.pt(), outputMlLcToPKPi);
+          }
+          if (pidLcToPiKP == 1 && pidBayesLcToPiKP == 1 && topolLcToPiKP) {
+            std::vector<float> inputFeaturesLcToPiKP = hfMlResponseDCA.getInputFeatures(candidate, false);
+            isSelectedMlLcToPiKP = hfMlResponseDCA.isSelectedMl(inputFeaturesLcToPiKP, candidate.pt(), outputMlLcToPiKP);
+          }
+        } else {
+          if (pidLcToPKPi == 1 && pidBayesLcToPKPi == 1 && topolLcToPKPi) {
+            std::vector<float> inputFeaturesLcToPKPi = hfMlResponseKF.getInputFeatures(candidate, true);
+            isSelectedMlLcToPKPi = hfMlResponseKF.isSelectedMl(inputFeaturesLcToPKPi, candidate.pt(), outputMlLcToPKPi);
+          }
+          if (pidLcToPiKP == 1 && pidBayesLcToPiKP == 1 && topolLcToPiKP) {
+            std::vector<float> inputFeaturesLcToPiKP = hfMlResponseKF.getInputFeatures(candidate, false);
+            isSelectedMlLcToPiKP = hfMlResponseKF.isSelectedMl(inputFeaturesLcToPiKP, candidate.pt(), outputMlLcToPiKP);
+          }
         }
 
         hfMlLcToPKPiCandidate(outputMlLcToPKPi, outputMlLcToPiKP);

--- a/PWGHF/TableProducer/candidateSelectorLc.cxx
+++ b/PWGHF/TableProducer/candidateSelectorLc.cxx
@@ -152,7 +152,7 @@ struct HfCandidateSelectorLc {
           hfMlResponseDCA.setModelPathsLocal(onnxFileNames);
         }
         hfMlResponseDCA.cacheInputFeaturesIndices(namesInputFeatures);
-        hfMlResponseDCA.cacheInputFeaturesIndices(namesInputFeatures);
+        hfMlResponseDCA.init();
       }
       if (doprocessNoBayesPidWithKFParticle || doprocessBayesPidWithKFParticle) {
         hfMlResponseKF.configure(binsPtMl, cutsMl, cutDirMl, nClassesMl);
@@ -163,7 +163,7 @@ struct HfCandidateSelectorLc {
           hfMlResponseKF.setModelPathsLocal(onnxFileNames);
         }
         hfMlResponseKF.cacheInputFeaturesIndices(namesInputFeatures);
-        hfMlResponseKF.cacheInputFeaturesIndices(namesInputFeatures);
+        hfMlResponseKF.init();
       }
     }
 

--- a/PWGHF/TableProducer/candidateSelectorLc.cxx
+++ b/PWGHF/TableProducer/candidateSelectorLc.cxx
@@ -143,20 +143,28 @@ struct HfCandidateSelectorLc {
     }
 
     if (applyMl) {
-      hfMlResponseDCA.configure(binsPtMl, cutsMl, cutDirMl, nClassesMl);
-      hfMlResponseKF.configure(binsPtMl, cutsMl, cutDirMl, nClassesMl);
-      if (loadModelsFromCCDB) {
-        ccdbApi.init(ccdbUrl);
-        hfMlResponseDCA.setModelPathsCCDB(onnxFileNames, ccdbApi, modelPathsCCDB, timestampCCDB);
-        hfMlResponseKF.setModelPathsCCDB(onnxFileNames, ccdbApi, modelPathsCCDB, timestampCCDB);
-      } else {
-        hfMlResponseDCA.setModelPathsLocal(onnxFileNames);
-        hfMlResponseKF.setModelPathsLocal(onnxFileNames);
+      if (doprocessNoBayesPidWithDCAFitterN || doprocessBayesPidWithDCAFitterN) {
+        hfMlResponseDCA.configure(binsPtMl, cutsMl, cutDirMl, nClassesMl);
+        if (loadModelsFromCCDB) {
+          ccdbApi.init(ccdbUrl);
+          hfMlResponseDCA.setModelPathsCCDB(onnxFileNames, ccdbApi, modelPathsCCDB, timestampCCDB);
+        } else {
+          hfMlResponseDCA.setModelPathsLocal(onnxFileNames);
+        }
+        hfMlResponseDCA.cacheInputFeaturesIndices(namesInputFeatures);
+        hfMlResponseDCA.cacheInputFeaturesIndices(namesInputFeatures);
       }
-      hfMlResponseDCA.cacheInputFeaturesIndices(namesInputFeatures);
-      hfMlResponseKF.init();
-      hfMlResponseDCA.cacheInputFeaturesIndices(namesInputFeatures);
-      hfMlResponseKF.init();
+      if (doprocessNoBayesPidWithKFParticle || doprocessBayesPidWithKFParticle) {
+        hfMlResponseKF.configure(binsPtMl, cutsMl, cutDirMl, nClassesMl);
+        if (loadModelsFromCCDB) {
+          ccdbApi.init(ccdbUrl);
+          hfMlResponseKF.setModelPathsCCDB(onnxFileNames, ccdbApi, modelPathsCCDB, timestampCCDB);
+        } else {
+          hfMlResponseKF.setModelPathsLocal(onnxFileNames);
+        }
+        hfMlResponseKF.cacheInputFeaturesIndices(namesInputFeatures);
+        hfMlResponseKF.cacheInputFeaturesIndices(namesInputFeatures);
+      }
     }
 
     massK0Star892 = o2::constants::physics::MassK0Star892;

--- a/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
@@ -17,7 +17,9 @@
 /// \author Nicolo' Jacazio <nicolo.jacazio@cern.ch>, CERN
 /// \author Luigi Dello Stritto <luigi.dello.stritto@cern.ch>, CERN
 
+#include <algorithm>
 #include <utility>
+#include <vector>
 
 #include "CommonConstants/PhysicsConstants.h"
 #include "Framework/AnalysisTask.h"
@@ -87,6 +89,9 @@ DECLARE_SOA_COLUMN(IsCandidateSwapped, isCandidateSwapped, int8_t);
 DECLARE_SOA_INDEX_COLUMN_FULL(Candidate, candidate, int, HfCand3ProngWPidPiKaPr, "_0");
 DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle);
 DECLARE_SOA_COLUMN(Channel, channel, int8_t); // direct or resonant
+DECLARE_SOA_COLUMN(MlScoreFirstClass, mlScoreFirstClass, float);
+DECLARE_SOA_COLUMN(MlScoreSecondClass, mlScoreSecondClass, float);
+DECLARE_SOA_COLUMN(MlScoreThirdClass, mlScoreThirdClass, float);
 // Events
 DECLARE_SOA_INDEX_COLUMN(McCollision, mcCollision);
 DECLARE_SOA_COLUMN(IsEventReject, isEventReject, int);
@@ -238,7 +243,10 @@ DECLARE_SOA_TABLE(HfCandLcLites, "AOD", "HFCANDLCLITE",
                   full::OriginMcRec,
                   full::IsCandidateSwapped,
                   full::Channel,
-                  full::MassKPi);
+                  full::MassKPi,
+                  full::MlScoreFirstClass,
+                  full::MlScoreSecondClass,
+                  full::MlScoreThirdClass);
 
 DECLARE_SOA_TABLE(HfCollIdLCLite, "AOD", "HFCOLLIDLCLITE",
                   full::CollisionId);
@@ -316,7 +324,10 @@ DECLARE_SOA_TABLE(HfCandLcFulls, "AOD", "HFCANDLCFULL",
                   full::IsCandidateSwapped,
                   full::CandidateId,
                   full::Channel,
-                  full::MassKPi);
+                  full::MassKPi,
+                  full::MlScoreFirstClass,
+                  full::MlScoreSecondClass,
+                  full::MlScoreThirdClass);
 
 DECLARE_SOA_TABLE(HfCandLcFullEvs, "AOD", "HFCANDLCFULLEV",
                   full::CollisionId,
@@ -374,6 +385,7 @@ struct HfTreeCreatorLcToPKPi {
   Configurable<bool> fillCandidateLiteTable{"fillCandidateLiteTable", false, "Switch to fill lite table with candidate properties"};
   Configurable<bool> fillCollIdTable{"fillCollIdTable", false, "Fill a single-column table with collision index"};
   Configurable<bool> fillCandidateMcTable{"fillCandidateMcTable", false, "Switch to fill a table with MC particles matched to candidates"};
+  Configurable<bool> applyMl{"applyMl", false, "Whether ML was used in candidateSelectorLc"};
   Configurable<bool> keepOnlySignalMc{"keepOnlySignalMc", false, "Fill MC tree only with signal candidates"};
   Configurable<bool> keepOnlyBkg{"keepOnlyBkg", false, "Fill MC tree only with background candidates"};
   Configurable<double> downSampleBkgFactor{"downSampleBkgFactor", 1., "Fraction of candidates to store in the tree"};
@@ -553,11 +565,39 @@ struct HfTreeCreatorLcToPKPi {
     return std::make_pair(invMass, invMassKPi);
   }
 
+  /// \brief function to get ML score values for the current candidate and assign them to input parameters
+  /// \param candidate candidate instance
+  /// \param candidateMlScore instance of handler of vectors with ML scores associated with the current candidate
+  /// \param mlScoreFirstClass ML score for belonging to the first class
+  /// \param mlScoreSecondClass ML score for belonging to the second class
+  /// \param mlScoreThirdClass ML score for belonging to the third class
+  /// \param candFlag flag indicating if PKPi (0) or PiKP (1) hypothesis is used
+  void assignMlScores(aod::HfMlLcToPKPi::iterator const& candidateMlScore, float& mlScoreFirstClass, float& mlScoreSecondClass, float& mlScoreThirdClass, int candFlag)
+  {
+    std::vector<float> mlScores;
+    if (candFlag == 0) {
+      std::copy(candidateMlScore.mlProbLcToPKPi().begin(), candidateMlScore.mlProbLcToPKPi().end(), std::back_inserter(mlScores));
+    } else {
+      std::copy(candidateMlScore.mlProbLcToPiKP().begin(), candidateMlScore.mlProbLcToPiKP().end(), std::back_inserter(mlScores));
+    }
+    constexpr int IndexFirstClass{0};
+    constexpr int IndexSecondClass{0};
+    constexpr int IndexThirdClass{0};
+    if (mlScores.size() == 0)
+      return; // when candidateSelectorLc rejects a candidate by "usual", non-ML cut, the ml score vector remains empty
+    mlScoreFirstClass = mlScores.at(IndexFirstClass);
+    mlScoreSecondClass = mlScores.at(IndexSecondClass);
+    if (mlScores.size() > IndexThirdClass) {
+      mlScoreThirdClass = mlScores.at(IndexThirdClass);
+    }
+  }
+
   /// \brief function to fill lite table
   /// \param candidate candidate instance
+  /// \param candidateMlScore instance of handler of vectors with ML scores associated with the current candidate
   /// \param candFlag flag indicating if PKPi (0) or PiKP (1) hypothesis is used
   template <bool isMc, int reconstructionType, typename CandType>
-  void fillLiteTable(CandType const& candidate, int candFlag)
+  void fillLiteTable(CandType const& candidate, aod::HfMlLcToPKPi::iterator const& candidateMlScore, int candFlag)
   {
     auto [functionInvMass, functionInvMassKPi] = evaluateInvariantMasses<reconstructionType>(candidate, candFlag);
     const float functionCt = hfHelper.ctLc(candidate);
@@ -573,6 +613,14 @@ struct HfTreeCreatorLcToPKPi {
       functionOriginMcRec = candidate.originMcRec();
       functionIsCandidateSwapped = candidate.isCandidateSwapped();
       functionFlagMcDecayChanRec = candidate.flagMcDecayChanRec();
+    }
+
+    float mlScoreFirstClass{UndefValueFloat};
+    float mlScoreSecondClass{UndefValueFloat};
+    float mlScoreThirdClass{UndefValueFloat};
+
+    if (applyMl) {
+      assignMlScores(candidateMlScore, mlScoreFirstClass, mlScoreSecondClass, mlScoreThirdClass, candFlag);
     }
 
     rowCandidateLite(
@@ -618,7 +666,10 @@ struct HfTreeCreatorLcToPKPi {
       functionOriginMcRec,
       functionIsCandidateSwapped,
       functionFlagMcDecayChanRec,
-      functionInvMassKPi);
+      functionInvMassKPi,
+      mlScoreFirstClass,
+      mlScoreSecondClass,
+      mlScoreThirdClass);
 
     if (fillCollIdTable) {
       /// save also candidate collision indices
@@ -628,9 +679,10 @@ struct HfTreeCreatorLcToPKPi {
 
   /// \brief function to fill lite table
   /// \param candidate candidate instance
+  /// \param candidateMlScore instance of handler of vectors with ML scores associated with the current candidate
   /// \param candFlag flag indicating if PKPi (0) or PiKP (1) hypothesis is used
   template <bool isMc, int reconstructionType, typename CandType>
-  void fillFullTable(CandType const& candidate, int candFlag)
+  void fillFullTable(CandType const& candidate, aod::HfMlLcToPKPi::iterator const& candidateMlScore, int candFlag)
   {
     auto [functionInvMass, functionInvMassKPi] = evaluateInvariantMasses<reconstructionType>(candidate, candFlag);
     const float functionCt = hfHelper.ctLc(candidate);
@@ -647,6 +699,14 @@ struct HfTreeCreatorLcToPKPi {
       functionOriginMcRec = candidate.originMcRec();
       functionIsCandidateSwapped = candidate.isCandidateSwapped();
       functionFlagMcDecayChanRec = candidate.flagMcDecayChanRec();
+    }
+
+    float mlScoreFirstClass{UndefValueFloat};
+    float mlScoreSecondClass{UndefValueFloat};
+    float mlScoreThirdClass{UndefValueFloat};
+
+    if (applyMl) {
+      assignMlScores(candidateMlScore, mlScoreFirstClass, mlScoreSecondClass, mlScoreThirdClass, candFlag);
     }
 
     rowCandidateFull(
@@ -722,7 +782,10 @@ struct HfTreeCreatorLcToPKPi {
       functionIsCandidateSwapped,
       candidate.globalIndex(),
       functionFlagMcDecayChanRec,
-      functionInvMassKPi);
+      functionInvMassKPi,
+      mlScoreFirstClass,
+      mlScoreSecondClass,
+      mlScoreThirdClass);
   }
 
   /// \brief function to fill lite table
@@ -839,6 +902,7 @@ struct HfTreeCreatorLcToPKPi {
   void fillTablesMc(Colls const& collisions,
                     aod::McCollisions const&,
                     CandType const& candidates,
+                    aod::HfMlLcToPKPi const& candidateMlScores,
                     soa::Join<aod::McParticles, aod::HfCand3ProngMcGen> const& particles,
                     soa::Join<TracksWPid, o2::aod::McTrackLabels> const&, aod::BCs const&)
   {
@@ -850,7 +914,10 @@ struct HfTreeCreatorLcToPKPi {
     const size_t candidatesSize = candidates.size();
     reserveTables<reconstructionType>(candidatesSize, IsMc);
 
+    int iCand{0};
     for (const auto& candidate : candidates) {
+      auto candidateMlScore = candidateMlScores.rawIteratorAt(iCand);
+      ++iCand;
       float ptProng0 = candidate.ptProng0();
       auto collision = candidate.template collision_as<Colls>();
       auto fillTable = [&](int candFlag) {
@@ -863,9 +930,9 @@ struct HfTreeCreatorLcToPKPi {
         const bool notSkippedBkg = isMcCandidateSignal || candidate.pt() > downSampleBkgPtMax || pseudoRndm < downSampleBkgFactor;
         if (passSelection && notSkippedBkg && (keepAll || (keepOnlySignalMc && isMcCandidateSignal) || (keepOnlyBkg && !isMcCandidateSignal))) {
           if (fillCandidateLiteTable) {
-            fillLiteTable<IsMc, reconstructionType>(candidate, candFlag);
+            fillLiteTable<IsMc, reconstructionType>(candidate, candidateMlScore, candFlag);
           } else {
-            fillFullTable<IsMc, reconstructionType>(candidate, candFlag);
+            fillFullTable<IsMc, reconstructionType>(candidate, candidateMlScore, candFlag);
           }
 
           if constexpr (reconstructionType == aod::hf_cand::VertexerType::KfParticle) {
@@ -954,11 +1021,12 @@ struct HfTreeCreatorLcToPKPi {
   /// \param bcs Bunch-crossing table
   void processMcNoCentralityWithDCAFitterN(soa::Join<aod::Collisions, aod::McCollisionLabels, aod::PVMultZeqs, aod::PVMults> const& collisions,
                                            aod::McCollisions const& mcCollisions,
-                                           soa::Join<aod::HfCand3ProngWPidPiKaPr, aod::HfCand3ProngMcRec, aod::HfSelLc> const& candidates,
+                                           soa::Join<aod::HfCand3ProngWPid, aod::HfCand3ProngMcRec, aod::HfSelLc> const& candidates,
+                                           aod::HfMlLcToPKPi const& candidateMlScores,
                                            soa::Join<aod::McParticles, aod::HfCand3ProngMcGen> const& particles,
                                            soa::Join<TracksWPid, o2::aod::McTrackLabels> const& tracks, aod::BCs const& bcs)
   {
-    fillTablesMc<false, aod::hf_cand::VertexerType::DCAFitter>(collisions, mcCollisions, candidates, particles, tracks, bcs);
+    fillTablesMc<false, aod::hf_cand::VertexerType::DCAFitter>(collisions, mcCollisions, candidates, candidateMlScores, particles, tracks, bcs);
   }
   PROCESS_SWITCH(HfTreeCreatorLcToPKPi, processMcNoCentralityWithDCAFitterN, "Process MC tree writer w/o centrality with DCAFitterN", false);
 
@@ -970,11 +1038,12 @@ struct HfTreeCreatorLcToPKPi {
   /// \param bcs Bunch-crossing table
   void processMcWithCentralityWithDCAFitterN(soa::Join<aod::Collisions, aod::McCollisionLabels, aod::PVMultZeqs, Cents, aod::PVMults> const& collisions,
                                              aod::McCollisions const& mcCollisions,
-                                             soa::Join<aod::HfCand3ProngWPidPiKaPr, aod::HfCand3ProngMcRec, aod::HfSelLc> const& candidates,
+                                             soa::Join<aod::HfCand3ProngWPid, aod::HfCand3ProngMcRec, aod::HfSelLc> const& candidates,
+                                             aod::HfMlLcToPKPi const& candidateMlScores,
                                              soa::Join<aod::McParticles, aod::HfCand3ProngMcGen> const& particles,
                                              soa::Join<TracksWPid, o2::aod::McTrackLabels> const& tracks, aod::BCs const& bcs)
   {
-    fillTablesMc<true, aod::hf_cand::VertexerType::DCAFitter>(collisions, mcCollisions, candidates, particles, tracks, bcs);
+    fillTablesMc<true, aod::hf_cand::VertexerType::DCAFitter>(collisions, mcCollisions, candidates, candidateMlScores, particles, tracks, bcs);
   }
   PROCESS_SWITCH(HfTreeCreatorLcToPKPi, processMcWithCentralityWithDCAFitterN, "Process MC tree writer with centrality with DCAFitterN", false);
 
@@ -987,11 +1056,12 @@ struct HfTreeCreatorLcToPKPi {
   /// \param bcs Bunch-crossing table
   void processMcNoCentralityWithKFParticle(soa::Join<aod::Collisions, aod::McCollisionLabels, aod::PVMultZeqs, aod::PVMults> const& collisions,
                                            aod::McCollisions const& mcCollisions,
-                                           soa::Join<aod::HfCand3ProngWPidPiKaPr, aod::HfCand3ProngMcRec, aod::HfSelLc, aod::HfCand3ProngKF> const& candidates,
+                                           soa::Join<aod::HfCand3ProngWPid, aod::HfCand3ProngMcRec, aod::HfSelLc, aod::HfCand3ProngKF> const& candidates,
+                                           aod::HfMlLcToPKPi const& candidateMlScores,
                                            soa::Join<aod::McParticles, aod::HfCand3ProngMcGen> const& particles,
                                            soa::Join<TracksWPid, o2::aod::McTrackLabels> const& tracks, aod::BCs const& bcs)
   {
-    fillTablesMc<false, aod::hf_cand::VertexerType::KfParticle>(collisions, mcCollisions, candidates, particles, tracks, bcs);
+    fillTablesMc<false, aod::hf_cand::VertexerType::KfParticle>(collisions, mcCollisions, candidates, candidateMlScores, particles, tracks, bcs);
   }
   PROCESS_SWITCH(HfTreeCreatorLcToPKPi, processMcNoCentralityWithKFParticle, "Process MC tree writer w/o centrality with KFParticle", false);
 
@@ -1003,11 +1073,12 @@ struct HfTreeCreatorLcToPKPi {
   /// \param bcs Bunch-crossing table
   void processMcWithCentralityWithKFParticle(soa::Join<aod::Collisions, aod::McCollisionLabels, aod::PVMultZeqs, Cents, aod::PVMults> const& collisions,
                                              aod::McCollisions const& mcCollisions,
-                                             soa::Join<aod::HfCand3ProngWPidPiKaPr, aod::HfCand3ProngMcRec, aod::HfSelLc, aod::HfCand3ProngKF> const& candidates,
+                                             soa::Join<aod::HfCand3ProngWPid, aod::HfCand3ProngMcRec, aod::HfSelLc, aod::HfCand3ProngKF> const& candidates,
+                                             aod::HfMlLcToPKPi const& candidateMlScores,
                                              soa::Join<aod::McParticles, aod::HfCand3ProngMcGen> const& particles,
                                              soa::Join<TracksWPid, o2::aod::McTrackLabels> const& tracks, aod::BCs const& bcs)
   {
-    fillTablesMc<true, aod::hf_cand::VertexerType::KfParticle>(collisions, mcCollisions, candidates, particles, tracks, bcs);
+    fillTablesMc<true, aod::hf_cand::VertexerType::KfParticle>(collisions, mcCollisions, candidates, candidateMlScores, particles, tracks, bcs);
   }
   PROCESS_SWITCH(HfTreeCreatorLcToPKPi, processMcWithCentralityWithKFParticle, "Process MC tree writer with centrality with KFParticle", false);
 
@@ -1017,6 +1088,7 @@ struct HfTreeCreatorLcToPKPi {
   template <bool useCentrality, int reconstructionType, typename Colls, typename CandType>
   void fillTablesData(Colls const& collisions,
                       CandType const& candidates,
+                      aod::HfMlLcToPKPi const& candidateMlScores,
                       TracksWPid const&, aod::BCs const&)
   {
 
@@ -1029,7 +1101,10 @@ struct HfTreeCreatorLcToPKPi {
 
     // Filling candidate properties
 
+    int iCand{0};
     for (const auto& candidate : candidates) {
+      auto candidateMlScore = candidateMlScores.rawIteratorAt(iCand);
+      ++iCand;
       float ptProng0 = candidate.ptProng0();
       auto collision = candidate.template collision_as<Colls>();
       auto fillTable = [&](int candFlag) {
@@ -1037,9 +1112,9 @@ struct HfTreeCreatorLcToPKPi {
         const int functionSelection = candFlag == 0 ? candidate.isSelLcToPKPi() : candidate.isSelLcToPiKP();
         if (functionSelection >= selectionFlagLc && (candidate.pt() > downSampleBkgPtMax || (pseudoRndm < downSampleBkgFactor && candidate.pt() < downSampleBkgPtMax))) {
           if (fillCandidateLiteTable) {
-            fillLiteTable<IsMc, reconstructionType>(candidate, candFlag);
+            fillLiteTable<IsMc, reconstructionType>(candidate, candidateMlScore, candFlag);
           } else {
-            fillFullTable<IsMc, reconstructionType>(candidate, candFlag);
+            fillFullTable<IsMc, reconstructionType>(candidate, candidateMlScore, candFlag);
           }
 
           if constexpr (reconstructionType == aod::hf_cand::VertexerType::KfParticle) {
@@ -1059,10 +1134,11 @@ struct HfTreeCreatorLcToPKPi {
   /// \param tracks Track table
   /// \param bcs Bunch-crossing table
   void processDataNoCentralityWithDCAFitterN(soa::Join<aod::Collisions, aod::PVMultZeqs, aod::PVMults> const& collisions,
-                                             soa::Join<aod::HfCand3ProngWPidPiKaPr, aod::HfSelLc> const& candidates,
+                                             soa::Join<aod::HfCand3ProngWPid, aod::HfSelLc> const& candidates,
+                                             aod::HfMlLcToPKPi const& candidateMlScores,
                                              TracksWPid const& tracks, aod::BCs const& bcs)
   {
-    fillTablesData<false, aod::hf_cand::VertexerType::DCAFitter>(collisions, candidates, tracks, bcs);
+    fillTablesData<false, aod::hf_cand::VertexerType::DCAFitter>(collisions, candidates, candidateMlScores, tracks, bcs);
   }
   PROCESS_SWITCH(HfTreeCreatorLcToPKPi, processDataNoCentralityWithDCAFitterN, "Process data tree writer w/o centrality with DCAFitterN", false);
 
@@ -1072,10 +1148,11 @@ struct HfTreeCreatorLcToPKPi {
   /// \param tracks Track table
   /// \param bcs Bunch-crossing table
   void processDataWithCentralityWithDCAFitterN(soa::Join<aod::Collisions, aod::PVMultZeqs, Cents, aod::PVMults> const& collisions,
-                                               soa::Join<aod::HfCand3ProngWPidPiKaPr, aod::HfSelLc> const& candidates,
+                                               soa::Join<aod::HfCand3ProngWPid, aod::HfSelLc> const& candidates,
+                                               aod::HfMlLcToPKPi const& candidateMlScores,
                                                TracksWPid const& tracks, aod::BCs const& bcs)
   {
-    fillTablesData<true, aod::hf_cand::VertexerType::DCAFitter>(collisions, candidates, tracks, bcs);
+    fillTablesData<true, aod::hf_cand::VertexerType::DCAFitter>(collisions, candidates, candidateMlScores, tracks, bcs);
   }
   PROCESS_SWITCH(HfTreeCreatorLcToPKPi, processDataWithCentralityWithDCAFitterN, "Process data tree writer with centrality with DCAFitterN", true);
 
@@ -1085,10 +1162,11 @@ struct HfTreeCreatorLcToPKPi {
   /// \param tracks Track table
   /// \param bcs Bunch-crossing table
   void processDataNoCentralityWithKFParticle(soa::Join<aod::Collisions, aod::PVMultZeqs, aod::PVMults> const& collisions,
-                                             soa::Join<aod::HfCand3ProngWPidPiKaPr, aod::HfSelLc, aod::HfCand3ProngKF> const& candidates,
+                                             soa::Join<aod::HfCand3ProngWPid, aod::HfSelLc, aod::HfCand3ProngKF> const& candidates,
+                                             aod::HfMlLcToPKPi const& candidateMlScores,
                                              TracksWPid const& tracks, aod::BCs const& bcs)
   {
-    fillTablesData<false, aod::hf_cand::VertexerType::KfParticle>(collisions, candidates, tracks, bcs);
+    fillTablesData<false, aod::hf_cand::VertexerType::KfParticle>(collisions, candidates, candidateMlScores, tracks, bcs);
   }
   PROCESS_SWITCH(HfTreeCreatorLcToPKPi, processDataNoCentralityWithKFParticle, "Process data tree writer w/o centrality with KFParticle", false);
 
@@ -1098,10 +1176,11 @@ struct HfTreeCreatorLcToPKPi {
   /// \param tracks Track table
   /// \param bcs Bunch-crossing table
   void processDataWithCentralityWithKFParticle(soa::Join<aod::Collisions, aod::PVMultZeqs, Cents, aod::PVMults> const& collisions,
-                                               soa::Join<aod::HfCand3ProngWPidPiKaPr, aod::HfSelLc, aod::HfCand3ProngKF> const& candidates,
+                                               soa::Join<aod::HfCand3ProngWPid, aod::HfSelLc, aod::HfCand3ProngKF> const& candidates,
+                                               aod::HfMlLcToPKPi const& candidateMlScores,
                                                TracksWPid const& tracks, aod::BCs const& bcs)
   {
-    fillTablesData<true, aod::hf_cand::VertexerType::KfParticle>(collisions, candidates, tracks, bcs);
+    fillTablesData<true, aod::hf_cand::VertexerType::KfParticle>(collisions, candidates, candidateMlScores, tracks, bcs);
   }
   PROCESS_SWITCH(HfTreeCreatorLcToPKPi, processDataWithCentralityWithKFParticle, "Process data tree writer with centrality with KFParticle", false);
 };

--- a/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
@@ -86,7 +86,7 @@ DECLARE_SOA_COLUMN(FlagMc, flagMc, int8_t);
 DECLARE_SOA_COLUMN(OriginMcRec, originMcRec, int8_t);
 DECLARE_SOA_COLUMN(OriginMcGen, originMcGen, int8_t);
 DECLARE_SOA_COLUMN(IsCandidateSwapped, isCandidateSwapped, int8_t);
-DECLARE_SOA_INDEX_COLUMN_FULL(Candidate, candidate, int, HfCand3ProngWPidPiKaPr, "_0");
+DECLARE_SOA_INDEX_COLUMN_FULL(Candidate, candidate, int, HfCand3ProngWPidPiKaPrPiKaPr, "_0");
 DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle);
 DECLARE_SOA_COLUMN(Channel, channel, int8_t); // direct or resonant
 DECLARE_SOA_COLUMN(MlScoreFirstClass, mlScoreFirstClass, float);
@@ -1021,7 +1021,7 @@ struct HfTreeCreatorLcToPKPi {
   /// \param bcs Bunch-crossing table
   void processMcNoCentralityWithDCAFitterN(soa::Join<aod::Collisions, aod::McCollisionLabels, aod::PVMultZeqs, aod::PVMults> const& collisions,
                                            aod::McCollisions const& mcCollisions,
-                                           soa::Join<aod::HfCand3ProngWPid, aod::HfCand3ProngMcRec, aod::HfSelLc> const& candidates,
+                                           soa::Join<aod::HfCand3ProngWPidPiKaPr, aod::HfCand3ProngMcRec, aod::HfSelLc> const& candidates,
                                            aod::HfMlLcToPKPi const& candidateMlScores,
                                            soa::Join<aod::McParticles, aod::HfCand3ProngMcGen> const& particles,
                                            soa::Join<TracksWPid, o2::aod::McTrackLabels> const& tracks, aod::BCs const& bcs)
@@ -1038,7 +1038,7 @@ struct HfTreeCreatorLcToPKPi {
   /// \param bcs Bunch-crossing table
   void processMcWithCentralityWithDCAFitterN(soa::Join<aod::Collisions, aod::McCollisionLabels, aod::PVMultZeqs, Cents, aod::PVMults> const& collisions,
                                              aod::McCollisions const& mcCollisions,
-                                             soa::Join<aod::HfCand3ProngWPid, aod::HfCand3ProngMcRec, aod::HfSelLc> const& candidates,
+                                             soa::Join<aod::HfCand3ProngWPidPiKaPr, aod::HfCand3ProngMcRec, aod::HfSelLc> const& candidates,
                                              aod::HfMlLcToPKPi const& candidateMlScores,
                                              soa::Join<aod::McParticles, aod::HfCand3ProngMcGen> const& particles,
                                              soa::Join<TracksWPid, o2::aod::McTrackLabels> const& tracks, aod::BCs const& bcs)
@@ -1056,7 +1056,7 @@ struct HfTreeCreatorLcToPKPi {
   /// \param bcs Bunch-crossing table
   void processMcNoCentralityWithKFParticle(soa::Join<aod::Collisions, aod::McCollisionLabels, aod::PVMultZeqs, aod::PVMults> const& collisions,
                                            aod::McCollisions const& mcCollisions,
-                                           soa::Join<aod::HfCand3ProngWPid, aod::HfCand3ProngMcRec, aod::HfSelLc, aod::HfCand3ProngKF> const& candidates,
+                                           soa::Join<aod::HfCand3ProngWPidPiKaPr, aod::HfCand3ProngMcRec, aod::HfSelLc, aod::HfCand3ProngKF> const& candidates,
                                            aod::HfMlLcToPKPi const& candidateMlScores,
                                            soa::Join<aod::McParticles, aod::HfCand3ProngMcGen> const& particles,
                                            soa::Join<TracksWPid, o2::aod::McTrackLabels> const& tracks, aod::BCs const& bcs)
@@ -1073,7 +1073,7 @@ struct HfTreeCreatorLcToPKPi {
   /// \param bcs Bunch-crossing table
   void processMcWithCentralityWithKFParticle(soa::Join<aod::Collisions, aod::McCollisionLabels, aod::PVMultZeqs, Cents, aod::PVMults> const& collisions,
                                              aod::McCollisions const& mcCollisions,
-                                             soa::Join<aod::HfCand3ProngWPid, aod::HfCand3ProngMcRec, aod::HfSelLc, aod::HfCand3ProngKF> const& candidates,
+                                             soa::Join<aod::HfCand3ProngWPidPiKaPr, aod::HfCand3ProngMcRec, aod::HfSelLc, aod::HfCand3ProngKF> const& candidates,
                                              aod::HfMlLcToPKPi const& candidateMlScores,
                                              soa::Join<aod::McParticles, aod::HfCand3ProngMcGen> const& particles,
                                              soa::Join<TracksWPid, o2::aod::McTrackLabels> const& tracks, aod::BCs const& bcs)
@@ -1134,7 +1134,7 @@ struct HfTreeCreatorLcToPKPi {
   /// \param tracks Track table
   /// \param bcs Bunch-crossing table
   void processDataNoCentralityWithDCAFitterN(soa::Join<aod::Collisions, aod::PVMultZeqs, aod::PVMults> const& collisions,
-                                             soa::Join<aod::HfCand3ProngWPid, aod::HfSelLc> const& candidates,
+                                             soa::Join<aod::HfCand3ProngWPidPiKaPr, aod::HfSelLc> const& candidates,
                                              aod::HfMlLcToPKPi const& candidateMlScores,
                                              TracksWPid const& tracks, aod::BCs const& bcs)
   {
@@ -1148,7 +1148,7 @@ struct HfTreeCreatorLcToPKPi {
   /// \param tracks Track table
   /// \param bcs Bunch-crossing table
   void processDataWithCentralityWithDCAFitterN(soa::Join<aod::Collisions, aod::PVMultZeqs, Cents, aod::PVMults> const& collisions,
-                                               soa::Join<aod::HfCand3ProngWPid, aod::HfSelLc> const& candidates,
+                                               soa::Join<aod::HfCand3ProngWPidPiKaPr, aod::HfSelLc> const& candidates,
                                                aod::HfMlLcToPKPi const& candidateMlScores,
                                                TracksWPid const& tracks, aod::BCs const& bcs)
   {
@@ -1162,7 +1162,7 @@ struct HfTreeCreatorLcToPKPi {
   /// \param tracks Track table
   /// \param bcs Bunch-crossing table
   void processDataNoCentralityWithKFParticle(soa::Join<aod::Collisions, aod::PVMultZeqs, aod::PVMults> const& collisions,
-                                             soa::Join<aod::HfCand3ProngWPid, aod::HfSelLc, aod::HfCand3ProngKF> const& candidates,
+                                             soa::Join<aod::HfCand3ProngWPidPiKaPr, aod::HfSelLc, aod::HfCand3ProngKF> const& candidates,
                                              aod::HfMlLcToPKPi const& candidateMlScores,
                                              TracksWPid const& tracks, aod::BCs const& bcs)
   {
@@ -1176,7 +1176,7 @@ struct HfTreeCreatorLcToPKPi {
   /// \param tracks Track table
   /// \param bcs Bunch-crossing table
   void processDataWithCentralityWithKFParticle(soa::Join<aod::Collisions, aod::PVMultZeqs, Cents, aod::PVMults> const& collisions,
-                                               soa::Join<aod::HfCand3ProngWPid, aod::HfSelLc, aod::HfCand3ProngKF> const& candidates,
+                                               soa::Join<aod::HfCand3ProngWPidPiKaPr, aod::HfSelLc, aod::HfCand3ProngKF> const& candidates,
                                                aod::HfMlLcToPKPi const& candidateMlScores,
                                                TracksWPid const& tracks, aod::BCs const& bcs)
   {

--- a/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
@@ -583,8 +583,9 @@ struct HfTreeCreatorLcToPKPi {
     constexpr int IndexFirstClass{0};
     constexpr int IndexSecondClass{1};
     constexpr int IndexThirdClass{2};
-    if (mlScores.size() == 0)
+    if (mlScores.size() == 0) {
       return; // when candidateSelectorLc rejects a candidate by "usual", non-ML cut, the ml score vector remains empty
+    }
     mlScoreFirstClass = mlScores.at(IndexFirstClass);
     mlScoreSecondClass = mlScores.at(IndexSecondClass);
     if (mlScores.size() > IndexThirdClass) {

--- a/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
@@ -86,7 +86,7 @@ DECLARE_SOA_COLUMN(FlagMc, flagMc, int8_t);
 DECLARE_SOA_COLUMN(OriginMcRec, originMcRec, int8_t);
 DECLARE_SOA_COLUMN(OriginMcGen, originMcGen, int8_t);
 DECLARE_SOA_COLUMN(IsCandidateSwapped, isCandidateSwapped, int8_t);
-DECLARE_SOA_INDEX_COLUMN_FULL(Candidate, candidate, int, HfCand3ProngWPidPiKaPrPiKaPr, "_0");
+DECLARE_SOA_INDEX_COLUMN_FULL(Candidate, candidate, int, HfCand3ProngWPidPiKaPr, "_0");
 DECLARE_SOA_INDEX_COLUMN(McParticle, mcParticle);
 DECLARE_SOA_COLUMN(Channel, channel, int8_t); // direct or resonant
 DECLARE_SOA_COLUMN(MlScoreFirstClass, mlScoreFirstClass, float);

--- a/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
@@ -581,8 +581,8 @@ struct HfTreeCreatorLcToPKPi {
       std::copy(candidateMlScore.mlProbLcToPiKP().begin(), candidateMlScore.mlProbLcToPiKP().end(), std::back_inserter(mlScores));
     }
     constexpr int IndexFirstClass{0};
-    constexpr int IndexSecondClass{0};
-    constexpr int IndexThirdClass{0};
+    constexpr int IndexSecondClass{1};
+    constexpr int IndexThirdClass{2};
     if (mlScores.size() == 0)
       return; // when candidateSelectorLc rejects a candidate by "usual", non-ML cut, the ml score vector remains empty
     mlScoreFirstClass = mlScores.at(IndexFirstClass);


### PR DESCRIPTION
1. Kalman Filter specific variables are added to the list of available features for ML selection of `Lc->PKPi` decays.
2. ML scores are propagated to the output of the `treeCreatorLcToPKPi` workflow.