### PR TITLE
[PWGHF] Cut variation: make analysis more flexible and output more informative

### DIFF
--- a/PWGHF/D2H/Macros/compute_fraction_cutvar.py
+++ b/PWGHF/D2H/Macros/compute_fraction_cutvar.py
@@ -56,6 +56,10 @@ def main(config):
         infile_eff.Close()
 
     pt_bin_to_process = cfg.get("pt_bin_to_process", -1)
+    if not isinstance(pt_bin_to_process, int):
+        sys.exit("Fatal error: pt_bin_to_process must be an integer value. Exit.")
+    if (pt_bin_to_process != -1 and pt_bin_to_process < 1) or pt_bin_to_process > hist_rawy[0].GetNbinsX():
+        sys.exit("Fatal error: pt_bin_to_process must be a positive value up to number of bins in raw yield histogram. Exit.")
 
     if cfg["central_efficiency"]["computerawfrac"]:
         infile_name = os.path.join(cfg["central_efficiency"]["inputdir"], cfg["central_efficiency"]["inputfile"])

--- a/PWGHF/D2H/Macros/compute_fraction_cutvar.py
+++ b/PWGHF/D2H/Macros/compute_fraction_cutvar.py
@@ -146,6 +146,10 @@ def main(config):
             unc_effp[iset] = heffp.GetBinError(ipt + 1)
             unc_effnp[iset] = heffnp.GetBinError(ipt + 1)
 
+        if cfg["minimisation"]["correlated"] and not (np.all(unc_rawy[1:] > unc_rawy[:-1]) or np.all(unc_rawy[1:] < unc_rawy[:-1])):
+            print("WARNING! main(): the raw yield uncertainties vector is not monotonous. Check the input for stability.")
+            print(f"raw yield uncertainties vector elements = {unc_rawy}\n")
+
         minimiser = CutVarMinimiser(rawy, effp, effnp, unc_rawy, unc_effp, unc_effnp)
         minimiser.minimise_system(cfg["minimisation"]["correlated"])
 

--- a/PWGHF/D2H/Macros/compute_fraction_cutvar.py
+++ b/PWGHF/D2H/Macros/compute_fraction_cutvar.py
@@ -185,10 +185,11 @@ def main(config):
         for _, hist in histos_rawy.items():
             hist.Write()
 
-        canv_rawy_unc, histo_rawy_unc = minimiser.plot_raw_yield_uncertainties(f"_pt{pt_min}_{pt_max}", hist_bin_title)
+        canv_unc, histos_unc, leg_unc = minimiser.plot_uncertainties(f"_pt{pt_min}_{pt_max}", hist_bin_title)
         output.cd()
-        canv_rawy_unc.Write()
-        histo_rawy_unc.Write()
+        canv_unc.Write()
+        for _, hist in histos_unc.items():
+            hist.Write()
 
         canv_eff, histos_eff, leg_e = minimiser.plot_efficiencies(f"_pt{pt_min}_{pt_max}", hist_bin_title)
         output.cd()
@@ -222,7 +223,7 @@ def main(config):
         output_name_eff_pdf = f"Eff_{cfg['output']['file'].replace('.root', '.pdf')}"
         output_name_frac_pdf = f"Frac_{cfg['output']['file'].replace('.root', '.pdf')}"
         output_name_covmat_pdf = f"CovMatrix_{cfg['output']['file'].replace('.root', '.pdf')}"
-        output_name_rawy_unc_pdf = f"RawYUnc_{cfg['output']['file'].replace('.root', '.pdf')}"
+        output_name_unc_pdf = f"Unc_{cfg['output']['file'].replace('.root', '.pdf')}"
         output_name_pdf = f"{cfg['output']['file'].replace('.root', '.pdf')}"
 
         if hist_rawy[0].GetNbinsX() == 1:
@@ -238,7 +239,7 @@ def main(config):
         canv_frac.Print(f"{os.path.join(cfg['output']['directory'], output_name_frac_pdf)}{print_bracket}")
         canv_cov.Print(f"{os.path.join(cfg['output']['directory'], output_name_covmat_pdf)}{print_bracket}")
         canv_combined.Print(f"{os.path.join(cfg['output']['directory'], output_name_pdf)}{print_bracket}")
-        canv_rawy_unc.Print(f"{os.path.join(cfg['output']['directory'], output_name_rawy_unc_pdf)}{print_bracket}")
+        canv_unc.Print(f"{os.path.join(cfg['output']['directory'], output_name_unc_pdf)}{print_bracket}")
 
     output.cd()
     hist_corry_prompt.Write()

--- a/PWGHF/D2H/Macros/compute_fraction_cutvar.py
+++ b/PWGHF/D2H/Macros/compute_fraction_cutvar.py
@@ -152,7 +152,7 @@ def main(config):
             continue
         pt_min = hist_rawy[0].GetXaxis().GetBinLowEdge(ipt + 1)
         pt_max = hist_rawy[0].GetXaxis().GetBinUpEdge(ipt + 1)
-        print(f"\n\nINFO: processing pt range {ipt} from {pt_min} to {pt_max} {pt_axis_title}")
+        print(f"\n\nINFO: processing pt range {ipt+1} from {pt_min} to {pt_max} {pt_axis_title}")
 
         rawy, effp, effnp, unc_rawy, unc_effp, unc_effnp = (np.zeros(n_sets) for _ in range(6))
         for iset, (hrawy, heffp, heffnp) in enumerate(zip(hist_rawy, hist_effp, hist_effnp)):
@@ -249,7 +249,7 @@ def main(config):
         output_name_unc_pdf = f"Unc_{output_name_template}"
         output_name_pdf = f"{output_name_template}"
 
-        if hist_rawy[0].GetNbinsX() == 1:
+        if hist_rawy[0].GetNbinsX() == 1 or pt_bin_to_process != -1:
             print_bracket = ""
         elif ipt == 0:
             print_bracket = "("

--- a/PWGHF/D2H/Macros/compute_fraction_cutvar.py
+++ b/PWGHF/D2H/Macros/compute_fraction_cutvar.py
@@ -135,6 +135,7 @@ def main(config):
     for ipt in range(hist_rawy[0].GetNbinsX()):
         pt_min = hist_rawy[0].GetXaxis().GetBinLowEdge(ipt + 1)
         pt_max = hist_rawy[0].GetXaxis().GetBinUpEdge(ipt + 1)
+        print(f"\n\nINFO: processing pt range {ipt} from {pt_min} to {pt_max} {pt_axis_title}")
 
         rawy, effp, effnp, unc_rawy, unc_effp, unc_effnp = (np.zeros(n_sets) for _ in range(6))
         for iset, (hrawy, heffp, heffnp) in enumerate(zip(hist_rawy, hist_effp, hist_effnp)):

--- a/PWGHF/D2H/Macros/compute_fraction_cutvar.py
+++ b/PWGHF/D2H/Macros/compute_fraction_cutvar.py
@@ -198,6 +198,11 @@ def main(config):
         canv_cov.Write()
         histo_cov.Write()
 
+        canv_rawy_unc, histo_rawy_unc = minimiser.plot_raw_yield_uncertainties(f"_pt{pt_min}_{pt_max}", hist_bin_title)
+        output.cd()
+        canv_rawy_unc.Write()
+        histo_rawy_unc.Write()
+
         canv_combined = ROOT.TCanvas(f"canv_combined_{ipt}", "", 1000, 1000)
         canv_combined.Divide(2, 2)
         canv_combined.cd(1)
@@ -213,6 +218,7 @@ def main(config):
         output_name_eff_pdf = f"Eff_{cfg['output']['file'].replace('.root', '.pdf')}"
         output_name_frac_pdf = f"Frac_{cfg['output']['file'].replace('.root', '.pdf')}"
         output_name_covmat_pdf = f"CovMatrix_{cfg['output']['file'].replace('.root', '.pdf')}"
+        output_name_rawy_unc_pdf = f"RawYUnc_{cfg['output']['file'].replace('.root', '.pdf')}"
         output_name_pdf = f"{cfg['output']['file'].replace('.root', '.pdf')}"
 
         if hist_rawy[0].GetNbinsX() == 1:
@@ -228,6 +234,7 @@ def main(config):
         canv_frac.Print(f"{os.path.join(cfg['output']['directory'], output_name_frac_pdf)}{print_bracket}")
         canv_cov.Print(f"{os.path.join(cfg['output']['directory'], output_name_covmat_pdf)}{print_bracket}")
         canv_combined.Print(f"{os.path.join(cfg['output']['directory'], output_name_pdf)}{print_bracket}")
+        canv_rawy_unc.Print(f"{os.path.join(cfg['output']['directory'], output_name_rawy_unc_pdf)}{print_bracket}")
 
     output.cd()
     hist_corry_prompt.Write()

--- a/PWGHF/D2H/Macros/compute_fraction_cutvar.py
+++ b/PWGHF/D2H/Macros/compute_fraction_cutvar.py
@@ -146,9 +146,13 @@ def main(config):
             unc_effp[iset] = heffp.GetBinError(ipt + 1)
             unc_effnp[iset] = heffnp.GetBinError(ipt + 1)
 
-        if cfg["minimisation"]["correlated"] and not (np.all(unc_rawy[1:] > unc_rawy[:-1]) or np.all(unc_rawy[1:] < unc_rawy[:-1])):
-            print("WARNING! main(): the raw yield uncertainties vector is not monotonous. Check the input for stability.")
-            print(f"raw yield uncertainties vector elements = {unc_rawy}\n")
+        if cfg["minimisation"]["correlated"]
+            if not (np.all(rawy[1:] > rawy[:-1]) or np.all(rawy[1:] < rawy[:-1])):
+                print("WARNING! main(): the raw yield vector is not monotonous. Check the input for stability.")
+                print(f"raw yield vector elements = {rawy}\n")
+            if not (np.all(unc_rawy[1:] > unc_rawy[:-1]) or np.all(unc_rawy[1:] < unc_rawy[:-1])):
+                print("WARNING! main(): the raw yield uncertainties vector is not monotonous. Check the input for stability.")
+                print(f"raw yield uncertainties vector elements = {unc_rawy}\n")
 
         minimiser = CutVarMinimiser(rawy, effp, effnp, unc_rawy, unc_effp, unc_effnp)
         minimiser.minimise_system(cfg["minimisation"]["correlated"])

--- a/PWGHF/D2H/Macros/compute_fraction_cutvar.py
+++ b/PWGHF/D2H/Macros/compute_fraction_cutvar.py
@@ -181,6 +181,11 @@ def main(config):
         for _, hist in histos_rawy.items():
             hist.Write()
 
+        canv_rawy_unc, histo_rawy_unc = minimiser.plot_raw_yield_uncertainties(f"_pt{pt_min}_{pt_max}", hist_bin_title)
+        output.cd()
+        canv_rawy_unc.Write()
+        histo_rawy_unc.Write()
+
         canv_eff, histos_eff, leg_e = minimiser.plot_efficiencies(f"_pt{pt_min}_{pt_max}", hist_bin_title)
         output.cd()
         canv_eff.Write()
@@ -197,11 +202,6 @@ def main(config):
         output.cd()
         canv_cov.Write()
         histo_cov.Write()
-
-        canv_rawy_unc, histo_rawy_unc = minimiser.plot_raw_yield_uncertainties(f"_pt{pt_min}_{pt_max}", hist_bin_title)
-        output.cd()
-        canv_rawy_unc.Write()
-        histo_rawy_unc.Write()
 
         canv_combined = ROOT.TCanvas(f"canv_combined_{ipt}", "", 1000, 1000)
         canv_combined.Divide(2, 2)

--- a/PWGHF/D2H/Macros/cut_variation.py
+++ b/PWGHF/D2H/Macros/cut_variation.py
@@ -443,6 +443,8 @@ class CutVarMinimiser:
         -----------------------------------------------------
         - suffix: str
             suffix to be added in the name of the output objects
+        - title: str
+            title to be written at the top margin of the output objects
 
         Returns
         -----------------------------------------------------
@@ -564,6 +566,8 @@ class CutVarMinimiser:
             correlation between cut sets
         - suffix: str
             suffix to be added in the name of the output objects
+        - title: str
+            title to be written at the top margin of the output objects
 
         Returns
         -----------------------------------------------------
@@ -623,6 +627,8 @@ class CutVarMinimiser:
         -----------------------------------------------------
         - suffix: str
             suffix to be added in the name of the output objects
+        - title: str
+            title to be written at the top margin of the output objects
 
         Returns
         -----------------------------------------------------
@@ -712,6 +718,8 @@ class CutVarMinimiser:
         -----------------------------------------------------
         - suffix: str
             suffix to be added in the name of the output objects
+        - title: str
+            title to be written at the top margin of the output objects
 
         Returns
         -----------------------------------------------------

--- a/PWGHF/D2H/Macros/cut_variation.py
+++ b/PWGHF/D2H/Macros/cut_variation.py
@@ -793,3 +793,54 @@ class CutVarMinimiser:
         canvas.Update()
 
         return canvas, histos, leg
+
+    # pylint: disable=no-member
+    def plot_raw_yield_uncertainties(self, suffix="", title=""):
+        """
+        Helper function to plot raw yield uncertainties as a function of cut set
+
+        Parameters
+        -----------------------------------------------------
+        - suffix: str
+            suffix to be added in the name of the output objects
+        - title: str
+            title to be written at the top margin of the output objects
+
+        Returns
+        -----------------------------------------------------
+        - canvas: ROOT.TCanvas
+            canvas with plot
+        - histo: ROOT.TH1F
+            ROOT.TH1F with raw yield uncertainties distributions
+        """
+
+        set_global_style(padleftmargin=0.16, padbottommargin=0.12, padtopmargin=0.075, titleoffsety=1.6)
+
+        hist_raw_yield_unc = ROOT.TH1F(
+            f"hRawYieldUncVsCut{suffix}",
+            ";cut set;raw yield unc.",
+            self.n_sets,
+            -0.5,
+            self.n_sets - 0.5,
+        )
+
+        for i_bin, unc_rawy in enumerate(self.unc_raw_yields):
+            hist_raw_yield_unc.SetBinContent(i_bin + 1, unc_rawy)
+
+        set_object_style(hist_raw_yield_unc)
+        canvas = ROOT.TCanvas(f"cRawYieldUncVsCut{suffix}", "", 500, 500)
+        canvas.DrawFrame(
+            -0.5,
+            0.0,
+            self.n_sets - 0.5,
+            hist_raw_yield_unc.GetMaximum() * 1.2,
+            ";cut set;raw yield unc.",
+        )
+        hist_raw_yield_unc.Draw("")
+        tex = ROOT.TLatex()
+        tex.SetTextSize(0.04)
+        tex.DrawLatexNDC(0.05, 0.95, title)
+        canvas.Modified()
+        canvas.Update()
+
+        return canvas, hist_raw_yield_unc


### PR DESCRIPTION
* implemented a possibility to run cut variation script with a single pT bin using following (optional) field in json config: `"pt_bin_to_process": 1`. If this field is missing, all pT bins will be analyzed by default;
* added warnings if cut sets are correlated and at least one of the following sequences is not monotonous: raw yield, raw yield uncertainty, residual vector uncertainty (i.e. diagonal elements of covariance matrix);
* added a plot with raw yield uncertainty and residual vector uncertainty as a function of the cut set for better visual perception of problematic cut sets
![unc-1](https://github.com/user-attachments/assets/d7dfd6af-0fdc-4a56-bc0e-8811b59f3b0e)