### PR TITLE
[Common,DPG] Add check for RCT CCDB object validity

### DIFF
--- a/Common/CCDB/RCTSelectionFlags.h
+++ b/Common/CCDB/RCTSelectionFlags.h
@@ -75,7 +75,15 @@ enum RCTSelectionFlags {
   kTPCLimAccMCRepr,
   kTRDBad,
   kZDCBad,
-  kNRCTSelectionFlags
+  kNRCTSelectionFlags,
+  kDummy24,
+  kDummy25,
+  kDummy26,
+  kDummy27,
+  kDummy28,
+  kDummy29,
+  kDummy30,
+  kCcdbObjectLoaded
 };
 
 template <typename T>
@@ -104,9 +112,14 @@ class RCTFlagsChecker : public o2::utils::EnumFlags<RCTSelectionFlags>
   // The checkZDC boolean flag controls whether to iclude the ZDC quality in all the pre-defined selections (for Pb-Pb data)
   // The treatLimitedAcceptanceAsBad boolean flag controls whether "LimitedAcceptanceMCReproducible" flags should be
   // treated as Bad and the corresponding events excluded
-  explicit RCTFlagsChecker(const std::string& label, bool checkZDC = false, bool treatLimitedAcceptanceAsBad = false)
+  // The checkTableValidity boolean flag controls whether events without a corresponding valid RCT CCDB object should be
+  // treated as Bad and excluded
+  explicit RCTFlagsChecker(const std::string& label,
+                           bool checkZDC = false,
+                           bool treatLimitedAcceptanceAsBad = false,
+                           bool checkTableValidity = false)
   {
-    init(label, checkZDC, treatLimitedAcceptanceAsBad);
+    init(label, checkZDC, treatLimitedAcceptanceAsBad, checkTableValidity);
   }
 
   // Initialize the object from an initializer list of RCTSelectionFlags values
@@ -121,13 +134,18 @@ class RCTFlagsChecker : public o2::utils::EnumFlags<RCTSelectionFlags>
   // - "CBT"
   // - "CBT_hadronPID"
   // - "CBT_electronPID"
-  // - "CBT_calo"
+  // - "CCBT_calo"
   // - "CBT_muon"
   // - "CBT_muon_glo"
   // The checkZDC boolean flag controls whether to iclude the ZDC quality in all the pre-defined selections (for Pb-Pb data)
   // The treatLimitedAcceptanceAsBad boolean flag controls whether "LimitedAcceptanceMCReproducible" flags should be
   // treated as Bad and the corresponding events excluded
-  void init(const std::string& label, bool checkZDC = false, bool treatLimitedAcceptanceAsBad = false)
+  // The checkTableValidity boolean flag controls whether events without a corresponding valid RCT CCDB object should be
+  // treated as Bad and excluded
+  void init(const std::string& label,
+            bool checkZDC = false,
+            bool treatLimitedAcceptanceAsBad = false,
+            bool checkTableValidity = false)
   {
     auto setFlags = [this](std::initializer_list<RCTSelectionFlags> flags) {
       std::for_each(flags.begin(),
@@ -182,6 +200,10 @@ class RCTFlagsChecker : public o2::utils::EnumFlags<RCTSelectionFlags>
     if (checkZDC) {
       set(kZDCBad);
     }
+
+    if (checkTableValidity) {
+      set(kCcdbObjectLoaded);
+    }
   }
 
   // Check the RCT column of a given event selection table.
@@ -199,6 +221,13 @@ class RCTFlagsChecker : public o2::utils::EnumFlags<RCTSelectionFlags>
 
     // return true if none of the checked bits is set in the table bitmask
     return ((tableBits & flagsBits) == 0);
+  }
+
+  // Check the validity of the RCT column of a given event selection table.
+  // The function returns true if the RCT CCDB object was correctly fetched (bit31 == 0).
+  bool isTableValid(const HasRCTFlags auto& table)
+  {
+    return (table.rct_bit(kCcdbObjectLoaded) == 0);
   }
 
   bool operator()(const HasRCTFlags auto& table)

--- a/Common/CCDB/RCTSelectionFlags.h
+++ b/Common/CCDB/RCTSelectionFlags.h
@@ -210,8 +210,9 @@ class RCTFlagsChecker : public o2::utils::EnumFlags<RCTSelectionFlags>
   // The function returns true if none of the checked flags is set in the RCT column.
   bool checkTable(const HasRCTFlags auto& table)
   {
+    // throw an exception if none of the bits in the checker mask is set
     if (!any()) {
-      throw std::out_of_range("RCTFlagsCheckerAlt with empty RCTSelectionFlags bits mask");
+      throw std::out_of_range("RCTFlagsChecker has empty RCTSelectionFlags bits mask");
     }
 
     // bitmask of the current table

--- a/DPG/Tasks/AOTEvent/timeDependentQa.cxx
+++ b/DPG/Tasks/AOTEvent/timeDependentQa.cxx
@@ -291,39 +291,40 @@ struct TimeDependentQaTask {
 
       // ### QA RCT flags
       int nRctFlagsTotal = enNumRctFlagsTotal;
-      histos.add("hSecondsRCTflags", "", kTH2F, {axisSecondsWideBins, {nRctFlagsTotal + 1, -0.5, nRctFlagsTotal + 1 - 0.5, "Monitoring of RCT flags"}});
+      histos.add("hSecondsRCTflags", "", kTH2F, {axisSecondsWideBins, {nRctFlagsTotal + 2, -0.5, nRctFlagsTotal + 2 - 0.5, "Monitoring of RCT flags"}});
       axRctFlags = reinterpret_cast<TAxis*>(histos.get<TH2>(HIST("hSecondsRCTflags"))->GetYaxis());
       axRctFlags->SetBinLabel(1, "NcollisionsSel8");
-      axRctFlags->SetBinLabel(2 + kCPVBad, "CPVBad");
-      axRctFlags->SetBinLabel(2 + kEMCBad, "EMCBad");
-      axRctFlags->SetBinLabel(2 + kEMCLimAccMCRepr, "EMCLimAccMCRepr");
-      axRctFlags->SetBinLabel(2 + kFDDBad, "FDDBad");
-      axRctFlags->SetBinLabel(2 + kFT0Bad, "FT0Bad");
-      axRctFlags->SetBinLabel(2 + kFV0Bad, "FV0Bad");
-      axRctFlags->SetBinLabel(2 + kHMPBad, "HMPBad");
-      axRctFlags->SetBinLabel(2 + kITSBad, "ITSBad");
-      axRctFlags->SetBinLabel(2 + kITSLimAccMCRepr, "ITSLimAccMCRepr");
-      axRctFlags->SetBinLabel(2 + kMCHBad, "MCHBad");
-      axRctFlags->SetBinLabel(2 + kMCHLimAccMCRepr, "MCHLimAccMCRepr");
-      axRctFlags->SetBinLabel(2 + kMFTBad, "MFTBad");
-      axRctFlags->SetBinLabel(2 + kMFTLimAccMCRepr, "MFTLimAccMCRepr");
-      axRctFlags->SetBinLabel(2 + kMIDBad, "MIDBad");
-      axRctFlags->SetBinLabel(2 + kMIDLimAccMCRepr, "MIDLimAccMCRepr");
-      axRctFlags->SetBinLabel(2 + kPHSBad, "PHSBad");
-      axRctFlags->SetBinLabel(2 + kTOFBad, "TOFBad");
-      axRctFlags->SetBinLabel(2 + kTOFLimAccMCRepr, "TOFLimAccMCRepr");
-      axRctFlags->SetBinLabel(2 + kTPCBadTracking, "TPCBadTracking");
-      axRctFlags->SetBinLabel(2 + kTPCBadPID, "TPCBadPID");
-      axRctFlags->SetBinLabel(2 + kTPCLimAccMCRepr, "TPCLimAccMCRepr");
-      axRctFlags->SetBinLabel(2 + kTRDBad, "TRDBad");
-      axRctFlags->SetBinLabel(2 + kZDCBad, "ZDCBad");
+      axRctFlags->SetBinLabel(2, "CcdbNotFound");
+      axRctFlags->SetBinLabel(3 + kCPVBad, "CPVBad");
+      axRctFlags->SetBinLabel(3 + kEMCBad, "EMCBad");
+      axRctFlags->SetBinLabel(3 + kEMCLimAccMCRepr, "EMCLimAccMCRepr");
+      axRctFlags->SetBinLabel(3 + kFDDBad, "FDDBad");
+      axRctFlags->SetBinLabel(3 + kFT0Bad, "FT0Bad");
+      axRctFlags->SetBinLabel(3 + kFV0Bad, "FV0Bad");
+      axRctFlags->SetBinLabel(3 + kHMPBad, "HMPBad");
+      axRctFlags->SetBinLabel(3 + kITSBad, "ITSBad");
+      axRctFlags->SetBinLabel(3 + kITSLimAccMCRepr, "ITSLimAccMCRepr");
+      axRctFlags->SetBinLabel(3 + kMCHBad, "MCHBad");
+      axRctFlags->SetBinLabel(3 + kMCHLimAccMCRepr, "MCHLimAccMCRepr");
+      axRctFlags->SetBinLabel(3 + kMFTBad, "MFTBad");
+      axRctFlags->SetBinLabel(3 + kMFTLimAccMCRepr, "MFTLimAccMCRepr");
+      axRctFlags->SetBinLabel(3 + kMIDBad, "MIDBad");
+      axRctFlags->SetBinLabel(3 + kMIDLimAccMCRepr, "MIDLimAccMCRepr");
+      axRctFlags->SetBinLabel(3 + kPHSBad, "PHSBad");
+      axRctFlags->SetBinLabel(3 + kTOFBad, "TOFBad");
+      axRctFlags->SetBinLabel(3 + kTOFLimAccMCRepr, "TOFLimAccMCRepr");
+      axRctFlags->SetBinLabel(3 + kTPCBadTracking, "TPCBadTracking");
+      axRctFlags->SetBinLabel(3 + kTPCBadPID, "TPCBadPID");
+      axRctFlags->SetBinLabel(3 + kTPCLimAccMCRepr, "TPCLimAccMCRepr");
+      axRctFlags->SetBinLabel(3 + kTRDBad, "TRDBad");
+      axRctFlags->SetBinLabel(3 + kZDCBad, "ZDCBad");
       // combined flags
-      axRctFlags->SetBinLabel(2 + enCBT, "CBT");
-      axRctFlags->SetBinLabel(2 + enCBT_hadronPID, "CBT_hadronPID");
-      axRctFlags->SetBinLabel(2 + enCBT_electronPID, "CBT_electronPID");
-      axRctFlags->SetBinLabel(2 + enCBT_calo, "CBT_calo");
-      axRctFlags->SetBinLabel(2 + enCBT_muon, "CBT_muon");
-      axRctFlags->SetBinLabel(2 + enCBT_muon_glo, "CBT_muon_glo");
+      axRctFlags->SetBinLabel(3 + enCBT, "CBT");
+      axRctFlags->SetBinLabel(3 + enCBT_hadronPID, "CBT_hadronPID");
+      axRctFlags->SetBinLabel(3 + enCBT_electronPID, "CBT_electronPID");
+      axRctFlags->SetBinLabel(3 + enCBT_calo, "CBT_calo");
+      axRctFlags->SetBinLabel(3 + enCBT_muon, "CBT_muon");
+      axRctFlags->SetBinLabel(3 + enCBT_muon_glo, "CBT_muon_glo");
 
       // QA for all tracks
       // const AxisSpec axisChi2ITS{40, 0., 20., "chi2/ndof"};
@@ -554,18 +555,20 @@ struct TimeDependentQaTask {
 
       // check RCT flags
       histos.fill(HIST("hSecondsRCTflags"), secFromSOR, 0); // n collisions sel8
+      histos.fill(HIST("hSecondsRCTflags"), secFromSOR, 1, col.rct_bit(kCcdbObjectLoaded)); // CCDB object not loaded
+      LOGP(debug, "i = 1, bitValue = {}, binLabel={}, binCenter={}", col.rct_bit(kCcdbObjectLoaded), axRctFlags->GetBinLabel(2), axRctFlags->GetBinCenter(2));
       for (int iFlag = 0; iFlag < kNRCTSelectionFlags; iFlag++) {
-        histos.fill(HIST("hSecondsRCTflags"), secFromSOR, 1 + iFlag, col.rct_bit(iFlag));
-        LOGP(debug, "i = {}, bitValue = {}, binLabel={}, binCenter={}", iFlag, col.rct_bit(iFlag), axRctFlags->GetBinLabel(2 + iFlag), axRctFlags->GetBinCenter(2 + iFlag));
+        histos.fill(HIST("hSecondsRCTflags"), secFromSOR, 2 + iFlag, col.rct_bit(iFlag));
+        LOGP(debug, "i = {}, bitValue = {}, binLabel={}, binCenter={}", iFlag, col.rct_bit(iFlag), axRctFlags->GetBinLabel(3 + iFlag), axRctFlags->GetBinCenter(3 + iFlag));
       }
       LOGP(debug, "CBT_hadronPID = {}, kFT0Bad = {}, kITSBad = {}, kTPCBadTracking = {}, kTPCBadPID = {}, kTOFBad = {}, 1 + enCBT_hadronPID = {}, binLabel={}, binCenter={}", rctCheckerCBT_hadronPID(col),
-           col.rct_bit(kFT0Bad), col.rct_bit(kITSBad), col.rct_bit(kTPCBadTracking), col.rct_bit(kTPCBadPID), col.rct_bit(kTOFBad), 1 + enCBT_hadronPID, axRctFlags->GetBinLabel(2 + enCBT_hadronPID), axRctFlags->GetBinCenter(2 + enCBT_hadronPID));
-      histos.fill(HIST("hSecondsRCTflags"), secFromSOR, 1 + enCBT, rctCheckerCBT(col));
-      histos.fill(HIST("hSecondsRCTflags"), secFromSOR, 1 + enCBT_hadronPID, rctCheckerCBT_hadronPID(col));
-      histos.fill(HIST("hSecondsRCTflags"), secFromSOR, 1 + enCBT_electronPID, rctCheckerCBT_electronPID(col));
-      histos.fill(HIST("hSecondsRCTflags"), secFromSOR, 1 + enCBT_calo, rctCheckerCBT_calo(col));
-      histos.fill(HIST("hSecondsRCTflags"), secFromSOR, 1 + enCBT_muon, rctCheckerCBT_muon(col));
-      histos.fill(HIST("hSecondsRCTflags"), secFromSOR, 1 + enCBT_muon_glo, rctCheckerCBT_muon_glo(col));
+           col.rct_bit(kFT0Bad), col.rct_bit(kITSBad), col.rct_bit(kTPCBadTracking), col.rct_bit(kTPCBadPID), col.rct_bit(kTOFBad), 2 + enCBT_hadronPID, axRctFlags->GetBinLabel(3 + enCBT_hadronPID), axRctFlags->GetBinCenter(3 + enCBT_hadronPID));
+      histos.fill(HIST("hSecondsRCTflags"), secFromSOR, 2 + enCBT, rctCheckerCBT(col));
+      histos.fill(HIST("hSecondsRCTflags"), secFromSOR, 2 + enCBT_hadronPID, rctCheckerCBT_hadronPID(col));
+      histos.fill(HIST("hSecondsRCTflags"), secFromSOR, 2 + enCBT_electronPID, rctCheckerCBT_electronPID(col));
+      histos.fill(HIST("hSecondsRCTflags"), secFromSOR, 2 + enCBT_calo, rctCheckerCBT_calo(col));
+      histos.fill(HIST("hSecondsRCTflags"), secFromSOR, 2 + enCBT_muon, rctCheckerCBT_muon(col));
+      histos.fill(HIST("hSecondsRCTflags"), secFromSOR, 2 + enCBT_muon_glo, rctCheckerCBT_muon_glo(col));
 
       // check hadronic rate
       double hadronicRate = mRateFetcher.fetch(ccdb.service, ts, runNumber, "ZNC hadronic") * 1.e-3; // kHz


### PR DESCRIPTION
The PR adds a check for bit 31 of the RCT flags, which when set to "1" indicates a failure in loading the corresponding RCT CCDB object.

It also adds a bin to the hSecondsRCTflags histogram to monitor the value of the RCT flags bit indicating the success of the CCDB object loading, and hence the validity of the RCT flags associated to the collisions and BCs.