### PR TITLE
[Common] Fix memory leak

### DIFF
--- a/Common/Tasks/qaMuon.cxx
+++ b/Common/Tasks/qaMuon.cxx
@@ -244,7 +244,7 @@ struct muonQa {
   // Derived version of mch::Track class that handles the associated clusters as internal objects and deletes them in the destructor
   class TrackRealigned : public mch::Track
   {
-  public:
+   public:
     TrackRealigned() = default;
     ~TrackRealigned()
     {


### PR DESCRIPTION
Memory leak which seems to have a strong effect on memory usage and performance when multiple matching candidates are saved. Fixed by introducing TrackRealigned class that deletes in destructor of the class.