### PR TITLE
O2 linter: Accept (almost) any exception reason

### DIFF
--- a/Scripts/o2_linter.py
+++ b/Scripts/o2_linter.py
@@ -248,7 +248,7 @@ class TestSpec:
         if self.name in line:
             self.n_disabled += 1
             # Look for a comment with a reason for disabling.
-            if re.search(r" \([\w\s]{3,}\)", line):
+            if re.search(r" \(.{3,}\)", line):
                 return True
         return False
 


### PR DESCRIPTION
Relax the expected pattern to just require at least 3 characters.