### PR TITLE
Add check for reducedMCTrack for muon triplets in dilepton-track task

### DIFF
--- a/PWGDQ/Tasks/dqEfficiency_withAssoc.cxx
+++ b/PWGDQ/Tasks/dqEfficiency_withAssoc.cxx
@@ -3788,6 +3788,9 @@ struct AnalysisDileptonTrack {
           VarManager::FillDileptonHadron(dilepton, track, fValuesHadron);
           VarManager::FillDileptonTrackVertexing<TCandidateType, TEventFillMap, TTrackFillMap>(event, lepton1, lepton2, track, fValuesHadron);
 
+          if (!track.has_reducedMCTrack()) {
+            continue;
+          }
           auto trackMC = track.reducedMCTrack();
           mcDecision = 0;
           isig = 0;


### PR DESCRIPTION
In the rare case when a reco track has no corresponding MC track, the dilepton-track tasks fails with `Accessing invalid index for reducedMCTrack`. This has only been observed for muon triplets, and this PR adds a check for the corresponding MC track