### PR TITLE
[Infrastructure] Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -58,7 +58,7 @@
 /PWGMM/Lumi @alibuild @aalkin @jgcn
 /PWGMM/UE   @alibuild @aalkin @aortizve @jgcn
 
-/PWGUD @alibuild @pbuehler @amatyja @rolavick
+/PWGUD @alibuild @pbuehler @nystrand @rolavick
 /PWGJE @alibuild @lhavener @maoyx @nzardosh @fjonasALICE @mfasDa @mhemmer-cern
 /Tools/PIDML @alibuild @saganatt
 /Tools/ML @alibuild @fcatalan92 @fmazzasc


### PR DESCRIPTION
Adding the other PWG-UD convener. Good to have one more PR approver during the summer holidays. Deleting Sasha Bylinkin as he left ALICE.