### PR TITLE
[Common,PWGHF] fix wrong CBT_Calo naming for rct flag

### DIFF
--- a/Common/CCDB/RCTSelectionFlags.h
+++ b/Common/CCDB/RCTSelectionFlags.h
@@ -18,11 +18,13 @@
 #define COMMON_CCDB_RCTSELECTIONFLAGS_H_
 
 #include <CommonUtils/EnumFlags.h>
-#include <Rtypes.h>
+
 #include <TMath.h>
 
-#include <stdexcept>
+#include <Rtypes.h>
+
 #include <algorithm>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -98,7 +100,7 @@ class RCTFlagsChecker : public o2::utils::EnumFlags<RCTSelectionFlags>
   // - "CBT"
   // - "CBT_hadronPID"
   // - "CBT_electronPID"
-  // - "CCBT_calo"
+  // - "CBT_calo"
   // - "CBT_muon"
   // - "CBT_muon_glo"
   // The checkZDC boolean flag controls whether to iclude the ZDC quality in all the pre-defined selections (for Pb-Pb data)
@@ -121,7 +123,7 @@ class RCTFlagsChecker : public o2::utils::EnumFlags<RCTSelectionFlags>
   // - "CBT"
   // - "CBT_hadronPID"
   // - "CBT_electronPID"
-  // - "CCBT_calo"
+  // - "CBT_calo"
   // - "CBT_muon"
   // - "CBT_muon_glo"
   // The checkZDC boolean flag controls whether to iclude the ZDC quality in all the pre-defined selections (for Pb-Pb data)

--- a/PWGHF/Utils/utilsEvSelHf.h
+++ b/PWGHF/Utils/utilsEvSelHf.h
@@ -176,7 +176,7 @@ struct HfEventSelection : o2::framework::ConfigurableGroup {
   o2::framework::ConfigurableAxis th2ConfigAxisCent{"th2ConfigAxisCent", {100, 0., 100.}, ""};
   o2::framework::ConfigurableAxis th2ConfigAxisOccupancy{"th2ConfigAxisOccupancy", {100, 0, 100000}, ""};
   o2::framework::Configurable<bool> requireGoodRct{"requireGoodRct", false, "Flag to require good RCT"};
-  o2::framework::Configurable<std::string> rctLabel{"rctLabel", "CBT_hadronPID", "RCT selection flag (CBT, CBT_hadronPID, CBT_electronPID, CCBT_calo, CBT_muon, CBT_muon_glo)"};
+  o2::framework::Configurable<std::string> rctLabel{"rctLabel", "CBT_hadronPID", "RCT selection flag (CBT, CBT_hadronPID, CBT_electronPID, CBT_calo, CBT_muon, CBT_muon_glo)"};
   o2::framework::Configurable<bool> rctCheckZDC{"rctCheckZDC", false, "RCT flag to check whether the ZDC is present or not"};
   o2::framework::Configurable<bool> rctTreatLimitedAcceptanceAsBad{"rctTreatLimitedAcceptanceAsBad", false, "RCT flag to reject events with limited acceptance for selected detectors"};
 


### PR DESCRIPTION
- Sometimes the rct label for runs with (good) EMCal have been written as `CCBT_calo` which should be `CBT_calo`. This spelling mistake did not break anything, but could cause confusion like in the PWGHF `utilsEvSelHf.h` where in the listing of potential rct flags it is listed as `CCBT_calo` which is wrong and would lead to a potential error if used.