### PR TITLE
FemtoUniverse: updating MCReco and MCGen functions for track-D0

### DIFF
--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -297,6 +297,7 @@ struct FemtoUniverseProducerTask {
     /// Phi meson
     Configurable<float> confPhiPtLowLimit{"confPhiPtLowLimit", 0.8, "Lower limit of the Phi pT."};
     Configurable<float> confPhiPtHighLimit{"confPhiPtHighLimit", 4.0, "Higher limit of the Phi pT."};
+    Configurable<float> confPhiEtaHighLimit{"confPhiEtaHighLimit", 0.8, "Maximum eta value of the Phi"};
     Configurable<float> confPhiInvMassLowLimit{"confPhiInvMassLowLimit", 1.011, "Lower limit of the Phi invariant mass"};
     Configurable<float> confPhiInvMassUpLimit{"confPhiInvMassUpLimit", 1.027, "Upper limit of the Phi invariant mass"};
     // Phi meson daughters
@@ -304,13 +305,21 @@ struct FemtoUniverseProducerTask {
     Configurable<float> confPhiKaonRejectProtonNsigma{"confPhiKaonRejectProtonNsigma", 3.0, "Reject if particle could be a Proton combined nsigma value."};
     // Kaons
     Configurable<bool> confPhiDoLFPID4Kaons{"confPhiDoLFPID4Kaons", true, "Switch on do PID for Kaons as in LF"};
-    Configurable<float> confPhiKaonNsigmaTPCfrom0_0to0_3{"confPhiKaonNsigmaTPCfrom0_0to0_3", 3.0, "Reject if Kaons in 0.0-0.3 are have TPC n sigma above this value."};
-    Configurable<float> confPhiKaonNsigmaTPCfrom0_3to0_45{"confPhiKaonNsigmaTPCfrom0_3to0_45", 2.0, "Reject if Kaons in 0.3-0.45 are have TPC n sigma above this value."};
-    Configurable<float> confPhiKaonNsigmaTPCfrom0_45to0_55{"confPhiKaonNsigmaTPCfrom0_45to0_55", 1.0, "Reject if Kaons in 0.45-0.55 are have TPC n sigma above this value."};
-    Configurable<float> confPhiKaonNsigmaTPCfrom0_55to1_5{"confPhiKaonNsigmaTPCfrom0_55to1_5", 3.0, "Reject if Kaons in 0.55-1.5 are have TPC n sigma above this value."};
-    Configurable<float> confPhiKaonNsigmaTOFfrom0_55to1_5{"confPhiKaonNsigmaTOFfrom0_55to1_5", 3.0, "Reject if Kaons in 0.55-1.5 are have TOF n sigma above this value."};
-    Configurable<float> confPhiKaonNsigmaTPCfrom1_5{"confPhiKaonNsigmaTPCfrom1_5", 3.0, "Reject if Kaons above 1.5 are have TPC n sigma above this value."};
-    Configurable<float> confPhiKaonNsigmaTOFfrom1_5{"confPhiKaonNsigmaTOFfrom1_5", 3.0, "Reject if Kaons above 1.5 are have TOF n sigma above this value."};
+    Configurable<float> confNSigmaTPCKaonLF{"confNSigmaTPCKaonLF", 3.0, "TPC Kaon Sigma as in LF"};
+    Configurable<float> confNSigmaCombKaonLF{"confNSigmaCombKaonLF", 3.0, "TPC and TOF Kaon Sigma (combined) as in LF"};
+    Configurable<float> confMomKaonLF{"confMomKaonLF", 0.5, "Momentum threshold for kaon identification as in LF"};
+    Configurable<float> confMomKaonRejected{"confMomKaonRejected", 0.5, "Momentum threshold for rejected kaon"};
+    Configurable<float> confMomKaon03{"confMomKaon03", 0.3, "Momentum threshold for kaon identification pT = 0.3 GeV/c"};
+    Configurable<float> confMomKaon045{"confMomKaon045", 0.45, "Momentum threshold for kaon identification pT = 0.45 GeV/c"};
+    Configurable<float> confMomKaon055{"confMomKaon055", 0.55, "Momentum threshold for kaon identification pT = 0.55 GeV/c"};
+    Configurable<float> confMomKaon15{"confMomKaon15", 1.5, "Momentum threshold for kaon identification pT = 1.5 GeV/c"};
+    Configurable<float> confPhiKaonNsigmaTPCfrom00to03{"confPhiKaonNsigmaTPCfrom00to03", 3.0, "Reject if Kaons in 0.0-0.3 are have TPC n sigma above this value."};
+    Configurable<float> confPhiKaonNsigmaTPCfrom03to045{"confPhiKaonNsigmaTPCfrom03to045", 2.0, "Reject if Kaons in 0.3-0.45 are have TPC n sigma above this value."};
+    Configurable<float> confPhiKaonNsigmaTPCfrom045to055{"confPhiKaonNsigmaTPCfrom045to055", 1.0, "Reject if Kaons in 0.45-0.55 are have TPC n sigma above this value."};
+    Configurable<float> confPhiKaonNsigmaTPCfrom055to15{"confPhiKaonNsigmaTPCfrom055to15", 3.0, "Reject if Kaons in 0.55-1.5 are have TPC n sigma above this value."};
+    Configurable<float> confPhiKaonNsigmaTOFfrom055to15{"confPhiKaonNsigmaTOFfrom055to15", 3.0, "Reject if Kaons in 0.55-1.5 are have TOF n sigma above this value."};
+    Configurable<float> confPhiKaonNsigmaTPCfrom15{"confPhiKaonNsigmaTPCfrom15", 3.0, "Reject if Kaons above 1.5 are have TPC n sigma above this value."};
+    Configurable<float> confPhiKaonNsigmaTOFfrom15{"confPhiKaonNsigmaTOFfrom15", 3.0, "Reject if Kaons above 1.5 are have TOF n sigma above this value."};
   } ConfPhiSelection;
 
   // PDG codes for fillMCParticle function
@@ -323,6 +332,8 @@ struct FemtoUniverseProducerTask {
     Configurable<float> confD0D0barCandEtaCut{"confD0D0barCandEtaCut", 0.8, "max. cand. pseudorapidity"};
     Configurable<float> yD0D0barCandRecoMax{"yD0D0barCandRecoMax", 0.8, "MC Reco, max. rapidity of D0/D0bar cand."};
     Configurable<float> yD0D0barCandGenMax{"yD0D0barCandGenMax", 0.8, "MC Truth, max. rapidity of D0/D0bar cand."};
+    Configurable<float> trackD0pTGenMin{"trackD0pTGenMin", 0.0, "MC Truth, min. pT for tracks and D0/D0bar cand."};
+    Configurable<float> trackD0pTGenMax{"trackD0pTGenMax", 24.0, "MC Truth, max. pT for tracks and D0/D0bar cand."};
     Configurable<bool> storeD0D0barDoubleMassHypo{"storeD0D0barDoubleMassHypo", false, "Store D0/D0bar cand. which pass selection criteria for both, D0 and D0bar"};
     Configurable<std::vector<int>> classMlD0D0bar{"classMlD0D0bar", {0, 1, 2}, "Indexes of ML scores to be stored. Three indexes max."};
   } ConfD0Selection;
@@ -340,34 +351,34 @@ struct FemtoUniverseProducerTask {
   bool isKaonNSigma(float mom, float nsigmaTPCK, float nsigmaTOFK)
   {
 
-    if (mom < 0.3) { // 0.0-0.3
-      if (std::abs(nsigmaTPCK) < ConfPhiSelection.confPhiKaonNsigmaTPCfrom0_0to0_3) {
+    if (mom < ConfPhiSelection.confMomKaon03) { // 0.0-0.3
+      if (std::abs(nsigmaTPCK) < ConfPhiSelection.confPhiKaonNsigmaTPCfrom00to03) {
         return true;
       } else {
         return false;
       }
-    } else if (mom < 0.45) { // 0.30 - 0.45
-      if (std::abs(nsigmaTPCK) < ConfPhiSelection.confPhiKaonNsigmaTPCfrom0_3to0_45) {
+    } else if (mom < ConfPhiSelection.confMomKaon045) { // 0.30 - 0.45
+      if (std::abs(nsigmaTPCK) < ConfPhiSelection.confPhiKaonNsigmaTPCfrom03to045) {
         return true;
       } else {
         return false;
       }
-    } else if (mom < 0.55) { // 0.45-0.55
-      if (std::abs(nsigmaTPCK) < ConfPhiSelection.confPhiKaonNsigmaTPCfrom0_45to0_55) {
+    } else if (mom < ConfPhiSelection.confMomKaon055) { // 0.45-0.55
+      if (std::abs(nsigmaTPCK) < ConfPhiSelection.confPhiKaonNsigmaTPCfrom045to055) {
         return true;
       } else {
         return false;
       }
-    } else if (mom < 1.5) { // 0.55-1.5 (now we use TPC and TOF)
-      if ((std::abs(nsigmaTOFK) < ConfPhiSelection.confPhiKaonNsigmaTOFfrom0_55to1_5) && (std::abs(nsigmaTPCK) < ConfPhiSelection.confPhiKaonNsigmaTPCfrom0_55to1_5)) {
+    } else if (mom < ConfPhiSelection.confMomKaon15) { // 0.55-1.5 (now we use TPC and TOF)
+      if ((std::abs(nsigmaTOFK) < ConfPhiSelection.confPhiKaonNsigmaTOFfrom055to15) && (std::abs(nsigmaTPCK) < ConfPhiSelection.confPhiKaonNsigmaTPCfrom055to15)) {
         {
           return true;
         }
       } else {
         return false;
       }
-    } else if (mom > 1.5) { // 1.5 -
-      if ((std::abs(nsigmaTOFK) < ConfPhiSelection.confPhiKaonNsigmaTOFfrom1_5) && (std::abs(nsigmaTPCK) < ConfPhiSelection.confPhiKaonNsigmaTPCfrom1_5)) {
+    } else if (mom > ConfPhiSelection.confMomKaon15) { // 1.5 -
+      if ((std::abs(nsigmaTOFK) < ConfPhiSelection.confPhiKaonNsigmaTOFfrom15) && (std::abs(nsigmaTPCK) < ConfPhiSelection.confPhiKaonNsigmaTPCfrom15)) {
         return true;
       } else {
         return false;
@@ -379,17 +390,17 @@ struct FemtoUniverseProducerTask {
 
   bool isKaonNSigmaLF(float mom, float nsigmaTPCK, float nsigmaTOFK, bool hasTOF)
   {
-    if (mom < 0.5) {
-      if (std::abs(nsigmaTPCK) < 3.0) {
+    if (mom < ConfPhiSelection.confMomKaonLF) {
+      if (std::abs(nsigmaTPCK) < ConfPhiSelection.confNSigmaTPCKaonLF) {
         return true;
       } else {
         return false;
       }
-    } else if (mom >= 0.5) { // 0.55-1.5 (now we use TPC and TOF)
+    } else if (mom >= ConfPhiSelection.confMomKaonLF) { // 0.5-1.5 (now we use TPC and TOF)
       if (!hasTOF) {
         return false;
       } else {
-        if (std::sqrt(nsigmaTPCK * nsigmaTPCK + nsigmaTOFK * nsigmaTOFK) < 3.0) {
+        if (std::sqrt(nsigmaTPCK * nsigmaTPCK + nsigmaTOFK * nsigmaTOFK) < ConfPhiSelection.confNSigmaCombKaonLF) {
           return true;
         } else {
           return false;
@@ -402,14 +413,14 @@ struct FemtoUniverseProducerTask {
 
   bool isKaonRejected(float mom, float nsigmaTPCPr, float nsigmaTOFPr, float nsigmaTPCPi, float nsigmaTOFPi)
   {
-    if (mom < 0.5) {
+    if (mom < ConfPhiSelection.confMomKaonRejected) {
       if (std::abs(nsigmaTPCPi) < ConfPhiSelection.confPhiKaonRejectPionNsigma.value) {
         return true;
       } else if (std::abs(nsigmaTPCPr) < ConfPhiSelection.confPhiKaonRejectProtonNsigma.value) {
         return true;
       }
     }
-    if (mom > 0.5) {
+    if (mom > ConfPhiSelection.confMomKaonRejected) {
       if (std::hypot(nsigmaTOFPi, nsigmaTPCPi) < ConfPhiSelection.confPhiKaonRejectPionNsigma.value) {
         return true;
       } else if (std::hypot(nsigmaTOFPr, nsigmaTPCPr) < ConfPhiSelection.confPhiKaonRejectProtonNsigma.value) {
@@ -442,7 +453,7 @@ struct FemtoUniverseProducerTask {
     if (mom <= ConfPIDBitmask.confMinMomTOF) {
       return (std::abs(nsigmaTPCParticle) < ConfPIDBitmask.confNsigmaTPCParticle);
     } else {
-      return (TMath::Hypot(nsigmaTOFParticle, nsigmaTPCParticle) < ConfPIDBitmask.confNsigmaCombinedParticle);
+      return (std::hypot(nsigmaTOFParticle, nsigmaTPCParticle) < ConfPIDBitmask.confNsigmaCombinedParticle);
     }
   }
 
@@ -723,7 +734,8 @@ struct FemtoUniverseProducerTask {
       outputDebugParts(-999., -999., -999., -999., -999., -999., -999., -999., -999.,
                        -999., -999., -999., -999., -999., -999., -999., -999.,
                        -999., -999., -999., -999., -999.,
-                       -999., -999.,
+                       -999.,
+                       hfHelper.yD0(particle), // getter transRadius
                        particle.mlProbD0()[0], // getter decayVtxX
                        particle.mlProbD0()[1], // getter decayVtxY
                        particle.mlProbD0()[2], // getter decayVtxZ
@@ -732,7 +744,48 @@ struct FemtoUniverseProducerTask {
       outputDebugParts(-999., -999., -999., -999., -999., -999., -999., -999., -999.,
                        -999., -999., -999., -999., -999., -999., -999., -999.,
                        -999., -999., -999., -999., -999.,
-                       -999., -999.,
+                       -999.,
+                       hfHelper.yD0(particle), // getter transRadius
+                       particle.mlProbD0bar()[0], // getter decayVtxX
+                       particle.mlProbD0bar()[1], // getter decayVtxY
+                       particle.mlProbD0bar()[2], // getter decayVtxZ
+                       -999.);                    // Additional info for D0/D0bar
+    } else {
+      outputDebugParts(-999., -999., -999., -999., -999., -999., -999., -999., -999.,
+                       -999., -999., -999., -999., -999., -999., -999., -999.,
+                       -999., -999., -999., -999., -999.,
+                       -999., -999., -999., -999., -999., -999.);
+    }
+  }
+
+  template <bool isD0ML, bool isD0barML, typename ParticleType>
+  void fillDebugD0D0barMcMl(ParticleType const& particle)
+  {
+    int8_t originMcReco = 2; // 0 - prompt, 1 - non-prompt, 2 - default/else 
+    if(particle.originMcRec() == RecoDecay::OriginType::Prompt) {
+      originMcReco = 0;
+    } else if(particle.originMcRec() == RecoDecay::OriginType::NonPrompt) {
+      originMcReco = 1;
+    } else {
+      originMcReco = 2;
+    }
+    if constexpr (isD0ML) {
+      outputDebugParts(particle.flagMcMatchRec(), // getter sign
+                       originMcReco, -999., -999., -999., -999., -999., -999., -999.,
+                       -999., -999., -999., -999., -999., -999., -999., -999.,
+                       -999., -999., -999., -999., -999.,
+                       -999., 
+                       hfHelper.yD0(particle), // getter transRadius
+                       particle.mlProbD0()[0], // getter decayVtxX
+                       particle.mlProbD0()[1], // getter decayVtxY
+                       particle.mlProbD0()[2], // getter decayVtxZ
+                       -999.);                 // Additional info for D0/D0bar
+    } else if constexpr (isD0barML) {
+      outputDebugParts(particle.flagMcMatchRec(), -999., -999., -999., -999., -999., -999., -999., -999.,
+                       originMcReco, -999., -999., -999., -999., -999., -999., -999.,
+                       -999., -999., -999., -999., -999.,
+                       -999.,
+                       hfHelper.yD0(particle), // getter transRadius
                        particle.mlProbD0bar()[0], // getter decayVtxX
                        particle.mlProbD0bar()[1], // getter decayVtxY
                        particle.mlProbD0bar()[2], // getter decayVtxZ
@@ -815,7 +868,7 @@ struct FemtoUniverseProducerTask {
         if ((kaon1MC.isPhysicalPrimary() && kaon2MC.isPhysicalPrimary()) && (!motherskaon1MC.empty() && !motherskaon2MC.empty())) {
           for (const auto& particleMotherOfNeg : motherskaon1MC) {
             for (const auto& particleMotherOfPos : motherskaon2MC) {
-              if (particleMotherOfNeg == particleMotherOfPos && particleMotherOfNeg.pdgCode() == 333) {
+              if (particleMotherOfNeg == particleMotherOfPos && particleMotherOfNeg.pdgCode() == Pdg::kPhi) {
                 phiOrigin = aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kPrimary;
               } else {
                 phiOrigin = aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kFake;
@@ -846,44 +899,6 @@ struct FemtoUniverseProducerTask {
       float phiPhi = sumVec.Phi();
 
       outputPartsMC(phiOrigin, 333, phiPt, phiEta, phiPhi);
-      outputPartsMCLabels(outputPartsMC.lastIndex());
-    } else {
-      outputPartsMCLabels(-1);
-    }
-  }
-
-  template <typename ParticleType>
-  void fillMCParticleD0(ParticleType const& hfCand)
-  {
-    if (std::abs(hfCand.flagMcMatchRec()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
-      // get corresponding MC particle and its info
-      int pdgCode = 0;
-      int hfCandOrigin = 99;
-
-      if (hfCand.originMcRec() == RecoDecay::OriginType::Prompt) {
-        if (hfCand.isSelD0() == 1 && hfCand.isSelD0bar() == 0) {
-          hfCandOrigin = aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kPrompt;
-          pdgCode = static_cast<int>(Pdg::kD0);
-        } else if (hfCand.isSelD0() == 0 && hfCand.isSelD0bar() == 1) {
-          hfCandOrigin = aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kPrompt;
-          pdgCode = static_cast<int>(Pdg::kD0Bar);
-        } else {
-          hfCandOrigin = aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kFake;
-          pdgCode = 0;
-        }
-      } else {
-        if (hfCand.isSelD0() == 1 && hfCand.isSelD0bar() == 0) {
-          hfCandOrigin = aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kNonPrompt;
-          pdgCode = static_cast<int>(Pdg::kD0);
-        } else if (hfCand.isSelD0() == 0 && hfCand.isSelD0bar() == 1) {
-          hfCandOrigin = aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kNonPrompt;
-          pdgCode = static_cast<int>(Pdg::kD0Bar);
-        } else {
-          hfCandOrigin = aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kFake;
-          pdgCode = 0;
-        }
-      }
-      outputPartsMC(hfCandOrigin, pdgCode, hfCand.pt(), hfHelper.yD0(hfCand), hfCand.phi());
       outputPartsMCLabels(outputPartsMC.lastIndex());
     } else {
       outputPartsMCLabels(-1);
@@ -1327,7 +1342,7 @@ struct FemtoUniverseProducerTask {
   }
 
   template <bool isMC, typename HfCandidate, typename TrackType, typename CollisionType>
-  void fillD0mesons(CollisionType const&, TrackType const&, HfCandidate const& hfCands)
+  void fillD0D0barData(CollisionType const&, TrackType const&, HfCandidate const& hfCands)
   {
     std::vector<int> childIDs = {0, 0}; // these IDs are necessary to keep track of the children
     std::vector<int> tmpIDtrack;        // this vector keeps track of the matching of the primary track table row <-> aod::track table global index
@@ -1450,15 +1465,14 @@ struct FemtoUniverseProducerTask {
   }
 
   template <bool isMC, typename HfCandidate, typename TrackType, typename CollisionType>
-  void fillD0D0barUsingML(CollisionType const&, TrackType const&, HfCandidate const& hfCands)
+  void fillD0D0barDataMl(CollisionType const&, TrackType const&, HfCandidate const& hfCands)
   {
     std::vector<int> childIDs = {0, 0}; // these IDs are necessary to keep track of the children
     std::vector<int> tmpIDtrack;        // this vector keeps track of the matching of the primary track table row <-> aod::track table global index
     double invMassD0 = 0.0;
     double invMassD0bar = 0.0;
     bool isD0D0bar = false;
-    double mlProbD0D0barBg = 0.0;
-    uint8_t daughFlag = 0; // flag = 0 (daugh of D0 or D0bar), 1 (daug of D0), -1 (daugh of D0bar)
+    int8_t daughFlag = 0; // flag = 0 (daugh of D0 or D0bar), 1 (daug of D0), -1 (daugh of D0bar)
 
     for (const auto& hfCand : hfCands) {
 
@@ -1474,7 +1488,6 @@ struct FemtoUniverseProducerTask {
         continue;
       }
 
-      // int postrackID = hfCand.prong0().globalIndex();
       int postrackID = hfCand.prong0Id(); // Index to first prong
       int rowInPrimaryTrackTablePos = -1;
       rowInPrimaryTrackTablePos = getRowDaughters(postrackID, tmpIDtrack);
@@ -1486,13 +1499,11 @@ struct FemtoUniverseProducerTask {
       if (hfCand.isSelD0() == 1 && hfCand.isSelD0bar() == 0) {
         invMassD0 = hfHelper.invMassD0ToPiK(hfCand);
         invMassD0bar = -hfHelper.invMassD0barToKPi(hfCand);
-        mlProbD0D0barBg = hfCand.mlProbD0()[0];
         isD0D0bar = true;
         daughFlag = 1;
       } else if (hfCand.isSelD0() == 0 && hfCand.isSelD0bar() == 1) {
         invMassD0 = -hfHelper.invMassD0ToPiK(hfCand);
         invMassD0bar = hfHelper.invMassD0barToKPi(hfCand);
-        mlProbD0D0barBg = hfCand.mlProbD0bar()[0];
         isD0D0bar = true;
         daughFlag = -1;
       } else if (hfCand.isSelD0() == 1 && hfCand.isSelD0bar() == 1) {
@@ -1558,7 +1569,7 @@ struct FemtoUniverseProducerTask {
                     aod::femtouniverseparticle::ParticleType::kD0,
                     -999,            // cut, CutContainerType
                     -999,            // PID, CutContainerType
-                    mlProbD0D0barBg, // saving the probability for ML score class 1
+                    -999., // tempFitVar
                     indexChildID,
                     invMassD0,     // D0 mass (mLambda)
                     invMassD0bar); // D0bar mass (mAntiLambda)
@@ -1566,9 +1577,9 @@ struct FemtoUniverseProducerTask {
         if (confIsDebug) {
           fillDebugParticle<false, true, false>(postrack); // QA for positive daughter
           fillDebugParticle<false, true, false>(negtrack); // QA for negative daughter
-          if (hfCand.isSelD0() == 1 && hfCand.isSelD0bar() == 0) {
+          if (hfCand.isSelD0() == 1) {
             fillDebugD0D0barML<true, false>(hfCand); // QA for D0/D0bar
-          } else if (hfCand.isSelD0() == 0 && hfCand.isSelD0bar() == 1) {
+          } else if (hfCand.isSelD0bar() == 1) {
             fillDebugD0D0barML<false, true>(hfCand);
           } else {
             fillDebugD0D0barML<false, false>(hfCand);
@@ -1576,6 +1587,149 @@ struct FemtoUniverseProducerTask {
         }
         if constexpr (isMC) {
           fillMCParticleD0(hfCand);
+        }
+      }
+    }
+  }
+
+  template <bool isMC, typename McPart, typename HfCandidate, typename TrackType, typename CollisionType>
+  void fillD0D0barMcMl(CollisionType const&, TrackType const&, HfCandidate const& hfCands, McPart const& mcParticles)
+  {
+    std::vector<int> childIDs = {0, 0}; // these IDs are necessary to keep track of the children
+    std::vector<int> tmpIDtrack;        // this vector keeps track of the matching of the primary track table row <-> aod::track table global index
+    double invMassD0 = 0.0;
+    double invMassD0bar = 0.0;
+    bool isD0D0bar = false;
+    int indexMcRec = -1;
+    int8_t sign = 0;
+    int8_t daughFlag = 0; // flag = 0 (daugh of D0 or D0bar), 1 (daug of D0), -1 (daugh of D0bar)
+
+    for (const auto& hfCand : hfCands) {
+
+      if (!(hfCand.hfflag() & 1 << aod::hf_cand_2prong::DecayType::D0ToPiK)) {
+        continue;
+      }
+
+      if (ConfD0Selection.confD0D0barCandMaxY >= 0. && std::abs(hfHelper.yD0(hfCand)) > ConfD0Selection.confD0D0barCandMaxY) {
+        continue;
+      }
+
+      if (std::abs(hfCand.eta()) > ConfD0Selection.confD0D0barCandEtaCut) {
+        continue;
+      }
+
+      // Check whether the D0 candidate has the corresponding MC particle
+      auto postrack = hfCand.template prong0_as<TrackType>();
+      auto negtrack = hfCand.template prong1_as<TrackType>();
+      auto arrayDaughters = std::array{postrack, negtrack};
+      indexMcRec = RecoDecay::getMatchedMCRec(mcParticles, arrayDaughters, Pdg::kD0, std::array{+kPiPlus, -kKPlus}, true, &sign);
+
+      if (!(indexMcRec > -1)) {
+        continue;
+      }
+
+      if (std::abs(hfCand.flagMcMatchRec()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
+        int postrackID = hfCand.prong0Id(); // Index to first prong
+        int rowInPrimaryTrackTablePos = -1;
+        rowInPrimaryTrackTablePos = getRowDaughters(postrackID, tmpIDtrack);
+        childIDs[0] = rowInPrimaryTrackTablePos;
+        childIDs[1] = 0;
+
+        if (hfCand.isSelD0() == 1 && hfCand.isSelD0bar() == 0) {
+          invMassD0 = hfHelper.invMassD0ToPiK(hfCand);
+          invMassD0bar = -hfHelper.invMassD0barToKPi(hfCand);
+          isD0D0bar = true;
+          daughFlag = 1;
+        } else if (hfCand.isSelD0() == 0 && hfCand.isSelD0bar() == 1) {
+          invMassD0 = -hfHelper.invMassD0ToPiK(hfCand);
+          invMassD0bar = hfHelper.invMassD0barToKPi(hfCand);
+          isD0D0bar = true;
+          daughFlag = -1;
+        } else if (hfCand.isSelD0() == 1 && hfCand.isSelD0bar() == 1) {
+          invMassD0 = hfHelper.invMassD0ToPiK(hfCand);
+          invMassD0bar = hfHelper.invMassD0barToKPi(hfCand);
+          if (ConfD0Selection.storeD0D0barDoubleMassHypo) {
+            isD0D0bar = true;
+            daughFlag = 0;
+          } else {
+            isD0D0bar = false;
+            daughFlag = 0;
+          }
+        } else {
+          invMassD0 = 0.0;
+          invMassD0bar = 0.0;
+          isD0D0bar = false;
+        }
+
+        if (isD0D0bar) {
+          outputParts(outputCollision.lastIndex(),
+                      hfCand.ptProng0(),
+                      RecoDecay::eta(std::array{hfCand.pxProng0(), hfCand.pyProng0(), hfCand.pzProng0()}), // eta
+                      RecoDecay::phi(hfCand.pxProng0(), hfCand.pyProng0()),                                // phi
+                      aod::femtouniverseparticle::ParticleType::kD0Child,
+                      -999, // cutContainerV0.at(femto_universe_v0_selection::V0ContainerPosition::kPosCuts),
+                      -999, // cutContainerV0.at(femto_universe_v0_selection::V0ContainerPosition::kPosPID),
+                      -999,
+                      childIDs,
+                      postrack.sign(), // D0 mass -> positive daughter of D0/D0bar
+                      daughFlag);      // D0bar mass -> sign that the daugh is from D0 or D0 decay
+          const int rowOfPosTrack = outputParts.lastIndex();
+          if constexpr (isMC) {
+            fillMCParticle(postrack, o2::aod::femtouniverseparticle::ParticleType::kD0Child);
+          }
+          // int negtrackID = hfCand.prong1().globalIndex();
+          int negtrackID = hfCand.prong1Id();
+          int rowInPrimaryTrackTableNeg = -1;
+          rowInPrimaryTrackTableNeg = getRowDaughters(negtrackID, tmpIDtrack);
+          childIDs[0] = 0;
+          childIDs[1] = rowInPrimaryTrackTableNeg;
+
+          outputParts(outputCollision.lastIndex(),
+                      hfCand.ptProng1(),
+                      RecoDecay::eta(std::array{hfCand.pxProng1(), hfCand.pyProng1(), hfCand.pzProng1()}), // eta
+                      RecoDecay::phi(hfCand.pxProng1(), hfCand.pyProng1()),                                // phi
+                      aod::femtouniverseparticle::ParticleType::kD0Child,
+                      -999, // cutContainerV0.at(femto_universe_v0_selection::V0ContainerPosition::kNegCuts),
+                      -999, // cutContainerV0.at(femto_universe_v0_selection::V0ContainerPosition::kNegPID),
+                      -999,
+                      childIDs,
+                      negtrack.sign(), // negative daughter of D0/D0bar
+                      daughFlag);      // sign that the daugh is from D0 or D0 decay
+          const int rowOfNegTrack = outputParts.lastIndex();
+          if constexpr (isMC) {
+            fillMCParticle(negtrack, o2::aod::femtouniverseparticle::ParticleType::kD0Child);
+          }
+          std::vector<int> indexChildID = {rowOfPosTrack, rowOfNegTrack};
+
+          outputParts(outputCollision.lastIndex(),
+                      hfCand.pt(),
+                      hfCand.eta(),
+                      hfCand.phi(),
+                      aod::femtouniverseparticle::ParticleType::kD0,
+                      -999,            // cut, CutContainerType
+                      -999,            // PID, CutContainerType
+                      -999., // tempFitVar
+                      indexChildID,
+                      invMassD0,     // D0 mass (mLambda)
+                      invMassD0bar); // D0bar mass (mAntiLambda)
+
+          if (confIsDebug) {
+            fillDebugParticle<false, true, false>(postrack); // QA for positive daughter
+            fillDebugParticle<false, true, false>(negtrack); // QA for negative daughter
+            if (hfCand.isSelD0() == 1) {
+              fillDebugD0D0barMcMl<true, false>(hfCand); // QA for D0/D0bar
+            } else if (hfCand.isSelD0bar() == 1) {
+              fillDebugD0D0barMcMl<false, true>(hfCand);
+            } else {
+              fillDebugD0D0barMcMl<false, false>(hfCand);
+            }
+          }
+          if constexpr (isMC) {
+            auto particleMother = mcParticles.rawIteratorAt(indexMcRec);                                                 // gen. level pT
+            auto yGen = RecoDecay::y(particleMother.pVector(), o2::constants::physics::MassD0); // gen. level y
+            outputPartsMC(0, particleMother.pdgCode(), particleMother.pt(), yGen, particleMother.phi());
+            outputPartsMCLabels(outputPartsMC.lastIndex());
+          }
         }
       }
     }
@@ -1633,7 +1787,7 @@ struct FemtoUniverseProducerTask {
       sumVec += part2Vec;
 
       float phiEta = sumVec.Eta();
-      if (std::abs(phiEta) > 0.8) {
+      if (std::abs(phiEta) > ConfPhiSelection.confPhiEtaHighLimit.value) {
         continue;
       }
 
@@ -1736,7 +1890,9 @@ struct FemtoUniverseProducerTask {
         std::vector<int> tmpPDGCodes = ConfGeneral.confMCTruthPDGCodes; // necessary due to some features of the Configurable
         for (auto const& pdg : tmpPDGCodes) {
           if (static_cast<int>(pdg) == static_cast<int>(pdgCode)) {
-            if (pdgCode == 333) { // && (recoMcIds && recoMcIds->get().contains(particle.globalIndex()))) { // ATTENTION: all Phi mesons are NOT primary particles
+            if (pdgCode == Pdg::kPhi) { // && (recoMcIds && recoMcIds->get().contains(particle.globalIndex()))) { // ATTENTION: all Phi mesons are NOT primary particles
+              pass = true;
+            } else if (pdgCode == Pdg::kD0) {
               pass = true;
             } else {
               if (confStoreMCmothers || particle.isPhysicalPrimary() || (ConfGeneral.confActivateSecondaries && recoMcIds && recoMcIds->get().contains(particle.globalIndex())))
@@ -1840,19 +1996,18 @@ struct FemtoUniverseProducerTask {
     }
   }
 
-  template <typename TrackType, bool transientLabels = false, bool resolveDaughs = false>
-  void fillMCTruthParticlesD0(TrackType const& tracks, std::optional<std::reference_wrapper<const std::set<int>>> recoMcIds = std::nullopt)
+  template <typename TrackType, bool transientLabels = false>
+  void fillMCTruthParticlesD0(TrackType const& mcParts, std::optional<std::reference_wrapper<const std::set<int>>> recoMcIds = std::nullopt)
   {
     std::vector<int> childIDs = {0, 0}; // these IDs are necessary to keep track of the children
     std::vector<int> tmpIDtrack;
+    float ptGenB = -1;
 
-    for (const auto& particle : tracks) {
-      /// if the most open selection criteria are not fulfilled there is no
-      /// point looking further at the track
+    for (const auto& particle : mcParts) {
 
       if (particle.eta() < -ConfFilterCuts.confEtaFilterCut || particle.eta() > ConfFilterCuts.confEtaFilterCut)
         continue;
-      if (particle.pt() < ConfFilterCuts.confPtLowFilterCut || particle.pt() > ConfFilterCuts.confPtHighFilterCut)
+      if (particle.pt() < ConfD0Selection.trackD0pTGenMin || particle.pt() > ConfD0Selection.trackD0pTGenMax)
         continue;
 
       uint32_t pdgCode = static_cast<uint32_t>(particle.pdgCode());
@@ -1862,9 +2017,9 @@ struct FemtoUniverseProducerTask {
         std::vector<int> tmpPDGCodes = ConfGeneral.confMCTruthPDGCodes; // necessary due to some features of the Configurable
         for (auto const& pdg : tmpPDGCodes) {
           if (static_cast<int>(pdg) == static_cast<int>(pdgCode)) {
-            if (pdgCode == 333) { // && (recoMcIds && recoMcIds->get().contains(particle.globalIndex()))) { // ATTENTION: all Phi mesons are NOT primary particles
+            if (pdgCode == Pdg::kPhi) {
               pass = true;
-            } else if (pdgCode == 421) {
+            } else if (pdgCode == Pdg::kD0) {
               pass = true;
             } else {
               if (particle.isPhysicalPrimary() || (ConfGeneral.confActivateSecondaries && recoMcIds && recoMcIds->get().contains(particle.globalIndex())))
@@ -1876,38 +2031,26 @@ struct FemtoUniverseProducerTask {
           continue;
       }
 
-      // now the table is filled
-      if constexpr (resolveDaughs) {
-        tmpIDtrack.push_back(particle.globalIndex());
-        continue;
-      }
-      if (ConfGeneral.confIsActiveD0) {
-
-        auto mcD0origin = aod::femtouniverseparticle::ParticleType::kMCTruthTrack;
-        float ptGenB = -1;
+      if (pdgCode == Pdg::kD0) {
         if (std::abs(particle.flagMcMatchGen()) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
           if (ConfD0Selection.yD0D0barCandGenMax >= 0. && std::abs(RecoDecay::y(particle.pVector(), o2::constants::physics::MassD0)) > ConfD0Selection.yD0D0barCandGenMax) {
             continue;
           }
-          mcD0origin = aod::femtouniverseparticle::ParticleType::kMCTruthTrack;
-          // WORK IN PROGRESS: If needed changed it to prompt and non-prompt
-          /*if (particle.originMcGen() == RecoDecay::OriginType::Prompt) {
-            mcD0origin = aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kPrompt;
+          if (particle.originMcGen() == RecoDecay::OriginType::Prompt) {
             ptGenB = -1;
           } else {
-            mcD0origin = aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kNonPrompt;
-            ptGenB = particle.idxBhadMotherPart().pt();
-          }*/
+            ptGenB = mcParts.rawIteratorAt(particle.idxBhadMotherPart()).pt();
+          }
           outputParts(outputCollision.lastIndex(),
                       particle.pt(),
                       particle.eta(),
                       particle.phi(),
-                      mcD0origin,
-                      0,
+                      aod::femtouniverseparticle::ParticleType::kMCTruthTrack,
+                      -999.,
                       pdgCode,
-                      pdgCode,
+                      pdgCode, // getter tempFitVar
                       childIDs,
-                      RecoDecay::y(particle.pVector(), o2::constants::physics::MassD0),
+                      particle.flagMcMatchGen(),
                       ptGenB); // pT of the B hadron (mother particle, only when non-prompt D0)
         }
       } else {
@@ -1916,10 +2059,12 @@ struct FemtoUniverseProducerTask {
                     particle.eta(),
                     particle.phi(),
                     aod::femtouniverseparticle::ParticleType::kMCTruthTrack,
-                    0,
+                    -999.,
                     pdgCode,
                     pdgCode,
-                    childIDs, 0, 0);
+                    childIDs,
+                    -999.,
+                    -999.);
       }
       if (confIsDebug) {
         fillDebugParticle<false, true, false>(particle);
@@ -1930,43 +2075,6 @@ struct FemtoUniverseProducerTask {
       if constexpr (transientLabels) {
         outputPartsMCLabels(-1);
         outputDebugPartsMC(9999);
-      }
-    }
-    if constexpr (resolveDaughs) {
-      childIDs[0] = 0;
-      childIDs[1] = 0;
-      for (std::size_t i = 0; i < tmpIDtrack.size(); i++) {
-        const auto& particle = tracks.iteratorAt(tmpIDtrack[i] - tracks.begin().globalIndex());
-        for (int daughIndex = 0, n = std::min(2ul, particle.daughtersIds().size()); daughIndex < n; daughIndex++) {
-          // loop to find the corresponding index of the daughters
-          for (std::size_t j = 0; j < tmpIDtrack.size(); j++) {
-            if (tmpIDtrack[j] == particle.daughtersIds()[daughIndex]) {
-              childIDs[daughIndex] = i - j;
-              break;
-            }
-          }
-        }
-        outputParts(outputCollision.lastIndex(),
-                    particle.pt(),
-                    particle.eta(),
-                    particle.phi(),
-                    aod::femtouniverseparticle::ParticleType::kMCTruthTrack,
-                    0,
-                    static_cast<uint32_t>(particle.pdgCode()),
-                    particle.pdgCode(),
-                    childIDs,
-                    0,
-                    0);
-        if (confIsDebug) {
-          fillDebugParticle<false, true, false>(particle);
-        }
-
-        // Workaround to keep the FDParticles and MC label tables
-        // aligned, so that they can be joined in the task.
-        if constexpr (transientLabels) {
-          outputPartsMCLabels(-1);
-          outputDebugPartsMC(9999);
-        }
       }
     }
   }
@@ -2174,7 +2282,7 @@ struct FemtoUniverseProducerTask {
     const auto colcheck = fillCollisions<false>(col, tracks);
     if (colcheck) {
       fillTracks<false>(tracks);
-      fillD0mesons<false>(col, tracks, candidates);
+      fillD0D0barData<false>(col, tracks, candidates);
     }
   }
   PROCESS_SWITCH(FemtoUniverseProducerTask, processTrackD0mesonData,
@@ -2191,7 +2299,7 @@ struct FemtoUniverseProducerTask {
     const auto colcheck = fillCollisions<false>(col, tracks);
     if (colcheck) {
       fillTracks<false>(tracks);
-      fillD0D0barUsingML<false>(col, tracks, candidates);
+      fillD0D0barDataMl<false>(col, tracks, candidates);
     }
   }
   PROCESS_SWITCH(FemtoUniverseProducerTask, processTrackD0DataML,
@@ -2415,14 +2523,15 @@ struct FemtoUniverseProducerTask {
   }
   PROCESS_SWITCH(FemtoUniverseProducerTask, processTruthAndFullMCCentRun3Casc, "Provide both MC truth and reco for tracks and cascades with centrality", false);
 
+  Preslice<soa::Join<aod::McParticles, aod::HfCand2ProngMcGen>> mcPartPerMcColl = aod::mcparticle::mcCollisionId;
   Preslice<soa::Join<aod::HfCand2Prong, aod::HfCand2ProngMcRec, aod::HfSelD0, aod::HfMlD0>> perCollisionD0s = aod::track::collisionId;
   void processTrackD0MC(aod::McCollisions const& mccols,
-                        aod::TracksWMc const&,
                         soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::McCollisionLabels> const& collisions,
                         soa::Filtered<soa::Join<aod::FemtoFullTracks, aod::McTrackLabels>> const& tracks,
                         soa::Join<aod::McParticles, aod::HfCand2ProngMcGen> const& hfMcGenCands,
                         soa::Join<aod::HfCand2Prong, aod::HfCand2ProngMcRec, aod::HfSelD0, aod::HfMlD0> const& hfMcRecoCands,
-                        aod::BCsWithTimestamps const&)
+                        aod::BCsWithTimestamps const&,
+                        aod::McParticles const& mcParts)
   {
     // MC Reco
     std::set<int> recoMcIds;
@@ -2434,8 +2543,8 @@ struct FemtoUniverseProducerTask {
       // fill the tables
       const auto colcheck = fillCollisions<true>(col, tracks);
       if (colcheck) {
-        fillTracks<true>(tracks);
-        fillD0D0barUsingML<true>(col, groupedTracks, groupedD0s);
+        fillTracks<true>(groupedTracks);
+        fillD0D0barMcMl<true>(col, groupedTracks, groupedD0s, mcParts);
         for (const auto& track : groupedTracks) {
           if (trackCuts.isSelectedMinimal(track))
             recoMcIds.insert(track.mcParticleId());
@@ -2444,10 +2553,10 @@ struct FemtoUniverseProducerTask {
     }
     // MC Truth
     for (const auto& mccol : mccols) {
-      auto groupedMCParticles = hfMcGenCands.sliceBy(perMCCollision, mccol.globalIndex());
+      auto groupedMCParticles = hfMcGenCands.sliceBy(mcPartPerMcColl, mccol.globalIndex());
       auto groupedCollisions = collisions.sliceBy(recoCollsPerMCColl, mccol.globalIndex());
-      fillMCTruthCollisions(groupedCollisions, groupedMCParticles);                                    // fills the reco collisions for mc collision
-      fillMCTruthParticlesD0<decltype(groupedMCParticles), true, true>(groupedMCParticles, recoMcIds); // fills mc particles
+      fillMCTruthCollisions(groupedCollisions, groupedMCParticles);                              // fills the reco collisions for mc collision
+      fillMCTruthParticlesD0<decltype(groupedMCParticles), true>(groupedMCParticles, recoMcIds); // fills mc particles
     }
   }
   PROCESS_SWITCH(FemtoUniverseProducerTask, processTrackD0MC, "Provide MC data for track D0 analysis", false);

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniverseEfficiencyBase.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniverseEfficiencyBase.cxx
@@ -70,6 +70,7 @@ struct FemtoUniverseEfficiencyBase {
 
   /// Kaon configurable
   Configurable<bool> isKaonRun2{"isKaonRun2", false, "Enable kaon selection used in Run2"}; // to check consistency with Run2 results
+  Configurable<bool> isKaonLF{"isKaonLF", false, "Enable kaon selection used in LF group"}; // select kaons according to the selection in LF group
   struct : o2::framework::ConfigurableGroup {
     // Momentum thresholds for Run2 and Run3
     Configurable<float> confMomKaonRun2{"confMomKaonRun2", 0.4, "Momentum threshold for kaon identification using ToF (Run2)"};
@@ -93,6 +94,10 @@ struct FemtoUniverseEfficiencyBase {
     Configurable<float> confKaonNsigmaTOFfrom055to15{"confKaonNsigmaTOFfrom055to15", 3.0, "Reject kaons within pT from 0.55 to 1.5 if ToF n sigma is above this value."};
     Configurable<float> confKaonNsigmaTPCfrom15{"confKaonNsigmaTPCfrom15", 3.0, "Reject kaons with pT above 1.5 if TPC n sigma is above this value."};
     Configurable<float> confKaonNsigmaTOFfrom15{"confKaonNsigmaTOFfrom15", 2.0, "Reject kaons with pT above 1.5 if ToF n sigma is above this value.."};
+    // n sigma cuts as in LF
+    Configurable<float> confMomKaonLF{"confMomKaonLF", 0.5, "Momentum threshold for kaon identification using TOF (LF selection)"};
+    Configurable<float> confNSigmaTPCKaonLF{"confNSigmaTPCKaonLF", 3.0, "TPC Kaon Sigma as in LF"};
+    Configurable<float> confNSigmaCombKaonLF{"confNSigmaCombKaonLF", 3.0, "TPC and TOF Kaon Sigma (combined) as in LF"};
   } ConfKaonSelection;
 
   /// Deuteron configurables
@@ -259,6 +264,25 @@ struct FemtoUniverseEfficiencyBase {
     }
   }
 
+  bool isKaonNSigmaLF(float mom, float nsigmaTPCK, float nsigmaTOFK)
+  {
+    if (mom < ConfKaonSelection.confMomKaonLF) {
+      if (std::abs(nsigmaTPCK) < ConfKaonSelection.confNSigmaTPCKaonLF) {
+        return true;
+      } else {
+        return false;
+      }
+    } else if (mom >= ConfKaonSelection.confMomKaonLF) {
+      if (std::sqrt(nsigmaTPCK * nsigmaTPCK + nsigmaTOFK * nsigmaTOFK) < ConfKaonSelection.confNSigmaCombKaonLF) {
+        return true;
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }
+
   bool isPionNSigma(float mom, float nsigmaTPCPi, float nsigmaTOFPi)
   {
     if (mom < ConfBothTracks.confMomPion) {
@@ -303,7 +327,11 @@ struct FemtoUniverseEfficiencyBase {
         break;
       case 321:  // Kaon+
       case -321: // Kaon-
-        return isKaonNSigma(mom, nsigmaTPCK, nsigmaTOFK);
+        if(isKaonLF) {
+          return isKaonNSigmaLF(mom, nsigmaTPCK, nsigmaTOFK);
+        } else {
+          return isKaonNSigma(mom, nsigmaTPCK, nsigmaTOFK);
+        }
         break;
       case 1000010020:  // Deuteron
       case -1000010020: // Antideuteron

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
@@ -17,37 +17,36 @@
 /// \author Zuzanna Chochulska, WUT Warsaw & CTU Prague, zchochul@cern.ch
 /// \author Katarzyna Gwiździel, WUT Warsaw, katarzyna.gwizdziel@cern.ch
 
-#include <vector>
-#include <string>
-
-#include "Framework/AnalysisTask.h"
-#include "Framework/runDataProcessing.h"
-#include "Framework/HistogramRegistry.h"
-#include "Framework/ASoAHelpers.h"
-#include "Framework/RunningWorkflowInfo.h"
-#include "Framework/StepTHn.h"
-#include "Framework/O2DatabasePDGPlugin.h"
-#include "ReconstructionDataFormats/PID.h"
-
-#include "Common/DataModel/PIDResponse.h"
-#include "Common/Core/RecoDecay.h"
-
-#include "PWGCF/FemtoUniverse/DataModel/FemtoDerived.h"
-#include "PWGCF/FemtoUniverse/Core/FemtoUniverseParticleHisto.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniverseContainer.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniverseDetaDphiStar.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniverseEfficiencyCalculator.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseEventHisto.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUniversePairCleaner.h"
-#include "PWGCF/FemtoUniverse/Core/FemtoUniverseFemtoContainer.h"
-#include "PWGCF/FemtoUniverse/Core/FemtoUniverseAngularContainer.h"
-#include "PWGCF/FemtoUniverse/Core/FemtoUniverseDetaDphiStar.h"
-#include "PWGCF/FemtoUniverse/Core/femtoUtils.h"
+#include "PWGCF/FemtoUniverse/Core/FemtoUniverseParticleHisto.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseTrackSelection.h"
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseSoftPionRemoval.h"
-#include "PWGCF/FemtoUniverse/Core/FemtoUniverseEfficiencyCalculator.h"
+#include "PWGCF/FemtoUniverse/Core/femtoUtils.h"
+#include "PWGCF/FemtoUniverse/DataModel/FemtoDerived.h"
 
 #include "PWGHF/Core/HfHelper.h"
+#include "PWGHF/Core/DecayChannels.h"
 #include "PWGHF/Core/SelectorCuts.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
+
+#include "Common/Core/RecoDecay.h"
+#include "Common/DataModel/PIDResponse.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/ASoAHelpers.h"
+#include "Framework/HistogramRegistry.h"
+#include "Framework/O2DatabasePDGPlugin.h"
+#include "Framework/runDataProcessing.h"
+#include "Framework/RunningWorkflowInfo.h"
+#include "Framework/StepTHn.h"
+#include "ReconstructionDataFormats/PID.h"
+
+#include <vector>
+#include <string>
 
 using namespace o2;
 using namespace o2::analysis;
@@ -84,15 +83,17 @@ struct FemtoUniversePairTaskTrackD0 {
   SliceCache cache;
   Preslice<FemtoFullParticles> perCol = aod::femtouniverseparticle::fdCollisionId;
 
-  using FemtoMCParticles = soa::Join<aod::FDParticles, aod::FDExtParticles, aod::FDMCLabels>;
-  Preslice<FemtoMCParticles> perColMC = aod::femtouniverseparticle::fdCollisionId;
+  using FemtoMcRecoParticles = soa::Join<aod::FDParticles, aod::FDExtParticles, aod::FDMCLabels>;
+  Preslice<FemtoMcRecoParticles> perColMc = aod::femtouniverseparticle::fdCollisionId;
 
   /// Table for both particles
   struct : o2::framework::ConfigurableGroup {
-    Configurable<float> confNsigmaCombinedProton{"confNsigmaCombinedProton", 3.0, "TPC and TOF Proton Sigma (combined) for momentum > 0.5"};
-    Configurable<float> confNsigmaTPCProton{"confNsigmaTPCProton", 3.0, "TPC Proton Sigma for momentum < 0.5"};
-    Configurable<float> confNsigmaCombinedPion{"confNsigmaCombinedPion", 3.0, "TPC and TOF Pion Sigma (combined) for momentum > 0.5"};
-    Configurable<float> confNsigmaTPCPion{"confNsigmaTPCPion", 3.0, "TPC Pion Sigma for momentum < 0.5"};
+    Configurable<float> confNsigmaCombinedProton{"confNsigmaCombinedProton", 3.0, "TPC and TOF Proton Sigma (combined)"};
+    Configurable<float> confNsigmaTPCProton{"confNsigmaTPCProton", 3.0, "TPC Proton Sigma"};
+    Configurable<float> confNsigmaCombinedPion{"confNsigmaCombinedPion", 3.0, "TPC and TOF Pion Sigma (combined)"};
+    Configurable<float> confNsigmaTPCPion{"confNsigmaTPCPion", 3.0, "TPC Pion Sigma"};
+    Configurable<float> confNsigmaCombinedKaon{"confNsigmaCombinedKaon", 3.0, "TPC and TOF Kaon Sigma (combined)"};
+    Configurable<float> confNsigmaTPCKaon{"confNsigmaTPCKaon", 3.0, "TPC Kaon Sigma"};
 
     Configurable<bool> confIsMC{"confIsMC", false, "Enable additional Histogramms in the case of a MonteCarlo Run"};
     Configurable<std::vector<float>> confTrkPIDnSigmaMax{"confTrkPIDnSigmaMax", std::vector<float>{4.f, 3.f, 2.f}, "This configurable needs to be the same as the one used in the producer task"};
@@ -110,8 +111,9 @@ struct FemtoUniversePairTaskTrackD0 {
     Configurable<bool> confIsTrackIdentified{"confIsTrackIdentified", true, "Enable PID for the track"};
     Configurable<float> confTrackLowPtCut{"confTrackLowPtCut", 0.5, "Low pT cut of the track"};
     Configurable<float> confTrackHighPtCut{"confTrackHighPtCut", 2.5, "High pT cut of the track"};
-    Configurable<float> protonMinPtPidTpcTof{"protonMinPtPidTpcTof", 0.5, "Momentum threshold for change of the PID method (from using TPC to TPC and TOF)."};
-    Configurable<float> pionMinPtPidTpcTof{"pionMinPtPidTpcTof", 0.5, "Momentum threshold for change of the PID method (from using TPC to TPC and TOF)."};
+    Configurable<float> minPtPidTpcTofProton{"minPtPidTpcTofProton", 0.5, "Momentum threshold for change of the PID method (from using TPC to TPC and TOF)."};
+    Configurable<float> minPtPidTpcTofPion{"minPtPidTpcTofPion", 0.5, "Momentum threshold for change of the PID method (from using TPC to TPC and TOF)."};
+    Configurable<float> minPtPidTpcTofKaonLF{"minPtPidTpcTofKaonLF", 0.5, "Momentum threshold for change of the PID method (from using TPC to TPC and TOF)."};
   } ConfTrack;
 
   /// Particle 2 --- D0/D0bar meson
@@ -120,6 +122,8 @@ struct FemtoUniversePairTaskTrackD0 {
     Configurable<int> confPDGCodeD0bar{"confPDGCodeD0bar", -421, "D0bar meson - PDG code"};
     Configurable<float> confMinPtD0D0bar{"confMinPtD0D0bar", 1.0, "D0/D0bar sel. - min. pT"};
     Configurable<float> confMaxPtD0D0bar{"confMaxPtD0D0bar", 3.0, "D0/D0bar sel. - max. pT"};
+    Configurable<float> confMinPtD0D0barReco{"confMinPtD0D0barReco", 0.5, "MC Reco - D0/D0bar sel. - min. pT"};
+    Configurable<float> confMaxPtD0D0barReco{"confMaxPtD0D0barReco", 24.0, "MC Reco - D0/D0bar sel. - max. pT"};
     Configurable<float> minInvMassD0D0barSignal{"minInvMassD0D0barSignal", 1.81, "Min. inv. mass of D0/D0bar for signal region"};
     Configurable<float> maxInvMassD0D0barSignal{"maxInvMassD0D0barSignal", 1.922, "Max. inv. mass of D0/D0bar for signal region"};
     Configurable<float> minInvMassD0D0barLeftSB{"minInvMassD0D0barLeftSB", 1.65, "Min. inv. mass of D0/D0bar for left SB region"};
@@ -148,34 +152,35 @@ struct FemtoUniversePairTaskTrackD0 {
 
   /// Partitions for particle 1
   Partition<FemtoFullParticles> partsTrack = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack)) && (aod::femtouniverseparticle::sign == int8_t(ConfTrack.confTrackSign)) && (aod::femtouniverseparticle::pt > ConfTrack.confTrackLowPtCut) && (aod::femtouniverseparticle::pt < ConfTrack.confTrackHighPtCut);
-  Partition<FemtoMCParticles> partsTrackMCReco = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack)) && (aod::femtouniverseparticle::sign == int8_t(ConfTrack.confTrackSign)) && (aod::femtouniverseparticle::pt > ConfTrack.confTrackLowPtCut) && (aod::femtouniverseparticle::pt < ConfTrack.confTrackHighPtCut);
-  Partition<FemtoMCParticles> partsTrackMCTruth = (aod::femtouniverseparticle::partType == static_cast<uint8_t>(aod::femtouniverseparticle::ParticleType::kMCTruthTrack)) && (aod::femtouniverseparticle::pidCut == static_cast<uint32_t>(ConfTrack.confPDGCodeTrack)) && (aod::femtouniverseparticle::pt > ConfTrack.confTrackLowPtCut) && (aod::femtouniverseparticle::pt < ConfTrack.confTrackHighPtCut);
+  Partition<FemtoMcRecoParticles> partsTrackMCReco = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack)) && (aod::femtouniverseparticle::sign == int8_t(ConfTrack.confTrackSign)) && (aod::femtouniverseparticle::pt > ConfTrack.confTrackLowPtCut) && (aod::femtouniverseparticle::pt < ConfTrack.confTrackHighPtCut);
+  Partition<FemtoMcRecoParticles> partsTrackMCTruth = (aod::femtouniverseparticle::partType == static_cast<uint8_t>(aod::femtouniverseparticle::ParticleType::kMCTruthTrack)) && (aod::femtouniverseparticle::pidCut == static_cast<uint32_t>(ConfTrack.confPDGCodeTrack)) && (aod::femtouniverseparticle::pt > ConfTrack.confTrackLowPtCut) && (aod::femtouniverseparticle::pt < ConfTrack.confTrackHighPtCut);
 
   /// Partitions for particle 2
-  /// Partition with all D0/D0bar mesons (which pass double mass hypothesis)
-  Partition<FemtoFullParticles> partsAllDmesons = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && ((aod::femtouniverseparticle::mLambda > 0.0f) || (aod::femtouniverseparticle::mAntiLambda > 0.0f));
+  /// Partition with all D0/D0bar mesons (which pass one and double mass hypothesis)
+  Partition<FemtoFullParticles> partsAllDmesons = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && ((aod::femtouniverseparticle::mLambda > 0.0f) || (aod::femtouniverseparticle::mAntiLambda > 0.0f)) && (aod::femtouniverseparticle::decayVtxX < ConfMlOpt.confMaxProbMlClass1Bg) && (aod::femtouniverseparticle::decayVtxY > ConfMlOpt.confMinProbMlClass2Prompt);
   /// Partition with D0/D0bar candidates, which pass only one mass hypothesis
-  Partition<FemtoFullParticles> partsOnlyD0D0bar = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && (aod::femtouniverseparticle::mLambda < 0.0f || aod::femtouniverseparticle::mAntiLambda < 0.0f) && (aod::femtouniverseparticle::tempFitVar < ConfMlOpt.confMaxProbMlClass1Bg) && (aod::femtouniverseparticle::decayVtxY > ConfMlOpt.confMinProbMlClass2Prompt);
+  Partition<FemtoFullParticles> partsOnlyD0D0bar = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && (aod::femtouniverseparticle::mLambda < 0.0f || aod::femtouniverseparticle::mAntiLambda < 0.0f) && (aod::femtouniverseparticle::decayVtxX < ConfMlOpt.confMaxProbMlClass1Bg) && (aod::femtouniverseparticle::decayVtxY > ConfMlOpt.confMinProbMlClass2Prompt);
   /// Partition with D0 mesons only (one and double mass hypothesis)
   Partition<FemtoFullParticles> partsAllD0s = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && (aod::femtouniverseparticle::mLambda > ConfDmesons.minInvMassD0D0barSignal) && (aod::femtouniverseparticle::mLambda < ConfDmesons.maxInvMassD0D0barSignal) && (aod::femtouniverseparticle::pt > ConfDmesons.confMinPtD0D0bar) && (aod::femtouniverseparticle::pt < ConfDmesons.confMaxPtD0D0bar);
   /// Partition with D0 mesons only (one mass hypothesis)
-  Partition<FemtoFullParticles> partsD0s = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && (aod::femtouniverseparticle::mLambda > ConfDmesons.minInvMassD0D0barSignal) && (aod::femtouniverseparticle::mLambda < ConfDmesons.maxInvMassD0D0barSignal) && (aod::femtouniverseparticle::mAntiLambda < 0.0f) && (aod::femtouniverseparticle::pt > ConfDmesons.confMinPtD0D0bar) && (aod::femtouniverseparticle::pt < ConfDmesons.confMaxPtD0D0bar) && (aod::femtouniverseparticle::tempFitVar < ConfMlOpt.confMaxProbMlClass1Bg) && (aod::femtouniverseparticle::decayVtxY > ConfMlOpt.confMinProbMlClass2Prompt);
+  Partition<FemtoFullParticles> partsD0s = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && (aod::femtouniverseparticle::mLambda > ConfDmesons.minInvMassD0D0barSignal) && (aod::femtouniverseparticle::mLambda < ConfDmesons.maxInvMassD0D0barSignal) && (aod::femtouniverseparticle::mAntiLambda < 0.0f) && (aod::femtouniverseparticle::pt > ConfDmesons.confMinPtD0D0bar) && (aod::femtouniverseparticle::pt < ConfDmesons.confMaxPtD0D0bar) && (aod::femtouniverseparticle::decayVtxX < ConfMlOpt.confMaxProbMlClass1Bg) && (aod::femtouniverseparticle::decayVtxY > ConfMlOpt.confMinProbMlClass2Prompt);
   /// Partition with D0s selected from the side-band (SB) regions (candidates with double mass hypothesis included)
   Partition<FemtoFullParticles> partsD0sFromSB = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && ((aod::femtouniverseparticle::mLambda > ConfDmesons.minInvMassD0D0barLeftSB && aod::femtouniverseparticle::mLambda < ConfDmesons.maxInvMassD0D0barLeftSB) || (aod::femtouniverseparticle::mLambda > ConfDmesons.minInvMassD0D0barRightSB && aod::femtouniverseparticle::mLambda < ConfDmesons.maxInvMassD0D0barRightSB)) && (aod::femtouniverseparticle::pt > ConfDmesons.confMinPtD0D0bar) && (aod::femtouniverseparticle::pt < ConfDmesons.confMaxPtD0D0bar);
   /// Partition with D0bar mesons only (one and double mass hypothesis)
   Partition<FemtoFullParticles> partsAllD0bars = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && (aod::femtouniverseparticle::mAntiLambda > ConfDmesons.minInvMassD0D0barSignal) && (aod::femtouniverseparticle::mAntiLambda < ConfDmesons.maxInvMassD0D0barSignal) && (aod::femtouniverseparticle::pt > ConfDmesons.confMinPtD0D0bar) && (aod::femtouniverseparticle::pt < ConfDmesons.confMaxPtD0D0bar);
   /// Partition with D0bar mesons only (one mass hypothesis)
-  Partition<FemtoFullParticles> partsD0bars = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && (aod::femtouniverseparticle::mLambda < 0.0f) && (aod::femtouniverseparticle::mAntiLambda > ConfDmesons.minInvMassD0D0barSignal) && (aod::femtouniverseparticle::mAntiLambda < ConfDmesons.maxInvMassD0D0barSignal) && (aod::femtouniverseparticle::pt > ConfDmesons.confMinPtD0D0bar) && (aod::femtouniverseparticle::pt < ConfDmesons.confMaxPtD0D0bar) && (aod::femtouniverseparticle::tempFitVar < ConfMlOpt.confMaxProbMlClass1Bg) && (aod::femtouniverseparticle::decayVtxY > ConfMlOpt.confMinProbMlClass2Prompt);
+  Partition<FemtoFullParticles> partsD0bars = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && (aod::femtouniverseparticle::mLambda < 0.0f) && (aod::femtouniverseparticle::mAntiLambda > ConfDmesons.minInvMassD0D0barSignal) && (aod::femtouniverseparticle::mAntiLambda < ConfDmesons.maxInvMassD0D0barSignal) && (aod::femtouniverseparticle::pt > ConfDmesons.confMinPtD0D0bar) && (aod::femtouniverseparticle::pt < ConfDmesons.confMaxPtD0D0bar) && (aod::femtouniverseparticle::decayVtxX < ConfMlOpt.confMaxProbMlClass1Bg) && (aod::femtouniverseparticle::decayVtxY > ConfMlOpt.confMinProbMlClass2Prompt);
   /// Partition with D0bars selected from the side-band (SB) regions (candidates with double mass hypothesis included)
   Partition<FemtoFullParticles> partsD0barsFromSB = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && ((aod::femtouniverseparticle::mAntiLambda > ConfDmesons.minInvMassD0D0barLeftSB && aod::femtouniverseparticle::mAntiLambda < ConfDmesons.maxInvMassD0D0barLeftSB) || (aod::femtouniverseparticle::mAntiLambda > ConfDmesons.minInvMassD0D0barRightSB && aod::femtouniverseparticle::mAntiLambda < ConfDmesons.maxInvMassD0D0barRightSB)) && (aod::femtouniverseparticle::pt > ConfDmesons.confMinPtD0D0bar) && (aod::femtouniverseparticle::pt < ConfDmesons.confMaxPtD0D0bar);
   /// Partition for D0/D0bar mesons from MC
-  Partition<FemtoMCParticles> partsD0D0barMCReco = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && (aod::femtouniverseparticle::mLambda < 0.0f || aod::femtouniverseparticle::mAntiLambda < 0.0f) && (aod::femtouniverseparticle::pt > ConfDmesons.confMinPtD0D0bar) && (aod::femtouniverseparticle::pt < ConfDmesons.confMaxPtD0D0bar) && (aod::femtouniverseparticle::tempFitVar < ConfMlOpt.confMaxProbMlClass1Bg) && (aod::femtouniverseparticle::decayVtxY > ConfMlOpt.confMinProbMlClass2Prompt);
-  Partition<FemtoMCParticles> partsD0D0barMCTruth = (aod::femtouniverseparticle::partType == static_cast<uint8_t>(aod::femtouniverseparticle::ParticleType::kMCTruthTrack)) && (aod::femtouniverseparticle::pidCut == static_cast<uint32_t>(ConfDmesons.confPDGCodeD0) || aod::femtouniverseparticle::pidCut == static_cast<uint32_t>(ConfDmesons.confPDGCodeD0bar)) && (aod::femtouniverseparticle::pt > ConfDmesons.confMinPtD0D0bar) && (aod::femtouniverseparticle::pt < ConfDmesons.confMaxPtD0D0bar);
+  Partition<FemtoMcRecoParticles> partsD0D0barMCReco = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0)) && (aod::femtouniverseparticle::mLambda < 0.0f || aod::femtouniverseparticle::mAntiLambda < 0.0f) && (aod::femtouniverseparticle::pt > ConfDmesons.confMinPtD0D0bar) && (aod::femtouniverseparticle::pt < ConfDmesons.confMaxPtD0D0bar) && (aod::femtouniverseparticle::decayVtxX < ConfMlOpt.confMaxProbMlClass1Bg) && (aod::femtouniverseparticle::decayVtxY > ConfMlOpt.confMinProbMlClass2Prompt);
+  Partition<FemtoMcRecoParticles> partsD0D0barMCTruth = (aod::femtouniverseparticle::partType == static_cast<uint8_t>(aod::femtouniverseparticle::ParticleType::kMCTruthTrack)) && (aod::femtouniverseparticle::pidCut == static_cast<uint32_t>(ConfDmesons.confPDGCodeD0) || aod::femtouniverseparticle::pidCut == static_cast<uint32_t>(ConfDmesons.confPDGCodeD0bar)) && (aod::femtouniverseparticle::pt > ConfDmesons.confMinPtD0D0bar) && (aod::femtouniverseparticle::pt < ConfDmesons.confMaxPtD0D0bar);
   /// Partition for D0/D0bar daughters
   Partition<FemtoFullParticles> partsDmesonsChildren = aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kD0Child);
 
   /// Histogramming for particle 1
-  FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kTrack, 2> trackHistoPartTrack;
+  FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kTrack, 1> trackHistoPartTrack;
+  FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kTrack, 1> hTrackDCA;
 
   /// Histogramming for particle 2
   FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kD0, 0> trackHistoPartD0D0bar;
@@ -191,6 +196,7 @@ struct FemtoUniversePairTaskTrackD0 {
   ConfigurableAxis confTempFitVarBins{"confTempFitVarBins", {300, -0.15, 0.15}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis confTempFitVarInvMassBins{"confTempFitVarInvMassBins", {6000, 0.9, 4.0}, "binning of the TempFitVar in the pT vs. TempFitVar plot"};
   ConfigurableAxis confTempFitVarpTBins{"confTempFitVarpTBins", {20, 0.5, 4.05}, "pT binning of the pT vs. TempFitVar plot"};
+  ConfigurableAxis confTempFitVarDCABins{"confTempFitVarDCABins", {500, -1.0, 1.0}, "binning of the DCA histograms"};
 
   /// Correlation part
   ConfigurableAxis confMultBins{"confMultBins", {VARIABLE_WIDTH, 0.0f, 4.0f, 8.0f, 12.0f, 16.0f, 20.0f, 24.0f, 28.0f, 32.0f, 36.0f, 40.0f, 44.0f, 48.0f, 52.0f, 56.0f, 60.0f, 64.0f, 68.0f, 72.0f, 76.0f, 80.0f, 84.0f, 88.0f, 92.0f, 96.0f, 100.0f, 200.0f, 99999.f}, "Mixing bins - multiplicity"}; // \todo to be obtained from the hash task
@@ -223,8 +229,8 @@ struct FemtoUniversePairTaskTrackD0 {
   // Event mixing configurables
   Configurable<int> confNEventsMix{"confNEventsMix", 5, "Number of events for mixing"};
 
-  FemtoUniverseAngularContainer<femto_universe_angular_container::EventType::same, femto_universe_angular_container::Observable::kstar> sameEventAngularCont;
-  FemtoUniverseAngularContainer<femto_universe_angular_container::EventType::mixed, femto_universe_angular_container::Observable::kstar> mixedEventAngularCont;
+  FemtoUniverseContainer<femto_universe_container::EventType::same, femto_universe_container::Observable::kstar> sameEventAngularCont;
+  FemtoUniverseContainer<femto_universe_container::EventType::mixed, femto_universe_container::Observable::kstar> mixedEventAngularCont;
   FemtoUniversePairCleaner<aod::femtouniverseparticle::ParticleType::kTrack, aod::femtouniverseparticle::ParticleType::kD0> pairCleaner;
   FemtoUniverseDetaDphiStar<aod::femtouniverseparticle::ParticleType::kTrack, aod::femtouniverseparticle::ParticleType::kD0> pairCloseRejection;
   FemtoUniverseSoftPionRemoval<aod::femtouniverseparticle::ParticleType::kTrack, aod::femtouniverseparticle::ParticleType::kD0> softPionRemoval;
@@ -237,8 +243,9 @@ struct FemtoUniversePairTaskTrackD0 {
   HistogramRegistry qaRegistry{"TrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
   HistogramRegistry resultRegistry{"Correlations", {}, OutputObjHandlingPolicy::AnalysisObject};
   HistogramRegistry mixQaRegistry{"mixQaRegistry", {}, OutputObjHandlingPolicy::AnalysisObject};
-  HistogramRegistry mcRecoRegistry{"mcRecoRegistry", {}, OutputObjHandlingPolicy::AnalysisObject, false, true};
-  HistogramRegistry mcTruthRegistry{"mcTruthRegistry", {}, OutputObjHandlingPolicy::AnalysisObject, false, true};
+  HistogramRegistry mcRecoRegistry{"McRecoHistos", {}, OutputObjHandlingPolicy::AnalysisObject, false, true};
+  HistogramRegistry mcTruthRegistry{"McGenHistos", {}, OutputObjHandlingPolicy::AnalysisObject, false, true};
+  HistogramRegistry registryDCA{"registryDCA", {}, OutputObjHandlingPolicy::AnalysisObject, false, true};
 
   // Efficiency
   EfficiencyConfigurableGroup effConfGroup;
@@ -246,16 +253,13 @@ struct FemtoUniversePairTaskTrackD0 {
   float weight = 1.0;
 
   HistogramRegistry registry{"registry",
-                             {{"hInvMassD0", ";#it{M}(K^{-}#pi^{+}) (GeV/#it{c}^{2});counts", {HistType::kTH1F, {confInvMassBins}}},
-                              {"hInvMassD0bar", ";#it{M}(#pi^{-}K^{+}) (GeV/#it{c}^{2});counts", {HistType::kTH1F, {confInvMassBins}}},
-                              {"hPtDmesonCand", "2-prong candidates;#it{p}_{T} (GeV/#it{c});counts", {HistType::kTH1F, {confPtBins}}},
-                              {"hPtD0", "D^{0} cand.;#it{p}_{T} (GeV/#it{c});counts", {HistType::kTH1F, {confPtBins}}},
+                              {{"hPtD0", "D^{0} cand.;#it{p}_{T} (GeV/#it{c});counts", {HistType::kTH1F, {confPtBins}}},
                               {"hPtD0bar", "#bar{D^{0}};#it{p}_{T} (GeV/#it{c});counts", {HistType::kTH1F, {confPtBins}}},
                               {"hPtD0D0bar", "#bar{D^{0}};#it{p}_{T} (GeV/#it{c});counts", {HistType::kTH1F, {confPtBins}}},
-                              {"hPhiDmesonCand", ";#varphi (rad);counts", {HistType::kTH1F, {{80, 0., o2::constants::math::TwoPI}}}},
+                              {"hPhiD0D0bar", ";#varphi (rad);counts", {HistType::kTH1F, {{80, 0., o2::constants::math::TwoPI}}}},
                               {"hPhiD0", ";#varphi (rad);counts", {HistType::kTH1F, {{80, 0., o2::constants::math::TwoPI}}}},
                               {"hPhiD0bar", ";#varphi (rad);counts", {HistType::kTH1F, {{80, 0., o2::constants::math::TwoPI}}}},
-                              {"hEtaDmesonCand", ";#eta ;counts", {HistType::kTH1F, {{200, -1., 1.}}}},
+                              {"hEtaD0D0bar", ";#eta ;counts", {HistType::kTH1F, {{200, -1., 1.}}}},
                               {"hEtaD0", ";#eta ;counts", {HistType::kTH1F, {{200, -1., 1.}}}},
                               {"hEtaD0bar", ";#eta ;counts", {HistType::kTH1F, {{200, -1., 1.}}}},
                               {"hDecayLengthD0", ";decay length (cm);counts", {HistType::kTH1F, {{800, 0., 4.}}}},
@@ -268,13 +272,13 @@ struct FemtoUniversePairTaskTrackD0 {
   // PID for protons
   bool isProtonNSigma(float mom, float nsigmaTPCPr, float nsigmaTOFPr) // previous version from: https://github.com/alisw/AliPhysics/blob/master/PWGCF/FEMTOSCOPY/AliFemtoUser/AliFemtoMJTrackCut.cxx
   {
-    if (mom < ConfTrack.protonMinPtPidTpcTof) {
+    if (mom < ConfTrack.minPtPidTpcTofProton) {
       if (std::abs(nsigmaTPCPr) < ConfBothTracks.confNsigmaTPCProton) {
         return true;
       } else {
         return false;
       }
-    } else if (mom > ConfTrack.protonMinPtPidTpcTof) {
+    } else if (mom > ConfTrack.minPtPidTpcTofProton) {
       if (std::hypot(nsigmaTOFPr, nsigmaTPCPr) < ConfBothTracks.confNsigmaCombinedProton) {
         return true;
       } else {
@@ -284,36 +288,16 @@ struct FemtoUniversePairTaskTrackD0 {
     return false;
   }
 
-  bool isKaonNSigma(float mom, float nsigmaTPCK, float nsigmaTOFK)
+  bool isKaonNSigmaLF(float mom, float nsigmaTPCK, float nsigmaTOFK)
   {
-    if (mom < 0.3) { // 0.0-0.3
-      if (std::abs(nsigmaTPCK) < 3.0) {
+    if (mom < ConfTrack.minPtPidTpcTofKaonLF) {
+      if (std::abs(nsigmaTPCK) < ConfBothTracks.confNsigmaTPCKaon) {
         return true;
       } else {
         return false;
       }
-    } else if (mom < 0.45) { // 0.30 - 0.45
-      if (std::abs(nsigmaTPCK) < 2.0) {
-        return true;
-      } else {
-        return false;
-      }
-    } else if (mom < 0.55) { // 0.45-0.55
-      if (std::abs(nsigmaTPCK) < 1.0) {
-        return true;
-      } else {
-        return false;
-      }
-    } else if (mom < 1.5) { // 0.55-1.5 (now we use TPC and TOF)
-      if ((std::abs(nsigmaTOFK) < 3.0) && (std::abs(nsigmaTPCK) < 3.0)) {
-        {
-          return true;
-        }
-      } else {
-        return false;
-      }
-    } else if (mom > 1.5) {
-      if ((std::abs(nsigmaTOFK) < 2.0) && (std::abs(nsigmaTPCK) < 3.0)) {
+    } else if (mom >= ConfTrack.minPtPidTpcTofKaonLF) {
+      if (std::sqrt(nsigmaTPCK * nsigmaTPCK + nsigmaTOFK * nsigmaTOFK) < ConfBothTracks.confNsigmaCombinedKaon) {
         return true;
       } else {
         return false;
@@ -326,16 +310,16 @@ struct FemtoUniversePairTaskTrackD0 {
   bool isPionNSigma(float mom, float nsigmaTPCPi, float nsigmaTOFPi)
   {
     // using configurables:
-    // confNsigmaTPCPion -> TPC Pion Sigma for momentum < 0.5 GeV/c
-    // confNsigmaCombinedPion -> TPC and TOF Pion Sigma (combined) for momentum > 0.5 GeV/c
+    // confNsigmaTPCPion -> TPC Pion Sigma for a given momentum
+    // confNsigmaCombinedPion -> TPC and TOF Pion Sigma (combined) for a given momentum
     if (true) {
-      if (mom < ConfTrack.pionMinPtPidTpcTof) {
+      if (mom < ConfTrack.minPtPidTpcTofPion) {
         if (std::abs(nsigmaTPCPi) < ConfBothTracks.confNsigmaTPCPion) {
           return true;
         } else {
           return false;
         }
-      } else if (mom > ConfTrack.pionMinPtPidTpcTof) {
+      } else if (mom > ConfTrack.minPtPidTpcTofPion) {
         if (std::hypot(nsigmaTOFPi, nsigmaTPCPi) < ConfBothTracks.confNsigmaCombinedPion) {
           return true;
         } else {
@@ -359,7 +343,7 @@ struct FemtoUniversePairTaskTrackD0 {
         break;
       case 321:  // Kaon+
       case -321: // Kaon-
-        return isKaonNSigma(mom, nsigmaTPCK, nsigmaTOFK);
+        return isKaonNSigmaLF(mom, nsigmaTPCK, nsigmaTOFK);
         break;
       default:
         return false;
@@ -368,12 +352,8 @@ struct FemtoUniversePairTaskTrackD0 {
 
   void init(InitContext&)
   {
-    // if (effConfGroup.confEfficiencyDoMCTruth) {
-    //   WORK IN PROGRESS
-    //   hMCTruth1.init(&qaRegistry, confBinsTempFitVarpT, confBinsTempFitVarPDG, false, ConfTrack.confTrackPDGCode, false);
-    //   hMCTruth2.init(&qaRegistry, confBinsTempFitVarpT, confBinsTempFitVarPDG, false, 333, false);
-    // }
     efficiencyCalculator.init();
+    hTrackDCA.init(&registryDCA, confTempFitVarpTBins, confTempFitVarDCABins, true, ConfTrack.confPDGCodeTrack, true);
 
     eventHisto.init(&qaRegistry);
     qaRegistry.add("QA_D0D0barSelection/hInvMassD0", ";#it{M}(K^{-}#pi^{+}) (GeV/#it{c}^{2});counts", kTH1F, {confInvMassBins});
@@ -418,22 +398,94 @@ struct FemtoUniversePairTaskTrackD0 {
     qaRegistry.add("Hadron/nSigmaTPCKa", "; #it{p} (GeV/#it{c}); n#sigma_{TPCKa}", kTH2F, {{100, 0, 10}, {200, -4.975, 5.025}});
     qaRegistry.add("Hadron/nSigmaTOFKa", "; #it{p} (GeV/#it{c}); n#sigma_{TOFKa}", kTH2F, {{100, 0, 10}, {200, -4.975, 5.025}});
 
-    // MC truth
-    mcTruthRegistry.add("MCTruthD0D0bar", "MC Truth D0/D0bar;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{360, 0, 36}, {400, -1.0, 1.0}}});
-    mcTruthRegistry.add("MCTruthAllPositivePt", "MC Truth all positive;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{360, 0, 36}}});
-    mcTruthRegistry.add("MCTruthAllNegativePt", "MC Truth all negative;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{360, 0, 36}}});
-    mcTruthRegistry.add("MCTruthKpPtVsEta", "MC Truth K+;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{500, 0, 5}, {400, -1.0, 1.0}}});
-    mcTruthRegistry.add("MCTruthKmPtVsEta", "MC Truth K-;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{500, 0, 5}, {400, -1.0, 1.0}}});
-    mcTruthRegistry.add("MCTruthPipPtVsEta", "MC Truth #pi+;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{500, 0, 5}, {400, -1.0, 1.0}}});
-    mcTruthRegistry.add("MCTruthPimPtVsEta", "MC Truth #pi-;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{500, 0, 5}, {400, -1.0, 1.0}}});
-    mcTruthRegistry.add("MCTruthProtonPtVsEta", "MC Truth proton;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{500, 0, 5}, {400, -1.0, 1.0}}});
-    mcTruthRegistry.add("MCTruthAntiProtonPtVsEta", "MC Truth antiproton;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{500, 0, 5}, {400, -1.0, 1.0}}});
-    mcTruthRegistry.add("MCTruthKpPt", "MC Truth K+;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{500, 0, 5}}});
-    mcTruthRegistry.add("MCTruthKmPt", "MC Truth K-;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{500, 0, 5}}});
-    mcTruthRegistry.add("MCTruthPipPt", "MC Truth #pi+;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{500, 0, 5}}});
-    mcTruthRegistry.add("MCTruthPimPt", "MC Truth #pi-;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{500, 0, 5}}});
-    mcTruthRegistry.add("MCTruthProtonPt", "MC Truth proton;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{500, 0, 5}}});
-    mcTruthRegistry.add("MCTruthAntiProtonPt", "MC Truth antiproton;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{500, 0, 5}}});
+    // D0/D0bar histograms
+    auto vbins = (std::vector<double>)binsPt;
+    if (doEfficiencyCorr) {
+      registry.add("D0D0bar_oneMassHypo/hMassVsPtEffCorr", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_oneMassHypo/hMassVsPtD0EffCorr", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_oneMassHypo/hMassVsPtD0barEffCorr", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_doubleMassHypo/hMassVsPtEffCorr", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_doubleMassHypo/hMassVsPtD0EffCorr", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_doubleMassHypo/hMassVsPtD0barEffCorr", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    } else {
+      registry.add("D0D0bar_oneMassHypo/hMassVsPt", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_oneMassHypo/hMassVsPtD0", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_oneMassHypo/hMassVsPtD0bar", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_doubleMassHypo/hMassVsPt", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_doubleMassHypo/hMassVsPtD0", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_doubleMassHypo/hMassVsPtD0bar", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    }
+    // Histograms for BDT score classes' check
+    registry.add("DebugBdt/hBdtScore1VsStatus", ";BDT score;status", {HistType::kTH2F, {axisBdtScore, axisSelStatus}});
+    registry.add("DebugBdt/hBdtScore2VsStatus", ";BDT score;status", {HistType::kTH2F, {axisBdtScore, axisSelStatus}});
+    registry.add("DebugBdt/hBdtScore3VsStatus", ";BDT score;status", {HistType::kTH2F, {axisBdtScore, axisSelStatus}});
+    if (applyMLOpt) {
+      registry.add("D0D0bar_MLSel/hMassVsPt1", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt2", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt3", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt4", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt5", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt6", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt7", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt8", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt9", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+      registry.add("D0D0bar_MLSel/hMassVsPt10", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    }
+    // MC Reco
+    mcRecoRegistry.add("hMcRecD0", "MC Reco all D0s;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{vbins, "#it{p}_{T} (GeV/#it{c})"}, {400, -1.0, 1.0}}});
+    mcRecoRegistry.add("hMcRecD0Prompt", "MC Reco prompt D0s;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{vbins, "#it{p}_{T} (GeV/#it{c})"}, {400, -1.0, 1.0}}});
+    mcRecoRegistry.add("hMcRecD0NonPrompt", "MC Reco non-prompt D0s;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{vbins, "#it{p}_{T} (GeV/#it{c})"}, {400, -1.0, 1.0}}});
+    mcRecoRegistry.add("hMcRecD0Phi", "MC Reco all D0s;#varphi (rad); counts", {HistType::kTH1F, {{80, 0., o2::constants::math::TwoPI}}});
+    mcRecoRegistry.add("hMcRecD0bar", "MC Reco all D0bars;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{vbins, "#it{p}_{T} (GeV/#it{c})"}, {400, -1.0, 1.0}}});
+    mcRecoRegistry.add("hMcRecD0barPrompt", "MC Reco prompt D0bars;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{vbins, "#it{p}_{T} (GeV/#it{c})"}, {400, -1.0, 1.0}}});
+    mcRecoRegistry.add("hMcRecD0barNonPrompt", "MC Reco non-prompt D0bars;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{vbins, "#it{p}_{T} (GeV/#it{c})"}, {400, -1.0, 1.0}}});
+    mcRecoRegistry.add("hMcRecD0barPhi", "MC Reco all D0bars;#varphi (rad); counts", {HistType::kTH1F, {{80, 0., o2::constants::math::TwoPI}}});
+    // Inv. mass histograms
+    mcRecoRegistry.add("hMassVsPtD0Sig", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    mcRecoRegistry.add("hMassVsPtD0Refl", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    mcRecoRegistry.add("hMassVsPtD0Bkg", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    mcRecoRegistry.add("hMassVsPtD0Prompt", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    mcRecoRegistry.add("hMassVsPtD0NonPrompt", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    mcRecoRegistry.add("hMassVsPtD0barSig", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    mcRecoRegistry.add("hMassVsPtD0barRefl", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    mcRecoRegistry.add("hMassVsPtD0barBkg", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    mcRecoRegistry.add("hMassVsPtD0barPrompt", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    mcRecoRegistry.add("hMassVsPtD0barNonPrompt", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
+    // Histograms for identified hadrons
+    mcRecoRegistry.add("hMcRecKpPt", "MC Reco K+;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{500, 0, 5}}});
+    mcRecoRegistry.add("hMcRecKpPtGenEtaGen", "MC Reco K+;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{500, 0, 5}, {400, -1.0, 1.0}}});
+    mcRecoRegistry.add("hMcRecKmPt", "MC Reco K-;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{500, 0, 5}}});
+    mcRecoRegistry.add("hMcRecKmPtGenEtaGen", "MC Reco K-;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{500, 0, 5}, {400, -1.0, 1.0}}});
+    mcRecoRegistry.add("hMcRecPipPt", "MC Reco #pi+;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{500, 0, 5}}});
+    mcRecoRegistry.add("hMcRecPipPtGenEtaGen", "MC Reco #pi+;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{500, 0, 5}, {400, -1.0, 1.0}}});
+    mcRecoRegistry.add("hMcRecPimPt", "MC Reco #pi-;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{500, 0, 5}}});
+    mcRecoRegistry.add("hMcRecPimPtGenEtaGen", "MC Reco #pi-;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{500, 0, 5}, {400, -1.0, 1.0}}});
+    mcRecoRegistry.add("hMcRecPrPt", "MC Reco proton;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{500, 0, 5}}});
+    mcRecoRegistry.add("hMcRecPrPtGenEtaGen", "MC Reco proton;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{500, 0, 5}, {400, -1.0, 1.0}}});
+    mcRecoRegistry.add("hMcRecAntiPrPt", "MC Reco antiproton;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{500, 0, 5}}});
+    mcRecoRegistry.add("hMcRecAntiPrPtGenEtaGen", "MC Reco antiproton;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{500, 0, 5}, {400, -1.0, 1.0}}});
+
+   // MC truth
+    mcTruthRegistry.add("hMcGenD0", "MC Truth all D0s;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{vbins, "#it{p}_{T} (GeV/#it{c})"}, {400, -1.0, 1.0}}});
+    mcTruthRegistry.add("hMcGenD0Prompt", "MC Truth prompt D0s;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{vbins, "#it{p}_{T} (GeV/#it{c})"}, {400, -1.0, 1.0}}});
+    mcTruthRegistry.add("hMcGenD0NonPrompt", "MC Truth non-prompt D0s;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{vbins, "#it{p}_{T} (GeV/#it{c})"}, {400, -1.0, 1.0}}});
+    mcTruthRegistry.add("hMcGenD0bar", "MC Truth all D0bars;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{vbins, "#it{p}_{T} (GeV/#it{c})"}, {400, -1.0, 1.0}}});
+    mcTruthRegistry.add("hMcGenD0barPrompt", "MC Truth prompt D0bars;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{vbins, "#it{p}_{T} (GeV/#it{c})"}, {400, -1.0, 1.0}}});
+    mcTruthRegistry.add("hMcGenD0barNonPrompt", "MC Truth non-prompt D0bars;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{vbins, "#it{p}_{T} (GeV/#it{c})"}, {400, -1.0, 1.0}}});
+    mcTruthRegistry.add("hMcGenAllPositivePt", "MC Truth all positive;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{360, 0, 36}}});
+    mcTruthRegistry.add("hMcGenAllNegativePt", "MC Truth all negative;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{360, 0, 36}}});
+    mcTruthRegistry.add("hMcGenKpPtVsEta", "MC Truth K+;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{500, 0, 5}, {400, -1.0, 1.0}}});
+    mcTruthRegistry.add("hMcGenKmPtVsEta", "MC Truth K-;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{500, 0, 5}, {400, -1.0, 1.0}}});
+    mcTruthRegistry.add("hMcGenPipPtVsEta", "MC Truth #pi+;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{500, 0, 5}, {400, -1.0, 1.0}}});
+    mcTruthRegistry.add("hMcGenPimPtVsEta", "MC Truth #pi-;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{500, 0, 5}, {400, -1.0, 1.0}}});
+    mcTruthRegistry.add("hMcGenPrPtVsEta", "MC Truth proton;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{500, 0, 5}, {400, -1.0, 1.0}}});
+    mcTruthRegistry.add("hMcGenAntiPrPtVsEta", "MC Truth antiproton;#it{p}_{T} (GeV/c); #eta", {HistType::kTH2F, {{500, 0, 5}, {400, -1.0, 1.0}}});
+    mcTruthRegistry.add("hMcGenKpPt", "MC Truth K+;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{500, 0, 5}}});
+    mcTruthRegistry.add("hMcGenKmPt", "MC Truth K-;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{500, 0, 5}}});
+    mcTruthRegistry.add("hMcGenPipPt", "MC Truth #pi+;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{500, 0, 5}}});
+    mcTruthRegistry.add("hMcGenPimPt", "MC Truth #pi-;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{500, 0, 5}}});
+    mcTruthRegistry.add("hMcGenPrPt", "MC Truth proton;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{500, 0, 5}}});
+    mcTruthRegistry.add("hMcGenAntiPrPt", "MC Truth antiproton;#it{p}_{T} (GeV/c); counts", {HistType::kTH1F, {{500, 0, 5}}});
 
     trackHistoPartD0D0bar.init(&qaRegistry, confTempFitVarpTBins, confTempFitVarInvMassBins, ConfBothTracks.confIsMC, ConfDmesons.confPDGCodeD0);
     if (!ConfTrack.confIsSame) {
@@ -458,33 +510,6 @@ struct FemtoUniversePairTaskTrackD0 {
     vPIDTrack = ConfTrack.confPIDTrack.value;
     kNsigma = ConfBothTracks.confTrkPIDnSigmaMax.value;
 
-    // D0/D0bar histograms
-    auto vbins = (std::vector<double>)binsPt;
-    registry.add("D0D0bar_oneMassHypo/hMassVsPt", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("D0D0bar_oneMassHypo/hMassVsPtReflected", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("D0D0bar_oneMassHypo/hMassVsPtD0", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("D0D0bar_oneMassHypo/hMassVsPtD0bar", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("D0D0bar_oneMassHypo/hMassVsPtD0Reflected", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("D0D0bar_oneMassHypo/hMassVsPtD0barReflected", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("D0D0bar_doubleMassHypo/hMassVsPt", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("D0D0bar_doubleMassHypo/hMassVsPtD0", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    registry.add("D0D0bar_doubleMassHypo/hMassVsPtD0bar", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    // Histograms for BDT score classes' check
-    registry.add("DebugBdt/hBdtScore1VsStatus", ";BDT score;status", {HistType::kTH2F, {axisBdtScore, axisSelStatus}});
-    registry.add("DebugBdt/hBdtScore2VsStatus", ";BDT score;status", {HistType::kTH2F, {axisBdtScore, axisSelStatus}});
-    registry.add("DebugBdt/hBdtScore3VsStatus", ";BDT score;status", {HistType::kTH2F, {axisBdtScore, axisSelStatus}});
-    if (applyMLOpt) {
-      registry.add("D0D0bar_MLSel/hMassVsPt1", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-      registry.add("D0D0bar_MLSel/hMassVsPt2", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-      registry.add("D0D0bar_MLSel/hMassVsPt3", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-      registry.add("D0D0bar_MLSel/hMassVsPt4", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-      registry.add("D0D0bar_MLSel/hMassVsPt5", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-      registry.add("D0D0bar_MLSel/hMassVsPt6", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-      registry.add("D0D0bar_MLSel/hMassVsPt7", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-      registry.add("D0D0bar_MLSel/hMassVsPt8", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-      registry.add("D0D0bar_MLSel/hMassVsPt9", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-      registry.add("D0D0bar_MLSel/hMassVsPt10", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
-    }
   }
 
   template <typename CollisionType>
@@ -496,7 +521,7 @@ struct FemtoUniversePairTaskTrackD0 {
 
   void processD0MLOptBg(o2::aod::FdCollision const& col, FemtoFullParticles const&)
   {
-    auto groupD0D0barCands = partsOnlyD0D0bar->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
+    auto groupD0D0barCands = partsAllDmesons->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
 
     // loop over selected D0/D0bar candidates
     for (auto const& charmCand : groupD0D0barCands) {
@@ -552,7 +577,7 @@ struct FemtoUniversePairTaskTrackD0 {
 
   void processD0MLOptBgAndPrompt(o2::aod::FdCollision const& col, FemtoFullParticles const&)
   {
-    auto groupD0D0barCands = partsOnlyD0D0bar->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
+    auto groupD0D0barCands = partsAllDmesons->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
 
     // loop over selected D0/D0bar candidates
     for (auto const& charmCand : groupD0D0barCands) {
@@ -639,42 +664,74 @@ struct FemtoUniversePairTaskTrackD0 {
   void processAllDmesons(o2::aod::FdCollision const& col, FemtoFullParticles const&)
   {
     auto groupPartsAllD0D0barCands = partsAllDmesons->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
-    auto groupPartsD0D0barChildren = partsDmesonsChildren->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
 
-    // loop over D0/D0bar mesons (ONLY)
+    // loop over D0/D0bar mesons
     for (auto const& d0d0bar : groupPartsAllD0D0barCands) {
 
       registry.fill(HIST("hPtD0D0bar"), d0d0bar.pt());
-      registry.fill(HIST("hPhiDmesonCand"), d0d0bar.phi());
-      registry.fill(HIST("hEtaDmesonCand"), d0d0bar.eta());
+      registry.fill(HIST("hPhiD0D0bar"), d0d0bar.phi());
+      registry.fill(HIST("hEtaD0D0bar"), d0d0bar.eta());
       // BDT score classes
       registry.fill(HIST("DebugBdt/hBdtScore1VsStatus"), d0d0bar.decayVtxX(), 1);
       registry.fill(HIST("DebugBdt/hBdtScore2VsStatus"), d0d0bar.decayVtxY(), 1);
       registry.fill(HIST("DebugBdt/hBdtScore3VsStatus"), d0d0bar.decayVtxZ(), 1);
-
-      if (d0d0bar.mLambda() > 0.0f) {
-        registry.fill(HIST("D0D0bar_doubleMassHypo/hMassVsPt"), d0d0bar.mLambda(), d0d0bar.pt());
-        registry.fill(HIST("D0D0bar_doubleMassHypo/hMassVsPtD0"), d0d0bar.mLambda(), d0d0bar.pt());
-        if (d0d0bar.mAntiLambda() < 0.0f) {
-          registry.fill(HIST("D0D0bar_oneMassHypo/hMassVsPt"), d0d0bar.mLambda(), d0d0bar.pt());
-          registry.fill(HIST("D0D0bar_oneMassHypo/hMassVsPtD0"), d0d0bar.mLambda(), d0d0bar.pt());
-          registry.fill(HIST("hPtD0"), d0d0bar.pt());
-          registry.fill(HIST("hPhiD0"), d0d0bar.phi());
-          registry.fill(HIST("hEtaD0"), d0d0bar.eta());
+      
+      weight = 1.0f;
+      if (doEfficiencyCorr) {
+        weight = efficiencyCalculator.getWeight(ParticleNo::TWO, d0d0bar.pt());
+        if (d0d0bar.mLambda() > 0.0f) {
+          registry.fill(HIST("D0D0bar_doubleMassHypo/hMassVsPtEffCorr"), d0d0bar.mLambda(), d0d0bar.pt(), weight);
+          registry.fill(HIST("D0D0bar_doubleMassHypo/hMassVsPtD0EffCorr"), d0d0bar.mLambda(), d0d0bar.pt(), weight);
+          if (d0d0bar.mAntiLambda() < 0.0f) {
+            registry.fill(HIST("D0D0bar_oneMassHypo/hMassVsPtEffCorr"), d0d0bar.mLambda(), d0d0bar.pt(), weight);
+            registry.fill(HIST("D0D0bar_oneMassHypo/hMassVsPtD0EffCorr"), d0d0bar.mLambda(), d0d0bar.pt(), weight);
+            registry.fill(HIST("hPtD0"), d0d0bar.pt());
+            registry.fill(HIST("hPhiD0"), d0d0bar.phi());
+            registry.fill(HIST("hEtaD0"), d0d0bar.eta());
+          }
         }
-      }
-      if (d0d0bar.mAntiLambda() > 0.0f) {
-        registry.fill(HIST("D0D0bar_doubleMassHypo/hMassVsPt"), d0d0bar.mLambda(), d0d0bar.pt());
-        registry.fill(HIST("D0D0bar_doubleMassHypo/hMassVsPtD0bar"), d0d0bar.mLambda(), d0d0bar.pt());
-        if (d0d0bar.mLambda() < 0.0f) {
-          registry.fill(HIST("D0D0bar_oneMassHypo/hMassVsPt"), d0d0bar.mAntiLambda(), d0d0bar.pt());
-          registry.fill(HIST("D0D0bar_oneMassHypo/hMassVsPtD0bar"), d0d0bar.mAntiLambda(), d0d0bar.pt());
-          registry.fill(HIST("hPtD0bar"), d0d0bar.pt());
-          registry.fill(HIST("hPhiD0bar"), d0d0bar.phi());
-          registry.fill(HIST("hEtaD0bar"), d0d0bar.eta());
+        if (d0d0bar.mAntiLambda() > 0.0f) {
+          registry.fill(HIST("D0D0bar_doubleMassHypo/hMassVsPtEffCorr"), d0d0bar.mLambda(), d0d0bar.pt(), weight);
+          registry.fill(HIST("D0D0bar_doubleMassHypo/hMassVsPtD0barEffCorr"), d0d0bar.mLambda(), d0d0bar.pt(), weight);
+          if (d0d0bar.mLambda() < 0.0f) {
+            registry.fill(HIST("D0D0bar_oneMassHypo/hMassVsPtEffCorr"), d0d0bar.mAntiLambda(), d0d0bar.pt(), weight);
+            registry.fill(HIST("D0D0bar_oneMassHypo/hMassVsPtD0barEffCorr"), d0d0bar.mAntiLambda(), d0d0bar.pt(), weight);
+            registry.fill(HIST("hPtD0bar"), d0d0bar.pt());
+            registry.fill(HIST("hPhiD0bar"), d0d0bar.phi());
+            registry.fill(HIST("hEtaD0bar"), d0d0bar.eta());
+          }
+        }
+      } else {
+        if (d0d0bar.mLambda() > 0.0f) {
+          registry.fill(HIST("D0D0bar_doubleMassHypo/hMassVsPt"), d0d0bar.mLambda(), d0d0bar.pt());
+          registry.fill(HIST("D0D0bar_doubleMassHypo/hMassVsPtD0"), d0d0bar.mLambda(), d0d0bar.pt());
+          if (d0d0bar.mAntiLambda() < 0.0f) {
+            registry.fill(HIST("D0D0bar_oneMassHypo/hMassVsPt"), d0d0bar.mLambda(), d0d0bar.pt());
+            registry.fill(HIST("D0D0bar_oneMassHypo/hMassVsPtD0"), d0d0bar.mLambda(), d0d0bar.pt());
+            registry.fill(HIST("hPtD0"), d0d0bar.pt());
+            registry.fill(HIST("hPhiD0"), d0d0bar.phi());
+            registry.fill(HIST("hEtaD0"), d0d0bar.eta());
+          }
+        }
+        if (d0d0bar.mAntiLambda() > 0.0f) {
+          registry.fill(HIST("D0D0bar_doubleMassHypo/hMassVsPt"), d0d0bar.mLambda(), d0d0bar.pt());
+          registry.fill(HIST("D0D0bar_doubleMassHypo/hMassVsPtD0bar"), d0d0bar.mLambda(), d0d0bar.pt());
+          if (d0d0bar.mLambda() < 0.0f) {
+            registry.fill(HIST("D0D0bar_oneMassHypo/hMassVsPt"), d0d0bar.mAntiLambda(), d0d0bar.pt());
+            registry.fill(HIST("D0D0bar_oneMassHypo/hMassVsPtD0bar"), d0d0bar.mAntiLambda(), d0d0bar.pt());
+            registry.fill(HIST("hPtD0bar"), d0d0bar.pt());
+            registry.fill(HIST("hPhiD0bar"), d0d0bar.phi());
+            registry.fill(HIST("hEtaD0bar"), d0d0bar.eta());
+          }
         }
       }
     }
+  }
+  PROCESS_SWITCH(FemtoUniversePairTaskTrackD0, processAllDmesons, "Enable processing over all D meson candidates", false);
+
+  void processD0Children(o2::aod::FdCollision const& col, FemtoFullParticles const&)
+  {
+    auto groupPartsD0D0barChildren = partsDmesonsChildren->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
 
     // loop over D mesons childen
     for (auto const& daughD0D0bar : groupPartsD0D0barChildren) {
@@ -706,76 +763,7 @@ struct FemtoUniversePairTaskTrackD0 {
       }
     }
   }
-  PROCESS_SWITCH(FemtoUniversePairTaskTrackD0, processAllDmesons, "Enable processing over all D meson candidates", false);
-
-  void processD0mesons(o2::aod::FdCollision const& col, FemtoFullParticles const&)
-  {
-    auto groupPartsAllD0D0barCands = partsAllDmesons->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
-    auto groupPartsOnlyD0D0bar = partsOnlyD0D0bar->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
-    auto groupPartsD0D0barChildren = partsDmesonsChildren->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
-
-    // loop over D0/D0bar mesons (ONLY)
-    for (auto const& d0d0bar : groupPartsOnlyD0D0bar) {
-
-      registry.fill(HIST("hPtD0D0bar"), d0d0bar.pt());
-      // BDT score classes
-      registry.fill(HIST("DebugBdt/hBdtScore1VsStatus"), d0d0bar.decayVtxX(), 1);
-      registry.fill(HIST("DebugBdt/hBdtScore2VsStatus"), d0d0bar.decayVtxY(), 1);
-      registry.fill(HIST("DebugBdt/hBdtScore3VsStatus"), d0d0bar.decayVtxZ(), 1);
-
-      if (d0d0bar.mLambda() > 0.0f && d0d0bar.mAntiLambda() < 0.0f) {
-        registry.fill(HIST("D0D0bar_oneMassHypo/hMassVsPt"), d0d0bar.mLambda(), d0d0bar.pt());
-        registry.fill(HIST("D0D0bar_oneMassHypo/hMassVsPtD0"), d0d0bar.mLambda(), d0d0bar.pt());
-        registry.fill(HIST("D0D0bar_oneMassHypo/hMassVsPtReflected"), std::abs(d0d0bar.mAntiLambda()), d0d0bar.pt());
-        registry.fill(HIST("D0D0bar_oneMassHypo/hMassVsPtD0Reflected"), std::abs(d0d0bar.mAntiLambda()), d0d0bar.pt());
-        registry.fill(HIST("hInvMassD0"), d0d0bar.mLambda());
-        registry.fill(HIST("hPtD0"), d0d0bar.pt());
-        registry.fill(HIST("hPhiD0"), d0d0bar.phi());
-        registry.fill(HIST("hEtaD0"), d0d0bar.eta());
-      }
-      if (d0d0bar.mLambda() < 0.0f && d0d0bar.mAntiLambda() > 0.0f) {
-        registry.fill(HIST("D0D0bar_oneMassHypo/hMassVsPt"), d0d0bar.mAntiLambda(), d0d0bar.pt());
-        registry.fill(HIST("D0D0bar_oneMassHypo/hMassVsPtD0bar"), d0d0bar.mAntiLambda(), d0d0bar.pt());
-        registry.fill(HIST("D0D0bar_oneMassHypo/hMassVsPtReflected"), std::abs(d0d0bar.mLambda()), d0d0bar.pt());
-        registry.fill(HIST("D0D0bar_oneMassHypo/hMassVsPtD0barReflected"), std::abs(d0d0bar.mLambda()), d0d0bar.pt());
-        registry.fill(HIST("hInvMassD0bar"), d0d0bar.mAntiLambda());
-        registry.fill(HIST("hPtD0bar"), d0d0bar.pt());
-        registry.fill(HIST("hPhiD0bar"), d0d0bar.phi());
-        registry.fill(HIST("hEtaD0bar"), d0d0bar.eta());
-      }
-    }
-
-    // loop over D mesons childen
-    for (auto const& daughD0D0bar : groupPartsD0D0barChildren) {
-      registry.fill(HIST("hPtDaughters"), daughD0D0bar.pt());
-      registry.fill(HIST("hSignDaughters"), daughD0D0bar.mLambda());
-      // filling QA plots for D0 mesons' positive daughters (K+)
-      if (daughD0D0bar.mLambda() == 1 && daughD0D0bar.mAntiLambda() == 1) {
-        qaRegistry.fill(HIST("D0_pos_daugh/pt"), daughD0D0bar.pt());
-        qaRegistry.fill(HIST("D0_pos_daugh/eta"), daughD0D0bar.eta());
-        qaRegistry.fill(HIST("D0_pos_daugh/phi"), daughD0D0bar.phi());
-      }
-      // filling QA plots for D0 mesons' negative daughters (pi-)
-      if (daughD0D0bar.mLambda() == -1 && daughD0D0bar.mAntiLambda() == 1) {
-        qaRegistry.fill(HIST("D0_neg_daugh/pt"), daughD0D0bar.pt());
-        qaRegistry.fill(HIST("D0_neg_daugh/eta"), daughD0D0bar.eta());
-        qaRegistry.fill(HIST("D0_neg_daugh/phi"), daughD0D0bar.phi());
-      }
-      // filling QA plots for D0bar mesons' positive daughters (pi+)
-      if (daughD0D0bar.mLambda() == 1 && daughD0D0bar.mAntiLambda() == -1) {
-        qaRegistry.fill(HIST("D0bar_pos_daugh/pt"), daughD0D0bar.pt());
-        qaRegistry.fill(HIST("D0bar_pos_daugh/eta"), daughD0D0bar.eta());
-        qaRegistry.fill(HIST("D0bar_pos_daugh/phi"), daughD0D0bar.phi());
-      }
-      // filling QA plots for D0bar mesons' negative daughters (K-)
-      if (daughD0D0bar.mLambda() == -1 && daughD0D0bar.mAntiLambda() == -1) {
-        qaRegistry.fill(HIST("D0bar_neg_daugh/pt"), daughD0D0bar.pt());
-        qaRegistry.fill(HIST("D0bar_neg_daugh/eta"), daughD0D0bar.eta());
-        qaRegistry.fill(HIST("D0bar_neg_daugh/phi"), daughD0D0bar.phi());
-      }
-    }
-  }
-  PROCESS_SWITCH(FemtoUniversePairTaskTrackD0, processD0mesons, "Enable processing D0 mesons", true);
+  PROCESS_SWITCH(FemtoUniversePairTaskTrackD0, processD0Children, "Enable processing over daughters of D0 meson candidates", false);
 
   /// This function processes the same event and takes care of all the histogramming
   /// \todo the trivial loops over the tracks should be factored out since they will be common to all combinations of T-T, T-V0, V0-V0, ...
@@ -925,9 +913,7 @@ struct FemtoUniversePairTaskTrackD0 {
   /// \param col subscribe to the collision table (Monte Carlo Reconstructed reconstructed)
   /// \param parts subscribe to joined table FemtoUniverseParticles and FemtoUniverseMCLables to access Monte Carlo truth
   /// \param FemtoUniverseMCParticles subscribe to the Monte Carlo truth table
-  void processSameEventMC(o2::aod::FdCollision const& col,
-                          soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels> const& parts,
-                          o2::aod::FdMCParticles const&)
+  void processSameEventMC(aod::FdCollision const& col, FemtoMcRecoParticles const& parts, aod::FdMCParticles const&)
   {
     fillCollision(col);
 
@@ -1094,9 +1080,7 @@ struct FemtoUniversePairTaskTrackD0 {
   /// @param cols subscribe to the collisions table (Monte Carlo Reconstructed reconstructed)
   /// @param parts subscribe to joined table FemtoUniverseParticles and FemtoUniverseMCLables to access Monte Carlo truth
   /// @param FemtoUniverseMCParticles subscribe to the Monte Carlo truth table
-  void processMixedEventMC(o2::aod::FdCollisions const& cols,
-                           soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels> const& parts,
-                           o2::aod::FdMCParticles const&)
+  void processMixedEventMC(aod::FdCollisions const& cols, FemtoMcRecoParticles const& parts, aod::FdMCParticles const&)
   {
     for (auto const& [collision1, collision2] : soa::selfCombinations(colBinning, confNEventsMix, -1, cols, cols)) {
 
@@ -1120,65 +1104,196 @@ struct FemtoUniversePairTaskTrackD0 {
   }
   PROCESS_SWITCH(FemtoUniversePairTaskTrackD0, processMixedEventMC, "Enable processing mixed events MC", false);
 
-  void processMCReco(FemtoMCParticles const&, aod::FdMCParticles const&)
+  void processMcReco(FemtoMcRecoParticles const& recoParts, aod::FdMCParticles const& mcParts)
   {
-    // WORK IN PROGRESS
-    // for (auto const& part : parts) {}
-  }
-  PROCESS_SWITCH(FemtoUniversePairTaskTrackD0, processMCReco, "Process MC reco data", false);
+    for (auto const& part : recoParts) {
+      auto mcPartId = part.fdMCParticleId();
+      if (mcPartId == -1) {
+        continue; // no MC particle
+      }
+      const auto& mcpart = mcParts.iteratorAt(mcPartId);
+      weight = 1.0f;
 
-  void processMCTruth(aod::FDParticles const& parts) // WORK IN PROGRESS
+      // filling the histograms for identified hadrons
+      if (part.partType() == aod::femtouniverseparticle::ParticleType::kTrack) {
+        if (part.sign() > 0) {
+          if ((mcpart.pdgMCTruth() == PDG_t::kProton) && (part.pt() > ConfTrack.confTrackLowPtCut) && (part.pt() < ConfTrack.confTrackHighPtCut) && isParticleNSigma(part.p(), trackCuts.getNsigmaTPC(part, o2::track::PID::Proton), trackCuts.getNsigmaTOF(part, o2::track::PID::Proton), trackCuts.getNsigmaTPC(part, o2::track::PID::Pion), trackCuts.getNsigmaTOF(part, o2::track::PID::Pion), trackCuts.getNsigmaTPC(part, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(part, o2::track::PID::Kaon))) {
+            mcRecoRegistry.fill(HIST("hMcRecPrPt"), part.pt());
+            if (mcpart.partOriginMCTruth() == aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kPrimary) {
+              mcRecoRegistry.fill(HIST("hMcRecPrPtGenEtaGen"), mcpart.pt(), mcpart.eta());
+            }
+          }
+          if ((mcpart.pdgMCTruth() == PDG_t::kPiPlus) && (part.pt() > ConfTrack.confTrackLowPtCut) && (part.pt() < ConfTrack.confTrackHighPtCut) && isParticleNSigma(part.p(), trackCuts.getNsigmaTPC(part, o2::track::PID::Proton), trackCuts.getNsigmaTOF(part, o2::track::PID::Proton), trackCuts.getNsigmaTPC(part, o2::track::PID::Pion), trackCuts.getNsigmaTOF(part, o2::track::PID::Pion), trackCuts.getNsigmaTPC(part, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(part, o2::track::PID::Kaon))) {
+            mcRecoRegistry.fill(HIST("hMcRecPipPt"), part.pt());
+            if (mcpart.partOriginMCTruth() == aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kPrimary) {
+              mcRecoRegistry.fill(HIST("hMcRecPipPtGenEtaGen"), mcpart.pt(), mcpart.eta());
+            }
+          }
+          if ((mcpart.pdgMCTruth() == PDG_t::kKPlus) && (part.pt() > ConfTrack.confTrackLowPtCut) && (part.pt() < ConfTrack.confTrackHighPtCut) && isParticleNSigma(part.p(), trackCuts.getNsigmaTPC(part, o2::track::PID::Proton), trackCuts.getNsigmaTOF(part, o2::track::PID::Proton), trackCuts.getNsigmaTPC(part, o2::track::PID::Pion), trackCuts.getNsigmaTOF(part, o2::track::PID::Pion), trackCuts.getNsigmaTPC(part, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(part, o2::track::PID::Kaon))) {
+            mcRecoRegistry.fill(HIST("hMcRecKpPt"), part.pt());
+            if (mcpart.partOriginMCTruth() == aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kPrimary) {
+              mcRecoRegistry.fill(HIST("hMcRecKpPtGenEtaGen"), mcpart.pt(), mcpart.eta());
+            }
+          }
+        } else if (part.sign() < 0) {
+          if ((mcpart.pdgMCTruth() == -PDG_t::kProton) && (part.pt() > ConfTrack.confTrackLowPtCut) && (part.pt() < ConfTrack.confTrackHighPtCut) && isParticleNSigma(part.p(), trackCuts.getNsigmaTPC(part, o2::track::PID::Proton), trackCuts.getNsigmaTOF(part, o2::track::PID::Proton), trackCuts.getNsigmaTPC(part, o2::track::PID::Pion), trackCuts.getNsigmaTOF(part, o2::track::PID::Pion), trackCuts.getNsigmaTPC(part, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(part, o2::track::PID::Kaon))) {
+            mcRecoRegistry.fill(HIST("hMcRecAntiPrPt"), part.pt());
+            if (mcpart.partOriginMCTruth() == aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kPrimary) {
+              mcRecoRegistry.fill(HIST("hMcRecAntiPrPtGenEtaGen"), mcpart.pt(), mcpart.eta());
+            }
+          }
+          if ((mcpart.pdgMCTruth() == -PDG_t::kPiPlus) && (part.pt() > ConfTrack.confTrackLowPtCut) && (part.pt() < ConfTrack.confTrackHighPtCut) && isParticleNSigma(part.p(), trackCuts.getNsigmaTPC(part, o2::track::PID::Proton), trackCuts.getNsigmaTOF(part, o2::track::PID::Proton), trackCuts.getNsigmaTPC(part, o2::track::PID::Pion), trackCuts.getNsigmaTOF(part, o2::track::PID::Pion), trackCuts.getNsigmaTPC(part, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(part, o2::track::PID::Kaon))) {
+            mcRecoRegistry.fill(HIST("hMcRecPimPt"), part.pt());
+            if (mcpart.partOriginMCTruth() == aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kPrimary) {
+              mcRecoRegistry.fill(HIST("hMcRecPimPtGenEtaGen"), mcpart.pt(), mcpart.eta());
+            }
+          }
+          if ((mcpart.pdgMCTruth() == -PDG_t::kKPlus) && (part.pt() > ConfTrack.confTrackLowPtCut) && (part.pt() < ConfTrack.confTrackHighPtCut) && isParticleNSigma(part.p(), trackCuts.getNsigmaTPC(part, o2::track::PID::Proton), trackCuts.getNsigmaTOF(part, o2::track::PID::Proton), trackCuts.getNsigmaTPC(part, o2::track::PID::Pion), trackCuts.getNsigmaTOF(part, o2::track::PID::Pion), trackCuts.getNsigmaTPC(part, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(part, o2::track::PID::Kaon))) {
+            mcRecoRegistry.fill(HIST("hMcRecKmPt"), part.pt());
+            if (mcpart.partOriginMCTruth() == aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kPrimary) {
+              mcRecoRegistry.fill(HIST("hMcRecKmPtGenEtaGen"), mcpart.pt(), mcpart.eta());
+            }
+          }
+        }  
+      } else if ((part.partType() == aod::femtouniverseparticle::ParticleType::kD0) && (part.pt() > ConfDmesons.confMinPtD0D0barReco) && (part.pt() < ConfDmesons.confMaxPtD0D0barReco)) {
+        if (mcpart.pdgMCTruth() == ConfDmesons.confPDGCodeD0) {
+          mcRecoRegistry.fill(HIST("hMcRecD0"), part.pt(), part.eta());
+          mcRecoRegistry.fill(HIST("hMcRecD0Phi"), part.phi());
+          if(part.tpcNClsFound() == 0) { // prompt candidates
+            mcRecoRegistry.fill(HIST("hMcRecD0Prompt"), part.pt(), part.eta());
+          } else if (part.tpcNClsFound() == 1) { // non-prompt candidates
+            mcRecoRegistry.fill(HIST("hMcRecD0NonPrompt"), part.pt(), part.eta());
+          }
+        } else if (mcpart.pdgMCTruth() == ConfDmesons.confPDGCodeD0bar) {
+          mcRecoRegistry.fill(HIST("hMcRecD0bar"), part.pt(), part.eta());
+          mcRecoRegistry.fill(HIST("hMcRecD0barPhi"), part.phi());
+          if(part.tpcNClsFound() == 0) { // prompt candidates
+            mcRecoRegistry.fill(HIST("hMcRecD0barPrompt"), part.pt(), part.eta());
+          } else if (part.tpcNClsFound() == 1) { // non-prompt candidates
+            mcRecoRegistry.fill(HIST("hMcRecD0barNonPrompt"), part.pt(), part.eta());
+          }
+        }
+      }
+      if (isParticleNSigma(part.p(), trackCuts.getNsigmaTPC(part, o2::track::PID::Proton), trackCuts.getNsigmaTOF(part, o2::track::PID::Proton), trackCuts.getNsigmaTPC(part, o2::track::PID::Pion), trackCuts.getNsigmaTOF(part, o2::track::PID::Pion), trackCuts.getNsigmaTPC(part, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(part, o2::track::PID::Kaon))) {
+        hTrackDCA.fillQA<true, true>(part);
+      }
+    }
+  }
+  PROCESS_SWITCH(FemtoUniversePairTaskTrackD0, processMcReco, "Process MC reco data", false);
+
+  void processMcRecoD0InvMass(FemtoMcRecoParticles const& recoParts)
+  {
+    for (auto const& part : recoParts) {
+      // filling the histograms for identified hadrons
+      if ((part.partType() == aod::femtouniverseparticle::ParticleType::kD0) && (part.pt() > ConfDmesons.confMinPtD0D0barReco) && (part.pt() < ConfDmesons.confMaxPtD0D0barReco)) {
+        // getting the efficiency value
+        if (doEfficiencyCorr) {
+          weight = efficiencyCalculator.getWeight(ParticleNo::TWO, part.pt());
+        } else {
+          weight = 1.0f;
+        }
+        // filling the inv. mass histograms
+        if (part.mLambda() > 0) {
+          if(part.sign() == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
+            mcRecoRegistry.fill(HIST("hMassVsPtD0Sig"), part.mLambda(), part.pt(), weight);
+          } else if (part.sign() == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
+            mcRecoRegistry.fill(HIST("hMassVsPtD0Refl"), part.mLambda(), part.pt(), weight);
+          } else {
+            mcRecoRegistry.fill(HIST("hMassVsPtD0Bkg"), part.mLambda(), part.pt(), weight);
+          }
+          if(part.tpcNClsFound() == 0) { // prompt candidates
+            mcRecoRegistry.fill(HIST("hMassVsPtD0Prompt"), part.mLambda(), part.pt(), weight);
+          } else if (part.tpcNClsFound() == 1) { // non-prompt candidates
+            mcRecoRegistry.fill(HIST("hMassVsPtD0NonPrompt"), part.mLambda(), part.pt(), weight);
+          }
+        } else if (part.mAntiLambda() > 0) {
+          if (part.sign() == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
+            mcRecoRegistry.fill(HIST("hMassVsPtD0barSig"), part.mAntiLambda(), part.pt(), weight);
+          } else if (part.sign() == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
+            mcRecoRegistry.fill(HIST("hMassVsPtD0barRefl"), part.mAntiLambda(), part.pt(), weight);
+          } else {
+            mcRecoRegistry.fill(HIST("hMassVsPtD0barBkg"), part.mAntiLambda(), part.pt(), weight);
+          }
+          if(part.tpcNClsFound() == 0) { // prompt candidates
+            mcRecoRegistry.fill(HIST("hMassVsPtD0barPrompt"), part.mAntiLambda(), part.pt(), weight);
+          } else if (part.tpcNClsFound() == 1) { // non-prompt candidates
+            mcRecoRegistry.fill(HIST("hMassVsPtD0barNonPrompt"), part.mAntiLambda(), part.pt(), weight);
+          }
+        }
+      }
+    }
+  }
+  PROCESS_SWITCH(FemtoUniversePairTaskTrackD0, processMcRecoD0InvMass, "Process MC reco inv. mass histograms for D0", false);
+
+  void processMcTruth(aod::FDParticles const& parts)
   {
     for (auto const& part : parts) {
-      if (part.partType() != uint8_t(aod::femtouniverseparticle::ParticleType::kMCTruthTrack))
+      if (part.partType() != uint8_t(aod::femtouniverseparticle::ParticleType::kMCTruthTrack)) {
         continue;
+      }
 
-      int pdgCode = static_cast<int>(part.pidCut());
+      int pdgCode = static_cast<int>(part.tempFitVar());
+      int8_t hfFlagMcGen = static_cast<int8_t>(part.mLambda());
       const auto& pdgParticle = pdgMC->GetParticle(pdgCode);
       if (!pdgParticle) {
         continue;
       }
 
       if (pdgParticle->Charge() > 0.0) {
-        mcTruthRegistry.fill(HIST("MCTruthAllPositivePt"), part.pt());
+        mcTruthRegistry.fill(HIST("hMcGenAllPositivePt"), part.pt());
       }
-      if (pdgCode == 211) {
-        mcTruthRegistry.fill(HIST("MCTruthPipPtVsEta"), part.pt(), part.eta());
-        mcTruthRegistry.fill(HIST("MCTruthPipPt"), part.pt());
+      if (pdgCode == PDG_t::kPiPlus) {
+        mcTruthRegistry.fill(HIST("hMcGenPipPtVsEta"), part.pt(), part.eta());
+        mcTruthRegistry.fill(HIST("hMcGenPipPt"), part.pt());
       }
-      if (pdgCode == 321) {
-        mcTruthRegistry.fill(HIST("MCTruthKpPtVsEta"), part.pt(), part.eta());
-        mcTruthRegistry.fill(HIST("MCTruthKpPt"), part.pt());
+      if (pdgCode == PDG_t::kKPlus) {
+        mcTruthRegistry.fill(HIST("hMcGenKpPtVsEta"), part.pt(), part.eta());
+        mcTruthRegistry.fill(HIST("hMcGenKpPt"), part.pt());
       }
-      if (pdgCode == 421) {
-        mcTruthRegistry.fill(HIST("MCTruthD0D0bar"), part.pt(), part.eta());
+      if (pdgCode == o2::constants::physics::Pdg::kD0) {
+        if (std::abs(hfFlagMcGen) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
+          mcTruthRegistry.fill(HIST("hMcGenD0"), part.pt(), part.eta());
+          if (part.mAntiLambda() > 0) {
+            mcTruthRegistry.fill(HIST("hMcGenD0Prompt"), part.pt(), part.eta());
+          } else {
+            mcTruthRegistry.fill(HIST("hMcGenD0NonPrompt"), part.pt(), part.eta());
+          }
+        }
+        
       }
-      if (pdgCode == 2212) {
-        mcTruthRegistry.fill(HIST("MCTruthProtonPtVsEta"), part.pt(), part.eta());
-        mcTruthRegistry.fill(HIST("MCTruthProtonPt"), part.pt());
+      if (pdgCode == PDG_t::kProton) {
+        mcTruthRegistry.fill(HIST("hMcGenPrPtVsEta"), part.pt(), part.eta());
+        mcTruthRegistry.fill(HIST("hMcGenPrPt"), part.pt());
       }
 
       if (pdgParticle->Charge() < 0.0) {
-        mcTruthRegistry.fill(HIST("MCTruthAllNegativePt"), part.pt());
+        mcTruthRegistry.fill(HIST("hMcGenAllNegativePt"), part.pt());
       }
-      if (pdgCode == -211) {
-        mcTruthRegistry.fill(HIST("MCTruthPimPtVsEta"), part.pt(), part.eta());
-        mcTruthRegistry.fill(HIST("MCTruthPimPt"), part.pt());
+      if (pdgCode == PDG_t::kPiMinus) {
+        mcTruthRegistry.fill(HIST("hMcGenPimPtVsEta"), part.pt(), part.eta());
+        mcTruthRegistry.fill(HIST("hMcGenPimPt"), part.pt());
       }
-      if (pdgCode == -321) {
-        mcTruthRegistry.fill(HIST("MCTruthKmPtVsEta"), part.pt(), part.eta());
-        mcTruthRegistry.fill(HIST("MCTruthKmPt"), part.pt());
+      if (pdgCode == PDG_t::kKMinus) {
+        mcTruthRegistry.fill(HIST("hMcGenKmPtVsEta"), part.pt(), part.eta());
+        mcTruthRegistry.fill(HIST("hMcGenKmPt"), part.pt());
       }
-      if (pdgCode == -421) {
-        mcTruthRegistry.fill(HIST("MCTruthD0D0bar"), part.pt(), part.eta());
+      if (pdgCode == o2::constants::physics::Pdg::kD0Bar) {
+        if (std::abs(hfFlagMcGen) == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
+          mcTruthRegistry.fill(HIST("hMcGenD0bar"), part.pt(), part.eta());
+          if (part.mAntiLambda() > 0) {
+            mcTruthRegistry.fill(HIST("hMcGenD0barPrompt"), part.pt(), part.eta());
+          } else {
+            mcTruthRegistry.fill(HIST("hMcGenD0barNonPrompt"), part.pt(), part.eta());
+          }
+        }
       }
-      if (pdgCode == -2212) {
-        mcTruthRegistry.fill(HIST("MCTruthAntiProtonPtVsEta"), part.pt(), part.eta());
-        mcTruthRegistry.fill(HIST("MCTruthAntiProtonPt"), part.pt());
+      if (pdgCode == -PDG_t::kProton) {
+        mcTruthRegistry.fill(HIST("hMcGenAntiPrPtVsEta"), part.pt(), part.eta());
+        mcTruthRegistry.fill(HIST("hMcGenAntiPrPt"), part.pt());
       }
     }
   }
-  PROCESS_SWITCH(FemtoUniversePairTaskTrackD0, processMCTruth, "Process MC truth data", false);
+  PROCESS_SWITCH(FemtoUniversePairTaskTrackD0, processMcTruth, "Process MC truth data", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)


### PR DESCRIPTION
Major changes: improving parts of the code related to the D0 mesons to be able to analyze tracks and D0s at MCReco and MCTruth level.

FemtoUniverseProducerTask changes:
- correction of the MC process function (processTrackD0MC) dedicated to fill tables with tracks and D0s
- new fillD0D0barMcMl and fillDebugD0D0barMcMl functions added
- correction of the fillMCTruthParticlesD0 function
- removing fillMCParticleD0 - no longer needed
- fixing some of the O2linter issues (among other by adding new configurables in ConfPhiSelection group)

FemtoUniversePairTaskTrackD0 changes:
- changing FemtoUniverseAngularContainer to FemtoUniverseContainer
- adding processMcReco and processMcRecoD0InvMass and set of histograms for McReco particles
- adding the efficiency weight to the inv. mass histograms of D0 candidates
- correcting processMcTruth
- adding the selection for kaons as in LF group (isKaonNSigmaLF) and removing the previous selection (isKaonNSigma)
- fixing headers order
- removing some unnecessary histograms

FemtoUniverseEfficiencyBase changes:
- adding the selection for kaons as in LF group (isKaonNSigmaLF)
 