### PR TITLE
[PWGHF] Fixed MC matching of partly reconstructed resonances

### DIFF
--- a/PWGHF/D2H/DataModel/ReducedDataModel.h
+++ b/PWGHF/D2H/DataModel/ReducedDataModel.h
@@ -1646,6 +1646,7 @@ DECLARE_SOA_TABLE(HfMcRecRedResos, "AOD", "HFMCRECREDRESO", //! Reconstruction-l
                   hf_reso_cand_reduced::Origin,
                   hf_reso_cand_reduced::PtGen,
                   hf_reso_cand_reduced::InvMassGen,
+                  hf_cand::NTracksDecayed,
                   o2::soa::Marker<1>);
 } // namespace aod
 

--- a/PWGHF/D2H/TableProducer/candidateCreatorCharmResoReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorCharmResoReduced.cxx
@@ -957,23 +957,24 @@ struct HfCandidateCreatorCharmResoReducedExpressions {
   {
     for (const auto& candReso : candsReso) {
       bool filledMcInfo{false};
-      for (const auto& rowDV0McRec : rowsMcRec) {
-        if ((rowDV0McRec.prong0Id() != candReso.prong0Id()) || (rowDV0McRec.prong1Id() != candReso.prong1Id())) {
+      for (const auto& rowMcRec : rowsMcRec) {
+        if ((rowMcRec.prong0Id() != candReso.prong0Id()) || (rowMcRec.prong1Id() != candReso.prong1Id())) {
           continue;
         }
-        rowResoMcRec(rowDV0McRec.flagMcMatchRec(),
-                     rowDV0McRec.flagMcMatchRecD(),
-                     rowDV0McRec.flagMcMatchChanD(),
-                     rowDV0McRec.debugMcRec(),
-                     rowDV0McRec.origin(),
-                     rowDV0McRec.ptGen(),
-                     rowDV0McRec.invMassGen());
+        rowResoMcRec(rowMcRec.flagMcMatchRec(),
+                     rowMcRec.flagMcMatchRecD(),
+                     rowMcRec.flagMcMatchChanD(),
+                     rowMcRec.debugMcRec(),
+                     rowMcRec.origin(),
+                     rowMcRec.ptGen(),
+                     rowMcRec.invMassGen(),
+                     rowMcRec.nTracksDecayed());
         filledMcInfo = true;
-        if (std::abs(rowDV0McRec.flagMcMatchRec()) > 0 &&
-            !TESTBIT(rowDV0McRec.debugMcRec(), hf_decay::hf_cand_reso::PartialMatchMc::ResoPartlyMatched)) {
+        if (std::abs(rowMcRec.flagMcMatchRec()) > 0 &&
+            !TESTBIT(rowMcRec.debugMcRec(), hf_decay::hf_cand_reso::PartialMatchMc::ResoPartlyMatched)) {
           registry.fill(HIST("hMassMcMatched"), candReso.invMass(), candReso.pt());
-        } else if (std::abs(rowDV0McRec.flagMcMatchRec()) > 0 &&
-                   TESTBIT(rowDV0McRec.debugMcRec(), hf_decay::hf_cand_reso::PartialMatchMc::ResoPartlyMatched)) {
+        } else if (std::abs(rowMcRec.flagMcMatchRec()) > 0 &&
+                   TESTBIT(rowMcRec.debugMcRec(), hf_decay::hf_cand_reso::PartialMatchMc::ResoPartlyMatched)) {
           registry.fill(HIST("hMassMcMatchedIncomplete"), candReso.invMass(), candReso.pt());
         } else {
           registry.fill(HIST("hMassMcUnmatched"), candReso.invMass(), candReso.pt());
@@ -981,7 +982,7 @@ struct HfCandidateCreatorCharmResoReducedExpressions {
         break;
       }
       if (!filledMcInfo) { // protection to get same size tables in case something went wrong: we created a candidate that was not preselected in the D-Pi creator
-        rowResoMcRec(0, 0, 0, 0, 0, -1.f, -1.f);
+        rowResoMcRec(0, 0, 0, 0, 0, -1.f, -1.f, 0);
         registry.fill(HIST("hMassMcNoEntry"), candReso.invMass(), candReso.pt());
       }
     }

--- a/PWGHF/D2H/TableProducer/dataCreatorCharmResoReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorCharmResoReduced.cxx
@@ -680,7 +680,7 @@ struct HfDataCreatorCharmResoReduced {
         std::array<int, 5> const pdgCodesDaughters = {+kPiPlus, -kKPlus, +kPiPlus, +kPiPlus, -kPiPlus};
         auto arrDaughtersReso = std::array{vecDaughtersReso[0], vecDaughtersReso[1], vecDaughtersReso[2], vecDaughtersReso[3], vecDaughtersReso[4]};
         for (const auto& [decayChannelFlag, pdgCodeReso] : hf_decay::hf_cand_reso::particlesToDstarK0s) {
-          indexRec = RecoDecay::getMatchedMCRec<false, true, true, true, true>(particlesMc, arrDaughtersReso, pdgCodeReso, pdgCodesDaughters, true, &sign, 3, &nKinkedTracks);
+          indexRec = RecoDecay::getMatchedMCRec<false, true, false, true, true>(particlesMc, arrDaughtersReso, pdgCodeReso, pdgCodesDaughters, true, &sign, 3, &nKinkedTracks);
           if (indexRec > -1) {
             flagReso = sign * decayChannelFlag;
             break;
@@ -734,19 +734,31 @@ struct HfDataCreatorCharmResoReduced {
         auto pdgCodesDplusDaughters = hf_decay::hf_cand_3prong::daughtersDplusMain.at(static_cast<hf_decay::hf_cand_3prong::DecayChannelMain>(std::abs(flagCharmBach)));
         auto pdgCodesDaughters = std::array{pdgCodesDplusDaughters[0], pdgCodesDplusDaughters[1], pdgCodesDplusDaughters[2], +kPiPlus, -kPiPlus};
         for (const auto& [decayChannelFlag, pdgCodeReso] : hf_decay::hf_cand_reso::particlesToDplusK0s) {
-          indexRec = RecoDecay::getMatchedMCRec<false, true, true, true, true>(particlesMc, arrDaughtersReso, pdgCodeReso, pdgCodesDaughters, true, &sign, 3, &nKinkedTracks);
+          indexRec = RecoDecay::getMatchedMCRec<false, true, false, true, true>(particlesMc, arrDaughtersReso, pdgCodeReso, pdgCodesDaughters, true, &sign, 3, &nKinkedTracks);
           if (indexRec > -1) {
             flagReso = sign * decayChannelFlag;
             break;
           }
         }
+        // Partial matching of Dsj -> D*K0s -> (D+ pi0) (K0s) with missing neutral
+        if (indexRec < 0) {
+          for (const auto& [decayChannelFlag, pdgCodeReso] : hf_decay::hf_cand_reso::particlesToDstarK0s) {
+            indexRec = RecoDecay::getMatchedMCRec<false, true, true, true, true>(particlesMc, arrDaughtersReso, pdgCodeReso, pdgCodesDaughters, true, &sign, 3, &nKinkedTracks);
+            if (indexRec > -1) {
+              flagReso = sign * decayChannelFlag;
+              SETBIT(debugMcRec, hf_decay::hf_cand_reso::PartialMatchMc::ResoPartlyMatched);
+              break;
+            }
+          }
+        }
+
       } else if (hf_decay::hf_cand_3prong::daughtersDplusMain.contains(static_cast<hf_decay::hf_cand_3prong::DecayChannelMain>(std::abs(flagCharmBach))) && std::abs(flagV0) == hf_decay::hf_cand_reso::PartialMatchMc::LambdaMatched) {
         // Peaking background of D+Lambda <- Ds* with spurious soft pion
         auto arrDaughtersReso = std::array{vecDaughtersReso[0], vecDaughtersReso[1], vecDaughtersReso[2], vecDaughtersReso[3], vecDaughtersReso[4]};
         auto pdgCodesDplusDaughters = hf_decay::hf_cand_3prong::daughtersDplusMain.at(static_cast<hf_decay::hf_cand_3prong::DecayChannelMain>(std::abs(flagCharmBach)));
         auto pdgCodesDaughters = std::array{pdgCodesDplusDaughters[0], pdgCodesDplusDaughters[1], pdgCodesDplusDaughters[2], +kProton, -kPiPlus};
         for (const auto& [decayChannelFlag, pdgCodeReso] : hf_decay::hf_cand_reso::particlesToDplusLambda) {
-          indexRec = RecoDecay::getMatchedMCRec<false, true, true, true, true>(particlesMc, arrDaughtersReso, pdgCodeReso, pdgCodesDaughters, true, &sign, 3, &nKinkedTracks);
+          indexRec = RecoDecay::getMatchedMCRec<false, true, false, true, true>(particlesMc, arrDaughtersReso, pdgCodeReso, pdgCodesDaughters, true, &sign, 3, &nKinkedTracks);
           if (indexRec > -1) {
             flagReso = sign * decayChannelFlag;
             break;
@@ -787,7 +799,7 @@ struct HfDataCreatorCharmResoReduced {
         auto pdgCodesDzeroDaughters = hf_decay::hf_cand_2prong::daughtersD0Main.at(static_cast<hf_decay::hf_cand_2prong::DecayChannelMain>(std::abs(flagCharmBach)));
         auto pdgCodesDaughters = std::array{pdgCodesDzeroDaughters[0], pdgCodesDzeroDaughters[1], +kProton, -kPiPlus};
         for (const auto& [decayChannelFlag, pdgCodeReso] : hf_decay::hf_cand_reso::particlesToD0Lambda) {
-          indexRec = RecoDecay::getMatchedMCRec<false, true, true, true, true>(particlesMc, arrDaughtersReso, pdgCodeReso, pdgCodesDaughters, true, &sign, 3, &nKinkedTracks);
+          indexRec = RecoDecay::getMatchedMCRec<false, true, false, true, true>(particlesMc, arrDaughtersReso, pdgCodeReso, pdgCodesDaughters, true, &sign, 3, &nKinkedTracks);
           if (indexRec > -1) {
             flagReso = sign * decayChannelFlag;
             break;
@@ -878,7 +890,7 @@ struct HfDataCreatorCharmResoReduced {
         auto arrDaughtersReso = std::array{vecDaughtersReso[0], vecDaughtersReso[1], vecDaughtersReso[2], bachelorTrack};
         auto pdgCodesDaughters = std::array{+kPiPlus, -kKPlus, +kPiPlus, -kPiPlus};
         for (const auto& [decayChannelFlag, pdgCodeReso] : hf_decay::hf_cand_reso::particlesToDstarPi) {
-          indexRec = RecoDecay::getMatchedMCRec<false, true, true, true, true>(particlesMc, arrDaughtersReso, pdgCodeReso, pdgCodesDaughters, true, &sign, 3, &nKinkedTracks);
+          indexRec = RecoDecay::getMatchedMCRec<false, true, false, true, true>(particlesMc, arrDaughtersReso, pdgCodeReso, pdgCodesDaughters, true, &sign, 3, &nKinkedTracks);
           if (indexRec > -1) {
             flagReso = sign * decayChannelFlag;
             break;
@@ -918,10 +930,21 @@ struct HfDataCreatorCharmResoReduced {
         auto pdgCodesDplusDaughters = hf_decay::hf_cand_3prong::daughtersDplusMain.at(static_cast<hf_decay::hf_cand_3prong::DecayChannelMain>(std::abs(flagCharmBach)));
         auto pdgCodesDaughters = std::array{pdgCodesDplusDaughters[0], pdgCodesDplusDaughters[1], pdgCodesDplusDaughters[2], -kPiPlus};
         for (const auto& [decayChannelFlag, pdgCodeReso] : hf_decay::hf_cand_reso::particlesToDplusPi) {
-          indexRec = RecoDecay::getMatchedMCRec<false, true, true, true, true>(particlesMc, arrDaughtersReso, pdgCodeReso, pdgCodesDaughters, true, &sign, 3, &nKinkedTracks);
+          indexRec = RecoDecay::getMatchedMCRec<false, true, false, true, true>(particlesMc, arrDaughtersReso, pdgCodeReso, pdgCodesDaughters, true, &sign, 3, &nKinkedTracks);
           if (indexRec > -1) {
             flagReso = sign * decayChannelFlag;
             break;
+          }
+        }
+        // Partial matching of Dj -> D*Pi -> (D+ pi0) (pi) with missing neutral
+        if (indexRec < 0) {
+          for (const auto& [decayChannelFlag, pdgCodeReso] : hf_decay::hf_cand_reso::particlesToDstarPi) {
+            indexRec = RecoDecay::getMatchedMCRec<false, true, true, true, true>(particlesMc, arrDaughtersReso, pdgCodeReso, pdgCodesDaughters, true, &sign, 3, &nKinkedTracks);
+            if (indexRec > -1) {
+              flagReso = sign * decayChannelFlag;
+              SETBIT(debugMcRec, hf_decay::hf_cand_reso::PartialMatchMc::ResoPartlyMatched);
+              break;
+            }
           }
         }
       }
@@ -955,10 +978,21 @@ struct HfDataCreatorCharmResoReduced {
         auto pdgCodesDzeroDaughters = hf_decay::hf_cand_2prong::daughtersD0Main.at(static_cast<hf_decay::hf_cand_2prong::DecayChannelMain>(std::abs(flagCharmBach)));
         auto pdgCodesDaughters = std::array{pdgCodesDzeroDaughters[0], pdgCodesDzeroDaughters[1], +kPiPlus};
         for (const auto& [decayChannelFlag, pdgCodeReso] : hf_decay::hf_cand_reso::particlesToD0Pi) {
-          indexRec = RecoDecay::getMatchedMCRec<false, true, true, true, true>(particlesMc, arrDaughtersReso, pdgCodeReso, pdgCodesDaughters, true, &sign, 3, &nKinkedTracks);
+          indexRec = RecoDecay::getMatchedMCRec<false, true, false, true, true>(particlesMc, arrDaughtersReso, pdgCodeReso, pdgCodesDaughters, true, &sign, 3, &nKinkedTracks);
           if (indexRec > -1) {
             flagReso = sign * decayChannelFlag;
             break;
+          }
+        }
+        // Partial matching of Dj -> D*Pi -> (D0 pi) (pi) with missing pion
+        if (indexRec < 0) {
+          for (const auto& [decayChannelFlag, pdgCodeReso] : hf_decay::hf_cand_reso::particlesToDstarPi) {
+            indexRec = RecoDecay::getMatchedMCRec<false, true, true, true, true>(particlesMc, arrDaughtersReso, pdgCodeReso, pdgCodesDaughters, true, &sign, 3, &nKinkedTracks);
+            if (indexRec > -1) {
+              flagReso = sign * decayChannelFlag;
+              SETBIT(debugMcRec, hf_decay::hf_cand_reso::PartialMatchMc::ResoPartlyMatched);
+              break;
+            }
           }
         }
       } else if (hf_decay::hf_cand_2prong::daughtersD0Main.contains(static_cast<hf_decay::hf_cand_2prong::DecayChannelMain>(std::abs(flagCharmBach))) && flagTrack == hf_decay::hf_cand_reso::PartialMatchMc::KaonMatched) {
@@ -966,7 +1000,7 @@ struct HfDataCreatorCharmResoReduced {
         auto pdgCodesDzeroDaughters = hf_decay::hf_cand_2prong::daughtersD0Main.at(static_cast<hf_decay::hf_cand_2prong::DecayChannelMain>(std::abs(flagCharmBach)));
         auto pdgCodesDaughters = std::array{pdgCodesDzeroDaughters[0], pdgCodesDzeroDaughters[1], +kKPlus};
         for (const auto& [decayChannelFlag, pdgCodeReso] : hf_decay::hf_cand_reso::particlesToD0Kplus) {
-          indexRec = RecoDecay::getMatchedMCRec<false, true, true, true, true>(particlesMc, arrDaughtersReso, pdgCodeReso, pdgCodesDaughters, true, &sign, 3, &nKinkedTracks);
+          indexRec = RecoDecay::getMatchedMCRec<false, true, false, true, true>(particlesMc, arrDaughtersReso, pdgCodeReso, pdgCodesDaughters, true, &sign, 3, &nKinkedTracks);
           if (indexRec > -1) {
             flagReso = sign * decayChannelFlag;
             break;

--- a/PWGHF/D2H/Tasks/taskCharmResoToDTrkReduced.cxx
+++ b/PWGHF/D2H/Tasks/taskCharmResoToDTrkReduced.cxx
@@ -83,6 +83,7 @@ DECLARE_SOA_COLUMN(PtGen, ptGen, float);                                        
 DECLARE_SOA_COLUMN(InvMassGen, invMassGen, float);                                         //! Invariant mass of candidate (GeV/c2)
 DECLARE_SOA_COLUMN(FlagCharmBach, flagCharmBach, int8_t);                                  //! Flag for charm bachelor classification
 DECLARE_SOA_COLUMN(FlagCharmBachInterm, flagCharmBachInterm, int8_t);                      //! Flag for charm bachelor classification intermediate
+DECLARE_SOA_COLUMN(NKinkedTracks, nKinkedTracks, int8_t);                                  //! Number of kinked tracks found in MC matching
 } // namespace hf_cand_reso_to_trk_lite
 
 DECLARE_SOA_TABLE(HfCandDTrkLites, "AOD", "HFCANDDTRKLITE", //! Table with some B0 properties
@@ -119,7 +120,8 @@ DECLARE_SOA_TABLE(HfCandDTrkLites, "AOD", "HFCANDDTRKLITE", //! Table with some 
                   hf_cand_reso_to_trk_lite::PtGen,
                   hf_cand_reso_to_trk_lite::InvMassGen,
                   hf_cand_reso_to_trk_lite::FlagCharmBach,
-                  hf_cand_reso_to_trk_lite::FlagCharmBachInterm);
+                  hf_cand_reso_to_trk_lite::FlagCharmBachInterm,
+                  hf_cand_reso_to_trk_lite::NKinkedTracks);
 
 DECLARE_SOA_TABLE(HfGenResoLites, "AOD", "HFGENRESOLITE", //! Table with some B0 properties
                   hf_cand_reso_to_trk_lite::Pt,
@@ -227,7 +229,7 @@ struct HfTaskCharmResoToDTrkReduced {
 
     // MC Rec
     float ptGen{-1.}, invMassGen{-1};
-    int8_t origin{0}, flagMcMatchRec{0}, flagCharmBach{0}, flagCharmBachInterm{0};
+    int8_t origin{0}, flagMcMatchRec{0}, flagCharmBach{0}, flagCharmBachInterm{0}, nKinkedTracks{0};
     int debugMcRec{-1};
     if constexpr (DoMc) {
       ptGen = candidate.ptGen();
@@ -237,6 +239,7 @@ struct HfTaskCharmResoToDTrkReduced {
       invMassGen = candidate.invMassGen();
       flagCharmBach = candidate.flagMcMatchRecD();
       flagCharmBachInterm = candidate.flagMcMatchChanD();
+      nKinkedTracks = candidate.nTracksDecayed();
       if (fillOnlySignal) {
         if (Channel == DecayChannel::D0Kplus &&
             !hf_decay::hf_cand_reso::particlesToD0Kplus.contains(static_cast<hf_decay::hf_cand_reso::DecayChannelMain>(std::abs(flagMcMatchRec)))) {
@@ -324,7 +327,8 @@ struct HfTaskCharmResoToDTrkReduced {
         ptGen,
         invMassGen,
         flagCharmBach,
-        flagCharmBachInterm);
+        flagCharmBachInterm,
+        nKinkedTracks);
     }
   } // fillCand
 

--- a/PWGHF/D2H/Tasks/taskCharmResoToDV0Reduced.cxx
+++ b/PWGHF/D2H/Tasks/taskCharmResoToDV0Reduced.cxx
@@ -88,6 +88,7 @@ DECLARE_SOA_COLUMN(PtGen, ptGen, float);                                        
 DECLARE_SOA_COLUMN(InvMassGen, invMassGen, float);                                         //! Invariant mass of candidate (GeV/c2)
 DECLARE_SOA_COLUMN(FlagCharmBach, flagCharmBach, int8_t);                                  //! Flag for charm bachelor classification
 DECLARE_SOA_COLUMN(FlagCharmBachInterm, flagCharmBachInterm, int8_t);                      //! Flag for charm bachelor classification intermediate
+DECLARE_SOA_COLUMN(NKinkedTracks, nKinkedTracks, int8_t);                                  //! Number of kinked tracks found in MC matching
 } // namespace hf_cand_reso_to_v0_lite
 
 DECLARE_SOA_TABLE(HfCandDV0Lites, "AOD", "HFCANDDV0LITE", //! Table with some Resonances properties
@@ -128,7 +129,8 @@ DECLARE_SOA_TABLE(HfCandDV0Lites, "AOD", "HFCANDDV0LITE", //! Table with some Re
                   hf_cand_reso_to_v0_lite::PtGen,
                   hf_cand_reso_to_v0_lite::InvMassGen,
                   hf_cand_reso_to_v0_lite::FlagCharmBach,
-                  hf_cand_reso_to_v0_lite::FlagCharmBachInterm);
+                  hf_cand_reso_to_v0_lite::FlagCharmBachInterm,
+                  hf_cand_reso_to_v0_lite::NKinkedTracks);
 
 DECLARE_SOA_TABLE(HfGenResoLites, "AOD", "HFGENRESOLITE", //! Table with some B0 properties
                   hf_cand_reso_to_v0_lite::Pt,
@@ -258,7 +260,7 @@ struct HfTaskCharmResoToDV0Reduced {
 
     // MC Rec
     float ptGen{-1.}, invMassGen{-1};
-    int8_t origin{0}, flagMcMatchRec{0}, flagCharmBach{0}, flagCharmBachInterm{0};
+    int8_t origin{0}, flagMcMatchRec{0}, flagCharmBach{0}, flagCharmBachInterm{0}, nKinkedTracks{0};
     int debugMcRec{-1};
     if constexpr (DoMc) {
       ptGen = candidate.ptGen();
@@ -268,6 +270,7 @@ struct HfTaskCharmResoToDV0Reduced {
       invMassGen = candidate.invMassGen();
       flagCharmBach = candidate.flagMcMatchRecD();
       flagCharmBachInterm = candidate.flagMcMatchChanD();
+      nKinkedTracks = candidate.nTracksDecayed();
       if (fillOnlySignal) {
         if (Channel == DecayChannel::DstarK0s &&
             !hf_decay::hf_cand_reso::particlesToDstarK0s.contains(static_cast<hf_decay::hf_cand_reso::DecayChannelMain>(std::abs(flagMcMatchRec)))) {
@@ -372,7 +375,8 @@ struct HfTaskCharmResoToDV0Reduced {
         ptGen,
         invMassGen,
         flagCharmBach,
-        flagCharmBachInterm);
+        flagCharmBachInterm,
+        nKinkedTracks);
     }
   } // fillCand
 


### PR DESCRIPTION
This PR changes default behaviour of MC matching of Charmed resonances. Partial matches are allowed only in some cases and marked with a flag.
Number of decayed tracks are added to MC tables produced by candidate Creator and tasks 