### PR TITLE
[Common] Set orbitsPerTF to 8 for MC production LHC25f3

### DIFF
--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -289,6 +289,8 @@ struct BcSelectionTask {
         bcSOR = runInfo.orbitSOR * nBCsPerOrbit;
         // duration of TF in bcs
         nBCsPerTF = confNumberOfOrbitsPerTF < 0 ? runInfo.orbitsPerTF * nBCsPerOrbit : confNumberOfOrbitsPerTF * nBCsPerOrbit;
+        if (strLPMProductionTag == "LHC25f3") // temporary workaround for MC production LHC25f3 anchored to Pb-Pb 2023 apass5 (to be removed once the info is in ccdb)
+          nBCsPerTF = 8 * nBCsPerOrbit;
       }
 
       // timestamp of the middle of the run used to access run-wise CCDB entries

--- a/Common/Tools/EventSelectionTools.h
+++ b/Common/Tools/EventSelectionTools.h
@@ -220,6 +220,8 @@ class BcSelectionModule
         bcSOR = runInfo.orbitSOR * nBCsPerOrbit;
         // duration of TF in bcs
         nBCsPerTF = bcselOpts.confNumberOfOrbitsPerTF < 0 ? runInfo.orbitsPerTF * nBCsPerOrbit : bcselOpts.confNumberOfOrbitsPerTF * nBCsPerOrbit;
+        if (strLPMProductionTag == "LHC25f3") // temporary workaround for MC production LHC25f3 anchored to Pb-Pb 2023 apass5 (to be removed once the info is in ccdb)
+          nBCsPerTF = 8 * nBCsPerOrbit;
       }
 
       // timestamp of the middle of the run used to access run-wise CCDB entries


### PR DESCRIPTION
Number of orbitsPerTF is set to 8 "by hand" for the MC production LHC25f3 anchored to Pb-Pb 2023 apass5 (to be removed once the info for this production is in ccdb).
This productions seems to be using an old software which is the reason why the entry is missing.