### PR TITLE
[PWGHF] correlatorFlowCharmHadrons: Fix missing using directives

### DIFF
--- a/PWGHF/HFC/TableProducer/correlatorFlowCharmHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorFlowCharmHadrons.cxx
@@ -45,6 +45,8 @@
 #include <vector>
 
 using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
 using namespace o2::hf_centrality;
 using namespace o2::hf_evsel;
 


### PR DESCRIPTION
Was compiling by accident because of namespace pollution from PWGUD headers.