### PR TITLE
[PWGHF] Remove redundant D0 ML selection in D* selector

### DIFF
--- a/PWGHF/Core/HfMlResponseDstarToD0Pi.h
+++ b/PWGHF/Core/HfMlResponseDstarToD0Pi.h
@@ -221,28 +221,6 @@ class HfMlResponseDstarToD0Pi : public HfMlResponse<TypeOutputScore>
     return inputFeatures;
   }
 
-  /// Method to get the input features used for D0 in HF triggers
-  /// \param candidate is the D* candidate
-  /// \return inputFeatures vector
-  template <typename T1>
-  std::vector<float> getInputFeaturesTrigger(T1 const& candidate)
-  {
-    std::vector<float> inputFeatures;
-
-    for (const auto& idx : MlResponse<TypeOutputScore>::mCachedIndices) {
-      switch (idx) {
-        CHECK_AND_FILL_VEC_DSTAR(ptProng0);
-        CHECK_AND_FILL_VEC_DSTAR_GETTER(impactParameterXY0, impactParameter0);
-        CHECK_AND_FILL_VEC_DSTAR(impactParameterZ0);
-        CHECK_AND_FILL_VEC_DSTAR(ptProng1);
-        CHECK_AND_FILL_VEC_DSTAR_GETTER(impactParameterXY1, impactParameter1);
-        CHECK_AND_FILL_VEC_DSTAR(impactParameterZ1);
-      }
-    }
-
-    return inputFeatures;
-  }
-
  protected:
   /// Method to fill the map of available input features
   void setAvailableInputFeatures()

--- a/PWGHF/DataModel/CandidateReconstructionTables.h
+++ b/PWGHF/DataModel/CandidateReconstructionTables.h
@@ -982,8 +982,6 @@ enum DecayType { DplusToPiKPi = 0,
                  XicToPKPi,
                  N3ProngDecays }; // always keep N3ProngDecays at the end
 
-static constexpr int DstarToPiKPiBkg = DecayType::N3ProngDecays;
-
 // Ds± → K± K∓ π± or D± → K± K∓ π±
 
 enum DecayChannelDToKKPi {

--- a/PWGHF/TableProducer/candidateSelectorDstarToD0Pi.cxx
+++ b/PWGHF/TableProducer/candidateSelectorDstarToD0Pi.cxx
@@ -97,8 +97,6 @@ struct HfCandidateSelectorDstarToD0Pi {
   Configurable<LabeledArray<double>> cutsMl{"cutsMl", {hf_cuts_ml::Cuts[0], hf_cuts_ml::NBinsPt, hf_cuts_ml::NCutScores, hf_cuts_ml::labelsPt, hf_cuts_ml::labelsCutScore}, "ML selections per pT bin"};
   Configurable<int> nClassesMl{"nClassesMl", static_cast<int>(hf_cuts_ml::NCutScores), "Number of classes in ML model"};
   Configurable<std::vector<std::string>> namesInputFeatures{"namesInputFeatures", std::vector<std::string>{"feature1", "feature2"}, "Names of ML model input features"};
-  // ML inference D0
-  Configurable<bool> applyMlD0Daug{"applyMlD0Daug", false, "Flag to apply ML selections on D0 daughter"};
 
   // CCDB configuration
   Configurable<std::string> ccdbUrl{"ccdbUrl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
@@ -149,14 +147,14 @@ struct HfCandidateSelectorDstarToD0Pi {
         registry.get<TH2>(HIST("QA/hSelections"))->GetXaxis()->SetBinLabel(iBin + 1, labels[iBin].data());
       }
 
-      if (applyMl || applyMlD0Daug) {
+      if (applyMl) {
         registry.add("QA/hBdtScore1VsStatus", ";BDT score", {HistType::kTH1F, {axisBdtScore}});
         registry.add("QA/hBdtScore2VsStatus", ";BDT score", {HistType::kTH1F, {axisBdtScore}});
         registry.add("QA/hBdtScore3VsStatus", ";BDT score", {HistType::kTH1F, {axisBdtScore}});
       }
     }
 
-    if (applyMl || applyMlD0Daug) {
+    if (applyMl) {
       hfMlResponse.configure(binsPtMl, cutsMl, cutDirMl, nClassesMl);
       if (loadModelsFromCCDB) {
         ccdbApi.init(ccdbUrl);
@@ -368,7 +366,7 @@ struct HfCandidateSelectorDstarToD0Pi {
 
       if (!TESTBIT(candDstar.hfflag(), aod::hf_cand_2prong::DecayType::D0ToPiK)) {
         hfSelDstarCandidate(statusDstar, statusD0Flag, statusTopol, statusCand, statusPID);
-        if (applyMl || applyMlD0Daug) {
+        if (applyMl) {
           hfMlDstarCandidate(outputMlDstarToD0Pi);
         }
         if (activateQA) {
@@ -384,7 +382,7 @@ struct HfCandidateSelectorDstarToD0Pi {
 
       if (!selectionDstar(candDstar)) {
         hfSelDstarCandidate(statusDstar, statusD0Flag, statusTopol, statusCand, statusPID);
-        if (applyMl || applyMlD0Daug) {
+        if (applyMl) {
           hfMlDstarCandidate(outputMlDstarToD0Pi);
         }
         continue;
@@ -397,7 +395,7 @@ struct HfCandidateSelectorDstarToD0Pi {
       bool topoDstar = selectionTopolConjugate(candDstar);
       if (!topoDstar) {
         hfSelDstarCandidate(statusDstar, statusD0Flag, statusTopol, statusCand, statusPID);
-        if (applyMl || applyMlD0Daug) {
+        if (applyMl) {
           hfMlDstarCandidate(outputMlDstarToD0Pi);
         }
         continue;
@@ -445,7 +443,7 @@ struct HfCandidateSelectorDstarToD0Pi {
 
       if (pidDstar == 0) {
         hfSelDstarCandidate(statusDstar, statusD0Flag, statusTopol, statusCand, statusPID);
-        if (applyMl || applyMlD0Daug) {
+        if (applyMl) {
           hfMlDstarCandidate(outputMlDstarToD0Pi);
         }
         continue;
@@ -460,16 +458,10 @@ struct HfCandidateSelectorDstarToD0Pi {
       }
       statusPID = true;
 
-      if (applyMl || applyMlD0Daug) {
+      if (applyMl) {
         // ML selections
         bool isSelectedMlDstar = false;
-
-        std::vector<float> inputFeatures{};
-        if (applyMlD0Daug) {
-          inputFeatures = hfMlResponse.getInputFeaturesTrigger(candDstar);
-        } else {
-          inputFeatures = hfMlResponse.getInputFeatures(candDstar);
-        }
+        std::vector<float> inputFeatures = hfMlResponse.getInputFeatures(candDstar);
         isSelectedMlDstar = hfMlResponse.isSelectedMl(inputFeatures, ptCand, outputMlDstarToD0Pi);
 
         hfMlDstarCandidate(outputMlDstarToD0Pi);


### PR DESCRIPTION
Several configurables introduced in #12176 are not needed when processing triggered data as the BDT selections on the D0 are not pt-differential at trigger level.