### PR TITLE
[PWGDQ] Fixes to dilepton track mc

### DIFF
--- a/PWGDQ/Tasks/dqEfficiency_withAssoc.cxx
+++ b/PWGDQ/Tasks/dqEfficiency_withAssoc.cxx
@@ -3730,6 +3730,9 @@ struct AnalysisDileptonTrack {
       // get full track info of tracks based on the index
       auto lepton1 = tracks.rawIteratorAt(dilepton.index0Id());
       auto lepton2 = tracks.rawIteratorAt(dilepton.index1Id());
+      if (!lepton1.has_reducedMCTrack() || !lepton2.has_reducedMCTrack()) {
+        continue;
+      }
       auto lepton1MC = lepton1.reducedMCTrack();
       auto lepton2MC = lepton2.reducedMCTrack();
       // Check that the dilepton has zero charge

--- a/PWGDQ/Tasks/dqEfficiency_withAssoc.cxx
+++ b/PWGDQ/Tasks/dqEfficiency_withAssoc.cxx
@@ -3844,8 +3844,6 @@ struct AnalysisDileptonTrack {
               mcDecision |= (static_cast<uint32_t>(1) << isig);
             }
           }
-          // Fill table for correlation analysis
-          DileptonTrackTable(fValuesHadron[VarManager::kDeltaEta], fValuesHadron[VarManager::kDeltaPhi], dilepton.mass(), dilepton.pt(), dilepton.eta(), track.pt(), track.eta(), mcDecision);
         }
 
         if constexpr (TCandidateType == VarManager::kBcToThreeMuons) {
@@ -3873,6 +3871,8 @@ struct AnalysisDileptonTrack {
               mcDecision |= (static_cast<uint32_t>(1) << isig);
             }
           }
+          // Fill table for correlation analysis
+          DileptonTrackTable(fValuesHadron[VarManager::kDeltaEta], fValuesHadron[VarManager::kDeltaPhi], dilepton.mass(), dilepton.pt(), dilepton.eta(), track.pt(), track.eta(), mcDecision);
         }
 
         // Fill histograms for the triplets


### PR DESCRIPTION
This PR

1. Add an additional check to the one implemented in #12723 checking for MC tracks in the two lepton legs for the rare cases where it does not exist
2. Moves the dimuon-track table implemented in #12850 to the right case