### PR TITLE
[Common,PWGUD,PWGLF,PWGHF] DPL Analysis: fix for reworked column getters

### DIFF
--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -1363,7 +1363,7 @@ struct LumiTask {
     const char* srun = Form("%d", run);
 
     for (const auto& bc : bcs) {
-      auto& selection = bc.selection_raw();
+      auto selection = bc.selection_raw();
       if (bcPatternB[bc.globalBC() % nBCsPerOrbit] == 0) // skip non-colliding bcs
         continue;
 

--- a/PWGHF/TableProducer/candidateCreatorXicToXiPiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXicToXiPiPi.cxx
@@ -505,7 +505,7 @@ struct HfCandidateCreatorXicToXiPiPi {
       // create KFParticle
       KFParticle kfXi;
       float massXi = casc.mXi();
-      kfXi.Create(parPosMom, casc.kfTrackCovMat(), casc.sign(), massXi);
+      kfXi.Create(parPosMom, casc.kfTrackCovMat().data(), casc.sign(), massXi);
       if (useXiMassConstraint) {
         kfXi.SetNonlinearMassConstraint(MassXiMinus);
       }

--- a/PWGHF/TableProducer/derivedDataCreatorB0ToDPi.cxx
+++ b/PWGHF/TableProducer/derivedDataCreatorB0ToDPi.cxx
@@ -124,7 +124,7 @@ struct HfDerivedDataCreatorB0ToDPi {
 
   template <typename T, typename U, typename V>
   void fillTablesCandidate(const T& candidate, const U& prongCharm, const V& prongBachelor, int candFlag, double invMass,
-                           double ct, double y, int8_t flagMc, int8_t origin, float mlScore, const std::vector<float>& mlScoresCharm)
+                           double ct, double y, int8_t flagMc, int8_t origin, float mlScore, std::vector<float>& mlScoresCharm)
   {
     rowsCommon.fillTablesCandidate(candidate, invMass, y);
     if (fillCandidatePar) {

--- a/PWGHF/TableProducer/derivedDataCreatorBplusToD0Pi.cxx
+++ b/PWGHF/TableProducer/derivedDataCreatorBplusToD0Pi.cxx
@@ -124,7 +124,7 @@ struct HfDerivedDataCreatorBplusToD0Pi {
 
   template <typename T, typename U, typename V>
   void fillTablesCandidate(const T& candidate, const U& prongCharm, const V& prongBachelor, int candFlag, double invMass,
-                           double ct, double y, int8_t flagMc, int8_t origin, float mlScore, const std::vector<float>& mlScoresCharm)
+                           double ct, double y, int8_t flagMc, int8_t origin, float mlScore, std::vector<float>& mlScoresCharm)
   {
     rowsCommon.fillTablesCandidate(candidate, invMass, y);
     if (fillCandidatePar) {

--- a/PWGHF/TableProducer/derivedDataCreatorD0ToKPi.cxx
+++ b/PWGHF/TableProducer/derivedDataCreatorD0ToKPi.cxx
@@ -136,7 +136,7 @@ struct HfDerivedDataCreatorD0ToKPi {
 
   template <typename T>
   void fillTablesCandidate(const T& candidate, int candFlag, double invMass, double cosThetaStar, double topoChi2,
-                           double ct, double y, int8_t flagMc, int8_t origin, const std::vector<float>& mlScores)
+                           double ct, double y, int8_t flagMc, int8_t origin, std::vector<float>& mlScores)
   {
     rowsCommon.fillTablesCandidate(candidate, invMass, y);
     if (fillCandidatePar) {

--- a/PWGHF/TableProducer/derivedDataCreatorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/derivedDataCreatorDplusToPiKPi.cxx
@@ -117,7 +117,7 @@ struct HfDerivedDataCreatorDplusToPiKPi {
 
   template <typename T>
   void fillTablesCandidate(const T& candidate, int candFlag, double invMass,
-                           double ct, double y, int8_t flagMc, int8_t origin, int8_t swapping, int8_t flagDecayChan, const std::vector<float>& mlScores)
+                           double ct, double y, int8_t flagMc, int8_t origin, int8_t swapping, int8_t flagDecayChan, std::vector<float>& mlScores)
   {
     rowsCommon.fillTablesCandidate(candidate, invMass, y);
     if (fillCandidatePar) {

--- a/PWGHF/TableProducer/derivedDataCreatorDstarToD0Pi.cxx
+++ b/PWGHF/TableProducer/derivedDataCreatorDstarToD0Pi.cxx
@@ -113,7 +113,7 @@ struct HfDerivedDataCreatorDstarToD0Pi {
 
   template <typename T, typename U>
   void fillTablesCandidate(const T& candidate, const U& prong0, const U& prong1, const U& prongSoftPi, int candFlag, double invMass,
-                           double y, int8_t flagMc, int8_t origin, const std::vector<float>& mlScores)
+                           double y, int8_t flagMc, int8_t origin, std::vector<float>& mlScores)
   {
     rowsCommon.fillTablesCandidate(candidate, invMass, y);
     if (fillCandidatePar) {

--- a/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/derivedDataCreatorLcToPKPi.cxx
@@ -117,7 +117,7 @@ struct HfDerivedDataCreatorLcToPKPi {
 
   template <typename T>
   void fillTablesCandidate(const T& candidate, int candFlag, double invMass,
-                           double ct, double y, int8_t flagMc, int8_t origin, int8_t swapping, const std::vector<float>& mlScores)
+                           double ct, double y, int8_t flagMc, int8_t origin, int8_t swapping, std::vector<float>& mlScores)
   {
     rowsCommon.fillTablesCandidate(candidate, invMass, y);
     if (fillCandidatePar) {

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -1183,11 +1183,11 @@ DECLARE_SOA_COLUMN(BachX, bachX, float); //! bachelor track X at min
 // REGULAR COLUMNS FOR CASCCOVS
 // Saved from finding: covariance matrix of parent track (on request)
 DECLARE_SOA_DYNAMIC_COLUMN(PositionCovMat, positionCovMat, //! for transparent handling
-                           [](const float covMat[21]) -> std::vector<float> {
+                           [](std::span<const float> covMat) -> std::vector<float> {
                             std::vector<float> posCovMat { covMat[0], covMat[1], covMat[2], covMat[3], covMat[4], covMat[5] };
                             return posCovMat; });
 DECLARE_SOA_DYNAMIC_COLUMN(MomentumCovMat, momentumCovMat, //! for transparent handling
-                           [](const float covMat[21]) -> std::vector<float> {
+                           [](std::span<const float> covMat) -> std::vector<float> {
                             std::vector<float> momCovMat { covMat[9], covMat[13], covMat[14], covMat[18], covMat[19], covMat[20] };
                             return momCovMat; });
 DECLARE_SOA_COLUMN(KFTrackCovMat, kfTrackCovMat, float[21]);                 //! covariance matrix elements for KF method (Cascade)

--- a/PWGUD/Core/UDHelpers.h
+++ b/PWGUD/Core/UDHelpers.h
@@ -316,16 +316,14 @@ float FT0AmplitudeC(TFT0 ft0)
 template <typename TFDD>
 float FDDAmplitudeA(TFDD fdd)
 {
-  std::vector<int16_t> ampsA(fdd.chargeA(), fdd.chargeA() + 8);
-  return std::accumulate(ampsA.begin(), ampsA.end(), 0);
+  return std::accumulate(fdd.chargeA().begin(), fdd.chargeA().end(), 0);
 }
 
 // -----------------------------------------------------------------------------
 template <typename TFDD>
 float FDDAmplitudeC(TFDD fdd)
 {
-  std::vector<int16_t> ampsC(fdd.chargeC(), fdd.chargeC() + 8);
-  return std::accumulate(ampsC.begin(), ampsC.end(), 0);
+  return std::accumulate(fdd.chargeC().begin(), fdd.chargeC().end(), 0);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Due to changes in how the column getters work made in https://github.com/AliceO2Group/AliceO2/pull/14421 the single-valued columns return an rvalue, while fixed- and variable-size array columns return a span. This requires some small changed throughout O2Physics where these kinds of columns are accessed.