### PR TITLE
[Common] Add protection for malformed ambiguous track table entries in AO2Ds

### DIFF
--- a/Common/Core/CollisionAssociation.h
+++ b/Common/Core/CollisionAssociation.h
@@ -200,7 +200,7 @@ class CollisionAssociation
       uint64_t collBC = collision.bc().globalBC();
 
       // This is done per block to allow optimization below. Within each block the globalBC increase continously
-      for (const auto& iterationWindow : trackIterationWindows) {
+      for (auto& iterationWindow : trackIterationWindows) { // o2-linter: disable=const-ref-in-for-loop (iterationWindow is modified)
         bool iteratorMoved = false;
         const bool isAssignedTrackWindow = (iterationWindow.first != iterationWindow.second) ? iterationWindow.first.has_collision() : false;
         for (auto trackInWindow = iterationWindow.first; trackInWindow != iterationWindow.second; ++trackInWindow) {


### PR DESCRIPTION
This PR adds a protection for buggy ambiguous track table entries (see https://mattermost.web.cern.ch/alice/pl/g9yaaf3tn3g4pgn7c1yex9copy for more details)