### PR TITLE
[PWGLF] Fix initialization of ccdbApi in strangenessbuilder

### DIFF
--- a/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
@@ -771,6 +771,9 @@ struct StrangenessBuilder {
     if (DeduplicationOpts.deduplicationAlgorithm.value == 4 || DeduplicationOpts.deduplicationAlgorithm.value == 6) {
       if (DeduplicationOpts.loadModelsFromCCDB) {
 
+        // Retrieve the model from CCDB
+        ccdbApi.init(ccdbConfigurations.ccdburl);
+        
         /// Fetching model for specific timestamp
         LOG(info) << "Fetching model for timestamp: " << DeduplicationOpts.timestampCCDB.value;
 


### PR DESCRIPTION
This PR includes the initialization of the ccdbApi object in the strangenessbuilder to load BDT models from the CCDB. 

Tagging @romainschotter @ddobrigk 