### PR TITLE
[DPG] tpcSkimsTableCreator: algo bugfix; add nSigma TOF cut; code cleaning

### DIFF
--- a/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
+++ b/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
@@ -35,15 +35,15 @@
 #include "Common/DataModel/TrackSelectionTables.h"
 #include "Common/TableProducer/PID/pidTPCBase.h"
 
-#include "CommonConstants/PhysicsConstants.h"
-#include "Framework/ASoAHelpers.h"
-#include "Framework/AnalysisDataModel.h"
-#include "Framework/AnalysisTask.h"
-#include "Framework/HistogramRegistry.h"
-#include "Framework/runDataProcessing.h"
 #include <CCDB/BasicCCDBManager.h>
+#include <CommonConstants/PhysicsConstants.h>
+#include <Framework/ASoAHelpers.h>
+#include <Framework/AnalysisDataModel.h>
+#include <Framework/AnalysisTask.h>
+#include <Framework/HistogramRegistry.h>
+#include <Framework/runDataProcessing.h>
 
-#include "TRandom3.h"
+#include <TRandom3.h>
 
 #include <cmath>
 #include <string>

--- a/DPG/Tasks/TPC/tpcSkimsTableCreator.h
+++ b/DPG/Tasks/TPC/tpcSkimsTableCreator.h
@@ -23,8 +23,8 @@
 #include "Common/Core/trackUtilities.h"
 #include "Common/DataModel/PIDResponse.h"
 
-#include "Framework/AnalysisDataModel.h"
-#include "Framework/AnalysisTask.h"
+#include <Framework/AnalysisDataModel.h>
+#include <Framework/AnalysisTask.h>
 
 namespace o2::aod
 {

--- a/DPG/Tasks/TPC/utilsTpcSkimsTableCreator.h
+++ b/DPG/Tasks/TPC/utilsTpcSkimsTableCreator.h
@@ -20,7 +20,7 @@
 #ifndef DPG_TASKS_TPC_UTILSTPCSKIMSTABLECREATOR_H_
 #define DPG_TASKS_TPC_UTILSTPCSKIMSTABLECREATOR_H_
 
-#include "TRandom3.h"
+#include <TRandom3.h>
 
 namespace o2::dpg_tpcskimstablecreator
 {


### PR DESCRIPTION
**Algorithm error fixes:**
* In the previous edition of the code when a certain V0 candidate (say $K^0_S$ ) was processed, its daughter tracks were filled into the tree not only as current V0's decay products ($\pi^+$ and $\pi^-$), but also as decay products of another V0 species (e.g. $\Lambda$) if these daughters participated in construction of such V0s (see attached picture).
<img width="756" height="813" alt="Screenshot from 2025-10-17 16-29-08" src="https://github.com/user-attachments/assets/8616b76b-698c-4350-b350-b60d2ed2a0d7" />
Quantitatively, this effect had very insufficient impact (less than $10^{-3}$). This error is fixed in the PR.

* Track selection, implemented via `soa::Filtered` had no effect in the V0 **struct**. It is fixed by implementation the track selection via boolean function.
**Note**: default track selection in the V0 **struct** is changed from 1 to 0 (`GlobalTrack` to `NoCut`).

**Functionality enhancement:**
Added a possibility to cut on $N \sigma_{\mathrm{TOF}}$ for V0-based selected tracks and a possibility to reject tracks unmatched to TOF. Both $N \sigma_{\mathrm{TOF}}$ and a requirement to reject unmatched to TOF tracks are added as configurables - float and bool respectively, individually for all particle species.
**Note**: `o2-analysis-lf-strangenesstofpid` workflow is required as dependency.

**Code cleaning:**
* got rid of instantiations of V0 daughter objects when they are not necessary (e.g. do not instantiate electrons when current V0 is $\Lambda$);
* got rid of copy of TOF track objects into a vector, use their pointers instead;
* factored out repeating peaces of code into lambda-functions;
* repeating parts of the data model factored out into macros;
* common for V0 and TOF **struct** functions (track, event selection, downsamling Tsallis) moved to the header file;
* removed `Tracks` table from passed into V0 process functions.

Tagging @amaringarcia 