### PR TITLE
[Common] Prevent CCDB crash -> always captured

### DIFF
--- a/Common/TableProducer/multCentTable.cxx
+++ b/Common/TableProducer/multCentTable.cxx
@@ -72,7 +72,8 @@ struct MultCentTable {
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
     ccdb->setURL(ccdburl.value);
-
+    ccdb->setFatalWhenNull(false); // please never crash on your own, all exceptions captured (as they always should)
+  
     // task-specific
     module.init(opts, initContext);
   }


### PR DESCRIPTION
This adds the `ccdb->setFatalWhenNull(false);` setting to the ccdb in the `multCentTable`. All exceptions are properly caught in subsequent code and dealt with so no need to crash. 