### PR TITLE
[PWGCF/FemtoUniverse] Fix: do swapping also for same particles

### DIFF
--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackExtended.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackExtended.cxx
@@ -567,7 +567,12 @@ struct FemtoUniversePairTaskTrackTrackExtended {
           weight *= effCorrection.getWeight(ParticleNo::TWO, p2);
         }
 
-        sameEventCont.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D, weight);
+        if (swpart)
+          sameEventCont.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D, weight);
+        else
+          sameEventCont.setPair<isMC>(p2, p1, multCol, twotracksconfigs.confUse3D, weight);
+
+        swpart = !swpart;
       }
     }
   }


### PR DESCRIPTION
This PR adds missing swapping for case when `confIsSame` is true.