### PR TITLE
[Infrastructure] Configure naming conventions in clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,23 @@
 CheckOptions:
-  - key: CheckPathRegex
-    value: '.*/O2/.*'
+  - { key: CheckPathRegex, value: ".*/O2/.*" }
+  # Naming conventions
+  - { key: readability-identifier-naming.ClassCase, value: CamelCase }
+  - { key: readability-identifier-naming.ClassMemberPrefix, value: m }
+  - { key: readability-identifier-naming.ConceptCase, value: CamelCase }
+  - { key: readability-identifier-naming.ConstexprVariableCase, value: CamelCase }
+  - { key: readability-identifier-naming.ConstexprVariableIgnoredRegexp, value: "^k[A-Z].*$" }  # Allow "k" prefix.
+  - { key: readability-identifier-naming.EnumCase, value: CamelCase }
+  - { key: readability-identifier-naming.EnumConstantCase, value: CamelCase }
+  - { key: readability-identifier-naming.EnumConstantIgnoredRegexp, value: "^k[A-Z].*$" }  # Allow "k" prefix.
+  - { key: readability-identifier-naming.FunctionCase, value: camelBack }
+  - { key: readability-identifier-naming.MacroDefinitionCase, value: UPPER_CASE }
+  - { key: readability-identifier-naming.MacroDefinitionIgnoredRegexp, value: "^[A-Z]+(_[A-Z]+)*_$" }  # Allow the trailing underscore in header guards.
+  - { key: readability-identifier-naming.MemberCase, value: camelBack }
+  - { key: readability-identifier-naming.NamespaceCase, value: lower_case }
+  - { key: readability-identifier-naming.ParameterCase, value: camelBack }
+  - { key: readability-identifier-naming.StructCase, value: CamelCase }
+  - { key: readability-identifier-naming.TemplateParameterCase, value: CamelCase }
+  - { key: readability-identifier-naming.TypeAliasCase, value: CamelCase }
+  - { key: readability-identifier-naming.TypedefCase, value: CamelCase }
+  - { key: readability-identifier-naming.TypeTemplateParameterCase, value: CamelCase }
+  - { key: readability-identifier-naming.VariableCase, value: camelBack }


### PR DESCRIPTION
Adds configuration of O2 naming conventions for the clang-tidy check
[readability-identifier-naming](https://clang.llvm.org/extra/clang-tidy/checks/readability/identifier-naming.html).