### PR TITLE
[FIT] Add output histos to FT0 QA task (AFIT-8)

### DIFF
--- a/Common/DataModel/FT0Corrected.h
+++ b/Common/DataModel/FT0Corrected.h
@@ -25,7 +25,7 @@ DECLARE_SOA_DYNAMIC_COLUMN(T0ACorrectedValid, t0ACorrectedValid, //! Was T0ACorr
                            [](float t0) -> bool { return t0 < 1e9; });
 DECLARE_SOA_DYNAMIC_COLUMN(T0CCorrectedValid, t0CCorrectedValid, //! Was T0CCorrected computable?
                            [](float t0) -> bool { return t0 < 1e9; });
-DECLARE_SOA_DYNAMIC_COLUMN(T0resolution, t0resolution, //! Was T0CCorrected computable?
+DECLARE_SOA_DYNAMIC_COLUMN(T0resolution, t0resolution, //! (T0ACorrected - T0CCorrected) / 2. FT0 time resoluition = std. dev. of this quantity's distribution. On event level, handle negative values as needed.
                            [](float t0A, float t0C) -> float { return 0.5f * (t0A - t0C); });
 DECLARE_SOA_DYNAMIC_COLUMN(T0ACValid, t0ACValid, //! Was T0AC computable?
                            [](float t0a, float t0c) -> bool { return (t0a < 1e9) && (t0c < 1e9); });

--- a/Common/Tasks/ft0Qa.cxx
+++ b/Common/Tasks/ft0Qa.cxx
@@ -78,6 +78,10 @@ struct ft0QaTask {
     histos.add("hT0AC", "T0AC;T0AC time (ns);counts", kTH1F, {axisTime});
     histos.add("hT0res", "FT0 resolution", kTH1F, {axisColTimeRes});
     histos.add("hColTime", "", kTH1F, {axisTime});
+    histos.add("hT0res_nContrib", "FT0 resolution vs. Ncontributors", kTH2F,
+               {axisColTimeRes, axisNcontrib});
+    histos.add("hT0res_MultT0AC", "FT0 resolution vs. T0AC multiplicity", kTH2F,
+               {axisColTimeRes, axisMultT0AC});
 
     // FT0 vertex
     histos.add("hT0vertex", "FT0 vertex;FT0 vertex (cm);counts", kTH1F,
@@ -103,6 +107,11 @@ struct ft0QaTask {
     histos.add("hPV_nContrib",
                "PV vs. Ncontributers;primary vertex (cm);(# contrubutors)",
                kTH2F, {axisVertex, axisNcontrib});
+    histos.add("hT0vertexDiff_vs_nContrib", "FT0V - PV vs. Ncontributors;FT0 vertex -  PV (cm);# contrubutors",
+               kTH2F, {axisVertex, axisNcontrib});
+    histos.add("hT0vertexDiff_vs_MultT0AC",
+               "FT0V - PV vs. T0AC multiplicity;FT0 vertex -  PV (cm);T0AC multiplicity (# ADC channels)",
+               kTH2F, {axisVertex, axisMultT0AC});
 
     // FT0 amplitude and multiplicity
     histos.add("hAmpT0A", "amplitude T0A;#ADC channels;counts", kTH1F,
@@ -363,7 +372,11 @@ struct ft0QaTask {
         histos.fill(HIST("hVertex_T0_PV"), ft0.posZ(), collision.posZ());
         histos.fill(HIST("hPV"), collision.posZ());
         histos.fill(HIST("hT0res"), collision.t0resolution());
+        histos.fill(HIST("hT0res_nContrib"), collision.t0resolution(), nContrib);
+        histos.fill(HIST("hT0res_MultT0AC"), collision.t0resolution(), multFT0M);
         histos.fill(HIST("hT0vertexDiff"), ft0.posZ() - collision.posZ());
+        histos.fill(HIST("hT0vertexDiff_vs_nContrib"),ft0.posZ() - collision.posZ(), nContrib);
+        histos.fill(HIST("hT0vertexDiff_vs_MultT0AC"), ft0.posZ() - collision.posZ(), multFT0M);
 
         if (nContrib > 20) {
 


### PR DESCRIPTION
Add the following to ft0Qa.cxx:
- FT0 time res vs. Ncontributors
- FT0 time res vs. FT0AC multiplicity
- FT0 vertex - PV vs. Ncontributors
- FT0 vertex - PV vs. FT0AC multiplicity

Add documentation comment for FT0 time resolution