### PR TITLE
[PWGEM,PWGEM-36] Pi0Flow: Reduce CPU time for LUT

### DIFF
--- a/PWGEM/PhotonMeson/Tasks/taskPi0FlowEMC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/taskPi0FlowEMC.cxx
@@ -102,7 +102,7 @@ enum Harmonics {
 enum class MapLevel {
   kGood = 1,
   kNoBad = 2,
-  kinEMC = 3,
+  kInEMC = 3,
   kAll = 4
 };
 


### PR DESCRIPTION
- changed `lookupTable1D` from `std::vector` to `std::array` and fill with all good values when MapLevel is >= 4 for same event and background set in the config