### PR TITLE
[PWGCF] Super minor fix to comment

### DIFF
--- a/PWGCF/FemtoUniverse/DataModel/FemtoDerived.h
+++ b/PWGCF/FemtoUniverse/DataModel/FemtoDerived.h
@@ -165,7 +165,7 @@ namespace femtouniversecascparticle
 DECLARE_SOA_INDEX_COLUMN(FDParticle, fdParticle);
 DECLARE_SOA_COLUMN(DcaV0daughters, dcaV0daughters, float);     //! DCA between V0 daughters
 DECLARE_SOA_COLUMN(Cpav0, cpav0, float);                       //! V0 cos of pointing angle
-DECLARE_SOA_COLUMN(V0radius, v0radius, float);                 //! V0 transverse radius*/
+DECLARE_SOA_COLUMN(V0radius, v0radius, float);                 //! V0 transverse radius
 DECLARE_SOA_COLUMN(CpaCasc, cpaCasc, float);                   //! cascade cosinus of pointing angle
 DECLARE_SOA_COLUMN(Dcacascdaughters, dcacascdaughters, float); //! DCA between cascade daughters
 DECLARE_SOA_COLUMN(Cascradius, cascradius, float);             //! cascade transverse radius


### PR DESCRIPTION
Cleans up a spurious `*/` in a comment line (should be harmless!). 

For now, this is the easiest way to fix a problem in the automatically generated Data Model page in our analysis documentation [1]. A better fix is to adjust the set of python scripts that parse the code: this will be pursued in continuation, but the first priority is to have some version of the auto-generated doc page for the tutorial. 

[1] https://aliceo2group.github.io/analysis-framework/docs/datamodel/