### PR TITLE
TimeDeadMap needs explicit dependence on O2::DataFormatsITSMFT

### DIFF
--- a/Common/TableProducer/CMakeLists.txt
+++ b/Common/TableProducer/CMakeLists.txt
@@ -25,11 +25,13 @@ o2physics_add_dpl_workflow(trackselection
 o2physics_add_dpl_workflow(event-selection
                     SOURCES eventSelection.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCCDB
+                                          O2::DataFormatsITSMFT
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(event-selection-service
                     SOURCES eventSelectionService.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCCDB
+                                          O2::DataFormatsITSMFT
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(multiplicity-table

--- a/DPG/Tasks/AOTEvent/CMakeLists.txt
+++ b/DPG/Tasks/AOTEvent/CMakeLists.txt
@@ -11,7 +11,7 @@
 
 o2physics_add_dpl_workflow(event-selection-qa
                            SOURCES eventSelectionQa.cxx
-                           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::AnalysisCCDB O2::DetectorsBase
+                           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::AnalysisCCDB O2::DetectorsBase O2::DataFormatsITSMFT
                            COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(lumi-qa

--- a/PWGCF/TwoParticleCorrelations/Tasks/CMakeLists.txt
+++ b/PWGCF/TwoParticleCorrelations/Tasks/CMakeLists.txt
@@ -40,7 +40,7 @@ o2physics_add_dpl_workflow(dpt-dpt-efficiency-and-qc
 
 o2physics_add_dpl_workflow(dpt-dpt-per-run-qc
                            SOURCES dptDptPerRunQc.cxx
-                           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::PWGCFCore O2Physics::AnalysisCCDB
+                           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::PWGCFCore O2Physics::AnalysisCCDB O2::DataFormatsITSMFT
                            COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(dpt-dpt-per-run-extra-qc


### PR DESCRIPTION
@vkucera the TimeDeadMap was not meant to be header only, so the CMakeLists should explicitly depend on O2::DataFormatsITSMFT. Once the https://github.com/AliceO2Group/AliceO2/pull/14436 is merged, then the `#include "DataFormatsITSMFT/NoiseMap.h"` can be removed from the O2Phyiscs.