### PR TITLE
[PWGEM,PWGEM-9] Fix `hCaloClusterFilter` filling and clean up of `emcalPi0Qc.cxx`

### DIFF
--- a/PWGEM/PhotonMeson/TableProducer/skimmerGammaCalo.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/skimmerGammaCalo.cxx
@@ -191,7 +191,6 @@ struct SkimmerGammaCalo {
       historeg.fill(HIST("EOut"), emccluster.energy());
       historeg.fill(HIST("M02Out"), emccluster.m02());
       historeg.fill(HIST("TimeOut"), emccluster.time());
-      historeg.fill(HIST("hCaloClusterFilter"), 6);
 
       tableGammaEMCReco(emccluster.collisionId(), emccluster.definition(), emccluster.energy(), emccluster.eta(), emccluster.phi(), emccluster.m02(),
                         emccluster.nCells(), emccluster.time(), emccluster.isExotic(), vPhi, vEta, vP, vPt);

--- a/PWGEM/PhotonMeson/Tasks/CMakeLists.txt
+++ b/PWGEM/PhotonMeson/Tasks/CMakeLists.txt
@@ -21,8 +21,8 @@ o2physics_add_dpl_workflow(gammaconversionstruthonlymc
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 
-o2physics_add_dpl_workflow(emc-pi0-qc
-                    SOURCES emcalPi0QC.cxx
+o2physics_add_dpl_workflow(emcal-pi0-qc
+                    SOURCES emcalPi0Qc.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::EMCALBase O2::EMCALCalib O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
 


### PR DESCRIPTION
- Fixed double filling of the out bin of `hCaloClusterFilter` inisde `skimmerGammaCalo`.
- Clear up `emcalPi0QC.cxx` and renamed to `emcalPi0Qc.cxx`:
  - Remove unused and potentially dangerous function
  - Includes got sorted and clang-tidyed
  - Fixed some O2 Linter errors