### PR TITLE
[PWGEM] PhotonMeson/Tasks/compconvbuilder: Fix linter and includes

### DIFF
--- a/PWGEM/PhotonMeson/Tasks/compconvbuilder.cxx
+++ b/PWGEM/PhotonMeson/Tasks/compconvbuilder.cxx
@@ -11,59 +11,47 @@
 
 /// \file compconvbuilder.cxx
 /// \brief QA task for photons in the EM and LF builder
-///
 /// \author S. Mrozinski, smrozins@cern.ch
 
 #include "PWGEM/Dilepton/Utils/MCUtilities.h"
 #include "PWGEM/PhotonMeson/Core/EMPhotonEventCut.h"
 #include "PWGEM/PhotonMeson/DataModel/gammaTables.h"
-#include "PWGEM/PhotonMeson/Utils/MCUtilities.h"
-#include "PWGEM/PhotonMeson/Utils/PCMUtilities.h"
-#include "PWGEM/PhotonMeson/Utils/PairUtilities.h"
-#include "PWGLF/DataModel/LFParticleIdentification.h"
 #include "PWGLF/DataModel/LFStrangenessMLTables.h"
 #include "PWGLF/DataModel/LFStrangenessPIDTables.h"
 #include "PWGLF/DataModel/LFStrangenessTables.h"
 
+#include "Common/CCDB/EventSelectionParams.h"
 #include "Common/Core/RecoDecay.h"
-#include "Common/Core/TPCVDriftManager.h"
-#include "Common/Core/TrackSelection.h"
-#include "Common/Core/trackUtilities.h"
-#include "Common/DataModel/Centrality.h"
-#include "Common/DataModel/EventSelection.h"
-#include "Common/DataModel/McCollisionExtra.h"
-#include "Common/DataModel/PIDResponse.h"
-#include "Common/DataModel/TrackSelectionTables.h"
 
-#include "CCDB/BasicCCDBManager.h"
-#include "DataFormatsParameters/GRPMagField.h"
-#include "DataFormatsParameters/GRPObject.h"
-#include "DetectorsBase/GeometryManager.h"
-#include "DetectorsBase/Propagator.h"
-#include "Framework/ASoAHelpers.h"
-#include "Framework/AnalysisDataModel.h"
-#include "Framework/AnalysisHelpers.h"
-#include "Framework/AnalysisTask.h"
-#include "Framework/HistogramRegistry.h"
-#include "Framework/runDataProcessing.h"
-#include "ReconstructionDataFormats/Track.h"
+#include <CommonConstants/MathConstants.h>
+#include <Framework/AnalysisDataModel.h>
+#include <Framework/AnalysisTask.h>
+#include <Framework/Configurable.h>
+#include <Framework/HistogramRegistry.h>
+#include <Framework/HistogramSpec.h>
+#include <Framework/InitContext.h>
+#include <Framework/runDataProcessing.h>
 
-#include <algorithm>
-#include <iterator>
+#include <TH1.h>
+#include <TH2.h>
+#include <THnSparse.h>
+#include <TPDGCode.h>
+
+#include <cstdlib>
+#include <optional>
 #include <ranges>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <unordered_map>
-#include <unordered_set>
 
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::aod;
 using namespace o2::soa;
+using namespace o2::constants;
 
-using namespace o2::aod::pwgem::photon;
 using namespace o2::aod::pwgem::dilepton::utils::mcutil;
-using namespace o2::aod::pwgem::photonmeson::utils::mcutil;
 
 using MyV0Photons = soa::Join<aod::V0PhotonsKF, aod::V0KFEMEventIds>;
 using MyMCV0Legs = soa::Join<aod::V0Legs, aod::V0LegMCLabels>;
@@ -79,25 +67,25 @@ using MyStraCollisions = soa::Join<aod::StraCollisions, aod::StraCents, aod::Str
 using MyStraCollision = MyStraCollisions::iterator;
 
 using MyTracksIUMC = soa::Join<aod::TracksIU, aod::McTrackLabels>;
-using MyMCParticles = aod::McParticles;
 
 using V0DerivedMCDatas = soa::Join<aod::V0Cores, aod::V0CollRefs, aod::V0Extras, aod::V0Indices, aod::V0MCMothers, aod::V0CoreMCLabels, aod::V0GammaMLScores>;
 
-using dauTracks = soa::Join<aod::DauTrackExtras, aod::DauTrackTPCPIDs>;
+using DauTracks = soa::Join<aod::DauTrackExtras, aod::DauTrackTPCPIDs>;
 
-struct Convbuildercomp {
-  HistogramRegistry registry{"Convbuildercomp"};
+struct Compconvbuilder {
+  HistogramRegistry registry{"Compconvbuilder"};
 
-  enum conversionBuilderID {
+  enum ConversionBuilderID {
     EMBuilder = 0,
     LFBuilder = 1,
     EMOnly = 2,
     LFOnly = 3,
-    Common = 4
+    Common = 4,
+    NConversionBuilder
   };
 
-  static constexpr std::string_view conversionBuilder[5] = {"EMBuilder/", "LFBuilder/", "EMOnly/", "LFOnly/", "Common/"};
-  static constexpr std::string_view event_types[2] = {"before/", "after/"};
+  static constexpr std::string_view kConversionBuilder[NConversionBuilder] = {"EMBuilder/", "LFBuilder/", "EMOnly/", "LFOnly/", "Common/"};
+  static constexpr std::string_view kEventTypes[2] = {"before/", "after/"};
 
   EMPhotonEventCut fEMEventCut;
   struct : ConfigurableGroup {
@@ -121,7 +109,7 @@ struct Convbuildercomp {
     Configurable<bool> cfgRequireNoHighMultCollInPrevRof{"cfgRequireNoHighMultCollInPrevRof", false, "require no HM collision in previous ITS ROF"};
   } eventcuts;
 
-  void DefineEMEventCut()
+  void defineEMEventCut()
   {
     fEMEventCut = EMPhotonEventCut("fEMEventCut", "fEMEventCut");
     fEMEventCut.SetRequireSel8(eventcuts.cfgRequireSel8);
@@ -145,30 +133,30 @@ struct Convbuildercomp {
   void init(InitContext const& /*ctx*/)
   {
 
-    DefineEMEventCut();
+    defineEMEventCut();
 
-    for (int i = 0; i < 5; ++i) {
+    for (int i = 0; i < NConversionBuilder; ++i) {
 
-      registry.add<TH1>(string(conversionBuilder[i]) + "hPt", ";p_{T} (GeV/c); Counts", kTH1F, {{1000, 0., 10.}});
-      registry.add<TH1>(string(conversionBuilder[i]) + "hR", ";R_{conv} (cm); Counts", kTH1F, {{100, 0., 100.}});
+      registry.add<TH1>(string(kConversionBuilder[i]) + "hPt", ";p_{T} (GeV/c); Counts", kTH1F, {{1000, 0., 10.}});
+      registry.add<TH1>(string(kConversionBuilder[i]) + "hR", ";R_{conv} (cm); Counts", kTH1F, {{100, 0., 100.}});
 
-      registry.add<TH1>(string(conversionBuilder[i]) + "hEta", ";#eta; Counts", kTH1F, {{200, -1.0f, 1.0f}});
+      registry.add<TH1>(string(kConversionBuilder[i]) + "hEta", ";#eta; Counts", kTH1F, {{200, -1.0f, 1.0f}});
 
-      registry.add<TH1>(string(conversionBuilder[i]) + "hcosPA", ";R_{conv} (cm); Counts", kTH1F, {{100, 0.99f, 1.0f}});
+      registry.add<TH1>(string(kConversionBuilder[i]) + "hcosPA", ";R_{conv} (cm); Counts", kTH1F, {{100, 0.99f, 1.0f}});
 
-      registry.add<TH1>(string(conversionBuilder[i]) + "MatchedDeltaRec", ";#Delta colID_{rec};Counts", kTH1F, {{21, -10.5, 10.5}});
+      registry.add<TH1>(string(kConversionBuilder[i]) + "MatchedDeltaRec", ";#Delta colID_{rec};Counts", kTH1F, {{21, -10.5, 10.5}});
 
-      registry.add<TH1>(string(conversionBuilder[i]) + "hZ", ";z (cm);Counts", kTH1F, {{200, -100, 100}});
+      registry.add<TH1>(string(kConversionBuilder[i]) + "hZ", ";z (cm);Counts", kTH1F, {{200, -100, 100}});
 
-      registry.add<TH2>(string(conversionBuilder[i]) + "hZR", "conversion point in RZ;Z (cm);R_{xy} (cm)", kTH2F, {{200, -100, 100}, {200, 0.0f, 100.0f}});
+      registry.add<TH2>(string(kConversionBuilder[i]) + "hZR", "conversion point in RZ;Z (cm);R_{xy} (cm)", kTH2F, {{200, -100, 100}, {200, 0.0f, 100.0f}});
 
-      registry.add<TH2>(string(conversionBuilder[i]) + "hAP", "AP plot;#alpha;q_{T} (GeV/c)", kTH2F, {{200, -1.0f, +1.0f}, {250, 0.0f, 0.25f}});
+      registry.add<TH2>(string(kConversionBuilder[i]) + "hAP", "AP plot;#alpha;q_{T} (GeV/c)", kTH2F, {{200, -1.0f, +1.0f}, {250, 0.0f, 0.25f}});
 
-      registry.add<THnSparse>(string(conversionBuilder[i]) + "ResolutionGen/Z_res", "Conversion radius resolution;z_{conv, gen} (cm);R_{conv, gen} (cm);#varphi_{gen} (rad.);#eta_{gen};p_{T, gen};z_{conv, rec} - z_{conv, gen} (cm);",
+      registry.add<THnSparse>(string(kConversionBuilder[i]) + "ResolutionGen/Z_res", "Conversion radius resolution;z_{conv, gen} (cm);R_{conv, gen} (cm);#varphi_{gen} (rad.);#eta_{gen};p_{T, gen};z_{conv, rec} - z_{conv, gen} (cm);",
                               kTHnSparseF,
                               {{200, -100, 100},
                                {200, 0, 100},
-                               {90, 0, 2 * M_PI},
+                               {90, 0, math::TwoPI},
                                {200, -1.0f, 1.0f},
                                {500, 0, 10},
                                {120, -30, 30}
@@ -176,11 +164,11 @@ struct Convbuildercomp {
                               },
                               false);
 
-      registry.add<THnSparse>(string(conversionBuilder[i]) + "ResolutionGen/R_res", "Conversion radius resolution;z_{conv, gen} (cm);R_{conv, gen} (cm);#varphi_{gen} (rad.);#eta_{gen};p_{T, gen};R_{conv, rec} - R_{conv, gen} (cm);",
+      registry.add<THnSparse>(string(kConversionBuilder[i]) + "ResolutionGen/R_res", "Conversion radius resolution;z_{conv, gen} (cm);R_{conv, gen} (cm);#varphi_{gen} (rad.);#eta_{gen};p_{T, gen};R_{conv, rec} - R_{conv, gen} (cm);",
                               kTHnSparseF,
                               {{200, -100, 100},
                                {200, 0, 100},
-                               {90, 0, 2 * M_PI},
+                               {90, 0, math::TwoPI},
                                {200, -1.0f, 1.0f},
                                {500, 0, 10},
                                {120, -30, 30}
@@ -188,11 +176,11 @@ struct Convbuildercomp {
                               },
                               false);
 
-      registry.add<THnSparse>(string(conversionBuilder[i]) + "ResolutionGen/Phi_res", "#varphi resolution;z_{conv, gen} (cm);R_{conv, gen} (cm);#varphi_{gen} (rad.);#eta_{gen};p_{T, gen};#varphi_{conv, rec} - #varphi_{conv, gen} (cm);",
+      registry.add<THnSparse>(string(kConversionBuilder[i]) + "ResolutionGen/Phi_res", "#varphi resolution;z_{conv, gen} (cm);R_{conv, gen} (cm);#varphi_{gen} (rad.);#eta_{gen};p_{T, gen};#varphi_{conv, rec} - #varphi_{conv, gen} (cm);",
                               kTHnSparseF,
                               {{200, -100, 100},
                                {200, 0, 100},
-                               {90, 0, 2 * M_PI},
+                               {90, 0, math::TwoPI},
                                {200, -1.0f, 1.0f},
                                {500, 0, 10},
                                {100, -0.2f, 0.2f}
@@ -200,11 +188,11 @@ struct Convbuildercomp {
                               },
                               false);
 
-      registry.add<THnSparse>(string(conversionBuilder[i]) + "ResolutionGen/Pt_res", "Conversion radius resolution;z_{conv, gen} (cm);R_{conv, gen} (cm);#varphi_{gen} (rad.);#eta_{gen};p_{T, gen};p_{T, rec} - p_{T, gen}/p_{T, gen};",
+      registry.add<THnSparse>(string(kConversionBuilder[i]) + "ResolutionGen/Pt_res", "Conversion radius resolution;z_{conv, gen} (cm);R_{conv, gen} (cm);#varphi_{gen} (rad.);#eta_{gen};p_{T, gen};p_{T, rec} - p_{T, gen}/p_{T, gen};",
                               kTHnSparseF,
                               {{200, -100, 100},
                                {200, 0, 100},
-                               {90, 0, 2 * M_PI},
+                               {90, 0, math::TwoPI},
                                {200, -1.0f, 1.0f},
                                {500, 0, 10},
                                {200, -1.0f, 1.0f}
@@ -212,11 +200,11 @@ struct Convbuildercomp {
                               },
                               false);
 
-      registry.add<THnSparse>(string(conversionBuilder[i]) + "ResolutionGen/Eta_res", "Conversion radius resolution;z_{conv, gen} (cm);R_{conv, gen} (cm);#varphi_{gen} (rad.);#eta_{gen};p_{T, gen};#eta_{conv, rec} - #eta_{conv, gen} (cm);",
+      registry.add<THnSparse>(string(kConversionBuilder[i]) + "ResolutionGen/Eta_res", "Conversion radius resolution;z_{conv, gen} (cm);R_{conv, gen} (cm);#varphi_{gen} (rad.);#eta_{gen};p_{T, gen};#eta_{conv, rec} - #eta_{conv, gen} (cm);",
                               kTHnSparseF,
                               {{200, -100, 100},
                                {200, 0, 100},
-                               {90, 0, 2 * M_PI},
+                               {90, 0, math::TwoPI},
                                {200, -1.0f, 1.0f},
                                {500, 0, 10},
                                {100, -0.5f, 0.5f}
@@ -224,11 +212,11 @@ struct Convbuildercomp {
                               },
                               false);
 
-      registry.add<THnSparse>(string(conversionBuilder[i]) + "ResolutionRec/Z_res", "Conversion radius resolution;z_{conv, rec} (cm);R_{conv, rec} (cm);#varphi_{rec} (rad.);#eta_{rec};p_{T, rec};z_{conv, rec} - z_{conv, gen} (cm);",
+      registry.add<THnSparse>(string(kConversionBuilder[i]) + "ResolutionRec/Z_res", "Conversion radius resolution;z_{conv, rec} (cm);R_{conv, rec} (cm);#varphi_{rec} (rad.);#eta_{rec};p_{T, rec};z_{conv, rec} - z_{conv, gen} (cm);",
                               kTHnSparseF,
                               {{200, -100, 100},
                                {200, 0, 100},
-                               {90, 0, 2 * M_PI},
+                               {90, 0, math::TwoPI},
                                {200, -1.0f, 1.0f},
                                {500, 0, 10},
                                {120, -30, 30}
@@ -236,11 +224,11 @@ struct Convbuildercomp {
                               },
                               false);
 
-      registry.add<THnSparse>(string(conversionBuilder[i]) + "ResolutionRec/R_res", "Conversion radius resolution;z_{conv, rec} (cm);R_{conv, rec} (cm);#varphi_{rec} (rad.);#eta_{rec};p_{T, rec};R_{conv, rec} - R_{conv, gen} (cm);",
+      registry.add<THnSparse>(string(kConversionBuilder[i]) + "ResolutionRec/R_res", "Conversion radius resolution;z_{conv, rec} (cm);R_{conv, rec} (cm);#varphi_{rec} (rad.);#eta_{rec};p_{T, rec};R_{conv, rec} - R_{conv, gen} (cm);",
                               kTHnSparseF,
                               {{200, -100, 100},
                                {200, 0, 100},
-                               {90, 0, 2 * M_PI},
+                               {90, 0, math::TwoPI},
                                {200, -1.0f, 1.0f},
                                {500, 0, 10},
                                {120, -30, 30}
@@ -248,11 +236,11 @@ struct Convbuildercomp {
                               },
                               false);
 
-      registry.add<THnSparse>(string(conversionBuilder[i]) + "ResolutionRec/Phi_res", "#varphi resolution;z_{conv, rec} (cm);R_{conv, rec} (cm);#varphi_{rec} (rad.);#eta_{rec};p_{T, rec};#varphi_{conv, rec} - #varphi_{conv, gen} (cm);",
+      registry.add<THnSparse>(string(kConversionBuilder[i]) + "ResolutionRec/Phi_res", "#varphi resolution;z_{conv, rec} (cm);R_{conv, rec} (cm);#varphi_{rec} (rad.);#eta_{rec};p_{T, rec};#varphi_{conv, rec} - #varphi_{conv, gen} (cm);",
                               kTHnSparseF,
                               {{200, -100, 100},
                                {200, 0, 100},
-                               {90, 0, 2 * M_PI},
+                               {90, 0, math::TwoPI},
                                {200, -1.0f, 1.0f},
                                {500, 0, 10},
                                {100, -0.2f, 0.2f}
@@ -260,11 +248,11 @@ struct Convbuildercomp {
                               },
                               false);
 
-      registry.add<THnSparse>(string(conversionBuilder[i]) + "ResolutionRec/Pt_res", "Conversion radius resolution;z_{conv, rec} (cm);R_{conv, rec} (cm);#varphi_{rec} (rad.);#eta_{rec};p_{T, rec};p_{T, rec} - p_{T, gen}/p_{T, gen};",
+      registry.add<THnSparse>(string(kConversionBuilder[i]) + "ResolutionRec/Pt_res", "Conversion radius resolution;z_{conv, rec} (cm);R_{conv, rec} (cm);#varphi_{rec} (rad.);#eta_{rec};p_{T, rec};p_{T, rec} - p_{T, gen}/p_{T, gen};",
                               kTHnSparseF,
                               {{200, -100, 100},
                                {200, 0, 100},
-                               {90, 0, 2 * M_PI},
+                               {90, 0, math::TwoPI},
                                {200, -1.0f, 1.0f},
                                {500, 0, 10},
                                {200, -1.0f, 1.0f}
@@ -272,34 +260,34 @@ struct Convbuildercomp {
                               },
                               false);
 
-      registry.add<THnSparse>(string(conversionBuilder[i]) + "ResolutionRec/Eta_res", "Conversion radius resolution;z_{conv, rec} (cm);R_{conv, rec} (cm);#varphi_{rec} (rad.);#eta_{rec};p_{T, rec};#eta_{conv, rec} - #eta_{conv, gen} (cm);",
+      registry.add<THnSparse>(string(kConversionBuilder[i]) + "ResolutionRec/Eta_res", "Conversion radius resolution;z_{conv, rec} (cm);R_{conv, rec} (cm);#varphi_{rec} (rad.);#eta_{rec};p_{T, rec};#eta_{conv, rec} - #eta_{conv, gen} (cm);",
                               kTHnSparseF,
                               {{200, -100, 100},
                                {200, 0, 100},
-                               {90, 0, 2 * M_PI},
+                               {90, 0, math::TwoPI},
                                {200, -1.0f, 1.0f},
                                {500, 0, 10},
                                {100, -0.5f, 0.5f}
 
                               },
                               false);
-      registry.add<THnSparse>(string(conversionBuilder[i]) + "ConvInfo", "Conversion radius resolution;x_{conv} (cm);y_{conv} (cm);z_{conv} (cm);R_{conv} (cm);#varphi (rad.);#eta;p_{T, gen};",
+      registry.add<THnSparse>(string(kConversionBuilder[i]) + "ConvInfo", "Conversion radius resolution;x_{conv} (cm);y_{conv} (cm);z_{conv} (cm);R_{conv} (cm);#varphi (rad.);#eta;p_{T, gen};",
                               kTHnSparseF,
                               {
                                 {200, -100, 100},
                                 {200, -100, 100},
                                 {200, -100, 100},
                                 {200, 0, 100},
-                                {90, 0, 2 * M_PI},
+                                {90, 0, math::TwoPI},
                                 {200, -1.0f, 1.0f},
                                 {500, 0, 10},
 
                               },
                               false);
 
-      registry.add<TH1>(string(conversionBuilder[i]) + "V0Leg/Asymmetry", "", kTH1F, {{100, 0, 1}});
+      registry.add<TH1>(string(kConversionBuilder[i]) + "V0Leg/Asymmetry", "", kTH1F, {{100, 0, 1}});
 
-      auto hCollisionCounter = registry.add<TH1>(string(conversionBuilder[i]) + "Event/before/hCollisionCounter", "collision counter;;Number of events", kTH1F, {{10, 0.5, 10.5}}, false);
+      auto hCollisionCounter = registry.add<TH1>(string(kConversionBuilder[i]) + "Event/before/hCollisionCounter", "collision counter;;Number of events", kTH1F, {{10, 0.5, 10.5}}, false);
       hCollisionCounter->GetXaxis()->SetBinLabel(1, "all");
       hCollisionCounter->GetXaxis()->SetBinLabel(2, "No TF border");
       hCollisionCounter->GetXaxis()->SetBinLabel(3, "No ITS ROF border");
@@ -311,16 +299,16 @@ struct Convbuildercomp {
       hCollisionCounter->GetXaxis()->SetBinLabel(9, "|Z_{vtx}| < 10 cm");
       hCollisionCounter->GetXaxis()->SetBinLabel(10, "accepted");
 
-      registry.add(string(conversionBuilder[i]) + "Event/before/hZvtx", "vertex z; Z_{vtx} (cm)", kTH1F, {{100, -50, +50}}, false);
-      registry.add(string(conversionBuilder[i]) + "Event/before/hMultNTracksPV", "hMultNTracksPV; N_{track} to PV", kTH1F, {{6001, -0.5, 6000.5}}, false);
-      registry.add(string(conversionBuilder[i]) + "Event/before/hMultNTracksPVeta1", "hMultNTracksPVeta1; N_{track} to PV", kTH1F, {{6001, -0.5, 6000.5}}, false);
-      registry.add(string(conversionBuilder[i]) + "Event/before/hMultFT0", "hMultFT0;mult. FT0A;mult. FT0C", kTH2F, {{300, 0, 6000}, {300, 0, 6000}}, false);
-      registry.add(string(conversionBuilder[i]) + "Event/before/hCentFT0A", "hCentFT0A;centrality FT0A (%)", kTH1F, {{110, 0, 110}}, false);
-      registry.add(string(conversionBuilder[i]) + "Event/before/hCentFT0C", "hCentFT0C;centrality FT0C (%)", kTH1F, {{110, 0, 110}}, false);
-      registry.add(string(conversionBuilder[i]) + "Event/before/hCentFT0M", "hCentFT0M;centrality FT0M (%)", kTH1F, {{110, 0, 110}}, false);
-      registry.add(string(conversionBuilder[i]) + "Event/before/hCentFT0MvsMultNTracksPV", "hCentFT0MvsMultNTracksPV;centrality FT0M (%);N_{track} to PV", kTH2F, {{110, 0, 110}, {600, 0, 6000}}, false);
-      registry.add(string(conversionBuilder[i]) + "Event/before/hMultFT0MvsMultNTracksPV", "hMultFT0MvsMultNTracksPV;mult. FT0M;N_{track} to PV", kTH2F, {{600, 0, 6000}, {600, 0, 6000}}, false);
-      registry.addClone(string(conversionBuilder[i]) + "Event/before/", string(conversionBuilder[i]) + "Event/after/");
+      registry.add(string(kConversionBuilder[i]) + "Event/before/hZvtx", "vertex z; Z_{vtx} (cm)", kTH1F, {{100, -50, +50}}, false);
+      registry.add(string(kConversionBuilder[i]) + "Event/before/hMultNTracksPV", "hMultNTracksPV; N_{track} to PV", kTH1F, {{6001, -0.5, 6000.5}}, false);
+      registry.add(string(kConversionBuilder[i]) + "Event/before/hMultNTracksPVeta1", "hMultNTracksPVeta1; N_{track} to PV", kTH1F, {{6001, -0.5, 6000.5}}, false);
+      registry.add(string(kConversionBuilder[i]) + "Event/before/hMultFT0", "hMultFT0;mult. FT0A;mult. FT0C", kTH2F, {{300, 0, 6000}, {300, 0, 6000}}, false);
+      registry.add(string(kConversionBuilder[i]) + "Event/before/hCentFT0A", "hCentFT0A;centrality FT0A (%)", kTH1F, {{110, 0, 110}}, false);
+      registry.add(string(kConversionBuilder[i]) + "Event/before/hCentFT0C", "hCentFT0C;centrality FT0C (%)", kTH1F, {{110, 0, 110}}, false);
+      registry.add(string(kConversionBuilder[i]) + "Event/before/hCentFT0M", "hCentFT0M;centrality FT0M (%)", kTH1F, {{110, 0, 110}}, false);
+      registry.add(string(kConversionBuilder[i]) + "Event/before/hCentFT0MvsMultNTracksPV", "hCentFT0MvsMultNTracksPV;centrality FT0M (%);N_{track} to PV", kTH2F, {{110, 0, 110}, {600, 0, 6000}}, false);
+      registry.add(string(kConversionBuilder[i]) + "Event/before/hMultFT0MvsMultNTracksPV", "hMultFT0MvsMultNTracksPV;mult. FT0M;N_{track} to PV", kTH2F, {{600, 0, 6000}, {600, 0, 6000}}, false);
+      registry.addClone(string(kConversionBuilder[i]) + "Event/before/", string(kConversionBuilder[i]) + "Event/after/");
     }
 
     registry.add<TH1>("truePhotons/hPt_Converted", "Converted Photons; p_{T} (GeV/c); Counts", kTH1F, {{100, 0., 10.}});
@@ -332,7 +320,7 @@ struct Convbuildercomp {
                              {200, -100, 100},
                              {200, -100, 100},
                              {200, 0, 100},
-                             {90, 0, 2 * M_PI},
+                             {90, 0, math::TwoPI},
                              {200, -1.0f, 1.0f},
                              {500, 0, 10}},
                             false);
@@ -350,36 +338,36 @@ struct Convbuildercomp {
   template <const int ev_id, int type, typename TCollision>
   void fillEventInfo(TCollision const& collision, const float /*weight*/ = 1.f)
   {
-    registry.fill(HIST(conversionBuilder[type]) + HIST("Event/") + HIST(event_types[ev_id]) + HIST("hCollisionCounter"), 1.0);
+    registry.fill(HIST(kConversionBuilder[type]) + HIST("Event/") + HIST(kEventTypes[ev_id]) + HIST("hCollisionCounter"), 1.0);
 
     if (collision.selection_bit(o2::aod::evsel::kNoTimeFrameBorder)) {
-      registry.fill(HIST(conversionBuilder[type]) + HIST("Event/") + HIST(event_types[ev_id]) + HIST("hCollisionCounter"), 2.0);
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("Event/") + HIST(kEventTypes[ev_id]) + HIST("hCollisionCounter"), 2.0);
     }
     if (collision.selection_bit(o2::aod::evsel::kNoITSROFrameBorder)) {
-      registry.fill(HIST(conversionBuilder[type]) + HIST("Event/") + HIST(event_types[ev_id]) + HIST("hCollisionCounter"), 3.0);
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("Event/") + HIST(kEventTypes[ev_id]) + HIST("hCollisionCounter"), 3.0);
     }
     if (collision.selection_bit(o2::aod::evsel::kNoSameBunchPileup)) {
-      registry.fill(HIST(conversionBuilder[type]) + HIST("Event/") + HIST(event_types[ev_id]) + HIST("hCollisionCounter"), 4.0);
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("Event/") + HIST(kEventTypes[ev_id]) + HIST("hCollisionCounter"), 4.0);
     }
     if (collision.selection_bit(o2::aod::evsel::kIsVertexITSTPC)) {
-      registry.fill(HIST(conversionBuilder[type]) + HIST("Event/") + HIST(event_types[ev_id]) + HIST("hCollisionCounter"), 5.0);
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("Event/") + HIST(kEventTypes[ev_id]) + HIST("hCollisionCounter"), 5.0);
     }
     if (collision.selection_bit(o2::aod::evsel::kIsGoodZvtxFT0vsPV)) {
-      registry.fill(HIST(conversionBuilder[type]) + HIST("Event/") + HIST(event_types[ev_id]) + HIST("hCollisionCounter"), 6.0);
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("Event/") + HIST(kEventTypes[ev_id]) + HIST("hCollisionCounter"), 6.0);
     }
 
     if (collision.selection_bit(o2::aod::evsel::kIsTriggerTVX)) {
-      registry.fill(HIST(conversionBuilder[type]) + HIST("Event/") + HIST(event_types[ev_id]) + HIST("hCollisionCounter"), 7.0);
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("Event/") + HIST(kEventTypes[ev_id]) + HIST("hCollisionCounter"), 7.0);
     }
 
     if (collision.sel8()) {
-      registry.fill(HIST(conversionBuilder[type]) + HIST("Event/") + HIST(event_types[ev_id]) + HIST("hCollisionCounter"), 8.0);
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("Event/") + HIST(kEventTypes[ev_id]) + HIST("hCollisionCounter"), 8.0);
     }
-    if (std::fabs(collision.posZ()) < 10.0) {
-      registry.fill(HIST(conversionBuilder[type]) + HIST("Event/") + HIST(event_types[ev_id]) + HIST("hCollisionCounter"), 9.0);
+    if (std::fabs(collision.posZ()) < eventcuts.cfgZvtxMax) {
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("Event/") + HIST(kEventTypes[ev_id]) + HIST("hCollisionCounter"), 9.0);
     }
 
-    registry.fill(HIST(conversionBuilder[type]) + HIST("Event/") + HIST(event_types[ev_id]) + HIST("hMultNTracksPVeta1"), collision.multNTracksPVeta1());
+    registry.fill(HIST(kConversionBuilder[type]) + HIST("Event/") + HIST(kEventTypes[ev_id]) + HIST("hMultNTracksPVeta1"), collision.multNTracksPVeta1());
   }
 
   template <int type>
@@ -391,7 +379,7 @@ struct Convbuildercomp {
       float ptNeg = negleg.pt();
       float asym = (ptPos - ptNeg) / (ptPos + ptNeg);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("V0Leg/Asymmetry"), asym);
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("V0Leg/Asymmetry"), asym);
 
     } else {
 
@@ -399,21 +387,21 @@ struct Convbuildercomp {
       float ptNeg = negleg.negtrackpt();
       float asym = (ptPos - ptNeg) / (ptPos + ptNeg);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("V0Leg/Asymmetry"), asym);
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("V0Leg/Asymmetry"), asym);
     }
   }
 
   template <int type>
   void fillV0Info(auto& v0, auto& v0MC, auto& mcleg)
   {
-    registry.fill(HIST(conversionBuilder[type]) + HIST("hPt"), v0.pt());
-    registry.fill(HIST(conversionBuilder[type]) + HIST("hEta"), v0.eta());
-    registry.fill(HIST(conversionBuilder[type]) + HIST("hAP"), v0.alpha(), v0.qtarm());
+    registry.fill(HIST(kConversionBuilder[type]) + HIST("hPt"), v0.pt());
+    registry.fill(HIST(kConversionBuilder[type]) + HIST("hEta"), v0.eta());
+    registry.fill(HIST(kConversionBuilder[type]) + HIST("hAP"), v0.alpha(), v0.qtarm());
 
-    if constexpr (type == 0 || type == 2) {
-      registry.fill(HIST(conversionBuilder[type]) + HIST("hZ"), v0.vz());
-      registry.fill(HIST(conversionBuilder[type]) + HIST("hcosPA"), v0.cospa());
-      registry.fill(HIST(conversionBuilder[type]) + HIST("hZR"), v0.vz(), v0.v0radius());
+    if constexpr (type == EMBuilder || type == EMOnly) {
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("hZ"), v0.vz());
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("hcosPA"), v0.cospa());
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("hZR"), v0.vz(), v0.v0radius());
 
       float deltapT = v0.pt() - v0MC.pt();
       float deltaZ = v0.vz() - mcleg.vz();
@@ -421,7 +409,7 @@ struct Convbuildercomp {
       float deltaEta = v0.eta() - v0MC.eta();
       float deltaR = v0.v0radius() - std::sqrt(std::pow(mcleg.vx(), 2) + std::pow(mcleg.vy(), 2));
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ResolutionGen/Z_res"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ResolutionGen/Z_res"),
                     mcleg.vz(),
                     std::sqrt(std::pow(mcleg.vx(), 2) + std::pow(mcleg.vy(), 2)),
                     v0MC.phi(),
@@ -429,7 +417,7 @@ struct Convbuildercomp {
                     v0MC.pt(),
                     deltaZ);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ResolutionGen/R_res"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ResolutionGen/R_res"),
                     mcleg.vz(),
                     std::sqrt(std::pow(mcleg.vx(), 2) + std::pow(mcleg.vy(), 2)),
                     v0MC.phi(),
@@ -437,7 +425,7 @@ struct Convbuildercomp {
                     v0MC.pt(),
                     deltaR);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ResolutionGen/Phi_res"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ResolutionGen/Phi_res"),
                     mcleg.vz(),
                     std::sqrt(std::pow(mcleg.vx(), 2) + std::pow(mcleg.vy(), 2)),
                     v0MC.phi(),
@@ -445,7 +433,7 @@ struct Convbuildercomp {
                     v0MC.pt(),
                     deltaPhi);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ResolutionGen/Pt_res"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ResolutionGen/Pt_res"),
                     mcleg.vz(),
                     std::sqrt(std::pow(mcleg.vx(), 2) + std::pow(mcleg.vy(), 2)),
                     v0MC.phi(),
@@ -453,7 +441,7 @@ struct Convbuildercomp {
                     v0MC.pt(),
                     deltapT);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ResolutionGen/Eta_res"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ResolutionGen/Eta_res"),
                     mcleg.vz(),
                     std::sqrt(std::pow(mcleg.vx(), 2) + std::pow(mcleg.vy(), 2)),
                     v0MC.phi(),
@@ -461,7 +449,7 @@ struct Convbuildercomp {
                     v0MC.pt(),
                     deltaEta);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ResolutionRec/Z_res"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ResolutionRec/Z_res"),
                     v0.vz(),
                     v0.v0radius(),
                     v0.phi(),
@@ -469,7 +457,7 @@ struct Convbuildercomp {
                     v0.pt(),
                     deltaZ);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ResolutionRec/R_res"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ResolutionRec/R_res"),
                     v0.vz(),
                     v0.v0radius(),
                     v0.phi(),
@@ -477,7 +465,7 @@ struct Convbuildercomp {
                     v0.pt(),
                     deltaR);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ResolutionRec/Phi_res"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ResolutionRec/Phi_res"),
                     v0.vz(),
                     v0.v0radius(),
                     v0.phi(),
@@ -485,7 +473,7 @@ struct Convbuildercomp {
                     v0.pt(),
                     deltaPhi);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ResolutionRec/Pt_res"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ResolutionRec/Pt_res"),
                     v0.vz(),
                     v0.v0radius(),
                     v0.phi(),
@@ -493,7 +481,7 @@ struct Convbuildercomp {
                     v0.pt(),
                     deltapT);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ResolutionRec/Eta_res"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ResolutionRec/Eta_res"),
                     v0.vz(),
                     v0.v0radius(),
                     v0.phi(),
@@ -501,7 +489,7 @@ struct Convbuildercomp {
                     v0.pt(),
                     deltaEta);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ConvInfo"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ConvInfo"),
                     v0.vx(),       // 0
                     v0.vy(),       // 1
                     v0.vz(),       // 2
@@ -511,26 +499,20 @@ struct Convbuildercomp {
                     v0.pt());      // 6
 
     } else {
-      registry.fill(HIST(conversionBuilder[type]) + HIST("hZ"), v0.z());
-      registry.fill(HIST(conversionBuilder[type]) + HIST("hcosPA"), v0.v0cosPA());
-      registry.fill(HIST(conversionBuilder[type]) + HIST("hZR"), v0.z(), v0.v0radius());
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("hZ"), v0.z());
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("hcosPA"), v0.v0cosPA());
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("hZR"), v0.z(), v0.v0radius());
 
       float deltaR = v0.v0radius() - std::hypot(v0MC.xMC(), v0MC.yMC());
 
       float phiRec = v0.phi();
-      if (phiRec < 0) {
-        phiRec += 2.0f * static_cast<float>(M_PI);
-      }
+      RecoDecay::constrainAngle(phiRec);
 
       float phiMC = std::atan2(v0MC.pyMC(), v0MC.pxMC());
-      if (phiMC < 0) {
-        phiMC += 2.0f * static_cast<float>(M_PI);
-      }
+      RecoDecay::constrainAngle(phiMC);
 
       float deltaPhi = phiRec - phiMC;
-      if (deltaPhi < 0) {
-        deltaPhi += 2.0f * static_cast<float>(M_PI);
-      }
+      RecoDecay::constrainAngle(deltaPhi);
 
       float etaGen = 0.5f * std::log((std::hypot(v0MC.pxMC(), v0MC.pyMC(), v0MC.pzMC()) + v0MC.pzMC()) / (std::hypot(v0MC.pxMC(), v0MC.pyMC(), v0MC.pzMC()) - v0MC.pzMC()));
 
@@ -540,7 +522,7 @@ struct Convbuildercomp {
       float deltaEta = etaRec - etaGen;
       float deltaZ = v0.z() - v0MC.zMC();
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ResolutionGen/Z_res"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ResolutionGen/Z_res"),
                     v0MC.zMC(),
                     std::hypot(v0MC.xMC(), v0MC.yMC()),
                     phiMC,
@@ -548,7 +530,7 @@ struct Convbuildercomp {
                     v0MC.ptMC(),
                     deltaZ);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ResolutionGen/R_res"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ResolutionGen/R_res"),
                     v0MC.zMC(),
                     std::hypot(v0MC.xMC(), v0MC.yMC()),
                     phiMC,
@@ -556,7 +538,7 @@ struct Convbuildercomp {
                     v0MC.ptMC(),
                     deltaR);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ResolutionGen/Phi_res"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ResolutionGen/Phi_res"),
                     v0MC.zMC(),
                     std::hypot(v0MC.xMC(), v0MC.yMC()),
                     phiMC,
@@ -564,7 +546,7 @@ struct Convbuildercomp {
                     v0MC.ptMC(),
                     deltaPhi);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ResolutionGen/Pt_res"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ResolutionGen/Pt_res"),
                     v0MC.zMC(),
                     std::hypot(v0MC.xMC(), v0MC.yMC()),
                     phiMC,
@@ -572,7 +554,7 @@ struct Convbuildercomp {
                     v0MC.ptMC(),
                     deltapT);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ResolutionGen/Eta_res"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ResolutionGen/Eta_res"),
                     v0MC.zMC(),
                     std::hypot(v0MC.xMC(), v0MC.yMC()),
                     phiMC,
@@ -580,7 +562,7 @@ struct Convbuildercomp {
                     v0MC.ptMC(),
                     deltaEta);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ResolutionRec/Z_res"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ResolutionRec/Z_res"),
                     v0.z(),
                     v0.v0radius(),
                     phiRec,
@@ -588,7 +570,7 @@ struct Convbuildercomp {
                     v0.pt(),
                     deltaZ);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ResolutionRec/R_res"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ResolutionRec/R_res"),
                     v0.z(),
                     v0.v0radius(),
                     phiRec,
@@ -596,7 +578,7 @@ struct Convbuildercomp {
                     v0.pt(),
                     deltaR);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ResolutionRec/Phi_res"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ResolutionRec/Phi_res"),
                     v0.z(),
                     v0.v0radius(),
                     phiRec,
@@ -604,7 +586,7 @@ struct Convbuildercomp {
                     v0.pt(),
                     deltaPhi);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ResolutionRec/Eta_res"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ResolutionRec/Eta_res"),
                     v0.z(),
                     v0.v0radius(),
                     phiRec,
@@ -612,7 +594,7 @@ struct Convbuildercomp {
                     v0.pt(),
                     deltaEta);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ResolutionRec/Pt_res"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ResolutionRec/Pt_res"),
                     v0.z(),
                     v0.v0radius(),
                     phiRec,
@@ -620,7 +602,7 @@ struct Convbuildercomp {
                     v0.pt(),
                     deltapT);
 
-      registry.fill(HIST(conversionBuilder[type]) + HIST("ConvInfo"),
+      registry.fill(HIST(kConversionBuilder[type]) + HIST("ConvInfo"),
                     v0.x(),
                     v0.y(),
                     v0.z(),
@@ -630,7 +612,7 @@ struct Convbuildercomp {
                     v0.pt());
     }
 
-    registry.fill(HIST(conversionBuilder[type]) + HIST("hR"), v0.v0radius());
+    registry.fill(HIST(kConversionBuilder[type]) + HIST("hR"), v0.v0radius());
   }
 
   Preslice<V0DerivedMCDatas> perCollisionMCDerived = o2::aod::v0data::straCollisionId;
@@ -638,10 +620,10 @@ struct Convbuildercomp {
   void processLFV0sMC(MyStraCollisions const& stracollisions,
                       soa::Join<aod::V0MCCores, aod::V0MCCollRefs> const&,
                       V0DerivedMCDatas const& strangeV0s,
-                      dauTracks const&)
+                      DauTracks const&)
   {
 
-    for (auto& collision : stracollisions) {
+    for (const auto& collision : stracollisions) {
 
       fillEventInfo<0, LFBuilder>(collision);
 
@@ -651,8 +633,8 @@ struct Convbuildercomp {
 
       fillEventInfo<1, LFBuilder>(collision);
 
-      registry.fill(HIST((conversionBuilder[1])) + HIST("Event/before/hCollisionCounter"), 10.0);
-      registry.fill(HIST((conversionBuilder[1])) + HIST("Event/after/hCollisionCounter"), 10.0); // accepted
+      registry.fill(HIST((kConversionBuilder[1])) + HIST("Event/before/hCollisionCounter"), 10.0);
+      registry.fill(HIST((kConversionBuilder[1])) + HIST("Event/after/hCollisionCounter"), 10.0); // accepted
 
       auto myV0s = strangeV0s.sliceBy(perCollisionMCDerived, collision.globalIndex());
 
@@ -663,11 +645,11 @@ struct Convbuildercomp {
 
         auto v0MC = v0.v0MCCore_as<soa::Join<aod::V0MCCores, aod::V0MCCollRefs>>();
 
-        if (v0MC.pdgCode() != 22 || !v0MC.isPhysicalPrimary()) {
+        if (v0MC.pdgCode() != kGamma || !v0MC.isPhysicalPrimary()) {
           continue;
         }
 
-        auto posTrack = v0.template posTrackExtra_as<dauTracks>();
+        auto posTrack = v0.template posTrackExtra_as<DauTracks>();
 
         fillV0Info<LFBuilder>(v0, v0MC, posTrack);
       }
@@ -679,7 +661,7 @@ struct Convbuildercomp {
   void processEMV0sMC(MyV0Photons const& v0s, aod::EMMCParticles const& mcparticles, MyMCV0Legs const&, MyCollisions const& collisions)
   {
 
-    for (auto& collision : collisions) {
+    for (const auto& collision : collisions) {
 
       fillEventInfo<0, EMBuilder>(collision);
 
@@ -688,19 +670,19 @@ struct Convbuildercomp {
       }
       fillEventInfo<1, EMBuilder>(collision);
 
-      registry.fill(HIST((conversionBuilder[0])) + HIST("Event/before/hCollisionCounter"), 10.0); // accepted
-      registry.fill(HIST((conversionBuilder[0])) + HIST("Event/after/hCollisionCounter"), 10.0);  // accepted
+      registry.fill(HIST((kConversionBuilder[0])) + HIST("Event/before/hCollisionCounter"), 10.0); // accepted
+      registry.fill(HIST((kConversionBuilder[0])) + HIST("Event/after/hCollisionCounter"), 10.0);  // accepted
 
-      auto V0Photons_coll = v0s.sliceBy(perCollision, collision.globalIndex());
+      auto v0PhotonsColl = v0s.sliceBy(perCollision, collision.globalIndex());
 
-      for (auto const& v0 : V0Photons_coll) {
+      for (auto const& v0 : v0PhotonsColl) {
 
         auto pos = v0.posTrack_as<MyMCV0Legs>();
         auto ele = v0.negTrack_as<MyMCV0Legs>();
         auto posmc = pos.template emmcparticle_as<aod::EMMCParticles>();
         auto elemc = ele.template emmcparticle_as<aod::EMMCParticles>();
 
-        int photonid = FindCommonMotherFrom2Prongs(posmc, elemc, -11, 11, 22, mcparticles);
+        int photonid = FindCommonMotherFrom2Prongs(posmc, elemc, kPositron, kElectron, kGamma, mcparticles);
 
         auto mcphoton = mcparticles.iteratorAt(photonid);
 
@@ -717,7 +699,7 @@ struct Convbuildercomp {
           registry.fill(HIST("EMBuilder/hV0SignType"), 3); // zero or undefined
         }
 
-        if ((posmc.pdgCode() == 11 && elemc.pdgCode() == -11) || (posmc.pdgCode() == -11 && elemc.pdgCode() == 11)) {
+        if ((posmc.pdgCode() == kElectron && elemc.pdgCode() == kPositron) || (posmc.pdgCode() == kPositron && elemc.pdgCode() == kElectron)) {
           registry.fill(HIST("EMBuilder/hV0ElectronPositronTrue"), 1); // good
         } else {
           registry.fill(HIST("EMBuilder/hV0ElectronPositronTrue"), 0); // mismatch
@@ -733,7 +715,10 @@ struct Convbuildercomp {
                       aod::EMMCParticles const& mcparticles,
                       MyTracksIUMC const& tracks)
   {
-    for (auto& collision : collisions) {
+    for (const auto& collision : collisions) {
+
+      const float minR = 5.0f;
+      const float maxR = 90.f;
 
       if (!fEMEventCut.IsSelected(collision)) {
         continue;
@@ -742,34 +727,34 @@ struct Convbuildercomp {
       auto mccollision = collision.template emmcevent_as<MyMCCollisions>();
 
       auto mcstack = mcparticles.sliceBy(perMcCollision, mccollision.globalIndex());
-      auto mctracks_coll = mcparticles.sliceBy(perMcCollision, mccollision.globalIndex());
+      auto mcTracksColl = mcparticles.sliceBy(perMcCollision, mccollision.globalIndex());
 
       std::unordered_map<int, int> mc2trk;
-      for (auto& trk : tracks) {
+      for (const auto& trk : tracks) {
         if (trk.mcParticleId() >= 0) {
           mc2trk[trk.mcParticleId()] = trk.globalIndex();
         }
       }
 
-      for (auto& mc : mctracks_coll) {
-        if (mc.pdgCode() != 22 || !mc.isPhysicalPrimary()) {
+      for (const auto& mc : mcTracksColl) {
+        if (mc.pdgCode() != kGamma || !mc.isPhysicalPrimary()) {
           continue;
         }
 
         auto daughters = mc.daughtersIds();
-        if (daughters.size() != 2) {
+        if (daughters.size() != 2) { // o2-linter: disable=magic-number (this is pretty clear and not magic)
           continue;
         }
 
         auto d1 = mcparticles.iteratorAt(daughters[0]);
         auto d2 = mcparticles.iteratorAt(daughters[1]);
 
-        if (std::abs(d1.pdgCode()) != 11 || std::abs(d2.pdgCode()) != 11) {
+        if (std::abs(d1.pdgCode()) != kElectron || std::abs(d2.pdgCode()) != kElectron) {
           continue;
         }
 
         float r = std::hypot(d1.vx(), d1.vy());
-        if (r < 5.0f || r > 90.0f) {
+        if (r < minR || r > maxR) {
           continue;
         }
 
@@ -797,7 +782,7 @@ struct Convbuildercomp {
     MyMCV0Legs const&,
     aod::EMMCParticles const&,
     aod::McParticles const& mcparticles,
-    dauTracks const&)
+    DauTracks const&)
   {
     std::unordered_map<int, int> trackToMcLabel;
     for (auto const& t : tracksgen) {
@@ -807,7 +792,7 @@ struct Convbuildercomp {
       }
     }
 
-    for (auto& collision : collisions) {
+    for (const auto& collision : collisions) {
       if (!fEMEventCut.IsSelected(collision))
         continue;
 
@@ -830,7 +815,7 @@ struct Convbuildercomp {
         auto negmc = it.negTrack_as<MyMCV0Legs>()
                        .emmcparticle_as<aod::EMMCParticles>();
         int pid = FindCommonMotherFrom2Prongs(posmc, negmc,
-                                              -11, 11, 22, mcparticles);
+                                              kPositron, kElectron, kGamma, mcparticles);
         if (pid >= 0)
           table[pid].emIt = it;
       }
@@ -844,7 +829,7 @@ struct Convbuildercomp {
         auto posmc = mcparticles.iteratorAt(trackToMcLabel[posTrackIndex]);
         auto negmc = mcparticles.iteratorAt(trackToMcLabel[negTrackIndex]);
         int pid = FindCommonMotherFrom2Prongs(posmc, negmc,
-                                              -11, 11, 22, mcparticles);
+                                              kPositron, kElectron, kGamma, mcparticles);
         if (pid >= 0)
           table[pid].lfIt = it;
       }
@@ -857,7 +842,7 @@ struct Convbuildercomp {
           auto& lfV0 = *entry.lfIt.value();
           auto v0MC = lfV0.template v0MCCore_as<
             soa::Join<aod::V0MCCores, aod::V0MCCollRefs>>();
-          auto posTrack = lfV0.template posTrackExtra_as<dauTracks>();
+          auto posTrack = lfV0.template posTrackExtra_as<DauTracks>();
           fillV0Info<Common>(lfV0, v0MC, posTrack);
 
         } else if (entry.emIt.has_value()) {
@@ -872,20 +857,20 @@ struct Convbuildercomp {
           auto& lfV0 = *entry.lfIt.value();
           auto v0MC = lfV0.template v0MCCore_as<
             soa::Join<aod::V0MCCores, aod::V0MCCollRefs>>();
-          auto posTrack = lfV0.template posTrackExtra_as<dauTracks>();
+          auto posTrack = lfV0.template posTrackExtra_as<DauTracks>();
           fillV0Info<LFOnly>(lfV0, v0MC, posTrack);
         }
       }
     }
   }
 
-  PROCESS_SWITCH(Convbuildercomp, processMatchCategories, "Process V0s matched via MC photon", false);
-  PROCESS_SWITCH(Convbuildercomp, processLFV0sMC, "Process LF Builder V0s", true);
-  PROCESS_SWITCH(Convbuildercomp, processEMV0sMC, "Process EM Builder V0s", false);
-  PROCESS_SWITCH(Convbuildercomp, processConvV0s, "Process generated converted V0s", false);
+  PROCESS_SWITCH(Compconvbuilder, processMatchCategories, "Process V0s matched via MC photon", false);
+  PROCESS_SWITCH(Compconvbuilder, processLFV0sMC, "Process LF Builder V0s", true);
+  PROCESS_SWITCH(Compconvbuilder, processEMV0sMC, "Process EM Builder V0s", false);
+  PROCESS_SWITCH(Compconvbuilder, processConvV0s, "Process generated converted V0s", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfg)
 {
-  return WorkflowSpec{adaptAnalysisTask<Convbuildercomp>(cfg)};
+  return WorkflowSpec{adaptAnalysisTask<Compconvbuilder>(cfg)};
 }


### PR DESCRIPTION
- Add missing includes using the IWYU principle
- Remove unused includes
- Fix O2Linter errors, except one magic number error, which was silenced: `if (daughters.size() != 2)`. This one is not a magic number imo.
- Fix include parenthese for ("outside") O2 headers