### PR TITLE
[PWGJE,EMCAL-1154] Core/emcalCrossTalEmulation: fix cell ID outside li…

### DIFF
--- a/PWGJE/Core/emcalCrossTalkEmulation.cxx
+++ b/PWGJE/Core/emcalCrossTalkEmulation.cxx
@@ -527,7 +527,7 @@ void EMCCrossTalk::addInducedEnergiesToNewCells()
         }
 
         // Avoid cells out of SM
-        if (ietai < 0 || ietai >= emcal::EMCAL_COLS || iphii < 0 || iphii >= emcal::EMCAL_ROWS) {
+        if (ietai < 0 || ietai >= NColumns[iSM] || iphii < 0 || iphii >= NRows[iSM]) {
           continue;
         }
 

--- a/PWGJE/Core/emcalCrossTalkEmulation.h
+++ b/PWGJE/Core/emcalCrossTalkEmulation.h
@@ -127,6 +127,9 @@ static constexpr int FirstDCal23SM = 12;      // index of the first 2/3 DCal SM
 static constexpr int LastDCal23SM = 17;       // index of the last 2/3 DCal SM
 static constexpr float MinCellEnergy = 0.01f; // Minimum energy a new cell needs to be added
 
+static constexpr int NColumns[NSM] = {48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 32, 32, 32, 32, 32, 32, 48, 48};
+static constexpr int NRows[NSM] = {24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 8, 8, 24, 24, 24, 24, 24, 24, 8, 8};
+
 // these labels are for later once labeledArrays work on hyperloop. Currently they sadly only allow fixed size not variable size.
 // static const std::vector<std::string> labelsSM{"SM0/all", "SM1", "SM2", "SM3", "SM4", "SM5", "SM6", "SM7", "SM8", "SM9", "SM10", "SM11", "SM12", "SM13", "SM14", "SM15", "SM16", "SM17", "SM18", "SM19"};
 // static const std::vector<std::string> labelsCells = {"Up&Down", "Up&Down x Left|Right", "Left|Right", "2Up&Down + 2Up&Down xLeft|Right"};


### PR DESCRIPTION
…mits bug

- Fix `Exception while running: Cell ID 17665 outside limits.. Rethrowing.`. This exception was triggered, because the EMCal constants `EMCAL_ROWS` and `EMCAL_COLS` are only valid for full EMCal SM. However, the EMCal does also have 1/3 and 2/3 SM where either the number of rows or columns can be smaller, making checks onlt work for full SM. For now this fix is locally done in the class for the corsstalkemulation. A general fix in O2 should be considered.