### PR TITLE
[PWGJE] Update RM to support median rho and local rho, and add non-eventplane RMs for check and compare

### DIFF
--- a/PWGJE/Tasks/jetChargedV2.cxx
+++ b/PWGJE/Tasks/jetChargedV2.cxx
@@ -1937,7 +1937,6 @@ struct JetChargedV2 {
           return;
         }
         if (useMedianRho) {
-          // fillMatchedHistograms<ChargedMCDMatchedJets::iterator, ChargedMCPMatchedJets>(mcdjet, collision.rho(), mcrho, ep2);
           fillGeoMatchedHistograms<ChargedMCDMatchedJets::iterator, ChargedMCPMatchedJets>(mcdjet, ep2, collision.rho(), mcrho);
         }
         if (useLocalRho) {


### PR DESCRIPTION
1. Updates the RMs to support median rho for background estimation to compare while use local rho. 
2. Add non-eventplane RM versions to allow quick cross-checks and comparisons with the standard eventplane-based RM.