### PR TITLE
[Common] zdcTaskLightIons: fix histo name compatibility

### DIFF
--- a/Common/TableProducer/zdcTaskLightIons.cxx
+++ b/Common/TableProducer/zdcTaskLightIons.cxx
@@ -208,7 +208,7 @@ struct ZdcTaskLightIons {
           }
         }
         if (isZNChit && isZNAhit) {
-          registry.get<TH1>(HIST("debunchHist"))->Fill(zna - znc, zna + znc);
+          registry.get<TH1>(HIST("zdcDebunchHist"))->Fill(zna - znc, zna + znc);
         }
 
         zdcTableLI(tdcZNA, zna, pmcZNA, pmqZNA[0], pmqZNA[1], pmqZNA[2], pmqZNA[3],
@@ -311,7 +311,7 @@ struct ZdcTaskLightIons {
           }
         }
         if (isZNChit && isZNAhit) {
-          registry.get<TH1>(HIST("debunchHist"))->Fill(zna - znc, zna + znc);
+          registry.get<TH1>(HIST("zdcDebunchHist"))->Fill(zna - znc, zna + znc);
         }
 
         zdcTableLI(tdcZNA, zna, pmcZNA, pmqZNA[0], pmqZNA[1], pmqZNA[2], pmqZNA[3],


### PR DESCRIPTION
@coppedis there were two small typos in histo names (which crash at runtime, not at compile time) - this should fix it :-)