### PR TITLE
[PWGHF] Remove meaningless check for Sc matching to MC.

### DIFF
--- a/PWGHF/D2H/Tasks/taskSigmac.cxx
+++ b/PWGHF/D2H/Tasks/taskSigmac.cxx
@@ -805,11 +805,6 @@ struct HfTaskSigmac {
     /// reconstructed Σc0,++ matched to MC
     for (const auto& candSc : candidatesSc) {
 
-      /// Candidate selected as Σc0 and/or Σc++
-      if (!(candSc.hfflag() & BIT(aod::hf_cand_sigmac::DecayType::Sc0ToPKPiPi)) && !(candSc.hfflag() & BIT(aod::hf_cand_sigmac::DecayType::ScplusplusToPKPiPi)) &&         // Σc0,++(2455)
-          !(candSc.hfflag() & BIT(aod::hf_cand_sigmac::DecayType::ScStar0ToPKPiPi)) && !(candSc.hfflag() & BIT(aod::hf_cand_sigmac::DecayType::ScStarPlusPlusToPKPiPi))) { // Σc0,++(2520)
-        continue;
-      }
       /// rapidity selection on Σc0,++
       /// NB: since in data we cannot tag Sc(2455) and Sc(2520), then we use only Sc(2455) for y selection on reconstructed signal
       if (yCandRecoMax >= 0. && std::abs(hfHelper.ySc0(candSc)) > yCandRecoMax && std::abs(hfHelper.yScPlusPlus(candSc)) > yCandRecoMax) {


### PR DESCRIPTION
The value of `candSc.hfflag()` corresponds to the one of the daughter Lambdac. By mistake, when matching the reco. Sc candidate to MC the decay channels of Sc signals were checked in this bitmap, even if obviously absent. This was a refuse inherited from the MC matching done in other codes (i.e. `candidateCreator3Prong`).
This check is actually harmless since `BIT(aod::hf_cand_sigmac::DecayType::ScplusplusToPKPiPi)` is equal to `1`, which by chance is the value of `BIT(aod::hf_cand_3prong::DecayType::LcToPKPi)` which is the Lc->pKpi related bit always switched-on in the bitmap from the `candidateCreatorSc`. A quick test offline confirms that using this check or not does not change the result.
Removing it to avoid further confusion.