### PR TITLE
PWGUD - Added RCT flags to UD tables

### DIFF
--- a/PWGUD/Core/SGSelector.h
+++ b/PWGUD/Core/SGSelector.h
@@ -12,13 +12,19 @@
 #ifndef PWGUD_CORE_SGSELECTOR_H_
 #define PWGUD_CORE_SGSELECTOR_H_
 
-#include <cmath>
+#include "PWGUD/Core/SGCutParHolder.h"
+#include "PWGUD/Core/UDHelpers.h"
+
+#include "Common/CCDB/RCTSelectionFlags.h"
+
+#include "Framework/AnalysisTask.h"
+#include "Framework/Logger.h"
+
 #include "TDatabasePDG.h"
 #include "TLorentzVector.h"
-#include "Framework/Logger.h"
-#include "Framework/AnalysisTask.h"
-#include "PWGUD/Core/UDHelpers.h"
-#include "PWGUD/Core/SGCutParHolder.h"
+
+#include <cmath>
+using namespace o2::aod::rctsel;
 
 template <typename BC>
 struct SelectionResult {
@@ -29,7 +35,7 @@ struct SelectionResult {
 class SGSelector
 {
  public:
-  SGSelector() : fPDG(TDatabasePDG::Instance()) {}
+  SGSelector() : fPDG(TDatabasePDG::Instance()), myRCTChecker{"CBT"}, myRCTCheckerHadron{"CBT_hadronPID"}, myRCTCheckerZDC{"CBT", true}, myRCTCheckerHadronZDC{"CBT_hadronPID", true} {}
 
   template <typename CC, typename BCs, typename TCs, typename FWs>
   int Print(SGCutParHolder /*diffCuts*/, CC& collision, BCs& /*bcRange*/, TCs& /*tracks*/, FWs& /*fwdtracks*/)
@@ -146,8 +152,48 @@ class SGSelector
     return true_gap;
   }
 
+  // check CBT flags
+  template <typename CC>
+  bool isCBTOk(CC& collision)
+  {
+    if (myRCTChecker(collision))
+      return true;
+    return false;
+  }
+
+  // check CBT+hadronPID flags
+  template <typename CC>
+  bool isCBTHadronOk(CC& collision)
+  {
+    if (myRCTCheckerHadron(collision))
+      return true;
+    return false;
+  }
+
+  // check CBT+ZDC flags
+  template <typename CC>
+  bool isCBTZdcOk(CC& collision)
+  {
+    if (myRCTCheckerZDC(collision))
+      return true;
+    return false;
+  }
+
+  // check CBT+hadronPID+ZDC flags
+  template <typename CC>
+  bool isCBTHadronZdcOk(CC& collision)
+  {
+    if (myRCTCheckerHadronZDC(collision))
+      return true;
+    return false;
+  }
+
  private:
   TDatabasePDG* fPDG;
+  RCTFlagsChecker myRCTChecker;
+  RCTFlagsChecker myRCTCheckerHadron;
+  RCTFlagsChecker myRCTCheckerZDC;
+  RCTFlagsChecker myRCTCheckerHadronZDC;
 };
 
 #endif // PWGUD_CORE_SGSELECTOR_H_

--- a/PWGUD/DataModel/UDTables.h
+++ b/PWGUD/DataModel/UDTables.h
@@ -8,18 +8,29 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
+//
+/// \file UDTables.h
+/// \brief Defines tables and colums for derived data used by UD group
+/// \author Paul Buhler <paul.buhler@cern.ch>, Wiena
+/// \since  January 2023
+/// \author Sasha Bylinkin <sasha.bylinkin@cern.ch>, Bergen
+/// \since  January 2024
+/// \author Adam Matyja <adam.tomasz.matyja@cern.ch>, INP PAN Krakow, Poland
+/// \since  May 2025
 
 #ifndef PWGUD_DATAMODEL_UDTABLES_H_
 #define PWGUD_DATAMODEL_UDTABLES_H_
 
-#include <vector>
-#include <cmath>
+#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+
 #include "Framework/ASoA.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/DataTypes.h"
 #include "MathUtils/Utils.h"
-#include "Common/DataModel/PIDResponse.h"
-#include "Common/DataModel/TrackSelectionTables.h"
+
+#include <cmath>
+#include <vector>
 
 namespace o2::aod
 {
@@ -111,6 +122,9 @@ DECLARE_SOA_COLUMN(ITSROFb, itsROFb, int);
 DECLARE_SOA_COLUMN(Sbp, sbp, int);
 DECLARE_SOA_COLUMN(ZvtxFT0vPV, zVtxFT0vPV, int);
 DECLARE_SOA_COLUMN(VtxITSTPC, vtxITSTPC, int);
+DECLARE_SOA_COLUMN(Rct_raw, rct_raw, uint32_t); //! run condition table mask
+// information about mask names -> Common/CCDB/RCTSelectionFlags.h
+
 // Gap Side Information
 DECLARE_SOA_COLUMN(GapSide, gapSide, uint8_t); // 0 for side A, 1 for side C, 2 for both sides (or use an enum for better readability)
 // FIT selection flags
@@ -249,6 +263,24 @@ DECLARE_SOA_TABLE_VERSIONED(UDCollisionSelExtras_002, "AOD", "UDCOLSELEXTRA", 2,
                             udcollision::ZvtxFT0vPV,      //! kIsGoodZvtxFT0vsPV
                             udcollision::VtxITSTPC);      //! kIsVertexITSTPC
 
+DECLARE_SOA_TABLE_VERSIONED(UDCollisionSelExtras_003, "AOD", "UDCOLSELEXTRA", 3,
+                            udcollision::ChFT0A,          //! number of active channels in FT0A
+                            udcollision::ChFT0C,          //! number of active channels in FT0C
+                            udcollision::ChFDDA,          //! number of active channels in FDDA
+                            udcollision::ChFDDC,          //! number of active channels in FDDC
+                            udcollision::ChFV0A,          //! number of active channels in FV0A
+                            udcollision::OccupancyInTime, //! Occupancy
+                            udcollision::HadronicRate,    //! Interaction Rate
+                            udcollision::Trs,             //! kNoCollInTimeRangeStandard
+                            udcollision::Trofs,           //! kNoCollInRofStandard
+                            udcollision::Hmpr,            //! kNoHighMultCollInPrevRof
+                            udcollision::TFb,             //! kNoTimeFrameBorder
+                            udcollision::ITSROFb,         //! kNoITSROFrameBorder
+                            udcollision::Sbp,             //! kNoSameBunchPileup
+                            udcollision::ZvtxFT0vPV,      //! kIsGoodZvtxFT0vsPV
+                            udcollision::VtxITSTPC,       //! kIsVertexITSTPC
+                            udcollision::Rct_raw);        //! RCT mask
+
 // central barrel-specific selections
 DECLARE_SOA_TABLE(UDCollisionsSelsCent, "AOD", "UDCOLSELCNT",
                   udcollision::DBcTOR,
@@ -272,7 +304,7 @@ DECLARE_SOA_TABLE(UDMcCollsLabels, "AOD", "UDMCCOLLSLABEL",
                   udcollision::UDMcCollisionId);
 
 using UDCollisions = UDCollisions_001;
-using UDCollisionSelExtras = UDCollisionSelExtras_002;
+using UDCollisionSelExtras = UDCollisionSelExtras_003;
 
 using UDCollision = UDCollisions::iterator;
 using SGCollision = SGCollisions::iterator;

--- a/PWGUD/TableProducer/Converters/CMakeLists.txt
+++ b/PWGUD/TableProducer/Converters/CMakeLists.txt
@@ -1,31 +1,26 @@
-# Copyright 2019-2020 CERN and copyright holders of ALICE O2.
-# See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
-# All rights not expressly granted are reserved.
+#Copyright 2019 - 2020 CERN and copyright holders of ALICE O2.
+#See https: // alice-o2.web.cern.ch/copyright for details of the copyright holders.
+#All rights not expressly granted are reserved.
 #
-# This software is distributed under the terms of the GNU General Public
-# License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+#This software is distributed under the terms of the GNU General Public
+#License v3(GPL Version 3), copied verbatim in the file "COPYING".
 #
-# In applying this license CERN does not waive the privileges and immunities
-# granted to it by virtue of its status as an Intergovernmental Organization
+#In applying this license CERN does not waive the privileges and immunities
+#granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-o2physics_add_dpl_workflow(fwd-tracks-extra-converter
-                           SOURCES UDFwdTracksExtraConverter.cxx
-                           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
-                           COMPONENT_NAME Analysis)
+o2physics_add_dpl_workflow(fwd - tracks - extra - converter SOURCES UDFwdTracksExtraConverter.cxx PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore COMPONENT_NAME Analysis)
 
+  o2physics_add_dpl_workflow(collisions - converter
+                                            SOURCES UDCollisionsConverter.cxx
+                                              PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+                                                COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(collisions-converter
-                           SOURCES UDCollisionsConverter.cxx
-                           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
-                           COMPONENT_NAME Analysis)
+    o2physics_add_dpl_workflow(collisionselextras - converter
+                                                      SOURCES UDCollisionSelExtrasConverter.cxx
+                                                        PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+                                                          COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(collisionselextras-converter
-                           SOURCES UDCollisionSelExtrasConverter.cxx
-                           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
-                           COMPONENT_NAME Analysis)
+      o2physics_add_dpl_workflow(collisionselextras - converter - v002 SOURCES UDCollisionSelExtrasV002Converter.cxx PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(collisionselextras-converter-v002
-        SOURCES UDCollisionSelExtrasV002Converter.cxx
-        PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
-        COMPONENT_NAME Analysis)
+        o2physics_add_dpl_workflow(collisionselextras - converter - v003 SOURCES UDCollisionSelExtrasV003Converter.cxx PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore COMPONENT_NAME Analysis)

--- a/PWGUD/TableProducer/Converters/UDCollisionSelExtrasV003Converter.cxx
+++ b/PWGUD/TableProducer/Converters/UDCollisionSelExtrasV003Converter.cxx
@@ -1,0 +1,126 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file UDCollisionSelExtrasV003Converter.cxx
+/// \brief Converts UDCollisionSelExtras table from version 000 to 003 and 001 to 003 and 002 to 003
+/// \author Adam Matyja <adam.tomasz.matyja@cern.ch>
+
+#include "PWGUD/DataModel/UDTables.h"
+
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/runDataProcessing.h"
+
+using namespace o2;
+using namespace o2::framework;
+
+// Converts UDCollisions for version 000 to 003 and 001 to 003 and 002 to 003
+struct UDCollisionSelExtrasV003Converter {
+  Produces<o2::aod::UDCollisionSelExtras_003> udCollisionSelExtras_003;
+
+  void init(InitContext const&)
+  {
+    if (!doprocessV000ToV003 && !doprocessV001ToV003 && !doprocessV002ToV003) {
+      LOGF(fatal, "Neither processV000ToV003 nor processV001ToV003 nor processV002ToV003 is enabled. Please choose one!");
+    }
+    if ((int)doprocessV000ToV003 + (int)doprocessV001ToV003 + (int)doprocessV002ToV003 > 1) {
+      LOGF(fatal, "More than one among processV000ToV003, processV001ToV003, processV002ToV003 is enabled. Please choose only one!");
+    }
+  }
+
+  void processV000ToV003(o2::aod::UDCollisionSelExtras_000 const& collisions)
+  {
+
+    for (const auto& collision : collisions) {
+
+      udCollisionSelExtras_003(collision.chFT0A(),
+                               collision.chFT0C(),
+                               collision.chFDDA(),
+                               collision.chFDDC(),
+                               collision.chFV0A(),
+                               0,    // dummy occupancy
+                               0.0f, // dummy rate
+                               0,    // dummy trs
+                               0,    // dummy trofs
+                               0,    // dummy hmpr
+                               0,    // dummy tfb
+                               0,    // dummy itsROFb
+                               0,    // dummy sbp
+                               0,    // dummy zVtxFT0vPV
+                               0,    // dummy vtxITSTPC
+                               0);   // dummy rct_raw
+    }
+  }
+  PROCESS_SWITCH(UDCollisionSelExtrasV003Converter, processV000ToV003, "process v000-to-v003 conversion", false);
+
+  void processV001ToV003(o2::aod::UDCollisionSelExtras_001 const& collisions)
+  {
+
+    for (const auto& collision : collisions) {
+
+      udCollisionSelExtras_003(collision.chFT0A(),
+                               collision.chFT0C(),
+                               collision.chFDDA(),
+                               collision.chFDDC(),
+                               collision.chFV0A(),
+                               collision.occupancyInTime(),
+                               collision.hadronicRate(),
+                               collision.trs(),
+                               collision.trofs(),
+                               collision.hmpr(),
+                               0,  // dummy tfb
+                               0,  // dummy itsROFb
+                               0,  // dummy sbp
+                               0,  // dummy zVtxFT0vPV
+                               0,  // dummy vtxITSTPC
+                               0); // dummy rct_raw
+    }
+  }
+  PROCESS_SWITCH(UDCollisionSelExtrasV003Converter, processV001ToV003, "process v001-to-v003 conversion", false);
+
+  void processV002ToV003(o2::aod::UDCollisionSelExtras_002 const& collisions)
+  {
+
+    for (const auto& collision : collisions) {
+
+      udCollisionSelExtras_003(collision.chFT0A(),
+                               collision.chFT0C(),
+                               collision.chFDDA(),
+                               collision.chFDDC(),
+                               collision.chFV0A(),
+                               collision.occupancyInTime(),
+                               collision.hadronicRate(),
+                               collision.trs(),
+                               collision.trofs(),
+                               collision.hmpr(),
+                               collision.tfb(),
+                               collision.itsROFb(),
+                               collision.sbp(),
+                               collision.zVtxFT0vPV(),
+                               collision.vtxITSTPC(),
+                               0); // dummy rct_raw
+    }
+  }
+  PROCESS_SWITCH(UDCollisionSelExtrasV003Converter, processV002ToV003, "process v002-to-v003 conversion", true);
+};
+
+/// Spawn the extended table for UDCollisionSelExtras003 to avoid the call to the internal spawner and a consequent circular dependency
+// struct UDCollisionSelExtrasSpawner {
+//   Spawns<aod::UDCollisionSelExtras_003> udCollisionSelExtras_003;
+// };
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<UDCollisionSelExtrasV003Converter>(cfgc),
+    //    adaptAnalysisTask<UDCollisionSelExtrasSpawner>(cfgc),
+  };
+}

--- a/PWGUD/TableProducer/DGCandProducer.cxx
+++ b/PWGUD/TableProducer/DGCandProducer.cxx
@@ -12,20 +12,23 @@
 // \brief Saves relevant information of DG candidates
 // \author Paul Buehler, paul.buehler@oeaw.ac.at
 
-#include <vector>
-#include <string>
-#include <map>
-#include "Framework/runDataProcessing.h"
-#include "Framework/AnalysisTask.h"
-#include "Framework/HistogramRegistry.h"
-#include "ReconstructionDataFormats/Vertex.h"
+#include "PWGUD/Core/DGSelector.h"
+#include "PWGUD/Core/UPCHelpers.h"
+#include "PWGUD/DataModel/UDTables.h"
+
+#include "Common/CCDB/ctpRateFetcher.h"
 #include "EventFiltering/Zorro.h"
 #include "EventFiltering/ZorroSummary.h"
+
 #include "CCDB/BasicCCDBManager.h"
-#include "Common/CCDB/ctpRateFetcher.h"
-#include "PWGUD/DataModel/UDTables.h"
-#include "PWGUD/Core/UPCHelpers.h"
-#include "PWGUD/Core/DGSelector.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/HistogramRegistry.h"
+#include "Framework/runDataProcessing.h"
+#include "ReconstructionDataFormats/Vertex.h"
+
+#include <map>
+#include <string>
+#include <vector>
 
 using namespace o2;
 using namespace o2::framework;
@@ -354,7 +357,7 @@ struct DGCandProducer {
                            fitInfo.BBFT0Apf, fitInfo.BBFT0Cpf, fitInfo.BGFT0Apf, fitInfo.BGFT0Cpf,
                            fitInfo.BBFV0Apf, fitInfo.BGFV0Apf,
                            fitInfo.BBFDDApf, fitInfo.BBFDDCpf, fitInfo.BGFDDApf, fitInfo.BGFDDCpf);
-      outputCollisionSelExtras(chFT0A, chFT0C, chFDDA, chFDDC, chFV0A, occ, ir, trs, trofs, hmpr, tfb, itsROFb, sbp, zVtxFT0vPv, vtxITSTPC);
+      outputCollisionSelExtras(chFT0A, chFT0C, chFDDA, chFDDC, chFV0A, occ, ir, trs, trofs, hmpr, tfb, itsROFb, sbp, zVtxFT0vPv, vtxITSTPC, collision.rct_raw());
       outputCollsLabels(collision.globalIndex());
 
       // update DGTracks tables

--- a/PWGUD/TableProducer/SGCandProducer.cxx
+++ b/PWGUD/TableProducer/SGCandProducer.cxx
@@ -14,38 +14,43 @@
 ///
 /// \author Alexander Bylinkin <roman.lavicka@cern.ch>, Uniersity of Bergen
 /// \since  23.11.2023
+/// \author Adam Matyja <adam.tomasz.matyja@cern.ch>, INP PAN Krakow, Poland
+/// \since  May 2025
 //
 
-#include <cmath>
-#include <vector>
-#include <string>
-#include <map>
-#include "CCDB/BasicCCDBManager.h"
-#include "Framework/ASoA.h"
-#include "Framework/AnalysisDataModel.h"
-#include "ReconstructionDataFormats/Vertex.h"
-#include "CommonConstants/LHCConstants.h"
-#include "DataFormatsFIT/Triggers.h"
-#include "DataFormatsParameters/GRPMagField.h"
-#include "DataFormatsParameters/GRPObject.h"
-#include "DataFormatsParameters/GRPLHCIFData.h"
-#include "DataFormatsParameters/AggregatedRunInfo.h"
+#include "PWGUD/Core/SGSelector.h"
+#include "PWGUD/Core/UPCHelpers.h"
+#include "PWGUD/DataModel/UDTables.h"
 
-#include "Framework/AnalysisTask.h"
-#include "Framework/ASoAHelpers.h"
-#include "Framework/HistogramRegistry.h"
-#include "Framework/runDataProcessing.h"
 #include "Common/CCDB/EventSelectionParams.h"
 #include "Common/CCDB/ctpRateFetcher.h"
 #include "Common/DataModel/EventSelection.h"
-#include "PWGUD/DataModel/UDTables.h"
-#include "PWGUD/Core/UPCHelpers.h"
-#include "PWGUD/Core/SGSelector.h"
+
+#include "CCDB/BasicCCDBManager.h"
+#include "CommonConstants/LHCConstants.h"
+#include "DataFormatsFIT/Triggers.h"
+#include "DataFormatsParameters/AggregatedRunInfo.h"
+#include "DataFormatsParameters/GRPLHCIFData.h"
+#include "DataFormatsParameters/GRPMagField.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "Framework/ASoA.h"
+#include "Framework/ASoAHelpers.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/HistogramRegistry.h"
+#include "Framework/runDataProcessing.h"
+#include "ReconstructionDataFormats/Vertex.h"
+
+#include <cmath>
+#include <map>
+#include <string>
+#include <vector>
 
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::dataformats;
+using namespace o2::aod::rctsel;
 
 #define getHist(type, name) std::get<std::shared_ptr<type>>(histPointers[name])
 
@@ -80,6 +85,9 @@ struct SGCandProducer {
   Configurable<bool> ITSTPCVertex{"ITSTPCVertex", true, "reject ITS-only vertex"}; // if one wants to look at Single Gap pp events
   Configurable<std::vector<int>> generatorIds{"generatorIds", std::vector<int>{-1}, "MC generatorIds to process"};
 
+  Configurable<bool> isGoodRCTCollision{"isGoodRCTCollision", true, "Check RCT flags for FT0,ITS,TPC and tracking"};
+  Configurable<bool> isGoodRCTZdc{"isGoodRCTZdc", false, "Check RCT flags for ZDC if present in run"};
+
   // Configurables to decide which tables are filled
   Configurable<bool> fillTrackTables{"fillTrackTables", true, "Fill track tables"};
   Configurable<bool> fillFwdTrackTables{"fillFwdTrackTables", true, "Fill forward track tables"};
@@ -87,6 +95,9 @@ struct SGCandProducer {
   //  SG selector
   SGSelector sgSelector;
   ctpRateFetcher mRateFetcher;
+
+  // initialize RCT flag checker
+  RCTFlagsChecker myRCTChecker{"CBT"};
 
   // data tables
   Produces<aod::SGCollisions> outputSGCollisions;
@@ -303,6 +314,18 @@ struct SGCandProducer {
       return;
     }
     getHist(TH1, histdir + "/Stat")->Fill(6., 1.);
+    // RCT CBT for collision check
+    if (isGoodRCTCollision && !myRCTChecker(collision)) {
+      return;
+    }
+    getHist(TH1, histdir + "/Stat")->Fill(7., 1.);
+    // RCT CBT+ZDC for collision check
+    if (isGoodRCTZdc && !myRCTChecker(collision)) {
+      return;
+    }
+    getHist(TH1, histdir + "/Stat")->Fill(8., 1.);
+
+    //
     int trs = collision.selection_bit(o2::aod::evsel::kNoCollInTimeRangeStandard) ? 1 : 0;
     int trofs = collision.selection_bit(o2::aod::evsel::kNoCollInRofStandard) ? 1 : 0;
     int hmpr = collision.selection_bit(o2::aod::evsel::kNoHighMultCollInPrevRof) ? 1 : 0;
@@ -331,7 +354,7 @@ struct SGCandProducer {
       if (verboseInfo)
         LOGF(info, "No Newbc %i", bc.globalBC());
     }
-    getHist(TH1, histdir + "/Stat")->Fill(issgevent + 8, 1.);
+    getHist(TH1, histdir + "/Stat")->Fill(issgevent + 10, 1.);
     if (issgevent <= 2) {
       if (verboseInfo)
         LOGF(info, "Current BC: %i, %i, %i", bc.globalBC(), newbc.globalBC(), issgevent);
@@ -363,7 +386,7 @@ struct SGCandProducer {
                            fitInfo.BBFT0Apf, fitInfo.BBFT0Cpf, fitInfo.BGFT0Apf, fitInfo.BGFT0Cpf,
                            fitInfo.BBFV0Apf, fitInfo.BGFV0Apf,
                            fitInfo.BBFDDApf, fitInfo.BBFDDCpf, fitInfo.BGFDDApf, fitInfo.BGFDDCpf);
-      outputCollisionSelExtras(chFT0A, chFT0C, chFDDA, chFDDC, chFV0A, occ, ir, trs, trofs, hmpr, tfb, itsROFb, sbp, zVtxFT0vPv, vtxITSTPC);
+      outputCollisionSelExtras(chFT0A, chFT0C, chFDDA, chFDDC, chFV0A, occ, ir, trs, trofs, hmpr, tfb, itsROFb, sbp, zVtxFT0vPv, vtxITSTPC, collision.rct_raw());
       outputCollsLabels(collision.globalIndex());
       if (newbc.has_zdc()) {
         auto zdc = newbc.zdc();
@@ -427,6 +450,10 @@ struct SGCandProducer {
     }
     if (context.mOptions.get<bool>("processMcData")) {
       histPointers.insert({"MCreco/Stat", registry.add("MCreco/Stat", "Cut statistics; Selection criterion; Collisions", {HistType::kTH1F, {{14, -0.5, 13.5}}})});
+    }
+
+    if (isGoodRCTZdc) {
+      myRCTChecker.init("CBT", true);
     }
   }
 

--- a/PWGUD/TableProducer/UPCCandidateProducer.cxx
+++ b/PWGUD/TableProducer/UPCCandidateProducer.cxx
@@ -12,24 +12,27 @@
 /// \author Diana Krupova, diana.krupova@cern.ch
 /// \since 04.06.2024
 
-#include <limits>
-#include <unordered_set>
-#include <utility>
-#include <unordered_map>
-#include <algorithm>
-#include <map>
-#include <vector>
-#include "Framework/runDataProcessing.h"
-#include "Framework/AnalysisTask.h"
-#include "Framework/AnalysisDataModel.h"
-#include "Common/CCDB/EventSelectionParams.h"
-#include "Common/DataModel/EventSelection.h"
-#include "CommonConstants/LHCConstants.h"
-#include "DataFormatsFIT/Triggers.h"
 #include "PWGUD/Core/UPCCutparHolder.h"
 #include "PWGUD/Core/UPCHelpers.h"
 #include "PWGUD/DataModel/UDTables.h"
+
+#include "Common/CCDB/EventSelectionParams.h"
+#include "Common/DataModel/EventSelection.h"
+
+#include "CommonConstants/LHCConstants.h"
+#include "DataFormatsFIT/Triggers.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/runDataProcessing.h"
+
+#include <algorithm>
+#include <limits>
+#include <map>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 using namespace o2::framework;
 using namespace o2::framework::expressions;
@@ -1512,7 +1515,7 @@ struct UpcCandProducer {
                           fitInfo.BBFT0Apf, fitInfo.BBFT0Cpf, fitInfo.BGFT0Apf, fitInfo.BGFT0Cpf,
                           fitInfo.BBFV0Apf, fitInfo.BGFV0Apf,
                           fitInfo.BBFDDApf, fitInfo.BBFDDCpf, fitInfo.BGFDDApf, fitInfo.BGFDDCpf);
-      eventCandidatesSelExtras(chFT0A, chFT0C, chFDDA, chFDDC, chFV0A, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+      eventCandidatesSelExtras(chFT0A, chFT0C, chFDDA, chFDDC, chFV0A, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
       eventCandidatesSelsFwd(fitInfo.distClosestBcV0A,
                              fitInfo.distClosestBcT0A,
                              amplitudesT0A,
@@ -1828,7 +1831,7 @@ struct UpcCandProducer {
                           fitInfo.BBFT0Apf, fitInfo.BBFT0Cpf, fitInfo.BGFT0Apf, fitInfo.BGFT0Cpf,
                           fitInfo.BBFV0Apf, fitInfo.BGFV0Apf,
                           fitInfo.BBFDDApf, fitInfo.BBFDDCpf, fitInfo.BGFDDApf, fitInfo.BGFDDCpf);
-      eventCandidatesSelExtras(chFT0A, chFT0C, chFDDA, chFDDC, chFV0A, 0, 0, trs, trofs, hmpr, tfb, itsROFb, sbp, zVtxFT0vPv, vtxITSTPC);
+      eventCandidatesSelExtras(chFT0A, chFT0C, chFDDA, chFDDC, chFV0A, 0, 0, trs, trofs, hmpr, tfb, itsROFb, sbp, zVtxFT0vPv, vtxITSTPC, 0);
       eventCandidatesSelsFwd(fitInfo.distClosestBcV0A,
                              fitInfo.distClosestBcT0A,
                              amplitudesT0A,


### PR DESCRIPTION
Added rct_raw variable to UD tables (RCT based flags for each collision)
New converter V003 for UDCCollisionsSelEvents added + CMakeList
New column added to SGCandProducer + configurables
DGCandProducer and UPCCandidateProducer adopted
Predefined function to select CBT or CBT_hadronPID or the same with ZDC from RCT