### PR TITLE
[PWGCF,PWGHF,PWGJE] Propagate new MC flags to 2-prongs

### DIFF
--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -17,45 +17,49 @@
 /// \author Pritam Chakraborty, WUT Warsaw, pritam.chakraborty@cern.ch
 /// \author Shirajum Monira, WUT Warsaw, shirajum.monira@cern.ch
 
-#include <experimental/type_traits>
-#include <CCDB/BasicCCDBManager.h>
-#include <TPDGCode.h>
-#include <vector>
-#include <algorithm>
-#include <set>
-
-#include "CommonConstants/PhysicsConstants.h"
-#include "Common/CCDB/ctpRateFetcher.h"
-#include "Common/Core/trackUtilities.h"
-#include "Common/Core/RecoDecay.h"
-#include "Common/DataModel/EventSelection.h"
-#include "Common/DataModel/Multiplicity.h"
-#include "Common/DataModel/Centrality.h"
-#include "Common/DataModel/PIDResponse.h"
-#include "Common/DataModel/TrackSelectionTables.h"
-#include "DataFormatsParameters/GRPMagField.h"
-#include "DataFormatsParameters/GRPObject.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniverseCascadeSelection.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseCollisionSelection.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniversePhiSelection.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseTrackSelection.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseV0Selection.h"
-#include "PWGCF/FemtoUniverse/Core/FemtoUniverseCascadeSelection.h"
-#include "PWGCF/FemtoUniverse/Core/FemtoUniversePhiSelection.h"
 #include "PWGCF/FemtoUniverse/Core/femtoUtils.h"
+#include "PWGCF/FemtoUniverse/DataModel/FemtoDerived.h"
+#include "PWGHF/Core/DecayChannels.h"
+#include "PWGHF/Core/HfHelper.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
-#include "PWGHF/Core/HfHelper.h"
+#include "PWGLF/DataModel/LFStrangenessTables.h"
+
+#include "Common/CCDB/ctpRateFetcher.h"
+#include "Common/Core/RecoDecay.h"
+#include "Common/Core/trackUtilities.h"
+#include "Common/DataModel/Centrality.h"
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/Multiplicity.h"
+#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+
+#include "CommonConstants/PhysicsConstants.h"
+#include "DataFormatsParameters/GRPMagField.h"
+#include "DataFormatsParameters/GRPObject.h"
 #include "Framework/ASoAHelpers.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/AnalysisTask.h"
 #include "Framework/HistogramRegistry.h"
-#include "Framework/runDataProcessing.h"
-#include "Math/Vector4D.h"
-#include "PWGCF/FemtoUniverse/DataModel/FemtoDerived.h"
-#include "PWGLF/DataModel/LFStrangenessTables.h"
-#include "ReconstructionDataFormats/Track.h"
-#include "TMath.h"
-#include "TLorentzVector.h"
 #include "Framework/O2DatabasePDGPlugin.h"
+#include "Framework/runDataProcessing.h"
+#include "ReconstructionDataFormats/Track.h"
+#include <CCDB/BasicCCDBManager.h>
+
+#include "Math/Vector4D.h"
+#include "TLorentzVector.h"
+#include "TMath.h"
+#include <TPDGCode.h>
+
+#include <algorithm>
+#include <experimental/type_traits>
+#include <set>
+#include <vector>
 
 using namespace o2;
 using namespace o2::analysis::femto_universe;
@@ -786,7 +790,7 @@ struct FemtoUniverseProducerTask {
   template <typename ParticleType>
   void fillMCParticleD0(ParticleType const& hfCand)
   {
-    if (std::abs(hfCand.flagMcMatchRec()) == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) {
+    if (std::abs(hfCand.flagMcMatchRec()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
       // get corresponding MC particle and its info
       int pdgCode = 0;
       int hfCandOrigin = 99;
@@ -1807,7 +1811,7 @@ struct FemtoUniverseProducerTask {
 
         auto mcD0origin = aod::femtouniverseparticle::ParticleType::kMCTruthTrack;
         float ptGenB = -1;
-        if (std::abs(particle.flagMcMatchGen()) == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) {
+        if (std::abs(particle.flagMcMatchGen()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
           if (ConfD0Selection.yD0D0barCandGenMax >= 0. && std::abs(RecoDecay::y(particle.pVector(), o2::constants::physics::MassD0)) > ConfD0Selection.yD0D0barCandGenMax) {
             continue;
           }

--- a/PWGCF/TableProducer/filter2Prong.cxx
+++ b/PWGCF/TableProducer/filter2Prong.cxx
@@ -12,6 +12,7 @@
 /// \author Jasper Parkkila <jasper.parkkila@cern.ch>
 
 #include "PWGCF/DataModel/CorrelationsDerived.h"
+#include "PWGHF/Core/DecayChannels.h"
 #include "PWGHF/Core/HfHelper.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
@@ -147,7 +148,7 @@ struct Filter2Prong {
     // The main filter outputs the primary MC particles. Here we just resolve the daughter indices that are needed for the efficiency matching.
     for (const auto& r : cfmcparticles) {
       const auto& mcParticle = r.mcParticle_as<HFMCTrack>();
-      if ((mcParticle.flagMcMatchGen() & (1 << aod::hf_cand_2prong::DecayType::D0ToPiK)) == 0 || mcParticle.daughtersIds().size() != 2) {
+      if ((std::abs(mcParticle.flagMcMatchGen()) != o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) || mcParticle.daughtersIds().size() != 2) {
         output2ProngMcParts(-1, -1, aod::cf2prongtrack::Generic2Prong);
         continue;
       }

--- a/PWGHF/Core/DecayChannels.h
+++ b/PWGHF/Core/DecayChannels.h
@@ -40,8 +40,11 @@ enum DecayChannelMain : int8_t {
   D0ToPiPi = 3,    // π+ π−
   D0ToPiPiPi0 = 4, // π+ π− π0
   D0ToKK = 5,      // K+ K−
+  // J/ψ
+  JpsiToEE = 6,   // e+ e−
+  JpsiToMuMu = 7, // μ+ μ−
   //
-  NChannelsMain = D0ToKK // last channel
+  NChannelsMain = JpsiToMuMu // last channel
 };
 /// @brief 2-prong candidates: resonant channels
 enum DecayChannelResonant : int8_t {
@@ -119,7 +122,7 @@ enum DecayChannelResonant : int8_t {
   DstarToDplusToRho0Pi = 22,       // ρ0 π+
   DstarToDplusToF2_1270Pi = 23,    // f2(1270) π+
   // Λc+
-  LcToPKstar0 = 24,        // p K*0(892)
+  LcToPKstar0 = 24,        // p anti-K*0(892)
   LcToDeltaplusplusK = 25, // Δ++ K−
   LcToL1520Pi = 26,        // Λ(1520) π+
   // Ξc+

--- a/PWGHF/D2H/Tasks/taskCharmPolarisation.cxx
+++ b/PWGHF/D2H/Tasks/taskCharmPolarisation.cxx
@@ -44,8 +44,6 @@
 #include <TPDGCode.h>
 #include <TRandom3.h>
 
-#include <Rtypes.h>
-
 #include <array>
 #include <cmath>
 #include <cstdint>
@@ -1626,8 +1624,8 @@ struct TaskPolarisationCharmHadrons {
     int8_t charge = -99;
     bool partRecoDstar{false};
     if constexpr (channel == charm_polarisation::DecayChannel::DstarToDzeroPi) {
-      partRecoDstar = TESTBIT(std::abs(mcParticle.flagMcMatchGen()), hf_decay::hf_cand_dstar::DecayChannelMain::DstarToPiKPiPi0) && TESTBIT(std::abs(mcParticle.flagMcMatchGenD0()), hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiKPi0);
-      bool signalDstar = TESTBIT(std::abs(mcParticle.flagMcMatchGen()), hf_decay::hf_cand_dstar::DecayChannelMain::DstarToPiKPi) && TESTBIT(std::abs(mcParticle.flagMcMatchGenD0()), hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK);
+      partRecoDstar = (std::abs(mcParticle.flagMcMatchGen()) == hf_decay::hf_cand_dstar::DecayChannelMain::DstarToPiKPiPi0) && (std::abs(mcParticle.flagMcMatchGenD0()) == hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiKPi0);
+      bool signalDstar = (std::abs(mcParticle.flagMcMatchGen()) == hf_decay::hf_cand_dstar::DecayChannelMain::DstarToPiKPi) && (std::abs(mcParticle.flagMcMatchGenD0()) == hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK);
 
       if (!signalDstar && (!activatePartRecoDstar || !partRecoDstar)) { // this particle is not signal and not partially reconstructed signal, skip
         return;

--- a/PWGHF/D2H/Tasks/taskD0.cxx
+++ b/PWGHF/D2H/Tasks/taskD0.cxx
@@ -16,6 +16,7 @@
 /// \author Vít Kučera <vit.kucera@cern.ch>, CERN
 
 #include "PWGHF/Core/CentralityEstimation.h"
+#include "PWGHF/Core/DecayChannels.h"
 #include "PWGHF/Core/HfHelper.h"
 #include "PWGHF/Core/SelectorCuts.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
@@ -569,7 +570,7 @@ struct HfTaskD0 {
       }
       auto trackPos = candidate.template prong0_as<TracksSelQuality>(); // positive daughter
       auto trackNeg = candidate.template prong1_as<TracksSelQuality>(); // negative daughter
-      if (std::abs(candidate.flagMcMatchRec()) == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) {
+      if (std::abs(candidate.flagMcMatchRec()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
         // Get the corresponding MC particle.
         auto indexMother = RecoDecay::getMother(mcParticles, trackPos.template mcParticle_as<soa::Join<aod::McParticles, aod::HfCand2ProngMcGen>>(), o2::constants::physics::Pdg::kD0, true);
         auto particleMother = mcParticles.rawIteratorAt(indexMother);
@@ -663,7 +664,7 @@ struct HfTaskD0 {
       int minTpcCrossedRowsOfProngs = std::min(trackPos.tpcNClsCrossedRows(), trackNeg.tpcNClsCrossedRows());
       if (candidate.isSelD0() >= selectionFlagD0) {
         registry.fill(HIST("hMassSigBkgD0"), massD0, ptCandidate, rapidityCandidate);
-        if (candidate.flagMcMatchRec() == (1 << aod::hf_cand_2prong::DecayType::D0ToPiK)) {
+        if (candidate.flagMcMatchRec() == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
           registry.fill(HIST("hPtProng0Sig"), ptProng0, rapidityCandidate);
           registry.fill(HIST("hPtProng1Sig"), ptProng1, rapidityCandidate);
           registry.fill(HIST("hDecLengthSig"), declengthCandidate, rapidityCandidate);
@@ -727,7 +728,7 @@ struct HfTaskD0 {
           registry.fill(HIST("hCPABkg"), cpaCandidate, rapidityCandidate);
           registry.fill(HIST("hCPAxyBkg"), cpaxyCandidate, rapidityCandidate);
           registry.fill(HIST("hMassBkgD0"), massD0, ptCandidate, rapidityCandidate);
-          if (candidate.flagMcMatchRec() == -(1 << aod::hf_cand_2prong::DecayType::D0ToPiK)) {
+          if (candidate.flagMcMatchRec() == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
             registry.fill(HIST("hMassReflBkgD0"), massD0, ptCandidate, rapidityCandidate);
             if constexpr (applyMl) {
               if (storeCentrality && storeOccupancy) {
@@ -759,7 +760,7 @@ struct HfTaskD0 {
       }
       if (candidate.isSelD0bar() >= selectionFlagD0bar) {
         registry.fill(HIST("hMassSigBkgD0bar"), massD0bar, ptCandidate, rapidityCandidate);
-        if (candidate.flagMcMatchRec() == -(1 << aod::hf_cand_2prong::DecayType::D0ToPiK)) {
+        if (candidate.flagMcMatchRec() == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
           registry.fill(HIST("hMassSigD0bar"), massD0bar, ptCandidate, rapidityCandidate);
           if constexpr (applyMl) {
             if (storeCentrality && storeOccupancy) {
@@ -788,7 +789,7 @@ struct HfTaskD0 {
           }
         } else {
           registry.fill(HIST("hMassBkgD0bar"), massD0bar, ptCandidate, rapidityCandidate);
-          if (candidate.flagMcMatchRec() == (1 << aod::hf_cand_2prong::DecayType::D0ToPiK)) {
+          if (candidate.flagMcMatchRec() == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
             registry.fill(HIST("hMassReflBkgD0bar"), massD0bar, ptCandidate, rapidityCandidate);
             if constexpr (applyMl) {
               if (storeCentrality && storeOccupancy) {
@@ -821,7 +822,7 @@ struct HfTaskD0 {
     }
     // MC gen.
     for (const auto& particle : mcParticles) {
-      if (std::abs(particle.flagMcMatchGen()) == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) {
+      if (std::abs(particle.flagMcMatchGen()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
         if (yCandGenMax >= 0. && std::abs(RecoDecay::y(particle.pVector(), o2::constants::physics::MassD0)) > yCandGenMax) {
           continue;
         }

--- a/PWGHF/D2H/Tasks/taskLcToK0sP.cxx
+++ b/PWGHF/D2H/Tasks/taskLcToK0sP.cxx
@@ -266,17 +266,9 @@ struct HfTaskLcToK0sP {
                TracksWPid const&)
   {
     for (const auto& candidate : candidates) {
-      /*
-      // no such selection for LcK0sp for now - it is the only cascade
-      if (!(candidate.hfflag() & 1 << D0ToPiK)) {
-        continue;
-      }
-      */
-
       if (etaCandMax >= 0. && std::abs(candidate.eta()) > etaCandMax) {
         continue;
       }
-
       if (yCandRecoMax >= 0. && std::abs(hfHelper.yLc(candidate)) > yCandRecoMax) {
         continue;
       }

--- a/PWGHF/D2H/Tasks/taskSigmac.cxx
+++ b/PWGHF/D2H/Tasks/taskSigmac.cxx
@@ -1070,7 +1070,7 @@ struct HfTaskSigmac {
         double decLengthLc(candidateLc.decayLength()), decLengthXYLc(candidateLc.decayLengthXY());
         double cpaLc(candidateLc.cpa()), cpaXYLc(candidateLc.cpaXY());
         int origin = candSc.originMcRec();
-        auto channel = candidateLc.flagMcDecayChanRec(); /// 0: direct; 1: Λc± → p± K*; 2: Λc± → Δ(1232)±± K∓; 3: Λc± → Λ(1520) π±
+        auto channel = candidateLc.flagMcDecayChanRec(); /// 0: direct; 1: Λc± → p± K*; 2: Λc± → Δ(1232)±± K∓; 3: Λc± → Λ(1520) π±; FIXME: DecayChannelResonant
 
         /// candidate Λc+ → pK-π+ (and charge conjugate) within the range of M(pK-π+) chosen in the Σc0,++ builder
         if ((TESTBIT(isCandPKPiPiKP, o2::aod::hf_cand_sigmac::Decays::PKPi)) && std::abs(candidateLc.template prong0_as<aod::TracksWMc>().mcParticle().pdgCode()) == kProton) {

--- a/PWGHF/HFC/TableProducer/correlatorD0D0bar.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorD0D0bar.cxx
@@ -14,6 +14,7 @@
 ///
 /// \author Fabio Colamaria <fabio.colamaria@ba.infn.it>, INFN Bari
 
+#include "PWGHF/Core/DecayChannels.h"
 #include "PWGHF/Core/HfHelper.h"
 #include "PWGHF/Core/SelectorCuts.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
@@ -306,7 +307,7 @@ struct HfCorrelatorD0D0bar {
         efficiencyWeight = 1. / efficiencyD->at(o2::analysis::findBin(binsPt, candidate1.pt()));
       }
 
-      if (std::abs(candidate1.flagMcMatchRec()) == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) {
+      if (std::abs(candidate1.flagMcMatchRec()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
         // fill per-candidate distributions from D0/D0bar true candidates
         registry.fill(HIST("hPtCandMCRec"), candidate1.pt());
         registry.fill(HIST("hPtProng0MCRec"), candidate1.ptProng0());
@@ -317,19 +318,19 @@ struct HfCorrelatorD0D0bar {
         registry.fill(HIST("hSelectionStatusMCRec"), candidate1.isSelD0bar() + (candidate1.isSelD0() * 2));
       }
       // fill invariant mass plots from D0/D0bar signal and background candidates
-      if (candidate1.isSelD0() >= selectionFlagD0) {                                       // only reco as D0
-        if (candidate1.flagMcMatchRec() == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) { // also matched as D0
+      if (candidate1.isSelD0() >= selectionFlagD0) {                                                  // only reco as D0
+        if (candidate1.flagMcMatchRec() == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) { // also matched as D0
           registry.fill(HIST("hMassD0MCRecSig"), hfHelper.invMassD0ToPiK(candidate1), candidate1.pt(), efficiencyWeight);
-        } else if (candidate1.flagMcMatchRec() == -(1 << aod::hf_cand_2prong::DecayType::D0ToPiK)) {
+        } else if (candidate1.flagMcMatchRec() == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
           registry.fill(HIST("hMassD0MCRecRefl"), hfHelper.invMassD0ToPiK(candidate1), candidate1.pt(), efficiencyWeight);
         } else {
           registry.fill(HIST("hMassD0MCRecBkg"), hfHelper.invMassD0ToPiK(candidate1), candidate1.pt(), efficiencyWeight);
         }
       }
-      if (candidate1.isSelD0bar() >= selectionFlagD0bar) {                                    // only reco as D0bar
-        if (candidate1.flagMcMatchRec() == -(1 << aod::hf_cand_2prong::DecayType::D0ToPiK)) { // also matched as D0bar
+      if (candidate1.isSelD0bar() >= selectionFlagD0bar) {                                             // only reco as D0bar
+        if (candidate1.flagMcMatchRec() == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) { // also matched as D0bar
           registry.fill(HIST("hMassD0barMCRecSig"), hfHelper.invMassD0barToKPi(candidate1), candidate1.pt(), efficiencyWeight);
-        } else if (candidate1.flagMcMatchRec() == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) {
+        } else if (candidate1.flagMcMatchRec() == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
           registry.fill(HIST("hMassD0barMCRecRefl"), hfHelper.invMassD0barToKPi(candidate1), candidate1.pt(), efficiencyWeight);
         } else {
           registry.fill(HIST("hMassD0barMCRecBkg"), hfHelper.invMassD0barToKPi(candidate1), candidate1.pt(), efficiencyWeight);
@@ -341,8 +342,8 @@ struct HfCorrelatorD0D0bar {
       if (candidate1.isSelD0() < selectionFlagD0) { // discard candidates not selected as D0 in outer loop
         continue;
       }
-      flagD0Signal = candidate1.flagMcMatchRec() == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK;        // flagD0Signal 'true' if candidate1 matched to D0 (particle)
-      flagD0Reflection = candidate1.flagMcMatchRec() == -(1 << aod::hf_cand_2prong::DecayType::D0ToPiK); // flagD0Reflection 'true' if candidate1, selected as D0 (particle), is matched to D0bar (antiparticle)
+      flagD0Signal = candidate1.flagMcMatchRec() == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK;      // flagD0Signal 'true' if candidate1 matched to D0 (particle)
+      flagD0Reflection = candidate1.flagMcMatchRec() == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK; // flagD0Reflection 'true' if candidate1, selected as D0 (particle), is matched to D0bar (antiparticle)
       for (const auto& candidate2 : selectedD0CandidatesGroupedMC) {
         if (!(candidate2.hfflag() & 1 << aod::hf_cand_2prong::DecayType::D0ToPiK)) { // check decay channel flag for candidate2
           continue;
@@ -350,8 +351,8 @@ struct HfCorrelatorD0D0bar {
         if (candidate2.isSelD0bar() < selectionFlagD0bar) { // discard candidates not selected as D0bar in inner loop
           continue;
         }
-        flagD0barSignal = candidate2.flagMcMatchRec() == -(1 << aod::hf_cand_2prong::DecayType::D0ToPiK);  // flagD0barSignal 'true' if candidate2 matched to D0bar (antiparticle)
-        flagD0barReflection = candidate2.flagMcMatchRec() == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK; // flagD0barReflection 'true' if candidate2, selected as D0bar (antiparticle), is matched to D0 (particle)
+        flagD0barSignal = candidate2.flagMcMatchRec() == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK;    // flagD0barSignal 'true' if candidate2 matched to D0bar (antiparticle)
+        flagD0barReflection = candidate2.flagMcMatchRec() == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK; // flagD0barReflection 'true' if candidate2, selected as D0bar (antiparticle), is matched to D0 (particle)
         if (yCandMax >= 0. && std::abs(hfHelper.yD0(candidate2)) > yCandMax) {
           continue;
         }
@@ -455,7 +456,7 @@ struct HfCorrelatorD0D0bar {
 
         // fill pairs vs etaCut plot
         bool rightDecayChannels = false;
-        if ((std::abs(particle1.flagMcMatchGen()) == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) && (std::abs(particle2.flagMcMatchGen()) == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK)) {
+        if ((std::abs(particle1.flagMcMatchGen()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) && (std::abs(particle2.flagMcMatchGen()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK)) {
           rightDecayChannels = true;
         }
         do {

--- a/PWGHF/HFC/TableProducer/correlatorD0D0barBarrelFullPid.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorD0D0barBarrelFullPid.cxx
@@ -14,6 +14,7 @@
 ///
 /// \author Fabio Colamaria <fabio.colamaria@ba.infn.it>, INFN Bari
 
+#include "PWGHF/Core/DecayChannels.h"
 #include "PWGHF/Core/HfHelper.h"
 #include "PWGHF/Core/SelectorCuts.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
@@ -307,7 +308,7 @@ struct HfCorrelatorD0D0barBarrelFullPid {
         efficiencyWeight = 1. / efficiencyD->at(o2::analysis::findBin(binsPt, candidate1.pt()));
       }
 
-      if (std::abs(candidate1.flagMcMatchRec()) == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) {
+      if (std::abs(candidate1.flagMcMatchRec()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
         // fill per-candidate distributions from D0/D0bar true candidates
         registry.fill(HIST("hPtCandMCRec"), candidate1.pt());
         registry.fill(HIST("hPtProng0MCRec"), candidate1.ptProng0());
@@ -318,19 +319,19 @@ struct HfCorrelatorD0D0barBarrelFullPid {
         registry.fill(HIST("hSelectionStatusMCRec"), candidate1.isSelD0barTofPlusRichPid() + (candidate1.isSelD0TofPlusRichPid() * 2));
       }
       // fill invariant mass plots from D0/D0bar signal and background candidates
-      if (candidate1.isSelD0TofPlusRichPid() >= selectionFlagD0) {                         // only reco as D0
-        if (candidate1.flagMcMatchRec() == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) { // also matched as D0
+      if (candidate1.isSelD0TofPlusRichPid() >= selectionFlagD0) {                                    // only reco as D0
+        if (candidate1.flagMcMatchRec() == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) { // also matched as D0
           registry.fill(HIST("hMassD0MCRecSig"), hfHelper.invMassD0ToPiK(candidate1), candidate1.pt(), efficiencyWeight);
-        } else if (candidate1.flagMcMatchRec() == -(1 << aod::hf_cand_2prong::DecayType::D0ToPiK)) {
+        } else if (candidate1.flagMcMatchRec() == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
           registry.fill(HIST("hMassD0MCRecRefl"), hfHelper.invMassD0ToPiK(candidate1), candidate1.pt(), efficiencyWeight);
         } else {
           registry.fill(HIST("hMassD0MCRecBkg"), hfHelper.invMassD0ToPiK(candidate1), candidate1.pt(), efficiencyWeight);
         }
       }
-      if (candidate1.isSelD0barTofPlusRichPid() >= selectionFlagD0bar) {                      // only reco as D0bar
-        if (candidate1.flagMcMatchRec() == -(1 << aod::hf_cand_2prong::DecayType::D0ToPiK)) { // also matched as D0bar
+      if (candidate1.isSelD0barTofPlusRichPid() >= selectionFlagD0bar) {                               // only reco as D0bar
+        if (candidate1.flagMcMatchRec() == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) { // also matched as D0bar
           registry.fill(HIST("hMassD0barMCRecSig"), hfHelper.invMassD0barToKPi(candidate1), candidate1.pt(), efficiencyWeight);
-        } else if (candidate1.flagMcMatchRec() == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) {
+        } else if (candidate1.flagMcMatchRec() == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
           registry.fill(HIST("hMassD0barMCRecRefl"), hfHelper.invMassD0barToKPi(candidate1), candidate1.pt(), efficiencyWeight);
         } else {
           registry.fill(HIST("hMassD0barMCRecBkg"), hfHelper.invMassD0barToKPi(candidate1), candidate1.pt(), efficiencyWeight);
@@ -342,8 +343,8 @@ struct HfCorrelatorD0D0barBarrelFullPid {
       if (candidate1.isSelD0TofPlusRichPid() < selectionFlagD0) { // discard candidates not selected as D0 in outer loop
         continue;
       }
-      flagD0Signal = candidate1.flagMcMatchRec() == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK;        // flagD0Signal 'true' if candidate1 matched to D0 (particle)
-      flagD0Reflection = candidate1.flagMcMatchRec() == -(1 << aod::hf_cand_2prong::DecayType::D0ToPiK); // flagD0Reflection 'true' if candidate1, selected as D0 (particle), is matched to D0bar (antiparticle)
+      flagD0Signal = candidate1.flagMcMatchRec() == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK;      // flagD0Signal 'true' if candidate1 matched to D0 (particle)
+      flagD0Reflection = candidate1.flagMcMatchRec() == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK; // flagD0Reflection 'true' if candidate1, selected as D0 (particle), is matched to D0bar (antiparticle)
       for (const auto& candidate2 : selectedD0candidatesGroupedMC) {
         if (!(candidate2.hfflag() & 1 << aod::hf_cand_2prong::DecayType::D0ToPiK)) { // check decay channel flag for candidate2
           continue;
@@ -351,8 +352,8 @@ struct HfCorrelatorD0D0barBarrelFullPid {
         if (candidate2.isSelD0barTofPlusRichPid() < selectionFlagD0bar) { // discard candidates not selected as D0bar in inner loop
           continue;
         }
-        flagD0barSignal = candidate2.flagMcMatchRec() == -(1 << aod::hf_cand_2prong::DecayType::D0ToPiK);  // flagD0barSignal 'true' if candidate2 matched to D0bar (antiparticle)
-        flagD0barReflection = candidate2.flagMcMatchRec() == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK; // flagD0barReflection 'true' if candidate2, selected as D0bar (antiparticle), is matched to D0 (particle)
+        flagD0barSignal = candidate2.flagMcMatchRec() == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK;    // flagD0barSignal 'true' if candidate2 matched to D0bar (antiparticle)
+        flagD0barReflection = candidate2.flagMcMatchRec() == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK; // flagD0barReflection 'true' if candidate2, selected as D0bar (antiparticle), is matched to D0 (particle)
         if (yCandMax >= 0. && std::abs(hfHelper.yD0(candidate2)) > yCandMax) {
           continue;
         }
@@ -456,7 +457,7 @@ struct HfCorrelatorD0D0barBarrelFullPid {
 
         // fill pairs vs etaCut plot
         bool rightDecayChannels = false;
-        if ((std::abs(particle1.flagMcMatchGen()) == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) && (std::abs(particle2.flagMcMatchGen()) == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK)) {
+        if ((std::abs(particle1.flagMcMatchGen()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) && (std::abs(particle2.flagMcMatchGen()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK)) {
           rightDecayChannels = true;
         }
         do {

--- a/PWGHF/HFC/TableProducer/correlatorD0Hadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorD0Hadrons.cxx
@@ -15,6 +15,7 @@
 /// \author Samrangy Sadhu <samrangy.sadhu@cern.ch>, INFN Bari
 /// \author Swapnesh Santosh Khade <swapnesh.santosh.khade@cern.ch>, IIT Indore
 
+#include "PWGHF/Core/DecayChannels.h"
 #include "PWGHF/Core/HfHelper.h"
 #include "PWGHF/Core/SelectorCuts.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
@@ -557,7 +558,7 @@ struct HfCorrelatorD0Hadrons {
         efficiencyWeight = 1. / efficiencyDmeson->at(o2::analysis::findBin(binsPtEfficiencyD, candidate.pt()));
       }
 
-      if (std::abs(candidate.flagMcMatchRec()) == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) {
+      if (std::abs(candidate.flagMcMatchRec()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
         // fill per-candidate distributions from D0/D0bar true candidates
         registry.fill(HIST("hPtCandRec"), candidate.pt());
         registry.fill(HIST("hPtProng0Rec"), candidate.ptProng0());
@@ -568,8 +569,8 @@ struct HfCorrelatorD0Hadrons {
         registry.fill(HIST("hSelectionStatusRec"), candidate.isSelD0bar() + (candidate.isSelD0() * 2));
       }
       // fill invariant mass plots from D0/D0bar signal and background candidates
-      if (candidate.isSelD0() >= selectionFlagD0) {                                       // only reco as D0
-        if (candidate.flagMcMatchRec() == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) { // also matched as D0
+      if (candidate.isSelD0() >= selectionFlagD0) {                                                  // only reco as D0
+        if (candidate.flagMcMatchRec() == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) { // also matched as D0
           registry.fill(HIST("hMassD0RecSig"), hfHelper.invMassD0ToPiK(candidate), candidate.pt(), efficiencyWeight);
           if (isD0Prompt) {
             registry.fill(HIST("hPtCandRecSigPrompt"), candidate.pt());
@@ -578,7 +579,7 @@ struct HfCorrelatorD0Hadrons {
             registry.fill(HIST("hPtCandRecSigNonPrompt"), candidate.pt());
             registry.fill(HIST("hPtVsMultiplicityRecNonPrompt"), candidate.pt(), collision.multFT0M());
           }
-        } else if (candidate.flagMcMatchRec() == -(1 << aod::hf_cand_2prong::DecayType::D0ToPiK)) {
+        } else if (candidate.flagMcMatchRec() == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
           registry.fill(HIST("hMassD0RecRef"), hfHelper.invMassD0ToPiK(candidate), candidate.pt(), efficiencyWeight);
         } else {
           registry.fill(HIST("hMassD0RecBg"), hfHelper.invMassD0ToPiK(candidate), candidate.pt(), efficiencyWeight);
@@ -587,8 +588,8 @@ struct HfCorrelatorD0Hadrons {
           outputMlD0[iclass] = candidate.mlProbD0()[classMl->at(iclass)];
         }
       }
-      if (candidate.isSelD0bar() >= selectionFlagD0bar) {                                    // only reco as D0bar
-        if (candidate.flagMcMatchRec() == -(1 << aod::hf_cand_2prong::DecayType::D0ToPiK)) { // also matched as D0bar
+      if (candidate.isSelD0bar() >= selectionFlagD0bar) {                                             // only reco as D0bar
+        if (candidate.flagMcMatchRec() == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) { // also matched as D0bar
           registry.fill(HIST("hMassD0barRecSig"), hfHelper.invMassD0barToKPi(candidate), candidate.pt(), efficiencyWeight);
           if (isD0Prompt) {
             registry.fill(HIST("hPtCandRecSigPrompt"), candidate.pt());
@@ -597,7 +598,7 @@ struct HfCorrelatorD0Hadrons {
             registry.fill(HIST("hPtCandRecSigNonPrompt"), candidate.pt());
             registry.fill(HIST("hPtVsMultiplicityRecNonPrompt"), candidate.pt(), collision.multFT0M());
           }
-        } else if (candidate.flagMcMatchRec() == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) {
+        } else if (candidate.flagMcMatchRec() == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
           registry.fill(HIST("hMassD0barRecRef"), hfHelper.invMassD0barToKPi(candidate), candidate.pt(), efficiencyWeight);
         } else {
           registry.fill(HIST("hMassD0barRecBg"), hfHelper.invMassD0barToKPi(candidate), candidate.pt(), efficiencyWeight);
@@ -615,8 +616,8 @@ struct HfCorrelatorD0Hadrons {
 
       // ============== D-h correlation dedicated section ====================================
 
-      flagD0 = candidate.flagMcMatchRec() == (1 << aod::hf_cand_2prong::DecayType::D0ToPiK);     // flagD0Signal 'true' if candidate matched to D0 (particle)
-      flagD0bar = candidate.flagMcMatchRec() == -(1 << aod::hf_cand_2prong::DecayType::D0ToPiK); // flagD0Reflection 'true' if candidate, selected as D0 (particle), is matched to D0bar (antiparticle)
+      flagD0 = candidate.flagMcMatchRec() == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK;     // flagD0Signal 'true' if candidate matched to D0 (particle)
+      flagD0bar = candidate.flagMcMatchRec() == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK; // flagD0Reflection 'true' if candidate, selected as D0 (particle), is matched to D0bar (antiparticle)
 
       // ========== track loop starts here ========================
 
@@ -740,7 +741,7 @@ struct HfCorrelatorD0Hadrons {
       if (std::abs(particleTrigg.pdgCode()) != Pdg::kD0) {
         continue;
       }
-      if (std::abs(particleTrigg.flagMcMatchGen()) == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) {
+      if (std::abs(particleTrigg.flagMcMatchGen()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
         double yD = RecoDecay::y(particleTrigg.pVector(), MassD0);
         if (yCandMax >= 0. && std::abs(yD) > yCandMax) {
           continue;
@@ -972,8 +973,8 @@ struct HfCorrelatorD0Hadrons {
           }
         }
 
-        flagD0 = candidate.flagMcMatchRec() == (1 << aod::hf_cand_2prong::DecayType::D0ToPiK);     // flagD0Signal 'true' if candidate matched to D0 (particle)
-        flagD0bar = candidate.flagMcMatchRec() == -(1 << aod::hf_cand_2prong::DecayType::D0ToPiK); // flagD0Reflection 'true' if candidate, selected as D0 (particle), is matched to D0bar (antiparticle)
+        flagD0 = candidate.flagMcMatchRec() == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK;     // flagD0Signal 'true' if candidate matched to D0 (particle)
+        flagD0bar = candidate.flagMcMatchRec() == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK; // flagD0Reflection 'true' if candidate, selected as D0 (particle), is matched to D0bar (antiparticle)
         int signalStatus = 0;
 
         if (flagD0 && (candidate.isSelD0() >= selectionFlagD0)) {
@@ -1050,7 +1051,7 @@ struct HfCorrelatorD0Hadrons {
         if (std::abs(particleTrigg.pdgCode()) != Pdg::kD0) {
           continue;
         }
-        if (std::abs(particleTrigg.flagMcMatchGen()) == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) {
+        if (std::abs(particleTrigg.flagMcMatchGen()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
           double yD = RecoDecay::y(particleTrigg.pVector(), MassD0);
           if (std::abs(yD) >= yCandMax || particleTrigg.pt() <= ptCandMin || std::abs(particleAssoc.eta()) >= etaTrackMax || particleAssoc.pt() <= ptTrackMin) {
             continue;

--- a/PWGHF/HFC/TableProducer/correlatorDMesonPairs.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDMesonPairs.cxx
@@ -14,6 +14,7 @@
 ///
 /// \author Andrea Tavira García <tavira-garcia@ijclab.in2p3.fr>, IJCLab Orsay
 
+#include "PWGHF/Core/DecayChannels.h"
 #include "PWGHF/Core/HfHelper.h"
 #include "PWGHF/Core/HfMlResponseD0ToKPi.h"
 #include "PWGHF/Core/SelectorCuts.h"
@@ -326,10 +327,10 @@ struct HfCorrelatorDMesonPairs {
       SETBIT(candidateType, SelectedDbar);
     }
     if constexpr (isMcRec) {
-      if (candidate.flagMcMatchRec() == 1 << o2::aod::hf_cand_2prong::DecayType::D0ToPiK) { // matched as D0
+      if (candidate.flagMcMatchRec() == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) { // matched as D0
         SETBIT(candidateType, TrueD);
       }
-      if (candidate.flagMcMatchRec() == -(1 << o2::aod::hf_cand_2prong::DecayType::D0ToPiK)) { // matched as D0bar
+      if (candidate.flagMcMatchRec() == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) { // matched as D0bar
         SETBIT(candidateType, TrueDbar);
       }
     }
@@ -532,18 +533,18 @@ struct HfCorrelatorDMesonPairs {
   {
     // Fill hMatchingMcRec - Cand 1
     registry.fill(HIST("hMatchingMcRec"), 1);
-    if (matchedRec1 == 1) {
+    if (matchedRec1 == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
       registry.fill(HIST("hMatchingMcRec"), 2);
-    } else if (matchedRec1 == -1) {
+    } else if (matchedRec1 == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
       registry.fill(HIST("hMatchingMcRec"), 3);
     } else if (matchedRec1 == 0) {
       registry.fill(HIST("hMatchingMcRec"), 4);
     }
     // Fill hMatchingMcRec - Cand 2
     registry.fill(HIST("hMatchingMcRec"), 5);
-    if (matchedRec2 == 1) {
+    if (matchedRec2 == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
       registry.fill(HIST("hMatchingMcRec"), 6);
-    } else if (matchedRec2 == -1) {
+    } else if (matchedRec2 == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
       registry.fill(HIST("hMatchingMcRec"), 7);
     } else if (matchedRec2 == 0) {
       registry.fill(HIST("hMatchingMcRec"), 8);
@@ -1057,18 +1058,18 @@ struct HfCorrelatorDMesonPairs {
 
         // Fill hMatchingMcGen - Cand 1
         registry.fill(HIST("hMatchingMcGen"), 1);
-        if (matchedGen1 == 1) {
+        if (matchedGen1 == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
           registry.fill(HIST("hMatchingMcGen"), 2);
-        } else if (matchedGen1 == -1) {
+        } else if (matchedGen1 == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
           registry.fill(HIST("hMatchingMcGen"), 3);
         } else if (matchedGen1 == 0) {
           registry.fill(HIST("hMatchingMcGen"), 4);
         }
         // Fill hMatchingMcRec - Cand 2
         registry.fill(HIST("hMatchingMcGen"), 5);
-        if (matchedGen2 == 1) {
+        if (matchedGen2 == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
           registry.fill(HIST("hMatchingMcGen"), 6);
-        } else if (matchedGen2 == -1) {
+        } else if (matchedGen2 == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
           registry.fill(HIST("hMatchingMcGen"), 7);
         } else if (matchedGen2 == 0) {
           registry.fill(HIST("hMatchingMcGen"), 8);

--- a/PWGHF/HFC/TableProducer/correlatorLcScHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorLcScHadrons.cxx
@@ -16,6 +16,7 @@
 /// \author Zhen Zhang <zhenz@cern.ch>
 /// \author Ravindra Singh <ravindra.singh@cern.ch>
 
+#include "PWGHF/Core/DecayChannels.h"
 #include "PWGHF/Core/HfHelper.h"
 #include "PWGHF/Core/SelectorCuts.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
@@ -642,7 +643,7 @@ struct HfCorrelatorLcScHadrons {
         auto trackPos2 = candidate.template prong2_as<TrackType>();
         chargeCand = trackPos1.sign();
         if constexpr (isMcRec) {
-          isSignal = TESTBIT(std::abs(candidate.flagMcMatchRec()), aod::hf_cand_3prong::DecayType::LcToPKPi);
+          isSignal = std::abs(candidate.flagMcMatchRec()) == o2::hf_decay::hf_cand_3prong::DecayChannelMain::LcToPKPi;
           if (calTrkEff && countCand == 1 && (isSignal || !calEffEventWithCand)) {
             calculateTrkEff(trackPos1, trackPos2, *mcParticles);
           }
@@ -849,7 +850,7 @@ struct HfCorrelatorLcScHadrons {
           auto trackPos1 = candidate.template prong0_as<TrackType>();
           chargeCand = trackPos1.sign();
           if constexpr (isMcRec) {
-            isSignal = TESTBIT(std::abs(candidate.flagMcMatchRec()), aod::hf_cand_3prong::DecayType::LcToPKPi);
+            isSignal = std::abs(candidate.flagMcMatchRec()) == o2::hf_decay::hf_cand_3prong::DecayChannelMain::LcToPKPi;
           }
         }
 

--- a/PWGHF/HFC/Tasks/taskCorrelationD0Hadrons.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationD0Hadrons.cxx
@@ -16,6 +16,7 @@
 /// \author Samrangy Sadhu <samrangy.sadhu@cern.ch>, INFN Bari
 /// \author Swapnesh Santosh Khade <swapnesh.santosh.khade@cern.ch>, IIT Indore
 
+#include "PWGHF/Core/DecayChannels.h"
 #include "PWGHF/Core/HfHelper.h"
 #include "PWGHF/Core/SelectorCuts.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
@@ -804,7 +805,7 @@ struct HfTaskCorrelationD0Hadrons {
         auto mcCollision = mcParticle.template mcCollision_as<soa::Join<aod::McCollisions, aod::MultsExtraMC>>();
         multiplicity = mcCollision.multMCFT0A() + mcCollision.multMCFT0C(); // multFT0M = multFt0A + multFT0C
         hCandidates->Fill(kCandidateStepMcGenAll, mcParticle.pt(), multiplicity, mcParticle.originMcGen());
-        if (std::abs(mcParticle.flagMcMatchGen()) == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) {
+        if (std::abs(mcParticle.flagMcMatchGen()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
           hCandidates->Fill(kCandidateStepMcGenD0ToPiKPi, mcParticle.pt(), multiplicity, mcParticle.originMcGen());
           auto yD0 = RecoDecay::y(mcParticle.pVector(), o2::constants::physics::MassD0);
           if (std::abs(yD0) <= yCandGenMax) {
@@ -856,7 +857,7 @@ struct HfTaskCorrelationD0Hadrons {
         continue;
       }
       multiplicity = collision.multFT0M();
-      if (std::abs(candidate.flagMcMatchRec()) == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) {
+      if (std::abs(candidate.flagMcMatchRec()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
         hCandidates->Fill(kCandidateStepMcReco, candidate.pt(), multiplicity, candidate.originMcRec());
         if (std::abs(hfHelper.yD0(candidate)) <= yCandMax) {
           hCandidates->Fill(kCandidateStepMcRecoInAcceptance, candidate.pt(), multiplicity, candidate.originMcRec());

--- a/PWGHF/HFC/Tasks/taskFlow.cxx
+++ b/PWGHF/HFC/Tasks/taskFlow.cxx
@@ -797,7 +797,7 @@ struct HfTaskFlow {
     auto etaCandidate = mcCandidate.eta();
 
     if constexpr (std::is_same_v<McParticles2ProngMatched, TMcTrack>) { // For now, that means we do D0
-      if (std::abs(mcCandidate.flagMcMatchGen()) == 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) {
+      if (std::abs(mcCandidate.flagMcMatchGen()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
 
         if (etaCandidateMax >= 0. && std::abs(etaCandidate) > etaCandidateMax) {
           return false;

--- a/PWGHF/TableProducer/candidateCreatorMcGen.cxx
+++ b/PWGHF/TableProducer/candidateCreatorMcGen.cxx
@@ -41,8 +41,8 @@ struct HfCandidateCreatorMcGen {
   Produces<aod::HfCandB0McGen> rowMcMatchGenB0;
   Configurable<bool> fill2Prong{"fill2Prong", false, "fill table for 2 prong candidates"};
   Configurable<bool> fill3Prong{"fill3Prong", false, "fill table for 3 prong candidates"};
-  Configurable<bool> matchCorrelatedBackgrounds{"matchCorrelatedBackgrounds", false, "Match correlated background candidates"};
-  Configurable<std::vector<int>> mothersCorrBkgsPdgs{"mothersCorrBkgsPdgs", {Pdg::kDPlus, Pdg::kDS, Pdg::kDStar, Pdg::kLambdaCPlus, Pdg::kXiCPlus}, "PDG codes of the mother particles of correlated background candidates"};
+  Configurable<bool> matchCorrelatedBackground{"matchCorrelatedBackground", false, "Match correlated background candidates"};
+  Configurable<std::vector<int>> pdgMothersCorrelBkg{"pdgMothersCorrelBkg", {Pdg::kDPlus, Pdg::kDS, Pdg::kDStar, Pdg::kLambdaCPlus, Pdg::kXiCPlus}, "PDG codes of the mother particles of correlated background candidates"};
   Configurable<bool> fillBplus{"fillBplus", false, "fill table for for B+ candidates"};
   Configurable<bool> fillB0{"fillB0", false, "fill table for B0 candidates"};
   Configurable<bool> rejectBackground2Prong{"rejectBackground2Prong", false, "Reject particles from PbPb background for 2 prong candidates"};
@@ -57,10 +57,10 @@ struct HfCandidateCreatorMcGen {
     for (const auto& mcCollision : mcCollisions) {
       const auto mcParticlesPerMcColl = mcParticles.sliceBy(mcParticlesPerMcCollision, mcCollision.globalIndex());
       if (fill2Prong) {
-        hf_mc_gen::fillMcMatchGen2Prong(mcParticles, mcParticlesPerMcColl, rowMcMatchGen2Prong, rejectBackground2Prong, matchCorrelatedBackgrounds);
+        hf_mc_gen::fillMcMatchGen2Prong(mcParticles, mcParticlesPerMcColl, rowMcMatchGen2Prong, rejectBackground2Prong, matchCorrelatedBackground);
       }
       if (fill3Prong) {
-        hf_mc_gen::fillMcMatchGen3Prong(mcParticles, mcParticlesPerMcColl, rowMcMatchGen3Prong, rejectBackground3Prong, matchCorrelatedBackgrounds ? mothersCorrBkgsPdgs : std::vector<int>{});
+        hf_mc_gen::fillMcMatchGen3Prong(mcParticles, mcParticlesPerMcColl, rowMcMatchGen3Prong, rejectBackground3Prong, matchCorrelatedBackground ? pdgMothersCorrelBkg : std::vector<int>{});
       }
     }
     if (fillBplus) {

--- a/PWGHF/TableProducer/derivedDataCreatorD0ToKPi.cxx
+++ b/PWGHF/TableProducer/derivedDataCreatorD0ToKPi.cxx
@@ -15,6 +15,7 @@
 ///
 /// \author Vít Kučera <vit.kucera@cern.ch>, Inha University
 
+#include "PWGHF/Core/DecayChannels.h"
 #include "PWGHF/Core/HfHelper.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
@@ -105,7 +106,7 @@ struct HfDerivedDataCreatorD0ToKPi {
   using TypeMcCollisions = soa::Join<aod::McCollisions, aod::McCentFT0Ms>;
 
   Filter filterSelectCandidates = aod::hf_sel_candidate_d0::isSelD0 >= 1 || aod::hf_sel_candidate_d0::isSelD0bar >= 1;
-  Filter filterMcGenMatching = nabs(aod::hf_cand_2prong::flagMcMatchGen) == static_cast<int8_t>(BIT(aod::hf_cand_2prong::DecayType::D0ToPiK));
+  Filter filterMcGenMatching = nabs(aod::hf_cand_2prong::flagMcMatchGen) == static_cast<int8_t>(o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK);
 
   Preslice<SelectedCandidates> candidatesPerCollision = aod::hf_cand::collisionId;
   Preslice<SelectedCandidatesKf> candidatesKfPerCollision = aod::hf_cand::collisionId;
@@ -127,14 +128,14 @@ struct HfDerivedDataCreatorD0ToKPi {
   Partition<SelectedCandidatesMcMl> candidatesMcMlAll = aod::hf_sel_candidate_d0::isSelD0 >= 0;
   Partition<SelectedCandidatesMcKfMl> candidatesMcKfMlAll = aod::hf_sel_candidate_d0::isSelD0 >= 0;
   // partitions for signal and background
-  Partition<SelectedCandidatesMc> candidatesMcSig = nabs(aod::hf_cand_2prong::flagMcMatchRec) == static_cast<int8_t>(BIT(aod::hf_cand_2prong::DecayType::D0ToPiK));
-  Partition<SelectedCandidatesMc> candidatesMcBkg = nabs(aod::hf_cand_2prong::flagMcMatchRec) != static_cast<int8_t>(BIT(aod::hf_cand_2prong::DecayType::D0ToPiK));
-  Partition<SelectedCandidatesMcKf> candidatesMcKfSig = nabs(aod::hf_cand_2prong::flagMcMatchRec) == static_cast<int8_t>(BIT(aod::hf_cand_2prong::DecayType::D0ToPiK));
-  Partition<SelectedCandidatesMcKf> candidatesMcKfBkg = nabs(aod::hf_cand_2prong::flagMcMatchRec) != static_cast<int8_t>(BIT(aod::hf_cand_2prong::DecayType::D0ToPiK));
-  Partition<SelectedCandidatesMcMl> candidatesMcMlSig = nabs(aod::hf_cand_2prong::flagMcMatchRec) == static_cast<int8_t>(BIT(aod::hf_cand_2prong::DecayType::D0ToPiK));
-  Partition<SelectedCandidatesMcMl> candidatesMcMlBkg = nabs(aod::hf_cand_2prong::flagMcMatchRec) != static_cast<int8_t>(BIT(aod::hf_cand_2prong::DecayType::D0ToPiK));
-  Partition<SelectedCandidatesMcKfMl> candidatesMcKfMlSig = nabs(aod::hf_cand_2prong::flagMcMatchRec) == static_cast<int8_t>(BIT(aod::hf_cand_2prong::DecayType::D0ToPiK));
-  Partition<SelectedCandidatesMcKfMl> candidatesMcKfMlBkg = nabs(aod::hf_cand_2prong::flagMcMatchRec) != static_cast<int8_t>(BIT(aod::hf_cand_2prong::DecayType::D0ToPiK));
+  Partition<SelectedCandidatesMc> candidatesMcSig = nabs(aod::hf_cand_2prong::flagMcMatchRec) == static_cast<int8_t>(o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK);
+  Partition<SelectedCandidatesMc> candidatesMcBkg = nabs(aod::hf_cand_2prong::flagMcMatchRec) != static_cast<int8_t>(o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK);
+  Partition<SelectedCandidatesMcKf> candidatesMcKfSig = nabs(aod::hf_cand_2prong::flagMcMatchRec) == static_cast<int8_t>(o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK);
+  Partition<SelectedCandidatesMcKf> candidatesMcKfBkg = nabs(aod::hf_cand_2prong::flagMcMatchRec) != static_cast<int8_t>(o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK);
+  Partition<SelectedCandidatesMcMl> candidatesMcMlSig = nabs(aod::hf_cand_2prong::flagMcMatchRec) == static_cast<int8_t>(o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK);
+  Partition<SelectedCandidatesMcMl> candidatesMcMlBkg = nabs(aod::hf_cand_2prong::flagMcMatchRec) != static_cast<int8_t>(o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK);
+  Partition<SelectedCandidatesMcKfMl> candidatesMcKfMlSig = nabs(aod::hf_cand_2prong::flagMcMatchRec) == static_cast<int8_t>(o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK);
+  Partition<SelectedCandidatesMcKfMl> candidatesMcKfMlBkg = nabs(aod::hf_cand_2prong::flagMcMatchRec) != static_cast<int8_t>(o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK);
 
   void init(InitContext const&)
   {
@@ -284,7 +285,7 @@ struct HfDerivedDataCreatorD0ToKPi {
           flagMcRec = candidate.flagMcMatchRec();
           origin = candidate.originMcRec();
           if constexpr (onlyBkg) {
-            if (TESTBIT(std::abs(flagMcRec), aod::hf_cand_2prong::DecayType::D0ToPiK)) {
+            if (std::abs(flagMcRec) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
               continue;
             }
             if (downSampleBkgFactor < 1.) {
@@ -295,7 +296,7 @@ struct HfDerivedDataCreatorD0ToKPi {
             }
           }
           if constexpr (onlySig) {
-            if (!TESTBIT(std::abs(flagMcRec), aod::hf_cand_2prong::DecayType::D0ToPiK)) {
+            if (std::abs(flagMcRec) != o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
               continue;
             }
           }

--- a/PWGHF/TableProducer/treeCreatorD0ToKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorD0ToKPi.cxx
@@ -17,6 +17,7 @@
 /// \author Nicolo' Jacazio <nicolo.jacazio@cern.ch>, CERN
 /// \author Andrea Tavira García <tavira-garcia@ijclab.in2p3.fr>, IJCLab
 
+#include "PWGHF/Core/DecayChannels.h"
 #include "PWGHF/Core/HfHelper.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
@@ -32,8 +33,6 @@
 #include <Framework/InitContext.h>
 #include <Framework/Logger.h>
 #include <Framework/runDataProcessing.h>
-
-#include <Rtypes.h>
 
 #include <array>
 #include <cstdint>
@@ -257,17 +256,17 @@ struct HfTreeCreatorD0ToKPi {
   using MatchedGenCandidatesMc = soa::Filtered<soa::Join<aod::McParticles, aod::HfCand2ProngMcGen>>;
 
   Filter filterSelectCandidates = aod::hf_sel_candidate_d0::isSelD0 >= 1 || aod::hf_sel_candidate_d0::isSelD0bar >= 1;
-  Filter filterMcGenMatching = nabs(aod::hf_cand_2prong::flagMcMatchGen) == static_cast<int8_t>(BIT(aod::hf_cand_2prong::DecayType::D0ToPiK)) || (fillCorrBkgs && (nabs(aod::hf_cand_2prong::flagMcMatchGen) != 0));
+  Filter filterMcGenMatching = nabs(aod::hf_cand_2prong::flagMcMatchGen) == static_cast<int8_t>(o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) || (fillCorrBkgs && (nabs(aod::hf_cand_2prong::flagMcMatchGen) != 0));
 
-  Partition<SelectedCandidatesMc> reconstructedCandSig = nabs(aod::hf_cand_2prong::flagMcMatchRec) == static_cast<int8_t>(BIT(aod::hf_cand_2prong::DecayType::D0ToPiK)) || (fillCorrBkgs && nabs(aod::hf_cand_2prong::flagMcMatchRec) != 0);
-  Partition<SelectedCandidatesMc> reconstructedCandBkg = nabs(aod::hf_cand_2prong::flagMcMatchRec) != static_cast<int8_t>(BIT(aod::hf_cand_2prong::DecayType::D0ToPiK));
-  Partition<SelectedCandidatesMcKf> reconstructedCandSigKF = nabs(aod::hf_cand_2prong::flagMcMatchRec) == static_cast<int8_t>(BIT(aod::hf_cand_2prong::DecayType::D0ToPiK)) || (fillCorrBkgs && nabs(aod::hf_cand_2prong::flagMcMatchRec) != 0);
-  Partition<SelectedCandidatesMcKf> reconstructedCandBkgKF = nabs(aod::hf_cand_2prong::flagMcMatchRec) != static_cast<int8_t>(BIT(aod::hf_cand_2prong::DecayType::D0ToPiK));
+  Partition<SelectedCandidatesMc> reconstructedCandSig = nabs(aod::hf_cand_2prong::flagMcMatchRec) == static_cast<int8_t>(o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) || (fillCorrBkgs && nabs(aod::hf_cand_2prong::flagMcMatchRec) != 0);
+  Partition<SelectedCandidatesMc> reconstructedCandBkg = nabs(aod::hf_cand_2prong::flagMcMatchRec) != static_cast<int8_t>(o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK);
+  Partition<SelectedCandidatesMcKf> reconstructedCandSigKF = nabs(aod::hf_cand_2prong::flagMcMatchRec) == static_cast<int8_t>(o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) || (fillCorrBkgs && nabs(aod::hf_cand_2prong::flagMcMatchRec) != 0);
+  Partition<SelectedCandidatesMcKf> reconstructedCandBkgKF = nabs(aod::hf_cand_2prong::flagMcMatchRec) != static_cast<int8_t>(o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK);
 
-  Partition<SelectedCandidatesMcMl> reconstructedCandSigMl = nabs(aod::hf_cand_2prong::flagMcMatchRec) == static_cast<int8_t>(BIT(aod::hf_cand_2prong::DecayType::D0ToPiK)) || (fillCorrBkgs && nabs(aod::hf_cand_2prong::flagMcMatchRec) != 0);
-  Partition<SelectedCandidatesMcMl> reconstructedCandBkgMl = nabs(aod::hf_cand_2prong::flagMcMatchRec) != static_cast<int8_t>(BIT(aod::hf_cand_2prong::DecayType::D0ToPiK));
-  Partition<SelectedCandidatesMcKfMl> reconstructedCandSigKFMl = nabs(aod::hf_cand_2prong::flagMcMatchRec) == static_cast<int8_t>(BIT(aod::hf_cand_2prong::DecayType::D0ToPiK)) || (fillCorrBkgs && nabs(aod::hf_cand_2prong::flagMcMatchRec) != 0);
-  Partition<SelectedCandidatesMcKfMl> reconstructedCandBkgKFMl = nabs(aod::hf_cand_2prong::flagMcMatchRec) != static_cast<int8_t>(BIT(aod::hf_cand_2prong::DecayType::D0ToPiK));
+  Partition<SelectedCandidatesMcMl> reconstructedCandSigMl = nabs(aod::hf_cand_2prong::flagMcMatchRec) == static_cast<int8_t>(o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) || (fillCorrBkgs && nabs(aod::hf_cand_2prong::flagMcMatchRec) != 0);
+  Partition<SelectedCandidatesMcMl> reconstructedCandBkgMl = nabs(aod::hf_cand_2prong::flagMcMatchRec) != static_cast<int8_t>(o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK);
+  Partition<SelectedCandidatesMcKfMl> reconstructedCandSigKFMl = nabs(aod::hf_cand_2prong::flagMcMatchRec) == static_cast<int8_t>(o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) || (fillCorrBkgs && nabs(aod::hf_cand_2prong::flagMcMatchRec) != 0);
+  Partition<SelectedCandidatesMcKfMl> reconstructedCandBkgKFMl = nabs(aod::hf_cand_2prong::flagMcMatchRec) != static_cast<int8_t>(o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK);
 
   void init(InitContext const&)
   {
@@ -526,7 +525,7 @@ struct HfTreeCreatorD0ToKPi {
     }
     for (const auto& candidate : candidates) {
       if constexpr (onlyBkg) {
-        if (TESTBIT(std::abs(candidate.flagMcMatchRec()), aod::hf_cand_2prong::DecayType::D0ToPiK) || (fillCorrBkgs && (candidate.flagMcMatchRec() != 0))) {
+        if ((std::abs(candidate.flagMcMatchRec()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) || (fillCorrBkgs && (candidate.flagMcMatchRec() != 0))) {
           continue;
         }
         if (downSampleBkgFactor < 1.) {
@@ -537,7 +536,7 @@ struct HfTreeCreatorD0ToKPi {
         }
       }
       if constexpr (onlySig) {
-        if (!(TESTBIT(std::abs(candidate.flagMcMatchRec()), aod::hf_cand_2prong::DecayType::D0ToPiK)) || (fillCorrBkgs && (candidate.flagMcMatchRec() != 0))) {
+        if ((std::abs(candidate.flagMcMatchRec()) != o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) || (fillCorrBkgs && (candidate.flagMcMatchRec() != 0))) {
           continue;
         }
       }
@@ -565,7 +564,7 @@ struct HfTreeCreatorD0ToKPi {
     // Filling particle properties
     rowCandidateFullParticles.reserve(mcParticles.size());
     for (const auto& particle : mcParticles) {
-      if (TESTBIT(std::abs(particle.flagMcMatchGen()), aod::hf_cand_2prong::DecayType::D0ToPiK) || (fillCorrBkgs && particle.flagMcMatchGen() != 0)) {
+      if ((std::abs(particle.flagMcMatchGen()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) || (fillCorrBkgs && particle.flagMcMatchGen() != 0)) {
         rowCandidateFullParticles(
           particle.mcCollisionId(),
           particle.pt(),

--- a/PWGHF/TableProducer/treeCreatorDsToKKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorDsToKKPi.cxx
@@ -284,8 +284,6 @@ struct HfTreeCreatorDsToKKPi {
   using CollisionsWithFT0M = soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Ms>;
   using CollisionsWithNTracksPV = soa::Join<aod::Collisions, aod::EvSels, aod::CentNTPVs>;
 
-  int offsetDplusDecayChannel = aod::hf_cand_3prong::DecayChannelDToKKPi::DplusToPhiPi - aod::hf_cand_3prong::DecayChannelDToKKPi::DsToPhiPi; // Offset between Dplus and Ds to use the same decay channel. See aod::hf_cand_3prong::DecayChannelDToKKPi
-
   Filter filterSelectCandidates = aod::hf_sel_candidate_ds::isSelDsToKKPi >= selectionFlagDs || aod::hf_sel_candidate_ds::isSelDsToPiKK >= selectionFlagDs;
   Filter filterMcGenMatching =
     nabs(o2::aod::hf_cand_3prong::flagMcMatchGen) == static_cast<int8_t>(hf_decay::hf_cand_3prong::DecayChannelMain::DsToPiKK) &&

--- a/PWGHF/Tasks/taskCharmHadImpactPar.cxx
+++ b/PWGHF/Tasks/taskCharmHadImpactPar.cxx
@@ -195,7 +195,7 @@ struct HfTaskCharmHadImpactPar {
       if (candidate.isSelD0()) { // D0 -> Kpi
         if constexpr (doMc) {
           if (fillOnlySignal) {
-            if (std::abs(candidate.flagMcMatchRec()) != 1 << aod::hf_cand_2prong::DecayType::D0ToPiK) {
+            if (std::abs(candidate.flagMcMatchRec()) != o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
               return;
             }
           }

--- a/PWGHF/Tasks/taskMcValidation.cxx
+++ b/PWGHF/Tasks/taskMcValidation.cxx
@@ -1098,7 +1098,7 @@ struct HfTaskMcValidationRec {
           continue;
         }
         int whichHad = -1;
-        if (isD0Sel && TESTBIT(std::abs(cand2Prong.flagMcMatchRec()), hf_cand_2prong::DecayType::D0ToPiK)) {
+        if (isD0Sel && std::abs(cand2Prong.flagMcMatchRec()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
           whichHad = DzeroToKPi;
         }
         int whichOrigin;

--- a/PWGHF/Tasks/taskSelOptimisation.cxx
+++ b/PWGHF/Tasks/taskSelOptimisation.cxx
@@ -287,7 +287,7 @@ struct HfSelOptimisation {
       bool isPrompt = false, isNonPrompt = false, isBkg = false;
       for (int iDecay{0}; iDecay < n2Prong; ++iDecay) {
         if (TESTBIT(cand2Prong.hfflag(), iDecay)) {
-          if (std::abs(cand2Prong.flagMcMatchRec()) == BIT(iDecay)) {
+          if (std::abs(cand2Prong.flagMcMatchRec()) == BIT(iDecay)) { // FIXME: Migrate to DecayChannelMain
             if (cand2Prong.originMcRec() == RecoDecay::OriginType::Prompt) {
               isPrompt = true;
               switch (iDecay) {
@@ -343,7 +343,7 @@ struct HfSelOptimisation {
       bool isPrompt = false, isNonPrompt = false, isBkg = false;
       for (int iDecay{0}; iDecay < n3Prong; ++iDecay) {
         if (TESTBIT(cand3Prong.hfflag(), iDecay)) {
-          if (std::abs(cand3Prong.flagMcMatchRec()) == BIT(iDecay)) {
+          if (std::abs(cand3Prong.flagMcMatchRec()) == BIT(iDecay)) { // FIXME: Migrate to DecayChannelMain
             if (cand3Prong.originMcRec() == RecoDecay::OriginType::Prompt) {
               isPrompt = true;
               switch (iDecay) {

--- a/PWGHF/Utils/utilsMcGen.h
+++ b/PWGHF/Utils/utilsMcGen.h
@@ -10,7 +10,7 @@
 // or submit itself to any jurisdiction.
 
 /// \file utilsMcGen.h
-/// \brief utility functions for HF Mc gen. workflows
+/// \brief utility functions for HF MC gen. workflows
 ///
 /// \author Nima Zardoshti, nima.zardoshti@cern.ch, CERN
 
@@ -39,53 +39,56 @@ namespace hf_mc_gen
 {
 
 template <typename T, typename U, typename V>
-void fillMcMatchGen2Prong(T const& mcParticles, U const& mcParticlesPerMcColl, V& rowMcMatchGen, bool rejectBackground, bool matchCorrelatedBackgrounds)
+void fillMcMatchGen2Prong(T const& mcParticles, U const& mcParticlesPerMcColl, V& rowMcMatchGen, bool rejectBackground, bool matchCorrelatedBackground)
 {
   using namespace o2::constants::physics;
+  using namespace o2::hf_decay::hf_cand_2prong;
+
   constexpr std::size_t NDaughtersResonant{2u};
 
   // Match generated particles.
   for (const auto& particle : mcParticlesPerMcColl) {
-    int8_t flag = 0;
+    int8_t flagChannelMain = 0;
+    int8_t flagChannelResonant = 0;
     int8_t origin = 0;
-    int8_t channel = 0;
     int8_t sign = 0;
     std::vector<int> idxBhadMothers{};
     // Reject particles from background events
     if (particle.fromBackgroundEvent() && rejectBackground) {
-      rowMcMatchGen(flag, origin, channel, -1);
+      rowMcMatchGen(flagChannelMain, origin, flagChannelResonant, -1);
       continue;
     }
-    if (matchCorrelatedBackgrounds) {
-      constexpr int MaxDepth = 2;     // Depth for final state matching
-      constexpr int ResoMaxDepth = 1; // Depth for resonant decay matching
+    if (matchCorrelatedBackground) {
+      constexpr int DepthMainMax = 2; // Depth for final state matching
+      constexpr int DepthResoMax = 1; // Depth for resonant decay matching
       bool matched = false;
 
-      for (const auto& [chn, finalState] : o2::hf_decay::hf_cand_2prong::daughtersD0Main) {
-        if (finalState.size() == 3) { // o2-linter: disable=magic-number (Partly Reco 3-prong decays)
-          std::array<int, 3> finalStateParts = std::array{finalState[0], finalState[1], finalState[2]};
-          o2::hf_decay::changeFinalStatePdgSign(particle.pdgCode(), +kPi0, finalStateParts);
-          matched = RecoDecay::isMatchedMCGen(mcParticles, particle, Pdg::kD0, finalStateParts, true, &sign, MaxDepth);
-        } else if (finalState.size() == 2) { // o2-linter: disable=magic-number (Fully Reco 2-prong decays)
-          std::array<int, 2> finalStateParts = std::array{finalState[0], finalState[1]};
-          matched = RecoDecay::isMatchedMCGen(mcParticles, particle, Pdg::kD0, finalStateParts, true, &sign, MaxDepth);
+      // TODO: J/ψ
+      for (const auto& [channelMain, finalState] : daughtersD0Main) {
+        if (finalState.size() == 3) { // o2-linter: disable=magic-number (partially reconstructed 3-prong decays)
+          std::array<int, 3> arrPdgDaughtersMain3Prongs = std::array{finalState[0], finalState[1], finalState[2]};
+          o2::hf_decay::flipPdgSign(particle.pdgCode(), +kPi0, arrPdgDaughtersMain3Prongs);
+          matched = RecoDecay::isMatchedMCGen(mcParticles, particle, Pdg::kD0, arrPdgDaughtersMain3Prongs, true, &sign, DepthMainMax);
+        } else if (finalState.size() == 2) { // o2-linter: disable=magic-number (fully reconstructed 2-prong decays)
+          std::array<int, 2> arrPdgDaughtersMain2Prongs = std::array{finalState[0], finalState[1]};
+          matched = RecoDecay::isMatchedMCGen(mcParticles, particle, Pdg::kD0, arrPdgDaughtersMain2Prongs, true, &sign, DepthMainMax);
         } else {
-          LOG(info) << "Final state size not supported: " << finalState.size();
-          continue;
+          LOG(fatal) << "Final state size not supported: " << finalState.size();
+          return;
         }
         if (matched) {
-          flag = sign * (1 << chn);
+          flagChannelMain = sign * channelMain;
 
           // Flag the resonant decay channel
           std::vector<int> arrResoDaughIndex = {};
-          RecoDecay::getDaughters(particle, &arrResoDaughIndex, std::array{0}, ResoMaxDepth);
-          std::array<int, NDaughtersResonant> arrPDGDaugh = {};
+          RecoDecay::getDaughters(particle, &arrResoDaughIndex, std::array{0}, DepthResoMax);
+          std::array<int, NDaughtersResonant> arrPdgDaughters = {};
           if (arrResoDaughIndex.size() == NDaughtersResonant) {
             for (auto iProng = 0u; iProng < arrResoDaughIndex.size(); ++iProng) {
               auto daughI = mcParticles.rawIteratorAt(arrResoDaughIndex[iProng]);
-              arrPDGDaugh[iProng] = daughI.pdgCode();
+              arrPdgDaughters[iProng] = daughI.pdgCode();
             }
-            channel = o2::hf_decay::flagResonantDecay(Pdg::kD0, arrPDGDaugh);
+            flagChannelResonant = o2::hf_decay::getDecayChannelResonant(Pdg::kD0, arrPdgDaughters);
           }
           break;
         }
@@ -93,121 +96,124 @@ void fillMcMatchGen2Prong(T const& mcParticles, U const& mcParticlesPerMcColl, V
     } else {
       // D0(bar) → π± K∓
       if (RecoDecay::isMatchedMCGen(mcParticles, particle, Pdg::kD0, std::array{+kPiPlus, -kKPlus}, true, &sign)) {
-        flag = sign * (1 << o2::aod::hf_cand_2prong::DecayType::D0ToPiK);
+        flagChannelMain = sign * DecayChannelMain::D0ToPiK;
       }
 
       // J/ψ → e+ e−
-      if (flag == 0) {
+      if (flagChannelMain == 0) {
         if (RecoDecay::isMatchedMCGen(mcParticles, particle, Pdg::kJPsi, std::array{+kElectron, -kElectron}, true)) {
-          flag = 1 << o2::aod::hf_cand_2prong::DecayType::JpsiToEE;
+          flagChannelMain = DecayChannelMain::JpsiToEE;
         }
       }
 
       // J/ψ → μ+ μ−
-      if (flag == 0) {
+      if (flagChannelMain == 0) {
         if (RecoDecay::isMatchedMCGen(mcParticles, particle, Pdg::kJPsi, std::array{+kMuonPlus, -kMuonPlus}, true)) {
-          flag = 1 << o2::aod::hf_cand_2prong::DecayType::JpsiToMuMu;
+          flagChannelMain = DecayChannelMain::JpsiToMuMu;
         }
       }
     }
 
     // Check whether the particle is non-prompt (from a b quark).
-    if (flag != 0) {
+    if (flagChannelMain != 0) {
       origin = RecoDecay::getCharmHadronOrigin(mcParticles, particle, false, &idxBhadMothers);
     }
     if (origin == RecoDecay::OriginType::NonPrompt) {
-      rowMcMatchGen(flag, origin, channel, idxBhadMothers[0]);
+      rowMcMatchGen(flagChannelMain, origin, flagChannelResonant, idxBhadMothers[0]);
     } else {
-      rowMcMatchGen(flag, origin, channel, -1);
+      rowMcMatchGen(flagChannelMain, origin, flagChannelResonant, -1);
     }
   }
 }
 
 template <typename T, typename U, typename V>
-void fillMcMatchGen3Prong(T const& mcParticles, U const& mcParticlesPerMcColl, V& rowMcMatchGen, bool rejectBackground, std::vector<int> const& corrBkgMothersPdgs = {})
+void fillMcMatchGen3Prong(T const& mcParticles, U const& mcParticlesPerMcColl, V& rowMcMatchGen, bool rejectBackground, std::vector<int> const& pdgMothersCorrelBkg = {})
 {
   using namespace o2::constants::physics;
+  using namespace o2::hf_decay::hf_cand_3prong;
+
   constexpr std::size_t NDaughtersResonant{2u};
 
   // Match generated particles.
   for (const auto& particle : mcParticlesPerMcColl) {
-    int8_t flag = 0;
+    int8_t flagChannelMain = 0;
+    int8_t flagChannelResonant = 0;
     int8_t origin = 0;
-    int8_t channel = 0;
     int8_t sign = 0;
     std::vector<int> arrDaughIndex;
     std::vector<int> idxBhadMothers{};
-    std::array<int, NDaughtersResonant> arrPDGDaugh;
-    std::array<int, NDaughtersResonant> arrPDGResonant1 = {kProton, Pdg::kK0Star892};      // Λc± → p± K*
-    std::array<int, NDaughtersResonant> arrPDGResonant2 = {2224, kKPlus};                  // Λc± → Δ(1232)±± K∓
-    std::array<int, NDaughtersResonant> arrPDGResonant3 = {102134, kPiPlus};               // Λc± → Λ(1520) π±
-    std::array<int, NDaughtersResonant> arrPDGResonantDPhiPi = {Pdg::kPhi, kPiPlus};       // Ds± → Phi π± and D± → Phi π±
-    std::array<int, NDaughtersResonant> arrPDGResonantDKstarK = {Pdg::kK0Star892, kKPlus}; // Ds± → K*(892)0bar K± and D± → K*(892)0bar K±
+    std::array<int, NDaughtersResonant> arrPdgDaugResonant;
+    const std::array<int, NDaughtersResonant> arrPdgDaugResonantLcToPKstar0{daughtersLcResonant.at(DecayChannelResonant::LcToPKstar0)};               // Λc± → p± K*
+    const std::array<int, NDaughtersResonant> arrPdgDaugResonantLcToDeltaplusplusK{daughtersLcResonant.at(DecayChannelResonant::LcToDeltaplusplusK)}; // Λc± → Δ(1232)±± K∓
+    const std::array<int, NDaughtersResonant> arrPdgDaugResonantLcToL1520Pi{daughtersLcResonant.at(DecayChannelResonant::LcToL1520Pi)};               // Λc± → Λ(1520) π±
+    const std::array<int, NDaughtersResonant> arrPdgDaugResonantDToPhiPi{daughtersDsResonant.at(DecayChannelResonant::DsToPhiPi)};                    // Ds± → φ π± and D± → φ π±
+    const std::array<int, NDaughtersResonant> arrPdgDaugResonantDToKstar0K{daughtersDsResonant.at(DecayChannelResonant::DsToKstar0K)};                // Ds± → anti-K*(892)0 K± and D± → anti-K*(892)0 K±
+
     // Reject particles from background events
     if (particle.fromBackgroundEvent() && rejectBackground) {
-      rowMcMatchGen(flag, origin, channel, -1);
+      rowMcMatchGen(flagChannelMain, origin, flagChannelResonant, -1);
       continue;
     }
 
-    if (corrBkgMothersPdgs.size() > 0) {
-      for (const auto& motherPdgCode : corrBkgMothersPdgs) {
-        if (std::abs(particle.pdgCode()) != motherPdgCode) {
+    if (pdgMothersCorrelBkg.size() > 0) {
+      for (const auto& pdgMother : pdgMothersCorrelBkg) {
+        if (std::abs(particle.pdgCode()) != pdgMother) {
           continue; // Skip if the particle PDG code does not match the mother PDG code
         }
-        auto finalStates = o2::hf_decay::hf_cand_3prong::getDecayChannelMain(motherPdgCode);
-        constexpr int MaxDepth = 2;     // Depth for final state matching
-        constexpr int ResoMaxDepth = 1; // Depth for resonant decay matching
+        auto finalStates = getDecayChannelsMain(pdgMother);
+        constexpr int DepthMainMax = 2; // Depth for final state matching
+        constexpr int DepthResoMax = 1; // Depth for resonant decay matching
 
-        int maxDepth = MaxDepth;
+        int depthMainMax = DepthMainMax;
         bool matched = false;
-        if (motherPdgCode == Pdg::kDStar) {
-          maxDepth = MaxDepth + 1; // D0 resonant decays are switched on
+        if (pdgMother == Pdg::kDStar) {
+          depthMainMax = DepthMainMax + 1; // D0 resonant decays are switched on
         }
 
         std::vector<int> arrAllDaughtersIndex;
-        for (const auto& [chn, finalState] : finalStates) {
-          if (finalState.size() == 5) { // o2-linter: disable=magic-number (Partly Reco 3-prong decays from 5-prong decays)
-            std::array<int, 5> finalStateParts = std::array{finalState[0], finalState[1], finalState[2], finalState[3], finalState[4]};
-            o2::hf_decay::changeFinalStatePdgSign(particle.pdgCode(), +kPi0, finalStateParts);
-            RecoDecay::getDaughters<false>(particle, &arrAllDaughtersIndex, finalStateParts, maxDepth);
-            matched = RecoDecay::isMatchedMCGen(mcParticles, particle, motherPdgCode, finalStateParts, true, &sign, -1);
-          } else if (finalState.size() == 4) { // o2-linter: disable=magic-number (Partly Reco 3-prong decays from 4-prong decays)
-            std::array<int, 4> finalStateParts = std::array{finalState[0], finalState[1], finalState[2], finalState[3]};
-            o2::hf_decay::changeFinalStatePdgSign(particle.pdgCode(), +kPi0, finalStateParts);
-            RecoDecay::getDaughters<false>(particle, &arrAllDaughtersIndex, finalStateParts, maxDepth);
-            matched = RecoDecay::isMatchedMCGen(mcParticles, particle, motherPdgCode, finalStateParts, true, &sign, -1);
-          } else if (finalState.size() == 3) { // o2-linter: disable=magic-number (Fully Reco 3-prong decays)
-            std::array<int, 3> finalStateParts = std::array{finalState[0], finalState[1], finalState[2]};
-            RecoDecay::getDaughters<false>(particle, &arrAllDaughtersIndex, finalStateParts, maxDepth);
-            matched = RecoDecay::isMatchedMCGen(mcParticles, particle, motherPdgCode, finalStateParts, true, &sign, maxDepth);
+        for (const auto& [channelMain, finalState] : finalStates) {
+          if (finalState.size() == 5) { // o2-linter: disable=magic-number (partially reconstructed 3-prong decays from 5-prong decays)
+            std::array<int, 5> arrPdgDaughtersMain5Prongs = std::array{finalState[0], finalState[1], finalState[2], finalState[3], finalState[4]};
+            o2::hf_decay::flipPdgSign(particle.pdgCode(), +kPi0, arrPdgDaughtersMain5Prongs);
+            RecoDecay::getDaughters<false>(particle, &arrAllDaughtersIndex, arrPdgDaughtersMain5Prongs, depthMainMax);
+            matched = RecoDecay::isMatchedMCGen(mcParticles, particle, pdgMother, arrPdgDaughtersMain5Prongs, true, &sign, -1);
+          } else if (finalState.size() == 4) { // o2-linter: disable=magic-number (partially reconstructed 3-prong decays from 4-prong decays)
+            std::array<int, 4> arrPdgDaughtersMain4Prongs = std::array{finalState[0], finalState[1], finalState[2], finalState[3]};
+            o2::hf_decay::flipPdgSign(particle.pdgCode(), +kPi0, arrPdgDaughtersMain4Prongs);
+            RecoDecay::getDaughters<false>(particle, &arrAllDaughtersIndex, arrPdgDaughtersMain4Prongs, depthMainMax);
+            matched = RecoDecay::isMatchedMCGen(mcParticles, particle, pdgMother, arrPdgDaughtersMain4Prongs, true, &sign, -1);
+          } else if (finalState.size() == 3) { // o2-linter: disable=magic-number (fully reconstructed 3-prong decays)
+            std::array<int, 3> arrPdgDaughtersMain3Prongs = std::array{finalState[0], finalState[1], finalState[2]};
+            RecoDecay::getDaughters<false>(particle, &arrAllDaughtersIndex, arrPdgDaughtersMain3Prongs, depthMainMax);
+            matched = RecoDecay::isMatchedMCGen(mcParticles, particle, pdgMother, arrPdgDaughtersMain3Prongs, true, &sign, depthMainMax);
           } else {
-            LOG(info) << "Final state size not supported: " << finalState.size();
-            continue;
+            LOG(fatal) << "Final state size not supported: " << finalState.size();
+            return;
           }
           if (matched) {
-            flag = sign * chn;
+            flagChannelMain = sign * channelMain;
             // Flag the resonant decay channel
             std::vector<int> arrResoDaughIndex = {};
-            if (std::abs(motherPdgCode) == Pdg::kDStar) {
+            if (std::abs(pdgMother) == Pdg::kDStar) {
               std::vector<int> arrResoDaughIndexDStar = {};
-              RecoDecay::getDaughters(particle, &arrResoDaughIndexDStar, std::array{0}, ResoMaxDepth);
-              for (size_t iDaug = 0; iDaug < arrResoDaughIndexDStar.size(); iDaug++) {
+              RecoDecay::getDaughters(particle, &arrResoDaughIndexDStar, std::array{0}, DepthResoMax);
+              for (std::size_t iDaug = 0; iDaug < arrResoDaughIndexDStar.size(); iDaug++) {
                 auto daughDstar = mcParticles.rawIteratorAt(arrResoDaughIndexDStar[iDaug]);
                 if (std::abs(daughDstar.pdgCode()) == Pdg::kD0 || std::abs(daughDstar.pdgCode()) == Pdg::kDPlus) {
-                  RecoDecay::getDaughters(daughDstar, &arrResoDaughIndex, std::array{0}, ResoMaxDepth);
+                  RecoDecay::getDaughters(daughDstar, &arrResoDaughIndex, std::array{0}, DepthResoMax);
                   break;
                 }
               }
             } else {
-              RecoDecay::getDaughters(particle, &arrResoDaughIndex, std::array{0}, ResoMaxDepth);
+              RecoDecay::getDaughters(particle, &arrResoDaughIndex, std::array{0}, DepthResoMax);
             }
-            std::array<int, NDaughtersResonant> arrPDGDaugh = {};
+            std::array<int, NDaughtersResonant> arrPdgDaughters = {};
             if (arrResoDaughIndex.size() == NDaughtersResonant) {
               for (auto iProng = 0u; iProng < NDaughtersResonant; ++iProng) {
                 auto daughI = mcParticles.rawIteratorAt(arrResoDaughIndex[iProng]);
-                arrPDGDaugh[iProng] = daughI.pdgCode();
+                arrPdgDaughters[iProng] = daughI.pdgCode();
               }
-              channel = o2::hf_decay::flagResonantDecay(motherPdgCode, arrPDGDaugh);
+              flagChannelResonant = o2::hf_decay::getDecayChannelResonant(pdgMother, arrPdgDaughters);
             }
             break; // Exit loop if a match is found
           }
@@ -219,87 +225,87 @@ void fillMcMatchGen3Prong(T const& mcParticles, U const& mcParticlesPerMcColl, V
     } else {
 
       // D± → π± K∓ π±
-      if (flag == 0) {
+      if (flagChannelMain == 0) {
         if (RecoDecay::isMatchedMCGen(mcParticles, particle, Pdg::kDPlus, std::array{+kPiPlus, -kKPlus, +kPiPlus}, true, &sign, 2)) {
-          flag = sign * o2::hf_decay::hf_cand_3prong::DecayChannelMain::DplusToPiKPi;
+          flagChannelMain = sign * DecayChannelMain::DplusToPiKPi;
         }
       }
 
       // Ds± → K± K∓ π± and D± → K± K∓ π±
-      if (flag == 0) {
+      if (flagChannelMain == 0) {
         bool isDplus = false;
         if (RecoDecay::isMatchedMCGen(mcParticles, particle, Pdg::kDS, std::array{+kKPlus, -kKPlus, +kPiPlus}, true, &sign, 2)) {
           // DecayType::DsToKKPi is used to flag both Ds± → K± K∓ π± and D± → K± K∓ π±
           // TODO: move to different and explicit flags
-          flag = sign * o2::hf_decay::hf_cand_3prong::DecayChannelMain::DsToPiKK;
+          flagChannelMain = sign * DecayChannelMain::DsToPiKK;
         } else if (RecoDecay::isMatchedMCGen(mcParticles, particle, Pdg::kDPlus, std::array{+kKPlus, -kKPlus, +kPiPlus}, true, &sign, 2)) {
           // DecayType::DsToKKPi is used to flag both Ds± → K± K∓ π± and D± → K± K∓ π±
           // TODO: move to different and explicit flags
-          flag = sign * o2::hf_decay::hf_cand_3prong::DecayChannelMain::DplusToPiKK;
+          flagChannelMain = sign * DecayChannelMain::DplusToPiKK;
           isDplus = true;
         }
-        if (flag != 0) {
+        if (flagChannelMain != 0) {
           RecoDecay::getDaughters(particle, &arrDaughIndex, std::array{0}, 1);
           if (arrDaughIndex.size() == NDaughtersResonant) {
-            for (auto jProng = 0u; jProng < arrDaughIndex.size(); ++jProng) {
-              auto daughJ = mcParticles.rawIteratorAt(arrDaughIndex[jProng]);
-              arrPDGDaugh[jProng] = std::abs(daughJ.pdgCode());
+            for (auto iProng = 0u; iProng < arrDaughIndex.size(); ++iProng) {
+              auto daughI = mcParticles.rawIteratorAt(arrDaughIndex[iProng]);
+              arrPdgDaugResonant[iProng] = std::abs(daughI.pdgCode());
             }
-            if ((arrPDGDaugh[0] == arrPDGResonantDPhiPi[0] && arrPDGDaugh[1] == arrPDGResonantDPhiPi[1]) || (arrPDGDaugh[0] == arrPDGResonantDPhiPi[1] && arrPDGDaugh[1] == arrPDGResonantDPhiPi[0])) {
-              channel = isDplus ? o2::hf_decay::hf_cand_3prong::DecayChannelResonant::DplusToPhiPi : o2::hf_decay::hf_cand_3prong::DecayChannelResonant::DsToPhiPi;
-            } else if ((arrPDGDaugh[0] == arrPDGResonantDKstarK[0] && arrPDGDaugh[1] == arrPDGResonantDKstarK[1]) || (arrPDGDaugh[0] == arrPDGResonantDKstarK[1] && arrPDGDaugh[1] == arrPDGResonantDKstarK[0])) {
-              channel = isDplus ? o2::hf_decay::hf_cand_3prong::DecayChannelResonant::DplusToKstar0K : o2::hf_decay::hf_cand_3prong::DecayChannelResonant::DsToKstar0K;
+            if ((arrPdgDaugResonant[0] == arrPdgDaugResonantDToPhiPi[0] && arrPdgDaugResonant[1] == arrPdgDaugResonantDToPhiPi[1]) || (arrPdgDaugResonant[0] == arrPdgDaugResonantDToPhiPi[1] && arrPdgDaugResonant[1] == arrPdgDaugResonantDToPhiPi[0])) {
+              flagChannelResonant = isDplus ? DecayChannelResonant::DplusToPhiPi : DecayChannelResonant::DsToPhiPi;
+            } else if ((arrPdgDaugResonant[0] == arrPdgDaugResonantDToKstar0K[0] && arrPdgDaugResonant[1] == arrPdgDaugResonantDToKstar0K[1]) || (arrPdgDaugResonant[0] == arrPdgDaugResonantDToKstar0K[1] && arrPdgDaugResonant[1] == arrPdgDaugResonantDToKstar0K[0])) {
+              flagChannelResonant = isDplus ? DecayChannelResonant::DplusToKstar0K : DecayChannelResonant::DsToKstar0K;
             }
           }
         }
       }
 
       // D*± → D0(bar) π±
-      if (flag == 0) {
+      if (flagChannelMain == 0) {
         if (RecoDecay::isMatchedMCGen(mcParticles, particle, Pdg::kDStar, std::array{+kPiPlus, +kPiPlus, -kKPlus}, true, &sign, 2)) {
-          flag = sign * o2::hf_decay::hf_cand_3prong::DecayChannelMain::DstarToPiKPi;
+          flagChannelMain = sign * DecayChannelMain::DstarToPiKPi;
         }
       }
 
       // Λc± → p± K∓ π±
-      if (flag == 0) {
+      if (flagChannelMain == 0) {
         if (RecoDecay::isMatchedMCGen(mcParticles, particle, Pdg::kLambdaCPlus, std::array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2)) {
-          flag = sign * o2::hf_decay::hf_cand_3prong::DecayChannelMain::LcToPKPi;
+          flagChannelMain = sign * DecayChannelMain::LcToPKPi;
 
           // Flagging the different Λc± → p± K∓ π± decay channels
           RecoDecay::getDaughters(particle, &arrDaughIndex, std::array{0}, 1);
           if (arrDaughIndex.size() == NDaughtersResonant) {
-            for (auto jProng = 0u; jProng < arrDaughIndex.size(); ++jProng) {
-              auto daughJ = mcParticles.rawIteratorAt(arrDaughIndex[jProng]);
-              arrPDGDaugh[jProng] = std::abs(daughJ.pdgCode());
+            for (auto iProng = 0u; iProng < arrDaughIndex.size(); ++iProng) {
+              auto daughI = mcParticles.rawIteratorAt(arrDaughIndex[iProng]);
+              arrPdgDaugResonant[iProng] = std::abs(daughI.pdgCode());
             }
-            if ((arrPDGDaugh[0] == arrPDGResonant1[0] && arrPDGDaugh[1] == arrPDGResonant1[1]) || (arrPDGDaugh[0] == arrPDGResonant1[1] && arrPDGDaugh[1] == arrPDGResonant1[0])) {
-              channel = 1;
-            } else if ((arrPDGDaugh[0] == arrPDGResonant2[0] && arrPDGDaugh[1] == arrPDGResonant2[1]) || (arrPDGDaugh[0] == arrPDGResonant2[1] && arrPDGDaugh[1] == arrPDGResonant2[0])) {
-              channel = 2;
-            } else if ((arrPDGDaugh[0] == arrPDGResonant3[0] && arrPDGDaugh[1] == arrPDGResonant3[1]) || (arrPDGDaugh[0] == arrPDGResonant3[1] && arrPDGDaugh[1] == arrPDGResonant3[0])) {
-              channel = 3;
+            if ((arrPdgDaugResonant[0] == arrPdgDaugResonantLcToPKstar0[0] && arrPdgDaugResonant[1] == arrPdgDaugResonantLcToPKstar0[1]) || (arrPdgDaugResonant[0] == arrPdgDaugResonantLcToPKstar0[1] && arrPdgDaugResonant[1] == arrPdgDaugResonantLcToPKstar0[0])) {
+              flagChannelResonant = DecayChannelResonant::LcToPKstar0;
+            } else if ((arrPdgDaugResonant[0] == arrPdgDaugResonantLcToDeltaplusplusK[0] && arrPdgDaugResonant[1] == arrPdgDaugResonantLcToDeltaplusplusK[1]) || (arrPdgDaugResonant[0] == arrPdgDaugResonantLcToDeltaplusplusK[1] && arrPdgDaugResonant[1] == arrPdgDaugResonantLcToDeltaplusplusK[0])) {
+              flagChannelResonant = DecayChannelResonant::LcToDeltaplusplusK;
+            } else if ((arrPdgDaugResonant[0] == arrPdgDaugResonantLcToL1520Pi[0] && arrPdgDaugResonant[1] == arrPdgDaugResonantLcToL1520Pi[1]) || (arrPdgDaugResonant[0] == arrPdgDaugResonantLcToL1520Pi[1] && arrPdgDaugResonant[1] == arrPdgDaugResonantLcToL1520Pi[0])) {
+              flagChannelResonant = DecayChannelResonant::LcToL1520Pi;
             }
           }
         }
       }
 
       // Ξc± → p± K∓ π±
-      if (flag == 0) {
+      if (flagChannelMain == 0) {
         if (RecoDecay::isMatchedMCGen(mcParticles, particle, Pdg::kXiCPlus, std::array{+kProton, -kKPlus, +kPiPlus}, true, &sign, 2)) {
-          flag = sign * o2::hf_decay::hf_cand_3prong::DecayChannelMain::XicToPKPi;
+          flagChannelMain = sign * DecayChannelMain::XicToPKPi;
         }
       }
     }
 
     // Check whether the particle is non-prompt (from a b quark).
-    if (flag != 0) {
+    if (flagChannelMain != 0) {
       origin = RecoDecay::getCharmHadronOrigin(mcParticles, particle, false, &idxBhadMothers);
     }
     if (origin == RecoDecay::OriginType::NonPrompt) {
-      rowMcMatchGen(flag, origin, channel, idxBhadMothers[0]);
+      rowMcMatchGen(flagChannelMain, origin, flagChannelResonant, idxBhadMothers[0]);
     } else {
-      rowMcMatchGen(flag, origin, channel, -1);
+      rowMcMatchGen(flagChannelMain, origin, flagChannelResonant, -1);
     }
   }
 }

--- a/PWGHF/Utils/utilsMcMatching.h
+++ b/PWGHF/Utils/utilsMcMatching.h
@@ -35,115 +35,128 @@ namespace o2::hf_decay
 namespace hf_cand_2prong
 {
 
+// D0
+
 static const std::unordered_map<DecayChannelMain, const std::vector<int>> daughtersD0Main{
-  {DecayChannelMain::D0ToPiK, {+kKMinus, +kPiPlus}},
-  {DecayChannelMain::D0ToPiKPi0, {+kKMinus, +kPiPlus, +kPi0}},
-  {DecayChannelMain::D0ToPiPi, {+kPiMinus, +kPiPlus}},
-  {DecayChannelMain::D0ToPiPiPi0, {+kPiMinus, +kPiPlus, +kPi0}},
-  {DecayChannelMain::D0ToKK, {+kKMinus, +kKPlus}},
+  {DecayChannelMain::D0ToPiK, {+PDG_t::kKMinus, +PDG_t::kPiPlus}},
+  {DecayChannelMain::D0ToPiKPi0, {+PDG_t::kKMinus, +PDG_t::kPiPlus, +PDG_t::kPi0}},
+  {DecayChannelMain::D0ToPiPi, {+PDG_t::kPiMinus, +PDG_t::kPiPlus}},
+  {DecayChannelMain::D0ToPiPiPi0, {+PDG_t::kPiMinus, +PDG_t::kPiPlus, +PDG_t::kPi0}},
+  {DecayChannelMain::D0ToKK, {+PDG_t::kKMinus, +PDG_t::kKPlus}},
 };
 
 static const std::unordered_map<DecayChannelResonant, const std::array<int, 2>> daughtersD0Resonant{
-  {DecayChannelResonant::D0ToRhoplusPi, {+kRho770Plus, +kPiMinus}},
-  {DecayChannelResonant::D0ToRhoplusK, {+kRho770Plus, +kKMinus}},
-  {DecayChannelResonant::D0ToKstar0Pi0, {-o2::constants::physics::kK0Star892, +kPi0}},
-  {DecayChannelResonant::D0ToKstarPi, {-o2::constants::physics::kKPlusStar892, +kPiPlus}},
+  {DecayChannelResonant::D0ToRhoplusPi, {+PDG_t::kRho770Plus, +PDG_t::kPiMinus}},
+  {DecayChannelResonant::D0ToRhoplusK, {+PDG_t::kRho770Plus, +PDG_t::kKMinus}},
+  {DecayChannelResonant::D0ToKstar0Pi0, {-o2::constants::physics::Pdg::kK0Star892, +PDG_t::kPi0}},
+  {DecayChannelResonant::D0ToKstarPi, {-o2::constants::physics::Pdg::kKPlusStar892, +PDG_t::kPiPlus}},
 };
 
+// J/ψ
+
+static const std::unordered_map<DecayChannelMain, const std::vector<int>> daughtersJpsiMain{
+  {DecayChannelMain::JpsiToEE, {+PDG_t::kElectron, +PDG_t::kPositron}},
+  {DecayChannelMain::JpsiToMuMu, {+PDG_t::kMuonMinus, +PDG_t::kMuonPlus}},
+};
 } // namespace hf_cand_2prong
 
 namespace hf_cand_3prong
 {
 
 // D±
+
 static const std::unordered_map<DecayChannelMain, const std::vector<int>> daughtersDplusMain{
-  {DecayChannelMain::DplusToPiKPi, {+kKMinus, +kPiPlus, +kPiPlus}},
-  {DecayChannelMain::DplusToPiKK, {+kKMinus, +kKPlus, +kPiPlus}},
-  {DecayChannelMain::DplusToPiKPiPi0, {+kKMinus, +kPiPlus, +kPiPlus, +kPi0}},
-  {DecayChannelMain::DplusToPiPiPi, {+kPiMinus, +kPiPlus, +kPiPlus}},
+  {DecayChannelMain::DplusToPiKPi, {+PDG_t::kKMinus, +PDG_t::kPiPlus, +PDG_t::kPiPlus}},
+  {DecayChannelMain::DplusToPiKK, {+PDG_t::kKMinus, +PDG_t::kKPlus, +PDG_t::kPiPlus}},
+  {DecayChannelMain::DplusToPiKPiPi0, {+PDG_t::kKMinus, +PDG_t::kPiPlus, +PDG_t::kPiPlus, +PDG_t::kPi0}},
+  {DecayChannelMain::DplusToPiPiPi, {+PDG_t::kPiMinus, +PDG_t::kPiPlus, +PDG_t::kPiPlus}},
 };
 
 static const std::unordered_map<DecayChannelResonant, const std::array<int, 2>> daughtersDplusResonant{
-  {DecayChannelResonant::DplusToPhiPi, {+o2::constants::physics::kPhi, +kPiPlus}},
-  {DecayChannelResonant::DplusToKstar0K, {-o2::constants::physics::kK0Star892, +kKPlus}},
-  {DecayChannelResonant::DplusToKstar1430_0K, {-10311, +kKPlus}},
-  {DecayChannelResonant::DplusToRho0Pi, {+kRho770_0, +kPiPlus}},
-  {DecayChannelResonant::DplusToF2_1270Pi, {+225, +kPiPlus}},
+  {DecayChannelResonant::DplusToPhiPi, {+o2::constants::physics::Pdg::kPhi, +PDG_t::kPiPlus}},
+  {DecayChannelResonant::DplusToKstar0K, {-o2::constants::physics::Pdg::kK0Star892, +PDG_t::kKPlus}},
+  {DecayChannelResonant::DplusToKstar1430_0K, {-10311, +PDG_t::kKPlus}},
+  {DecayChannelResonant::DplusToRho0Pi, {+PDG_t::kRho770_0, +PDG_t::kPiPlus}},
+  {DecayChannelResonant::DplusToF2_1270Pi, {+225, +PDG_t::kPiPlus}},
 };
 
 // Ds±
+
 static const std::unordered_map<DecayChannelMain, const std::vector<int>> daughtersDsMain{
-  {DecayChannelMain::DsToPiKK, {+kKMinus, +kKPlus, +kPiPlus}},
-  {DecayChannelMain::DsToPiKKPi0, {+kKMinus, +kKPlus, +kPiPlus, +kPi0}},
-  {DecayChannelMain::DsToPiPiK, {+kKPlus, +kPiPlus, +kPiMinus}},
-  {DecayChannelMain::DsToPiPiPi, {+kPiMinus, +kPiPlus, +kPiPlus}},
-  {DecayChannelMain::DsToPiPiPiPi0, {+kPiMinus, +kPiPlus, +kPiPlus, +kPi0}},
+  {DecayChannelMain::DsToPiKK, {+PDG_t::kKMinus, +PDG_t::kKPlus, +PDG_t::kPiPlus}},
+  {DecayChannelMain::DsToPiKKPi0, {+PDG_t::kKMinus, +PDG_t::kKPlus, +PDG_t::kPiPlus, +PDG_t::kPi0}},
+  {DecayChannelMain::DsToPiPiK, {+PDG_t::kKPlus, +PDG_t::kPiPlus, +PDG_t::kPiMinus}},
+  {DecayChannelMain::DsToPiPiPi, {+PDG_t::kPiMinus, +PDG_t::kPiPlus, +PDG_t::kPiPlus}},
+  {DecayChannelMain::DsToPiPiPiPi0, {+PDG_t::kPiMinus, +PDG_t::kPiPlus, +PDG_t::kPiPlus, +PDG_t::kPi0}},
 };
 
 static const std::unordered_map<DecayChannelResonant, const std::array<int, 2>> daughtersDsResonant{
-  {DecayChannelResonant::DsToPhiPi, {+o2::constants::physics::kPhi, +kPiPlus}},
-  {DecayChannelResonant::DsToPhiRhoplus, {+o2::constants::physics::kPhi, +kRho770Plus}},
-  {DecayChannelResonant::DsToKstar0K, {-o2::constants::physics::kK0Star892, +kKPlus}},
-  {DecayChannelResonant::DsToKstar0Pi, {+o2::constants::physics::kK0Star892, +kPiPlus}},
-  {DecayChannelResonant::DsToRho0Pi, {+kRho770_0, +kPiPlus}},
-  {DecayChannelResonant::DsToRho0K, {+kRho770_0, +kKPlus}},
-  {DecayChannelResonant::DsToF2_1270Pi, {225, +kPiPlus}},
-  {DecayChannelResonant::DsToF0_1370K, {10221, +kKPlus}},
-  {DecayChannelResonant::DsToEtaPi, {221, +kPiPlus}},
+  {DecayChannelResonant::DsToPhiPi, {+o2::constants::physics::Pdg::kPhi, +PDG_t::kPiPlus}},
+  {DecayChannelResonant::DsToPhiRhoplus, {+o2::constants::physics::Pdg::kPhi, +PDG_t::kRho770Plus}},
+  {DecayChannelResonant::DsToKstar0K, {-o2::constants::physics::Pdg::kK0Star892, +PDG_t::kKPlus}},
+  {DecayChannelResonant::DsToKstar0Pi, {+o2::constants::physics::Pdg::kK0Star892, +PDG_t::kPiPlus}},
+  {DecayChannelResonant::DsToRho0Pi, {+PDG_t::kRho770_0, +PDG_t::kPiPlus}},
+  {DecayChannelResonant::DsToRho0K, {+PDG_t::kRho770_0, +PDG_t::kKPlus}},
+  {DecayChannelResonant::DsToF2_1270Pi, {225, +PDG_t::kPiPlus}},
+  {DecayChannelResonant::DsToF0_1370K, {10221, +PDG_t::kKPlus}},
+  {DecayChannelResonant::DsToEtaPi, {221, +PDG_t::kPiPlus}},
 };
 
-// Dstar
+// D*+
+
 static const std::unordered_map<DecayChannelMain, const std::vector<int>> daughtersDstarMain{
-  {DecayChannelMain::DstarToPiKPi, {+kKMinus, +kPiPlus, +kPiPlus}},
-  {DecayChannelMain::DstarToPiKPiPi0, {+kKMinus, +kPiPlus, +kPiPlus, +kPi0}},
-  {DecayChannelMain::DstarToPiKPiPi0Pi0, {+kKMinus, +kPiPlus, +kPiPlus, +kPi0, +kPi0}},
-  {DecayChannelMain::DstarToPiKK, {+kKMinus, +kKPlus, +kPiPlus}},
-  {DecayChannelMain::DstarToPiKKPi0, {+kKMinus, +kKPlus, +kPiPlus, +kPi0}},
-  {DecayChannelMain::DstarToPiPiPi, {+kPiMinus, +kPiPlus, +kPiPlus}},
-  {DecayChannelMain::DstarToPiPiPiPi0, {+kPiMinus, +kPiPlus, +kPiPlus, +kPi0}},
+  {DecayChannelMain::DstarToPiKPi, {+PDG_t::kKMinus, +PDG_t::kPiPlus, +PDG_t::kPiPlus}},
+  {DecayChannelMain::DstarToPiKPiPi0, {+PDG_t::kKMinus, +PDG_t::kPiPlus, +PDG_t::kPiPlus, +PDG_t::kPi0}},
+  {DecayChannelMain::DstarToPiKPiPi0Pi0, {+PDG_t::kKMinus, +PDG_t::kPiPlus, +PDG_t::kPiPlus, +PDG_t::kPi0, +PDG_t::kPi0}},
+  {DecayChannelMain::DstarToPiKK, {+PDG_t::kKMinus, +PDG_t::kKPlus, +PDG_t::kPiPlus}},
+  {DecayChannelMain::DstarToPiKKPi0, {+PDG_t::kKMinus, +PDG_t::kKPlus, +PDG_t::kPiPlus, +PDG_t::kPi0}},
+  {DecayChannelMain::DstarToPiPiPi, {+PDG_t::kPiMinus, +PDG_t::kPiPlus, +PDG_t::kPiPlus}},
+  {DecayChannelMain::DstarToPiPiPiPi0, {+PDG_t::kPiMinus, +PDG_t::kPiPlus, +PDG_t::kPiPlus, +PDG_t::kPi0}},
 };
 
 static const std::unordered_map<DecayChannelResonant, const std::array<int, 2>> daughtersDstarResonant{
-  {DecayChannelResonant::DstarToD0ToRhoplusPi, {+kRho770Plus, +kPiMinus}},
-  {DecayChannelResonant::DstarToD0ToRhoplusK, {+kRho770Plus, +kKMinus}},
-  {DecayChannelResonant::DstarToD0ToKstar0Pi0, {-o2::constants::physics::kK0Star892, +kPi0}},
-  {DecayChannelResonant::DstarToD0ToKstarPi, {-o2::constants::physics::kKPlusStar892, +kPiPlus}},
-  {DecayChannelResonant::DstarToDplusToPhiPi, {+o2::constants::physics::kPhi, +kPiPlus}},
-  {DecayChannelResonant::DstarToDplusToKstar0K, {-o2::constants::physics::kK0Star892, +kKPlus}},
-  {DecayChannelResonant::DstarToDplusToKstar1430_0K, {-10311, +kKPlus}},
-  {DecayChannelResonant::DstarToDplusToRho0Pi, {+kRho770_0, +kPiPlus}},
-  {DecayChannelResonant::DstarToDplusToF2_1270Pi, {+225, +kPiPlus}},
+  {DecayChannelResonant::DstarToD0ToRhoplusPi, {+PDG_t::kRho770Plus, +PDG_t::kPiMinus}},
+  {DecayChannelResonant::DstarToD0ToRhoplusK, {+PDG_t::kRho770Plus, +PDG_t::kKMinus}},
+  {DecayChannelResonant::DstarToD0ToKstar0Pi0, {-o2::constants::physics::Pdg::kK0Star892, +PDG_t::kPi0}},
+  {DecayChannelResonant::DstarToD0ToKstarPi, {-o2::constants::physics::Pdg::kKPlusStar892, +PDG_t::kPiPlus}},
+  {DecayChannelResonant::DstarToDplusToPhiPi, {+o2::constants::physics::Pdg::kPhi, +PDG_t::kPiPlus}},
+  {DecayChannelResonant::DstarToDplusToKstar0K, {-o2::constants::physics::Pdg::kK0Star892, +PDG_t::kKPlus}},
+  {DecayChannelResonant::DstarToDplusToKstar1430_0K, {-10311, +PDG_t::kKPlus}},
+  {DecayChannelResonant::DstarToDplusToRho0Pi, {+PDG_t::kRho770_0, +PDG_t::kPiPlus}},
+  {DecayChannelResonant::DstarToDplusToF2_1270Pi, {+225, +PDG_t::kPiPlus}},
 };
 
-// Lc
+// Λc+
+
 static const std::unordered_map<DecayChannelMain, const std::vector<int>> daughtersLcMain{
-  {DecayChannelMain::LcToPKPi, {+kProton, +kKMinus, +kPiPlus}},
-  {DecayChannelMain::LcToPKPiPi0, {+kProton, +kKMinus, +kPiPlus, +kPi0}},
-  {DecayChannelMain::LcToPPiPi, {+kProton, +kPiMinus, +kPiPlus}},
-  {DecayChannelMain::LcToPKK, {+kProton, +kKMinus, +kKPlus}}};
+  {DecayChannelMain::LcToPKPi, {+PDG_t::kProton, +PDG_t::kKMinus, +PDG_t::kPiPlus}},
+  {DecayChannelMain::LcToPKPiPi0, {+PDG_t::kProton, +PDG_t::kKMinus, +PDG_t::kPiPlus, +PDG_t::kPi0}},
+  {DecayChannelMain::LcToPPiPi, {+PDG_t::kProton, +PDG_t::kPiMinus, +PDG_t::kPiPlus}},
+  {DecayChannelMain::LcToPKK, {+PDG_t::kProton, +PDG_t::kKMinus, +PDG_t::kKPlus}}};
 
 static const std::unordered_map<DecayChannelResonant, const std::array<int, 2>> daughtersLcResonant{
-  {DecayChannelResonant::LcToPKstar0, {-o2::constants::physics::kK0Star892, +kProton}},
-  {DecayChannelResonant::LcToDeltaplusplusK, {+2224, +kKMinus}},
-  {DecayChannelResonant::LcToL1520Pi, {+102134, +kPiPlus}},
+  {DecayChannelResonant::LcToPKstar0, {-o2::constants::physics::Pdg::kK0Star892, +PDG_t::kProton}},
+  {DecayChannelResonant::LcToDeltaplusplusK, {+2224, +PDG_t::kKMinus}},
+  {DecayChannelResonant::LcToL1520Pi, {+102134, +PDG_t::kPiPlus}},
 };
 
-// Xic
+// Ξc+
+
 static const std::unordered_map<DecayChannelMain, const std::vector<int>> daughtersXicMain{
-  {DecayChannelMain::XicToPKPi, {+kProton, +kKMinus, +kPiPlus}},
-  {DecayChannelMain::XicToPKK, {+kProton, +kKMinus, +kKPlus}},
-  {DecayChannelMain::XicToSPiPi, {+kSigmaPlus, +kPiMinus, +kPiPlus}},
+  {DecayChannelMain::XicToPKPi, {+PDG_t::kProton, +PDG_t::kKMinus, +PDG_t::kPiPlus}},
+  {DecayChannelMain::XicToPKK, {+PDG_t::kProton, +PDG_t::kKMinus, +PDG_t::kKPlus}},
+  {DecayChannelMain::XicToSPiPi, {+PDG_t::kSigmaPlus, +PDG_t::kPiMinus, +PDG_t::kPiPlus}},
 };
 
 static const std::unordered_map<DecayChannelResonant, const std::array<int, 2>> daughtersXicResonant{
-  {DecayChannelResonant::XicToPKstar0, {-o2::constants::physics::kK0Star892, +kProton}},
-  {DecayChannelResonant::XicToPPhi, {+kProton, +o2::constants::physics::kPhi}},
+  {DecayChannelResonant::XicToPKstar0, {-o2::constants::physics::Pdg::kK0Star892, +PDG_t::kProton}},
+  {DecayChannelResonant::XicToPPhi, {+PDG_t::kProton, +o2::constants::physics::Pdg::kPhi}},
 };
 
 /// Returns a map of the possible final states for a specific 3-prong particle specie
 /// \param pdgMother PDG code of the mother particle
 /// \return a map of final states with their corresponding PDG codes
-inline std::unordered_map<DecayChannelMain, const std::vector<int>> getDecayChannelMain(int pdgMother)
+inline std::unordered_map<DecayChannelMain, const std::vector<int>> getDecayChannelsMain(int pdgMother)
 {
   switch (pdgMother) {
     case o2::constants::physics::Pdg::kDPlus:
@@ -169,7 +182,7 @@ inline std::unordered_map<DecayChannelMain, const std::vector<int>> getDecayChan
 /// \param arrPdgExpected array of the expected PDG codes
 /// \return true if the arrays are equal, false otherwise
 template <std::size_t N>
-inline bool checkDecayChannel(std::array<int, N> const& arrPdgTested, std::array<int, N> arrPdgExpected)
+inline bool areSamePdgArrays(std::array<int, N> const& arrPdgTested, std::array<int, N> arrPdgExpected)
 {
   for (std::size_t i = 0; i < N; i++) {
     bool foundPdg = false;
@@ -187,59 +200,59 @@ inline bool checkDecayChannel(std::array<int, N> const& arrPdgTested, std::array
   return true;
 }
 
-/// Flag the resonant decays
+/// Flag the resonant decay channel
 /// \tparam N size of the array of daughter PDG codes
-/// \param motherPdg PDG code of the mother particle
-/// \param arrDaughPdgs array of daughter PDG codes
-/// \return the flag for the matched resonant decay channel
+/// \param pdgMother PDG code of the mother particle
+/// \param arrPdgDaughters array of daughter PDG codes
+/// \return the channel for the matched resonant decay channel
 template <std::size_t N>
-inline int8_t flagResonantDecay(const int motherPdg, std::array<int, N> const& arrDaughPdgs)
+inline int8_t getDecayChannelResonant(const int pdgMother, std::array<int, N> const& arrPdgDaughters)
 {
-  switch (motherPdg) {
+  switch (pdgMother) {
     case o2::constants::physics::Pdg::kD0:
-      for (const auto& [flag, pdgCodes] : o2::hf_decay::hf_cand_2prong::daughtersD0Resonant) {
-        if (o2::hf_decay::checkDecayChannel(arrDaughPdgs, pdgCodes)) {
-          return flag;
+      for (const auto& [channelResonant, arrPdgDaughtersResonant] : hf_cand_2prong::daughtersD0Resonant) {
+        if (areSamePdgArrays(arrPdgDaughters, arrPdgDaughtersResonant)) {
+          return channelResonant;
         }
       }
       break;
     case o2::constants::physics::Pdg::kDPlus:
-      for (const auto& [flag, pdgCodes] : o2::hf_decay::hf_cand_3prong::daughtersDplusResonant) {
-        if (o2::hf_decay::checkDecayChannel(arrDaughPdgs, pdgCodes)) {
-          return flag;
+      for (const auto& [channelResonant, arrPdgDaughtersResonant] : hf_cand_3prong::daughtersDplusResonant) {
+        if (areSamePdgArrays(arrPdgDaughters, arrPdgDaughtersResonant)) {
+          return channelResonant;
         }
       }
       break;
     case o2::constants::physics::Pdg::kDS:
-      for (const auto& [flag, pdgCodes] : o2::hf_decay::hf_cand_3prong::daughtersDsResonant) {
-        if (o2::hf_decay::checkDecayChannel(arrDaughPdgs, pdgCodes)) {
-          return flag;
+      for (const auto& [channelResonant, arrPdgDaughtersResonant] : hf_cand_3prong::daughtersDsResonant) {
+        if (areSamePdgArrays(arrPdgDaughters, arrPdgDaughtersResonant)) {
+          return channelResonant;
         }
       }
       break;
     case o2::constants::physics::Pdg::kDStar:
-      for (const auto& [flag, pdgCodes] : o2::hf_decay::hf_cand_3prong::daughtersDstarResonant) {
-        if (o2::hf_decay::checkDecayChannel(arrDaughPdgs, pdgCodes)) {
-          return flag;
+      for (const auto& [channelResonant, arrPdgDaughtersResonant] : hf_cand_3prong::daughtersDstarResonant) {
+        if (areSamePdgArrays(arrPdgDaughters, arrPdgDaughtersResonant)) {
+          return channelResonant;
         }
       }
       break;
     case o2::constants::physics::Pdg::kLambdaCPlus:
-      for (const auto& [flag, pdgCodes] : o2::hf_decay::hf_cand_3prong::daughtersLcResonant) {
-        if (o2::hf_decay::checkDecayChannel(arrDaughPdgs, pdgCodes)) {
-          return flag;
+      for (const auto& [channelResonant, arrPdgDaughtersResonant] : hf_cand_3prong::daughtersLcResonant) {
+        if (areSamePdgArrays(arrPdgDaughters, arrPdgDaughtersResonant)) {
+          return channelResonant;
         }
       }
       break;
     case o2::constants::physics::Pdg::kXiCPlus:
-      for (const auto& [flag, pdgCodes] : o2::hf_decay::hf_cand_3prong::daughtersXicResonant) {
-        if (o2::hf_decay::checkDecayChannel(arrDaughPdgs, pdgCodes)) {
-          return flag;
+      for (const auto& [channelResonant, arrPdgDaughtersResonant] : hf_cand_3prong::daughtersXicResonant) {
+        if (areSamePdgArrays(arrPdgDaughters, arrPdgDaughtersResonant)) {
+          return channelResonant;
         }
       }
       break;
     default:
-      LOG(fatal) << "Unknown PDG code for 3-prong final states: " << motherPdg;
+      LOG(fatal) << "Unknown PDG code for 3-prong final states: " << pdgMother;
       return -1;
   }
   return 0;
@@ -248,18 +261,18 @@ inline int8_t flagResonantDecay(const int motherPdg, std::array<int, N> const& a
 /// Flip the sign of a specific PDG code in an array
 /// of PDG codes associated to an antiparticle.
 /// \tparam N size of the array of PDG codes
-/// \param motherPdgCode PDG code of the mother particle
-/// \param partPdgCode PDG code to be flipped
-/// \param arrFinalStatePdgs array of PDG codes to be modified
+/// \param pdgMother PDG code of the mother particle
+/// \param pdgToFlip PDG code to be flipped
+/// \param arrPdg array of PDG codes to be modified
 template <std::size_t N>
-inline void changeFinalStatePdgSign(const int motherPdgCode, const int partPdgCode, std::array<int, N>& arrFinalStatePdgs)
+inline void flipPdgSign(const int pdgMother, const int pdgToFlip, std::array<int, N>& arrPdg)
 {
-  if (motherPdgCode >= 0) {
+  if (pdgMother >= 0) {
     return;
   }
-  for (auto& part : arrFinalStatePdgs) { // o2-linter: disable=const-ref-in-for-loop (arrFinalStatePdgs entries are modified)
-    if (part == partPdgCode) {
-      part = -part;
+  for (auto& pdg : arrPdg) { // o2-linter: disable=const-ref-in-for-loop (arrPdg entries are modified)
+    if (pdg == pdgToFlip) {
+      pdg = -pdg;
     }
   }
 }

--- a/PWGJE/Core/JetHFUtilities.h
+++ b/PWGJE/Core/JetHFUtilities.h
@@ -263,7 +263,7 @@ template <typename T>
 constexpr bool isMatchedHFCandidate(T const& candidate)
 {
   if constexpr (isD0Candidate<T>()) {
-    if (std::abs(candidate.flagMcMatchRec()) == 1 << o2::aod::hf_cand_2prong::DecayType::D0ToPiK) {
+    if (std::abs(candidate.flagMcMatchRec()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
       return true;
     } else {
       return false;
@@ -287,7 +287,7 @@ constexpr bool isMatchedHFCandidate(T const& candidate)
       return false;
     }
   } else if constexpr (isD0McCandidate<T>()) {
-    if (std::abs(candidate.flagMcMatchGen()) == 1 << o2::aod::hf_cand_2prong::DecayType::D0ToPiK) {
+    if (std::abs(candidate.flagMcMatchGen()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
       return true;
     } else {
       return false;

--- a/PWGJE/Tasks/hfFragmentationFunction.cxx
+++ b/PWGJE/Tasks/hfFragmentationFunction.cxx
@@ -16,13 +16,15 @@
 ///
 /// The task store data relevant to the calculation of hadronization observables radial
 /// profile and/or jet momentum fraction for charmed hadrons
-#include "JetDerivedDataUtilities.h"
-#include "RecoDecay.h"
 
-#include "PWGHF/DataModel/CandidateReconstructionTables.h"
+#include "PWGJE/Core/JetDerivedDataUtilities.h"
 #include "PWGJE/Core/JetUtilities.h"
 #include "PWGJE/DataModel/Jet.h"
 #include "PWGJE/DataModel/JetReducedData.h"
+//
+#include "PWGHF/Core/DecayChannels.h"
+
+#include "Common/Core/RecoDecay.h"
 
 #include "Framework/ASoA.h"
 #include "Framework/AnalysisDataModel.h"
@@ -325,7 +327,7 @@ struct HfFragmentationFunction {
 
           // reflection information for storage: D0 = +1, D0bar = -1, neither = 0
           int matchedFrom = 0;
-          int decayChannel = 1 << aod::hf_cand_2prong::DecayType::D0ToPiK;
+          int decayChannel = o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK;
           int selectedAs = 0;
 
           if (mcdd0cand.flagMcMatchRec() == decayChannel) { // matched to D0 on truth level
@@ -416,7 +418,7 @@ struct HfFragmentationFunction {
 
           // reflection information for storage: D0 = +1, D0bar = -1, neither = 0
           int matchedFrom = 0;
-          int decayChannel = 1 << aod::hf_cand_2prong::DecayType::D0ToPiK;
+          int decayChannel = o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK;
           int selectedAs = 0;
 
           if (mcdd0cand.flagMcMatchRec() == decayChannel) { // matched to D0 on truth level


### PR DESCRIPTION
Continuation of #11382
- Propagate new D0 MC flags.
- Add main J/ψ channels.
- Replace duplicated hard-coded PDG arrays.
- Migrate Lc and Ds+ resonant channels.
- Improve and unify naming.
- Fix bugs in:
  - PWGHF/D2H/Tasks/taskCharmPolarisation.cxx (wrong `TESTBIT` for D*+)
  - PWGHF/HFC/TableProducer/correlatorLcScHadrons.cxx (using old flags)
  - PWGCF/TableProducer/filter2Prong.cxx (missing `abs`)