### PR TITLE
[PWGHF] Change default value of minimum centrality cut in HF event selection

### DIFF
--- a/PWGHF/Core/CentralityEstimation.h
+++ b/PWGHF/Core/CentralityEstimation.h
@@ -107,7 +107,7 @@ float getCentralityColl(const TCollision& collision)
 template <typename TCollision>
 float getCentralityColl(const TCollision&)
 {
-  return 105.0f;
+  return -1.f;
 }
 
 /// Get the centrality
@@ -146,7 +146,7 @@ float getCentralityColl(const TCollision& collision, const int centEstimator)
       LOG(fatal) << "Centrality estimator not valid. See CentralityEstimator for valid values.";
       break;
   }
-  return -999.f;
+  return -1.f;
 }
 
 /// \brief Function to get MC collision centrality
@@ -155,11 +155,10 @@ float getCentralityColl(const TCollision& collision, const int centEstimator)
 template <typename TCollisions>
 float getCentralityGenColl(TCollisions const& collSlice)
 {
-  using TMult = uint16_t; // type of numContrib
+  uint16_t multiplicity{}; // type of numContrib
   float centrality{-1.f};
-  TMult multiplicity{};
   for (const auto& collision : collSlice) {
-    const TMult collMult = collision.numContrib();
+    const uint16_t collMult = collision.numContrib();
     if (collMult > multiplicity) {
       centrality = getCentralityColl(collision);
       multiplicity = collMult;
@@ -175,11 +174,10 @@ float getCentralityGenColl(TCollisions const& collSlice)
 template <typename TCollisions>
 float getCentralityGenColl(TCollisions const& collSlice, const int centEstimator)
 {
-  using TMult = uint16_t; // type of numContrib
+  uint16_t multiplicity{}; // type of numContrib
   float centrality{-1.f};
-  TMult multiplicity{};
   for (const auto& collision : collSlice) {
-    const TMult collMult = collision.numContrib();
+    const uint16_t collMult = collision.numContrib();
     if (collMult > multiplicity) {
       centrality = getCentralityColl(collision, centEstimator);
       multiplicity = collMult;

--- a/PWGHF/Utils/utilsEvSelHf.h
+++ b/PWGHF/Utils/utilsEvSelHf.h
@@ -150,7 +150,7 @@ void setEventRejectionLabels(Histo& hRejection, std::string const& softwareTrigg
 struct HfEventSelection : o2::framework::ConfigurableGroup {
   std::string prefix = "hfEvSel"; // JSON group name
   // event selection parameters (in chronological order of application)
-  o2::framework::Configurable<float> centralityMin{"centralityMin", 0.f, "Minimum centrality"};
+  o2::framework::Configurable<float> centralityMin{"centralityMin", -10.f, "Minimum centrality (0 rejects gen. collisions with no reco. collision)"};
   o2::framework::Configurable<float> centralityMax{"centralityMax", 100.f, "Maximum centrality"};
   o2::framework::Configurable<bool> useSel8Trigger{"useSel8Trigger", true, "Apply the sel8 event selection"};
   o2::framework::Configurable<int> triggerClass{"triggerClass", -1, "Trigger class different from sel8 (e.g. kINT7 for Run2) used only if useSel8Trigger is false"};
@@ -432,7 +432,7 @@ struct HfEventSelectionMc {
   bool useItsRofBorderCut{false};             // Apply the ITS RO frame border cut
   float zPvPosMin{-1000.f};                   // Minimum PV posZ (cm)
   float zPvPosMax{1000.f};                    // Maximum PV posZ (cm)
-  float centralityMin{0.f};                   // Minimum centrality
+  float centralityMin{-10.f};                 // Minimum centrality
   float centralityMax{100.f};                 // Maximum centrality
   bool requireGoodRct{false};                 // Apply RCT selection
   std::string rctLabel{""};                   // RCT selection flag


### PR DESCRIPTION
Having `centralityMin = 0` as default value in the configuration had the effect of silently rejecting all generated collisions with no reconstructed one when running tasks using the centrality information. Thus, the generated particles of these collisions were forever lost since not matched by the candidate creators (while they are useful to compute, e.g., the signal loss).