### PR TITLE
Prevent dangling reference error when switching from `gsl::span` to `std::span`

### DIFF
--- a/Common/TableProducer/multiplicityTable.cxx
+++ b/Common/TableProducer/multiplicityTable.cxx
@@ -267,12 +267,14 @@ struct MultiplicityTable {
     int multNContribsEtaHalf = 0;
 
     if (collision.has_fv0a()) {
-      for (const auto& amplitude : collision.fv0a().amplitude()) {
+      auto fv0a = collision.fv0a();
+      for (const auto& amplitude : fv0a.amplitude()) {
         multFV0A += amplitude;
       }
     }
     if (collision.has_fv0c()) {
-      for (const auto& amplitude : collision.fv0c().amplitude()) {
+      auto fv0c = collision.fv0c();
+      for (const auto& amplitude : fv0c.amplitude()) {
         multFV0C += amplitude;
       }
     }

--- a/Common/Tools/MultModule.h
+++ b/Common/Tools/MultModule.h
@@ -500,12 +500,14 @@ class MultModule
     //_______________________________________________________________________
     // forward detector signals, raw
     if (collision.has_fv0a()) {
-      for (const auto& amplitude : collision.fv0a().amplitude()) {
+      auto fv0a = collision.fv0a();
+      for (const auto& amplitude : fv0a.amplitude()) {
         mults.multFV0A += amplitude;
       }
     }
     if (collision.has_fv0c()) {
-      for (const auto& amplitude : collision.fv0c().amplitude()) {
+      auto fv0c = collision.fv0c();
+      for (const auto& amplitude : fv0c.amplitude()) {
         mults.multFV0C += amplitude;
       }
     }


### PR DESCRIPTION
In the original code a temporary iterator to fv0a/fv0c is created and immediately discarded, leaving the result of `amplitude()` (which is a span, a non-owning view) a with dangling references to the internals of the iterator. This worked by accident, since the underlying array in shared memory is available regardless, but can potentially lead to problems. Switching from `gsl::span` to the `std::span` (PR https://github.com/AliceO2Group/AliceO2/pull/14421) makes the original code fail to compile. 

@ddobrigk @ktf 