### PR TITLE
[Common] fix bug in z-vertex eq for Nglobal estimator

### DIFF
--- a/Common/Tools/MultModule.h
+++ b/Common/Tools/MultModule.h
@@ -862,7 +862,7 @@ class MultModule
       if (!hVtxZNGlobalTracks || std::fabs(collision.posZ()) > 15.0f) {
         mults.multGlobalTracksZeq = mults.multGlobalTracks; // if no equalization available, don't do it
       } else {
-        mults.multGlobalTracksZeq = hVtxZNGlobalTracks->Interpolate(0.0) * mults.multFT0C / hVtxZNGlobalTracks->Interpolate(collision.posZ());
+        mults.multGlobalTracksZeq = hVtxZNGlobalTracks->Interpolate(0.0) * mults.multGlobalTracks / hVtxZNGlobalTracks->Interpolate(collision.posZ());
       }
 
       // provide vertex-Z equalized Nglobals (or non-equalized if missing or beyond range)


### PR DESCRIPTION
Thanks to @Luzhiyongg for spotting! 