### PR TITLE
[PWGHF] Ds-h correlation - Adding multi-dimensional histogram for efficiency correction

### DIFF
--- a/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
@@ -794,7 +794,6 @@ struct HfTaskCorrelationDsHadrons {
     for (const auto& mcParticle : mcParticles) {
       // generated candidates
       if ((std::abs(mcParticle.flagMcMatchGen()) == hf_decay::hf_cand_3prong::DecayChannelMain::DsToPiKK) && (mcParticle.flagMcDecayChanGen() == decayChannel)) {
-        auto mcCollision = mcParticle.template mcCollision_as<soa::Join<aod::McCollisions, aod::MultsExtraMC>>();
         auto yDs = RecoDecay::y(mcParticle.pVector(), o2::constants::physics::MassDS);
         if (std::abs(yDs) <= yCandGenMax) {
           if (mcParticle.originMcGen() == RecoDecay::OriginType::Prompt) {


### PR DESCRIPTION
Dear all,
I have added some histograms to be able to evaluate the  Ds-meson and associated particle efficiencies as a function of multiplicity (Ds and associated particles), eta, z-vertex position (associated particles).
Let me know for any comment.

Cheers,
Samuele