### PR TITLE
[Common] Update workflow definition to check for existing tables

### DIFF
--- a/Common/TableProducer/Converters/tracksExtraV002Converter.cxx
+++ b/Common/TableProducer/Converters/tracksExtraV002Converter.cxx
@@ -123,6 +123,9 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
       workflow.push_back(adaptAnalysisTask<TracksExtraV002Converter>(cfgc));
       workflow.push_back(adaptAnalysisTask<TracksExtraSpawner>(cfgc));
     }
+  } else {
+    workflow.push_back(adaptAnalysisTask<TracksExtraV002Converter>(cfgc));
+    workflow.push_back(adaptAnalysisTask<TracksExtraSpawner>(cfgc));
   }
   return workflow;
 }

--- a/Common/TableProducer/Converters/tracksExtraV002Converter.cxx
+++ b/Common/TableProducer/Converters/tracksExtraV002Converter.cxx
@@ -113,8 +113,16 @@ struct TracksExtraSpawner {
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{
-    adaptAnalysisTask<TracksExtraV002Converter>(cfgc),
-    adaptAnalysisTask<TracksExtraSpawner>(cfgc),
-  };
+  auto workflow = WorkflowSpec{};
+  // Check if 'aod-metadata-tables' option is available in the config context
+  if (cfgc.options().hasOption("aod-metadata-tables")) {
+    // Get the list of tables from the config context
+    const std::vector<std::string> tables = cfgc.options().get<std::vector<std::string>>("aod-metadata-tables");
+    // If the table is already found, do not add the converter and spawner
+    if (std::find(tables.begin(), tables.end(), "O2trackextra_002") == tables.end()) {
+      workflow.push_back(adaptAnalysisTask<TracksExtraV002Converter>(cfgc));
+      workflow.push_back(adaptAnalysisTask<TracksExtraSpawner>(cfgc));
+    }
+  }
+  return workflow;
 }

--- a/Common/TableProducer/Converters/tracksExtraV002Converter.cxx
+++ b/Common/TableProducer/Converters/tracksExtraV002Converter.cxx
@@ -116,14 +116,19 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   auto workflow = WorkflowSpec{};
   // Check if 'aod-metadata-tables' option is available in the config context
   if (cfgc.options().hasOption("aod-metadata-tables")) {
+    LOG(debug) << "'aod-metadata-tables' option found in the config context, checking for existing tables";
     // Get the list of tables from the config context
     const std::vector<std::string> tables = cfgc.options().get<std::vector<std::string>>("aod-metadata-tables");
     // If the table is already found, do not add the converter and spawner
     if (std::find(tables.begin(), tables.end(), "O2trackextra_002") == tables.end()) {
+      LOG(debug) << "Adding TracksExtraV002Converter and TracksExtraSpawner to the workflow";
       workflow.push_back(adaptAnalysisTask<TracksExtraV002Converter>(cfgc));
       workflow.push_back(adaptAnalysisTask<TracksExtraSpawner>(cfgc));
+    } else {
+      LOG(debug) << "Table O2trackextra_002 already found, not adding converter and spawner";
     }
   } else {
+    LOG(debug) << "'aod-metadata-tables' option not found in the config context, adding converter and spawner by default";
     workflow.push_back(adaptAnalysisTask<TracksExtraV002Converter>(cfgc));
     workflow.push_back(adaptAnalysisTask<TracksExtraSpawner>(cfgc));
   }


### PR DESCRIPTION
Added conditional logic to check for 'aod-metadata-tables' option and avoid adding converters if the table is already present.