### PR TITLE
[PWGCF] Fix CMakeLists.txt in femtodream

### DIFF
--- a/PWGCF/FemtoDream/Tasks/CMakeLists.txt
+++ b/PWGCF/FemtoDream/Tasks/CMakeLists.txt
@@ -88,3 +88,8 @@ o2physics_add_dpl_workflow(femtodream-pair-v0-v0
           SOURCES femtoDreamPairTaskV0V0.cxx
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
           COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(femto-dream-pair-efficiency
+          SOURCES femtoDreamPairEfficiency.cxx
+          PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+          COMPONENT_NAME Analysis)


### PR DESCRIPTION
In a prevoius PR one task was removed by accident from CMakeLists.txt. 