### PR TITLE
[PWGHF] Fix potential bug in Dstar candidate selection in debug mode 

### DIFF
--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1884,8 +1884,8 @@ struct HfTrackIndexSkimCreator {
       isSelected = 0;
       if (config.debug) {
         CLRBIT(cutStatus, 0);
-      } 
-        return isSelected;
+      }
+      return isSelected;
     }
 
     // D0 mass


### PR DESCRIPTION
Fix potential bug in Dstar candidate selection in debug mode 

- whatever enables debug or not, we should return 0 when bin pt is not in the required pt range 