### PR TITLE
[PWGJE] V0 Jet Framework update

### DIFF
--- a/PWGJE/Core/JetFindingUtilities.h
+++ b/PWGJE/Core/JetFindingUtilities.h
@@ -271,7 +271,7 @@ bool analyseV0s(std::vector<fastjet::PseudoJet>& inputParticles, T const& v0s, f
  * @param doHFJetFinding set whether only jets containing a HF candidate are saved
  */
 template <typename T, typename U, typename V>
-void findJets(JetFinder& jetFinder, std::vector<fastjet::PseudoJet>& inputParticles, float jetPtMin, float jetPtMax, std::vector<double> jetRadius, float jetAreaFractionMin, T const& collision, U& jetsTable, V& constituentsTable, std::shared_ptr<THn> thnSparseJet, bool fillThnSparse, bool doCandidateJetFinding = false, bool saveJetsWithoutCandidates = false)
+void findJets(JetFinder& jetFinder, std::vector<fastjet::PseudoJet>& inputParticles, float jetPtMin, float jetPtMax, std::vector<double> jetRadius, float jetAreaFractionMin, T const& collision, U& jetsTable, V& constituentsTable, std::shared_ptr<THn> thnSparseJet, bool fillThnSparse, bool doCandidateJetFinding = false)
 {
   auto jetRValues = static_cast<std::vector<double>>(jetRadius);
   jetFinder.jetPtMin = jetPtMin;
@@ -296,7 +296,7 @@ void findJets(JetFinder& jetFinder, std::vector<fastjet::PseudoJet>& inputPartic
             break;
           }
         }
-        if (!isCandidateJet && !saveJetsWithoutCandidates) {
+        if (!isCandidateJet) {
           continue;
         }
       }

--- a/PWGJE/Core/JetV0Utilities.h
+++ b/PWGJE/Core/JetV0Utilities.h
@@ -138,9 +138,9 @@ auto slicedPerV0Candidate(T const& table, U const& candidate, V const& perV0Cand
 }
 
 template <typename T, typename U>
-bool isV0Particle(T const& particles, U const& particle, bool onlyChargedDecays)
+bool isV0Particle(T const& particles, U const& particle, bool v0ChargedDecaysOnly)
 {
-  if (onlyChargedDecays) {
+  if (v0ChargedDecaysOnly) {
     return RecoDecay::isMatchedMCGen(particles, particle, +kK0Short, std::array{+kPiPlus, -kPiPlus}, true) || RecoDecay::isMatchedMCGen(particles, particle, +kLambda0, std::array{+kProton, -kPiPlus}, true) || RecoDecay::isMatchedMCGen(particles, particle, -kLambda0, std::array{-kProton, +kPiPlus}, true);
   } else {
     return RecoDecay::isMatchedMCGen(particles, particle, +kK0Short, std::array{+kPiPlus, -kPiPlus}, true) || RecoDecay::isMatchedMCGen(particles, particle, +kK0Short, std::array{+kPi0, +kPi0}, true) || RecoDecay::isMatchedMCGen(particles, particle, +kLambda0, std::array{+kProton, -kPiPlus}, true) || RecoDecay::isMatchedMCGen(particles, particle, +kLambda0, std::array{+kNeutron, +kPi0}, true) || RecoDecay::isMatchedMCGen(particles, particle, -kLambda0, std::array{-kProton, +kPiPlus}, true) || RecoDecay::isMatchedMCGen(particles, particle, -kLambda0, std::array{+kNeutron, +kPi0}, true);

--- a/PWGJE/JetFinders/jetFinderV0.cxx
+++ b/PWGJE/JetFinders/jetFinderV0.cxx
@@ -93,7 +93,7 @@ struct JetFinderV0Task {
   Configurable<bool> fillTHnSparse{"fillTHnSparse", true, "switch to fill the THnSparse"};
   Configurable<double> jetExtraParam{"jetExtraParam", -99.0, "sets the _extra_param in fastjet"};
   Configurable<bool> useV0SignalFlags{"useV0SignalFlags", true, "use V0 signal flags table"};
-  Configurable<bool> saveJetsWithoutCandidates{"saveJetsWithoutCandidates", false, "save all jets, even those without V0s"};
+  Configurable<bool> saveJetsWithCandidatesOnly{"saveJetsWithCandidatesOnly", true, "only save jets if they contain a V0"};
 
   Service<o2::framework::O2DatabasePDG> pdgDatabase;
   int trackSelection = -1;
@@ -172,7 +172,7 @@ struct JetFinderV0Task {
     }
     inputParticles.clear();
     if (!jetfindingutilities::analyseV0s(inputParticles, candidates, candPtMin, candPtMax, candYMin, candYMax, candIndex, useV0SignalFlags)) {
-      if (!saveJetsWithoutCandidates) {
+      if (saveJetsWithCandidatesOnly) {
         return;
       }
     }
@@ -186,7 +186,7 @@ struct JetFinderV0Task {
         */
     jetfindingutilities::analyseTracksMultipleCandidates(inputParticles, tracks, trackSelection, trackingEfficiency, candidates);
 
-    jetfindingutilities::findJets(jetFinder, inputParticles, minJetPt, maxJetPt, jetRadius, jetAreaFractionMin, collision, jetsTableInput, constituentsTableInput, registry.get<THn>(HIST("hJet")), fillTHnSparse, true, saveJetsWithoutCandidates);
+    jetfindingutilities::findJets(jetFinder, inputParticles, minJetPt, maxJetPt, jetRadius, jetAreaFractionMin, collision, jetsTableInput, constituentsTableInput, registry.get<THn>(HIST("hJet")), fillTHnSparse, saveJetsWithCandidatesOnly);
   }
 
   template <typename T, typename U, typename V>
@@ -195,12 +195,12 @@ struct JetFinderV0Task {
 
     inputParticles.clear();
     if (!jetfindingutilities::analyseV0s(inputParticles, candidates, candPtMin, candPtMax, candYMin, candYMax, candIndex, useV0SignalFlags)) {
-      if (!saveJetsWithoutCandidates) {
+      if (saveJetsWithCandidatesOnly) {
         return;
       }
     }
     jetfindingutilities::analyseParticles<true>(inputParticles, particleSelection, jetTypeParticleLevel, particles, pdgDatabase, &candidates);
-    jetfindingutilities::findJets(jetFinder, inputParticles, minJetPt, maxJetPt, jetRadius, jetAreaFractionMin, collision, jetsTable, constituentsTable, registry.get<THn>(HIST("hJetMCP")), fillTHnSparse, true, saveJetsWithoutCandidates);
+    jetfindingutilities::findJets(jetFinder, inputParticles, minJetPt, maxJetPt, jetRadius, jetAreaFractionMin, collision, jetsTable, constituentsTable, registry.get<THn>(HIST("hJetMCP")), fillTHnSparse, saveJetsWithCandidatesOnly);
   }
 
   void processDummy(aod::JetCollisions const&)


### PR DESCRIPTION
* Added option to either save all jets or only those containing V0 candidates

* Added option to select all MCP V0s or only those that decay to charged particles

The framework must be able to propagate all jets (not only those with V0 constituents). This is important for unfolding the jet pt spectrum, necessary for the normalisation of the V0 in-jet fragmentation spectrum.
All MCP V0 particles must be propagated ensure a correct determination of the reconstruction efficiency in jets. It may also affect the particle-level jet population.