### PR TITLE
[Tools] Fix C++ issues

### DIFF
--- a/Tools/PIDML/pidMl.h
+++ b/Tools/PIDML/pidMl.h
@@ -17,10 +17,12 @@
 #ifndef TOOLS_PIDML_PIDML_H_
 #define TOOLS_PIDML_PIDML_H_
 
-#include "Framework/AnalysisDataModel.h"
-#include "Common/DataModel/PIDResponse.h"
 #include "Common/DataModel/Centrality.h"
 #include "Common/DataModel/Multiplicity.h"
+#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+
+#include <Framework/AnalysisDataModel.h>
 
 namespace o2::aod
 {

--- a/Tools/PIDML/pidMl.h
+++ b/Tools/PIDML/pidMl.h
@@ -17,12 +17,14 @@
 #ifndef TOOLS_PIDML_PIDML_H_
 #define TOOLS_PIDML_PIDML_H_
 
-#include "Common/DataModel/Centrality.h"
 #include "Common/DataModel/Multiplicity.h"
-#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/PIDResponseTOF.h"
+#include "Common/DataModel/PIDResponseTPC.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 
 #include <Framework/AnalysisDataModel.h>
+
+#include <cstdint>
 
 namespace o2::aod
 {

--- a/Tools/PIDML/pidMlBatchEffAndPurProducer.cxx
+++ b/Tools/PIDML/pidMlBatchEffAndPurProducer.cxx
@@ -16,22 +16,24 @@
 /// \author Michał Olędzki <m.oledzki@cern.ch>
 /// \author Marek Mytkowski <marek.mytkowski@cern.ch>
 
-#include <cstddef>
-#include <string_view>
-#include <algorithm>
-#include <string>
-#include <vector>
-#include <limits>
-
-#include "Framework/AnalysisDataModel.h"
-#include "Framework/runDataProcessing.h"
-#include "Framework/AnalysisTask.h"
-#include "Framework/StaticFor.h"
-#include "CCDB/CcdbApi.h"
-#include "Common/DataModel/TrackSelectionTables.h"
-#include "Common/DataModel/PIDResponse.h"
 #include "Tools/PIDML/pidOnnxModel.h"
 #include "Tools/PIDML/pidUtils.h"
+//
+#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+
+#include <CCDB/CcdbApi.h>
+#include <Framework/AnalysisDataModel.h>
+#include <Framework/AnalysisTask.h>
+#include <Framework/StaticFor.h>
+#include <Framework/runDataProcessing.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <vector>
 
 using namespace o2;
 using namespace o2::framework;

--- a/Tools/PIDML/pidMlBatchEffAndPurProducer.cxx
+++ b/Tools/PIDML/pidMlBatchEffAndPurProducer.cxx
@@ -19,18 +19,33 @@
 #include "Tools/PIDML/pidOnnxModel.h"
 #include "Tools/PIDML/pidUtils.h"
 //
-#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/PIDResponseTOF.h"
+#include "Common/DataModel/PIDResponseTPC.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 
 #include <CCDB/CcdbApi.h>
 #include <Framework/AnalysisDataModel.h>
+#include <Framework/AnalysisHelpers.h>
 #include <Framework/AnalysisTask.h>
+#include <Framework/Configurable.h>
+#include <Framework/HistogramRegistry.h>
+#include <Framework/HistogramSpec.h>
+#include <Framework/InitContext.h>
+#include <Framework/OutputObjHeader.h>
 #include <Framework/StaticFor.h>
 #include <Framework/runDataProcessing.h>
 
+#include <TH1.h>
+
 #include <algorithm>
+#include <array>
+#include <cmath>
 #include <cstddef>
+#include <cstdint>
+#include <cstdlib>
 #include <limits>
+#include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/Tools/PIDML/pidMlEffAndPurProducer.cxx
+++ b/Tools/PIDML/pidMlEffAndPurProducer.cxx
@@ -15,16 +15,18 @@
 /// \author Michał Olędzki <m.oledzki@cern.ch>
 /// \author Marek Mytkowski <marek.mytkowski@cern.ch>
 
-#include <string>
-
-#include "Framework/AnalysisDataModel.h"
-#include "Framework/runDataProcessing.h"
-#include "Framework/AnalysisTask.h"
-#include "CCDB/CcdbApi.h"
-#include "Common/DataModel/TrackSelectionTables.h"
-#include "Common/DataModel/PIDResponse.h"
 #include "Tools/PIDML/pidOnnxModel.h"
 #include "Tools/PIDML/pidUtils.h"
+//
+#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+
+#include <CCDB/CcdbApi.h>
+#include <Framework/AnalysisDataModel.h>
+#include <Framework/AnalysisTask.h>
+#include <Framework/runDataProcessing.h>
+
+#include <string>
 
 using namespace o2;
 using namespace o2::framework;
@@ -91,7 +93,7 @@ struct PidMlEffAndPurProducer {
     return nSigma;
   }
 
-  bool isNSigmaAccept(const BigTracks::iterator& track, nSigma_t& nSigma)
+  bool isNSigmaAccept(const BigTracks::iterator& track, const nSigma_t& nSigma)
   {
     // FIXME: for current particles it works, but there are some particles,
     //  which can have different sign and pdgSign

--- a/Tools/PIDML/pidMlEffAndPurProducer.cxx
+++ b/Tools/PIDML/pidMlEffAndPurProducer.cxx
@@ -18,14 +18,23 @@
 #include "Tools/PIDML/pidOnnxModel.h"
 #include "Tools/PIDML/pidUtils.h"
 //
-#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/PIDResponseTOF.h"
+#include "Common/DataModel/PIDResponseTPC.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 
 #include <CCDB/CcdbApi.h>
 #include <Framework/AnalysisDataModel.h>
 #include <Framework/AnalysisTask.h>
+#include <Framework/Configurable.h>
+#include <Framework/HistogramRegistry.h>
+#include <Framework/HistogramSpec.h>
+#include <Framework/InitContext.h>
+#include <Framework/OutputObjHeader.h>
 #include <Framework/runDataProcessing.h>
 
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
 #include <string>
 
 using namespace o2;

--- a/Tools/PIDML/pidMlProducer.cxx
+++ b/Tools/PIDML/pidMlProducer.cxx
@@ -15,18 +15,21 @@
 /// \author Maja Kabus <mkabus@cern.ch>
 /// \author Marek Mytkowski <marek.mytkowski@cern.ch>
 
-#include <string_view>
-#include <limits>
-#include "Framework/AnalysisTask.h"
-#include "Framework/StaticFor.h"
-#include "Framework/AnalysisDataModel.h"
-#include "Framework/HistogramRegistry.h"
-#include "Framework/runDataProcessing.h"
+#include "Tools/PIDML/pidMl.h"
+#include "Tools/PIDML/pidUtils.h"
+//
 #include "Common/DataModel/Centrality.h"
 #include "Common/DataModel/Multiplicity.h"
 #include "Common/DataModel/TrackSelectionTables.h"
-#include "Tools/PIDML/pidMl.h"
-#include "Tools/PIDML/pidUtils.h"
+
+#include <Framework/AnalysisDataModel.h>
+#include <Framework/AnalysisTask.h>
+#include <Framework/HistogramRegistry.h>
+#include <Framework/StaticFor.h>
+#include <Framework/runDataProcessing.h>
+
+#include <limits>
+#include <string_view>
 
 using namespace o2;
 using namespace o2::framework;

--- a/Tools/PIDML/pidMlProducer.cxx
+++ b/Tools/PIDML/pidMlProducer.cxx
@@ -18,17 +18,29 @@
 #include "Tools/PIDML/pidMl.h"
 #include "Tools/PIDML/pidUtils.h"
 //
-#include "Common/DataModel/Centrality.h"
 #include "Common/DataModel/Multiplicity.h"
+#include "Common/DataModel/PIDResponseTOF.h"
+#include "Common/DataModel/PIDResponseTPC.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 
 #include <Framework/AnalysisDataModel.h>
+#include <Framework/AnalysisHelpers.h>
 #include <Framework/AnalysisTask.h>
+#include <Framework/Configurable.h>
 #include <Framework/HistogramRegistry.h>
-#include <Framework/StaticFor.h>
+#include <Framework/HistogramSpec.h>
+#include <Framework/InitContext.h>
+#include <Framework/OutputObjHeader.h>
 #include <Framework/runDataProcessing.h>
 
+#include <TH1.h>
+#include <TH2.h>
+#include <TString.h>
+
+#include <array>
+#include <cstdint>
 #include <limits>
+#include <memory>
 #include <string_view>
 
 using namespace o2;

--- a/Tools/PIDML/pidOnnxInterface.h
+++ b/Tools/PIDML/pidOnnxInterface.h
@@ -17,13 +17,14 @@
 #ifndef TOOLS_PIDML_PIDONNXINTERFACE_H_
 #define TOOLS_PIDML_PIDONNXINTERFACE_H_
 
-#include <string>
+#include "Tools/PIDML/pidOnnxModel.h"
+
+#include <Framework/Array2D.h>
+
 #include <array>
 #include <set>
+#include <string>
 #include <vector>
-
-#include "Framework/Array2D.h"
-#include "Tools/PIDML/pidOnnxModel.h"
 
 namespace pidml_pt_cuts
 {
@@ -110,7 +111,7 @@ struct PidONNXInterface {
   }
 
   std::vector<PidONNXModel<T>> mModels;
-  std::size_t mNPids;
+  std::size_t mNPids{0};
   o2::framework::LabeledArray<double> mPLimits;
 };
 #endif // TOOLS_PIDML_PIDONNXINTERFACE_H_

--- a/Tools/PIDML/pidOnnxInterface.h
+++ b/Tools/PIDML/pidOnnxInterface.h
@@ -18,10 +18,13 @@
 #define TOOLS_PIDML_PIDONNXINTERFACE_H_
 
 #include "Tools/PIDML/pidOnnxModel.h"
-
+//
+#include <CCDB/CcdbApi.h>
 #include <Framework/Array2D.h>
+#include <Framework/Logger.h>
 
-#include <array>
+#include <cstddef>
+#include <cstdint>
 #include <set>
 #include <string>
 #include <vector>

--- a/Tools/PIDML/pidOnnxModel.h
+++ b/Tools/PIDML/pidOnnxModel.h
@@ -17,26 +17,28 @@
 #ifndef TOOLS_PIDML_PIDONNXMODEL_H_
 #define TOOLS_PIDML_PIDONNXMODEL_H_
 
+#include "Tools/PIDML/pidUtils.h"
+
+#include <CCDB/CcdbApi.h>
 #include <Framework/ASoA.h>
-#include <array>
+
+#include <onnxruntime_cxx_api.h>
+#include <rapidjson/document.h>
+#include <rapidjson/filereadstream.h>
+
 #include <algorithm>
+#include <array>
 #include <cstdint>
-#include <cstring>
 #include <cstdio>
+#include <cstring>
 #include <limits>
+#include <map>
+#include <memory>
 #include <optional>
 #include <string>
-#include <map>
 #include <type_traits>
 #include <utility>
-#include <memory>
 #include <vector>
-#include <onnxruntime_cxx_api.h>
-
-#include "rapidjson/document.h"
-#include "rapidjson/filereadstream.h"
-#include "CCDB/CcdbApi.h"
-#include "Tools/PIDML/pidUtils.h"
 
 enum PidMLDetector {
   kTPCOnly = 0,
@@ -57,7 +59,7 @@ constexpr MomentumLimitsMatrix defaultModelPLimits({0.0, 0.5, 0.8});
 // TODO: Copied from cefpTask, shall we put it in some common utils code?
 namespace
 {
-bool readJsonFile(const std::string& config, rapidjson::Document& d)
+bool readJsonFile(std::string const& config, rapidjson::Document& d)
 {
   FILE* fp = fopen(config.data(), "rb");
   if (!fp) {
@@ -77,7 +79,7 @@ bool readJsonFile(const std::string& config, rapidjson::Document& d)
 template <typename T>
 struct PidONNXModel {
  public:
-  PidONNXModel(std::string& localPath, std::string& ccdbPath, bool useCCDB, o2::ccdb::CcdbApi& ccdbApi, uint64_t timestamp,
+  PidONNXModel(std::string const& localPath, std::string const& ccdbPath, bool useCCDB, o2::ccdb::CcdbApi const& ccdbApi, uint64_t timestamp,
                int pid, double minCertainty, const double* pLimits = &pidml_pt_cuts::defaultModelPLimits[0])
     : mPid(pid), mMinCertainty(minCertainty), mPLimits(pLimits, pLimits + kNDetectors)
   {
@@ -136,8 +138,8 @@ struct PidONNXModel {
     return getModelOutput(track) >= mMinCertainty;
   }
 
-  int mPid;
-  double mMinCertainty;
+  int mPid{0};
+  double mMinCertainty{0};
 
  private:
   void getModelPaths(std::string const& path, std::string& modelDir, std::string& modelFile, std::string& modelPath, int pid, std::string const& ext)
@@ -155,7 +157,7 @@ struct PidONNXModel {
     modelPath = modelDir + "/" + modelFile;
   }
 
-  void downloadFromCCDB(o2::ccdb::CcdbApi& ccdbApi, std::string const& ccdbFile, uint64_t timestamp, std::string const& localDir, std::string const& localFile)
+  void downloadFromCCDB(o2::ccdb::CcdbApi const& ccdbApi, std::string const& ccdbFile, uint64_t timestamp, std::string const& localDir, std::string const& localFile)
   {
     std::map<std::string, std::string> metadata;
     bool retrieveSuccess = ccdbApi.retrieveBlob(ccdbFile, localDir, metadata, timestamp, false, localFile);
@@ -167,7 +169,7 @@ struct PidONNXModel {
     }
   }
 
-  void loadInputFiles(std::string const& localPath, std::string const& ccdbPath, bool useCCDB, o2::ccdb::CcdbApi& ccdbApi, uint64_t timestamp, int pid, std::string& modelPath)
+  void loadInputFiles(std::string const& localPath, std::string const& ccdbPath, bool useCCDB, o2::ccdb::CcdbApi const& ccdbApi, uint64_t timestamp, int pid, std::string& modelPath)
   {
     rapidjson::Document trainColumnsDoc;
     rapidjson::Document scalingParamsDoc;

--- a/Tools/PIDML/pidOnnxModel.h
+++ b/Tools/PIDML/pidOnnxModel.h
@@ -18,16 +18,19 @@
 #define TOOLS_PIDML_PIDONNXMODEL_H_
 
 #include "Tools/PIDML/pidUtils.h"
-
+//
 #include <CCDB/CcdbApi.h>
 #include <Framework/ASoA.h>
+#include <Framework/Logger.h>
 
+#include <onnxruntime_c_api.h>
 #include <onnxruntime_cxx_api.h>
 #include <rapidjson/document.h>
 #include <rapidjson/filereadstream.h>
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -35,8 +38,8 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <sstream>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <vector>
 

--- a/Tools/PIDML/qaPid.cxx
+++ b/Tools/PIDML/qaPid.cxx
@@ -14,14 +14,16 @@
 /// \author Łukasz Sawicki
 /// \since
 
-#include "Framework/runDataProcessing.h"
-#include "Framework/AnalysisTask.h"
-#include "Framework/HistogramRegistry.h"
-#include "Framework/StaticFor.h"
-#include "Common/DataModel/TrackSelectionTables.h"
 #include "Common/DataModel/PIDResponse.h"
-#include <TParameter.h>
+#include "Common/DataModel/TrackSelectionTables.h"
+
+#include <Framework/AnalysisTask.h>
+#include <Framework/HistogramRegistry.h>
+#include <Framework/StaticFor.h>
+#include <Framework/runDataProcessing.h>
+
 #include <TPDGCode.h>
+#include <TParameter.h>
 
 using namespace o2;
 using namespace o2::framework;
@@ -371,7 +373,7 @@ struct QaPid {
     for (int j = 0; j < kArrLen; ++j) {
       if (p < PSwitch[j]) {
         particleNSigma[j] = std::abs(tpcNSigmas[j]);
-      } else if (p >= PSwitch[j]) {
+      } else {
         particleNSigma[j] = combinedSignal(tpcNSigmas[j], tofNSigmas[j]);
       }
     }
@@ -409,7 +411,7 @@ struct QaPid {
     for (int j = 0; j < kArrLen; ++j) {
       if (p < PSwitch[j]) {
         particleNSigma[j] = std::abs(tpcNSigmas[j]);
-      } else if (p >= PSwitch[j]) {
+      } else {
         particleNSigma[j] = combinedSignal(tpcNSigmas[j], tofNSigmas[j]);
       }
     }

--- a/Tools/PIDML/qaPid.cxx
+++ b/Tools/PIDML/qaPid.cxx
@@ -14,16 +14,28 @@
 /// \author Łukasz Sawicki
 /// \since
 
-#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/PIDResponseCombined.h"
+#include "Common/DataModel/PIDResponseTOF.h"
+#include "Common/DataModel/PIDResponseTPC.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 
+#include <Framework/ASoA.h>
+#include <Framework/AnalysisDataModel.h>
 #include <Framework/AnalysisTask.h>
+#include <Framework/Configurable.h>
+#include <Framework/Expressions.h>
 #include <Framework/HistogramRegistry.h>
+#include <Framework/HistogramSpec.h>
 #include <Framework/StaticFor.h>
 #include <Framework/runDataProcessing.h>
+#include <ReconstructionDataFormats/PID.h>
 
 #include <TPDGCode.h>
-#include <TParameter.h>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdlib>
+#include <string_view>
 
 using namespace o2;
 using namespace o2::framework;

--- a/Tools/PIDML/qaPidMl.cxx
+++ b/Tools/PIDML/qaPidMl.cxx
@@ -16,18 +16,26 @@
 
 #include "Tools/PIDML/pidOnnxModel.h"
 //
-#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/PIDResponseTOF.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 
+#include <CCDB/CcdbApi.h>
+#include <Framework/ASoA.h>
+#include <Framework/AnalysisDataModel.h>
 #include <Framework/AnalysisTask.h>
+#include <Framework/Configurable.h>
+#include <Framework/Expressions.h>
 #include <Framework/HistogramRegistry.h>
+#include <Framework/HistogramSpec.h>
+#include <Framework/InitContext.h>
 #include <Framework/StaticFor.h>
 #include <Framework/runDataProcessing.h>
 
 #include <TPDGCode.h>
-#include <TParameter.h>
 
+#include <cstddef>
 #include <string>
+#include <string_view>
 
 using namespace o2;
 using namespace o2::framework;

--- a/Tools/PIDML/qaPidMl.cxx
+++ b/Tools/PIDML/qaPidMl.cxx
@@ -14,17 +14,20 @@
 /// \author Łukasz Sawicki
 /// \since
 
-#include <string>
-
-#include "Framework/runDataProcessing.h"
-#include "Framework/AnalysisTask.h"
-#include "Framework/HistogramRegistry.h"
-#include "Framework/StaticFor.h"
-#include "Common/DataModel/TrackSelectionTables.h"
-#include "Common/DataModel/PIDResponse.h"
-#include <TParameter.h>
-#include <TPDGCode.h>
 #include "Tools/PIDML/pidOnnxModel.h"
+//
+#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+
+#include <Framework/AnalysisTask.h>
+#include <Framework/HistogramRegistry.h>
+#include <Framework/StaticFor.h>
+#include <Framework/runDataProcessing.h>
+
+#include <TPDGCode.h>
+#include <TParameter.h>
+
+#include <string>
 
 using namespace o2;
 using namespace o2::framework;
@@ -311,7 +314,7 @@ struct QaPidMl {
 
   static constexpr float kCertaintyThreshold = 0.5f;
 
-  int getParticlePdg(float pidCertainties[])
+  int getParticlePdg(const float pidCertainties[])
   {
     // index of the biggest value in an array
     int index = 0;

--- a/Tools/PIDML/simpleApplyPidOnnxInterface.cxx
+++ b/Tools/PIDML/simpleApplyPidOnnxInterface.cxx
@@ -14,15 +14,17 @@
 ///
 /// \author Maja Kabus <mkabus@cern.ch>
 
+#include "Tools/PIDML/pidOnnxInterface.h"
+//
+#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+
+#include <CCDB/CcdbApi.h>
+#include <Framework/AnalysisTask.h>
+#include <Framework/runDataProcessing.h>
+
 #include <string>
 #include <vector>
-
-#include "Framework/runDataProcessing.h"
-#include "Framework/AnalysisTask.h"
-#include "CCDB/CcdbApi.h"
-#include "Common/DataModel/TrackSelectionTables.h"
-#include "Common/DataModel/PIDResponse.h"
-#include "Tools/PIDML/pidOnnxInterface.h"
 
 using namespace o2;
 using namespace o2::framework;

--- a/Tools/PIDML/simpleApplyPidOnnxInterface.cxx
+++ b/Tools/PIDML/simpleApplyPidOnnxInterface.cxx
@@ -16,13 +16,21 @@
 
 #include "Tools/PIDML/pidOnnxInterface.h"
 //
-#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/PIDResponseTOF.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 
 #include <CCDB/CcdbApi.h>
+#include <Framework/ASoA.h>
+#include <Framework/AnalysisDataModel.h>
+#include <Framework/AnalysisHelpers.h>
 #include <Framework/AnalysisTask.h>
+#include <Framework/Array2D.h>
+#include <Framework/Configurable.h>
+#include <Framework/Expressions.h>
+#include <Framework/InitContext.h>
 #include <Framework/runDataProcessing.h>
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/Tools/PIDML/simpleApplyPidOnnxModel.cxx
+++ b/Tools/PIDML/simpleApplyPidOnnxModel.cxx
@@ -16,13 +16,20 @@
 
 #include "Tools/PIDML/pidOnnxModel.h"
 //
-#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/PIDResponseTOF.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 
 #include <CCDB/CcdbApi.h>
+#include <Framework/ASoA.h>
+#include <Framework/AnalysisDataModel.h>
+#include <Framework/AnalysisHelpers.h>
 #include <Framework/AnalysisTask.h>
+#include <Framework/Configurable.h>
+#include <Framework/Expressions.h>
+#include <Framework/InitContext.h>
 #include <Framework/runDataProcessing.h>
 
+#include <cstdint>
 #include <string>
 
 using namespace o2;

--- a/Tools/PIDML/simpleApplyPidOnnxModel.cxx
+++ b/Tools/PIDML/simpleApplyPidOnnxModel.cxx
@@ -14,14 +14,16 @@
 ///
 /// \author Maja Kabus <mkabus@cern.ch>
 
-#include <string>
-
-#include "Framework/runDataProcessing.h"
-#include "Framework/AnalysisTask.h"
-#include "CCDB/CcdbApi.h"
-#include "Common/DataModel/TrackSelectionTables.h"
-#include "Common/DataModel/PIDResponse.h"
 #include "Tools/PIDML/pidOnnxModel.h"
+//
+#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+
+#include <CCDB/CcdbApi.h>
+#include <Framework/AnalysisTask.h>
+#include <Framework/runDataProcessing.h>
+
+#include <string>
 
 using namespace o2;
 using namespace o2::framework;


### PR DESCRIPTION
- Fix bugs:
  - Parameter ... can be declared as (reference to) const. (cppcheck)
  - Member variable ... is not initialized in the constructor. (cppcheck)
    - `PidONNXModel::mPid`
    - `PidONNXModel::mMinCertainty`
    - `PidONNXInterface::mNPids`
  - Expression is always true because 'else if' condition is opposite to previous condition. (cppcheck)
- Fix includes:
  - IWYU (clang-tidy)
  - Include external headers with `<>`. (manual)
  - Sort includes. (clang-format)