### PR TITLE
[PWGLF] Add histogram for truth-tagged reco invariant mass distribution

### DIFF
--- a/PWGLF/Tasks/Resonances/chk892pp.cxx
+++ b/PWGLF/Tasks/Resonances/chk892pp.cxx
@@ -988,7 +988,7 @@ struct Chk892pp {
         }
       }
     }
-  } //effKstarProcessReco
+  } // effKstarProcessReco
 
   void fillSigLossNum(MCTrueTrackCandidates const& mcparts)
   {


### PR DESCRIPTION
Added histograms for truth-tagged reco and non-tagged reco invariant mass distributions.