### PR TITLE
O2 linter: Add config with warning categories

### DIFF
--- a/o2linter_config
+++ b/o2linter_config
@@ -1,0 +1,15 @@
+# O2 linter warning categories
+root/entity
+external-pi
+pi-multiple-fraction
+doc/file
+name/function-variable
+name/macro
+name/constexpr-constant
+name/namespace
+name/type
+name/enum
+name/class
+name/struct
+name/file-cpp
+name/file-python


### PR DESCRIPTION
As proposed at the WP4 + WP14 meeting on 5 May 2025
<https://indico.cern.ch/event/1513748/#29-o2-linter-development>