### PR TITLE
[PWGCF] Update femto framework

### DIFF
--- a/PWGCF/Femto/Core/closePairRejection.h
+++ b/PWGCF/Femto/Core/closePairRejection.h
@@ -16,6 +16,8 @@
 #ifndef PWGCF_FEMTO_CORE_CLOSEPAIRREJECTION_H_
 #define PWGCF_FEMTO_CORE_CLOSEPAIRREJECTION_H_
 
+#include "RecoDecay.h"
+
 #include "PWGCF/Femto/Core/femtoUtils.h"
 #include "PWGCF/Femto/Core/histManager.h"
 
@@ -51,62 +53,35 @@ enum CprHist {
   kCprHistogramLast
 };
 
-// default config, cpr between two charged tracks (or track vs particle which decays into one charged track, like sigma)
+// template configurable group for Cpr
+template <const char* Prefix>
 struct ConfCpr : o2::framework::ConfigurableGroup {
-  std::string prefix = std::string("ClosePairRejection");
-  o2::framework::Configurable<bool> on{"on", true, "Turn on CPR"};
-  o2::framework::Configurable<bool> plotAllRadii{"plotAllRadii", false, "Plot deta-dphi distribution at all radii"};
+  std::string prefix = std::string(Prefix);
+  o2::framework::Configurable<bool> cutAverage{"cutAverage", true, "Apply CPR if the average deta-dphistar is below the configured values"};
+  o2::framework::Configurable<bool> cutAnyRadius{"cutAnyRadius", false, "Apply CPR if the deta-dphistar is below the configured values at any radius"};
+  o2::framework::Configurable<bool> plotAllRadii{"plotAllRadii", true, "Plot deta-dphi distribution at all radii"};
   o2::framework::Configurable<bool> plotAverage{"plotAverage", true, "Plot average deta dphi distribution"};
   o2::framework::Configurable<float> detaMax{"detaMax", 0.01f, "Maximium deta"};
   o2::framework::Configurable<float> dphistarMax{"dphistarMax", 0.01f, "Maximum dphistar"};
-  o2::framework::ConfigurableAxis binningDeta{"binningDeta", {{500, -0.5, 0.5}}, "deta"};
-  o2::framework::ConfigurableAxis binningDphistar{"binningDphistar", {{500, -0.5, 0.5}}, "dphi"};
+  o2::framework::ConfigurableAxis binningDeta{"binningDeta", {{250, -0.5, 0.5}}, "deta"};
+  o2::framework::ConfigurableAxis binningDphistar{"binningDphistar", {{250, -0.5, 0.5}}, "dphi"};
 };
 
-struct ConfCprTrackV0 : o2::framework::ConfigurableGroup {
-  std::string prefix = std::string("ClosePairRejectionTrackV0");
-  o2::framework::Configurable<bool> onSameCharge{"onSameCharge", true, "Turn on CPR for track and same charge daughter"};
-  o2::framework::Configurable<bool> onOppositeCharge{"onOppositeCharge", false, "Turn on CPR for track and opposite charge daughter"};
-  o2::framework::Configurable<bool> plotAllRadii{"plotAllRadii", false, "Plot deta-dphi distribution at all radii"};
-  o2::framework::Configurable<bool> plotAverage{"plotAverage", true, "Plot average deta dphi distribution"};
-  o2::framework::Configurable<float> detaMaxSameCharge{"detaMaxSameCharge", 0.01f, "Maximium deta between track and same charge daughter"};
-  o2::framework::Configurable<float> dphistarMaxSameCharge{"dphistarMaxSameCharge", 0.01f, "Maximium dphistar between track and same charge daughter"};
-  o2::framework::Configurable<float> detaMaxOppositeCharge{"detaMaxOppositeCharge", 0.01f, "Maximum deta between track and opposite charge daughter"};
-  o2::framework::Configurable<float> dphistarMaxOppositeCharge{"dphistarMaxOppositeCharge", 0.01f, "Maximum dphistar between track and opposite charge daughter"};
-  o2::framework::ConfigurableAxis binningDeta{"binningDeta", {{500, -0.5, 0.5}}, "deta"};
-  o2::framework::ConfigurableAxis binningDphistar{"binningDphistar", {{500, -0.5, 0.5}}, "dphi"};
-};
+constexpr const char PrefixCprTrackTrack[] = "CprTrackTrack";
+constexpr const char PrefixCprTrackV0Daughter[] = "CprTrackV0Daughter";
+constexpr const char PrefixCprTrackResonanceDaughter[] = "CprTrackResonanceDaughter";
+constexpr const char PrefixCprTrackKinkDaughter[] = "CprTrackKinkDaughter";
+constexpr const char PrefixCprV0DaughterV0DaughterPos[] = "CprV0DaughterV0DaughterPos";
+constexpr const char PrefixCprV0DaughterV0DaughterNeg[] = "CprV0DaughterV0DaughterNeg";
+constexpr const char PrefixCprTrackCascadeBachelor[] = "CprTrackCascadeBachelor";
 
-struct ConfCprV0V0 : o2::framework::ConfigurableGroup {
-  std::string prefix = std::string("ClosePairRejectionV0V0");
-  o2::framework::Configurable<bool> on{"on", true, "Turn on CPR"};
-  o2::framework::Configurable<bool> plotAllRadii{"plotAllRadii", false, "Plot deta-dphi distribution at all radii"};
-  o2::framework::Configurable<bool> plotAverage{"plotAverage", true, "Plot average deta dphi distribution"};
-  o2::framework::Configurable<float> detaMaxPosDau{"detaMaxPosDau", 0.01f, "Maximium deta between positive daughters"};
-  o2::framework::Configurable<float> dphistarMaxPosDau{"dphistarMaxPosDau", 0.01f, "Maximium dphistar between positive daughters"};
-  o2::framework::Configurable<float> detaMaxNegDau{"detaMaxNegDau", 0.01f, "Maximum deta between negative daughters"};
-  o2::framework::Configurable<float> dphistarMaxNegDau{"dphistarMaxNegDau", 0.01f, "Maximum dphistar between negative daughters"};
-  o2::framework::ConfigurableAxis binningDeta{"binningDeta", {{500, -0.5, 0.5}}, "deta"};
-  o2::framework::ConfigurableAxis binningDphistar{"binningDphistar", {{500, -0.5, 0.5}}, "dphi"};
-};
-
-struct ConfCprTrrackCascade : o2::framework::ConfigurableGroup {
-  std::string prefix = std::string("ClosePairRejectionTrackCascade");
-  o2::framework::Configurable<bool> onBachelor{"onBachelor", true, "Turn on CPR for track and bachelor"};
-  o2::framework::Configurable<bool> onSameCharge{"onSameCharge", false, "Turn on CPR for track and same charge V0 daughter"};
-  o2::framework::Configurable<bool> onOppositeCharge{"onOppositeCharge", false, "Turn on CPR for track and opposite charge V0 daughter"};
-  o2::framework::Configurable<bool> plotAllRadii{"plotAllRadii", false, "Plot deta-dphi distribution at all radii"};
-  o2::framework::Configurable<bool> plotAverage{"plotAverage", true, "Plot average deta dphi distribution"};
-  o2::framework::Configurable<float> detaMaxBachelor{"detaMaxBachelor", 0.01f, "Maximium deta between track and bachelor"};
-  o2::framework::Configurable<float> dphistarMaxBachelor{"dphistarMaxBachelor", 0.01f, "Maximium dphistar between track and bachelor"};
-  o2::framework::Configurable<float> detaMaxSameCharge{"detaMaxSameCharge", 0.01f, "Maximium deta between track and same charge daughter"};
-  o2::framework::Configurable<float> dphistarMaxSameCharge{"dphistarMaxSameCharge", 0.01f, "Maximium dphistar between track and same charge daughter"};
-  o2::framework::Configurable<float> detaMaxOppositeCharge{"detaMaxOppositeCharge", 0.01f, "Maximum deta between track and opposite charge daughter"};
-  o2::framework::Configurable<float> dphistarMaxOppositeCharge{"dphistarMaxOppositeCharge", 0.01f, "Maximum dphistar between track and opposite charge daughter"};
-  o2::framework::ConfigurableAxis binningDeta{"binningDeta", {{500, -0.5, 0.5}}, "deta"};
-  o2::framework::ConfigurableAxis binningDphistar{"binningDphistar", {{500, -0.5, 0.5}}, "dphi"};
-  o2::framework::Configurable<bool> on{"on", true, "Turn on CPR"};
-};
+using ConfCprTrackTrack = ConfCpr<PrefixCprTrackTrack>;
+using ConfCprTrackV0Daughter = ConfCpr<PrefixCprTrackV0Daughter>;
+using ConfCprTrackResonanceDaughter = ConfCpr<PrefixCprTrackResonanceDaughter>;
+using ConfCprTrackKinkDaughter = ConfCpr<PrefixCprTrackKinkDaughter>;
+using ConfCprV0DaugherV0DaughterPos = ConfCpr<PrefixCprV0DaughterV0DaughterPos>;
+using ConfCprV0DaugherV0DaughterNeg = ConfCpr<PrefixCprV0DaughterV0DaughterNeg>;
+using ConfCprTrackCascadeBachelor = ConfCpr<PrefixCprTrackCascadeBachelor>;
 
 // tpc radii for computing phistar
 constexpr int Nradii = 9;
@@ -115,16 +90,14 @@ constexpr std::array<float, Nradii> TpcRadii = {85., 105., 125., 145., 165., 185
 // directory names
 constexpr char PrefixTrackTrackSe[] = "CPR_TrackTrack/SE/";
 constexpr char PrefixTrackTrackMe[] = "CPR_TrackTrack/ME/";
-constexpr char PrefixTrackV0SameChargeSe[] = "CPR_TrackV0DauSameCharge/SE/";
-constexpr char PrefixTrackV0SameChargeMe[] = "CPR_TrackV0DauSameCharge/ME/";
-constexpr char PrefixTrackV0OppositeChargeSe[] = "CPR_TrackV0DauOppositeCharge/SE/";
-constexpr char PrefixTrackV0OppositeChargeMe[] = "CPR_TrackV0DauOppositeCharge/ME/";
+constexpr char PrefixTrackV0DaughterSe[] = "CPR_TrackV0Dau/SE/";
+constexpr char PrefixTrackV0DaughterMe[] = "CPR_TrackV0Dau/ME/";
 constexpr char PrefixV0V0PosSe[] = "CPR_V0V0_PosDau/SE/";
 constexpr char PrefixV0V0NegSe[] = "CPR_V0V0_NegDau/SE/";
 constexpr char PrefixV0V0PosMe[] = "CPR_V0V0_PosDau/ME/";
 constexpr char PrefixV0V0NegMe[] = "CPR_V0V0_NegDau/ME/";
-constexpr char PrefixTrackTwoTrackResonanceSe[] = "CPR_TrackResonanceDaughter/SE/";
-constexpr char PrefixTrackTwoTrackResonnaceMe[] = "CPR_TrackResonanceDaughter/ME/";
+constexpr char PrefixTrackTwoTrackResonanceSe[] = "CPR_TrackResonanceDau/SE/";
+constexpr char PrefixTrackTwoTrackResonanceMe[] = "CPR_TrackResonanceDau/ME/";
 constexpr char PrefixTrackCascadeBachelorSe[] = "CPR_TrackCascadeBachelor/SE/";
 constexpr char PrefixTrackCascadeBachelorMe[] = "CPR_TrackCascadeBachelor/ME/";
 constexpr char PrefixTrackKinkSe[] = "CPR_TrackKink/SE/";
@@ -171,6 +144,8 @@ class CloseTrackRejection
             std::map<CprHist, std::vector<o2::framework::AxisSpec>> const& specs,
             bool plotAverage,
             bool plotAllRadii,
+            bool cutOnAverage,
+            bool cutOnAnyRadius,
             float detaMax,
             float dphistarMax,
             int chargeAbsTrack1,
@@ -181,19 +156,22 @@ class CloseTrackRejection
 
     // check the limits
     if (mDetaMax <= 0 || mDphistarMax <= 0) {
-      LOG(warn) << "Close Pair Rejection configured with 0 or negative limits. Histograms will be filled, but no CPR cut will be applied!";
-      mPlotOnly = true;
-    } else {
-      mPlotOnly = false;
+      LOG(fatal) << "Limits for Close Pair Rejection are invalid (0 or negative). Breaking...";
     }
 
-    mChargeAbsTrack1 = chargeAbsTrack1;
-    mChargeAbsTrack2 = chargeAbsTrack2;
+    mChargeAbsTrack1 = std::abs(chargeAbsTrack1);
+    mChargeAbsTrack2 = std::abs(chargeAbsTrack2);
 
-    mHistogramRegistry = registry;
+    mCutOnAverage = cutOnAverage;
+    mCutOnAnyRadius = cutOnAnyRadius;
 
     mPlotAverage = plotAverage;
     mPlotAllRadii = plotAllRadii;
+
+    // check if we need to apply any cut a plot is requested
+    mIsActivated = mCutOnAverage || mCutOnAnyRadius || mPlotAverage || mPlotAllRadii;
+
+    mHistogramRegistry = registry;
 
     if (mPlotAverage) {
       mHistogramRegistry->add(std::string(prefix) + getHistNameV2(kAverage, HistTable), getHistDesc(kAverage, HistTable), getHistType(kAverage, HistTable), {specs.at(kAverage)});
@@ -216,26 +194,36 @@ class CloseTrackRejection
   template <typename T1, typename T2>
   void compute(T1 const& track1, T2 const& track2)
   {
+    if (!mIsActivated) {
+      return;
+    }
     // reset values
     mAverageDphistar = 0.f;
+    int count = 0;
     mDeta = 0.f;
     mDphistar.fill(0.f);
+    mDphistarMask.fill(false);
 
     mDeta = track1.eta() - track2.eta();
+
     for (size_t i = 0; i < TpcRadii.size(); i++) {
       auto phistar1 = utils::dphistar(mMagField, TpcRadii[i], mChargeAbsTrack1 * track1.signedPt(), track1.phi());
       auto phistar2 = utils::dphistar(mMagField, TpcRadii[i], mChargeAbsTrack2 * track2.signedPt(), track2.phi());
       if (phistar1 && phistar2) {
-        // if the calculation for one phistar fails, keep the default value, which is 0
-        // this makes it more likelier for the pair to be rejected sind the averave will be biased towards lower values
-        mDphistar.at(i) = phistar1.value() - phistar2.value();
+        mDphistar.at(i) = RecoDecay::constrainAngle(phistar1.value() - phistar2.value(), -o2::constants::math::PI); // const angle difference between -pi and pi
+        mDphistarMask.at(i) = true;
+        count++;
       }
     }
-    mAverageDphistar = std::accumulate(mDphistar.begin(), mDphistar.end(), 0.f) / mDphistar.size();
+    // for small momemeta the calculation of phistar might fail, if the particle did not reach a certain radius
+    mAverageDphistar = std::accumulate(mDphistar.begin(), mDphistar.end(), 0.f) / count; // only average values if phistar could be computed
   }
 
   void fill()
   {
+    if (!mIsActivated) {
+      return;
+    }
     // fill average hist
     if (mPlotAverage) {
       mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kAverage, HistTable)), mDeta, mAverageDphistar);
@@ -243,27 +231,72 @@ class CloseTrackRejection
 
     // fill radii hists
     if (mPlotAllRadii) {
-      mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius0, HistTable)), mDeta, mDphistar.at(0));
-      mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius1, HistTable)), mDeta, mDphistar.at(1));
-      mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius2, HistTable)), mDeta, mDphistar.at(2));
-      mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius3, HistTable)), mDeta, mDphistar.at(3));
-      mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius4, HistTable)), mDeta, mDphistar.at(4));
-      mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius5, HistTable)), mDeta, mDphistar.at(5));
-      mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius6, HistTable)), mDeta, mDphistar.at(6));
-      mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius7, HistTable)), mDeta, mDphistar.at(7));
-      mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius8, HistTable)), mDeta, mDphistar.at(8));
+      if (mDphistarMask.at(0)) {
+        mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius0, HistTable)), mDeta, mDphistar.at(0));
+      }
+      if (mDphistarMask.at(1)) {
+        mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius1, HistTable)), mDeta, mDphistar.at(1));
+      }
+      if (mDphistarMask.at(2)) {
+        mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius2, HistTable)), mDeta, mDphistar.at(2));
+      }
+      if (mDphistarMask.at(3)) {
+        mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius3, HistTable)), mDeta, mDphistar.at(3));
+      }
+      if (mDphistarMask.at(4)) {
+        mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius4, HistTable)), mDeta, mDphistar.at(4));
+      }
+      if (mDphistarMask.at(5)) {
+        mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius5, HistTable)), mDeta, mDphistar.at(5));
+      }
+      if (mDphistarMask.at(6)) {
+        mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius6, HistTable)), mDeta, mDphistar.at(6));
+      }
+      if (mDphistarMask.at(7)) {
+        mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius7, HistTable)), mDeta, mDphistar.at(7));
+      }
+      if (mDphistarMask.at(8)) {
+        mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius8, HistTable)), mDeta, mDphistar.at(8));
+      }
     }
   }
 
   bool isClosePair() const
   {
-    return !mPlotOnly && std::hypot(mAverageDphistar / mDphistarMax, mDeta / mDetaMax) < 1.f;
+    if (!mIsActivated) {
+      return false;
+    }
+    bool isCloseAverage = false;
+    bool isCloseAnyRadius = false;
+
+    if (mCutOnAverage) {
+      isCloseAverage = std::hypot(mAverageDphistar / mDphistarMax, mDeta / mDetaMax) < 1.f;
+    }
+
+    if (mCutOnAnyRadius) {
+      for (size_t i = 0; i < TpcRadii.size(); i++) {
+        if (isCloseAnyRadius) {
+          break;
+        }
+        if (mDphistarMask.at(i)) {
+          isCloseAnyRadius = std::hypot(mDphistar.at(i) / mDphistarMax, mDeta / mDetaMax) < 1.f;
+        }
+      }
+    }
+    return isCloseAverage || isCloseAnyRadius;
   }
+
+  bool isActivated() const { return mIsActivated; }
 
  private:
   o2::framework::HistogramRegistry* mHistogramRegistry = nullptr;
   bool mPlotAllRadii = false;
-  bool mPlotAverage = true;
+  bool mPlotAverage = false;
+
+  bool mCutOnAverage = false;
+  bool mCutOnAnyRadius = false;
+
+  bool mIsActivated = false;
 
   int mChargeAbsTrack1 = 0;
   int mChargeAbsTrack2 = 0;
@@ -274,8 +307,7 @@ class CloseTrackRejection
   float mAverageDphistar = 0.f;
   float mDeta = 0.f;
   std::array<float, Nradii> mDphistar = {0.f};
-
-  bool mPlotOnly = true;
+  std::array<bool, Nradii> mDphistarMask = {false};
 };
 
 template <const char* prefix>
@@ -289,10 +321,7 @@ class ClosePairRejectionTrackTrack
             int absChargeTrack1,
             int absChargeTrack2)
   {
-    mIsActivated = confCpr.on.value;
-    if (mIsActivated) {
-      mCtr.init(registry, specs, confCpr.plotAverage.value, confCpr.plotAllRadii.value, confCpr.detaMax.value, confCpr.dphistarMax.value, absChargeTrack1, absChargeTrack2);
-    }
+    mCtr.init(registry, specs, confCpr.plotAverage.value, confCpr.plotAllRadii.value, confCpr.cutAverage.value, confCpr.cutAnyRadius.value, confCpr.detaMax.value, confCpr.dphistarMax.value, absChargeTrack1, absChargeTrack2);
   }
 
   void setMagField(float magField) { mCtr.setMagField(magField); }
@@ -303,27 +332,24 @@ class ClosePairRejectionTrackTrack
   }
   bool isClosePair() const { return mCtr.isClosePair(); }
   void fill() { mCtr.fill(); }
-  bool isActivated() const { return mIsActivated; }
 
  private:
   CloseTrackRejection<prefix> mCtr;
-  bool mIsActivated = true;
 };
 
 template <const char* prefixPosDaus, const char* prefixNegDaus>
 class ClosePairRejectionV0V0
 {
  public:
-  template <typename T>
+  template <typename T1, typename T2>
   void init(o2::framework::HistogramRegistry* registry,
-            std::map<CprHist, std::vector<o2::framework::AxisSpec>> const& specs,
-            T const& confCpr)
+            std::map<CprHist, std::vector<o2::framework::AxisSpec>> const& specsPos,
+            std::map<CprHist, std::vector<o2::framework::AxisSpec>> const& specsNeg,
+            T1 const& confCprPos,
+            T2 const& confCprNeg)
   {
-    mIsActivated = confCpr.on.value;
-    if (mIsActivated) {
-      mCtrPos.init(registry, specs, confCpr.plotAverage.value, confCpr.plotAllRadii.value, confCpr.detaMaxPosDau.value, confCpr.dphistarMaxPosDau.value, 1, 1);
-      mCtrNeg.init(registry, specs, confCpr.plotAverage.value, confCpr.plotAllRadii.value, confCpr.detaMaxNegDau.value, confCpr.dphistarMaxNegDau.value, 1, 1);
-    }
+    mCtrPos.init(registry, specsPos, confCprPos.plotAverage.value, confCprPos.plotAllRadii.value, confCprPos.cutAverage.value, confCprPos.cutAnyRadius.value, confCprPos.detaMax.value, confCprPos.dphistarMax.value, 1, 1);
+    mCtrNeg.init(registry, specsNeg, confCprNeg.plotAverage.value, confCprNeg.plotAllRadii.value, confCprNeg.cutAverage.value, confCprNeg.cutAnyRadius.value, confCprNeg.detaMax.value, confCprNeg.dphistarMax.value, 1, 1);
   }
 
   void setMagField(float magField)
@@ -331,20 +357,20 @@ class ClosePairRejectionV0V0
     mCtrPos.setMagField(magField);
     mCtrNeg.setMagField(magField);
   }
+
   template <typename T1, typename T2, typename T3>
   void setPair(T1 const& v01, T2 const& v02, T3 const& tracks)
   {
     auto posDau1 = tracks.rawIteratorAt(v01.posDauId() - tracks.offset());
-    auto negDau1 = tracks.rawIteratorAt(v01.negDauId() - tracks.offset());
-
     auto posDau2 = tracks.rawIteratorAt(v02.posDauId() - tracks.offset());
-    auto negDau2 = tracks.rawIteratorAt(v02.negDauId() - tracks.offset());
-
     mCtrPos.compute(posDau1, posDau2);
+
+    auto negDau1 = tracks.rawIteratorAt(v01.negDauId() - tracks.offset());
+    auto negDau2 = tracks.rawIteratorAt(v02.negDauId() - tracks.offset());
     mCtrNeg.compute(negDau1, negDau2);
   }
 
-  bool isClosePair() const { return mCtrPos.isClosePair() && mCtrNeg.isClosePair(); }
+  bool isClosePair() const { return mCtrPos.isClosePair() || mCtrNeg.isClosePair(); }
 
   void fill()
   {
@@ -352,15 +378,12 @@ class ClosePairRejectionV0V0
     mCtrNeg.fill();
   }
 
-  bool isActivated() const { return mIsActivated; }
-
  private:
   CloseTrackRejection<prefixPosDaus> mCtrPos;
   CloseTrackRejection<prefixNegDaus> mCtrNeg;
-  bool mIsActivated = true;
 };
 
-template <const char* prefixSameCharge, const char* prefixOppositeCharge>
+template <const char* prefixTrackV0>
 class ClosePairRejectionTrackV0 // can also be used for any particle type that has pos/neg daughters, like resonances
 {
  public:
@@ -370,176 +393,83 @@ class ClosePairRejectionTrackV0 // can also be used for any particle type that h
             T const& confCpr,
             int absChargeTrack)
   {
-    mIsActivatedSameCharge = confCpr.onSameCharge.value;
-    if (mIsActivatedSameCharge) {
-      mCtrSameCharge.init(registry, specs, confCpr.plotAverage.value, confCpr.plotAllRadii.value, confCpr.detaMaxSameCharge.value, confCpr.dphistarMaxSameCharge.value, absChargeTrack, 1);
-    }
-
-    mIsActivatedOppositeCharge = confCpr.onOppositeCharge.value;
-    if (mIsActivatedOppositeCharge) {
-      mCtrOppositeCharge.init(registry, specs, confCpr.plotAverage.value, confCpr.plotAllRadii.value, confCpr.detaMaxOppositeCharge.value, confCpr.dphistarMaxOppositeCharge.value, absChargeTrack, 1);
-    }
-
-    mIsActivated = mIsActivatedSameCharge || mIsActivatedOppositeCharge;
+    mCtr.init(registry, specs, confCpr.plotAverage.value, confCpr.plotAllRadii.value, confCpr.cutAverage.value, confCpr.cutAnyRadius.value, confCpr.detaMax.value, confCpr.dphistarMax.value, absChargeTrack, 1);
   }
 
-  void setMagField(float magField)
-  {
-    if (mIsActivatedSameCharge) {
-      mCtrSameCharge.setMagField(magField);
-    }
-    if (mIsActivatedOppositeCharge) {
-      mCtrOppositeCharge.setMagField(magField);
-    }
-  }
+  void setMagField(float magField) { mCtr.setMagField(magField); }
 
   template <typename T1, typename T2, typename T3>
   void setPair(T1 const& track, T2 const& v0, T3 const& trackTable)
   {
-    auto posDau = trackTable.rawIteratorAt(v0.posDauId() - trackTable.offset());
-    auto negDau = trackTable.rawIteratorAt(v0.negDauId() - trackTable.offset());
     if (track.sign() > 0) {
-      if (mIsActivatedSameCharge) {
-        mCtrSameCharge.compute(track, posDau);
-      }
-      if (mIsActivatedOppositeCharge) {
-        mCtrOppositeCharge.compute(track, negDau);
-      }
+      auto posDau = trackTable.rawIteratorAt(v0.posDauId() - trackTable.offset());
+      mCtr.compute(track, posDau);
     } else {
-      if (mIsActivatedSameCharge) {
-        mCtrSameCharge.compute(track, negDau);
-      }
-      if (mIsActivatedOppositeCharge) {
-        mCtrOppositeCharge.compute(track, posDau);
-      }
+      auto negDau = trackTable.rawIteratorAt(v0.negDauId() - trackTable.offset());
+      mCtr.compute(track, negDau);
     }
   }
 
-  bool isClosePair() const
-  {
-    bool cprSameCharge = mIsActivatedSameCharge && mCtrSameCharge.isClosePair();
-    bool cprOppositeCharrge = mIsActivatedOppositeCharge && mCtrOppositeCharge.isClosePair();
-    return cprSameCharge || cprOppositeCharrge;
-  }
+  bool isClosePair() const { return mCtr.isClosePair(); }
 
-  void fill()
-  {
-    if (mIsActivatedSameCharge) {
-      mCtrSameCharge.fill();
-    }
-    if (mIsActivatedOppositeCharge) {
-      mCtrOppositeCharge.fill();
-    }
-  }
-  bool isActivated() const { return mIsActivated; }
+  void fill() { mCtr.fill(); }
 
  private:
-  CloseTrackRejection<prefixSameCharge> mCtrSameCharge;
-  CloseTrackRejection<prefixOppositeCharge> mCtrOppositeCharge;
-  bool mIsActivated = true;
-  bool mIsActivatedSameCharge = true;
-  bool mIsActivatedOppositeCharge = false;
+  CloseTrackRejection<prefixTrackV0> mCtr;
 };
 
-template <const char* prefixBachelor, const char* prefixSameCharge, const char* prefixOppositeCharge>
+template <const char* prefixBachelor, const char* prefixV0Daughter>
 class ClosePairRejectionTrackCascade
 {
  public:
-  template <typename T>
+  template <typename T1, typename T2>
   void init(o2::framework::HistogramRegistry* registry,
-            std::map<CprHist, std::vector<o2::framework::AxisSpec>> const& specs,
-            T const& confCpr,
+            std::map<CprHist, std::vector<o2::framework::AxisSpec>> const& specsBachelor,
+            std::map<CprHist, std::vector<o2::framework::AxisSpec>> const& specsV0Daughter,
+            T1 const& confCprBachelor,
+            T2 const& confCprV0Daughter,
             int absChargeTrack)
   {
-    mIsActivatedBachelor = confCpr.onBachelor.value;
-    if (mIsActivatedBachelor) {
-      mCtrBachelor.init(registry, specs, confCpr.plotAverage.value, confCpr.plotAllRadii.value, confCpr.detaMaxBachelor.value, confCpr.dphistarMaxBachelor.value, absChargeTrack, 1);
-    }
-
-    mIsActivatedSameChargeV0Daughter = confCpr.onSameCharge.value;
-    if (mIsActivatedSameChargeV0Daughter) {
-      mCtrSameChargeV0Daughter.init(registry, specs, confCpr.plotAverage.value, confCpr.plotAllRadii.value, confCpr.detaMaxSameCharge.value, confCpr.dphistarMaxSameCharge.value, absChargeTrack, 1);
-    }
-
-    mIsActivatedOppositeChargeV0Daughter = confCpr.onOppositeCharge.value;
-    if (mIsActivatedOppositeChargeV0Daughter) {
-      mCtrOppositeChargeV0Daughter.init(registry, specs, confCpr.plotAverage.value, confCpr.plotAllRadii.value, confCpr.detaMaxOppositeCharge.value, confCpr.dphistarMaxOppositeCharge.value, absChargeTrack, 1);
-    }
-
-    mIsActivated = mIsActivatedBachelor || mIsActivatedSameChargeV0Daughter || mIsActivatedOppositeChargeV0Daughter;
+    mCtrBachelor.init(registry, specsBachelor, confCprBachelor.plotAverage.value, confCprBachelor.plotAllRadii.value, confCprBachelor.cutAverage.value, confCprBachelor.cutAnyRadius.value, confCprBachelor.detaMax.value, confCprBachelor.dphistarMax.value, absChargeTrack, 1);
+    mCtrV0Daughter.init(registry, specsV0Daughter, confCprV0Daughter.plotAverage.value, confCprV0Daughter.plotAllRadii.value, confCprV0Daughter.cutAverage.value, confCprV0Daughter.cutAnyRadius.value, confCprV0Daughter.detaMax.value, confCprV0Daughter.dphistarMax.value, absChargeTrack, 1);
   }
 
   void setMagField(float magField)
   {
-    if (mIsActivatedBachelor) {
-      mCtrBachelor.setMagField(magField);
-    }
-    if (mIsActivatedSameChargeV0Daughter) {
-      mCtrSameChargeV0Daughter.setMagField(magField);
-    }
-    if (mIsActivatedOppositeChargeV0Daughter) {
-      mCtrOppositeChargeV0Daughter.setMagField(magField);
-    }
+    mCtrBachelor.setMagField(magField);
+    mCtrV0Daughter.setMagField(magField);
   }
+
   template <typename T1, typename T2, typename T3>
   void setPair(T1 const& track, T2 const& cascade, T3 const& trackTable)
   {
     auto bachelor = trackTable.rawIteratorAt(cascade.bachelorId() - trackTable.offset());
-    auto posDau = trackTable.rawIteratorAt(cascade.posDauId() - trackTable.offset());
-    auto negDau = trackTable.rawIteratorAt(cascade.negDauId() - trackTable.offset());
-
-    if (mIsActivatedBachelor) {
-      mCtrBachelor.compute(track, bachelor);
-    }
+    mCtrBachelor.compute(track, bachelor);
 
     if (track.sign() > 0) {
-      if (mIsActivatedSameChargeV0Daughter) {
-        mCtrSameChargeV0Daughter.compute(track, posDau);
-      }
-      if (mIsActivatedOppositeChargeV0Daughter) {
-        mCtrOppositeChargeV0Daughter.compute(track, negDau);
-      }
+      auto posDau = trackTable.rawIteratorAt(cascade.posDauId() - trackTable.offset());
+      mCtrV0Daughter.compute(track, posDau);
     } else {
-      if (mIsActivatedSameChargeV0Daughter) {
-        mCtrSameChargeV0Daughter.compute(track, negDau);
-      }
-      if (mIsActivatedOppositeChargeV0Daughter) {
-        mCtrOppositeChargeV0Daughter.compute(track, posDau);
-      }
+      auto negDau = trackTable.rawIteratorAt(cascade.negDauId() - trackTable.offset());
+      mCtrV0Daughter.compute(track, negDau);
     }
   }
 
-  bool isClosePair() const
+  bool
+    isClosePair() const
   {
-    bool cprBachelor = mIsActivatedBachelor && mCtrBachelor.isClosePair();
-    bool cprSameCharge = mIsActivatedSameChargeV0Daughter && mCtrSameChargeV0Daughter.isClosePair();
-    bool cprOppositeCharrge = mIsActivatedOppositeChargeV0Daughter && mCtrOppositeChargeV0Daughter.isClosePair();
-    return cprBachelor || cprSameCharge || cprOppositeCharrge;
+    return mCtrBachelor.isClosePair() || mCtrBachelor.isClosePair();
   }
 
   void fill()
   {
-    if (mIsActivatedBachelor) {
-      mCtrBachelor.fill();
-    }
-    if (mIsActivatedSameChargeV0Daughter) {
-      mCtrSameChargeV0Daughter.fill();
-    }
-    if (mIsActivatedOppositeChargeV0Daughter) {
-      mCtrOppositeChargeV0Daughter.fill();
-    }
+    mCtrBachelor.fill();
+    mCtrV0Daughter.fill();
   }
-
-  bool isActivated() const { return mIsActivated; }
 
  private:
   CloseTrackRejection<prefixBachelor> mCtrBachelor;
-  CloseTrackRejection<prefixSameCharge> mCtrSameChargeV0Daughter;
-  CloseTrackRejection<prefixOppositeCharge> mCtrOppositeChargeV0Daughter;
-  bool mIsActivated = true;
-  bool mIsActivatedBachelor = false;
-  bool mIsActivatedSameChargeV0Daughter = false;
-  bool mIsActivatedOppositeChargeV0Daughter = false;
+  CloseTrackRejection<prefixV0Daughter> mCtrV0Daughter;
 };
 
 template <const char* prefix>
@@ -552,10 +482,7 @@ class ClosePairRejectionTrackKink
             T const& confCpr,
             int absChargeTrack)
   {
-    mIsActivated = confCpr.on.value;
-    if (mIsActivated) {
-      mCtr.init(registry, specs, confCpr.plotAverage.value, confCpr.plotAllRadii.value, confCpr.detaMax.value, confCpr.dphistarMax.value, absChargeTrack, 1);
-    }
+    mCtr.init(registry, specs, confCpr.plotAverage.value, confCpr.plotAllRadii.value, confCpr.cutAverage.value, confCpr.cutAnyRadius.value, confCpr.detaMax.value, confCpr.dphistarMax.value, absChargeTrack, 1);
   }
 
   void setMagField(float magField)
@@ -571,15 +498,10 @@ class ClosePairRejectionTrackKink
   }
 
   bool isClosePair() const { return mCtr.isClosePair(); }
-  void fill()
-  {
-    mCtr.fill();
-  }
-  bool isActivated() const { return mIsActivated; }
+  void fill() { mCtr.fill(); }
 
  private:
   CloseTrackRejection<prefix> mCtr;
-  bool mIsActivated = true;
 };
 
 }; // namespace closepairrejection

--- a/PWGCF/Femto/Core/femtoUtils.h
+++ b/PWGCF/Femto/Core/femtoUtils.h
@@ -16,8 +16,11 @@
 #ifndef PWGCF_FEMTO_CORE_FEMTOUTILS_H_
 #define PWGCF_FEMTO_CORE_FEMTOUTILS_H_
 
+#include "RecoDecay.h"
+
 #include "Common/Core/TableHelper.h"
 
+#include "CommonConstants/MathConstants.h"
 #include "CommonConstants/PhysicsConstants.h"
 #include "Framework/InitContext.h"
 
@@ -172,8 +175,8 @@ float qn(T const& col)
 inline std::optional<float> dphistar(float magfield, float radius, float signedPt, float phi)
 {
   float arg = 0.3f * (0.1f * magfield) * (0.01 * radius) / (2.f * signedPt);
-  if (std::fabs(arg) < 1.f) {
-    return phi - std::asin(arg);
+  if (std::fabs(arg) <= 1.f) {
+    return RecoDecay::constrainAngle(phi - std::asin(arg));
   }
   return std::nullopt;
 }

--- a/PWGCF/Femto/Core/pairBuilder.h
+++ b/PWGCF/Femto/Core/pairBuilder.h
@@ -239,21 +239,25 @@ class PairV0V0Builder
             typename T10,
             typename T11,
             typename T12,
-            typename T13>
+            typename T13,
+            typename T14,
+            typename T15>
   void init(o2::framework::HistogramRegistry* registry,
             T1 const& confV0Selection1,
             T2 const& confV0Selection2,
-            T3 const& confCpr,
-            T4 const& confMixing,
-            T5 const& confPairBinning,
-            T6 const& confPairCuts,
-            std::map<T7, std::vector<framework::AxisSpec>>& colHistSpec,
-            std::map<T8, std::vector<framework::AxisSpec>>& V0HistSpec1,
-            std::map<T9, std::vector<framework::AxisSpec>>& V0HistSpec2,
-            std::map<T10, std::vector<framework::AxisSpec>>& PosDauHistSpec,
-            std::map<T11, std::vector<framework::AxisSpec>>& NegDauHistSpec,
-            std::map<T12, std::vector<framework::AxisSpec>>& pairHistSpec,
-            std::map<T13, std::vector<framework::AxisSpec>>& cprHistSpec)
+            T3 const& confCprPos,
+            T4 const& confCprNeg,
+            T5 const& confMixing,
+            T6 const& confPairBinning,
+            T7 const& confPairCuts,
+            std::map<T8, std::vector<framework::AxisSpec>> const& colHistSpec,
+            std::map<T9, std::vector<framework::AxisSpec>> const& V0HistSpec1,
+            std::map<T10, std::vector<framework::AxisSpec>> const& V0HistSpec2,
+            std::map<T11, std::vector<framework::AxisSpec>> const& PosDauHistSpec,
+            std::map<T12, std::vector<framework::AxisSpec>> const& NegDauHistSpec,
+            std::map<T13, std::vector<framework::AxisSpec>> const& pairHistSpec,
+            std::map<T14, std::vector<framework::AxisSpec>> const& cprHistSpecPos,
+            std::map<T15, std::vector<framework::AxisSpec>> const& cprHistSpecNeg)
   {
 
     // check if correlate the same tracks or not
@@ -268,22 +272,22 @@ class PairV0V0Builder
 
       mPairHistManagerSe.setMass(confV0Selection1.pdgCode.value, confV0Selection1.pdgCode.value);
       mPairHistManagerSe.setCharge(1, 1);
-      mCprSe.init(registry, cprHistSpec, confCpr);
+      mCprSe.init(registry, cprHistSpecPos, cprHistSpecNeg, confCprPos, confCprPos);
 
       mPairHistManagerMe.setMass(confV0Selection1.pdgCode.value, confV0Selection1.pdgCode.value);
       mPairHistManagerMe.setCharge(1, 1);
-      mCprMe.init(registry, cprHistSpec, confCpr);
+      mCprMe.init(registry, cprHistSpecPos, cprHistSpecNeg, confCprPos, confCprNeg);
     } else {
       mV0HistManager1.init(registry, V0HistSpec1, PosDauHistSpec, NegDauHistSpec);
       mV0HistManager2.init(registry, V0HistSpec2, PosDauHistSpec, NegDauHistSpec);
 
       mPairHistManagerSe.setMass(confV0Selection1.pdgCode.value, confV0Selection2.pdgCode.value);
       mPairHistManagerSe.setCharge(1, 1);
-      mCprSe.init(registry, cprHistSpec, confCpr);
+      mCprSe.init(registry, cprHistSpecPos, cprHistSpecNeg, confCprPos, confCprNeg);
 
       mPairHistManagerMe.setMass(confV0Selection1.pdgCode.value, confV0Selection2.pdgCode.value);
       mPairHistManagerMe.setCharge(1, 1);
-      mCprMe.init(registry, cprHistSpec, confCpr);
+      mCprMe.init(registry, cprHistSpecPos, cprHistSpecNeg, confCprPos, confCprNeg);
     }
 
     // setup mixing
@@ -384,10 +388,8 @@ template <
   const char* prefixNegDau,
   const char* prefixSe,
   const char* prefixMe,
-  const char* prefixCprSameChargeSe,
-  const char* prefixCprSameChargeMe,
-  const char* prefixCprOppositeChargeSe,
-  const char* prefixCprOppositeChargeMe,
+  const char* prefixCprSe,
+  const char* prefixCprMe,
   modes::Mode mode,
   modes::V0 v0Type>
 class PairTrackV0Builder
@@ -481,8 +483,8 @@ class PairTrackV0Builder
   v0histmanager::V0HistManager<prefixV0, prefixPosDau, prefixNegDau, mode, v0Type> mV0HistManager;
   pairhistmanager::PairHistManager<prefixSe, modes::Particle::kTrack, modes::Particle::kV0, mode> mPairHistManagerSe;
   pairhistmanager::PairHistManager<prefixMe, modes::Particle::kTrack, modes::Particle::kV0, mode> mPairHistManagerMe;
-  closepairrejection::ClosePairRejectionTrackV0<prefixCprSameChargeSe, prefixCprOppositeChargeSe> mCprSe;
-  closepairrejection::ClosePairRejectionTrackV0<prefixCprSameChargeMe, prefixCprOppositeChargeMe> mCprMe;
+  closepairrejection::ClosePairRejectionTrackV0<prefixCprSe> mCprSe;
+  closepairrejection::ClosePairRejectionTrackV0<prefixCprMe> mCprMe;
   paircleaner::TrackV0PairCleaner mPc;
   pairhistmanager::MixingPolicy mMixingPolicy = pairhistmanager::MixingPolicy::kVtxMult;
   int mMixingDepth = 5;
@@ -495,10 +497,8 @@ template <
   const char* prefixNegDau,
   const char* prefixSe,
   const char* prefixMe,
-  const char* prefixCprSameChargeSe,
-  const char* prefixCprSameChargeMe,
-  const char* prefixCprOppositeChargeSe,
-  const char* prefixCprOppositeChargeMe,
+  const char* prefixCprSe,
+  const char* prefixCprMe,
   modes::Mode mode,
   modes::TwoTrackResonance resonanceType>
 class PairTrackTwoTrackResonanceBuilder
@@ -592,9 +592,9 @@ class PairTrackTwoTrackResonanceBuilder
   twotrackresonancehistmanager::TwoTrackResonanceHistManager<prefixResonance, prefixPosDau, prefixNegDau, mode, resonanceType> mResonanceHistManager;
   pairhistmanager::PairHistManager<prefixSe, modes::Particle::kTrack, modes::Particle::kTwoTrackResonance, mode> mPairHistManagerSe;
   pairhistmanager::PairHistManager<prefixMe, modes::Particle::kTrack, modes::Particle::kTwoTrackResonance, mode> mPairHistManagerMe;
-  closepairrejection::ClosePairRejectionTrackV0<prefixCprSameChargeSe, prefixCprOppositeChargeSe> mCprSe; // cpr for twotrackresonances and v0 work the same way
-  closepairrejection::ClosePairRejectionTrackV0<prefixCprSameChargeMe, prefixCprOppositeChargeMe> mCprMe; // cpr for twotrackresonances and v0 work the same way
-  paircleaner::TrackV0PairCleaner mPc;                                                                    // pc for twotrackresonances and v0 work the same way
+  closepairrejection::ClosePairRejectionTrackV0<prefixCprSe> mCprSe; // cpr for twotrackresonances and v0 work the same way
+  closepairrejection::ClosePairRejectionTrackV0<prefixCprMe> mCprMe; // cpr for twotrackresonances and v0 work the same way
+  paircleaner::TrackV0PairCleaner mPc;                               // pc for twotrackresonances and v0 work the same way
   pairhistmanager::MixingPolicy mMixingPolicy = pairhistmanager::MixingPolicy::kVtxMult;
   int mMixingDepth = 5;
 };
@@ -714,11 +714,9 @@ template <
   const char* prefixSe,
   const char* prefixMe,
   const char* prefixCprBachelorSe,
-  const char* prefixCprSameChargeSe,
-  const char* prefixCprOppositeChargeSe,
+  const char* prefixCprV0DaughterSe,
   const char* prefixCprBachelorMe,
-  const char* prefixCprSameChargeMe,
-  const char* prefixCprOppositeChargeMe,
+  const char* prefixCprV0DaughterMe,
   modes::Mode mode,
   modes::Cascade cascadeType>
 class PairTrackCascadeBuilder
@@ -740,22 +738,26 @@ class PairTrackCascadeBuilder
             typename T11,
             typename T12,
             typename T13,
-            typename T14>
+            typename T14,
+            typename T15,
+            typename T16>
   void init(o2::framework::HistogramRegistry* registry,
             T1 const& confTrackSelection,
             T2 const& confCascadeSelection,
-            T3 const& confCpr,
-            T4 const& confMixing,
-            T5 const& confPairBinning,
-            T6 const& confPairCuts,
-            std::map<T7, std::vector<framework::AxisSpec>> const& colHistSpec,
-            std::map<T8, std::vector<framework::AxisSpec>> const& trackHistSpec,
-            std::map<T9, std::vector<framework::AxisSpec>> const& cascadeHistSpec,
-            std::map<T10, std::vector<framework::AxisSpec>> const& bachelorHistSpec,
-            std::map<T11, std::vector<framework::AxisSpec>> const& posDauHistSpec,
-            std::map<T12, std::vector<framework::AxisSpec>> const& negDauHistSpec,
-            std::map<T13, std::vector<framework::AxisSpec>> const& pairHistSpec,
-            std::map<T14, std::vector<framework::AxisSpec>> const& cprHistSpec)
+            T3 const& confCprBachelor,
+            T4 const& confCprV0Daughter,
+            T5 const& confMixing,
+            T6 const& confPairBinning,
+            T7 const& confPairCuts,
+            std::map<T8, std::vector<framework::AxisSpec>> const& colHistSpec,
+            std::map<T9, std::vector<framework::AxisSpec>> const& trackHistSpec,
+            std::map<T10, std::vector<framework::AxisSpec>> const& cascadeHistSpec,
+            std::map<T11, std::vector<framework::AxisSpec>> const& bachelorHistSpec,
+            std::map<T12, std::vector<framework::AxisSpec>> const& posDauHistSpec,
+            std::map<T13, std::vector<framework::AxisSpec>> const& negDauHistSpec,
+            std::map<T14, std::vector<framework::AxisSpec>> const& pairHistSpec,
+            std::map<T15, std::vector<framework::AxisSpec>> const& cprHistSpecBachelor,
+            std::map<T16, std::vector<framework::AxisSpec>> const& cprHistSpecV0Daughter)
   {
     mColHistManager.init(registry, colHistSpec);
 
@@ -765,12 +767,12 @@ class PairTrackCascadeBuilder
     mPairHistManagerSe.init(registry, pairHistSpec, confPairBinning, confPairCuts);
     mPairHistManagerSe.setMass(confTrackSelection.pdgCode.value, confCascadeSelection.pdgCode.value);
     mPairHistManagerSe.setCharge(confTrackSelection.chargeAbs.value, 1);
-    mCprSe.init(registry, cprHistSpec, confCpr, confTrackSelection.chargeAbs.value);
+    mCprSe.init(registry, cprHistSpecBachelor, cprHistSpecV0Daughter, confCprBachelor, confCprV0Daughter, confTrackSelection.chargeAbs.value);
 
     mPairHistManagerMe.init(registry, pairHistSpec, confPairBinning, confPairCuts);
     mPairHistManagerMe.setMass(confTrackSelection.pdgCode.value, confCascadeSelection.pdgCode.value);
     mPairHistManagerMe.setCharge(confTrackSelection.chargeAbs.value, 1);
-    mCprMe.init(registry, cprHistSpec, confCpr, confTrackSelection.chargeAbs.value);
+    mCprMe.init(registry, cprHistSpecBachelor, cprHistSpecV0Daughter, confCprBachelor, confCprV0Daughter, confTrackSelection.chargeAbs.value);
 
     // setup mixing
     mMixingPolicy = static_cast<pairhistmanager::MixingPolicy>(confMixing.policy.value);
@@ -814,8 +816,8 @@ class PairTrackCascadeBuilder
   cascadehistmanager::CascadeHistManager<prefixCascade, prefixBachelor, prefixPosDau, prefixNegDau, mode, cascadeType> mCascadeHistManager;
   pairhistmanager::PairHistManager<prefixSe, modes::Particle::kTrack, modes::Particle::kCascade, mode> mPairHistManagerSe;
   pairhistmanager::PairHistManager<prefixMe, modes::Particle::kTrack, modes::Particle::kCascade, mode> mPairHistManagerMe;
-  closepairrejection::ClosePairRejectionTrackCascade<prefixCprBachelorSe, prefixCprSameChargeSe, prefixCprOppositeChargeSe> mCprSe;
-  closepairrejection::ClosePairRejectionTrackCascade<prefixCprBachelorMe, prefixCprSameChargeMe, prefixCprOppositeChargeMe> mCprMe;
+  closepairrejection::ClosePairRejectionTrackCascade<prefixCprBachelorSe, prefixCprV0DaughterSe> mCprSe;
+  closepairrejection::ClosePairRejectionTrackCascade<prefixCprBachelorMe, prefixCprV0DaughterMe> mCprMe;
   paircleaner::TrackCascadePairCleaner mPc;
   pairhistmanager::MixingPolicy mMixingPolicy = pairhistmanager::MixingPolicy::kVtxMult;
   int mMixingDepth = 5;

--- a/PWGCF/Femto/Core/pairCleaner.h
+++ b/PWGCF/Femto/Core/pairCleaner.h
@@ -51,12 +51,12 @@ class V0V0PairCleaner : public BasePairCleaner
  public:
   V0V0PairCleaner() = default;
   template <typename T1, typename T2, typename T3>
-  bool isCleanPair(const T1& v01, const T2& v02, const T3& /*tracks*/) const
+  bool isCleanPair(const T1& v01, const T2& v02, const T3& trackTable) const
   {
-    auto posDaughter1 = v01.template posDau_as<T3>();
-    auto negDaughter1 = v01.template negDau_as<T3>();
-    auto posDaughter2 = v02.template posDau_as<T3>();
-    auto negDaughter2 = v02.template negDau_as<T3>();
+    auto posDaughter1 = trackTable.rawIteratorAt(v01.posDauId() - trackTable.offset());
+    auto negDaughter1 = trackTable.rawIteratorAt(v01.negDauId() - trackTable.offset());
+    auto posDaughter2 = trackTable.rawIteratorAt(v02.posDauId() - trackTable.offset());
+    auto negDaughter2 = trackTable.rawIteratorAt(v02.negDauId() - trackTable.offset());
     return this->isCleanTrackPair(posDaughter1, posDaughter2) && this->isCleanTrackPair(negDaughter1, negDaughter2);
   }
 };
@@ -66,10 +66,10 @@ class TrackV0PairCleaner : public BasePairCleaner // also works for particles de
  public:
   TrackV0PairCleaner() = default;
   template <typename T1, typename T2, typename T3>
-  bool isCleanPair(const T1& track, const T2& v0, const T3& /*trackTable*/) const
+  bool isCleanPair(const T1& track, const T2& v0, const T3& trackTable) const
   {
-    auto posDaughter = v0.template posDau_as<T3>();
-    auto negDaughter = v0.template negDau_as<T3>();
+    auto posDaughter = trackTable.rawIteratorAt(v0.posDauId() - trackTable.offset());
+    auto negDaughter = trackTable.rawIteratorAt(v0.negDauId() - trackTable.offset());
     return (this->isCleanTrackPair(posDaughter, track) && this->isCleanTrackPair(negDaughter, track));
   }
 };
@@ -79,9 +79,9 @@ class TrackKinkPairCleaner : public BasePairCleaner
  public:
   TrackKinkPairCleaner() = default;
   template <typename T1, typename T2, typename T3>
-  bool isCleanPair(const T1& track, const T2& kink, const T3& /*trackTable*/) const
+  bool isCleanPair(const T1& track, const T2& kink, const T3& trackTable) const
   {
-    auto chaDaughter = kink.template chaDau_as<T3>();
+    auto chaDaughter = trackTable.rawIteratorAt(kink.chaDauId() - trackTable.offset());
     return this->isCleanTrackPair(chaDaughter, track);
   }
 };
@@ -91,11 +91,11 @@ class TrackCascadePairCleaner : public BasePairCleaner
  public:
   TrackCascadePairCleaner() = default;
   template <typename T1, typename T2, typename T3>
-  bool isCleanPair(const T1& track, const T2& cascade, const T3& /*trackTable*/) const
+  bool isCleanPair(const T1& track, const T2& cascade, const T3& trackTable) const
   {
-    auto bachelor = cascade.template bachelor_as<T3>();
-    auto posDaughter = cascade.template posDau_as<T3>();
-    auto negDaughter = cascade.template negDau_as<T3>();
+    auto bachelor = trackTable.rawIteratorAt(cascade.bachelorId() - trackTable.offset());
+    auto posDaughter = trackTable.rawIteratorAt(cascade.posDauId() - trackTable.offset());
+    auto negDaughter = trackTable.rawIteratorAt(cascade.posDauId() - trackTable.offset());
     return (this->isCleanTrackPair(bachelor, track) && this->isCleanTrackPair(posDaughter, track) && this->isCleanTrackPair(negDaughter, track));
   }
 };

--- a/PWGCF/Femto/Core/pairProcessHelpers.h
+++ b/PWGCF/Femto/Core/pairProcessHelpers.h
@@ -50,11 +50,9 @@ void processSameEvent(T1 const& SliceParticle,
   }
   std::uniform_real_distribution<float> dist(0.f, 1.f);
   for (auto const& [p1, p2] : o2::soa::combinations(o2::soa::CombinationsStrictlyUpperIndexPolicy(SliceParticle, SliceParticle))) {
-    if (CprManager.isActivated()) {
-      CprManager.setPair(p1, p2, TrackTable);
-      if (CprManager.isClosePair()) {
-        continue;
-      }
+    CprManager.setPair(p1, p2, TrackTable);
+    if (CprManager.isClosePair()) {
+      continue;
     }
     // Randomize pair order if enabled
     float threshold = 0.5f;
@@ -104,11 +102,9 @@ void processSameEvent(T1 const& SliceParticle1,
       continue;
     }
     // Close pair rejection
-    if (CprManager.isActivated()) {
-      CprManager.setPair(p1, p2, TrackTable);
-      if (CprManager.isClosePair()) {
-        continue;
-      }
+    CprManager.setPair(p1, p2, TrackTable);
+    if (CprManager.isClosePair()) {
+      continue;
     }
     PairHistManager.setPair(p1, p2, Collision);
     if (PairHistManager.checkPairCuts()) {
@@ -154,11 +150,9 @@ void processMixedEvent(T1& Collisions,
         continue;
       }
       // Close pair rejection
-      if (CprManager.isActivated()) {
-        CprManager.setPair(p1, p2, TrackTable);
-        if (CprManager.isClosePair()) {
-          continue;
-        }
+      CprManager.setPair(p1, p2, TrackTable);
+      if (CprManager.isClosePair()) {
+        continue;
       }
       PairHistManager.setPair(p1, p2, collision1, collision2);
       if (PairHistManager.checkPairCuts()) {
@@ -207,11 +201,9 @@ void processMixedEvent(T1& Collisions,
         continue;
       }
       // Close pair rejection
-      if (CprManager.isActivated()) {
-        CprManager.setPair(p1, p2, TrackTable);
-        if (CprManager.isClosePair()) {
-          continue;
-        }
+      CprManager.setPair(p1, p2, TrackTable);
+      if (CprManager.isClosePair()) {
+        continue;
       }
       PairHistManager.setPair(p1, p2, collision1, collision2);
       if (PairHistManager.checkPairCuts()) {

--- a/PWGCF/Femto/DataModel/FemtoTables.h
+++ b/PWGCF/Femto/DataModel/FemtoTables.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2025 CERN and copyright holders of ALICE O2.
+// Copyright 2019-2025 CERN and copyright holders of ALICE O.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/Femto/DataModel/FemtoTables.h
+++ b/PWGCF/Femto/DataModel/FemtoTables.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2025 CERN and copyright holders of ALICE O.
+// Copyright 2019-2025 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/Femto/Tasks/femtoPairTrackCascade.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackCascade.cxx
@@ -103,11 +103,9 @@ struct FemtoPairTrackCascade {
     pairhistmanager::PrefixTrackCascadeSe,
     pairhistmanager::PrefixTrackCascadeMe,
     closepairrejection::PrefixTrackCascadeBachelorSe,
-    closepairrejection::PrefixTrackV0SameChargeSe,
-    closepairrejection::PrefixTrackV0OppositeChargeSe,
+    closepairrejection::PrefixTrackV0DaughterSe,
     closepairrejection::PrefixTrackCascadeBachelorMe,
-    closepairrejection::PrefixTrackV0SameChargeMe,
-    closepairrejection::PrefixTrackV0OppositeChargeMe,
+    closepairrejection::PrefixTrackV0DaughterMe,
     modes::Mode::kAnalysis,
     modes::Cascade::kXi>
     pairTrackXiBuilder;
@@ -121,11 +119,9 @@ struct FemtoPairTrackCascade {
     pairhistmanager::PrefixTrackCascadeSe,
     pairhistmanager::PrefixTrackCascadeMe,
     closepairrejection::PrefixTrackCascadeBachelorSe,
-    closepairrejection::PrefixTrackV0SameChargeSe,
-    closepairrejection::PrefixTrackV0OppositeChargeSe,
+    closepairrejection::PrefixTrackV0DaughterSe,
     closepairrejection::PrefixTrackCascadeBachelorMe,
-    closepairrejection::PrefixTrackV0SameChargeMe,
-    closepairrejection::PrefixTrackV0OppositeChargeMe,
+    closepairrejection::PrefixTrackV0DaughterMe,
     modes::Mode::kAnalysis,
     modes::Cascade::kOmega>
     pairTrackOmegaBuilder;
@@ -142,7 +138,8 @@ struct FemtoPairTrackCascade {
   HistogramRegistry hRegistry{"FemtoTrackCascade", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   // setup cpr
-  closepairrejection::ConfCprTrrackCascade confCpr;
+  closepairrejection::ConfCprTrackCascadeBachelor confCprBachelor;
+  closepairrejection::ConfCprTrackV0Daughter confCprV0Daughter;
 
   void init(InitContext&)
   {
@@ -160,20 +157,21 @@ struct FemtoPairTrackCascade {
     auto posDauSpec = trackhistmanager::makeTrackHistSpecMap(confPosDauBinning);
     auto negDauSpec = trackhistmanager::makeTrackHistSpecMap(confNegDauBinning);
     auto pairHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning);
-    auto cprHistSpec = closepairrejection::makeCprHistSpecMap(confCpr);
+    auto cprHistSpecBachelor = closepairrejection::makeCprHistSpecMap(confCprBachelor);
+    auto cprHistSpecV0Daughter = closepairrejection::makeCprHistSpecMap(confCprV0Daughter);
 
     // setup for xis
     if (doprocessXiSameEvent || doprocessXiMixedEvent) {
       auto xiHistSpec = cascadehistmanager::makeCascadeHistSpecMap(confXiBinning);
       auto pairTrackXiHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning);
-      pairTrackXiBuilder.init(&hRegistry, trackSelection, xiSelection, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, xiHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, pairTrackXiHistSpec, cprHistSpec);
+      pairTrackXiBuilder.init(&hRegistry, trackSelection, xiSelection, confCprBachelor, confCprV0Daughter, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, xiHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, pairTrackXiHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter);
     }
 
     // setup for omegas
     if (doprocessOmegaSameEvent || doprocessOmegaMixedEvent) {
       auto omegaHistSpec = cascadehistmanager::makeCascadeHistSpecMap(confOmegaBinning);
       auto pairTrackOmegaHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning);
-      pairTrackOmegaBuilder.init(&hRegistry, trackSelection, omegaSelection, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, omegaHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, pairTrackOmegaHistSpec, cprHistSpec);
+      pairTrackOmegaBuilder.init(&hRegistry, trackSelection, xiSelection, confCprBachelor, confCprV0Daughter, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, omegaHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, pairTrackOmegaHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter);
     }
 
     if (((doprocessXiSameEvent || doprocessXiMixedEvent) + (doprocessOmegaSameEvent || doprocessOmegaMixedEvent)) > 1) {

--- a/PWGCF/Femto/Tasks/femtoPairTrackKink.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackKink.cxx
@@ -110,7 +110,7 @@ struct FemtoPairTrackKink {
   HistogramRegistry hRegistry{"FemtoTrackKink", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   // setup cpr
-  closepairrejection::ConfCpr confCpr;
+  closepairrejection::ConfCprTrackKinkDaughter confCpr;
 
   void init(InitContext&)
   {

--- a/PWGCF/Femto/Tasks/femtoPairTrackTrack.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackTrack.cxx
@@ -78,7 +78,7 @@ struct FemtoPairTrackTrack {
   pairhistmanager::ConfPairBinning confPairBinning;
   pairhistmanager::ConfPairCuts confPairCuts;
 
-  closepairrejection::ConfCpr confCpr;
+  closepairrejection::ConfCprTrackTrack confCpr;
 
   pairbuilder::PairTrackTrackBuilder<
     trackhistmanager::PrefixTrack1,

--- a/PWGCF/Femto/Tasks/femtoPairTrackTwoTrackResonance.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackTwoTrackResonance.cxx
@@ -108,10 +108,8 @@ struct FemtoPairTrackTwoTrackResonance {
     trackhistmanager::PrefixResonanceNegDaughter,
     pairhistmanager::PrefixTrackResonanceSe,
     pairhistmanager::PrefixTrackResonanceMe,
-    closepairrejection::PrefixTrackV0SameChargeSe,
-    closepairrejection::PrefixTrackV0SameChargeMe,
-    closepairrejection::PrefixTrackV0OppositeChargeSe,
-    closepairrejection::PrefixTrackV0OppositeChargeMe,
+    closepairrejection::PrefixTrackTwoTrackResonanceSe,
+    closepairrejection::PrefixTrackTwoTrackResonanceMe,
     modes::Mode::kAnalysis,
     modes::TwoTrackResonance::kPhi>
     pairTrackPhiBuilder;
@@ -124,10 +122,8 @@ struct FemtoPairTrackTwoTrackResonance {
     trackhistmanager::PrefixResonanceNegDaughter,
     pairhistmanager::PrefixTrackResonanceSe,
     pairhistmanager::PrefixTrackResonanceMe,
-    closepairrejection::PrefixTrackV0SameChargeSe,
-    closepairrejection::PrefixTrackV0SameChargeMe,
-    closepairrejection::PrefixTrackV0OppositeChargeSe,
-    closepairrejection::PrefixTrackV0OppositeChargeMe,
+    closepairrejection::PrefixTrackTwoTrackResonanceSe,
+    closepairrejection::PrefixTrackTwoTrackResonanceMe,
     modes::Mode::kAnalysis,
     modes::TwoTrackResonance::kKstar0>
     pairTrackKstar0Builder;
@@ -140,10 +136,8 @@ struct FemtoPairTrackTwoTrackResonance {
     trackhistmanager::PrefixResonanceNegDaughter,
     pairhistmanager::PrefixTrackResonanceSe,
     pairhistmanager::PrefixTrackResonanceMe,
-    closepairrejection::PrefixTrackV0SameChargeSe,
-    closepairrejection::PrefixTrackV0SameChargeMe,
-    closepairrejection::PrefixTrackV0OppositeChargeSe,
-    closepairrejection::PrefixTrackV0OppositeChargeMe,
+    closepairrejection::PrefixTrackTwoTrackResonanceSe,
+    closepairrejection::PrefixTrackTwoTrackResonanceMe,
     modes::Mode::kAnalysis,
     modes::TwoTrackResonance::kRho0>
     pairTrackRho0Builder;
@@ -160,7 +154,7 @@ struct FemtoPairTrackTwoTrackResonance {
   HistogramRegistry hRegistry{"FemtoTrackTwoTrackResonance", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   // setup cpr
-  closepairrejection::ConfCprTrackV0 confCpr;
+  closepairrejection::ConfCprTrackResonanceDaughter confCpr;
 
   void init(InitContext&)
   {

--- a/PWGCF/Femto/Tasks/femtoPairTrackV0.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackV0.cxx
@@ -100,10 +100,8 @@ struct FemtoPairTrackV0 {
     trackhistmanager::PrefixV0NegDaughter1,
     pairhistmanager::PrefixTrackV0Se,
     pairhistmanager::PrefixTrackV0Me,
-    closepairrejection::PrefixTrackV0SameChargeSe,
-    closepairrejection::PrefixTrackV0SameChargeMe,
-    closepairrejection::PrefixTrackV0OppositeChargeSe,
-    closepairrejection::PrefixTrackV0OppositeChargeMe,
+    closepairrejection::PrefixTrackV0DaughterSe,
+    closepairrejection::PrefixTrackV0DaughterMe,
     modes::Mode::kAnalysis,
     modes::V0::kLambda>
     pairTrackLambdaBuilder;
@@ -115,10 +113,8 @@ struct FemtoPairTrackV0 {
     trackhistmanager::PrefixV0NegDaughter1,
     pairhistmanager::PrefixTrackV0Se,
     pairhistmanager::PrefixTrackV0Me,
-    closepairrejection::PrefixTrackV0SameChargeSe,
-    closepairrejection::PrefixTrackV0SameChargeMe,
-    closepairrejection::PrefixTrackV0OppositeChargeSe,
-    closepairrejection::PrefixTrackV0OppositeChargeMe,
+    closepairrejection::PrefixTrackV0DaughterSe,
+    closepairrejection::PrefixTrackV0DaughterMe,
     modes::Mode::kAnalysis,
     modes::V0::kK0short>
     pairTrackK0shortBuilder;
@@ -135,7 +131,7 @@ struct FemtoPairTrackV0 {
   HistogramRegistry hRegistry{"FemtoTrackV0", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   // setup cpr
-  closepairrejection::ConfCprTrackV0 confCpr;
+  closepairrejection::ConfCprTrackV0Daughter confCpr;
 
   void init(InitContext&)
   {

--- a/PWGCF/Femto/Tasks/femtoPairV0V0.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairV0V0.cxx
@@ -135,7 +135,8 @@ struct FemtoPairV0V0 {
   HistogramRegistry hRegistry{"FemtoTrackV0", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   // setup cpr
-  closepairrejection::ConfCprV0V0 confCpr;
+  closepairrejection::ConfCprV0DaugherV0DaughterPos confCprPos;
+  closepairrejection::ConfCprV0DaugherV0DaughterNeg confCprNeg;
 
   void init(InitContext&)
   {
@@ -150,20 +151,21 @@ struct FemtoPairV0V0 {
     auto colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
     auto posDauSpec = trackhistmanager::makeTrackHistSpecMap(confPosDauBinning);
     auto negDauSpec = trackhistmanager::makeTrackHistSpecMap(confNegDauBinning);
-    auto cprHistSpec = closepairrejection::makeCprHistSpecMap(confCpr);
+    auto cprHistSpecPos = closepairrejection::makeCprHistSpecMap(confCprPos);
+    auto cprHistSpecNeg = closepairrejection::makeCprHistSpecMap(confCprNeg);
 
     // setup for lambda
     if (doprocessLambdaLambdaSameEvent || doprocessLambdaLambdaMixedEvent) {
       auto lambdaHistSpec = v0histmanager::makeV0HistSpecMap(confLambdaBinning);
       auto pairLambdaLambdaHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning);
-      pairLambdaLambdaBuilder.init(&hRegistry, lambdaSelection, lambdaSelection, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec, lambdaHistSpec, posDauSpec, negDauSpec, pairLambdaLambdaHistSpec, cprHistSpec);
+      pairLambdaLambdaBuilder.init(&hRegistry, lambdaSelection, lambdaSelection, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec, lambdaHistSpec, posDauSpec, negDauSpec, pairLambdaLambdaHistSpec, cprHistSpecPos, cprHistSpecNeg);
     }
 
     // setup for k0short
     if (doprocessK0shortK0shortSameEvent || doprocessK0shortK0shortMixedEvent) {
       auto k0shortHistSpec = v0histmanager::makeV0HistSpecMap(confK0shortBinning);
       auto pairLambdaLambdaHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning);
-      pairLambdaLambdaBuilder.init(&hRegistry, k0shortSelection, k0shortSelection, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, k0shortHistSpec, k0shortHistSpec, posDauSpec, negDauSpec, pairLambdaLambdaHistSpec, cprHistSpec);
+      pairLambdaLambdaBuilder.init(&hRegistry, k0shortSelection, k0shortSelection, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, k0shortHistSpec, k0shortHistSpec, posDauSpec, negDauSpec, pairLambdaLambdaHistSpec, cprHistSpecPos, cprHistSpecNeg);
     }
 
     if (((doprocessLambdaLambdaSameEvent || doprocessLambdaLambdaMixedEvent) + (doprocessK0shortK0shortSameEvent || doprocessK0shortK0shortMixedEvent)) > 1) {


### PR DESCRIPTION
Fix close pair rejection such that edge cases are handled correctly, i.e. 
- all angles are now explicity constrained to 0 to 2pi and angle differences are constrained to -pi to pi
- if a track does not reach a radius at which the difference is computed, this values is not considered when applying CPR