### PR TITLE
[PWGHF] Remove need for extended pt column in B -> J/Psi workflow

### DIFF
--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -215,6 +215,12 @@ DECLARE_SOA_DYNAMIC_COLUMN(EtaProng2, etaProng2, //!
                            [](float pxProng2, float pyProng2, float pzProng2) -> float { return RecoDecay::eta(std::array<float, 3>{pxProng2, pyProng2, pzProng2}); });
 } // namespace hf_track_vars_reduced
 
+namespace hf_b_to_jpsi_track_vars_reduced
+{
+DECLARE_SOA_DYNAMIC_COLUMN(Pt, pt, //! transverse momentum
+                           [](float signed1Pt) -> float { return std::abs(signed1Pt) <= o2::constants::math::Almost0 ? o2::constants::math::VeryBig : 1.f / std::abs(signed1Pt); });
+} // namespace hf_b_to_jpsi_track_vars_reduced
+
 namespace hf_track_pid_reduced
 {
 DECLARE_SOA_COLUMN(TPCNSigmaPiProng0, tpcNSigmaPiProng0, float); //! NsigmaTPCPi for prong0, o2-linter: disable=name/o2-column (written to disk)
@@ -288,6 +294,7 @@ DECLARE_SOA_TABLE(HfRedBach0Bases, "AOD", "HFREDBACH0BASE", //! Table with track
                   hf_track_index_reduced::TrackId,
                   hf_track_index_reduced::HfRedCollisionId,
                   HFTRACKPAR_COLUMNS,
+                  hf_b_to_jpsi_track_vars_reduced::Pt<aod::track::Signed1Pt>,
                   hf_track_vars_reduced::ItsNCls,
                   hf_track_vars_reduced::TpcNClsCrossedRows,
                   hf_track_vars_reduced::TpcChi2NCl,
@@ -318,6 +325,7 @@ DECLARE_SOA_TABLE(HfRedBach1Bases, "AOD", "HFREDBACH1BASE", //! Table with track
                   hf_track_index_reduced::TrackId,
                   hf_track_index_reduced::HfRedCollisionId,
                   HFTRACKPAR_COLUMNS,
+                  hf_b_to_jpsi_track_vars_reduced::Pt<aod::track::Signed1Pt>,
                   hf_track_vars_reduced::ItsNCls,
                   hf_track_vars_reduced::TpcNClsCrossedRows,
                   hf_track_vars_reduced::TpcChi2NCl,
@@ -358,8 +366,8 @@ DECLARE_SOA_EXTENDED_TABLE_USER(HfRedBach1Ext, HfRedBach1Bases, "HFREDBACH1EXT",
                                 aod::track::Pt);
 
 using HfRedTracks = HfRedTracksExt;
-using HfRedBach0Tracks = HfRedBach0Ext;
-using HfRedBach1Tracks = HfRedBach1Ext;
+using HfRedBach0Tracks = HfRedBach0Bases;
+using HfRedBach1Tracks = HfRedBach1Bases;
 
 namespace hf_charm_cand_reduced
 {

--- a/PWGHF/D2H/TableProducer/candidateCreatorBToJpsiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorBToJpsiReduced.cxx
@@ -421,8 +421,6 @@ struct HfCandidateCreatorBToJpsiReduced {
 struct HfCandidateCreatorBToJpsiReducedExpressions {
   Spawns<aod::HfCandBpJPExt> rowCandidateBPlus;
   Spawns<aod::HfCandBsJPExt> rowCandidateBs;
-  Spawns<aod::HfRedBach0Ext> rowTracksExt0;
-  Spawns<aod::HfRedBach1Ext> rowTracksExt1;
   Produces<aod::HfMcRecRedBps> rowBplusMcRec;
   Produces<aod::HfMcRecRedBss> rowBsMcRec;
 

--- a/PWGHF/D2H/Tasks/taskBplusToJpsiKReduced.cxx
+++ b/PWGHF/D2H/Tasks/taskBplusToJpsiKReduced.cxx
@@ -275,7 +275,7 @@ struct HfTaskBplusToJpsiKReduced {
     if (doprocessMc || doprocessMcWithBplusMl) {
       registry.add("hPtJpsiGen", mcParticleMatched + "J/#Psi #it{p}_{T}^{gen} (GeV/#it{c}); B^{+} " + stringPt, {HistType::kTH2F, {axisPtProng, axisPtB}});
       registry.add("hPtKGen", mcParticleMatched + "Kaon #it{p}_{T}^{gen} (GeV/#it{c}); B^{+} " + stringPt, {HistType::kTH2F, {axisPtProng, axisPtB}});
-      registry.add("hYGenWithProngsInAcceptance", mcParticleMatched + "Kaon #it{p}_{T}^{gen} (GeV/#it{c}); B^{+} " + stringPt, {HistType::kTH2F, {axisPtProng, axisRapidity}});
+      registry.add("hYGenWithProngsInAcceptance", mcParticleMatched + "B^{+} #it{p}_{T}^{gen} (GeV/#it{c}); B^{+} #it{y}", {HistType::kTH2F, {axisPtProng, axisRapidity}});
       registry.add("hMassRecSig", bPlusCandMatch + "inv. mass J/#Psi K^{+} (GeV/#it{c}^{2}); B^{+} " + stringPt, {HistType::kTH2F, {axisMassBplus, axisPtB}});
       registry.add("hMassJpsiRecSig", bPlusCandMatch + "inv. mass #mu^{+}#mu^{#minus} (GeV/#it{c}^{2}); J/#Psi " + stringPt, {HistType::kTH2F, {axisMassJpsi, axisPtJpsi}});
       registry.add("hd0KRecSig", bPlusCandMatch + "Kaon DCAxy to prim. vertex (cm); K^{+} " + stringPt, {HistType::kTH2F, {axisImpactPar, axisPtKa}});

--- a/PWGHF/D2H/Tasks/taskBsToJpsiPhiReduced.cxx
+++ b/PWGHF/D2H/Tasks/taskBsToJpsiPhiReduced.cxx
@@ -298,7 +298,7 @@ struct HfTaskBsToJpsiPhiReduced {
       registry.add("hPtJpsiGen", mcParticleMatched + "J/#Psi #it{p}_{T}^{gen} (GeV/#it{c}); B_{s}^{0} " + stringPt, {HistType::kTH2F, {axisPtProng, axisPtB}});
       registry.add("hPtPhiGen", mcParticleMatched + "#phi #it{p}_{T}^{gen} (GeV/#it{c}); B_{s}^{0} " + stringPt, {HistType::kTH2F, {axisPtProng, axisPtB}});
       registry.add("hPtKGen", mcParticleMatched + "Kaon #it{p}_{T}^{gen} (GeV/#it{c}); B_{s}^{0} " + stringPt, {HistType::kTH2F, {axisPtProng, axisPtB}});
-      registry.add("hYGenWithProngsInAcceptance", mcParticleMatched + "Kaon #it{p}_{T}^{gen} (GeV/#it{c}); B_{s}^{0} " + stringPt, {HistType::kTH2F, {axisPtProng, axisRapidity}});
+      registry.add("hYGenWithProngsInAcceptance", mcParticleMatched + "B_{s}^{0} #it{p}_{T}^{gen} (GeV/#it{c}); B_{s}^{0} #it{y}", {HistType::kTH2F, {axisPtProng, axisRapidity}});
       registry.add("hMassRecSig", bSCandMatch + "inv. mass J/#Psi K^{+} (GeV/#it{c}^{2}); B_{s}^{0} " + stringPt, {HistType::kTH2F, {axisMassBs, axisPtB}});
       registry.add("hMassJpsiRecSig", bSCandMatch + "inv. mass #mu^{+}#mu^{#minus} (GeV/#it{c}^{2}); J/#Psi " + stringPt, {HistType::kTH2F, {axisMassJpsi, axisPtJpsi}});
       registry.add("hMassPhiRecSig", bSCandMatch + "inv. mass K^{+}K^{#minus} (GeV/#it{c}^{2}); #phi " + stringPt, {HistType::kTH2F, {axisMassPhi, axisPtPhi}});


### PR DESCRIPTION
When the B+ workflow is run alone, `Spawns<aod::HfRedBach1Ext> rowTracksExt1;` would cause the workflow to crash (as the B+ decays in J/Psi K and the table for the second LF track is not produced).
This solves the issue as we now use a dynamic column and there is no need to extend the table anymore