### PR TITLE
[PWGLF] Optimization: skip V0s not satisfying configuration earlier

### DIFF
--- a/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
@@ -1425,7 +1425,7 @@ struct StrangenessBuilder {
         }
       }
 
-      if (!straHelper.buildV0Candidate(v0.collisionId, pvX, pvY, pvZ, posTrack, negTrack, posTrackPar, negTrackPar, v0.isCollinearV0, mEnabledTables[kV0Covs], true)) {
+      if (!straHelper.buildV0Candidate(v0.collisionId, pvX, pvY, pvZ, posTrack, negTrack, posTrackPar, negTrackPar, v0.isCollinearV0, mEnabledTables[kV0Covs], v0BuilderOpts.generatePhotonCandidates)) {
         products.v0dataLink(-1, -1);
         continue;
       }


### PR DESCRIPTION
Currently, photon-like candidates (V0 type != 1) are correctly skipped from final analysis table population if the configuration is such that they are not of interest, but they could be skipped in a more optimized manner (earlier in the processing chain) as done with this PR to save CPU. Note: V0 data link is still generated for V0s skipped due to this change, which is a necessity to keep that link joinable with `aod::V0s`. 