### PR TITLE
[Common] RecoDecay: Templatize MC particle.

### DIFF
--- a/Common/Core/RecoDecay.h
+++ b/Common/Core/RecoDecay.h
@@ -732,7 +732,7 @@ struct RecoDecay {
         if (!arrDaughters[iProng].has_mcParticle()) {
           return -1;
         }
-        auto particleI = arrDaughters[iProng].mcParticle();                                // ith daughter particle
+        auto particleI = arrDaughters[iProng].template mcParticle_as<T>();                 // ith daughter particle
         if (std::abs(particleI.getGenStatusCode()) == StatusCodeAfterFlavourOscillation) { // oscillation decay product spotted
           coefFlavourOscillation = -1;                                                     // select the sign of the mother after oscillation (and not before)
           break;
@@ -744,7 +744,7 @@ struct RecoDecay {
       if (!arrDaughters[iProng].has_mcParticle()) {
         return -1;
       }
-      auto particleI = arrDaughters[iProng].mcParticle(); // ith daughter particle
+      auto particleI = arrDaughters[iProng].template mcParticle_as<T>(); // ith daughter particle
       if constexpr (acceptTrackDecay) {
         // Replace the MC particle associated with the prong by its mother for π → μ and K → π.
         auto motherI = particleI.template mothers_first_as<T>();


### PR DESCRIPTION
Data type for `particleI` changed in the template one `T`.

In the method `getMatchedMCRec` the candidate daughter particles are retrieved with `auto particleI = arrDaughters[iProng].mcParticle();`, i.e. `particleI` is always of type `McParticles::iterator`. This means that the current version of the code works if and only if `T == McParticles`, but it does not work if it is something else, e.g. `soa::Join<McParticles, <something_else> >`. This fails e.g. in the `getMother` function, were the 2nd argument must always be an `iterator` of the 1st one.