### PR TITLE
[PWGCF] JCorran: Fix multiplicity correlations histogram naming

### DIFF
--- a/PWGCF/JCorran/Core/JFFlucAnalysisO2Hist.cxx
+++ b/PWGCF/JCorran/Core/JFFlucAnalysisO2Hist.cxx
@@ -21,6 +21,7 @@
 #include <vector>
 
 using namespace o2;
+using namespace o2::framework;
 
 JFFlucAnalysisO2Hist::JFFlucAnalysisO2Hist(HistogramRegistry& registry, AxisSpec& axisMultiplicity, AxisSpec& phiAxis, AxisSpec& etaAxis, AxisSpec& zvtAxis, AxisSpec& ptAxis, AxisSpec& massAxis, uint16_t multCorrMask, const TString& folder) : JFFlucAnalysis()
 {
@@ -39,8 +40,7 @@ JFFlucAnalysisO2Hist::JFFlucAnalysisO2Hist(HistogramRegistry& registry, AxisSpec
       multAxes.emplace_back(100, 0, 1000, "Nch PV");
     if (multCorrMask & aod::cfmultset::MultNTracksGlobal)
       multAxes.emplace_back(100, 0, 1000, "Nch Global");
-    registry.add("multCorrelations", "Multiplicity correlations", {HistType::kTHnSparseF, multAxes});
-    phs[HIST_THN_SPARSE_MULTCORR] = std::get<std::shared_ptr<THnSparse>>(registry.add(Form("%s/h_multcorr", folder.Data()), "multiplicity/centrality correlations", {HistType::kTHnSparseF, multAxes})).get();
+    phs[HIST_THN_SPARSE_MULTCORR] = std::get<std::shared_ptr<THnSparse>>(registry.add(Form("%s/multCorrelations", folder.Data()), "multiplicity/centrality correlations", {HistType::kTHnSparseF, multAxes})).get();
   } else {
     phs[HIST_THN_SPARSE_MULTCORR] = 0;
   }

--- a/PWGCF/JCorran/Core/JFFlucAnalysisO2Hist.h
+++ b/PWGCF/JCorran/Core/JFFlucAnalysisO2Hist.h
@@ -18,13 +18,10 @@
 
 #include "Framework/HistogramRegistry.h"
 
-using namespace o2;
-using namespace o2::framework;
-
 class JFFlucAnalysisO2Hist : public JFFlucAnalysis
 {
  public:
-  JFFlucAnalysisO2Hist(HistogramRegistry&, AxisSpec&, AxisSpec&, AxisSpec&, AxisSpec&, AxisSpec&, AxisSpec&, uint16_t, const TString&);
+  JFFlucAnalysisO2Hist(o2::framework::HistogramRegistry&, o2::framework::AxisSpec&, o2::framework::AxisSpec&, o2::framework::AxisSpec&, o2::framework::AxisSpec&, o2::framework::AxisSpec&, o2::framework::AxisSpec&, uint16_t, const TString&);
   ~JFFlucAnalysisO2Hist();
 };
 


### PR DESCRIPTION
- fix the naming and referencing of the multiplicity correlations histogram
- remove `using namespace` from header