### PR TITLE
[PWGHF] Add proper lifetime into THnSparse at taskLc

### DIFF
--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -362,7 +362,7 @@ struct HfTaskLc {
         }
       }
       if (storeProperLifetime) {
-        for (const auto& axes : std::array<std::vector<AxisSpec>*, 2>{&axesGen, &axesWithBdt}) {
+        for (const auto& axes : std::array<std::vector<AxisSpec>*, 3>{&axesWithBdt, &axesStd, &axesGen}) {
           if (!axes->empty()) {
             axes->push_back(thnAxisProperLifetime);
           }
@@ -585,6 +585,9 @@ struct HfTaskLc {
               if (storeOccupancy && occEstimator != o2::hf_occupancy::OccupancyEstimator::None) {
                 valuesToFill.push_back(occ);
               }
+              if (storeProperLifetime) {
+                valuesToFill.push_back(properLifetime);
+              }
               registry.get<THnSparse>(HIST("hnLcVars"))->Fill(valuesToFill.data());
             }
           }
@@ -610,6 +613,9 @@ struct HfTaskLc {
               std::vector<double> valuesToFill{massLc, pt, cent, ptProng0, ptProng1, ptProng2, chi2PCA, decayLength, cpa, static_cast<double>(numPvContributors), ptRecB, static_cast<double>(originType)};
               if (storeOccupancy && occEstimator != o2::hf_occupancy::OccupancyEstimator::None) {
                 valuesToFill.push_back(occ);
+              }
+              if (storeProperLifetime) {
+                valuesToFill.push_back(properLifetime);
               }
               registry.get<THnSparse>(HIST("hnLcVars"))->Fill(valuesToFill.data());
             }
@@ -802,6 +808,9 @@ struct HfTaskLc {
             if (storeOccupancy && occEstimator != o2::hf_occupancy::OccupancyEstimator::None) {
               valuesToFill.push_back(occ);
             }
+            if (storeProperLifetime) {
+              valuesToFill.push_back(properLifetime);
+            }
             registry.get<THnSparse>(HIST("hnLcVars"))->Fill(valuesToFill.data());
           }
         }
@@ -827,6 +836,9 @@ struct HfTaskLc {
             std::vector<double> valuesToFill{massLc, pt, cent, ptProng0, ptProng1, ptProng2, chi2PCA, decayLength, cpa, static_cast<double>(numPvContributors)};
             if (storeOccupancy && occEstimator != o2::hf_occupancy::OccupancyEstimator::None) {
               valuesToFill.push_back(occ);
+            }
+            if (storeProperLifetime) {
+              valuesToFill.push_back(properLifetime);
             }
             registry.get<THnSparse>(HIST("hnLcVars"))->Fill(valuesToFill.data());
           }


### PR DESCRIPTION
1. Proper lifetime of $\Lambda_{c}$ added into THnSparse in the `taskLc` workflow.
~~2. Bugfix: in the `treeCreatorLcToPKPi` workflow the invariant mass of $pK\pi$ and $K\pi$ in `Lite` and `Full` tables was written either from dynamic column of the DCAFitter or KFParticle depending on the mode in which reconstruction was run. However the KF-related variables have a dedicated table, therefore there is no need to write them into `Lite` and `Full`. This PR fixes this issue and enables writing of mentioned invariant masses from only from dynamic column associated with DCAFitter.~~
moved to a separate [PR12906](https://github.com/AliceO2Group/O2Physics/pull/12906)