### PR TITLE
[PWGCF] Add process function for Phi and V0s in filter2Prong

### DIFF
--- a/PWGCF/DataModel/CorrelationsDerived.h
+++ b/PWGCF/DataModel/CorrelationsDerived.h
@@ -70,14 +70,12 @@ DECLARE_SOA_COLUMN(Pt, pt, float);                    //! pT (GeV/c)
 DECLARE_SOA_COLUMN(Eta, eta, float);                  //! Pseudorapidity
 DECLARE_SOA_COLUMN(Phi, phi, float);                  //! Phi angle
 DECLARE_SOA_COLUMN(Sign, sign, int8_t);               //! Sign (positive, negative)
-DECLARE_SOA_COLUMN(NsigmaTPCPr, nsigmatpcpr, float);  //! nsigma tpc proton
-DECLARE_SOA_COLUMN(NsigmaTOFPr, nsigmatofpr, float);  //! nsigma tpc proton
 } // namespace cftrack
 DECLARE_SOA_TABLE(CFTracks, "AOD", "CFTRACK", //! Reduced track table
                   o2::soa::Index<>,
                   cftrack::CFCollisionId,
                   cftrack::Pt, cftrack::Eta, cftrack::Phi,
-                  cftrack::Sign, track::TrackType, cftrack::NsigmaTPCPr, cftrack::NsigmaTOFPr);
+                  cftrack::Sign, track::TrackType);
 DECLARE_SOA_TABLE(CFTrackLabels, "AOD", "CFTRACKLABEL", //! Labels for reduced track table
                   cftrack::CFMcParticleId);
 using CFTrack = CFTracks::iterator;
@@ -125,6 +123,7 @@ enum ParticleDecay {
   D0barToKPi,
   JPsiToEE,
   JPsiToMuMu,
+  Generic2Prong,
   PhiToKK,
   K0stoPiPi,
   LambdatoPPi,

--- a/PWGCF/DataModel/CorrelationsDerived.h
+++ b/PWGCF/DataModel/CorrelationsDerived.h
@@ -70,15 +70,14 @@ DECLARE_SOA_COLUMN(Pt, pt, float);                    //! pT (GeV/c)
 DECLARE_SOA_COLUMN(Eta, eta, float);                  //! Pseudorapidity
 DECLARE_SOA_COLUMN(Phi, phi, float);                  //! Phi angle
 DECLARE_SOA_COLUMN(Sign, sign, int8_t);               //! Sign (positive, negative)
-DECLARE_SOA_COLUMN(TPCNsigmaPr, tpcNsigmaPr, float);  //! TPC n-sigma for proton
-DECLARE_SOA_COLUMN(TOFNsigmaPr, tofNsigmaPr, float);  //! TOF n-sigma for proton
+DECLARE_SOA_COLUMN(NsigmaTPCPr, nsigmatpcpr, float);  //! nsigma tpc proton
+DECLARE_SOA_COLUMN(NsigmaTOFPr, nsigmatofpr, float);  //! nsigma tpc proton
 } // namespace cftrack
 DECLARE_SOA_TABLE(CFTracks, "AOD", "CFTRACK", //! Reduced track table
                   o2::soa::Index<>,
                   cftrack::CFCollisionId,
                   cftrack::Pt, cftrack::Eta, cftrack::Phi,
-                  cftrack::Sign, track::TrackType,
-                  cftrack::TPCNsigmaPr, cftrack::TOFNsigmaPr);
+                  cftrack::Sign, track::TrackType, cftrack::NsigmaTPCPr, cftrack::NsigmaTOFPr);
 DECLARE_SOA_TABLE(CFTrackLabels, "AOD", "CFTRACKLABEL", //! Labels for reduced track table
                   cftrack::CFMcParticleId);
 using CFTrack = CFTracks::iterator;

--- a/PWGCF/DataModel/CorrelationsDerived.h
+++ b/PWGCF/DataModel/CorrelationsDerived.h
@@ -123,7 +123,10 @@ enum ParticleDecay {
   D0barToKPi,
   JPsiToEE,
   JPsiToMuMu,
-  Generic2Prong,
+  PhiToKK,
+  K0stoPiPi,
+  LambdatoPPi,
+  AntiLambdatoPiP
 };
 } // namespace cf2prongtrack
 DECLARE_SOA_TABLE(CF2ProngTracks, "AOD", "CF2PRONGTRACK", //! Reduced track table

--- a/PWGCF/DataModel/CorrelationsDerived.h
+++ b/PWGCF/DataModel/CorrelationsDerived.h
@@ -70,12 +70,15 @@ DECLARE_SOA_COLUMN(Pt, pt, float);                    //! pT (GeV/c)
 DECLARE_SOA_COLUMN(Eta, eta, float);                  //! Pseudorapidity
 DECLARE_SOA_COLUMN(Phi, phi, float);                  //! Phi angle
 DECLARE_SOA_COLUMN(Sign, sign, int8_t);               //! Sign (positive, negative)
+DECLARE_SOA_COLUMN(TPCNsigmaPr, tpcNsigmaPr, float);  //! TPC n-sigma for proton
+DECLARE_SOA_COLUMN(TOFNsigmaPr, tofNsigmaPr, float);  //! TOF n-sigma for proton
 } // namespace cftrack
 DECLARE_SOA_TABLE(CFTracks, "AOD", "CFTRACK", //! Reduced track table
                   o2::soa::Index<>,
                   cftrack::CFCollisionId,
                   cftrack::Pt, cftrack::Eta, cftrack::Phi,
-                  cftrack::Sign, track::TrackType);
+                  cftrack::Sign, track::TrackType,
+                  cftrack::TPCNsigmaPr, cftrack::TOFNsigmaPr);
 DECLARE_SOA_TABLE(CFTrackLabels, "AOD", "CFTRACKLABEL", //! Labels for reduced track table
                   cftrack::CFMcParticleId);
 using CFTrack = CFTracks::iterator;

--- a/PWGCF/TableProducer/filter2Prong.cxx
+++ b/PWGCF/TableProducer/filter2Prong.cxx
@@ -44,13 +44,9 @@ struct Filter2Prong {
   O2_DEFINE_CONFIGURABLE(cfgYMax, float, -1.0f, "Maximum candidate rapidity")
   O2_DEFINE_CONFIGURABLE(cfgImPart1Mass, float, o2::constants::physics::MassKPlus, "Daughter particle 1 mass in GeV")
   O2_DEFINE_CONFIGURABLE(cfgImPart2Mass, float, o2::constants::physics::MassKMinus, "Daughter particle 2 mass in GeV")
-  // O2_DEFINE_CONFIGURABLE(cfgImPart1PID, int, o2::track::PID::Kaon, "PID of daughter particle 1 (O2 PID ID)")
-  // O2_DEFINE_CONFIGURABLE(cfgImPart2PID, int, o2::track::PID::Kaon, "PID of daughter particle 2 (O2 PID ID)")
-  O2_DEFINE_CONFIGURABLE(cfgMomDepPID, bool, 1, "Use mommentum dependent PID for Phi meson")
   O2_DEFINE_CONFIGURABLE(cfgImCutPt, float, 0.2f, "Minimal pT for candidates")
   O2_DEFINE_CONFIGURABLE(cfgImMinInvMass, float, 0.95f, "Minimum invariant mass (GeV)")
   O2_DEFINE_CONFIGURABLE(cfgImMaxInvMass, float, 1.07f, "Maximum invariant mass (GeV)")
-  // O2_DEFINE_CONFIGURABLE(cfgImSigmaFormula, std::string, "(z < 0.5 && x < 3.0) || (z >= 0.5 && x < 2.5 && y < 3.0)", "pT dependent daughter track sigma pass condition (x = TPC sigma, y = TOF sigma, z = pT)")
   O2_DEFINE_CONFIGURABLE(cfgDoPhi, bool, false, "Store phi information")
   O2_DEFINE_CONFIGURABLE(cfgDoV0, bool, true, "Store V0s candidates")
   O2_DEFINE_CONFIGURABLE(tpcNClsCrossedRowsTrackMin, float, 70, "Minimum number of crossed rows in TPC")
@@ -62,6 +58,7 @@ struct Filter2Prong {
   O2_DEFINE_CONFIGURABLE(ITSPIDPthreshold, float, 1.0, "Momentum threshold for ITS PID (GeV/c) (only used if ITSPIDSelection is true)")
   O2_DEFINE_CONFIGURABLE(ITSPIDNsigma, float, 3.0, "PID nsigma for ITS")
   O2_DEFINE_CONFIGURABLE(ConfDaughPIDCuts, float, 4.0, "PID nsigma for V0s")
+  O2_DEFINE_CONFIGURABLE(cfgMomDepPID, bool, true, "Use momentum dependent PID cuts for V0s")
   O2_DEFINE_CONFIGURABLE(massK0Min, float, 0.4, "Minimum mass for K0")
   O2_DEFINE_CONFIGURABLE(massK0Max, float, 0.6, "Maximum mass for K0")
   O2_DEFINE_CONFIGURABLE(massLambdaMin, float, 1.0, "Minimum mass for lambda")
@@ -108,12 +105,8 @@ struct Filter2Prong {
   using PIDTrack = soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection, aod::pidTPCPi, aod::pidTPCKa, aod::pidTPCPr, aod::pidTOFPi, aod::pidTOFKa, aod::pidTOFPr, aod::pidTOFbeta>;
   using ResoV0s = aod::V0Datas;
 
-  // std::unique_ptr<TFormula> sigmaFormula;
-
   void init(InitContext&)
   {
-    // if (doprocessDataInvMass)
-    // sigmaFormula = std::make_unique<TFormula>("sigmaFormula", cfgImSigmaFormula.value.c_str());
   }
 
   template <class HFCandidatesType>
@@ -394,6 +387,7 @@ struct Filter2Prong {
         if (removefaketrack && isFakeKaon(p1)) { // Check if the track is a fake kaon
           continue;
         }
+
         for (const auto& cftrack2 : cftracks) {                 // Loop over second track
           if (cftrack2.globalIndex() == cftrack1.globalIndex()) // Skip if it's the same track as the first one
             continue;
@@ -414,6 +408,7 @@ struct Filter2Prong {
           if (!selectionPair(p1, p2)) {
             continue;
           }
+
           ROOT::Math::PtEtaPhiMVector vec1(p1.pt(), p1.eta(), p1.phi(), cfgImPart1Mass);
           ROOT::Math::PtEtaPhiMVector vec2(p2.pt(), p2.eta(), p2.phi(), cfgImPart2Mass);
           ROOT::Math::PtEtaPhiMVector s = vec1 + vec2;

--- a/PWGCF/TableProducer/filter2Prong.cxx
+++ b/PWGCF/TableProducer/filter2Prong.cxx
@@ -44,48 +44,56 @@ struct Filter2Prong {
   O2_DEFINE_CONFIGURABLE(cfgYMax, float, -1.0f, "Maximum candidate rapidity")
   O2_DEFINE_CONFIGURABLE(cfgImPart1Mass, float, o2::constants::physics::MassKPlus, "Daughter particle 1 mass in GeV")
   O2_DEFINE_CONFIGURABLE(cfgImPart2Mass, float, o2::constants::physics::MassKMinus, "Daughter particle 2 mass in GeV")
+  O2_DEFINE_CONFIGURABLE(cfgImPart1PID, int, o2::track::PID::Kaon, "PID of daughter particle 1 (O2 PID ID)")
+  O2_DEFINE_CONFIGURABLE(cfgImPart2PID, int, o2::track::PID::Kaon, "PID of daughter particle 2 (O2 PID ID)")
+  O2_DEFINE_CONFIGURABLE(cfgMomDepPID, bool, 1, "Use mommentum dependent PID for Phi meson")
   O2_DEFINE_CONFIGURABLE(cfgImCutPt, float, 0.2f, "Minimal pT for candidates")
-  O2_DEFINE_CONFIGURABLE(cfgImMinInvMass, float, 0.95f, "Minimum invariant mass (GeV)")
-  O2_DEFINE_CONFIGURABLE(cfgImMaxInvMass, float, 1.07f, "Maximum invariant mass (GeV)")
-  O2_DEFINE_CONFIGURABLE(cfgDoPhi, bool, false, "Store phi information")
-  O2_DEFINE_CONFIGURABLE(cfgDoV0, bool, true, "Store V0s candidates")
-  O2_DEFINE_CONFIGURABLE(tpcNClsCrossedRowsTrackMin, float, 70, "Minimum number of crossed rows in TPC")
-  O2_DEFINE_CONFIGURABLE(etaTrackMax, float, 0.8, "Maximum pseudorapidity")
-  O2_DEFINE_CONFIGURABLE(ptTrackMin, float, 0.1, "Minimum transverse momentum")
-  O2_DEFINE_CONFIGURABLE(cMinV0DCAPr, float, 0.1, "Min V0 proton DCA")
-  O2_DEFINE_CONFIGURABLE(cMinV0DCAPi, float, 0.1, "Min V0 pion DCA")
-  O2_DEFINE_CONFIGURABLE(ITSPIDSelection, bool, true, "PID ITS")
-  O2_DEFINE_CONFIGURABLE(ITSPIDPthreshold, float, 1.0, "Momentum threshold for ITS PID (GeV/c) (only used if ITSPIDSelection is true)")
-  O2_DEFINE_CONFIGURABLE(ITSPIDNsigma, float, 3.0, "PID nsigma for ITS")
-  O2_DEFINE_CONFIGURABLE(ConfDaughPIDCuts, float, 4.0, "PID nsigma for V0s")
-  O2_DEFINE_CONFIGURABLE(cfgMomDepPID, bool, true, "Use momentum dependent PID cuts for V0s")
-  O2_DEFINE_CONFIGURABLE(massK0Min, float, 0.4, "Minimum mass for K0")
-  O2_DEFINE_CONFIGURABLE(massK0Max, float, 0.6, "Maximum mass for K0")
-  O2_DEFINE_CONFIGURABLE(massLambdaMin, float, 1.0, "Minimum mass for lambda")
-  O2_DEFINE_CONFIGURABLE(massLambdaMax, float, 1.3, "Maximum mass for lambda")
-  O2_DEFINE_CONFIGURABLE(massOmegaMin, float, 1.5, "Minimum mass for omega")
-  O2_DEFINE_CONFIGURABLE(massOmegaMax, float, 1.8, "Maximum mass for omega")
-  O2_DEFINE_CONFIGURABLE(interactionRateMin, float, -1, "Minimum interaction rate (kHz)")
-  O2_DEFINE_CONFIGURABLE(interactionRateMax, float, 1.e20, "Maximum interaction rate (kHz)")
-  O2_DEFINE_CONFIGURABLE(radiusMax, float, 2.3, "Maximum decay radius (cm)")
-  O2_DEFINE_CONFIGURABLE(radiusMin, float, 0.0, "Minimum decay radius (cm)")
-  O2_DEFINE_CONFIGURABLE(cosPaMin, float, 0.98, "Minimum cosine of pointing angle")
-  O2_DEFINE_CONFIGURABLE(dcaV0DaughtersMax, float, 0.2, "Maximum DCA among the V0 daughters (cm)")
-  O2_DEFINE_CONFIGURABLE(dcaV0ToPvMax, float, 0.2, "Maximum DCA of the V0 from the primary vertex (cm)")
-  O2_DEFINE_CONFIGURABLE(cosPaV0Min, float, 0.95, "Minimum cosine of pointing angle for V0 stemming from cascade decays")
-  O2_DEFINE_CONFIGURABLE(qtArmenterosMinForK0, float, 0.12, "Minimum Armenteros' qt for K0")
-  O2_DEFINE_CONFIGURABLE(qtArmenterosMaxForLambda, float, 0.12, "Minimum Armenteros' qt for (anti)Lambda")
-  O2_DEFINE_CONFIGURABLE(ConfV0Rap, float, 0.5, "Store rapidity of v0")
-  O2_DEFINE_CONFIGURABLE(cMaxLambdaLifeTime, float, 30, "Store Lambda lifetime")
-  O2_DEFINE_CONFIGURABLE(cMaxK0sLifeTime, float, 30, "Store K0s lifetime")
-  O2_DEFINE_CONFIGURABLE(isDeepAngle, bool, true, "flag for applying deep angle")
-  O2_DEFINE_CONFIGURABLE(cfgDeepAngle, float, 0.04, "deep angle cut")
-  O2_DEFINE_CONFIGURABLE(removefaketrack, bool, true, "flag to remove fake kaon")
-  O2_DEFINE_CONFIGURABLE(ConfFakeKaonCut, float, 0.1, "Cut based on track from momentum difference")
-  O2_DEFINE_CONFIGURABLE(nsigmaCutTPC, float, 3, "nsigma tpc")
-  O2_DEFINE_CONFIGURABLE(nsigmaCutTOF, float, 3, "nsigma tof")
-  O2_DEFINE_CONFIGURABLE(cfgCutTOFBeta, float, 0.0, "TOF beta")
-  O2_DEFINE_CONFIGURABLE(isTOFOnly, bool, false, "flag to select kaon with only TOF condition")
+  O2_DEFINE_CONFIGURABLE(cfgImMinInvMass, float, 0.98f, "Minimum invariant mass for generic 2 prong")
+  O2_DEFINE_CONFIGURABLE(cfgImMaxInvMass, float, 1.07f, "Maximum invariant mass for generic 2 prong")
+  O2_DEFINE_CONFIGURABLE(cfgImSigmaFormula, std::string, "(z < 0.5 && x < 3.0) || (z >= 0.5 && x < 2.5 && y < 3.0)", "pT dependent daughter track sigma pass condition (x = TPC sigma, y = TOF sigma, z = pT)")
+  struct : ConfigurableGroup{
+             O2_DEFINE_CONFIGURABLE(cfgImMinInvMassPhiMeson, float, 0.98f, "Minimum invariant mass Phi meson (GeV)")
+               O2_DEFINE_CONFIGURABLE(cfgImMaxInvMassPhiMeson, float, 1.07f, "Maximum invariant mass Phi meson (GeV)")
+                 O2_DEFINE_CONFIGURABLE(cfgDoPhi, bool, false, "Store phi information")
+                   O2_DEFINE_CONFIGURABLE(cfgITSclusterPhiMeson, int, 5, "Minimum number of ITS cluster for phi meson track")
+                     O2_DEFINE_CONFIGURABLE(cfgTPCCrossedRowsPhiMeson, int, 80, "Minimum number of TPC Crossed Rows for phi meson track")
+                       O2_DEFINE_CONFIGURABLE(cfgCutDCAxyPhiMeson, float, 0.1, "Maximum DCAxy for phi meson track")
+                         O2_DEFINE_CONFIGURABLE(cfgCutDCAzPhiMeson, float, 0.1, "Maximum DCAz for phi meson track")
+                           O2_DEFINE_CONFIGURABLE(cfgCutEtaPhiMeson, float, 0.8, "Maximum eta for phi meson track")
+                             O2_DEFINE_CONFIGURABLE(cfgCutPTPhiMeson, float, 0.15, "Maximum pt for phi meson track")
+                               O2_DEFINE_CONFIGURABLE(cfgDoV0, bool, true, "Store V0s candidates")
+             // O2_DEFINE_CONFIGURABLE(tpcNClsCrossedRowsTrackMin, float, 70, "Minimum number of crossed rows in TPC") // already present in strangeness builder
+             //  dca pos and neg already prsent in strangeness builder
+             // O2_DEFINE_CONFIGURABLE(etaTrackMax, float, 0.8, "Maximum pseudorapidity")
+             O2_DEFINE_CONFIGURABLE(ptTrackMin, float, 0.1, "Minimum transverse momentum")
+               O2_DEFINE_CONFIGURABLE(cMinV0DCAPr, float, 0.1, "Min V0 proton DCA")
+                 O2_DEFINE_CONFIGURABLE(cMinV0DCAPi, float, 0.1, "Min V0 pion DCA")
+                   O2_DEFINE_CONFIGURABLE(ITSPIDSelection, bool, true, "PID ITS")
+                     O2_DEFINE_CONFIGURABLE(ITSPIDPthreshold, float, 1.0, "Momentum threshold for ITS PID (GeV/c) (only used if ITSPIDSelection is true)")
+                       O2_DEFINE_CONFIGURABLE(lowITSPIDNsigma, float, 3.0, "lower cut on PID nsigma for ITS")
+                         O2_DEFINE_CONFIGURABLE(highITSPIDNsigma, float, 3.0, "higher cut on PID nsigma for ITS")
+                           O2_DEFINE_CONFIGURABLE(ConfDaughPIDCuts, float, 4.0, "PID nsigma for V0s")
+                             O2_DEFINE_CONFIGURABLE(massK0Min, float, 0.4, "Minimum mass for K0")
+                               O2_DEFINE_CONFIGURABLE(massK0Max, float, 0.6, "Maximum mass for K0")
+                                 O2_DEFINE_CONFIGURABLE(massLambdaMin, float, 1.0, "Minimum mass for lambda")
+                                   O2_DEFINE_CONFIGURABLE(massLambdaMax, float, 1.3, "Maximum mass for lambda")
+             // O2_DEFINE_CONFIGURABLE(radiusMax, float, 2.3, "Maximum decay radius (cm)") // already present in strangeness builder
+             // O2_DEFINE_CONFIGURABLE(radiusMin, float, 0.0, "Minimum decay radius (cm)") // already present in strangeness builder
+             // O2_DEFINE_CONFIGURABLE(cosPaMin, float, 0.98, "Minimum cosine of pointing angle") // already present in strangeness builder
+             // O2_DEFINE_CONFIGURABLE(dcaV0DaughtersMax, float, 0.2, "Maximum DCA among the V0 daughters (cm)") // already present in strangeness builder
+             O2_DEFINE_CONFIGURABLE(dcaV0ToPvMax, float, 0.2, "Maximum DCA of the V0 from the primary vertex (cm)")
+               O2_DEFINE_CONFIGURABLE(cosPaV0Min, float, 0.95, "Minimum cosine of pointing angle for V0 stemming from cascade decays")
+                 O2_DEFINE_CONFIGURABLE(qtArmenterosMinForK0, float, 0.12, "Minimum Armenteros' qt for K0")
+                   O2_DEFINE_CONFIGURABLE(ConfV0Rap, float, 0.5, "Store rapidity of v0")
+                     O2_DEFINE_CONFIGURABLE(cMaxLambdaLifeTime, float, 30, "Store Lambda lifetime")
+                       O2_DEFINE_CONFIGURABLE(cMaxK0sLifeTime, float, 30, "Store K0s lifetime")
+                         O2_DEFINE_CONFIGURABLE(isDeepAngle, bool, true, "flag for applying deep angle")
+                           O2_DEFINE_CONFIGURABLE(cfgDeepAngle, float, 0.04, "deep angle cut")
+                             O2_DEFINE_CONFIGURABLE(removefaketrack, bool, true, "flag to remove fake kaon")
+                               O2_DEFINE_CONFIGURABLE(ConfFakeKaonCut, float, 0.15, "Cut based on track from momentum difference")
+                                 O2_DEFINE_CONFIGURABLE(nsigmaCutTPC, float, 2.5, "nsigma tpc")
+                                   O2_DEFINE_CONFIGURABLE(nsigmaCutTOF, float, 2.5, "nsigma tof")
+                                     O2_DEFINE_CONFIGURABLE(cfgCutTOFBeta, float, 0.5, "TOF beta")} grpphiV0;
 
   HfHelper hfHelper;
   Produces<aod::CF2ProngTracks> output2ProngTracks;
@@ -102,11 +110,15 @@ struct Filter2Prong {
   template <class T>
   using HasMLProb = decltype(std::declval<T&>().mlProbD0());
 
-  using PIDTrack = soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection, aod::pidTPCPi, aod::pidTPCKa, aod::pidTPCPr, aod::pidTOFPi, aod::pidTOFKa, aod::pidTOFPr, aod::pidTOFbeta>;
+  using PIDTrack = soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection, aod::pidTPCPi, aod::pidTPCKa, aod::pidTPCPr, aod::pidTOFPi, aod::pidTOFKa, aod::pidTOFPr, aod::pidTOFbeta, aod::TracksDCA>;
   using ResoV0s = aod::V0Datas;
+
+  std::unique_ptr<TFormula> sigmaFormula;
 
   void init(InitContext&)
   {
+    if (doprocessDataInvMass)
+      sigmaFormula = std::make_unique<TFormula>("sigmaFormula", cfgImSigmaFormula.value.c_str());
   }
 
   template <class HFCandidatesType>
@@ -203,6 +215,15 @@ struct Filter2Prong {
   }
   PROCESS_SWITCH(Filter2Prong, processMC, "Process MC 2-prong daughters", false);
 
+  template <typename T>
+  bool selectionTrack(const T& candidate)
+  {
+    if (candidate.isGlobalTrack() && candidate.isPVContributor() && candidate.itsNCls() >= grpphiV0.cfgITSclusterPhiMeson && candidate.tpcNClsCrossedRows() > grpphiV0.cfgTPCCrossedRowsPhiMeson && std::abs(candidate.dcaXY()) <= grpphiV0.cfgCutDCAxyPhiMeson && std::abs(candidate.dcaZ()) <= grpphiV0.cfgCutDCAzPhiMeson && std::abs(candidate.eta()) <= grpphiV0.cfgCutEtaPhiMeson && candidate.pt() >= grpphiV0.cfgCutPTPhiMeson) {
+      return true;
+    }
+    return false;
+  }
+
   template <typename T1, typename T2>
   bool selectionPair(const T1& candidate1, const T2& candidate2)
   {
@@ -214,18 +235,18 @@ struct Filter2Prong {
     p1 = candidate1.p();
     p2 = candidate2.p();
     angle = TMath::ACos((pt1 * pt2 + pz1 * pz2) / (p1 * p2));
-    if (isDeepAngle && angle < cfgDeepAngle) {
+    if (grpphiV0.isDeepAngle && angle < grpphiV0.cfgDeepAngle) {
       return false;
     }
     return true;
   }
 
   template <typename T>
-  bool isFakeKaon(T const& track)
+  bool isFakeTrack(T const& track)
   {
     const auto pglobal = track.p();
     const auto ptpc = track.tpcInnerParam();
-    if (TMath::Abs(pglobal - ptpc) > ConfFakeKaonCut) {
+    if (TMath::Abs(pglobal - ptpc) > grpphiV0.ConfFakeKaonCut) {
       return true;
     }
     return false;
@@ -239,34 +260,34 @@ struct Filter2Prong {
 
     float CtauK0s = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::constants::physics::MassK0;
 
-    if (v0.mK0Short() < massK0Min || v0.mK0Short() > massK0Max) {
+    if (v0.mK0Short() < grpphiV0.massK0Min || v0.mK0Short() > grpphiV0.massK0Max) {
       return false;
     }
-    if ((v0.qtarm() / std::abs(v0.alpha())) < qtArmenterosMinForK0) {
+    if ((v0.qtarm() / std::abs(v0.alpha())) < grpphiV0.qtArmenterosMinForK0) {
       return false;
     }
-    if (v0.v0radius() > radiusMax || v0.v0radius() < radiusMin) {
+    // if (v0.v0radius() > grpphiV0.radiusMax || v0.v0radius() < grpphiV0.radiusMin) {
+    //   return false;
+    // }
+    // if (v0.v0cosPA() < grpphiV0.cosPaMin) {
+    //  return false;
+    //}
+    // if (v0.dcaV0daughters() > grpphiV0.dcaV0DaughtersMax) {
+    //  return false;
+    //}
+    if (v0.dcav0topv() > grpphiV0.dcaV0ToPvMax) {
       return false;
     }
-    if (v0.v0cosPA() < cosPaMin) {
+    if (std::abs(CtauK0s) > grpphiV0.cMaxK0sLifeTime) {
       return false;
     }
-    if (v0.dcaV0daughters() > dcaV0DaughtersMax) {
+    if (std::abs(v0.yK0Short()) > grpphiV0.ConfV0Rap) {
       return false;
     }
-    if (v0.dcav0topv() > dcaV0ToPvMax) {
+    if (((std::abs(posTrack.tpcNSigmaPi()) > grpphiV0.ConfDaughPIDCuts) || (std::abs(negTrack.tpcNSigmaPi()) > grpphiV0.ConfDaughPIDCuts))) {
       return false;
     }
-    if (std::abs(CtauK0s) > cMaxK0sLifeTime) {
-      return false;
-    }
-    if (std::abs(v0.yK0Short()) > ConfV0Rap) {
-      return false;
-    }
-    if (((std::abs(posTrack.tpcNSigmaPi()) > ConfDaughPIDCuts) || (std::abs(negTrack.tpcNSigmaPi()) > ConfDaughPIDCuts))) {
-      return false;
-    }
-    if ((TMath::Abs(v0.dcapostopv()) < cMinV0DCAPi || TMath::Abs(v0.dcanegtopv()) < cMinV0DCAPi)) {
+    if ((TMath::Abs(v0.dcapostopv()) < grpphiV0.cMinV0DCAPi || TMath::Abs(v0.dcanegtopv()) < grpphiV0.cMinV0DCAPi)) {
       return false;
     }
     return true;
@@ -280,38 +301,38 @@ struct Filter2Prong {
 
     float CtauLambda = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::constants::physics::MassLambda;
 
-    if ((v0.mLambda() < massLambdaMin || v0.mLambda() > massLambdaMax) &&
-        (v0.mAntiLambda() < massLambdaMin || v0.mAntiLambda() > massLambdaMax)) {
+    if ((v0.mLambda() < grpphiV0.massLambdaMin || v0.mLambda() > grpphiV0.massLambdaMax) &&
+        (v0.mAntiLambda() < grpphiV0.massLambdaMin || v0.mAntiLambda() > grpphiV0.massLambdaMax)) {
       return false;
     }
-    if (v0.v0radius() > radiusMax || v0.v0radius() < radiusMin) {
+    // if (v0.v0radius() > grpphiV0.radiusMax || v0.v0radius() < grpphiV0.radiusMin) {
+    //   return false;
+    // }
+    // if (v0.v0cosPA() < grpphiV0.cosPaMin) {
+    //  return false;
+    //}
+    // if (v0.dcaV0daughters() > grpphiV0.dcaV0DaughtersMax) {
+    //  return false;
+    //}
+    if (v0.dcav0topv() > grpphiV0.dcaV0ToPvMax) {
       return false;
     }
-    if (v0.v0cosPA() < cosPaMin) {
+    if (pid == 0 && (TMath::Abs(v0.dcapostopv()) < grpphiV0.cMinV0DCAPr || TMath::Abs(v0.dcanegtopv()) < grpphiV0.cMinV0DCAPi)) {
       return false;
     }
-    if (v0.dcaV0daughters() > dcaV0DaughtersMax) {
+    if (pid == 1 && (TMath::Abs(v0.dcapostopv()) < grpphiV0.cMinV0DCAPi || TMath::Abs(v0.dcanegtopv()) < grpphiV0.cMinV0DCAPr)) {
       return false;
     }
-    if (v0.dcav0topv() > dcaV0ToPvMax) {
+    if (pid == 0 && ((std::abs(posTrack.tpcNSigmaPr()) > grpphiV0.ConfDaughPIDCuts) || (std::abs(negTrack.tpcNSigmaPi()) > grpphiV0.ConfDaughPIDCuts))) {
       return false;
     }
-    if (pid == 0 && (TMath::Abs(v0.dcapostopv()) < cMinV0DCAPr || TMath::Abs(v0.dcanegtopv()) < cMinV0DCAPi)) {
+    if (pid == 1 && ((std::abs(posTrack.tpcNSigmaPi()) > grpphiV0.ConfDaughPIDCuts) || (std::abs(negTrack.tpcNSigmaPr()) > grpphiV0.ConfDaughPIDCuts))) {
       return false;
     }
-    if (pid == 1 && (TMath::Abs(v0.dcapostopv()) < cMinV0DCAPi || TMath::Abs(v0.dcanegtopv()) < cMinV0DCAPr)) {
+    if (std::abs(CtauLambda) > grpphiV0.cMaxLambdaLifeTime) {
       return false;
     }
-    if (pid == 0 && ((std::abs(posTrack.tpcNSigmaPr()) > ConfDaughPIDCuts) || (std::abs(negTrack.tpcNSigmaPi()) > ConfDaughPIDCuts))) {
-      return false;
-    }
-    if (pid == 1 && ((std::abs(posTrack.tpcNSigmaPi()) > ConfDaughPIDCuts) || (std::abs(negTrack.tpcNSigmaPr()) > ConfDaughPIDCuts))) {
-      return false;
-    }
-    if (std::abs(CtauLambda) > cMaxLambdaLifeTime) {
-      return false;
-    }
-    if (std::abs(v0.yLambda()) > ConfV0Rap) {
+    if (std::abs(v0.yLambda()) > grpphiV0.ConfV0Rap) {
       return false;
     }
     return true;
@@ -326,16 +347,16 @@ struct Filter2Prong {
     if (!posTrack.hasTPC() || !negTrack.hasTPC()) {
       return false;
     }
-    if (posTrack.tpcNClsCrossedRows() < tpcNClsCrossedRowsTrackMin || negTrack.tpcNClsCrossedRows() < tpcNClsCrossedRowsTrackMin) {
-      return false;
-    }
+    // if (posTrack.tpcNClsCrossedRows() < grpphiV0.tpcNClsCrossedRowsTrackMin || negTrack.tpcNClsCrossedRows() < grpphiV0.tpcNClsCrossedRowsTrackMin) {
+    //   return false;
+    // }
     if (posTrack.tpcCrossedRowsOverFindableCls() < 0.8 || negTrack.tpcCrossedRowsOverFindableCls() < 0.8) {
       return false;
     }
-    if (std::abs(v0.positiveeta()) > etaTrackMax || std::abs(v0.negativeeta()) > etaTrackMax) {
-      return false;
-    }
-    if (v0.positivept() < ptTrackMin || v0.negativept() < ptTrackMin) {
+    // if (std::abs(v0.positiveeta()) > grpphiV0.etaTrackMax || std::abs(v0.negativeeta()) > grpphiV0.etaTrackMax) {
+    //   return false;
+    // }
+    if (v0.positivept() < grpphiV0.ptTrackMin || v0.negativept() < grpphiV0.ptTrackMin) {
       return false;
     }
     return true;
@@ -346,18 +367,18 @@ struct Filter2Prong {
   {
     if (cfgMomDepPID) {
       if (candidate.p() < 0.5) {
-        if (!candidate.hasTOF() && TMath::Abs(candidate.tpcNSigmaKa()) < nsigmaCutTPC) {
+        if (!candidate.hasTOF() && TMath::Abs(candidate.tpcNSigmaKa()) < grpphiV0.nsigmaCutTPC) {
           return true;
-        } else if (candidate.hasTOF() && TMath::Sqrt(candidate.tpcNSigmaKa() * candidate.tpcNSigmaKa() + candidate.tofNSigmaKa() * candidate.tofNSigmaKa()) < nsigmaCutTOF && candidate.beta() > cfgCutTOFBeta) {
+        } else if (candidate.hasTOF() && TMath::Sqrt(candidate.tpcNSigmaKa() * candidate.tpcNSigmaKa() + candidate.tofNSigmaKa() * candidate.tofNSigmaKa()) < grpphiV0.nsigmaCutTOF && candidate.beta() > grpphiV0.cfgCutTOFBeta) {
           return true;
         }
-      } else if (candidate.hasTOF() && TMath::Sqrt(candidate.tpcNSigmaKa() * candidate.tpcNSigmaKa() + candidate.tofNSigmaKa() * candidate.tofNSigmaKa()) < nsigmaCutTOF && candidate.beta() > cfgCutTOFBeta) {
+      } else if (candidate.hasTOF() && TMath::Sqrt(candidate.tpcNSigmaKa() * candidate.tpcNSigmaKa() + candidate.tofNSigmaKa() * candidate.tofNSigmaKa()) < grpphiV0.nsigmaCutTOF && candidate.beta() > grpphiV0.cfgCutTOFBeta) {
         return true;
       }
     } else if (!cfgMomDepPID) {
-      if (!candidate.hasTOF() && TMath::Abs(candidate.tpcNSigmaKa()) < nsigmaCutTPC) {
+      if (!candidate.hasTOF() && TMath::Abs(candidate.tpcNSigmaKa()) < grpphiV0.nsigmaCutTPC) {
         return true;
-      } else if (candidate.hasTOF() && TMath::Sqrt(candidate.tpcNSigmaKa() * candidate.tpcNSigmaKa() + candidate.tofNSigmaKa() * candidate.tofNSigmaKa()) < nsigmaCutTOF && candidate.beta() > cfgCutTOFBeta) {
+      } else if (candidate.hasTOF() && TMath::Sqrt(candidate.tpcNSigmaKa() * candidate.tpcNSigmaKa() + candidate.tofNSigmaKa() * candidate.tofNSigmaKa()) < grpphiV0.nsigmaCutTOF && candidate.beta() > grpphiV0.cfgCutTOFBeta) {
         return true;
       }
     }
@@ -365,26 +386,62 @@ struct Filter2Prong {
   }
 
   // Generic 2-prong invariant mass method candidate finder. Only works for non-identical daughters of opposite charge for now.
-  void processDataInvMass(aod::Collisions::iterator const& collision, aod::BCsWithTimestamps const&, aod::CFCollRefs const& cfcollisions, aod::CFTrackRefs const& cftracks, PIDTrack const& tracks, aod::V0Datas const& V0s)
+  void processDataInvMass(aod::Collisions::iterator const&, aod::BCsWithTimestamps const&, aod::CFCollRefs const& cfcollisions, aod::CFTrackRefs const& cftracks, Filter2Prong::PIDTrack const& tracks)
+  {
+    if (cfcollisions.size() <= 0 || cftracks.size() <= 0)
+      return; // rejected collision
+    for (const auto& cftrack1 : cftracks) {
+      const auto& p1 = tracks.iteratorAt(cftrack1.trackId() - tracks.begin().globalIndex());
+      if (p1.sign() != 1)
+        continue;
+      if (sigmaFormula->Eval(o2::aod::pidutils::tpcNSigma(cfgImPart1PID, p1), o2::aod::pidutils::tofNSigma(cfgImPart1PID, p1)) <= 0.0f)
+        continue;
+      for (const auto& cftrack2 : cftracks) {
+        if (cftrack2.globalIndex() == cftrack1.globalIndex())
+          continue;
+        const auto& p2 = tracks.iteratorAt(cftrack2.trackId() - tracks.begin().globalIndex());
+        if (p2.sign() != -1)
+          continue;
+        if (sigmaFormula->Eval(o2::aod::pidutils::tpcNSigma(cfgImPart2PID, p2), o2::aod::pidutils::tofNSigma(cfgImPart2PID, p2)) <= 0.0f)
+          continue;
+        ROOT::Math::PtEtaPhiMVector vec1(p1.pt(), p1.eta(), p1.phi(), cfgImPart1Mass);
+        ROOT::Math::PtEtaPhiMVector vec2(p2.pt(), p2.eta(), p2.phi(), cfgImPart2Mass);
+        ROOT::Math::PtEtaPhiMVector s = vec1 + vec2;
+        if (s.pt() < cfgImCutPt || s.M() < cfgImMinInvMass || s.M() > cfgImMaxInvMass)
+          continue;
+
+        float phi = RecoDecay::constrainAngle(s.Phi(), 0.0f);
+        output2ProngTracks(cfcollisions.begin().globalIndex(),
+                           cftrack1.globalIndex(), cftrack2.globalIndex(), s.pt(), s.eta(), phi, s.M(), aod::cf2prongtrack::Generic2Prong);
+      }
+    }
+  }
+  PROCESS_SWITCH(Filter2Prong, processDataInvMass, "Process data generic 2-prong candidates with invariant mass method", false);
+
+  // Generic 2-prong invariant mass method candidate finder. Only works for non-identical daughters of opposite charge for now.
+  void processDataPhiV0(aod::Collisions::iterator const& collision, aod::BCsWithTimestamps const&, aod::CFCollRefs const& cfcollisions, aod::CFTrackRefs const& cftracks, Filter2Prong::PIDTrack const& tracks, aod::V0Datas const& V0s)
   {
     if (cfcollisions.size() <= 0 || cftracks.size() <= 0)
       return; // rejected collision
 
     o2::aod::ITSResponse itsResponse;
 
-    if (cfgDoPhi) {                           // Process Phi mesons
+    if (grpphiV0.cfgDoPhi) {                  // Process Phi mesons
       for (const auto& cftrack1 : cftracks) { // Loop over first track
         const auto& p1 = tracks.iteratorAt(cftrack1.trackId() - tracks.begin().globalIndex());
         if (p1.sign() != 1) {
           continue;
         }
-        if (ITSPIDSelection && p1.p() < ITSPIDPthreshold.value && !(itsResponse.nSigmaITS<o2::track::PID::Kaon>(p1) > -ITSPIDNsigma.value && itsResponse.nSigmaITS<o2::track::PID::Kaon>(p1) < ITSPIDNsigma.value)) { // Check ITS PID condition
+        if (!selectionTrack(p1)) {
+          continue;
+        }
+        if (grpphiV0.ITSPIDSelection && p1.p() < grpphiV0.ITSPIDPthreshold.value && !(itsResponse.nSigmaITS<o2::track::PID::Kaon>(p1) > grpphiV0.lowITSPIDNsigma.value && itsResponse.nSigmaITS<o2::track::PID::Kaon>(p1) < grpphiV0.highITSPIDNsigma.value)) { // Check ITS PID condition
           continue;
         }
         if (!selectionPID(p1)) {
           continue;
         }
-        if (removefaketrack && isFakeKaon(p1)) { // Check if the track is a fake kaon
+        if (grpphiV0.removefaketrack && isFakeTrack(p1)) { // Check if the track is a fake kaon
           continue;
         }
 
@@ -396,13 +453,16 @@ struct Filter2Prong {
           if (p2.sign() != -1) {
             continue;
           }
+          if (!selectionTrack(p2)) {
+            continue;
+          }
           if (!selectionPID(p2)) {
             continue;
           }
-          if (ITSPIDSelection && p2.p() < ITSPIDPthreshold.value && !(itsResponse.nSigmaITS<o2::track::PID::Kaon>(p2) > -ITSPIDNsigma.value && itsResponse.nSigmaITS<o2::track::PID::Kaon>(p2) < ITSPIDNsigma.value)) { // Check ITS PID condition
+          if (grpphiV0.ITSPIDSelection && p2.p() < grpphiV0.ITSPIDPthreshold.value && !(itsResponse.nSigmaITS<o2::track::PID::Kaon>(p2) > grpphiV0.lowITSPIDNsigma.value && itsResponse.nSigmaITS<o2::track::PID::Kaon>(p2) < grpphiV0.highITSPIDNsigma.value)) { // Check ITS PID condition
             continue;
           }
-          if (removefaketrack && isFakeKaon(p2)) { // Check if the track is a fake kaon
+          if (grpphiV0.removefaketrack && isFakeTrack(p2)) { // Check if the track is a fake kaon
             continue;
           }
           if (!selectionPair(p1, p2)) {
@@ -412,9 +472,9 @@ struct Filter2Prong {
           ROOT::Math::PtEtaPhiMVector vec1(p1.pt(), p1.eta(), p1.phi(), cfgImPart1Mass);
           ROOT::Math::PtEtaPhiMVector vec2(p2.pt(), p2.eta(), p2.phi(), cfgImPart2Mass);
           ROOT::Math::PtEtaPhiMVector s = vec1 + vec2;
-          if (s.pt() < cfgImCutPt || s.M() < cfgImMinInvMass || s.M() > cfgImMaxInvMass)
+          if (s.M() < grpphiV0.cfgImMinInvMassPhiMeson || s.M() > grpphiV0.cfgImMaxInvMassPhiMeson) {
             continue;
-
+          }
           float phi = RecoDecay::constrainAngle(s.Phi(), 0.0f);
           output2ProngTracks(cfcollisions.begin().globalIndex(),
                              cftrack1.globalIndex(), cftrack2.globalIndex(), s.pt(), s.eta(), phi, s.M(), aod::cf2prongtrack::PhiToKK);
@@ -422,7 +482,7 @@ struct Filter2Prong {
       } // end of loop over first track
     } // end of processing Phi mesons
 
-    if (cfgDoV0) {                    // Process V0 candidates (K0s, Lambdas, Anti-Lambdas)
+    if (grpphiV0.cfgDoV0) {           // Process V0 candidates (K0s, Lambdas, Anti-Lambdas)
       for (const auto& v0 : V0s) {    // Loop over V0 candidates
         if (!isV0TrackSelected(v0)) { // Quality selection for V0 prongs
           continue;
@@ -454,7 +514,8 @@ struct Filter2Prong {
           massV0 = v0.mLambda();
           output2ProngTracks(cfcollisions.begin().globalIndex(), posTrack.globalIndex(), negTrack.globalIndex(),
                              v0.pt(), v0.eta(), v0.phi(), massV0, v0Type);
-        } else if (aLambdaTag) { // candidate is Anti-lambda
+        }
+        if (aLambdaTag) { // candidate is Anti-lambda
           SETBIT(v0Type, aod::cf2prongtrack::AntiLambdatoPiP);
           massV0 = v0.mAntiLambda();
           output2ProngTracks(cfcollisions.begin().globalIndex(), posTrack.globalIndex(), negTrack.globalIndex(),
@@ -463,7 +524,8 @@ struct Filter2Prong {
       } // end of loop over V0 candidates
     } // end of processing V0 candidates
   }
-  PROCESS_SWITCH(Filter2Prong, processDataInvMass, "Process data generic 2-prong candidates with invariant mass method", false);
+  PROCESS_SWITCH(Filter2Prong, processDataPhiV0, "Process data PhiV0 candidates with invariant mass method", false);
+
 }; // struct
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGCF/TableProducer/filter2Prong.cxx
+++ b/PWGCF/TableProducer/filter2Prong.cxx
@@ -62,38 +62,37 @@ struct Filter2Prong {
                            O2_DEFINE_CONFIGURABLE(cfgCutEtaPhiMeson, float, 0.8, "Maximum eta for phi meson track")
                              O2_DEFINE_CONFIGURABLE(cfgCutPTPhiMeson, float, 0.15, "Maximum pt for phi meson track")
                                O2_DEFINE_CONFIGURABLE(cfgDoV0, bool, true, "Store V0s candidates")
-             // O2_DEFINE_CONFIGURABLE(tpcNClsCrossedRowsTrackMin, float, 70, "Minimum number of crossed rows in TPC") // already present in strangeness builder
-             //  dca pos and neg already prsent in strangeness builder
-             // O2_DEFINE_CONFIGURABLE(etaTrackMax, float, 0.8, "Maximum pseudorapidity")
-             O2_DEFINE_CONFIGURABLE(ptTrackMin, float, 0.1, "Minimum transverse momentum")
-               O2_DEFINE_CONFIGURABLE(cMinV0DCAPr, float, 0.1, "Min V0 proton DCA")
-                 O2_DEFINE_CONFIGURABLE(cMinV0DCAPi, float, 0.1, "Min V0 pion DCA")
-                   O2_DEFINE_CONFIGURABLE(ITSPIDSelection, bool, true, "PID ITS")
-                     O2_DEFINE_CONFIGURABLE(ITSPIDPthreshold, float, 1.0, "Momentum threshold for ITS PID (GeV/c) (only used if ITSPIDSelection is true)")
-                       O2_DEFINE_CONFIGURABLE(lowITSPIDNsigma, float, 3.0, "lower cut on PID nsigma for ITS")
-                         O2_DEFINE_CONFIGURABLE(highITSPIDNsigma, float, 3.0, "higher cut on PID nsigma for ITS")
-                           O2_DEFINE_CONFIGURABLE(ConfDaughPIDCuts, float, 4.0, "PID nsigma for V0s")
-                             O2_DEFINE_CONFIGURABLE(massK0Min, float, 0.4, "Minimum mass for K0")
-                               O2_DEFINE_CONFIGURABLE(massK0Max, float, 0.6, "Maximum mass for K0")
-                                 O2_DEFINE_CONFIGURABLE(massLambdaMin, float, 1.0, "Minimum mass for lambda")
-                                   O2_DEFINE_CONFIGURABLE(massLambdaMax, float, 1.3, "Maximum mass for lambda")
-             // O2_DEFINE_CONFIGURABLE(radiusMax, float, 2.3, "Maximum decay radius (cm)") // already present in strangeness builder
-             // O2_DEFINE_CONFIGURABLE(radiusMin, float, 0.0, "Minimum decay radius (cm)") // already present in strangeness builder
-             // O2_DEFINE_CONFIGURABLE(cosPaMin, float, 0.98, "Minimum cosine of pointing angle") // already present in strangeness builder
-             // O2_DEFINE_CONFIGURABLE(dcaV0DaughtersMax, float, 0.2, "Maximum DCA among the V0 daughters (cm)") // already present in strangeness builder
-             O2_DEFINE_CONFIGURABLE(dcaV0ToPvMax, float, 0.2, "Maximum DCA of the V0 from the primary vertex (cm)")
-               O2_DEFINE_CONFIGURABLE(cosPaV0Min, float, 0.95, "Minimum cosine of pointing angle for V0 stemming from cascade decays")
-                 O2_DEFINE_CONFIGURABLE(qtArmenterosMinForK0, float, 0.12, "Minimum Armenteros' qt for K0")
-                   O2_DEFINE_CONFIGURABLE(ConfV0Rap, float, 0.5, "Store rapidity of v0")
-                     O2_DEFINE_CONFIGURABLE(cMaxLambdaLifeTime, float, 30, "Store Lambda lifetime")
-                       O2_DEFINE_CONFIGURABLE(cMaxK0sLifeTime, float, 30, "Store K0s lifetime")
-                         O2_DEFINE_CONFIGURABLE(isDeepAngle, bool, true, "flag for applying deep angle")
-                           O2_DEFINE_CONFIGURABLE(cfgDeepAngle, float, 0.04, "deep angle cut")
-                             O2_DEFINE_CONFIGURABLE(removefaketrack, bool, true, "flag to remove fake kaon")
-                               O2_DEFINE_CONFIGURABLE(ConfFakeKaonCut, float, 0.15, "Cut based on track from momentum difference")
-                                 O2_DEFINE_CONFIGURABLE(nsigmaCutTPC, float, 2.5, "nsigma tpc")
-                                   O2_DEFINE_CONFIGURABLE(nsigmaCutTOF, float, 2.5, "nsigma tof")
-                                     O2_DEFINE_CONFIGURABLE(cfgCutTOFBeta, float, 0.5, "TOF beta")} grpphiV0;
+                                 O2_DEFINE_CONFIGURABLE(tpcNClsCrossedRowsTrackMin, float, 70, "Minimum number of crossed rows in TPC")
+                                   O2_DEFINE_CONFIGURABLE(etaTrackMax, float, 0.8, "Maximum pseudorapidity")
+                                     O2_DEFINE_CONFIGURABLE(ptTrackMin, float, 0.1, "Minimum transverse momentum")
+                                       O2_DEFINE_CONFIGURABLE(cMinV0DCAPr, float, 0.1, "Min V0 proton DCA")
+                                         O2_DEFINE_CONFIGURABLE(cMinV0DCAPi, float, 0.1, "Min V0 pion DCA")
+                                           O2_DEFINE_CONFIGURABLE(ITSPIDSelection, bool, true, "PID ITS")
+                                             O2_DEFINE_CONFIGURABLE(ITSPIDPthreshold, float, 1.0, "Momentum threshold for ITS PID (GeV/c) (only used if ITSPIDSelection is true)")
+                                               O2_DEFINE_CONFIGURABLE(lowITSPIDNsigma, float, 3.0, "lower cut on PID nsigma for ITS")
+                                                 O2_DEFINE_CONFIGURABLE(highITSPIDNsigma, float, 3.0, "higher cut on PID nsigma for ITS")
+                                                   O2_DEFINE_CONFIGURABLE(ConfDaughPIDCuts, float, 4.0, "PID nsigma for V0s")
+                                                     O2_DEFINE_CONFIGURABLE(massK0Min, float, 0.4, "Minimum mass for K0")
+                                                       O2_DEFINE_CONFIGURABLE(massK0Max, float, 0.6, "Maximum mass for K0")
+                                                         O2_DEFINE_CONFIGURABLE(massLambdaMin, float, 1.0, "Minimum mass for lambda")
+                                                           O2_DEFINE_CONFIGURABLE(massLambdaMax, float, 1.3, "Maximum mass for lambda")
+                                                             O2_DEFINE_CONFIGURABLE(radiusMax, float, 2.3, "Maximum decay radius (cm)")
+                                                               O2_DEFINE_CONFIGURABLE(radiusMin, float, 0.0, "Minimum decay radius (cm)")
+                                                                 O2_DEFINE_CONFIGURABLE(cosPaMin, float, 0.98, "Minimum cosine of pointing angle")
+                                                                   O2_DEFINE_CONFIGURABLE(dcaV0DaughtersMax, float, 0.2, "Maximum DCA among the V0 daughters (cm)")
+                                                                     O2_DEFINE_CONFIGURABLE(dcaV0ToPvMax, float, 0.2, "Maximum DCA of the V0 from the primary vertex (cm)")
+                                                                       O2_DEFINE_CONFIGURABLE(cosPaV0Min, float, 0.95, "Minimum cosine of pointing angle for V0 stemming from cascade decays")
+                                                                         O2_DEFINE_CONFIGURABLE(qtArmenterosMinForK0, float, 0.12, "Minimum Armenteros' qt for K0")
+                                                                           O2_DEFINE_CONFIGURABLE(ConfV0Rap, float, 0.5, "Store rapidity of v0")
+                                                                             O2_DEFINE_CONFIGURABLE(cMaxLambdaLifeTime, float, 30, "Store Lambda lifetime")
+                                                                               O2_DEFINE_CONFIGURABLE(cMaxK0sLifeTime, float, 30, "Store K0s lifetime")
+                                                                                 O2_DEFINE_CONFIGURABLE(isDeepAngle, bool, true, "flag for applying deep angle")
+                                                                                   O2_DEFINE_CONFIGURABLE(cfgDeepAngle, float, 0.04, "deep angle cut")
+                                                                                     O2_DEFINE_CONFIGURABLE(removefaketrack, bool, true, "flag to remove fake kaon")
+                                                                                       O2_DEFINE_CONFIGURABLE(ConfFakeKaonCut, float, 0.15, "Cut based on track from momentum difference")
+                                                                                         O2_DEFINE_CONFIGURABLE(nsigmaCutTPC, float, 2.5, "nsigma tpc")
+                                                                                           O2_DEFINE_CONFIGURABLE(nsigmaCutTOF, float, 2.5, "nsigma tof")
+                                                                                             O2_DEFINE_CONFIGURABLE(cfgCutTOFBeta, float, 0.5, "TOF beta")} grpphiV0;
 
   HfHelper hfHelper;
   Produces<aod::CF2ProngTracks> output2ProngTracks;
@@ -266,15 +265,15 @@ struct Filter2Prong {
     if ((v0.qtarm() / std::abs(v0.alpha())) < grpphiV0.qtArmenterosMinForK0) {
       return false;
     }
-    // if (v0.v0radius() > grpphiV0.radiusMax || v0.v0radius() < grpphiV0.radiusMin) {
-    //   return false;
-    // }
-    // if (v0.v0cosPA() < grpphiV0.cosPaMin) {
-    //  return false;
-    //}
-    // if (v0.dcaV0daughters() > grpphiV0.dcaV0DaughtersMax) {
-    //  return false;
-    //}
+    if (v0.v0radius() > grpphiV0.radiusMax || v0.v0radius() < grpphiV0.radiusMin) {
+      return false;
+    }
+    if (v0.v0cosPA() < grpphiV0.cosPaMin) {
+      return false;
+    }
+    if (v0.dcaV0daughters() > grpphiV0.dcaV0DaughtersMax) {
+      return false;
+    }
     if (v0.dcav0topv() > grpphiV0.dcaV0ToPvMax) {
       return false;
     }
@@ -305,15 +304,15 @@ struct Filter2Prong {
         (v0.mAntiLambda() < grpphiV0.massLambdaMin || v0.mAntiLambda() > grpphiV0.massLambdaMax)) {
       return false;
     }
-    // if (v0.v0radius() > grpphiV0.radiusMax || v0.v0radius() < grpphiV0.radiusMin) {
-    //   return false;
-    // }
-    // if (v0.v0cosPA() < grpphiV0.cosPaMin) {
-    //  return false;
-    //}
-    // if (v0.dcaV0daughters() > grpphiV0.dcaV0DaughtersMax) {
-    //  return false;
-    //}
+    if (v0.v0radius() > grpphiV0.radiusMax || v0.v0radius() < grpphiV0.radiusMin) {
+      return false;
+    }
+    if (v0.v0cosPA() < grpphiV0.cosPaMin) {
+      return false;
+    }
+    if (v0.dcaV0daughters() > grpphiV0.dcaV0DaughtersMax) {
+      return false;
+    }
     if (v0.dcav0topv() > grpphiV0.dcaV0ToPvMax) {
       return false;
     }
@@ -347,15 +346,15 @@ struct Filter2Prong {
     if (!posTrack.hasTPC() || !negTrack.hasTPC()) {
       return false;
     }
-    // if (posTrack.tpcNClsCrossedRows() < grpphiV0.tpcNClsCrossedRowsTrackMin || negTrack.tpcNClsCrossedRows() < grpphiV0.tpcNClsCrossedRowsTrackMin) {
-    //   return false;
-    // }
+    if (posTrack.tpcNClsCrossedRows() < grpphiV0.tpcNClsCrossedRowsTrackMin || negTrack.tpcNClsCrossedRows() < grpphiV0.tpcNClsCrossedRowsTrackMin) {
+      return false;
+    }
     if (posTrack.tpcCrossedRowsOverFindableCls() < 0.8 || negTrack.tpcCrossedRowsOverFindableCls() < 0.8) {
       return false;
     }
-    // if (std::abs(v0.positiveeta()) > grpphiV0.etaTrackMax || std::abs(v0.negativeeta()) > grpphiV0.etaTrackMax) {
-    //   return false;
-    // }
+    if (std::abs(v0.positiveeta()) > grpphiV0.etaTrackMax || std::abs(v0.negativeeta()) > grpphiV0.etaTrackMax) {
+      return false;
+    }
     if (v0.positivept() < grpphiV0.ptTrackMin || v0.negativept() < grpphiV0.ptTrackMin) {
       return false;
     }

--- a/PWGCF/TableProducer/filter2Prong.cxx
+++ b/PWGCF/TableProducer/filter2Prong.cxx
@@ -16,6 +16,8 @@
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
 
+#include "Common/DataModel/PIDResponseITS.h"
+
 #include "Framework/ASoAHelpers.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/AnalysisTask.h"
@@ -48,6 +50,41 @@ struct Filter2Prong {
   O2_DEFINE_CONFIGURABLE(cfgImMinInvMass, float, 0.95f, "Minimum invariant mass (GeV)")
   O2_DEFINE_CONFIGURABLE(cfgImMaxInvMass, float, 1.07f, "Maximum invariant mass (GeV)")
   O2_DEFINE_CONFIGURABLE(cfgImSigmaFormula, std::string, "(z < 0.5 && x < 3.0) || (z >= 0.5 && x < 2.5 && y < 3.0)", "pT dependent daughter track sigma pass condition (x = TPC sigma, y = TOF sigma, z = pT)")
+
+  O2_DEFINE_CONFIGURABLE(cfgDoPhi, bool, false, "Store phi information")
+  O2_DEFINE_CONFIGURABLE(cfgDoV0, bool, true, "Store V0s candidates")
+  O2_DEFINE_CONFIGURABLE(tpcNClsCrossedRowsTrackMin, float, 70, "Minimum number of crossed rows in TPC")
+  O2_DEFINE_CONFIGURABLE(etaTrackMax, float, 0.8, "Maximum pseudorapidity")
+  O2_DEFINE_CONFIGURABLE(ptTrackMin, float, 0.1, "Minimum transverse momentum")
+  O2_DEFINE_CONFIGURABLE(cMinV0DCAPr, float, 0.1, "Min V0 proton DCA")
+  O2_DEFINE_CONFIGURABLE(cMinV0DCAPi, float, 0.1, "Min V0 pion DCA")
+  O2_DEFINE_CONFIGURABLE(ITSPIDSelection, bool, true, "PID ITS")
+  O2_DEFINE_CONFIGURABLE(ITSPIDPthreshold, float, 1.0, "Momentum threshold for ITS PID (GeV/c) (only used if ITSPIDSelection is true)")
+  O2_DEFINE_CONFIGURABLE(ITSPIDNsigma, float, 3.0, "PID nsigma for ITS")
+  O2_DEFINE_CONFIGURABLE(ConfDaughPIDCuts, float, 4.0, "PID nsigma for V0s")
+  O2_DEFINE_CONFIGURABLE(massK0Min, float, 0.4, "Minimum mass for K0")
+  O2_DEFINE_CONFIGURABLE(massK0Max, float, 0.6, "Maximum mass for K0")
+  O2_DEFINE_CONFIGURABLE(massLambdaMin, float, 1.0, "Minimum mass for lambda")
+  O2_DEFINE_CONFIGURABLE(massLambdaMax, float, 1.3, "Maximum mass for lambda")
+  O2_DEFINE_CONFIGURABLE(massOmegaMin, float, 1.5, "Minimum mass for omega")
+  O2_DEFINE_CONFIGURABLE(massOmegaMax, float, 1.8, "Maximum mass for omega")
+  O2_DEFINE_CONFIGURABLE(interactionRateMin, float, -1, "Minimum interaction rate (kHz)")
+  O2_DEFINE_CONFIGURABLE(interactionRateMax, float, 1.e20, "Maximum interaction rate (kHz)")
+  O2_DEFINE_CONFIGURABLE(radiusMax, float, 2.3, "Maximum decay radius (cm)")
+  O2_DEFINE_CONFIGURABLE(radiusMin, float, 0.0, "Minimum decay radius (cm)")
+  O2_DEFINE_CONFIGURABLE(cosPaMin, float, 0.98, "Minimum cosine of pointing angle")
+  O2_DEFINE_CONFIGURABLE(dcaV0DaughtersMax, float, 0.2, "Maximum DCA among the V0 daughters (cm)")
+  O2_DEFINE_CONFIGURABLE(dcaV0ToPvMax, float, 0.2, "Maximum DCA of the V0 from the primary vertex (cm)")
+  O2_DEFINE_CONFIGURABLE(cosPaV0Min, float, 0.95, "Minimum cosine of pointing angle for V0 stemming from cascade decays")
+  O2_DEFINE_CONFIGURABLE(qtArmenterosMinForK0, float, 0.12, "Minimum Armenteros' qt for K0")
+  O2_DEFINE_CONFIGURABLE(qtArmenterosMaxForLambda, float, 0.12, "Minimum Armenteros' qt for (anti)Lambda")
+  O2_DEFINE_CONFIGURABLE(ConfV0Rap, float, 0.5, "Store rapidity of v0")
+  O2_DEFINE_CONFIGURABLE(cMaxLambdaLifeTime, float, 30, "Store Lambda lifetime")
+  O2_DEFINE_CONFIGURABLE(cMaxK0sLifeTime, float, 30, "Store K0s lifetime")
+  O2_DEFINE_CONFIGURABLE(isDeepAngle, bool, true, "flag for applying deep angle")
+  O2_DEFINE_CONFIGURABLE(cfgDeepAngle, float, 0.04, "deep angle cut")
+  O2_DEFINE_CONFIGURABLE(removefaketrack, bool, true, "flag to remove fake kaon")
+  O2_DEFINE_CONFIGURABLE(ConfFakeKaonCut, float, 0.1, "Cut based on track from momentum difference")
 
   HfHelper hfHelper;
   Produces<aod::CF2ProngTracks> output2ProngTracks;
@@ -166,37 +203,249 @@ struct Filter2Prong {
   }
   PROCESS_SWITCH(Filter2Prong, processMC, "Process MC 2-prong daughters", false);
 
-  // Generic 2-prong invariant mass method candidate finder. Only works for non-identical daughters of opposite charge for now.
+  template <typename T1, typename T2>
+  bool selectionPair(const T1& candidate1, const T2& candidate2)
+  {
+    double pt1, pt2, pz1, pz2, p1, p2, angle;
+    pt1 = candidate1.pt();
+    pt2 = candidate2.pt();
+    pz1 = candidate1.pz();
+    pz2 = candidate2.pz();
+    p1 = candidate1.p();
+    p2 = candidate2.p();
+    angle = TMath::ACos((pt1 * pt2 + pz1 * pz2) / (p1 * p2));
+    if (isDeepAngle && angle < cfgDeepAngle) {
+      return false;
+    }
+    return true;
+  }
+
+  template <typename T>
+  bool isFakeKaon(T const& track)
+  {
+    const auto pglobal = track.p();
+    const auto ptpc = track.tpcInnerParam();
+    if (TMath::Abs(pglobal - ptpc) > ConfFakeKaonCut) {
+      return true;
+    }
+    return false;
+  }
+
+  template <typename Collision, typename V0Cand>
+  bool isSelectedV0AsK0s(Collision const& collision, const V0Cand& v0)
+  {
+    const auto& posTrack = v0.template posTrack_as<PIDTrack>();
+    const auto& negTrack = v0.template negTrack_as<PIDTrack>();
+
+    float CtauK0s = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::constants::physics::MassK0;
+
+    if (v0.mK0Short() < massK0Min || v0.mK0Short() > massK0Max) {
+      return false;
+    }
+    if (v0.qtarm() < qtArmenterosMinForK0) {
+      return false;
+    }
+    if (v0.v0radius() > radiusMax) {
+      return false;
+    }
+    if (v0.v0radius() < radiusMin) {
+      return false;
+    }
+    if (v0.v0cosPA() < cosPaMin) {
+      return false;
+    }
+    if (v0.dcaV0daughters() > dcaV0DaughtersMax) {
+      return false;
+    }
+    if (v0.dcav0topv() > dcaV0ToPvMax) {
+      return false;
+    }
+    if (std::abs(CtauK0s) > cMaxK0sLifeTime) {
+      return false;
+    }
+    if (std::abs(v0.yK0Short()) > ConfV0Rap) {
+      return false;
+    }
+    if (((std::abs(posTrack.tpcNSigmaPi()) > ConfDaughPIDCuts) || (std::abs(negTrack.tpcNSigmaPi()) > ConfDaughPIDCuts))) {
+      return false;
+    }
+    if ((TMath::Abs(v0.dcapostopv()) < cMinV0DCAPi || TMath::Abs(v0.dcanegtopv()) < cMinV0DCAPi)) {
+      return false;
+    }
+    return true;
+  }
+
+  template <typename Collision, typename V0Cand>
+  bool isSelectedV0AsLambda(Collision const& collision, const V0Cand& v0, int pid /*0: lambda, 1: antilambda*/)
+  {
+    const auto& posTrack = v0.template posTrack_as<PIDTrack>();
+    const auto& negTrack = v0.template negTrack_as<PIDTrack>();
+
+    float CtauLambda = v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::constants::physics::MassLambda;
+
+    if ((v0.mLambda() < massLambdaMin || v0.mLambda() > massLambdaMax) &&
+        (v0.mAntiLambda() < massLambdaMin || v0.mAntiLambda() > massLambdaMax)) {
+      return false;
+    }
+    if (v0.qtarm() > qtArmenterosMaxForLambda) {
+      return false;
+    }
+    if (v0.v0radius() > radiusMax) {
+      return false;
+    }
+    if (v0.v0radius() < radiusMin) {
+      return false;
+    }
+    if (v0.v0cosPA() < cosPaMin) {
+      return false;
+    }
+    if (v0.dcaV0daughters() > dcaV0DaughtersMax) {
+      return false;
+    }
+    if (v0.dcav0topv() > dcaV0ToPvMax) {
+      return false;
+    }
+    if (pid == 0 && (TMath::Abs(v0.dcapostopv()) < cMinV0DCAPr || TMath::Abs(v0.dcanegtopv()) < cMinV0DCAPi)) {
+      return false;
+    }
+    if (pid == 1 && (TMath::Abs(v0.dcapostopv()) < cMinV0DCAPi || TMath::Abs(v0.dcanegtopv()) < cMinV0DCAPr)) {
+      return false;
+    }
+    if (pid == 0 && ((std::abs(posTrack.tpcNSigmaPr()) > ConfDaughPIDCuts) || (std::abs(negTrack.tpcNSigmaPi()) > ConfDaughPIDCuts))) {
+      return false;
+    }
+    if (pid == 1 && ((std::abs(posTrack.tpcNSigmaPi()) > ConfDaughPIDCuts) || (std::abs(negTrack.tpcNSigmaPr()) > ConfDaughPIDCuts))) {
+      return false;
+    }
+    if (std::abs(CtauLambda) > cMaxLambdaLifeTime) {
+      return false;
+    }
+    if (std::abs(v0.yLambda()) > ConfV0Rap) {
+      return false;
+    }
+    return true;
+  }
+
+  template <typename T1>
+  bool isV0TrackSelected(const T1& v0)
+  {
+    const auto& posTrack = v0.template posTrack_as<PIDTrack>();
+    const auto& negTrack = v0.template negTrack_as<PIDTrack>();
+
+    if (!posTrack.hasTPC() || !negTrack.hasTPC()) {
+      return false;
+    }
+    if (posTrack.tpcNClsCrossedRows() < tpcNClsCrossedRowsTrackMin || negTrack.tpcNClsCrossedRows() < tpcNClsCrossedRowsTrackMin) {
+      return false;
+    }
+    if (posTrack.tpcCrossedRowsOverFindableCls() < 0.8 || negTrack.tpcCrossedRowsOverFindableCls() < 0.8) {
+      return false;
+    }
+    if (std::abs(v0.positiveeta()) > etaTrackMax || std::abs(v0.negativeeta()) > etaTrackMax) {
+      return false;
+    }
+    if (v0.positivept() < ptTrackMin || v0.negativept() < ptTrackMin) {
+      return false;
+    }
+    return true;
+  }
+
+  // Processing data for invariant mass analysis for 2-prong tracks, including V0s (K0s, Lambdas, Anti-Lambdas) and Phi mesons
   using PIDTrack = soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection, aod::pidTPCPi, aod::pidTPCKa, aod::pidTPCPr, aod::pidTOFPi, aod::pidTOFKa, aod::pidTOFPr>;
-  void processDataInvMass(aod::Collisions::iterator const&, aod::BCsWithTimestamps const&, aod::CFCollRefs const& cfcollisions, aod::CFTrackRefs const& cftracks, PIDTrack const& tracks)
+  void processDataInvMass(aod::Collisions::iterator const& collision, aod::BCsWithTimestamps const&, aod::CFCollRefs const& cfcollisions, aod::CFTrackRefs const& cftracks, PIDTrack const& tracks, aod::V0Datas const& V0s)
   {
     if (cfcollisions.size() <= 0 || cftracks.size() <= 0)
       return; // rejected collision
-    for (const auto& cftrack1 : cftracks) {
-      const auto& p1 = tracks.iteratorAt(cftrack1.trackId() - tracks.begin().globalIndex());
-      if (p1.sign() != 1)
-        continue;
-      if (sigmaFormula->Eval(o2::aod::pidutils::tpcNSigma(cfgImPart1PID, p1), o2::aod::pidutils::tofNSigma(cfgImPart1PID, p1)) <= 0.0f)
-        continue;
-      for (const auto& cftrack2 : cftracks) {
-        if (cftrack2.globalIndex() == cftrack1.globalIndex())
-          continue;
-        const auto& p2 = tracks.iteratorAt(cftrack2.trackId() - tracks.begin().globalIndex());
-        if (p2.sign() != -1)
-          continue;
-        if (sigmaFormula->Eval(o2::aod::pidutils::tpcNSigma(cfgImPart2PID, p2), o2::aod::pidutils::tofNSigma(cfgImPart2PID, p2)) <= 0.0f)
-          continue;
-        ROOT::Math::PtEtaPhiMVector vec1(p1.pt(), p1.eta(), p1.phi(), cfgImPart1Mass);
-        ROOT::Math::PtEtaPhiMVector vec2(p2.pt(), p2.eta(), p2.phi(), cfgImPart2Mass);
-        ROOT::Math::PtEtaPhiMVector s = vec1 + vec2;
-        if (s.pt() < cfgImCutPt || s.M() < cfgImMinInvMass || s.M() > cfgImMaxInvMass)
-          continue;
 
-        float phi = RecoDecay::constrainAngle(s.Phi(), 0.0f);
-        output2ProngTracks(cfcollisions.begin().globalIndex(),
-                           cftrack1.globalIndex(), cftrack2.globalIndex(), s.pt(), s.eta(), phi, s.M(), aod::cf2prongtrack::Generic2Prong);
-      }
-    }
+    o2::aod::ITSResponse itsResponse;
+
+    if (cfgDoPhi) {                           // Process Phi mesons
+      for (const auto& cftrack1 : cftracks) { // Loop over first track
+        const auto& p1 = tracks.iteratorAt(cftrack1.trackId() - tracks.begin().globalIndex());
+
+        if (p1.sign() != 1) // Only consider positive tracks
+          continue;
+        if (sigmaFormula->Eval(o2::aod::pidutils::tpcNSigma(cfgImPart1PID, p1), o2::aod::pidutils::tofNSigma(cfgImPart1PID, p1)) <= 0.0f) // Check if the track passes PID condition
+          continue;
+        if (ITSPIDSelection && p1.p() < ITSPIDPthreshold.value && !(itsResponse.nSigmaITS<o2::track::PID::Kaon>(p1) > -ITSPIDNsigma.value && itsResponse.nSigmaITS<o2::track::PID::Kaon>(p1) < ITSPIDNsigma.value)) { // Check ITS PID condition
+          continue;
+        }
+        if (removefaketrack && isFakeKaon(p1)) { // Check if the track is a fake kaon
+          continue;
+        }
+
+        for (const auto& cftrack2 : cftracks) {                 // Loop over second track
+          if (cftrack2.globalIndex() == cftrack1.globalIndex()) // Skip if it's the same track as the first one
+            continue;
+
+          const auto& p2 = tracks.iteratorAt(cftrack2.trackId() - tracks.begin().globalIndex());
+          if (p2.sign() != -1) // Only consider negative tracks
+            continue;
+          if (sigmaFormula->Eval(o2::aod::pidutils::tpcNSigma(cfgImPart2PID, p2), o2::aod::pidutils::tofNSigma(cfgImPart2PID, p2)) <= 0.0f) // Check if the track passes PID condition
+            continue;
+          if (ITSPIDSelection && p2.p() < ITSPIDPthreshold.value && !(itsResponse.nSigmaITS<o2::track::PID::Kaon>(p2) > -ITSPIDNsigma.value && itsResponse.nSigmaITS<o2::track::PID::Kaon>(p2) < ITSPIDNsigma.value)) { // Check ITS PID condition
+            continue;
+          }
+          if (!selectionPair(p1, p2)) {
+            continue;
+          }
+          if (removefaketrack && isFakeKaon(p2)) {
+            continue;
+          }
+
+          ROOT::Math::PtEtaPhiMVector vec1(p1.pt(), p1.eta(), p1.phi(), cfgImPart1Mass);
+          ROOT::Math::PtEtaPhiMVector vec2(p2.pt(), p2.eta(), p2.phi(), cfgImPart2Mass);
+          ROOT::Math::PtEtaPhiMVector s = vec1 + vec2;
+          if (s.pt() < cfgImCutPt || s.M() < cfgImMinInvMass || s.M() > cfgImMaxInvMass)
+            continue;
+
+          float phi = RecoDecay::constrainAngle(s.Phi(), 0.0f);
+          output2ProngTracks(cfcollisions.begin().globalIndex(),
+                             cftrack1.globalIndex(), cftrack2.globalIndex(), s.pt(), s.eta(), phi, s.M(), aod::cf2prongtrack::PhiToKK);
+        } // end of loop over second track
+      } // end of loop over first track
+    } // end of processing Phi mesons
+
+    if (cfgDoV0) {                    // Process V0 candidates (K0s, Lambdas, Anti-Lambdas)
+      for (const auto& v0 : V0s) {    // Loop over V0 candidates
+        if (!isV0TrackSelected(v0)) { // Quality selection for V0 prongs
+          continue;
+        }
+
+        const auto& posTrack = v0.template posTrack_as<PIDTrack>();
+        const auto& negTrack = v0.template negTrack_as<PIDTrack>();
+
+        auto v0Type = 0;
+        double massV0 = 0.0;
+        if (isSelectedV0AsK0s(collision, v0)) { // candidate is K0s
+          SETBIT(v0Type, aod::cf2prongtrack::K0stoPiPi);
+
+          output2ProngTracks(cfcollisions.begin().globalIndex(),
+                             posTrack.globalIndex(), negTrack.globalIndex(),
+                             v0.pt(), v0.eta(), v0.phi(), v0.mK0Short(), v0Type);
+
+          continue; // candidate is K0s, skip to next V0 candidate
+        }
+
+        bool LambdaTag = isSelectedV0AsLambda(collision, v0, 0);
+        bool aLambdaTag = isSelectedV0AsLambda(collision, v0, 1);
+        if (!LambdaTag && !aLambdaTag) { // neither Lambda nor Anti-Lambda
+          continue;
+        }
+        // Note: candidate compatible with Lambda and Anti-Lambda hypothesis are counted twice (once for each hypothesis)
+        if (LambdaTag) { // candidate is Lambda
+          SETBIT(v0Type, aod::cf2prongtrack::LambdatoPPi);
+          massV0 = v0.mLambda();
+          output2ProngTracks(cfcollisions.begin().globalIndex(), posTrack.globalIndex(), negTrack.globalIndex(),
+                             v0.pt(), v0.eta(), v0.phi(), massV0, v0Type);
+        } else if (aLambdaTag) { // candidate is Anti-lambda
+          SETBIT(v0Type, aod::cf2prongtrack::AntiLambdatoPiP);
+          massV0 = v0.mAntiLambda();
+          output2ProngTracks(cfcollisions.begin().globalIndex(), posTrack.globalIndex(), negTrack.globalIndex(),
+                             v0.pt(), v0.eta(), v0.phi(), massV0, v0Type);
+        } // end of Lambda and Anti-Lambda processing
+      } // end of loop over V0 candidates
+    } // end of processing V0 candidates
   }
   PROCESS_SWITCH(Filter2Prong, processDataInvMass, "Process data generic 2-prong candidates with invariant mass method", false);
 }; // struct

--- a/PWGCF/TableProducer/filter2Prong.cxx
+++ b/PWGCF/TableProducer/filter2Prong.cxx
@@ -417,7 +417,7 @@ struct Filter2Prong {
   }
   PROCESS_SWITCH(Filter2Prong, processDataInvMass, "Process data generic 2-prong candidates with invariant mass method", false);
 
-  // Generic 2-prong invariant mass method candidate finder. Only works for non-identical daughters of opposite charge for now.
+  // Phi and V0s invariant mass method candidate finder. Only works for non-identical daughters of opposite charge for now.
   void processDataPhiV0(aod::Collisions::iterator const& collision, aod::BCsWithTimestamps const&, aod::CFCollRefs const& cfcollisions, aod::CFTrackRefs const& cftracks, Filter2Prong::PIDTrack const& tracks, aod::V0Datas const& V0s)
   {
     if (cfcollisions.size() <= 0 || cftracks.size() <= 0)

--- a/PWGCF/TableProducer/filterCorrelations.cxx
+++ b/PWGCF/TableProducer/filterCorrelations.cxx
@@ -79,6 +79,8 @@ struct FilterCF {
   O2_DEFINE_CONFIGURABLE(dcaselection, bool, false, "flag for applying dca selection on tracks")
   O2_DEFINE_CONFIGURABLE(dcaxymax, float, 0.1f, "dcaxy of tracks")
   O2_DEFINE_CONFIGURABLE(dcazmax, float, 0.1f, "dcaz of tracks")
+  O2_DEFINE_CONFIGURABLE(itsnclusters, int, 5, "minimum number of ITS clusters for tracks")
+  O2_DEFINE_CONFIGURABLE(tpcncrossedrows, int, 80, "minimum number of TPC crossed rows for tracks")
 
   // Filters and input definitions
   Filter collisionZVtxFilter = nabs(aod::collision::posZ) < cfgCutVertex;
@@ -181,10 +183,10 @@ struct FilterCF {
       uint8_t trackType = 0;
       if (track.isGlobalTrack()) {
         trackType |= kTrackSelected;
-        if (track.itsNCls() >= 5) {
+        if (track.itsNCls() >= itsnclusters) {
           trackType |= kITS5Clusters;
         }
-        if (track.tpcNClsCrossedRows() >= 90) {
+        if (track.tpcNClsCrossedRows() >= tpcncrossedrows) {
           trackType |= kTPC90CrossedRows;
         }
       }
@@ -193,10 +195,10 @@ struct FilterCF {
       uint8_t trackType = 0;
       if (track.isGlobalTrack()) {
         trackType |= kTrackSelected;
-        if (track.itsNCls() >= 5) {
+        if (track.itsNCls() >= itsnclusters) {
           trackType |= kITS5Clusters;
         }
-        if (track.tpcNClsCrossedRows() >= 90) {
+        if (track.tpcNClsCrossedRows() >= tpcncrossedrows) {
           trackType |= kTPC90CrossedRows;
         }
         if (isprot) {


### PR DESCRIPTION
This PR adds the possibility to process Phi and V0s in the filter2Prong code. PID selections can be applied at the filterCorrelation and filter2Prong levels. @skundu692 @jgrosseo @prottayCMT for your information.