### PR TITLE
[Common] Add run number column to ZDC extra table

### DIFF
--- a/Common/DataModel/ZDCExtra.h
+++ b/Common/DataModel/ZDCExtra.h
@@ -46,6 +46,7 @@ DECLARE_SOA_COLUMN(Vx, vx, float);                         //! Vertex X
 DECLARE_SOA_COLUMN(Vy, vy, float);                         //! Vertex Y
 DECLARE_SOA_COLUMN(Vz, vz, float);                         //! Vertex Z
 DECLARE_SOA_COLUMN(Timestamp, timestamp, uint64_t);        //! Timestamp
+DECLARE_SOA_COLUMN(RunNumber, runNumber, uint32_t);        //! Run Number
 DECLARE_SOA_COLUMN(SelectionBits, selectionBits, uint8_t); //! Selection Flags
 } // namespace zdcextra
 
@@ -71,6 +72,7 @@ DECLARE_SOA_TABLE(ZdcExtras, "AOD", "ZDCEXTRA", o2::soa::Index<>,
                   zdcextra::Vy,
                   zdcextra::Vz,
                   zdcextra::Timestamp,
+                  zdcextra::RunNumber,
                   zdcextra::SelectionBits);
 } // namespace o2::aod
 

--- a/Common/TableProducer/zdcExtraTableProducer.cxx
+++ b/Common/TableProducer/zdcExtraTableProducer.cxx
@@ -312,7 +312,7 @@ struct ZdcExtraTableProducer {
         auto vy = collision.posY();
 
         if (isZNAhit || isZNChit) {
-          zdcextras(pmcZNA, pmqZNA[0], pmqZNA[1], pmqZNA[2], pmqZNA[3], tdcZNA, centroidZNA[0], centroidZNA[1], pmcZNC, pmqZNC[0], pmqZNC[1], pmqZNC[2], pmqZNC[3], tdcZNC, centroidZNC[0], centroidZNC[1], centrality, vx, vy, vz, foundBC.timestamp(), evSelection);
+          zdcextras(pmcZNA, pmqZNA[0], pmqZNA[1], pmqZNA[2], pmqZNA[3], tdcZNA, centroidZNA[0], centroidZNA[1], pmcZNC, pmqZNC[0], pmqZNC[1], pmqZNC[2], pmqZNC[3], tdcZNC, centroidZNC[0], centroidZNC[1], centrality, vx, vy, vz, foundBC.timestamp(), foundBC.runNumber(), evSelection);
         }
       }
     }

--- a/Common/TableProducer/zdcExtraTableProducer.cxx
+++ b/Common/TableProducer/zdcExtraTableProducer.cxx
@@ -95,8 +95,8 @@ struct ZdcExtraTableProducer {
     registry.add("ZNAsumq", "ZNAsumq; ZNA uncalib. sum PMQ; Entries", {HistType::kTH1F, {{nBins, -0.5, maxZN}}});
     registry.add("ZNCsumq", "ZNCsumq; ZNC uncalib. sum PMQ; Entries", {HistType::kTH1F, {{nBins, -0.5, maxZN}}});
 
-    registry.add("ZNACentroid", "ZNACentroid; ZNA Centroid; X; Y", {HistType::kTH2F, {{50, -1.5, 1.5}, {50, -1.5, 1.5}}});
-    registry.add("ZNCCentroid", "ZNCCentroid; ZNC Centroid; X; Y", {HistType::kTH2F, {{50, -1.5, 1.5}, {50, -1.5, 1.5}}});
+    registry.add("ZNACentroid", "ZNA Centroid; X; Y", {HistType::kTH2F, {{50, -1.5, 1.5}, {50, -1.5, 1.5}}});
+    registry.add("ZNCCentroid", "ZNC Centroid; X; Y", {HistType::kTH2F, {{50, -1.5, 1.5}, {50, -1.5, 1.5}}});
 
     registry.add("hEventCount", "Number of Event; Cut; #Events Passed Cut", {HistType::kTH1D, {{nEventSelections, 0, nEventSelections}}});
     registry.get<TH1>(HIST("hEventCount"))->GetXaxis()->SetBinLabel(evSel_allEvents + 1, "All events");


### PR DESCRIPTION
The run number is required for the multi-step calibration of the Q-vectors calculated using ZDCs
