### PR TITLE
[Common] Update centrality task with run dependant histograms

### DIFF
--- a/Common/DataModel/Multiplicity.h
+++ b/Common/DataModel/Multiplicity.h
@@ -125,6 +125,7 @@ DECLARE_SOA_TABLE(MFTMults, "AOD", "MFTMULT", //! Multiplicity with MFT
                   mult::MFTNalltracks, mult::MFTNtracks);
 using BarrelMults = soa::Join<TrackletMults, TPCMults, PVMults>;
 using Mults = soa::Join<BarrelMults, FV0Mults, FT0Mults, FDDMults, ZDCMults>;
+using MultsRun3 = soa::Join<TPCMults, PVMults, FV0Mults, FT0Mults, FDDMults, ZDCMults>;
 using FT0Mult = FT0Mults::iterator;
 using MFTMult = MFTMults::iterator;
 using Mult = Mults::iterator;

--- a/Common/Tasks/centralityStudy.cxx
+++ b/Common/Tasks/centralityStudy.cxx
@@ -30,8 +30,8 @@
 #include "TH2F.h"
 #include "TProfile.h"
 
-#include <string>
 #include <map>
+#include <string>
 
 using namespace o2;
 using namespace o2::framework;

--- a/Common/Tasks/centralityStudy.cxx
+++ b/Common/Tasks/centralityStudy.cxx
@@ -352,12 +352,12 @@ struct centralityStudy {
     initRun(collision);
     histos.fill(HIST("hCollisionSelection"), 0); // all collisions
     getHist(TH1, histPath + "hCollisionSelection")->Fill(0);
-    
+
     if (applySel8 && !collision.multSel8())
       return;
     histos.fill(HIST("hCollisionSelection"), 1);
     getHist(TH1, histPath + "hCollisionSelection")->Fill(1);
-    
+
     if (applyVtxZ && TMath::Abs(collision.multPVz()) > 10)
       return;
     histos.fill(HIST("hCollisionSelection"), 2);
@@ -459,7 +459,7 @@ struct centralityStudy {
     }
     histos.fill(HIST("hCollisionSelection"), 15 /* pass em/upc rejection */);
     getHist(TH1, histPath + "hCollisionSelection")->Fill(15);
-    
+
     // if we got here, we also finally fill the FT0C histogram, please
     histos.fill(HIST("hNPVContributors"), collision.multNTracksPV());
     histos.fill(HIST("hFT0C_Collisions"), collision.multFT0C() * scaleSignalFT0C);
@@ -482,7 +482,7 @@ struct centralityStudy {
     getHist(TProfile, histPath + "hFV0AvsPVz_Collisions")->Fill(collision.multPVz(), collision.multFV0A() * scaleSignalFV0A);
     getHist(TProfile, histPath + "hNGlobalTracksvsPVz_Collisions")->Fill(collision.multPVz(), collision.multNTracksGlobal());
     getHist(TProfile, histPath + "hNMFTTracksvsPVz_Collisions")->Fill(collision.multPVz(), collision.mftNtracks());
-    
+
     if (collision.multFT0C() > minFT0CforVertexZ) {
       histos.fill(HIST("hFT0CvsPVz_Collisions"), collision.multPVz(), collision.multFT0C() * scaleSignalFT0C);
       getHist(TProfile, histPath + "hFT0CvsPVz_Collisions")->Fill(collision.multPVz(), collision.multFT0C() * scaleSignalFT0C);
@@ -571,8 +571,8 @@ struct centralityStudy {
       uint64_t bcTimestamp = multbc.timestamp();
       o2::parameters::GRPECSObject* grpo = ccdb->getForTimeStamp<o2::parameters::GRPECSObject>(pathGRPECSObject, bcTimestamp);
       uint64_t startOfRunTimestamp = grpo->getTimeStart();
-      float hoursAfterStartOfRun = static_cast<float>(bcTimestamp - startOfRunTimestamp) / 3600000.0;      
-      
+      float hoursAfterStartOfRun = static_cast<float>(bcTimestamp - startOfRunTimestamp) / 3600000.0;
+
       getHist(TH2, histPath + "hFT0AVsTime")->Fill(hoursAfterStartOfRun, collision.multFT0A());
       getHist(TH2, histPath + "hFT0CVsTime")->Fill(hoursAfterStartOfRun, collision.multFT0C());
       getHist(TH2, histPath + "hFT0MVsTime")->Fill(hoursAfterStartOfRun, collision.multFT0M());
@@ -586,7 +586,7 @@ struct centralityStudy {
       if (doTimeStudyFV0AOuterVsFT0A3d) {
         histos.fill(HIST("h3dFV0AVsTime"), hoursAfterStartOfRun, collision.multFV0A(), collision.multFV0AOuter());
       }
-      
+
       if (irDoRateVsTime) {
         float interactionRate = mRateFetcher.fetch(ccdb.service, bcTimestamp, mRunNumber, irSource.value, irCrashOnNull) / 1000.; // kHz
         getHist(TProfile, histPath + "hIRProfileVsTime")->Fill(hoursAfterStartOfRun, interactionRate);

--- a/Common/Tasks/centralityStudy.cxx
+++ b/Common/Tasks/centralityStudy.cxx
@@ -36,12 +36,16 @@ using namespace o2;
 using namespace o2::framework;
 
 using BCsWithRun3Matchings = soa::Join<aod::BCs, aod::Timestamps, aod::Run3MatchedToBCSparse>;
+#define getHist(type, name) std::get<std::shared_ptr<type>>(histPointers[name])
 
 struct centralityStudy {
   // Raw multiplicities
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
+  std::map<std::string, HistPtr> histPointers;
+  std::string histPath;
   Service<o2::ccdb::BasicCCDBManager> ccdb;
   ctpRateFetcher mRateFetcher;
+  int mRunNumber;
 
   // Configurables
   Configurable<bool> do2DPlots{"do2DPlots", true, "0 - no, 1 - yes"};
@@ -50,6 +54,7 @@ struct centralityStudy {
   Configurable<bool> doOccupancyStudyVsCentrality3d{"doOccupancyStudyVsCentrality3d", false, "0 - no, 1 - yes"};
   Configurable<bool> doOccupancyStudyVsRawValues3d{"doOccupancyStudyVsRawValues3d", false, "0 - no, 1 - yes"};
   Configurable<bool> doTimeStudies{"doTimeStudies", true, "0 - no, 1 - yes"};
+  Configurable<bool> doTimeStudyFV0AOuterVsFT0A3d{"doTimeStudyFV0AOuterVsFT0A3d", false, "0 - no, 1 - yes"};
   Configurable<bool> doNGlobalTracksVsRawSignals{"doNGlobalTracksVsRawSignals", true, "0 - no, 1 - yes"};
   Configurable<bool> applySel8{"applySel8", true, "0 - no, 1 - yes"};
   Configurable<bool> applyVtxZ{"applyVtxZ", true, "0 - no, 1 - yes"};
@@ -85,6 +90,7 @@ struct centralityStudy {
   Configurable<std::string> pathGRPECSObject{"pathGRPECSObject", "GLO/Config/GRPECS", "Path to GRPECS object"};
   Configurable<std::string> irSource{"irSource", "ZNC hadronic", "Source of the interaction rate: (Recommended: pp --> T0VTX, Pb-Pb --> ZNC hadronic)"};
   Configurable<bool> irCrashOnNull{"irCrashOnNull", false, "Flag to avoid CTP RateFetcher crash."};
+  Configurable<bool> irDoRateVsTime{"irDoRateVsTime", true, "Do IR plots"};
 
   // _______________________________________
   // upc rejection criteria
@@ -129,8 +135,10 @@ struct centralityStudy {
   ConfigurableAxis axisCentrality{"axisCentrality", {100, 0, 100}, "FT0C percentile"};
   ConfigurableAxis axisPVChi2{"axisPVChi2", {300, 0, 30}, "FT0C percentile"};
   ConfigurableAxis axisDeltaTime{"axisDeltaTime", {300, 0, 300}, "#Delta time"};
+
   ConfigurableAxis axisDeltaTimestamp{"axisDeltaTimestamp", {1440, 0, 24}, "#Delta timestamp - sor (hours)"};
   ConfigurableAxis axisInteractionRate{"axisInteractionRate", {500, 0, 100}, "Binning for the interaction rate (kHz)"};
+  ConfigurableAxis axisMultCoarseFV0A{"axisMultCoarseFV0A", {350, 0, 70000}, "FV0A amplitude"};
 
   // For profile Z
   ConfigurableAxis axisPVz{"axisPVz", {400, -20.0f, +20.0f}, "PVz (cm)"};
@@ -250,17 +258,90 @@ struct centralityStudy {
       ccdb->setCaching(true);
       ccdb->setLocalObjectValidityChecking();
       ccdb->setFatalWhenNull(false);
+      if (doTimeStudyFV0AOuterVsFT0A3d) {
+        histos.add((histPath + "h3dFV0AVsTime").c_str(), "", {kTH3F, {{axisDeltaTimestamp, axisMultCoarseFV0A, axisMultCoarseFV0A}}});
+      }
+    }
+  }
 
-      histos.add("hFT0AvsTime", "hFT0AvsTime", kTH2F, {axisDeltaTimestamp, axisMultFT0A});
-      histos.add("hFT0CvsTime", "hFT0CvsTime", kTH2F, {axisDeltaTimestamp, axisMultFT0C});
-      histos.add("hFT0MvsTime", "hFT0MvsTime", kTH2F, {axisDeltaTimestamp, axisMultFT0M});
-      histos.add("hFV0AvsTime", "hFV0AvsTime", kTH2F, {axisDeltaTimestamp, axisMultFV0A});
-      histos.add("hMFTTracksvsTime", "hMFTTracksvsTime", kTH2F, {axisDeltaTimestamp, axisMultMFTTracks});
-      histos.add("hNGlobalVsTime", "hNGlobalVsTime", kTH2F, {axisDeltaTimestamp, axisMultGlobalTracks});
-      histos.add("hNTPVContributorsvsTime", "hNTPVContributorsvsTime", kTH2F, {axisDeltaTimestamp, axisMultPVContributors});
-      histos.add("hIRProfileVsTime", "hIRProfileVsTime", kTProfile, {axisDeltaTimestamp});
-      histos.add("hPVzProfileCoVsTime", "hPVzProfileCoVsTime", kTProfile, {axisDeltaTimestamp});
-      histos.add("hPVzProfileBcVsTime", "hPVzProfileBcVsTime", kTProfile, {axisDeltaTimestamp});
+  template <typename TCollision>
+  void initRun(TCollision collision)
+  {
+    if (mRunNumber == collision.multRunNumber()) {
+      return;
+    }
+
+    mRunNumber = collision.multRunNumber();
+    histPath = std::format("Run_{}/", mRunNumber);
+
+    if (doprocessCollisions || doprocessCollisionsWithCentrality) {
+      histPointers.insert({histPath + "hCollisionSelection", histos.add((histPath + "hCollisionSelection").c_str(), "hCollisionSelection", {kTH1D, {{20, -0.5f, +19.5f}}})});
+      getHist(TH1, histPath + "hCollisionSelection")->GetXaxis()->SetBinLabel(1, "All collisions");
+      getHist(TH1, histPath + "hCollisionSelection")->GetXaxis()->SetBinLabel(2, "sel8 cut");
+      getHist(TH1, histPath + "hCollisionSelection")->GetXaxis()->SetBinLabel(3, "posZ cut");
+      getHist(TH1, histPath + "hCollisionSelection")->GetXaxis()->SetBinLabel(4, "kNoITSROFrameBorder");
+      getHist(TH1, histPath + "hCollisionSelection")->GetXaxis()->SetBinLabel(5, "kNoTimeFrameBorder");
+      getHist(TH1, histPath + "hCollisionSelection")->GetXaxis()->SetBinLabel(6, "kIsVertexITSTPC");
+      getHist(TH1, histPath + "hCollisionSelection")->GetXaxis()->SetBinLabel(7, "kIsGoodZvtxFT0vsPV");
+      getHist(TH1, histPath + "hCollisionSelection")->GetXaxis()->SetBinLabel(8, "kIsVertexTOFmatched");
+      getHist(TH1, histPath + "hCollisionSelection")->GetXaxis()->SetBinLabel(9, "kIsVertexTRDmatched");
+      getHist(TH1, histPath + "hCollisionSelection")->GetXaxis()->SetBinLabel(10, "kNoSameBunchPileup");
+      getHist(TH1, histPath + "hCollisionSelection")->GetXaxis()->SetBinLabel(11, "Neighbour rejection");
+      getHist(TH1, histPath + "hCollisionSelection")->GetXaxis()->SetBinLabel(12, "no ITS in-ROF pileup (standard)");
+      getHist(TH1, histPath + "hCollisionSelection")->GetXaxis()->SetBinLabel(13, "no ITS in-ROF pileup (strict)");
+
+      histPointers.insert({histPath + "hFT0C_Collisions", histos.add((histPath + "hFT0C_Collisions").c_str(), "hFT0C_Collisions", {kTH1D, {{axisMultUltraFineFT0C}}})});
+      histPointers.insert({histPath + "hFT0M_Collisions", histos.add((histPath + "hFT0M_Collisions").c_str(), "hFT0M_Collisions", {kTH1D, {{axisMultUltraFineFT0M}}})});
+      histPointers.insert({histPath + "hFV0A_Collisions", histos.add((histPath + "hFV0A_Collisions").c_str(), "hFV0A_Collisions", {kTH1D, {{axisMultUltraFineFV0A}}})});
+      histPointers.insert({histPath + "hNGlobalTracks", histos.add((histPath + "hNGlobalTracks").c_str(), "hNGlobalTracks", {kTH1D, {{axisMultUltraFineGlobalTracks}}})});
+      histPointers.insert({histPath + "hNMFTTracks", histos.add((histPath + "hNMFTTracks").c_str(), "hNMFTTracks", {kTH1D, {{axisMultUltraFineMFTTracks}}})});
+      histPointers.insert({histPath + "hNPVContributors", histos.add((histPath + "hNPVContributors").c_str(), "hNPVContributors", {kTH1D, {{axisMultUltraFinePVContributors}}})});
+
+      histPointers.insert({histPath + "hFT0CvsPVz_Collisions_All", histos.add((histPath + "hFT0CvsPVz_Collisions_All").c_str(), "hFT0CvsPVz_Collisions_All", {kTProfile, {{axisPVz}}})});
+      histPointers.insert({histPath + "hFT0CvsPVz_Collisions", histos.add((histPath + "hFT0CvsPVz_Collisions").c_str(), "hFT0CvsPVz_Collisions", {kTProfile, {{axisPVz}}})});
+      histPointers.insert({histPath + "hFV0AvsPVz_Collisions", histos.add((histPath + "hFV0AvsPVz_Collisions").c_str(), "hFV0AvsPVz_Collisions", {kTProfile, {{axisPVz}}})});
+      histPointers.insert({histPath + "hNGlobalTracksvsPVz_Collisions", histos.add((histPath + "hNGlobalTracksvsPVz_Collisions").c_str(), "hNGlobalTracksvsPVz_Collisions", {kTProfile, {{axisPVz}}})});
+      histPointers.insert({histPath + "hNMFTTracksvsPVz_Collisions", histos.add((histPath + "hNMFTTracksvsPVz_Collisions").c_str(), "hNMFTTracksvsPVz_Collisions", {kTProfile, {{axisPVz}}})});
+    }
+
+    if (do2DPlots) {
+      histPointers.insert({histPath + "hNContribsVsFT0C", histos.add((histPath + "hNContribsVsFT0C").c_str(), "hNContribsVsFT0C", {kTH2F, {{axisMultFT0C, axisMultPVContributors}}})});
+      histPointers.insert({histPath + "hNContribsVsFV0A", histos.add((histPath + "hNContribsVsFV0A").c_str(), "hNContribsVsFV0A", {kTH2F, {{axisMultFV0A, axisMultPVContributors}}})});
+      histPointers.insert({histPath + "hMatchedVsITSOnly", histos.add((histPath + "hMatchedVsITSOnly").c_str(), "hMatchedVsITSOnly", {kTH2F, {{axisMultITSOnly, axisMultITSTPC}}})});
+
+      // 2d correlation of fit signals
+      histPointers.insert({histPath + "hFT0AVsFT0C", histos.add((histPath + "hFT0AVsFT0C").c_str(), "hFT0AVsFT0C", {kTH2F, {{axisMultFT0C, axisMultFT0A}}})});
+      histPointers.insert({histPath + "hFV0AVsFT0C", histos.add((histPath + "hFV0AVsFT0C").c_str(), "hFV0AVsFT0C", {kTH2F, {{axisMultFT0C, axisMultFV0A}}})});
+      histPointers.insert({histPath + "hFDDAVsFT0C", histos.add((histPath + "hFDDAVsFT0C").c_str(), "hFDDAVsFT0C", {kTH2F, {{axisMultFT0C, axisMultFDDA}}})});
+      histPointers.insert({histPath + "hFDDCVsFT0C", histos.add((histPath + "hFDDCVsFT0C").c_str(), "hFDDCVsFT0C", {kTH2F, {{axisMultFT0C, axisMultFDDC}}})});
+    }
+
+    if (doprocessCollisionsWithCentrality) {
+      // in case requested: do vs centrality debugging
+      histPointers.insert({histPath + "hCentrality", histos.add((histPath + "hCentrality").c_str(), "hCentrality", {kTH1F, {{axisCentrality}}})});
+      histPointers.insert({histPath + "hNContribsVsCentrality", histos.add((histPath + "hNContribsVsCentrality").c_str(), "hNContribsVsCentrality", {kTH2F, {{axisCentrality, axisMultPVContributors}}})});
+      histPointers.insert({histPath + "hNITSTPCTracksVsCentrality", histos.add((histPath + "hNITSTPCTracksVsCentrality").c_str(), "hNITSTPCTracksVsCentrality", {kTH2F, {{axisCentrality, axisMultPVContributors}}})});
+      histPointers.insert({histPath + "hNITSOnlyTracksVsCentrality", histos.add((histPath + "hNITSOnlyTracksVsCentrality").c_str(), "hNITSOnlyTracksVsCentrality", {kTH2F, {{axisCentrality, axisMultPVContributors}}})});
+      histPointers.insert({histPath + "hNGlobalTracksVsCentrality", histos.add((histPath + "hNGlobalTracksVsCentrality").c_str(), "hNGlobalTracksVsCentrality", {kTH2F, {{axisCentrality, axisMultPVContributors}}})});
+      histPointers.insert({histPath + "hNMFTTracksVsCentrality", histos.add((histPath + "hNMFTTracksVsCentrality").c_str(), "hNMFTTracksVsCentrality", {kTH2F, {{axisCentrality, axisMultMFTTracks}}})});
+      histPointers.insert({histPath + "hPVChi2VsCentrality", histos.add((histPath + "hPVChi2VsCentrality").c_str(), "hPVChi2VsCentrality", {kTH2F, {{axisCentrality, axisPVChi2}}})});
+      histPointers.insert({histPath + "hDeltaTimeVsCentrality", histos.add((histPath + "hDeltaTimeVsCentrality").c_str(), "hDeltaTimeVsCentrality", {kTH2F, {{axisCentrality, axisDeltaTime}}})});
+    }
+
+    if (doTimeStudies) {
+      histPointers.insert({histPath + "hFT0AVsTime", histos.add((histPath + "hFT0AVsTime").c_str(), "hFT0AVsTime", {kTH2D, {{axisDeltaTimestamp, axisMultFT0A}}})});
+      histPointers.insert({histPath + "hFT0CVsTime", histos.add((histPath + "hFT0CVsTime").c_str(), "hFT0CVsTime", {kTH2D, {{axisDeltaTimestamp, axisMultFT0C}}})});
+      histPointers.insert({histPath + "hFT0MVsTime", histos.add((histPath + "hFT0MVsTime").c_str(), "hFT0MVsTime", {kTH2D, {{axisDeltaTimestamp, axisMultFT0M}}})});
+      histPointers.insert({histPath + "hFV0AVsTime", histos.add((histPath + "hFV0AVsTime").c_str(), "hFV0AVsTime", {kTH2D, {{axisDeltaTimestamp, axisMultFV0A}}})});
+      histPointers.insert({histPath + "hFV0AOuterVsTime", histos.add((histPath + "hFV0AOuterVsTime").c_str(), "hFV0AOuterVsTime", {kTH2D, {{axisDeltaTimestamp, axisMultFV0A}}})});
+      histPointers.insert({histPath + "hMFTTracksVsTime", histos.add((histPath + "hMFTTracksVsTime").c_str(), "hMFTTracksVsTime", {kTH2D, {{axisDeltaTimestamp, axisMultMFTTracks}}})});
+      histPointers.insert({histPath + "hNGlobalVsTime", histos.add((histPath + "hNGlobalVsTime").c_str(), "hNGlobalVsTime", {kTH2D, {{axisDeltaTimestamp, axisMultGlobalTracks}}})});
+      histPointers.insert({histPath + "hNTPVContributorsVsTime", histos.add((histPath + "hNTPVContributorsVsTime").c_str(), "hNTPVContributorsVsTime", {kTH2D, {{axisDeltaTimestamp, axisMultPVContributors}}})});
+      histPointers.insert({histPath + "hPVzProfileCoVsTime", histos.add((histPath + "hPVzProfileCoVsTime").c_str(), "hPVzProfileCoVsTime", {kTProfile, {{axisDeltaTimestamp}}})});
+      histPointers.insert({histPath + "hPVzProfileBcVsTime", histos.add((histPath + "hPVzProfileBcVsTime").c_str(), "hPVzProfileBcVsTime", {kTProfile, {{axisDeltaTimestamp}}})});
+      if (irDoRateVsTime) {
+        histPointers.insert({histPath + "hIRProfileVsTime", histos.add((histPath + "hIRProfileVsTime").c_str(), "hIRProfileVsTime", {kTProfile, {{axisDeltaTimestamp}}})});
+      }
     }
   }
 
@@ -268,13 +349,19 @@ struct centralityStudy {
   void genericProcessCollision(TCollision collision)
   // process this collisions
   {
+    initRun(collision);
     histos.fill(HIST("hCollisionSelection"), 0); // all collisions
+    getHist(TH1, histPath + "hCollisionSelection")->Fill(0);
+    
     if (applySel8 && !collision.multSel8())
       return;
     histos.fill(HIST("hCollisionSelection"), 1);
+    getHist(TH1, histPath + "hCollisionSelection")->Fill(1);
+    
     if (applyVtxZ && TMath::Abs(collision.multPVz()) > 10)
       return;
     histos.fill(HIST("hCollisionSelection"), 2);
+    getHist(TH1, histPath + "hCollisionSelection")->Fill(2);
 
     // _______________________________________________________
     // Extra event selections start here
@@ -282,36 +369,43 @@ struct centralityStudy {
       return;
     }
     histos.fill(HIST("hCollisionSelection"), 3 /* Not at ITS ROF border */);
+    getHist(TH1, histPath + "hCollisionSelection")->Fill(3);
 
     if (rejectTFBorder && !collision.selection_bit(o2::aod::evsel::kNoTimeFrameBorder)) {
       return;
     }
     histos.fill(HIST("hCollisionSelection"), 4 /* Not at TF border */);
+    getHist(TH1, histPath + "hCollisionSelection")->Fill(4);
 
     if (requireIsVertexITSTPC && !collision.selection_bit(o2::aod::evsel::kIsVertexITSTPC)) {
       return;
     }
     histos.fill(HIST("hCollisionSelection"), 5 /* Contains at least one ITS-TPC track */);
+    getHist(TH1, histPath + "hCollisionSelection")->Fill(5);
 
     if (requireIsGoodZvtxFT0VsPV && !collision.selection_bit(o2::aod::evsel::kIsGoodZvtxFT0vsPV)) {
       return;
     }
     histos.fill(HIST("hCollisionSelection"), 6 /* PV position consistency check */);
+    getHist(TH1, histPath + "hCollisionSelection")->Fill(6);
 
     if (requireIsVertexTOFmatched && !collision.selection_bit(o2::aod::evsel::kIsVertexTOFmatched)) {
       return;
     }
     histos.fill(HIST("hCollisionSelection"), 7 /* PV with at least one contributor matched with TOF */);
+    getHist(TH1, histPath + "hCollisionSelection")->Fill(7);
 
     if (requireIsVertexTRDmatched && !collision.selection_bit(o2::aod::evsel::kIsVertexTRDmatched)) {
       return;
     }
     histos.fill(HIST("hCollisionSelection"), 8 /* PV with at least one contributor matched with TRD */);
+    getHist(TH1, histPath + "hCollisionSelection")->Fill(8);
 
     if (rejectSameBunchPileup && !collision.selection_bit(o2::aod::evsel::kNoSameBunchPileup)) {
       return;
     }
     histos.fill(HIST("hCollisionSelection"), 9 /* Not at same bunch pile-up */);
+    getHist(TH1, histPath + "hCollisionSelection")->Fill(9);
 
     // do this only if information is available
     if constexpr (requires { collision.timeToNext(); }) {
@@ -323,27 +417,32 @@ struct centralityStudy {
         return;
       }
       histos.fill(HIST("hCollisionSelection"), 10 /* has suspicious neighbour */);
+      getHist(TH1, histPath + "hCollisionSelection")->Fill(10);
     }
 
     if (rejectITSinROFpileupStandard && !collision.selection_bit(o2::aod::evsel::kNoCollInRofStandard)) {
       return;
     }
     histos.fill(HIST("hCollisionSelection"), 11 /* Not ITS ROF pileup (standard) */);
+    getHist(TH1, histPath + "hCollisionSelection")->Fill(11);
 
     if (rejectITSinROFpileupStrict && !collision.selection_bit(o2::aod::evsel::kNoCollInRofStrict)) {
       return;
     }
     histos.fill(HIST("hCollisionSelection"), 12 /* Not ITS ROF pileup (strict) */);
+    getHist(TH1, histPath + "hCollisionSelection")->Fill(12);
 
     if (selectUPCcollisions && collision.flags() < 1) { // if zero then NOT upc, otherwise UPC
       return;
     }
     histos.fill(HIST("hCollisionSelection"), 13 /* is UPC event */);
+    getHist(TH1, histPath + "hCollisionSelection")->Fill(13);
 
     if (rejectCollInTimeRangeNarrow && !collision.selection_bit(o2::aod::evsel::kNoCollInTimeRangeNarrow)) {
       return;
     }
     histos.fill(HIST("hCollisionSelection"), 14 /* Not ITS ROF pileup (strict) */);
+    getHist(TH1, histPath + "hCollisionSelection")->Fill(14);
 
     if (collision.multFT0C() < upcRejection.maxFT0CforZNACselection &&
         collision.multZNA() < upcRejection.minZNACsignal &&
@@ -359,7 +458,8 @@ struct centralityStudy {
       return;
     }
     histos.fill(HIST("hCollisionSelection"), 15 /* pass em/upc rejection */);
-
+    getHist(TH1, histPath + "hCollisionSelection")->Fill(15);
+    
     // if we got here, we also finally fill the FT0C histogram, please
     histos.fill(HIST("hNPVContributors"), collision.multNTracksPV());
     histos.fill(HIST("hFT0C_Collisions"), collision.multFT0C() * scaleSignalFT0C);
@@ -371,19 +471,39 @@ struct centralityStudy {
     histos.fill(HIST("hFV0AvsPVz_Collisions"), collision.multPVz(), collision.multFV0A() * scaleSignalFV0A);
     histos.fill(HIST("hNGlobalTracksvsPVz_Collisions"), collision.multPVz(), collision.multNTracksGlobal());
     histos.fill(HIST("hNMFTTracksvsPVz_Collisions"), collision.multPVz(), collision.mftNtracks());
+
+    getHist(TH1, histPath + "hNPVContributors")->Fill(collision.multNTracksPV());
+    getHist(TH1, histPath + "hFT0C_Collisions")->Fill(collision.multFT0C() * scaleSignalFT0C);
+    getHist(TH1, histPath + "hFT0M_Collisions")->Fill((collision.multFT0A() + collision.multFT0C()) * scaleSignalFT0M);
+    getHist(TH1, histPath + "hFV0A_Collisions")->Fill(collision.multFV0A() * scaleSignalFV0A);
+    getHist(TH1, histPath + "hNGlobalTracks")->Fill(collision.multNTracksGlobal());
+    getHist(TH1, histPath + "hNMFTTracks")->Fill(collision.mftNtracks());
+    getHist(TProfile, histPath + "hFT0CvsPVz_Collisions_All")->Fill(collision.multPVz(), collision.multFT0C() * scaleSignalFT0C);
+    getHist(TProfile, histPath + "hFV0AvsPVz_Collisions")->Fill(collision.multPVz(), collision.multFV0A() * scaleSignalFV0A);
+    getHist(TProfile, histPath + "hNGlobalTracksvsPVz_Collisions")->Fill(collision.multPVz(), collision.multNTracksGlobal());
+    getHist(TProfile, histPath + "hNMFTTracksvsPVz_Collisions")->Fill(collision.multPVz(), collision.mftNtracks());
+    
     if (collision.multFT0C() > minFT0CforVertexZ) {
       histos.fill(HIST("hFT0CvsPVz_Collisions"), collision.multPVz(), collision.multFT0C() * scaleSignalFT0C);
+      getHist(TProfile, histPath + "hFT0CvsPVz_Collisions")->Fill(collision.multPVz(), collision.multFT0C() * scaleSignalFT0C);
     }
     if (do2DPlots) {
       histos.fill(HIST("hNContribsVsFT0C"), collision.multFT0C() * scaleSignalFT0C, collision.multPVTotalContributors());
       histos.fill(HIST("hNContribsVsFV0A"), collision.multFV0A() * scaleSignalFV0A, collision.multPVTotalContributors());
       histos.fill(HIST("hMatchedVsITSOnly"), collision.multNTracksITSOnly(), collision.multNTracksITSTPC());
+      getHist(TH2, histPath + "hNContribsVsFT0C")->Fill(collision.multFT0C() * scaleSignalFT0C, collision.multPVTotalContributors());
+      getHist(TH2, histPath + "hNContribsVsFV0A")->Fill(collision.multFV0A() * scaleSignalFV0A, collision.multPVTotalContributors());
+      getHist(TH2, histPath + "hMatchedVsITSOnly")->Fill(collision.multNTracksITSOnly(), collision.multNTracksITSTPC());
 
       // correlate also FIT detector signals
       histos.fill(HIST("hFT0AVsFT0C"), collision.multFT0C() * scaleSignalFT0C, collision.multFT0A());
       histos.fill(HIST("hFV0AVsFT0C"), collision.multFT0C() * scaleSignalFT0C, collision.multFV0A());
       histos.fill(HIST("hFDDAVsFT0C"), collision.multFT0C() * scaleSignalFT0C, collision.multFDDA());
       histos.fill(HIST("hFDDCVsFT0C"), collision.multFT0C() * scaleSignalFT0C, collision.multFDDC());
+      getHist(TH2, histPath + "hFT0AVsFT0C")->Fill(collision.multFT0C() * scaleSignalFT0C, collision.multFT0A());
+      getHist(TH2, histPath + "hFV0AVsFT0C")->Fill(collision.multFT0C() * scaleSignalFT0C, collision.multFV0A());
+      getHist(TH2, histPath + "hFDDAVsFT0C")->Fill(collision.multFT0C() * scaleSignalFT0C, collision.multFDDA());
+      getHist(TH2, histPath + "hFDDCVsFT0C")->Fill(collision.multFT0C() * scaleSignalFT0C, collision.multFDDC());
     }
 
     if (doOccupancyStudyVsCentrality2d) {
@@ -422,6 +542,13 @@ struct centralityStudy {
       histos.fill(HIST("hNGlobalTracksVsCentrality"), collision.centFT0C(), collision.multNTracksGlobal());
       histos.fill(HIST("hNMFTTracksVsCentrality"), collision.centFT0C(), collision.mftNtracks());
       histos.fill(HIST("hPVChi2VsCentrality"), collision.centFT0C(), collision.multPVChi2());
+      getHist(TH1, histPath + "hCentrality")->Fill(collision.centFT0C());
+      getHist(TH2, histPath + "hNContribsVsCentrality")->Fill(collision.centFT0C(), collision.multPVTotalContributors());
+      getHist(TH2, histPath + "hNITSTPCTracksVsCentrality")->Fill(collision.centFT0C(), collision.multNTracksITSTPC());
+      getHist(TH2, histPath + "hNITSOnlyTracksVsCentrality")->Fill(collision.centFT0C(), collision.multNTracksITSOnly());
+      getHist(TH2, histPath + "hNGlobalTracksVsCentrality")->Fill(collision.centFT0C(), collision.multNTracksGlobal());
+      getHist(TH2, histPath + "hNMFTTracksVsCentrality")->Fill(collision.centFT0C(), collision.mftNtracks());
+      getHist(TH2, histPath + "hPVChi2VsCentrality")->Fill(collision.centFT0C(), collision.multPVChi2());
 
       if (doOccupancyStudyVsCentrality2d) {
         histos.fill(HIST("hNcontribsProfileVsTrackOccupancyVsCentrality"), collision.trackOccupancyInTimeRange(), collision.centFT0C(), collision.multPVTotalContributors());
@@ -439,43 +566,50 @@ struct centralityStudy {
     }
 
     if (doTimeStudies && collision.has_multBC()) {
+      initRun(collision);
       auto multbc = collision.template multBC_as<aod::MultBCs>();
       uint64_t bcTimestamp = multbc.timestamp();
       o2::parameters::GRPECSObject* grpo = ccdb->getForTimeStamp<o2::parameters::GRPECSObject>(pathGRPECSObject, bcTimestamp);
       uint64_t startOfRunTimestamp = grpo->getTimeStart();
-
-      float hoursAfterStartOfRun = static_cast<float>(bcTimestamp - startOfRunTimestamp) / 3600000.0;
-      float interactionRate = mRateFetcher.fetch(ccdb.service, bcTimestamp, collision.multRunNumber(), irSource.value, irCrashOnNull) / 1000.; // kHz
-
-      histos.fill(HIST("hFT0AvsTime"), hoursAfterStartOfRun, collision.multFT0A());
-      histos.fill(HIST("hFT0CvsTime"), hoursAfterStartOfRun, collision.multFT0C());
-      histos.fill(HIST("hFT0MvsTime"), hoursAfterStartOfRun, collision.multFT0M());
-      histos.fill(HIST("hFV0AvsTime"), hoursAfterStartOfRun, collision.multFV0A());
-      histos.fill(HIST("hMFTTracksvsTime"), hoursAfterStartOfRun, collision.mftNtracks());
-      histos.fill(HIST("hNGlobalVsTime"), hoursAfterStartOfRun, collision.multNTracksGlobal());
-      histos.fill(HIST("hNTPVContributorsvsTime"), hoursAfterStartOfRun, collision.multPVTotalContributors());
-      histos.fill(HIST("hPVzProfileCoVsTime"), hoursAfterStartOfRun, collision.multPVz());
-      histos.fill(HIST("hPVzProfileBcVsTime"), hoursAfterStartOfRun, multbc.multFT0PosZ());
-      histos.fill(HIST("hIRProfileVsTime"), hoursAfterStartOfRun, interactionRate);
+      float hoursAfterStartOfRun = static_cast<float>(bcTimestamp - startOfRunTimestamp) / 3600000.0;      
+      
+      getHist(TH2, histPath + "hFT0AVsTime")->Fill(hoursAfterStartOfRun, collision.multFT0A());
+      getHist(TH2, histPath + "hFT0CVsTime")->Fill(hoursAfterStartOfRun, collision.multFT0C());
+      getHist(TH2, histPath + "hFT0MVsTime")->Fill(hoursAfterStartOfRun, collision.multFT0M());
+      getHist(TH2, histPath + "hFV0AVsTime")->Fill(hoursAfterStartOfRun, collision.multFV0A());
+      getHist(TH2, histPath + "hFV0AOuterVsTime")->Fill(hoursAfterStartOfRun, collision.multFV0AOuter());
+      getHist(TH2, histPath + "hMFTTracksVsTime")->Fill(hoursAfterStartOfRun, collision.mftNtracks());
+      getHist(TH2, histPath + "hNGlobalVsTime")->Fill(hoursAfterStartOfRun, collision.multNTracksGlobal());
+      getHist(TH2, histPath + "hNTPVContributorsVsTime")->Fill(hoursAfterStartOfRun, collision.multPVTotalContributors());
+      getHist(TProfile, histPath + "hPVzProfileCoVsTime")->Fill(hoursAfterStartOfRun, collision.multPVz());
+      getHist(TProfile, histPath + "hPVzProfileBcVsTime")->Fill(hoursAfterStartOfRun, multbc.multFT0PosZ());
+      if (doTimeStudyFV0AOuterVsFT0A3d) {
+        histos.fill(HIST("h3dFV0AVsTime"), hoursAfterStartOfRun, collision.multFV0A(), collision.multFV0AOuter());
+      }
+      
+      if (irDoRateVsTime) {
+        float interactionRate = mRateFetcher.fetch(ccdb.service, bcTimestamp, mRunNumber, irSource.value, irCrashOnNull) / 1000.; // kHz
+        getHist(TProfile, histPath + "hIRProfileVsTime")->Fill(hoursAfterStartOfRun, interactionRate);
+      }
     }
   }
 
-  void processCollisions(soa::Join<aod::Mults, aod::MFTMults, aod::MultsExtra, aod::MultsGlobal, aod::MultSelections, aod::Mults2BC>::iterator const& collision, aod::MultBCs const&)
+  void processCollisions(soa::Join<aod::MultsRun3, aod::MFTMults, aod::MultsExtra, aod::MultsGlobal, aod::MultSelections, aod::Mults2BC, aod::FV0AOuterMults>::iterator const& collision, aod::MultBCs const&)
   {
     genericProcessCollision(collision);
   }
 
-  void processCollisionsWithCentrality(soa::Join<aod::Mults, aod::MFTMults, aod::MultsExtra, aod::MultSelections, aod::CentFT0Cs, aod::MultsGlobal, aod::Mults2BC>::iterator const& collision, aod::MultBCs const&)
+  void processCollisionsWithCentrality(soa::Join<aod::MultsRun3, aod::MFTMults, aod::MultsExtra, aod::MultSelections, aod::CentFT0Cs, aod::MultsGlobal, aod::Mults2BC, aod::FV0AOuterMults>::iterator const& collision, aod::MultBCs const&)
   {
     genericProcessCollision(collision);
   }
 
-  void processCollisionsWithCentralityWithNeighbours(soa::Join<aod::Mults, aod::MFTMults, aod::MultsExtra, aod::MultSelections, aod::CentFT0Cs, aod::MultsGlobal, aod::MultNeighs, aod::Mults2BC>::iterator const& collision, aod::MultBCs const&)
+  void processCollisionsWithCentralityWithNeighbours(soa::Join<aod::MultsRun3, aod::MFTMults, aod::MultsExtra, aod::MultSelections, aod::CentFT0Cs, aod::MultsGlobal, aod::MultNeighs, aod::Mults2BC, aod::FV0AOuterMults>::iterator const& collision, aod::MultBCs const&)
   {
     genericProcessCollision(collision);
   }
 
-  void processBCs(soa::Join<aod::BC2Mults, aod::MultBCs>::iterator const& multbc, soa::Join<aod::Mults, aod::MFTMults, aod::MultsExtra, aod::MultSelections, aod::CentFT0Cs, aod::MultsGlobal> const&)
+  void processBCs(soa::Join<aod::BC2Mults, aod::MultBCs>::iterator const& multbc, soa::Join<aod::MultsRun3, aod::MFTMults, aod::MultsExtra, aod::MultSelections, aod::CentFT0Cs, aod::MultsGlobal> const&)
   {
     // process BCs, calculate FT0C distribution
     // conditionals suggested by FIT team (Jacek O. et al)
@@ -530,7 +664,7 @@ struct centralityStudy {
     }
 
     if (multbc.has_ft0Mult()) {
-      auto multco = multbc.ft0Mult_as<soa::Join<aod::Mults, aod::MFTMults, aod::MultsExtra, aod::MultSelections, aod::CentFT0Cs, aod::MultsGlobal>>();
+      auto multco = multbc.ft0Mult_as<soa::Join<aod::MultsRun3, aod::MFTMults, aod::MultsExtra, aod::MultSelections, aod::CentFT0Cs, aod::MultsGlobal>>();
       if (multbc.multFT0PosZValid()) {
         histos.fill(HIST("hVertexZ_BCvsCO"), multco.multPVz(), multbc.multFT0PosZ());
       }

--- a/Common/Tasks/centralityStudy.cxx
+++ b/Common/Tasks/centralityStudy.cxx
@@ -31,6 +31,7 @@
 #include "TProfile.h"
 
 #include <string>
+#include <map>
 
 using namespace o2;
 using namespace o2::framework;


### PR DESCRIPTION
This PR includes the following changes 
-  Addition of `MultsRun3` which no longer joins the Run 3 multiplicity tables with the Run 2 `TrackletMults` and changing subscription in the process functions accordingly.
- Created `initRun` which creates the essential histograms dynamically for each Run. Each Run adds ~80 MB of memory needed by the histogram registry which initially needs ~50MB.
- Flag for ir fetcher which sometimes causes crashes in light ion runs.
- Add subscription and histograms for FV0AOuter in process functions calling `genericProcessCollision()`.
- Added 3d histogram FV0A vs FV0AOuter vs time which needs to be enabled with flag `doTimeStudyFV0AOuterVsFT0A3d` (not created per Run).

