### PR TITLE
[PWGHF] Fix issues in correlated bkg matching

### DIFF
--- a/PWGHF/Utils/utilsMcGen.h
+++ b/PWGHF/Utils/utilsMcGen.h
@@ -219,7 +219,7 @@ void fillMcMatchGen3Prong(T const& mcParticles, U const& mcParticlesPerMcColl, V
       // D± → π± K∓ π±
       if (flag == 0) {
         if (RecoDecay::isMatchedMCGen(mcParticles, particle, Pdg::kDPlus, std::array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign, 2)) {
-          flag = sign * (1 << o2::aod::hf_cand_3prong::DecayType::DplusToPiKPi);
+          flag = sign * o2::hf_decay::hf_cand_3prong::DecayChannelMain::DplusToPiKPi;
         }
       }
 
@@ -229,11 +229,11 @@ void fillMcMatchGen3Prong(T const& mcParticles, U const& mcParticlesPerMcColl, V
         if (RecoDecay::isMatchedMCGen(mcParticles, particle, Pdg::kDS, std::array{+kKPlus, -kKPlus, +kPiPlus}, true, &sign, 2)) {
           // DecayType::DsToKKPi is used to flag both Ds± → K± K∓ π± and D± → K± K∓ π±
           // TODO: move to different and explicit flags
-          flag = sign * (1 << o2::aod::hf_cand_3prong::DecayType::DsToKKPi);
+          flag = sign * o2::hf_decay::hf_cand_3prong::DecayChannelMain::DsToPiKK;
         } else if (RecoDecay::isMatchedMCGen(mcParticles, particle, Pdg::kDPlus, std::array{+kKPlus, -kKPlus, +kPiPlus}, true, &sign, 2)) {
           // DecayType::DsToKKPi is used to flag both Ds± → K± K∓ π± and D± → K± K∓ π±
           // TODO: move to different and explicit flags
-          flag = sign * (1 << o2::aod::hf_cand_3prong::DecayType::DsToKKPi);
+          flag = sign * o2::hf_decay::hf_cand_3prong::DecayChannelMain::DplusToPiKK;
           isDplus = true;
         }
         if (flag != 0) {
@@ -244,9 +244,9 @@ void fillMcMatchGen3Prong(T const& mcParticles, U const& mcParticlesPerMcColl, V
               arrPDGDaugh[jProng] = std::abs(daughJ.pdgCode());
             }
             if ((arrPDGDaugh[0] == arrPDGResonantDPhiPi[0] && arrPDGDaugh[1] == arrPDGResonantDPhiPi[1]) || (arrPDGDaugh[0] == arrPDGResonantDPhiPi[1] && arrPDGDaugh[1] == arrPDGResonantDPhiPi[0])) {
-              channel = isDplus ? o2::aod::hf_cand_3prong::DecayChannelDToKKPi::DplusToPhiPi : o2::aod::hf_cand_3prong::DecayChannelDToKKPi::DsToPhiPi;
+              channel = isDplus ? o2::hf_decay::hf_cand_3prong::DecayChannelResonant::DplusToPhiPi : o2::hf_decay::hf_cand_3prong::DecayChannelResonant::DsToPhiPi;
             } else if ((arrPDGDaugh[0] == arrPDGResonantDKstarK[0] && arrPDGDaugh[1] == arrPDGResonantDKstarK[1]) || (arrPDGDaugh[0] == arrPDGResonantDKstarK[1] && arrPDGDaugh[1] == arrPDGResonantDKstarK[0])) {
-              channel = isDplus ? o2::aod::hf_cand_3prong::DecayChannelDToKKPi::DplusToK0starK : o2::aod::hf_cand_3prong::DecayChannelDToKKPi::DsToK0starK;
+              channel = isDplus ? o2::hf_decay::hf_cand_3prong::DecayChannelResonant::DplusToKstar0K : o2::hf_decay::hf_cand_3prong::DecayChannelResonant::DsToKstar0K;
             }
           }
         }

--- a/PWGHF/Utils/utilsMcMatching.h
+++ b/PWGHF/Utils/utilsMcMatching.h
@@ -57,8 +57,8 @@ namespace hf_cand_3prong
 
 // D±
 static const std::unordered_map<DecayChannelMain, const std::vector<int>> daughtersDplusMain{
-  {DecayChannelMain::DplusToPiKPi, {+kKMinus, +kKPlus, +kPiPlus}},
-  {DecayChannelMain::DplusToPiKK, {+kKMinus, +kPiPlus, +kPiPlus}},
+  {DecayChannelMain::DplusToPiKPi, {+kKMinus, +kPiPlus, +kPiPlus}},
+  {DecayChannelMain::DplusToPiKK, {+kKMinus, +kKPlus, +kPiPlus}},
   {DecayChannelMain::DplusToPiKPiPi0, {+kKMinus, +kPiPlus, +kPiPlus, +kPi0}},
   {DecayChannelMain::DplusToPiPiPi, {+kPiMinus, +kPiPlus, +kPiPlus}},
 };
@@ -66,7 +66,7 @@ static const std::unordered_map<DecayChannelMain, const std::vector<int>> daught
 static const std::unordered_map<DecayChannelResonant, const std::array<int, 2>> daughtersDplusResonant{
   {DecayChannelResonant::DplusToPhiPi, {+o2::constants::physics::kPhi, +kPiPlus}},
   {DecayChannelResonant::DplusToKstar0K, {-o2::constants::physics::kK0Star892, +kKPlus}},
-  {DecayChannelResonant::DplusToKstar1430_0K, {+10311, +kKPlus}},
+  {DecayChannelResonant::DplusToKstar1430_0K, {-10311, +kKPlus}},
   {DecayChannelResonant::DplusToRho0Pi, {+kRho770_0, +kPiPlus}},
   {DecayChannelResonant::DplusToF2_1270Pi, {+225, +kPiPlus}},
 };
@@ -110,7 +110,7 @@ static const std::unordered_map<DecayChannelResonant, const std::array<int, 2>> 
   {DecayChannelResonant::DstarToD0ToKstarPi, {-o2::constants::physics::kKPlusStar892, +kPiPlus}},
   {DecayChannelResonant::DstarToDplusToPhiPi, {+o2::constants::physics::kPhi, +kPiPlus}},
   {DecayChannelResonant::DstarToDplusToKstar0K, {-o2::constants::physics::kK0Star892, +kKPlus}},
-  {DecayChannelResonant::DstarToDplusToKstar1430_0K, {+10311, +kKPlus}},
+  {DecayChannelResonant::DstarToDplusToKstar1430_0K, {-10311, +kKPlus}},
   {DecayChannelResonant::DstarToDplusToRho0Pi, {+kRho770_0, +kPiPlus}},
   {DecayChannelResonant::DstarToDplusToF2_1270Pi, {+225, +kPiPlus}},
 };
@@ -123,7 +123,7 @@ static const std::unordered_map<DecayChannelMain, const std::vector<int>> daught
   {DecayChannelMain::LcToPKK, {+kProton, +kKMinus, +kKPlus}}};
 
 static const std::unordered_map<DecayChannelResonant, const std::array<int, 2>> daughtersLcResonant{
-  {DecayChannelResonant::LcToPKstar0, {+o2::constants::physics::kK0Star892, +kProton}},
+  {DecayChannelResonant::LcToPKstar0, {-o2::constants::physics::kK0Star892, +kProton}},
   {DecayChannelResonant::LcToDeltaplusplusK, {+2224, +kKMinus}},
   {DecayChannelResonant::LcToL1520Pi, {+102134, +kPiPlus}},
 };


### PR DESCRIPTION
In this PR, two issues introduced in PR #11418 are fixed:
- Wrong PDG codes in `utilsMcMatching.h`
- Restore new flags for D+ and Ds in `utilsMcGen.h` 