### PR TITLE
[PWGCF] Set PDG code of container

### DIFF
--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
@@ -298,6 +298,7 @@ struct femtoDreamPairTaskTrackTrack {
       sameEventQnCont.init_qn(&Registry,
                               Binning4D.kstar, Binning4D.mT, Binning4D.multPercentile,
                               Option.IsMC, Option.HighkstarCut);
+      sameEventQnCont.setPDGCodes(Track1.PDGCode, Track2.PDGCode);
       if (qnCal.doFillHisto) {
         qnBinCalculator.initQn(&Registry, qnCal.numQnBins);
       }


### PR DESCRIPTION
The PDG code was not set previously. The container `sameEventQnCont` didn't obtain the correct particle mass and therefore calculated the k* observable incorrectly. 