### PR TITLE
[PWGLF] StraTOF: Addition of hasTOF functionality, remove ITS requirement

### DIFF
--- a/PWGLF/DataModel/LFStrangenessPIDTables.h
+++ b/PWGLF/DataModel/LFStrangenessPIDTables.h
@@ -15,8 +15,8 @@
 //**********************************************************************
 
 //**********************************************************************
-// Nota bene: when using, do not check track.hasTOF! That conditional may not match 
-// the calculation of strangeness TOF, which requires e.g. a successful calculation 
+// Nota bene: when using, do not check track.hasTOF! That conditional may not match
+// the calculation of strangeness TOF, which requires e.g. a successful calculation
 // of the collision time for the reassociated collision
 //**********************************************************************
 
@@ -213,21 +213,21 @@ DECLARE_SOA_COLUMN(TOFNSigmaK0PiMinus, tofNSigmaK0PiMinus, float); //! negative 
 
 // dynamics to replace hasTOF (note: that condition does not match track hasTOF!)
 // note: only single hypothesis check necessary; other hypotheses will always be valid
-DECLARE_SOA_DYNAMIC_COLUMN(PositiveHasTOF, positiveHasTOF, //! positive daughter TOF calculation valid 
+DECLARE_SOA_DYNAMIC_COLUMN(PositiveHasTOF, positiveHasTOF, //! positive daughter TOF calculation valid
                            [](float TOFNSigmaLaPr) -> bool {
-                                bool returnStatus = true;
-                                if(std::abs(TOFNSigmaLaPr - kNoTOFValue) < kEpsilon){ 
-                                  returnStatus = false; 
-                                }
-                                return returnStatus;
+                             bool returnStatus = true;
+                             if (std::abs(TOFNSigmaLaPr - kNoTOFValue) < kEpsilon) {
+                               returnStatus = false;
+                             }
+                             return returnStatus;
                            });
-DECLARE_SOA_DYNAMIC_COLUMN(NegativeHasTOF, negativeHasTOF, //! negative daughter TOF calculation valid 
+DECLARE_SOA_DYNAMIC_COLUMN(NegativeHasTOF, negativeHasTOF, //! negative daughter TOF calculation valid
                            [](float TOFNSigmaALaPr) -> bool {
-                                bool returnStatus = true;
-                                if(std::abs(TOFNSigmaALaPr - kNoTOFValue) < kEpsilon){ 
-                                  returnStatus = false; 
-                                }
-                                return returnStatus;
+                             bool returnStatus = true;
+                             if (std::abs(TOFNSigmaALaPr - kNoTOFValue) < kEpsilon) {
+                               returnStatus = false;
+                             }
+                             return returnStatus;
                            });
 
 // dynamics based on n-sigmas with use-only-if-tof-present logic
@@ -356,31 +356,30 @@ DECLARE_SOA_COLUMN(TOFNSigmaOmKa, tofNSigmaOmKa, float);     //! bachelor track 
 
 // dynamics to replace hasTOF (note: that condition does not match track hasTOF!)
 // note: only single hypothesis check necessary; other hypotheses will always be valid
-DECLARE_SOA_DYNAMIC_COLUMN(PositiveHasTOF, positiveHasTOF, //! positive daughter TOF calculation valid 
+DECLARE_SOA_DYNAMIC_COLUMN(PositiveHasTOF, positiveHasTOF, //! positive daughter TOF calculation valid
                            [](float PosTOFDeltaTXiPr) -> bool {
-                                bool returnStatus = true;
-                                if(std::abs(PosTOFDeltaTXiPr - kNoTOFValue) < kEpsilon){ 
-                                  returnStatus = false; 
-                                }
-                                return returnStatus;
+                             bool returnStatus = true;
+                             if (std::abs(PosTOFDeltaTXiPr - kNoTOFValue) < kEpsilon) {
+                               returnStatus = false;
+                             }
+                             return returnStatus;
                            });
-DECLARE_SOA_DYNAMIC_COLUMN(NegativeHasTOF, negativeHasTOF, //! positive daughter TOF calculation valid 
+DECLARE_SOA_DYNAMIC_COLUMN(NegativeHasTOF, negativeHasTOF, //! positive daughter TOF calculation valid
                            [](float NegTOFDeltaTXiPr) -> bool {
-                                bool returnStatus = true;
-                                if(std::abs(NegTOFDeltaTXiPr - kNoTOFValue) < kEpsilon){ 
-                                  returnStatus = false; 
-                                }
-                                return returnStatus;
+                             bool returnStatus = true;
+                             if (std::abs(NegTOFDeltaTXiPr - kNoTOFValue) < kEpsilon) {
+                               returnStatus = false;
+                             }
+                             return returnStatus;
                            });
-DECLARE_SOA_DYNAMIC_COLUMN(BachelorHasTOF, bachelorHasTOF, //! bachelor daughter TOF calculation valid 
+DECLARE_SOA_DYNAMIC_COLUMN(BachelorHasTOF, bachelorHasTOF, //! bachelor daughter TOF calculation valid
                            [](float BachTOFDeltaTXiPi) -> bool {
-                                bool returnStatus = true;
-                                if(std::abs(BachTOFDeltaTXiPi - kNoTOFValue) < kEpsilon){ 
-                                  returnStatus = false; 
-                                }
-                                return returnStatus;
+                             bool returnStatus = true;
+                             if (std::abs(BachTOFDeltaTXiPi - kNoTOFValue) < kEpsilon) {
+                               returnStatus = false;
+                             }
+                             return returnStatus;
                            });
-                           
 
 // dynamics based on n-sigmas with use-only-if-tof-present logic
 DECLARE_SOA_DYNAMIC_COLUMN(TofXiCompatibility, tofXiCompatibility, //! compatibility with being lambda, checked only if TOF present. Argument: number of sigmas

--- a/PWGLF/TableProducer/Strangeness/strangenesstofpid.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangenesstofpid.cxx
@@ -823,7 +823,7 @@ struct strangenesstofpid {
           const o2::math_utils::Point3D<float> trackVertex{trackCollision.posX(), trackCollision.posY(), trackCollision.posZ()};
           o2::track::TrackLTIntegral ltIntegral;
           bool successPropag = o2::base::Propagator::Instance()->propagateToDCA(trackVertex, posTrack, d_bz, 2.f, o2::base::Propagator::MatCorrType::USEMatCorrNONE, nullptr, &ltIntegral);
-          if(doQA){
+          if (doQA) {
             histos.fill(HIST("hPropagationBookkeeping"), kPropagPosV0, static_cast<float>(successPropag));
           }
           if (successPropag) {
@@ -901,7 +901,7 @@ struct strangenesstofpid {
           const o2::math_utils::Point3D<float> trackVertex{trackCollision.posX(), trackCollision.posY(), trackCollision.posZ()};
           o2::track::TrackLTIntegral ltIntegral;
           bool successPropag = o2::base::Propagator::Instance()->propagateToDCA(trackVertex, negTrack, d_bz, 2.f, o2::base::Propagator::MatCorrType::USEMatCorrNONE, nullptr, &ltIntegral);
-          if(doQA){
+          if (doQA) {
             histos.fill(HIST("hPropagationBookkeeping"), kPropagNegV0, static_cast<float>(successPropag));
           }
           if (successPropag) {
@@ -1096,7 +1096,7 @@ struct strangenesstofpid {
           const o2::math_utils::Point3D<float> trackVertex{trackCollision.posX(), trackCollision.posY(), trackCollision.posZ()};
           o2::track::TrackLTIntegral ltIntegral;
           bool successPropag = o2::base::Propagator::Instance()->propagateToDCA(trackVertex, posTrack, d_bz, 2.f, o2::base::Propagator::MatCorrType::USEMatCorrNONE, nullptr, &ltIntegral);
-          if(doQA){
+          if (doQA) {
             histos.fill(HIST("hPropagationBookkeeping"), kPropagPosCasc, static_cast<float>(successPropag));
           }
           if (successPropag) {
@@ -1188,7 +1188,7 @@ struct strangenesstofpid {
           const o2::math_utils::Point3D<float> trackVertex{trackCollision.posX(), trackCollision.posY(), trackCollision.posZ()};
           o2::track::TrackLTIntegral ltIntegral;
           bool successPropag = o2::base::Propagator::Instance()->propagateToDCA(trackVertex, negTrack, d_bz, 2.f, o2::base::Propagator::MatCorrType::USEMatCorrNONE, nullptr, &ltIntegral);
-          if(doQA){
+          if (doQA) {
             histos.fill(HIST("hPropagationBookkeeping"), kPropagNegCasc, static_cast<float>(successPropag));
           }
           if (successPropag) {
@@ -1280,7 +1280,7 @@ struct strangenesstofpid {
           const o2::math_utils::Point3D<float> trackVertex{trackCollision.posX(), trackCollision.posY(), trackCollision.posZ()};
           o2::track::TrackLTIntegral ltIntegral;
           bool successPropag = o2::base::Propagator::Instance()->propagateToDCA(trackVertex, bachTrack, d_bz, 2.f, o2::base::Propagator::MatCorrType::USEMatCorrNONE, nullptr, &ltIntegral);
-          if(doQA){
+          if (doQA) {
             histos.fill(HIST("hPropagationBookkeeping"), kPropagBachCasc, static_cast<float>(successPropag));
           }
           if (successPropag) {


### PR DESCRIPTION
This PR: 
* adds getters for `hasTOF` functionality (`positiveHasTOF`, `negativeHasTOF`, `bachelorHasTOF`). These are necessary as a simple `track.hasTOF()` won't match the conditionals necessary for strangeness TOF (notably, reassociation requires that the collision time for the new collision be defined, which may not always be the case) 
* removes the `hasITS` requirement for daughter prongs for strangeness TOF calculation that was a leftover from development, which will result in assignment of strangeness TOF info also to TPCTRD and TPCTOF tracks. 
* Fixes a minor issue in which a histogram was filled without checking if `doQA` was enabled. This is necessary to ensure that, whenever `strangeness-tof-pid` is used solely to calculate Nsigmas, unnecessary histograms are not put in memory. 