### PR TITLE
[Common] Adding hCounterTVXZDC & hCounterTVXZDCafterBCcuts

### DIFF
--- a/Common/TableProducer/eventSelection.cxx
+++ b/Common/TableProducer/eventSelection.cxx
@@ -1201,10 +1201,12 @@ struct LumiTask {
     histos.add("hCounterTCE", "", kTH1D, {{1, 0., 1.}});
     histos.add("hCounterZEM", "", kTH1D, {{1, 0., 1.}});
     histos.add("hCounterZNC", "", kTH1D, {{1, 0., 1.}});
+    histos.add("hCounterTVXZDC", "", kTH1D, {{1, 0., 1.}});
     histos.add("hCounterTVXafterBCcuts", "", kTH1D, {{1, 0., 1.}});
     histos.add("hCounterTCEafterBCcuts", "", kTH1D, {{1, 0., 1.}});
     histos.add("hCounterZEMafterBCcuts", "", kTH1D, {{1, 0., 1.}});
     histos.add("hCounterZNCafterBCcuts", "", kTH1D, {{1, 0., 1.}});
+    histos.add("hCounterTVXZDCafterBCcuts", "", kTH1D, {{1, 0., 1.}});
     histos.add("hLumiTVX", ";;Luminosity, 1/#mub", kTH1D, {{1, 0., 1.}});
     histos.add("hLumiTCE", ";;Luminosity, 1/#mub", kTH1D, {{1, 0., 1.}});
     histos.add("hLumiZEM", ";;Luminosity, 1/#mub", kTH1D, {{1, 0., 1.}});
@@ -1428,9 +1430,15 @@ struct LumiTask {
       if (isTriggerTVX) {
         histos.get<TH1>(HIST("hCounterTVX"))->Fill(srun, 1);
         histos.get<TH1>(HIST("hLumiTVX"))->Fill(srun, lumiTVX);
+        if (isTriggerZNA && isTriggerZNC) {
+          histos.get<TH1>(HIST("hCounterTVXZDC"))->Fill(srun, 1);
+        }
         if (noBorder) {
           histos.get<TH1>(HIST("hCounterTVXafterBCcuts"))->Fill(srun, 1);
           histos.get<TH1>(HIST("hLumiTVXafterBCcuts"))->Fill(srun, lumiTVX);
+          if (isTriggerZNA && isTriggerZNC) {
+            histos.get<TH1>(HIST("hCounterTVXZDCafterBCcuts"))->Fill(srun, 1);
+          }
           for (size_t i = 0; i < mRCTFlagsCheckers.size(); i++) {
             if (mRCTFlagsCheckers[i](bc))
               histos.get<TH2>(HIST("hLumiTVXafterBCcutsRCT"))->Fill(srun, i, lumiTVX);

--- a/Common/Tools/EventSelectionModule.h
+++ b/Common/Tools/EventSelectionModule.h
@@ -1557,10 +1557,12 @@ class LumiModule
     histos.add("luminosity/hCounterTCE", "", framework::kTH1D, {{1, 0., 1.}});
     histos.add("luminosity/hCounterZEM", "", framework::kTH1D, {{1, 0., 1.}});
     histos.add("luminosity/hCounterZNC", "", framework::kTH1D, {{1, 0., 1.}});
+    histos.add("luminosity/hCounterTVXZDC", "", framework::kTH1D, {{1, 0., 1.}});
     histos.add("luminosity/hCounterTVXafterBCcuts", "", framework::kTH1D, {{1, 0., 1.}});
     histos.add("luminosity/hCounterTCEafterBCcuts", "", framework::kTH1D, {{1, 0., 1.}});
     histos.add("luminosity/hCounterZEMafterBCcuts", "", framework::kTH1D, {{1, 0., 1.}});
     histos.add("luminosity/hCounterZNCafterBCcuts", "", framework::kTH1D, {{1, 0., 1.}});
+    histos.add("luminosity/hCounterTVXZDCafterBCcuts", "", framework::kTH1D, {{1, 0., 1.}});
     histos.add("luminosity/hLumiTVX", ";;Luminosity, 1/#mub", framework::kTH1D, {{1, 0., 1.}});
     histos.add("luminosity/hLumiTCE", ";;Luminosity, 1/#mub", framework::kTH1D, {{1, 0., 1.}});
     histos.add("luminosity/hLumiZEM", ";;Luminosity, 1/#mub", framework::kTH1D, {{1, 0., 1.}});
@@ -1803,9 +1805,15 @@ class LumiModule
       if (isTriggerTVX) {
         histos.template get<TH1>(HIST("luminosity/hCounterTVX"))->Fill(srun, 1);
         histos.template get<TH1>(HIST("luminosity/hLumiTVX"))->Fill(srun, lumiTVX);
+        if (isTriggerZNA && isTriggerZNC) {
+          histos.template get<TH1>(HIST("luminosity/hCounterTVXZDC"))->Fill(srun, 1);
+        }
         if (noBorder) {
           histos.template get<TH1>(HIST("luminosity/hCounterTVXafterBCcuts"))->Fill(srun, 1);
           histos.template get<TH1>(HIST("luminosity/hLumiTVXafterBCcuts"))->Fill(srun, lumiTVX);
+          if (isTriggerZNA && isTriggerZNC) {
+            histos.template get<TH1>(HIST("luminosity/hCounterTVXZDCafterBCcuts"))->Fill(srun, 1);
+          }
           for (size_t i = 0; i < mRCTFlagsCheckers.size(); i++) {
             if ((rct & mRCTFlagsCheckers[i].value()) == 0)
               histos.template get<TH2>(HIST("luminosity/hLumiTVXafterBCcutsRCT"))->Fill(srun, i, lumiTVX);


### PR DESCRIPTION
Dear @altsybee @ekryshen this PR Adds hCounterTVXZDC & hCounterTVXZDCafterBCcuts. These histograms are filled with the AND of isTriggerTVX, isTriggerZNA, isTriggerZNC. This combination allows to count the number of MB events excluding EM contamination and it is needed for the normalization in RAA calculation.