### PR TITLE
[PWGHF] Used DeltaEta and DeltaPhi from EMCalMatchedTracks Table for Track-Cluster Matching

### DIFF
--- a/PWGHF/HFC/TableProducer/correlatorHfeHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorHfeHadrons.cxx
@@ -152,12 +152,17 @@ struct HfCorrelatorHfeHadrons {
     int gCollisionId = collision.globalIndex();
     int64_t timeStamp = bc.timestamp();
 
+    // Add hadron Table For Mix Event Electron Hadron correlation
+    for (const auto& hTrack : tracks) {
+      registry.fill(HIST("hTracksBin"), poolBin);
+      entryHadron(hTrack.phi(), hTrack.eta(), hTrack.pt(), poolBin, gCollisionId, timeStamp);
+    }
+
     //  Construct Deta Phi between electrons and hadrons
 
     double ptElectron = -999;
     double phiElectron = -999;
     double etaElectron = -999;
-    int nElectron = 0;
 
     for (const auto& eTrack : electron) {
       ptElectron = eTrack.ptTrack();
@@ -209,10 +214,7 @@ struct HfCorrelatorHfeHadrons {
         if (ptCondition && (ptElectron < ptHadron)) {
           continue;
         }
-        if (nElectron == 0) {
-          registry.fill(HIST("hTracksBin"), poolBin);
-          entryHadron(phiHadron, etaHadron, ptHadron, poolBin, gCollisionId, timeStamp);
-        }
+
         deltaPhi = RecoDecay::constrainAngle(phiElectron - phiHadron, -o2::constants::math::PIHalf);
         deltaEta = etaElectron - etaHadron;
         registry.fill(HIST("hInclusiveEHCorrel"), ptElectron, ptHadron, deltaPhi, deltaEta);
@@ -236,8 +238,7 @@ struct HfCorrelatorHfeHadrons {
         entryElectronHadronPair(deltaPhi, deltaEta, ptElectron, ptHadron, poolBin, nElHadLSCorr, nElHadUSCorr);
 
       } // end Hadron Track loop
-      nElectron++;
-    } // end Electron loop
+    }   // end Electron loop
   }
 
   // mix event electron-hadron correlation

--- a/PWGHF/HFC/TableProducer/correlatorHfeHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorHfeHadrons.cxx
@@ -238,7 +238,8 @@ struct HfCorrelatorHfeHadrons {
         entryElectronHadronPair(deltaPhi, deltaEta, ptElectron, ptHadron, poolBin, nElHadLSCorr, nElHadUSCorr);
 
       } // end Hadron Track loop
-    }   // end Electron loop
+
+    } // end Electron loop
   }
 
   // mix event electron-hadron correlation

--- a/PWGHF/HFL/TableProducer/electronSelectionWithTpcEmcal.cxx
+++ b/PWGHF/HFL/TableProducer/electronSelectionWithTpcEmcal.cxx
@@ -468,8 +468,8 @@ struct HfElectronSelectionWithTpcEmcal {
         timeEmcCluster = emcCluster.time();
         cellEmcCluster = emcCluster.nCells();
 
-        deltaPhiMatch = matchTrack.trackPhiEmcal() - phiMatchEmcCluster;
-        deltaEtaMatch = matchTrack.trackEtaEmcal() - etaMatchEmcCluster;
+        deltaPhiMatch = ematchTrack.deltaPhi();
+        deltaEtaMatch = ematchTrack.deltaEta();
 
         // Track and EMCal cluster Matching
         if (std::abs(timeEmcCluster) > timeEmcClusterMax) {


### PR DESCRIPTION
Use DeltaEta and DeltaPhi from EMCalMatchedTracks Table for Track-Cluster Matching 