### PR TITLE
[PWGLF] Refine jet definition for generated particles and code optimization

### DIFF
--- a/PWGLF/Tasks/Strangeness/strangenessInJets.cxx
+++ b/PWGLF/Tasks/Strangeness/strangenessInJets.cxx
@@ -355,6 +355,7 @@ struct StrangenessInJets {
     u.SetXYZ(ux, uy, uz);
     return;
   }
+  */
 
   // Delta phi calculation
   double getDeltaPhi(double a1, double a2)
@@ -371,7 +372,6 @@ struct StrangenessInJets {
 
     return deltaPhi;
   }
-  */
 
   // Check if particle is a physical primary or a decay product of a heavy-flavor hadron
   bool isPhysicalPrimaryOrFromHF(aod::McParticle const& particle, aod::McParticles const& mcParticles)


### PR DESCRIPTION
- Jet for generated particles is now constructed using final-state charged particles that are physical primary or from HF decays
- Calculation of two perpendicular axes for UE studies is now done in a single function call to reduce CPU usage
- Defined per-event particle containers to reduce memory usage