### PR TITLE
[PWGLF] Optimize de-duplication and DCAtoPV calculation

### DIFF
--- a/PWGLF/Utils/strangenessBuilderHelper.h
+++ b/PWGLF/Utils/strangenessBuilderHelper.h
@@ -266,8 +266,8 @@ class strangenessBuilderHelper
   //_______________________________________________________________________
   // standard build V0 function. Populates ::v0 object
   // ::v0 will be initialized to defaults if build fails
-  // --- useSelections: meant to maximize recovery, but beware high cost in CPU 
-  // --- calculateProngDCAtoPV: optionally don't propagate prongs to PV, saves 
+  // --- useSelections: meant to maximize recovery, but beware high cost in CPU
+  // --- calculateProngDCAtoPV: optionally don't propagate prongs to PV, saves
   //     CPU, of interest when dealing with de-duplication (variable not checked)
   template <bool useSelections = true, bool calculateProngDCAtoPV = true, typename TTrack, typename TTrackParametrization>
   bool buildV0Candidate(int collisionIndex,
@@ -314,8 +314,8 @@ class strangenessBuilderHelper
       std::array<float, 2> dcaInfo;
 
       // do DCA to PV on TrackPar copies and not TrackParCov
-      // TrackPar preferred: don't calculate multiple scattering / CovMat changes 
-      // Spares CPU since variables not checked 
+      // TrackPar preferred: don't calculate multiple scattering / CovMat changes
+      // Spares CPU since variables not checked
       o2::track::TrackPar positiveTrackParamCopy(positiveTrackParam);
       o2::track::TrackPar negativeTrackParamCopy(negativeTrackParam);
 
@@ -338,7 +338,7 @@ class strangenessBuilderHelper
           return false;
         }
       }
-    }else{
+    } else {
       v0.positiveDCAxy = 0.0f; // default invalid
       v0.negativeDCAxy = 0.0f; // default invalid
     }
@@ -510,8 +510,8 @@ class strangenessBuilderHelper
     std::array<float, 2> dcaInfo;
 
     // do DCA to PV on TrackPar copies and not TrackParCov
-    // TrackPar preferred: don't calculate multiple scattering / CovMat changes 
-    // Spares CPU since variables not checked 
+    // TrackPar preferred: don't calculate multiple scattering / CovMat changes
+    // Spares CPU since variables not checked
     o2::track::TrackPar positiveTrackParamCopy(positiveTrackParam);
     o2::track::TrackPar negativeTrackParamCopy(negativeTrackParam);
 

--- a/PWGLF/Utils/strangenessBuilderHelper.h
+++ b/PWGLF/Utils/strangenessBuilderHelper.h
@@ -280,6 +280,8 @@ class strangenessBuilderHelper
                         bool calculateCovariance = false,
                         bool acceptTPCOnly = false)
   {
+    v0 = {}; // safe initialization: start new
+
     if constexpr (useSelections) {
       // verify track quality
       if (positiveTrack.tpcNClsCrossedRows() < v0selections.minCrossedRows) {
@@ -312,6 +314,7 @@ class strangenessBuilderHelper
     if constexpr (calculateProngDCAtoPV) {
       // Calculate DCA with respect to the collision associated to the V0
       std::array<float, 2> dcaInfo;
+      dcaInfo[0] = dcaInfo[1] = 0.0f; // invalid
 
       // do DCA to PV on TrackPar copies and not TrackParCov
       // TrackPar preferred: don't calculate multiple scattering / CovMat changes
@@ -350,10 +353,12 @@ class strangenessBuilderHelper
       nCand = fitter.process(positiveTrackParam, negativeTrackParam);
     } catch (...) {
       v0 = {};
+      fitter.setCollinear(false); // even if returned, reset
       return false;
     }
     if (nCand == 0) {
       v0 = {};
+      fitter.setCollinear(false); // even if returned, reset
       return false;
     }
     fitter.setCollinear(false); // proper cleaning: when exiting this loop, always reset to not collinear
@@ -508,6 +513,7 @@ class strangenessBuilderHelper
 
     // Calculate DCA with respect to the collision associated to the V0
     std::array<float, 2> dcaInfo;
+    dcaInfo[0] = dcaInfo[1] = 0.0f; // invalid
 
     // do DCA to PV on TrackPar copies and not TrackParCov
     // TrackPar preferred: don't calculate multiple scattering / CovMat changes
@@ -738,6 +744,7 @@ class strangenessBuilderHelper
     // bachelor DCA track to PV
     // Calculate DCA with respect to the collision associated to the V0, not individual tracks
     std::array<float, 2> dcaInfo;
+    dcaInfo[0] = dcaInfo[1] = 0.0f; // invalid
 
     auto bachTrackPar = getTrackPar(bachelorTrack);
     o2::base::Propagator::Instance()->propagateToDCABxByBz({pvX, pvY, pvZ}, bachTrackPar, 2.f, fitter.getMatCorrType(), &dcaInfo);

--- a/PWGLF/Utils/strangenessBuilderHelper.h
+++ b/PWGLF/Utils/strangenessBuilderHelper.h
@@ -693,6 +693,8 @@ class strangenessBuilderHelper
                              bool useCascadeMomentumAtPV = false,
                              bool processCovariances = false)
   {
+    cascade = {}; // initialize / empty (extra safety)
+
     // verify track quality
     if (positiveTrack.tpcNClsCrossedRows() < cascadeselections.minCrossedRows) {
       cascade = {};
@@ -924,6 +926,8 @@ class strangenessBuilderHelper
                                    bool kfDoDCAFitterPreMinimV0 = false,
                                    bool kfDoDCAFitterPreMinimCasc = false)
   {
+    cascade = {}; // initialize / empty (extra safety)
+
     //*>~<*>~<*>~<*>~<*>~<*>~<*>~<*>~<*>~<*
     // KF particle based rebuilding
     // dispenses prior V0 generation, uses constrained (re-)fit based on bachelor charge

--- a/PWGLF/Utils/strangenessBuilderHelper.h
+++ b/PWGLF/Utils/strangenessBuilderHelper.h
@@ -301,11 +301,11 @@ class strangenessBuilderHelper
         v0 = {};
         return false;
       }
-      if (!acceptTPCOnly && !positiveTrack.hasITS()) {
+      if (!acceptTPCOnly && !positiveTrack.hasITS() && !negativeTrack.hasTRD() && !negativeTrack.hasTOF()) {
         v0 = {};
         return false;
       }
-      if (!acceptTPCOnly && !negativeTrack.hasITS()) {
+      if (!acceptTPCOnly && !negativeTrack.hasITS() && !negativeTrack.hasTRD() && !negativeTrack.hasTOF()) {
         v0 = {};
         return false;
       }

--- a/PWGLF/Utils/strangenessBuilderHelper.h
+++ b/PWGLF/Utils/strangenessBuilderHelper.h
@@ -314,7 +314,6 @@ class strangenessBuilderHelper
     if constexpr (calculateProngDCAtoPV) {
       // Calculate DCA with respect to the collision associated to the V0
       std::array<float, 2> dcaInfo;
-      dcaInfo[0] = dcaInfo[1] = 0.0f; // invalid
 
       // do DCA to PV on TrackPar copies and not TrackParCov
       // TrackPar preferred: don't calculate multiple scattering / CovMat changes
@@ -322,16 +321,18 @@ class strangenessBuilderHelper
       o2::track::TrackPar positiveTrackParamCopy(positiveTrackParam);
       o2::track::TrackPar negativeTrackParamCopy(negativeTrackParam);
 
+      dcaInfo[0] = dcaInfo[1] = 999.0f; // by default, take large value to make sure candidate accepted
       o2::base::Propagator::Instance()->propagateToDCABxByBz({pvX, pvY, pvZ}, positiveTrackParamCopy, 2.f, fitter.getMatCorrType(), &dcaInfo);
       v0.positiveDCAxy = dcaInfo[0];
 
       if constexpr (useSelections) {
-        if (std::fabs(v0.positiveDCAxy) < v0selections.dcanegtopv) {
+        if (std::fabs(v0.positiveDCAxy) < v0selections.dcapostopv) {
           v0 = {};
           return false;
         }
       }
 
+      dcaInfo[0] = dcaInfo[1] = 999.0f; // by default, take large value to make sure candidate accepted
       o2::base::Propagator::Instance()->propagateToDCABxByBz({pvX, pvY, pvZ}, negativeTrackParamCopy, 2.f, fitter.getMatCorrType(), &dcaInfo);
       v0.negativeDCAxy = dcaInfo[0];
 
@@ -369,6 +370,7 @@ class strangenessBuilderHelper
     std::array<float, 2> dcaV0Info;
 
     // propagate to collision vertex
+    dcaV0Info[0] = dcaV0Info[1] = 999.0f; // default DCA: large, use with care if propagation fails
     o2::base::Propagator::Instance()->propagateToDCABxByBz({pvX, pvY, pvZ}, V0Temp, 2.f, fitter.getMatCorrType(), &dcaV0Info);
     v0.v0DCAToPVxy = dcaV0Info[0];
     v0.v0DCAToPVz = dcaV0Info[1];
@@ -513,7 +515,6 @@ class strangenessBuilderHelper
 
     // Calculate DCA with respect to the collision associated to the V0
     std::array<float, 2> dcaInfo;
-    dcaInfo[0] = dcaInfo[1] = 0.0f; // invalid
 
     // do DCA to PV on TrackPar copies and not TrackParCov
     // TrackPar preferred: don't calculate multiple scattering / CovMat changes
@@ -521,6 +522,7 @@ class strangenessBuilderHelper
     o2::track::TrackPar positiveTrackParamCopy(positiveTrackParam);
     o2::track::TrackPar negativeTrackParamCopy(negativeTrackParam);
 
+    dcaInfo[0] = dcaInfo[1] = 999.0f; // by default, take large value to make sure candidate accepted
     o2::base::Propagator::Instance()->propagateToDCABxByBz({pvX, pvY, pvZ}, positiveTrackParamCopy, 2.f, fitter.getMatCorrType(), &dcaInfo);
     v0.positiveDCAxy = dcaInfo[0];
 
@@ -529,6 +531,7 @@ class strangenessBuilderHelper
       return false;
     }
 
+    dcaInfo[0] = dcaInfo[1] = 999.0f; // reset to default value
     o2::base::Propagator::Instance()->propagateToDCABxByBz({pvX, pvY, pvZ}, negativeTrackParamCopy, 2.f, fitter.getMatCorrType(), &dcaInfo);
     v0.negativeDCAxy = dcaInfo[0];
 
@@ -744,7 +747,7 @@ class strangenessBuilderHelper
     // bachelor DCA track to PV
     // Calculate DCA with respect to the collision associated to the V0, not individual tracks
     std::array<float, 2> dcaInfo;
-    dcaInfo[0] = dcaInfo[1] = 0.0f; // invalid
+    dcaInfo[0] = dcaInfo[1] = 999.0f; // by default, take large value to make sure candidate accepted
 
     auto bachTrackPar = getTrackPar(bachelorTrack);
     o2::base::Propagator::Instance()->propagateToDCABxByBz({pvX, pvY, pvZ}, bachTrackPar, 2.f, fitter.getMatCorrType(), &dcaInfo);
@@ -969,13 +972,18 @@ class strangenessBuilderHelper
     // bachelor DCA track to PV
     // Calculate DCA with respect to the collision associated to the V0, not individual tracks
     std::array<float, 2> dcaInfo;
+    dcaInfo[0] = dcaInfo[1] = 999.0f; // by default, take large value to make sure candidate accepted
 
     auto bachTrackPar = getTrackPar(bachelorTrack);
     o2::base::Propagator::Instance()->propagateToDCABxByBz({pvX, pvY, pvZ}, bachTrackPar, 2.f, fitter.getMatCorrType(), &dcaInfo);
     cascade.bachelorDCAxy = dcaInfo[0];
+
+    dcaInfo[0] = dcaInfo[1] = 999.0f; // by default, take large value to make sure candidate accepted
     o2::track::TrackParCov posTrackParCovForDCA = getTrackParCov(positiveTrack);
     o2::base::Propagator::Instance()->propagateToDCABxByBz({pvX, pvY, pvZ}, posTrackParCovForDCA, 2.f, fitter.getMatCorrType(), &dcaInfo);
     cascade.positiveDCAxy = dcaInfo[0];
+
+    dcaInfo[0] = dcaInfo[1] = 999.0f; // by default, take large value to make sure candidate accepted
     o2::track::TrackParCov negTrackParCovForDCA = getTrackParCov(negativeTrack);
     o2::base::Propagator::Instance()->propagateToDCABxByBz({pvX, pvY, pvZ}, negTrackParCovForDCA, 2.f, fitter.getMatCorrType(), &dcaInfo);
     cascade.negativeDCAxy = dcaInfo[0];
@@ -1291,8 +1299,7 @@ class strangenessBuilderHelper
     o2::track::TrackPar wrongV0 = fitter.createParentTrackPar();
     wrongV0.setAbsCharge(0); // charge zero
     std::array<float, 2> dcaInfo;
-    dcaInfo[0] = 999;
-    dcaInfo[1] = 999;
+    dcaInfo[0] = dcaInfo[1] = 999.0f; // by default, take large value
 
     // bachelor-baryon DCAxy to PV
     o2::base::Propagator::Instance()->propagateToDCABxByBz({pvX, pvY, pvZ}, wrongV0, 2.f, fitter.getMatCorrType(), &dcaInfo);

--- a/PWGLF/Utils/strangenessBuilderModule.h
+++ b/PWGLF/Utils/strangenessBuilderModule.h
@@ -914,9 +914,10 @@ class BuilderModule
             } // end TPC drift treatment
 
             // process candidate with helper, generate properties for consulting
-            // <false>: do not apply selections: do as much as possible to preserve
+            // first 'false' : do not apply selections: do as much as possible to preserve
+            // second 'false': do not calculate prong DCA to PV, unnecessary, costly if XIU = 83.1f
             // candidate at this level and do not select with topo selections
-            if (straHelper.buildV0Candidate<false>(v0tableGrouped[iV0].collisionIds[ic], collision.posX(), collision.posY(), collision.posZ(), pTrack, nTrack, posTrackPar, negTrackPar, true, false, true)) {
+            if (straHelper.buildV0Candidate<false, false>(v0tableGrouped[iV0].collisionIds[ic], collision.posX(), collision.posY(), collision.posZ(), pTrack, nTrack, posTrackPar, negTrackPar, true, false, true)) {
               // candidate built, check pointing angle
               if (straHelper.v0.pointingAngle < bestPointingAngle) {
                 bestPointingAngle = straHelper.v0.pointingAngle;


### PR DESCRIPTION
Optimization changes: 
* When including photon processing, the V0 building done to evaluate duplicates was propagating prongs with XIU = 83.1f to the PV to calculate the DCA to PV, incurring in a large CPU cost for obtaining a variable that isn't checked in the de-duplication process. This PR makes it such that this propagation is skipped when constructing V0s in the de-duplication procedure, but kept for all other use cases, keeping default operation unchanged. Will lead to a sizable improvement in performance when processing photons. Tagging @gianniliveraro 
* Switches the propagate-to-PV call for V0 prongs to be done only on `TrackPar` (instead of `TrackParCov`) to avoid that multiple scattering contributions are calculated needlessly as only DCAxy is used, further saving some CPU. 