### PR TITLE
[PWGHF] OmegaC task, rework output structure + add info for vs mult. analysis

### DIFF
--- a/PWGHF/D2H/Tasks/taskOmegac0ToOmegapi.cxx
+++ b/PWGHF/D2H/Tasks/taskOmegac0ToOmegapi.cxx
@@ -113,8 +113,8 @@ struct HfTaskOmegac0ToOmegapi {
 
   void init(InitContext&)
   {
-    std::array<bool, 8> doprocess{doprocessDataWithKFParticle, doprocessDataWithKFParticleMl, doprocessDataWithKFParticleFT0C, doprocessDataWithKFParticleMlFT0C,
-                                  doprocessDataWithKFParticleFT0M, doprocessDataWithKFParticleMlFT0M, doprocessMcWithKFParticle, doprocessMcWithKFParticleMl};
+    std::array<bool, 8> doprocess{doprocessDataKFParticle, doprocessDataKFParticleMl, doprocessDataKFParticleFT0C, doprocessDataKFParticleMlFT0C,
+                                  doprocessDataKFParticleFT0M, doprocessDataKFParticleMlFT0M, doprocessMcKFParticle, doprocessMcKFParticleMl};
     if ((std::accumulate(doprocess.begin(), doprocess.end(), 0)) != 1) {
       LOGP(fatal, "One and only one process function should be enabled at a time.");
     }
@@ -133,12 +133,12 @@ struct HfTaskOmegac0ToOmegapi {
 
     std::vector<AxisSpec> axes = {thnAxisMass, thnAxisPt, thnAxisY};
 
-    if (doprocessDataWithKFParticleFT0C || doprocessDataWithKFParticleMlFT0C || doprocessDataWithKFParticleFT0M || doprocessDataWithKFParticleMlFT0M) {
+    if (doprocessDataKFParticleFT0C || doprocessDataKFParticleMlFT0C || doprocessDataKFParticleFT0M || doprocessDataKFParticleMlFT0M) {
       axes.push_back(thnAxisCent);
       axes.push_back(thnConfigAxisNumPvContr);
     }
 
-    if (doprocessMcWithKFParticle || doprocessMcWithKFParticleMl) {
+    if (doprocessMcKFParticle || doprocessMcKFParticleMl) {
       std::vector<AxisSpec> axesMcGen = {thnAxisGenPtD, thnAxisGenPtB, thnAxisY, thnAxisOrigin, thnAxisNumPvContr};
       registry.add("hMcGen", "Thn for generated #Omega_{c}^{0} from charm and beauty", HistType::kTHnSparseD, axesMcGen);
       registry.get<THnSparse>(HIST("hMcGen"))->Sumw2();
@@ -148,7 +148,7 @@ struct HfTaskOmegac0ToOmegapi {
       axes.push_back(thnAxisMatchFlag);
     }
 
-    if (doprocessDataWithKFParticleMl || doprocessDataWithKFParticleMlFT0C || doprocessDataWithKFParticleMlFT0M || doprocessMcWithKFParticleMl) {
+    if (doprocessDataKFParticleMl || doprocessDataKFParticleMlFT0C || doprocessDataKFParticleMlFT0M || doprocessMcKFParticleMl) {
       axes.push_back(thnAxisPromptScore);
     }
 
@@ -256,59 +256,59 @@ struct HfTaskOmegac0ToOmegapi {
     }
   }
 
-  void processDataWithKFParticle(Omegac0CandsKF const& candidates)
+  void processDataKFParticle(Omegac0CandsKF const& candidates)
   {
     processData<false>(candidates);
   }
-  PROCESS_SWITCH(HfTaskOmegac0ToOmegapi, processDataWithKFParticle, "process HfTaskOmegac0ToOmegapi with KFParticle", false);
+  PROCESS_SWITCH(HfTaskOmegac0ToOmegapi, processDataKFParticle, "process HfTaskOmegac0ToOmegapi with KFParticle", false);
 
-  void processDataWithKFParticleMl(Omegac0CandsMlKF const& candidates)
+  void processDataKFParticleMl(Omegac0CandsMlKF const& candidates)
   {
     processData<true>(candidates);
   }
-  PROCESS_SWITCH(HfTaskOmegac0ToOmegapi, processDataWithKFParticleMl, "process HfTaskOmegac0ToOmegapi with KFParticle and ML selections", false);
+  PROCESS_SWITCH(HfTaskOmegac0ToOmegapi, processDataKFParticleMl, "process HfTaskOmegac0ToOmegapi with KFParticle and ML selections", false);
 
-  void processDataWithKFParticleFT0C(Omegac0CandsKF const& candidates,
-                                     CollisionsWithFT0C const& collisions)
+  void processDataKFParticleFT0C(Omegac0CandsKF const& candidates,
+                                 CollisionsWithFT0C const& collisions)
   {
     processDataCent<false>(candidates, collisions);
   }
-  PROCESS_SWITCH(HfTaskOmegac0ToOmegapi, processDataWithKFParticleFT0C, "process HfTaskOmegac0ToOmegapi with KFParticle and with FT0C centrality", false);
+  PROCESS_SWITCH(HfTaskOmegac0ToOmegapi, processDataKFParticleFT0C, "process HfTaskOmegac0ToOmegapi with KFParticle and with FT0C centrality", false);
 
-  void processDataWithKFParticleMlFT0C(Omegac0CandsMlKF const& candidates,
-                                       CollisionsWithFT0C const& collisions)
+  void processDataKFParticleMlFT0C(Omegac0CandsMlKF const& candidates,
+                                   CollisionsWithFT0C const& collisions)
   {
     processDataCent<true>(candidates, collisions);
   }
-  PROCESS_SWITCH(HfTaskOmegac0ToOmegapi, processDataWithKFParticleMlFT0C, "process HfTaskOmegac0ToOmegapi with KFParticle and ML selections and with FT0C centrality", false);
+  PROCESS_SWITCH(HfTaskOmegac0ToOmegapi, processDataKFParticleMlFT0C, "process HfTaskOmegac0ToOmegapi with KFParticle and ML selections and with FT0C centrality", false);
 
-  void processDataWithKFParticleFT0M(Omegac0CandsKF const& candidates,
-                                     CollisionsWithFT0M const& collisions)
+  void processDataKFParticleFT0M(Omegac0CandsKF const& candidates,
+                                 CollisionsWithFT0M const& collisions)
   {
     processDataCent<false>(candidates, collisions);
   }
-  PROCESS_SWITCH(HfTaskOmegac0ToOmegapi, processDataWithKFParticleFT0M, "process HfTaskOmegac0ToOmegapi with KFParticle and with FT0M centrality", false);
+  PROCESS_SWITCH(HfTaskOmegac0ToOmegapi, processDataKFParticleFT0M, "process HfTaskOmegac0ToOmegapi with KFParticle and with FT0M centrality", false);
 
-  void processDataWithKFParticleMlFT0M(Omegac0CandsMlKF const& candidates,
-                                       CollisionsWithFT0M const& collisions)
+  void processDataKFParticleMlFT0M(Omegac0CandsMlKF const& candidates,
+                                   CollisionsWithFT0M const& collisions)
   {
     processDataCent<true>(candidates, collisions);
   }
-  PROCESS_SWITCH(HfTaskOmegac0ToOmegapi, processDataWithKFParticleMlFT0M, "process HfTaskOmegac0ToOmegapi with KFParticle and ML selections and with FT0M centrality", false);
+  PROCESS_SWITCH(HfTaskOmegac0ToOmegapi, processDataKFParticleMlFT0M, "process HfTaskOmegac0ToOmegapi with KFParticle and ML selections and with FT0M centrality", false);
 
-  void processMcWithKFParticle(OmegaC0CandsMcKF const& omegaC0CandidatesMcKF,
-                               Omegac0Gen const& mcParticles)
+  void processMcKFParticle(OmegaC0CandsMcKF const& omegaC0CandidatesMcKF,
+                           Omegac0Gen const& mcParticles)
   {
     processMc<false>(omegaC0CandidatesMcKF, mcParticles);
   }
-  PROCESS_SWITCH(HfTaskOmegac0ToOmegapi, processMcWithKFParticle, "Process MC with KFParticle", false);
+  PROCESS_SWITCH(HfTaskOmegac0ToOmegapi, processMcKFParticle, "Process MC with KFParticle", false);
 
-  void processMcWithKFParticleMl(Omegac0CandsMlMcKF const& omegac0CandidatesMlMcKF,
-                                 Omegac0Gen const& mcParticles)
+  void processMcKFParticleMl(Omegac0CandsMlMcKF const& omegac0CandidatesMlMcKF,
+                             Omegac0Gen const& mcParticles)
   {
     processMc<true>(omegac0CandidatesMlMcKF, mcParticles);
   }
-  PROCESS_SWITCH(HfTaskOmegac0ToOmegapi, processMcWithKFParticleMl, "Process MC with KFParticle and ML selections", false);
+  PROCESS_SWITCH(HfTaskOmegac0ToOmegapi, processMcKFParticleMl, "Process MC with KFParticle and ML selections", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGHF/D2H/Tasks/taskOmegac0ToOmegapi.cxx
+++ b/PWGHF/D2H/Tasks/taskOmegac0ToOmegapi.cxx
@@ -103,15 +103,13 @@ struct HfTaskOmegac0ToOmegapi {
 
   ConfigurableAxis thnConfigAxisPromptScore{"thnConfigAxisPromptScore", {100, 0, 1}, "Prompt score"};
   ConfigurableAxis thnConfigAxisMass{"thnConfigAxisMass", {700, 2.4, 3.1}, "Cand. inv. mass"};
-  ConfigurableAxis thnConfigAxisPtB{"thnConfigAxisPtB", {500, 0, 50}, "Cand. beauty mother pT"};
   ConfigurableAxis thnConfigAxisPt{"thnConfigAxisPt", {500, 0, 50}, "Cand. pT"};
+  ConfigurableAxis thnConfigAxisPtB{"thnConfigAxisPtB", {500, 0, 50}, "Cand. beauty mother pT"};
   ConfigurableAxis thnConfigAxisY{"thnConfigAxisY", {20, -1, 1}, "Cand. rapidity"};
   ConfigurableAxis thnConfigAxisCent{"thnConfigAxisCent", {100, 0, 100}, "Centrality"};
   ConfigurableAxis thnConfigAxisOrigin{"thnConfigAxisOrigin", {3, -0.5, 2.5}, "Cand. origin"};
   ConfigurableAxis thnConfigAxisMatchFlag{"thnConfigAxisMatchFlag", {15, -7.5, 7.5}, "Cand. MC match flag"};
-  ConfigurableAxis thnConfigAxisGenPtD{"thnConfigAxisGenPtD", {500, 0, 50}, "Gen pT"};
-  ConfigurableAxis thnConfigAxisGenPtB{"thnConfigAxisGenPtB", {500, 0, 50}, "Gen beauty mother pT"};
-  ConfigurableAxis thnConfigAxisNumPvContr{"thnConfigAxisNumPvContr", {200, -0.5, 199.5}, "Number of PV contributors"};
+  ConfigurableAxis thnConfigAxisNumPvContr{"thnConfigAxisNumPvContr", {200, -0.5, 199.5}, "PV contributors"};
   HistogramRegistry registry{"registry", {}};
 
   void init(InitContext&)
@@ -129,14 +127,12 @@ struct HfTaskOmegac0ToOmegapi {
     const AxisSpec thnAxisY{thnConfigAxisY, "y"};
     const AxisSpec thnAxisOrigin{thnConfigAxisOrigin, "Origin"};
     const AxisSpec thnAxisMatchFlag{thnConfigAxisMatchFlag, "MC match flag"};
-    const AxisSpec thnAxisGenPtD{thnConfigAxisGenPtD, "#it{p}_{T} (GeV/#it{c})"};
-    const AxisSpec thnAxisGenPtB{thnConfigAxisGenPtB, "#it{p}_{T}^{B} (GeV/#it{c})"};
-    const AxisSpec thnAxisNumPvContr{thnConfigAxisNumPvContr, "Number of PV contributors"};
+    const AxisSpec thnAxisNumPvContr{thnConfigAxisNumPvContr, "PV contributors"};
     const AxisSpec thnAxisPromptScore{thnConfigAxisPromptScore, "BDT score prompt"};
     const AxisSpec thnAxisCent{thnConfigAxisCent, "Centrality"};
 
     std::vector<AxisSpec> axes = {thnAxisMass, thnAxisPt, thnAxisY};
-    std::vector<AxisSpec> axesMcGen = {thnAxisGenPtD, thnAxisGenPtB, thnAxisY, thnAxisOrigin};
+    std::vector<AxisSpec> axesMcGen = {thnAxisPt, thnAxisPtB, thnAxisY, thnAxisOrigin};
 
     if (doprocessDataKFParticleFT0C || doprocessDataKFParticleMlFT0C || doprocessDataKFParticleFT0M || doprocessDataKFParticleMlFT0M || doprocessMcKFParticleFT0M || doprocessMcKFParticleMlFT0M) {
       axes.push_back(thnAxisCent);
@@ -151,6 +147,7 @@ struct HfTaskOmegac0ToOmegapi {
 
       if (doprocessMcKFParticleFT0M || doprocessMcKFParticleMlFT0M) {
         registry.add("hMcGenWithRecoColl", "Gen. #Omega_{c}^{0} from charm and beauty (associated to a reco collision)", HistType::kTHnSparseD, axesMcGen);
+        registry.add("hNumRecoCollPerMcColl", "Number of reco collisions associated to a mc collision;Num. reco. coll. per Mc coll.;", {HistType::kTH1D, {{10, -1.5, 8.5}}});
         registry.get<THnSparse>(HIST("hMcGenWithRecoColl"))->Sumw2();
       }
 
@@ -316,6 +313,8 @@ struct HfTaskOmegac0ToOmegapi {
         float ptGenB = mcParticles.rawIteratorAt(particle.idxBhadMotherPart()).pt();
         registry.fill(HIST("hMcGen"), ptGen, ptGenB, yGen, RecoDecay::OriginType::NonPrompt, mcCent, maxNumContrib);
       }
+
+      registry.fill(HIST("hNumRecoCollPerMcColl"), recoCollsPerMcColl.size());
 
       // fill sparse only for gen particles associated to a reconstructed collision
       if (recoCollsPerMcColl.size() >= 1) {

--- a/PWGHF/D2H/Tasks/taskOmegac0ToOmegapi.cxx
+++ b/PWGHF/D2H/Tasks/taskOmegac0ToOmegapi.cxx
@@ -113,18 +113,10 @@ struct HfTaskOmegac0ToOmegapi {
 
   void init(InitContext&)
   {
-    std::array<bool, 6> doprocess{doprocessDataWithKFParticle, doprocessDataWithKFParticleMl, doprocessDataWithKFParticleFT0C, doprocessDataWithKFParticleMlFT0C, doprocessDataWithKFParticleFT0M, doprocessDataWithKFParticleMlFT0M};
-    if (std::accumulate(doprocess.begin(), doprocess.end(), 0) > 1) {
-      LOGP(fatal, "At most one data process function should be enabled at a time.");
-    }
-
-    std::array<bool, 2> doprocessMc{doprocessMcWithKFParticle, doprocessMcWithKFParticleMl};
-    if (std::accumulate(doprocessMc.begin(), doprocessMc.end(), 0) > 1) {
-      LOGP(fatal, "At most one MC process function should be enabled at a time.");
-    }
-
-    if ((std::accumulate(doprocess.begin(), doprocess.end(), 0) + std::accumulate(doprocessMc.begin(), doprocessMc.end(), 0)) == 0) {
-      LOGP(fatal, "At least one process function should be enabled.");
+    std::array<bool, 8> doprocess{doprocessDataWithKFParticle, doprocessDataWithKFParticleMl, doprocessDataWithKFParticleFT0C, doprocessDataWithKFParticleMlFT0C,
+                                  doprocessDataWithKFParticleFT0M, doprocessDataWithKFParticleMlFT0M, doprocessMcWithKFParticle, doprocessMcWithKFParticleMl};
+    if ((std::accumulate(doprocess.begin(), doprocess.end(), 0)) != 1) {
+      LOGP(fatal, "One and only one process function should be enabled at a time.");
     }
 
     const AxisSpec thnAxisMass{thnConfigAxisMass, "inv. mass (#Omega#pi) (GeV/#it{c}^{2})"};
@@ -244,10 +236,10 @@ struct HfTaskOmegac0ToOmegapi {
       auto numPvContributors = candidate.template collision_as<CollType>().numContrib();
 
       if constexpr (applyMl) {
-        registry.fill(HIST("hReco"), candidate.invMassCharmBaryon(), candidate.ptCharmBaryon(), candidate.kfRapOmegac(), candidate.ptBhadMotherPart(), candidate.originMcRec(), candidate.flagMcMatchRec(), numPvContributors);
+        registry.fill(HIST("hReco"), candidate.invMassCharmBaryon(), candidate.ptCharmBaryon(), candidate.kfRapOmegac(), candidate.ptBhadMotherPart(), candidate.originMcRec(), candidate.flagMcMatchRec(), numPvContributors, candidate.mlProbOmegac()[0]);
 
       } else {
-        registry.fill(HIST("hReco"), candidate.invMassCharmBaryon(), candidate.ptCharmBaryon(), candidate.kfRapOmegac(), candidate.ptBhadMotherPart(), candidate.originMcRec(), candidate.flagMcMatchRec(), numPvContributors, candidate.mlProbOmegac()[0]);
+        registry.fill(HIST("hReco"), candidate.invMassCharmBaryon(), candidate.ptCharmBaryon(), candidate.kfRapOmegac(), candidate.ptBhadMotherPart(), candidate.originMcRec(), candidate.flagMcMatchRec(), numPvContributors);
       }
     }
 

--- a/PWGHF/D2H/Tasks/taskOmegac0ToOmegapi.cxx
+++ b/PWGHF/D2H/Tasks/taskOmegac0ToOmegapi.cxx
@@ -75,8 +75,6 @@ struct HfTaskOmegac0ToOmegapi {
   HfHelper hfHelper;
   SliceCache cache;
 
-  // using TracksMc = soa::Join<aod::Tracks, aod::TracksIU, aod::McTrackLabels>;
-
   using Omegac0Cands = soa::Filtered<soa::Join<aod::HfCandToOmegaPi, aod::HfSelToOmegaPi>>;
   using Omegac0CandsKF = soa::Filtered<soa::Join<aod::HfCandToOmegaPi, aod::HfSelToOmegaPi, aod::HfOmegacKf>>;
   using OmegaC0CandsMcKF = soa::Filtered<soa::Join<aod::HfCandToOmegaPi, aod::HfSelToOmegaPi, aod::HfOmegacKf, aod::HfToOmegaPiMCRec>>;


### PR DESCRIPTION
@Yunfan-Liu @mtorresc15 Please have a look, since this likely impact your offline macros.
I re-worked the output of the task, now when running on data only a ThnSparse called `hReco` is produced, while running on MC you will get also one with the generated information `hMcGen` (and `hMcGenWithRecoColl` in case one runs with the centrality information on). The axes of the sparses depend on the process function selected (more axes are added when running with centrality). 
