### PR TITLE
[Common] move from retrieveBlob to getFromtimeStamp for TrackTuner inputs

### DIFF
--- a/Common/Tools/TrackTuner.h
+++ b/Common/Tools/TrackTuner.h
@@ -447,11 +447,6 @@ struct TrackTuner : o2::framework::ConfigurableGroup {
     return outputString;
   }
 
-  std::string getFullNameInputPath()
-  {
-    return pathInputFile + std::string("/") + nameInputFile;
-  }
-
   void getDcaGraphs()
   {
     std::string fullNameInputFile = pathInputFile + std::string("/") + nameInputFile;

--- a/Common/Tools/TrackTuner.h
+++ b/Common/Tools/TrackTuner.h
@@ -105,7 +105,6 @@ struct TrackTuner : o2::framework::ConfigurableGroup {
   bool isConfigFromConfigurables = false;
   int nPhiBins = 1;
 
-  o2::ccdb::CcdbApi ccdbApi;
   std::map<std::string, std::string> metadata;
 
   std::vector<std::unique_ptr<TGraphErrors>> grDcaXYResVsPtPionMC;
@@ -465,11 +464,6 @@ struct TrackTuner : o2::framework::ConfigurableGroup {
 
     if (isInputFileFromCCDB) {
       /// use input correction file from CCDB
-
-      // properly init the ccdb
-      std::string tmpDir = ".";
-      ccdbApi.init("http://alice-ccdb.cern.ch");
-      LOG(info) << "[TrackTuner] CCDB Api OK!";
 
       // get the TList from the DCA correction file present in CCDB
       ccdb_object_dca = o2::ccdb::BasicCCDBManager::instance().get<TList>(pathInputFile);


### PR DESCRIPTION
This development should prevent conflicts in calibration file download/reading in case of multi-thread execution (`pipeline` option)