### PR TITLE
automatic extraction of orbitsPerTF from ccdb by LPMProductionTag in bc- and event-selection

### DIFF
--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -84,6 +84,8 @@ struct BcSelectionTask {
   int mITSROFrameEndBorderMargin = 20;   // default value
   int mTimeFrameStartBorderMargin = 300; // default value
   int mTimeFrameEndBorderMargin = 4000;  // default value
+  std::string strLPMProductionTag = "";  // MC production tag to be retrieved from AO2D metadata
+
   TriggerAliases* aliases = nullptr;
   EventSelectionParams* par = nullptr;
   std::map<uint64_t, uint32_t>* mapRCT = nullptr;
@@ -99,6 +101,8 @@ struct BcSelectionTask {
     ccdb->setURL("http://alice-ccdb.cern.ch");
     ccdb->setCaching(true);
     ccdb->setLocalObjectValidityChecking();
+    strLPMProductionTag = metadataInfo.get("LPMProductionTag"); // to extract info from ccdb by the tag
+
     histos.add("hCounterInvalidBCTimestamp", "", kTH1D, {{1, 0., 1.}});
   }
 
@@ -256,7 +260,7 @@ struct BcSelectionTask {
         // duration of TF in bcs
         nBCsPerTF = 32; // hard-coded for Run3 MC (no info from ccdb at the moment)
       } else {
-        auto runInfo = o2::parameters::AggregatedRunInfo::buildAggregatedRunInfo(o2::ccdb::BasicCCDBManager::instance(), run);
+        auto runInfo = o2::parameters::AggregatedRunInfo::buildAggregatedRunInfo(o2::ccdb::BasicCCDBManager::instance(), run, strLPMProductionTag);
         // SOR and EOR timestamps
         sorTimestamp = runInfo.sor;
         eorTimestamp = runInfo.eor;
@@ -511,10 +515,11 @@ struct EventSelectionTask {
   int lastRun = -1;                     // last run number (needed to access ccdb only if run!=lastRun)
   std::bitset<nBCsPerOrbit> bcPatternB; // bc pattern of colliding bunches
 
-  int64_t bcSOR = -1;     // global bc of the start of the first orbit
-  int64_t nBCsPerTF = -1; // duration of TF in bcs, should be 128*3564 or 32*3564
-  int rofOffset = -1;     // ITS ROF offset, in bc
-  int rofLength = -1;     // ITS ROF length, in bc
+  int64_t bcSOR = -1;                   // global bc of the start of the first orbit
+  int64_t nBCsPerTF = -1;               // duration of TF in bcs, should be 128*3564 or 32*3564
+  int rofOffset = -1;                   // ITS ROF offset, in bc
+  int rofLength = -1;                   // ITS ROF length, in bc
+  std::string strLPMProductionTag = ""; // MC production tag to be retrieved from AO2D metadata
 
   int32_t findClosest(int64_t globalBC, std::map<int64_t, int32_t>& bcs)
   {
@@ -580,6 +585,7 @@ struct EventSelectionTask {
         }
       }
     }
+    strLPMProductionTag = metadataInfo.get("LPMProductionTag"); // to extract info from ccdb by the tag
 
     ccdb->setURL("http://alice-ccdb.cern.ch");
     ccdb->setCaching(true);
@@ -678,7 +684,7 @@ struct EventSelectionTask {
     int run3min = 500000;
     if (run != lastRun && run >= run3min) {
       lastRun = run;
-      auto runInfo = o2::parameters::AggregatedRunInfo::buildAggregatedRunInfo(o2::ccdb::BasicCCDBManager::instance(), run);
+      auto runInfo = o2::parameters::AggregatedRunInfo::buildAggregatedRunInfo(o2::ccdb::BasicCCDBManager::instance(), run, strLPMProductionTag);
       // first bc of the first orbit
       bcSOR = runInfo.orbitSOR * nBCsPerOrbit;
       // duration of TF in bcs

--- a/Common/TableProducer/eventSelectionService.cxx
+++ b/Common/TableProducer/eventSelectionService.cxx
@@ -91,7 +91,7 @@ struct eventselectionRun2 {
 
     // task-specific
     timestampMod.init(timestampConfigurables, metadataInfo);
-    bcselmodule.init(context, bcselOpts, histos);
+    bcselmodule.init(context, bcselOpts, histos, metadataInfo);
     evselmodule.init(context, evselOpts, histos, metadataInfo);
   }
 
@@ -154,7 +154,7 @@ struct eventselectionRun3 {
 
     // task-specific
     timestampMod.init(timestampConfigurables, metadataInfo);
-    bcselmodule.init(context, bcselOpts, histos);
+    bcselmodule.init(context, bcselOpts, histos, metadataInfo);
     evselmodule.init(context, evselOpts, histos, metadataInfo);
     lumimodule.init(context, lumiOpts, histos);
   }

--- a/DPG/Tasks/AOTEvent/eventSelectionQa.cxx
+++ b/DPG/Tasks/AOTEvent/eventSelectionQa.cxx
@@ -14,32 +14,30 @@
 ///
 /// \author Evgeny Kryshen <evgeny.kryshen@cern.ch> and Igor Altsybeev <Igor.Altsybeev@cern.ch>
 
-#include "Common/CCDB/EventSelectionParams.h"
-#include "Common/DataModel/EventSelection.h"
-
-#include "CCDB/BasicCCDBManager.h"
-#include "CommonDataFormat/BunchFilling.h"
-#include "DataFormatsITSMFT/NoiseMap.h" // missing include in TimeDeadMap.h
-#include "DataFormatsITSMFT/ROFRecord.h"
-#include "DataFormatsITSMFT/TimeDeadMap.h"
-#include "DataFormatsParameters/AggregatedRunInfo.h"
-#include "DataFormatsParameters/GRPECSObject.h"
-#include "DataFormatsParameters/GRPLHCIFData.h"
-#include "Framework/AnalysisDataModel.h"
-#include "Framework/AnalysisTask.h"
-#include "Framework/HistogramRegistry.h"
-#include "Framework/runDataProcessing.h"
-#include "ITSMFTBase/DPLAlpideParam.h"
-#include "ITSMFTReconstruction/ChipMappingITS.h"
-#include "ReconstructionDataFormats/Vertex.h"
-
-#include "TH1F.h"
-#include "TH2F.h"
-
 #include <map>
+#include <vector>
 #include <string>
 #include <unordered_map>
-#include <vector>
+
+#include "Framework/runDataProcessing.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Common/DataModel/EventSelection.h"
+#include "Common/CCDB/EventSelectionParams.h"
+#include "CCDB/BasicCCDBManager.h"
+#include "Framework/HistogramRegistry.h"
+#include "CommonDataFormat/BunchFilling.h"
+#include "DataFormatsParameters/GRPLHCIFData.h"
+#include "DataFormatsParameters/GRPECSObject.h"
+#include "DataFormatsParameters/AggregatedRunInfo.h"
+#include "DataFormatsITSMFT/NoiseMap.h" // missing include in TimeDeadMap.h
+#include "DataFormatsITSMFT/TimeDeadMap.h"
+#include "DataFormatsITSMFT/ROFRecord.h"
+#include "ReconstructionDataFormats/Vertex.h"
+#include "ITSMFTBase/DPLAlpideParam.h"
+#include "ITSMFTReconstruction/ChipMappingITS.h"
+#include "TH1F.h"
+#include "TH2F.h"
 
 using namespace o2::framework;
 using namespace o2;

--- a/DPG/Tasks/AOTEvent/eventSelectionQa.cxx
+++ b/DPG/Tasks/AOTEvent/eventSelectionQa.cxx
@@ -12,32 +12,34 @@
 /// \file eventSelectionQa.cxx
 /// \brief Event selection QA task
 ///
-/// \author Evgeny Kryshen <evgeny.kryshen@cern.ch>
+/// \author Evgeny Kryshen <evgeny.kryshen@cern.ch> and Igor Altsybeev <Igor.Altsybeev@cern.ch>
 
-#include <map>
-#include <vector>
-#include <string>
-#include <unordered_map>
-
-#include "Framework/runDataProcessing.h"
-#include "Framework/AnalysisTask.h"
-#include "Framework/AnalysisDataModel.h"
-#include "Common/DataModel/EventSelection.h"
 #include "Common/CCDB/EventSelectionParams.h"
+#include "Common/DataModel/EventSelection.h"
+
 #include "CCDB/BasicCCDBManager.h"
-#include "Framework/HistogramRegistry.h"
 #include "CommonDataFormat/BunchFilling.h"
-#include "DataFormatsParameters/GRPLHCIFData.h"
-#include "DataFormatsParameters/GRPECSObject.h"
-#include "DataFormatsParameters/AggregatedRunInfo.h"
 #include "DataFormatsITSMFT/NoiseMap.h" // missing include in TimeDeadMap.h
-#include "DataFormatsITSMFT/TimeDeadMap.h"
 #include "DataFormatsITSMFT/ROFRecord.h"
-#include "ReconstructionDataFormats/Vertex.h"
+#include "DataFormatsITSMFT/TimeDeadMap.h"
+#include "DataFormatsParameters/AggregatedRunInfo.h"
+#include "DataFormatsParameters/GRPECSObject.h"
+#include "DataFormatsParameters/GRPLHCIFData.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/HistogramRegistry.h"
+#include "Framework/runDataProcessing.h"
 #include "ITSMFTBase/DPLAlpideParam.h"
 #include "ITSMFTReconstruction/ChipMappingITS.h"
+#include "ReconstructionDataFormats/Vertex.h"
+
 #include "TH1F.h"
 #include "TH2F.h"
+
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 using namespace o2::framework;
 using namespace o2;
@@ -361,7 +363,17 @@ struct EventSelectionQaTask {
       // requested by TPC experts: nTPConly tracks vs occupancy
       histos.add("occupancyQA/hNumTracksTPConly_vs_V0A_vs_occupancy", "", kTH3F, {axisMultV0AForOccup, axisNtracksTPConly, axisOccupancyTracks});
       histos.add("occupancyQA/hNumTracksTPConlyNoITS_vs_V0A_vs_occupancy", "", kTH3F, {axisMultV0AForOccup, axisNtracksTPConly, axisOccupancyTracks});
+      // request from experts to add track properties vs occupancy, to compare data vs MC
+      const AxisSpec axisOccupancyForTrackQA{60, 0., 15000, "occupancy (n ITS tracks weighted)"};
+      const AxisSpec axisNTPCcls{150, 0, 150, "n TPC clusters"};
+      histos.add("occupancyQA/tpcNClsFound_vs_V0A_vs_occupancy", "", kTH3F, {axisMultV0AForOccup, axisNTPCcls, axisOccupancyForTrackQA});
+      histos.add("occupancyQA/tpcNClsFindable_vs_V0A_vs_occupancy", "", kTH3F, {axisMultV0AForOccup, axisNTPCcls, axisOccupancyForTrackQA});
+      histos.add("occupancyQA/tpcNClsShared_vs_V0A_vs_occupancy", "", kTH3F, {axisMultV0AForOccup, axisNTPCcls, axisOccupancyForTrackQA});
+      histos.add("occupancyQA/tpcNCrossedRows_vs_V0A_vs_occupancy", "", kTH3F, {axisMultV0AForOccup, axisNTPCcls, axisOccupancyForTrackQA});
+      const AxisSpec axisChi2TPC{150, 0, 15, "chi2Ncl TPC"};
+      histos.add("occupancyQA/tpcChi2_vs_V0A_vs_occupancy", "", kTH3F, {axisMultV0AForOccup, axisChi2TPC, axisOccupancyForTrackQA});
 
+      // ITS in-ROF occupancy
       histos.add("occupancyQA/hITSTracks_ev1_vs_ev2_2coll_in_ROF", ";nITStracks event #1;nITStracks event #2", kTH2D, {{200, 0., 6000}, {200, 0., 6000}});
       histos.add("occupancyQA/hITSTracks_ev1_vs_ev2_2coll_in_ROF_UPC", ";nITStracks event #1;nITStracks event #2", kTH2D, {{41, -0.5, 40.5}, {41, -0.5, 40.5}});
       histos.add("occupancyQA/hITSTracks_ev1_vs_ev2_2coll_in_ROF_nonUPC", ";nITStracks event #1;nITStracks event #2", kTH2D, {{200, 0., 6000}, {200, 0., 6000}});
@@ -1128,6 +1140,10 @@ struct EventSelectionQaTask {
       int nTracksITSTPC = 0;
 
       bool isTVX = col.selection_bit(kIsTriggerTVX);
+
+      int occupancyByTracks = col.trackOccupancyInTimeRange();
+      float occupancyByFT0C = col.ft0cOccupancyInTimeRange();
+
       for (const auto& track : tracksGrouped) {
         int trackBcDiff = bcDiff + track.trackTime() / o2::constants::lhc::LHCBunchSpacingNS;
 
@@ -1158,7 +1174,19 @@ struct EventSelectionQaTask {
           nPV++;
           if (track.hasTPC()) {
             nContributorsAfterEtaTPCLooseCuts++;
-          }
+
+            if (!isLowFlux && col.sel8() && col.selection_bit(kNoSameBunchPileup) && fabs(col.posZ()) < 10 && occupancyByTracks >= 0) {
+              histos.fill(HIST("occupancyQA/tpcNClsFound_vs_V0A_vs_occupancy"), multV0A, track.tpcNClsFound(), occupancyByTracks);
+              histos.fill(HIST("occupancyQA/tpcNClsFindable_vs_V0A_vs_occupancy"), multV0A, track.tpcNClsFindable(), occupancyByTracks);
+              histos.fill(HIST("occupancyQA/tpcNClsShared_vs_V0A_vs_occupancy"), multV0A, track.tpcNClsShared(), occupancyByTracks);
+              histos.fill(HIST("occupancyQA/tpcChi2_vs_V0A_vs_occupancy"), multV0A, track.tpcChi2NCl(), occupancyByTracks);
+              int tpcNClsFindableMinusCrossedRowsCorrected = track.tpcNClsFindableMinusCrossedRows();
+              // correct for a buggy behaviour due to int8 and uint8 difference:
+              if (tpcNClsFindableMinusCrossedRowsCorrected < -70)
+                tpcNClsFindableMinusCrossedRowsCorrected += 256;
+              histos.fill(HIST("occupancyQA/tpcNCrossedRows_vs_V0A_vs_occupancy"), multV0A, track.tpcNClsFindable() - tpcNClsFindableMinusCrossedRowsCorrected, occupancyByTracks);
+            }
+          } // end of hasTPC
           if (track.tpcNClsFound() > 70 && track.tpcNClsCrossedRows() > 80 && track.itsChi2NCl() < 36 && track.tpcChi2NCl() < 4) {
             nContributorsAfterEtaTPCCuts++;
             // ROF border QA
@@ -1183,10 +1211,8 @@ struct EventSelectionQaTask {
 
       histos.fill(HIST("hNcontribAfterCutsVsBcInTF"), bcInTF, nContributorsAfterEtaTPCCuts);
 
-      if (!isLowFlux && col.sel8() && fabs(col.posZ()) < 10) {
-        int occupancyByTracks = col.trackOccupancyInTimeRange();
+      if (!isLowFlux && col.sel8() && col.selection_bit(kNoSameBunchPileup) && fabs(col.posZ()) < 10) {
         histos.fill(HIST("occupancyQA/hOccupancyByTracks"), occupancyByTracks);
-        float occupancyByFT0C = col.ft0cOccupancyInTimeRange();
         histos.fill(HIST("occupancyQA/hOccupancyByFT0C"), occupancyByFT0C);
         if (occupancyByTracks >= 0) {
           histos.fill(HIST("occupancyQA/hOccupancyByFT0CvsByTracks"), occupancyByTracks, occupancyByFT0C);


### PR DESCRIPTION
adding automatic extraction of orbitsPerTF from ccdb by LPMProductionTag,
in view of the new functionality added in PR AliceO2Group/O2DPG#2048 (publishes MCProdInfo on CCDB) and AliceO2Group/AliceO2#14406

