### PR TITLE
[PWGHF] Ds-h correlation, removed hAssocTrack histo

### DIFF
--- a/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
@@ -887,7 +887,6 @@ struct HfTaskCorrelationDsHadrons {
                                 aod::McParticles const& mcParticles,
                                 TracksWithMc const& tracksData)
   {
-    auto hAssocTracks = registry.get<StepTHn>(HIST("hAssocTracks"));
 
     /// loop over generated collisions
     for (const auto& mcCollision : mcCollisions) {


### PR DESCRIPTION
Dear all,
I have just removed one unnecessary histogram in a process that I forgot to remove before.

Cheers,
Samuele