### PR TITLE
[Common,PWGCF,PWGDQ,PWGEM,PWGLF,PWGUD,DPG,Trigger] [Cleanup] Add fully qualified names for std::string and std::map

### DIFF
--- a/Common/CCDB/ctpRateFetcher.cxx
+++ b/Common/CCDB/ctpRateFetcher.cxx
@@ -109,7 +109,7 @@ void ctpRateFetcher::setupRun(int runNumber, o2::ccdb::BasicCCDBManager* ccdb, u
     delete mScalers;
     delete mLHCIFdata;
   }
-  std::map<string, string> metadata;
+  std::map<std::string, std::string> metadata;
   mLHCIFdata = ccdb->getSpecific<parameters::GRPLHCIFData>("GLO/Config/GRPLHCIF", timeStamp, metadata);
   if (mLHCIFdata == nullptr) {
     LOG(fatal) << "GRPLHCIFData not in database, timestamp:" << timeStamp;

--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -1286,7 +1286,7 @@ struct LumiTask {
         LOGP(warn, "Cross section for z={} + z={} @ {} GeV is not defined", beamZ1, beamZ2, sqrts);
       }
       // getting CTP config to extract lumi class indices (used for rate fetching and pileup correction)
-      std::map<string, string> metadata;
+      std::map<std::string, std::string> metadata;
       metadata["runNumber"] = std::to_string(run);
       auto config = ccdb->getSpecific<o2::ctp::CTPConfiguration>("CTP/Config/Config", ts, metadata);
       auto classes = config->getCTPClasses();

--- a/Common/TableProducer/qVectorsTable.cxx
+++ b/Common/TableProducer/qVectorsTable.cxx
@@ -149,7 +149,7 @@ struct qVectorsTable {
   Produces<aod::QvectorBTotVecs> qVectorBTotVec;
   /////////////////////////////////////////////////////////////////
 
-  std::unordered_map<string, bool> useDetector = {
+  std::unordered_map<std::string, bool> useDetector = {
     {"QvectorBTots", cfgUseBTot},
     {"QvectorBNegs", cfgUseBNeg},
     {"QvectorBPoss", cfgUseBPos},

--- a/Common/Tools/PID/handleParamTPCResponse.cxx
+++ b/Common/Tools/PID/handleParamTPCResponse.cxx
@@ -48,7 +48,7 @@ bool initOptionsAndParse(bpo::options_description& options, int argc, char* argv
     "paramMultNormalization", bpo::value<float>()->default_value(11000.), "Multiplicity Normalization")(
     "paramnClNormalization", bpo::value<float>()->default_value(152.), "Maximum nClusters for normalisation (159 for run 2, 152 for run 3)")(
     "useDefaultParam", bpo::value<bool>()->default_value(true), "Use default sigma parametrisation")(
-    "mode", bpo::value<string>()->default_value(""), "Running mode ('read' from file, 'write' to file, 'pull' from CCDB, 'push' to CCDB)")(
+    "mode", bpo::value<std::string>()->default_value(""), "Running mode ('read' from file, 'write' to file, 'pull' from CCDB, 'push' to CCDB)")(
     "help,h", "Produce help message.");
   setStandardOpt(options);
   try {

--- a/DPG/Tasks/AOTEvent/detectorOccupancyQa.cxx
+++ b/DPG/Tasks/AOTEvent/detectorOccupancyQa.cxx
@@ -736,7 +736,7 @@ struct DetectorOccupancyQaTask {
       int nCollInTimeWindowSelIfTOF = 0;
       double multFT0CmainCollision = 0.f;
       double multFT0CInTimeWindow = 0.f;
-      map<int64_t, int32_t> mUniqueBC;
+      std::map<int64_t, int32_t> mUniqueBC;
 
       bool sel = col.selection_bit(kIsTriggerTVX);
 

--- a/EventFiltering/PWGCF/CFFilterQA.cxx
+++ b/EventFiltering/PWGCF/CFFilterQA.cxx
@@ -1033,7 +1033,7 @@ struct CFFilterQA {
 
   std::vector<double> setValuesBB(aod::BCsWithTimestamps::iterator const& bunchCrossing, const std::string ccdbPath)
   {
-    map<string, string> metadata;
+    std::map<std::string, std::string> metadata;
     auto h = ccdbApi.retrieveFromTFileAny<TH1F>(ccdbPath, metadata, bunchCrossing.timestamp());
     // auto h = ccdb->getForTimeStamp<TH1F>(ccdbPath, bunchCrossing.timestamp()); //check if possible to use this without getting fatal
     if (!h) {
@@ -1055,7 +1055,7 @@ struct CFFilterQA {
 
   std::vector<double> setValuesAvg(aod::BCsWithTimestamps::iterator const& bunchCrossing, const std::string ccdbPath)
   {
-    map<string, string> metadata;
+    std::map<std::string, std::string> metadata;
     auto h = ccdbApi.retrieveFromTFileAny<TH1F>(ccdbPath, metadata, bunchCrossing.timestamp());
     // auto h = ccdb->getForTimeStamp<TH1F>(ccdbPath, bunchCrossing.timestamp()); //check if possible to use this without getting fatal
     if (!h) {

--- a/EventFiltering/PWGLF/filterf1proton.cxx
+++ b/EventFiltering/PWGLF/filterf1proton.cxx
@@ -436,7 +436,7 @@ struct filterf1proton {
 
   std::vector<double> setValuesBB(o2::ccdb::CcdbApi& ccdbApi, aod::BCsWithTimestamps::iterator const& bunchCrossing, const std::string ccdbPath)
   {
-    map<string, string> metadata;
+    std::map<std::string, std::string> metadata;
     auto h = ccdbApi.retrieveFromTFileAny<TH1F>(ccdbPath, metadata, bunchCrossing.timestamp());
     // auto h = ccdb->getForTimeStamp<TH1F>(ccdbPath, bunchCrossing.timestamp()); // check if possible to use this without getting fatal
     if (!h) {

--- a/PWGDQ/TableProducer/tableMaker.cxx
+++ b/PWGDQ/TableProducer/tableMaker.cxx
@@ -191,15 +191,15 @@ struct TableMaker {
 
   struct : ConfigurableGroup {
     Configurable<bool> fConfigRunZorro{"cfgRunZorro", false, "Enable event selection with zorro"};
-    Configurable<string> fConfigZorroTrigMask{"cfgZorroTriggerMask", "fDiMuon", "DQ Trigger masks: fSingleE,fLMeeIMR,fLMeeHMR,fDiElectron,fSingleMuLow,fSingleMuHigh,fDiMuon"};
+    Configurable<std::string> fConfigZorroTrigMask{"cfgZorroTriggerMask", "fDiMuon", "DQ Trigger masks: fSingleE,fLMeeIMR,fLMeeHMR,fDiElectron,fSingleMuLow,fSingleMuHigh,fDiMuon"};
     Configurable<bool> fConfigRunZorroSel{"cfgRunZorroSel", false, "Select events with trigger mask"};
     Configurable<uint64_t> fBcTolerance{"cfgBcTolerance", 100, "Number of BCs of margin for software triggers"};
   } useZorro;
 
   struct : ConfigurableGroup {
-    Configurable<string> fConfigCcdbUrl{"useCCDBConfigurations.ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
-    Configurable<string> fConfigCcdbPathTPC{"useCCDBConfigurations.ccdb-path-tpc", "Users/z/zhxiong/TPCPID/PostCalib", "base path to the ccdb object"};
-    Configurable<string> fConfigCcdbPathZorro{"useCCDBConfigurations.ccdb-path-zorro", "/Users/m/mpuccio/EventFiltering/OTS/", "base path to the ccdb object for zorro"};
+    Configurable<std::string> fConfigCcdbUrl{"useCCDBConfigurations.ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+    Configurable<std::string> fConfigCcdbPathTPC{"useCCDBConfigurations.ccdb-path-tpc", "Users/z/zhxiong/TPCPID/PostCalib", "base path to the ccdb object"};
+    Configurable<std::string> fConfigCcdbPathZorro{"useCCDBConfigurations.ccdb-path-zorro", "/Users/m/mpuccio/EventFiltering/OTS/", "base path to the ccdb object for zorro"};
   } useCCDBConfigurations;
 
   Configurable<int64_t> fConfigNoLaterThan{"ccdb-no-later-than", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(), "latest acceptable timestamp of creation for the object"};

--- a/PWGDQ/TableProducer/tableMakerMC_withAssoc.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC_withAssoc.cxx
@@ -1112,7 +1112,7 @@ struct TableMakerMC {
           VarManager::SetupMuonMagField();
         }
       }
-      std::map<string, string> metadataRCT, header;
+      std::map<std::string, std::string> metadataRCT, header;
       header = fCCDBApi.retrieveHeaders(Form("RCT/Info/RunInformation/%i", bcs.begin().runNumber()), metadataRCT, -1);
       uint64_t sor = std::atol(header["SOR"].c_str());
       uint64_t eor = std::atol(header["EOR"].c_str());

--- a/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
+++ b/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
@@ -225,9 +225,9 @@ struct TableMaker {
 
   // CCDB connection configurables
   struct : ConfigurableGroup {
-    Configurable<string> fConfigCcdbUrl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
-    Configurable<string> fConfigCcdbPathTPC{"ccdb-path-tpc", "Users/z/zhxiong/TPCPID/PostCalib", "base path to the ccdb object"};
-    Configurable<string> fConfigCcdbPathZorro{"ccdb-path-zorro", "/Users/m/mpuccio/EventFiltering/OTS/Chunked/", "base path to the ccdb object for zorro"};
+    Configurable<std::string> fConfigCcdbUrl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+    Configurable<std::string> fConfigCcdbPathTPC{"ccdb-path-tpc", "Users/z/zhxiong/TPCPID/PostCalib", "base path to the ccdb object"};
+    Configurable<std::string> fConfigCcdbPathZorro{"ccdb-path-zorro", "/Users/m/mpuccio/EventFiltering/OTS/Chunked/", "base path to the ccdb object for zorro"};
     Configurable<int64_t> fConfigNoLaterThan{"ccdb-no-later-than", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(), "latest acceptable timestamp of creation for the object"};
     Configurable<std::string> fConfigGeoPath{"geoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
     Configurable<std::string> fConfigGrpMagPath{"grpmagPath", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
@@ -1317,7 +1317,7 @@ struct TableMaker {
           VarManager::SetupMuonMagField();
         }
       }
-      std::map<string, string> metadataRCT, header;
+      std::map<std::string, std::string> metadataRCT, header;
       header = fCCDBApi.retrieveHeaders(Form("RCT/Info/RunInformation/%i", bcs.begin().runNumber()), metadataRCT, -1);
       uint64_t sor = std::atol(header["SOR"].c_str());
       uint64_t eor = std::atol(header["EOR"].c_str());

--- a/PWGDQ/Tasks/muonDCA.cxx
+++ b/PWGDQ/Tasks/muonDCA.cxx
@@ -44,7 +44,7 @@ struct muonExtrap {
   Produces<ReducedMuonsDca> dcaTable;
   Configurable<std::string> geoPath{"geoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
   Configurable<std::string> grpmagPath{"grpmagPath", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
-  Configurable<string> fConfigCcdbUrl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+  Configurable<std::string> fConfigCcdbUrl{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
 
   Service<o2::ccdb::BasicCCDBManager> fCCDB;
   o2::parameters::GRPMagField* grpmag = nullptr; // for run 3, we access GRPMagField from GLO/Config/GRPMagField

--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -344,7 +344,7 @@ struct AnalysisEventSelection {
   void runEventSelection(TEvents const& events)
   {
     if (events.size() > 0 && events.begin().runNumber() != fCurrentRun) {
-      std::map<string, string> metadataRCT, header;
+      std::map<std::string, std::string> metadataRCT, header;
       header = fCCDBApi.retrieveHeaders(Form("RCT/Info/RunInformation/%i", events.begin().runNumber()), metadataRCT, -1);
       uint64_t sor = std::atol(header["SOR"].c_str());
       uint64_t eor = std::atol(header["EOR"].c_str());
@@ -641,7 +641,7 @@ struct AnalysisTrackSelection {
         LOGF(fatal, "GRP object is not available in CCDB at timestamp=%llu", events.begin().timestamp());
       }
 
-      std::map<string, string> metadataRCT, header;
+      std::map<std::string, std::string> metadataRCT, header;
       header = fCCDBApi.retrieveHeaders(Form("RCT/Info/RunInformation/%i", events.begin().runNumber()), metadataRCT, -1);
       uint64_t sor = std::atol(header["SOR"].c_str());
       uint64_t eor = std::atol(header["EOR"].c_str());

--- a/PWGEM/Dilepton/TableProducer/skimmerPrimaryMuon.cxx
+++ b/PWGEM/Dilepton/TableProducer/skimmerPrimaryMuon.cxx
@@ -117,7 +117,7 @@ struct skimmerPrimaryMuon {
     }
     mRunNumber = bc.runNumber();
 
-    std::map<string, string> metadata;
+    std::map<std::string, std::string> metadata;
     auto soreor = o2::ccdb::BasicCCDBManager::getRunDuration(ccdbApi, mRunNumber);
     auto ts = soreor.first;
     auto grpmag = ccdbApi.retrieveFromTFileAny<o2::parameters::GRPMagField>(grpmagPath, metadata, ts);

--- a/PWGEM/Dilepton/Tasks/matchingMFT.cxx
+++ b/PWGEM/Dilepton/Tasks/matchingMFT.cxx
@@ -126,7 +126,7 @@ struct matchingMFT {
     }
     mRunNumber = bc.runNumber();
     LOGF(info, "mRunNumber = %d", mRunNumber);
-    std::map<string, string> metadata;
+    std::map<std::string, std::string> metadata;
     auto soreor = o2::ccdb::BasicCCDBManager::getRunDuration(ccdbApi, mRunNumber);
     auto ts = soreor.first;
     auto grpmag = ccdbApi.retrieveFromTFileAny<o2::parameters::GRPMagField>(grpmagPath, metadata, ts);

--- a/PWGLF/TableProducer/Resonances/f1protonreducedtable.cxx
+++ b/PWGLF/TableProducer/Resonances/f1protonreducedtable.cxx
@@ -400,7 +400,7 @@ struct f1protonreducedtable {
 
   std::vector<double> setValuesBB(o2::ccdb::CcdbApi& ccdbApi, aod::BCsWithTimestamps::iterator const& bunchCrossing, const std::string ccdbPath)
   {
-    map<string, string> metadata;
+    std::map<std::string, std::string> metadata;
     auto h = ccdbApi.retrieveFromTFileAny<TH1F>(ccdbPath, metadata, bunchCrossing.timestamp());
     // auto h = ccdb->getForTimeStamp<TH1F>(ccdbPath, bunchCrossing.timestamp()); // check if possible to use this without getting fatal
     if (!h) {

--- a/PWGLF/TableProducer/Resonances/filterf1proton.cxx
+++ b/PWGLF/TableProducer/Resonances/filterf1proton.cxx
@@ -368,7 +368,7 @@ struct filterf1proton {
 
   std::vector<double> setValuesBB(o2::ccdb::CcdbApi& ccdbApi, aod::BCsWithTimestamps::iterator const& bunchCrossing, const std::string ccdbPath)
   {
-    map<string, string> metadata;
+    std::map<std::string, std::string> metadata;
     auto h = ccdbApi.retrieveFromTFileAny<TH1F>(ccdbPath, metadata, bunchCrossing.timestamp());
     // auto h = ccdb->getForTimeStamp<TH1F>(ccdbPath, bunchCrossing.timestamp()); // check if possible to use this without getting fatal
     if (!h) {

--- a/PWGLF/Tasks/Strangeness/hStrangeCorrelation.cxx
+++ b/PWGLF/Tasks/Strangeness/hStrangeCorrelation.cxx
@@ -62,7 +62,7 @@ struct HStrangeCorrelation {
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   // event filtering
-  Configurable<string> zorroMask{"zorroMask", "", "zorro trigger class to select on (empty: none)"};
+  Configurable<std::string> zorroMask{"zorroMask", "", "zorro trigger class to select on (empty: none)"};
 
   Zorro zorro;
   OutputObj<ZorroSummary> zorroSummary{"zorroSummary"};

--- a/PWGUD/TableProducer/fwdTrackPropagation.cxx
+++ b/PWGUD/TableProducer/fwdTrackPropagation.cxx
@@ -99,7 +99,7 @@ struct FwdTrackPropagation {
 
     if (run != fRun) {
       fRun = run;
-      std::map<string, string> metadata;
+      std::map<std::string, std::string> metadata;
       auto soreor = o2::ccdb::BasicCCDBManager::getRunDuration(fCCDBApi, run);
       auto ts = soreor.first;
       auto grpmag = fCCDBApi.retrieveFromTFileAny<o2::parameters::GRPMagField>("GLO/Config/GRPMagField", metadata, ts);


### PR DESCRIPTION
The header TJAlienCredentials.h polluted the global namespace, included usually with CCDB or something related.

See AliceO2Group/AliceO2#14524 for more background.
This prepares for the removal of the polluted namespace.