### PR TITLE
[Trigger,PWGCF] Fix order of enums

### DIFF
--- a/EventFiltering/PWGCF/CFFilterAll.cxx
+++ b/EventFiltering/PWGCF/CFFilterAll.cxx
@@ -61,8 +61,8 @@ enum CFTriggers {
   kPPRho,
   kPD,
   kLD,
-  kRhoD,
   kPhiD,
+  kRhoD,
   kNTriggers
 };
 


### PR DESCRIPTION
Fix the order of enums. The number of triggered Evens for the PhiD and RhoD had been switched.