### PR TITLE
[PWGLF] Very minor cleanup of printouts

### DIFF
--- a/PWGLF/Utils/strangenessBuilderHelper.h
+++ b/PWGLF/Utils/strangenessBuilderHelper.h
@@ -132,7 +132,7 @@ std::vector<V0group> groupDuplicates(const T& V0s)
   }
   v0tableGrouped.push_back(thisV0); // publish last
 
-  LOGF(info, "Duplicate V0s grouped. aod::V0s counted: %i, unique index pairs: %i", V0s.size(), v0tableGrouped.size());
+  LOGF(debug, "Duplicate V0s grouped. aod::V0s counted: %i, unique index pairs: %i", V0s.size(), v0tableGrouped.size());
   return v0tableGrouped;
 }
 

--- a/PWGLF/Utils/strangenessBuilderModule.h
+++ b/PWGLF/Utils/strangenessBuilderModule.h
@@ -1278,7 +1278,7 @@ class BuilderModule
       sorted_cascade = sort_indices(cascadeList, (baseOpts.mc_findableMode.value > 0));
     }
 
-    LOGF(info, "AO2D input: %i V0s, %i cascades. Building list sizes: %i V0s, %i cascades", v0s.size(), cascades.size(), v0List.size(), cascadeList.size());
+    LOGF(debug, "AO2D input: %i V0s, %i cascades. Building list sizes: %i V0s, %i cascades", v0s.size(), cascades.size(), v0List.size(), cascadeList.size());
   }
 
   //__________________________________________________


### PR DESCRIPTION
Removes per-DF summary of strangeness candidates processed to reduce log sizes