### PR TITLE
[Infrastructure] Enable more categories in Cppcheck

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -40,5 +40,5 @@ PYTHON_RUFF_CONFIG_FILE: pyproject.toml
 CPP_CPPLINT_FILE_EXTENSIONS: [".C", ".c", ".c++", ".cc", ".cl", ".cpp", ".cu", ".cuh", ".cxx", ".cxx.in", ".h", ".h++", ".hh", ".h.in", ".hpp", ".hxx", ".inc", ".inl", ".macro"]
 CPP_CLANG_FORMAT_FILE_EXTENSIONS: [".C", ".c", ".c++", ".cc", ".cl", ".cpp", ".cu", ".cuh", ".cxx", ".cxx.in", ".h", ".h++", ".hh", ".h.in", ".hpp", ".hxx", ".inc", ".inl", ".macro"]
 CPP_CPPCHECK_FILE_EXTENSIONS: [".C", ".c", ".c++", ".cc", ".cl", ".cpp", ".cu", ".cuh", ".cxx", ".cxx.in", ".h", ".h++", ".hh", ".h.in", ".hpp", ".hxx", ".inc", ".inl", ".macro"]
-CPP_CPPCHECK_ARGUMENTS: --language=c++ --std=c++20 --check-level=exhaustive --suppressions-list=cppcheck_config
+CPP_CPPCHECK_ARGUMENTS: --language=c++ --std=c++20 --enable=style --check-level=exhaustive --suppressions-list=cppcheck_config
 REPOSITORY_GITLEAKS_PR_COMMITS_SCAN: true

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -40,5 +40,5 @@ PYTHON_RUFF_CONFIG_FILE: pyproject.toml
 CPP_CPPLINT_FILE_EXTENSIONS: [".C", ".c", ".c++", ".cc", ".cl", ".cpp", ".cu", ".cuh", ".cxx", ".cxx.in", ".h", ".h++", ".hh", ".h.in", ".hpp", ".hxx", ".inc", ".inl", ".macro"]
 CPP_CLANG_FORMAT_FILE_EXTENSIONS: [".C", ".c", ".c++", ".cc", ".cl", ".cpp", ".cu", ".cuh", ".cxx", ".cxx.in", ".h", ".h++", ".hh", ".h.in", ".hpp", ".hxx", ".inc", ".inl", ".macro"]
 CPP_CPPCHECK_FILE_EXTENSIONS: [".C", ".c", ".c++", ".cc", ".cl", ".cpp", ".cu", ".cuh", ".cxx", ".cxx.in", ".h", ".h++", ".hh", ".h.in", ".hpp", ".hxx", ".inc", ".inl", ".macro"]
-CPP_CPPCHECK_ARGUMENTS: --language=c++ --std=c++20 --enable=style --check-level=exhaustive --suppressions-list=cppcheck_config
+CPP_CPPCHECK_ARGUMENTS: --language=c++ --std=c++20 --enable=style --check-level=exhaustive --suppressions-list=cppcheck_suppressions --inline-suppr --force
 REPOSITORY_GITLEAKS_PR_COMMITS_SCAN: true

--- a/cppcheck_config
+++ b/cppcheck_config
@@ -1,5 +1,0 @@
-syntaxError
-unknownMacro
-missingIncludeSystem
-missingInclude
-unusedStructMember:*.h

--- a/cppcheck_suppressions
+++ b/cppcheck_suppressions
@@ -1,0 +1,9 @@
+functionStatic
+missingInclude
+missingIncludeSystem
+syntaxError
+unknownMacro
+unreadVariable
+unusedStructMember:*.h
+useStlAlgorithm
+variableScope


### PR DESCRIPTION
In the default configuration, cppcheck (which runs as one of the MegaLinter PR checks) only reports the most critical bugs, such as out of bound access, memory leaks, null pointer dereferences and uninitialised data members. The current codebase has around 90 such reported bugs.
With all checks enabled, cppcheck finds significantly more bugs, potential bugs (such as useless, duplicated, nonsensical, or unreachable code), inefficient code, and many other issues that would otherwise be considered compilation warnings if found by the compiler.
With this configuration, cppcheck has found over 4000 issues in the current codebase among which hundreds are genuine bugs, other hundreds are suspicious constructs (which are likely bugs too), and hundreds more are inefficient constructs.
Despite the high number of true positives the number of false positives stays very low.

EDIT: Instructions for local execution here: https://github.com/AliceO2Group/analysis-framework/pull/313

EDIT [2026-04-12]: Reopen the PR with updates.

- Extend suppression list with other harmless and very frequent errors (more can always be added later if needed). Reduces the total number of issues to around 2000.
- Add the `--inline-suppr` option to allow inline suppressions. (format: `// cppcheck-suppress warningId`)

Here are some recent examples of detected bugs:

- [AliceO2Group/O2Physics#15605](https://github.com/AliceO2Group/O2Physics/pull/15605#discussion_r3068323311)
- [AliceO2Group/O2Physics#14279](https://github.com/AliceO2Group/O2Physics/pull/14279#discussion_r3068340197)
- [AliceO2Group/O2Physics#13419](https://github.com/AliceO2Group/O2Physics/pull/13419#discussion_r3068344370)
- [AliceO2Group/O2Physics#12488](https://github.com/AliceO2Group/O2Physics/pull/12488#discussion_r3068358626)
