### PR TITLE
[PWGDQ] Add geometry loading to dilepton-track task

### DIFF
--- a/PWGDQ/Tasks/dqEfficiency.cxx
+++ b/PWGDQ/Tasks/dqEfficiency.cxx
@@ -1048,7 +1048,7 @@ struct AnalysisDileptonTrack {
   Configurable<bool> fNoCorr{"cfgNoCorrFwdProp", false, "Do not correct for MCS effects in track propagation"};
   Configurable<std::string> lutPath{"lutPath", "GLO/Param/MatLUT", "Path of the Lut parametrization"};
   Configurable<std::string> geoPath{"geoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
-                                               
+
   Filter eventFilter = aod::dqanalysisflags::isEventSelected == 1;
   // Filter dileptonFilter = aod::reducedpair::mass > 2.92f && aod::reducedpair::mass < 3.16f && aod::reducedpair::sign == 0;
   // Filter dileptonFilter = aod::reducedpair::mass > 2.6f && aod::reducedpair::mass < 3.5f && aod::reducedpair::sign == 0;
@@ -1095,7 +1095,7 @@ struct AnalysisDileptonTrack {
       lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(lutPath));
       VarManager::SetupMatLUTFwdDCAFitter(lut);
     }
-    
+
     TString sigNamesStr = fConfigMCRecSignals.value;
     std::unique_ptr<TObjArray> objRecSigArray(sigNamesStr.Tokenize(","));
     TString histNames;

--- a/PWGDQ/Tasks/dqEfficiency.cxx
+++ b/PWGDQ/Tasks/dqEfficiency.cxx
@@ -1040,6 +1040,9 @@ struct AnalysisSameEventPairing {
 struct AnalysisDileptonTrack {
   Produces<aod::DileptonTrackCandidates> dileptontrackcandidatesList;
   OutputObj<THashList> fOutputList{"output"};
+  Service<o2::ccdb::BasicCCDBManager> ccdb;
+  o2::base::MatLayerCylSet* lut = nullptr;
+
   // TODO: For now this is only used to determine the position in the filter bit map for the hadron cut
   Configurable<string> fConfigTrackCuts{"cfgLeptonCuts", "", "Comma separated list of barrel track cuts"};
   Configurable<bool> fConfigFillCandidateTable{"cfgFillCandidateTable", false, "Produce a single flat tables with all relevant information dilepton-track candidates"};


### PR DESCRIPTION
This PR fixes the same issue as #11478 but for the efficiency task.

A check is added for the geometry similar to the one in AnalysisSameEventPairing tasks, along with the required configurables.