### PR TITLE
[Common] Bug fixing and adding more histograms

### DIFF
--- a/Common/Tasks/qaMuon.cxx
+++ b/Common/Tasks/qaMuon.cxx
@@ -3148,8 +3148,8 @@ struct muonQa {
         // dimuon variables
         double mass = GetMuMuInvariantMass(fgValuesMuonPV1, fgValuesMuonPV2);
         double pT = GetMuMuPt(fgValuesMuonPV1, fgValuesMuonPV2);
-        double dcaXPair;
-        double dcaYPair;
+        double dcaXPair = 0.0;
+        double dcaYPair = 0.0;
         if (TopBottom1 != TopBottom2) {             // only mixed pairs
           if (TopBottom1 == 0 && TopBottom2 == 1) { // muon1 = top, muon2 = bottom
             if (configRealign.fDoRealign) {


### PR DESCRIPTION
The following changes were made for now:
- Added histograms for MCH with global muon selection cuts
- Added top-bottom seperations for MCH tracks with global muon selection cuts and for global tracks
- Added pT dependence into 2D-histograms for above mentioned histograms, as well as for scaled MFT tracks. This is also done for top-bottom selections.
- Modified the definition of top-bottom mixed same-sign pairs to always calculate the DCA as muon (top) minus muon (bottom)
- Bug fix of scaled MFT momentum. Now the MCH track is properly propagated to the PV and the MCH momentum is taken from there