### PR TITLE
Speedup DQ event selection

### DIFF
--- a/PWGDQ/Tasks/dqEfficiency_withAssoc.cxx
+++ b/PWGDQ/Tasks/dqEfficiency_withAssoc.cxx
@@ -370,7 +370,7 @@ struct AnalysisEventSelection {
     // loop over the BC map, get the collision vectors and make in-bunch and out of bunch 2-event correlations
     for (auto bc1It = fBCCollMap.begin(); bc1It != fBCCollMap.end(); ++bc1It) {
       uint64_t bc1 = bc1It->first;
-      auto bc1Events = bc1It->second;
+      auto const& bc1Events = bc1It->second;
 
       // same bunch event correlations, if more than 1 collisions in this bunch
       if (bc1Events.size() > 1) {
@@ -393,9 +393,9 @@ struct AnalysisEventSelection {
       for (auto bc2It = std::next(bc1It); bc2It != fBCCollMap.end(); ++bc2It) {
         uint64_t bc2 = bc2It->first;
         if ((bc2 > bc1 ? bc2 - bc1 : bc1 - bc2) > fConfigSplitCollisionsDeltaBC) {
-          continue;
+          break;
         }
-        auto bc2Events = bc2It->second;
+        auto const& bc2Events = bc2It->second;
 
         // loop over events in the first BC
         for (auto ev1It : bc1Events) {

--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -456,7 +456,7 @@ struct AnalysisEventSelection {
       // loop over the BC map, get the collision vectors and make in-bunch and out of bunch 2-event correlations
       for (auto bc1It = fBCCollMap.begin(); bc1It != fBCCollMap.end(); ++bc1It) {
         uint64_t bc1 = bc1It->first;
-        auto bc1Events = bc1It->second;
+        auto &bc1Events = bc1It->second;
 
         // same bunch event correlations, if more than 1 collisions in this bunch
         if (bc1Events.size() > 1) {
@@ -483,7 +483,7 @@ struct AnalysisEventSelection {
           if ((bc2 > bc1 ? bc2 - bc1 : bc1 - bc2) > fConfigSplitCollisionsDeltaBC) {
             break;
           }
-          auto bc2Events = bc2It->second;
+          auto &bc2Events = bc2It->second;
 
           // loop over events in the first BC
           for (auto ev1It : bc1Events) {


### PR DESCRIPTION
* Avoid vector copies.
* Exploit the fact the collection is ordered.