### PR TITLE
[PWGCF] FemtoUniverse - Fixing mismatched table sizes for cascades with default TOF signal

### DIFF
--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -734,6 +734,12 @@ struct FemtoUniverseProducerTask {
                          particle.tofNSigmaOmLaPr(), particle.tofNSigmaOmKa(),
                          particle.dcacascdaughters(), particle.cascradius(),
                          particle.x(), particle.y(), particle.z(), -999.);
+      } else {
+        outputDebugParts(-999., -999., -999., -999., -999., -999., -999., -999., -999.,
+                         -999., -999., -999., -999., -999., -999., -999., -999.,
+                         -999., -999., -999., -999., -999.,
+                         particle.dcacascdaughters(), particle.cascradius(),
+                         particle.x(), particle.y(), particle.z(), -999.);
       }
     } else {
       // LOGF(info, "isTrack0orV0: %d, isPhi: %d", isTrackOrV0, isPhiOrD0);


### PR DESCRIPTION
Adding the filling of outputDebugParts for cascades, which don't use the strangeness TOF table.