### PR TITLE
[PWGEM,PWGEM-36] Update EMCal flow task to use TProfile3D

### DIFF
--- a/PWGEM/PhotonMeson/Tasks/taskPi0FlowEMC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/taskPi0FlowEMC.cxx
@@ -448,7 +448,7 @@ struct TaskPi0FlowEMC {
     }
 
     if (cfgDoM02.value) {
-      registry.add("hSparseFlow", "THn for SP", HistType::kTHnSparseF, {thnAxisM02, thnAxisPt, thnAxisCent, thnAxisScalarProd});
+      registry.add("hSparseFlow", "THn for SP", HistType::kTHnSparseF, {thnAxisM02, thnAxisPt, thnAxisCent});
     }
 
     ccdb->setURL(ccdbUrl);


### PR DESCRIPTION
- Instead of using 4D THnSparse to get for a specific pT and cent the 2D v_n vs m_inv histogram to then make a TProfile to average over the v_n, directly use a TProfile3D, reducing the dimensions and making sure that there are no issues for calculating <v_n> from discretizing v_n.
- Similar for the spReso plots where only the <Q_A * Q_B> vs cent is needed: instead of using 2D histogram its now a TProfile