### PR TITLE
[PWGLF]  Fix V0DataLink filling + return calls when moving TPC only tracks

### DIFF
--- a/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
@@ -905,7 +905,7 @@ struct StrangenessBuilder {
           posTrackPar.setPID(o2::track::PID::Electron);
           negTrackPar.setPID(o2::track::PID::Electron);
           if (!mVDriftMgr.moveTPCTrack<TBCs, TCollisions>(collision, pTrack, posTrackPar)) {
-            continue;
+	    continue;
           }
         }
         if (isNegTPCOnly) {
@@ -913,7 +913,7 @@ struct StrangenessBuilder {
           posTrackPar.setPID(o2::track::PID::Electron);
           negTrackPar.setPID(o2::track::PID::Electron);
           if (!mVDriftMgr.moveTPCTrack<TBCs, TCollisions>(collision, nTrack, negTrackPar)) {
-            continue;
+	    continue;
           }
         }
       } // end TPC drift treatment
@@ -1648,7 +1648,8 @@ struct StrangenessBuilder {
 
           auto const& collision = collisions.rawIteratorAt(v0.collisionId);
           if (!mVDriftMgr.moveTPCTrack<TBCs, TCollisions>(collision, posTrack, posTrackPar)) {
-            return;
+	    products.v0dataLink(-1, -1);
+            continue;
           }
         }
 
@@ -1660,7 +1661,8 @@ struct StrangenessBuilder {
 
           auto const& collision = collisions.rawIteratorAt(v0.collisionId);
           if (!mVDriftMgr.moveTPCTrack<TBCs, TCollisions>(collision, negTrack, negTrackPar)) {
-            return;
+	    products.v0dataLink(-1, -1);
+            continue;
           }
         }
       }

--- a/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
@@ -1927,6 +1927,8 @@ struct StrangenessBuilder {
             }
           } // enabled tables check
         } // constexpr requires check
+      } else {
+        products.v0dataLink(-1, -1);
       }
     }
 

--- a/PWGLF/Utils/strangenessBuilderModule.h
+++ b/PWGLF/Utils/strangenessBuilderModule.h
@@ -1649,6 +1649,8 @@ class BuilderModule
             }
           } // enabled tables check
         } // constexpr requires check
+      } else {
+        products.v0dataLink(-1, -1);
       }
     }
 

--- a/PWGLF/Utils/strangenessBuilderModule.h
+++ b/PWGLF/Utils/strangenessBuilderModule.h
@@ -894,7 +894,7 @@ class BuilderModule
                 posTrackPar.setPID(o2::track::PID::Electron);
                 negTrackPar.setPID(o2::track::PID::Electron);
                 if (!mVDriftMgr.moveTPCTrack<TBCs, TCollisions>(collision, pTrack, posTrackPar)) {
-                  return;
+                  continue;
                 }
               }
               if (isNegTPCOnly) {
@@ -902,7 +902,7 @@ class BuilderModule
                 posTrackPar.setPID(o2::track::PID::Electron);
                 negTrackPar.setPID(o2::track::PID::Electron);
                 if (!mVDriftMgr.moveTPCTrack<TBCs, TCollisions>(collision, nTrack, negTrackPar)) {
-                  return;
+                  continue;
                 }
               }
             } // end TPC drift treatment
@@ -1370,7 +1370,8 @@ class BuilderModule
 
           auto const& collision = collisions.rawIteratorAt(v0.collisionId);
           if (!mVDriftMgr.moveTPCTrack<TBCs, TCollisions>(collision, posTrack, posTrackPar)) {
-            return;
+	    products.v0dataLink(-1, -1);
+            continue;
           }
         }
 
@@ -1382,7 +1383,8 @@ class BuilderModule
 
           auto const& collision = collisions.rawIteratorAt(v0.collisionId);
           if (!mVDriftMgr.moveTPCTrack<TBCs, TCollisions>(collision, negTrack, negTrackPar)) {
-            return;
+	    products.v0dataLink(-1, -1);
+            continue;
           }
         }
       }


### PR DESCRIPTION
-  Fix V0DataLink filling, creating discrepancies between the V0 and the V0DataLink table sizes (@ChiaraDeMartin95 @ercolessi for your information)
-  Replace return calls by continue calls when moving TPC only tracks

@ddobrigk @gianniliveraro for your information