### PR TITLE
[PWGCF] CCDB access added properly for NUA and NUE corrections

### DIFF
--- a/PWGCF/JCorran/Tasks/jflucWeightsLoader.cxx
+++ b/PWGCF/JCorran/Tasks/jflucWeightsLoader.cxx
@@ -8,9 +8,12 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
-/// \author Jasper Parkkila (jparkkil@cern.ch)
+///
+/// \file jflucWeightsLoader.cxx
+/// \brief Task to load the NUA and NUE weights from local files or CCDB.
+/// \author Jasper Parkkila (jparkkil@cern.ch), Maxim Virta (maxim.virta@cern.ch)
 /// \since May 2024
-// o2-linter: disable='doc/file'
+/// The weights are loaded from the local files or CCDB and stored in the JWeights table.
 
 #include "PWGCF/DataModel/CorrelationsDerived.h"
 #include "PWGCF/JCorran/DataModel/JCatalyst.h"
@@ -43,10 +46,9 @@ using namespace o2::framework::expressions;
 // The standalone jfluc code expects the entire list of tracks for an event. At the same time, it expects weights together with other track attributes.
 // This workflow creates a table of weights that can be joined with track tables.
 struct JflucWeightsLoader {
-  O2_DEFINE_CONFIGURABLE(cfgPathPhiWeights, std::string, "http://alice-ccdb.cern.ch", "Local (local://) or CCDB path for the phi acceptance correction histogram");
-  O2_DEFINE_CONFIGURABLE(cfgPathEffWeights, std::string, "", "Local (local://) or CCDB path for the efficiency correction histogram");
+  O2_DEFINE_CONFIGURABLE(cfgPathPhiWeights, std::string, "Users/m/mavirta/corrections/NUA/LHC23zzh", "Local (local://) or CCDB path for the phi acceptance correction histogram");
+  O2_DEFINE_CONFIGURABLE(cfgPathEffWeights, std::string, "Users/m/mavirta/corrections/NUE/LHC23zzh", "Local (local://) or CCDB path for the efficiency correction histogram");
   O2_DEFINE_CONFIGURABLE(cfgForRunNumber, bool, false, "Get CCDB object by run");
-  O2_DEFINE_CONFIGURABLE(cfgCCDBPath, std::string, "Users/m/mavirta/corrections/NUA/LHC23zzh", "Internal path in CCDB");
 
   THnF* ph = 0;
   TFile* pf = 0;
@@ -54,8 +56,11 @@ struct JflucWeightsLoader {
   TFile* pfeff = 0;
   int runNumber = 0;
   int timestamp = 0;
-  bool useCCDB = false;
+  bool useNUAFromCCDB = false;
+  bool useEffFromCCDB = false;
   Service<o2::ccdb::BasicCCDBManager> ccdb;
+  std::string ccdbURL = "http://alice-ccdb.cern.ch";
+enum { kNUA, kEFF };
 
   ~JflucWeightsLoader()
   {
@@ -73,12 +78,20 @@ struct JflucWeightsLoader {
     }
   }
 
-  void initCCDB(int runNum, int ts)
+  void initCCDB(int runNum, int ts, int NUAorEFF = kNUA)
   {
     if (cfgForRunNumber) {
-      ph = ccdb->getForRun<THnF>(cfgCCDBPath, runNum);
+      if (NUAorEFF == kNUA) {
+        ph = ccdb->getForRun<THnF>(cfgPathPhiWeights, runNum);
+      } else {
+        pheff = ccdb->getForRun<THnF>(cfgPathEffWeights, runNum);
+      }
     } else {
-      ph = ccdb->getForTimeStamp<THnF>(cfgCCDBPath, ts);
+      if (NUAorEFF == kNUA) {
+        ph = ccdb->getForTimeStamp<THnF>(cfgPathPhiWeights, ts);
+      } else {
+        pheff = ccdb->getForTimeStamp<THnF>(cfgPathEffWeights, ts);
+      }
     }
   }
 
@@ -90,40 +103,49 @@ struct JflucWeightsLoader {
 
     if (doprocessLoadWeights && doprocessLoadWeightsCF)
       LOGF(fatal, "Only one of JTracks or CFTracks processing can be enabled at a time.");
-    if (cfgPathPhiWeights.value.find("ccdb") != std::string::npos) {
-      LOGF(info, "Using corrections from: ccdb");
-      useCCDB = true;
-      ccdb->setURL(cfgPathPhiWeights);
-      ccdb->setCaching(true);
-      ccdb->setLocalObjectValidityChecking();
-      ccdb->setFatalWhenNull(false);
-    } else if (cfgPathPhiWeights.value.substr(0, 8) == "local://") {
-      LOGF(info, "Using non-uniform acceptance corrections from: %s", cfgPathPhiWeights.value.substr(8).c_str());
+
+    // NUA corrections from local file or CCDB
+    if (cfgPathPhiWeights.value.substr(0, 8) == "local://") {
+      LOGF(info, "Using NUA corrections locally from: %s", cfgPathPhiWeights.value.substr(8).c_str());
       pf = new TFile(cfgPathPhiWeights.value.substr(8).c_str(), "read");
       if (!pf->IsOpen()) {
         delete pf;
         pf = 0;
         LOGF(fatal, "NUA correction weights file not found: %s", cfgPathPhiWeights.value.substr(8).c_str());
       }
-      useCCDB = false;
+      useNUAFromCCDB = false;
     } else {
-      LOGF(info, "Didn't find \"local://\" or \"ccdb\" for non-uniform acceptance corrections.");
+      LOGF(info, "Assuming NUA corrections from CCDB.");
+      useNUAFromCCDB = true;
+      ccdb->setURL(ccdbURL.data()); // default CCDB URL
+      ccdb->setCaching(true);
+      ccdb->setLocalObjectValidityChecking();
+      ccdb->setFatalWhenNull(false);
     }
 
+    // Efficiency corrections from local file or CCDB
     if (cfgPathEffWeights.value.substr(0, 8) == "local://") {
-      LOGF(info, "Using efficiency corrections from: %s", cfgPathEffWeights.value.substr(8).c_str());
+      LOGF(info, "Using efficiency corrections locally from: %s", cfgPathEffWeights.value.substr(8).c_str());
       pfeff = new TFile(cfgPathEffWeights.value.substr(8).c_str(), "read");
       if (!pfeff->IsOpen()) {
         delete pfeff;
         pfeff = 0;
         LOGF(fatal, "Efficiency correction weights file not found: %s", cfgPathEffWeights.value.substr(8).c_str());
-      } else if (!(pheff = pfeff->Get<THnF>("ccdb_object"))) {
-        LOGF(warning, "Efficiency correction histogram not found.");
       } else {
         LOGF(info, "Loaded efficiency correction histogram locally.");
       }
+      useEffFromCCDB = false;
     } else {
-      LOGF(info, "Didn't find \"local://\" or \"ccdb\" for efficiency corrections.");
+      LOGF(info, "Assuming efficiency corrections from CCDB.");
+      useEffFromCCDB = true;
+      // If NUA corrections are from CCDB, use the same CCDB URL for efficiency corrections
+      if (!useNUAFromCCDB) { 
+        ccdb->setURL(ccdbURL.data()); // default CCDB URL
+        ccdb->setCaching(true);
+        ccdb->setLocalObjectValidityChecking();
+        ccdb->setFatalWhenNull(false);
+      }
+      
     }
   }
 
@@ -133,21 +155,36 @@ struct JflucWeightsLoader {
   template <class ProducesT, class CollisionT, class TrackT>
   void loadWeights(Produces<ProducesT>& outputT, CollisionT const& collision, TrackT const& tracks)
   {
-    if (pf || useCCDB) {
+    if (pf || useNUAFromCCDB) {
       if (collision.runNumber() != runNumber) {
         if (ph)
           delete ph;
-        if (!useCCDB) {
+        if (!useNUAFromCCDB) {
           // Check if NUA correction can be found from a local file and load it
           if (!(ph = pf->Get<THnF>(Form("NUAWeights_%d", collision.runNumber()))))
             LOGF(warning, "NUA correction histogram not found for run %d.", collision.runNumber());
           else
             LOGF(info, "Loaded NUA correction histogram locally for run %d.", collision.runNumber());
         } else {
-          initCCDB(collision.runNumber(), timestamp);
+          initCCDB(collision.runNumber(), timestamp, kNUA);
           LOGF(info, "Loaded NUA correction histogram from CCDB for run %d.", collision.runNumber());
         }
         runNumber = collision.runNumber();
+      }
+    }
+    if (pfeff) {
+      if (collision.runNumber() != runNumber) {
+        if (pheff) delete pheff;
+        if (!useEffFromCCDB) {
+          if (!(pheff = pfeff->Get<THnF>("ccdb_object"))) {
+            LOGF(warning, "Efficiency correction histogram not found.");
+          } else {
+            LOGF(info, "Loaded NUE correction histogram locally for run %d.", collision.runNumber());
+          }
+        } else {
+          initCCDB(collision.runNumber(), timestamp, kEFF);
+          LOGF(info, "Loaded efficiency correction histogram from CCDB for run %d.", collision.runNumber());
+        }
       }
     }
     for (const auto& track : tracks) {
@@ -165,19 +202,18 @@ struct JflucWeightsLoader {
               break;
           }
         }*/
-        const double coords[] = {collision.multiplicity(), static_cast<double>(partType), track.phi(), track.eta(), collision.posZ()};
-        phiWeight = ph->GetBinContent(ph->GetBin(coords));
+        // NUA corrections are a function of multiplicity, partType, phi, eta, and z-vertex
+        const double nuaCoords[] = {collision.multiplicity(), static_cast<double>(partType), track.phi(), track.eta(), collision.posZ()};
+        phiWeight = ph->GetBinContent(ph->GetBin(nuaCoords));
       } else {
         phiWeight = 1.0f;
       }
 
       if (pheff) {
-        const int effVars[] = {
-          pheff->GetAxis(0)->FindBin(track.eta()),
-          pheff->GetAxis(1)->FindBin(track.pt()),
-          pheff->GetAxis(2)->FindBin(collision.multiplicity()),
-          pheff->GetAxis(3)->FindBin(collision.posZ())};
-        effWeight = pheff->GetBinContent(effVars);
+        // Efficiency corrections are a function of eta, pT, multiplicity, and z-vertex
+        const double nueCoords[] = {track.eta(), track.pt(), collision.multiplicity(), collision.posZ()};
+
+        effWeight = pheff->GetBinContent(pheff->GetBin(nueCoords));
       } else {
         effWeight = 1.0f;
       }


### PR DESCRIPTION
CCDB access added for efficiency. NUA and NUE corrections can now be accessed locally or from CCDB with automatic assignment depending on the given path.