### PR TITLE
feat(nucleiSpectra): Add configurable option to fill generated secondaries

### DIFF
--- a/PWGLF/TableProducer/Nuspex/nucleiSpectra.cxx
+++ b/PWGLF/TableProducer/Nuspex/nucleiSpectra.cxx
@@ -293,6 +293,7 @@ struct nucleiSpectra {
   Configurable<LabeledArray<double>> cfgDownscaling{"cfgDownscaling", {nuclei::DownscalingDefault[0], 5, 1, nuclei::names, nuclei::DownscalingConfigName}, "Fraction of kept candidates for light nuclei"};
   Configurable<LabeledArray<int>> cfgTreeConfig{"cfgTreeConfig", {nuclei::TreeConfigDefault[0], 5, 2, nuclei::names, nuclei::treeConfigNames}, "Filtered trees configuration"};
   Configurable<bool> cfgFillPairTree{"cfgFillPairTree", true, "Fill trees for pairs of light nuclei"};
+  Configurable<int> cfgFillGenSecondaries{"cfgFillGenSecondaries", 0, "Fill generated secondaries (0: no, 1: only weak decays, 2: all of them)"};
   Configurable<LabeledArray<int>> cfgDCAHists{"cfgDCAHists", {nuclei::DCAHistDefault[0], 5, 2, nuclei::names, nuclei::DCAConfigNames}, "DCA hist configuration"};
   Configurable<LabeledArray<int>> cfgFlowHist{"cfgFlowHist", {nuclei::FlowHistDefault[0], 5, 1, nuclei::names, nuclei::flowConfigNames}, "Flow hist configuration"};
 
@@ -1008,8 +1009,13 @@ struct nucleiSpectra {
         }
 
         if (!isReconstructed[index] && (cfgTreeConfig->get(iS, 0u) || cfgTreeConfig->get(iS, 1u))) {
+          if ((flags & kIsPhysicalPrimary) == 0 && cfgFillGenSecondaries == 0) {
+            continue; // skip secondaries if not requested
+          }
+          if ((flags & (kIsPhysicalPrimary | kIsSecondaryFromWeakDecay)) == 0 && cfgFillGenSecondaries == 1) {
+            continue; // skip secondaries from material if not requested
+          }
           float absDecL = computeAbsoDecL(particle);
-
           nucleiTableMC(999., 999., 999., 0., 0., 999., -1, 999., 999., -1, -1, -1, -1, flags, 0, 0, 0, 0, 0, 0, goodCollisions[particle.mcCollisionId()], particle.pt(), particle.eta(), particle.phi(), particle.pdgCode(), motherPdgCode, motherDecRadius, absDecL);
         }
         break;


### PR DESCRIPTION
The changes introduce a new configurable option `cfgFillGenSecondaries` that allows
controlling the filling of generated secondary particles in the nuclei table. The
new option provides three modes:

0. Do not fill any generated secondaries
1. Fill only secondaries from weak decays
2. Fill all generated secondaries

This feature gives more flexibility in the analysis of light nuclei, allowing
users to focus on primary particles or include secondary particles as needed.