### PR TITLE
[PWGLF] Minor safety changes for strangenesstofpid task

### DIFF
--- a/PWGLF/TableProducer/Strangeness/strangenesstofpid.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangenesstofpid.cxx
@@ -1209,7 +1209,7 @@ struct strangenesstofpid {
         pTof.tpcNSigmaPr = pTra.tpcNSigmaPr();
         if (tofIndices[V0.posTrackExtraId()] >= 0 && collision.eventTime() > -1e+5) {
           auto pTofExt = dauTrackTOFPIDs.rawIteratorAt(tofIndices[V0.posTrackExtraId()]);
-          pTof.collisionId = pTofExt.straCollisionId();
+          pTof.collisionId = isNewTOFFormat ? pTofExt.straCollisionId() : V0.straCollisionId();
           pTof.tofExpMom = pTofExt.tofExpMom();
           pTof.tofEvTime = collision.eventTime();
           pTof.tofSignal = pTofExt.tofSignal();
@@ -1223,7 +1223,7 @@ struct strangenesstofpid {
         nTof.tpcNSigmaPr = nTra.tpcNSigmaPr();
         if (tofIndices[V0.negTrackExtraId()] >= 0 && collision.eventTime() > -1e+5) {
           auto nTofExt = dauTrackTOFPIDs.rawIteratorAt(tofIndices[V0.negTrackExtraId()]);
-          nTof.collisionId = nTofExt.straCollisionId();
+          nTof.collisionId = isNewTOFFormat ? nTofExt.straCollisionId() : V0.straCollisionId();
           nTof.tofExpMom = nTofExt.tofExpMom();
           nTof.tofEvTime = collision.eventTime();
           nTof.tofSignal = nTofExt.tofSignal();
@@ -1257,7 +1257,7 @@ struct strangenesstofpid {
         pTof.tpcNSigmaPr = pTra.tpcNSigmaPr();
         if (tofIndices[cascade.posTrackExtraId()] >= 0 && collision.eventTime() > -1e+5) {
           auto pTofExt = dauTrackTOFPIDs.rawIteratorAt(tofIndices[cascade.posTrackExtraId()]);
-          pTof.collisionId = pTofExt.straCollisionId();
+          pTof.collisionId = isNewTOFFormat ? pTofExt.straCollisionId() : cascade.straCollisionId();
           pTof.tofExpMom = pTofExt.tofExpMom();
           pTof.tofEvTime = collision.eventTime();
           pTof.tofSignal = pTofExt.tofSignal();
@@ -1271,7 +1271,7 @@ struct strangenesstofpid {
         nTof.tpcNSigmaPr = nTra.tpcNSigmaPr();
         if (tofIndices[cascade.negTrackExtraId()] >= 0 && collision.eventTime() > -1e+5) {
           auto nTofExt = dauTrackTOFPIDs.rawIteratorAt(tofIndices[cascade.negTrackExtraId()]);
-          nTof.collisionId = nTofExt.straCollisionId();
+          nTof.collisionId = isNewTOFFormat ? nTofExt.straCollisionId() : cascade.straCollisionId();
           nTof.tofExpMom = nTofExt.tofExpMom();
           nTof.tofEvTime = collision.eventTime();
           nTof.tofSignal = nTofExt.tofSignal();
@@ -1285,7 +1285,7 @@ struct strangenesstofpid {
         bTof.tpcNSigmaKa = bTra.tpcNSigmaKa();
         if (tofIndices[cascade.bachTrackExtraId()] >= 0 && collision.eventTime() > -1e+5) {
           auto bTofExt = dauTrackTOFPIDs.rawIteratorAt(tofIndices[cascade.bachTrackExtraId()]);
-          bTof.collisionId = bTofExt.straCollisionId();
+          bTof.collisionId = isNewTOFFormat ? bTofExt.straCollisionId() : cascade.straCollisionId();
           bTof.tofExpMom = bTofExt.tofExpMom();
           bTof.tofEvTime = collision.eventTime();
           bTof.tofSignal = bTofExt.tofSignal();

--- a/PWGLF/TableProducer/Strangeness/strangenesstofpid.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangenesstofpid.cxx
@@ -1172,7 +1172,7 @@ struct strangenesstofpid {
     bool isNewTOFFormat = firstTOFPID.straCollisionId() < 0 ? false : true;
 
     LOGF(info, "Processing derived data. Is this the new TOF info format? %i", isNewTOFFormat);
-    
+
     // Fire up CCDB with first collision in record. If no collisions, bypass
     if (useCustomRunNumber || collisions.size() < 1) {
       initCCDB(manualRunNumber);

--- a/PWGLF/TableProducer/Strangeness/strangenesstofpid.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangenesstofpid.cxx
@@ -1173,7 +1173,7 @@ struct strangenesstofpid {
 
     LOGF(info, "Processing derived data. Is this the new TOF info format? %i", isNewTOFFormat);
 
-    if(!isNewTOFFormat && calculationMethod.value > 0){ 
+    if (!isNewTOFFormat && calculationMethod.value > 0) {
       LOGF(fatal, "Using the old derived data format with the new calculation method is not viable due to lack of needed info! Crashing.");
     }
 

--- a/PWGLF/TableProducer/Strangeness/strangenesstofpid.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangenesstofpid.cxx
@@ -1169,8 +1169,10 @@ struct strangenesstofpid {
       return;
     }
     auto firstTOFPID = dauTrackTOFPIDs.rawIteratorAt(0);
-    bool isNewTOFFOrmat = firstTOFPID.straCollisionId() < 0 ? false : true;
+    bool isNewTOFFormat = firstTOFPID.straCollisionId() < 0 ? false : true;
 
+    LOGF(info, "Processing derived data. Is this the new TOF info format? %i", isNewTOFFormat);
+    
     // Fire up CCDB with first collision in record. If no collisions, bypass
     if (useCustomRunNumber || collisions.size() < 1) {
       initCCDB(manualRunNumber);
@@ -1182,7 +1184,7 @@ struct strangenesstofpid {
     // hold indices
     std::vector<int> tofIndices(dauTrackTable.size(), -1);
 
-    if (isNewTOFFOrmat) {
+    if (isNewTOFFormat) {
       // re-index
       for (const auto& dauTrackTOFPID : dauTrackTOFPIDs) {
         tofIndices[dauTrackTOFPID.dauTrackExtraId()] = dauTrackTOFPID.globalIndex();

--- a/PWGLF/TableProducer/Strangeness/strangenesstofpid.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangenesstofpid.cxx
@@ -10,7 +10,7 @@
 // or submit itself to any jurisdiction.
 //
 //  *+-+*+-+*+-+*+-+*+-+*+-+*
-//     Lambdakzero PID
+//    Strangeness TOF PID
 //  *+-+*+-+*+-+*+-+*+-+*+-+*
 //
 /// \author Nicolò Jacazio
@@ -162,23 +162,23 @@ struct strangenesstofpid {
 
   // for n-sigma calibration
   bool nSigmaCalibLoaded;
-  TList* nSigmaCalibObjects;
-  TH1 *hMeanPosLaPi, *hSigmaPosLaPi;
-  TH1 *hMeanPosLaPr, *hSigmaPosLaPr;
-  TH1 *hMeanNegLaPi, *hSigmaNegLaPi;
-  TH1 *hMeanNegLaPr, *hSigmaNegLaPr;
-  TH1 *hMeanPosK0Pi, *hSigmaPosK0Pi;
-  TH1 *hMeanNegK0Pi, *hSigmaNegK0Pi;
-  TH1 *hMeanPosXiPi, *hSigmaPosXiPi;
-  TH1 *hMeanPosXiPr, *hSigmaPosXiPr;
-  TH1 *hMeanNegXiPi, *hSigmaNegXiPi;
-  TH1 *hMeanNegXiPr, *hSigmaNegXiPr;
-  TH1 *hMeanBachXiPi, *hSigmaBachXiPi;
-  TH1 *hMeanPosOmPi, *hSigmaPosOmPi;
-  TH1 *hMeanPosOmPr, *hSigmaPosOmPr;
-  TH1 *hMeanNegOmPi, *hSigmaNegOmPi;
-  TH1 *hMeanNegOmPr, *hSigmaNegOmPr;
-  TH1 *hMeanBachOmKa, *hSigmaBachOmKa;
+  TList* nSigmaCalibObjects = nullptr;
+  TH1 *hMeanPosLaPi = nullptr, *hSigmaPosLaPi = nullptr;
+  TH1 *hMeanPosLaPr = nullptr, *hSigmaPosLaPr = nullptr;
+  TH1 *hMeanNegLaPi = nullptr, *hSigmaNegLaPi = nullptr;
+  TH1 *hMeanNegLaPr = nullptr, *hSigmaNegLaPr = nullptr;
+  TH1 *hMeanPosK0Pi = nullptr, *hSigmaPosK0Pi = nullptr;
+  TH1 *hMeanNegK0Pi = nullptr, *hSigmaNegK0Pi = nullptr;
+  TH1 *hMeanPosXiPi = nullptr, *hSigmaPosXiPi = nullptr;
+  TH1 *hMeanPosXiPr = nullptr, *hSigmaPosXiPr = nullptr;
+  TH1 *hMeanNegXiPi = nullptr, *hSigmaNegXiPi = nullptr;
+  TH1 *hMeanNegXiPr = nullptr, *hSigmaNegXiPr = nullptr;
+  TH1 *hMeanBachXiPi = nullptr, *hSigmaBachXiPi = nullptr;
+  TH1 *hMeanPosOmPi = nullptr, *hSigmaPosOmPi = nullptr;
+  TH1 *hMeanPosOmPr = nullptr, *hSigmaPosOmPr = nullptr;
+  TH1 *hMeanNegOmPi = nullptr, *hSigmaNegOmPi = nullptr;
+  TH1 *hMeanNegOmPr = nullptr, *hSigmaNegOmPr = nullptr;
+  TH1 *hMeanBachOmKa = nullptr, *hSigmaBachOmKa = nullptr;
 
   int mRunNumber;
   float d_bz;
@@ -191,7 +191,7 @@ struct strangenesstofpid {
                  kNEnums };
 
   /// function to calculate track length of this track up to a certain segment of a detector
-  /// to be used internally in another funcrtion that calculates length until it finds the proper one
+  /// to be used internally in another function that calculates length until it finds the proper one
   /// warning: this could be optimised further for speed
   /// \param track the input track
   /// \param x1 x of the first point of the detector segment

--- a/PWGLF/TableProducer/Strangeness/strangenesstofpid.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangenesstofpid.cxx
@@ -1173,6 +1173,10 @@ struct strangenesstofpid {
 
     LOGF(info, "Processing derived data. Is this the new TOF info format? %i", isNewTOFFormat);
 
+    if(!isNewTOFFormat && calculationMethod.value > 0){ 
+      LOGF(fatal, "Using the old derived data format with the new calculation method is not viable due to lack of needed info! Crashing.");
+    }
+
     // Fire up CCDB with first collision in record. If no collisions, bypass
     if (useCustomRunNumber || collisions.size() < 1) {
       initCCDB(manualRunNumber);
@@ -1209,7 +1213,7 @@ struct strangenesstofpid {
         pTof.tpcNSigmaPr = pTra.tpcNSigmaPr();
         if (tofIndices[V0.posTrackExtraId()] >= 0 && collision.eventTime() > -1e+5) {
           auto pTofExt = dauTrackTOFPIDs.rawIteratorAt(tofIndices[V0.posTrackExtraId()]);
-          pTof.collisionId = isNewTOFFormat ? pTofExt.straCollisionId() : V0.straCollisionId();
+          pTof.collisionId = pTofExt.straCollisionId();
           pTof.tofExpMom = pTofExt.tofExpMom();
           pTof.tofEvTime = collision.eventTime();
           pTof.tofSignal = pTofExt.tofSignal();
@@ -1223,7 +1227,7 @@ struct strangenesstofpid {
         nTof.tpcNSigmaPr = nTra.tpcNSigmaPr();
         if (tofIndices[V0.negTrackExtraId()] >= 0 && collision.eventTime() > -1e+5) {
           auto nTofExt = dauTrackTOFPIDs.rawIteratorAt(tofIndices[V0.negTrackExtraId()]);
-          nTof.collisionId = isNewTOFFormat ? nTofExt.straCollisionId() : V0.straCollisionId();
+          nTof.collisionId = nTofExt.straCollisionId();
           nTof.tofExpMom = nTofExt.tofExpMom();
           nTof.tofEvTime = collision.eventTime();
           nTof.tofSignal = nTofExt.tofSignal();
@@ -1257,7 +1261,7 @@ struct strangenesstofpid {
         pTof.tpcNSigmaPr = pTra.tpcNSigmaPr();
         if (tofIndices[cascade.posTrackExtraId()] >= 0 && collision.eventTime() > -1e+5) {
           auto pTofExt = dauTrackTOFPIDs.rawIteratorAt(tofIndices[cascade.posTrackExtraId()]);
-          pTof.collisionId = isNewTOFFormat ? pTofExt.straCollisionId() : cascade.straCollisionId();
+          pTof.collisionId = pTofExt.straCollisionId();
           pTof.tofExpMom = pTofExt.tofExpMom();
           pTof.tofEvTime = collision.eventTime();
           pTof.tofSignal = pTofExt.tofSignal();
@@ -1271,7 +1275,7 @@ struct strangenesstofpid {
         nTof.tpcNSigmaPr = nTra.tpcNSigmaPr();
         if (tofIndices[cascade.negTrackExtraId()] >= 0 && collision.eventTime() > -1e+5) {
           auto nTofExt = dauTrackTOFPIDs.rawIteratorAt(tofIndices[cascade.negTrackExtraId()]);
-          nTof.collisionId = isNewTOFFormat ? nTofExt.straCollisionId() : cascade.straCollisionId();
+          nTof.collisionId = nTofExt.straCollisionId();
           nTof.tofExpMom = nTofExt.tofExpMom();
           nTof.tofEvTime = collision.eventTime();
           nTof.tofSignal = nTofExt.tofSignal();
@@ -1285,7 +1289,7 @@ struct strangenesstofpid {
         bTof.tpcNSigmaKa = bTra.tpcNSigmaKa();
         if (tofIndices[cascade.bachTrackExtraId()] >= 0 && collision.eventTime() > -1e+5) {
           auto bTofExt = dauTrackTOFPIDs.rawIteratorAt(tofIndices[cascade.bachTrackExtraId()]);
-          bTof.collisionId = isNewTOFFormat ? bTofExt.straCollisionId() : cascade.straCollisionId();
+          bTof.collisionId = bTofExt.straCollisionId();
           bTof.tofExpMom = bTofExt.tofExpMom();
           bTof.tofEvTime = collision.eventTime();
           bTof.tofSignal = bTofExt.tofSignal();


### PR DESCRIPTION
Very minor change: initialize data members to `nullptr` to avoid that 'time exceeded' problems in HY are not accompanied by a problematic destructor call sequence ([example](https://alimonitor.cern.ch/hyperloop/wagon-test/500396/general)). But: timeouts are sadly still very much unsolved ... 