### PR TITLE
[PWGLF] Add TPC PID clusters and PID info to He3 and Lambda

### DIFF
--- a/PWGLF/DataModel/LFSlimHeLambda.h
+++ b/PWGLF/DataModel/LFSlimHeLambda.h
@@ -42,17 +42,22 @@ DECLARE_SOA_COLUMN(CosPA, cosPA, float);
 DECLARE_SOA_COLUMN(DCAxy, dcaXY, float);
 DECLARE_SOA_COLUMN(DCAz, dcaZ, float);
 DECLARE_SOA_COLUMN(TPCnCls, tpcNCls, int);
+DECLARE_SOA_COLUMN(TPCnClsPID, tpcNClsPID, int);
 DECLARE_SOA_COLUMN(ITSClusterSizes, itsClusterSizes, uint32_t);
+DECLARE_SOA_COLUMN(NsigmaTPCPion, nSigmaTPCPion, float);
+DECLARE_SOA_COLUMN(NsigmaTPCProton, nSigmaTPCProton, float);
 DECLARE_SOA_COLUMN(NsigmaTPC, nSigmaTPC, float);
-// DECLARE_SOA_COLUMN(NsigmaTPCproton, nSigmaTPCproton, float);
 DECLARE_SOA_COLUMN(DCAdaughters, dcaDaughters, float);
 DECLARE_SOA_COLUMN(DCAPVProton, dcaPVProton, float);
 DECLARE_SOA_COLUMN(DCAPVPion, dcaPVPion, float);
 DECLARE_SOA_COLUMN(V0Radius, v0Radius, float);
 DECLARE_SOA_COLUMN(Sign, sign, int8_t);
 } // namespace lfv0he3
-DECLARE_SOA_TABLE(LFHe3, "AOD", "LFHE3V0", lfv0he3::LFEventId, lfv0he3::Pt, lfv0he3::Eta, lfv0he3::Phi, lfv0he3::DCAxy, lfv0he3::DCAz, lfv0he3::TPCnCls, lfv0he3::ITSClusterSizes, lfv0he3::NsigmaTPC, lfv0he3::Sign);
-DECLARE_SOA_TABLE(LFLambda, "AOD", "LFLAMBDA", lfv0he3::LFEventId, lfv0he3::Pt, lfv0he3::Eta, lfv0he3::Phi, lfv0he3::Mass, lfv0he3::CosPA, lfv0he3::DCAdaughters, lfv0he3::DCAPVProton, lfv0he3::DCAPVPion, lfv0he3::V0Radius, lfv0he3::Sign);
+DECLARE_SOA_TABLE_VERSIONED(LFHe3_000, "AOD", "LFHE3V0", 0, lfv0he3::LFEventId, lfv0he3::Pt, lfv0he3::Eta, lfv0he3::Phi, lfv0he3::DCAxy, lfv0he3::DCAz, lfv0he3::TPCnCls, lfv0he3::ITSClusterSizes, lfv0he3::NsigmaTPC, lfv0he3::Sign);
+DECLARE_SOA_TABLE_VERSIONED(LFLambda_000, "AOD", "LFLAMBDA", 0, lfv0he3::LFEventId, lfv0he3::Pt, lfv0he3::Eta, lfv0he3::Phi, lfv0he3::Mass, lfv0he3::CosPA, lfv0he3::DCAdaughters, lfv0he3::DCAPVProton, lfv0he3::DCAPVPion, lfv0he3::V0Radius, lfv0he3::Sign);
+
+DECLARE_SOA_TABLE_VERSIONED(LFHe3_001, "AOD", "LFHE3V0", 1, lfv0he3::LFEventId, lfv0he3::Pt, lfv0he3::Eta, lfv0he3::Phi, lfv0he3::DCAxy, lfv0he3::DCAz, lfv0he3::TPCnCls, lfv0he3::TPCnClsPID, lfv0he3::ITSClusterSizes, lfv0he3::NsigmaTPC, lfv0he3::Sign);
+DECLARE_SOA_TABLE_VERSIONED(LFLambda_001, "AOD", "LFLAMBDA", 1, lfv0he3::LFEventId, lfv0he3::Pt, lfv0he3::Eta, lfv0he3::Phi, lfv0he3::Mass, lfv0he3::CosPA, lfv0he3::DCAdaughters, lfv0he3::DCAPVProton, lfv0he3::DCAPVPion, lfv0he3::V0Radius, lfv0he3::NsigmaTPCProton, lfv0he3::NsigmaTPCPion, lfv0he3::Sign);
 } // namespace o2::aod
 
 struct he3Candidate {
@@ -61,6 +66,7 @@ struct he3Candidate {
   float dcaXY = -999.f;
   float dcaZ = -999.f;
   int tpcNClsFound = 0;         // Number of TPC clusters found
+  int tpcNClsPID = 0;           // Number of TPC clusters used for PID
   int itsNCls = 0;              // Number of ITS clusters
   uint32_t itsClusterSizes = 0; // ITS cluster sizes
   int8_t sign = 0;              // Charge sign of the He3 candidate
@@ -75,7 +81,7 @@ struct lambdaCandidate {
   float dcaPionToPV = -999.f;     // DCA of the pion to primary vertex
   float v0Radius = -1.f;          // V0 radius
   float protonNSigmaTPC = -999.f; // Proton TPC nSigma
-  float pionNSigmaTPC = -999.f;
+  float pionNSigmaTPC = -999.f;   // Pion TPC nSigma
   int8_t sign = 0; // Charge sign of the Lambda candidate
 };
 

--- a/PWGLF/TableProducer/Nuspex/he3LambdaAnalysis.cxx
+++ b/PWGLF/TableProducer/Nuspex/he3LambdaAnalysis.cxx
@@ -92,8 +92,8 @@ struct he3LambdaAnalysis {
   o2::vertexing::DCAFitterN<2> fitter;
 
   Produces<o2::aod::LFEvents> lfHe3V0Collision;
-  Produces<o2::aod::LFHe3> lfHe3;
-  Produces<o2::aod::LFLambda> lfLambda;
+  Produces<o2::aod::LFHe3_001> lfHe3;
+  Produces<o2::aod::LFLambda_001> lfLambda;
 
   // Configurables for event selection
   struct : ConfigurableGroup {
@@ -280,6 +280,7 @@ struct he3LambdaAnalysis {
       candidate.dcaXY = dcaInfo[0];
       candidate.dcaZ = dcaInfo[1];
       candidate.tpcNClsFound = track.tpcNClsFound();
+      candidate.tpcNClsPID = track.tpcNClsPID();
       candidate.itsNCls = track.itsNCls();
       candidate.itsClusterSizes = track.itsClusterSizes();
       candidate.sign = track.sign() > 0 ? 1 : -1;
@@ -376,11 +377,11 @@ struct he3LambdaAnalysis {
     lfHe3V0Collision(collision.posZ(), collision.centFT0C());
     for (const auto& he3 : he3Candidates) {
       lfHe3(lfHe3V0Collision.lastIndex(), he3.momentum.Pt(), he3.momentum.Eta(), he3.momentum.Phi(),
-            he3.dcaXY, he3.dcaZ, he3.tpcNClsFound, he3.itsClusterSizes, he3.nSigmaTPC, he3.sign);
+            he3.dcaXY, he3.dcaZ, he3.tpcNClsFound, he3.tpcNClsPID, he3.itsClusterSizes, he3.nSigmaTPC, he3.sign);
     }
     for (const auto& lambda : lambdaCandidates) {
       lfLambda(lfHe3V0Collision.lastIndex(), lambda.momentum.Pt(), lambda.momentum.Eta(), lambda.momentum.Phi(),
-               lambda.mass, lambda.cosPA, lambda.dcaV0Daughters, lambda.dcaProtonToPV, lambda.dcaPionToPV, lambda.v0Radius, lambda.sign);
+               lambda.mass, lambda.cosPA, lambda.dcaV0Daughters, lambda.dcaProtonToPV, lambda.dcaPionToPV, lambda.v0Radius, lambda.protonNSigmaTPC, lambda.pionNSigmaTPC, lambda.sign);
     }
 
     for (const auto& he3 : he3Candidates) {
@@ -391,12 +392,6 @@ struct he3LambdaAnalysis {
     }
   }
   PROCESS_SWITCH(he3LambdaAnalysis, processData, "Process data", true);
-
-  // void processDerived(o2::aod::LFEvents::iterator const& collision, o2::aod::LFHe3 const& he3s, o2::aod::LFLambda const& lambdas)
-  // {
-  //
-  // }
-  // PROCESS_SWITCH(he3LambdaAnalysis, processDerived, "Process derived", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGLF/Tasks/Nuspex/he3LambdaDerivedAnalysis.cxx
+++ b/PWGLF/Tasks/Nuspex/he3LambdaDerivedAnalysis.cxx
@@ -64,7 +64,7 @@ struct he3LambdaDerivedAnalysis {
     hNsigmaProton = mRegistry.add<TH2>("hNsigmaProton", "nSigma TPC for Proton", {HistType::kTH2D, {{100, -10., 10.}, {200, -5, 5.}}});
   }
 
-  void processSameEvent(o2::aod::LFEvents::iterator const& collision, o2::aod::LFHe3 const& he3s, o2::aod::LFLambda const& lambdas)
+  void processSameEvent(o2::aod::LFEvents::iterator const& collision, o2::aod::LFHe3_000 const& he3s, o2::aod::LFLambda_000 const& lambdas)
   {
     std::vector<he3Candidate> he3Candidates;
     he3Candidates.reserve(he3s.size());


### PR DESCRIPTION
The changes made in this commit include:

1. Updating the `LFHe3` and `LFLambda` data tables to include additional
   columns for TPC PID clusters (`tpcNClsPID`) and PID information 
   (`nSigmaTPCProton`, `nSigmaTPCPion`) for the He3 and Lambda candidates, 
   respectively.
2. Updating the `he3Candidate` and `lambdaCandidate` structs to include the new `tpcNClsPID` member.
3. Modifying the `he3LambdaAnalysis` class to populate the new columns in the output data tables.

These changes will provide more detailed information about the He3 and Lambda candidates, which can be useful for further analysis and selection.