### PR TITLE
[PWGEM,PWGEM-36] skimmerGammaCalo: Fix processMC processRec cut diffe…

### DIFF
--- a/PWGEM/PhotonMeson/TableProducer/skimmerGammaCalo.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/skimmerGammaCalo.cxx
@@ -175,6 +175,10 @@ struct SkimmerGammaCalo {
       return;
     }
 
+    if (needEMCTrigger.value && !collision.alias_bit(kTVXinEMC)) {
+      return;
+    }
+
     for (const auto& emccluster : emcclusters) {
 
       // Definition cut


### PR DESCRIPTION
…rence

- `processMC` was missing the check `if (needEMCTrigger.value && !collision.alias_bit(kTVXinEMC))` which is in the `processRec` resulting in `[ERROR] Exception while running: Tables SkimEMCClusters and EMCClusterMCLabels have different sizes`.