### PR TITLE
[PWGLF] Add rotational bkg and configurables for secondary selections for 'chk892pp.cxx'

### DIFF
--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -1223,7 +1223,7 @@ struct LumiTask {
     LOGP(debug, "Dummy process function for Run 2");
   }
 
-  PROCESS_SWITCH(LumiTask, processRun2, "Process Run2 lumi task", false);
+  PROCESS_SWITCH(LumiTask, processRun2, "Process Run2 lumi task", true);
 
   void processRun3(BCsWithBcSelsRun3 const& bcs, aod::FT0s const&)
   {

--- a/PWGLF/Tasks/Resonances/chk892pp.cxx
+++ b/PWGLF/Tasks/Resonances/chk892pp.cxx
@@ -63,6 +63,7 @@
 #include "Common/Core/RecoDecay.h"
 
 #include "CommonConstants/PhysicsConstants.h"
+#include "CommonConstants/MathConstants.h"
 
 #include "ReconstructionDataFormats/Track.h"
 
@@ -80,23 +81,16 @@ using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::soa;
 using namespace o2::constants::physics;
+using namespace o2::aod::rctsel;
 
-struct chk892pp {
-  enum binType : unsigned int {
+struct Chk892pp {
+   enum BinType : unsigned int {
     kKstarP = 0,
     kKstarN,
     kKstarP_Mix,
     kKstarN_Mix,
-    kKstarP_GenINEL10,
-    kKstarN_GenINEL10,
-    kKstarP_GenINELgt10,
-    kKstarN_GenINELgt10,
-    kKstarP_GenTrig10,
-    kKstarN_GenTrig10,
-    kKstarP_GenEvtSel,
-    kKstarN_GenEvtSel,
-    kKstarP_Rec,
-    kKstarN_Rec,
+    kKstarP_Rot,
+    kKstarN_Rot,
     kTYEnd
   };
 
@@ -118,35 +112,45 @@ struct chk892pp {
   Service<o2::framework::O2DatabasePDG> pdg;
   o2::ccdb::CcdbApi ccdbApi;
 
-  Configurable<std::string> cfgURL{"cfgURL", "http://alice-ccdb.cern.ch", "Address of the CCDB to browse"};
-  Configurable<int64_t> nolaterthan{"ccdb-no-later-than", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(), "Latest acceptable timestamp of creation for the object"};
+  struct : ConfigurableGroup {
+    Configurable<std::string> cfgURL{"cfgURL", "http://alice-ccdb.cern.ch", "Address of the CCDB to browse"};
+  } CCDBConfig;
+ // Configurable<int64_t> nolaterthan{"ccdb-no-later-than", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(), "Latest acceptable timestamp of creation for the object"};
 
   // Configurables
-  ConfigurableAxis cfgBinsPt{"cfgBinsPt", {VARIABLE_WIDTH, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5.0, 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6.0, 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 6.9, 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9, 9.0, 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8, 9.9, 10.0, 10.1, 10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8, 10.9, 11.0, 11.1, 11.2, 11.3, 11.4, 11.5, 11.6, 11.7, 11.8, 11.9, 12.0, 12.1, 12.2, 12.3, 12.4, 12.5, 12.6, 12.7, 12.8, 12.9, 13.0, 13.1, 13.2, 13.3, 13.4, 13.5, 13.6, 13.7, 13.8, 13.9, 14.0, 14.1, 14.2, 14.3, 14.4, 14.5, 14.6, 14.7, 14.8, 14.9, 15.0}, "Binning of the pT axis"};
-  ConfigurableAxis cfgBinsPtQA{"cfgBinsPtQA", {VARIABLE_WIDTH, 0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0, 2.2, 2.4, 2.6, 2.8, 3.0, 3.2, 3.4, 3.6, 3.8, 4.0, 4.2, 4.4, 4.6, 4.8, 5.0, 5.2, 5.4, 5.6, 5.8, 6.0, 6.2, 6.4, 6.6, 6.8, 7.0, 7.2, 7.4, 7.6, 7.8, 8.0, 8.2, 8.4, 8.6, 8.8, 9.0, 9.2, 9.4, 9.6, 9.8, 10.0}, "Binning of the pT axis"};
-  ConfigurableAxis cfgBinsCent{"cfgBinsCent", {VARIABLE_WIDTH, 0.0, 1.0, 5.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0, 110.0}, "Binning of the centrality axis"};
-  ConfigurableAxis cfgBinsVtxZ{"cfgBinsVtxZ", {VARIABLE_WIDTH, -10.0, -9.0, -8.0, -7.0, -6.0, -5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0}, "Binning of the z-vertex axis"};
-  Configurable<int> cNbinsDiv{"cNbinsDiv", 1, "Integer to divide the number of bins"};
+  struct : ConfigurableGroup {
+    ConfigurableAxis cfgBinsPt{"cfgBinsPt", {VARIABLE_WIDTH, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 4.0, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5.0, 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6.0, 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 6.9, 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9, 9.0, 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8, 9.9, 10.0, 10.1, 10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8, 10.9, 11.0, 11.1, 11.2, 11.3, 11.4, 11.5, 11.6, 11.7, 11.8, 11.9, 12.0, 12.1, 12.2, 12.3, 12.4, 12.5, 12.6, 12.7, 12.8, 12.9, 13.0, 13.1, 13.2, 13.3, 13.4, 13.5, 13.6, 13.7, 13.8, 13.9, 14.0, 14.1, 14.2, 14.3, 14.4, 14.5, 14.6, 14.7, 14.8, 14.9, 15.0}, "Binning of the pT axis"};
+		ConfigurableAxis cfgBinsPtQA{"cfgBinsPtQA", {VARIABLE_WIDTH, 0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0, 2.2, 2.4, 2.6, 2.8, 3.0, 3.2, 3.4, 3.6, 3.8, 4.0, 4.2, 4.4, 4.6, 4.8, 5.0, 5.2, 5.4, 5.6, 5.8, 6.0, 6.2, 6.4, 6.6, 6.8, 7.0, 7.2, 7.4, 7.6, 7.8, 8.0, 8.2, 8.4, 8.6, 8.8, 9.0, 9.2, 9.4, 9.6, 9.8, 10.0}, "Binning of the pT axis"};
+		ConfigurableAxis cfgBinsCent{"cfgBinsCent", {VARIABLE_WIDTH, 0.0, 1.0, 5.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0, 110.0}, "Binning of the centrality axis"};
+		ConfigurableAxis cfgBinsVtxZ{"cfgBinsVtxZ", {VARIABLE_WIDTH, -10.0, -9.0, -8.0, -7.0, -6.0, -5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0}, "Binning of the z-vertex axis"};
+		Configurable<int> cNbinsDiv{"cNbinsDiv", 1, "Integer to divide the number of bins"};
+    Configurable<int> cNbinsDivQA{"cNbinsDivQA", 1, "Integer to divide the number of bins for QA"};
+  } AxisConfig;
 
   /// Event cuts
   o2::analysis::CollisonCuts colCuts;
-  Configurable<float> ConfEvtZvtx{"ConfEvtZvtx", 10.f, "Evt sel: Max. z-Vertex (cm)"};
-  Configurable<int> ConfEvtOccupancyInTimeRangeMax{"ConfEvtOccupancyInTimeRangeMax", -1, "Evt sel: maximum track occupancy"};
-  Configurable<int> ConfEvtOccupancyInTimeRangeMin{"ConfEvtOccupancyInTimeRangeMin", -1, "Evt sel: minimum track occupancy"};
-  Configurable<bool> ConfEvtTriggerCheck{"ConfEvtTriggerCheck", false, "Evt sel: check for trigger"};
-  Configurable<bool> ConfEvtOfflineCheck{"ConfEvtOfflineCheck", true, "Evt sel: check for offline selection"};
-  Configurable<bool> ConfEvtTriggerTVXSel{"ConfEvtTriggerTVXSel", false, "Evt sel: triggerTVX selection (MB)"};
-  Configurable<bool> ConfEvtTFBorderCut{"ConfEvtTFBorderCut", false, "Evt sel: apply TF border cut"};
-  Configurable<bool> ConfEvtUseITSTPCvertex{"ConfEvtUseITSTPCvertex", false, "Evt sel: use at lease on ITS-TPC track for vertexing"};
-  Configurable<bool> ConfEvtZvertexTimedifference{"ConfEvtZvertexTimedifference", true, "Evt sel: apply Z-vertex time difference"};
-  Configurable<bool> ConfEvtPileupRejection{"ConfEvtPileupRejection", true, "Evt sel: apply pileup rejection"};
-  Configurable<bool> ConfEvtNoITSROBorderCut{"ConfEvtNoITSROBorderCut", false, "Evt sel: apply NoITSRO border cut"};
-  Configurable<bool> ConfincludeCentralityMC{"ConfincludeCentralityMC", false, "Include centrality in MC"};
-  Configurable<bool> ConfEvtCollInTimeRangeStandard{"ConfEvtCollInTimeRangeStandard", true, "Evt sel: apply NoCollInTimeRangeStandard"};
-
-  /// Track selections
-  Configurable<float> cMinPtcut{"cMinPtcut", 0.15, "Track minium pt cut"};
-  Configurable<float> cMaxEtacut{"cMaxEtacut", 0.8, "Track maximum eta cut"};
+ struct : ConfigurableGroup {
+    Configurable<float> cfgEvtZvtx{"cfgEvtZvtx", 10.f, "Evt sel: Max. z-Vertex (cm)"};
+    Configurable<int> cfgEvtOccupancyInTimeRangeMax{"cfgEvtOccupancyInTimeRangeMax", -1, "Evt sel: maximum track occupancy"};
+    Configurable<int> cfgEvtOccupancyInTimeRangeMin{"cfgEvtOccupancyInTimeRangeMin", -1, "Evt sel: minimum track occupancy"};
+    Configurable<bool> cfgEvtTriggerCheck{"cfgEvtTriggerCheck", false, "Evt sel: check for trigger"};
+    Configurable<bool> cfgEvtOfflineCheck{"cfgEvtOfflineCheck", true, "Evt sel: check for offline selection"};
+    Configurable<bool> cfgEvtTriggerTVXSel{"cfgEvtTriggerTVXSel", false, "Evt sel: triggerTVX selection (MB)"};
+    Configurable<bool> cfgEvtTFBorderCut{"cfgEvtTFBorderCut", false, "Evt sel: apply TF border cut"};
+    Configurable<bool> cfgEvtUseITSTPCvertex{"cfgEvtUseITSTPCvertex", false, "Evt sel: use at lease on ITS-TPC track for vertexing"};
+    Configurable<bool> cfgEvtZvertexTimedifference{"cfgEvtZvertexTimedifference", true, "Evt sel: apply Z-vertex time difference"};
+    Configurable<bool> cfgEvtPileupRejection{"cfgEvtPileupRejection", true, "Evt sel: apply pileup rejection"};
+    Configurable<bool> cfgEvtNoITSROBorderCut{"cfgEvtNoITSROBorderCut", false, "Evt sel: apply NoITSRO border cut"};
+    Configurable<bool> cfgincludeCentralityMC{"cfgincludeCentralityMC", false, "Include centrality in MC"};
+    Configurable<bool> cfgEvtCollInTimeRangeStandard{"cfgEvtCollInTimeRangeStandard", true, "Evt sel: apply NoCollInTimeRangeStandard"};
+		Configurable<float> cfgEventCentralityMin{"cfgEventCentralityMin", 0.0f, "Event sel: minimum centrality"};
+    Configurable<float> cfgEventCentralityMax{"cfgEventCentralityMax", 80.0f, "Event sel: maximum centrality"};
+    Configurable<bool> cfgEvtUseRCTFlagChecker{"cfgEvtUseRCTFlagChecker", false, "Evt sel: use RCT flag checker"};
+    Configurable<std::string> cfgEvtRCTFlagCheckerLabel{"cfgEvtRCTFlagCheckerLabel", "CBT_hadronPID", "Evt sel: RCT flag checker label"};
+    Configurable<bool> cfgEvtRCTFlagCheckerZDCCheck{"cfgEvtRCTFlagCheckerZDCCheck", false, "Evt sel: RCT flag checker ZDC check"};
+    Configurable<bool> cfgEvtRCTFlagCheckerLimitAcceptAsBad{"cfgEvtRCTFlagCheckerLimitAcceptAsBad", false, "Evt sel: RCT flag checker treat Limited Acceptance As Bad"};
+  } EventCuts;
+  RCTFlagsChecker rctChecker;
 
   /*
   // Cuts from polarization analysis
@@ -157,86 +161,114 @@ struct chk892pp {
 */
   Configurable<int> cfgCentEst{"cfgCentEst", 1, "Centrality estimator, 1: FT0C, 2: FT0M"};
 
-  // DCAr to PV
-  Configurable<float> cMaxbDCArToPVcut{"cMaxbDCArToPVcut", 0.1, "Track DCAr cut to PV Maximum"};
-  // DCAz to PV
-  Configurable<float> cMaxbDCAzToPVcut{"cMaxbDCAzToPVcut", 0.1, "Track DCAz cut to PV Maximum"};
+ 
 
   /// PID Selections, pion
-  Configurable<bool> cTPConly{"cTPConly", true, "Use only TPC for PID"};                                    // bool
-  Configurable<float> cMaxTPCnSigmaPion{"cMaxTPCnSigmaPion", 3.0, "TPC nSigma cut for Pion"};               // TPC
-  Configurable<float> cMaxTOFnSigmaPion{"cMaxTOFnSigmaPion", 3.0, "TOF nSigma cut for Pion"};               // TOF
-  Configurable<float> nsigmaCutCombinedPion{"nsigmaCutCombinedPion", -999, "Combined nSigma cut for Pion"}; // Combined
-  Configurable<bool> cTOFVeto{"cTOFVeto", true, "TOF Veto, if false, TOF is nessessary for PID selection"}; // TOF Veto
+  struct : ConfigurableGroup {
+    Configurable<bool> cfgTPConly{"cfgTPConly", true, "Use only TPC for PID"};                                    // bool
+    Configurable<float> cfgMaxTPCnSigmaPion{"cfgMaxTPCnSigmaPion", 3.0, "TPC nSigma cut for Pion"};               // TPC
+    Configurable<float> cfgMaxTOFnSigmaPion{"cfgMaxTOFnSigmaPion", 3.0, "TOF nSigma cut for Pion"};               // TOF
+    Configurable<float> cfgNsigmaCutCombinedPion{"cfgNsigmaCutCombinedPion", -999, "Combined nSigma cut for Pion"}; // Combined
+    Configurable<bool> cfgTOFVeto{"cfgTOFVeto", true, "TOF Veto, if false, TOF is nessessary for PID selection"}; // TOF Veto
+  } PIDCuts;
 
   // Track selections
-  Configurable<bool> cfgPrimaryTrack{"cfgPrimaryTrack", true, "Primary track selection"};                    // kGoldenChi2 | kDCAxy | kDCAz
-  Configurable<bool> cfgGlobalWoDCATrack{"cfgGlobalWoDCATrack", true, "Global track selection without DCA"}; // kQualityTracks (kTrackType | kTPCNCls | kTPCCrossedRows | kTPCCrossedRowsOverNCls | kTPCChi2NDF | kTPCRefit | kITSNCls | kITSChi2NDF | kITSRefit | kITSHits) | kInAcceptanceTracks (kPtRange | kEtaRange)
-  Configurable<bool> cfgGlobalTrack{"cfgGlobalTrack", false, "Global track selection"};                      // kGoldenChi2 | kDCAxy | kDCAz
-  Configurable<bool> cfgPVContributor{"cfgPVContributor", false, "PV contributor track selection"};          // PV Contriuibutor
+	struct : ConfigurableGroup {
+    Configurable<float> cfgMinPtcut{"cfgMinPtcut", 0.15, "Track minium pt cut"};
+    Configurable<float> cfgMaxEtacut{"cfgMaxEtacut", 0.8, "Track maximum eta cut"};
+    Configurable<bool> cfgPrimaryTrack{"cfgPrimaryTrack", true, "Primary track selection"};                    // kGoldenChi2 | kDCAxy | kDCAz
+    Configurable<bool> cfgGlobalWoDCATrack{"cfgGlobalWoDCATrack", true, "Global track selection without DCA"}; // kQualityTracks (kTrackType | kTPCNCls | kTPCCrossedRows | kTPCCrossedRowsOverNCls | kTPCChi2NDF | kTPCRefit | kITSNCls | kITSChi2NDF | kITSRefit | kITSHits) | kInAcceptanceTracks (kPtRange | kEtaRange)
+    Configurable<bool> cfgGlobalTrack{"cfgGlobalTrack", false, "Global track selection"};                      // kGoldenChi2 | kDCAxy | kDCAz
+    Configurable<bool> cfgPVContributor{"cfgPVContributor", false, "PV contributor track selection"};          // PV Contriuibutor
 
-  Configurable<int> cfgITScluster{"cfgITScluster", 0, "Number of ITS cluster"};
-  Configurable<int> cfgTPCcluster{"cfgTPCcluster", 0, "Number of TPC cluster"};
-  Configurable<float> cfgRatioTPCRowsOverFindableCls{"cfgRatioTPCRowsOverFindableCls", 0.0f, "TPC Crossed Rows to Findable Clusters"};
-  Configurable<float> cfgITSChi2NCl{"cfgITSChi2NCl", 999.0, "ITS Chi2/NCl"};
-  Configurable<float> cfgTPCChi2NCl{"cfgTPCChi2NCl", 999.0, "TPC Chi2/NCl"};
-  Configurable<bool> cfgUseTPCRefit{"cfgUseTPCRefit", false, "Require TPC Refit"};
-  Configurable<bool> cfgUseITSRefit{"cfgUseITSRefit", false, "Require ITS Refit"};
-  Configurable<bool> cfgHasITS{"cfgHasITS", false, "Require ITS"};
-  Configurable<bool> cfgHasTPC{"cfgHasTPC", false, "Require TPC"};
-  Configurable<bool> cfgHasTOF{"cfgHasTOF", false, "Require TOF"};
+    Configurable<bool> cfgpTdepDCAxyCut{"cfgpTdepDCAxyCut", false, "pT-dependent DCAxy cut"};
+		Configurable<int> cfgITScluster{"cfgITScluster", 0, "Number of ITS cluster"};
+		Configurable<int> cfgTPCcluster{"cfgTPCcluster", 0, "Number of TPC cluster"};
+		Configurable<float> cfgRatioTPCRowsOverFindableCls{"cfgRatioTPCRowsOverFindableCls", 0.0f, "TPC Crossed Rows to Findable Clusters"};
+		Configurable<float> cfgITSChi2NCl{"cfgITSChi2NCl", 999.0, "ITS Chi2/NCl"};
+		Configurable<float> cfgTPCChi2NCl{"cfgTPCChi2NCl", 999.0, "TPC Chi2/NCl"};
+		Configurable<bool> cfgUseTPCRefit{"cfgUseTPCRefit", false, "Require TPC Refit"};
+		Configurable<bool> cfgUseITSRefit{"cfgUseITSRefit", false, "Require ITS Refit"};
+		Configurable<bool> cfgHasITS{"cfgHasITS", false, "Require ITS"};
+		Configurable<bool> cfgHasTPC{"cfgHasTPC", false, "Require TPC"};
+		Configurable<bool> cfgHasTOF{"cfgHasTOF", false, "Require TOF"};
+		// DCAr to PV
+		Configurable<float> cfgMaxbDCArToPVcut{"cfgMaxbDCArToPVcut", 0.1, "Track DCAr cut to PV Maximum"};
+		// DCAz to PV
+		Configurable<float> cfgMaxbDCAzToPVcut{"cfgMaxbDCAzToPVcut", 0.1, "Track DCAz cut to PV Maximum"};
+	} TrackCuts;
 
   // Secondary Selection
-  Configurable<bool> cfgReturnFlag{"boolReturnFlag", false, "Return Flag for debugging"};
-  Configurable<bool> cSecondaryRequire{"bool", true, "Secondary cuts on/off"};
-  Configurable<bool> cSecondaryArmenterosCut{"boolArmenterosCut", true, "cut on Armenteros-Podolanski graph"};
+	struct : ConfigurableGroup {
+    Configurable<bool> cfgReturnFlag{"cfgReturnFlag", false, "Return Flag for debugging"};
+		Configurable<bool> cfgSecondaryRequire{"cfgSecondaryRequire", true, "Secondary cuts on/off"};
+		Configurable<bool> cfgSecondaryArmenterosCut{"cfgSecondaryArmenterosCut", true, "cut on Armenteros-Podolanski graph"};
+    Configurable<bool> cfgSecondaryCrossMassHypothesisCut{"cfgSecondaryCrossMassHypothesisCut", false, "Apply cut based on the lambda mass hypothesis"};
 
-  Configurable<bool> cfgByPassDauPIDSelection{"cfgByPassDauPIDSelection", true, "Bypass Daughters PID selection"};
-  Configurable<float> cSecondaryDauDCAMax{"cSecondaryDauDCAMax", 1., "Maximum DCA Secondary daughters to PV"};
-  Configurable<float> cSecondaryDauPosDCAtoPVMin{"cSecondaryDauPosDCAtoPVMin", 0.0, "Minimum DCA Secondary positive daughters to PV"};
-  Configurable<float> cSecondaryDauNegDCAtoPVMin{"cSecondaryDauNegDCAtoPVMin", 0.0, "Minimum DCA Secondary negative daughters to PV"};
+		Configurable<bool> cfgByPassDauPIDSelection{"cfgByPassDauPIDSelection", true, "Bypass Daughters PID selection"};
+		Configurable<float> cfgSecondaryDauDCAMax{"cfgSecondaryDauDCAMax", 1., "Maximum DCA Secondary daughters to PV"};
+		Configurable<float> cfgSecondaryDauPosDCAtoPVMin{"cfgSecondaryDauPosDCAtoPVMin", 0.0, "Minimum DCA Secondary positive daughters to PV"};
+		Configurable<float> cfgSecondaryDauNegDCAtoPVMin{"cfgSecondaryDauNegDCAtoPVMin", 0.0, "Minimum DCA Secondary negative daughters to PV"};
 
-  Configurable<float> cSecondaryPtMin{"cSecondaryPtMin", 0.f, "Minimum transverse momentum of Secondary"};
-  Configurable<float> cSecondaryRapidityMax{"cSecondaryRapidityMax", 0.5, "Maximum rapidity of Secondary"};
-  Configurable<float> cSecondaryRadiusMin{"cSecondaryRadiusMin", 1.2, "Minimum transverse radius of Secondary"};
-  Configurable<float> cSecondaryCosPAMin{"cSecondaryCosPAMin", 0.995, "Mininum cosine pointing angle of Secondary"};
-  Configurable<float> cSecondaryDCAtoPVMax{"cSecondaryDCAtoPVMax", 0.3, "Maximum DCA Secondary to PV"};
-  Configurable<float> cSecondaryProperLifetimeMax{"cSecondaryProperLifetimeMax", 20, "Maximum Secondary Lifetime"};
-  Configurable<float> cSecondaryparamArmenterosCut{"paramArmenterosCut", 0.2, "parameter for Armenteros Cut"};
-  Configurable<float> cSecondaryMassWindow{"cSecondaryMassWindow", 0.075, "Secondary inv mass selciton window"};
+		Configurable<float> cfgSecondaryPtMin{"cfgSecondaryPtMin", 0.f, "Minimum transverse momentum of Secondary"};
+		Configurable<float> cfgSecondaryRapidityMax{"cfgSecondaryRapidityMax", 0.8, "Maximum rapidity of Secondary"};
+		Configurable<float> cfgSecondaryRadiusMin{"cfgSecondaryRadiusMin", 1.2, "Minimum transverse radius of Secondary"};
+    Configurable<float> cfgSecondaryRadiusMax{"cfgSecondaryRadiusMax", 999.9, "Maximum transverse radius of Secondary"};
+    Configurable<float> cfgSecondaryCosPAMin{"cfgSecondaryCosPAMin", 0.995, "Mininum cosine pointing angle of Secondary"};
+		Configurable<float> cfgSecondaryDCAtoPVMax{"cfgSecondaryDCAtoPVMax", 0.3, "Maximum DCA Secondary to PV"};
+		Configurable<float> cfgSecondaryProperLifetimeMax{"cfgSecondaryProperLifetimeMax", 20, "Maximum Secondary Lifetime"};
+		Configurable<float> cfgSecondaryparamArmenterosCut{"cfgSecondaryparamArmenterosCut", 0.2, "parameter for Armenteros Cut"};
+		Configurable<float> cfgSecondaryMassWindow{"cfgSecondaryMassWindow", 0.03, "Secondary inv mass selciton window"};
+    Configurable<float> cfgSecondaryCrossMassCutWindow{"cfgSecondaryCrossMassCutWindow", 0.05, "Secondary inv mass selection window with (anti)lambda hypothesis"};
+  } SecondaryCuts;
 
   // K* selection
-  Configurable<float> cKstarMaxRap{"cKstarMaxRap", 0.5, "Kstar maximum rapidity"};
-  Configurable<float> cKstarMinRap{"cKstarMinRap", -0.5, "Kstar minimum rapidity"};
+	struct : ConfigurableGroup {
+    Configurable<float> cfgKstarMaxRap{"cfgKstarMaxRap", 0.5, "Kstar maximum rapidity"};
+    Configurable<float> cfgKstarMinRap{"cfgKstarMinRap", -0.5, "Kstar minimum rapidity"};
+	} KstarCuts;
 
-  float centrality;
+  // Bkg estimation
+  struct : ConfigurableGroup {
+    Configurable<bool> cfgFillRotBkg{"cfgFillRotBkg", true, "Fill rotated background"};
+    Configurable<float> cfgMinRot{"cfgMinRot", 5.0 * constants::math::PI / 6.0, "Minimum of rotation"};
+    Configurable<float> cfgMaxRot{"cfgMaxRot", 7.0 * constants::math::PI / 6.0, "Maximum of rotation"};
+    Configurable<bool> cfgRotPion{"cfgRotPion", true, "Rotate pion"};
+    Configurable<int> cfgNrotBkg{"cfgNrotBkg", 4, "Number of rotated copies (background) per each original candidate"};
+  } BkgEstimationConfig;
+
+
+  float lCentrality;
 
   // PDG code
-  int kPDGK0s = 310;
-  int kPDGK0 = 311;
-  int kKstarPlus = 323;
-  int kPiPlus = 211;
+  int kPDGK0s = kK0Short;
+  int kPDGK0 = kK0;
+  int kKstarPlus = o2::constants::physics::Pdg::kKPlusStar892;
+  //int kPiPlus = 211;
 
   void init(o2::framework::InitContext&)
   {
-    centrality = -999;
+    lCentrality = -999;
 
-    colCuts.setCuts(ConfEvtZvtx, ConfEvtTriggerCheck, ConfEvtOfflineCheck, /*checkRun3*/ true, /*triggerTVXsel*/ false, ConfEvtOccupancyInTimeRangeMax, ConfEvtOccupancyInTimeRangeMin);
+    colCuts.setCuts(EventCuts.cfgEvtZvtx, EventCuts.cfgEvtTriggerCheck, EventCuts.cfgEvtOfflineCheck, /*checkRun3*/ true, /*triggerTVXsel*/ false, EventCuts.cfgEvtOccupancyInTimeRangeMax, EventCuts.cfgEvtOccupancyInTimeRangeMin);
     colCuts.init(&histos);
-    colCuts.setTriggerTVX(ConfEvtTriggerTVXSel);
-    colCuts.setApplyTFBorderCut(ConfEvtTFBorderCut);
-    colCuts.setApplyITSTPCvertex(ConfEvtUseITSTPCvertex);
-    colCuts.setApplyZvertexTimedifference(ConfEvtZvertexTimedifference);
-    colCuts.setApplyPileupRejection(ConfEvtPileupRejection);
-    colCuts.setApplyNoITSROBorderCut(ConfEvtNoITSROBorderCut);
-    colCuts.setApplyCollInTimeRangeStandard(ConfEvtCollInTimeRangeStandard);
+    colCuts.setTriggerTVX(EventCuts.cfgEvtTriggerTVXSel);
+    colCuts.setApplyTFBorderCut(EventCuts.cfgEvtTFBorderCut);
+    colCuts.setApplyITSTPCvertex(EventCuts.cfgEvtUseITSTPCvertex);
+    colCuts.setApplyZvertexTimedifference(EventCuts.cfgEvtZvertexTimedifference);
+    colCuts.setApplyPileupRejection(EventCuts.cfgEvtPileupRejection);
+    colCuts.setApplyNoITSROBorderCut(EventCuts.cfgEvtNoITSROBorderCut);
+    colCuts.setApplyCollInTimeRangeStandard(EventCuts.cfgEvtCollInTimeRangeStandard);
+		colCuts.printCuts();
 
-    AxisSpec centAxis = {cfgBinsCent, "T0M (%)"};
-    AxisSpec vtxzAxis = {cfgBinsVtxZ, "Z Vertex (cm)"};
+    rctChecker.init(EventCuts.cfgEvtRCTFlagCheckerLabel, EventCuts.cfgEvtRCTFlagCheckerZDCCheck, EventCuts.cfgEvtRCTFlagCheckerLimitAcceptAsBad);
+
+    AxisSpec centAxis = {AxisConfig.cfgBinsCent, "T0M (%)"};
+    AxisSpec vtxzAxis = {AxisConfig.cfgBinsVtxZ, "Z Vertex (cm)"};
     AxisSpec epAxis = {100, -1.0 * constants::math::PI, constants::math::PI};
     AxisSpec epresAxis = {100, -1.02, 1.02};
-    AxisSpec ptAxis = {cfgBinsPt, "#it{p}_{T} (GeV/#it{c})"};
-    AxisSpec ptAxisQA = {cfgBinsPtQA, "#it{p}_{T} (GeV/#it{c})"};
+    AxisSpec ptAxis = {AxisConfig.cfgBinsPt, "#it{p}_{T} (GeV/#it{c})"};
+    AxisSpec ptAxisQA = {AxisConfig.cfgBinsPtQA, "#it{p}_{T} (GeV/#it{c})"};
     AxisSpec radiusAxis = {50, 0, 5, "Radius (cm)"};
     AxisSpec cpaAxis = {50, 0.95, 1.0, "CPA"};
     AxisSpec tauAxis = {250, 0, 25, "Lifetime (cm)"};
@@ -244,15 +276,14 @@ struct chk892pp {
     AxisSpec dcaxyAxis = {200, 0, 2, "DCA_{#it{xy}} (cm)"};
     AxisSpec dcazAxis = {200, 0, 2, "DCA_{#it{z}} (cm)"};
     AxisSpec yAxis = {100, -1, 1, "Rapidity"};
-    AxisSpec invMassAxisK0s = {400 / cNbinsDiv, 0.3, 0.7, "Invariant Mass (GeV/#it{c}^2)"};    // K0s ~497.611
-    AxisSpec invMassAxisReso = {900 / cNbinsDiv, 0.5f, 1.4f, "Invariant Mass (GeV/#it{c}^2)"}; // chK(892) ~892
-    AxisSpec invMassAxisScan = {150, 0, 1.5, "Invariant Mass (GeV/#it{c}^2)"};                 // For selection
-    AxisSpec pidQAAxis = {130, -6.5, 6.5};
+    AxisSpec invMassAxisK0s = {800 / AxisConfig.cNbinsDiv, 0.46, 0.54, "Invariant Mass (GeV/#it{c}^2)"};    // K0s ~497.611
+    AxisSpec invMassAxisReso = {900 / AxisConfig.cNbinsDiv, 0.5f, 1.4f, "Invariant Mass (GeV/#it{c}^2)"}; // chK(892) ~892
+    AxisSpec pidQAAxis = {130 / AxisConfig.cNbinsDivQA, -6.5, 6.5};
     AxisSpec dataTypeAxis = {9, 0, 9, "Histogram types"};
     AxisSpec mcTypeAxis = {4, 0, 4, "Histogram types"};
 
     // THnSparse
-    AxisSpec axisType = {binType::kTYEnd, 0, binType::kTYEnd, "Type of bin with charge and mix"};
+    AxisSpec axisType = {BinType::kTYEnd, 0, BinType::kTYEnd, "Type of bin with charge and mix"};
     AxisSpec mcLabelAxis = {5, -0.5, 4.5, "MC Label"};
 
     histos.add("QA/K0sCutCheck", "Check K0s cut", HistType::kTH1D, {AxisSpec{12, -0.5, 11.5, "Check"}});
@@ -397,7 +428,7 @@ struct chk892pp {
 
       histos.add("hInvmass_Kstar_MC", "Invariant mass of unlike chK(892)", HistType::kTHnSparseD, {axisType, centAxis, ptAxis, invMassAxisReso});
 
-      ccdb->setURL(cfgURL);
+      ccdb->setURL(CCDBConfig.cfgURL);
       ccdbApi.init("http://alice-ccdb.cern.ch");
       ccdb->setCaching(true);
       ccdb->setLocalObjectValidityChecking();
@@ -410,7 +441,7 @@ struct chk892pp {
   }
 
   template <typename CollisionType>
-  float GetCentrality(CollisionType const& collision)
+  float getCentrality(CollisionType const& collision)
   {
     if (cfgCentEst == 1) {
       return collision.multFT0C();
@@ -422,7 +453,7 @@ struct chk892pp {
   }
 
   template <typename DetNameType>
-  int GetDetId(DetNameType const& name)
+  int getlDetId(DetNameType const& name)
   {
     LOGF(info, "GetDetID running");
     if (name.value == "FT0C") {
@@ -447,41 +478,47 @@ struct chk892pp {
   bool trackCut(TrackType const& track)
   {
     // basic track cuts
-    if (std::abs(track.pt()) < cMinPtcut)
+    if (std::abs(track.pt()) < TrackCuts.cfgMinPtcut)
       return false;
-    if (std::abs(track.eta()) > cMaxEtacut)
+    if (std::abs(track.eta()) > TrackCuts.cfgMaxEtacut)
       return false;
-    if (track.itsNCls() < cfgITScluster)
+    if (track.itsNCls() < TrackCuts.cfgITScluster)
       return false;
-    if (track.tpcNClsFound() < cfgTPCcluster)
+    if (track.tpcNClsFound() < TrackCuts.cfgTPCcluster)
       return false;
-    if (track.tpcCrossedRowsOverFindableCls() < cfgRatioTPCRowsOverFindableCls)
+    if (track.tpcCrossedRowsOverFindableCls() < TrackCuts.cfgRatioTPCRowsOverFindableCls)
       return false;
-    if (track.itsChi2NCl() >= cfgITSChi2NCl)
+    if (track.itsChi2NCl() >= TrackCuts.cfgITSChi2NCl)
       return false;
-    if (track.tpcChi2NCl() >= cfgTPCChi2NCl)
+    if (track.tpcChi2NCl() >= TrackCuts.cfgTPCChi2NCl)
       return false;
-    if (cfgHasITS && !track.hasITS())
+    if (TrackCuts.cfgHasITS && !track.hasITS())
       return false;
-    if (cfgHasTPC && !track.hasTPC())
+    if (TrackCuts.cfgHasTPC && !track.hasTPC())
       return false;
-    if (cfgHasTOF && !track.hasTOF())
+    if (TrackCuts.cfgHasTOF && !track.hasTOF())
       return false;
-    if (cfgUseITSRefit && !track.passedITSRefit())
+    if (TrackCuts.cfgUseITSRefit && !track.passedITSRefit())
       return false;
-    if (cfgUseTPCRefit && !track.passedTPCRefit())
+    if (TrackCuts.cfgUseTPCRefit && !track.passedTPCRefit())
       return false;
-    if (cfgPVContributor && !track.isPVContributor())
+    if (TrackCuts.cfgPVContributor && !track.isPVContributor())
       return false;
-    if (cfgGlobalWoDCATrack && !track.isGlobalTrackWoDCA())
+    if (TrackCuts.cfgGlobalWoDCATrack && !track.isGlobalTrackWoDCA())
       return false;
-    if (cfgGlobalTrack && !track.isGlobalTrack())
+    if (TrackCuts.cfgGlobalTrack && !track.isGlobalTrack())
       return false;
-    if (cfgPrimaryTrack && !track.isPrimaryTrack())
+    if (TrackCuts.cfgPrimaryTrack && !track.isPrimaryTrack())
       return false;
-    if (std::abs(track.dcaXY()) > cMaxbDCArToPVcut)
-      return false;
-    if (std::abs(track.dcaZ()) > cMaxbDCAzToPVcut)
+		if (TrackCuts.cfgpTdepDCAxyCut) {
+      // Tuned on the LHC22f anchored MC LHC23d1d on primary pions. 7 Sigmas of the resolution
+      if (std::abs(track.dcaXY()) > (0.004 + (0.013 / track.pt())))
+				return false;
+		} else {
+			if (std::abs(track.dcaXY()) > TrackCuts.cfgMaxbDCArToPVcut)
+				return false;
+		}
+    if (std::abs(track.dcaZ()) > TrackCuts.cfgMaxbDCAzToPVcut)
       return false;
     return true;
   }
@@ -490,217 +527,158 @@ struct chk892pp {
   template <typename TrackType>
   bool selectionPIDPion(TrackType const& candidate)
   {
-    bool tpcPIDPassed{false}, tofPIDPassed{false};
+    bool tpcPIDPassed = std::abs(candidate.tpcNSigmaPi()) < PIDCuts.cfgMaxTPCnSigmaPion;
+    bool tofPIDPassed = false;
 
-    if (cTPConly) {
+    if (PIDCuts.cfgTPConly) {
+      return tpcPIDPassed;
+    }
 
-      if (std::abs(candidate.tpcNSigmaPi()) < cMaxTPCnSigmaPion) {
-        tpcPIDPassed = true;
-      } else {
-        return false;
-      }
-      tofPIDPassed = true;
-
+    if (candidate.hasTOF()) {
+      tofPIDPassed = std::abs(candidate.tofNSigmaPi()) < PIDCuts.cfgMaxTOFnSigmaPion ||
+                     (PIDCuts.cfgNsigmaCutCombinedPion > 0 &&
+                      candidate.tpcNSigmaPi() * candidate.tpcNSigmaPi() +
+                          candidate.tofNSigmaPi() * candidate.tofNSigmaPi() <
+                        PIDCuts.cfgNsigmaCutCombinedPion * PIDCuts.cfgNsigmaCutCombinedPion);
     } else {
-
-      if (std::abs(candidate.tpcNSigmaPi()) < cMaxTPCnSigmaPion) {
-        tpcPIDPassed = true;
-      } else {
-        return false;
-      }
-      if (candidate.hasTOF()) {
-        if (std::abs(candidate.tofNSigmaPi()) < cMaxTOFnSigmaPion) {
-          tofPIDPassed = true;
-        }
-        if ((nsigmaCutCombinedPion > 0) && (candidate.tpcNSigmaPi() * candidate.tpcNSigmaPi() + candidate.tofNSigmaPi() * candidate.tofNSigmaPi() < nsigmaCutCombinedPion * nsigmaCutCombinedPion)) {
-          tofPIDPassed = true;
-        }
-      } else {
-        if (!cTOFVeto) {
-          return false;
-        }
-        tofPIDPassed = true;
-      }
+      tofPIDPassed = PIDCuts.cfgTOFVeto;
     }
 
-    if (tpcPIDPassed && tofPIDPassed) {
-      return true;
-    }
-    return false;
+    return tpcPIDPassed && tofPIDPassed;
   }
 
   template <typename CollisionType, typename K0sType>
   bool selectionK0s(CollisionType const& collision, K0sType const& candidate)
   {
-    auto DauDCA = candidate.dcaV0daughters();
-    auto DauPosDCAtoPV = candidate.dcapostopv();
-    auto DauNegDCAtoPV = candidate.dcanegtopv();
-    auto pT = candidate.pt();
-    auto Rapidity = candidate.yK0Short();
-    auto Radius = candidate.v0radius();
-    auto DCAtoPV = candidate.dcav0topv();
-    auto CPA = candidate.v0cosPA();
-    auto PropTauK0s = candidate.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * MassK0Short;
-    auto mK0s = candidate.mK0Short();
+    auto lDauDCA = candidate.dcaV0daughters();
+    auto lDauPosDCAtoPV = candidate.dcapostopv();
+    auto lDauNegDCAtoPV = candidate.dcanegtopv();
+    auto lPt = candidate.pt();
+    auto lRapidity = candidate.yK0Short();
+    auto lRadius = candidate.v0radius();
+    auto lDCAtoPV = candidate.dcav0topv();
+    auto lCPA = candidate.v0cosPA();
+    auto lPropTauK0s = candidate.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * MassK0Short;
+    auto lMk0s = candidate.mK0Short();
+		auto lMLambda = candidate.mLambda();
+    auto lMALambda = candidate.mAntiLambda();
 
-    if (cfgReturnFlag) {
+		auto checkCommonCuts = [&]() {
+      if (lDauDCA > SecondaryCuts.cfgSecondaryDauDCAMax)
+        return false;
+      if (lDauPosDCAtoPV < SecondaryCuts.cfgSecondaryDauPosDCAtoPVMin)
+        return false;
+      if (lDauNegDCAtoPV < SecondaryCuts.cfgSecondaryDauNegDCAtoPVMin)
+        return false;
+      if (lPt < SecondaryCuts.cfgSecondaryPtMin)
+        return false;
+      if (std::fabs(lRapidity) > SecondaryCuts.cfgSecondaryRapidityMax)
+        return false;
+      if (lRadius < SecondaryCuts.cfgSecondaryRadiusMin || lRadius > SecondaryCuts.cfgSecondaryRadiusMax)
+        return false;
+      if (lDCAtoPV > SecondaryCuts.cfgSecondaryDCAtoPVMax)
+        return false;
+      if (lCPA < SecondaryCuts.cfgSecondaryCosPAMin)
+        return false;
+      if (lPropTauK0s > SecondaryCuts.cfgSecondaryProperLifetimeMax)
+        return false;
+      if (candidate.qtarm() < SecondaryCuts.cfgSecondaryparamArmenterosCut * std::abs(candidate.alpha()))
+        return false;
+      if (std::fabs(lMk0s - MassK0Short) > SecondaryCuts.cfgSecondaryMassWindow)
+        return false;
+      if (SecondaryCuts.cfgSecondaryCrossMassHypothesisCut &&
+          ((std::fabs(lMLambda - MassLambda0) < SecondaryCuts.cfgSecondaryCrossMassCutWindow) || (std::fabs(lMALambda - MassLambda0Bar) < SecondaryCuts.cfgSecondaryCrossMassCutWindow)))
+        return false;
+      return true;
+    };
+
+		if (SecondaryCuts.cfgReturnFlag) { // For cut study
       bool returnFlag = true;
-
-      if (cSecondaryRequire) {
-        histos.fill(HIST("QA/K0sCutCheck"), 0);
-        if (DauDCA > cSecondaryDauDCAMax) {
-          histos.fill(HIST("QA/K0sCutCheck"), 1);
-          returnFlag = false;
-        }
-        if (DauPosDCAtoPV < cSecondaryDauPosDCAtoPVMin) {
-          histos.fill(HIST("QA/K0sCutCheck"), 2);
-          returnFlag = false;
-        }
-        if (DauNegDCAtoPV < cSecondaryDauNegDCAtoPVMin) {
-          histos.fill(HIST("QA/K0sCutCheck"), 3);
-          returnFlag = false;
-        }
-        if (pT < cSecondaryPtMin) {
-          histos.fill(HIST("QA/K0sCutCheck"), 4);
-          returnFlag = false;
-        }
-        if (Rapidity > cSecondaryRapidityMax) {
-          histos.fill(HIST("QA/K0sCutCheck"), 5);
-          returnFlag = false;
-        }
-        if (Radius < cSecondaryRadiusMin) {
-          histos.fill(HIST("QA/K0sCutCheck"), 6);
-          returnFlag = false;
-        }
-        if (DCAtoPV > cSecondaryDCAtoPVMax) {
-          histos.fill(HIST("QA/K0sCutCheck"), 7);
-          returnFlag = false;
-        }
-        if (CPA < cSecondaryCosPAMin) {
-          histos.fill(HIST("QA/K0sCutCheck"), 8);
-          returnFlag = false;
-        }
-        if (PropTauK0s > cSecondaryProperLifetimeMax) {
-          histos.fill(HIST("QA/K0sCutCheck"), 9);
-          returnFlag = false;
-        }
-        if (candidate.qtarm() < cSecondaryparamArmenterosCut * TMath::Abs(candidate.alpha())) {
-          histos.fill(HIST("QA/K0sCutCheck"), 11);
-          returnFlag = false;
-        }
-        if (fabs(mK0s - MassK0Short) > cSecondaryMassWindow) {
-          histos.fill(HIST("QA/K0sCutCheck"), 10);
-          returnFlag = false;
-        }
-
-        return returnFlag;
-
-      } else {
-        if (fabs(mK0s - MassK0Short) > cSecondaryMassWindow) {
-          histos.fill(HIST("QA/K0sCutCheck"), 10);
-          returnFlag = false;
-        }
-
-        return returnFlag;
+      histos.fill(HIST("QA/K0sCutCheck"), 0);
+      if (lDauDCA > SecondaryCuts.cfgSecondaryDauDCAMax) {
+        histos.fill(HIST("QA/K0sCutCheck"), 1);
+        returnFlag = false;
       }
-
-    } else {
-      if (cSecondaryRequire) {
-
-        histos.fill(HIST("QA/K0sCutCheck"), 0);
-        if (DauDCA > cSecondaryDauDCAMax) {
-          histos.fill(HIST("QA/K0sCutCheck"), 1);
-          return false;
-        }
-        if (DauPosDCAtoPV < cSecondaryDauPosDCAtoPVMin) {
-          histos.fill(HIST("QA/K0sCutCheck"), 2);
-          return false;
-        }
-        if (DauNegDCAtoPV < cSecondaryDauNegDCAtoPVMin) {
-          histos.fill(HIST("QA/K0sCutCheck"), 3);
-          return false;
-        }
-        if (pT < cSecondaryPtMin) {
-          histos.fill(HIST("QA/K0sCutCheck"), 4);
-          return false;
-        }
-        if (Rapidity > cSecondaryRapidityMax) {
-          histos.fill(HIST("QA/K0sCutCheck"), 5);
-          return false;
-        }
-        if (Radius < cSecondaryRadiusMin) {
-          histos.fill(HIST("QA/K0sCutCheck"), 6);
-          return false;
-        }
-        if (DCAtoPV > cSecondaryDCAtoPVMax) {
-          histos.fill(HIST("QA/K0sCutCheck"), 7);
-          return false;
-        }
-        if (CPA < cSecondaryCosPAMin) {
-          histos.fill(HIST("QA/K0sCutCheck"), 8);
-          return false;
-        }
-        if (PropTauK0s > cSecondaryProperLifetimeMax) {
-          histos.fill(HIST("QA/K0sCutCheck"), 9);
-          return false;
-        }
-        if (candidate.qtarm() < cSecondaryparamArmenterosCut * TMath::Abs(candidate.alpha())) {
-          histos.fill(HIST("QA/K0sCutCheck"), 11);
-          return false;
-        }
-        if (fabs(mK0s - MassK0Short) > cSecondaryMassWindow) {
-          histos.fill(HIST("QA/K0sCutCheck"), 10);
-          return false;
-        }
-        return true;
-
+      if (lDauPosDCAtoPV < SecondaryCuts.cfgSecondaryDauPosDCAtoPVMin) {
+        histos.fill(HIST("QA/K0sCutCheck"), 2);
+        returnFlag = false;
+      }
+      if (lDauNegDCAtoPV < SecondaryCuts.cfgSecondaryDauNegDCAtoPVMin) {
+        histos.fill(HIST("QA/K0sCutCheck"), 3);
+        returnFlag = false;
+      }
+      if (lPt < SecondaryCuts.cfgSecondaryPtMin) {
+        histos.fill(HIST("QA/K0sCutCheck"), 4);
+        returnFlag = false;
+      }
+      if (std::fabs(lRapidity) > SecondaryCuts.cfgSecondaryRapidityMax) {
+        histos.fill(HIST("QA/K0sCutCheck"), 5);
+        returnFlag = false;
+      }
+      if (lRadius < SecondaryCuts.cfgSecondaryRadiusMin || lRadius > SecondaryCuts.cfgSecondaryRadiusMax) {
+        histos.fill(HIST("QA/K0sCutCheck"), 6);
+        returnFlag = false;
+      }
+      if (lDCAtoPV > SecondaryCuts.cfgSecondaryDCAtoPVMax) {
+        histos.fill(HIST("QA/K0sCutCheck"), 7);
+        returnFlag = false;
+      }
+      if (lCPA < SecondaryCuts.cfgSecondaryCosPAMin) {
+        histos.fill(HIST("QA/K0sCutCheck"), 8);
+        returnFlag = false;
+      }
+      if (lPropTauK0s > SecondaryCuts.cfgSecondaryProperLifetimeMax) {
+        histos.fill(HIST("QA/K0sCutCheck"), 9);
+        returnFlag = false;
+      }
+      if (candidate.qtarm() < SecondaryCuts.cfgSecondaryparamArmenterosCut * std::abs(candidate.alpha())) {
+        histos.fill(HIST("QA/K0sCutCheck"), 10);
+        returnFlag = false;
+      }
+      if (std::fabs(lMk0s - MassK0Short) > SecondaryCuts.cfgSecondaryMassWindow) {
+        histos.fill(HIST("QA/K0sCutCheck"), 11);
+        returnFlag = false;
+      }
+      if (SecondaryCuts.cfgSecondaryCrossMassHypothesisCut &&
+          ((std::fabs(lMLambda - MassLambda0) < SecondaryCuts.cfgSecondaryCrossMassCutWindow) || (std::fabs(lMALambda - MassLambda0Bar) < SecondaryCuts.cfgSecondaryCrossMassCutWindow))) {
+        histos.fill(HIST("QA/K0sCutCheck"), 12);
+        returnFlag = false;
+      }
+      return returnFlag;
+    } else { // normal usage
+      if (SecondaryCuts.cfgSecondaryRequire) {
+        return checkCommonCuts();
       } else {
-        if (fabs(mK0s - MassK0Short) > cSecondaryMassWindow) {
-          histos.fill(HIST("QA/K0sCutCheck"), 10);
-          return false;
-        }
-        return true;
+        return std::fabs(lMk0s - MassK0Short) <= SecondaryCuts.cfgSecondaryMassWindow; // always apply mass window cut
       }
     }
   } // selectionK0s
 
-  double GetPhiInRange(double phi)
-  {
-    double result = phi;
-    while (result < 0) {
-      result = result + 2. * TMath::Pi() / 2;
-    }
-    while (result > 2. * TMath::Pi() / 2) {
-      result = result - 2. * TMath::Pi() / 2;
-    }
-    return result;
-  }
-
   template <typename TrackTemplate, typename V0Template>
   bool isTrueKstar(const TrackTemplate& bTrack, const V0Template& K0scand)
   {
-    if (abs(bTrack.PDGCode()) != kPiPlus) // Are you pion?
+    if (std::abs(bTrack.PDGCode()) != kPiPlus) // Are you pion?
       return false;
-    if (abs(K0scand.PDGCode()) != kPDGK0s) // Are you K0s?
+    if (std::abs(K0scand.PDGCode()) != kPDGK0s) // Are you K0s?
       return false;
 
     auto motherbTrack = bTrack.template mothers_as<aod::McParticles>();
     auto motherkV0 = K0scand.template mothers_as<aod::McParticles>();
 
     // Check bTrack first
-    if (abs(motherbTrack.pdgCode()) != kKstarPlus) // Are you charged Kstar's daughter?
+    if (std::abs(motherbTrack.pdgCode()) != kKstarPlus) // Are you charged Kstar's daughter?
       return false;                                // Apply first since it's more restrictive
 
-    if (abs(motherkV0.pdgCode()) != 310) // Is it K0s?
+    if (std::abs(motherkV0.pdgCode()) != 310) // Is it K0s?
       return false;
     // Check if K0s's mother is K0 (311)
     auto motherK0 = motherkV0.template mothers_as<aod::McParticles>();
-    if (abs(motherK0.pdgCode()) != 311)
+    if (std::abs(motherK0.pdgCode()) != 311)
       return false;
 
     // Check if K0's mother is Kstar (323)
     auto motherKstar = motherK0.template mothers_as<aod::McParticles>();
-    if (abs(motherKstar.pdgCode()) != 323)
+    if (std::abs(motherKstar.pdgCode()) != 323)
       return false;
 
     // Check if bTrack and K0 have the same mother (global index)
@@ -715,9 +693,9 @@ struct chk892pp {
   template <bool IsMC, bool IsMix, typename CollisionType, typename TracksType, typename TracksTypeK0s>
   void fillHistograms(const CollisionType& collision, const TracksType& dTracks1, const TracksTypeK0s& dTracks2)
   {
-    histos.fill(HIST("QA/before/CentDist"), centrality);
+    histos.fill(HIST("QA/before/CentDist"), lCentrality);
 
-    TLorentzVector lDecayDaughter1, lDecayDaughter2, lResoSecondary, lDecayDaughter_bach, lResoKstar;
+    TLorentzVector lDecayDaughter1, lDecayDaughter2, lResoSecondary, lDecayDaughter_bach, lResoKstar, lDaughterRot, lResonanceRot;
     std::vector<int> trackIndicies = {};
     std::vector<int> k0sIndicies = {};
 
@@ -758,9 +736,9 @@ struct chk892pp {
       trackIndicies.push_back(bTrack.index());
     }
 
-    for (auto& K0scand : dTracks2) {
-      auto posDauTrack = K0scand.template posTrack_as<TrackCandidates>();
-      auto negDauTrack = K0scand.template negTrack_as<TrackCandidates>();
+    for (auto& k0sCand : dTracks2) {
+      auto posDauTrack = k0sCand.template posTrack_as<TrackCandidates>();
+      auto negDauTrack = k0sCand.template negTrack_as<TrackCandidates>();
 
       /// Daughters
       // Positve pion
@@ -775,16 +753,16 @@ struct chk892pp {
       auto trknNSigmaPiTOF = (istrknhasTOF) ? negDauTrack.tofNSigmaPi() : -999.;
 
       /// K0s
-      auto trkkDauDCA = K0scand.dcaV0daughters();
-      auto trkkDauDCAPostoPV = K0scand.dcapostopv();
-      auto trkkDauDCANegtoPV = K0scand.dcanegtopv();
-      auto trkkpt = K0scand.pt();
-      auto trkky = K0scand.yK0Short();
-      auto trkkRadius = K0scand.v0radius();
-      auto trkkDCAtoPV = K0scand.dcav0topv();
-      auto trkkCPA = K0scand.v0cosPA();
-      auto trkkPropTau = K0scand.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * MassK0Short;
-      auto trkkMass = K0scand.mK0Short();
+      auto trkkDauDCA = k0sCand.dcaV0daughters();
+      auto trkky = k0sCand.yK0Short();
+      auto trkkDCAtoPV = k0sCand.dcav0topv();
+      auto trkkCPA = k0sCand.v0cosPA();
+      auto trkkPropTau = k0sCand.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * MassK0Short;
+      auto trkkMass = k0sCand.mK0Short();
+      auto trkkDauDCAPostoPV = k0sCand.dcapostopv();
+      auto trkkDauDCANegtoPV = k0sCand.dcanegtopv();
+      auto trkkpt = k0sCand.pt();
+      auto trkkRadius = k0sCand.v0radius();
 
       if constexpr (!IsMix) {
         // Seconddary QA plots
@@ -819,13 +797,11 @@ struct chk892pp {
         histos.fill(HIST("QA/before/hInvmassSecondary"), trkkMass);
       }
 
-      // if (!trackCut(posDauTrack) || !trackCut(negDauTrack)) // Too tight cut for K0s daugthers
-      //   continue;
-      if (!cfgByPassDauPIDSelection && !selectionPIDPion(posDauTrack)) // Perhaps it's already applied in trackCut (need to check QA plots)
+      if (!SecondaryCuts.cfgByPassDauPIDSelection && !selectionPIDPion(posDauTrack))
         continue;
-      if (!cfgByPassDauPIDSelection && !selectionPIDPion(negDauTrack))
+      if (!SecondaryCuts.cfgByPassDauPIDSelection && !selectionPIDPion(negDauTrack))
         continue;
-      if (!selectionK0s(collision, K0scand))
+      if (!selectionK0s(collision, k0sCand))
         continue;
 
       if constexpr (!IsMix) {
@@ -860,17 +836,19 @@ struct chk892pp {
         histos.fill(HIST("QA/after/hCPASecondary"), trkkCPA);
         histos.fill(HIST("QA/after/hPropTauSecondary"), trkkPropTau);
         histos.fill(HIST("QA/after/hInvmassSecondary"), trkkMass);
+				histos.fill(HIST("hInvmass_K0s"), lCentrality, lResoSecondary.Pt(), lResoSecondary.M());
       }
-      k0sIndicies.push_back(K0scand.index());
+      k0sIndicies.push_back(k0sCand.index());
     }
 
     for (auto& trackIndex : trackIndicies) {
       for (auto& k0sIndex : k0sIndicies) {
         auto bTrack = dTracks1.rawIteratorAt(trackIndex);
-        auto K0scand = dTracks2.rawIteratorAt(k0sIndex);
+        auto k0sCand = dTracks2.rawIteratorAt(k0sIndex);
+				auto trkkMass = k0sCand.mK0Short();
 
         lDecayDaughter_bach.SetXYZM(bTrack.px(), bTrack.py(), bTrack.pz(), MassPionCharged);
-        lResoSecondary.SetXYZM(K0scand.px(), K0scand.py(), K0scand.pz(), MassK0Short);
+        lResoSecondary.SetXYZM(k0sCand.px(), k0sCand.py(), k0sCand.pz(), trkkMass);
         lResoKstar = lResoSecondary + lDecayDaughter_bach;
 
         // QA plots
@@ -879,16 +857,33 @@ struct chk892pp {
           histos.fill(HIST("QA/before/kstarinvmass"), lResoKstar.M());
         }
 
-        if (lResoKstar.Rapidity() > cKstarMaxRap || lResoKstar.Rapidity() < cKstarMinRap)
+        if (lResoKstar.Rapidity() > KstarCuts.cfgKstarMaxRap || lResoKstar.Rapidity() < KstarCuts.cfgKstarMinRap)
           continue;
 
         if constexpr (!IsMix) {
-          unsigned int typeKstar = bTrack.sign() > 0 ? binType::kKstarP : binType::kKstarN;
+          unsigned int typeKstar = bTrack.sign() > 0 ? BinType::kKstarP : BinType::kKstarN;
 
           histos.fill(HIST("QA/after/KstarRapidity"), lResoKstar.Rapidity());
           histos.fill(HIST("QA/after/kstarinvmass"), lResoKstar.M());
-          histos.fill(HIST("hInvmass_Kstar"), typeKstar, centrality, lResoKstar.Pt(), lResoKstar.M());
+          histos.fill(HIST("hInvmass_Kstar"), typeKstar, lCentrality, lResoKstar.Pt(), lResoKstar.M());
 
+					if (BkgEstimationConfig.cfgFillRotBkg) {
+						for (int i = 0; i < BkgEstimationConfig.cfgNrotBkg; i++) {
+							auto lRotAngle = BkgEstimationConfig.cfgMinRot + i * ((BkgEstimationConfig.cfgMaxRot - BkgEstimationConfig.cfgMinRot) / (BkgEstimationConfig.cfgNrotBkg - 1));
+							histos.fill(HIST("QA/RotBkg/hRotBkg"), lRotAngle);
+							if (BkgEstimationConfig.cfgRotPion) {
+								lDaughterRot = lDecayDaughter_bach;
+								lDaughterRot.RotateZ(lRotAngle);
+								lResonanceRot = lDaughterRot + lResoSecondary;
+							} else {
+								lDaughterRot = lResoSecondary;
+								lDaughterRot.RotateZ(lRotAngle);
+								lResonanceRot = lDecayDaughter_bach + lDaughterRot;
+							}
+							typeKstar = bTrack.sign() > 0 ? BinType::kKstarP_Rot : BinType::kKstarN_Rot;
+							histos.fill(HIST("hInvmass_Kstar"), typeKstar, lCentrality, lResonanceRot.Pt(), lResonanceRot.M());
+						}
+					}
         } // IsMix
       } // K0scand
     } // bTrack
@@ -905,12 +900,17 @@ struct chk892pp {
   {
     if (!colCuts.isSelected(collision)) // Default event selection
       return;
+    if (EventCuts.cfgEvtUseRCTFlagChecker && !rctChecker(collision)) {
+      return;
+    }
+    lCentrality = getCentrality(collision);
+    if (lCentrality < EventCuts.cfgEventCentralityMin || lCentrality > EventCuts.cfgEventCentralityMax)
+      return;
     colCuts.fillQA(collision);
-    centrality = GetCentrality(collision);
 
     fillHistograms<false, false>(collision, tracks, v0s); // second order
   }
-  PROCESS_SWITCH(chk892pp, processData, "Process Event for data without Partitioning", true);
+  PROCESS_SWITCH(Chk892pp, processData, "Process Event for data without Partitioning", true);
 
   // process MC reconstructed level
   void processMC(EventCandidates::iterator const& collision,
@@ -922,9 +922,9 @@ struct chk892pp {
 
     fillHistograms<true, false>(collision, tracks, v0s);
   }
-  PROCESS_SWITCH(chk892pp, processMC, "Process Event for MC", false);
+  PROCESS_SWITCH(Chk892pp, processMC, "Process Event for MC", false);
 };
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{adaptAnalysisTask<chk892pp>(cfgc, TaskName{"lf-chk892pp"})};
+  return WorkflowSpec{adaptAnalysisTask<Chk892pp>(cfgc)};
 }


### PR DESCRIPTION
For the analysis code 'chk892pp.cxx',
 - Rotational background is added to describe the combinatorial background
 - Configurables for secondary selections (Lambda mass hypothesis cut, maximum radius)
 - Grouping configurables depending on the selections
 - Fixed some of o2linter issues