### PR TITLE
[Common,PWGLF] Expose configurables inside TrackTuner in propagationService

### DIFF
--- a/Common/TableProducer/trackPropagationTester.cxx
+++ b/Common/TableProducer/trackPropagationTester.cxx
@@ -39,6 +39,7 @@
 #include "Framework/HistogramRegistry.h"
 #include "DataFormatsCalibration/MeanVertexObject.h"
 #include "CommonConstants/GeomConstants.h"
+#include "Common/Tools/TrackTuner.h"
 #include "Common/Tools/TrackPropagationModule.h"
 #include "Common/Tools/StandardCCDBLoader.h"
 

--- a/Common/TableProducer/trackPropagationTester.cxx
+++ b/Common/TableProducer/trackPropagationTester.cxx
@@ -44,6 +44,8 @@
 #include "Framework/runDataProcessing.h"
 #include "ReconstructionDataFormats/DCA.h"
 
+#include <string>
+
 // The Run 3 AO2D stores the tracks at the point of innermost update. For a track with ITS this is the innermost (or second innermost)
 // ITS layer. For a track without ITS, this is the TPC inner wall or for loopers in the TPC even a radius beyond that.
 // In order to use the track parameters, the tracks have to be propagated to the collision vertex which is done by this task.

--- a/Common/TableProducer/trackPropagationTester.cxx
+++ b/Common/TableProducer/trackPropagationTester.cxx
@@ -59,6 +59,9 @@ struct TrackPropagationTester {
   o2::common::TrackPropagationProducts trackPropagationProducts;
   o2::common::TrackPropagationConfigurables trackPropagationConfigurables;
 
+  // the track tuner object -> needs to be here as it inherits from ConfigurableGroup (+ has its own copy of ccdbApi)
+  TrackTuner trackTunerObj;
+
   // CCDB boilerplate declarations
   o2::framework::Configurable<std::string> ccdburl{"ccdburl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Service<o2::ccdb::BasicCCDBManager> ccdb;
@@ -76,14 +79,14 @@ struct TrackPropagationTester {
     ccdb->setURL(ccdburl.value);
 
     // task-specific
-    trackPropagation.init(trackPropagationConfigurables, registry, initContext);
+    trackPropagation.init(trackPropagationConfigurables, trackTunerObj, registry, initContext);
   }
 
   void processReal(aod::Collisions const& collisions, soa::Join<aod::StoredTracksIU, aod::TracksCovIU, aod::TracksExtra> const& tracks, aod::Collisions const&, aod::BCs const& bcs)
   {
     // task-specific
     ccdbLoader.initCCDBfromBCs(standardCCDBLoaderConfigurables, ccdb, bcs);
-    trackPropagation.fillTrackTables<false>(trackPropagationConfigurables, ccdbLoader, collisions, tracks, trackPropagationProducts, registry);
+    trackPropagation.fillTrackTables<false>(trackPropagationConfigurables, trackTunerObj, ccdbLoader, collisions, tracks, trackPropagationProducts, registry);
   }
   PROCESS_SWITCH(TrackPropagationTester, processReal, "Process Real Data", true);
 
@@ -91,7 +94,7 @@ struct TrackPropagationTester {
   void processMc(aod::Collisions const& collisions, soa::Join<aod::StoredTracksIU, aod::McTrackLabels, aod::TracksCovIU, aod::TracksExtra> const& tracks, aod::McParticles const&, aod::Collisions const&, aod::BCs const& bcs)
   {
     ccdbLoader.initCCDBfromBCs(standardCCDBLoaderConfigurables, ccdb, bcs);
-    trackPropagation.fillTrackTables<false>(trackPropagationConfigurables, ccdbLoader, collisions, tracks, trackPropagationProducts, registry);
+    trackPropagation.fillTrackTables<false>(trackPropagationConfigurables, trackTunerObj, ccdbLoader, collisions, tracks, trackPropagationProducts, registry);
   }
   PROCESS_SWITCH(TrackPropagationTester, processMc, "Process Monte Carlo", false);
 };

--- a/Common/TableProducer/trackPropagationTester.cxx
+++ b/Common/TableProducer/trackPropagationTester.cxx
@@ -23,25 +23,26 @@
 //
 //===============================================================
 
+#include "Common/Core/trackUtilities.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+#include "Common/Tools/StandardCCDBLoader.h"
+#include "Common/Tools/TrackPropagationModule.h"
+#include "Common/Tools/TrackTuner.h"
+
+#include "CCDB/BasicCCDBManager.h"
+#include "CCDB/CcdbApi.h"
+#include "CommonConstants/GeomConstants.h"
+#include "CommonUtils/NameConf.h"
+#include "DataFormatsCalibration/MeanVertexObject.h"
+#include "DataFormatsParameters/GRPMagField.h"
+#include "DetectorsBase/GeometryManager.h"
+#include "DetectorsBase/Propagator.h"
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/AnalysisTask.h"
-#include "Framework/runDataProcessing.h"
-#include "Framework/RunningWorkflowInfo.h"
-#include "Common/DataModel/TrackSelectionTables.h"
-#include "Common/Core/trackUtilities.h"
-#include "ReconstructionDataFormats/DCA.h"
-#include "DetectorsBase/Propagator.h"
-#include "DetectorsBase/GeometryManager.h"
-#include "CommonUtils/NameConf.h"
-#include "CCDB/CcdbApi.h"
-#include "DataFormatsParameters/GRPMagField.h"
-#include "CCDB/BasicCCDBManager.h"
 #include "Framework/HistogramRegistry.h"
-#include "DataFormatsCalibration/MeanVertexObject.h"
-#include "CommonConstants/GeomConstants.h"
-#include "Common/Tools/TrackTuner.h"
-#include "Common/Tools/TrackPropagationModule.h"
-#include "Common/Tools/StandardCCDBLoader.h"
+#include "Framework/RunningWorkflowInfo.h"
+#include "Framework/runDataProcessing.h"
+#include "ReconstructionDataFormats/DCA.h"
 
 // The Run 3 AO2D stores the tracks at the point of innermost update. For a track with ITS this is the innermost (or second innermost)
 // ITS layer. For a track without ITS, this is the TPC inner wall or for loopers in the TPC even a radius beyond that.

--- a/Common/Tools/StandardCCDBLoader.h
+++ b/Common/Tools/StandardCCDBLoader.h
@@ -16,16 +16,17 @@
 #ifndef COMMON_TOOLS_STANDARDCCDBLOADER_H_
 #define COMMON_TOOLS_STANDARDCCDBLOADER_H_
 
-#include <string>
-#include <cstdlib>
-#include <cmath>
-#include <array>
+#include "CCDB/BasicCCDBManager.h"
 #include "DataFormatsCalibration/MeanVertexObject.h"
 #include "DataFormatsParameters/GRPMagField.h"
 #include "DetectorsBase/GeometryManager.h"
 #include "DetectorsBase/Propagator.h"
-#include "CCDB/BasicCCDBManager.h"
 #include "Framework/AnalysisDataModel.h"
+
+#include <array>
+#include <cmath>
+#include <cstdlib>
+#include <string>
 
 //__________________________________________
 // Standard class to load stuff

--- a/Common/Tools/StandardCCDBLoader.h
+++ b/Common/Tools/StandardCCDBLoader.h
@@ -20,6 +20,11 @@
 #include <cstdlib>
 #include <cmath>
 #include <array>
+#include "DataFormatsCalibration/MeanVertexObject.h"
+#include "DataFormatsParameters/GRPMagField.h"
+#include "DetectorsBase/GeometryManager.h"
+#include "DetectorsBase/Propagator.h"
+#include "CCDB/BasicCCDBManager.h"
 #include "Framework/AnalysisDataModel.h"
 
 //__________________________________________

--- a/Common/Tools/TrackPropagationModule.h
+++ b/Common/Tools/TrackPropagationModule.h
@@ -89,8 +89,8 @@ class TrackPropagationModule
   o2::track::TrackParametrization<float> mTrackPar;
   o2::track::TrackParametrizationWithError<float> mTrackParCov;
 
-  template <typename TConfigurableGroup, typename TTrackTuner, typename TInitContext, typename THistoRegistry>
-  void init(TConfigurableGroup const& cGroup, TTrackTuner& trackTunerObj, THistoRegistry& registry, TInitContext& initContext)
+  template <typename TConfigurableGroup, typename TInitContext, typename THistoRegistry>
+  void init(TConfigurableGroup const& cGroup, TrackTuner& trackTunerObj, THistoRegistry& registry, TInitContext& initContext)
   {
     // Checking if the tables are requested in the workflow and enabling them
     fillTracks = isTableRequiredInWorkflow(initContext, "Tracks");
@@ -152,8 +152,8 @@ class TrackPropagationModule
     registry.template add<TH2>("hDCAzVsPtMC", "hDCAzVsPtMC", o2::framework::kTH2F, {axisBinsDCA, cGroup.axisPtQA});
   }
 
-  template <bool isMc, typename TConfigurableGroup, typename TTrackTuner, typename TCCDBLoader, typename TCollisions, typename TTracks, typename TOutputGroup, typename THistoRegistry>
-  void fillTrackTables(TConfigurableGroup const& cGroup, TTrackTuner& trackTunerObj, TCCDBLoader const& ccdbLoader, TCollisions const& collisions, TTracks const& tracks, TOutputGroup& cursors, THistoRegistry& registry)
+  template <bool isMc, typename TConfigurableGroup, typename TCCDBLoader, typename TCollisions, typename TTracks, typename TOutputGroup, typename THistoRegistry>
+  void fillTrackTables(TConfigurableGroup const& cGroup, TrackTuner& trackTunerObj, TCCDBLoader const& ccdbLoader, TCollisions const& collisions, TTracks const& tracks, TOutputGroup& cursors, THistoRegistry& registry)
   {
     if (!fillTracks) {
       return; // suppress everything

--- a/Common/Tools/TrackPropagationModule.h
+++ b/Common/Tools/TrackPropagationModule.h
@@ -16,20 +16,22 @@
 #ifndef COMMON_TOOLS_TRACKPROPAGATIONMODULE_H_
 #define COMMON_TOOLS_TRACKPROPAGATIONMODULE_H_
 
-#include <memory>
-#include <cstdlib>
-#include <cmath>
-#include <array>
-#include <string>
-#include "Framework/AnalysisDataModel.h"
-#include "Framework/Configurable.h"
-#include "Framework/HistogramSpec.h"
+#include "TableHelper.h"
+
+#include "Common/Tools/TrackTuner.h"
 
 #include "DataFormatsCalibration/MeanVertexObject.h"
 #include "DataFormatsParameters/GRPMagField.h"
 #include "DetectorsBase/Propagator.h"
-#include "Common/Tools/TrackTuner.h"
-#include "TableHelper.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/Configurable.h"
+#include "Framework/HistogramSpec.h"
+
+#include <array>
+#include <cmath>
+#include <cstdlib>
+#include <memory>
+#include <string>
 
 //__________________________________________
 // track propagation module

--- a/Common/Tools/TrackPropagationModule.h
+++ b/Common/Tools/TrackPropagationModule.h
@@ -24,6 +24,10 @@
 #include "Framework/AnalysisDataModel.h"
 #include "Framework/Configurable.h"
 #include "Framework/HistogramSpec.h"
+
+#include "DataFormatsCalibration/MeanVertexObject.h"
+#include "DataFormatsParameters/GRPMagField.h"
+#include "DetectorsBase/Propagator.h"
 #include "Common/Tools/TrackTuner.h"
 #include "TableHelper.h"
 

--- a/Common/Tools/TrackPropagationModule.h
+++ b/Common/Tools/TrackPropagationModule.h
@@ -81,7 +81,6 @@ class TrackPropagationModule
 
   // pointers to objs needed for operation
   std::shared_ptr<TH1> trackTunedTracks;
-  TrackTuner trackTunerObj;
 
   // Running variables
   std::array<float, 2> mDcaInfo;
@@ -90,8 +89,8 @@ class TrackPropagationModule
   o2::track::TrackParametrization<float> mTrackPar;
   o2::track::TrackParametrizationWithError<float> mTrackParCov;
 
-  template <typename TConfigurableGroup, typename TInitContext, typename THistoRegistry>
-  void init(TConfigurableGroup const& cGroup, THistoRegistry& registry, TInitContext& initContext)
+  template <typename TConfigurableGroup, typename TTrackTuner, typename TInitContext, typename THistoRegistry>
+  void init(TConfigurableGroup const& cGroup, TTrackTuner& trackTunerObj, THistoRegistry& registry, TInitContext& initContext)
   {
     // Checking if the tables are requested in the workflow and enabling them
     fillTracks = isTableRequiredInWorkflow(initContext, "Tracks");
@@ -153,8 +152,8 @@ class TrackPropagationModule
     registry.template add<TH2>("hDCAzVsPtMC", "hDCAzVsPtMC", o2::framework::kTH2F, {axisBinsDCA, cGroup.axisPtQA});
   }
 
-  template <bool isMc, typename TConfigurableGroup, typename TCCDBLoader, typename TCollisions, typename TTracks, typename TOutputGroup, typename THistoRegistry>
-  void fillTrackTables(TConfigurableGroup const& cGroup, TCCDBLoader const& ccdbLoader, TCollisions const& collisions, TTracks const& tracks, TOutputGroup& cursors, THistoRegistry& registry)
+  template <bool isMc, typename TConfigurableGroup, typename TTrackTuner, typename TCCDBLoader, typename TCollisions, typename TTracks, typename TOutputGroup, typename THistoRegistry>
+  void fillTrackTables(TConfigurableGroup const& cGroup, TTrackTuner& trackTunerObj, TCCDBLoader const& ccdbLoader, TCollisions const& collisions, TTracks const& tracks, TOutputGroup& cursors, THistoRegistry& registry)
   {
     if (!fillTracks) {
       return; // suppress everything

--- a/PWGLF/TableProducer/Strangeness/propagationService.cxx
+++ b/PWGLF/TableProducer/Strangeness/propagationService.cxx
@@ -30,8 +30,8 @@
 #include "Common/Core/trackUtilities.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 #include "Common/Tools/StandardCCDBLoader.h"
-#include "Common/Tools/TrackTuner.h"
 #include "Common/Tools/TrackPropagationModule.h"
+#include "Common/Tools/TrackTuner.h"
 
 #include "CCDB/BasicCCDBManager.h"
 #include "CCDB/CcdbApi.h"

--- a/PWGLF/TableProducer/Strangeness/propagationService.cxx
+++ b/PWGLF/TableProducer/Strangeness/propagationService.cxx
@@ -81,6 +81,9 @@ struct propagationService {
   o2::pwglf::strangenessbuilder::preSelectOpts preSelectOpts;
   o2::pwglf::strangenessbuilder::BuilderModule strangenessBuilderModule;
 
+  // the track tuner object -> needs to be here as it inherits from ConfigurableGroup (+ has its own copy of ccdbApi)
+  TrackTuner trackTunerObj;
+
   // track propagation
   o2::common::TrackPropagationProducts trackPropagationProducts;
   o2::common::TrackPropagationConfigurables trackPropagationConfigurables;
@@ -97,21 +100,21 @@ struct propagationService {
     ccdb->setURL(ccdburl.value);
 
     // task-specific
-    trackPropagation.init(trackPropagationConfigurables, histos, initContext);
+    trackPropagation.init(trackPropagationConfigurables, trackTunerObj, histos, initContext);
     strangenessBuilderModule.init(baseOpts, v0BuilderOpts, cascadeBuilderOpts, preSelectOpts, histos, initContext);
   }
 
   void processRealData(soa::Join<aod::Collisions, aod::EvSels> const& collisions, aod::V0s const& v0s, aod::Cascades const& cascades, aod::TrackedCascades const& trackedCascades, FullTracksExtIU const& tracks, aod::BCsWithTimestamps const& bcs)
   {
     ccdbLoader.initCCDBfromBCs(standardCCDBLoaderConfigurables, ccdb, bcs);
-    trackPropagation.fillTrackTables<false>(trackPropagationConfigurables, ccdbLoader, collisions, tracks, trackPropagationProducts, histos);
+    trackPropagation.fillTrackTables<false>(trackPropagationConfigurables, trackTunerObj, ccdbLoader, collisions, tracks, trackPropagationProducts, histos);
     strangenessBuilderModule.dataProcess(ccdb, histos, collisions, static_cast<TObject*>(nullptr), v0s, cascades, trackedCascades, tracks, bcs, static_cast<TObject*>(nullptr), products);
   }
 
   void processMonteCarlo(soa::Join<aod::Collisions, aod::EvSels, aod::McCollisionLabels> const& collisions, aod::McCollisions const& mccollisions, aod::V0s const& v0s, aod::Cascades const& cascades, aod::TrackedCascades const& trackedCascades, FullTracksExtLabeledIU const& tracks, aod::BCsWithTimestamps const& bcs, aod::McParticles const& mcParticles)
   {
     ccdbLoader.initCCDBfromBCs(standardCCDBLoaderConfigurables, ccdb, bcs);
-    trackPropagation.fillTrackTables<true>(trackPropagationConfigurables, ccdbLoader, collisions, tracks, trackPropagationProducts, histos);
+    trackPropagation.fillTrackTables<true>(trackPropagationConfigurables, trackTunerObj, ccdbLoader, collisions, tracks, trackPropagationProducts, histos);
     strangenessBuilderModule.dataProcess(ccdb, histos, collisions, mccollisions, v0s, cascades, trackedCascades, tracks, bcs, mcParticles, products);
   }
 

--- a/PWGLF/TableProducer/Strangeness/propagationService.cxx
+++ b/PWGLF/TableProducer/Strangeness/propagationService.cxx
@@ -47,6 +47,8 @@
 #include "Framework/runDataProcessing.h"
 #include "ReconstructionDataFormats/DCA.h"
 
+#include <string>
+
 using namespace o2;
 using namespace o2::framework;
 // using namespace o2::framework::expressions;

--- a/PWGLF/TableProducer/Strangeness/propagationService.cxx
+++ b/PWGLF/TableProducer/Strangeness/propagationService.cxx
@@ -30,6 +30,7 @@
 #include "Common/Core/trackUtilities.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 #include "Common/Tools/StandardCCDBLoader.h"
+#include "Common/Tools/TrackTuner.h"
 #include "Common/Tools/TrackPropagationModule.h"
 
 #include "CCDB/BasicCCDBManager.h"


### PR DESCRIPTION
Since the tracktuner class derives from ConfigurableGroups, it has to be put in the analysis task itself for the relevant configurables to be exposed directly to the user of a joint service such as propagationService. 