### PR TITLE
[PWGLF] do not include ITS internal code

### DIFF
--- a/PWGLF/TableProducer/Strangeness/Converters/CMakeLists.txt
+++ b/PWGLF/TableProducer/Strangeness/Converters/CMakeLists.txt
@@ -41,22 +41,22 @@ o2physics_add_dpl_workflow(straevselsconverter
 
 o2physics_add_dpl_workflow(straevselsconverter2
                     SOURCES straevselsconverter2.cxx
-                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::ITStracking
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::ReconstructionDataFormats
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(straevselsconverter3
                     SOURCES straevselsconverter3.cxx
-                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::ITStracking
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::ReconstructionDataFormats
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(straevselsconverter4
                     SOURCES straevselsconverter4.cxx
-                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::ITStracking
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(straevselsconverter5
                     SOURCES straevselsconverter5.cxx
-                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2::ITStracking O2Physics::AnalysisCCDB
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::AnalysisCCDB
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(straevselsconverter2rawcents

--- a/PWGLF/TableProducer/Strangeness/Converters/straevselsconverter2.cxx
+++ b/PWGLF/TableProducer/Strangeness/Converters/straevselsconverter2.cxx
@@ -8,11 +8,12 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#include "Framework/runDataProcessing.h"
-#include "Framework/AnalysisTask.h"
-#include "Framework/AnalysisDataModel.h"
-#include "ITStracking/Vertexer.h"
 #include "PWGLF/DataModel/LFStrangenessTables.h"
+
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/runDataProcessing.h"
+#include "ReconstructionDataFormats/Vertex.h"
 
 using namespace o2;
 using namespace o2::framework;
@@ -52,7 +53,7 @@ struct straevselsconverter2 {
                      values.totalFDDAmplitudeC(),
                      values.energyCommonZNA(),
                      values.energyCommonZNC(),
-                     o2::its::Vertex::FlagsMask /*dummy flag value*/);
+                     o2::dataformats::Vertex<bool>::FlagsMask /*dummy flag value*/);
     }
   }
 };

--- a/PWGLF/TableProducer/Strangeness/Converters/straevselsconverter3.cxx
+++ b/PWGLF/TableProducer/Strangeness/Converters/straevselsconverter3.cxx
@@ -8,11 +8,12 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#include "Framework/runDataProcessing.h"
-#include "Framework/AnalysisTask.h"
-#include "Framework/AnalysisDataModel.h"
-#include "ITStracking/Vertexer.h"
 #include "PWGLF/DataModel/LFStrangenessTables.h"
+
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/runDataProcessing.h"
+#include "ReconstructionDataFormats/Vertex.h"
 
 using namespace o2;
 using namespace o2::framework;
@@ -53,7 +54,7 @@ struct straevselsconverter3 {
                      values.totalFDDAmplitudeC(),
                      values.energyCommonZNA(),
                      values.energyCommonZNC(),
-                     o2::its::Vertex::FlagsMask /*dummy flag value*/);
+                     o2::dataformats::Vertex<bool>::FlagsMask /*dummy flag value*/);
     }
   }
 };

--- a/PWGLF/TableProducer/Strangeness/Converters/straevselsconverter4.cxx
+++ b/PWGLF/TableProducer/Strangeness/Converters/straevselsconverter4.cxx
@@ -8,11 +8,11 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#include "Framework/runDataProcessing.h"
-#include "Framework/AnalysisTask.h"
-#include "Framework/AnalysisDataModel.h"
-#include "ITStracking/Vertexer.h"
 #include "PWGLF/DataModel/LFStrangenessTables.h"
+
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/runDataProcessing.h"
 
 using namespace o2;
 using namespace o2::framework;

--- a/PWGLF/TableProducer/Strangeness/Converters/straevselsconverter5.cxx
+++ b/PWGLF/TableProducer/Strangeness/Converters/straevselsconverter5.cxx
@@ -8,13 +8,13 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-#include "Framework/runDataProcessing.h"
-#include "Framework/AnalysisTask.h"
-#include "Framework/AnalysisDataModel.h"
+#include "PWGLF/DataModel/LFStrangenessTables.h"
+
 #include "CCDB/BasicCCDBManager.h"
 #include "DataFormatsParameters/AggregatedRunInfo.h"
-#include "ITStracking/Vertexer.h"
-#include "PWGLF/DataModel/LFStrangenessTables.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/runDataProcessing.h"
 
 using namespace o2;
 using namespace o2::framework;


### PR DESCRIPTION
CI will check if this compiles.
I think it is not advisable to rely on some internal tracking data structures, we might internally do something different in the future which is not visible from the outside, rather rely on the core library.