### PR TITLE
[PWGDQ] Fix for invalid cursor call with 8 arguments instead of 9

### DIFF
--- a/PWGDQ/Tasks/dqEfficiency_withAssoc.cxx
+++ b/PWGDQ/Tasks/dqEfficiency_withAssoc.cxx
@@ -2077,7 +2077,7 @@ struct AnalysisSameEventPairing {
               fHistMan->FillHistClass(Form("MCTruthGenPair_%s", sig->GetName()), VarManager::fgValues);
               if (useMiniTree.fConfigMiniTree) {
                 // WARNING! To be checked
-                dileptonMiniTreeGen(mcDecision, -999, t1.pt(), t1.eta(), t1.phi(), t2.pt(), t2.eta(), t2.phi());
+                dileptonMiniTreeGen(mcDecision, -999, VarManager::fgValues[VarManager::kCentFT0C], t1.pt(), t1.eta(), t1.phi(), t2.pt(), t2.eta(), t2.phi());
               }
             }
             isig++;


### PR DESCRIPTION
The O2 PR https://github.com/AliceO2Group/AliceO2/pull/14421 adds sanity check for the table filling cursor and it fails in `PWGDQ/Tasks/dqEfficiency_withAssoc.cxx`:2080 - the filling call has 8 arguments while the table has 9 columns. From the context I assume that the centrality value was missing. Could you please verify that this is a correct fix? Thank you.