### PR TITLE
[PWGJE] HadronPhotonCorrelation Task: Small bug fixes

### DIFF
--- a/PWGJE/Tasks/hadronPhotonCorrelation.cxx
+++ b/PWGJE/Tasks/hadronPhotonCorrelation.cxx
@@ -120,12 +120,12 @@ struct HadronPhotonCorrelation {
 
   // Particle ids for storing neutral hadrons
   std::map<std::string, int> pidCodes = {
-    {"pi0", 1},   // pi0
-    {"eta", 2},   // eta
-    {"eta'", 3},  // eta'
-    {"phi", 4},   // phi
-    {"omega", 5}, // omega
-    //{"Sigma0", 6}, // Sigma
+    {"pi0", 1},    // pi0
+    {"eta", 2},    // eta
+    {"eta'", 3},   // eta'
+    {"phi", 4},    // phi
+    {"omega", 5},  // omega
+    {"Sigma0", 6}, // Sigma
     {"Sigma0_bar", 6}};
 
   std::map<int, int> pidToPdg = {
@@ -1016,6 +1016,9 @@ struct HadronPhotonCorrelation {
 
           for (const auto& track_trig : tracks_true) {
             if (!initTrigParticle(track_trig)) {
+              continue;
+            }
+            if (track_trig == track_assoc) {
               continue;
             }
             float dphi = RecoDecay::constrainAngle(daughter->Phi() - track_trig.phi(), -PIHalf);


### PR DESCRIPTION
Fixed two minor bugs in the hadron photon correlation task:

1. Erroneously commented out Sigma0 (but not Sigma0 bar)
2. In hadron - cocktail photon correlations did not check if charged hadron as trigger and charged hadron as associated particle are identical