### PR TITLE
[PWGHF] Reduced workflow for charm hadron correlations

### DIFF
--- a/PWGHF/HFC/DataModel/DerivedDataCorrelationTables.h
+++ b/PWGHF/HFC/DataModel/DerivedDataCorrelationTables.h
@@ -49,20 +49,20 @@ using HfcRedCollision = HfcRedCollisions::iterator;
 
 namespace hf_candidate_reduced
 {
-DECLARE_SOA_INDEX_COLUMN(HfcRedCollision, hfcRedCollision);  //! ReducedCollision index
-DECLARE_SOA_INDEX_COLUMN(HfcRedFlowColl, hfcRedFlowColl);    //! ReducedCollision index
-DECLARE_SOA_COLUMN(Prong0Id, prong0Id, int);                 //! Prong 0 index
-DECLARE_SOA_COLUMN(Prong1Id, prong1Id, int);                 //! Prong 1 index
-DECLARE_SOA_COLUMN(Prong2Id, prong2Id, int);                 //! Prong2 index
-DECLARE_SOA_COLUMN(PhiCand, phiCand, float);                 //! Phi of the candidate
-DECLARE_SOA_COLUMN(EtaCand, etaCand, float);                 //! Eta of the candidate
-DECLARE_SOA_COLUMN(PtCand, ptCand, float);                   //! Pt of the candidate
-DECLARE_SOA_COLUMN(InvMassDs, invMassDs, float);             //! Invariant mass of Ds candidate
-DECLARE_SOA_COLUMN(InvMassCharmHad, invMassCharmHad, float); //! Invariant mass of CharmHad candidate
-DECLARE_SOA_COLUMN(BdtScorePrompt, bdtScorePrompt, float);   //! BDT output score for prompt hypothesis
-DECLARE_SOA_COLUMN(BdtScoreBkg, bdtScoreBkg, float);         //! BDT output score for backgronud hypothesis
-DECLARE_SOA_COLUMN(BdtScore0, bdtScore0, float);             //! First BDT output score
-DECLARE_SOA_COLUMN(BdtScore1, bdtScore1, float);             //! Second BDT output score
+DECLARE_SOA_INDEX_COLUMN(HfcRedCollision, hfcRedCollision);     //! ReducedCollision index
+DECLARE_SOA_INDEX_COLUMN(HfcRedFlowColl, hfcRedFlowColl);       //! ReducedCollision index
+DECLARE_SOA_COLUMN(Prong0Id, prong0Id, int);                    //! Prong 0 index
+DECLARE_SOA_COLUMN(Prong1Id, prong1Id, int);                    //! Prong 1 index
+DECLARE_SOA_COLUMN(Prong2Id, prong2Id, int);                    //! Prong2 index
+DECLARE_SOA_COLUMN(PhiCand, phiCand, float);                    //! Phi of the candidate
+DECLARE_SOA_COLUMN(EtaCand, etaCand, float);                    //! Eta of the candidate
+DECLARE_SOA_COLUMN(PtCand, ptCand, float);                      //! Pt of the candidate
+DECLARE_SOA_COLUMN(InvMassDs, invMassDs, float);                //! Invariant mass of Ds candidate
+DECLARE_SOA_COLUMN(InvMassCand, invMassCand, float);            //! Invariant mass of Charm candidate
+DECLARE_SOA_COLUMN(BdtScorePrompt, bdtScorePrompt, float);      //! BDT output score for prompt hypothesis
+DECLARE_SOA_COLUMN(BdtScoreBkg, bdtScoreBkg, float);            //! BDT output score for background hypothesis
+DECLARE_SOA_COLUMN(BdtScore0, bdtScore0, float);                //! First BDT output score
+DECLARE_SOA_COLUMN(BdtScore1, bdtScore1, float);                //! Second BDT output score
 } // namespace hf_candidate_reduced
 DECLARE_SOA_TABLE(DsCandReduceds, "AOD", "DSCANDREDUCED", //! Table with Ds candidate info
                   soa::Index<>,
@@ -81,23 +81,13 @@ DECLARE_SOA_TABLE(DsCandSelInfos, "AOD", "DSCANDSELINFO", //! Table with Ds cand
                   aod::hf_candidate_reduced::BdtScorePrompt,
                   aod::hf_candidate_reduced::BdtScoreBkg);
 
-DECLARE_SOA_TABLE(HfcRedCharmHads2P, "AOD", "HFCREDCHARM2P", //! Table with 2-prong charm hadron candidate info
+DECLARE_SOA_TABLE(HfcRedCharmTrigs, "AOD", "HFCREDCHARMTRIG", //! Table with charm hadron candidate info
                   soa::Index<>,
                   aod::hf_candidate_reduced::HfcRedFlowCollId,
                   aod::hf_candidate_reduced::PhiCand,
                   aod::hf_candidate_reduced::EtaCand,
                   aod::hf_candidate_reduced::PtCand,
-                  aod::hf_candidate_reduced::InvMassCharmHad,
-                  aod::hf_candidate_reduced::Prong0Id,
-                  aod::hf_candidate_reduced::Prong1Id);
-
-DECLARE_SOA_TABLE(HfcRedCharmHads3P, "AOD", "HFCREDCHARM3P", //! Table with 3-prong charm hadron candidate info
-                  soa::Index<>,
-                  aod::hf_candidate_reduced::HfcRedFlowCollId,
-                  aod::hf_candidate_reduced::PhiCand,
-                  aod::hf_candidate_reduced::EtaCand,
-                  aod::hf_candidate_reduced::PtCand,
-                  aod::hf_candidate_reduced::InvMassCharmHad,
+                  aod::hf_candidate_reduced::InvMassCand,
                   aod::hf_candidate_reduced::Prong0Id,
                   aod::hf_candidate_reduced::Prong1Id,
                   aod::hf_candidate_reduced::Prong2Id);
@@ -137,7 +127,7 @@ DECLARE_SOA_TABLE(AssocTrackSels, "AOD", "ASSOCTRACKSEL", //! Table with associa
                   aod::hf_assoc_track_reduced::DcaXY,
                   aod::hf_assoc_track_reduced::DcaZ)
 
-DECLARE_SOA_TABLE(HfcRedTrkAssoc, "AOD", "HFCREDTRKASSOC", //! Table with associated track info
+DECLARE_SOA_TABLE(HfcRedTrkAssocs, "AOD", "HFCREDTRKASSOC", //! Table with associated track info
                   soa::Index<>,
                   aod::hf_candidate_reduced::HfcRedFlowCollId,
                   aod::hf_assoc_track_reduced::OriginTrackId,
@@ -145,7 +135,7 @@ DECLARE_SOA_TABLE(HfcRedTrkAssoc, "AOD", "HFCREDTRKASSOC", //! Table with associ
                   aod::hf_assoc_track_reduced::EtaAssocTrack,
                   aod::hf_assoc_track_reduced::PtAssocTrack);
 
-DECLARE_SOA_TABLE(HfcRedTrkSels, "AOD", "HFCREDTRKSELS", //! Table with associated track info
+DECLARE_SOA_TABLE(HfcRedTrkSels, "AOD", "HFCREDTRKSEL", //! Table with associated track info
                   soa::Index<>,
                   aod::hf_candidate_reduced::HfcRedFlowCollId,
                   aod::hf_assoc_track_reduced::NTpcCrossedRows,
@@ -153,6 +143,32 @@ DECLARE_SOA_TABLE(HfcRedTrkSels, "AOD", "HFCREDTRKSELS", //! Table with associat
                   aod::hf_assoc_track_reduced::ItsNCls,
                   aod::hf_assoc_track_reduced::DcaXY,
                   aod::hf_assoc_track_reduced::DcaZ)
+
+// definition of columns and tables for Charm-Hadron and Hadron-Hadron correlation pairs
+namespace hf_correlation_charm_hadron_reduced
+{
+DECLARE_SOA_INDEX_COLUMN_FULL(CharmTrig, charmTrig, int, HfcRedCharmTrigs, "_0");   //! Reduced charm trigger candidate index
+DECLARE_SOA_INDEX_COLUMN_FULL(HadTrig, hadTrig, int, HfcRedTrkAssocs, "_1");        //! Reduced hadron trigger candidate index
+DECLARE_SOA_INDEX_COLUMN_FULL(TrkAssoc, trkAssoc, int, HfcRedTrkAssocs, "_2");      //! Reduced associated track index
+DECLARE_SOA_COLUMN(DeltaPhi, deltaPhi, float);                //! DeltaPhi between charm hadron and Hadrons
+DECLARE_SOA_COLUMN(DeltaEta, deltaEta, float);                //! DeltaEta between charm hadron and Hadrons
+DECLARE_SOA_COLUMN(PoolBin, poolBin, int);                    //! Pool Bin for the MixedEvent
+} // namespace hf_correlation_charm_hadron_reduced
+
+DECLARE_SOA_TABLE(HfcRedChHads, "AOD", "HFCREDCHHAD", //! Charm-Hadron pairs information
+                  aod::hf_correlation_charm_hadron_reduced::CharmTrigId,
+                  aod::hf_correlation_charm_hadron_reduced::TrkAssocId,
+                  aod::hf_correlation_charm_hadron_reduced::DeltaPhi,
+                  aod::hf_correlation_charm_hadron_reduced::DeltaEta,
+                  aod::hf_correlation_charm_hadron_reduced::PoolBin);
+
+DECLARE_SOA_TABLE(HfcRedHadHads, "AOD", "HFCREDHADHAD", //! Hadron-Hadron pairs information
+                  aod::hf_correlation_charm_hadron_reduced::HadTrigId,
+                  aod::hf_correlation_charm_hadron_reduced::TrkAssocId,
+                  aod::hf_correlation_charm_hadron_reduced::DeltaPhi,
+                  aod::hf_correlation_charm_hadron_reduced::DeltaEta,
+                  aod::hf_correlation_charm_hadron_reduced::PoolBin);
+
 } // namespace o2::aod
 
 #endif // PWGHF_HFC_DATAMODEL_DERIVEDDATACORRELATIONTABLES_H_

--- a/PWGHF/HFC/TableProducer/CMakeLists.txt
+++ b/PWGHF/HFC/TableProducer/CMakeLists.txt
@@ -44,9 +44,14 @@ o2physics_add_dpl_workflow(correlator-ds-hadrons
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(correlator-flow-charm-hadrons
-                    SOURCES correlatorFlowCharmHadrons.cxx
+o2physics_add_dpl_workflow(derived-data-creator-correlations-reduced
+                    SOURCES derivedDataCreatorCorrelationsReduced.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::EventFilteringUtils
+                    COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(correlator-flow-charm-hadrons-reduced
+                    SOURCES correlatorFlowCharmHadronsReduced.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(correlator-ds-hadrons-reduced

--- a/PWGHF/HFC/TableProducer/correlatorFlowCharmHadronsReduced.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorFlowCharmHadronsReduced.cxx
@@ -1,0 +1,456 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file correlatorFlowCharmHadrons.cxx
+/// \brief CharmHadrons-Hadrons correlator tree creator for data and MC-reco analyses
+/// \author Marcello Di Costanzo <marcello.di.costanzo@cern.ch>, Politecnico and INFN Torino
+
+#include "PWGHF/Core/HfHelper.h"
+#include "PWGHF/DataModel/CandidateReconstructionTables.h"
+#include "PWGHF/DataModel/CandidateSelectionTables.h"
+#include "PWGHF/HFC/DataModel/DerivedDataCorrelationTables.h"
+// #include "PWGHF/HFC/DataModel/CorrelationTables.h"
+// #include "PWGHF/Utils/utilsEvSelHf.h"
+
+#include "Common/DataModel/Multiplicity.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+
+#include <CCDB/BasicCCDBManager.h>
+#include <CommonConstants/MathConstants.h>
+#include <CommonConstants/PhysicsConstants.h>
+#include <Framework/ASoA.h>
+#include <Framework/ASoAHelpers.h>
+#include <Framework/AnalysisDataModel.h>
+#include <Framework/AnalysisHelpers.h>
+#include <Framework/AnalysisTask.h>
+#include <Framework/BinningPolicy.h>
+#include <Framework/Configurable.h>
+#include <Framework/GroupedCombinations.h>
+#include <Framework/HistogramRegistry.h>
+#include <Framework/HistogramSpec.h>
+#include <Framework/InitContext.h>
+#include <Framework/Logger.h>
+#include <Framework/OutputObjHeader.h>
+#include <Framework/SliceCache.h>
+#include <Framework/runDataProcessing.h>
+
+#include <string>
+#include <vector>
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using namespace o2::hf_centrality;
+using namespace o2::hf_evsel;
+
+using BinningTypeDerivedCent = ColumnBinningPolicy<aod::hf_collisions_reduced::PosZ, aod::hf_collisions_reduced::Centrality>;
+using BinningTypeDerivedMult = ColumnBinningPolicy<aod::hf_collisions_reduced::PosZ, aod::hf_collisions_reduced::Multiplicity>;
+
+struct HfCorrelatorFlowCharmHadrons {
+  Produces<aod::HfcRedChHads> entryCharmHadPair;
+  Produces<aod::HfcRedHadHads> entryHadHadPair;
+
+  Configurable<bool> fillQaHistos{"fillQaHistos", true, "Flag for filling histograms in data processes"};
+  Configurable<bool> fillSparses{"fillSparses", true, "Fill sparse histograms"};
+  Configurable<bool> fillTables{"fillTables", false, "Fill tables"};
+  Configurable<int> numberEventsMixed{"numberEventsMixed", 5, "Number of events mixed in ME process"};
+  Configurable<std::vector<double>> binsPtTrig{"binsPtTrig", std::vector<double>{1., 3., 5., 8., 16., 36.}, "pT bin limits for trigger candidates"};
+  Configurable<std::vector<double>> binsPtAssoc{"binsPtAssoc", std::vector<double>{0.3, 1., 2., 50.}, "pT bin limits for associated particles"};
+
+  SliceCache cache;
+
+  Preslice<aod::HfcRedTrkAssocs> tracksPerCol = aod::hf_candidate_reduced::hfcRedFlowCollId;
+  Preslice<aod::HfcRedCharmTrigs> candsPerCol = aod::hf_candidate_reduced::hfcRedFlowCollId;
+
+  ConfigurableAxis zPoolBins{"zPoolBins", {VARIABLE_WIDTH, -10.0, -2.5, 2.5, 10.0}, "Z vertex position pools"};
+  ConfigurableAxis multPoolBins{"multPoolBins", {VARIABLE_WIDTH, 0., 900., 1800., 6000.}, "Event multiplicity pools (FT0M)"};
+  ConfigurableAxis centPoolBins{"centPoolBins", {VARIABLE_WIDTH, 0., 10., 20., 30.}, "Event centrality pools"};
+  ConfigurableAxis binsInvMass{"binsInvMass", {300, 1.6, 2.2}, ""};
+  ConfigurableAxis binsMultFT0M{"binsMultFT0M", {100, 0., 10000.}, "Multiplicity as FT0M signal amplitude"};
+  ConfigurableAxis binsCent{"binsCent", {100, 0., 100.}, "Centrality bins"};
+  ConfigurableAxis binsPosZ{"binsPosZ", {100, -10., 10.}, "Primary vertex z coordinate"};
+  ConfigurableAxis binsEta{"binsEta", {50, -2., 2.}, "Eta bins"};
+  ConfigurableAxis binsPhi{"binsPhi", {64, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf}, "Phi bins"};
+  ConfigurableAxis binsDeltaEta{"binsDeltaEta", {100, -2., 2.}, "Delta Eta bins"};
+  ConfigurableAxis binsDeltaPhi{"binsDeltaPhi", {64, -3., 3.}, "Delta Phi bins"};
+  ConfigurableAxis binsPoolBin{"binsPoolBin", {9, 0., 9.}, "PoolBin"};
+  ConfigurableAxis binsMlOne{"binsMlOne", {100, 0., 1.}, ""};
+  ConfigurableAxis binsMlTwo{"binsMlTwo", {100, 0., 1.}, ""};
+
+  HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject};
+
+  void init(InitContext&)
+  {
+    std::array<bool, 8> doprocess{doprocessSameEventCharmHadWCentMix, doprocessSameEventCharmHadWMultMix, doprocessMixedEventCharmHadWCentMix, doprocessMixedEventCharmHadWMultMix,
+                                  doprocessSameEventHadHadWCentMix, doprocessSameEventHadHadWMultMix, doprocessMixedEventHadHadWCentMix, doprocessMixedEventHadHadWMultMix};
+    if ((std::accumulate(doprocess.begin(), doprocess.end(), 0)) > 1) {
+      LOGP(fatal, "Only one process function should be enabled! Please check your configuration!");
+      if ( !((doprocessSameEventCharmHadWCentMix && doprocessMixedEventCharmHadWCentMix) || (doprocessSameEventCharmHadWMultMix && doprocessMixedEventCharmHadWMultMix)) ){
+        LOG(fatal) << "Different binning policies between Same Event and Mixed Event";
+      }
+      if ( !((doprocessSameEventHadHadWCentMix && doprocessMixedEventHadHadWCentMix) || (doprocessSameEventHadHadWMultMix && doprocessMixedEventHadHadWMultMix)) ){
+        LOG(fatal) << "Different binning policies between Same Event and Mixed Event";
+      }
+    }
+
+    const AxisSpec axisInvMass{binsInvMass, "Inv. mass (GeV/#it{c}^{2})"};
+    const AxisSpec axisCent = {binsCent, "Centrality"};
+    const AxisSpec axisMultFT0M = {binsMultFT0M, "MultiplicityFT0M"};
+    const AxisSpec axisPosZ = {binsPosZ, "PosZ"};
+    const AxisSpec axisPoolBin = {binsPoolBin, "PoolBin"};
+    const AxisSpec axisEta = {binsEta, "#it{#eta}"};
+    const AxisSpec axisPhi = {binsPhi, "#it{#varphi}"};
+    const AxisSpec axisDeltaEta = {binsDeltaEta, "#Delta#it{#eta}"};
+    const AxisSpec axisDeltaPhi = {binsDeltaPhi, "#Delta#it{#varphi}"};
+    const AxisSpec axisPtTrig = {(std::vector<double>)binsPtTrig, "#it{p}_{T} Trig (GeV/#it{c})"};
+    const AxisSpec axisPtAssoc = {(std::vector<double>)binsPtAssoc, "#it{p}_{T} Assoc (GeV/#it{c})"};
+    const AxisSpec axisMlOne{binsMlOne, "bdtScore0"};
+    const AxisSpec axisMlTwo{binsMlTwo, "bdtScore1"};
+
+    // Histograms for data analysis
+    if (fillQaHistos) {
+      if (doprocessSameEventCharmHadWCentMix || doprocessMixedEventCharmHadWCentMix || doprocessSameEventHadHadWCentMix || doprocessMixedEventHadHadWCentMix) {
+        registry.add("hCent", "Centrality", {HistType::kTH2F, {{axisCent}, {axisPoolBin}}});
+      } else {
+        registry.add("hMultFT0M", "Multiplicity FT0M", {HistType::kTH2F, {{axisMultFT0M}, {axisPoolBin}}});
+      }
+      registry.add("hZVtx", "z vertex", {HistType::kTH2F, {{axisPosZ}, {axisPoolBin}}});
+      registry.add("hCollisionPoolBin", "Collision pool bin", {HistType::kTH1F, {axisPoolBin}});
+      registry.add("hPoolBinTrig", "Trigger candidates pool bin", {HistType::kTH1F, {axisPoolBin}});
+      registry.add("hPhiVsPtTrig", "Trigger candidates phiVsPt", {HistType::kTH2F, {{axisPhi}, {axisPtTrig}}});
+      registry.add("hEtaVsPtTrig", "Trigger candidates etaVsPt", {HistType::kTH2F, {{axisEta}, {axisPtTrig}}});
+      registry.add("hPoolBinAssoc", "Associated particles pool bin", {HistType::kTH1F, {axisPoolBin}});
+      registry.add("hPhiVsPtAssoc", "Associated particles phiVsPt", {HistType::kTH3F, {{axisPhi}, {axisPtTrig}, {axisPtAssoc}}});
+      registry.add("hEtaVsPtAssoc", "Associated particles etaVsPt", {HistType::kTH3F, {{axisEta}, {axisPtTrig}, {axisPtAssoc}}});
+    }
+
+    if (fillSparses) {
+      std::vector<AxisSpec> axes = {axisPtTrig, axisPtAssoc, axisDeltaEta, axisDeltaPhi, axisPoolBin};
+      if (doprocessSameEventHadHadWCentMix || doprocessSameEventHadHadWMultMix) {
+        registry.add("hSparseCorrelationsSEHadHad", "THn for SE Had-Had correlations", HistType::kTHnSparseF, axes);
+      } else if (doprocessMixedEventHadHadWCentMix || doprocessMixedEventHadHadWMultMix) {
+        registry.add("hSparseCorrelationsMEHadHad", "THn for ME Had-Had correlations", HistType::kTHnSparseF, axes);
+      } else {
+        axes.insert(axes.end(), {axisMlOne, axisMlTwo, axisInvMass});
+        if (doprocessSameEventCharmHadWCentMix || doprocessSameEventCharmHadWMultMix) {
+          registry.add("hSparseCorrelationsSECharmHad", "THn for SE Charm-Had correlations", HistType::kTHnSparseF, axes);
+        } else if (doprocessMixedEventCharmHadWCentMix || doprocessMixedEventCharmHadWMultMix) {
+        registry.add("hSparseCorrelationsMECharmHad", "THn for ME Charm-Had correlations", HistType::kTHnSparseF, axes);
+        }
+      }
+    }
+  }
+
+  /// Get charm candidate or hadron track pT
+  /// \param track is the candidate
+  template<typename TTrack>
+  double getPt(const TTrack& track) {
+    if constexpr (requires { track.ptAssocTrack(); }) {
+      return track.ptAssocTrack();
+    } else {
+      return track.ptCand();
+    }
+    return -1.;
+  }
+
+  /// Get charm candidate or hadron track eta
+  /// \param track is the candidate
+  template<typename TTrack>
+  double getEta(const TTrack& track) {
+    if constexpr (requires { track.etaAssocTrack(); }) {
+      return track.etaAssocTrack();
+    } else {
+      return track.etaCand();
+    }
+    return -1.;
+  }
+
+  /// Get charm candidate or hadron track phi
+  /// \param track is the candidate
+  template<typename TTrack>
+  double getPhi(const TTrack& track) {
+    if constexpr (requires { track.phiAssocTrack(); }) {
+      return track.phiAssocTrack();
+    } else {
+      return track.phiCand();
+    }
+    return -1.;
+  }
+
+  /// Get the binning pool associated to the collision
+  /// \param collision is the collision
+  /// \param corrBinning is the binning policy for the correlation
+  template<bool fillHistos, typename TColl, typename TBinningType>
+  int getPoolBin(const TColl& collision, const TBinningType& corrBinning) {
+    int poolBin{0};
+    if constexpr (std::is_same_v<TBinningType, BinningTypeDerivedCent>) {
+      poolBin = corrBinning.getBin(std::make_tuple(collision.posZ(), collision.centrality()));
+      if constexpr (fillHistos) {
+        registry.fill(HIST("hCent"), collision.centrality(), poolBin);
+      }
+    } else if constexpr (std::is_same_v<TBinningType, BinningTypeDerivedMult>) {
+      poolBin = corrBinning.getBin(std::make_tuple(collision.posZ(), collision.multiplicity()));
+      if constexpr (fillHistos) {
+        registry.fill(HIST("hMultFT0M"), collision.multiplicity(), poolBin);
+      }
+    }
+    return poolBin;
+  }
+
+  /// Reject daughter-track pairs and same-track pairs
+  /// \param cand is the trigger candidate
+  /// \param track is the associated track
+  template<typename TTrigPart, typename TTrack>
+  bool rejSameEvtPair(const TTrigPart& cand, const TTrack& track) {
+    if constexpr (requires { cand.originTrackId(); }) {
+      // Remove same track pairs for Had-Had correlations
+      return (cand.originTrackId() == track.originTrackId());
+    } else if constexpr (requires { cand.prong2Id(); }) {
+      // Remove pairs with 3-prong daughters
+      return ((cand.prong0Id() == track.originTrackId()) || (cand.prong1Id() == track.originTrackId()) || (cand.prong2Id() == track.originTrackId()));
+    } else {
+      // Remove pairs with 2-prong daughters
+      return ((cand.prong0Id() == track.originTrackId()) || (cand.prong1Id() == track.originTrackId()));
+    }
+    return true;
+  }
+
+  /// Slice trigger candidates by collision
+  /// \param cands are the trigger candidates
+  /// \param collId is the collision index
+  template<typename TTrigCands>
+  auto sliceTrigCands(TTrigCands const& cands, const int collId) {
+    if constexpr (std::is_same_v<TTrigCands, soa::Join<aod::HfcRedTrkAssocs, aod::HfcRedTrkSels>>) {
+      return cands.sliceBy(tracksPerCol, collId);
+    } else {
+      return cands.sliceBy(candsPerCol, collId);
+    }
+  }
+
+  /// Fill Charm-Hadron correlation table and sparse
+  /// \param trigCand is the trigger charm hadron candidate
+  /// \param assocTrack is the associated hadron track
+  /// \param poolBin is the pool bin of the collision
+  template<bool isMixedEvent, typename TTrigCand, typename TTrack>
+  void fillCharmHadInfo(TTrigCand const& trigCand,
+                        TTrack const& assocTrack,
+                        const int poolBin) {
+    double deltaPhi = RecoDecay::constrainAngle(getPhi(assocTrack), getPhi(trigCand), -o2::constants::math::PIHalf);
+    if (fillTables) {
+      entryCharmHadPair(trigCand.globalIndex(), assocTrack.globalIndex(), deltaPhi, getEta(assocTrack) - getEta(trigCand), poolBin);
+    }
+    if (fillSparses) {
+      if constexpr (isMixedEvent) {
+        registry.fill(HIST("hSparseCorrelationsMECharmHad"), getPt(trigCand), getPt(assocTrack),
+                                                             getEta(trigCand) - getEta(assocTrack),
+                                                             deltaPhi, poolBin, trigCand.bdtScore0(),
+                                                             trigCand.bdtScore1(), trigCand.invMassCand());
+      } else {
+        registry.fill(HIST("hSparseCorrelationsSECharmHad"), getPt(trigCand), getPt(assocTrack),
+                                                             getEta(trigCand) - getEta(assocTrack),
+                                                             deltaPhi, poolBin, trigCand.bdtScore0(),
+                                                             trigCand.bdtScore1(), trigCand.invMassCand());
+      }
+    }
+  }
+
+  /// Fill Hadron-Hadron correlation table and sparse
+  /// \param trigCand is the trigger hadron candidate
+  /// \param assocTrack is the associated hadron track
+  /// \param poolBin is the pool bin of the collision
+  template<bool isMixedEvent, typename TCand>
+  void fillHadHadInfo(TCand const& trigCand,
+                      TCand const& assocTrack,
+                      const int poolBin) {
+    double deltaPhi = RecoDecay::constrainAngle(getPhi(assocTrack), getPhi(trigCand), -o2::constants::math::PIHalf);
+    if (fillTables) {
+      entryHadHadPair(trigCand.globalIndex(), assocTrack.globalIndex(), deltaPhi, getEta(assocTrack) - getEta(trigCand), poolBin);
+    }
+    if (fillSparses) {
+      if constexpr (isMixedEvent) {
+        registry.fill(HIST("hSparseCorrelationsMEHadHad"), getPt(trigCand), getPt(assocTrack), getEta(assocTrack) - getEta(trigCand), deltaPhi, poolBin);
+      } else {
+        registry.fill(HIST("hSparseCorrelationsSEHadHad"), getPt(trigCand), getPt(assocTrack), getEta(assocTrack) - getEta(trigCand), deltaPhi, poolBin);
+      }
+    }
+  }
+
+  /// Save info for Same Event pairs
+  /// \param collisions are the selected collisions
+  /// \param trigCands are the selected trigger candidates
+  /// \param assocTracks are the selected associated tracks
+  /// \param corrBinning is the binning policy for the correlation
+  template<typename TTrigCands, typename TAssocTracks, typename TBinningType>
+  void fillSameEvent(aod::HfcRedFlowColls const& collisions,
+                     TTrigCands const& trigCands,
+                     TAssocTracks const& assocTracks,
+                     TBinningType corrBinning)
+  {
+    for (const auto& collision : collisions) {
+      int poolBin = getPoolBin<true>(collision, corrBinning);
+      registry.fill(HIST("hCollisionPoolBin"), poolBin);
+      registry.fill(HIST("hZVtx"), collision.posZ(), poolBin);
+      
+      auto thisCollId = collision.globalIndex();
+      auto trigCandsThisColl = sliceTrigCands(trigCands, thisCollId);
+      auto assocCandsThisColl = assocTracks.sliceBy(tracksPerCol, thisCollId);
+
+      for (const auto& candidate : trigCandsThisColl) {
+        registry.fill(HIST("hPoolBinTrig"), poolBin);
+        registry.fill(HIST("hPhiVsPtTrig"), RecoDecay::constrainAngle(getPhi(candidate), -o2::constants::math::PIHalf), getPt(candidate));
+        registry.fill(HIST("hEtaVsPtTrig"), getEta(candidate), getPt(candidate));
+        for (const auto& track : assocCandsThisColl) {
+          if (rejSameEvtPair(candidate, track)) {
+            continue;
+          }
+          registry.fill(HIST("hPoolBinAssoc"), poolBin);
+          registry.fill(HIST("hPhiVsPtAssoc"), RecoDecay::constrainAngle(getPhi(track), -o2::constants::math::PIHalf), getPt(candidate), getPt(track));
+          registry.fill(HIST("hEtaVsPtAssoc"), getEta(track), getPt(candidate), getPt(track));
+
+          if constexpr (std::is_same_v<TTrigCands, soa::Join<aod::HfcRedTrkAssocs, aod::HfcRedTrkSels>>) {
+            fillHadHadInfo<false>(candidate, track, poolBin);
+          } else {
+            fillCharmHadInfo<false>(candidate, track, poolBin);
+          }
+        }
+      }
+    }
+  }
+
+  /// Save info for Mixed Event pairs
+  /// \param collisions are the selected collisions
+  /// \param trigCands are the selected trigger candidates
+  /// \param assocTracks are the selected associated tracks
+  /// \param corrBinning is the binning policy for the correlation
+  template<typename TTrigCands, typename TAssocTracks, typename TBinningType>
+  void fillMixedEvent(aod::HfcRedFlowColls const& collisions,
+                      TTrigCands const& trigCands,
+                      TAssocTracks const& assocTracks,
+                      TBinningType corrBinning)
+  {
+    for (const auto& collision : collisions) {
+      int poolBin = getPoolBin<true>(collision, corrBinning);
+      registry.fill(HIST("hCollisionPoolBin"), poolBin);
+      registry.fill(HIST("hZVtx"), collision.posZ(), poolBin);
+
+      auto thisCollId = collision.globalIndex();
+      auto trigCandsThisColl = sliceTrigCands(trigCands, thisCollId);
+      auto assocCandsThisColl = assocTracks.sliceBy(tracksPerCol, thisCollId);
+      for (const auto& candidate : trigCandsThisColl) {
+        registry.fill(HIST("hPoolBinTrig"), poolBin);
+        registry.fill(HIST("hPhiVsPtTrig"), RecoDecay::constrainAngle(getPhi(candidate), -o2::constants::math::PIHalf), getPt(candidate));
+        for (const auto& track : assocCandsThisColl) {
+          registry.fill(HIST("hEtaVsPtTrig"), getEta(candidate), getPt(candidate));
+          registry.fill(HIST("hPoolBinAssoc"), poolBin);
+          registry.fill(HIST("hPhiVsPtAssoc"), RecoDecay::constrainAngle(getPhi(track), -o2::constants::math::PIHalf), getPt(candidate), getPt(track));
+          registry.fill(HIST("hEtaVsPtAssoc"), getEta(track), getPt(candidate), getPt(track));
+        }
+      }
+    }
+
+    auto pairsTuple = std::make_tuple(trigCands, assocTracks);
+    Pair<aod::HfcRedFlowColls, TTrigCands, TAssocTracks, TBinningType> pairData{corrBinning, numberEventsMixed, -1, collisions, pairsTuple, &cache};
+
+    for (const auto& [trigColl, trigCands, assocColl, assocTracks] : pairData) {
+      if (trigCands.size() == 0 || assocTracks.size() == 0) {
+        continue;
+      }
+      int poolBinCharm = getPoolBin<false>(trigColl, corrBinning);
+      int poolBinAssoc = getPoolBin<false>(assocColl, corrBinning);
+      if (poolBinAssoc != poolBinCharm) {
+        LOGF(info, "Error, poolBins are different");
+      }
+
+      for (const auto& [trigCand, assocTrack] : o2::soa::combinations(o2::soa::CombinationsFullIndexPolicy(trigCands, assocTracks))) {
+        // LOGF(info, "Mixed event tracks pair: (%d, %d) from events (%d, %d), track event: (%d, %d)", trigCand.index(), assocTrack.index(), trigColl.index(), assocColl.index(), trigCand.hfcRedFlowCollId(), assocTrack.hfcRedFlowCollId());
+        if constexpr (std::is_same_v<TTrigCands, soa::Join<aod::HfcRedTrkAssocs, aod::HfcRedTrkSels>>) {
+          fillHadHadInfo<true>(trigCand, assocTrack, poolBinCharm);
+        } else {
+          fillCharmHadInfo<true>(trigCand, assocTrack, poolBinCharm);
+        }
+      }
+    }
+  }
+
+  void processSameEventCharmHadWCentMix(aod::HfcRedFlowColls const& collisions,
+                                        soa::Join<aod::HfcRedCharmTrigs, aod::HfcRedCharmMls> const& candidates,
+                                        soa::Join<aod::HfcRedTrkAssocs, aod::HfcRedTrkSels> const& tracks)
+  {
+    ColumnBinningPolicy<aod::hf_collisions_reduced::PosZ, aod::hf_collisions_reduced::Centrality> corrBinningCent{{zPoolBins, centPoolBins}, true};
+    fillSameEvent(collisions, candidates, tracks, corrBinningCent);
+  }
+  PROCESS_SWITCH(HfCorrelatorFlowCharmHadrons, processSameEventCharmHadWCentMix, "Process Same Event for Charm-Had with centrality pools", true);
+  
+  void processSameEventCharmHadWMultMix(aod::HfcRedFlowColls const& collisions,
+                                        soa::Join<aod::HfcRedCharmTrigs, aod::HfcRedCharmMls> const& candidates,
+                                        soa::Join<aod::HfcRedTrkAssocs, aod::HfcRedTrkSels> const& tracks)
+  {
+    ColumnBinningPolicy<aod::hf_collisions_reduced::PosZ, aod::hf_collisions_reduced::Multiplicity> corrBinningMult{{zPoolBins, multPoolBins}, true};
+    fillSameEvent(collisions, candidates, tracks, corrBinningMult);
+  }
+  PROCESS_SWITCH(HfCorrelatorFlowCharmHadrons, processSameEventCharmHadWMultMix, "Process Same Event for Charm-Had with multiplicity pools", false);
+
+  void processMixedEventCharmHadWCentMix(aod::HfcRedFlowColls const& collisions,
+                                         soa::Join<aod::HfcRedCharmTrigs, aod::HfcRedCharmMls> const& candidates,
+                                         soa::Join<aod::HfcRedTrkAssocs, aod::HfcRedTrkSels> const& tracks)
+  {
+    ColumnBinningPolicy<aod::hf_collisions_reduced::PosZ, aod::hf_collisions_reduced::Centrality> corrBinningCent{{zPoolBins, centPoolBins}, true};
+    fillMixedEvent(collisions, candidates, tracks, corrBinningCent);
+  }
+  PROCESS_SWITCH(HfCorrelatorFlowCharmHadrons, processMixedEventCharmHadWCentMix, "Process Mixed Event for Charm-Had with centrality pools", false);
+
+  void processMixedEventCharmHadWMultMix(aod::HfcRedFlowColls const& collisions,
+                                         soa::Join<aod::HfcRedCharmTrigs, aod::HfcRedCharmMls> const& candidates,
+                                         soa::Join<aod::HfcRedTrkAssocs, aod::HfcRedTrkSels> const& tracks)
+  {
+    ColumnBinningPolicy<aod::hf_collisions_reduced::PosZ, aod::hf_collisions_reduced::Multiplicity> corrBinningMult{{zPoolBins, multPoolBins}, true};
+    fillMixedEvent(collisions, candidates, tracks, corrBinningMult);
+  }
+  PROCESS_SWITCH(HfCorrelatorFlowCharmHadrons, processMixedEventCharmHadWMultMix, "Process Mixed Event for Charm-Had with multiplicity pools", false);
+
+  void processSameEventHadHadWCentMix(aod::HfcRedFlowColls const& collisions,
+                                      soa::Join<aod::HfcRedTrkAssocs, aod::HfcRedTrkSels> const& tracks)
+  {
+    ColumnBinningPolicy<aod::hf_collisions_reduced::PosZ, aod::hf_collisions_reduced::Centrality> corrBinningCent{{zPoolBins, centPoolBins}, true};
+    fillSameEvent(collisions, tracks, tracks, corrBinningCent);
+  }
+  PROCESS_SWITCH(HfCorrelatorFlowCharmHadrons, processSameEventHadHadWCentMix, "Process Same Event for Had-Had with centrality pools", false);
+
+  void processSameEventHadHadWMultMix(aod::HfcRedFlowColls const& collisions,
+                                      soa::Join<aod::HfcRedTrkAssocs, aod::HfcRedTrkSels> const& tracks)
+  {
+    ColumnBinningPolicy<aod::hf_collisions_reduced::PosZ, aod::hf_collisions_reduced::Multiplicity> corrBinningMult{{zPoolBins, multPoolBins}, true};
+    fillSameEvent(collisions, tracks, tracks, corrBinningMult);
+  }
+  PROCESS_SWITCH(HfCorrelatorFlowCharmHadrons, processSameEventHadHadWMultMix, "Process Same Event for Had-Had with multiplicity pools", false);
+
+  void processMixedEventHadHadWCentMix(aod::HfcRedFlowColls const& collisions,
+                                       soa::Join<aod::HfcRedTrkAssocs, aod::HfcRedTrkSels> const& tracks)
+  {
+    ColumnBinningPolicy<aod::hf_collisions_reduced::PosZ, aod::hf_collisions_reduced::Centrality> corrBinningCent{{zPoolBins, centPoolBins}, true};
+    fillMixedEvent(collisions, tracks, tracks, corrBinningCent);
+  }
+  PROCESS_SWITCH(HfCorrelatorFlowCharmHadrons, processMixedEventHadHadWCentMix, "Process Mixed Event for Had-Had with centrality pools", false);
+
+  void processMixedEventHadHadWMultMix(aod::HfcRedFlowColls const& collisions,
+                                       soa::Join<aod::HfcRedTrkAssocs, aod::HfcRedTrkSels> const& tracks)
+  {
+    ColumnBinningPolicy<aod::hf_collisions_reduced::PosZ, aod::hf_collisions_reduced::Multiplicity> corrBinningMult{{zPoolBins, multPoolBins}, true};
+    fillMixedEvent(collisions, tracks, tracks, corrBinningMult);
+  }
+  PROCESS_SWITCH(HfCorrelatorFlowCharmHadrons, processMixedEventHadHadWMultMix, "Process Mixed Event for Had-Had with multiplicity pools", false);
+
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{adaptAnalysisTask<HfCorrelatorFlowCharmHadrons>(cfgc)};
+}

--- a/PWGHF/HFC/TableProducer/derivedDataCreatorCorrelationsReduced.cxx
+++ b/PWGHF/HFC/TableProducer/derivedDataCreatorCorrelationsReduced.cxx
@@ -60,12 +60,11 @@ enum DecayChannel {
 };
 
 /// Code to select collisions with at least one Ds meson
-struct HfCorrelatorFlowCharmHadrons {
+struct HfDerivedDataCreatorCorrelationsReduced {
   Produces<aod::HfcRedFlowColls> rowCollisions;
-  Produces<aod::HfcRedCharmHads2P> rowCharmCandidates2P;
-  Produces<aod::HfcRedCharmHads3P> rowCharmCandidates3P;
+  Produces<aod::HfcRedCharmTrigs> rowCharmCandidates;
   Produces<aod::HfcRedCharmMls> rowCharmCandidatesMl;
-  Produces<aod::HfcRedTrkAssoc> rowAssocTrackReduced;
+  Produces<aod::HfcRedTrkAssocs> rowAssocTrackReduced;
   Produces<aod::HfcRedTrkSels> rowAssocTrackSelInfo;
 
   Configurable<int> centEstimator{"centEstimator", 2, "Centrality estimation (FT0A: 1, FT0C: 2, FT0M: 3, FV0A: 4)"};
@@ -231,9 +230,9 @@ struct HfCorrelatorFlowCharmHadrons {
       }
       double massCand = getCandMass<channel>(candidate);
       if constexpr (channel == DecayChannel::D0ToKPi || channel == DecayChannel::D0ToPiK) {
-        rowCharmCandidates2P(indexRedColl, candidate.phi(), candidate.eta(), candidate.pt(), massCand, candidate.prong0Id(), candidate.prong1Id());
+        rowCharmCandidates(indexRedColl, candidate.phi(), candidate.eta(), candidate.pt(), massCand, candidate.prong0Id(), candidate.prong1Id(), -1);
       } else {
-        rowCharmCandidates3P(indexRedColl, candidate.phi(), candidate.eta(), candidate.pt(), massCand, candidate.prong0Id(), candidate.prong1Id(), candidate.prong2Id());
+        rowCharmCandidates(indexRedColl, candidate.phi(), candidate.eta(), candidate.pt(), massCand, candidate.prong0Id(), candidate.prong1Id(), candidate.prong2Id());
       }
       std::vector<float> outputMl = getCandMlScores<channel>(candidate);
       rowCharmCandidatesMl(indexRedColl, outputMl[0], outputMl[1]);
@@ -274,7 +273,7 @@ struct HfCorrelatorFlowCharmHadrons {
       fillTracksTables(trackIdsThisColl);
     }
   }
-  PROCESS_SWITCH(HfCorrelatorFlowCharmHadrons, processDplusWithMl, "Process Dplus candidates with ML info", false);
+  PROCESS_SWITCH(HfDerivedDataCreatorCorrelationsReduced, processDplusWithMl, "Process Dplus candidates with ML info", false);
 
   // Ds with ML selections
   void processDsWithMl(CollsWithCentMult const& colls,
@@ -297,7 +296,7 @@ struct HfCorrelatorFlowCharmHadrons {
       fillTracksTables(trackIdsThisColl);
     }
   }
-  PROCESS_SWITCH(HfCorrelatorFlowCharmHadrons, processDsWithMl, "Process Ds candidates with ML info", false);
+  PROCESS_SWITCH(HfDerivedDataCreatorCorrelationsReduced, processDsWithMl, "Process Ds candidates with ML info", false);
 
   // D0 with ML selections
   void processD0WithMl(CollsWithCentMult const& colls,
@@ -320,10 +319,10 @@ struct HfCorrelatorFlowCharmHadrons {
       fillTracksTables(trackIdsThisColl);
     }
   }
-  PROCESS_SWITCH(HfCorrelatorFlowCharmHadrons, processD0WithMl, "Process D0 candidates with ML info", false);
+  PROCESS_SWITCH(HfDerivedDataCreatorCorrelationsReduced, processD0WithMl, "Process D0 candidates with ML info", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{adaptAnalysisTask<HfCorrelatorFlowCharmHadrons>(cfgc)};
+  return WorkflowSpec{adaptAnalysisTask<HfDerivedDataCreatorCorrelationsReduced>(cfgc)};
 }


### PR DESCRIPTION
In this PR, the reduced workflow to perform flow correlation analyses for D mesons is implemented. Moreover, also process functions to compute the correlation maps for hadron pairs are included, to validate the workflow and correct the results.

Tagging @stefanopolitano, @scattaru, @wuctlby for info.