### PR TITLE
[ALICE3] Add more qa of ml use to otf multi-charm task

### DIFF
--- a/ALICE3/TableProducer/alice3-multicharmTable.cxx
+++ b/ALICE3/TableProducer/alice3-multicharmTable.cxx
@@ -124,6 +124,7 @@ struct alice3multicharmTable {
   Configurable<float> xiccMaxEta{"xiccMaxEta", 1.5, "Max eta"};
   Configurable<float> massWindowXi{"massWindowXi", 0.015, "Mass window around Xi peak (GeV/c)"};
   Configurable<float> massWindowXiC{"massWindowXiC", 0.015, "Mass window around XiC peak (GeV/c)"};
+  Configurable<float> massWindowXiCC{"massWindowXiCC", 0.4, "Mass window around XiCC peak (GeV/c). Make sure that bkg region is included in this window"};
 
   ConfigurableAxis axisEta{"axisEta", {80, -4.0f, +4.0f}, "#eta"};
   ConfigurableAxis axisPt{"axisPt", {VARIABLE_WIDTH, 0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f, 1.6f, 1.7f, 1.8f, 1.9f, 2.0f, 2.2f, 2.4f, 2.6f, 2.8f, 3.0f, 3.2f, 3.4f, 3.6f, 3.8f, 4.0f, 4.4f, 4.8f, 5.2f, 5.6f, 6.0f, 6.5f, 7.0f, 7.5f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 17.0f, 19.0f, 21.0f, 23.0f, 25.0f, 30.0f, 35.0f, 40.0f, 50.0f}, "pt axis for QA histograms"};
@@ -251,6 +252,14 @@ struct alice3multicharmTable {
     }
 
     thisXiCCcandidate.mass = RecoDecay::m(array{array{thisXiCCcandidate.prong0mom[0], thisXiCCcandidate.prong0mom[1], thisXiCCcandidate.prong0mom[2]}, array{thisXiCCcandidate.prong1mom[0], thisXiCCcandidate.prong1mom[1], thisXiCCcandidate.prong1mom[2]}}, array{mass0, mass1});
+
+    std::cout << thisXiCCcandidate.mass << std::endl;
+    std::cout << o2::constants::physics::kXiCCPlusPlus << std::endl;
+    std::cout << std::endl;
+    if (std::fabs(thisXiCCcandidate.mass - o2::constants::physics::MassXiCCPlusPlus) > massWindowXiCC) {
+      return false;
+    }
+
     thisXiCCcandidate.pt = std::hypot(thisXiCCcandidate.prong0mom[0] + thisXiCCcandidate.prong1mom[0], thisXiCCcandidate.prong0mom[1] + thisXiCCcandidate.prong1mom[1]);
     thisXiCCcandidate.eta = RecoDecay::eta(array{thisXiCCcandidate.prong0mom[0] + thisXiCCcandidate.prong1mom[0], thisXiCCcandidate.prong0mom[1] + thisXiCCcandidate.prong1mom[1], thisXiCCcandidate.prong0mom[2] + thisXiCCcandidate.prong1mom[2]});
     return true;

--- a/ALICE3/TableProducer/alice3-multicharmTable.cxx
+++ b/ALICE3/TableProducer/alice3-multicharmTable.cxx
@@ -253,9 +253,6 @@ struct alice3multicharmTable {
 
     thisXiCCcandidate.mass = RecoDecay::m(array{array{thisXiCCcandidate.prong0mom[0], thisXiCCcandidate.prong0mom[1], thisXiCCcandidate.prong0mom[2]}, array{thisXiCCcandidate.prong1mom[0], thisXiCCcandidate.prong1mom[1], thisXiCCcandidate.prong1mom[2]}}, array{mass0, mass1});
 
-    std::cout << thisXiCCcandidate.mass << std::endl;
-    std::cout << o2::constants::physics::kXiCCPlusPlus << std::endl;
-    std::cout << std::endl;
     if (std::fabs(thisXiCCcandidate.mass - o2::constants::physics::MassXiCCPlusPlus) > massWindowXiCC) {
       return false;
     }

--- a/ALICE3/Tasks/alice3-multicharm.cxx
+++ b/ALICE3/Tasks/alice3-multicharm.cxx
@@ -252,7 +252,8 @@ struct alice3multicharm {
 
       histos.add("hBDTScore", "hBDTScore", kTH1D, {axisBDTScore});
       histos.add("hBDTScoreVsXiccMass", "hBDTScoreVsXiccMass", kTH2D, {axisXiccMass, axisBDTScore});
-      histos.add("hBDTScoreVsXiccPt", "hBDTScoreVsXiccPt", kTH2D, {axisXiccMass, axisPt});
+      histos.add("hBDTScoreVsXiccPt", "hBDTScoreVsXiccPt", kTH2D, {axisPt, axisBDTScore});
+      histos.add("h3dBDTScore", "h3dBDTScore", kTH3D, {axisPt, axisXiccMass, axisBDTScore});
       for (const auto& score : bdt.requiredScores.value) {
         histPath = std::format("MLQA/RequiredBDTScore_{}/", static_cast<int>(score * 100));
         histPointers.insert({histPath + "hDCAXicDaughters", histos.add((histPath + "hDCAXicDaughters").c_str(), "hDCAXicDaughters", {kTH1D, {{axisDcaDaughters}}})});
@@ -293,7 +294,7 @@ struct alice3multicharm {
   }
 
   template <typename TMCharmCands>
-  void genericProcessXicc(TMCharmCands xiccCands)
+  void genericProcessXicc(TMCharmCands const& xiccCands)
   {
     for (const auto& xiccCand : xiccCands) {
       if (bdt.enableML) {
@@ -324,6 +325,7 @@ struct alice3multicharm {
         histos.fill(HIST("hBDTScore"), bdtScore);
         histos.fill(HIST("hBDTScoreVsXiccMass"), xiccCand.xiccMass(), bdtScore);
         histos.fill(HIST("hBDTScoreVsXiccPt"), xiccCand.xiccPt(), bdtScore);
+        histos.fill(HIST("h3dBDTScore"), xiccCand.xiccPt(), xiccCand.xiccMass(), bdtScore);
 
         for (const auto& requiredScore : bdt.requiredScores.value) {
           if (bdtScore > requiredScore) {


### PR DESCRIPTION
- Fix axis for bdt score vs pt and add an additional qa plot
- Add mass cut when creating of tree of xicc candidates