### PR TITLE
[PWGEM/PhotonMeson,PWGJE/EMCal] Include BCWise centrality and qa histograms

### DIFF
--- a/PWGEM/PhotonMeson/TableProducer/bcWiseClusterSkimmer.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/bcWiseClusterSkimmer.cxx
@@ -43,7 +43,7 @@ using namespace o2::framework::expressions;
 
 using MyCollisions = soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Ms>;
 using MyMCCollisions = soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Ms, aod::McCollisionLabels>;
-using MyBCs = soa::Join<aod::BCs, aod::BcSels, aod::Timestamps>;
+using MyBCs = soa::Join<aod::BCs, aod::BcSels, aod::Timestamps, aod::BCCentFT0Ms>;
 
 using SelectedUniqueClusters = soa::Filtered<aod::EMCALClusters>;                                                         // Clusters from collisions with only one collision in the BC
 using SelectedUniqueMCClusters = soa::Filtered<soa::Join<aod::EMCALClusters, aod::EMCALMCClusters>>;                      // Clusters from collisions with only one collision in the BC
@@ -100,6 +100,7 @@ struct bcWiseClusterSkimmer {
       mHistManager.get<TH1>(HIST("nBCs"))->GetXaxis()->SetBinLabel(iBin + 1, binLabels[iBin]);
 
     mHistManager.add("CentralityVsGenMultiplicity", "Centrality vs number of generated MC particles;Centrality;#bf{#it{N}_{gen}}", HistType::kTH2F, {{102, 0., 102}, cfgMultiplicityBinning});
+    mHistManager.add("BCCentVsCollCent", "Centrality of the BC vs Centrality of the collision;BC Centrality;Collision Centrality", HistType::kTH2F, {{102, 0., 102}, {102, 0., 102}});
 
     LOG(info) << "BC wise cluster skimmer cuts:";
     LOG(info) << "------------------------------------";
@@ -232,11 +233,14 @@ struct bcWiseClusterSkimmer {
 
     double mu = cfgStoreMu ? calculateMu(bc) : 0.;
     float ft0Amp = hasFT0 ? bc.foundFT0().sumAmpA() + bc.foundFT0().sumAmpC() : 0.;
-    double centrality = 101.5;
+    double centralityOfCollision = 101.5;
     if (collisionsInBC.size() > 0)
-      centrality = collisionsInBC.iteratorAt(0).centFT0M();
+      centralityOfCollision = collisionsInBC.iteratorAt(0).centFT0M();
+    double centralityOfBC = bc.centFT0M();
 
-    bcTable(hasFT0, hasTVX, haskTVXinEMC, hasEMCCell, hasNoTFROFBorder, convertForStorage<uint8_t>(centrality, kFT0MCent), convertForStorage<uint16_t>(ft0Amp, kFT0Amp), convertForStorage<uint16_t>(mu, kMu));
+    mHistManager.fill(HIST("BCCentVsCollCent"), centralityOfBC, centralityOfCollision);
+
+    bcTable(hasFT0, hasTVX, haskTVXinEMC, hasEMCCell, hasNoTFROFBorder, convertForStorage<uint8_t>(centralityOfBC, kFT0MCent), convertForStorage<uint16_t>(ft0Amp, kFT0Amp), convertForStorage<uint16_t>(mu, kMu));
 
     for (const auto& collision : collisionsInBC)
       collisionTable(bcTable.lastIndex(), convertForStorage<uint8_t>(collision.centFT0M(), kFT0MCent), convertForStorage<int16_t>(collision.posZ(), kZVtx));
@@ -316,7 +320,7 @@ struct bcWiseClusterSkimmer {
         double centrality = 101.5;
         if (collisionsInBC.size() > 0)
           centrality = collisionsInBC.iteratorAt(0).centFT0M();
-        mHistManager.fill(HIST("CentralityVsGenMultiplicity"), centrality, mcParticlesInColl.size());
+        mHistManager.fill(HIST("CentralityVsGenMultiplicity"), bc.centFT0M(), mcParticlesInColl.size());
         for (const auto& mcParticle : mcParticlesInColl) {
           if (mcParticle.pdgCode() != 111 || std::abs(mcParticle.y()) > cfgRapidityCut || !isGammaGammaDecay(mcParticle, mcParticles) || mcParticle.pt() < cfgMinPtGenPi0)
             continue;

--- a/PWGEM/PhotonMeson/TableProducer/bcWiseClusterSkimmer.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/bcWiseClusterSkimmer.cxx
@@ -317,9 +317,6 @@ struct bcWiseClusterSkimmer {
       auto mcCollisionsBC = mcCollisions.sliceBy(mcCollperBC, bc.globalIndex());
       for (const auto& mcCollision : mcCollisionsBC) {
         auto mcParticlesInColl = mcParticles.sliceBy(perMcCollision, mcCollision.globalIndex());
-        double centrality = 101.5;
-        if (collisionsInBC.size() > 0)
-          centrality = collisionsInBC.iteratorAt(0).centFT0M();
         mHistManager.fill(HIST("CentralityVsGenMultiplicity"), bc.centFT0M(), mcParticlesInColl.size());
         for (const auto& mcParticle : mcParticlesInColl) {
           if (mcParticle.pdgCode() != 111 || std::abs(mcParticle.y()) > cfgRapidityCut || !isGammaGammaDecay(mcParticle, mcParticles) || mcParticle.pt() < cfgMinPtGenPi0)

--- a/PWGEM/PhotonMeson/Tasks/CMakeLists.txt
+++ b/PWGEM/PhotonMeson/Tasks/CMakeLists.txt
@@ -24,8 +24,8 @@ o2physics_add_dpl_workflow(emc-pi0-qc
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::EMCALBase O2::EMCALCalib O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(emc-bc-wise-pi0
-                    SOURCES emcalBcWisePi0.cxx
+o2physics_add_dpl_workflow(emc-bc-wise-gammagamma
+                    SOURCES emcalBcWiseGammaGamma.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::EMCALBase O2::EMCALCalib O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 

--- a/PWGEM/PhotonMeson/Tasks/emcalBcWiseGammaGamma.cxx
+++ b/PWGEM/PhotonMeson/Tasks/emcalBcWiseGammaGamma.cxx
@@ -39,7 +39,7 @@ using namespace o2::framework::expressions;
 using SelectedClusters = soa::Filtered<aod::BCWiseClusters>;
 using SelectedMCClusters = soa::Filtered<soa::Join<aod::BCWiseClusters, aod::BCWiseMCClusters>>;
 
-struct EmcalBcWisePi0 {
+struct EmcalBcWiseGammaGamma {
   HistogramRegistry mHistManager{"EmcalGammaGammaBcWiseHistograms"};
 
   Configurable<bool> cfgRequirekTVXinEMC{"cfgRequirekTVXinEMC", true, "Reconstruct pi0s only in kTVXinEMC triggered BCs"};
@@ -313,7 +313,7 @@ struct EmcalBcWisePi0 {
 
     reconstructTrueMesons(clusters, mcPi0s, bc);
   }
-  PROCESS_SWITCH(EmcalBcWisePi0, processMCInfo, "Run true and gen", false);
+  PROCESS_SWITCH(EmcalBcWiseGammaGamma, processMCInfo, "Run true and gen", false);
 };
 
-WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc) { return WorkflowSpec{adaptAnalysisTask<EmcalBcWisePi0>(cfgc)}; }
+WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc) { return WorkflowSpec{adaptAnalysisTask<EmcalBcWiseGammaGamma>(cfgc)}; }

--- a/PWGJE/Tasks/emcEventSelectionQA.cxx
+++ b/PWGJE/Tasks/emcEventSelectionQA.cxx
@@ -145,7 +145,7 @@ struct EmcEventSelectionQA {
       if (bc.runNumber() > mRun3MinNumber) {
         // in case of run3 not all BCs contain EMCAL data, require trigger selection also for min. bias
         // in addition select also L0/L1 triggers as triggers with EMCAL in reaodut
-        if (bc.alias_bit(kTVXinEMC) || bc.alias_bit(kEMC7) || bc.alias_bit(kEG1) || bc.alias_bit(kEG2) || bc.alias_bit(kDG1) || bc.alias_bit(kDG2) || bc.alias_bit(kEJ1) || bc.alias_bit(kEJ2) || bc.alias_bit(kDJ1) || bc.alias_bit(kDJ2)) {
+        if (bc.alias_bit(kTVXinEMC) || bc.alias_bit(kEMC7) || bc.alias_bit(kDMC7) || bc.alias_bit(kEG1) || bc.alias_bit(kEG2) || bc.alias_bit(kDG1) || bc.alias_bit(kDG2) || bc.alias_bit(kEJ1) || bc.alias_bit(kEJ2) || bc.alias_bit(kDJ1) || bc.alias_bit(kDJ2)) {
           isEMCALreadout = true;
         }
       } else {


### PR DESCRIPTION
EM:
- Move from collision wise to BC wise centrality in gammagamma task
- Rename pi0task to gammagamma task to allow for addition of eta (in a later PR)

JE:
- Add DMC7 as DCal L0 trigger to list of emcal readout triggers (Bugfix)