### PR TITLE
[Infrastructure] Add mpuccio as codeowner for MM (legacy)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -56,10 +56,10 @@
 /PWGLF/Utils @alibuild @sustripathy @skundu692 @mpuccio @gbencedi @abmodak @fmazzasc @maciacco @dmallick2 @smaff92 @ercolessi @romainschotter
 
 # PWG-MM (fused with LF, LF conveners included. Directories to be merged in the future)
-/PWGMM      @alibuild @sustripathy @skundu692 @aalkin @jgcn
-/PWGMM/Mult @alibuild @sustripathy @skundu692 @aalkin @aortizve @ddobrigk @gbencedi @jgcn
-/PWGMM/Lumi @alibuild @sustripathy @skundu692 @aalkin @jgcn @gbencedi @abmodak
-/PWGMM/UE   @alibuild @sustripathy @skundu692 @aalkin @aortizve @jgcn
+/PWGMM      @alibuild @mpuccio @skundu692 @aalkin @jgcn
+/PWGMM/Mult @alibuild @mpuccio @skundu692 @aalkin @aortizve @ddobrigk @gbencedi @jgcn
+/PWGMM/Lumi @alibuild @mpuccio @skundu692 @aalkin @jgcn @gbencedi @abmodak
+/PWGMM/UE   @alibuild @mpuccio @skundu692 @aalkin @aortizve @jgcn
 
 /PWGUD @alibuild @amatyja @rolavick
 /PWGJE @alibuild @lhavener @maoyx @nzardosh @fjonasALICE @mfasDa @mhemmer-cern


### PR DESCRIPTION
@mpuccio: sorry, when I touched codeowners previously, I missed granting you also MM codeownership (for legacy MM activities). This should fix that once merged.