### PR TITLE
Fix HfMlResponse features naming for PID Exp

### DIFF
--- a/PWGHF/Core/HfMlResponseDsToKKPi.h
+++ b/PWGHF/Core/HfMlResponseDsToKKPi.h
@@ -16,10 +16,10 @@
 #ifndef PWGHF_CORE_HFMLRESPONSEDSTOKKPI_H_
 #define PWGHF_CORE_HFMLRESPONSEDSTOKKPI_H_
 
-#include <vector>
-
 #include "PWGHF/Core/HfHelper.h"
 #include "PWGHF/Core/HfMlResponse.h"
+
+#include <vector>
 
 // Fill the map of available input features
 // the key is the feature's name (std::string)
@@ -132,12 +132,12 @@ enum class InputFeaturesDsToKKPi : uint8_t {
   nSigTpcTofKa0,
   nSigTpcTofKa1,
   nSigTpcTofKa2,
-  nSigTpcKaExpKa0,
-  nSigTpcPiExpPi2,
-  nSigTofKaExpKa0,
-  nSigTofPiExpPi2,
-  nSigTpcTofKaExpKa0,
-  nSigTpcTofPiExpPi2,
+  nSigTpcKaExpKa,
+  nSigTpcPiExpPi,
+  nSigTofKaExpKa,
+  nSigTofPiExpPi,
+  nSigTpcTofKaExpKa,
+  nSigTpcTofPiExpPi,
   absCos3PiK,
   deltaMassPhi
 };
@@ -198,10 +198,10 @@ class HfMlResponseDsToKKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_DS_FULL(candidate, nSigTofKa0, nSigTofKa0);
         CHECK_AND_FILL_VEC_DS_FULL(candidate, nSigTofKa1, nSigTofKa1);
         CHECK_AND_FILL_VEC_DS_FULL(candidate, nSigTofKa2, nSigTofKa2);
-        CHECK_AND_FILL_VEC_DS_SIGNED(candidate, nSigTpcKaExpKa0, nSigTpcKa0, nSigTpcKa2);
-        CHECK_AND_FILL_VEC_DS_SIGNED(candidate, nSigTpcPiExpPi2, nSigTpcPi2, nSigTpcPi0);
-        CHECK_AND_FILL_VEC_DS_SIGNED(candidate, nSigTofKaExpKa0, nSigTofKa0, nSigTofKa2);
-        CHECK_AND_FILL_VEC_DS_SIGNED(candidate, nSigTofPiExpPi2, nSigTofPi2, nSigTofPi0);
+        CHECK_AND_FILL_VEC_DS_SIGNED(candidate, nSigTpcKaExpKa, nSigTpcKa0, nSigTpcKa2);
+        CHECK_AND_FILL_VEC_DS_SIGNED(candidate, nSigTpcPiExpPi, nSigTpcPi2, nSigTpcPi0);
+        CHECK_AND_FILL_VEC_DS_SIGNED(candidate, nSigTofKaExpKa, nSigTofKa0, nSigTofKa2);
+        CHECK_AND_FILL_VEC_DS_SIGNED(candidate, nSigTofPiExpPi, nSigTofPi2, nSigTofPi0);
 
         // Combined PID variables
         CHECK_AND_FILL_VEC_DS_FULL(candidate, nSigTpcTofPi0, tpcTofNSigmaPi0);
@@ -210,8 +210,8 @@ class HfMlResponseDsToKKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_DS_FULL(candidate, nSigTpcTofKa0, tpcTofNSigmaKa0);
         CHECK_AND_FILL_VEC_DS_FULL(candidate, nSigTpcTofKa1, tpcTofNSigmaKa1);
         CHECK_AND_FILL_VEC_DS_FULL(candidate, nSigTpcTofKa2, tpcTofNSigmaKa2);
-        CHECK_AND_FILL_VEC_DS_SIGNED(candidate, nSigTpcTofKaExpKa0, tpcTofNSigmaKa0, tpcTofNSigmaKa2);
-        CHECK_AND_FILL_VEC_DS_SIGNED(candidate, nSigTpcTofPiExpPi2, tpcTofNSigmaPi2, tpcTofNSigmaPi0);
+        CHECK_AND_FILL_VEC_DS_SIGNED(candidate, nSigTpcTofKaExpKa, tpcTofNSigmaKa0, tpcTofNSigmaKa2);
+        CHECK_AND_FILL_VEC_DS_SIGNED(candidate, nSigTpcTofPiExpPi, tpcTofNSigmaPi2, tpcTofNSigmaPi0);
 
         // Ds specific variables
         CHECK_AND_FILL_VEC_DS_HFHELPER_SIGNED(candidate, absCos3PiK, absCos3PiKDsToKKPi, absCos3PiKDsToPiKK);
@@ -258,10 +258,10 @@ class HfMlResponseDsToKKPi : public HfMlResponse<TypeOutputScore>
       FILL_MAP_DS(nSigTofKa0),
       FILL_MAP_DS(nSigTofKa1),
       FILL_MAP_DS(nSigTofKa2),
-      FILL_MAP_DS(nSigTpcKaExpKa0),
-      FILL_MAP_DS(nSigTpcPiExpPi2),
-      FILL_MAP_DS(nSigTofKaExpKa0),
-      FILL_MAP_DS(nSigTofPiExpPi2),
+      FILL_MAP_DS(nSigTpcKaExpKa),
+      FILL_MAP_DS(nSigTpcPiExpPi),
+      FILL_MAP_DS(nSigTofKaExpKa),
+      FILL_MAP_DS(nSigTofPiExpPi),
       // Combined PID variables
       FILL_MAP_DS(nSigTpcTofPi0),
       FILL_MAP_DS(nSigTpcTofPi1),
@@ -269,8 +269,8 @@ class HfMlResponseDsToKKPi : public HfMlResponse<TypeOutputScore>
       FILL_MAP_DS(nSigTpcTofKa0),
       FILL_MAP_DS(nSigTpcTofKa1),
       FILL_MAP_DS(nSigTpcTofKa2),
-      FILL_MAP_DS(nSigTpcTofKaExpKa0),
-      FILL_MAP_DS(nSigTpcTofPiExpPi2),
+      FILL_MAP_DS(nSigTpcTofKaExpKa),
+      FILL_MAP_DS(nSigTpcTofPiExpPi),
 
       // Ds specific variables
       FILL_MAP_DS(absCos3PiK),

--- a/PWGHF/Core/HfMlResponseLcToPKPi.h
+++ b/PWGHF/Core/HfMlResponseLcToPKPi.h
@@ -16,13 +16,12 @@
 #ifndef PWGHF_CORE_HFMLRESPONSELCTOPKPI_H_
 #define PWGHF_CORE_HFMLRESPONSELCTOPKPI_H_
 
+#include "PWGHF/Core/HfMlResponse.h"
+#include "PWGHF/DataModel/CandidateReconstructionTables.h"
+
 #include <map>
 #include <string>
 #include <vector>
-
-#include "PWGHF/DataModel/CandidateReconstructionTables.h"
-
-#include "PWGHF/Core/HfMlResponse.h"
 
 // Fill the map of available input features
 // the key is the feature's name (std::string)
@@ -128,12 +127,12 @@ enum class InputFeaturesLcToPKPi : uint8_t {
   tpcTofNSigmaPr0,
   tpcTofNSigmaPr1,
   tpcTofNSigmaPr2,
-  tpcNSigmaPrExpPr0,
-  tpcNSigmaPiExpPi2,
-  tofNSigmaPrExpPr0,
-  tofNSigmaPiExpPi2,
-  tpcTofNSigmaPrExpPr0,
-  tpcTofNSigmaPiExpPi2,
+  tpcNSigmaPrExpPr,
+  tpcNSigmaPiExpPi,
+  tofNSigmaPrExpPr,
+  tofNSigmaPiExpPi,
+  tpcTofNSigmaPrExpPr,
+  tpcTofNSigmaPiExpPi,
   kfChi2PrimProton,
   kfChi2PrimKaon,
   kfChi2PrimPion,
@@ -195,8 +194,8 @@ class HfMlResponseLcToPKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tpcNSigmaPr2, nSigTpcPr2);
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tpcNSigmaKa2, nSigTpcKa2);
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tpcNSigmaPi2, nSigTpcPi2);
-        CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, tpcNSigmaPrExpPr0, nSigTpcPr0, nSigTpcPr2);
-        CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, tpcNSigmaPiExpPi2, nSigTpcPi2, nSigTpcPi0);
+        CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, tpcNSigmaPrExpPr, nSigTpcPr0, nSigTpcPr2);
+        CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, tpcNSigmaPiExpPi, nSigTpcPi2, nSigTpcPi0);
         // TOF PID variables
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tofNSigmaPr0, nSigTofPr0);
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tofNSigmaKa0, nSigTofKa0);
@@ -207,8 +206,8 @@ class HfMlResponseLcToPKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tofNSigmaPr2, nSigTofPr2);
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tofNSigmaKa2, nSigTofKa2);
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tofNSigmaPi2, nSigTofPi2);
-        CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, tofNSigmaPrExpPr0, nSigTofPr0, nSigTofPr2);
-        CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, tofNSigmaPiExpPi2, nSigTofPi2, nSigTofPi0);
+        CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, tofNSigmaPrExpPr, nSigTofPr0, nSigTofPr2);
+        CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, tofNSigmaPiExpPi, nSigTofPi2, nSigTofPi0);
         // Combined PID variables
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tpcTofNSigmaPi0, tpcTofNSigmaPi0);
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tpcTofNSigmaPi1, tpcTofNSigmaPi1);
@@ -219,8 +218,8 @@ class HfMlResponseLcToPKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tpcTofNSigmaPr0, tpcTofNSigmaPr0);
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tpcTofNSigmaPr1, tpcTofNSigmaPr1);
         CHECK_AND_FILL_VEC_LCTOPKPI_FULL(candidate, tpcTofNSigmaPr2, tpcTofNSigmaPr2);
-        CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, tpcTofNSigmaPrExpPr0, tpcTofNSigmaPr0, tpcTofNSigmaPr2);
-        CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, tpcTofNSigmaPiExpPi2, tpcTofNSigmaPi2, tpcTofNSigmaPi0);
+        CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, tpcTofNSigmaPrExpPr, tpcTofNSigmaPr0, tpcTofNSigmaPr2);
+        CHECK_AND_FILL_VEC_LCTOPKPI_SIGNED(candidate, tpcTofNSigmaPiExpPi, tpcTofNSigmaPi2, tpcTofNSigmaPi0);
       }
       if constexpr (reconstructionType == aod::hf_cand::VertexerType::KfParticle) {
         switch (idx) {
@@ -275,8 +274,8 @@ class HfMlResponseLcToPKPi : public HfMlResponse<TypeOutputScore>
       FILL_MAP_LCTOPKPI(tpcNSigmaPr2),
       FILL_MAP_LCTOPKPI(tpcNSigmaKa2),
       FILL_MAP_LCTOPKPI(tpcNSigmaPi2),
-      FILL_MAP_LCTOPKPI(tpcNSigmaPrExpPr0),
-      FILL_MAP_LCTOPKPI(tpcNSigmaPiExpPi2),
+      FILL_MAP_LCTOPKPI(tpcNSigmaPrExpPr),
+      FILL_MAP_LCTOPKPI(tpcNSigmaPiExpPi),
       // TOF PID variables
       FILL_MAP_LCTOPKPI(tofNSigmaPr0),
       FILL_MAP_LCTOPKPI(tofNSigmaKa0),
@@ -287,8 +286,8 @@ class HfMlResponseLcToPKPi : public HfMlResponse<TypeOutputScore>
       FILL_MAP_LCTOPKPI(tofNSigmaPr2),
       FILL_MAP_LCTOPKPI(tofNSigmaKa2),
       FILL_MAP_LCTOPKPI(tofNSigmaPi2),
-      FILL_MAP_LCTOPKPI(tofNSigmaPrExpPr0),
-      FILL_MAP_LCTOPKPI(tofNSigmaPiExpPi2),
+      FILL_MAP_LCTOPKPI(tofNSigmaPrExpPr),
+      FILL_MAP_LCTOPKPI(tofNSigmaPiExpPi),
       // Combined PID variables
       FILL_MAP_LCTOPKPI(tpcTofNSigmaPi0),
       FILL_MAP_LCTOPKPI(tpcTofNSigmaPi1),
@@ -299,8 +298,8 @@ class HfMlResponseLcToPKPi : public HfMlResponse<TypeOutputScore>
       FILL_MAP_LCTOPKPI(tpcTofNSigmaPr0),
       FILL_MAP_LCTOPKPI(tpcTofNSigmaPr1),
       FILL_MAP_LCTOPKPI(tpcTofNSigmaPr2),
-      FILL_MAP_LCTOPKPI(tpcTofNSigmaPrExpPr0),
-      FILL_MAP_LCTOPKPI(tpcTofNSigmaPiExpPi2)};
+      FILL_MAP_LCTOPKPI(tpcTofNSigmaPrExpPr),
+      FILL_MAP_LCTOPKPI(tpcTofNSigmaPiExpPi)};
     if constexpr (reconstructionType == aod::hf_cand::VertexerType::KfParticle) {
       std::map<std::string, uint8_t> mapKfFeatures{
         // KFParticle variables

--- a/PWGHF/Core/HfMlResponseXicToPKPi.h
+++ b/PWGHF/Core/HfMlResponseXicToPKPi.h
@@ -16,11 +16,11 @@
 #ifndef PWGHF_CORE_HFMLRESPONSEXICTOPKPI_H_
 #define PWGHF_CORE_HFMLRESPONSEXICTOPKPI_H_
 
+#include "PWGHF/Core/HfMlResponse.h"
+
 #include <map>
 #include <string>
 #include <vector>
-
-#include "PWGHF/Core/HfMlResponse.h"
 
 // Fill the map of available input features
 // the key is the feature's name (std::string)
@@ -119,12 +119,12 @@ enum class InputFeaturesXicToPKPi : uint8_t {
   tpcTofNSigmaPr0,
   tpcTofNSigmaPr1,
   tpcTofNSigmaPr2,
-  tpcNSigmaPrExpPr0,
-  tpcNSigmaPiExpPi2,
-  tofNSigmaPrExpPr0,
-  tofNSigmaPiExpPi2,
-  tpcTofNSigmaPrExpPr0,
-  tpcTofNSigmaPiExpPi2
+  tpcNSigmaPrExpPr,
+  tpcNSigmaPiExpPi,
+  tofNSigmaPrExpPr,
+  tofNSigmaPiExpPi,
+  tpcTofNSigmaPrExpPr,
+  tpcTofNSigmaPiExpPi
 };
 
 template <typename TypeOutputScore = float>
@@ -174,8 +174,8 @@ class HfMlResponseXicToPKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_XIC_FULL(candidate, tpcNSigmaPr2, nSigTpcPr2);
         CHECK_AND_FILL_VEC_XIC_FULL(candidate, tpcNSigmaKa2, nSigTpcKa2);
         CHECK_AND_FILL_VEC_XIC_FULL(candidate, tpcNSigmaPi2, nSigTpcPi2);
-        CHECK_AND_FILL_VEC_XIC_SIGNED(candidate, tpcNSigmaPrExpPr0, nSigTpcPr0, nSigTpcPr2);
-        CHECK_AND_FILL_VEC_XIC_SIGNED(candidate, tpcNSigmaPiExpPi2, nSigTpcPi2, nSigTpcPi0);
+        CHECK_AND_FILL_VEC_XIC_SIGNED(candidate, tpcNSigmaPrExpPr, nSigTpcPr0, nSigTpcPr2);
+        CHECK_AND_FILL_VEC_XIC_SIGNED(candidate, tpcNSigmaPiExpPi, nSigTpcPi2, nSigTpcPi0);
         // TOF PID variables
         CHECK_AND_FILL_VEC_XIC_FULL(candidate, tofNSigmaPr0, nSigTofPr0);
         CHECK_AND_FILL_VEC_XIC_FULL(candidate, tofNSigmaKa0, nSigTofKa0);
@@ -186,8 +186,8 @@ class HfMlResponseXicToPKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_XIC_FULL(candidate, tofNSigmaPr2, nSigTofPr2);
         CHECK_AND_FILL_VEC_XIC_FULL(candidate, tofNSigmaKa2, nSigTofKa2);
         CHECK_AND_FILL_VEC_XIC_FULL(candidate, tofNSigmaPi2, nSigTofPi2);
-        CHECK_AND_FILL_VEC_XIC_SIGNED(candidate, tofNSigmaPrExpPr0, nSigTofPr0, nSigTofPr2);
-        CHECK_AND_FILL_VEC_XIC_SIGNED(candidate, tofNSigmaPiExpPi2, nSigTofPi2, nSigTofPi0);
+        CHECK_AND_FILL_VEC_XIC_SIGNED(candidate, tofNSigmaPrExpPr, nSigTofPr0, nSigTofPr2);
+        CHECK_AND_FILL_VEC_XIC_SIGNED(candidate, tofNSigmaPiExpPi, nSigTofPi2, nSigTofPi0);
         // Combined PID variables
         CHECK_AND_FILL_VEC_XIC_FULL(candidate, tpcTofNSigmaPi0, tpcTofNSigmaPi0);
         CHECK_AND_FILL_VEC_XIC_FULL(candidate, tpcTofNSigmaPi1, tpcTofNSigmaPi1);
@@ -198,8 +198,8 @@ class HfMlResponseXicToPKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_XIC_FULL(candidate, tpcTofNSigmaPr0, tpcTofNSigmaPr0);
         CHECK_AND_FILL_VEC_XIC_FULL(candidate, tpcTofNSigmaPr1, tpcTofNSigmaPr1);
         CHECK_AND_FILL_VEC_XIC_FULL(candidate, tpcTofNSigmaPr2, tpcTofNSigmaPr2);
-        CHECK_AND_FILL_VEC_XIC_SIGNED(candidate, tpcTofNSigmaPrExpPr0, tpcTofNSigmaPr0, tpcTofNSigmaPr2);
-        CHECK_AND_FILL_VEC_XIC_SIGNED(candidate, tpcTofNSigmaPiExpPi2, tpcTofNSigmaPi2, tpcTofNSigmaPi0);
+        CHECK_AND_FILL_VEC_XIC_SIGNED(candidate, tpcTofNSigmaPrExpPr, tpcTofNSigmaPr0, tpcTofNSigmaPr2);
+        CHECK_AND_FILL_VEC_XIC_SIGNED(candidate, tpcTofNSigmaPiExpPi, tpcTofNSigmaPi2, tpcTofNSigmaPi0);
       }
     }
 
@@ -236,8 +236,8 @@ class HfMlResponseXicToPKPi : public HfMlResponse<TypeOutputScore>
       FILL_MAP_XIC(tpcNSigmaPr2),
       FILL_MAP_XIC(tpcNSigmaKa2),
       FILL_MAP_XIC(tpcNSigmaPi2),
-      FILL_MAP_XIC(tpcNSigmaPrExpPr0),
-      FILL_MAP_XIC(tpcNSigmaPiExpPi2),
+      FILL_MAP_XIC(tpcNSigmaPrExpPr),
+      FILL_MAP_XIC(tpcNSigmaPiExpPi),
       // TOF PID variables
       FILL_MAP_XIC(tofNSigmaPr0),
       FILL_MAP_XIC(tofNSigmaKa0),
@@ -248,8 +248,8 @@ class HfMlResponseXicToPKPi : public HfMlResponse<TypeOutputScore>
       FILL_MAP_XIC(tofNSigmaPr2),
       FILL_MAP_XIC(tofNSigmaKa2),
       FILL_MAP_XIC(tofNSigmaPi2),
-      FILL_MAP_XIC(tofNSigmaPrExpPr0),
-      FILL_MAP_XIC(tofNSigmaPiExpPi2),
+      FILL_MAP_XIC(tofNSigmaPrExpPr),
+      FILL_MAP_XIC(tofNSigmaPiExpPi),
       // Combined PID variables
       FILL_MAP_XIC(tpcTofNSigmaPi0),
       FILL_MAP_XIC(tpcTofNSigmaPi1),
@@ -260,8 +260,8 @@ class HfMlResponseXicToPKPi : public HfMlResponse<TypeOutputScore>
       FILL_MAP_XIC(tpcTofNSigmaPr0),
       FILL_MAP_XIC(tpcTofNSigmaPr1),
       FILL_MAP_XIC(tpcTofNSigmaPr2),
-      FILL_MAP_XIC(tpcTofNSigmaPrExpPr0),
-      FILL_MAP_XIC(tpcTofNSigmaPiExpPi2)};
+      FILL_MAP_XIC(tpcTofNSigmaPrExpPr),
+      FILL_MAP_XIC(tpcTofNSigmaPiExpPi)};
   }
 };
 


### PR DESCRIPTION
In ML features names for N sigmas PID in case of certain prong's type expectation (i.e. assumption of specific order of prongs) the index of the prong is not needed, moreover it is misleading. E.g. in `Lc->PKPi `decay the proton can be either 0-th or 2-nd, and therefore the name `tpcNSigmaPrExpPr0` is not correct.