### PR TITLE
[PWGLF] Modify DCA binning and add reconstructed histograms

### DIFF
--- a/PWGLF/Tasks/QC/systematicsMapping.cxx
+++ b/PWGLF/Tasks/QC/systematicsMapping.cxx
@@ -192,9 +192,6 @@ struct SystematicsMapping {
           case -321: // K-
             registry.fill(HIST("K/ReconstructedNegative"), track.pt(), track.eta(), track.phi());
             break;
-          case 310: // K0s
-            registry.fill(HIST("K0s/Reconstructed"), track.pt(), track.eta(), track.phi());
-            break;
           default:
             break;
         }


### PR DESCRIPTION
Updated DCA binning to use variable width and added new reconstructed histograms for K and K0s particles.