### PR TITLE
[PWGHF/D2H] addinng a THnSparse for signal loss correction

### DIFF
--- a/PWGHF/D2H/Tasks/taskDstarToD0Pi.cxx
+++ b/PWGHF/D2H/Tasks/taskDstarToD0Pi.cxx
@@ -254,6 +254,7 @@ struct HfTaskDstarToD0Pi {
     // Hists at Gen level usefull for efficiency calculation
     if (doprocessMcWoMl || doprocessMcWML) {
       if (isCentStudy) {
+        registry.add("SignalLoss/hPtVsCentVsPvContribGenWRecEve", "Pt Vs Cent Vs PvContrib", {HistType::kTHnSparseF, axesPtVsCentVsPvContrib}, true);
         registry.add("Efficiency/hPtVsCentVsPvContribGen", "Pt Vs Cent Vs PvContrib", {HistType::kTHnSparseF, axesPtVsCentVsPvContrib}, true);
         registry.add("Efficiency/hPtPromptVsCentVsPvContribGen", "Pt Vs Cent Vs PvContrib", {HistType::kTHnSparseF, axesPtVsCentVsPvContrib}, true);
         registry.add("Efficiency/hPtNonPromptVsCentVsPvContribGen", "Pt Vs Cent Vs PvContrib", {HistType::kTHnSparseF, axesPtVsCentVsPvContrib}, true);
@@ -672,6 +673,9 @@ struct HfTaskDstarToD0Pi {
 
         registry.fill(HIST("Efficiency/hPtVsYDstarGen"), ptGen, yGen, weightValue);
         if (isCentStudy) {
+          if (recCollisions.size() != 0) {
+            registry.fill(HIST("SignalLoss/hPtVsCentVsPvContribGenWRecEve"), ptGen, centFT0MGen, pvContributors, weightValue);
+          }
           registry.fill(HIST("Efficiency/hPtVsCentVsPvContribGen"), ptGen, centFT0MGen, pvContributors, weightValue);
         } else {
           registry.fill(HIST("Efficiency/hPtGen"), ptGen, weightValue);


### PR DESCRIPTION
Hi @fgrosa !

I am adding a extra THnSparse for the calculation of signal loss as per definition.

Signal Loss = {Λ+cgen associated to at least 1 rec. event (pT,T0M)}/{ Λ+cgen(pT,T0M)}

To get "Λ+cgen associated to at least 1 rec. event", I ensured that for current McParticle we have recCollisions.size() != 0.

Please let me know if I need some correction. Thanks.