### PR TITLE
[Trigger] Zorro: Fix various C++ issues

### DIFF
--- a/EventFiltering/Zorro.h
+++ b/EventFiltering/Zorro.h
@@ -19,18 +19,20 @@
 #ifndef EVENTFILTERING_ZORRO_H_
 #define EVENTFILTERING_ZORRO_H_
 
+#include "ZorroHelper.h"
+#include "ZorroSummary.h"
+
+#include <CommonDataFormat/IRFrame.h>
+#include <Framework/HistogramRegistry.h>
+
+#include <TH1.h>
+#include <TH2.h>
+
 #include <bitset>
-#include <memory>
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include "TH1D.h"
-#include "TH2D.h"
-#include "CommonDataFormat/IRFrame.h"
-#include "Framework/HistogramRegistry.h"
-#include "ZorroHelper.h"
-#include "ZorroSummary.h"
 
 namespace o2
 {
@@ -61,8 +63,8 @@ class Zorro
   std::vector<bool> getTriggerOfInterestResults() const;
   int getNTOIs() const { return mTOIs.size(); }
 
-  void setCCDBpath(std::string path) { mBaseCCDBPath = path; }
-  void setBaseCCDBPath(std::string path) { mBaseCCDBPath = path; }
+  void setCCDBpath(const std::string& path) { mBaseCCDBPath = path; }
+  void setBaseCCDBPath(const std::string& path) { mBaseCCDBPath = path; }
   void setBCtolerance(int tolerance) { mBCtolerance = tolerance; }
 
   ZorroSummary* getZorroSummary() { return &mZorroSummary; }
@@ -76,8 +78,8 @@ class Zorro
   int mRunNumber = 0;
   std::pair<int64_t, int64_t> mRunDuration;
   int64_t mOrbitResetTimestamp = 0;
-  TH1* mAnalysedTriggers;           /// Accounting for all triggers in the current run
-  TH1* mAnalysedTriggersOfInterest; /// Accounting for triggers of interest in the current run
+  TH1* mAnalysedTriggers = nullptr;           /// Accounting for all triggers in the current run
+  TH1* mAnalysedTriggersOfInterest = nullptr; /// Accounting for triggers of interest in the current run
 
   std::vector<int> mRunNumberHistos;
   std::vector<TH1*> mAnalysedTriggersList;           /// Per run histograms

--- a/EventFiltering/ZorroHelper.h
+++ b/EventFiltering/ZorroHelper.h
@@ -13,7 +13,8 @@
 #ifndef EVENTFILTERING_ZORROHELPER_H_
 #define EVENTFILTERING_ZORROHELPER_H_
 
-#include "Rtypes.h"
+#include <Rtypes.h>
+#include <RtypesCore.h>
 
 struct ZorroHelper {
   ULong64_t bcAOD, bcEvSel, trigMask[2], selMask[2];

--- a/EventFiltering/ZorroSummary.cxx
+++ b/EventFiltering/ZorroSummary.cxx
@@ -11,7 +11,12 @@
 
 #include "ZorroSummary.h"
 
-#include "TCollection.h"
+#include <TCollection.h>
+#include <TObject.h>
+
+#include <RtypesCore.h>
+
+#include <cstddef>
 
 void ZorroSummary::Copy(TObject& c) const
 {
@@ -42,7 +47,7 @@ Long64_t ZorroSummary::Merge(TCollection* list)
         mTOIcounters[runNumber] = entry->getTOIcounters().at(runNumber);
       } else {
         auto& thisCounters = mAnalysedTOIcounters[runNumber];
-        for (size_t i = 0; i < thisCounters.size(); ++i) {
+        for (std::size_t i = 0; i < thisCounters.size(); ++i) {
           thisCounters[i] += currentAnalysedToiCounters[i];
         }
       }

--- a/EventFiltering/ZorroSummary.h
+++ b/EventFiltering/ZorroSummary.h
@@ -15,6 +15,9 @@
 
 #include <TNamed.h>
 
+#include <Rtypes.h>
+#include <RtypesCore.h>
+
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -41,9 +44,7 @@ class ZorroSummary : public TNamed
     mRunNumber = runNumber;
     mTVXcounters[runNumber] = tvxCountes;
     mTOIcounters[runNumber] = toiCounters;
-    if (mAnalysedTOIcounters.find(runNumber) == mAnalysedTOIcounters.end()) {
-      mAnalysedTOIcounters[runNumber] = std::vector<ULong64_t>(mNtois, 0ull);
-    }
+    mAnalysedTOIcounters.try_emplace(runNumber, std::vector<ULong64_t>(mNtois, 0ull));
     mCurrentAnalysedTOIcounters = &mAnalysedTOIcounters[runNumber];
   }
   double getNormalisationFactor(int toiId) const;


### PR DESCRIPTION
- Member variable ... is not initialized in the constructor. (cppcheck)
- Function parameter ... should be passed by const reference. (cppcheck)
- Searching before insertion is not necessary. Use `try_emplace` instead. (cppcheck)
- Use `static_cast` instead of deprecated casting style. (cpplint)
- IWYU (clang-tidy)
- Include external headers with `<>`. (manual)
- Sort includes. (clang-format)
- Replace `size_t` with `std::size_t`.
- Use `const&` to iterate `std::vector<ZorroHelper>`. (O2 linter)