### PR TITLE
[PWGHF] Improve skimming code

### DIFF
--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1930,7 +1930,7 @@ struct HfTrackIndexSkimCreator {
   void performPvRefitCandProngs(SelectedCollisions::iterator const& collision,
                                 aod::BCsWithTimestamps const&,
                                 std::vector<int64_t> vecPvContributorGlobId,
-                                std::vector<o2::track::TrackParCov> vecPvContributorTrackParCov,
+                                std::vector<o2::track::TrackParCov> const& vecPvContributorTrackParCov,
                                 std::vector<int64_t> vecCandPvContributorGlobId,
                                 std::array<float, 3>& pvCoord,
                                 std::array<float, 6>& pvCovMatrix)

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -2296,7 +2296,7 @@ struct HfTrackIndexSkimCreator {
                   pvCoord2Prong[2] = pvRefitCoord2Prong[2];
                 }
                 applySelection2Prong(pVecCandProng2, secondaryVertex2, pvCoord2Prong, cutStatus2Prong, isSelected2ProngCand);
-                if (is2ProngCandidateGoodFor3Prong && config.do3Prong == 1) {
+                if (is2ProngCandidateGoodFor3Prong && config.do3Prong) {
                   is2ProngCandidateGoodFor3Prong = isTwoTrackVertexSelectedFor3Prongs(secondaryVertex2, pvCoord2Prong, df2);
                 }
 
@@ -2378,7 +2378,7 @@ struct HfTrackIndexSkimCreator {
           }
 
           // if the cut on the decay length of 3-prongs computed with the first two tracks is enabled and the vertex was not computed for the D0, we compute it now
-          if (config.do3Prong == 1 && is2ProngCandidateGoodFor3Prong && (config.minTwoTrackDecayLengthFor3Prongs > 0.f || config.maxTwoTrackChi2PcaFor3Prongs < 1.e9f) && nVtxFrom2ProngFitter == 0) {
+          if (config.do3Prong && is2ProngCandidateGoodFor3Prong && (config.minTwoTrackDecayLengthFor3Prongs > 0.f || config.maxTwoTrackChi2PcaFor3Prongs < 1.e9f) && nVtxFrom2ProngFitter == 0) {
             try {
               nVtxFrom2ProngFitter = df2.process(trackParVarPos1, trackParVarNeg1);
             } catch (...) {
@@ -2392,7 +2392,7 @@ struct HfTrackIndexSkimCreator {
             }
           }
 
-          if (config.do3Prong == 1 && is2ProngCandidateGoodFor3Prong) { // if 3 prongs are enabled and the first 2 tracks are selected for the 3-prong channels
+          if (config.do3Prong && is2ProngCandidateGoodFor3Prong) { // if 3 prongs are enabled and the first 2 tracks are selected for the 3-prong channels
             // second loop over positive tracks
             for (auto trackIndexPos2 = trackIndexPos1 + 1; trackIndexPos2 != groupedTrackIndicesPos1.end(); ++trackIndexPos2) {
 

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -133,7 +133,7 @@ struct HfTrackIndexSkimCreatorTagSelCollisions {
 
   void init(InitContext const&)
   {
-    std::array<int, 7> doProcess = {doprocessTrigAndCentFT0ASel, doprocessTrigAndCentFT0CSel, doprocessTrigAndCentFT0MSel, doprocessTrigAndCentFV0ASel, doprocessTrigSel, doprocessNoTrigSel, doprocessUpcSel};
+    const std::array<int, 7> doProcess = {doprocessTrigAndCentFT0ASel, doprocessTrigAndCentFT0CSel, doprocessTrigAndCentFT0MSel, doprocessTrigAndCentFV0ASel, doprocessTrigSel, doprocessNoTrigSel, doprocessUpcSel};
     if (std::accumulate(doProcess.begin(), doProcess.end(), 0) != 1) {
       LOGP(fatal, "One and only one process function for collision selection can be enabled at a time!");
     }
@@ -148,7 +148,7 @@ struct HfTrackIndexSkimCreatorTagSelCollisions {
       hfEvSel.addHistograms(registry); // collision monitoring
 
       if (doprocessTrigAndCentFT0ASel || doprocessTrigAndCentFT0CSel || doprocessTrigAndCentFT0MSel || doprocessTrigAndCentFV0ASel) {
-        AxisSpec const axisCentrality{200, 0., 100., "centrality percentile"};
+        const AxisSpec axisCentrality{200, 0., 100., "centrality percentile"};
         registry.add("hCentralitySelected", "Centrality percentile of selected events in the centrality interval; centrality percentile;entries", {HistType::kTH1D, {axisCentrality}});
         registry.add("hCentralityRejected", "Centrality percentile of selected events outside the centrality interval; centrality percentile;entries", {HistType::kTH1D, {axisCentrality}});
       }
@@ -158,9 +158,10 @@ struct HfTrackIndexSkimCreatorTagSelCollisions {
   /// Collision selection
   /// \param collision  collision table with
   template <bool applyTrigSel, bool applyUpcSel, o2::hf_centrality::CentralityEstimator centEstimator, typename Col, typename BCsType>
-  void selectCollision(const Col& collision, const BCsType& bcs)
+  void selectCollision(const Col& collision,
+                       const BCsType& bcs)
   {
-    float centrality = -1.f;
+    float centrality{-1.f};
     o2::hf_evsel::HfCollisionRejectionMask rejectionMask{};
 
     if constexpr (applyUpcSel) {
@@ -349,7 +350,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
 
   void init(InitContext const&)
   {
-    std::array<int, 5> doProcess = {doprocessNoPid, doprocessProtonPidTpc, doprocessProtonPidTof, doprocessProtonPidTpcOrTof, doprocessProtonPidTpcAndTof};
+    const std::array<int, 5> doProcess = {doprocessNoPid, doprocessProtonPidTpc, doprocessProtonPidTof, doprocessProtonPidTpcOrTof, doprocessProtonPidTpcAndTof};
     if (std::accumulate(doProcess.begin(), doProcess.end(), 0) != 1) {
       LOGP(fatal, "One and only one process function for the different PID selection strategies can be enabled at a time!");
     }
@@ -398,8 +399,8 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
       registry.add("hDCAToPrimXYVsPtCutsCascadeBachelor", "tracks selected for cascade-bachelor vertexing;#it{p}_{T}^{track} (GeV/#it{c});DCAxy to prim. vtx. (cm);entries", {HistType::kTH2D, {{360, 0., 36.}, {400, -2., 2.}}});
       registry.add("hEtaCutsCascadeBachelor", "tracks selected for cascade-bachelor vertexing;#it{#eta};entries", {HistType::kTH1D, {{static_cast<int>(0.6 * (config.etaMaxTrackBachLfCasc - config.etaMinTrackBachLfCasc) * 100), -1.2 * config.etaMinTrackBachLfCasc, 1.2 * config.etaMaxTrackBachLfCasc}}});
 
-      std::string cutNames[nCuts + 1] = {"selected", "rej pT", "rej eta", "rej track quality", "rej dca"};
-      std::string candNames[CandidateType::NCandidateTypes] = {"2-prong", "3-prong", "bachelor", "dstar", "lfCascBachelor"};
+      const std::string cutNames[nCuts + 1] = {"selected", "rej pT", "rej eta", "rej track quality", "rej dca"};
+      const std::string candNames[CandidateType::NCandidateTypes] = {"2-prong", "3-prong", "bachelor", "dstar", "lfCascBachelor"};
       for (int iCandType = 0; iCandType < CandidateType::NCandidateTypes; iCandType++) {
         for (int iCut = 0; iCut < nCuts + 1; iCut++) {
           registry.get<TH1>(HIST("hRejTracks"))->GetXaxis()->SetBinLabel((nCuts + 1) * iCandType + iCut + 1, Form("%s %s", candNames[iCandType].data(), cutNames[iCut].data()));
@@ -410,16 +411,16 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
     // Needed for PV refitting
     if (config.doPvRefit) {
       if (config.fillHistograms) {
-        AxisSpec const axisCollisionX{100, -20.f, 20.f, "X (cm)"};
-        AxisSpec const axisCollisionY{100, -20.f, 20.f, "Y (cm)"};
-        AxisSpec const axisCollisionZ{100, -20.f, 20.f, "Z (cm)"};
-        AxisSpec const axisCollisionXOriginal{100, -2.f, 2.f, "X original PV (cm)"};
-        AxisSpec const axisCollisionYOriginal{100, -2.f, 2.f, "Y original PV (cm)"};
-        AxisSpec const axisCollisionZOriginal{100, -2.f, 2.f, "Z original PV (cm)"};
-        AxisSpec const axisCollisionNContrib{1000, 0, 1000, "Number of contributors"};
-        AxisSpec const axisCollisionDeltaX{axisPvRefitDeltaX, "#Delta x_{PV} (cm)"};
-        AxisSpec const axisCollisionDeltaY{axisPvRefitDeltaY, "#Delta y_{PV} (cm)"};
-        AxisSpec const axisCollisionDeltaZ{axisPvRefitDeltaZ, "#Delta z_{PV} (cm)"};
+        const AxisSpec axisCollisionX{100, -20.f, 20.f, "X (cm)"};
+        const AxisSpec axisCollisionY{100, -20.f, 20.f, "Y (cm)"};
+        const AxisSpec axisCollisionZ{100, -20.f, 20.f, "Z (cm)"};
+        const AxisSpec axisCollisionXOriginal{100, -2.f, 2.f, "X original PV (cm)"};
+        const AxisSpec axisCollisionYOriginal{100, -2.f, 2.f, "Y original PV (cm)"};
+        const AxisSpec axisCollisionZOriginal{100, -2.f, 2.f, "Z original PV (cm)"};
+        const AxisSpec axisCollisionNContrib{1000, 0, 1000, "Number of contributors"};
+        const AxisSpec axisCollisionDeltaX{axisPvRefitDeltaX, "#Delta x_{PV} (cm)"};
+        const AxisSpec axisCollisionDeltaY{axisPvRefitDeltaY, "#Delta y_{PV} (cm)"};
+        const AxisSpec axisCollisionDeltaZ{axisPvRefitDeltaZ, "#Delta z_{PV} (cm)"};
 
         registry.add("PvRefit/hVerticesPerTrack", "", kTH1D, {{3, 0.5f, 3.5f, ""}});
         registry.get<TH1>(HIST("PvRefit/hVerticesPerTrack"))->GetXaxis()->SetBinLabel(1, "All PV");
@@ -739,8 +740,8 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
   template <typename TTrack>
   void performPvRefitTrack(aod::Collision const& collision,
                            aod::BCsWithTimestamps const&,
-                           std::vector<int64_t> vecPvContributorGlobId,
-                           std::vector<o2::track::TrackParCov> vecPvContributorTrackParCov,
+                           std::vector<int64_t> const& vecPvContributorGlobId,
+                           std::vector<o2::track::TrackParCov> const& vecPvContributorTrackParCov,
                            TTrack const& trackToRemove,
                            std::array<float, 3>& pvCoord,
                            std::array<float, 6>& pvCovMatrix,
@@ -949,8 +950,8 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
         pvRefitPvCovMatrix = {collision.covXX(), collision.covXY(), collision.covYY(), collision.covXZ(), collision.covYZ(), collision.covZZ()};
 
         /// retrieve PV contributors for the current collision
-        std::vector<int64_t> vecPvContributorGlobId = {};
-        std::vector<o2::track::TrackParCov> vecPvContributorTrackParCov = {};
+        std::vector<int64_t> vecPvContributorGlobId{};
+        std::vector<o2::track::TrackParCov> vecPvContributorTrackParCov{};
 
         for (const auto& contributor : pvContrCollision) {
           vecPvContributorGlobId.push_back(contributor.globalIndex());
@@ -1275,17 +1276,17 @@ struct HfTrackIndexSkimCreator {
   static constexpr int kNCuts2Prong[kN2ProngDecays] = {hf_cuts_presel_2prong::NCutVars, hf_cuts_presel_2prong::NCutVars, hf_cuts_presel_2prong::NCutVars};                                      // how many different selections are made on 2-prongs
   static constexpr int kNCuts3Prong[kN3ProngDecays] = {hf_cuts_presel_3prong::NCutVars, hf_cuts_presel_3prong::NCutVars + 1, hf_cuts_presel_ds::NCutVars, hf_cuts_presel_3prong::NCutVars + 1}; // how many different selections are made on 3-prongs (Lc and Xic have also PID potentially)
   static constexpr int kNCutsDstar = 3;                                                                                                                                                         // how many different selections are made on Dstars
-  std::array<std::array<std::array<double, 2>, 2>, kN2ProngDecays> arrMass2Prong;
-  std::array<std::array<std::array<double, 3>, 2>, kN3ProngDecays> arrMass3Prong;
+  std::array<std::array<std::array<double, 2>, 2>, kN2ProngDecays> arrMass2Prong{};
+  std::array<std::array<std::array<double, 3>, 2>, kN3ProngDecays> arrMass3Prong{};
   // arrays of 2-prong and 3-prong cuts
-  std::array<LabeledArray<double>, kN2ProngDecays> cut2Prong;
-  std::array<std::vector<double>, kN2ProngDecays> binsPt2Prong;
-  std::array<LabeledArray<double>, kN3ProngDecays> cut3Prong;
-  std::array<std::vector<double>, kN3ProngDecays> binsPt3Prong;
+  std::array<LabeledArray<double>, kN2ProngDecays> cut2Prong{};
+  std::array<std::vector<double>, kN2ProngDecays> binsPt2Prong{};
+  std::array<LabeledArray<double>, kN3ProngDecays> cut3Prong{};
+  std::array<std::vector<double>, kN3ProngDecays> binsPt3Prong{};
 
   // ML response
-  o2::analysis::MlResponse<float> hfMlResponse2Prongs;                             // only D0
-  std::array<o2::analysis::MlResponse<float>, kN3ProngDecays> hfMlResponse3Prongs; // D+, Lc, Ds, Xic
+  o2::analysis::MlResponse<float> hfMlResponse2Prongs;                               // only D0
+  std::array<o2::analysis::MlResponse<float>, kN3ProngDecays> hfMlResponse3Prongs{}; // D+, Lc, Ds, Xic
   std::array<bool, kN3ProngDecays> hasMlModel3Prong{false};
   o2::ccdb::CcdbApi ccdbApi;
 
@@ -1294,7 +1295,7 @@ struct HfTrackIndexSkimCreator {
   using FilteredTrackAssocSel = soa::Filtered<soa::Join<aod::TrackAssoc, aod::HfSelTrack>>;
 
   // filter collisions
-  Filter filterSelectCollisions = (aod::hf_sel_collision::whyRejectColl == static_cast<o2::hf_evsel::HfCollisionRejectionMask>(0));
+  Filter filterSelectCollisions = (aod::hf_sel_collision::whyRejectColl == static_cast<uint32_t>(0));
   // filter track indices
   Filter filterSelectTrackIds = ((aod::hf_sel_track::isSelProng & static_cast<uint32_t>(BIT(CandidateType::Cand2Prong))) != 0u) || ((aod::hf_sel_track::isSelProng & static_cast<uint32_t>(BIT(CandidateType::Cand3Prong))) != 0u) || ((aod::hf_sel_track::isSelProng & static_cast<uint32_t>(BIT(CandidateType::CandDstar))) != 0u);
 
@@ -1502,7 +1503,7 @@ struct HfTrackIndexSkimCreator {
 
     for (int iDecay2P = 0; iDecay2P < kN2ProngDecays; iDecay2P++) {
 
-      // pt
+      // pT
       const auto binPt = findBin(&binsPt2Prong[iDecay2P], pt);
       // return immediately if it is outside the defined pT bins
       if (binPt == -1) {
@@ -1543,7 +1544,7 @@ struct HfTrackIndexSkimCreator {
 
       // imp. par. product cut
       if (config.debug || TESTBIT(isSelected, iDecay2P)) {
-        auto impParProduct = dcaTrack0 * dcaTrack1;
+        const auto impParProduct = dcaTrack0 * dcaTrack1;
         if (impParProduct > cut2Prong[iDecay2P].get(binPt, 3u)) {
           CLRBIT(isSelected, iDecay2P);
           if (config.debug) {
@@ -1554,10 +1555,10 @@ struct HfTrackIndexSkimCreator {
 
       // additional check for D0 to be used in D* finding
       if (iDecay2P == hf_cand_2prong::DecayType::D0ToPiK && config.doDstar && TESTBIT(isSelected, iDecay2P)) {
-        auto pTBinDstar = findBin(config.binsPtDstarToD0Pi, pt * 1.2); // assuming the D* pT about 20% higher than the one of the D0 to be safe
-        if (pTBinDstar >= 0) {
+        const auto binPtDstar = findBin(config.binsPtDstarToD0Pi, pt * 1.2); // assuming the D* pT about 20% higher than the one of the D0 to be safe
+        if (binPtDstar >= 0) {
           whichHypo[kN2ProngDecays] = whichHypo[hf_cand_2prong::DecayType::D0ToPiK];
-          const double deltaMass = config.cutsDstarToD0Pi->get(pTBinDstar, 1u);
+          const double deltaMass = config.cutsDstarToD0Pi->get(binPtDstar, 1u);
 
           if (TESTBIT(whichHypo[iDecay2P], 0) && (massHypos[0] > (MassD0 + deltaMass) * (MassD0 + deltaMass) || massHypos[0] < (MassD0 - deltaMass) * (MassD0 - deltaMass))) {
             CLRBIT(whichHypo[kN2ProngDecays], 0);
@@ -1703,7 +1704,7 @@ struct HfTrackIndexSkimCreator {
           continue;
         }
 
-        // cosp
+        // cos of pointing angle
         if (config.debug || TESTBIT(isSelected, iDecay2P)) {
           const auto cpa = RecoDecay::cpa(primVtx, secVtx, pVecCand);
           if (cpa < cut2Prong[iDecay2P].get(binPt, 2u)) { // 2u == "cospIndex[iDecay2P]"
@@ -1768,11 +1769,11 @@ struct HfTrackIndexSkimCreator {
   {
     if (config.debug || isSelected > 0) {
 
-      auto pT = RecoDecay::pt(pVecCand);
+      const auto pt = RecoDecay::pt(pVecCand);
       for (int iDecay3P = 0; iDecay3P < kN3ProngDecays; iDecay3P++) {
 
         // pT
-        const auto binPt = findBin(&binsPt3Prong[iDecay3P], pT);
+        const auto binPt = findBin(&binsPt3Prong[iDecay3P], pt);
         if (binPt == -1) { // cut if it is outside the defined pT bins
           CLRBIT(isSelected, iDecay3P);
           if (config.debug) {
@@ -1781,7 +1782,7 @@ struct HfTrackIndexSkimCreator {
           continue;
         }
 
-        // cosp
+        // cos of pointing angle
         if (config.debug || TESTBIT(isSelected, iDecay3P)) {
           const auto cpa = RecoDecay::cpa(primVtx, secVtx, pVecCand);
           if (cpa < cut3Prong[iDecay3P].get(binPt, 2u)) { // 2u == cospIndex[iDecay3P]
@@ -1819,7 +1820,7 @@ struct HfTrackIndexSkimCreator {
       return;
     }
 
-    const float ptDummy = 1.; // dummy pT value (only one pT bin)
+    const float ptDummy = 1.f; // dummy pT value (only one pT bin)
     for (int iDecay3P{0}; iDecay3P < kN3ProngDecays; ++iDecay3P) {
       if (TESTBIT(isSelected, iDecay3P) && hasMlModel3Prong[iDecay3P]) {
         bool isMlSel = false;
@@ -1884,7 +1885,7 @@ struct HfTrackIndexSkimCreator {
     const std::array arrMomD0{pVecTrack0, pVecTrack1};
     const auto pt = RecoDecay::pt(pVecTrack0, pVecTrack1, pVecTrack2) + config.ptTolerance; // add tolerance because of no reco decay vertex
 
-    // pt
+    // pT
     const auto binPt = findBin(config.binsPtDstarToD0Pi, pt);
     // return immediately if it is outside the defined pT bins
     if (binPt == -1) {
@@ -2116,8 +2117,8 @@ struct HfTrackIndexSkimCreator {
       int const n2ProngBit = BIT(kN2ProngDecays) - 1; // bit value for 2-prong candidates where each candidate is one bit and they are all set to 1
       int const n3ProngBit = BIT(kN3ProngDecays) - 1; // bit value for 3-prong candidates where each candidate is one bit and they are all set to 1
 
-      std::array<std::vector<bool>, kN2ProngDecays> cutStatus2Prong;
-      std::array<std::vector<bool>, kN3ProngDecays> cutStatus3Prong;
+      std::array<std::vector<bool>, kN2ProngDecays> cutStatus2Prong{};
+      std::array<std::vector<bool>, kN3ProngDecays> cutStatus3Prong{};
       uint8_t nCutStatus2ProngBit[kN2ProngDecays]; // bit value for selection status for each 2-prong candidate where each selection is one bit and they are all set to 1
       uint8_t nCutStatus3ProngBit[kN3ProngDecays]; // bit value for selection status for each 3-prong candidate where each selection is one bit and they are all set to 1
 
@@ -2812,7 +2813,7 @@ struct HfTrackIndexSkimCreator {
               // 3-prong selections after secondary vertex
               applySelection3Prong(pVecCandProng3Neg, secondaryVertex3, pvRefitCoord3Prong1Pos2Neg, cutStatus3Prong, isSelected3ProngCand);
 
-              std::array<std::vector<float>, kN3ProngDecays> mlScores3Prongs;
+              std::array<std::vector<float>, kN3ProngDecays> mlScores3Prongs{};
               if (config.applyMlForHfFilters) {
                 std::vector<float> const inputFeatures{trackParVarPcaNeg1.getPt(), dcaInfoNeg1[0], dcaInfoNeg1[1], trackParVarPcaPos1.getPt(), dcaInfoPos1[0], dcaInfoPos1[1], trackParVarPcaNeg2.getPt(), dcaInfoNeg2[0], dcaInfoNeg2[1]};
                 std::vector<float> inputFeaturesLcPid{};
@@ -3095,7 +3096,7 @@ struct HfTrackIndexSkimCreatorCascades {
   using SelectedCollisions = soa::Filtered<soa::Join<aod::Collisions, aod::HfSelCollision>>;
   using FilteredTrackAssocSel = soa::Filtered<soa::Join<aod::TrackAssoc, aod::HfSelTrack>>;
 
-  Filter filterSelectCollisions = (aod::hf_sel_collision::whyRejectColl == static_cast<o2::hf_evsel::HfCollisionRejectionMask>(0));
+  Filter filterSelectCollisions = (aod::hf_sel_collision::whyRejectColl == static_cast<uint32_t>(0));
   Filter filterSelectTrackIds = (aod::hf_sel_track::isSelProng & static_cast<uint32_t>(BIT(CandidateType::CandV0bachelor))) != 0u && (config.applyProtonPid == false || (aod::hf_sel_track::isIdentifiedPid & static_cast<uint32_t>(BIT(ChannelsProtonPid::LcToPK0S))) != 0u);
 
   Preslice<FilteredTrackAssocSel> trackIndicesPerCollision = aod::track_association::collisionId;
@@ -3364,7 +3365,7 @@ struct HfTrackIndexSkimCreatorLfCascades {
   using CascFull = soa::Join<aod::CascDatas, aod::CascCovs>;
   using V0Full = soa::Join<aod::V0Datas, aod::V0Covs>;
 
-  Filter filterSelectCollisions = (aod::hf_sel_collision::whyRejectColl == static_cast<o2::hf_evsel::HfCollisionRejectionMask>(0));
+  Filter filterSelectCollisions = (aod::hf_sel_collision::whyRejectColl == static_cast<uint32_t>(0));
   Filter filterSelectTrackIds = (aod::hf_sel_track::isSelProng & static_cast<uint32_t>(BIT(CandidateType::CandCascadeBachelor))) != 0u;
 
   Preslice<aod::TracksWCovDca> tracksPerCollision = aod::track::collisionId;                     // needed for PV refit
@@ -3502,7 +3503,7 @@ struct HfTrackIndexSkimCreatorLfCascades {
   template <typename T1>
   bool isPreselectedCandidateXic(T1 const& pVecXi, T1 const& pVecPi1, T1 const& pVecPi2)
   {
-    // pt
+    // pT
     if (config.ptMinXicplusLfCasc > 0.f) {
       const auto pt = RecoDecay::pt(pVecXi, pVecPi1, pVecPi2) + config.ptTolerance; // add tolerance because of no reco decay vertex
       if (pt < config.ptMinXicplusLfCasc) {
@@ -3532,7 +3533,7 @@ struct HfTrackIndexSkimCreatorLfCascades {
   template <typename T1, typename T2, typename T3>
   bool isSelectedCandidateXic(const T1& pVecCand, const T2& secVtx, const T3& primVtx)
   {
-    // pt
+    // pT
     if (config.ptMinXicplusLfCasc > 0.f) {
       const auto pt = RecoDecay::pt(pVecCand);
       if (pt < config.ptMinXicplusLfCasc) {
@@ -3690,11 +3691,11 @@ struct HfTrackIndexSkimCreatorLfCascades {
             df2.propagateTracksToVertex();
 
             if (df2.isPropagateTracksToVertexDone()) {
-              std::array<float, 3> pVecXi = {0.f};
-              std::array<float, 3> pVecPion1XiHyp = {0.f};
+              std::array<float, 3> pVecXi{};
+              std::array<float, 3> pVecPion1XiHyp{};
               df2.getTrack(0).getPxPyPzGlo(pVecXi);
               df2.getTrack(1).getPxPyPzGlo(pVecPion1XiHyp);
-              float const ptXic = RecoDecay::pt(pVecXi, pVecPion1XiHyp);
+              const float ptXic = RecoDecay::pt(pVecXi, pVecPion1XiHyp);
 
               const std::array arrMomToXi{pVecXi, pVecPion1XiHyp};
               auto mass2ProngXiHyp = RecoDecay::m(arrMomToXi, arrMass2Prong[hf_cand_casc_lf::DecayType2Prong::XiczeroOmegaczeroToXiPi]);
@@ -3737,15 +3738,15 @@ struct HfTrackIndexSkimCreatorLfCascades {
 
             if (df2.isPropagateTracksToVertexDone()) {
 
-              std::array<float, 3> pVecOmega{0.f};
-              std::array<float, 3> pVecCharmBachelor1OmegaHyp{0.f};
+              std::array<float, 3> pVecOmega{};
+              std::array<float, 3> pVecCharmBachelor1OmegaHyp{};
               df2.getTrack(0).getPxPyPzGlo(pVecOmega);
               df2.getTrack(1).getPxPyPzGlo(pVecCharmBachelor1OmegaHyp);
-              float const ptOmegac = RecoDecay::pt(pVecOmega, pVecCharmBachelor1OmegaHyp);
+              const float ptOmegac = RecoDecay::pt(pVecOmega, pVecCharmBachelor1OmegaHyp);
 
               const std::array arrMomToOmega{pVecOmega, pVecCharmBachelor1OmegaHyp};
-              auto mass2ProngOmegaPiHyp = RecoDecay::m(arrMomToOmega, arrMass2Prong[hf_cand_casc_lf::DecayType2Prong::OmegaczeroToOmegaPi]);
-              auto mass2ProngOmegaKHyp = RecoDecay::m(arrMomToOmega, arrMass2Prong[hf_cand_casc_lf::DecayType2Prong::OmegaczeroToOmegaK]);
+              const auto mass2ProngOmegaPiHyp = RecoDecay::m(arrMomToOmega, arrMass2Prong[hf_cand_casc_lf::DecayType2Prong::OmegaczeroToOmegaPi]);
+              const auto mass2ProngOmegaKHyp = RecoDecay::m(arrMomToOmega, arrMass2Prong[hf_cand_casc_lf::DecayType2Prong::OmegaczeroToOmegaK]);
 
               if (std::abs(casc.mOmega() - MassOmegaMinus) < config.cascadeMassWindow) {
                 if ((mass2ProngOmegaPiHyp >= config.massOmegaCharmBachelorMin) && (mass2ProngOmegaPiHyp <= config.massOmegaCharmBachelorMax)) {

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1804,12 +1804,12 @@ struct HfTrackIndexSkimCreator {
   }
 
   /// Method to perform ML selections for 2-prong candidates after the rectangular selections
+  /// \tparam usePidForHfFiltersBdt is the flag to determine whether to use also the PID features for the Lc BDT
   /// \param featuresCand is the vector with the candidate features
   /// \param featuresCandPid is the vector with the candidate PID features
   /// \param outputScores is the array of vectors with the output scores to be filled
   /// \param isSelected ia s bitmap with selection outcome
-  /// \param usePidForHfFiltersBdt is the flag to determine whether to use also the PID features for the Lc BDT
-  template <bool usePidForHfFiltersBdt = false>
+  template <bool usePidForHfFiltersBdt>
   void applyMlSelectionForHfFilters3Prong(std::vector<float> featuresCand, std::vector<float> featuresCandPid, std::array<std::vector<float>, kN3ProngDecays>& outputScores, auto& isSelected)
   {
     if (isSelected == 0) {
@@ -1929,7 +1929,7 @@ struct HfTrackIndexSkimCreator {
   /// \param pvCovMatrix is a vector where to store the covariance matrix values of refitted PV
   void performPvRefitCandProngs(SelectedCollisions::iterator const& collision,
                                 aod::BCsWithTimestamps const&,
-                                std::vector<int64_t> vecPvContributorGlobId,
+                                std::vector<int64_t> const& vecPvContributorGlobId,
                                 std::vector<o2::track::TrackParCov> const& vecPvContributorTrackParCov,
                                 std::vector<int64_t> vecCandPvContributorGlobId,
                                 std::array<float, 3>& pvCoord,
@@ -2055,7 +2055,7 @@ struct HfTrackIndexSkimCreator {
     return;
   } /// end of performPvRefitCandProngs function
 
-  template <bool doPvRefit = false, bool usePidForHfFiltersBdt = false, typename TTracks>
+  template <bool doPvRefit, bool usePidForHfFiltersBdt, typename TTracks>
   void run2And3Prongs(SelectedCollisions const& collisions,
                       aod::BCsWithTimestamps const& bcWithTimeStamps,
                       FilteredTrackAssocSel const&,
@@ -2832,8 +2832,8 @@ struct HfTrackIndexSkimCreator {
               if (config.applyMlForHfFilters) {
                 rowTrackIndexMlScoreProng3(mlScores3Prongs[0], mlScores3Prongs[1], mlScores3Prongs[2], mlScores3Prongs[3]);
               }
-              // fill table row of coordinates of PV refit
               if constexpr (doPvRefit) {
+                // fill table row of coordinates of PV refit
                 rowProng3PVrefit(pvRefitCoord3Prong1Pos2Neg[0], pvRefitCoord3Prong1Pos2Neg[1], pvRefitCoord3Prong1Pos2Neg[2],
                                  pvRefitCovMatrix3Prong1Pos2Neg[0], pvRefitCovMatrix3Prong1Pos2Neg[1], pvRefitCovMatrix3Prong1Pos2Neg[2], pvRefitCovMatrix3Prong1Pos2Neg[3], pvRefitCovMatrix3Prong1Pos2Neg[4], pvRefitCovMatrix3Prong1Pos2Neg[5]);
               }
@@ -3001,7 +3001,7 @@ struct HfTrackIndexSkimCreator {
     FilteredTrackAssocSel const& trackIndices,
     TracksWithPVRefitAndDCA const& tracks)
   {
-    run2And3Prongs<true>(collisions, bcWithTimeStamps, trackIndices, tracks);
+    run2And3Prongs<true, false>(collisions, bcWithTimeStamps, trackIndices, tracks);
   }
   PROCESS_SWITCH(HfTrackIndexSkimCreator, process2And3ProngsWithPvRefit, "Process 2-prong and 3-prong skim with PV refit", false);
 
@@ -3011,7 +3011,7 @@ struct HfTrackIndexSkimCreator {
     FilteredTrackAssocSel const& trackIndices,
     aod::TracksWCovDcaExtra const& tracks)
   {
-    run2And3Prongs(collisions, bcWithTimeStamps, trackIndices, tracks);
+    run2And3Prongs<false, false>(collisions, bcWithTimeStamps, trackIndices, tracks);
   }
   PROCESS_SWITCH(HfTrackIndexSkimCreator, process2And3ProngsNoPvRefit, "Process 2-prong and 3-prong skim without PV refit", true);
 

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -2252,7 +2252,7 @@ struct HfTrackIndexSkimCreator {
                     nCandContr--;
                     isTrackSecondContr = false;
                   }
-                  if (nCandContr == 2) {
+                  if (nCandContr == 2) { // o2-linter: disable="magic-number" (see comment below)
                     /// Both the daughter tracks were used for the original PV refit, let's refit it after excluding them
                     if (config.debugPvRefit) {
                       LOG(info) << "### [2 Prong] Calling performPvRefitCandProngs for HF 2 prong candidate";
@@ -2377,7 +2377,7 @@ struct HfTrackIndexSkimCreator {
           }
 
           // if the cut on the decay length of 3-prongs computed with the first two tracks is enabled and the vertex was not computed for the D0, we compute it now
-          if (config.do3Prong && is2ProngCandidateGoodFor3Prong && (config.minTwoTrackDecayLengthFor3Prongs > 0.f || config.maxTwoTrackChi2PcaFor3Prongs < 1.e9f) && nVtxFrom2ProngFitter == 0) {
+          if (config.do3Prong && is2ProngCandidateGoodFor3Prong && (config.minTwoTrackDecayLengthFor3Prongs > 0.f || config.maxTwoTrackChi2PcaFor3Prongs < 1.e9f) && nVtxFrom2ProngFitter == 0) { // o2-linter: disable="magic-number" (default maxTwoTrackChi2PcaFor3Prongs is 1.e10)
             try {
               nVtxFrom2ProngFitter = df2.process(trackParVarPos1, trackParVarNeg1);
             } catch (...) {
@@ -2492,7 +2492,7 @@ struct HfTrackIndexSkimCreator {
                   vecCandPvContributorGlobId.push_back(trackPos2.globalIndex());
                 }
 
-                if (nCandContr == 3 || nCandContr == 2) {
+                if (nCandContr == 3 || nCandContr == 2) { // o2-linter: disable="magic-number" (see comment below)
                   /// At least two of the daughter tracks were used for the original PV refit, let's refit it after excluding them
                   if (config.debugPvRefit) {
                     LOG(info) << "### [3 prong] Calling performPvRefitCandProngs for HF 3 prong candidate, removing " << nCandContr << " daughters";
@@ -2744,7 +2744,7 @@ struct HfTrackIndexSkimCreator {
                   vecCandPvContributorGlobId.push_back(trackNeg2.globalIndex());
                 }
 
-                if (nCandContr == 3 || nCandContr == 2) {
+                if (nCandContr == 3 || nCandContr == 2) { // o2-linter: disable="magic-number" (see comment below)
                   /// At least two of the daughter tracks were used for the original PV refit, let's refit it after excluding them
                   if (config.debugPvRefit) {
                     LOG(info) << "### [3 prong] Calling performPvRefitCandProngs for HF 3 prong candidate, removing " << nCandContr << " daughters";
@@ -2898,7 +2898,8 @@ struct HfTrackIndexSkimCreator {
             }
           }
 
-          if (config.doDstar && TESTBIT(isSelected2ProngCand, hf_cand_2prong::DecayType::D0ToPiK) && (pt2Prong + config.ptTolerance) * 1.2 > config.binsPtDstarToD0Pi->at(0) && whichHypo2Prong[kN2ProngDecays] != 0) { // if D* enabled and pt of the D0 is larger than the minimum of the D* one within 20% (D* and D0 momenta are very similar, always within 20% according to PYTHIA8)
+          if (config.doDstar && TESTBIT(isSelected2ProngCand, hf_cand_2prong::DecayType::D0ToPiK) && (pt2Prong + config.ptTolerance) * 1.2 > config.binsPtDstarToD0Pi->at(0) && whichHypo2Prong[kN2ProngDecays] != 0) { // o2-linter: disable="magic-number" (see comment below)
+                                                                                                                                                                                                                        // if D* enabled and pt of the D0 is larger than the minimum of the D* one within 20% (D* and D0 momenta are very similar, always within 20% according to PYTHIA8)
             // second loop over positive tracks
             if (TESTBIT(whichHypo2Prong[kN2ProngDecays], 0) && (!config.applyKaonPidIn3Prongs || TESTBIT(trackIndexNeg1.isIdentifiedPid(), ChannelKaonPid))) { // only for D0 candidates; moreover if kaon PID enabled, apply to the negative track
               auto groupedTrackIndicesSoftPionsPos = positiveSoftPions->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
@@ -3227,8 +3228,9 @@ struct HfTrackIndexSkimCreatorCascades {
             const std::array vertexV0{v0.x(), v0.y(), v0.z()};
             // we build the neutral track to then build the cascade
             std::array<float, 21> covV{};
-            constexpr int MomInd[6] = {9, 13, 14, 18, 19, 20}; // cov matrix elements for momentum component
-            for (int i = 0; i < 6; i++) {
+            constexpr std::size_t NIndicesMom{6u};
+            constexpr std::size_t MomInd[NIndicesMom] = {9, 13, 14, 18, 19, 20}; // cov matrix elements for momentum component
+            for (std::size_t i = 0; i < NIndicesMom; i++) {
               covV[MomInd[i]] = v0.momentumCovMat()[i];
               covV[i] = v0.positionCovMat()[i];
             }
@@ -3263,7 +3265,7 @@ struct HfTrackIndexSkimCreatorCascades {
           std::array posCasc{0., 0., 0.};
           if (config.useDCAFitter) {
             const auto& cascVtx = df2.getPCACandidate();
-            for (int iCoord{0}; iCoord < 3; ++iCoord) {
+            for (int iCoord{0}; iCoord < 3; ++iCoord) { // o2-linter: disable="magic-number" ({x, y, z} coordinates})
               posCasc[iCoord] = cascVtx[iCoord];
             }
           }
@@ -3623,8 +3625,9 @@ struct HfTrackIndexSkimCreatorLfCascades {
         const std::array vertexCasc{casc.x(), casc.y(), casc.z()};
         const std::array pVecCasc{casc.px(), casc.py(), casc.pz()};
         std::array<float, 21> covCasc{};
-        constexpr int MomInd[6] = {9, 13, 14, 18, 19, 20}; // cov matrix elements for momentum component
-        for (int i = 0; i < 6; i++) {
+        constexpr std::size_t NIndicesMom{6u};
+        constexpr std::size_t MomInd[NIndicesMom] = {9, 13, 14, 18, 19, 20}; // cov matrix elements for momentum component
+        for (std::size_t i = 0; i < NIndicesMom; i++) {
           covCasc[MomInd[i]] = casc.momentumCovMat()[i];
           covCasc[i] = casc.positionCovMat()[i];
         }

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -165,7 +165,7 @@ struct HfTrackIndexSkimCreatorTagSelCollisions {
     o2::hf_evsel::HfCollisionRejectionMask rejectionMask{};
 
     if constexpr (applyUpcSel) {
-      rejectionMask = hfEvSel.getHfCollisionRejectionMaskWithUpc<applyTrigSel, centEstimator, BCsType>(
+      rejectionMask = hfEvSel.getHfCollisionRejectionMaskWithUpc<applyTrigSel, centEstimator>(
         collision, centrality, ccdb, registry, bcs);
     } else {
       rejectionMask = hfEvSel.getHfCollisionRejectionMask<applyTrigSel, centEstimator, BCsType>(

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -77,8 +77,9 @@
 #include <cstdlib>
 #include <iterator> // std::distance
 #include <numeric>
-#include <string> // std::string
-#include <vector> // std::vector
+#include <string>  // std::string
+#include <utility> // std::forward
+#include <vector>  // std::vector
 
 using namespace o2;
 using namespace o2::analysis;
@@ -260,6 +261,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
   Produces<aod::HfPvRefitTrack> tabPvRefitTrack;
 
   struct : ConfigurableGroup {
+    double etaMinDefault{-99999.};
     Configurable<bool> isRun2{"isRun2", false, "enable Run 2 or Run 3 GRP objects for magnetic field"};
     Configurable<bool> doPvRefit{"doPvRefit", false, "do PV refit excluding the considered track"};
     Configurable<bool> fillHistograms{"fillHistograms", true, "fill histograms"};
@@ -275,29 +277,29 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
     // 2-prong cuts
     Configurable<double> ptMinTrack2Prong{"ptMinTrack2Prong", -1., "min. track pT for 2 prong candidate"};
     Configurable<LabeledArray<double>> cutsTrack2Prong{"cutsTrack2Prong", {hf_cuts_single_track::CutsTrack[0], hf_cuts_single_track::NBinsPtTrack, hf_cuts_single_track::NCutVarsTrack, hf_cuts_single_track::labelsPtTrack, hf_cuts_single_track::labelsCutVarTrack}, "Single-track selections per pT bin for 2-prong candidates"};
-    Configurable<double> etaMinTrack2Prong{"etaMinTrack2Prong", -99999., "min. pseudorapidity for 2 prong candidate"};
+    Configurable<double> etaMinTrack2Prong{"etaMinTrack2Prong", std::forward<double>(etaMinDefault), "min. pseudorapidity for 2 prong candidate"};
     Configurable<double> etaMaxTrack2Prong{"etaMaxTrack2Prong", 4., "max. pseudorapidity for 2 prong candidate"};
     // 3-prong cuts
     Configurable<double> ptMinTrack3Prong{"ptMinTrack3Prong", -1., "min. track pT for 3 prong candidate"};
     Configurable<LabeledArray<double>> cutsTrack3Prong{"cutsTrack3Prong", {hf_cuts_single_track::CutsTrack[0], hf_cuts_single_track::NBinsPtTrack, hf_cuts_single_track::NCutVarsTrack, hf_cuts_single_track::labelsPtTrack, hf_cuts_single_track::labelsCutVarTrack}, "Single-track selections per pT bin for 3-prong candidates"};
-    Configurable<double> etaMinTrack3Prong{"etaMinTrack3Prong", -99999., "min. pseudorapidity for 3 prong candidate"};
+    Configurable<double> etaMinTrack3Prong{"etaMinTrack3Prong", std::forward<double>(etaMinDefault), "min. pseudorapidity for 3 prong candidate"};
     Configurable<double> etaMaxTrack3Prong{"etaMaxTrack3Prong", 4., "max. pseudorapidity for 3 prong candidate"};
     // bachelor cuts (V0 + bachelor decays)
     Configurable<double> ptMinTrackBach{"ptMinTrackBach", 0.3, "min. track pT for bachelor in cascade candidate"}; // 0.5 for PbPb 2015?
     Configurable<LabeledArray<double>> cutsTrackBach{"cutsTrackBach", {hf_cuts_single_track::CutsTrack[0], hf_cuts_single_track::NBinsPtTrack, hf_cuts_single_track::NCutVarsTrack, hf_cuts_single_track::labelsPtTrack, hf_cuts_single_track::labelsCutVarTrack}, "Single-track selections per pT bin for the bachelor of V0-bachelor candidates"};
-    Configurable<double> etaMinTrackBach{"etaMinTrackBach", -99999., "min. pseudorapidity for bachelor in cascade candidate"};
+    Configurable<double> etaMinTrackBach{"etaMinTrackBach", std::forward<double>(etaMinDefault), "min. pseudorapidity for bachelor in cascade candidate"};
     Configurable<double> etaMaxTrackBach{"etaMaxTrackBach", 0.8, "max. pseudorapidity for bachelor in cascade candidate"};
     // bachelor cuts (cascade + bachelor decays)
     Configurable<double> ptMinTrackBachLfCasc{"ptMinTrackBachLfCasc", 0.1, "min. track pT for bachelor in cascade + bachelor decays"}; // 0.5 for PbPb 2015?
     Configurable<LabeledArray<double>> cutsTrackBachLfCasc{"cutsTrackBachLfCasc", {hf_cuts_single_track::CutsTrack[0], hf_cuts_single_track::NBinsPtTrack, hf_cuts_single_track::NCutVarsTrack, hf_cuts_single_track::labelsPtTrack, hf_cuts_single_track::labelsCutVarTrack}, "Single-track selections per pT bin for the bachelor in cascade + bachelor decays"};
-    Configurable<double> etaMinTrackBachLfCasc{"etaMinTrackBachLfCasc", -99999., "min. pseudorapidity for bachelor in cascade + bachelor decays"};
+    Configurable<double> etaMinTrackBachLfCasc{"etaMinTrackBachLfCasc", std::forward<double>(etaMinDefault), "min. pseudorapidity for bachelor in cascade + bachelor decays"};
     Configurable<double> etaMaxTrackBachLfCasc{"etaMaxTrackBachLfCasc", 1.1, "max. pseudorapidity for bachelor in cascade + bachelor decays"};
     Configurable<bool> useIsGlobalTrackForBachLfCasc{"useIsGlobalTrackForBachLfCasc", false, "check isGlobalTrack status for bachelor in cascade + bachelor decays"};
     Configurable<bool> useIsGlobalTrackWoDCAForBachLfCasc{"useIsGlobalTrackWoDCAForBachLfCasc", false, "check isGlobalTrackWoDCA status for bachelor in cascade + bachelor decays"};
     Configurable<bool> useIsQualityTrackITSForBachLfCasc{"useIsQualityTrackITSForBachLfCasc", true, "check isQualityTrackITS status for bachelor in cascade + bachelor decays"};
     // soft pion cuts for D*
     Configurable<double> ptMinSoftPionForDstar{"ptMinSoftPionForDstar", 0.05, "min. track pT for soft pion in D* candidate"};
-    Configurable<double> etaMinSoftPionForDstar{"etaMinSoftPionForDstar", -99999., "min. pseudorapidity for soft pion in D* candidate"};
+    Configurable<double> etaMinSoftPionForDstar{"etaMinSoftPionForDstar", std::forward<double>(etaMinDefault), "min. pseudorapidity for soft pion in D* candidate"};
     Configurable<double> etaMaxSoftPionForDstar{"etaMaxSoftPionForDstar", 0.8, "max. pseudorapidity for soft pion in D* candidate"};
     Configurable<LabeledArray<double>> cutsTrackDstar{"cutsTrackDstar", {hf_cuts_single_track::CutsTrackPrimary[0], hf_cuts_single_track::NBinsPtTrack, hf_cuts_single_track::NCutVarsTrack, hf_cuts_single_track::labelsPtTrack, hf_cuts_single_track::labelsCutVarTrack}, "Single-track selections per pT bin for the soft pion of D* candidates"};
     Configurable<bool> useIsGlobalTrackForSoftPion{"useIsGlobalTrackForSoftPion", false, "check isGlobalTrack status for soft pion tracks"};
@@ -357,19 +359,19 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
 
     cutsSingleTrack = {config.cutsTrack2Prong, config.cutsTrack3Prong, config.cutsTrackBach, config.cutsTrackDstar, config.cutsTrackBachLfCasc};
 
-    if (config.etaMinTrack2Prong == -99999.) {
+    if (config.etaMinTrack2Prong == config.etaMinDefault) {
       config.etaMinTrack2Prong.value = -config.etaMaxTrack2Prong;
     }
-    if (config.etaMinTrack3Prong == -99999.) {
+    if (config.etaMinTrack3Prong == config.etaMinDefault) {
       config.etaMinTrack3Prong.value = -config.etaMaxTrack3Prong;
     }
-    if (config.etaMinTrackBach == -99999.) {
+    if (config.etaMinTrackBach == config.etaMinDefault) {
       config.etaMinTrackBach.value = -config.etaMaxTrackBach;
     }
-    if (config.etaMinSoftPionForDstar == -99999.) {
+    if (config.etaMinSoftPionForDstar == config.etaMinDefault) {
       config.etaMinSoftPionForDstar.value = -config.etaMaxSoftPionForDstar;
     }
-    if (config.etaMinTrackBachLfCasc == -99999.) {
+    if (config.etaMinTrackBachLfCasc == config.etaMinDefault) {
       config.etaMinTrackBachLfCasc.value = -config.etaMaxTrackBachLfCasc;
     }
 
@@ -3049,6 +3051,7 @@ struct HfTrackIndexSkimCreatorCascades {
   Produces<aod::HfCascades> rowTrackIndexCasc;
 
   struct : ConfigurableGroup {
+    double etaMinDefault{-99999.};
     Configurable<bool> isRun2{"isRun2", false, "enable Run 2 or Run 3 GRP objects for magnetic field"};
     Configurable<bool> fillHistograms{"fillHistograms", true, "fill histograms"};
     // vertexing
@@ -3061,7 +3064,7 @@ struct HfTrackIndexSkimCreatorCascades {
     Configurable<bool> useAbsDCA{"useAbsDCA", true, "Minimise abs. distance rather than chi2"};
     Configurable<bool> useWeightedFinalPCA{"useWeightedFinalPCA", true, "Recalculate vertex position using track covariances, effective only if useAbsDCA is true"};
     // track cuts for V0 daughters
-    Configurable<double> etaMinV0Daugh{"etaMinV0Daugh", -99999., "min. pseudorapidity V0 daughters"};
+    Configurable<double> etaMinV0Daugh{"etaMinV0Daugh", std::forward<double>(etaMinDefault), "min. pseudorapidity V0 daughters"};
     Configurable<double> etaMaxV0Daugh{"etaMaxV0Daugh", 1.1, "max. pseudorapidity V0 daughters"};
     Configurable<double> ptMinV0Daugh{"ptMinV0Daugh", 0.05, "min. pT V0 daughters"};
     // v0 cuts
@@ -3107,7 +3110,7 @@ struct HfTrackIndexSkimCreatorCascades {
       return;
     }
 
-    if (config.etaMinV0Daugh == -99999.) {
+    if (config.etaMinV0Daugh == config.etaMinDefault) {
       config.etaMinV0Daugh.value = -config.etaMaxV0Daugh;
     }
 

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1291,7 +1291,7 @@ struct HfTrackIndexSkimCreator {
   using FilteredTrackAssocSel = soa::Filtered<soa::Join<aod::TrackAssoc, aod::HfSelTrack>>;
 
   // filter collisions
-  Filter filterSelectCollisions = (aod::hf_sel_collision::whyRejectColl == static_cast<uint32_t>(0));
+  Filter filterSelectCollisions = (aod::hf_sel_collision::whyRejectColl == static_cast<o2::hf_evsel::HfCollisionRejectionMask>(0));
   // filter track indices
   Filter filterSelectTrackIds = ((aod::hf_sel_track::isSelProng & static_cast<uint32_t>(BIT(CandidateType::Cand2Prong))) != 0u) || ((aod::hf_sel_track::isSelProng & static_cast<uint32_t>(BIT(CandidateType::Cand3Prong))) != 0u) || ((aod::hf_sel_track::isSelProng & static_cast<uint32_t>(BIT(CandidateType::CandDstar))) != 0u);
 
@@ -3092,7 +3092,7 @@ struct HfTrackIndexSkimCreatorCascades {
   using SelectedCollisions = soa::Filtered<soa::Join<aod::Collisions, aod::HfSelCollision>>;
   using FilteredTrackAssocSel = soa::Filtered<soa::Join<aod::TrackAssoc, aod::HfSelTrack>>;
 
-  Filter filterSelectCollisions = (aod::hf_sel_collision::whyRejectColl == static_cast<uint32_t>(0));
+  Filter filterSelectCollisions = (aod::hf_sel_collision::whyRejectColl == static_cast<o2::hf_evsel::HfCollisionRejectionMask>(0));
   Filter filterSelectTrackIds = (aod::hf_sel_track::isSelProng & static_cast<uint32_t>(BIT(CandidateType::CandV0bachelor))) != 0u && (config.applyProtonPid == false || (aod::hf_sel_track::isIdentifiedPid & static_cast<uint32_t>(BIT(ChannelsProtonPid::LcToPK0S))) != 0u);
 
   Preslice<FilteredTrackAssocSel> trackIndicesPerCollision = aod::track_association::collisionId;
@@ -3361,7 +3361,7 @@ struct HfTrackIndexSkimCreatorLfCascades {
   using CascFull = soa::Join<aod::CascDatas, aod::CascCovs>;
   using V0Full = soa::Join<aod::V0Datas, aod::V0Covs>;
 
-  Filter filterSelectCollisions = (aod::hf_sel_collision::whyRejectColl == static_cast<uint32_t>(0));
+  Filter filterSelectCollisions = (aod::hf_sel_collision::whyRejectColl == static_cast<o2::hf_evsel::HfCollisionRejectionMask>(0));
   Filter filterSelectTrackIds = (aod::hf_sel_track::isSelProng & static_cast<uint32_t>(BIT(CandidateType::CandCascadeBachelor))) != 0u;
 
   Preslice<aod::TracksWCovDca> tracksPerCollision = aod::track::collisionId;                     // needed for PV refit

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -139,7 +139,7 @@ struct HfTrackIndexSkimCreatorTagSelCollisions {
     }
 
     // set numerical value of the Run 2 trigger class
-    auto triggerAlias = std::find(aliasLabels, aliasLabels + kNaliases, triggerClassName.value.data());
+    const auto triggerAlias = std::find(aliasLabels, aliasLabels + kNaliases, triggerClassName.value.data());
     if (triggerAlias != aliasLabels + kNaliases) {
       hfEvSel.triggerClass.value = std::distance(aliasLabels, triggerAlias);
     }
@@ -750,7 +750,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
 
     /// Prepare the vertex refitting
     // set the magnetic field from CCDB
-    auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
+    const auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
     initCCDB(bc, runNumber, ccdb, config.isRun2 ? config.ccdbPathGrp : config.ccdbPathGrpMag, lut, config.isRun2);
     /*if (runNumber != bc.runNumber()) {
 
@@ -2170,14 +2170,14 @@ struct HfTrackIndexSkimCreator {
         }
 
         // first loop over negative tracks
-        auto groupedTrackIndicesNeg1 = negativeFor2And3Prongs->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
+        const auto groupedTrackIndicesNeg1 = negativeFor2And3Prongs->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
         for (auto trackIndexNeg1 = groupedTrackIndicesNeg1.begin(); trackIndexNeg1 != groupedTrackIndicesNeg1.end(); ++trackIndexNeg1) {
-          auto trackNeg1 = trackIndexNeg1.template track_as<TTracks>();
+          const auto trackNeg1 = trackIndexNeg1.template track_as<TTracks>();
 
           // retrieve the selection flag that corresponds to this collision
-          auto isSelProngNeg1 = trackIndexNeg1.isSelProng();
-          bool const sel2ProngStatusNeg = TESTBIT(isSelProngNeg1, CandidateType::Cand2Prong);
-          bool const sel3ProngStatusNeg1 = TESTBIT(isSelProngNeg1, CandidateType::Cand3Prong);
+          const auto isSelProngNeg1 = trackIndexNeg1.isSelProng();
+          const bool sel2ProngStatusNeg = TESTBIT(isSelProngNeg1, CandidateType::Cand2Prong);
+          const bool sel3ProngStatusNeg1 = TESTBIT(isSelProngNeg1, CandidateType::Cand3Prong);
 
           auto trackParVarNeg1 = getTrackParCov(trackNeg1);
           std::array<float, 3> pVecTrackNeg1{trackNeg1.pVector()};
@@ -2800,14 +2800,14 @@ struct HfTrackIndexSkimCreator {
               std::array<float, 3> pvec0;
               std::array<float, 3> pvec1;
               std::array<float, 3> pvec2;
-              auto trackParVarPcaNeg1 = df3.getTrack(0);
-              auto trackParVarPcaPos1 = df3.getTrack(1);
-              auto trackParVarPcaNeg2 = df3.getTrack(2);
+              const auto trackParVarPcaNeg1 = df3.getTrack(0);
+              const auto trackParVarPcaPos1 = df3.getTrack(1);
+              const auto trackParVarPcaNeg2 = df3.getTrack(2);
               trackParVarPcaNeg1.getPxPyPzGlo(pvec0);
               trackParVarPcaPos1.getPxPyPzGlo(pvec1);
               trackParVarPcaNeg2.getPxPyPzGlo(pvec2);
 
-              auto pVecCandProng3Neg = RecoDecay::pVec(pvec0, pvec1, pvec2);
+              const auto pVecCandProng3Neg = RecoDecay::pVec(pvec0, pvec1, pvec2);
 
               // 3-prong selections after secondary vertex
               applySelection3Prong(pVecCandProng3Neg, secondaryVertex3, pvRefitCoord3Prong1Pos2Neg, cutStatus3Prong, isSelected3ProngCand);

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -464,7 +464,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
   template <int pidStrategy, typename T>
   uint8_t isSelectedPid(const T& hfTrack)
   {
-    std::array<int, 4> statusPid = {TrackSelectorPID::Accepted, TrackSelectorPID::Accepted, TrackSelectorPID::Accepted, TrackSelectorPID::Accepted};
+    std::array statusPid{TrackSelectorPID::Accepted, TrackSelectorPID::Accepted, TrackSelectorPID::Accepted, TrackSelectorPID::Accepted};
     if constexpr (pidStrategy == ProtonPidStrategy::PidTofOnly) {
       if (hfTrack.hasTOF()) {
         for (auto iChannel{0u}; iChannel < ChannelsProtonPid::NChannelsProtonPid; ++iChannel) {
@@ -870,7 +870,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
       /// Track propagation to the PV refit considering also the material budget
       /// Mandatory for tracks updated at most only to the innermost ITS layer
       auto trackPar = getTrackPar(trackToRemove);
-      std::array<float, 2> dcaInfo{-999., -999.};
+      std::array dcaInfo{-999.f, -999.f};
       if (o2::base::Propagator::Instance()->propagateToDCABxByBz({primVtxBaseRecalc.getX(), primVtxBaseRecalc.getY(), primVtxBaseRecalc.getZ()}, trackPar, 2.f, noMatCorr, &dcaInfo)) {
         pvCoord[0] = primVtxBaseRecalc.getX();
         pvCoord[1] = primVtxBaseRecalc.getY();
@@ -939,9 +939,9 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
       float trackPt = track.pt();
       float trackEta = track.eta();
 
-      std::array<float, 2> pvRefitDcaXYDcaZ{track.dcaXY(), track.dcaZ()};
-      std::array<float, 3> pvRefitPvCoord{0.f, 0.f, 0.f};
-      std::array<float, 6> pvRefitPvCovMatrix{1e10f, 1e10f, 1e10f, 1e10f, 1e10f, 1e10f};
+      std::array pvRefitDcaXYDcaZ{track.dcaXY(), track.dcaZ()};
+      std::array pvRefitPvCoord{0.f, 0.f, 0.f};
+      std::array pvRefitPvCovMatrix{1e10f, 1e10f, 1e10f, 1e10f, 1e10f, 1e10f};
 
       // PV refit and DCA recalculation only for tracks with an assigned collision
       if (config.doPvRefit && track.has_collision() && track.collisionId() == thisCollId && track.isPVContributor()) {
@@ -970,10 +970,10 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
         pvRefitPvCoordPerTrack[trackIdx] = pvRefitPvCoord;
         pvRefitPvCovMatrixPerTrack[trackIdx] = pvRefitPvCovMatrix;
       } else if (track.collisionId() != thisCollId) {
-        auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
+        const auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
         initCCDB(bc, runNumber, ccdb, config.isRun2 ? config.ccdbPathGrp : config.ccdbPathGrpMag, lut, config.isRun2);
         auto trackPar = getTrackPar(track);
-        std::array<float, 2> dcaInfo{-999., -999.};
+        std::array dcaInfo{-999.f, -999.f};
         o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackPar, 2.f, noMatCorr, &dcaInfo);
         trackPt = trackPar.getPt();
         trackEta = trackPar.getEta();
@@ -1279,9 +1279,9 @@ struct HfTrackIndexSkimCreator {
   std::array<std::array<std::array<double, 3>, 2>, kN3ProngDecays> arrMass3Prong;
   // arrays of 2-prong and 3-prong cuts
   std::array<LabeledArray<double>, kN2ProngDecays> cut2Prong;
-  std::array<std::vector<double>, kN2ProngDecays> pTBins2Prong;
+  std::array<std::vector<double>, kN2ProngDecays> binsPt2Prong;
   std::array<LabeledArray<double>, kN3ProngDecays> cut3Prong;
-  std::array<std::vector<double>, kN3ProngDecays> pTBins3Prong;
+  std::array<std::vector<double>, kN3ProngDecays> binsPt3Prong;
 
   // ML response
   o2::analysis::MlResponse<float> hfMlResponse2Prongs;                             // only D0
@@ -1344,10 +1344,10 @@ struct HfTrackIndexSkimCreator {
 
     // cuts for 2-prong decays retrieved by json. the order must be then one in hf_cand_2prong::DecayType
     cut2Prong = {config.cutsD0ToPiK, config.cutsJpsiToEE, config.cutsJpsiToMuMu};
-    pTBins2Prong = {config.binsPtD0ToPiK, config.binsPtJpsiToEE, config.binsPtJpsiToMuMu};
+    binsPt2Prong = {config.binsPtD0ToPiK, config.binsPtJpsiToEE, config.binsPtJpsiToMuMu};
     // cuts for 3-prong decays retrieved by json. the order must be then one in hf_cand_3prong::DecayType
     cut3Prong = {config.cutsDplusToPiKPi, config.cutsLcToPKPi, config.cutsDsToKKPi, config.cutsXicToPKPi};
-    pTBins3Prong = {config.binsPtDplusToPiKPi, config.binsPtLcToPKPi, config.binsPtDsToKKPi, config.binsPtXicToPKPi};
+    binsPt3Prong = {config.binsPtDplusToPiKPi, config.binsPtLcToPKPi, config.binsPtDsToKKPi, config.binsPtXicToPKPi};
 
     df2.setPropagateToPCA(config.propagateToPCA);
     df2.setMaxR(config.maxR);
@@ -1498,12 +1498,12 @@ struct HfTrackIndexSkimCreator {
     whichHypo[kN2ProngDecays] = 0; // D0 for D*
 
     pt2Prong = RecoDecay::pt(pVecTrack0, pVecTrack1);
-    auto pt = pt2Prong + config.ptTolerance; // add tolerance because of no reco decay vertex
+    const auto pt = pt2Prong + config.ptTolerance; // add tolerance because of no reco decay vertex
 
     for (int iDecay2P = 0; iDecay2P < kN2ProngDecays; iDecay2P++) {
 
-      // pT
-      auto binPt = findBin(&pTBins2Prong[iDecay2P], pt);
+      // pt
+      const auto binPt = findBin(&binsPt2Prong[iDecay2P], pt);
       // return immediately if it is outside the defined pT bins
       if (binPt == -1) {
         CLRBIT(isSelected, iDecay2P);
@@ -1518,14 +1518,14 @@ struct HfTrackIndexSkimCreator {
       whichHypo[iDecay2P] = 3; // 2 bits on
 
       if (config.debug || TESTBIT(isSelected, iDecay2P)) {
-        double const minMass = cut2Prong[iDecay2P].get(binPt, 0u);
-        double const maxMass = cut2Prong[iDecay2P].get(binPt, 1u);
+        const double minMass = cut2Prong[iDecay2P].get(binPt, 0u);
+        const double maxMass = cut2Prong[iDecay2P].get(binPt, 1u);
         if (minMass >= 0. && maxMass > 0.) {
-          auto arrMom = std::array{pVecTrack0, pVecTrack1};
+          const std::array arrMom{pVecTrack0, pVecTrack1};
           massHypos[0] = RecoDecay::m2(arrMom, arrMass2Prong[iDecay2P][0]);
           massHypos[1] = (iDecay2P == hf_cand_2prong::DecayType::D0ToPiK) ? RecoDecay::m2(arrMom, arrMass2Prong[iDecay2P][1]) : massHypos[0];
-          double const min2 = minMass * minMass;
-          double const max2 = maxMass * maxMass;
+          const double min2 = minMass * minMass;
+          const double max2 = maxMass * maxMass;
           if (massHypos[0] < min2 || massHypos[0] >= max2) {
             CLRBIT(whichHypo[iDecay2P], 0);
           }
@@ -1557,7 +1557,7 @@ struct HfTrackIndexSkimCreator {
         auto pTBinDstar = findBin(config.binsPtDstarToD0Pi, pt * 1.2); // assuming the D* pT about 20% higher than the one of the D0 to be safe
         if (pTBinDstar >= 0) {
           whichHypo[kN2ProngDecays] = whichHypo[hf_cand_2prong::DecayType::D0ToPiK];
-          double const deltaMass = config.cutsDstarToD0Pi->get(pTBinDstar, 1u);
+          const double deltaMass = config.cutsDstarToD0Pi->get(pTBinDstar, 1u);
 
           if (TESTBIT(whichHypo[iDecay2P], 0) && (massHypos[0] > (MassD0 + deltaMass) * (MassD0 + deltaMass) || massHypos[0] < (MassD0 - deltaMass) * (MassD0 - deltaMass))) {
             CLRBIT(whichHypo[kN2ProngDecays], 0);
@@ -1571,7 +1571,7 @@ struct HfTrackIndexSkimCreator {
   }
 
   /// Method to perform selections on difference from nominal mass for phi decay
-  /// \param pTBin pt bin for the cuts
+  /// \param binPt pt bin for the cuts
   /// \param pVecTrack0 is the momentum array of the first daughter track
   /// \param pVecTrack1 is the momentum array of the second daughter track
   /// \param pVecTrack2 is the momentum array of the third daughter track
@@ -1579,17 +1579,17 @@ struct HfTrackIndexSkimCreator {
   /// \param whichHypo information of the mass hypoteses that were selected
   /// \param isSelected is a bitmap with selection outcome
   template <typename T1, typename T2, typename T3>
-  void applyPreselectionPhiDecay(int& pTBin, T1 const& pVecTrack0, T1 const& pVecTrack1, T1 const& pVecTrack2, T2& cutStatus, T3& whichHypo, int& isSelected)
+  void applyPreselectionPhiDecay(const int binPt, T1 const& pVecTrack0, T1 const& pVecTrack1, T1 const& pVecTrack2, T2& cutStatus, T3& whichHypo, int& isSelected)
   {
-    double const deltaMassMax = cut3Prong[hf_cand_3prong::DecayType::DsToKKPi].get(pTBin, 4u);
+    const double deltaMassMax = cut3Prong[hf_cand_3prong::DecayType::DsToKKPi].get(binPt, 4u);
     if (TESTBIT(whichHypo[hf_cand_3prong::DecayType::DsToKKPi], 0)) {
-      double const mass2PhiKKPi = RecoDecay::m2(std::array{pVecTrack0, pVecTrack1}, std::array{arrMass3Prong[hf_cand_3prong::DecayType::DsToKKPi][0][0], arrMass3Prong[hf_cand_3prong::DecayType::DsToKKPi][0][1]});
+      const double mass2PhiKKPi = RecoDecay::m2(std::array{pVecTrack0, pVecTrack1}, std::array{arrMass3Prong[hf_cand_3prong::DecayType::DsToKKPi][0][0], arrMass3Prong[hf_cand_3prong::DecayType::DsToKKPi][0][1]});
       if (mass2PhiKKPi > (MassPhi + deltaMassMax) * (MassPhi + deltaMassMax) || mass2PhiKKPi < (MassPhi - deltaMassMax) * (MassPhi - deltaMassMax)) {
         CLRBIT(whichHypo[hf_cand_3prong::DecayType::DsToKKPi], 0);
       }
     }
     if (TESTBIT(whichHypo[hf_cand_3prong::DecayType::DsToKKPi], 1)) {
-      double const mass2PhiPiKK = RecoDecay::m2(std::array{pVecTrack1, pVecTrack2}, std::array{arrMass3Prong[hf_cand_3prong::DecayType::DsToKKPi][1][1], arrMass3Prong[hf_cand_3prong::DecayType::DsToKKPi][1][2]});
+      const double mass2PhiPiKK = RecoDecay::m2(std::array{pVecTrack1, pVecTrack2}, std::array{arrMass3Prong[hf_cand_3prong::DecayType::DsToKKPi][1][1], arrMass3Prong[hf_cand_3prong::DecayType::DsToKKPi][1][2]});
       if (mass2PhiPiKK > (MassPhi + deltaMassMax) * (MassPhi + deltaMassMax) || mass2PhiPiKK < (MassPhi - deltaMassMax) * (MassPhi - deltaMassMax)) {
         CLRBIT(whichHypo[hf_cand_3prong::DecayType::DsToKKPi], 1);
       }
@@ -1614,7 +1614,7 @@ struct HfTrackIndexSkimCreator {
   template <typename T1, typename T2, typename T3>
   void applyPreselection3Prong(T1 const& pVecTrack0, T1 const& pVecTrack1, T1 const& pVecTrack2, int8_t& isIdentifiedPidTrack0, int8_t& isIdentifiedPidTrack2, T2& cutStatus, T3& whichHypo, int& isSelected)
   {
-    auto pt = RecoDecay::pt(pVecTrack0, pVecTrack1, pVecTrack2) + config.ptTolerance; // add tolerance because of no reco decay vertex
+    const auto pt = RecoDecay::pt(pVecTrack0, pVecTrack1, pVecTrack2) + config.ptTolerance; // add tolerance because of no reco decay vertex
 
     for (int iDecay3P = 0; iDecay3P < kN3ProngDecays; iDecay3P++) {
 
@@ -1637,7 +1637,7 @@ struct HfTrackIndexSkimCreator {
       }
 
       // pT
-      auto binPt = findBin(&pTBins3Prong[iDecay3P], pt);
+      const auto binPt = findBin(&binsPt3Prong[iDecay3P], pt);
       // return immediately if it is outside the defined pT bins
       if (binPt == -1) {
         CLRBIT(isSelected, iDecay3P);
@@ -1650,13 +1650,13 @@ struct HfTrackIndexSkimCreator {
 
       // invariant mass
       if ((config.debug || TESTBIT(isSelected, iDecay3P))) {
-        double const minMass = cut3Prong[iDecay3P].get(binPt, 0u);
-        double const maxMass = cut3Prong[iDecay3P].get(binPt, 1u);
+        const double minMass = cut3Prong[iDecay3P].get(binPt, 0u);
+        const double maxMass = cut3Prong[iDecay3P].get(binPt, 1u);
         if (minMass >= 0. && maxMass > 0.) { // no need to check isSelected but to avoid mistakes
           double massHypos[2] = {0., 0.};
-          auto arrMom = std::array{pVecTrack0, pVecTrack1, pVecTrack2};
-          double const min2 = minMass * minMass;
-          double const max2 = maxMass * maxMass;
+          const std::array arrMom{pVecTrack0, pVecTrack1, pVecTrack2};
+          const double min2 = minMass * minMass;
+          const double max2 = maxMass * maxMass;
           massHypos[0] = RecoDecay::m2(arrMom, arrMass3Prong[iDecay3P][0]);
           massHypos[1] = (iDecay3P != hf_cand_3prong::DecayType::DplusToPiKPi) ? RecoDecay::m2(arrMom, arrMass3Prong[iDecay3P][1]) : massHypos[0];
           if (massHypos[0] < min2 || massHypos[0] >= max2) {
@@ -1694,8 +1694,8 @@ struct HfTrackIndexSkimCreator {
       for (int iDecay2P = 0; iDecay2P < kN2ProngDecays; iDecay2P++) {
 
         // pT
-        auto pTBin = findBin(&pTBins2Prong[iDecay2P], RecoDecay::pt(pVecCand));
-        if (pTBin == -1) { // cut if it is outside the defined pT bins
+        const auto binPt = findBin(&binsPt2Prong[iDecay2P], RecoDecay::pt(pVecCand));
+        if (binPt == -1) { // cut if it is outside the defined pT bins
           CLRBIT(isSelected, iDecay2P);
           if (config.debug) {
             cutStatus[iDecay2P][0] = false;
@@ -1705,8 +1705,8 @@ struct HfTrackIndexSkimCreator {
 
         // cosp
         if (config.debug || TESTBIT(isSelected, iDecay2P)) {
-          auto cpa = RecoDecay::cpa(primVtx, secVtx, pVecCand);
-          if (cpa < cut2Prong[iDecay2P].get(pTBin, 2u)) { // 2u == "cospIndex[iDecay2P]"
+          const auto cpa = RecoDecay::cpa(primVtx, secVtx, pVecCand);
+          if (cpa < cut2Prong[iDecay2P].get(binPt, 2u)) { // 2u == "cospIndex[iDecay2P]"
             CLRBIT(isSelected, iDecay2P);
             if (config.debug) {
               cutStatus[iDecay2P][3] = false;
@@ -1772,8 +1772,8 @@ struct HfTrackIndexSkimCreator {
       for (int iDecay3P = 0; iDecay3P < kN3ProngDecays; iDecay3P++) {
 
         // pT
-        auto pTBin = findBin(&pTBins3Prong[iDecay3P], pT);
-        if (pTBin == -1) { // cut if it is outside the defined pT bins
+        const auto binPt = findBin(&binsPt3Prong[iDecay3P], pT);
+        if (binPt == -1) { // cut if it is outside the defined pT bins
           CLRBIT(isSelected, iDecay3P);
           if (config.debug) {
             cutStatus[iDecay3P][0] = false;
@@ -1782,9 +1782,9 @@ struct HfTrackIndexSkimCreator {
         }
 
         // cosp
-        if ((config.debug || TESTBIT(isSelected, iDecay3P))) {
-          auto cpa = RecoDecay::cpa(primVtx, secVtx, pVecCand);
-          if (cpa < cut3Prong[iDecay3P].get(pTBin, 2u)) { // 2u == cospIndex[iDecay3P]
+        if (config.debug || TESTBIT(isSelected, iDecay3P)) {
+          const auto cpa = RecoDecay::cpa(primVtx, secVtx, pVecCand);
+          if (cpa < cut3Prong[iDecay3P].get(binPt, 2u)) { // 2u == cospIndex[iDecay3P]
             CLRBIT(isSelected, iDecay3P);
             if (config.debug) {
               cutStatus[iDecay3P][2] = false;
@@ -1794,8 +1794,8 @@ struct HfTrackIndexSkimCreator {
 
         // decay length
         if ((config.debug || TESTBIT(isSelected, iDecay3P))) {
-          auto decayLength = RecoDecay::distance(primVtx, secVtx);
-          if (decayLength < cut3Prong[iDecay3P].get(pTBin, 3u)) { // 3u == decLenIndex[iDecay3P]
+          const auto decayLength = RecoDecay::distance(primVtx, secVtx);
+          if (decayLength < cut3Prong[iDecay3P].get(binPt, 3u)) { // 3u == decLenIndex[iDecay3P]
             CLRBIT(isSelected, iDecay3P);
             if (config.debug) {
               cutStatus[iDecay3P][3] = false;
@@ -1880,14 +1880,14 @@ struct HfTrackIndexSkimCreator {
   uint8_t applySelectionDstar(T1 const& pVecTrack0, T1 const& pVecTrack1, T1 const& pVecTrack2, uint8_t& cutStatus, T2& deltaMass)
   {
     uint8_t isSelected{1};
-    auto arrMom = std::array{pVecTrack0, pVecTrack1, pVecTrack2};
-    auto arrMomD0 = std::array{pVecTrack0, pVecTrack1};
-    auto pT = RecoDecay::pt(pVecTrack0, pVecTrack1, pVecTrack2) + config.ptTolerance; // add tolerance because of no reco decay vertex
+    const std::array arrMom{pVecTrack0, pVecTrack1, pVecTrack2};
+    const std::array arrMomD0{pVecTrack0, pVecTrack1};
+    const auto pt = RecoDecay::pt(pVecTrack0, pVecTrack1, pVecTrack2) + config.ptTolerance; // add tolerance because of no reco decay vertex
 
-    // pT
-    auto pTBin = findBin(config.binsPtDstarToD0Pi, pT);
+    // pt
+    const auto binPt = findBin(config.binsPtDstarToD0Pi, pt);
     // return immediately if it is outside the defined pT bins
-    if (pTBin == -1) {
+    if (binPt == -1) {
       isSelected = 0;
       if (config.debug) {
         CLRBIT(cutStatus, 0);
@@ -1897,8 +1897,8 @@ struct HfTrackIndexSkimCreator {
     }
 
     // D0 mass
-    double const deltaMassD0 = config.cutsDstarToD0Pi->get(pTBin, 1u); // 1u == deltaMassD0Index
-    double const invMassD0 = RecoDecay::m(arrMomD0, std::array{MassPiPlus, MassKPlus});
+    const double deltaMassD0 = config.cutsDstarToD0Pi->get(binPt, 1u); // 1u == deltaMassD0Index
+    const double invMassD0 = RecoDecay::m(arrMomD0, std::array{MassPiPlus, MassKPlus});
     if (std::abs(invMassD0 - MassD0) > deltaMassD0) {
       isSelected = 0;
       if (config.debug) {
@@ -1908,8 +1908,8 @@ struct HfTrackIndexSkimCreator {
     }
 
     // D*+ mass
-    double const maxDeltaMass = config.cutsDstarToD0Pi->get(pTBin, 0u); // 0u == deltaMassIndex
-    double const invMassDstar = RecoDecay::m(arrMom, std::array{MassPiPlus, MassKPlus, MassPiPlus});
+    const double maxDeltaMass = config.cutsDstarToD0Pi->get(binPt, 0u); // 0u == deltaMassIndex
+    const double invMassDstar = RecoDecay::m(arrMom, std::array{MassPiPlus, MassKPlus, MassPiPlus});
     deltaMass = invMassDstar - invMassD0;
     if (deltaMass > maxDeltaMass) {
       isSelected = 0;
@@ -1942,7 +1942,7 @@ struct HfTrackIndexSkimCreator {
 
     /// Prepare the vertex refitting
     // set the magnetic field from CCDB
-    auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
+    const auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
     initCCDB(bc, runNumber, ccdb, config.isRun2 ? config.ccdbPathGrp : config.ccdbPathGrpMag, lut, config.isRun2);
 
     // build the VertexBase to initialize the vertexer
@@ -2134,7 +2134,7 @@ struct HfTrackIndexSkimCreator {
       int whichHypo3Prong[kN3ProngDecays];
 
       // set the magnetic field from CCDB
-      auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
+      const auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
       initCCDB(bc, runNumber, ccdb, config.isRun2 ? config.ccdbPathGrp : config.ccdbPathGrpMag, lut, config.isRun2);
       df2.setBz(o2::base::Propagator::Instance()->getNominalBz());
       df3.setBz(o2::base::Propagator::Instance()->getNominalBz());
@@ -2162,8 +2162,8 @@ struct HfTrackIndexSkimCreator {
         bool const sel3ProngStatusPos1 = TESTBIT(isSelProngPos1, CandidateType::Cand3Prong);
 
         auto trackParVarPos1 = getTrackParCov(trackPos1);
-        std::array<float, 3> pVecTrackPos1{trackPos1.pVector()};
-        std::array<float, 2> dcaInfoPos1{trackPos1.dcaXY(), trackPos1.dcaZ()};
+        std::array pVecTrackPos1{trackPos1.pVector()};
+        std::array dcaInfoPos1{trackPos1.dcaXY(), trackPos1.dcaZ()};
         if (thisCollId != trackPos1.collisionId()) { // this is not the "default" collision for this track, we have to re-propagate it
           o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParVarPos1, 2.f, noMatCorr, &dcaInfoPos1);
           getPxPyPz(trackParVarPos1, pVecTrackPos1);
@@ -2180,8 +2180,8 @@ struct HfTrackIndexSkimCreator {
           const bool sel3ProngStatusNeg1 = TESTBIT(isSelProngNeg1, CandidateType::Cand3Prong);
 
           auto trackParVarNeg1 = getTrackParCov(trackNeg1);
-          std::array<float, 3> pVecTrackNeg1{trackNeg1.pVector()};
-          std::array<float, 2> dcaInfoNeg1{trackNeg1.dcaXY(), trackNeg1.dcaZ()};
+          std::array pVecTrackNeg1{trackNeg1.pVector()};
+          std::array dcaInfoNeg1{trackNeg1.dcaXY(), trackNeg1.dcaZ()};
           if (thisCollId != trackNeg1.collisionId()) { // this is not the "default" collision for this track, we have to re-propagate it
             o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParVarNeg1, 2.f, noMatCorr, &dcaInfoNeg1);
             getPxPyPz(trackParVarNeg1, pVecTrackNeg1);
@@ -2198,8 +2198,8 @@ struct HfTrackIndexSkimCreator {
           }
 
           // initialise PV refit coordinates and cov matrix for 2-prongs already here for D*
-          std::array<float, 3> pvRefitCoord2Prong = {collision.posX(), collision.posY(), collision.posZ()}; /// initialize to the original PV
-          std::array<float, 6> pvRefitCovMatrix2Prong = getPrimaryVertex(collision).getCov();               /// initialize to the original PV
+          std::array pvRefitCoord2Prong = {collision.posX(), collision.posY(), collision.posZ()}; /// initialize to the original PV
+          std::array pvRefitCovMatrix2Prong = getPrimaryVertex(collision).getCov();               /// initialize to the original PV
 
           // 2-prong vertex reconstruction
           float pt2Prong{-1.};
@@ -2222,8 +2222,8 @@ struct HfTrackIndexSkimCreator {
                 // get secondary vertex
                 const auto& secondaryVertex2 = df2.getPCACandidate();
                 // get track momenta
-                std::array<float, 3> pvec0;
-                std::array<float, 3> pvec1;
+                std::array<float, 3> pvec0{};
+                std::array<float, 3> pvec1{};
                 df2.getTrack(0).getPxPyPzGlo(pvec0);
                 df2.getTrack(1).getPxPyPzGlo(pvec1);
 
@@ -2289,7 +2289,7 @@ struct HfTrackIndexSkimCreator {
 
                 auto pVecCandProng2 = RecoDecay::pVec(pvec0, pvec1);
                 // 2-prong selections after secondary vertex
-                std::array<float, 3> pvCoord2Prong = {collision.posX(), collision.posY(), collision.posZ()};
+                std::array pvCoord2Prong = {collision.posX(), collision.posY(), collision.posZ()};
                 if constexpr (doPvRefit) {
                   pvCoord2Prong[0] = pvRefitCoord2Prong[0];
                   pvCoord2Prong[1] = pvRefitCoord2Prong[1];
@@ -2342,7 +2342,7 @@ struct HfTrackIndexSkimCreator {
                     registry.fill(HIST("hVtx2ProngX"), secondaryVertex2[0]);
                     registry.fill(HIST("hVtx2ProngY"), secondaryVertex2[1]);
                     registry.fill(HIST("hVtx2ProngZ"), secondaryVertex2[2]);
-                    std::array<std::array<float, 3>, 2> const arrMom = {pvec0, pvec1};
+                    const std::array arrMom{pvec0, pvec1};
                     for (int iDecay2P = 0; iDecay2P < kN2ProngDecays; iDecay2P++) {
                       if (TESTBIT(isSelected2ProngCand, iDecay2P)) {
                         if (TESTBIT(whichHypo2Prong[iDecay2P], 0)) {
@@ -2385,7 +2385,7 @@ struct HfTrackIndexSkimCreator {
             }
             if (nVtxFrom2ProngFitter > 0) {
               const auto& secondaryVertex2 = df2.getPCACandidate();
-              std::array<float, 3> const pvCoord2Prong = {collision.posX(), collision.posY(), collision.posZ()};
+              const std::array pvCoord2Prong{collision.posX(), collision.posY(), collision.posZ()};
               is2ProngCandidateGoodFor3Prong = isTwoTrackVertexSelectedFor3Prongs(secondaryVertex2, pvCoord2Prong, df2);
             } else {
               is2ProngCandidateGoodFor3Prong = false;
@@ -2415,11 +2415,11 @@ struct HfTrackIndexSkimCreator {
 
               auto trackPos2 = trackIndexPos2.template track_as<TTracks>();
               auto trackParVarPos2 = getTrackParCov(trackPos2);
-              std::array<float, 2> dcaInfoPos2{trackPos2.dcaXY(), trackPos2.dcaZ()};
+              std::array dcaInfoPos2{trackPos2.dcaXY(), trackPos2.dcaZ()};
 
               // preselection of 3-prong candidates
               if (isSelected3ProngCand) {
-                std::array<float, 3> pVecTrackPos2{trackPos2.pVector()};
+                std::array pVecTrackPos2{trackPos2.pVector()};
                 if (thisCollId != trackPos2.collisionId()) { // this is not the "default" collision for this track and we still did not re-propagate it, we have to re-propagate it
                   o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParVarPos2, 2.f, noMatCorr, &dcaInfoPos2);
                   getPxPyPz(trackParVarPos2, pVecTrackPos2);
@@ -2443,8 +2443,8 @@ struct HfTrackIndexSkimCreator {
               }
 
               /// PV refit excluding the candidate daughters, if contributors
-              std::array<float, 3> pvRefitCoord3Prong2Pos1Neg = {collision.posX(), collision.posY(), collision.posZ()}; /// initialize to the original PV
-              std::array<float, 6> pvRefitCovMatrix3Prong2Pos1Neg = getPrimaryVertex(collision).getCov();               /// initialize to the original PV
+              std::array pvRefitCoord3Prong2Pos1Neg{collision.posX(), collision.posY(), collision.posZ()}; /// initialize to the original PV
+              std::array pvRefitCovMatrix3Prong2Pos1Neg{getPrimaryVertex(collision).getCov()};             /// initialize to the original PV
               if constexpr (doPvRefit) {
                 if (config.fillHistograms) {
                   registry.fill(HIST("PvRefit/verticesPerCandidate"), 1);
@@ -2545,9 +2545,9 @@ struct HfTrackIndexSkimCreator {
               // get secondary vertex
               const auto& secondaryVertex3 = df3.getPCACandidate();
               // get track momenta
-              std::array<float, 3> pvec0;
-              std::array<float, 3> pvec1;
-              std::array<float, 3> pvec2;
+              std::array<float, 3> pvec0{};
+              std::array<float, 3> pvec1{};
+              std::array<float, 3> pvec2{};
               auto trackParVarPcaPos1 = df3.getTrack(0);
               auto trackParVarPcaNeg1 = df3.getTrack(1);
               auto trackParVarPcaPos2 = df3.getTrack(2);
@@ -2606,7 +2606,7 @@ struct HfTrackIndexSkimCreator {
                 registry.fill(HIST("hVtx3ProngX"), secondaryVertex3[0]);
                 registry.fill(HIST("hVtx3ProngY"), secondaryVertex3[1]);
                 registry.fill(HIST("hVtx3ProngZ"), secondaryVertex3[2]);
-                std::array<std::array<float, 3>, 3> const arr3Mom = {pvec0, pvec1, pvec2};
+                const std::array arr3Mom{pvec0, pvec1, pvec2};
                 for (int iDecay3P = 0; iDecay3P < kN3ProngDecays; iDecay3P++) {
                   if (TESTBIT(isSelected3ProngCand, iDecay3P)) {
                     if (TESTBIT(whichHypo3Prong[iDecay3P], 0)) {
@@ -2667,11 +2667,11 @@ struct HfTrackIndexSkimCreator {
 
               auto trackNeg2 = trackIndexNeg2.template track_as<TTracks>();
               auto trackParVarNeg2 = getTrackParCov(trackNeg2);
-              std::array<float, 2> dcaInfoNeg2{trackNeg2.dcaXY(), trackNeg2.dcaZ()};
+              std::array dcaInfoNeg2{trackNeg2.dcaXY(), trackNeg2.dcaZ()};
 
               // preselection of 3-prong candidates
               if (isSelected3ProngCand) {
-                std::array<float, 3> pVecTrackNeg2{trackNeg2.pVector()};
+                std::array pVecTrackNeg2{trackNeg2.pVector()};
                 if (thisCollId != trackNeg2.collisionId()) { // this is not the "default" collision for this track and we still did not re-propagate it, we have to re-propagate it
                   o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParVarNeg2, 2.f, noMatCorr, &dcaInfoNeg2);
                   getPxPyPz(trackParVarNeg2, pVecTrackNeg2);
@@ -2695,8 +2695,8 @@ struct HfTrackIndexSkimCreator {
               }
 
               /// PV refit excluding the candidate daughters, if contributors
-              std::array<float, 3> pvRefitCoord3Prong1Pos2Neg = {collision.posX(), collision.posY(), collision.posZ()}; /// initialize to the original PV
-              std::array<float, 6> pvRefitCovMatrix3Prong1Pos2Neg = getPrimaryVertex(collision).getCov();               /// initialize to the original PV
+              std::array pvRefitCoord3Prong1Pos2Neg{collision.posX(), collision.posY(), collision.posZ()}; /// initialize to the original PV
+              std::array pvRefitCovMatrix3Prong1Pos2Neg{getPrimaryVertex(collision).getCov()};             /// initialize to the original PV
               if constexpr (doPvRefit) {
                 if (config.fillHistograms) {
                   registry.fill(HIST("PvRefit/verticesPerCandidate"), 1);
@@ -2797,9 +2797,9 @@ struct HfTrackIndexSkimCreator {
               // get secondary vertex
               const auto& secondaryVertex3 = df3.getPCACandidate();
               // get track momenta
-              std::array<float, 3> pvec0;
-              std::array<float, 3> pvec1;
-              std::array<float, 3> pvec2;
+              std::array<float, 3> pvec0{};
+              std::array<float, 3> pvec1{};
+              std::array<float, 3> pvec2{};
               const auto trackParVarPcaNeg1 = df3.getTrack(0);
               const auto trackParVarPcaPos1 = df3.getTrack(1);
               const auto trackParVarPcaNeg2 = df3.getTrack(2);
@@ -2859,7 +2859,7 @@ struct HfTrackIndexSkimCreator {
                 registry.fill(HIST("hVtx3ProngX"), secondaryVertex3[0]);
                 registry.fill(HIST("hVtx3ProngY"), secondaryVertex3[1]);
                 registry.fill(HIST("hVtx3ProngZ"), secondaryVertex3[2]);
-                std::array<std::array<float, 3>, 3> const arr3Mom = {pvec0, pvec1, pvec2};
+                const std::array arr3Mom{pvec0, pvec1, pvec2};
                 for (int iDecay3P = 0; iDecay3P < kN3ProngDecays; iDecay3P++) {
                   if (TESTBIT(isSelected3ProngCand, iDecay3P)) {
                     if (TESTBIT(whichHypo3Prong[iDecay3P], 0)) {
@@ -2908,10 +2908,10 @@ struct HfTrackIndexSkimCreator {
                   continue;
                 }
                 auto trackPos2 = trackIndexPos2.template track_as<TTracks>();
-                std::array<float, 3> pVecTrackPos2{trackPos2.pVector()};
+                std::array pVecTrackPos2{trackPos2.pVector()};
                 if (thisCollId != trackPos2.collisionId()) { // this is not the "default" collision for this track, we have to re-propagate it
                   auto trackParVarPos2 = getTrackParCov(trackPos2);
-                  std::array<float, 2> dcaInfoPos2{trackPos2.dcaXY(), trackPos2.dcaZ()};
+                  std::array dcaInfoPos2{trackPos2.dcaXY(), trackPos2.dcaZ()};
                   o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParVarPos2, 2.f, noMatCorr, &dcaInfoPos2);
                   getPxPyPz(trackParVarPos2, pVecTrackPos2);
                 }
@@ -2945,10 +2945,10 @@ struct HfTrackIndexSkimCreator {
                   continue;
                 }
                 auto trackNeg2 = trackIndexNeg2.template track_as<TTracks>();
-                std::array<float, 3> pVecTrackNeg2{trackNeg2.pVector()};
+                std::array pVecTrackNeg2{trackNeg2.pVector()};
                 if (thisCollId != trackNeg2.collisionId()) { // this is not the "default" collision for this track, we have to re-propagate it
                   auto trackParVarNeg2 = getTrackParCov(trackNeg2);
-                  std::array<float, 2> dcaInfoNeg2{trackNeg2.dcaXY(), trackNeg2.dcaZ()};
+                  std::array dcaInfoNeg2{trackNeg2.dcaXY(), trackNeg2.dcaZ()};
                   o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackParVarNeg2, 2.f, noMatCorr, &dcaInfoNeg2);
                   getPxPyPz(trackParVarNeg2, pVecTrackNeg2);
                 }
@@ -3151,7 +3151,7 @@ struct HfTrackIndexSkimCreatorCascades {
   {
     // set the magnetic field from CCDB
     for (const auto& collision : collisions) {
-      auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
+      const auto bc = collision.bc_as<o2::aod::BCsWithTimestamps>();
       initCCDB(bc, runNumber, ccdb, config.isRun2 ? config.ccdbPathGrp : config.ccdbPathGrpMag, lut, config.isRun2);
       if (config.useDCAFitter) {
         df2.setBz(o2::base::Propagator::Instance()->getNominalBz());
@@ -3166,10 +3166,10 @@ struct HfTrackIndexSkimCreatorCascades {
       for (const auto& bachIdx : groupedBachTrackIndices) {
 
         auto bach = bachIdx.track_as<aod::TracksWCovDcaExtra>();
-        std::array<float, 3> pVecBach{bach.pVector()};
+        std::array pVecBach{bach.pVector()};
         auto trackBach = getTrackParCov(bach);
         if (thisCollId != bach.collisionId()) { // this is not the "default" collision for this track, we have to re-propagate it
-          std::array<float, 2> dcaInfoBach{bach.dcaXY(), bach.dcaZ()};
+          std::array dcaInfoBach{bach.dcaXY(), bach.dcaZ()};
           o2::base::Propagator::Instance()->propagateToDCABxByBz({collision.posX(), collision.posY(), collision.posZ()}, trackBach, 2.f, noMatCorr, &dcaInfoBach);
           getPxPyPz(trackBach, pVecBach);
         }
@@ -3185,18 +3185,18 @@ struct HfTrackIndexSkimCreatorCascades {
             continue;
           }
 
-          std::array<float, 3> const pVecPos = {v0.pxpos(), v0.pypos(), v0.pzpos()};
-          std::array<float, 3> const pVecNeg = {v0.pxneg(), v0.pyneg(), v0.pzneg()};
+          const std::array pVecPos{v0.pxpos(), v0.pypos(), v0.pzpos()};
+          const std::array pVecNeg{v0.pxneg(), v0.pyneg(), v0.pzneg()};
 
-          float const ptPos = RecoDecay::pt(pVecPos);
-          float const ptNeg = RecoDecay::pt(pVecNeg);
+          const float ptPos = RecoDecay::pt(pVecPos);
+          const float ptNeg = RecoDecay::pt(pVecNeg);
           if (ptPos < config.ptMinV0Daugh || // to the filters? I can't for now, it is not in the tables
               ptNeg < config.ptMinV0Daugh) {
             continue;
           }
 
-          float const etaPos = RecoDecay::eta(pVecPos);
-          float const etaNeg = RecoDecay::eta(pVecNeg);
+          const float etaPos = RecoDecay::eta(pVecPos);
+          const float etaNeg = RecoDecay::eta(pVecNeg);
           if ((etaPos > config.etaMaxV0Daugh || etaPos < config.etaMinV0Daugh) || // to the filters? I can't for now, it is not in the tables
               (etaNeg > config.etaMaxV0Daugh || etaNeg < config.etaMinV0Daugh)) {
             continue;
@@ -3212,7 +3212,7 @@ struct HfTrackIndexSkimCreatorCascades {
             continue;
           }
 
-          std::array<float, 3> pVecV0 = {v0.px(), v0.py(), v0.pz()};
+          std::array pVecV0{v0.px(), v0.py(), v0.pz()};
 
           // invariant-mass cut: we do it here, before updating the momenta of bach and V0 during the fitting to save CPU
           // TODO: but one should better check that the value here and after the fitter do not change significantly!!!
@@ -3224,9 +3224,9 @@ struct HfTrackIndexSkimCreatorCascades {
           // now we find the DCA between the V0 and the bachelor, for the cascade
           if (config.useDCAFitter) {
 
-            const std::array<float, 3> vertexV0 = {v0.x(), v0.y(), v0.z()};
+            const std::array vertexV0{v0.x(), v0.y(), v0.z()};
             // we build the neutral track to then build the cascade
-            std::array<float, 21> covV = {0.};
+            std::array<float, 21> covV{};
             constexpr int MomInd[6] = {9, 13, 14, 18, 19, 20}; // cov matrix elements for momentum component
             for (int i = 0; i < 6; i++) {
               covV[MomInd[i]] = v0.momentumCovMat()[i];
@@ -3260,7 +3260,7 @@ struct HfTrackIndexSkimCreatorCascades {
           // invariant mass
           // re-calculate invariant masses with updated momenta, to fill the histogram
           mass2K0sP = RecoDecay::m(std::array{pVecBach, pVecV0}, std::array{MassProton, MassK0Short});
-          std::array<float, 3> posCasc = {0., 0., 0.};
+          std::array posCasc{0., 0., 0.};
           if (config.useDCAFitter) {
             const auto& cascVtx = df2.getPCACandidate();
             for (int iCoord{0}; iCoord < 3; ++iCoord) {
@@ -3356,8 +3356,8 @@ struct HfTrackIndexSkimCreatorLfCascades {
   // array of PDG masses of possible charm baryon daughters
   static constexpr int kN2ProngDecays = hf_cand_casc_lf::DecayType2Prong::N2ProngDecays; // number of 2-prong hadron types
   static constexpr int kN3ProngDecays = hf_cand_casc_lf::DecayType3Prong::N3ProngDecays; // number of 3-prong hadron types
-  std::array<std::array<double, 2>, kN2ProngDecays> arrMass2Prong;
-  std::array<std::array<double, 3>, kN3ProngDecays> arrMass3Prong;
+  std::array<std::array<double, 2>, kN2ProngDecays> arrMass2Prong{};
+  std::array<std::array<double, 3>, kN3ProngDecays> arrMass3Prong{};
 
   using SelectedCollisions = soa::Filtered<soa::Join<aod::Collisions, aod::HfSelCollision>>;
   using SelectedHfTrackAssoc = soa::Filtered<soa::Join<aod::TrackAssoc, aod::HfSelTrack>>;
@@ -3620,9 +3620,9 @@ struct HfTrackIndexSkimCreatorLfCascades {
           continue;
         }
 
-        const std::array<float, 3> vertexCasc = {casc.x(), casc.y(), casc.z()};
-        const std::array<float, 3> pVecCasc = {casc.px(), casc.py(), casc.pz()};
-        std::array<float, 21> covCasc = {0.};
+        const std::array vertexCasc{casc.x(), casc.y(), casc.z()};
+        const std::array pVecCasc{casc.px(), casc.py(), casc.pz()};
+        std::array<float, 21> covCasc{};
         constexpr int MomInd[6] = {9, 13, 14, 18, 19, 20}; // cov matrix elements for momentum component
         for (int i = 0; i < 6; i++) {
           covCasc[MomInd[i]] = casc.momentumCovMat()[i];
@@ -3690,13 +3690,13 @@ struct HfTrackIndexSkimCreatorLfCascades {
             df2.propagateTracksToVertex();
 
             if (df2.isPropagateTracksToVertexDone()) {
-              std::array<float, 3> pVecXi = {0.};
-              std::array<float, 3> pVecPion1XiHyp = {0.};
+              std::array<float, 3> pVecXi = {0.f};
+              std::array<float, 3> pVecPion1XiHyp = {0.f};
               df2.getTrack(0).getPxPyPzGlo(pVecXi);
               df2.getTrack(1).getPxPyPzGlo(pVecPion1XiHyp);
               float const ptXic = RecoDecay::pt(pVecXi, pVecPion1XiHyp);
 
-              std::array<std::array<float, 3>, 2> const arrMomToXi = {pVecXi, pVecPion1XiHyp};
+              const std::array arrMomToXi{pVecXi, pVecPion1XiHyp};
               auto mass2ProngXiHyp = RecoDecay::m(arrMomToXi, arrMass2Prong[hf_cand_casc_lf::DecayType2Prong::XiczeroOmegaczeroToXiPi]);
 
               if ((std::abs(casc.mXi() - MassXiMinus) < config.cascadeMassWindow) && (mass2ProngXiHyp >= config.massXiPiMin) && (mass2ProngXiHyp <= config.massXiPiMax)) {
@@ -3737,13 +3737,13 @@ struct HfTrackIndexSkimCreatorLfCascades {
 
             if (df2.isPropagateTracksToVertexDone()) {
 
-              std::array<float, 3> pVecOmega = {0.};
-              std::array<float, 3> pVecCharmBachelor1OmegaHyp = {0.};
+              std::array<float, 3> pVecOmega{0.f};
+              std::array<float, 3> pVecCharmBachelor1OmegaHyp{0.f};
               df2.getTrack(0).getPxPyPzGlo(pVecOmega);
               df2.getTrack(1).getPxPyPzGlo(pVecCharmBachelor1OmegaHyp);
               float const ptOmegac = RecoDecay::pt(pVecOmega, pVecCharmBachelor1OmegaHyp);
 
-              std::array<std::array<float, 3>, 2> const arrMomToOmega = {pVecOmega, pVecCharmBachelor1OmegaHyp};
+              const std::array arrMomToOmega{pVecOmega, pVecCharmBachelor1OmegaHyp};
               auto mass2ProngOmegaPiHyp = RecoDecay::m(arrMomToOmega, arrMass2Prong[hf_cand_casc_lf::DecayType2Prong::OmegaczeroToOmegaPi]);
               auto mass2ProngOmegaKHyp = RecoDecay::m(arrMomToOmega, arrMass2Prong[hf_cand_casc_lf::DecayType2Prong::OmegaczeroToOmegaK]);
 

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -148,7 +148,7 @@ struct HfTrackIndexSkimCreatorTagSelCollisions {
       hfEvSel.addHistograms(registry); // collision monitoring
 
       if (doprocessTrigAndCentFT0ASel || doprocessTrigAndCentFT0CSel || doprocessTrigAndCentFT0MSel || doprocessTrigAndCentFV0ASel) {
-        AxisSpec axisCentrality{200, 0., 100., "centrality percentile"};
+        AxisSpec const axisCentrality{200, 0., 100., "centrality percentile"};
         registry.add("hCentralitySelected", "Centrality percentile of selected events in the centrality interval; centrality percentile;entries", {HistType::kTH1D, {axisCentrality}});
         registry.add("hCentralityRejected", "Centrality percentile of selected events outside the centrality interval; centrality percentile;entries", {HistType::kTH1D, {axisCentrality}});
       }
@@ -410,16 +410,16 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
     // Needed for PV refitting
     if (config.doPvRefit) {
       if (config.fillHistograms) {
-        AxisSpec axisCollisionX{100, -20.f, 20.f, "X (cm)"};
-        AxisSpec axisCollisionY{100, -20.f, 20.f, "Y (cm)"};
-        AxisSpec axisCollisionZ{100, -20.f, 20.f, "Z (cm)"};
-        AxisSpec axisCollisionXOriginal{100, -2.f, 2.f, "X original PV (cm)"};
-        AxisSpec axisCollisionYOriginal{100, -2.f, 2.f, "Y original PV (cm)"};
-        AxisSpec axisCollisionZOriginal{100, -2.f, 2.f, "Z original PV (cm)"};
-        AxisSpec axisCollisionNContrib{1000, 0, 1000, "Number of contributors"};
-        AxisSpec axisCollisionDeltaX{axisPvRefitDeltaX, "#Delta x_{PV} (cm)"};
-        AxisSpec axisCollisionDeltaY{axisPvRefitDeltaY, "#Delta y_{PV} (cm)"};
-        AxisSpec axisCollisionDeltaZ{axisPvRefitDeltaZ, "#Delta z_{PV} (cm)"};
+        AxisSpec const axisCollisionX{100, -20.f, 20.f, "X (cm)"};
+        AxisSpec const axisCollisionY{100, -20.f, 20.f, "Y (cm)"};
+        AxisSpec const axisCollisionZ{100, -20.f, 20.f, "Z (cm)"};
+        AxisSpec const axisCollisionXOriginal{100, -2.f, 2.f, "X original PV (cm)"};
+        AxisSpec const axisCollisionYOriginal{100, -2.f, 2.f, "Y original PV (cm)"};
+        AxisSpec const axisCollisionZOriginal{100, -2.f, 2.f, "Z original PV (cm)"};
+        AxisSpec const axisCollisionNContrib{1000, 0, 1000, "Number of contributors"};
+        AxisSpec const axisCollisionDeltaX{axisPvRefitDeltaX, "#Delta x_{PV} (cm)"};
+        AxisSpec const axisCollisionDeltaY{axisPvRefitDeltaY, "#Delta y_{PV} (cm)"};
+        AxisSpec const axisCollisionDeltaZ{axisPvRefitDeltaZ, "#Delta z_{PV} (cm)"};
 
         registry.add("PvRefit/hVerticesPerTrack", "", kTH1D, {{3, 0.5f, 3.5f, ""}});
         registry.get<TH1>(HIST("PvRefit/hVerticesPerTrack"))->GetXaxis()->SetBinLabel(1, "All PV");
@@ -600,7 +600,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
           hasGoodQuality = false;
         }
       } else {
-        UChar_t clustermap = hfTrack.itsClusterMap();
+        UChar_t const clustermap = hfTrack.itsClusterMap();
         if (!(hfTrack.tpcNClsFound() >= config.tpcNClsFoundMin.value && // is this the number of TPC clusters? It should not be used
               TESTBIT(hfTrack.flags(), o2::aod::track::ITSrefit) &&
               (TESTBIT(clustermap, 0) || TESTBIT(clustermap, 1)))) {
@@ -636,7 +636,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
           hasGoodQuality = false;
         }
       } else { // selections for Run2 converted data
-        UChar_t clustermap = hfTrack.itsClusterMap();
+        UChar_t const clustermap = hfTrack.itsClusterMap();
         if (!(TESTBIT(hfTrack.flags(), o2::aod::track::ITSrefit) && (TESTBIT(clustermap, 0) || TESTBIT(clustermap, 1)))) {
           hasGoodQuality = false;
         }
@@ -665,7 +665,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
           hasGoodQuality = false;
         }
       } else { // selections for Run2 converted data
-        UChar_t clustermap = hfTrack.itsClusterMap();
+        UChar_t const clustermap = hfTrack.itsClusterMap();
         if (!(TESTBIT(hfTrack.flags(), o2::aod::track::ITSrefit) && (TESTBIT(clustermap, 0) || TESTBIT(clustermap, 1)))) {
           hasGoodQuality = false;
         }
@@ -787,7 +787,7 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
     o2::vertexing::PVertexer vertexer;
     o2::conf::ConfigurableParam::updateFromString("pvertexer.useMeanVertexConstraint=false"); /// remove diamond constraint (let's keep it at the moment...)
     vertexer.init();
-    bool pvRefitDoable = vertexer.prepareVertexRefit(vecPvContributorTrackParCov, primVtx);
+    bool const pvRefitDoable = vertexer.prepareVertexRefit(vecPvContributorTrackParCov, primVtx);
     if (!pvRefitDoable) {
       LOG(info) << "Not enough tracks accepted for the refit";
       if (config.doPvRefit && config.fillHistograms) {
@@ -991,8 +991,8 @@ struct HfTrackIndexSkimCreatorTagSelTracks {
       // }
 
       isSelectedTrack(track, trackPt, trackEta, pvRefitDcaXYDcaZ, statusProng);
-      int8_t isIdentifiedPid = isSelectedPid<pidStrategy>(track);
-      bool isPositive = track.sign() > 0;
+      int8_t const isIdentifiedPid = isSelectedPid<pidStrategy>(track);
+      bool const isPositive = track.sign() > 0;
       rowSelectedTrack(statusProng, isIdentifiedPid, isPositive);
     }
   }
@@ -1372,8 +1372,8 @@ struct HfTrackIndexSkimCreator {
     runNumber = 0;
 
     if (config.fillHistograms) {
-      AxisSpec axisNumTracks{500, -0.5f, 499.5f, "Number of tracks"};
-      AxisSpec axisNumCands{1000, -0.5f, 999.5f, "Number of candidates"};
+      AxisSpec const axisNumTracks{500, -0.5f, 499.5f, "Number of tracks"};
+      AxisSpec const axisNumCands{1000, -0.5f, 999.5f, "Number of candidates"};
       registry.add("hNTracks", "Number of selected tracks;# of selected tracks;entries", {HistType::kTH1D, {axisNumTracks}});
       // 2-prong histograms
       registry.add("hVtx2ProngX", "2-prong candidates;#it{x}_{sec. vtx.} (cm);entries", {HistType::kTH1D, {{1000, -2., 2.}}});
@@ -1398,16 +1398,16 @@ struct HfTrackIndexSkimCreator {
 
       // needed for PV refitting
       if (doprocess2And3ProngsWithPvRefit || doprocess2And3ProngsWithPvRefitWithPidForHfFiltersBdt) {
-        AxisSpec axisCollisionX{100, -20.f, 20.f, "X (cm)"};
-        AxisSpec axisCollisionY{100, -20.f, 20.f, "Y (cm)"};
-        AxisSpec axisCollisionZ{100, -20.f, 20.f, "Z (cm)"};
-        AxisSpec axisCollisionXOriginal{1000, -20.f, 20.f, "X original PV (cm)"};
-        AxisSpec axisCollisionYOriginal{1000, -20.f, 20.f, "Y original PV (cm)"};
-        AxisSpec axisCollisionZOriginal{1000, -20.f, 20.f, "Z original PV (cm)"};
-        AxisSpec axisCollisionNContrib{1000, 0, 1000, "Number of contributors"};
-        AxisSpec axisCollisionDeltaX{axisPvRefitDeltaX, "#Delta x_{PV} (cm)"};
-        AxisSpec axisCollisionDeltaY{axisPvRefitDeltaY, "#Delta y_{PV} (cm)"};
-        AxisSpec axisCollisionDeltaZ{axisPvRefitDeltaZ, "#Delta z_{PV} (cm)"};
+        AxisSpec const axisCollisionX{100, -20.f, 20.f, "X (cm)"};
+        AxisSpec const axisCollisionY{100, -20.f, 20.f, "Y (cm)"};
+        AxisSpec const axisCollisionZ{100, -20.f, 20.f, "Z (cm)"};
+        AxisSpec const axisCollisionXOriginal{1000, -20.f, 20.f, "X original PV (cm)"};
+        AxisSpec const axisCollisionYOriginal{1000, -20.f, 20.f, "Y original PV (cm)"};
+        AxisSpec const axisCollisionZOriginal{1000, -20.f, 20.f, "Z original PV (cm)"};
+        AxisSpec const axisCollisionNContrib{1000, 0, 1000, "Number of contributors"};
+        AxisSpec const axisCollisionDeltaX{axisPvRefitDeltaX, "#Delta x_{PV} (cm)"};
+        AxisSpec const axisCollisionDeltaY{axisPvRefitDeltaY, "#Delta y_{PV} (cm)"};
+        AxisSpec const axisCollisionDeltaZ{axisPvRefitDeltaZ, "#Delta z_{PV} (cm)"};
         registry.add("PvRefit/verticesPerCandidate", "", kTH1D, {{6, 0.5f, 6.5f, ""}});
         registry.get<TH1>(HIST("PvRefit/verticesPerCandidate"))->GetXaxis()->SetBinLabel(1, "All PV");
         registry.get<TH1>(HIST("PvRefit/verticesPerCandidate"))->GetXaxis()->SetBinLabel(2, "PV refit doable");
@@ -1427,7 +1427,7 @@ struct HfTrackIndexSkimCreator {
       }
 
       if (config.applyMlForHfFilters) {
-        AxisSpec axisBdtScore{100, 0.f, 1.f};
+        AxisSpec const axisBdtScore{100, 0.f, 1.f};
         registry.add("ML/hMlScoreBkgD0", "Bkg ML score for D^{0} candidates;Bkg ML score;entries", kTH1D, {axisBdtScore});
         registry.add("ML/hMlScorePromptD0", "Prompt ML score for D^{0} candidates;Prompt ML score;entries", kTH1D, {axisBdtScore});
         registry.add("ML/hMlScoreNonpromptD0", "Non-prompt ML score for D^{0} candidates;Non-prompt ML score;entries", kTH1D, {axisBdtScore});
@@ -1518,14 +1518,14 @@ struct HfTrackIndexSkimCreator {
       whichHypo[iDecay2P] = 3; // 2 bits on
 
       if (config.debug || TESTBIT(isSelected, iDecay2P)) {
-        double minMass = cut2Prong[iDecay2P].get(binPt, 0u);
-        double maxMass = cut2Prong[iDecay2P].get(binPt, 1u);
+        double const minMass = cut2Prong[iDecay2P].get(binPt, 0u);
+        double const maxMass = cut2Prong[iDecay2P].get(binPt, 1u);
         if (minMass >= 0. && maxMass > 0.) {
           auto arrMom = std::array{pVecTrack0, pVecTrack1};
           massHypos[0] = RecoDecay::m2(arrMom, arrMass2Prong[iDecay2P][0]);
           massHypos[1] = (iDecay2P == hf_cand_2prong::DecayType::D0ToPiK) ? RecoDecay::m2(arrMom, arrMass2Prong[iDecay2P][1]) : massHypos[0];
-          double min2 = minMass * minMass;
-          double max2 = maxMass * maxMass;
+          double const min2 = minMass * minMass;
+          double const max2 = maxMass * maxMass;
           if (massHypos[0] < min2 || massHypos[0] >= max2) {
             CLRBIT(whichHypo[iDecay2P], 0);
           }
@@ -1557,7 +1557,7 @@ struct HfTrackIndexSkimCreator {
         auto pTBinDstar = findBin(config.binsPtDstarToD0Pi, pt * 1.2); // assuming the D* pT about 20% higher than the one of the D0 to be safe
         if (pTBinDstar >= 0) {
           whichHypo[kN2ProngDecays] = whichHypo[hf_cand_2prong::DecayType::D0ToPiK];
-          double deltaMass = config.cutsDstarToD0Pi->get(pTBinDstar, 1u);
+          double const deltaMass = config.cutsDstarToD0Pi->get(pTBinDstar, 1u);
 
           if (TESTBIT(whichHypo[iDecay2P], 0) && (massHypos[0] > (MassD0 + deltaMass) * (MassD0 + deltaMass) || massHypos[0] < (MassD0 - deltaMass) * (MassD0 - deltaMass))) {
             CLRBIT(whichHypo[kN2ProngDecays], 0);
@@ -1581,15 +1581,15 @@ struct HfTrackIndexSkimCreator {
   template <typename T1, typename T2, typename T3>
   void applyPreselectionPhiDecay(int& pTBin, T1 const& pVecTrack0, T1 const& pVecTrack1, T1 const& pVecTrack2, T2& cutStatus, T3& whichHypo, int& isSelected)
   {
-    double deltaMassMax = cut3Prong[hf_cand_3prong::DecayType::DsToKKPi].get(pTBin, 4u);
+    double const deltaMassMax = cut3Prong[hf_cand_3prong::DecayType::DsToKKPi].get(pTBin, 4u);
     if (TESTBIT(whichHypo[hf_cand_3prong::DecayType::DsToKKPi], 0)) {
-      double mass2PhiKKPi = RecoDecay::m2(std::array{pVecTrack0, pVecTrack1}, std::array{arrMass3Prong[hf_cand_3prong::DecayType::DsToKKPi][0][0], arrMass3Prong[hf_cand_3prong::DecayType::DsToKKPi][0][1]});
+      double const mass2PhiKKPi = RecoDecay::m2(std::array{pVecTrack0, pVecTrack1}, std::array{arrMass3Prong[hf_cand_3prong::DecayType::DsToKKPi][0][0], arrMass3Prong[hf_cand_3prong::DecayType::DsToKKPi][0][1]});
       if (mass2PhiKKPi > (MassPhi + deltaMassMax) * (MassPhi + deltaMassMax) || mass2PhiKKPi < (MassPhi - deltaMassMax) * (MassPhi - deltaMassMax)) {
         CLRBIT(whichHypo[hf_cand_3prong::DecayType::DsToKKPi], 0);
       }
     }
     if (TESTBIT(whichHypo[hf_cand_3prong::DecayType::DsToKKPi], 1)) {
-      double mass2PhiPiKK = RecoDecay::m2(std::array{pVecTrack1, pVecTrack2}, std::array{arrMass3Prong[hf_cand_3prong::DecayType::DsToKKPi][1][1], arrMass3Prong[hf_cand_3prong::DecayType::DsToKKPi][1][2]});
+      double const mass2PhiPiKK = RecoDecay::m2(std::array{pVecTrack1, pVecTrack2}, std::array{arrMass3Prong[hf_cand_3prong::DecayType::DsToKKPi][1][1], arrMass3Prong[hf_cand_3prong::DecayType::DsToKKPi][1][2]});
       if (mass2PhiPiKK > (MassPhi + deltaMassMax) * (MassPhi + deltaMassMax) || mass2PhiPiKK < (MassPhi - deltaMassMax) * (MassPhi - deltaMassMax)) {
         CLRBIT(whichHypo[hf_cand_3prong::DecayType::DsToKKPi], 1);
       }
@@ -1650,13 +1650,13 @@ struct HfTrackIndexSkimCreator {
 
       // invariant mass
       if ((config.debug || TESTBIT(isSelected, iDecay3P))) {
-        double minMass = cut3Prong[iDecay3P].get(binPt, 0u);
-        double maxMass = cut3Prong[iDecay3P].get(binPt, 1u);
+        double const minMass = cut3Prong[iDecay3P].get(binPt, 0u);
+        double const maxMass = cut3Prong[iDecay3P].get(binPt, 1u);
         if (minMass >= 0. && maxMass > 0.) { // no need to check isSelected but to avoid mistakes
           double massHypos[2] = {0., 0.};
           auto arrMom = std::array{pVecTrack0, pVecTrack1, pVecTrack2};
-          double min2 = minMass * minMass;
-          double max2 = maxMass * maxMass;
+          double const min2 = minMass * minMass;
+          double const max2 = maxMass * maxMass;
           massHypos[0] = RecoDecay::m2(arrMom, arrMass3Prong[iDecay3P][0]);
           massHypos[1] = (iDecay3P != hf_cand_3prong::DecayType::DplusToPiKPi) ? RecoDecay::m2(arrMom, arrMass3Prong[iDecay3P][1]) : massHypos[0];
           if (massHypos[0] < min2 || massHypos[0] >= max2) {
@@ -1727,7 +1727,7 @@ struct HfTrackIndexSkimCreator {
       return;
     }
     const float ptDummy = 1.; // dummy pT value (only one pT bin)
-    bool isSelMl = hfMlResponse2Prongs.isSelectedMl(featuresCand, ptDummy, outputScores);
+    bool const isSelMl = hfMlResponse2Prongs.isSelectedMl(featuresCand, ptDummy, outputScores);
     if (config.fillHistograms) {
       registry.fill(HIST("ML/hMlScoreBkgD0"), outputScores[0]);
       registry.fill(HIST("ML/hMlScorePromptD0"), outputScores[1]);
@@ -1897,8 +1897,8 @@ struct HfTrackIndexSkimCreator {
     }
 
     // D0 mass
-    double deltaMassD0 = config.cutsDstarToD0Pi->get(pTBin, 1u); // 1u == deltaMassD0Index
-    double invMassD0 = RecoDecay::m(arrMomD0, std::array{MassPiPlus, MassKPlus});
+    double const deltaMassD0 = config.cutsDstarToD0Pi->get(pTBin, 1u); // 1u == deltaMassD0Index
+    double const invMassD0 = RecoDecay::m(arrMomD0, std::array{MassPiPlus, MassKPlus});
     if (std::abs(invMassD0 - MassD0) > deltaMassD0) {
       isSelected = 0;
       if (config.debug) {
@@ -1908,8 +1908,8 @@ struct HfTrackIndexSkimCreator {
     }
 
     // D*+ mass
-    double maxDeltaMass = config.cutsDstarToD0Pi->get(pTBin, 0u); // 0u == deltaMassIndex
-    double invMassDstar = RecoDecay::m(arrMom, std::array{MassPiPlus, MassKPlus, MassPiPlus});
+    double const maxDeltaMass = config.cutsDstarToD0Pi->get(pTBin, 0u); // 0u == deltaMassIndex
+    double const invMassDstar = RecoDecay::m(arrMom, std::array{MassPiPlus, MassKPlus, MassPiPlus});
     deltaMass = invMassDstar - invMassD0;
     if (deltaMass > maxDeltaMass) {
       isSelected = 0;
@@ -1955,7 +1955,7 @@ struct HfTrackIndexSkimCreator {
     o2::vertexing::PVertexer vertexer;
     o2::conf::ConfigurableParam::updateFromString("pvertexer.useMeanVertexConstraint=false"); /// remove diamond constraint (let's keep it at the moment...)
     vertexer.init();
-    bool pvRefitDoable = vertexer.prepareVertexRefit(vecPvContributorTrackParCov, primVtx);
+    bool const pvRefitDoable = vertexer.prepareVertexRefit(vecPvContributorTrackParCov, primVtx);
     if (!pvRefitDoable) {
       LOG(info) << "Not enough tracks accepted for the refit";
       if ((doprocess2And3ProngsWithPvRefit || doprocess2And3ProngsWithPvRefitWithPidForHfFiltersBdt) && config.fillHistograms) {
@@ -1975,7 +1975,7 @@ struct HfTrackIndexSkimCreator {
       }
       recalcPvRefit = true;
       int nCandContr = 0;
-      for (uint64_t myGlobalID : vecCandPvContributorGlobId) {                                                    // o2-linter: disable=const-ref-in-for-loop (small type)
+      for (uint64_t const myGlobalID : vecCandPvContributorGlobId) {                                              // o2-linter: disable=const-ref-in-for-loop (small type)
         auto trackIterator = std::find(vecPvContributorGlobId.begin(), vecPvContributorGlobId.end(), myGlobalID); /// track global index
         if (trackIterator != vecPvContributorGlobId.end()) {
           /// this is a contributor, let's remove it for the PV refit
@@ -2113,8 +2113,8 @@ struct HfTrackIndexSkimCreator {
 
       // auto centrality = collision.centV0M(); //FIXME add centrality when option for variations to the process function appears
 
-      int n2ProngBit = BIT(kN2ProngDecays) - 1; // bit value for 2-prong candidates where each candidate is one bit and they are all set to 1
-      int n3ProngBit = BIT(kN3ProngDecays) - 1; // bit value for 3-prong candidates where each candidate is one bit and they are all set to 1
+      int const n2ProngBit = BIT(kN2ProngDecays) - 1; // bit value for 2-prong candidates where each candidate is one bit and they are all set to 1
+      int const n3ProngBit = BIT(kN3ProngDecays) - 1; // bit value for 3-prong candidates where each candidate is one bit and they are all set to 1
 
       std::array<std::vector<bool>, kN2ProngDecays> cutStatus2Prong;
       std::array<std::vector<bool>, kN3ProngDecays> cutStatus3Prong;
@@ -2158,8 +2158,8 @@ struct HfTrackIndexSkimCreator {
 
         // retrieve the selection flag that corresponds to this collision
         auto isSelProngPos1 = trackIndexPos1.isSelProng();
-        bool sel2ProngStatusPos = TESTBIT(isSelProngPos1, CandidateType::Cand2Prong);
-        bool sel3ProngStatusPos1 = TESTBIT(isSelProngPos1, CandidateType::Cand3Prong);
+        bool const sel2ProngStatusPos = TESTBIT(isSelProngPos1, CandidateType::Cand2Prong);
+        bool const sel3ProngStatusPos1 = TESTBIT(isSelProngPos1, CandidateType::Cand3Prong);
 
         auto trackParVarPos1 = getTrackParCov(trackPos1);
         std::array<float, 3> pVecTrackPos1{trackPos1.pVector()};
@@ -2176,8 +2176,8 @@ struct HfTrackIndexSkimCreator {
 
           // retrieve the selection flag that corresponds to this collision
           auto isSelProngNeg1 = trackIndexNeg1.isSelProng();
-          bool sel2ProngStatusNeg = TESTBIT(isSelProngNeg1, CandidateType::Cand2Prong);
-          bool sel3ProngStatusNeg1 = TESTBIT(isSelProngNeg1, CandidateType::Cand3Prong);
+          bool const sel2ProngStatusNeg = TESTBIT(isSelProngNeg1, CandidateType::Cand2Prong);
+          bool const sel3ProngStatusNeg1 = TESTBIT(isSelProngNeg1, CandidateType::Cand3Prong);
 
           auto trackParVarNeg1 = getTrackParCov(trackNeg1);
           std::array<float, 3> pVecTrackNeg1{trackNeg1.pVector()};
@@ -2304,7 +2304,7 @@ struct HfTrackIndexSkimCreator {
                 if (config.applyMlForHfFilters) {
                   auto trackParVarPcaPos1 = df2.getTrack(0);
                   auto trackParVarPcaNeg1 = df2.getTrack(1);
-                  std::vector<float> inputFeatures{trackParVarPcaPos1.getPt(), dcaInfoPos1[0], dcaInfoPos1[1], trackParVarPcaNeg1.getPt(), dcaInfoNeg1[0], dcaInfoNeg1[1]};
+                  std::vector<float> const inputFeatures{trackParVarPcaPos1.getPt(), dcaInfoPos1[0], dcaInfoPos1[1], trackParVarPcaNeg1.getPt(), dcaInfoNeg1[0], dcaInfoNeg1[1]};
                   applyMlSelectionForHfFilters2Prong(inputFeatures, mlScoresD0, isSelected2ProngCand);
                 }
 
@@ -2342,7 +2342,7 @@ struct HfTrackIndexSkimCreator {
                     registry.fill(HIST("hVtx2ProngX"), secondaryVertex2[0]);
                     registry.fill(HIST("hVtx2ProngY"), secondaryVertex2[1]);
                     registry.fill(HIST("hVtx2ProngZ"), secondaryVertex2[2]);
-                    std::array<std::array<float, 3>, 2> arrMom = {pvec0, pvec1};
+                    std::array<std::array<float, 3>, 2> const arrMom = {pvec0, pvec1};
                     for (int iDecay2P = 0; iDecay2P < kN2ProngDecays; iDecay2P++) {
                       if (TESTBIT(isSelected2ProngCand, iDecay2P)) {
                         if (TESTBIT(whichHypo2Prong[iDecay2P], 0)) {
@@ -2385,7 +2385,7 @@ struct HfTrackIndexSkimCreator {
             }
             if (nVtxFrom2ProngFitter > 0) {
               const auto& secondaryVertex2 = df2.getPCACandidate();
-              std::array<float, 3> pvCoord2Prong = {collision.posX(), collision.posY(), collision.posZ()};
+              std::array<float, 3> const pvCoord2Prong = {collision.posX(), collision.posY(), collision.posZ()};
               is2ProngCandidateGoodFor3Prong = isTwoTrackVertexSelectedFor3Prongs(secondaryVertex2, pvCoord2Prong, df2);
             } else {
               is2ProngCandidateGoodFor3Prong = false;
@@ -2561,7 +2561,7 @@ struct HfTrackIndexSkimCreator {
 
               std::array<std::vector<float>, kN3ProngDecays> mlScores3Prongs;
               if (config.applyMlForHfFilters) {
-                std::vector<float> inputFeatures{trackParVarPcaPos1.getPt(), dcaInfoPos1[0], dcaInfoPos1[1], trackParVarPcaNeg1.getPt(), dcaInfoNeg1[0], dcaInfoNeg1[1], trackParVarPcaPos2.getPt(), dcaInfoPos2[0], dcaInfoPos2[1]};
+                std::vector<float> const inputFeatures{trackParVarPcaPos1.getPt(), dcaInfoPos1[0], dcaInfoPos1[1], trackParVarPcaNeg1.getPt(), dcaInfoNeg1[0], dcaInfoNeg1[1], trackParVarPcaPos2.getPt(), dcaInfoPos2[0], dcaInfoPos2[1]};
                 std::vector<float> inputFeaturesLcPid{};
                 if constexpr (usePidForHfFiltersBdt) {
                   inputFeaturesLcPid.push_back(trackPos1.tpcNSigmaPr());
@@ -2606,7 +2606,7 @@ struct HfTrackIndexSkimCreator {
                 registry.fill(HIST("hVtx3ProngX"), secondaryVertex3[0]);
                 registry.fill(HIST("hVtx3ProngY"), secondaryVertex3[1]);
                 registry.fill(HIST("hVtx3ProngZ"), secondaryVertex3[2]);
-                std::array<std::array<float, 3>, 3> arr3Mom = {pvec0, pvec1, pvec2};
+                std::array<std::array<float, 3>, 3> const arr3Mom = {pvec0, pvec1, pvec2};
                 for (int iDecay3P = 0; iDecay3P < kN3ProngDecays; iDecay3P++) {
                   if (TESTBIT(isSelected3ProngCand, iDecay3P)) {
                     if (TESTBIT(whichHypo3Prong[iDecay3P], 0)) {
@@ -2814,7 +2814,7 @@ struct HfTrackIndexSkimCreator {
 
               std::array<std::vector<float>, kN3ProngDecays> mlScores3Prongs;
               if (config.applyMlForHfFilters) {
-                std::vector<float> inputFeatures{trackParVarPcaNeg1.getPt(), dcaInfoNeg1[0], dcaInfoNeg1[1], trackParVarPcaPos1.getPt(), dcaInfoPos1[0], dcaInfoPos1[1], trackParVarPcaNeg2.getPt(), dcaInfoNeg2[0], dcaInfoNeg2[1]};
+                std::vector<float> const inputFeatures{trackParVarPcaNeg1.getPt(), dcaInfoNeg1[0], dcaInfoNeg1[1], trackParVarPcaPos1.getPt(), dcaInfoPos1[0], dcaInfoPos1[1], trackParVarPcaNeg2.getPt(), dcaInfoNeg2[0], dcaInfoNeg2[1]};
                 std::vector<float> inputFeaturesLcPid{};
                 if constexpr (usePidForHfFiltersBdt) {
                   inputFeaturesLcPid.push_back(trackNeg1.tpcNSigmaPr());
@@ -2859,7 +2859,7 @@ struct HfTrackIndexSkimCreator {
                 registry.fill(HIST("hVtx3ProngX"), secondaryVertex3[0]);
                 registry.fill(HIST("hVtx3ProngY"), secondaryVertex3[1]);
                 registry.fill(HIST("hVtx3ProngZ"), secondaryVertex3[2]);
-                std::array<std::array<float, 3>, 3> arr3Mom = {pvec0, pvec1, pvec2};
+                std::array<std::array<float, 3>, 3> const arr3Mom = {pvec0, pvec1, pvec2};
                 for (int iDecay3P = 0; iDecay3P < kN3ProngDecays; iDecay3P++) {
                   if (TESTBIT(isSelected3ProngCand, iDecay3P)) {
                     if (TESTBIT(whichHypo3Prong[iDecay3P], 0)) {
@@ -2977,7 +2977,7 @@ struct HfTrackIndexSkimCreator {
         }
       }
 
-      int nTracks = 0;
+      int const nTracks = 0;
       // auto nTracks = trackIndicesPerCollision.lastIndex() - trackIndicesPerCollision.firstIndex(); // number of tracks passing 2 and 3 prong selection in this collision
       nCand2 = rowTrackIndexProng2.lastIndex() - nCand2; // number of 2-prong candidates in this collision
       nCand3 = rowTrackIndexProng3.lastIndex() - nCand3; // number of 3-prong candidates in this collision
@@ -3185,18 +3185,18 @@ struct HfTrackIndexSkimCreatorCascades {
             continue;
           }
 
-          std::array<float, 3> pVecPos = {v0.pxpos(), v0.pypos(), v0.pzpos()};
-          std::array<float, 3> pVecNeg = {v0.pxneg(), v0.pyneg(), v0.pzneg()};
+          std::array<float, 3> const pVecPos = {v0.pxpos(), v0.pypos(), v0.pzpos()};
+          std::array<float, 3> const pVecNeg = {v0.pxneg(), v0.pyneg(), v0.pzneg()};
 
-          float ptPos = RecoDecay::pt(pVecPos);
-          float ptNeg = RecoDecay::pt(pVecNeg);
+          float const ptPos = RecoDecay::pt(pVecPos);
+          float const ptNeg = RecoDecay::pt(pVecNeg);
           if (ptPos < config.ptMinV0Daugh || // to the filters? I can't for now, it is not in the tables
               ptNeg < config.ptMinV0Daugh) {
             continue;
           }
 
-          float etaPos = RecoDecay::eta(pVecPos);
-          float etaNeg = RecoDecay::eta(pVecNeg);
+          float const etaPos = RecoDecay::eta(pVecPos);
+          float const etaNeg = RecoDecay::eta(pVecNeg);
           if ((etaPos > config.etaMaxV0Daugh || etaPos < config.etaMinV0Daugh) || // to the filters? I can't for now, it is not in the tables
               (etaNeg > config.etaMaxV0Daugh || etaNeg < config.etaMinV0Daugh)) {
             continue;
@@ -3400,9 +3400,9 @@ struct HfTrackIndexSkimCreatorLfCascades {
     runNumber = 0;
 
     if (config.fillHistograms) {
-      AxisSpec ptAxis = {400, 0.0f, 20.0f, "it{p}_{T} (GeV/c)"};
-      AxisSpec massAxisXi = {200, 1.222f, 1.422f, "Inv. Mass (GeV/c^{2})"};
-      AxisSpec massAxisOmega = {200, 1.572f, 1.772f, "Inv. Mass (GeV/c^{2})"};
+      AxisSpec const ptAxis = {400, 0.0f, 20.0f, "it{p}_{T} (GeV/c)"};
+      AxisSpec const massAxisXi = {200, 1.222f, 1.422f, "Inv. Mass (GeV/c^{2})"};
+      AxisSpec const massAxisOmega = {200, 1.572f, 1.772f, "Inv. Mass (GeV/c^{2})"};
 
       registry.add("hCandidateCounter", "hCandidateCounter", {HistType::kTH1D, {{10, 0.0f, 10.0f}}});
 
@@ -3694,9 +3694,9 @@ struct HfTrackIndexSkimCreatorLfCascades {
               std::array<float, 3> pVecPion1XiHyp = {0.};
               df2.getTrack(0).getPxPyPzGlo(pVecXi);
               df2.getTrack(1).getPxPyPzGlo(pVecPion1XiHyp);
-              float ptXic = RecoDecay::pt(pVecXi, pVecPion1XiHyp);
+              float const ptXic = RecoDecay::pt(pVecXi, pVecPion1XiHyp);
 
-              std::array<std::array<float, 3>, 2> arrMomToXi = {pVecXi, pVecPion1XiHyp};
+              std::array<std::array<float, 3>, 2> const arrMomToXi = {pVecXi, pVecPion1XiHyp};
               auto mass2ProngXiHyp = RecoDecay::m(arrMomToXi, arrMass2Prong[hf_cand_casc_lf::DecayType2Prong::XiczeroOmegaczeroToXiPi]);
 
               if ((std::abs(casc.mXi() - MassXiMinus) < config.cascadeMassWindow) && (mass2ProngXiHyp >= config.massXiPiMin) && (mass2ProngXiHyp <= config.massXiPiMax)) {
@@ -3741,9 +3741,9 @@ struct HfTrackIndexSkimCreatorLfCascades {
               std::array<float, 3> pVecCharmBachelor1OmegaHyp = {0.};
               df2.getTrack(0).getPxPyPzGlo(pVecOmega);
               df2.getTrack(1).getPxPyPzGlo(pVecCharmBachelor1OmegaHyp);
-              float ptOmegac = RecoDecay::pt(pVecOmega, pVecCharmBachelor1OmegaHyp);
+              float const ptOmegac = RecoDecay::pt(pVecOmega, pVecCharmBachelor1OmegaHyp);
 
-              std::array<std::array<float, 3>, 2> arrMomToOmega = {pVecOmega, pVecCharmBachelor1OmegaHyp};
+              std::array<std::array<float, 3>, 2> const arrMomToOmega = {pVecOmega, pVecCharmBachelor1OmegaHyp};
               auto mass2ProngOmegaPiHyp = RecoDecay::m(arrMomToOmega, arrMass2Prong[hf_cand_casc_lf::DecayType2Prong::OmegaczeroToOmegaPi]);
               auto mass2ProngOmegaKHyp = RecoDecay::m(arrMomToOmega, arrMass2Prong[hf_cand_casc_lf::DecayType2Prong::OmegaczeroToOmegaK]);
 

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1188,7 +1188,7 @@ struct HfTrackIndexSkimCreator {
 
   struct : ConfigurableGroup {
     Configurable<bool> isRun2{"isRun2", false, "enable Run 2 or Run 3 GRP objects for magnetic field"};
-    Configurable<bool> do3Prong{"do3Prong", 0, "do 3 prong"};
+    Configurable<bool> do3Prong{"do3Prong", false, "do 3 prong"};
     Configurable<bool> doDstar{"doDstar", false, "do D* candidates"};
     Configurable<bool> debug{"debug", false, "debug mode"};
     Configurable<bool> debugPvRefit{"debugPvRefit", false, "debug lines for primary vertex refit"};
@@ -2117,8 +2117,8 @@ struct HfTrackIndexSkimCreator {
 
       std::array<std::vector<bool>, kN2ProngDecays> cutStatus2Prong;
       std::array<std::vector<bool>, kN3ProngDecays> cutStatus3Prong;
-      bool nCutStatus2ProngBit[kN2ProngDecays]; // bit value for selection status for each 2-prong candidate where each selection is one bit and they are all set to 1
-      bool nCutStatus3ProngBit[kN3ProngDecays]; // bit value for selection status for each 3-prong candidate where each selection is one bit and they are all set to 1
+      uint8_t nCutStatus2ProngBit[kN2ProngDecays]; // bit value for selection status for each 2-prong candidate where each selection is one bit and they are all set to 1
+      uint8_t nCutStatus3ProngBit[kN3ProngDecays]; // bit value for selection status for each 3-prong candidate where each selection is one bit and they are all set to 1
 
       for (int iDecay2P = 0; iDecay2P < kN2ProngDecays; iDecay2P++) {
         nCutStatus2ProngBit[iDecay2P] = BIT(kNCuts2Prong[iDecay2P]) - 1;
@@ -2324,7 +2324,7 @@ struct HfTrackIndexSkimCreator {
                   }
 
                   if (config.debug) {
-                    int prong2CutStatus[kN2ProngDecays];
+                    uint8_t prong2CutStatus[kN2ProngDecays];
                     for (int iDecay2P = 0; iDecay2P < kN2ProngDecays; iDecay2P++) {
                       prong2CutStatus[iDecay2P] = nCutStatus2ProngBit[iDecay2P];
                       for (int iCut = 0; iCut < kNCuts2Prong[iDecay2P]; iCut++) {
@@ -2588,7 +2588,7 @@ struct HfTrackIndexSkimCreator {
               }
 
               if (config.debug) {
-                int prong3CutStatus[kN3ProngDecays];
+                uint8_t prong3CutStatus[kN3ProngDecays];
                 for (int iDecay3P = 0; iDecay3P < kN3ProngDecays; iDecay3P++) {
                   prong3CutStatus[iDecay3P] = nCutStatus3ProngBit[iDecay3P];
                   for (int iCut = 0; iCut < kNCuts3Prong[iDecay3P]; iCut++) {


### PR DESCRIPTION
- Fix types of bitmaps `nCutStatus2ProngBit`, `nCutStatus3ProngBit`, `prong2CutStatus`, `prong3CutStatus`.
- Reduce unnecessary operations in `applyPreselection2Prong`, `applyPreselection3Prong`.
- Use `do3Prong` as `bool` properly.
- Improve `const` correctness.
- Simplify `array` declarations using type deduction.
- Fix `array` initialisations.
- Fix `UChar_t` type for `itsClusterMap`.
- Pass by `const&`.
- Use `auto` more to capture return values.
- Remove default template arguments of `applyMlSelectionForHfFilters3Prong`, `run2And3Prongs`.
- Remove useless argument of `getHfCollisionRejectionMaskWithUpc`.
- Define `etaMinDefault` to fix magic numbers.
