### PR TITLE
[PWGLF] Improvements in sigma0 tasks

### DIFF
--- a/PWGLF/DataModel/LFSigmaTables.h
+++ b/PWGLF/DataModel/LFSigmaTables.h
@@ -33,9 +33,6 @@ DECLARE_SOA_COLUMN(SigmapT, sigmapT, float);
 DECLARE_SOA_COLUMN(SigmaMass, sigmaMass, float);
 DECLARE_SOA_COLUMN(SigmaRapidity, sigmaRapidity, float);
 DECLARE_SOA_COLUMN(SigmaOPAngle, sigmaOPAngle, float);
-DECLARE_SOA_COLUMN(SigmaCentrality, sigmaCentrality, float);
-DECLARE_SOA_COLUMN(SigmaRunNumber, sigmaRunNumber, int);
-DECLARE_SOA_COLUMN(SigmaTimestamp, sigmaTimestamp, uint64_t);
 
 } // namespace sigma0Core
 
@@ -43,13 +40,10 @@ DECLARE_SOA_TABLE(Sigma0Cores, "AOD", "SIGMA0CORES",
                   sigma0Core::SigmapT,
                   sigma0Core::SigmaMass,
                   sigma0Core::SigmaRapidity,
-                  sigma0Core::SigmaOPAngle,
-                  sigma0Core::SigmaCentrality,
-                  sigma0Core::SigmaRunNumber,
-                  sigma0Core::SigmaTimestamp);
+                  sigma0Core::SigmaOPAngle);
 
 // For Photon extra info
-namespace sigmaPhotonExtra
+namespace sigma0PhotonExtra
 {
 DECLARE_SOA_COLUMN(PhotonPt, photonPt, float);
 DECLARE_SOA_COLUMN(PhotonMass, photonMass, float);
@@ -86,46 +80,46 @@ DECLARE_SOA_COLUMN(PhotonNegTrackCode, photonNegTrackCode, uint8_t);
 DECLARE_SOA_COLUMN(PhotonV0Type, photonV0Type, uint8_t);
 DECLARE_SOA_COLUMN(GammaBDTScore, gammaBDTScore, float);
 
-} // namespace sigmaPhotonExtra
+} // namespace sigma0PhotonExtra
 
-DECLARE_SOA_TABLE(SigmaPhotonExtras, "AOD", "SIGMA0PHOTON",
-                  sigmaPhotonExtra::PhotonPt,
-                  sigmaPhotonExtra::PhotonMass,
-                  sigmaPhotonExtra::PhotonQt,
-                  sigmaPhotonExtra::PhotonAlpha,
-                  sigmaPhotonExtra::PhotonRadius,
-                  sigmaPhotonExtra::PhotonCosPA,
-                  sigmaPhotonExtra::PhotonDCADau,
-                  sigmaPhotonExtra::PhotonDCANegPV,
-                  sigmaPhotonExtra::PhotonDCAPosPV,
-                  sigmaPhotonExtra::PhotonZconv,
-                  sigmaPhotonExtra::PhotonEta,
-                  sigmaPhotonExtra::PhotonY,
-                  sigmaPhotonExtra::PhotonPhi,
-                  sigmaPhotonExtra::PhotonPosTPCNSigmaEl,
-                  sigmaPhotonExtra::PhotonNegTPCNSigmaEl,
-                  sigmaPhotonExtra::PhotonPosTPCNSigmaPi,
-                  sigmaPhotonExtra::PhotonNegTPCNSigmaPi,
-                  sigmaPhotonExtra::PhotonPosTPCCrossedRows,
-                  sigmaPhotonExtra::PhotonNegTPCCrossedRows,
-                  sigmaPhotonExtra::PhotonPosPt,
-                  sigmaPhotonExtra::PhotonNegPt,
-                  sigmaPhotonExtra::PhotonPosEta,
-                  sigmaPhotonExtra::PhotonNegEta,
-                  sigmaPhotonExtra::PhotonPosY,
-                  sigmaPhotonExtra::PhotonNegY,
-                  sigmaPhotonExtra::PhotonPsiPair,
-                  sigmaPhotonExtra::PhotonPosITSCls,
-                  sigmaPhotonExtra::PhotonNegITSCls,
-                  sigmaPhotonExtra::PhotonPosITSChi2PerNcl,
-                  sigmaPhotonExtra::PhotonNegITSChi2PerNcl,
-                  sigmaPhotonExtra::PhotonPosTrackCode,
-                  sigmaPhotonExtra::PhotonNegTrackCode,
-                  sigmaPhotonExtra::PhotonV0Type,
-                  sigmaPhotonExtra::GammaBDTScore);
+DECLARE_SOA_TABLE(Sigma0PhotonExtras, "AOD", "SIGMA0PHOTON",
+                  sigma0PhotonExtra::PhotonPt,
+                  sigma0PhotonExtra::PhotonMass,
+                  sigma0PhotonExtra::PhotonQt,
+                  sigma0PhotonExtra::PhotonAlpha,
+                  sigma0PhotonExtra::PhotonRadius,
+                  sigma0PhotonExtra::PhotonCosPA,
+                  sigma0PhotonExtra::PhotonDCADau,
+                  sigma0PhotonExtra::PhotonDCANegPV,
+                  sigma0PhotonExtra::PhotonDCAPosPV,
+                  sigma0PhotonExtra::PhotonZconv,
+                  sigma0PhotonExtra::PhotonEta,
+                  sigma0PhotonExtra::PhotonY,
+                  sigma0PhotonExtra::PhotonPhi,
+                  sigma0PhotonExtra::PhotonPosTPCNSigmaEl,
+                  sigma0PhotonExtra::PhotonNegTPCNSigmaEl,
+                  sigma0PhotonExtra::PhotonPosTPCNSigmaPi,
+                  sigma0PhotonExtra::PhotonNegTPCNSigmaPi,
+                  sigma0PhotonExtra::PhotonPosTPCCrossedRows,
+                  sigma0PhotonExtra::PhotonNegTPCCrossedRows,
+                  sigma0PhotonExtra::PhotonPosPt,
+                  sigma0PhotonExtra::PhotonNegPt,
+                  sigma0PhotonExtra::PhotonPosEta,
+                  sigma0PhotonExtra::PhotonNegEta,
+                  sigma0PhotonExtra::PhotonPosY,
+                  sigma0PhotonExtra::PhotonNegY,
+                  sigma0PhotonExtra::PhotonPsiPair,
+                  sigma0PhotonExtra::PhotonPosITSCls,
+                  sigma0PhotonExtra::PhotonNegITSCls,
+                  sigma0PhotonExtra::PhotonPosITSChi2PerNcl,
+                  sigma0PhotonExtra::PhotonNegITSChi2PerNcl,
+                  sigma0PhotonExtra::PhotonPosTrackCode,
+                  sigma0PhotonExtra::PhotonNegTrackCode,
+                  sigma0PhotonExtra::PhotonV0Type,
+                  sigma0PhotonExtra::GammaBDTScore);
 
 // For Lambda extra info
-namespace sigmaLambdaExtra
+namespace sigma0LambdaExtra
 {
 DECLARE_SOA_COLUMN(LambdaPt, lambdaPt, float);
 DECLARE_SOA_COLUMN(LambdaMass, lambdaMass, float);
@@ -169,55 +163,55 @@ DECLARE_SOA_COLUMN(LambdaV0Type, lambdaV0Type, uint8_t);
 DECLARE_SOA_COLUMN(LambdaBDTScore, lambdaBDTScore, float);
 DECLARE_SOA_COLUMN(AntiLambdaBDTScore, antilambdaBDTScore, float);
 
-} // namespace sigmaLambdaExtra
+} // namespace sigma0LambdaExtra
 
-DECLARE_SOA_TABLE(SigmaLambdaExtras, "AOD", "SIGMA0LAMBDA",
-                  sigmaLambdaExtra::LambdaPt,
-                  sigmaLambdaExtra::LambdaMass,
-                  sigmaLambdaExtra::AntiLambdaMass,
-                  sigmaLambdaExtra::LambdaQt,
-                  sigmaLambdaExtra::LambdaAlpha,
-                  sigmaLambdaExtra::LambdaLifeTime,
-                  sigmaLambdaExtra::LambdaRadius,
-                  sigmaLambdaExtra::LambdaCosPA,
-                  sigmaLambdaExtra::LambdaDCADau,
-                  sigmaLambdaExtra::LambdaDCANegPV,
-                  sigmaLambdaExtra::LambdaDCAPosPV,
-                  sigmaLambdaExtra::LambdaEta,
-                  sigmaLambdaExtra::LambdaY,
-                  sigmaLambdaExtra::LambdaPhi,
-                  sigmaLambdaExtra::LambdaPosPrTPCNSigma,
-                  sigmaLambdaExtra::LambdaPosPiTPCNSigma,
-                  sigmaLambdaExtra::LambdaNegPrTPCNSigma,
-                  sigmaLambdaExtra::LambdaNegPiTPCNSigma,
-                  sigmaLambdaExtra::LambdaPrTOFNSigma,
-                  sigmaLambdaExtra::LambdaPiTOFNSigma,
-                  sigmaLambdaExtra::ALambdaPrTOFNSigma,
-                  sigmaLambdaExtra::ALambdaPiTOFNSigma,
-                  sigmaLambdaExtra::LambdaPosTPCCrossedRows,
-                  sigmaLambdaExtra::LambdaNegTPCCrossedRows,
-                  sigmaLambdaExtra::LambdaPosPt,
-                  sigmaLambdaExtra::LambdaNegPt,
-                  sigmaLambdaExtra::LambdaPosEta,
-                  sigmaLambdaExtra::LambdaNegEta,
-                  sigmaLambdaExtra::LambdaPosPrY,
-                  sigmaLambdaExtra::LambdaPosPiY,
-                  sigmaLambdaExtra::LambdaNegPrY,
-                  sigmaLambdaExtra::LambdaNegPiY,
-                  sigmaLambdaExtra::LambdaPosITSCls,
-                  sigmaLambdaExtra::LambdaNegITSCls,
-                  sigmaLambdaExtra::LambdaPosITSChi2PerNcl,
-                  sigmaLambdaExtra::LambdaNegITSChi2PerNcl,
-                  sigmaLambdaExtra::LambdaPosTrackCode,
-                  sigmaLambdaExtra::LambdaNegTrackCode,
-                  sigmaLambdaExtra::LambdaV0Type,
-                  sigmaLambdaExtra::LambdaBDTScore,
-                  sigmaLambdaExtra::AntiLambdaBDTScore);
+DECLARE_SOA_TABLE(Sigma0LambdaExtras, "AOD", "SIGMA0LAMBDA",
+                  sigma0LambdaExtra::LambdaPt,
+                  sigma0LambdaExtra::LambdaMass,
+                  sigma0LambdaExtra::AntiLambdaMass,
+                  sigma0LambdaExtra::LambdaQt,
+                  sigma0LambdaExtra::LambdaAlpha,
+                  sigma0LambdaExtra::LambdaLifeTime,
+                  sigma0LambdaExtra::LambdaRadius,
+                  sigma0LambdaExtra::LambdaCosPA,
+                  sigma0LambdaExtra::LambdaDCADau,
+                  sigma0LambdaExtra::LambdaDCANegPV,
+                  sigma0LambdaExtra::LambdaDCAPosPV,
+                  sigma0LambdaExtra::LambdaEta,
+                  sigma0LambdaExtra::LambdaY,
+                  sigma0LambdaExtra::LambdaPhi,
+                  sigma0LambdaExtra::LambdaPosPrTPCNSigma,
+                  sigma0LambdaExtra::LambdaPosPiTPCNSigma,
+                  sigma0LambdaExtra::LambdaNegPrTPCNSigma,
+                  sigma0LambdaExtra::LambdaNegPiTPCNSigma,
+                  sigma0LambdaExtra::LambdaPrTOFNSigma,
+                  sigma0LambdaExtra::LambdaPiTOFNSigma,
+                  sigma0LambdaExtra::ALambdaPrTOFNSigma,
+                  sigma0LambdaExtra::ALambdaPiTOFNSigma,
+                  sigma0LambdaExtra::LambdaPosTPCCrossedRows,
+                  sigma0LambdaExtra::LambdaNegTPCCrossedRows,
+                  sigma0LambdaExtra::LambdaPosPt,
+                  sigma0LambdaExtra::LambdaNegPt,
+                  sigma0LambdaExtra::LambdaPosEta,
+                  sigma0LambdaExtra::LambdaNegEta,
+                  sigma0LambdaExtra::LambdaPosPrY,
+                  sigma0LambdaExtra::LambdaPosPiY,
+                  sigma0LambdaExtra::LambdaNegPrY,
+                  sigma0LambdaExtra::LambdaNegPiY,
+                  sigma0LambdaExtra::LambdaPosITSCls,
+                  sigma0LambdaExtra::LambdaNegITSCls,
+                  sigma0LambdaExtra::LambdaPosITSChi2PerNcl,
+                  sigma0LambdaExtra::LambdaNegITSChi2PerNcl,
+                  sigma0LambdaExtra::LambdaPosTrackCode,
+                  sigma0LambdaExtra::LambdaNegTrackCode,
+                  sigma0LambdaExtra::LambdaV0Type,
+                  sigma0LambdaExtra::LambdaBDTScore,
+                  sigma0LambdaExtra::AntiLambdaBDTScore);
 
-// for MC data
-namespace sigmaMCCore
+// for MC 
+namespace sigma0MCCore
 {
-DECLARE_SOA_COLUMN(IsSigma, isSigma, bool); // TODO: include PDG + IsPhysicalPrimary
+DECLARE_SOA_COLUMN(IsSigma, isSigma, bool); 
 DECLARE_SOA_COLUMN(IsAntiSigma, isAntiSigma, bool);
 DECLARE_SOA_COLUMN(SigmaMCPt, sigmaMCPt, float);
 DECLARE_SOA_COLUMN(PhotonCandPDGCode, photonCandPDGCode, int);
@@ -231,22 +225,178 @@ DECLARE_SOA_COLUMN(IsLambdaCandPrimary, isLambdaCandPrimary, bool);
 DECLARE_SOA_COLUMN(LambdaMCPt, lambdaMCPt, float);
 DECLARE_SOA_COLUMN(LambdaIsCorrectlyAssoc, lambdaIsCorrectlyAssoc, bool);
 
-} // namespace sigmaMCCore
+} // namespace sigma0MCCore
 
-DECLARE_SOA_TABLE(SigmaMCCores, "AOD", "SIGMA0MCCORES",
-                  sigmaMCCore::IsSigma,
-                  sigmaMCCore::IsAntiSigma,
-                  sigmaMCCore::SigmaMCPt,
-                  sigmaMCCore::PhotonCandPDGCode,
-                  sigmaMCCore::PhotonCandPDGCodeMother,
-                  sigmaMCCore::IsPhotonCandPrimary,
-                  sigmaMCCore::PhotonMCPt,
-                  sigmaMCCore::PhotonIsCorrectlyAssoc,
-                  sigmaMCCore::LambdaCandPDGCode,
-                  sigmaMCCore::LambdaCandPDGCodeMother,
-                  sigmaMCCore::IsLambdaCandPrimary,
-                  sigmaMCCore::LambdaMCPt,
-                  sigmaMCCore::LambdaIsCorrectlyAssoc);
+DECLARE_SOA_TABLE(Sigma0MCCores, "AOD", "SIGMA0MCCORES",
+                  sigma0MCCore::IsSigma,
+                  sigma0MCCore::IsAntiSigma,
+                  sigma0MCCore::SigmaMCPt,
+                  sigma0MCCore::PhotonCandPDGCode,
+                  sigma0MCCore::PhotonCandPDGCodeMother,
+                  sigma0MCCore::IsPhotonCandPrimary,
+                  sigma0MCCore::PhotonMCPt,
+                  sigma0MCCore::PhotonIsCorrectlyAssoc,
+                  sigma0MCCore::LambdaCandPDGCode,
+                  sigma0MCCore::LambdaCandPDGCodeMother,
+                  sigma0MCCore::IsLambdaCandPrimary,
+                  sigma0MCCore::LambdaMCPt,
+                  sigma0MCCore::LambdaIsCorrectlyAssoc);
+
+namespace sigma0Gen
+{
+DECLARE_SOA_COLUMN(IsSigma0, isSigma0, bool);           // true: sigma0, false: antisigma0                   
+DECLARE_SOA_COLUMN(Sigma0MCPt, sigma0MCPt, float);      // MC pT
+DECLARE_SOA_COLUMN(Sigma0Type, sigma0Type, int);        // Decay channel
+} // namespace sigma0Gen
+
+DECLARE_SOA_TABLE(Sigma0Gens, "AOD", "SIGMA0GENS",
+                  sigma0Gen::IsSigma0,    
+                  sigma0Gen::Sigma0MCPt,  
+                  sigma0Gen::Sigma0Type); 
+
+DECLARE_SOA_TABLE(SigmaCollRef, "AOD", "SIGMACOLLREF", //! optional table to refer back to a collision
+                  o2::soa::Index<>, v0data::StraCollisionId);
+
+DECLARE_SOA_TABLE(SigmaGenCollRef, "AOD", "SIGMAGENCOLLREF", //! optional table to refer back to a collision
+                  o2::soa::Index<>, v0data::StraMCCollisionId);
+
+// ___________________________________________________________________________
+// pi0 QA
+namespace Pi0Core
+{
+DECLARE_SOA_COLUMN(Pi0Pt, pi0Pt, float);
+DECLARE_SOA_COLUMN(Pi0Mass, pi0Mass, float);
+DECLARE_SOA_COLUMN(Pi0Y, pi0Y, float);
+
+DECLARE_SOA_COLUMN(Photon1Mass, photon1Mass, float);
+DECLARE_SOA_COLUMN(Photon1Pt, photon1Pt, float);
+DECLARE_SOA_COLUMN(Photon1Qt, photon1Qt, float);
+DECLARE_SOA_COLUMN(Photon1Alpha, photon1Alpha, float);
+DECLARE_SOA_COLUMN(Photon1DCAPosPV, photon1DCAPosPV, float);
+DECLARE_SOA_COLUMN(Photon1DCANegPV, photon1DCANegPV, float);
+DECLARE_SOA_COLUMN(Photon1DCADau, photon1DCADau, float);
+DECLARE_SOA_COLUMN(Photon1NegEta, photon1NegEta, float);
+DECLARE_SOA_COLUMN(Photon1PosEta, photon1PosEta, float);
+DECLARE_SOA_COLUMN(Photon1CosPA, photon1CosPA, float);
+DECLARE_SOA_COLUMN(Photon1Radius, photon1Radius, float);
+DECLARE_SOA_COLUMN(Photon1Zconv, photon1Zconv, float);
+DECLARE_SOA_COLUMN(Photon1PosTPCCrossedRows, photon1PosTPCCrossedRows, uint8_t);
+DECLARE_SOA_COLUMN(Photon1NegTPCCrossedRows, photon1NegTPCCrossedRows, uint8_t);
+DECLARE_SOA_COLUMN(Photon1PosTPCNSigmaEl, photon1PosTPCNSigmaEl, float);
+DECLARE_SOA_COLUMN(Photon1NegTPCNSigmaEl, photon1NegTPCNSigmaEl, float);
+DECLARE_SOA_COLUMN(Photon1Y, photon1Y, float);
+DECLARE_SOA_COLUMN(Photon1V0Type, photon1V0Type, uint8_t);
+
+DECLARE_SOA_COLUMN(Photon2Mass, photon2Mass, float);
+DECLARE_SOA_COLUMN(Photon2Pt, photon2Pt, float);
+DECLARE_SOA_COLUMN(Photon2Qt, photon2Qt, float);
+DECLARE_SOA_COLUMN(Photon2Alpha, photon2Alpha, float);
+DECLARE_SOA_COLUMN(Photon2DCAPosPV, photon2DCAPosPV, float);
+DECLARE_SOA_COLUMN(Photon2DCANegPV, photon2DCANegPV, float);
+DECLARE_SOA_COLUMN(Photon2DCADau, photon2DCADau, float);
+DECLARE_SOA_COLUMN(Photon2NegEta, photon2NegEta, float);
+DECLARE_SOA_COLUMN(Photon2PosEta, photon2PosEta, float);
+DECLARE_SOA_COLUMN(Photon2CosPA, photon2CosPA, float);
+DECLARE_SOA_COLUMN(Photon2Radius, photon2Radius, float);
+DECLARE_SOA_COLUMN(Photon2Zconv, photon2Zconv, float);
+DECLARE_SOA_COLUMN(Photon2PosTPCCrossedRows, photon2PosTPCCrossedRows, uint8_t);
+DECLARE_SOA_COLUMN(Photon2NegTPCCrossedRows, photon2NegTPCCrossedRows, uint8_t);
+DECLARE_SOA_COLUMN(Photon2PosTPCNSigmaEl, photon2PosTPCNSigmaEl, float);
+DECLARE_SOA_COLUMN(Photon2NegTPCNSigmaEl, photon2NegTPCNSigmaEl, float);
+DECLARE_SOA_COLUMN(Photon2Y, photon2Y, float);
+DECLARE_SOA_COLUMN(Photon2V0Type, photon2V0Type, uint8_t);
+
+
+} // namespace Pi0Core
+
+DECLARE_SOA_TABLE(Pi0Cores, "AOD", "PI0CORES",
+                  Pi0Core::Pi0Pt,
+                  Pi0Core::Pi0Mass,
+                  Pi0Core::Pi0Y,
+                  Pi0Core::Photon1Mass,
+                  Pi0Core::Photon1Pt,                  
+                  Pi0Core::Photon1Qt,
+                  Pi0Core::Photon1Alpha,
+                  Pi0Core::Photon1DCAPosPV,
+                  Pi0Core::Photon1DCANegPV,
+                  Pi0Core::Photon1DCADau,
+                  Pi0Core::Photon1NegEta,
+                  Pi0Core::Photon1PosEta,
+                  Pi0Core::Photon1CosPA,                  
+                  Pi0Core::Photon1Radius,                                          
+                  Pi0Core::Photon1Zconv,
+                  Pi0Core::Photon1PosTPCCrossedRows,
+                  Pi0Core::Photon1NegTPCCrossedRows,
+                  Pi0Core::Photon1PosTPCNSigmaEl,
+                  Pi0Core::Photon1NegTPCNSigmaEl,   
+                  Pi0Core::Photon1Y,                                                                        
+                  Pi0Core::Photon1V0Type,  
+                  Pi0Core::Photon2Mass,
+                  Pi0Core::Photon2Pt,                  
+                  Pi0Core::Photon2Qt,
+                  Pi0Core::Photon2Alpha,
+                  Pi0Core::Photon2DCAPosPV,
+                  Pi0Core::Photon2DCANegPV,
+                  Pi0Core::Photon2DCADau,
+                  Pi0Core::Photon2NegEta,
+                  Pi0Core::Photon2PosEta,
+                  Pi0Core::Photon2CosPA,                  
+                  Pi0Core::Photon2Radius,                                          
+                  Pi0Core::Photon2Zconv,
+                  Pi0Core::Photon2PosTPCCrossedRows,
+                  Pi0Core::Photon2NegTPCCrossedRows,
+                  Pi0Core::Photon2PosTPCNSigmaEl,
+                  Pi0Core::Photon2NegTPCNSigmaEl,   
+                  Pi0Core::Photon2Y,                                                                        
+                  Pi0Core::Photon2V0Type);
+
+// for MC 
+namespace Pi0CoreMC
+{
+DECLARE_SOA_COLUMN(IsPi0, isPi0, bool); 
+DECLARE_SOA_COLUMN(Pi0MCPt, pi0MCPt, float);
+DECLARE_SOA_COLUMN(Photon1MCPt, photon1MCPt, float);
+DECLARE_SOA_COLUMN(Photon1PDGCode, photon1PDGCode, int);
+DECLARE_SOA_COLUMN(Photon1PDGCodeMother, photon1PDGCodeMother, int);
+DECLARE_SOA_COLUMN(IsPhoton1Primary, isPhoton1Primary, bool);
+DECLARE_SOA_COLUMN(Photon1IsCorrectlyAssoc, photon1IsCorrectlyAssoc, bool);
+DECLARE_SOA_COLUMN(Photon2MCPt, photon2MCPt, float);
+DECLARE_SOA_COLUMN(Photon2PDGCode, photon2PDGCode, int);
+DECLARE_SOA_COLUMN(Photon2PDGCodeMother, photon2PDGCodeMother, int);
+DECLARE_SOA_COLUMN(IsPhoton2Primary, isPhoton2Primary, bool);
+DECLARE_SOA_COLUMN(Photon2IsCorrectlyAssoc, photon2IsCorrectlyAssoc, bool);
+
+} // namespace Pi0CoreMC
+
+DECLARE_SOA_TABLE(Pi0CoresMC, "AOD", "PI0CORESMC",
+                  Pi0CoreMC::IsPi0,                  
+                  Pi0CoreMC::Pi0MCPt,
+                  Pi0CoreMC::Photon1MCPt,
+                  Pi0CoreMC::Photon1PDGCode,
+                  Pi0CoreMC::Photon1PDGCodeMother,
+                  Pi0CoreMC::IsPhoton1Primary,                  
+                  Pi0CoreMC::Photon1IsCorrectlyAssoc,
+                  Pi0CoreMC::Photon2MCPt,
+                  Pi0CoreMC::Photon2PDGCode,
+                  Pi0CoreMC::Photon2PDGCodeMother,
+                  Pi0CoreMC::IsPhoton2Primary,                  
+                  Pi0CoreMC::Photon2IsCorrectlyAssoc);
+
+
+DECLARE_SOA_TABLE(Pi0CollRef, "AOD", "PI0COLLREF", //! optional table to refer back to a collision
+                  o2::soa::Index<>, v0data::StraCollisionId);
+
+namespace pi0Gen
+{
+DECLARE_SOA_COLUMN(Pi0MCPt, pi0MCPt, float);      // MC pT
+} // namespace pi0Gen
+
+DECLARE_SOA_TABLE(Pi0Gens, "AOD", "PI0GENS",                     
+                  pi0Gen::Pi0MCPt); 
+
+DECLARE_SOA_TABLE(Pi0GenCollRef, "AOD", "PI0GENCOLLREF", //! optional table to refer back to a collision
+                  o2::soa::Index<>, v0data::StraMCCollisionId);
+
 } // namespace o2::aod
 
 #endif // PWGLF_DATAMODEL_LFSIGMATABLES_H_

--- a/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
@@ -78,11 +78,11 @@ struct sigma0builder {
 
   //__________________________________________________
   // Pi0 specific
-  Produces<aod::Pi0Cores> pi0cores;                    // pi0 candidates info for analysis  
-  Produces<aod::Pi0CollRef> pi0coresRefs;          // references collisions from photonpair
-  Produces<aod::Pi0CoresMC> pi0coresmc;                 // Reco pi0 MC properties
-  Produces<aod::Pi0Gens> pi0Gens;                            // Generated pi0s
-  Produces<aod::Pi0GenCollRef> pi0GenCollRefs;               // references collisions from pi0Gens
+  Produces<aod::Pi0Cores> pi0cores;                               // pi0 candidates info for analysis  
+  Produces<aod::Pi0CollRef> pi0coresRefs;                         // references collisions from photonpair
+  Produces<aod::Pi0CoresMC> pi0coresmc;                           // Reco pi0 MC properties
+  Produces<aod::Pi0Gens> pi0Gens;                                 // Generated pi0s
+  Produces<aod::Pi0GenCollRef> pi0GenCollRefs;                    // references collisions from pi0Gens
 
   //__________________________________________________
   // pack track quality but separte also afterburner
@@ -125,7 +125,7 @@ struct sigma0builder {
   Configurable<float> LambdaMaxv0radius{"LambdaMaxv0radius", 60, "Max V0 radius (cm)"};
   Configurable<float> LambdaWindow{"LambdaWindow", 0.05, "Mass window around expected (in GeV/c2)"};
 
-  //// Photon criteria:
+  //// Photon criteria (for sigma0s and pi0s):
   Configurable<float> PhotonMaxDauPseudoRap{"PhotonMaxDauPseudoRap", 1.5, "Max pseudorapidity of daughter tracks"};
   Configurable<float> PhotonMinDCAToPv{"PhotonMinDCAToPv", 0.0, "Min DCA daughter To PV (cm)"};
   Configurable<float> PhotonMaxDCAV0Dau{"PhotonMaxDCAV0Dau", 3.5, "Max DCA V0 Daughters (cm)"};

--- a/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
@@ -407,15 +407,17 @@ struct sigma0builder {
         histos.fill(HIST("Gen/hPrimaryPi0s"), 0);
         if (isPrimary) histos.fill(HIST("Gen/hPrimaryPi0s"), 1);
         
-        pi0Gens(ptmc); // optional table to store generated pi0 candidates. Be careful, this is a large table!
-        pi0GenCollRefs(mccollisionid); // link to stramccollision table
+        if (fillPi0Tables){
+          pi0Gens(ptmc); // optional table to store generated pi0 candidates. Be careful, this is a large table!
+          pi0GenCollRefs(mccollisionid); // link to stramccollision table
+        }        
       }  
       
       // Sigma0-specific
       if (isSigma0 || isAntiSigma0){     
         
         // Checking decay mode
-        auto daughtersIDs = mcParticle.daughtersIds();
+        //auto daughtersIDs = mcParticle.daughtersIds();
         auto const& daughters = mcParticle.template daughters_as<aod::McParticles>();
                 
         if (daughters.size() == 2) {

--- a/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
@@ -20,6 +20,7 @@
 //    gianni.shigeru.setoue.liveraro@cern.ch
 //
 
+#include "Math/Vector3D.h"
 #include <Math/Vector4D.h>
 #include <cmath>
 #include <array>
@@ -95,7 +96,6 @@ struct sigma0builder {
   // Histogram registry
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
 
-  Configurable<bool> fillQAhistos{"fillQAhistos", false, "if true, fill QA histograms"};  
   Configurable<bool> doAssocStudy{"doAssocStudy", false, "Do v0 to collision association study."};
   Configurable<bool> doPPAnalysis{"doPPAnalysis", true, "if in pp, set to true"};
   
@@ -137,12 +137,18 @@ struct sigma0builder {
   Configurable<float> Sigma0Window{"Sigma0Window", 0.1, "Mass window around expected (in GeV/c2)"};
   Configurable<float> SigmaMaxRap{"SigmaMaxRap", 0.8, "Max sigma0 rapidity"};
   
-  //// Extras:
+  //// Pi0 criteria::
   Configurable<float> Pi0MaxRap{"Pi0MaxRap", 0.8, "Max Pi0 Rapidity"};
   Configurable<float> Pi0MassWindow{"Pi0MassWindow", 0.115, "Mass window around expected (in GeV/c2)"};
 
-
-  Configurable<float> GenMaxRap{"GenMaxRap", 0.5, "Max generated particle rapidity"};
+  //// Generated particles criteria:
+  struct : ConfigurableGroup {
+    Configurable<bool> doQA{"doQA", true, "If True, fill QA histos"};
+    Configurable<bool> mc_keepOnlyFromGenerator{"mc_keepOnlyFromGenerator", false, "Keep only mcparticles from the generator"};
+    Configurable<bool> mc_keepOnlyFromTransport{"mc_keepOnlyFromTransport", false, "Keep only mcparticles from the transport code"};    
+    Configurable<int> mc_selectMCProcess{"mc_selectMCProcess", -1, "Keep only mcparticles produced in the selected MC process"};
+    Configurable<float> mc_rapidityWindow{"mc_rapidityWindow", 0.5, "Max generated particle rapidity"};
+  } genSelections;
 
   // Axis
   // base properties
@@ -152,16 +158,8 @@ struct sigma0builder {
   // Invariant Mass
   ConfigurableAxis axisSigmaMass{"axisSigmaMass", {500, 1.10f, 1.30f}, "M_{#Sigma^{0}} (GeV/c^{2})"};
   ConfigurableAxis axisLambdaMass{"axisLambdaMass", {200, 1.05f, 1.151f}, "M_{#Lambda} (GeV/c^{2})"};
-  ConfigurableAxis axisPhotonMass{"axisPhotonMass", {200, -0.1f, 0.5f}, "M_{#Gamma}"};
-  ConfigurableAxis axisPi0Mass{"axisPi0Mass", {200, 0.08f, 0.18f}, "M_{#Pi^{0}}"};
+  ConfigurableAxis axisPhotonMass{"axisPhotonMass", {200, -0.1f, 0.5f}, "M_{#Gamma}"};  
   ConfigurableAxis axisK0SMass{"axisK0SMass", {200, 0.4f, 0.6f}, "M_{K^{0}}"};
-
-  // AP plot axes
-  ConfigurableAxis axisAPAlpha{"axisAPAlpha", {220, -1.1f, 1.1f}, "V0 AP alpha"};
-  ConfigurableAxis axisAPQt{"axisAPQt", {220, 0.0f, 0.5f}, "V0 AP alpha"};
-
-  // Track quality axes
-  ConfigurableAxis axisTPCrows{"axisTPCrows", {160, 0.0f, 160.0f}, "N TPC rows"};
 
   // topological variable QA axes
   ConfigurableAxis axisDCAtoPV{"axisDCAtoPV", {500, 0.0f, 50.0f}, "DCA (cm)"};
@@ -171,9 +169,8 @@ struct sigma0builder {
   ConfigurableAxis axisPA{"axisPA", {100, 0.0f, 1}, "Pointing angle"};
   ConfigurableAxis axisRapidity{"axisRapidity", {100, -2.0f, 2.0f}, "Rapidity"};
   ConfigurableAxis axisCandSel{"axisCandSel", {7, 0.5f, +7.5f}, "Candidate Selection"};
-  ConfigurableAxis axisNch{"axisNch", {300, 0.0f, 3000.0f}, "N_{ch}"};
   ConfigurableAxis axisIRBinning{"axisIRBinning", {151, -10, 1500}, "Binning for the interaction rate (kHz)"};
-  
+    
   void init(InitContext const&)
   {        
     LOGF(info, "Initializing now: cross-checking correctness...");
@@ -190,6 +187,10 @@ struct sigma0builder {
     ccdb->setFatalWhenNull(false);
 
     histos.add("hEventCentrality", "hEventCentrality", kTH1D, {axisCentrality});
+
+    histos.add("PhotonSel/h2dMassGammaVsK0S", "h2dMassGammaVsK0S", kTH2D, {axisPhotonMass, axisK0SMass});
+    histos.add("PhotonSel/h2dMassGammaVsLambda", "h2dMassGammaVsLambda", kTH2D, {axisPhotonMass, axisLambdaMass});
+    histos.add("PhotonSel/h2dV0XY", "h2dV0XY", kTH2F, {axisXY, axisXY});
 
     histos.add("PhotonSel/hSelectionStatistics", "hSelectionStatistics", kTH1D, {axisCandSel});
     histos.get<TH1>(HIST("PhotonSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(1, "No Sel");
@@ -209,6 +210,8 @@ struct sigma0builder {
     histos.add("PhotonSel/hPhotonRadius", "hPhotonRadius", kTH1F, {axisRadius});
     histos.add("PhotonSel/h3dPhotonMass", "h3dPhotonMass", kTH3D, {axisCentrality, axisPt, axisPhotonMass});
 
+    histos.add("LambdaSel/h2dMassLambdaVsK0S", "h2dMassLambdaVsK0S", kTH2D, {axisLambdaMass, axisK0SMass});      
+    histos.add("LambdaSel/h2dMassLambdaVsGamma", "h2dMassLambdaVsGamma", kTH2D, {axisLambdaMass, axisPhotonMass});
     histos.add("LambdaSel/hSelectionStatistics", "hSelectionStatistics", kTH1D, {axisCandSel});
     histos.get<TH1>(HIST("LambdaSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(1, "No Sel");
     histos.get<TH1>(HIST("LambdaSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(2, "Lambda Mass Cut");
@@ -234,26 +237,9 @@ struct sigma0builder {
     histos.get<TH1>(HIST("SigmaSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(2, "Sigma Mass Window");
     histos.get<TH1>(HIST("SigmaSel/hSelectionStatistics"))->GetXaxis()->SetBinLabel(3, "Sigma Y Window");
 
-    // For selection:
-    histos.add("SigmaSel/h3dMassSigma0BeforeSel", "h3dMassSigma0BeforeSel", kTH3F, {axisCentrality, axisPt, axisSigmaMass});
-    histos.add("SigmaSel/hSigmaMass", "hSigmaMass", kTH1F, {axisSigmaMass});
-    histos.add("SigmaSel/hSigmaMassWindow", "hSigmaMassWindow", kTH1F, {{200, -0.09f, 0.11f}});
-    histos.add("SigmaSel/hSigmaY", "hSigmaY", kTH1F, {axisRapidity});
+    // For selection:    
     histos.add("SigmaSel/hSigmaMassSelected", "hSigmaMassSelected", kTH1F, {axisSigmaMass});
-    histos.add("SigmaSel/h3dMassSigma0AfterSel", "h3dMassSigma0AfterSel", kTH3D, {axisCentrality, axisPt, axisSigmaMass});
-
-    if (fillQAhistos) {
-      histos.add("GeneralQA/h2dMassGammaVsK0S", "h2dMassGammaVsK0S", kTH2D, {axisPhotonMass, axisK0SMass});
-      histos.add("GeneralQA/h2dMassLambdaVsK0S", "h2dMassLambdaVsK0S", kTH2D, {axisLambdaMass, axisK0SMass});
-      histos.add("GeneralQA/h2dMassGammaVsLambda", "h2dMassGammaVsLambda", kTH2D, {axisPhotonMass, axisLambdaMass});
-      histos.add("GeneralQA/h2dMassLambdaVsGamma", "h2dMassLambdaVsGamma", kTH2D, {axisLambdaMass, axisPhotonMass});
-      histos.add("GeneralQA/h3dMassSigma0VsDaupTs", "h3dMassSigma0VsDaupTs", kTH3F, {axisPt, axisPt, axisSigmaMass});
-      histos.add("GeneralQA/h2dMassGammaVsK0SAfterMassSel", "h2dMassGammaVsK0SAfterMassSel", kTH2D, {axisPhotonMass, axisK0SMass});
-      histos.add("GeneralQA/h2dMassLambdaVsK0SAfterMassSel", "h2dMassLambdaVsK0SAfterMassSel", kTH2D, {axisLambdaMass, axisK0SMass});
-      histos.add("GeneralQA/h2dMassGammaVsLambdaAfterMassSel", "h2dMassGammaVsLambdaAfterMassSel", kTH2D, {axisPhotonMass, axisLambdaMass});
-      histos.add("GeneralQA/h2dV0XY", "h2dV0XY", kTH2F, {axisXY, axisXY});
-    }
-
+  
     if (doAssocStudy && (doprocessMonteCarlo || doprocessMonteCarloWithTOF)) {
       histos.add("V0AssoQA/h2dIRVsPt_TrueGamma", "h2dIRVsPt_TrueGamma", kTH2F, {axisIRBinning, axisPt});
       histos.add("V0AssoQA/h3dPAVsIRVsPt_TrueGamma", "h3dPAVsIRVsPt_TrueGamma", kTH3F, {axisPA, axisIRBinning, axisPt});
@@ -268,69 +254,221 @@ struct sigma0builder {
 
     // MC
     if (doprocessMonteCarlo || doprocessMonteCarloWithTOF) {
-      histos.add("MC/h2dPtVsCentralityBeforeSel_MCAssocGamma", "h2dPtVsCentralityBeforeSel_MCAssocGamma", kTH2D, {axisCentrality, axisPt});
-      histos.add("MC/h2dPtVsCentralityBeforeSel_MCAssocLambda", "h2dPtVsCentralityBeforeSel_MCAssocLambda", kTH2D, {axisCentrality, axisPt});
-      histos.add("MC/h2dPtVsCentralityBeforeSel_MCAssocALambda", "h2dPtVsCentralityBeforeSel_MCAssocALambda", kTH2D, {axisCentrality, axisPt});
-      histos.add("MC/h2dPtVsCentralityBeforeSel_MCAssocSigma0", "h2dPtVsCentralityBeforeSel_MCAssocSigma0", kTH2D, {axisCentrality, axisPt});
-      histos.add("MC/h2dPtVsCentralityBeforeSel_MCAssocASigma0", "h2dPtVsCentralityBeforeSel_MCAssocASigma0", kTH2D, {axisCentrality, axisPt});
-      histos.add("MC/h2dSigma0PtVsLambdaPtBeforeSel_MCAssoc", "h2dSigma0PtVsLambdaPtBeforeSel_MCAssoc", kTH2D, {axisPt, axisPt});
-      histos.add("MC/h2dSigma0PtVsGammaPtBeforeSel_MCAssoc", "h2dSigma0PtVsGammaPtBeforeSel_MCAssoc", kTH2D, {axisPt, axisPt});
-      histos.add("MC/h2dPtVsCentralityAfterSel_MCAssocSigma0", "h2dPtVsCentralityAfterSel_MCAssocSigma0", kTH2D, {axisCentrality, axisPt});
-      histos.add("MC/h2dPtVsCentralityAfterSel_MCAssocASigma0", "h2dPtVsCentralityAfterSel_MCAssocASigma0", kTH2D, {axisCentrality, axisPt});
       histos.add("MC/h2dGammaXYConversion", "h2dGammaXYConversion", kTH2F, {axisXY, axisXY});
+      histos.add("MC/h2dPtVsCentrality_MCAssocGamma", "h2dPtVsCentrality_MCAssocGamma", kTH2D, {axisCentrality, axisPt});
+      histos.add("MC/h2dPtVsCentrality_MCAssocLambda", "h2dPtVsCentrality_MCAssocLambda", kTH2D, {axisCentrality, axisPt});
+      histos.add("MC/h2dPtVsCentrality_MCAssocALambda", "h2dPtVsCentrality_MCAssocALambda", kTH2D, {axisCentrality, axisPt});                  
     }
 
-    if (doprocessGeneratedRun3) {
+    if (doprocessGeneratedRun3 && genSelections.doQA) {
       
-      histos.add("Gen/hGenGamma", "hGenGamma", kTH1D, {axisPt});
-      histos.add("Gen/hGenLambda", "hGenLambda", kTH1D, {axisPt});
-      histos.add("Gen/hGenAntiLambda", "hGenAntiLambda", kTH1D, {axisPt});
-      histos.add("Gen/hGenSigma0", "hGenSigma0", kTH1D, {axisPt});
-      histos.add("Gen/hGenAntiSigma0", "hGenAntiSigma0", kTH1D, {axisPt});
-      histos.add("Gen/hGenPi0", "hGenPi0", kTH1D, {axisPt});
-
-      auto hGenSpecies = histos.add<TH1>("Gen/hGenSpecies", "hGenSpecies", kTH1D, {{4, -0.5f, 3.5f}});
-      hGenSpecies->GetXaxis()->SetBinLabel(1, "Primary Lambda");
-      hGenSpecies->GetXaxis()->SetBinLabel(2, "Primary ALambda");
-      hGenSpecies->GetXaxis()->SetBinLabel(3, "Sigma0");
-      hGenSpecies->GetXaxis()->SetBinLabel(4, "ASigma0");
-      
-      auto hPrimaryPi0s = histos.add<TH1>("Gen/hPrimaryPi0s", "hPrimaryPi0s", kTH1D, {{2, -0.5f, 1.5f}});
+      // Pi0s
+      histos.add("GenQA/hGenPi0", "hGenPi0", kTH1D, {axisPt});
+            
+      auto hPrimaryPi0s = histos.add<TH1>("GenQA/hPrimaryPi0s", "hPrimaryPi0s", kTH1D, {{2, -0.5f, 1.5f}});
       hPrimaryPi0s->GetXaxis()->SetBinLabel(1, "All Pi0s");
-      hPrimaryPi0s->GetXaxis()->SetBinLabel(2, "Primary Pi0s");
+      hPrimaryPi0s->GetXaxis()->SetBinLabel(2, "Primary Pi0s");   
 
-      auto h2DGenSigma0TypeVsProcess = histos.add<TH2>("Gen/h2DGenSigma0TypeVsProcess", "h2DGenSigma0TypeVsProcess", kTH2D, {{4, -0.5f, 3.5f}, {50, -0.5f, 49.5f}});
-      h2DGenSigma0TypeVsProcess->GetXaxis()->SetBinLabel(1, "All Sigma0s");
-      h2DGenSigma0TypeVsProcess->GetXaxis()->SetBinLabel(2, "Sterile");
-      h2DGenSigma0TypeVsProcess->GetXaxis()->SetBinLabel(3, "Lambda+Gamma");
-      h2DGenSigma0TypeVsProcess->GetXaxis()->SetBinLabel(4, "Others");
+      histos.add("GenQA/h2dPi0MCSourceVsPDGMother", "h2dPi0MCSourceVsPDGMother", kTHnSparseD, {{2, -0.5f, 1.5f}, {10001, -5000.5f, +5000.5f}});    
+      histos.add("GenQA/h2dPi0NDaughtersVsPDG", "h2dPi0NDaughtersVsPDG", kTHnSparseD, {{10, -0.5f, +9.5f}, {10001, -5000.5f, +5000.5f}});
+      
+      auto h2DGenPi0TypeVsProducedByGen = histos.add<TH2>("GenQA/h2DGenPi0TypeVsProducedByGen", "h2DGenPi0TypeVsProducedByGen", kTH2D, {{2, -0.5f, 1.5f}, {2, -0.5f, 1.5f}});
+      h2DGenPi0TypeVsProducedByGen->GetXaxis()->SetBinLabel(1, "Sterile");
+      h2DGenPi0TypeVsProducedByGen->GetXaxis()->SetBinLabel(2, "Non-Sterile");
+      h2DGenPi0TypeVsProducedByGen->GetYaxis()->SetBinLabel(1, "Generator");
+      h2DGenPi0TypeVsProducedByGen->GetYaxis()->SetBinLabel(2, "Transport");
+
+      // ______________________________________________________
+      // Sigma0s
+      histos.add("GenQA/hGenSigma0", "hGenSigma0", kTH1D, {axisPt});      
+      histos.add("GenQA/hGenAntiSigma0", "hGenAntiSigma0", kTH1D, {axisPt});      
+      
+      histos.add("GenQA/h2dGenSigma0xy_Generator", "hGenSigma0xy_Generator", kTH2D, {axisXY, axisXY}); 
+      histos.add("GenQA/h2dGenSigma0xy_Transport", "hGenSigma0xy_Transport", kTH2D, {axisXY, axisXY}); 
+      histos.add("GenQA/hGenSigma0Radius_Generator", "hGenSigma0Radius_Generator", kTH1D, {axisRadius}); 
+      histos.add("GenQA/hGenSigma0Radius_Transport", "hGenSigma0Radius_Transport", kTH1D, {axisRadius}); 
+
+      histos.add("GenQA/h2dSigma0MCSourceVsPDGMother", "h2dSigma0MCSourceVsPDGMother", kTHnSparseD, {{2, -0.5f, 1.5f}, {10001, -5000.5f, +5000.5f}});    
+      histos.add("GenQA/h2dSigma0NDaughtersVsPDG", "h2dSigma0NDaughtersVsPDG", kTHnSparseD, {{10, -0.5f, +9.5f}, {10001, -5000.5f, +5000.5f}});
+      
+      auto hPrimarySigma0s = histos.add<TH1>("GenQA/hPrimarySigma0s", "hPrimarySigma0s", kTH1D, {{2, -0.5f, 1.5f}});
+      hPrimarySigma0s->GetXaxis()->SetBinLabel(1, "All Sigma0s");
+      hPrimarySigma0s->GetXaxis()->SetBinLabel(2, "Primary Sigma0s");      
+      
+      auto hGenSpecies = histos.add<TH1>("GenQA/hGenSpecies", "hGenSpecies", kTH1D, {{4, -0.5f, 3.5f}});
+      hGenSpecies->GetXaxis()->SetBinLabel(1, "All Prim. Lambda");
+      hGenSpecies->GetXaxis()->SetBinLabel(2, "All Prim. ALambda");
+      hGenSpecies->GetXaxis()->SetBinLabel(5, "All Sigma0s");
+      hGenSpecies->GetXaxis()->SetBinLabel(6, "All ASigma0s");
+
+      histos.add("GenQA/hSigma0NDau", "hSigma0NDau", kTH1D, {{10, -0.5f, +9.5f}}); 
+      histos.add("GenQA/h2dSigma0NDauVsProcess", "h2dSigma0NDauVsProcess", kTH2D, {{10, -0.5f, +9.5f}, {50, -0.5f, 49.5f}}); 
+
+      auto h2DGenSigma0TypeVsProducedByGen = histos.add<TH2>("GenQA/h2DGenSigma0TypeVsProducedByGen", "h2DGenSigma0TypeVsProducedByGen", kTH2D, {{2, -0.5f, 1.5f}, {2, -0.5f, 1.5f}});
+      h2DGenSigma0TypeVsProducedByGen->GetXaxis()->SetBinLabel(1, "Sterile");
+      h2DGenSigma0TypeVsProducedByGen->GetXaxis()->SetBinLabel(2, "Non-Sterile");
+      h2DGenSigma0TypeVsProducedByGen->GetYaxis()->SetBinLabel(1, "Generator");
+      h2DGenSigma0TypeVsProducedByGen->GetYaxis()->SetBinLabel(2, "Transport");
+      
     }
   }
 
   // ______________________________________________________
-  // Helper struct to store sigma0 reco and MC properties
-  struct {
-    float Mass;
-    float pT;
-    float Y;
-    float SigmaOPAngle;
-    bool fIsSigma;
-    bool fIsAntiSigma;
-    bool fIsPhotonCorrectlyAssign;
-    bool fIsLambdaCorrectlyAssign;
-    bool fIsPhotonPrimary;
-    bool fIsLambdaPrimary;
-    int PhotonCandPDGCode;
-    int PhotonCandPDGCodeMother;
-    int LambdaCandPDGCode;
-    int LambdaCandPDGCodeMother;         
-    float SigmaMCpT;
-    float LambdaMCpT;
-    float PhotonMCpT;
+  // Struct to store V0Pair properties
+  struct V0PairTopoInfo {
+    float X=-999.f;
+    float Y=-999.f;
+    float Z=-999.f;
+    float DCADau=-999.f;
+    float CosPA=-1.f;
+  };
 
-  } sigmaCandidate;
-  
   // ______________________________________________________
+  // Struct to store V0Pair MC properties
+  struct V0PairMCInfo {       
+    bool fIsV01CorrectlyAssign=false;    
+    bool fIsV02CorrectlyAssign=false;
+    bool fIsV01Primary=false;
+    bool fIsV02Primary=false;
+    bool fV0PairProducedByGenerator = false; 
+    int V01PDGCode=0;
+    int V02PDGCode=0;
+    int V01PDGCodeMother=0;    
+    int V02PDGCodeMother=0;
+    int V0PairPDGCode=0;         
+    int V0PairPDGCodeMother=0;   
+    int V0PairMCProcess=-1;
+    int V0PairMCParticleID=-1;    
+    float V01MCpT=-999.f;
+    float V02MCpT=-999.f;
+    float V0PairMCRadius=-999.f;
+    float V0PairMCpT=-999.f;            
+  };
+
+    // ______________________________________________________
+  // Struct to store V0Pair Generated properties
+  struct V0PairGenInfo {    
+    bool IsPrimary = false;
+    bool IsV0Lambda = false;
+    bool IsV0AntiLambda = false;
+    bool IsPi0 = false;
+    bool IsSigma0 = false;
+    bool IsAntiSigma0 = false;
+    bool IsProducedByGenerator = false;
+    bool IsSterile = false;
+    int MCProcess = -1;
+    int MCCollId = -1;
+    int PDGCodeMother = 0;
+    int NDaughters = -1;    
+    float MCPt = -999.f;
+    float MCvx = 999.f;            
+    float MCvy = 999.f;     
+  };
+
+  template <typename TV01, typename TV02>
+  V0PairTopoInfo propagateV0PairToDCA(TV01 const& v01, TV02 const& v02) {
+    V0PairTopoInfo info;
+
+    // Positions
+    ROOT::Math::XYZVector v01position(v01.x(), v01.y(), v01.z());
+    ROOT::Math::XYZVector v02position(v02.x(), v02.y(), v02.z());
+
+    // Momenta
+    ROOT::Math::XYZVector v01momentum(v01.px(), v01.py(), v01.pz());
+    ROOT::Math::XYZVector v02momentum(v02.px(), v02.py(), v02.pz());
+
+    // Momenta (normalized)
+    ROOT::Math::XYZVector v01momentumNorm(v01.px() / v01.p(), v01.py() / v01.p(), v01.pz() / v01.p());
+    ROOT::Math::XYZVector v02momentumNorm(v02.px() / v02.p(), v02.py() / v02.p(), v02.pz() / v02.p());
+
+    // DCADau calculation (using full momenta for precision)
+    ROOT::Math::XYZVector posdiff = v02position - v01position;
+    ROOT::Math::XYZVector cross = v01momentum.Cross(v02momentum);
+
+    float d = 1.0f - TMath::Power(v01momentumNorm.Dot(v02momentumNorm), 2);
+    float t = posdiff.Dot(v01momentumNorm - v01momentumNorm.Dot(v02momentumNorm) * v02momentumNorm) / d;
+    float s = -posdiff.Dot(v02momentumNorm - v01momentumNorm.Dot(v02momentumNorm) * v01momentumNorm) / d;
+
+    ROOT::Math::XYZVector pointOn1 = v01position + t * v01momentumNorm;
+    ROOT::Math::XYZVector pointOn2 = v02position + s * v02momentumNorm;
+    ROOT::Math::XYZVector PCA = 0.5 * (pointOn1 + pointOn2);
+
+    // Calculate properties and fill struct
+    info.DCADau = (cross.Mag2() > 0) ? std::abs(posdiff.Dot(cross)) / cross.R() : 999.f;
+    info.CosPA = v01momentumNorm.Dot(v02momentumNorm);
+    
+    if (d < 1e-5f) { // Parallel or nearly parallel lines
+      info.X = info.Y = info.Z = 0.f; // should we use another dummy value? Perhaps 999.f?      
+      return info;
+    }
+        
+    info.X = PCA.X();
+    info.Y = PCA.Y();
+    info.Z = PCA.Z();    
+
+    return info;
+  }
+
+  template <typename TV01, typename TV02, typename TCollision, typename TMCParticles>
+  V0PairMCInfo getV0PairMCInfo(TV01 const& v01, TV02 const& v02, TCollision const& collision, TMCParticles const& mcparticles) {
+    V0PairMCInfo MCinfo;
+           
+    if (!v01.has_v0MCCore() || !v02.has_v0MCCore())
+      return MCinfo;
+    
+    auto v01MC = v01.template v0MCCore_as<soa::Join<aod::V0MCCores, aod::V0MCCollRefs>>();
+    auto v02MC = v02.template v0MCCore_as<soa::Join<aod::V0MCCores, aod::V0MCCollRefs>>();
+
+    if (collision.has_straMCCollision()) {
+      auto MCCollision = collision.template straMCCollision_as<soa::Join<aod::StraMCCollisions, aod::StraMCCollMults>>();      
+      MCinfo.fIsV01CorrectlyAssign = (v01MC.straMCCollisionId() == MCCollision.globalIndex());      
+      MCinfo.fIsV02CorrectlyAssign = (v02MC.straMCCollisionId() == MCCollision.globalIndex());
+    }
+    
+    // Get corresponding entries in MCParticles table
+    auto MCParticle_v01 = mcparticles.rawIteratorAt(v01MC.particleIdMC());
+    auto MCParticle_v02 = mcparticles.rawIteratorAt(v02MC.particleIdMC());
+
+    // Get MC Mothers
+    auto const& MCMothersList_v01 = MCParticle_v01.template mothers_as<aod::McParticles>(); 
+    auto const& MCMothersList_v02 = MCParticle_v02.template mothers_as<aod::McParticles>(); 
+    
+    if (!MCMothersList_v01.empty() && !MCMothersList_v02.empty()){ // Are there mothers? 
+
+      auto const& MCMother_v01 = MCMothersList_v01.front(); // First mother
+      auto const& MCMother_v02 = MCMothersList_v02.front(); // First mother
+
+      if (MCMother_v01.globalIndex() == MCMother_v02.globalIndex()){ // Is it the same mother?
+                  
+        MCinfo.fV0PairProducedByGenerator = MCMother_v01.producedByGenerator();
+        MCinfo.V0PairPDGCode = MCMother_v01.pdgCode();
+        MCinfo.V0PairMCProcess = MCMother_v01.getProcess();
+        MCinfo.V0PairMCParticleID = MCMother_v01.globalIndex();
+        MCinfo.V0PairMCRadius = std::hypot(MCMother_v01.vx(), MCMother_v01.vy()); // production position radius      
+        MCinfo.V0PairMCpT = MCMother_v01.pt();      
+
+        auto const& v0pairmothers = MCMother_v01.template mothers_as<aod::McParticles>(); // Get mothers
+        if (!v0pairmothers.empty()){
+          auto& v0PairMother = v0pairmothers.front(); // V0Pair mother, V0s grandmother            
+          MCinfo.V0PairPDGCodeMother = v0PairMother.pdgCode();
+        }
+      }         
+    }
+         
+    MCinfo.fIsV01Primary = v01MC.isPhysicalPrimary();
+    MCinfo.fIsV02Primary = v02MC.isPhysicalPrimary();
+    MCinfo.V01PDGCode = v01MC.pdgCode();
+    MCinfo.V02PDGCode = v02MC.pdgCode();
+    MCinfo.V01PDGCodeMother = v01MC.pdgCodeMother();    
+    MCinfo.V02PDGCodeMother = v02MC.pdgCodeMother();        
+     
+    MCinfo.V01MCpT = RecoDecay::pt(array{v01MC.pxMC(), v01MC.pyMC()});
+    MCinfo.V02MCpT = RecoDecay::pt(array{v02MC.pxMC(), v02MC.pyMC()});
+    
+    return MCinfo;
+  }
+
+    // ______________________________________________________
   // MC-specific
   // Analyze v0-to-collision association
   template <typename TCollision, typename TV0Object>
@@ -369,102 +507,153 @@ struct sigma0builder {
     }
   }
 
+  template <typename TMCParticle>
+  V0PairGenInfo getV0PairGenInfo(TMCParticle const& mcParticle) {
+    V0PairGenInfo GenInfo; // auxiliary struct to store info
+
+    // Fill with properties
+    GenInfo.IsPrimary = mcParticle.isPhysicalPrimary();
+    GenInfo.IsV0Lambda = mcParticle.pdgCode() == 3122;
+    GenInfo.IsV0AntiLambda = mcParticle.pdgCode() == -3122;
+    GenInfo.IsPi0 = mcParticle.pdgCode() == 111;
+    GenInfo.IsSigma0 = mcParticle.pdgCode() == 3212;
+    GenInfo.IsAntiSigma0 = mcParticle.pdgCode() == -3212;
+    GenInfo.IsProducedByGenerator = mcParticle.producedByGenerator();
+    GenInfo.MCProcess = mcParticle.getProcess();
+    GenInfo.MCPt = mcParticle.pt();
+    GenInfo.MCvx = mcParticle.vx(); // production position X      
+    GenInfo.MCvy = mcParticle.vy(); // production position Y      
+
+    if (mcParticle.has_mcCollision()) 
+      GenInfo.MCCollId = mcParticle.mcCollisionId(); // save this reference, please
+
+    // Checking decay mode if sigma0
+    if (GenInfo.IsSigma0 || GenInfo.IsAntiSigma0 || GenInfo.IsPi0){    
+      
+      // This is a costly operation, so we do it only for pi0s and sigma0s
+      auto const& daughters = mcParticle.template daughters_as<aod::McParticles>();
+      GenInfo.NDaughters = daughters.size();
+      GenInfo.IsSterile = daughters.size()==0;
+
+      auto const& GenMothersList = mcParticle.template mothers_as<aod::McParticles>(); 
+      GenInfo.PDGCodeMother = (!GenMothersList.empty()) ? GenMothersList.front().pdgCode(): 0;
+
+      if ((GenInfo.IsSigma0 || GenInfo.IsAntiSigma0) && genSelections.doQA){            
+        histos.fill(HIST("GenQA/h2dSigma0MCSourceVsPDGMother"), GenInfo.IsProducedByGenerator, GenInfo.PDGCodeMother);    
+        for (auto& daughter : daughters)  // checking decay modes
+          histos.fill(HIST("GenQA/h2dSigma0NDaughtersVsPDG"), daughters.size(), daughter.pdgCode());                 
+      }
+
+      if (GenInfo.IsPi0 && genSelections.doQA){            
+        histos.fill(HIST("GenQA/h2dPi0MCSourceVsPDGMother"), GenInfo.IsProducedByGenerator, GenInfo.PDGCodeMother);    
+        for (auto& daughter : daughters)  // checking decay modes
+          histos.fill(HIST("GenQA/h2dPi0NDaughtersVsPDG"), daughters.size(), daughter.pdgCode());                 
+      }            
+    }        
+    return GenInfo;
+  }
+
+  // ______________________________________________________
+  // Simulated processing (subscribes to MC information too)  
+  void fillGenQAHistos(V0PairGenInfo const& GenInfo)
+  {            
+    if (GenInfo.IsPi0){        
+      histos.fill(HIST("GenQA/hGenPi0"), GenInfo.MCPt);
+      histos.fill(HIST("GenQA/hPrimaryPi0s"), 0);
+      if (GenInfo.IsPrimary) histos.fill(HIST("GenQA/hPrimaryPi0s"), 1);
+
+      if (GenInfo.IsSterile){          
+        if (GenInfo.IsProducedByGenerator) histos.fill(HIST("GenQA/h2DGenPi0TypeVsProducedByGen"), 0, 0); 
+        else histos.fill(HIST("GenQA/h2DGenPi0TypeVsProducedByGen"), 0, 1);         
+      }          
+      else {          
+        if (GenInfo.IsProducedByGenerator) histos.fill(HIST("GenQA/h2DGenPi0TypeVsProducedByGen"), 1, 0); 
+        else histos.fill(HIST("GenQA/h2DGenPi0TypeVsProducedByGen"), 1, 1);         
+      }
+    }
+
+    if (GenInfo.IsV0Lambda && GenInfo.IsPrimary) histos.fill(HIST("GenQA/hGenSpecies"), 0);
+    if (GenInfo.IsV0AntiLambda && GenInfo.IsPrimary) histos.fill(HIST("GenQA/hGenSpecies"), 1);           
+
+    // Checking decay mode
+    if (GenInfo.IsSigma0 || GenInfo.IsAntiSigma0){      
+      histos.fill(HIST("GenQA/hSigma0NDau"), GenInfo.NDaughters);
+      histos.fill(HIST("GenQA/h2dSigma0NDauVsProcess"), GenInfo.NDaughters, GenInfo.MCProcess); 
+
+      const auto radius = std::hypot(GenInfo.MCvx, GenInfo.MCvy);      
+      // Sigma0 XY and radius (separate histos for Gen/Transport)
+      if (GenInfo.IsProducedByGenerator) {
+        histos.fill(HIST("GenQA/h2dGenSigma0xy_Generator"), GenInfo.MCvx, GenInfo.MCvy);
+        histos.fill(HIST("GenQA/hGenSigma0Radius_Generator"), radius);
+      } else {
+        histos.fill(HIST("GenQA/h2dGenSigma0xy_Transport"), GenInfo.MCvx, GenInfo.MCvy);
+        histos.fill(HIST("GenQA/hGenSigma0Radius_Transport"), radius);
+      }
+
+      // Sigma0 type vs origin (single 2D histo)
+      const int genIndex = GenInfo.IsProducedByGenerator ? 0 : 1; // 0 = Generator, 1 = Transport
+      const int typeIndex = GenInfo.IsSterile ? 0 : 1;            // 0 = Sterile,   1 = Normal
+      histos.fill(HIST("GenQA/h2DGenSigma0TypeVsProducedByGen"), typeIndex, genIndex);
+        
+      // Fill histograms
+      if (GenInfo.IsSigma0){        
+        histos.fill(HIST("GenQA/hGenSpecies"), 2);
+        histos.fill(HIST("GenQA/hGenSigma0"), GenInfo.MCPt);         
+                
+        histos.fill(HIST("GenQA/hPrimarySigma0s"), 0);
+        if (GenInfo.IsPrimary) histos.fill(HIST("GenQA/hPrimarySigma0s"), 1);                                  
+      }
+      if (GenInfo.IsAntiSigma0){
+        histos.fill(HIST("GenQA/hGenSpecies"), 3);
+        histos.fill(HIST("GenQA/hGenAntiSigma0"), GenInfo.MCPt);           
+      }
+    }            
+  }
+    
   // ______________________________________________________
   // Simulated processing (subscribes to MC information too)  
   template <typename TMCParticles>
-  void fillGeneratedTable(TMCParticles const& mcParticles)
+  void genProcess(TMCParticles const& mcParticles)
   {    
-    for (auto& mcParticle : mcParticles) {
-      if (TMath::Abs(mcParticle.y()) > GenMaxRap)
+    for (auto& mcParticle : mcParticles) {      
+      // Rapidity selection
+      if (TMath::Abs(mcParticle.y()) > genSelections.mc_rapidityWindow)
         continue;
 
-      // Calculating properties               
-      float ptmc = mcParticle.pt();                
-      bool isV0Photon = mcParticle.pdgCode() == 22;
-      bool isV0Lambda = mcParticle.pdgCode() == 3122;
-      bool isV0AntiLambda = mcParticle.pdgCode() == -3122;
-      bool isSigma0 = mcParticle.pdgCode() == 3212;
-      bool isAntiSigma0 = mcParticle.pdgCode() == -3212;
-      bool isPi0 = mcParticle.pdgCode() == 111;        
-      bool isPrimary = mcParticle.isPhysicalPrimary();
-      int sigma0Type = 0;
-      int mccollisionid = -1;
-
-      if (mcParticle.has_mcCollision()) 
-        mccollisionid = mcParticle.mcCollisionId(); // save this reference, please
-      
-      if (isV0Photon && isPrimary) {                  
-        histos.fill(HIST("Gen/hGenGamma"), ptmc);
+      // Selection on the source (generator/transport)
+      if (genSelections.mc_keepOnlyFromGenerator && !genSelections.mc_keepOnlyFromTransport) {
+        if (!mcParticle.producedByGenerator())
+          continue;
       }
-      if (isV0Lambda && isPrimary) {        
-        histos.fill(HIST("Gen/hGenLambda"), ptmc);
+
+      if (genSelections.mc_keepOnlyFromTransport && !genSelections.mc_keepOnlyFromGenerator) {
+        if (mcParticle.producedByGenerator())
+          continue;
       }
-      if (isV0AntiLambda && isPrimary) {        
-        histos.fill(HIST("Gen/hGenAntiLambda"), ptmc);
-      }                                              
-      if (isPi0){        
-        histos.fill(HIST("Gen/hGenPi0"), ptmc);
-        histos.fill(HIST("Gen/hPrimaryPi0s"), 0);
-        if (isPrimary) histos.fill(HIST("Gen/hPrimaryPi0s"), 1);
-        
-        if (fillPi0Tables){
-          pi0Gens(ptmc); // optional table to store generated pi0 candidates. Be careful, this is a large table!
-          pi0GenCollRefs(mccollisionid); // link to stramccollision table
-        }        
-      }  
+
+      // MC Process selection
+      if ((genSelections.mc_selectMCProcess >= 0) && (genSelections.mc_selectMCProcess!= mcParticle.getProcess()))
+        continue;
       
-      // Sigma0-specific
-      if (isSigma0 || isAntiSigma0){     
-        
-        // Checking decay mode
-        //auto daughtersIDs = mcParticle.daughtersIds();
-        auto const& daughters = mcParticle.template daughters_as<aod::McParticles>();
-                
-        if (daughters.size() == 2) {
-          bool hasPhoton = false;
-          bool hasLambdaOrAntiLambda = false;
+      // Get generated particle info
+      auto MCGenInfo = getV0PairGenInfo(mcParticle);
 
-          for (auto& daughter : daughters) {
-            int daupdg = daughter.pdgCode();
-            if (daupdg == 22)
-              hasPhoton = true;
-            if (TMath::Abs(daupdg) == 3122)
-              hasLambdaOrAntiLambda = true;
-          }
+      // Fill QA histos
+      if (genSelections.doQA) 
+        fillGenQAHistos(MCGenInfo);
 
-          if (hasPhoton && hasLambdaOrAntiLambda)
-            sigma0Type = 1;
-          else
-            sigma0Type = 2;
-
-        } else if (daughters.size() > 0) {
-          sigma0Type = 2;
-        }
-
-        // Fill QA histograms and tables
-        if (isSigma0)          
-          histos.fill(HIST("Gen/hGenSigma0"), ptmc);        
-        if (isAntiSigma0)
-          histos.fill(HIST("Gen/hGenAntiSigma0"), ptmc);                    
-              
-        histos.fill(HIST("Gen/h2DGenSigma0TypeVsProcess"), 0, mcParticle.getProcess()); 
-        if (sigma0Type==0)          
-          histos.fill(HIST("Gen/h2DGenSigma0TypeVsProcess"), 1, mcParticle.getProcess());         
-        if (sigma0Type==1)
-          histos.fill(HIST("Gen/h2DGenSigma0TypeVsProcess"), 2, mcParticle.getProcess());         
-        if (sigma0Type==2)          
-          histos.fill(HIST("Gen/h2DGenSigma0TypeVsProcess"), 3, mcParticle.getProcess());         
-
-        if (fillSigma0Tables){
-          sigma0Gens(isSigma0, ptmc, sigma0Type); 
-          sigma0GenCollRefs(mccollisionid); // link to stramccollision table
-        }                        
+      // Fill tables
+      // Pi0
+      if (fillPi0Tables && MCGenInfo.IsPi0){
+        pi0Gens(MCGenInfo.IsProducedByGenerator, MCGenInfo.MCPt); // optional table to store generated pi0 candidates. Be careful, this is a large table!
+        pi0GenCollRefs(MCGenInfo.MCCollId); // link to stramccollision table
       }
-      
-      if (isV0Lambda && isPrimary) histos.fill(HIST("Gen/hGenSpecies"), 0);
-      if (isV0AntiLambda && isPrimary) histos.fill(HIST("Gen/hGenSpecies"), 1);
-      if (isSigma0) histos.fill(HIST("Gen/hGenSpecies"), 2);
-      if (isAntiSigma0) histos.fill(HIST("Gen/hGenSpecies"), 3);
+
+      // Sigma0/ASigma0
+      if (fillSigma0Tables && (MCGenInfo.IsSigma0 || MCGenInfo.IsAntiSigma0)){
+        sigma0Gens(MCGenInfo.IsSigma0, MCGenInfo.IsProducedByGenerator, MCGenInfo.MCPt); 
+        sigma0GenCollRefs(MCGenInfo.MCCollId); // link to stramccollision table
+      }      
     }      
   }
 
@@ -478,24 +667,10 @@ struct sigma0builder {
       return false;
 
     float centrality = doPPAnalysis ? collision.centFT0M() : collision.centFT0C();
+    float PhotonY = RecoDecay::y(std::array{gamma.px(), gamma.py(), gamma.pz()}, o2::constants::physics::MassGamma);
+    histos.fill(HIST("PhotonSel/h2dMassGammaVsK0S"), gamma.mGamma(), gamma.mK0Short());
+    histos.fill(HIST("PhotonSel/h2dMassGammaVsLambda"), gamma.mGamma(), gamma.mLambda());
 
-    //_______________________________________________
-    // MC Processing
-    if constexpr (requires { gamma.motherMCPartId();}) {
-      if (!gamma.has_v0MCCore())
-        return false;
-
-      auto gammaMC = gamma.template v0MCCore_as<soa::Join<aod::V0MCCores, aod::V0MCCollRefs>>();      
-
-      if (gammaMC.pdgCode() == 22) {
-        histos.fill(HIST("MC/h2dGammaXYConversion"), gamma.x(), gamma.y());
-        float GammaY = TMath::Abs(RecoDecay::y(std::array{gamma.px(), gamma.py(), gamma.pz()}, o2::constants::physics::MassGamma));
-        if (GammaY <= 0.5) {                                                                                                                // rapidity selection
-          histos.fill(HIST("MC/h2dPtVsCentralityBeforeSel_MCAssocGamma"), centrality, gamma.pt());                                            // isgamma
-        }
-      }
-    }
-        
     if (useMLScores) {      
       if (gamma.gammaBDTScore() <= Gamma_MLThreshold)
         return false;
@@ -506,8 +681,7 @@ struct sigma0builder {
       histos.fill(HIST("PhotonSel/hSelectionStatistics"), 1.);
       histos.fill(HIST("PhotonSel/hPhotonMass"), gamma.mGamma());
       if ((gamma.mGamma() < 0) || (gamma.mGamma() > PhotonMaxMass))
-        return false;
-      float PhotonY = RecoDecay::y(std::array{gamma.px(), gamma.py(), gamma.pz()}, o2::constants::physics::MassGamma);
+        return false;      
       histos.fill(HIST("PhotonSel/hPhotonNegEta"), gamma.negativeeta());
       histos.fill(HIST("PhotonSel/hPhotonPosEta"), gamma.positiveeta());
       histos.fill(HIST("PhotonSel/hPhotonY"), PhotonY);
@@ -530,7 +704,21 @@ struct sigma0builder {
       histos.fill(HIST("PhotonSel/hSelectionStatistics"), 6.);
     }
     
+    histos.fill(HIST("PhotonSel/h2dV0XY"), gamma.x(), gamma.y());
     histos.fill(HIST("PhotonSel/h3dPhotonMass"), centrality, gamma.pt(), gamma.mGamma());
+
+    //_______________________________________________
+    // MC Processing
+    if constexpr (requires { gamma.motherMCPartId();}) {
+      if (gamma.has_v0MCCore()){
+        auto gammaMC = gamma.template v0MCCore_as<soa::Join<aod::V0MCCores, aod::V0MCCollRefs>>();      
+        if (gammaMC.pdgCode() == 22) {
+          histos.fill(HIST("MC/h2dGammaXYConversion"), gamma.x(), gamma.y());          
+          histos.fill(HIST("MC/h2dPtVsCentrality_MCAssocGamma"), centrality, gamma.pt());          
+        }
+      }        
+    }
+
     return true;
   }
 
@@ -544,22 +732,8 @@ struct sigma0builder {
       return false;
 
     float centrality = doPPAnalysis ? collision.centFT0M() : collision.centFT0C();
-    
-    //_______________________________________________
-    // MC Processing
-    if constexpr (requires { lambda.motherMCPartId();}) {
-      if (!lambda.has_v0MCCore())
-        return false;
-      
-      auto lambdaMC = lambda.template v0MCCore_as<soa::Join<aod::V0MCCores, aod::V0MCCollRefs>>();
-      
-      if (TMath::Abs(lambda.yLambda()) <= 0.5) {
-        if (lambdaMC.pdgCode() == 3122) // Is Lambda
-          histos.fill(HIST("MC/h2dPtVsCentralityBeforeSel_MCAssocLambda"), centrality, lambda.pt());
-        if (lambdaMC.pdgCode() == -3122) // Is AntiLambda
-          histos.fill(HIST("MC/h2dPtVsCentralityBeforeSel_MCAssocALambda"), centrality, lambda.pt());
-      }
-    }
+    histos.fill(HIST("LambdaSel/h2dMassLambdaVsK0S"), lambda.mLambda(), lambda.mK0Short());
+    histos.fill(HIST("LambdaSel/h2dMassLambdaVsGamma"), lambda.mLambda(), lambda.mGamma());
         
     if (useMLScores) {
       if ((lambda.lambdaBDTScore() <= Lambda_MLThreshold) && (lambda.antiLambdaBDTScore() <= AntiLambda_MLThreshold))
@@ -597,13 +771,25 @@ struct sigma0builder {
     histos.fill(HIST("LambdaSel/h3dLambdaMass"), centrality, lambda.pt(), lambda.mLambda());
     histos.fill(HIST("LambdaSel/h3dALambdaMass"), centrality, lambda.pt(), lambda.mAntiLambda());
 
+    //_______________________________________________
+    // MC Processing (if available)
+    if constexpr (requires { lambda.motherMCPartId();}) {
+      if (lambda.has_v0MCCore()){
+        auto lambdaMC = lambda.template v0MCCore_as<soa::Join<aod::V0MCCores, aod::V0MCCollRefs>>();              
+        if (lambdaMC.pdgCode() == 3122) // Is Lambda
+          histos.fill(HIST("MC/h2dPtVsCentrality_MCAssocLambda"), centrality, lambda.pt());
+        if (lambdaMC.pdgCode() == -3122) // Is AntiLambda
+          histos.fill(HIST("MC/h2dPtVsCentrality_MCAssocALambda"), centrality, lambda.pt());      
+      }                    
+    }
+
     return true;
   }
 
   //_______________________________________________
   // Build pi0 candidate for QA
-  template <typename TV0Object, typename TCollision>
-  bool buildPi0(TV0Object const& gamma1, TV0Object const& gamma2, TCollision collision)
+  template <typename TV0Object, typename TCollision, typename TMCParticles>
+  bool buildPi0(TV0Object const& gamma1, TV0Object const& gamma2, TCollision const& collision, TMCParticles const& mcparticles)
   {
     //_______________________________________________
     // Check if both V0s are made of the same tracks
@@ -617,8 +803,7 @@ struct sigma0builder {
     std::array<float, 3> pVecGamma1{gamma1.px(), gamma1.py(), gamma1.pz()};
     std::array<float, 3> pVecGamma2{gamma2.px(), gamma2.py(), gamma2.pz()};
     std::array arrpi0{pVecGamma1, pVecGamma2};
-    float pi0Mass = RecoDecay::m(arrpi0, std::array{o2::constants::physics::MassPhoton, o2::constants::physics::MassPhoton});
-    float pi0Pt = RecoDecay::pt(std::array{gamma1.px() + gamma2.px(), gamma1.py() + gamma2.py()});
+    float pi0Mass = RecoDecay::m(arrpi0, std::array{o2::constants::physics::MassPhoton, o2::constants::physics::MassPhoton});    
     float pi0Y = RecoDecay::y(std::array{gamma1.px() + gamma2.px(), gamma1.py() + gamma2.py(), gamma1.pz() + gamma2.pz()}, o2::constants::physics::MassPi0);    
 
     //_______________________________________________
@@ -635,61 +820,29 @@ struct sigma0builder {
     auto negTrackGamma1 = gamma1.template negTrackExtra_as<dauTracks>();
     auto posTrackGamma2 = gamma2.template posTrackExtra_as<dauTracks>();
     auto negTrackGamma2 = gamma2.template negTrackExtra_as<dauTracks>();
-
-    float fPhoton1Y = RecoDecay::y(std::array{gamma1.px(), gamma1.py(), gamma1.pz()}, o2::constants::physics::MassGamma);
-    float fPhoton2Y = RecoDecay::y(std::array{gamma2.px(), gamma2.py(), gamma2.pz()}, o2::constants::physics::MassGamma);
+    
+    // Calculate Pi0 topological info
+    auto pi0TopoInfo = propagateV0PairToDCA(gamma1, gamma2);
 
     // Check if MC data and populate corresponding table
     if constexpr (requires { gamma1.motherMCPartId(); gamma2.motherMCPartId(); }) {
-      bool fIsPi0 = false;
-      bool fhasMCColl = false;
-      bool fIsPhoton1CorrectlyAssign = false;
-      bool fIsPhoton2CorrectlyAssign = false;
-      
-      if (collision.has_straMCCollision())
-        fhasMCColl = true;
+      auto pi0MCInfo = getV0PairMCInfo(gamma1, gamma2, collision, mcparticles);
+        
+      pi0coresmc(pi0MCInfo.V0PairMCpT, pi0MCInfo.V0PairMCRadius, pi0MCInfo.V0PairPDGCode, pi0MCInfo.V0PairPDGCodeMother, pi0MCInfo.V0PairMCProcess, pi0MCInfo.fV0PairProducedByGenerator,
+                 pi0MCInfo.V01MCpT, pi0MCInfo.fIsV01Primary, pi0MCInfo.V01PDGCode, pi0MCInfo.V01PDGCodeMother, pi0MCInfo.fIsV01CorrectlyAssign, 
+                 pi0MCInfo.V02MCpT, pi0MCInfo.fIsV02Primary, pi0MCInfo.V02PDGCode, pi0MCInfo.V02PDGCodeMother, pi0MCInfo.fIsV02CorrectlyAssign);
 
-      if (!gamma1.has_v0MCCore() || !gamma2.has_v0MCCore())
-        return false;
-      
-      auto gamma1MC = gamma1.template v0MCCore_as<soa::Join<aod::V0MCCores, aod::V0MCCollRefs>>();
-      auto gamma2MC = gamma2.template v0MCCore_as<soa::Join<aod::V0MCCores, aod::V0MCCollRefs>>();
-
-      if (gamma1MC.pdgCode() == 22 && gamma2MC.pdgCode() == 22 &&
-          gamma1MC.pdgCodeMother() == 111 && gamma2MC.pdgCodeMother() == 111 &&
-          gamma1.motherMCPartId() == gamma2.motherMCPartId()) {
-        fIsPi0 = true;        
-      }
-
-      if (fhasMCColl) {
-        auto MCCollision = collision.template straMCCollision_as<soa::Join<aod::StraMCCollisions, aod::StraMCCollMults>>();        
-        fIsPhoton1CorrectlyAssign = (gamma1MC.straMCCollisionId() == MCCollision.globalIndex());      
-        fIsPhoton2CorrectlyAssign = (gamma2MC.straMCCollisionId() == MCCollision.globalIndex());
-      }
-
-      bool fIsPhoton1Primary = gamma1MC.isPhysicalPrimary();
-      bool fIsPhoton2Primary = gamma2MC.isPhysicalPrimary();
-
-      int Photon1PDGCode = gamma1MC.pdgCode();
-      int Photon1PDGCodeMother = gamma1MC.pdgCodeMother();
-      int Photon2PDGCode = gamma2MC.pdgCode();
-      int Photon2PDGCodeMother = gamma2MC.pdgCodeMother();
-      
-      float pi0MCpT = RecoDecay::pt(array{gamma1MC.pxMC() + gamma2MC.pxMC(), gamma1MC.pyMC() + gamma2MC.pyMC()});
-      float Photon1MCpT = RecoDecay::pt(array{gamma1MC.pxMC(), gamma1MC.pyMC()});
-      float Photon2MCpT = RecoDecay::pt(array{gamma2MC.pxMC(), gamma2MC.pyMC()});
-
-      // Fill table with MC info
-      pi0coresmc(fIsPi0, pi0MCpT, 
-                    Photon1MCpT, Photon1PDGCode, Photon1PDGCodeMother, fIsPhoton1Primary, fIsPhoton1CorrectlyAssign,
-                    Photon2MCpT, Photon2PDGCode, Photon2PDGCodeMother, fIsPhoton2Primary, fIsPhoton2CorrectlyAssign);             
     }
-    
-    pi0cores(pi0Pt, pi0Mass, pi0Y,
-                gamma1.mGamma(), gamma1.pt(), gamma1.qtarm(), gamma1.alpha(), gamma1.dcapostopv(), gamma1.dcanegtopv(), gamma1.dcaV0daughters(), gamma1.negativeeta(), gamma1.positiveeta(), 
-                gamma1.v0cosPA(), gamma1.v0radius(), gamma1.z(), posTrackGamma1.tpcCrossedRows(), negTrackGamma1.tpcCrossedRows(), posTrackGamma1.tpcNSigmaEl(), negTrackGamma1.tpcNSigmaEl(), fPhoton1Y, gamma1.v0Type(), 
-                gamma2.mGamma(), gamma2.pt(), gamma2.qtarm(), gamma2.alpha(), gamma2.dcapostopv(), gamma2.dcanegtopv(), gamma2.dcaV0daughters(), gamma2.negativeeta(), gamma2.positiveeta(), 
-                gamma2.v0cosPA(), gamma2.v0radius(), gamma2.z(), posTrackGamma2.tpcCrossedRows(), negTrackGamma2.tpcCrossedRows(), posTrackGamma2.tpcNSigmaEl(), negTrackGamma2.tpcNSigmaEl(), fPhoton2Y, gamma2.v0Type()); 
+
+    pi0cores(pi0TopoInfo.X, pi0TopoInfo.Y, pi0TopoInfo.Z, pi0TopoInfo.DCADau, pi0TopoInfo.CosPA,            
+             gamma1.px(), gamma1.py(), gamma1.pz(),
+             gamma1.mGamma(), gamma1.qtarm(), gamma1.alpha(), gamma1.dcapostopv(), gamma1.dcanegtopv(), gamma1.dcaV0daughters(), 
+             gamma1.negativeeta(), gamma1.positiveeta(), gamma1.v0cosPA(), gamma1.v0radius(), gamma1.z(), 
+             posTrackGamma1.tpcCrossedRows(), negTrackGamma1.tpcCrossedRows(), posTrackGamma1.tpcNSigmaEl(), negTrackGamma1.tpcNSigmaEl(), gamma1.v0Type(),             
+             gamma2.px(), gamma2.py(), gamma2.pz(),
+             gamma2.mGamma(), gamma2.qtarm(), gamma2.alpha(), gamma2.dcapostopv(), gamma2.dcanegtopv(), gamma2.dcaV0daughters(), 
+             gamma2.negativeeta(), gamma2.positiveeta(), gamma2.v0cosPA(), gamma2.v0radius(), gamma2.z(), 
+             posTrackGamma2.tpcCrossedRows(), negTrackGamma2.tpcCrossedRows(), posTrackGamma2.tpcNSigmaEl(), negTrackGamma2.tpcNSigmaEl(), gamma2.v0Type());
   
     pi0coresRefs(collision.globalIndex());   
 
@@ -698,208 +851,61 @@ struct sigma0builder {
 
   //_______________________________________________
   // Build sigma0 candidate 
-  template <typename TV0Object, typename TCollision>
-  bool buildSigma0(TV0Object const& lambda, TV0Object const& gamma, TCollision const& collision)
+  template <typename TV0Object, typename TCollision, typename TMCParticles>
+  bool buildSigma0(TV0Object const& lambda, TV0Object const& gamma, TCollision const& collision, TMCParticles const& mcparticles)
   {
     //_______________________________________________
-    // Initial setup
     // Checking if both V0s are made of the very same tracks
     if (gamma.posTrackExtraId() == lambda.posTrackExtraId() ||
         gamma.negTrackExtraId() == lambda.negTrackExtraId()) {
       return false;
     }
 
-    // Sigma0 candidate properties
+    //_______________________________________________
+    // Sigma0 pre-selections
     std::array<float, 3> pVecPhotons{gamma.px(), gamma.py(), gamma.pz()};
     std::array<float, 3> pVecLambda{lambda.px(), lambda.py(), lambda.pz()};
 
-    TVector3 v1(gamma.px(), gamma.py(), gamma.pz());
-    TVector3 v2(lambda.px(), lambda.py(), lambda.pz());
-
     auto arrMom = std::array{pVecPhotons, pVecLambda};
-    float sigmaMass = RecoDecay::m(arrMom, std::array{o2::constants::physics::MassPhoton, o2::constants::physics::MassLambda0});
-    float SigmapT = RecoDecay::pt(array{gamma.px() + lambda.px(), gamma.py() + lambda.py()});
+    float sigmaMass = RecoDecay::m(arrMom, std::array{o2::constants::physics::MassPhoton, o2::constants::physics::MassLambda0});    
     float sigmaY = RecoDecay::y(std::array{gamma.px() + lambda.px(), gamma.py() + lambda.py(), gamma.pz() + lambda.pz()}, o2::constants::physics::MassSigma0);
-    float fSigmaOPAngle = v1.Angle(v2);
-    float centrality = doPPAnalysis ? collision.centFT0M() : collision.centFT0C();
 
-    //_______________________________________________
-    // MC-specific
-    bool fIsSigma = false;
-    bool fIsAntiSigma = false;
-    bool fhasMCColl = false;
-    bool fIsPhotonCorrectlyAssign = false;
-    bool fIsLambdaCorrectlyAssign = false;
-    bool fIsPhotonPrimary = false;
-    bool fIsLambdaPrimary = false;
-    int PhotonCandPDGCode = -1;
-    int PhotonCandPDGCodeMother = -1;
-    int LambdaCandPDGCode = -1;
-    int LambdaCandPDGCodeMother = -1;
-    float SigmaMCpT = -1;
-    float LambdaMCpT = -1;
-    float PhotonMCpT = -1;
-
-    if constexpr (requires { gamma.motherMCPartId(); lambda.motherMCPartId(); }) {
-
-      if (collision.has_straMCCollision())
-        fhasMCColl = true;
-
-      if (!gamma.has_v0MCCore() || !lambda.has_v0MCCore())
-        return false;
-      
-      auto gammaMC = gamma.template v0MCCore_as<soa::Join<aod::V0MCCores, aod::V0MCCollRefs>>();
-      auto lambdaMC = lambda.template v0MCCore_as<soa::Join<aod::V0MCCores, aod::V0MCCollRefs>>();
-
-      if (fhasMCColl) {
-        auto gammaMCCollision = collision.template straMCCollision_as<soa::Join<aod::StraMCCollisions, aod::StraMCCollMults>>();
-        auto lambdaMCCollision = collision.template straMCCollision_as<soa::Join<aod::StraMCCollisions, aod::StraMCCollMults>>();
-        fIsPhotonCorrectlyAssign = (gammaMC.straMCCollisionId() == gammaMCCollision.globalIndex());      
-        fIsLambdaCorrectlyAssign = (lambdaMC.straMCCollisionId() == lambdaMCCollision.globalIndex());
-      }
-
-      fIsPhotonPrimary = gammaMC.isPhysicalPrimary();
-      fIsLambdaPrimary = lambdaMC.isPhysicalPrimary();
-
-      PhotonCandPDGCode = gammaMC.pdgCode();
-      PhotonCandPDGCodeMother = gammaMC.pdgCodeMother();
-      LambdaCandPDGCode = lambdaMC.pdgCode();
-      LambdaCandPDGCodeMother = lambdaMC.pdgCodeMother();
-      SigmaMCpT = RecoDecay::pt(array{gammaMC.pxMC() + lambdaMC.pxMC(), gammaMC.pyMC() + lambdaMC.pyMC()});
-      LambdaMCpT = RecoDecay::pt(array{lambdaMC.pxMC(), lambdaMC.pyMC()});
-      PhotonMCpT = RecoDecay::pt(array{gammaMC.pxMC(), gammaMC.pyMC()});
-
-      if ((PhotonCandPDGCode == 22) && (PhotonCandPDGCodeMother == 3212) && (LambdaCandPDGCode == 3122) && (LambdaCandPDGCodeMother == 3212) && (gamma.motherMCPartId() == lambda.motherMCPartId()))
-        fIsSigma = true;
-      if ((PhotonCandPDGCode == 22) && (PhotonCandPDGCodeMother == -3212) && (LambdaCandPDGCode == -3122) && (LambdaCandPDGCodeMother == -3212) && (gamma.motherMCPartId() == lambda.motherMCPartId()))
-        fIsAntiSigma = true;
-
-      if (TMath::Abs(sigmaY) <= 0.5) {
-        if (fIsSigma) {
-          histos.fill(HIST("MC/h2dPtVsCentralityBeforeSel_MCAssocSigma0"), centrality, SigmaMCpT);
-          histos.fill(HIST("MC/h2dSigma0PtVsLambdaPtBeforeSel_MCAssoc"), SigmaMCpT, LambdaMCpT);
-          histos.fill(HIST("MC/h2dSigma0PtVsGammaPtBeforeSel_MCAssoc"), SigmaMCpT, PhotonMCpT);
-        }
-        if (fIsAntiSigma)
-          histos.fill(HIST("MC/h2dPtVsCentralityBeforeSel_MCAssocASigma0"), centrality, SigmaMCpT);
-      }
-    }
-      
-    //_______________________________________________
-    // Before any selection
-    histos.fill(HIST("SigmaSel/h3dMassSigma0BeforeSel"), centrality, SigmapT, sigmaMass);
     histos.fill(HIST("SigmaSel/hSelectionStatistics"), 1.);
-    histos.fill(HIST("SigmaSel/hSigmaMass"), sigmaMass);
-    histos.fill(HIST("SigmaSel/hSigmaMassWindow"), sigmaMass - o2::constants::physics::MassSigma0);
-
-    if (fillQAhistos) {
-      histos.fill(HIST("GeneralQA/h2dMassGammaVsK0S"), gamma.mGamma(), gamma.mK0Short());
-      histos.fill(HIST("GeneralQA/h2dMassLambdaVsK0S"), lambda.mLambda(), lambda.mK0Short());
-      histos.fill(HIST("GeneralQA/h2dMassGammaVsLambda"), gamma.mGamma(), gamma.mLambda());
-      histos.fill(HIST("GeneralQA/h2dMassLambdaVsGamma"), lambda.mLambda(), lambda.mGamma());
-      histos.fill(HIST("GeneralQA/h3dMassSigma0VsDaupTs"), gamma.pt(), lambda.pt(), sigmaMass);
-    }
-
-    //_______________________________________________
-    // Sigma0 selections
     if (TMath::Abs(sigmaMass - o2::constants::physics::MassSigma0) > Sigma0Window)
       return false;
 
-    histos.fill(HIST("SigmaSel/hSigmaY"), sigmaY);
     histos.fill(HIST("SigmaSel/hSelectionStatistics"), 2.);
-
     if (TMath::Abs(sigmaY) > SigmaMaxRap)
       return false;
 
     histos.fill(HIST("SigmaSel/hSigmaMassSelected"), sigmaMass);
     histos.fill(HIST("SigmaSel/hSelectionStatistics"), 3.);
-
     //_______________________________________________
-    // After selections
-    if (fillQAhistos) {
-      histos.fill(HIST("GeneralQA/h2dMassGammaVsK0SAfterMassSel"), gamma.mGamma(), gamma.mK0Short());
-      histos.fill(HIST("GeneralQA/h2dMassLambdaVsK0SAfterMassSel"), lambda.mLambda(), lambda.mK0Short());
-      histos.fill(HIST("GeneralQA/h2dMassGammaVsLambdaAfterMassSel"), gamma.mGamma(), lambda.mLambda());
-      histos.fill(HIST("GeneralQA/h2dV0XY"), gamma.x(), gamma.y());
+    // Calculate properties & Fill tables
+
+    // Sigma0 topological info
+    auto sigma0TopoInfo = propagateV0PairToDCA(gamma, lambda);
+
+    sigma0cores(sigma0TopoInfo.X, sigma0TopoInfo.Y, sigma0TopoInfo.Z, sigma0TopoInfo.DCADau, 
+                gamma.px(), gamma.py(), gamma.pz(), gamma.mGamma(), lambda.px(), lambda.py(), lambda.pz(), lambda.mLambda(), lambda.mAntiLambda());
+
+    // MC properties
+    if constexpr (requires { gamma.motherMCPartId(); lambda.motherMCPartId(); }) {
+      auto sigma0MCInfo = getV0PairMCInfo(gamma, lambda, collision, mcparticles);
+
+      sigma0mccores(sigma0MCInfo.V0PairMCpT, sigma0MCInfo.V0PairMCRadius, sigma0MCInfo.V0PairPDGCode, sigma0MCInfo.V0PairPDGCodeMother, sigma0MCInfo.V0PairMCProcess, sigma0MCInfo.fV0PairProducedByGenerator,
+                    sigma0MCInfo.V01MCpT, sigma0MCInfo.fIsV01Primary, sigma0MCInfo.V01PDGCode, sigma0MCInfo.V01PDGCodeMother, sigma0MCInfo.fIsV01CorrectlyAssign, 
+                    sigma0MCInfo.V02MCpT, sigma0MCInfo.fIsV02Primary, sigma0MCInfo.V02PDGCode, sigma0MCInfo.V02PDGCodeMother, sigma0MCInfo.fIsV02CorrectlyAssign);
+      
     }
-    
-    // MC-specific
-    if constexpr (requires { gamma.motherMCPartId();}) {
-      if (TMath::Abs(sigmaY) <= 0.5) {
-        if (fIsSigma)
-          histos.fill(HIST("MC/h2dPtVsCentralityAfterSel_MCAssocSigma0"), centrality, SigmaMCpT);
-        if (fIsAntiSigma)
-          histos.fill(HIST("MC/h2dPtVsCentralityAfterSel_MCAssocASigma0"), centrality, SigmaMCpT);              
-      }      
-    }
-    
-    histos.fill(HIST("SigmaSel/h3dMassSigma0AfterSel"), centrality, SigmapT, sigmaMass);
 
-    // Store Reco properties in struct
-    sigmaCandidate.Mass = sigmaMass;
-    sigmaCandidate.pT = SigmapT;
-    sigmaCandidate.Y = sigmaY;
-    sigmaCandidate.SigmaOPAngle = fSigmaOPAngle;
-
-    // Store MC properties if available
-    sigmaCandidate.fIsSigma = fIsSigma;
-    sigmaCandidate.fIsAntiSigma = fIsAntiSigma;
-    sigmaCandidate.fIsPhotonCorrectlyAssign = fIsPhotonCorrectlyAssign;
-    sigmaCandidate.fIsLambdaCorrectlyAssign = fIsLambdaCorrectlyAssign;
-    sigmaCandidate.fIsPhotonPrimary = fIsPhotonPrimary;
-    sigmaCandidate.fIsLambdaPrimary = fIsLambdaPrimary;
-    sigmaCandidate.PhotonCandPDGCode = PhotonCandPDGCode;
-    sigmaCandidate.PhotonCandPDGCodeMother = PhotonCandPDGCodeMother;
-    sigmaCandidate.LambdaCandPDGCode = LambdaCandPDGCode;
-    sigmaCandidate.LambdaCandPDGCodeMother = LambdaCandPDGCodeMother;    
-    sigmaCandidate.SigmaMCpT = SigmaMCpT;
-    sigmaCandidate.LambdaMCpT = LambdaMCpT;
-    sigmaCandidate.PhotonMCpT = PhotonMCpT;
-
-    return true;
-  }
-
-  //_______________________________________________
-  // Fill tables with reconstructed sigma0 candidate
-  template <typename TV0Object, typename TCollision>
-  void buildSigma0Tables(TV0Object const& lambda, TV0Object const& gamma, TCollision const& coll)
-  {
+    // Sigma0s -> stracollisions link
+    sigma0CollRefs(collision.globalIndex());                
+                      
     //_______________________________________________    
-    // Photon properties
+    // Photon extra properties
     auto posTrackGamma = gamma.template posTrackExtra_as<dauTracks>();
     auto negTrackGamma = gamma.template negTrackExtra_as<dauTracks>();
-
-    float fPhotonPt = gamma.pt();
-    float fPhotonMass = gamma.mGamma();
-    float fPhotonQt = gamma.qtarm();
-    float fPhotonAlpha = gamma.alpha();
-    float fPhotonRadius = gamma.v0radius();
-    float fPhotonCosPA = gamma.v0cosPA();
-    float fPhotonDCADau = gamma.dcaV0daughters();
-    float fPhotonDCANegPV = gamma.dcanegtopv();
-    float fPhotonDCAPosPV = gamma.dcapostopv();
-    float fPhotonZconv = gamma.z();
-    float fPhotonEta = gamma.eta();
-    float fPhotonY = RecoDecay::y(std::array{gamma.px(), gamma.py(), gamma.pz()}, o2::constants::physics::MassGamma);
-    float fPhotonPhi = RecoDecay::phi(gamma.px(), gamma.py());
-    float fPhotonPosTPCNSigmaEl = posTrackGamma.tpcNSigmaEl();
-    float fPhotonNegTPCNSigmaEl = negTrackGamma.tpcNSigmaEl();
-    float fPhotonPosTPCNSigmaPi = posTrackGamma.tpcNSigmaPi();
-    float fPhotonNegTPCNSigmaPi = negTrackGamma.tpcNSigmaPi();
-    uint8_t fPhotonPosTPCCrossedRows = posTrackGamma.tpcCrossedRows();
-    uint8_t fPhotonNegTPCCrossedRows = negTrackGamma.tpcCrossedRows();
-    float fPhotonPosPt = gamma.positivept();
-    float fPhotonNegPt = gamma.negativept();
-    float fPhotonPosEta = gamma.positiveeta();
-    float fPhotonNegEta = gamma.negativeeta();
-    float fPhotonPosY = RecoDecay::y(std::array{gamma.pxpos(), gamma.pypos(), gamma.pzpos()}, o2::constants::physics::MassElectron);
-    float fPhotonNegY = RecoDecay::y(std::array{gamma.pxneg(), gamma.pyneg(), gamma.pzneg()}, o2::constants::physics::MassElectron);
-    float fPhotonPsiPair = gamma.psipair();
-    int fPhotonPosITSCls = posTrackGamma.itsNCls();
-    int fPhotonNegITSCls = negTrackGamma.itsNCls();
-    float fPhotonPosITSChi2PerNcl = posTrackGamma.itsChi2PerNcl();
-    float fPhotonNegITSChi2PerNcl = negTrackGamma.itsChi2PerNcl();
-    uint8_t fPhotonV0Type = gamma.v0Type();
 
     uint8_t fPhotonPosTrackCode = ((uint8_t(posTrackGamma.hasTPC()) << hasTPC) |
                                    (uint8_t(posTrackGamma.hasITSTracker()) << hasITSTracker) |
@@ -913,59 +919,16 @@ struct sigma0builder {
                                    (uint8_t(negTrackGamma.hasTRD()) << hasTRD) |
                                    (uint8_t(negTrackGamma.hasTOF()) << hasTOF));
 
-    float GammaBDTScore = gamma.gammaBDTScore();
+    sigmaPhotonExtras(gamma.qtarm(), gamma.alpha(), gamma.v0cosPA(), gamma.dcaV0daughters(), gamma.dcanegtopv(), gamma.dcapostopv(), gamma.v0radius(), gamma.z(),
+                      posTrackGamma.tpcNSigmaEl(), negTrackGamma.tpcNSigmaEl(), posTrackGamma.tpcCrossedRows(), negTrackGamma.tpcCrossedRows(), 
+                      gamma.positiveeta(), gamma.negativeeta(), gamma.psipair(), posTrackGamma.itsNCls(), negTrackGamma.itsNCls(), posTrackGamma.itsChi2PerNcl(), negTrackGamma.itsChi2PerNcl(), 
+                      fPhotonPosTrackCode, fPhotonNegTrackCode, gamma.v0Type());
+            
 
     //_______________________________________________    
-    // Lambda properties
+    // Lambda extra properties
     auto posTrackLambda = lambda.template posTrackExtra_as<dauTracks>();
     auto negTrackLambda = lambda.template negTrackExtra_as<dauTracks>();
-
-    float fLambdaPt = lambda.pt();
-    float fLambdaMass = lambda.mLambda();
-    float fAntiLambdaMass = lambda.mAntiLambda();
-    float fLambdaQt = lambda.qtarm();
-    float fLambdaAlpha = lambda.alpha();
-    float fLambdaLifeTime = lambda.distovertotmom(coll.posX(), coll.posY(), coll.posZ()) * o2::constants::physics::MassLambda0;
-    float fLambdaRadius = lambda.v0radius();
-    float fLambdaCosPA = lambda.v0cosPA();
-    float fLambdaDCADau = lambda.dcaV0daughters();
-    float fLambdaDCANegPV = lambda.dcanegtopv();
-    float fLambdaDCAPosPV = lambda.dcapostopv();
-    float fLambdaEta = lambda.eta();
-    float fLambdaY = lambda.yLambda();
-    float fLambdaPhi = RecoDecay::phi(lambda.px(), lambda.py());
-    float fLambdaPosPrTPCNSigma = posTrackLambda.tpcNSigmaPr();
-    float fLambdaPosPiTPCNSigma = posTrackLambda.tpcNSigmaPi();
-    float fLambdaNegPrTPCNSigma = negTrackLambda.tpcNSigmaPr();
-    float fLambdaNegPiTPCNSigma = negTrackLambda.tpcNSigmaPi();
-
-    float fLambdaPrTOFNSigma = -999.f;
-    float fLambdaPiTOFNSigma = -999.f;
-    float fALambdaPrTOFNSigma = -999.f;
-    float fALambdaPiTOFNSigma = -999.f;
-
-    if constexpr (requires { lambda.tofNSigmaLaPr();}) { // If TOF info avaiable
-      fLambdaPrTOFNSigma = lambda.tofNSigmaLaPr();
-      fLambdaPiTOFNSigma = lambda.tofNSigmaLaPi();
-      fALambdaPrTOFNSigma = lambda.tofNSigmaALaPr();
-      fALambdaPiTOFNSigma = lambda.tofNSigmaALaPi();
-    }    
-
-    uint8_t fLambdaPosTPCCrossedRows = posTrackLambda.tpcCrossedRows();
-    uint8_t fLambdaNegTPCCrossedRows = negTrackLambda.tpcCrossedRows();
-    float fLambdaPosPt = lambda.positivept();
-    float fLambdaNegPt = lambda.negativept();
-    float fLambdaPosEta = lambda.positiveeta();
-    float fLambdaNegEta = lambda.negativeeta();
-    float fLambdaPosPrY = RecoDecay::y(std::array{lambda.pxpos(), lambda.pypos(), lambda.pzpos()}, o2::constants::physics::MassProton);
-    float fLambdaPosPiY = RecoDecay::y(std::array{lambda.pxpos(), lambda.pypos(), lambda.pzpos()}, o2::constants::physics::MassPionCharged);
-    float fLambdaNegPrY = RecoDecay::y(std::array{lambda.pxneg(), lambda.pyneg(), lambda.pzneg()}, o2::constants::physics::MassProton);
-    float fLambdaNegPiY = RecoDecay::y(std::array{lambda.pxneg(), lambda.pyneg(), lambda.pzneg()}, o2::constants::physics::MassPionCharged);
-    int fLambdaPosITSCls = posTrackLambda.itsNCls();
-    int fLambdaNegITSCls = negTrackLambda.itsNCls();
-    float fLambdaPosITSChi2PerNcl = posTrackLambda.itsChi2PerNcl();
-    float fLambdaNegITSChi2PerNcl = negTrackLambda.itsChi2PerNcl();
-    uint8_t fLambdaV0Type = lambda.v0Type();
 
     uint8_t fLambdaPosTrackCode = ((uint8_t(posTrackLambda.hasTPC()) << hasTPC) |
                                    (uint8_t(posTrackLambda.hasITSTracker()) << hasITSTracker) |
@@ -978,47 +941,34 @@ struct sigma0builder {
                                    (uint8_t(negTrackLambda.hasITSAfterburner()) << hasITSAfterburner) |
                                    (uint8_t(negTrackLambda.hasTRD()) << hasTRD) |
                                    (uint8_t(negTrackLambda.hasTOF()) << hasTOF));
+    
+    float fLambdaLifeTime = lambda.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * o2::constants::physics::MassLambda0;
+    float fLambdaPrTOFNSigma = -999.f;
+    float fLambdaPiTOFNSigma = -999.f;
+    float fALambdaPrTOFNSigma = -999.f;
+    float fALambdaPiTOFNSigma = -999.f;
 
-    float LambdaBDTScore = lambda.lambdaBDTScore();
-    float AntiLambdaBDTScore = lambda.antiLambdaBDTScore();                                   
-
-    //_______________________________________________    
-    // Fill the tables, please
-    sigma0cores(sigmaCandidate.pT, sigmaCandidate.Mass, sigmaCandidate.Y, sigmaCandidate.SigmaOPAngle);
-
-    sigmaPhotonExtras(fPhotonPt, fPhotonMass, fPhotonQt, fPhotonAlpha, fPhotonRadius,
-                      fPhotonCosPA, fPhotonDCADau, fPhotonDCANegPV, fPhotonDCAPosPV, fPhotonZconv,
-                      fPhotonEta, fPhotonY, fPhotonPhi, fPhotonPosTPCNSigmaEl, fPhotonNegTPCNSigmaEl, fPhotonPosTPCNSigmaPi, fPhotonNegTPCNSigmaPi, fPhotonPosTPCCrossedRows,
-                      fPhotonNegTPCCrossedRows, fPhotonPosPt, fPhotonNegPt, fPhotonPosEta,
-                      fPhotonNegEta, fPhotonPosY, fPhotonNegY, fPhotonPsiPair,
-                      fPhotonPosITSCls, fPhotonNegITSCls, fPhotonPosITSChi2PerNcl, fPhotonNegITSChi2PerNcl, fPhotonPosTrackCode, fPhotonNegTrackCode,
-                      fPhotonV0Type, GammaBDTScore);
-
-    sigmaLambdaExtras(fLambdaPt, fLambdaMass, fAntiLambdaMass, fLambdaQt, fLambdaAlpha, fLambdaLifeTime,
-                      fLambdaRadius, fLambdaCosPA, fLambdaDCADau, fLambdaDCANegPV,
-                      fLambdaDCAPosPV, fLambdaEta, fLambdaY, fLambdaPhi, fLambdaPosPrTPCNSigma,
-                      fLambdaPosPiTPCNSigma, fLambdaNegPrTPCNSigma, fLambdaNegPiTPCNSigma,
-                      fLambdaPrTOFNSigma, fLambdaPiTOFNSigma, fALambdaPrTOFNSigma, fALambdaPiTOFNSigma,
-                      fLambdaPosTPCCrossedRows, fLambdaNegTPCCrossedRows, fLambdaPosPt, fLambdaNegPt, fLambdaPosEta,
-                      fLambdaNegEta, fLambdaPosPrY, fLambdaPosPiY, fLambdaNegPrY, fLambdaNegPiY,
-                      fLambdaPosITSCls, fLambdaNegITSCls, fLambdaPosITSChi2PerNcl, fLambdaNegITSChi2PerNcl, fLambdaPosTrackCode, fLambdaNegTrackCode,
-                      fLambdaV0Type, LambdaBDTScore, AntiLambdaBDTScore);
-
-    if (doprocessMonteCarlo || doprocessMonteCarloWithTOF){
-
-      sigma0mccores(sigmaCandidate.fIsSigma, sigmaCandidate.fIsAntiSigma, sigmaCandidate.SigmaMCpT,
-                    sigmaCandidate.PhotonCandPDGCode, sigmaCandidate.PhotonCandPDGCodeMother, sigmaCandidate.fIsPhotonPrimary, sigmaCandidate.PhotonMCpT, sigmaCandidate.fIsPhotonCorrectlyAssign,
-                    sigmaCandidate.LambdaCandPDGCode, sigmaCandidate.LambdaCandPDGCodeMother, sigmaCandidate.fIsLambdaPrimary, sigmaCandidate.LambdaMCpT, sigmaCandidate.fIsLambdaCorrectlyAssign);
-      
+    if constexpr (requires { lambda.tofNSigmaLaPr();}) { // If TOF info avaiable
+      fLambdaPrTOFNSigma = lambda.tofNSigmaLaPr();
+      fLambdaPiTOFNSigma = lambda.tofNSigmaLaPi();
+      fALambdaPrTOFNSigma = lambda.tofNSigmaALaPr();
+      fALambdaPiTOFNSigma = lambda.tofNSigmaALaPi();
     }
 
-    sigma0CollRefs(coll.globalIndex());
-       
+    sigmaLambdaExtras(lambda.qtarm(), lambda.alpha(), fLambdaLifeTime, lambda.v0radius(), lambda.v0cosPA(), lambda.dcaV0daughters(), lambda.dcanegtopv(), lambda.dcapostopv(),
+                      posTrackLambda.tpcNSigmaPr(), posTrackLambda.tpcNSigmaPi(), negTrackLambda.tpcNSigmaPr(), negTrackLambda.tpcNSigmaPi(), 
+                      fLambdaPrTOFNSigma, fLambdaPiTOFNSigma, fALambdaPrTOFNSigma, fALambdaPiTOFNSigma,
+                      posTrackLambda.tpcCrossedRows(), negTrackLambda.tpcCrossedRows(), 
+                      lambda.positiveeta(), lambda.negativeeta(), 
+                      posTrackLambda.itsNCls(), negTrackLambda.itsNCls(), posTrackLambda.itsChi2PerNcl(), negTrackLambda.itsChi2PerNcl(),
+                      fLambdaPosTrackCode, fLambdaNegTrackCode, lambda.v0Type());                                                 
+        
+    return true;
   }
 
   // Process photon and lambda candidates to build sigma0 candidates
-  template <typename TCollision, typename TV0s>
-  void dataProcess(TCollision const& collisions, TV0s const& fullV0s)
+  template <typename TCollision, typename TV0s, typename TMCParticles>
+  void dataProcess(TCollision const& collisions, TV0s const& fullV0s, TMCParticles const& mcparticles)
   {
     //_______________________________________________
     // Initial setup
@@ -1075,12 +1025,10 @@ struct sigma0builder {
           for (size_t j = 0; j < bestLambdasArray.size(); ++j) {
             auto lambda = fullV0s.rawIteratorAt(bestLambdasArray[j]);
                             
-            // Building sigma0 candidate
-            if (!buildSigma0(lambda, gamma1, coll))
+            // Building sigma0 candidate & filling tables
+            if (!buildSigma0(lambda, gamma1, coll, mcparticles))
               continue;
-          
-            // Fill tables with accepted candidates           
-            buildSigma0Tables(lambda, gamma1, coll);          
+                      
           }
         }
         
@@ -1089,7 +1037,9 @@ struct sigma0builder {
         if (fillPi0Tables){
           for (size_t j = i + 1; j < bestGammasArray.size(); ++j) {
             auto gamma2 = fullV0s.rawIteratorAt(bestGammasArray[j]);
-            if (!buildPi0(gamma1, gamma2, coll))
+
+            // Building pi0 candidate & filling tables
+            if (!buildPi0(gamma1, gamma2, coll, mcparticles))
               continue;
           }
         }
@@ -1099,35 +1049,35 @@ struct sigma0builder {
 
   void processRealData(soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraStamps> const& collisions, V0StandardDerivedDatas const& fullV0s, dauTracks const&)
   {
-    dataProcess(collisions, fullV0s);
-  }
-
-  void processMonteCarlo(soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraStamps, aod::StraCollLabels> const& collisions, V0DerivedMCDatas const& fullV0s, dauTracks const&, aod::MotherMCParts const&, soa::Join<aod::StraMCCollisions, aod::StraMCCollMults> const&, soa::Join<aod::V0MCCores, aod::V0MCCollRefs> const&)
-  {
-    dataProcess(collisions, fullV0s);
+    dataProcess(collisions, fullV0s, nullptr);
   }
 
   void processRealDataWithTOF(soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraStamps> const& collisions, V0TOFStandardDerivedDatas const& fullV0s, dauTracks const&)
   {
-    dataProcess(collisions, fullV0s);
+    dataProcess(collisions, fullV0s, nullptr);
   }
 
-  void processMonteCarloWithTOF(soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraStamps, aod::StraCollLabels> const& collisions, V0TOFDerivedMCDatas const& fullV0s, dauTracks const&, aod::MotherMCParts const&, soa::Join<aod::StraMCCollisions, aod::StraMCCollMults> const&, soa::Join<aod::V0MCCores, aod::V0MCCollRefs> const&)
+  void processMonteCarlo(soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraStamps, aod::StraCollLabels> const& collisions, V0DerivedMCDatas const& fullV0s, aod::McParticles const& mcParticles, dauTracks const&, aod::MotherMCParts const&, soa::Join<aod::StraMCCollisions, aod::StraMCCollMults> const&, soa::Join<aod::V0MCCores, aod::V0MCCollRefs> const&)
   {
-    dataProcess(collisions, fullV0s);
+    dataProcess(collisions, fullV0s, mcParticles);
+  }
+
+  void processMonteCarloWithTOF(soa::Join<aod::StraCollisions, aod::StraCents, aod::StraEvSels, aod::StraStamps, aod::StraCollLabels> const& collisions, V0TOFDerivedMCDatas const& fullV0s, aod::McParticles const& mcParticles, dauTracks const&, aod::MotherMCParts const&, soa::Join<aod::StraMCCollisions, aod::StraMCCollMults> const&, soa::Join<aod::V0MCCores, aod::V0MCCollRefs> const&)
+  {
+    dataProcess(collisions, fullV0s, mcParticles);
   }
 
   // Simulated processing in Run 3 - run this over original AO2Ds
   void processGeneratedRun3(aod::McParticles const& mcParticles)
   {
-    fillGeneratedTable(mcParticles);
+    genProcess(mcParticles);
   }
   
   PROCESS_SWITCH(sigma0builder, processRealData, "process as if real data", true);
   PROCESS_SWITCH(sigma0builder, processRealDataWithTOF, "process as if real data", false);
   PROCESS_SWITCH(sigma0builder, processMonteCarlo, "process as if MC data", false);
   PROCESS_SWITCH(sigma0builder, processMonteCarloWithTOF, "process as if MC data, uses TOF PID info", false);
-  PROCESS_SWITCH(sigma0builder, processGeneratedRun3, "process generated MC info", false);
+  PROCESS_SWITCH(sigma0builder, processGeneratedRun3, "process generated MC info", false);  
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx
@@ -644,6 +644,7 @@ struct StrangenessBuilder {
       histos.add("DeduplicationQA/hBestPA", "hBestPA", kTH1F, {{200, 0.0f, 0.4f}});
       histos.add("DeduplicationQA/hBestDCADau", "hBestDCADau", kTH1F, {{200, -10.0f, 10.0f}});
       histos.add("DeduplicationQA/hBestMLScore", "hBestMLScore", kTH1F, {{200, 0.0f, 1.0f}});
+      histos.add("DeduplicationQA/hPAOfBestMLScore", "hPAOfBestMLScore", kTH1F, {{200, 0.0f, 0.4f}});
     }
 
     auto hPrimaryV0s = histos.add<TH1>("hPrimaryV0s", "hPrimaryV0s", kTH1D, {{2, -0.5f, 1.5f}});
@@ -1001,8 +1002,11 @@ struct StrangenessBuilder {
       V0DuplicateExtras[bestPointingAngleIndex].isBestPA = true;
     if (bestDCADaughtersIndex != static_cast<size_t>(-1))
       V0DuplicateExtras[bestDCADaughtersIndex].isBestDCADau = true;
-    if (bestMLScoreIndex != static_cast<size_t>(-1))
+    if (bestMLScoreIndex != static_cast<size_t>(-1)){
       V0DuplicateExtras[bestMLScoreIndex].isBestMLScore = true;
+      histos.fill(HIST("DeduplicationQA/hPAOfBestMLScore"), V0DuplicateExtras[bestMLScoreIndex].PA);
+    }
+      
 
     // return vector with duplicates info
     return V0DuplicateExtras;

--- a/PWGLF/Tasks/Strangeness/sigmaanalysis.cxx
+++ b/PWGLF/Tasks/Strangeness/sigmaanalysis.cxx
@@ -191,11 +191,18 @@ struct sigmaanalysis {
     Configurable<float> PhotonPhiMax2{"PhotonPhiMax2", -1, "Phi min value to reject photons, region 2 (leave negative if no selection desired)"};
   } photonSelections;
 
-  Configurable<float> Sigma0MaxRap{"Sigma0MaxRap", 0.5, "Max sigma0 rapidity"};
-  Configurable<float> Sigma0MaxRadius{"Sigma0MaxRadius", 200, "Max sigma0 decay radius"};
-  Configurable<float> Sigma0MaxDCADau{"Sigma0MaxDCADau", 50, "Max sigma0 DCA between daughters"};
-  Configurable<float> Sigma0MaxOPAngle{"Sigma0MaxOPAngle", 7, "Max sigma0 OP Angle between daughters"};
-  Configurable<float> Pi0MaxRap{"Pi0MaxRap", 0.5, "Max sigma0 rapidity"};
+  struct : ConfigurableGroup {
+    Configurable<float> Sigma0MaxRap{"Sigma0MaxRap", 0.5, "Max sigma0 rapidity"};
+    Configurable<float> Sigma0MaxRadius{"Sigma0MaxRadius", 200, "Max sigma0 decay radius"};
+    Configurable<float> Sigma0MaxDCADau{"Sigma0MaxDCADau", 50, "Max sigma0 DCA between daughters"};
+    Configurable<float> Sigma0MaxOPAngle{"Sigma0MaxOPAngle", 7, "Max sigma0 OP Angle between daughters"};
+  } sigma0Selections;
+
+  struct : ConfigurableGroup {
+    Configurable<float> Pi0MaxRap{"Pi0MaxRap", 0.5, "Max sigma0 rapidity"};
+    Configurable<float> Pi0MaxRadius{"Pi0MaxRadius", 200, "Max sigma0 decay radius"};
+    Configurable<float> Pi0MaxDCADau{"Pi0MaxDCADau", 50, "Max sigma0 DCA between daughters"};
+  } pi0Selections;
 
   // Axis
   // base properties
@@ -292,189 +299,191 @@ struct sigmaanalysis {
       histos.add("GeneralQA/hCentralityVsInteractionRate", "hCentralityVsInteractionRate", kTH2D, {axisCentrality, axisIRBinning});
     }
 
-    for (const auto& histodir : DirList) {
+    if (doprocessRealData || doprocessMonteCarlo){
+      for (const auto& histodir : DirList) {
 
-      histos.add(histodir + "/Photon/hTrackCode", "hTrackCode", kTH1D, {{11, 0.5f, 11.5f}});
-      histos.add(histodir + "/Photon/hV0Type", "hV0Type", kTH1D, {{8, 0.5f, 8.5f}});      
-      histos.add(histodir + "/Photon/hDCANegToPV", "hDCANegToPV", kTH1D, {axisDCAtoPV});
-      histos.add(histodir + "/Photon/hDCAPosToPV", "hDCAPosToPV", kTH1D, {axisDCAtoPV});
-      histos.add(histodir + "/Photon/hDCADau", "hDCADau", kTH1D, {axisDCAdau});
-      histos.add(histodir + "/Photon/hPosTPCCR", "hPosTPCCR", kTH1D, {axisTPCrows});
-      histos.add(histodir + "/Photon/hNegTPCCR", "hNegTPCCR", kTH1D, {axisTPCrows});      
-      histos.add(histodir + "/Photon/hPosTPCNSigmaEl", "hPosTPCNSigmaEl", kTH1D, {axisTPCNSigma});
-      histos.add(histodir + "/Photon/hNegTPCNSigmaEl", "hNegTPCNSigmaEl", kTH1D, {axisTPCNSigma});
-      
-      histos.add(histodir + "/Photon/hpT", "hpT", kTH1D, {axisPt});
-      histos.add(histodir + "/Photon/hY", "hY", kTH1D, {axisRapidity});
-      histos.add(histodir + "/Photon/hPosEta", "hPosEta", kTH1D, {axisRapidity});
-      histos.add(histodir + "/Photon/hNegEta", "hNegEta", kTH1D, {axisRapidity});
-      histos.add(histodir + "/Photon/hRadius", "hRadius", kTH1D, {axisV0Radius});
-      histos.add(histodir + "/Photon/hZ", "hZ", kTH1D, {axisZ});
-      histos.add(histodir + "/Photon/h2dRZCut", "h2dRZCut", kTH2D, {axisZ, axisV0Radius});
-      histos.add(histodir + "/Photon/h2dRZPlane", "h2dRZPlane", kTH2D, {axisZ, axisV0Radius});
-      histos.add(histodir + "/Photon/hCosPA", "hCosPA", kTH1D, {axisCosPA});
-      histos.add(histodir + "/Photon/hPsiPair", "hPsiPair", kTH1D, {axisPsiPair});
-      histos.add(histodir + "/Photon/hPhi", "hPhi", kTH1D, {axisPhi});
-      histos.add(histodir + "/Photon/h3dMass", "h3dMass", kTH3D, {axisCentrality, axisPt, axisPhotonMass});
-      histos.add(histodir + "/Photon/hMass", "hMass", kTH1D, {axisPhotonMass});
-
-      histos.add(histodir + "/Lambda/hTrackCode", "hTrackCode", kTH1D, {{11, 0.5f, 11.5f}});
-      histos.add(histodir + "/Lambda/hRadius", "hRadius", kTH1D, {axisV0Radius});
-      histos.add(histodir + "/Lambda/hDCADau", "hDCADau", kTH1D, {axisDCAdau});
-      histos.add(histodir + "/Lambda/hCosPA", "hCosPA", kTH1D, {axisCosPA});
-      histos.add(histodir + "/Lambda/hY", "hY", kTH1D, {axisRapidity});
-      histos.add(histodir + "/Lambda/hPosEta", "hPosEta", kTH1D, {axisRapidity});
-      histos.add(histodir + "/Lambda/hNegEta", "hNegEta", kTH1D, {axisRapidity});
-      histos.add(histodir + "/Lambda/hPosTPCCR", "hPosTPCCR", kTH1D, {axisTPCrows});
-      histos.add(histodir + "/Lambda/hNegTPCCR", "hNegTPCCR", kTH1D, {axisTPCrows});
-      histos.add(histodir + "/Lambda/hPosITSCls", "hPosITSCls", kTH1D, {axisNCls});
-      histos.add(histodir + "/Lambda/hNegITSCls", "hNegITSCls", kTH1D, {axisNCls});
-      histos.add(histodir + "/Lambda/hPosChi2PerNc", "hPosChi2PerNc", kTH1D, {axisChi2PerNcl});
-      histos.add(histodir + "/Lambda/hNegChi2PerNc", "hNegChi2PerNc", kTH1D, {axisChi2PerNcl});
-      histos.add(histodir + "/Lambda/hLifeTime", "hLifeTime", kTH1D, {axisLifetime});
-      histos.add(histodir + "/Lambda/h2dTPCvsTOFNSigma_LambdaPr", "h2dTPCvsTOFNSigma_LambdaPr", kTH2D, {axisTPCNSigma, axisTOFNSigma});
-      histos.add(histodir + "/Lambda/h2dTPCvsTOFNSigma_LambdaPi", "h2dTPCvsTOFNSigma_LambdaPi", kTH2D, {axisTPCNSigma, axisTOFNSigma});
-      histos.add(histodir + "/Lambda/hLambdaDCANegToPV", "hLambdaDCANegToPV", kTH1D, {axisDCAtoPV});
-      histos.add(histodir + "/Lambda/hLambdaDCAPosToPV", "hLambdaDCAPosToPV", kTH1D, {axisDCAtoPV});
-      histos.add(histodir + "/Lambda/hLambdapT", "hLambdapT", kTH1D, {axisPt});
-      histos.add(histodir + "/Lambda/hLambdaMass", "hLambdaMass", kTH1D, {axisLambdaMass});
-      histos.add(histodir + "/Lambda/h3dLambdaMass", "h3dLambdaMass", kTH3D, {axisCentrality, axisPt, axisLambdaMass});
-      histos.add(histodir + "/Lambda/h2dTPCvsTOFNSigma_ALambdaPr", "h2dTPCvsTOFNSigma_ALambdaPr", kTH2D, {axisTPCNSigma, axisTOFNSigma});
-      histos.add(histodir + "/Lambda/h2dTPCvsTOFNSigma_ALambdaPi", "h2dTPCvsTOFNSigma_ALambdaPi", kTH2D, {axisTPCNSigma, axisTOFNSigma});
-      histos.add(histodir + "/Lambda/hALambdaDCANegToPV", "hALambdaDCANegToPV", kTH1D, {axisDCAtoPV});
-      histos.add(histodir + "/Lambda/hALambdaDCAPosToPV", "hALambdaDCAPosToPV", kTH1D, {axisDCAtoPV});
-      histos.add(histodir + "/Lambda/hALambdapT", "hALambdapT", kTH1D, {axisPt});
-      histos.add(histodir + "/Lambda/hAntiLambdaMass", "hAntiLambdaMass", kTH1D, {axisLambdaMass});
-      histos.add(histodir + "/Lambda/h3dAntiLambdaMass", "h3dAntiLambdaMass", kTH3D, {axisCentrality, axisPt, axisLambdaMass});
-
-      histos.add(histodir + "/h2dArmenteros", "h2dArmenteros", kTH2D, {axisAPAlpha, axisAPQt});
-
-      histos.add(histodir + "/Sigma0/hMass", "hMass", kTH1D, {axisSigmaMass});
-      histos.add(histodir + "/Sigma0/hPt", "hPt", kTH1D, {axisPt});
-      histos.add(histodir + "/Sigma0/hY", "hY", kTH1D, {axisRapidity});
-      histos.add(histodir + "/Sigma0/hRadius", "hRadius", kTH1D, {axisV0PairRadius});
-      histos.add(histodir + "/Sigma0/h2dRadiusVspT", "h2dRadiusVspT", kTH2D, {axisV0PairRadius, axisPt});
-      histos.add(histodir + "/Sigma0/hDCAPairDau", "hDCAPairDau", kTH1D, {axisDCAdau});      
-      histos.add(histodir + "/Sigma0/h3dMass", "h3dMass", kTH3D, {axisCentrality, axisPt, axisSigmaMass});      
-      histos.add(histodir + "/Sigma0/h3dOPAngleVsMass", "h3dOPAngleVsMass", kTH3D, {{140, 0.0f, +7.0f}, axisPt, axisSigmaMass});
-      
-      histos.add(histodir + "/ASigma0/hMass", "hMass", kTH1D, {axisSigmaMass});
-      histos.add(histodir + "/ASigma0/hPt", "hPt", kTH1D, {axisPt});
-      histos.add(histodir + "/ASigma0/hY", "hY", kTH1D, {axisRapidity});      
-      histos.add(histodir + "/ASigma0/hRadius", "hRadius", kTH1D, {axisV0PairRadius});
-      histos.add(histodir + "/ASigma0/h2dRadiusVspT", "h2dRadiusVspT", kTH2D, {axisV0PairRadius, axisPt});
-      histos.add(histodir + "/ASigma0/hDCAPairDau", "hDCAPairDau", kTH1D, {axisDCAdau});      
-      histos.add(histodir + "/ASigma0/h3dMass", "h3dMass", kTH3D, {axisCentrality, axisPt, axisSigmaMass});      
-      histos.add(histodir + "/ASigma0/h3dOPAngleVsMass", "h3dOPAngleVsMass", kTH3D, {{140, 0.0f, +7.0f}, axisPt, axisSigmaMass});
-      
-
-      // Process MC
-      if (doprocessMonteCarlo) {
-        histos.add(histodir + "/MC/Photon/hV0ToCollAssoc", "hV0ToCollAssoc", kTH1D, {{2, 0.0f, 2.0f}});
-        histos.add(histodir + "/MC/Photon/hPt", "hPt", kTH1D, {axisPt});
-        histos.add(histodir + "/MC/Photon/hMCPt", "hMCPt", kTH1D, {axisPt});        
-        histos.add(histodir + "/MC/Photon/hPosTPCNSigmaEl", "hPosTPCNSigmaEl", kTH1D, {axisTPCNSigma});
-        histos.add(histodir + "/MC/Photon/hNegTPCNSigmaEl", "hNegTPCNSigmaEl", kTH1D, {axisTPCNSigma});        
-        histos.add(histodir + "/MC/Photon/h2dPAVsPt", "h2dPAVsPt", kTH2D, {axisPA, axisPt});
-        histos.add(histodir + "/MC/Photon/hPt_BadCollAssig", "hPt_BadCollAssig", kTH1D, {axisPt});
-        histos.add(histodir + "/MC/Photon/h2dPAVsPt_BadCollAssig", "h2dPAVsPt_BadCollAssig", kTH2D, {axisPA, axisPt});
-
-        histos.add(histodir + "/MC/Lambda/hV0ToCollAssoc", "hV0ToCollAssoc", kTH1D, {{2, 0.0f, 2.0f}});
-        histos.add(histodir + "/MC/Lambda/hPt", "hPt", kTH1D, {axisPt});
-        histos.add(histodir + "/MC/Lambda/hMCPt", "hMCPt", kTH1D, {axisPt});
-        histos.add(histodir + "/MC/Lambda/h3dTPCvsTOFNSigma_Pr", "h3dTPCvsTOFNSigma_Pr", kTH3D, {axisTPCNSigma, axisTOFNSigma, axisPt});
-        histos.add(histodir + "/MC/Lambda/h3dTPCvsTOFNSigma_Pi", "h3dTPCvsTOFNSigma_Pi", kTH3D, {axisTPCNSigma, axisTOFNSigma, axisPt});
-
-        histos.add(histodir + "/MC/ALambda/hV0ToCollAssoc", "hV0ToCollAssoc", kTH1D, {{2, 0.0f, 2.0f}});
-        histos.add(histodir + "/MC/ALambda/hPt", "hPt", kTH1D, {axisPt});
-        histos.add(histodir + "/MC/ALambda/hMCPt", "hMCPt", kTH1D, {axisPt});
-        histos.add(histodir + "/MC/ALambda/h3dTPCvsTOFNSigma_Pr", "h3dTPCvsTOFNSigma_Pr", kTH3D, {axisTPCNSigma, axisTOFNSigma, axisPt});
-        histos.add(histodir + "/MC/ALambda/h3dTPCvsTOFNSigma_Pi", "h3dTPCvsTOFNSigma_Pi", kTH3D, {axisTPCNSigma, axisTOFNSigma, axisPt});
-
-        histos.add(histodir + "/MC/h2dArmenteros", "h2dArmenteros", kTH2D, {axisAPAlpha, axisAPQt});
-
-        histos.add(histodir + "/MC/Sigma0/hPt", "hPt", kTH1D, {axisPt});
-        histos.add(histodir + "/MC/Sigma0/hMCPt", "hMCPt", kTH1D, {axisPt});        
-        histos.add(histodir + "/MC/Sigma0/hMass", "hMass", kTH1D, {axisSigmaMass});
-        histos.add(histodir + "/MC/Sigma0/hMCProcess", "hMCProcess", kTH1D, {{50, -0.5f, 49.5f}});
-        histos.add(histodir + "/MC/Sigma0/hGenRadius", "hGenRadius", kTH1D, {axisV0PairRadius});
-        histos.add(histodir + "/MC/Sigma0/h2dMCPtVsLambdaMCPt", "h2dMCPtVsLambdaMCPt", kTH2D, {axisPt, axisPt});
-        histos.add(histodir + "/MC/Sigma0/h2dMCPtVsPhotonMCPt", "h2dMCPtVsPhotonMCPt", kTH2D, {axisPt, axisPt});
-        histos.add(histodir + "/MC/Sigma0/h2dMCProcessVsGenRadius", "h2dMCProcessVsGenRadius", kTH2D, {{50, -0.5f, 49.5f}, axisV0PairRadius});
-        histos.add(histodir + "/MC/Sigma0/h3dMass", "h3dMass", kTH3D, {axisCentrality, axisPt, axisSigmaMass});                
-        histos.add(histodir + "/MC/Sigma0/h3dMCProcess", "h3dMCProcess", kTH3D, {{50, -0.5f, 49.5f}, axisPt, axisSigmaMass});
-
-        histos.add(histodir + "/MC/ASigma0/hPt", "hPt", kTH1D, {axisPt});
-        histos.add(histodir + "/MC/ASigma0/hMCPt", "hMCPt", kTH1D, {axisPt});        
-        histos.add(histodir + "/MC/ASigma0/hMass", "hMass", kTH1D, {axisSigmaMass});
-        histos.add(histodir + "/MC/ASigma0/hMCProcess", "hMCProcess", kTH1D, {{50, -0.5f, 49.5f}});
-        histos.add(histodir + "/MC/ASigma0/hGenRadius", "hGenRadius", kTH1D, {axisV0PairRadius});
-        histos.add(histodir + "/MC/ASigma0/h2dMCPtVsLambdaMCPt", "h2dMCPtVsLambdaMCPt", kTH2D, {axisPt, axisPt});
-        histos.add(histodir + "/MC/ASigma0/h2dMCPtVsPhotonMCPt", "h2dMCPtVsPhotonMCPt", kTH2D, {axisPt, axisPt});
-        histos.add(histodir + "/MC/ASigma0/h2dMCProcessVsGenRadius", "h2dMCProcessVsGenRadius", kTH2D, {{50, -0.5f, 49.5f}, axisV0PairRadius});
-        histos.add(histodir + "/MC/ASigma0/h3dMass", "h3dMass", kTH3D, {axisCentrality, axisPt, axisSigmaMass});                
-        histos.add(histodir + "/MC/ASigma0/h3dMCProcess", "h3dMCProcess", kTH3D, {{50, -0.5f, 49.5f}, axisPt, axisSigmaMass});
+        histos.add(histodir + "/Photon/hTrackCode", "hTrackCode", kTH1D, {{11, 0.5f, 11.5f}});
+        histos.add(histodir + "/Photon/hV0Type", "hV0Type", kTH1D, {{8, 0.5f, 8.5f}});      
+        histos.add(histodir + "/Photon/hDCANegToPV", "hDCANegToPV", kTH1D, {axisDCAtoPV});
+        histos.add(histodir + "/Photon/hDCAPosToPV", "hDCAPosToPV", kTH1D, {axisDCAtoPV});
+        histos.add(histodir + "/Photon/hDCADau", "hDCADau", kTH1D, {axisDCAdau});
+        histos.add(histodir + "/Photon/hPosTPCCR", "hPosTPCCR", kTH1D, {axisTPCrows});
+        histos.add(histodir + "/Photon/hNegTPCCR", "hNegTPCCR", kTH1D, {axisTPCrows});      
+        histos.add(histodir + "/Photon/hPosTPCNSigmaEl", "hPosTPCNSigmaEl", kTH1D, {axisTPCNSigma});
+        histos.add(histodir + "/Photon/hNegTPCNSigmaEl", "hNegTPCNSigmaEl", kTH1D, {axisTPCNSigma});
         
-        // 1/pT Resolution:
-        if (fillResoQAhistos && histodir == "BeforeSel") {
-          histos.add(histodir + "/MC/Reso/h3dGammaPtResoVsTPCCR", "h3dGammaPtResoVsTPCCR", kTH3D, {axisInvPt, axisDeltaPt, axisTPCrows});
-          histos.add(histodir + "/MC/Reso/h3dGammaPtResoVsTPCCR", "h3dGammaPtResoVsTPCCR", kTH3D, {axisInvPt, axisDeltaPt, axisTPCrows});
-          histos.add(histodir + "/MC/Reso/h2dGammaPtResolution", "h2dGammaPtResolution", kTH2D, {axisInvPt, axisDeltaPt});
-          histos.add(histodir + "/MC/Reso/h2dLambdaPtResolution", "h2dLambdaPtResolution", kTH2D, {axisInvPt, axisDeltaPt});
-          histos.add(histodir + "/MC/Reso/h3dLambdaPtResoVsTPCCR", "h3dLambdaPtResoVsTPCCR", kTH3D, {axisInvPt, axisDeltaPt, axisTPCrows});
-          histos.add(histodir + "/MC/Reso/h3dLambdaPtResoVsTPCCR", "h3dLambdaPtResoVsTPCCR", kTH3D, {axisInvPt, axisDeltaPt, axisTPCrows});
-          histos.add(histodir + "/MC/Reso/h2dAntiLambdaPtResolution", "h2dAntiLambdaPtResolution", kTH2D, {axisInvPt, axisDeltaPt});
-          histos.add(histodir + "/MC/Reso/h3dAntiLambdaPtResoVsTPCCR", "h3dAntiLambdaPtResoVsTPCCR", kTH3D, {axisInvPt, axisDeltaPt, axisTPCrows});
-          histos.add(histodir + "/MC/Reso/h3dAntiLambdaPtResoVsTPCCR", "h3dAntiLambdaPtResoVsTPCCR", kTH3D, {axisInvPt, axisDeltaPt, axisTPCrows});
-          histos.add(histodir + "/MC/Reso/h2dSigma0PtResolution", "h2dSigma0PtResolution", kTH2D, {axisInvPt, axisDeltaPt});
-          histos.add(histodir + "/MC/Reso/h2dAntiSigma0PtResolution", "h2dAntiSigma0PtResolution", kTH2D, {axisInvPt, axisDeltaPt});
-          histos.add(histodir + "/MC/Reso/h2dSigma0RadiusResolution", "h2dSigma0RadiusResolution", kTH2D, {axisPt, axisDeltaPt});
-          histos.add(histodir + "/MC/Reso/h2dASigma0RadiusResolution", "h2dASigma0RadiusResolution", kTH2D, {axisPt, axisDeltaPt});          
-        }
+        histos.add(histodir + "/Photon/hpT", "hpT", kTH1D, {axisPt});
+        histos.add(histodir + "/Photon/hY", "hY", kTH1D, {axisRapidity});
+        histos.add(histodir + "/Photon/hPosEta", "hPosEta", kTH1D, {axisRapidity});
+        histos.add(histodir + "/Photon/hNegEta", "hNegEta", kTH1D, {axisRapidity});
+        histos.add(histodir + "/Photon/hRadius", "hRadius", kTH1D, {axisV0Radius});
+        histos.add(histodir + "/Photon/hZ", "hZ", kTH1D, {axisZ});
+        histos.add(histodir + "/Photon/h2dRZCut", "h2dRZCut", kTH2D, {axisZ, axisV0Radius});
+        histos.add(histodir + "/Photon/h2dRZPlane", "h2dRZPlane", kTH2D, {axisZ, axisV0Radius});
+        histos.add(histodir + "/Photon/hCosPA", "hCosPA", kTH1D, {axisCosPA});
+        histos.add(histodir + "/Photon/hPsiPair", "hPsiPair", kTH1D, {axisPsiPair});
+        histos.add(histodir + "/Photon/hPhi", "hPhi", kTH1D, {axisPhi});
+        histos.add(histodir + "/Photon/h3dMass", "h3dMass", kTH3D, {axisCentrality, axisPt, axisPhotonMass});
+        histos.add(histodir + "/Photon/hMass", "hMass", kTH1D, {axisPhotonMass});
 
-        // For background decomposition study
-        if (fillBkgQAhistos) {
-          histos.add(histodir + "/MC/BkgStudy/h2dPtVsMassSigma_All", "h2dPtVsMassSigma_All", kTH2D, {axisPt, axisSigmaMass});
-          histos.add(histodir + "/MC/BkgStudy/h2dPtVsMassSigma_TrueDaughters", "h2dPtVsMassSigma_TrueDaughters", kTH2D, {axisPt, axisSigmaMass});
-          histos.add(histodir + "/MC/BkgStudy/h2dTrueDaughtersMatrix", "h2dTrueDaughtersMatrix", kTHnSparseD, {{10001, -5000.5f, +5000.5f}, {10001, -5000.5f, +5000.5f}});
-          histos.add(histodir + "/MC/BkgStudy/h2dPtVsMassSigma_TrueGammaFakeLambda", "h2dPtVsMassSigma_TrueGammaFakeLambda", kTH2D, {axisPt, axisSigmaMass});
-          histos.add(histodir + "/MC/BkgStudy/h2dPtVsMassSigma_FakeGammaTrueLambda", "h2dPtVsMassSigma_FakeGammaTrueLambda", kTH2D, {axisPt, axisSigmaMass});
-          histos.add(histodir + "/MC/BkgStudy/h2dPtVsMassSigma_FakeDaughters", "h2dPtVsMassSigma_FakeDaughters", kTH2D, {axisPt, axisSigmaMass});
+        histos.add(histodir + "/Lambda/hTrackCode", "hTrackCode", kTH1D, {{11, 0.5f, 11.5f}});
+        histos.add(histodir + "/Lambda/hRadius", "hRadius", kTH1D, {axisV0Radius});
+        histos.add(histodir + "/Lambda/hDCADau", "hDCADau", kTH1D, {axisDCAdau});
+        histos.add(histodir + "/Lambda/hCosPA", "hCosPA", kTH1D, {axisCosPA});
+        histos.add(histodir + "/Lambda/hY", "hY", kTH1D, {axisRapidity});
+        histos.add(histodir + "/Lambda/hPosEta", "hPosEta", kTH1D, {axisRapidity});
+        histos.add(histodir + "/Lambda/hNegEta", "hNegEta", kTH1D, {axisRapidity});
+        histos.add(histodir + "/Lambda/hPosTPCCR", "hPosTPCCR", kTH1D, {axisTPCrows});
+        histos.add(histodir + "/Lambda/hNegTPCCR", "hNegTPCCR", kTH1D, {axisTPCrows});
+        histos.add(histodir + "/Lambda/hPosITSCls", "hPosITSCls", kTH1D, {axisNCls});
+        histos.add(histodir + "/Lambda/hNegITSCls", "hNegITSCls", kTH1D, {axisNCls});
+        histos.add(histodir + "/Lambda/hPosChi2PerNc", "hPosChi2PerNc", kTH1D, {axisChi2PerNcl});
+        histos.add(histodir + "/Lambda/hNegChi2PerNc", "hNegChi2PerNc", kTH1D, {axisChi2PerNcl});
+        histos.add(histodir + "/Lambda/hLifeTime", "hLifeTime", kTH1D, {axisLifetime});
+        histos.add(histodir + "/Lambda/h2dTPCvsTOFNSigma_LambdaPr", "h2dTPCvsTOFNSigma_LambdaPr", kTH2D, {axisTPCNSigma, axisTOFNSigma});
+        histos.add(histodir + "/Lambda/h2dTPCvsTOFNSigma_LambdaPi", "h2dTPCvsTOFNSigma_LambdaPi", kTH2D, {axisTPCNSigma, axisTOFNSigma});
+        histos.add(histodir + "/Lambda/hLambdaDCANegToPV", "hLambdaDCANegToPV", kTH1D, {axisDCAtoPV});
+        histos.add(histodir + "/Lambda/hLambdaDCAPosToPV", "hLambdaDCAPosToPV", kTH1D, {axisDCAtoPV});
+        histos.add(histodir + "/Lambda/hLambdapT", "hLambdapT", kTH1D, {axisPt});
+        histos.add(histodir + "/Lambda/hLambdaMass", "hLambdaMass", kTH1D, {axisLambdaMass});
+        histos.add(histodir + "/Lambda/h3dLambdaMass", "h3dLambdaMass", kTH3D, {axisCentrality, axisPt, axisLambdaMass});
+        histos.add(histodir + "/Lambda/h2dTPCvsTOFNSigma_ALambdaPr", "h2dTPCvsTOFNSigma_ALambdaPr", kTH2D, {axisTPCNSigma, axisTOFNSigma});
+        histos.add(histodir + "/Lambda/h2dTPCvsTOFNSigma_ALambdaPi", "h2dTPCvsTOFNSigma_ALambdaPi", kTH2D, {axisTPCNSigma, axisTOFNSigma});
+        histos.add(histodir + "/Lambda/hALambdaDCANegToPV", "hALambdaDCANegToPV", kTH1D, {axisDCAtoPV});
+        histos.add(histodir + "/Lambda/hALambdaDCAPosToPV", "hALambdaDCAPosToPV", kTH1D, {axisDCAtoPV});
+        histos.add(histodir + "/Lambda/hALambdapT", "hALambdapT", kTH1D, {axisPt});
+        histos.add(histodir + "/Lambda/hAntiLambdaMass", "hAntiLambdaMass", kTH1D, {axisLambdaMass});
+        histos.add(histodir + "/Lambda/h3dAntiLambdaMass", "h3dAntiLambdaMass", kTH3D, {axisCentrality, axisPt, axisLambdaMass});
+
+        histos.add(histodir + "/h2dArmenteros", "h2dArmenteros", kTH2D, {axisAPAlpha, axisAPQt});
+
+        histos.add(histodir + "/Sigma0/hMass", "hMass", kTH1D, {axisSigmaMass});
+        histos.add(histodir + "/Sigma0/hPt", "hPt", kTH1D, {axisPt});
+        histos.add(histodir + "/Sigma0/hY", "hY", kTH1D, {axisRapidity});
+        histos.add(histodir + "/Sigma0/hRadius", "hRadius", kTH1D, {axisV0PairRadius});
+        histos.add(histodir + "/Sigma0/h2dRadiusVspT", "h2dRadiusVspT", kTH2D, {axisV0PairRadius, axisPt});
+        histos.add(histodir + "/Sigma0/hDCAPairDau", "hDCAPairDau", kTH1D, {axisDCAdau});      
+        histos.add(histodir + "/Sigma0/h3dMass", "h3dMass", kTH3D, {axisCentrality, axisPt, axisSigmaMass});      
+        histos.add(histodir + "/Sigma0/h3dOPAngleVsMass", "h3dOPAngleVsMass", kTH3D, {{140, 0.0f, +7.0f}, axisPt, axisSigmaMass});
+        
+        histos.add(histodir + "/ASigma0/hMass", "hMass", kTH1D, {axisSigmaMass});
+        histos.add(histodir + "/ASigma0/hPt", "hPt", kTH1D, {axisPt});
+        histos.add(histodir + "/ASigma0/hY", "hY", kTH1D, {axisRapidity});      
+        histos.add(histodir + "/ASigma0/hRadius", "hRadius", kTH1D, {axisV0PairRadius});
+        histos.add(histodir + "/ASigma0/h2dRadiusVspT", "h2dRadiusVspT", kTH2D, {axisV0PairRadius, axisPt});
+        histos.add(histodir + "/ASigma0/hDCAPairDau", "hDCAPairDau", kTH1D, {axisDCAdau});      
+        histos.add(histodir + "/ASigma0/h3dMass", "h3dMass", kTH3D, {axisCentrality, axisPt, axisSigmaMass});      
+        histos.add(histodir + "/ASigma0/h3dOPAngleVsMass", "h3dOPAngleVsMass", kTH3D, {{140, 0.0f, +7.0f}, axisPt, axisSigmaMass});
+        
+
+        // Process MC
+        if (doprocessMonteCarlo) {
+          histos.add(histodir + "/MC/Photon/hV0ToCollAssoc", "hV0ToCollAssoc", kTH1D, {{2, 0.0f, 2.0f}});
+          histos.add(histodir + "/MC/Photon/hPt", "hPt", kTH1D, {axisPt});
+          histos.add(histodir + "/MC/Photon/hMCPt", "hMCPt", kTH1D, {axisPt});        
+          histos.add(histodir + "/MC/Photon/hPosTPCNSigmaEl", "hPosTPCNSigmaEl", kTH1D, {axisTPCNSigma});
+          histos.add(histodir + "/MC/Photon/hNegTPCNSigmaEl", "hNegTPCNSigmaEl", kTH1D, {axisTPCNSigma});        
+          histos.add(histodir + "/MC/Photon/h2dPAVsPt", "h2dPAVsPt", kTH2D, {axisPA, axisPt});
+          histos.add(histodir + "/MC/Photon/hPt_BadCollAssig", "hPt_BadCollAssig", kTH1D, {axisPt});
+          histos.add(histodir + "/MC/Photon/h2dPAVsPt_BadCollAssig", "h2dPAVsPt_BadCollAssig", kTH2D, {axisPA, axisPt});
+
+          histos.add(histodir + "/MC/Lambda/hV0ToCollAssoc", "hV0ToCollAssoc", kTH1D, {{2, 0.0f, 2.0f}});
+          histos.add(histodir + "/MC/Lambda/hPt", "hPt", kTH1D, {axisPt});
+          histos.add(histodir + "/MC/Lambda/hMCPt", "hMCPt", kTH1D, {axisPt});
+          histos.add(histodir + "/MC/Lambda/h3dTPCvsTOFNSigma_Pr", "h3dTPCvsTOFNSigma_Pr", kTH3D, {axisTPCNSigma, axisTOFNSigma, axisPt});
+          histos.add(histodir + "/MC/Lambda/h3dTPCvsTOFNSigma_Pi", "h3dTPCvsTOFNSigma_Pi", kTH3D, {axisTPCNSigma, axisTOFNSigma, axisPt});
+
+          histos.add(histodir + "/MC/ALambda/hV0ToCollAssoc", "hV0ToCollAssoc", kTH1D, {{2, 0.0f, 2.0f}});
+          histos.add(histodir + "/MC/ALambda/hPt", "hPt", kTH1D, {axisPt});
+          histos.add(histodir + "/MC/ALambda/hMCPt", "hMCPt", kTH1D, {axisPt});
+          histos.add(histodir + "/MC/ALambda/h3dTPCvsTOFNSigma_Pr", "h3dTPCvsTOFNSigma_Pr", kTH3D, {axisTPCNSigma, axisTOFNSigma, axisPt});
+          histos.add(histodir + "/MC/ALambda/h3dTPCvsTOFNSigma_Pi", "h3dTPCvsTOFNSigma_Pi", kTH3D, {axisTPCNSigma, axisTOFNSigma, axisPt});
+
+          histos.add(histodir + "/MC/h2dArmenteros", "h2dArmenteros", kTH2D, {axisAPAlpha, axisAPQt});
+
+          histos.add(histodir + "/MC/Sigma0/hPt", "hPt", kTH1D, {axisPt});
+          histos.add(histodir + "/MC/Sigma0/hMCPt", "hMCPt", kTH1D, {axisPt});        
+          histos.add(histodir + "/MC/Sigma0/hMass", "hMass", kTH1D, {axisSigmaMass});
+          histos.add(histodir + "/MC/Sigma0/hMCProcess", "hMCProcess", kTH1D, {{50, -0.5f, 49.5f}});
+          histos.add(histodir + "/MC/Sigma0/hGenRadius", "hGenRadius", kTH1D, {axisV0PairRadius});
+          histos.add(histodir + "/MC/Sigma0/h2dMCPtVsLambdaMCPt", "h2dMCPtVsLambdaMCPt", kTH2D, {axisPt, axisPt});
+          histos.add(histodir + "/MC/Sigma0/h2dMCPtVsPhotonMCPt", "h2dMCPtVsPhotonMCPt", kTH2D, {axisPt, axisPt});
+          histos.add(histodir + "/MC/Sigma0/h2dMCProcessVsGenRadius", "h2dMCProcessVsGenRadius", kTH2D, {{50, -0.5f, 49.5f}, axisV0PairRadius});
+          histos.add(histodir + "/MC/Sigma0/h3dMass", "h3dMass", kTH3D, {axisCentrality, axisPt, axisSigmaMass});                
+          histos.add(histodir + "/MC/Sigma0/h3dMCProcess", "h3dMCProcess", kTH3D, {{50, -0.5f, 49.5f}, axisPt, axisSigmaMass});
+
+          histos.add(histodir + "/MC/ASigma0/hPt", "hPt", kTH1D, {axisPt});
+          histos.add(histodir + "/MC/ASigma0/hMCPt", "hMCPt", kTH1D, {axisPt});        
+          histos.add(histodir + "/MC/ASigma0/hMass", "hMass", kTH1D, {axisSigmaMass});
+          histos.add(histodir + "/MC/ASigma0/hMCProcess", "hMCProcess", kTH1D, {{50, -0.5f, 49.5f}});
+          histos.add(histodir + "/MC/ASigma0/hGenRadius", "hGenRadius", kTH1D, {axisV0PairRadius});
+          histos.add(histodir + "/MC/ASigma0/h2dMCPtVsLambdaMCPt", "h2dMCPtVsLambdaMCPt", kTH2D, {axisPt, axisPt});
+          histos.add(histodir + "/MC/ASigma0/h2dMCPtVsPhotonMCPt", "h2dMCPtVsPhotonMCPt", kTH2D, {axisPt, axisPt});
+          histos.add(histodir + "/MC/ASigma0/h2dMCProcessVsGenRadius", "h2dMCProcessVsGenRadius", kTH2D, {{50, -0.5f, 49.5f}, axisV0PairRadius});
+          histos.add(histodir + "/MC/ASigma0/h3dMass", "h3dMass", kTH3D, {axisCentrality, axisPt, axisSigmaMass});                
+          histos.add(histodir + "/MC/ASigma0/h3dMCProcess", "h3dMCProcess", kTH3D, {{50, -0.5f, 49.5f}, axisPt, axisSigmaMass});
+          
+          // 1/pT Resolution:
+          if (fillResoQAhistos && histodir == "BeforeSel") {
+            histos.add(histodir + "/MC/Reso/h3dGammaPtResoVsTPCCR", "h3dGammaPtResoVsTPCCR", kTH3D, {axisInvPt, axisDeltaPt, axisTPCrows});
+            histos.add(histodir + "/MC/Reso/h3dGammaPtResoVsTPCCR", "h3dGammaPtResoVsTPCCR", kTH3D, {axisInvPt, axisDeltaPt, axisTPCrows});
+            histos.add(histodir + "/MC/Reso/h2dGammaPtResolution", "h2dGammaPtResolution", kTH2D, {axisInvPt, axisDeltaPt});
+            histos.add(histodir + "/MC/Reso/h2dLambdaPtResolution", "h2dLambdaPtResolution", kTH2D, {axisInvPt, axisDeltaPt});
+            histos.add(histodir + "/MC/Reso/h3dLambdaPtResoVsTPCCR", "h3dLambdaPtResoVsTPCCR", kTH3D, {axisInvPt, axisDeltaPt, axisTPCrows});
+            histos.add(histodir + "/MC/Reso/h3dLambdaPtResoVsTPCCR", "h3dLambdaPtResoVsTPCCR", kTH3D, {axisInvPt, axisDeltaPt, axisTPCrows});
+            histos.add(histodir + "/MC/Reso/h2dAntiLambdaPtResolution", "h2dAntiLambdaPtResolution", kTH2D, {axisInvPt, axisDeltaPt});
+            histos.add(histodir + "/MC/Reso/h3dAntiLambdaPtResoVsTPCCR", "h3dAntiLambdaPtResoVsTPCCR", kTH3D, {axisInvPt, axisDeltaPt, axisTPCrows});
+            histos.add(histodir + "/MC/Reso/h3dAntiLambdaPtResoVsTPCCR", "h3dAntiLambdaPtResoVsTPCCR", kTH3D, {axisInvPt, axisDeltaPt, axisTPCrows});
+            histos.add(histodir + "/MC/Reso/h2dSigma0PtResolution", "h2dSigma0PtResolution", kTH2D, {axisInvPt, axisDeltaPt});
+            histos.add(histodir + "/MC/Reso/h2dAntiSigma0PtResolution", "h2dAntiSigma0PtResolution", kTH2D, {axisInvPt, axisDeltaPt});
+            histos.add(histodir + "/MC/Reso/h2dSigma0RadiusResolution", "h2dSigma0RadiusResolution", kTH2D, {axisPt, axisDeltaPt});
+            histos.add(histodir + "/MC/Reso/h2dASigma0RadiusResolution", "h2dASigma0RadiusResolution", kTH2D, {axisPt, axisDeltaPt});          
+          }
+
+          // For background decomposition study
+          if (fillBkgQAhistos) {
+            histos.add(histodir + "/MC/BkgStudy/h2dPtVsMassSigma_All", "h2dPtVsMassSigma_All", kTH2D, {axisPt, axisSigmaMass});
+            histos.add(histodir + "/MC/BkgStudy/h2dPtVsMassSigma_TrueDaughters", "h2dPtVsMassSigma_TrueDaughters", kTH2D, {axisPt, axisSigmaMass});
+            histos.add(histodir + "/MC/BkgStudy/h2dTrueDaughtersMatrix", "h2dTrueDaughtersMatrix", kTHnSparseD, {{10001, -5000.5f, +5000.5f}, {10001, -5000.5f, +5000.5f}});
+            histos.add(histodir + "/MC/BkgStudy/h2dPtVsMassSigma_TrueGammaFakeLambda", "h2dPtVsMassSigma_TrueGammaFakeLambda", kTH2D, {axisPt, axisSigmaMass});
+            histos.add(histodir + "/MC/BkgStudy/h2dPtVsMassSigma_FakeGammaTrueLambda", "h2dPtVsMassSigma_FakeGammaTrueLambda", kTH2D, {axisPt, axisSigmaMass});
+            histos.add(histodir + "/MC/BkgStudy/h2dPtVsMassSigma_FakeDaughters", "h2dPtVsMassSigma_FakeDaughters", kTH2D, {axisPt, axisSigmaMass});
+          }
         }
       }
-    }
 
-    // Selections
-    histos.add("Selection/Photon/hCandidateSel", "hCandidateSel", kTH1D, {axisCandSel});
-    histos.add("Selection/Lambda/hCandidateSel", "hCandidateSel", kTH1D, {axisCandSel});
+      // Selections
+      histos.add("Selection/Photon/hCandidateSel", "hCandidateSel", kTH1D, {axisCandSel});
+      histos.add("Selection/Lambda/hCandidateSel", "hCandidateSel", kTH1D, {axisCandSel});
 
-    // For background decomposition study
-    if (fillBkgQAhistos && doprocessMonteCarlo) {
-      histos.add("BkgStudy/h2dPtVsMassSigma_All", "h2dPtVsMassSigma_All", kTH2D, {axisPt, axisSigmaMass});
-      histos.add("BkgStudy/h2dPtVsMassSigma_TrueDaughters", "h2dPtVsMassSigma_TrueDaughters", kTH2D, {axisPt, axisSigmaMass});
-      histos.add("BkgStudy/h2dPtVsMassSigma_TrueGammaFakeLambda", "h2dPtVsMassSigma_TrueGammaFakeLambda", kTH2D, {axisPt, axisSigmaMass});
-      histos.add("BkgStudy/h2dPtVsMassSigma_FakeGammaTrueLambda", "h2dPtVsMassSigma_FakeGammaTrueLambda", kTH2D, {axisPt, axisSigmaMass});
-      histos.add("BkgStudy/h2dPtVsMassSigma_FakeDaughters", "h2dPtVsMassSigma_FakeDaughters", kTH2D, {axisPt, axisSigmaMass});
-      histos.add("BkgStudy/h2dTrueDaughtersMatrix", "h2dTrueDaughtersMatrix", kTHnSparseD, {{10001, -5000.5f, +5000.5f}, {10001, -5000.5f, +5000.5f}});
-      histos.add("BkgStudy/h2dTrueGammaFakeLambdaMatrix", "h2dTrueGammaFakeLambdaMatrix", kTHnSparseD, {{10001, -5000.5f, +5000.5f}, {10001, -5000.5f, +5000.5f}});
-      histos.add("BkgStudy/h2dFakeGammaTrueLambdaMatrix", "h2dFakeGammaTrueLambdaMatrix", kTHnSparseD, {{10001, -5000.5f, +5000.5f}, {10001, -5000.5f, +5000.5f}});
-      histos.add("BkgStudy/h2dFakeDaughtersMatrix", "h2dFakeDaughtersMatrix", kTHnSparseD, {{10001, -5000.5f, +5000.5f}, {10001, -5000.5f, +5000.5f}});
-    }
+      // For background decomposition study
+      if (fillBkgQAhistos && doprocessMonteCarlo) {
+        histos.add("BkgStudy/h2dPtVsMassSigma_All", "h2dPtVsMassSigma_All", kTH2D, {axisPt, axisSigmaMass});
+        histos.add("BkgStudy/h2dPtVsMassSigma_TrueDaughters", "h2dPtVsMassSigma_TrueDaughters", kTH2D, {axisPt, axisSigmaMass});
+        histos.add("BkgStudy/h2dPtVsMassSigma_TrueGammaFakeLambda", "h2dPtVsMassSigma_TrueGammaFakeLambda", kTH2D, {axisPt, axisSigmaMass});
+        histos.add("BkgStudy/h2dPtVsMassSigma_FakeGammaTrueLambda", "h2dPtVsMassSigma_FakeGammaTrueLambda", kTH2D, {axisPt, axisSigmaMass});
+        histos.add("BkgStudy/h2dPtVsMassSigma_FakeDaughters", "h2dPtVsMassSigma_FakeDaughters", kTH2D, {axisPt, axisSigmaMass});
+        histos.add("BkgStudy/h2dTrueDaughtersMatrix", "h2dTrueDaughtersMatrix", kTHnSparseD, {{10001, -5000.5f, +5000.5f}, {10001, -5000.5f, +5000.5f}});
+        histos.add("BkgStudy/h2dTrueGammaFakeLambdaMatrix", "h2dTrueGammaFakeLambdaMatrix", kTHnSparseD, {{10001, -5000.5f, +5000.5f}, {10001, -5000.5f, +5000.5f}});
+        histos.add("BkgStudy/h2dFakeGammaTrueLambdaMatrix", "h2dFakeGammaTrueLambdaMatrix", kTHnSparseD, {{10001, -5000.5f, +5000.5f}, {10001, -5000.5f, +5000.5f}});
+        histos.add("BkgStudy/h2dFakeDaughtersMatrix", "h2dFakeDaughtersMatrix", kTHnSparseD, {{10001, -5000.5f, +5000.5f}, {10001, -5000.5f, +5000.5f}});
+      }
 
-    for (size_t i = 0; i < PhotonSels.size(); ++i) {
-      const auto& sel = PhotonSels[i];
+      for (size_t i = 0; i < PhotonSels.size(); ++i) {
+        const auto& sel = PhotonSels[i];
 
-      histos.add(Form("Selection/Photon/h2d%s", sel.c_str()), ("h2d" + sel).c_str(), kTH2D, {axisPt, axisPhotonMass});
-      histos.get<TH1>(HIST("Selection/Photon/hCandidateSel"))->GetXaxis()->SetBinLabel(i + 1, sel.c_str());
-      histos.add(Form("Selection/Sigma0/h2dPhoton%s", sel.c_str()), ("h2dPhoton" + sel).c_str(), kTH2D, {axisPt, axisSigmaMass});
-    }
+        histos.add(Form("Selection/Photon/h2d%s", sel.c_str()), ("h2d" + sel).c_str(), kTH2D, {axisPt, axisPhotonMass});
+        histos.get<TH1>(HIST("Selection/Photon/hCandidateSel"))->GetXaxis()->SetBinLabel(i + 1, sel.c_str());
+        histos.add(Form("Selection/Sigma0/h2dPhoton%s", sel.c_str()), ("h2dPhoton" + sel).c_str(), kTH2D, {axisPt, axisSigmaMass});
+      }
 
-    for (size_t i = 0; i < LambdaSels.size(); ++i) {
-      const auto& sel = LambdaSels[i];
+      for (size_t i = 0; i < LambdaSels.size(); ++i) {
+        const auto& sel = LambdaSels[i];
 
-      histos.add(Form("Selection/Lambda/h2d%s", sel.c_str()), ("h2d" + sel).c_str(), kTH2D, {axisPt, axisLambdaMass});
-      histos.get<TH1>(HIST("Selection/Lambda/hCandidateSel"))->GetXaxis()->SetBinLabel(i + 1, sel.c_str());
-      histos.add(Form("Selection/Sigma0/h2dLambda%s", sel.c_str()), ("h2dLambda" + sel).c_str(), kTH2D, {axisPt, axisSigmaMass});
+        histos.add(Form("Selection/Lambda/h2d%s", sel.c_str()), ("h2d" + sel).c_str(), kTH2D, {axisPt, axisLambdaMass});
+        histos.get<TH1>(HIST("Selection/Lambda/hCandidateSel"))->GetXaxis()->SetBinLabel(i + 1, sel.c_str());
+        histos.add(Form("Selection/Sigma0/h2dLambda%s", sel.c_str()), ("h2dLambda" + sel).c_str(), kTH2D, {axisPt, axisSigmaMass});
+      }
     }
 
     if (doprocessPi0RealData || doprocessPi0MonteCarlo) {
@@ -1349,19 +1358,19 @@ struct sigmaanalysis {
 
     // Sigma0 specific selections    
     // Rapidity 
-    if (TMath::Abs(cand.sigma0Y()) > Sigma0MaxRap)
+    if (TMath::Abs(cand.sigma0Y()) > sigma0Selections.Sigma0MaxRap)
       return false;
 
     // V0Pair Radius
-    if (cand.radius() > Sigma0MaxRadius)
+    if (cand.radius() > sigma0Selections.Sigma0MaxRadius)
       return false;
 
     // DCA V0Pair Daughters 
-    if (cand.dcadaughters() > Sigma0MaxDCADau)
+    if (cand.dcadaughters() > sigma0Selections.Sigma0MaxDCADau)
       return false;
 
     // Opening Angle
-    if (cand.opAngle() > Sigma0MaxOPAngle)
+    if (cand.opAngle() > sigma0Selections.Sigma0MaxOPAngle)
       return false;
      
     return true;
@@ -1473,9 +1482,18 @@ struct sigmaanalysis {
     if ((TMath::Abs(cand.photon1Mass()) > photonSelections.PhotonMaxMass) || (TMath::Abs(cand.photon2Mass()) > photonSelections.PhotonMaxMass))
       return false;
 
-    if (TMath::Abs(cand.pi0Y()) > Pi0MaxRap)
+    // Pi0 specific selections
+    if (TMath::Abs(cand.pi0Y()) > pi0Selections.Pi0MaxRap)
       return false;
-    
+
+    // V0Pair Radius
+    if (cand.radius() > pi0Selections.Pi0MaxRadius)
+      return false;
+
+    // DCA V0Pair Daughters 
+    if (cand.dcadaughters() > pi0Selections.Pi0MaxDCADau)
+      return false;
+  
     return true;
   }
 

--- a/PWGLF/Tasks/Strangeness/sigmaanalysis.cxx
+++ b/PWGLF/Tasks/Strangeness/sigmaanalysis.cxx
@@ -486,30 +486,31 @@ struct sigmaanalysis {
       histos.add("Gen/hCentralityVsPVzMC", "hCentralityVsPVzMC", kTH2F, {{101, 0.0f, 101.0f}, {100, -20.0f, +20.0f}});
     
       // Sigma0 specific
-      histos.add("Gen/h2dGenSigma0", "h2dGenSigma0", kTH2D, {axisCentrality, axisPt});
-      histos.add("Gen/h2dGenAntiSigma0", "h2dGenAntiSigma0", kTH2D, {axisCentrality, axisPt});      
-      histos.add("Gen/h2dGenSigma0VsMultMC_RecoedEvt", "h2dGenSigma0VsMultMC_RecoedEvt", kTH2D, {axisNch, axisPt});
-      histos.add("Gen/h2dGenAntiSigma0VsMultMC_RecoedEvt", "h2dGenAntiSigma0VsMultMC_RecoedEvt", kTH2D, {axisNch, axisPt});
-      histos.add("Gen/h2dGenSigma0VsMultMC", "h2dGenSigma0VsMultMC", kTH2D, {axisNch, axisPt});
-      histos.add("Gen/h2dGenAntiSigma0VsMultMC", "h2dGenAntiSigma0VsMultMC", kTH2D, {axisNch, axisPt});      
+      if (doprocessGeneratedRun3){
+        histos.add("Gen/h2dGenSigma0", "h2dGenSigma0", kTH2D, {axisCentrality, axisPt});
+        histos.add("Gen/h2dGenAntiSigma0", "h2dGenAntiSigma0", kTH2D, {axisCentrality, axisPt});      
+        histos.add("Gen/h2dGenSigma0VsMultMC_RecoedEvt", "h2dGenSigma0VsMultMC_RecoedEvt", kTH2D, {axisNch, axisPt});
+        histos.add("Gen/h2dGenAntiSigma0VsMultMC_RecoedEvt", "h2dGenAntiSigma0VsMultMC_RecoedEvt", kTH2D, {axisNch, axisPt});
+        histos.add("Gen/h2dGenSigma0VsMultMC", "h2dGenSigma0VsMultMC", kTH2D, {axisNch, axisPt});
+        histos.add("Gen/h2dGenAntiSigma0VsMultMC", "h2dGenAntiSigma0VsMultMC", kTH2D, {axisNch, axisPt});      
 
-      auto hGenSigma0Type = histos.add<TH1>("Gen/hGenSigma0Type", "hGenSigma0Type", kTH1D, {{4, -0.5f, 3.5f}});
-      hGenSigma0Type->GetXaxis()->SetBinLabel(1, "All Sigma0s");
-      hGenSigma0Type->GetXaxis()->SetBinLabel(2, "Sterile");
-      hGenSigma0Type->GetXaxis()->SetBinLabel(3, "Lambda+Gamma");
-      hGenSigma0Type->GetXaxis()->SetBinLabel(4, "Others");
+        auto hGenSigma0Type = histos.add<TH1>("Gen/hGenSigma0Type", "hGenSigma0Type", kTH1D, {{4, -0.5f, 3.5f}});
+        hGenSigma0Type->GetXaxis()->SetBinLabel(1, "All Sigma0s");
+        hGenSigma0Type->GetXaxis()->SetBinLabel(2, "Sterile");
+        hGenSigma0Type->GetXaxis()->SetBinLabel(3, "Lambda+Gamma");
+        hGenSigma0Type->GetXaxis()->SetBinLabel(4, "Others");
 
-      auto h2DGenSigma0Type = histos.add<TH2>("Gen/h2DGenSigma0Type", "h2DGenSigma0Type", kTH2D, {{4, -0.5f, 3.5f}, axisGeneratorIds});
-      h2DGenSigma0Type->GetXaxis()->SetBinLabel(1, "All Sigma0s");
-      h2DGenSigma0Type->GetXaxis()->SetBinLabel(2, "Sterile");
-      h2DGenSigma0Type->GetXaxis()->SetBinLabel(3, "Lambda+Gamma");
-      h2DGenSigma0Type->GetXaxis()->SetBinLabel(4, "Others");
-
-      // Pi0 specific
-      histos.add("Gen/h2dGenPi0VsMultMC_RecoedEvt", "h2dGenPi0VsMultMC_RecoedEvt", kTH2D, {axisNch, axisPt});
-      histos.add("Gen/h2dGenPi0", "h2dGenPi0", kTH2D, {axisCentrality, axisPt});
-      histos.add("Gen/h2dGenPi0VsMultMC", "h2dGenPi0VsMultMC", kTH2D, {axisNch, axisPt});
-      
+        auto h2DGenSigma0Type = histos.add<TH2>("Gen/h2DGenSigma0Type", "h2DGenSigma0Type", kTH2D, {{4, -0.5f, 3.5f}, axisGeneratorIds});
+        h2DGenSigma0Type->GetXaxis()->SetBinLabel(1, "All Sigma0s");
+        h2DGenSigma0Type->GetXaxis()->SetBinLabel(2, "Sterile");
+        h2DGenSigma0Type->GetXaxis()->SetBinLabel(3, "Lambda+Gamma");
+        h2DGenSigma0Type->GetXaxis()->SetBinLabel(4, "Others");
+      }
+      else{ // Pi0 specific        
+        histos.add("Gen/h2dGenPi0VsMultMC_RecoedEvt", "h2dGenPi0VsMultMC_RecoedEvt", kTH2D, {axisNch, axisPt});
+        histos.add("Gen/h2dGenPi0", "h2dGenPi0", kTH2D, {axisCentrality, axisPt});
+        histos.add("Gen/h2dGenPi0VsMultMC", "h2dGenPi0VsMultMC", kTH2D, {axisNch, axisPt});        
+      }      
     }
   }
 


### PR DESCRIPTION

**This PR introduces several important updates to the `sigma0builder` and `sigmaanalysis` tasks:**

* **Refactoring & modularization:**

  * Further modularizes `sigma0builder` and centralizes the data processing into a single template function.
  * TOF PID tables are now optional → making the `lambdakzeropid` task optional as well, reducing memory usage.

* **New features in `sigma0builder`:**

  * Added a module to calculate topological properties of V0 pairs.
  * Introduced a dedicated table for generated Sigma0 candidates, with the option to restrict entries to generator-only candidates (analogous to the `IsPhysicalPrimary` selection).
  * Optionally produces three main tables (`Pi0Cores`, `Pi0MCCores`, `Pi0Gen`) for Pi0 analysis, supporting photon QA and strangeness-related studies.

* **Table updates & optimizations:**

  * Updated `Sigma0Cores`, `Sigma0MCCores`, `Sigma0PhotonExtras`, and `Sigma0LambdaExtras` tables: unused variables removed, dynamic columns introduced → reduces disk usage for derived data and improves flexibility.
  * All Sigma0 and Pi0 tables are now linked to `stracollision` and `stramccollision` tables.

* **Changes in `sigmaanalysis`:**

  * Now subscribes directly to `stracollision` and `stramccollision`.
  * Event selection module moved from `sigma0builder` to `sigmaanalysis`, improving flexibility and enabling signal loss, event loss, and event splitting studies.
  * Dedicated process functions added for Pi0 analysis, making efficiency estimation possible.

* **Selections & QA:**

  * Added new topological selections for Sigma0 candidates.
  * Added QA modules for generated Sigma0s and Pi0s.
  * Added a QA histogram for the photon deduplication procedure in the `strangenessbuilder`.

