### PR TITLE
[PWGCF] Suggested improvements for resonance implementation

### DIFF
--- a/PWGCF/FemtoDream/Core/femtoDreamContainer.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamContainer.h
@@ -270,7 +270,7 @@ class FemtoDreamContainer
     }
     if (extendedplots) {
       mHistogramRegistry->fill(HIST(mFolderSuffix[mEventType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/relPairkstarmTPtPart1PtPart2MultPercentile"), femtoObs, mT, part1.pt(), part2.pt(), multPercentile);
-      if constexpr (std::is_same_v<T1, o2::aod::FDParticle> && std::is_same_v<T2, o2::aod::FDParticle>) {
+      if constexpr (requires { part1.mLambda(); part2.mLambda(); }) {
         mHistogramRegistry->fill(HIST(mFolderSuffix[mEventType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("/invMassPart1invMassPart2kstar"), part1.mLambda(), part2.mLambda(), femtoObs);
       }
     }

--- a/PWGCF/FemtoDream/Core/femtoDreamResoSelection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamResoSelection.h
@@ -65,7 +65,7 @@ class FemtoDreamResoSelection
   virtual ~FemtoDreamResoSelection() = default;
 
   template <typename V>
-  uint32_t getType(V const& track1, V const& track2, bool resoIsNotAnti);
+  int getType(V const& track1, V const& track2, bool resoIsNotAnti);
 
   /// assigns value from configurbale to private class member
   template <typename V>
@@ -218,7 +218,7 @@ class FemtoDreamResoSelection
 }; // namespace femtoDream
 
 template <typename V>
-uint32_t FemtoDreamResoSelection::getType(V const& track1, V const& track2, bool resoIsNotAnti)
+int FemtoDreamResoSelection::getType(V const& track1, V const& track2, bool resoIsNotAnti)
 {
   float posThresh = 0.;
   float negThresh = 0.;
@@ -403,13 +403,9 @@ float FemtoDreamResoSelection::getNSigTotal(T const& track, V const& pid, float 
     return std::abs(nSigTPC);
   }
 
-  float nSigTOF = 0.;
-  if (!track.hasTOF()) {
-    nSigTOF = 999.f;
-  } else {
-    nSigTOF = o2::aod::pidutils::tofNSigma(pid, track);
-  }
-  return std::sqrt(nSigTPC * nSigTPC + nSigTOF * nSigTOF);
+  float nSigTOF = track.hasTOF() ? o2::aod::pidutils::tofNSigma(pid, track) : 999.f;
+
+  return std::hypot(nSigTPC, nSigTOF);
 }
 
 //// new getCutContainer


### PR DESCRIPTION
inside ResoSelection some uint_32 return types  were replaced by integer types. A suggested use case for std::hypot was implemented. A check for iterator type inside femtoDreamContainer.h was improved.
@AntonRiedel 
@gmantzar 