### PR TITLE
Revert "[PWGCF] FemtoUniverse: Fixing the bug in phi calculation at R"

### DIFF
--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseDetaDphiStar.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseDetaDphiStar.h
@@ -621,7 +621,7 @@ class FemtoUniverseDetaDphiStar
     for (size_t i = 0; i < 9; i++) {
       double arg = 0.3 * charge * magfield * TmpRadiiTPC[i] * 0.01 / (2. * pt);
       if (std::abs(arg) < 1.0) {
-        tmpVec.push_back(phi0 + std::asin(arg));
+        tmpVec.push_back(phi0 - std::asin(arg));
       } else {
         tmpVec.push_back(999.0);
       }


### PR DESCRIPTION
Reverts AliceO2Group/O2Physics#12315

The use of (-)ve sign takes care of proper bending of the charged particles due to the magnetic field.