### PR TITLE
[PWGDQ,PWGLF,DPG] TPC PID: fill clean kaon sample from Omega decay

### DIFF
--- a/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
+++ b/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
@@ -107,8 +107,8 @@ struct TreeWriterTpcV0 {
   ctpRateFetcher mRateFetcher;
 
   /// Funktion to fill skimmed tables
-  template <bool doUseCorreceddEdx = false, typename T, typename C, typename V0>
-  void fillSkimmedV0Table(V0 const& v0, T const& track, C const& collision, const float nSigmaTPC, const float nSigmaTOF, const float dEdxExp, const o2::track::PID::ID id, int runnumber, double dwnSmplFactor, float hadronicRate)
+  template <bool doUseCorreceddEdx = false, typename T, typename C, typename V0Casc>
+  void fillSkimmedV0Table(V0Casc const& v0casc, T const& track, C const& collision, const float nSigmaTPC, const float nSigmaTOF, const float dEdxExp, const o2::track::PID::ID id, int runnumber, double dwnSmplFactor, float hadronicRate)
   {
 
     const double ncl = track.tpcNClsFound();
@@ -120,12 +120,12 @@ struct TreeWriterTpcV0 {
     auto trackocc = collision.trackOccupancyInTimeRange();
     auto ft0occ = collision.ft0cOccupancyInTimeRange();
 
-    const float alpha = v0.alpha();
-    const float qt = v0.qtarm();
-    const float cosPA = v0.v0cosPA();
-    const float pT = v0.pt();
-    const float v0radius = v0.v0radius();
-    const float gammapsipair = v0.psipair();
+    const float alpha = v0casc.alpha();
+    const float qt = v0casc.qtarm();
+    const float cosPA = GetCosPA(v0casc);
+    const float pT = v0casc.pt();
+    const float v0radius = GetRadius(v0casc);
+    const float gammapsipair = v0casc.psipair();
 
     const double pseudoRndm = track.pt() * 1000. - static_cast<int64_t>(track.pt() * 1000);
     if (pseudoRndm < dwnSmplFactor) {
@@ -348,6 +348,30 @@ struct TreeWriterTpcV0 {
     ccdb->setFatalWhenNull(false);
   }
 
+  /// Evaluate cosPA of the v0
+  double GetCosPA(V0sWithID::iterator const& v0)
+  {
+    return v0.v0cosPA();
+  }
+
+  /// Evaluate cosPA of the cascade
+  double GetCosPA(CascsWithID::iterator const& casc)
+  {
+    return casc.casccosPA();
+  }
+
+  /// Evaluate radius of the v0
+  double GetRadius(V0sWithID::iterator const& v0)
+  {
+    return v0.v0radius();
+  }
+
+  /// Evaluate radius of the cascade
+  double GetRadius(CascsWithID::iterator const& casc)
+  {
+    return casc.cascradius();
+  }
+
   /// Apply a track quality selection with a filter!
   void processStandard(Colls::iterator const& collision, soa::Filtered<Trks> const& tracks, V0sWithID const& v0s, CascsWithID const& cascs, aod::BCsWithTimestamps const&)
   {
@@ -419,7 +443,7 @@ struct TreeWriterTpcV0 {
       // Omega
       if (static_cast<bool>(bachTrack.pidbit() & (1 << kOmega))) {
         if (downsampleTsalisCharged(bachTrack.pt(), downsamplingTsalisKaons, sqrtSNN, o2::track::pid_constants::sMasses[o2::track::PID::Kaon], maxPt4dwnsmplTsalisKaons)) {
-          //           fillSkimmedV0Table(casc, bachTrack, collision, bachTrack.tpcNSigmaPr(), bachTrack.tofNSigmaPr(), bachTrack.tpcExpSignalPr(bachTrack.tpcSignal()), o2::track::PID::Proton, runnumber, dwnSmplFactor_Pr, hadronicRate);
+          fillSkimmedV0Table(casc, bachTrack, collision, bachTrack.tpcNSigmaPr(), bachTrack.tofNSigmaPr(), bachTrack.tpcExpSignalPr(bachTrack.tpcSignal()), o2::track::PID::Proton, runnumber, dwnSmplFactor_Pr, hadronicRate);
         }
       }
     }

--- a/PWGDQ/DataModel/ReducedInfoTables.h
+++ b/PWGDQ/DataModel/ReducedInfoTables.h
@@ -1124,10 +1124,10 @@ DECLARE_SOA_COLUMN(V0AddID, v0addid, int8_t); //!
 DECLARE_SOA_TABLE(V0MapID, "AOD", "V0MAPID", //!
                   v0mapID::V0AddID);
 
-namespace cascmapId
+namespace cascmapID
 {
 DECLARE_SOA_COLUMN(CascAddID, cascaddid, int8_t); //!
-} // namespace cascmapId
+} // namespace cascmapID
 
 DECLARE_SOA_TABLE(CascMapID, "AOD", "CASCMAPID", //!
                   cascmapID::CascAddID);

--- a/PWGDQ/DataModel/ReducedInfoTables.h
+++ b/PWGDQ/DataModel/ReducedInfoTables.h
@@ -1124,6 +1124,14 @@ DECLARE_SOA_COLUMN(V0AddID, v0addid, int8_t); //!
 DECLARE_SOA_TABLE(V0MapID, "AOD", "V0MAPID", //!
                   v0mapID::V0AddID);
 
+namespace cascmapId
+{
+DECLARE_SOA_COLUMN(CascAddID, cascaddid, int8_t); //!
+} // namespace cascmapId
+
+DECLARE_SOA_TABLE(CascMapID, "AOD", "CASCMAPID", //!
+                  cascmapID::CascAddID);
+
 namespace DalBits
 {
 DECLARE_SOA_COLUMN(DALITZBits, dalitzBits, uint8_t); //!

--- a/PWGDQ/Tasks/v0selector.cxx
+++ b/PWGDQ/Tasks/v0selector.cxx
@@ -599,7 +599,7 @@ struct v0selector {
           }
         };
 
-        if (cascid == kOmega) {
+        if (cascid == kOmega && v0id == kLambda) {
           if (fillhisto) {
             registry.fill(HIST("hMassOmega"), cascRadius, mOmega);
           }
@@ -607,7 +607,7 @@ struct v0selector {
             pidmap[casc.bachelorId()] |= (uint8_t(1) << kOmega);
             storeCascAddID(casc.globalIndex(), kOmega);
           }
-        } else if (cascid == kAntiOmega) {
+        } else if (cascid == kAntiOmega && v0id == kAntiLambda) {
           if (fillhisto) {
             registry.fill(HIST("hMassAntiOmega"), cascRadius, mOmega);
           }

--- a/PWGDQ/Tasks/v0selector.cxx
+++ b/PWGDQ/Tasks/v0selector.cxx
@@ -17,35 +17,39 @@
 //    Comments, questions, complaints, suggestions?
 //    Please write to: daiki.sekihata@cern.ch
 //
-#include <array>
-#include <map>
-#include <string>
-#include <memory>
-#include <vector>
-#include "Math/Vector4D.h"
-#include "Framework/runDataProcessing.h"
-#include "Framework/AnalysisTask.h"
-#include "Framework/AnalysisDataModel.h"
-#include "Framework/ASoAHelpers.h"
-#include "ReconstructionDataFormats/Track.h"
-#include "Common/Core/trackUtilities.h"
-#include "PWGLF/DataModel/LFStrangenessTables.h"
-#include "Common/Core/TrackSelection.h"
-#include "Common/DataModel/TrackSelectionTables.h"
-#include "Common/DataModel/EventSelection.h"
-#include "Common/DataModel/Centrality.h"
-#include "Common/DataModel/PIDResponse.h"
-#include "Common/Core/RecoDecay.h"
-#include "DCAFitter/DCAFitterN.h"
-#include "PWGDQ/DataModel/ReducedInfoTables.h"
-#include "PWGDQ/Core/VarManager.h"
 #include "PWGDQ/Core/HistogramManager.h"
 #include "PWGDQ/Core/HistogramsLibrary.h"
-#include "DetectorsBase/Propagator.h"
-#include "DetectorsBase/GeometryManager.h"
-#include "DataFormatsParameters/GRPObject.h"
-#include "DataFormatsParameters/GRPMagField.h"
+#include "PWGDQ/Core/VarManager.h"
+#include "PWGDQ/DataModel/ReducedInfoTables.h"
+#include "PWGLF/DataModel/LFStrangenessTables.h"
+
+#include "Common/Core/RecoDecay.h"
+#include "Common/Core/TrackSelection.h"
+#include "Common/Core/trackUtilities.h"
+#include "Common/DataModel/Centrality.h"
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/PIDResponse.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+
 #include "CCDB/BasicCCDBManager.h"
+#include "DCAFitter/DCAFitterN.h"
+#include "DataFormatsParameters/GRPMagField.h"
+#include "DataFormatsParameters/GRPObject.h"
+#include "DetectorsBase/GeometryManager.h"
+#include "DetectorsBase/Propagator.h"
+#include "Framework/ASoAHelpers.h"
+#include "Framework/AnalysisDataModel.h"
+#include "Framework/AnalysisTask.h"
+#include "Framework/runDataProcessing.h"
+#include "ReconstructionDataFormats/Track.h"
+
+#include "Math/Vector4D.h"
+
+#include <array>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 using namespace o2;
 using namespace o2::framework;
@@ -112,7 +116,7 @@ struct v0selector {
 
     // // K0S cuts
     // const float cutQTK0S[2] = {0.1075, 0.215};
-    // const float cutAPK0S[2] = {0.199, 0.8}; // parameters for curved QT cut
+    // const float cutAPK0S[2] = {0.199, 0.8}; //  parameters for curved QT cut
 
     // // Lambda & A-Lambda cuts
     // const float cutQTL = 0.03;
@@ -574,7 +578,7 @@ struct trackPIDQA {
       }
 
     } // end of track loop
-  }   // end of process
+  } // end of process
 
   void DefineHistograms(TString histClasses)
   {

--- a/PWGDQ/Tasks/v0selector.cxx
+++ b/PWGDQ/Tasks/v0selector.cxx
@@ -99,6 +99,7 @@ struct v0selector {
   Configurable<float> cutAPOmegaDown3{"cutAPOmegaDown3", 0.16, "cutAPOmegaDown3"};
   Configurable<float> cutAlphaOmegaHigh{"cutAlphaOmegaHigh", 0.358, "cutAlphaOmegaHigh"};
   Configurable<float> cutAlphaOmegaLow{"cutAlphaOmegaLow", 0., "cutAlphaOmegaLow"};
+  Configurable<float> cutQTOmegaLowOuterArc{"cutQTOmegaLowOuterArc", 0.14, "cutQTOmegaLowOuterArc"};
   Configurable<float> cutMassOmegaHigh{"cutMassOmegaHigh", 1.677, "cutMassOmegaHigh"};
   Configurable<float> cutMassOmegaLow{"cutMassOmegaLow", 1.667, "cutMassOmegaLow"};
   Configurable<float> cutMassCascV0Low{"cutMassCascV0Low", 1.110, "cutMassCascV0Low"};
@@ -186,6 +187,10 @@ struct v0selector {
     const float qDown = std::abs(alpha - cutAPOmegaDown2) > std::abs(cutAPOmegaDown3) ? 0. : cutAPOmegaDown1 * std::sqrt(1.0f - ((alpha - cutAPOmegaDown2) * (alpha - cutAPOmegaDown2)) / (cutAPOmegaDown3 * cutAPOmegaDown3));
 
     if (alpha < cutAlphaOmegaLow || alpha > cutAlphaOmegaHigh || qt < qDown || qt > qUp) {
+      return kUndef;
+    }
+
+    if (alpha > cutAPOmegaUp2 && qt < cutQTOmegaLowOuterArc) {
       return kUndef;
     }
 

--- a/PWGDQ/Tasks/v0selector.cxx
+++ b/PWGDQ/Tasks/v0selector.cxx
@@ -310,55 +310,21 @@ struct v0selector {
       if (fillhisto) {
         registry.fill(HIST("hV0Candidate"), 1);
       }
-      if (std::fabs(V0.posTrack_as<FullTracksExt>().eta()) > 0.9) {
-        continue;
-      }
-      if (std::fabs(V0.negTrack_as<FullTracksExt>().eta()) > 0.9) {
-        continue;
-      }
 
-      if (V0.posTrack_as<FullTracksExt>().tpcNClsCrossedRows() < mincrossedrows) {
-        continue;
-      }
-      if (V0.negTrack_as<FullTracksExt>().tpcNClsCrossedRows() < mincrossedrows) {
-        continue;
-      }
-      if (V0.posTrack_as<FullTracksExt>().tpcChi2NCl() > maxchi2tpc) {
-        continue;
-      }
-      if (V0.negTrack_as<FullTracksExt>().tpcChi2NCl() > maxchi2tpc) {
-        continue;
-      }
-      if (std::fabs(V0.posTrack_as<FullTracksExt>().dcaXY()) < dcamin) {
-        continue;
-      }
-      if (std::fabs(V0.negTrack_as<FullTracksExt>().dcaXY()) < dcamin) {
-        continue;
-      }
-      if (std::fabs(V0.posTrack_as<FullTracksExt>().dcaXY()) > dcamax) {
-        continue;
-      }
-      if (std::fabs(V0.negTrack_as<FullTracksExt>().dcaXY()) > dcamax) {
-        continue;
-      }
+      const auto& posTrack = casc.posTrack_as<FullTracksExt>();
+      const auto& negTrack = casc.negTrack_as<FullTracksExt>();
 
-      if (V0.posTrack_as<FullTracksExt>().sign() * V0.negTrack_as<FullTracksExt>().sign() > 0) { // reject same sign pair
-        continue;
+      bool isRejectV0{false};
+      for(const auto& prong : std::array<FullTracksExt, 2>{posTrack, negTrack}) {
+        isRejectV0 = isRejectV0 || std::fabs(prong.eta()) > 0.9;
+        isRejectV0 = isRejectV0 || prong.tpcNClsCrossedRows() < mincrossedrows;
+        isRejectV0 = isRejectV0 || prong.tpcChi2NCl() > maxchi2tpc;
+        isRejectV0 = isRejectV0 || std::fabs(prong.dcaXY()) < dcamin;
+        isRejectV0 = isRejectV0 || std::fabs(prong.dcaXY()) > dcamax;
       }
+      isRejectV0 = isRejectV0 || (posTrack.sign() * negTrack.sign() > 0);
 
-      // if (V0.posTrack_as<FullTracksExt>().collisionId() != V0.negTrack_as<FullTracksExt>().collisionId()) {
-      //   continue;
-      // }
-
-      // if (!V0.posTrack_as<FullTracksExt>().has_collision() || !V0.negTrack_as<FullTracksExt>().has_collision()) {
-      //   continue;
-      // }
-
-      // auto const& collision = V0.collision_as<aod::Collisions>();
-
-      //      if (V0.collisionId() != collision.globalIndex()) {
-      //        continue;
-      //      }
+      if (isRejectV0) continue;
 
       float V0dca = V0.dcaV0daughters();
       float V0CosinePA = V0.v0cosPA();
@@ -471,56 +437,21 @@ struct v0selector {
           registry.fill(HIST("hCascCandidate"), 1);
         }
 
-        if (std::fabs(casc.posTrack_as<FullTracksExt>().eta()) > 0.9) {
-          continue;
-        }
-        if (std::fabs(casc.negTrack_as<FullTracksExt>().eta()) > 0.9) {
-          continue;
-        }
-        if (std::fabs(casc.negTrack_as<FullTracksExt>().eta()) > 0.9) {
-          continue;
-        }
+        const auto& posTrack = casc.posTrack_as<FullTracksExt>();
+        const auto& negTrack = casc.negTrack_as<FullTracksExt>();
+        const auto& bachelor = casc.bachelor_as<FullTracksExt>();
 
-        if (casc.posTrack_as<FullTracksExt>().tpcNClsCrossedRows() < mincrossedrows) {
-          continue;
+        bool isRejectCascade{false};
+        for(const auto& prong : std::array<FullTracksExt, 3>{posTrack, negTrack, bachelor}) {
+          isRejectCascade = isRejectCascade || std::fabs(prong.eta()) > 0.9;
+          isRejectCascade = isRejectCascade || prong.tpcNClsCrossedRows() < mincrossedrows;
+          isRejectCascade = isRejectCascade || prong.tpcChi2NCl() > maxchi2tpc;
+          isRejectCascade = isRejectCascade || std::fabs(prong.dcaXY()) < dcamin;
+          isRejectCascade = isRejectCascade || std::fabs(prong.dcaXY()) > dcamax;
         }
-        if (casc.negTrack_as<FullTracksExt>().tpcNClsCrossedRows() < mincrossedrows) {
-          continue;
-        }
-        if (casc.bachelor_as<FullTracksExt>().tpcNClsCrossedRows() < mincrossedrows) {
-          continue;
-        }
-        if (casc.posTrack_as<FullTracksExt>().tpcChi2NCl() > maxchi2tpc) {
-          continue;
-        }
-        if (casc.negTrack_as<FullTracksExt>().tpcChi2NCl() > maxchi2tpc) {
-          continue;
-        }
-        if (casc.bachelor_as<FullTracksExt>().tpcChi2NCl() > maxchi2tpc) {
-          continue;
-        }
-        if (std::fabs(casc.posTrack_as<FullTracksExt>().dcaXY()) < dcamin) {
-          continue;
-        }
-        if (std::fabs(casc.negTrack_as<FullTracksExt>().dcaXY()) < dcamin) {
-          continue;
-        }
-        if (std::fabs(casc.bachelor_as<FullTracksExt>().dcaXY()) < dcamin) {
-          continue;
-        }
-        if (std::fabs(casc.posTrack_as<FullTracksExt>().dcaXY()) > dcamax) {
-          continue;
-        }
-        if (std::fabs(casc.negTrack_as<FullTracksExt>().dcaXY()) > dcamax) {
-          continue;
-        }
-        if (std::fabs(casc.bachelor_as<FullTracksExt>().dcaXY()) > dcamax) {
-          continue;
-        }
+        isRejectCascade = isRejectCascade || (posTrack.sign() * negTrack.sign() > 0);
 
-        if (casc.posTrack_as<FullTracksExt>().sign() * casc.negTrack_as<FullTracksExt>().sign() > 0) { // reject same sign pair
-          continue;
-        }
+        if (isRejectCascade) continue;
 
         if (fillhisto) {
           registry.fill(HIST("hCascCandidate"), 2);

--- a/PWGDQ/Tasks/v0selector.cxx
+++ b/PWGDQ/Tasks/v0selector.cxx
@@ -101,6 +101,8 @@ struct v0selector {
   Configurable<float> cutAlphaOmegaLow{"cutAlphaOmegaLow", 0., "cutAlphaOmegaLow"};
   Configurable<float> cutMassOmegaHigh{"cutMassOmegaHigh", 1.677, "cutMassOmegaHigh"};
   Configurable<float> cutMassOmegaLow{"cutMassOmegaLow", 1.667, "cutMassOmegaLow"};
+  Configurable<float> cutMassCascV0Low{"cutMassCascV0Low", 1.110, "cutMassCascV0Low"};
+  Configurable<float> cutMassCascV0High{"cutMassCascV0High", 1.120, "cutMassCascV0High"};
 
   Configurable<bool> produceV0ID{"produceV0ID", false, "Produce additional V0ID table"};
   Configurable<bool> selectCascades{"selectCascades", false, "Select cascades in addition to v0s"};
@@ -556,6 +558,7 @@ struct v0selector {
         }
 
         const float mOmega = casc.mOmega();
+        const float mV0Lambda = casc.mLambda();
         const float alpha = casc.alpha();
         const float qt = casc.qtarm();
         const float v0Alpha = casc.v0Alpha();
@@ -603,7 +606,7 @@ struct v0selector {
           if (fillhisto) {
             registry.fill(HIST("hMassOmega"), cascRadius, mOmega);
           }
-          if (cutMassOmegaLow < mOmega && mOmega < cutMassOmegaHigh && std::abs(casc.posTrack_as<FullTracksExt>().tpcNSigmaPr()) < cutNsigmaPrTPC && std::abs(casc.negTrack_as<FullTracksExt>().tpcNSigmaPi()) < cutNsigmaPiTPC && std::abs(casc.bachelor_as<FullTracksExt>().tpcNSigmaKa()) < cutNsigmaKaTPC) {
+          if (cutMassOmegaLow < mOmega && mOmega < cutMassOmegaHigh && cutMassCascV0Low < mV0Lambda && mV0Lambda < cutMassCascV0High && std::abs(casc.posTrack_as<FullTracksExt>().tpcNSigmaPr()) < cutNsigmaPrTPC && std::abs(casc.negTrack_as<FullTracksExt>().tpcNSigmaPi()) < cutNsigmaPiTPC && std::abs(casc.bachelor_as<FullTracksExt>().tpcNSigmaKa()) < cutNsigmaKaTPC) {
             pidmap[casc.bachelorId()] |= (uint8_t(1) << kOmega);
             storeCascAddID(casc.globalIndex(), kOmega);
           }
@@ -611,7 +614,7 @@ struct v0selector {
           if (fillhisto) {
             registry.fill(HIST("hMassAntiOmega"), cascRadius, mOmega);
           }
-          if (cutMassOmegaLow < mOmega && mOmega < cutMassOmegaHigh && std::abs(casc.posTrack_as<FullTracksExt>().tpcNSigmaPi()) < cutNsigmaPiTPC && std::abs(casc.negTrack_as<FullTracksExt>().tpcNSigmaPr()) < cutNsigmaPrTPC && std::abs(casc.bachelor_as<FullTracksExt>().tpcNSigmaKa()) < cutNsigmaKaTPC) {
+          if (cutMassOmegaLow < mOmega && mOmega < cutMassOmegaHigh && cutMassCascV0Low < mV0Lambda && mV0Lambda < cutMassCascV0High && std::abs(casc.posTrack_as<FullTracksExt>().tpcNSigmaPi()) < cutNsigmaPiTPC && std::abs(casc.negTrack_as<FullTracksExt>().tpcNSigmaPr()) < cutNsigmaPrTPC && std::abs(casc.bachelor_as<FullTracksExt>().tpcNSigmaKa()) < cutNsigmaKaTPC) {
             pidmap[casc.bachelorId()] |= (uint8_t(1) << kAntiOmega);
             storeCascAddID(casc.globalIndex(), kAntiOmega);
           }

--- a/PWGDQ/Tasks/v0selector.cxx
+++ b/PWGDQ/Tasks/v0selector.cxx
@@ -315,7 +315,7 @@ struct v0selector {
       const auto& negTrack = V0.negTrack_as<FullTracksExt>();
 
       bool isRejectV0{false};
-      for(const auto& prong : std::array<FullTracksExt, 2>{posTrack, negTrack}) {
+      for(const auto& prong : {posTrack, negTrack}) {
         isRejectV0 = isRejectV0 || std::fabs(prong.eta()) > 0.9;
         isRejectV0 = isRejectV0 || prong.tpcNClsCrossedRows() < mincrossedrows;
         isRejectV0 = isRejectV0 || prong.tpcChi2NCl() > maxchi2tpc;
@@ -442,7 +442,7 @@ struct v0selector {
         const auto& bachelor = casc.bachelor_as<FullTracksExt>();
 
         bool isRejectCascade{false};
-        for(const auto& prong : std::array<FullTracksExt, 3>{posTrack, negTrack, bachelor}) {
+        for(const auto& prong : {posTrack, negTrack, bachelor}) {
           isRejectCascade = isRejectCascade || std::fabs(prong.eta()) > 0.9;
           isRejectCascade = isRejectCascade || prong.tpcNClsCrossedRows() < mincrossedrows;
           isRejectCascade = isRejectCascade || prong.tpcChi2NCl() > maxchi2tpc;

--- a/PWGDQ/Tasks/v0selector.cxx
+++ b/PWGDQ/Tasks/v0selector.cxx
@@ -311,8 +311,8 @@ struct v0selector {
         registry.fill(HIST("hV0Candidate"), 1);
       }
 
-      const auto& posTrack = casc.posTrack_as<FullTracksExt>();
-      const auto& negTrack = casc.negTrack_as<FullTracksExt>();
+      const auto& posTrack = V0.posTrack_as<FullTracksExt>();
+      const auto& negTrack = V0.negTrack_as<FullTracksExt>();
 
       bool isRejectV0{false};
       for(const auto& prong : std::array<FullTracksExt, 2>{posTrack, negTrack}) {

--- a/PWGDQ/Tasks/v0selector.cxx
+++ b/PWGDQ/Tasks/v0selector.cxx
@@ -315,7 +315,7 @@ struct v0selector {
       const auto& negTrack = V0.negTrack_as<FullTracksExt>();
 
       bool isRejectV0{false};
-      for(const auto& prong : {posTrack, negTrack}) {
+      for (const auto& prong : {posTrack, negTrack}) {
         isRejectV0 = isRejectV0 || std::fabs(prong.eta()) > 0.9;
         isRejectV0 = isRejectV0 || prong.tpcNClsCrossedRows() < mincrossedrows;
         isRejectV0 = isRejectV0 || prong.tpcChi2NCl() > maxchi2tpc;
@@ -324,7 +324,8 @@ struct v0selector {
       }
       isRejectV0 = isRejectV0 || (posTrack.sign() * negTrack.sign() > 0);
 
-      if (isRejectV0) continue;
+      if (isRejectV0)
+        continue;
 
       float V0dca = V0.dcaV0daughters();
       float V0CosinePA = V0.v0cosPA();
@@ -442,7 +443,7 @@ struct v0selector {
         const auto& bachelor = casc.bachelor_as<FullTracksExt>();
 
         bool isRejectCascade{false};
-        for(const auto& prong : {posTrack, negTrack, bachelor}) {
+        for (const auto& prong : {posTrack, negTrack, bachelor}) {
           isRejectCascade = isRejectCascade || std::fabs(prong.eta()) > 0.9;
           isRejectCascade = isRejectCascade || prong.tpcNClsCrossedRows() < mincrossedrows;
           isRejectCascade = isRejectCascade || prong.tpcChi2NCl() > maxchi2tpc;
@@ -451,7 +452,8 @@ struct v0selector {
         }
         isRejectCascade = isRejectCascade || (posTrack.sign() * negTrack.sign() > 0);
 
-        if (isRejectCascade) continue;
+        if (isRejectCascade)
+          continue;
 
         if (fillhisto) {
           registry.fill(HIST("hCascCandidate"), 2);

--- a/PWGDQ/Tasks/v0selector.cxx
+++ b/PWGDQ/Tasks/v0selector.cxx
@@ -103,6 +103,7 @@ struct v0selector {
   Configurable<float> cutMassOmegaLow{"cutMassOmegaLow", 1.667, "cutMassOmegaLow"};
 
   Configurable<bool> produceV0ID{"produceV0ID", false, "Produce additional V0ID table"};
+  Configurable<bool> selectCascades{"selectCascades", false, "Select cascades in addition to v0s"};
   Configurable<bool> produceCascID{"produceCascID", false, "Produce additional CascID table"};
 
   enum { // Reconstructed V0
@@ -205,10 +206,21 @@ struct v0selector {
   Configurable<int> mincrossedrows{"mincrossedrows", 70, "min crossed rows"};
   Configurable<float> maxchi2tpc{"maxchi2tpc", 4.0, "max chi2/NclsTPC"};
   Configurable<bool> fillhisto{"fillhisto", false, "flag to fill histograms"};
-  // cutNsigmaElTPC, cutNsigmaPiTPC, cutNsigmaPrTPC
+  // Cascade-related Configurables
+  Configurable<float> cascDcaMax{"cascDcaMax", 0.3, "DCA cascade daughters"};
+  Configurable<float> cascV0DcaMax{"cascV0DcaMax", 0.3, "DCA V0 daughters of the cascade"};
+  Configurable<float> cascRadiusMin{"cascRadiusMin", 0.0, "Cascade Radius min"};
+  Configurable<float> cascRadiusMax{"cascRadiusMax", 90.0, "Cascade Radius max"};
+  Configurable<float> cascV0RadiusMin{"cascV0RadiusMin", 0.0, "V0 of the Cascade Radius min"};
+  Configurable<float> cascV0RadiusMax{"cascV0RadiusMax", 90.0, "V0 of the Cascade Radius max"};
+  Configurable<float> cascCosinePAMin{"cascCosinePAMin", 0.998, "Cascade CosPA min"};
+  Configurable<float> cascV0CosinePAMin{"cascV0CosinePAMin", 0.995, "V0 of the Cascade CosPA min"};
+  Configurable<float> cascV0CosinePAMax{"cascV0CosinePAMax", 1.000, "V0 of the Cascade CosPA max"};
+  // cutNsigmaElTPC, cutNsigmaPiTPC, cutNsigmaPrTPC, cutNsigmaKaTPC
   Configurable<float> cutNsigmaElTPC{"cutNsigmaElTPC", 5.0, "cutNsigmaElTPC"};
   Configurable<float> cutNsigmaPiTPC{"cutNsigmaPiTPC", 5.0, "cutNsigmaPiTPC"};
   Configurable<float> cutNsigmaPrTPC{"cutNsigmaPrTPC", 5.0, "cutNsigmaPrTPC"};
+  Configurable<float> cutNsigmaKaTPC{"cutNsigmaKaTPC", 5.0, "cutNsigmaKaTPC"};
 
   HistogramRegistry registry{"registry"};
   void init(o2::framework::InitContext&)
@@ -236,10 +248,35 @@ struct v0selector {
       registry.add("hV0APplot", "hV0APplot", HistType::kTH2F, {{200, -1.0f, +1.0f}, {250, 0.0f, 0.25f}});
       registry.add("hV0APplotSelected", "hV0APplotSelected", HistType::kTH2F, {{200, -1.0f, +1.0f}, {250, 0.0f, 0.25f}});
       registry.add("hV0Psi", "hV0Psi", HistType::kTH2F, {{100, 0, TMath::PiOver2()}, {100, 0, 0.1}});
-      registry.add("hCascAPplot", "hCascAPplot", HistType::kTH2F, {{200, -1.0f, +1.0f}, {300, 0.0f, 0.3f}});
-      registry.add("hCascAPplotSelected", "hCascAPplotSelected", HistType::kTH2F, {{200, -1.0f, +1.0f}, {300, 0.0f, 0.3f}});
-      registry.add("hMassOmega", "hMassOmega", HistType::kTH2F, {{900, 0.0f, 90.0f}, {100, 1.62f, 1.72f}});
-      registry.add("hMassAntiOmega", "hMassAntiOmega", HistType::kTH2F, {{900, 0.0f, 90.0f}, {100, 1.62f, 1.72f}});
+      if (selectCascades) {
+        registry.add("hCascPt", "pT", HistType::kTH1F, {{100, 0.0f, 10}});
+        registry.add("hCascEtaPhi", "#eta vs. #varphi", HistType::kTH2F, {{63, 0, 6.3}, {20, -1.0f, 1.0f}});
+        registry.add("hCascDCAxyPosToPV", "hCascDCAxyPosToPV", HistType::kTH1F, {{1000, -5.0f, 5.0f}});
+        registry.add("hCascDCAxyNegToPV", "hCascDCAxyNegToPV", HistType::kTH1F, {{1000, -5.0f, 5.0f}});
+        registry.add("hCascDCAxyBachToPV", "hCascDCAxyBachToPV", HistType::kTH1F, {{1000, -5.0f, 5.0f}});
+        registry.add("hCascDCAzPosToPV", "hCascDCAzPosToPV", HistType::kTH1F, {{1000, -5.0f, 5.0f}});
+        registry.add("hCascDCAzNegToPV", "hCascDCAzNegToPV", HistType::kTH1F, {{1000, -5.0f, 5.0f}});
+        registry.add("hCascDCAzBachToPV", "hCascDCAzBachToPV", HistType::kTH1F, {{1000, -5.0f, 5.0f}});
+        registry.add("hCascAPplot", "hCascAPplot", HistType::kTH2F, {{200, -1.0f, +1.0f}, {300, 0.0f, 0.3f}});
+        registry.add("hCascV0APplot", "hCascV0APplot", HistType::kTH2F, {{200, -1.0f, +1.0f}, {250, 0.0f, 0.25f}});
+        registry.add("hCascAPplotSelected", "hCascAPplotSelected", HistType::kTH2F, {{200, -1.0f, +1.0f}, {300, 0.0f, 0.3f}});
+        registry.add("hCascV0APplotSelected", "hCascV0APplotSelected", HistType::kTH2F, {{200, -1.0f, +1.0f}, {250, 0.0f, 0.25f}});
+        registry.add("hCascRadius", "hCascRadius", HistType::kTH1F, {{1000, 0.0f, 100.0f}});
+        registry.add("hCascV0Radius", "hCascV0Radius", HistType::kTH1F, {{1000, 0.0f, 100.0f}});
+        registry.add("hCascCosPA", "hCascCosPA", HistType::kTH1F, {{50, 0.95f, 1.0f}});
+        registry.add("hCascV0CosPA", "hCascV0CosPA", HistType::kTH1F, {{50, 0.95f, 1.0f}});
+        registry.add("hMassOmega", "hMassOmega", HistType::kTH2F, {{900, 0.0f, 90.0f}, {100, 1.62f, 1.72f}});
+        registry.add("hMassAntiOmega", "hMassAntiOmega", HistType::kTH2F, {{900, 0.0f, 90.0f}, {100, 1.62f, 1.72f}});
+        registry.add("hCascDCADau", "hCascDCADau", HistType::kTH1F, {{1000, 0.0f, 10.0f}});
+        registry.add("hCascV0DCADau", "hCascV0DCADau", HistType::kTH1F, {{1000, 0.0f, 10.0f}});
+      }
+    }
+
+    if (selectCascades == false && produceCascID == true) {
+      LOGP(error, "produceCascID is available only when selectCascades is enabled");
+    }
+    if (cutAPOmegaUp1 < cutAPOmegaDown1) {
+      LOGP(error, "cutAPOmegaUp1 must be greater than cutAPOmegaDown1");
     }
   }
 
@@ -426,63 +463,164 @@ struct v0selector {
       }
     }
 
-    for (const auto& Casc : Cascs) {
-      if (fillhisto) {
-        registry.fill(HIST("hCascCandidate"), 1);
-      }
-
-      // topological selections
-
-      if (fillhisto) {
-        registry.fill(HIST("hCascCandidate"), 2);
-      }
-
-      const float Cascradius = Casc.cascradius();
-
-      const float mOmega = Casc.mOmega();
-
-      const float alpha = Casc.alpha();
-      const float qt = Casc.qtarm();
-
-      if (fillhisto) {
-        registry.fill(HIST("hCascAPplot"), alpha, qt);
-      }
-
-      const int cascid = checkCascade(alpha, qt);
-      if (cascid < 0) {
-        continue;
-      }
-      if (fillhisto) {
-        registry.fill(HIST("hCascAPplotSelected"), alpha, qt);
-      }
-
-      auto storeCascAddID = [&](auto gix, auto id) {
-        if (produceCascID.value) {
-          cascpidmap[gix] = id;
-        }
-      };
-
-      if (cascid == kOmega) {
+    if (selectCascades) {
+      for (const auto& casc : Cascs) {
         if (fillhisto) {
-          registry.fill(HIST("hMassOmega"), Cascradius, mOmega);
+          registry.fill(HIST("hCascCandidate"), 1);
         }
-        if (cutMassOmegaLow < mOmega && mOmega < cutMassOmegaHigh) {
-          pidmap[Casc.bachelorId()] |= (uint8_t(1) << kOmega);
-          storeCascAddID(Casc.globalIndex(), kOmega);
+
+        if (std::fabs(casc.posTrack_as<FullTracksExt>().eta()) > 0.9) {
+          continue;
         }
-      } else if (cascid == kAntiOmega) {
+        if (std::fabs(casc.negTrack_as<FullTracksExt>().eta()) > 0.9) {
+          continue;
+        }
+        if (std::fabs(casc.negTrack_as<FullTracksExt>().eta()) > 0.9) {
+          continue;
+        }
+
+        if (casc.posTrack_as<FullTracksExt>().tpcNClsCrossedRows() < mincrossedrows) {
+          continue;
+        }
+        if (casc.negTrack_as<FullTracksExt>().tpcNClsCrossedRows() < mincrossedrows) {
+          continue;
+        }
+        if (casc.bachelor_as<FullTracksExt>().tpcNClsCrossedRows() < mincrossedrows) {
+          continue;
+        }
+        if (casc.posTrack_as<FullTracksExt>().tpcChi2NCl() > maxchi2tpc) {
+          continue;
+        }
+        if (casc.negTrack_as<FullTracksExt>().tpcChi2NCl() > maxchi2tpc) {
+          continue;
+        }
+        if (casc.bachelor_as<FullTracksExt>().tpcChi2NCl() > maxchi2tpc) {
+          continue;
+        }
+        if (std::fabs(casc.posTrack_as<FullTracksExt>().dcaXY()) < dcamin) {
+          continue;
+        }
+        if (std::fabs(casc.negTrack_as<FullTracksExt>().dcaXY()) < dcamin) {
+          continue;
+        }
+        if (std::fabs(casc.bachelor_as<FullTracksExt>().dcaXY()) < dcamin) {
+          continue;
+        }
+        if (std::fabs(casc.posTrack_as<FullTracksExt>().dcaXY()) > dcamax) {
+          continue;
+        }
+        if (std::fabs(casc.negTrack_as<FullTracksExt>().dcaXY()) > dcamax) {
+          continue;
+        }
+        if (std::fabs(casc.bachelor_as<FullTracksExt>().dcaXY()) > dcamax) {
+          continue;
+        }
+
+        if (casc.posTrack_as<FullTracksExt>().sign() * casc.negTrack_as<FullTracksExt>().sign() > 0) { // reject same sign pair
+          continue;
+        }
+
         if (fillhisto) {
-          registry.fill(HIST("hMassAntiOmega"), Cascradius, mOmega);
+          registry.fill(HIST("hCascCandidate"), 2);
         }
-        if (cutMassOmegaLow < mOmega && mOmega < cutMassOmegaHigh) {
-          pidmap[Casc.bachelorId()] |= (uint8_t(1) << kAntiOmega);
-          storeCascAddID(Casc.globalIndex(), kAntiOmega);
+
+        auto collision = casc.collision_as<aod::Collisions>();
+        const float collisionX = collision.posX();
+        const float collisionY = collision.posY();
+        const float collisionZ = collision.posZ();
+
+        const float cascDca = casc.dcacascdaughters(); // NOTE the name of getter is misleading. In case of no-KF this is sqrt(Chi2)
+        const float cascV0Dca = casc.dcaV0daughters(); // NOTE the name of getter is misleading. In case of kfDoDCAFitterPreMinimV0 this is sqrt(Chi2)
+        const float cascRadius = casc.cascradius();
+        const float cascV0Radius = casc.dcaV0daughters();
+        const float cascCosinePA = casc.casccosPA(collisionX, collisionY, collisionZ);
+        const float cascV0CosinePA = casc.v0cosPA(collisionX, collisionY, collisionZ);
+
+        if (cascDca > cascDcaMax) {
+          continue;
         }
-      }
-    } // end of Casc loop
-    if (produceCascID.value) {
-      for (auto& Casc : Cascs) {
-        cascmapID(cascpidmap[Casc.globalIndex()]);
+        if (cascV0Dca > cascV0DcaMax) {
+          continue;
+        }
+        if (cascRadius < cascRadiusMin || cascRadius > cascRadiusMax) {
+          continue;
+        }
+        if (cascV0Radius < cascV0RadiusMin || cascV0Radius > cascV0RadiusMax) {
+          continue;
+        }
+        if (cascCosinePA < cascCosinePAMin) {
+          continue;
+        }
+        if (cascV0CosinePA < cascV0CosinePAMin || cascV0CosinePA > cascV0CosinePAMax) {
+          continue;
+        }
+
+        const float mOmega = casc.mOmega();
+        const float alpha = casc.alpha();
+        const float qt = casc.qtarm();
+        const float v0Alpha = casc.v0Alpha();
+        const float v0Qt = casc.v0Qtarm();
+
+        if (fillhisto) {
+          registry.fill(HIST("hCascPt"), casc.pt());
+          registry.fill(HIST("hCascEtaPhi"), casc.phi(), casc.eta());
+          registry.fill(HIST("hCascDCAxyPosToPV"), casc.posTrack_as<FullTracksExt>().dcaXY());
+          registry.fill(HIST("hCascDCAxyNegToPV"), casc.negTrack_as<FullTracksExt>().dcaXY());
+          registry.fill(HIST("hCascDCAxyBachToPV"), casc.bachelor_as<FullTracksExt>().dcaXY());
+          registry.fill(HIST("hCascDCAzPosToPV"), casc.posTrack_as<FullTracksExt>().dcaZ());
+          registry.fill(HIST("hCascDCAzNegToPV"), casc.negTrack_as<FullTracksExt>().dcaZ());
+          registry.fill(HIST("hCascDCAzBachToPV"), casc.bachelor_as<FullTracksExt>().dcaZ());
+          registry.fill(HIST("hCascAPplot"), alpha, qt);
+          registry.fill(HIST("hCascV0APplot"), v0Alpha, v0Qt);
+          registry.fill(HIST("hCascRadius"), cascRadius);
+          registry.fill(HIST("hCascV0Radius"), cascV0Radius);
+          registry.fill(HIST("hCascCosPA"), cascCosinePA);
+          registry.fill(HIST("hCascV0CosPA"), cascV0CosinePA);
+          registry.fill(HIST("hCascDCADau"), cascDca);
+          registry.fill(HIST("hCascV0DCADau"), cascV0Dca);
+        }
+
+        const int cascid = checkCascade(alpha, qt);
+        const int v0id = checkV0(v0Alpha, v0Qt);
+        if (cascid < 0) {
+          continue;
+        }
+        if (v0id != kLambda && v0id != kAntiLambda) {
+          continue;
+        }
+        if (fillhisto) {
+          registry.fill(HIST("hCascAPplotSelected"), alpha, qt);
+          registry.fill(HIST("hCascV0APplotSelected"), v0Alpha, v0Qt);
+        }
+
+        auto storeCascAddID = [&](auto gix, auto id) {
+          if (produceCascID.value) {
+            cascpidmap[gix] = id;
+          }
+        };
+
+        if (cascid == kOmega) {
+          if (fillhisto) {
+            registry.fill(HIST("hMassOmega"), cascRadius, mOmega);
+          }
+          if (cutMassOmegaLow < mOmega && mOmega < cutMassOmegaHigh && std::abs(casc.posTrack_as<FullTracksExt>().tpcNSigmaPr()) < cutNsigmaPrTPC && std::abs(casc.negTrack_as<FullTracksExt>().tpcNSigmaPi()) < cutNsigmaPiTPC && std::abs(casc.bachelor_as<FullTracksExt>().tpcNSigmaKa()) < cutNsigmaKaTPC) {
+            pidmap[casc.bachelorId()] |= (uint8_t(1) << kOmega);
+            storeCascAddID(casc.globalIndex(), kOmega);
+          }
+        } else if (cascid == kAntiOmega) {
+          if (fillhisto) {
+            registry.fill(HIST("hMassAntiOmega"), cascRadius, mOmega);
+          }
+          if (cutMassOmegaLow < mOmega && mOmega < cutMassOmegaHigh && std::abs(casc.posTrack_as<FullTracksExt>().tpcNSigmaPi()) < cutNsigmaPiTPC && std::abs(casc.negTrack_as<FullTracksExt>().tpcNSigmaPr()) < cutNsigmaPrTPC && std::abs(casc.bachelor_as<FullTracksExt>().tpcNSigmaKa()) < cutNsigmaKaTPC) {
+            pidmap[casc.bachelorId()] |= (uint8_t(1) << kAntiOmega);
+            storeCascAddID(casc.globalIndex(), kAntiOmega);
+          }
+        }
+      } // end of Casc loop
+      if (produceCascID.value) {
+        for (auto& casc : Cascs) {
+          cascmapID(cascpidmap[casc.globalIndex()]);
+        }
       }
     }
     for (auto& track : tracks) {

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -713,21 +713,21 @@ DECLARE_SOA_DYNAMIC_COLUMN(MLambda, mLambda, //! mass under lambda hypothesis
                            [](int v0type, float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float {
                              if ((v0type & (0x1 << o2::dataformats::V0Index::kPhotonOnly)) != 0) {
                                return 0.0f; // provide mass only if NOT a photon with TPC-only tracks (special handling)
-                             };
+                             }
                              return RecoDecay::m(std::array{std::array{pxpos, pypos, pzpos}, std::array{pxneg, pyneg, pzneg}}, std::array{o2::constants::physics::MassProton, o2::constants::physics::MassPionCharged});
                            });
 DECLARE_SOA_DYNAMIC_COLUMN(MAntiLambda, mAntiLambda, //! mass under antilambda hypothesis
                            [](int v0type, float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float {
                              if ((v0type & (0x1 << o2::dataformats::V0Index::kPhotonOnly)) != 0) {
                                return 0.0f; // provide mass only if NOT a photon with TPC-only tracks (special handling)
-                             };
+                             }
                              return RecoDecay::m(std::array{std::array{pxpos, pypos, pzpos}, std::array{pxneg, pyneg, pzneg}}, std::array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassProton});
                            });
 DECLARE_SOA_DYNAMIC_COLUMN(MK0Short, mK0Short, //! mass under K0short hypothesis
                            [](int v0type, float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) -> float {
                              if ((v0type & (0x1 << o2::dataformats::V0Index::kPhotonOnly)) != 0) {
                                return 0.0f; // provide mass only if NOT a photon with TPC-only tracks (special handling)
-                             };
+                             }
                              return RecoDecay::m(std::array{std::array{pxpos, pypos, pzpos}, std::array{pxneg, pyneg, pzneg}}, std::array{o2::constants::physics::MassPionCharged, o2::constants::physics::MassPionCharged});
                            });
 DECLARE_SOA_DYNAMIC_COLUMN(MLambda_unchecked, mLambda_unchecked, //! mass under lambda hypothesis without v0 type check (will include TPC only and potentially duplicates! use with care)
@@ -1417,6 +1417,53 @@ DECLARE_SOA_DYNAMIC_COLUMN(Phi, phi, //! Cascade phi in the range [0, 2pi)
                            [](float px, float py) -> float { return RecoDecay::phi(px, py); });
 DECLARE_SOA_DYNAMIC_COLUMN(Eta, eta, //! Cascade pseudorapidity
                            [](float px, float py, float pz) -> float { return RecoDecay::eta(std::array{px, py, pz}); });
+
+// Armenteros-Podolanski variables
+DECLARE_SOA_DYNAMIC_COLUMN(Alpha, alpha, //! Armenteros Alpha
+                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg, float pxbach, float pybach, float pzbach, int sign) {
+                             const float pxv0 = pxpos + pxneg;
+                             const float pyv0 = pypos + pyneg;
+                             const float pzv0 = pzpos + pzneg;
+
+                             // No need to divide by momentum of the cascade (as in the v0data namespace) since the ratio of lQl is evaluated
+                             const float lQlBach = RecoDecay::dotProd(std::array{pxbach, pybach, pzbach}, std::array{pxv0 + pxbach, pyv0 + pybach, pzv0 + pzbach});
+                             const float lQlV0 = RecoDecay::dotProd(std::array{pxv0, pyv0, pzv0}, std::array{pxv0 + pxbach, pyv0 + pybach, pzv0 + pzbach});
+                             float alpha = (lQlBach - lQlV0) / (lQlV0 + lQlBach); // alphacascade
+                             if (sign < 0) {
+                               alpha = -alpha;
+                             }
+                             return alpha;
+                           });
+
+DECLARE_SOA_DYNAMIC_COLUMN(QtArm, qtarm, //! Armenteros Qt
+                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg, float pxbach, float pybach, float pzbach) {
+                             const float pxv0 = pxpos + pxneg;
+                             const float pyv0 = pypos + pyneg;
+                             const float pzv0 = pzpos + pzneg;
+
+                             const float momTot2 = RecoDecay::p2(pxv0 + pxbach, pyv0 + pybach, pzv0 + pzbach);
+                             const float dp = RecoDecay::dotProd(std::array{pxbach, pybach, pzbach}, std::array{pxv0 + pxbach, pyv0 + pybach, pzv0 + pzbach});
+                             return std::sqrt(RecoDecay::p2(pxbach, pybach, pzbach) - dp * dp / momTot2); // qtarm
+                           });
+
+// Psi pair angle: angle between the plane defined by the v0 and bachelor momenta and the xy plane
+DECLARE_SOA_DYNAMIC_COLUMN(PsiPair, psipair, //! psi pair angle
+                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg, float pxbach, float pybach, float pzbach, int sign) {
+                             auto clipToPM1 = [](float x) { return x < -1.f ? -1.f : (x > 1.f ? 1.f : x); };
+                             const float pxv0 = pxpos + pxneg;
+                             const float pyv0 = pypos + pyneg;
+                             const float pzv0 = pzpos + pzneg;
+
+                             const float ptot2 = RecoDecay::p2(pxbach, pybach, pzbach) * RecoDecay::p2(pxv0, pyv0, pzv0);
+                             const float argcos = RecoDecay::dotProd(std::array{pxbach, pybach, pzbach}, std::array{pxv0, pyv0, pzv0}) / std::sqrt(ptot2);
+                             const float thetaV0 = std::atan2(RecoDecay::sqrtSumOfSquares(pxv0, pyv0), pzv0);
+                             const float thetaBach = std::atan2(RecoDecay::sqrtSumOfSquares(pxbach, pybach), pzbach);
+                             float argsin = (thetaV0 - thetaBach) / std::acos(clipToPM1(argcos));
+                             if (sign < 0) {
+                               argsin = -argsin;
+                             }
+                             return std::asin(clipToPM1(argsin));
+                           });
 } // namespace cascdata
 
 //______________________________________________________
@@ -1493,7 +1540,12 @@ DECLARE_SOA_TABLE(StoredCascCores, "AOD", "CASCCORE", //! core information about
                   cascdata::PositiveEta<cascdata::PxPos, cascdata::PyPos, cascdata::PzPos>,
                   cascdata::PositivePhi<cascdata::PxPos, cascdata::PyPos>,
                   cascdata::BachelorEta<cascdata::PxBach, cascdata::PyBach, cascdata::PzBach>,
-                  cascdata::BachelorPhi<cascdata::PxBach, cascdata::PyBach>);
+                  cascdata::BachelorPhi<cascdata::PxBach, cascdata::PyBach>,
+
+                  // Armenteros-Podolanski
+                  cascdata::Alpha<cascdata::PxPos, cascdata::PyPos, cascdata::PzPos, cascdata::PxNeg, cascdata::PyNeg, cascdata::PzNeg, cascdata::PxBach, cascdata::PyBach, cascdata::PzBach, cascdata::Sign>,
+                  cascdata::QtArm<cascdata::PxPos, cascdata::PyPos, cascdata::PzPos, cascdata::PxNeg, cascdata::PyNeg, cascdata::PzNeg, cascdata::PxBach, cascdata::PyBach, cascdata::PzBach>,
+                  cascdata::PsiPair<cascdata::PxPos, cascdata::PyPos, cascdata::PzPos, cascdata::PxNeg, cascdata::PyNeg, cascdata::PzNeg, cascdata::PxBach, cascdata::PyBach, cascdata::PzBach, cascdata::Sign>);
 
 DECLARE_SOA_TABLE(StoredKFCascCores, "AOD", "KFCASCCORE", //!
                   cascdata::Sign, cascdata::MXi, cascdata::MOmega,

--- a/PWGLF/DataModel/LFStrangenessTables.h
+++ b/PWGLF/DataModel/LFStrangenessTables.h
@@ -1464,6 +1464,21 @@ DECLARE_SOA_DYNAMIC_COLUMN(PsiPair, psipair, //! psi pair angle
                              }
                              return std::asin(clipToPM1(argsin));
                            });
+
+DECLARE_SOA_DYNAMIC_COLUMN(V0Alpha, v0Alpha, //! Armenteros Alpha
+                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) {
+                             // No need to divide by momentum of the v0 (as in the v0data namespace) since the ratio of lQl is evaluated
+                             const float lQlPos = RecoDecay::dotProd(std::array{pxpos, pypos, pzpos}, std::array{pxneg + pxpos, pyneg + pypos, pzneg + pzpos});
+                             const float lQlNeg = RecoDecay::dotProd(std::array{pxneg, pyneg, pzneg}, std::array{pxneg + pxpos, pyneg + pypos, pzneg + pzpos});
+                             return (lQlPos - lQlNeg) / (lQlPos + lQlNeg);
+                           });
+
+DECLARE_SOA_DYNAMIC_COLUMN(V0QtArm, v0Qtarm, //! Armenteros Qt
+                           [](float pxpos, float pypos, float pzpos, float pxneg, float pyneg, float pzneg) {
+                             const float momTot2 = RecoDecay::p2(pxpos + pxneg, pypos + pyneg, pzpos + pzneg);
+                             const float dp = RecoDecay::dotProd(std::array{pxneg, pyneg, pzneg}, std::array{pxpos + pxneg, pypos + pyneg, pzpos + pzneg});
+                             return std::sqrt(RecoDecay::p2(pxneg, pyneg, pzneg) - dp * dp / momTot2); // qtarm
+                           });
 } // namespace cascdata
 
 //______________________________________________________
@@ -1542,10 +1557,12 @@ DECLARE_SOA_TABLE(StoredCascCores, "AOD", "CASCCORE", //! core information about
                   cascdata::BachelorEta<cascdata::PxBach, cascdata::PyBach, cascdata::PzBach>,
                   cascdata::BachelorPhi<cascdata::PxBach, cascdata::PyBach>,
 
-                  // Armenteros-Podolanski
+                  // Armenteros-Podolanski and psi-pair
                   cascdata::Alpha<cascdata::PxPos, cascdata::PyPos, cascdata::PzPos, cascdata::PxNeg, cascdata::PyNeg, cascdata::PzNeg, cascdata::PxBach, cascdata::PyBach, cascdata::PzBach, cascdata::Sign>,
                   cascdata::QtArm<cascdata::PxPos, cascdata::PyPos, cascdata::PzPos, cascdata::PxNeg, cascdata::PyNeg, cascdata::PzNeg, cascdata::PxBach, cascdata::PyBach, cascdata::PzBach>,
-                  cascdata::PsiPair<cascdata::PxPos, cascdata::PyPos, cascdata::PzPos, cascdata::PxNeg, cascdata::PyNeg, cascdata::PzNeg, cascdata::PxBach, cascdata::PyBach, cascdata::PzBach, cascdata::Sign>);
+                  cascdata::PsiPair<cascdata::PxPos, cascdata::PyPos, cascdata::PzPos, cascdata::PxNeg, cascdata::PyNeg, cascdata::PzNeg, cascdata::PxBach, cascdata::PyBach, cascdata::PzBach, cascdata::Sign>,
+                  cascdata::V0Alpha<cascdata::PxPos, cascdata::PyPos, cascdata::PzPos, cascdata::PxNeg, cascdata::PyNeg, cascdata::PzNeg>,
+                  cascdata::V0QtArm<cascdata::PxPos, cascdata::PyPos, cascdata::PzPos, cascdata::PxNeg, cascdata::PyNeg, cascdata::PzNeg>);
 
 DECLARE_SOA_TABLE(StoredKFCascCores, "AOD", "KFCASCCORE", //!
                   cascdata::Sign, cascdata::MXi, cascdata::MOmega,


### PR DESCRIPTION
Enabled filling a clean kaon sample for TPC PID NN training (in addition to existing samples of electrons, pions and protons).
* [PWGLF/DataModel/LFStrangenessTables.h](https://github.com/AliceO2Group/O2Physics/blob/b178c96d03ede873ee769ef8a4d7c1e21bf78332/PWGLF/DataModel/LFStrangenessTables.h): cascade table is extended with dynamic columns like in V0 table, i.e. Armenteros-Podolanski variables, Psi pair angle etc.
* [PWGDQ/Tasks/v0selector.cxx](https://github.com/AliceO2Group/O2Physics/blob/b178c96d03ede873ee769ef8a4d7c1e21bf78332/PWGDQ/Tasks/v0selector.cxx): implemented selection of $\Omega\rightarrow\Lambda K^-$ decays reconstructed by [PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx](https://github.com/AliceO2Group/O2Physics/blob/b178c96d03ede873ee769ef8a4d7c1e21bf78332/PWGLF/TableProducer/Strangeness/strangenessbuilder.cxx). The cascade selection algorithm generally reproduces that of V0s;
* [DPG/Tasks/TPC/tpcSkimsTableCreator.cxx](https://github.com/AliceO2Group/O2Physics/blob/b178c96d03ede873ee769ef8a4d7c1e21bf78332/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx): table with clean particle samples is extended with kaons - bachelor tracks of cascades selected at the previous step.