### PR TITLE
[DPG] Update timeDependentQa.cxx - add mult distributions vs time

### DIFF
--- a/DPG/Tasks/AOTEvent/timeDependentQa.cxx
+++ b/DPG/Tasks/AOTEvent/timeDependentQa.cxx
@@ -769,7 +769,7 @@ struct TimeDependentQaTask {
         histos.fill(HIST("multDistributions/hSecondsDistrZNA"), secFromSOR, col.multZNA());
         histos.fill(HIST("multDistributions/hSecondsDistrZNC"), secFromSOR, col.multZNC());
         float ZNdiff = col.multZNA() - col.multZNC();
-        float ZNsum = col.multZNA() - col.multZNC();
+        float ZNsum = col.multZNA() + col.multZNC();
         histos.fill(HIST("multDistributions/hSecondsDistrZNACdiff"), secFromSOR, ZNdiff);
         if (ZNsum > 0)
           histos.fill(HIST("multDistributions/hSecondsDistrZNACdiffNorm"), secFromSOR, ZNdiff / ZNsum);


### PR DESCRIPTION
Several multiplicity distributions vs time bins are added (nPVtracks, ZNA,C, FT0A,C, V0A, default time bin = 10 sec),
needed for O-O and Ne-Ne runs to monitor how beam content is changing with time.