### PR TITLE
special check for ambTracks to avoid crashes

### DIFF
--- a/DPG/Tasks/AOTEvent/eventSelectionQa.cxx
+++ b/DPG/Tasks/AOTEvent/eventSelectionQa.cxx
@@ -999,20 +999,24 @@ struct EventSelectionQaTask {
     for (const auto& track : tracks) {
       auto mapAmbTrIdsIt = mapAmbTrIds.find(track.globalIndex());
       int ambTrId = mapAmbTrIdsIt == mapAmbTrIds.end() ? -1 : mapAmbTrIdsIt->second;
-      int indexBc = ambTrId < 0 ? track.collision_as<ColEvSels>().bc_as<BCsRun3>().globalIndex() : ambTracks.iteratorAt(ambTrId).bc_as<BCsRun3>().begin().globalIndex();
-      if (ambTrId < 0) { // temprorary limitation, to avoid crashes, in particular, on MC Pb-Pb datasets
-        auto bc = bcs.iteratorAt(indexBc);
-        int64_t globalBC = bc.globalBC() + floor(track.trackTime() / o2::constants::lhc::LHCBunchSpacingNS);
 
-        int32_t indexClosestTVX = findClosest(globalBC, mapGlobalBcWithTVX);
-        int bcDiff = static_cast<int>(globalBC - vGlobalBCs[indexClosestTVX]);
-        if (track.hasTOF() || track.hasTRD() || !track.hasITS() || !track.hasTPC() || track.pt() < 1)
-          continue;
-        histos.fill(HIST("hTrackBcDiffVsEtaAll"), track.eta(), bcDiff);
-        if (track.eta() < -0.2 || track.eta() > 0.2)
-          continue;
-        histos.fill(HIST("hSecondsTVXvsBcDifAll"), bc.timestamp() / 1000., bcDiff);
-      }
+      // special check to avoid crashes (in particular, on some MC Pb-Pb datasets)
+      // (related to shifts in ambiguous tracks association to bc slices (off by 1) - see https://mattermost.web.cern.ch/alice/pl/g9yaaf3tn3g4pgn7c1yex9copy
+      if (ambTrId >= 0 && (ambTracks.iteratorAt(ambTrId).bcIds()[0] >= bcs.size()))
+        continue;
+
+      int indexBc = ambTrId < 0 ? track.collision_as<ColEvSels>().bc_as<BCsRun3>().globalIndex() : ambTracks.iteratorAt(ambTrId).bc_as<BCsRun3>().begin().globalIndex();
+      auto bc = bcs.iteratorAt(indexBc);
+      int64_t globalBC = bc.globalBC() + floor(track.trackTime() / o2::constants::lhc::LHCBunchSpacingNS);
+
+      int32_t indexClosestTVX = findClosest(globalBC, mapGlobalBcWithTVX);
+      int bcDiff = static_cast<int>(globalBC - vGlobalBCs[indexClosestTVX]);
+      if (track.hasTOF() || track.hasTRD() || !track.hasITS() || !track.hasTPC() || track.pt() < 1)
+        continue;
+      histos.fill(HIST("hTrackBcDiffVsEtaAll"), track.eta(), bcDiff);
+      if (track.eta() < -0.2 || track.eta() > 0.2)
+        continue;
+      histos.fill(HIST("hSecondsTVXvsBcDifAll"), bc.timestamp() / 1000., bcDiff);
     }
 
     // collision-based event selection qa


### PR DESCRIPTION
special check to avoid crashes (in particular, on some MC Pb-Pb datasets),
related to shifts in ambiguous tracks association to bc slices (off by 1)
- according to the discussion https://mattermost.web.cern.ch/alice/pl/g9yaaf3tn3g4pgn7c1yex9copy