### PR TITLE
[PWGLF] Custom v0 grouping in sigma0builder

### DIFF
--- a/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
@@ -63,7 +63,7 @@ struct sigma0builder {
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   ctpRateFetcher rateFetcher;
 
-  SliceCache cache;
+  //SliceCache cache;
 
   Produces<aod::Sigma0Cores> sigma0cores;             // save sigma0 candidates for analysis
   Produces<aod::SigmaPhotonExtras> sigmaPhotonExtras; // save sigma0 candidates for analysis
@@ -71,8 +71,8 @@ struct sigma0builder {
   Produces<aod::SigmaMCCores> sigma0mccores;
 
   // For manual sliceBy
-  PresliceUnsorted<V0DerivedMCDatas> perCollisionMCDerived = o2::aod::v0data::straCollisionId;
-  PresliceUnsorted<V0StandardDerivedDatas> perCollisionSTDDerived = o2::aod::v0data::straCollisionId;
+  //PresliceUnsorted<V0DerivedMCDatas> perCollisionMCDerived = o2::aod::v0data::straCollisionId;
+  //PresliceUnsorted<V0StandardDerivedDatas> perCollisionSTDDerived = o2::aod::v0data::straCollisionId;
   PresliceUnsorted<soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraCollLabels>> perMcCollision = aod::v0data::straMCCollisionId;
 
   // pack track quality but separte also afterburner
@@ -385,7 +385,7 @@ struct sigma0builder {
   }
 
   template <typename TCollision>
-  bool IsEventAccepted(TCollision collision, bool fillHists)
+  bool IsEventAccepted(TCollision const& collision, bool fillHists)
   // check whether the collision passes our collision selections
   {
     if (fillHists)
@@ -1138,16 +1138,27 @@ struct sigma0builder {
 
   void processMonteCarlo(soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraStamps, aod::StraCollLabels> const& collisions, V0DerivedMCDatas const& fullV0s, dauTracks const&, aod::MotherMCParts const&, soa::Join<aod::StraMCCollisions, aod::StraMCCollMults> const&, soa::Join<aod::V0MCCores, aod::V0MCCollRefs> const&)
   {
+    // Initialize auxiliary vectors
+    std::vector<int> bestGammasArray;
+    std::vector<int> bestLambdasArray;
+
+    // brute force grouped index construction 
+    std::vector<std::vector<int>> v0grouped(collisions.size()); 
+      
+    for (const auto& v0 : fullV0s) {
+      v0grouped[v0.straCollisionId()].push_back(v0.globalIndex());
+    }
+
     for (const auto& coll : collisions) {
+      // Clear vectors
+      bestGammasArray.clear();
+      bestLambdasArray.clear();
 
       if (!IsEventAccepted(coll, true))
         continue;
 
-      // Do analysis with collision-grouped V0s, retain full collision information
-      const uint64_t collIdx = coll.globalIndex();
-      auto V0s = fullV0s.sliceBy(perCollisionMCDerived, collIdx);
       float centrality = doPPAnalysis ? coll.centFT0M() : coll.centFT0C();
-
+      
       bool fhasMCColl = false;
       if (coll.has_straMCCollision())
         fhasMCColl = true;
@@ -1164,12 +1175,11 @@ struct sigma0builder {
         histos.fill(HIST("GeneralQA/hCentralityVsInteractionRate"), centrality, interactionRate);
       }
 
-      std::vector<int> bestGammasArray;
-      std::vector<int> bestLambdasArray;
-
       //_______________________________________________
       // V0s loop
-      for (auto& v0 : V0s) {
+      for (size_t i = 0; i < v0grouped[coll.globalIndex()].size(); i++) {
+        auto v0 = fullV0s.rawIteratorAt(v0grouped[coll.globalIndex()][i]);
+
         if (!v0.has_v0MCCore())
           continue;
 
@@ -1317,14 +1327,25 @@ struct sigma0builder {
 
   void processRealData(soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraStamps> const& collisions, V0StandardDerivedDatas const& fullV0s, dauTracks const&)
   {
+    // Initialize auxiliary vectors
+    std::vector<int> bestGammasArray;
+    std::vector<int> bestLambdasArray;
+
+    // brute force grouped index construction 
+    std::vector<std::vector<int>> v0grouped(collisions.size()); 
+      
+    for (const auto& v0 : fullV0s) {
+      v0grouped[v0.straCollisionId()].push_back(v0.globalIndex());
+    }
+
     for (const auto& coll : collisions) {
+      // Clear vectors
+      bestGammasArray.clear();
+      bestLambdasArray.clear();
 
       if (!IsEventAccepted(coll, true))
         continue;
 
-      // Do analysis with collision-grouped V0s, retain full collision information
-      const uint64_t collIdx = coll.globalIndex();
-      auto V0s = fullV0s.sliceBy(perCollisionSTDDerived, collIdx);
       float centrality = doPPAnalysis ? coll.centFT0M() : coll.centFT0C();
 
       //_______________________________________________
@@ -1339,12 +1360,10 @@ struct sigma0builder {
         histos.fill(HIST("GeneralQA/hCentralityVsInteractionRate"), centrality, interactionRate);
       }
 
-      std::vector<int> bestGammasArray;
-      std::vector<int> bestLambdasArray;
-
       //_______________________________________________
       // V0s loop
-      for (auto& v0 : V0s) {
+      for (size_t i = 0; i < v0grouped[coll.globalIndex()].size(); i++) {
+        auto v0 = fullV0s.rawIteratorAt(v0grouped[coll.globalIndex()][i]);
         if (processPhotonCandidate(v0, coll))          // selecting photons
           bestGammasArray.push_back(v0.globalIndex()); // Save indices of best gamma candidates
 
@@ -1402,3 +1421,4 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{adaptAnalysisTask<sigma0builder>(cfgc)};
 }
+

--- a/PWGLF/Tasks/Strangeness/phik0shortanalysis.cxx
+++ b/PWGLF/Tasks/Strangeness/phik0shortanalysis.cxx
@@ -2843,28 +2843,16 @@ struct Phik0shortanalysis {
         continue;
 
       // Phi selection
-      if (mcParticle.pdgCode() != o2::constants::physics::Pdg::kPhi)
-        continue;
-      if (mcParticle.pt() < minPhiPt)
-        continue;
-
-      mcPhiHist.fill(HIST("h3PhiMCGenRecoCheckNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
+      if (mcParticle.pdgCode() == o2::constants::physics::Pdg::kPhi && mcParticle.pt() >= minPhiPt)
+        mcPhiHist.fill(HIST("h3PhiMCGenRecoCheckNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
 
       // K0S selection
-      if (mcParticle.pdgCode() != PDG_t::kK0Short)
-        continue;
-      if (!mcParticle.isPhysicalPrimary() || mcParticle.pt() < v0Configs.v0SettingMinPt)
-        continue;
-
-      mcK0SHist.fill(HIST("h3K0SMCGenRecoCheckNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
+      if (mcParticle.pdgCode() == PDG_t::kK0Short && mcParticle.isPhysicalPrimary() && mcParticle.pt() >= v0Configs.v0SettingMinPt)
+        mcK0SHist.fill(HIST("h3K0SMCGenRecoCheckNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
 
       // Pion selection
-      if (std::abs(mcParticle.pdgCode()) != PDG_t::kPiPlus)
-        continue;
-      if (!mcParticle.isPhysicalPrimary() || mcParticle.pt() < trackConfigs.cMinPionPtcut)
-        continue;
-
-      mcPionHist.fill(HIST("h3PiMCGenRecoCheckNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
+      if (std::abs(mcParticle.pdgCode()) == PDG_t::kPiPlus && mcParticle.isPhysicalPrimary() && mcParticle.pt() >= trackConfigs.cMinPionPtcut)
+        mcPionHist.fill(HIST("h3PiMCGenRecoCheckNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
     }
   }
 
@@ -2891,25 +2879,16 @@ struct Phik0shortanalysis {
             continue;
 
           // Phi selection
-          if (mcParticle.pdgCode() != o2::constants::physics::Pdg::kPhi)
-            continue;
-          if (mcParticle.pt() < minPhiPt)
-            continue;
-          mcPhiHist.fill(HIST("h3PhiMCGenRecoNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
+          if (mcParticle.pdgCode() == o2::constants::physics::Pdg::kPhi && mcParticle.pt() >= minPhiPt)
+            mcPhiHist.fill(HIST("h3PhiMCGenRecoNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
 
           // K0S selection
-          if (mcParticle.pdgCode() != PDG_t::kK0Short)
-            continue;
-          if (!mcParticle.isPhysicalPrimary() || mcParticle.pt() < v0Configs.v0SettingMinPt)
-            continue;
-          mcK0SHist.fill(HIST("h3K0SMCGenRecoNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
+          if (mcParticle.pdgCode() == PDG_t::kK0Short && mcParticle.isPhysicalPrimary() && mcParticle.pt() >= v0Configs.v0SettingMinPt)
+            mcK0SHist.fill(HIST("h3K0SMCGenRecoNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
 
           // Pion selection
-          if (std::abs(mcParticle.pdgCode()) != PDG_t::kPiPlus)
-            continue;
-          if (!mcParticle.isPhysicalPrimary() || mcParticle.pt() < trackConfigs.cMinPionPtcut)
-            continue;
-          mcPionHist.fill(HIST("h3PiMCGenRecoNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
+          if (std::abs(mcParticle.pdgCode()) == PDG_t::kPiPlus && mcParticle.isPhysicalPrimary() && mcParticle.pt() >= trackConfigs.cMinPionPtcut)
+            mcPionHist.fill(HIST("h3PiMCGenRecoNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
         }
 
         numberAssocColl++;
@@ -2929,34 +2908,25 @@ struct Phik0shortanalysis {
         continue;
 
       // Phi selection
-      if (mcParticle.pdgCode() != o2::constants::physics::Pdg::kPhi)
-        continue;
-      if (mcParticle.pt() < minPhiPt)
-        continue;
-
-      mcPhiHist.fill(HIST("h3PhiMCGenNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
-      if (numberAssocColl > 0)
-        mcPhiHist.fill(HIST("h3PhiMCGenAssocRecoNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
+      if (mcParticle.pdgCode() == o2::constants::physics::Pdg::kPhi && mcParticle.pt() >= minPhiPt) {
+        mcPhiHist.fill(HIST("h3PhiMCGenNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
+        if (numberAssocColl > 0)
+          mcPhiHist.fill(HIST("h3PhiMCGenAssocRecoNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
+      }
 
       // K0S selection
-      if (mcParticle.pdgCode() != PDG_t::kK0Short)
-        continue;
-      if (!mcParticle.isPhysicalPrimary() || mcParticle.pt() < v0Configs.v0SettingMinPt)
-        continue;
-
-      mcK0SHist.fill(HIST("h3K0SMCGenNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
-      if (numberAssocColl > 0)
-        mcK0SHist.fill(HIST("h3K0SMCGenAssocRecoNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
+      if (mcParticle.pdgCode() == PDG_t::kK0Short && mcParticle.isPhysicalPrimary() && mcParticle.pt() >= v0Configs.v0SettingMinPt) {
+        mcK0SHist.fill(HIST("h3K0SMCGenNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
+        if (numberAssocColl > 0)
+          mcK0SHist.fill(HIST("h3K0SMCGenAssocRecoNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
+      }
 
       // Pion selection
-      if (std::abs(mcParticle.pdgCode()) != PDG_t::kPiPlus)
-        continue;
-      if (!mcParticle.isPhysicalPrimary() || mcParticle.pt() < trackConfigs.cMinPionPtcut)
-        continue;
-
-      mcPionHist.fill(HIST("h3PiMCGenNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
-      if (numberAssocColl > 0)
-        mcPionHist.fill(HIST("h3PiMCGenAssocRecoNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
+      if (std::abs(mcParticle.pdgCode()) == PDG_t::kPiPlus && mcParticle.isPhysicalPrimary() && mcParticle.pt() >= trackConfigs.cMinPionPtcut) {
+        mcPionHist.fill(HIST("h3PiMCGenNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
+        if (numberAssocColl > 0)
+          mcPionHist.fill(HIST("h3PiMCGenAssocRecoNewProc"), genmultiplicity, mcParticle.pt(), mcParticle.y());
+      }
     }
   }
 


### PR DESCRIPTION
This PR updates the sigma0builder task to adopt a custom v0 grouping strategy - which involves the use of a simple vector-of-vectors. Other small changes were made to improve performance. 