### PR TITLE
[PWGCF] Update femto framework

### DIFF
--- a/PWGCF/Femto/Core/cascadeHistManager.h
+++ b/PWGCF/Femto/Core/cascadeHistManager.h
@@ -215,30 +215,30 @@ constexpr std::array<histmanager::HistInfo<CascadeHist>, kCascadeHistLast> HistT
 template <typename T>
 auto makeCascadeHistSpecMap(const T& confBinningAnalysis)
 {
-  return std::map<CascadeHist, std::vector<framework::AxisSpec>>{
+  return std::map<CascadeHist, std::vector<o2::framework::AxisSpec>>{
     CASCADE_HIST_ANALYSIS_MAP(confBinningAnalysis)};
 }
 
 template <typename T>
 auto makeCascadeMcHistSpecMap(const T& confBinningAnalysis)
 {
-  return std::map<CascadeHist, std::vector<framework::AxisSpec>>{
+  return std::map<CascadeHist, std::vector<o2::framework::AxisSpec>>{
     CASCADE_HIST_ANALYSIS_MAP(confBinningAnalysis)
       CASCADE_HIST_MC_MAP(confBinningAnalysis)};
 }
 
 template <typename T1, typename T2>
-std::map<CascadeHist, std::vector<framework::AxisSpec>> makeCascadeQaHistSpecMap(T1 const& confBinningAnalysis, T2 const& confBinningQa)
+std::map<CascadeHist, std::vector<o2::framework::AxisSpec>> makeCascadeQaHistSpecMap(T1 const& confBinningAnalysis, T2 const& confBinningQa)
 {
-  return std::map<CascadeHist, std::vector<framework::AxisSpec>>{
+  return std::map<CascadeHist, std::vector<o2::framework::AxisSpec>>{
     CASCADE_HIST_ANALYSIS_MAP(confBinningAnalysis)
       CASCADE_HIST_QA_MAP(confBinningAnalysis, confBinningQa)};
 }
 
 template <typename T1, typename T2>
-std::map<CascadeHist, std::vector<framework::AxisSpec>> makeCascadeMcQaHistSpecMap(T1 const& confBinningAnalysis, T2 const& confBinningQa)
+std::map<CascadeHist, std::vector<o2::framework::AxisSpec>> makeCascadeMcQaHistSpecMap(T1 const& confBinningAnalysis, T2 const& confBinningQa)
 {
-  return std::map<CascadeHist, std::vector<framework::AxisSpec>>{
+  return std::map<CascadeHist, std::vector<o2::framework::AxisSpec>>{
     CASCADE_HIST_ANALYSIS_MAP(confBinningAnalysis)
       CASCADE_HIST_QA_MAP(confBinningAnalysis, confBinningQa)
         CASCADE_HIST_MC_MAP(confBinningAnalysis)
@@ -494,7 +494,7 @@ class CascadeHistManager
     mHistogramRegistry->add(mcDir + getHistNameV2(kTruePhiVsPhi, HistTable), getHistDesc(kTruePhiVsPhi, HistTable), getHistType(kTruePhiVsPhi, HistTable), {V0Specs.at(kTruePhiVsPhi)});
 
     // mc origin can be configured here
-    const framework::AxisSpec axisOrigin = {static_cast<int>(modes::McOrigin::kMcOriginLast), -0.5, static_cast<double>(modes::McOrigin::kMcOriginLast) - 0.5};
+    const o2::framework::AxisSpec axisOrigin = {static_cast<int>(modes::McOrigin::kMcOriginLast), -0.5, static_cast<double>(modes::McOrigin::kMcOriginLast) - 0.5};
     mHistogramRegistry->add(mcDir + getHistNameV2(kOrigin, HistTable), getHistDesc(kOrigin, HistTable), getHistType(kOrigin, HistTable), {axisOrigin});
     mHistogramRegistry->get<TH1>(HIST(cascadePrefix) + HIST(McDir) + HIST(histmanager::getHistName(kOrigin, HistTable)))->GetXaxis()->SetBinLabel(1 + static_cast<int>(modes::McOrigin::kNoMcParticle), modes::mcOriginToString(modes::McOrigin::kNoMcParticle));
     mHistogramRegistry->get<TH1>(HIST(cascadePrefix) + HIST(McDir) + HIST(histmanager::getHistName(kOrigin, HistTable)))->GetXaxis()->SetBinLabel(1 + static_cast<int>(modes::McOrigin::kFromWrongCollision), modes::mcOriginToString(modes::McOrigin::kFromWrongCollision));

--- a/PWGCF/Femto/Core/closePairRejection.h
+++ b/PWGCF/Femto/Core/closePairRejection.h
@@ -18,7 +18,6 @@
 
 #include "RecoDecay.h"
 
-#include "PWGCF/Femto/Core/femtoUtils.h"
 #include "PWGCF/Femto/Core/histManager.h"
 
 #include "Framework/Configurable.h"

--- a/PWGCF/Femto/Core/closePairRejection.h
+++ b/PWGCF/Femto/Core/closePairRejection.h
@@ -124,7 +124,7 @@ constexpr std::array<histmanager::HistInfo<CprHist>, kCprHistogramLast> HistTabl
 template <typename T>
 auto makeCprHistSpecMap(const T& confCpr)
 {
-  return std::map<CprHist, std::vector<framework::AxisSpec>>{
+  return std::map<CprHist, std::vector<o2::framework::AxisSpec>>{
     {kAverage, {confCpr.binningDeta, confCpr.binningDphistar}},
     {kRadius0, {confCpr.binningDeta, confCpr.binningDphistar}},
     {kRadius1, {confCpr.binningDeta, confCpr.binningDphistar}},

--- a/PWGCF/Femto/Core/closeTripletRejection.h
+++ b/PWGCF/Femto/Core/closeTripletRejection.h
@@ -41,6 +41,11 @@ constexpr char PrefixTrack1Track2Me[] = "CPR_Track1Track2/ME/";
 constexpr char PrefixTrack2Track3Me[] = "CPR_Track2Track3/ME/";
 constexpr char PrefixTrack1Track3Me[] = "CPR_Track1Track3/ME/";
 
+constexpr char PrefixTrack1V0Se[] = "CPR_Track1V0/SE/";
+constexpr char PrefixTrack2V0Se[] = "CPR_Track2V0/SE/";
+constexpr char PrefixTrack1V0Me[] = "CPR_Track1V0/ME/";
+constexpr char PrefixTrack2V0Me[] = "CPR_Track2V0/ME/";
+
 template <const char* prefixTrack1Track2,
           const char* prefixTrack2Track3,
           const char* prefixTrack1Track3>
@@ -58,40 +63,92 @@ class CloseTripletRejectionTrackTrackTrack
             int absChargeTrack2,
             int absChargeTrack3)
   {
-    mCtr1.init(registry, specs, confCpr, absChargeTrack1, absChargeTrack2);
-    mCtr2.init(registry, specs, confCpr, absChargeTrack2, absChargeTrack3);
-    mCtr3.init(registry, specs, confCpr, absChargeTrack1, absChargeTrack3);
+    mCtrTrack12.init(registry, specs, confCpr, absChargeTrack1, absChargeTrack2);
+    mCtrTrack23.init(registry, specs, confCpr, absChargeTrack2, absChargeTrack3);
+    mCtrTrack13.init(registry, specs, confCpr, absChargeTrack1, absChargeTrack3);
   }
 
   void setMagField(float magField)
   {
-    mCtr1.setMagField(magField);
-    mCtr2.setMagField(magField);
-    mCtr3.setMagField(magField);
+    mCtrTrack12.setMagField(magField);
+    mCtrTrack23.setMagField(magField);
+    mCtrTrack13.setMagField(magField);
   }
   template <typename T1, typename T2, typename T3, typename T4>
-  void setTriplet(T1 const& track1, T2 const& track2, T3 const& track3, T4 const& /*tracks*/)
+  void setTriplet(T1 const& track1, T2 const& track2, T3 const& track3, T4 const& trackTable)
   {
-    mCtr1.compute(track1, track2);
-    mCtr2.compute(track2, track3);
-    mCtr3.compute(track1, track3);
+    mCtrTrack12.setPair(track1, track2, trackTable);
+    mCtrTrack23.setPair(track2, track3, trackTable);
+    mCtrTrack13.setPair(track1, track3, trackTable);
   }
   bool isCloseTriplet() const
   {
-    return mCtr1.isClosePair() || mCtr2.isClosePair() || mCtr3.isClosePair();
+    return mCtrTrack12.isClosePair() || mCtrTrack23.isClosePair() || mCtrTrack13.isClosePair();
   }
 
   void fill(float q3)
   {
-    mCtr1.fill(q3);
-    mCtr2.fill(q3);
-    mCtr3.fill(q3);
+    mCtrTrack12.fill(q3);
+    mCtrTrack23.fill(q3);
+    mCtrTrack13.fill(q3);
   }
 
  private:
-  closepairrejection::CloseTrackRejection<prefixTrack1Track2> mCtr1;
-  closepairrejection::CloseTrackRejection<prefixTrack2Track3> mCtr2;
-  closepairrejection::CloseTrackRejection<prefixTrack1Track3> mCtr3;
+  closepairrejection::ClosePairRejectionTrackTrack<prefixTrack1Track2> mCtrTrack12;
+  closepairrejection::ClosePairRejectionTrackTrack<prefixTrack2Track3> mCtrTrack23;
+  closepairrejection::ClosePairRejectionTrackTrack<prefixTrack1Track3> mCtrTrack13;
+};
+
+template <const char* prefixTrack1Track2,
+          const char* prefixTrack1V0,
+          const char* prefixTrack2V0>
+class CloseTripletRejectionTrackTrackV0
+{
+ public:
+  CloseTripletRejectionTrackTrackV0() = default;
+  ~CloseTripletRejectionTrackTrackV0() = default;
+
+  template <typename T>
+  void init(o2::framework::HistogramRegistry* registry,
+            std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> const& specs,
+            T const& confCpr,
+            int absChargeTrack1,
+            int absChargeTrack2)
+  {
+    mCtrTrack12.init(registry, specs, confCpr, absChargeTrack1, absChargeTrack2);
+    mCtrTrack1V0.init(registry, specs, confCpr, absChargeTrack1);
+    mCtrTrack2V0.init(registry, specs, confCpr, absChargeTrack2);
+  }
+
+  void setMagField(float magField)
+  {
+    mCtrTrack12.setMagField(magField);
+    mCtrTrack1V0.setMagField(magField);
+    mCtrTrack2V0.setMagField(magField);
+  }
+  template <typename T1, typename T2, typename T3, typename T4>
+  void setTriplet(T1 const& track1, T2 const& track2, T3 const& v0, T4 const& trackTable)
+  {
+    mCtrTrack12.setPair(track1, track2, trackTable);
+    mCtrTrack1V0.setPair(track1, v0, trackTable);
+    mCtrTrack2V0.setPair(track2, v0, trackTable);
+  }
+  bool isCloseTriplet() const
+  {
+    return mCtrTrack12.isClosePair() || mCtrTrack1V0.isClosePair() || mCtrTrack2V0.isClosePair();
+  }
+
+  void fill(float q3)
+  {
+    mCtrTrack12.fill(q3);
+    mCtrTrack1V0.fill(q3);
+    mCtrTrack2V0.fill(q3);
+  }
+
+ private:
+  closepairrejection::ClosePairRejectionTrackTrack<prefixTrack1Track2> mCtrTrack12;
+  closepairrejection::ClosePairRejectionTrackV0<prefixTrack1V0> mCtrTrack1V0;
+  closepairrejection::ClosePairRejectionTrackV0<prefixTrack2V0> mCtrTrack2V0;
 };
 
 }; // namespace closetripletrejection

--- a/PWGCF/Femto/Core/collisionHistManager.h
+++ b/PWGCF/Femto/Core/collisionHistManager.h
@@ -109,14 +109,14 @@ constexpr std::array<histmanager::HistInfo<ColHist>, kColHistLast> HistTable = {
 template <typename T>
 auto makeColHistSpecMap(const T& confBinningAnalysis)
 {
-  return std::map<ColHist, std::vector<framework::AxisSpec>>{
+  return std::map<ColHist, std::vector<o2::framework::AxisSpec>>{
     COL_HIST_ANALYSIS_MAP(confBinningAnalysis)};
 }
 
 template <typename T>
 auto makeColMcHistSpecMap(const T& confBinningAnalysis)
 {
-  return std::map<ColHist, std::vector<framework::AxisSpec>>{
+  return std::map<ColHist, std::vector<o2::framework::AxisSpec>>{
     COL_HIST_ANALYSIS_MAP(confBinningAnalysis)
       COL_HIST_MC_MAP(confBinningAnalysis)};
 }
@@ -124,7 +124,7 @@ auto makeColMcHistSpecMap(const T& confBinningAnalysis)
 template <typename T1, typename T2>
 auto makeColQaHistSpecMap(const T1& confBinningAnalysis, const T2& confBinningQa)
 {
-  return std::map<ColHist, std::vector<framework::AxisSpec>>{
+  return std::map<ColHist, std::vector<o2::framework::AxisSpec>>{
     COL_HIST_ANALYSIS_MAP(confBinningAnalysis)
       COL_HIST_QA_MAP(confBinningAnalysis, confBinningQa)};
 }
@@ -132,7 +132,7 @@ auto makeColQaHistSpecMap(const T1& confBinningAnalysis, const T2& confBinningQa
 template <typename T1, typename T2>
 auto makeColMcQaHistSpecMap(const T1& confBinningAnalysis, const T2& confBinningQa)
 {
-  return std::map<ColHist, std::vector<framework::AxisSpec>>{
+  return std::map<ColHist, std::vector<o2::framework::AxisSpec>>{
     COL_HIST_ANALYSIS_MAP(confBinningAnalysis)
       COL_HIST_QA_MAP(confBinningAnalysis, confBinningQa)
         COL_HIST_MC_MAP(confBinningAnalysis)};

--- a/PWGCF/Femto/Core/kinkHistManager.h
+++ b/PWGCF/Femto/Core/kinkHistManager.h
@@ -210,30 +210,30 @@ constexpr std::array<histmanager::HistInfo<KinkHist>, kKinkHistLast> HistTable =
 template <typename T>
 auto makeKinkHistSpecMap(const T& confBinningAnalysis)
 {
-  return std::map<KinkHist, std::vector<framework::AxisSpec>>{
+  return std::map<KinkHist, std::vector<o2::framework::AxisSpec>>{
     KINK_HIST_ANALYSIS_MAP(confBinningAnalysis)};
 }
 
 template <typename T>
 auto makeKinkMcHistSpecMap(const T& confBinningAnalysis)
 {
-  return std::map<KinkHist, std::vector<framework::AxisSpec>>{
+  return std::map<KinkHist, std::vector<o2::framework::AxisSpec>>{
     KINK_HIST_ANALYSIS_MAP(confBinningAnalysis)
       KINK_HIST_MC_MAP(confBinningAnalysis)};
 }
 
 template <typename T1, typename T2>
-std::map<KinkHist, std::vector<framework::AxisSpec>> makeKinkQaHistSpecMap(T1 const& confBinningAnalysis, T2 const& confBinningQa)
+std::map<KinkHist, std::vector<o2::framework::AxisSpec>> makeKinkQaHistSpecMap(T1 const& confBinningAnalysis, T2 const& confBinningQa)
 {
-  return std::map<KinkHist, std::vector<framework::AxisSpec>>{
+  return std::map<KinkHist, std::vector<o2::framework::AxisSpec>>{
     KINK_HIST_ANALYSIS_MAP(confBinningAnalysis)
       KINK_HIST_QA_MAP(confBinningAnalysis, confBinningQa)};
 }
 
 template <typename T1, typename T2>
-std::map<KinkHist, std::vector<framework::AxisSpec>> makeKinkMcQaHistSpecMap(T1 const& confBinningAnalysis, T2 const& confBinningQa)
+std::map<KinkHist, std::vector<o2::framework::AxisSpec>> makeKinkMcQaHistSpecMap(T1 const& confBinningAnalysis, T2 const& confBinningQa)
 {
-  return std::map<KinkHist, std::vector<framework::AxisSpec>>{
+  return std::map<KinkHist, std::vector<o2::framework::AxisSpec>>{
     KINK_HIST_ANALYSIS_MAP(confBinningAnalysis)
       KINK_HIST_QA_MAP(confBinningAnalysis, confBinningQa)
         KINK_HIST_MC_MAP(confBinningAnalysis)
@@ -450,7 +450,7 @@ class KinkHistManager
     mHistogramRegistry->add(mcDir + getHistNameV2(kTruePhi, HistTable), getHistDesc(kTruePhi, HistTable), getHistType(kTruePhi, HistTable), {KinkSpecs.at(kTruePhi)});
 
     // mc origin can be configured here
-    const framework::AxisSpec axisOrigin = {static_cast<int>(modes::McOrigin::kMcOriginLast), -0.5, static_cast<double>(modes::McOrigin::kMcOriginLast) - 0.5};
+    const o2::framework::AxisSpec axisOrigin = {static_cast<int>(modes::McOrigin::kMcOriginLast), -0.5, static_cast<double>(modes::McOrigin::kMcOriginLast) - 0.5};
     mHistogramRegistry->add(mcDir + getHistNameV2(kOrigin, HistTable), getHistDesc(kOrigin, HistTable), getHistType(kOrigin, HistTable), {axisOrigin});
     mHistogramRegistry->get<TH1>(HIST(kinkPrefix) + HIST(McDir) + HIST(histmanager::getHistName(kOrigin, HistTable)))->GetXaxis()->SetBinLabel(1 + static_cast<int>(modes::McOrigin::kNoMcParticle), modes::mcOriginToString(modes::McOrigin::kNoMcParticle));
     mHistogramRegistry->get<TH1>(HIST(kinkPrefix) + HIST(McDir) + HIST(histmanager::getHistName(kOrigin, HistTable)))->GetXaxis()->SetBinLabel(1 + static_cast<int>(modes::McOrigin::kFromWrongCollision), modes::mcOriginToString(modes::McOrigin::kFromWrongCollision));

--- a/PWGCF/Femto/Core/pairBuilder.h
+++ b/PWGCF/Femto/Core/pairBuilder.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2025 CERN and copyright holders of ALICE O2.pairb
+// Copyright 2019-2025 CERN and copyright holders of ALICE O2.
 // See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
 // All rights not expressly granted are reserved.
 //

--- a/PWGCF/Femto/Core/pairBuilder.h
+++ b/PWGCF/Femto/Core/pairBuilder.h
@@ -965,6 +965,19 @@ class PairTrackCascadeBuilder
     pairprocesshelpers::processSameEvent<mode>(trackSlice, v0Slice, trackTable, col, mTrackHistManager, mCascadeHistManager, mPairHistManagerSe, mCprSe, mPc);
   }
 
+  template <modes::Mode mode, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10>
+  void processSameEvent(T1 const& col, T2 const& mcCols, T3 const& trackTable, T4& trackPartition, T5 const& /*cascadeTabel*/, T6& cascadePartition, T7 const& mcParticles, T8 const& mcMothers, T9 const& mcPartonicMothers, T10& cache)
+  {
+    auto trackSlice = trackPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
+    auto cascadeSlice = cascadePartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
+    if (trackSlice.size() == 0 || cascadeSlice.size() == 0) {
+      return;
+    }
+    mColHistManager.template fill<mode>(col, mcCols);
+    mCprSe.setMagField(col.magField());
+    pairprocesshelpers::processSameEvent<mode>(trackSlice, cascadeSlice, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager, mCascadeHistManager, mPairHistManagerSe, mTrackCleaner, mCascadeCleaner, mCprSe, mPc);
+  }
+
   template <modes::Mode mode, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
   void processMixedEvent(T1 const& cols, T2& trackTable, T3& trackPartition, T4& v0Partition, T5& cache, T6& binsVtxMult, T7& binsVtxCent, T8& binsVtxMultCent)
   {
@@ -977,6 +990,24 @@ class PairTrackCascadeBuilder
         break;
       case static_cast<int>(pairhistmanager::kVtxMultCent):
         pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, v0Partition, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        break;
+      default:
+        LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
+    }
+  }
+
+  template <modes::Mode mode, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12>
+  void processMixedEvent(T1 const& cols, T2 const& mcCols, T3& trackTable, T4& trackPartition, T5& cascadePartition, T6 const& mcParticles, T7 const& mcMothers, T8 const& mcPartonicMothers, T9& cache, T10& binsVtxMult, T11& binsVtxCent, T12& binsVtxMultCent)
+  {
+    switch (mMixingPolicy) {
+      case static_cast<int>(pairhistmanager::kVtxMult):
+        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, cascadePartition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mCascadeCleaner, mCprMe, mPc);
+        break;
+      case static_cast<int>(pairhistmanager::kVtxCent):
+        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, cascadePartition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mCascadeCleaner, mCprMe, mPc);
+        break;
+      case static_cast<int>(pairhistmanager::kVtxMultCent):
+        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, cascadePartition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mCascadeCleaner, mCprMe, mPc);
         break;
       default:
         LOG(fatal) << "Invalid binning policiy specifed. Breaking...";

--- a/PWGCF/Femto/Core/pairCleaner.h
+++ b/PWGCF/Femto/Core/pairCleaner.h
@@ -94,9 +94,9 @@ class TrackTrackPairCleaner : public BasePairCleaner
   }
 
   template <typename T1, typename T2, typename T3, typename T4>
-  bool isCleanPair(T1 const& track1, T2 const& track2, T3 const& /*trackTable*/, T4 const& partonicMothers) const
+  bool isCleanPair(T1 const& track1, T2 const& track2, T3 const& trackTable, T4 const& partonicMothers) const
   {
-    if (!this->isCleanTrackPair(track1, track2)) {
+    if (!this->isCleanPair(track1, track2, trackTable)) {
       return false;
     }
     // pair is clean
@@ -123,6 +123,23 @@ class V0V0PairCleaner : public BasePairCleaner
     auto posDaughter2 = trackTable.rawIteratorAt(v02.posDauId() - trackTable.offset());
     auto negDaughter2 = trackTable.rawIteratorAt(v02.negDauId() - trackTable.offset());
     return this->isCleanTrackPair(posDaughter1, posDaughter2) && this->isCleanTrackPair(negDaughter1, negDaughter2);
+  }
+
+  template <typename T1, typename T2, typename T3, typename T4>
+  bool isCleanPair(T1 const& v01, T2 const& v02, T3 const& trackTable, T4 const& partonicMothers) const
+  {
+    if (!this->isCleanPair(v01, v02, trackTable)) {
+      return false;
+    }
+    // pair is clean
+    // no check if we require common or non-common ancestry
+    if (mMixPairsWithCommonAncestor) {
+      return this->pairHasCommonAncestor(v01, v02, partonicMothers);
+    }
+    if (mMixPairsWithNonCommonAncestor) {
+      return this->pairHasNonCommonAncestor(v01, v02, partonicMothers);
+    }
+    return true;
   }
 };
 

--- a/PWGCF/Femto/Core/pairCleaner.h
+++ b/PWGCF/Femto/Core/pairCleaner.h
@@ -197,6 +197,23 @@ class TrackCascadePairCleaner : public BasePairCleaner
     auto negDaughter = trackTable.rawIteratorAt(cascade.negDauId() - trackTable.offset());
     return (this->isCleanTrackPair(bachelor, track) && this->isCleanTrackPair(posDaughter, track) && this->isCleanTrackPair(negDaughter, track));
   }
+
+  template <typename T1, typename T2, typename T3, typename T4>
+  bool isCleanPair(T1 const& track1, T2 const& cascade, T3 const& trackTable, T4 const& partonicMothers) const
+  {
+    if (!this->isCleanPair(track1, cascade, trackTable)) {
+      return false;
+    }
+    // pair is clean
+    // now check if we require common or non-common ancestry
+    if (mMixPairsWithCommonAncestor) {
+      return this->pairHasCommonAncestor(track1, cascade, partonicMothers);
+    }
+    if (mMixPairsWithNonCommonAncestor) {
+      return this->pairHasNonCommonAncestor(track1, cascade, partonicMothers);
+    }
+    return true;
+  }
 };
 } // namespace paircleaner
 } // namespace o2::analysis::femto

--- a/PWGCF/Femto/Core/pairHistManager.h
+++ b/PWGCF/Femto/Core/pairHistManager.h
@@ -213,14 +213,14 @@ constexpr std::array<histmanager::HistInfo<PairHist>, kPairHistogramLast>
 template <typename T>
 auto makePairHistSpecMap(const T& confPairBinning)
 {
-  return std::map<PairHist, std::vector<framework::AxisSpec>>{
+  return std::map<PairHist, std::vector<o2::framework::AxisSpec>>{
     PAIR_HIST_ANALYSIS_MAP(confPairBinning)};
 };
 
 template <typename T>
 auto makePairMcHistSpecMap(const T& confPairBinning)
 {
-  return std::map<PairHist, std::vector<framework::AxisSpec>>{
+  return std::map<PairHist, std::vector<o2::framework::AxisSpec>>{
     PAIR_HIST_ANALYSIS_MAP(confPairBinning)
       PAIR_HIST_MC_MAP(confPairBinning)};
 };

--- a/PWGCF/Femto/Core/partitions.h
+++ b/PWGCF/Femto/Core/partitions.h
@@ -17,126 +17,126 @@
 #define PWGCF_FEMTO_CORE_PARTITIONS_H_
 
 // collsion selection
-#define MAKE_COLLISION_FILTER(selection)                                                                                                                    \
-  (femtocollisions::posZ >= selection.vtxZMin && femtocollisions::posZ <= selection.vtxZMax) &&                                                             \
-    (femtocollisions::mult >= selection.multMin && femtocollisions::mult <= selection.multMax) &&                                                           \
-    (femtocollisions::cent >= selection.centMin && femtocollisions::cent <= selection.centMax) &&                                                           \
-    (femtocollisions::magField >= static_cast<int8_t>(selection.magFieldMin) && femtocollisions::magField <= static_cast<int8_t>(selection.magFieldMax)) && \
-    ncheckbit(femtocollisions::mask, selection.collisionMask)
+#define MAKE_COLLISION_FILTER(selection)                                                                                                                                      \
+  (o2::aod::femtocollisions::posZ >= selection.vtxZMin && o2::aod::femtocollisions::posZ <= selection.vtxZMax) &&                                                             \
+    (o2::aod::femtocollisions::mult >= selection.multMin && o2::aod::femtocollisions::mult <= selection.multMax) &&                                                           \
+    (o2::aod::femtocollisions::cent >= selection.centMin && o2::aod::femtocollisions::cent <= selection.centMax) &&                                                           \
+    (o2::aod::femtocollisions::magField >= static_cast<int8_t>(selection.magFieldMin) && o2::aod::femtocollisions::magField <= static_cast<int8_t>(selection.magFieldMax)) && \
+    ncheckbit(o2::aod::femtocollisions::mask, selection.collisionMask)
 
 // standard track partition
-#define MAKE_TRACK_PARTITION(selection)                                                                                                                                         \
-  ifnode(selection.chargeSign.node() != 0, ifnode(selection.chargeSign.node() > 0, femtobase::stored::signedPt > 0.f, femtobase::stored::signedPt < 0.f), true) &&              \
-    (nabs(selection.chargeAbs.node() * femtobase::stored::signedPt) > selection.ptMin) &&                                                                                       \
-    (nabs(selection.chargeAbs.node() * femtobase::stored::signedPt) < selection.ptMax) &&                                                                                       \
-    (femtobase::stored::eta > selection.etaMin) &&                                                                                                                              \
-    (femtobase::stored::eta < selection.etaMax) &&                                                                                                                              \
-    (femtobase::stored::phi > selection.phiMin) &&                                                                                                                              \
-    (femtobase::stored::phi < selection.phiMax) &&                                                                                                                              \
-    ifnode(nabs(selection.chargeAbs.node() * femtobase::stored::signedPt) * (nexp(femtobase::stored::eta) + nexp(-1.f * femtobase::stored::eta)) / (2.f) <= selection.pidThres, \
-           ncheckbit(femtotracks::mask, selection.maskLowMomentum),                                                                                                             \
-           ncheckbit(femtotracks::mask, selection.maskHighMomentum))
+#define MAKE_TRACK_PARTITION(selection)                                                                                                                                                                    \
+  ifnode(selection.chargeSign.node() != 0, ifnode(selection.chargeSign.node() > 0, o2::aod::femtobase::stored::signedPt > 0.f, o2::aod::femtobase::stored::signedPt < 0.f), true) &&                       \
+    (nabs(selection.chargeAbs.node() * o2::aod::femtobase::stored::signedPt) > selection.ptMin) &&                                                                                                         \
+    (nabs(selection.chargeAbs.node() * o2::aod::femtobase::stored::signedPt) < selection.ptMax) &&                                                                                                         \
+    (o2::aod::femtobase::stored::eta > selection.etaMin) &&                                                                                                                                                \
+    (o2::aod::femtobase::stored::eta < selection.etaMax) &&                                                                                                                                                \
+    (o2::aod::femtobase::stored::phi > selection.phiMin) &&                                                                                                                                                \
+    (o2::aod::femtobase::stored::phi < selection.phiMax) &&                                                                                                                                                \
+    ifnode(nabs(selection.chargeAbs.node() * o2::aod::femtobase::stored::signedPt) * (nexp(o2::aod::femtobase::stored::eta) + nexp(-1.f * o2::aod::femtobase::stored::eta)) / (2.f) <= selection.pidThres, \
+           ncheckbit(o2::aod::femtotracks::mask, selection.maskLowMomentum),                                                                                                                               \
+           ncheckbit(o2::aod::femtotracks::mask, selection.maskHighMomentum))
 
 // partition for phis and rhos, i.e. resonance that are their own antiparticle
-#define MAKE_RESONANCE_0_PARTITON(selection)                                            \
-  (femtobase::stored::pt > selection.ptMin) &&                                          \
-    (femtobase::stored::pt < selection.ptMax) &&                                        \
-    (femtobase::stored::eta > selection.etaMin) &&                                      \
-    (femtobase::stored::eta < selection.etaMax) &&                                      \
-    (femtobase::stored::phi > selection.phiMin) &&                                      \
-    (femtobase::stored::phi < selection.phiMax) &&                                      \
-    (femtobase::stored::mass > selection.massMin) &&                                    \
-    (femtobase::stored::mass < selection.massMax) &&                                    \
-    ifnode(ncheckbit(femtotwotrackresonances::mask, selection.posDauBitForThres),       \
-           ncheckbit(femtotwotrackresonances::mask, selection.posDauMaskAboveThres),    \
-           ncheckbit(femtotwotrackresonances::mask, selection.posDauMaskBelowThres)) && \
-    ifnode(ncheckbit(femtotwotrackresonances::mask, selection.negDauBitForThres),       \
-           ncheckbit(femtotwotrackresonances::mask, selection.negDauMaskAboveThres),    \
-           ncheckbit(femtotwotrackresonances::mask, selection.negDauMaskBelowThres))
+#define MAKE_RESONANCE_0_PARTITON(selection)                                                     \
+  (o2::aod::femtobase::stored::pt > selection.ptMin) &&                                          \
+    (o2::aod::femtobase::stored::pt < selection.ptMax) &&                                        \
+    (o2::aod::femtobase::stored::eta > selection.etaMin) &&                                      \
+    (o2::aod::femtobase::stored::eta < selection.etaMax) &&                                      \
+    (o2::aod::femtobase::stored::phi > selection.phiMin) &&                                      \
+    (o2::aod::femtobase::stored::phi < selection.phiMax) &&                                      \
+    (o2::aod::femtobase::stored::mass > selection.massMin) &&                                    \
+    (o2::aod::femtobase::stored::mass < selection.massMax) &&                                    \
+    ifnode(ncheckbit(o2::aod::femtotwotrackresonances::mask, selection.posDauBitForThres),       \
+           ncheckbit(o2::aod::femtotwotrackresonances::mask, selection.posDauMaskAboveThres),    \
+           ncheckbit(o2::aod::femtotwotrackresonances::mask, selection.posDauMaskBelowThres)) && \
+    ifnode(ncheckbit(o2::aod::femtotwotrackresonances::mask, selection.negDauBitForThres),       \
+           ncheckbit(o2::aod::femtotwotrackresonances::mask, selection.negDauMaskAboveThres),    \
+           ncheckbit(o2::aod::femtotwotrackresonances::mask, selection.negDauMaskBelowThres))
 
 // partition for kstars, they have distinct antiparticle
-#define MAKE_RESONANCE_1_PARTITON(selection)                                                                               \
-  ifnode(selection.sign.node() != 0,                                                                                       \
-         ifnode(selection.sign.node() > 0, femtobase::stored::signedPt > 0.f, femtobase::stored::signedPt < 0.f), true) && \
-    (nabs(femtobase::stored::signedPt) > selection.ptMin) &&                                                               \
-    (nabs(femtobase::stored::signedPt) < selection.ptMax) &&                                                               \
-    (femtobase::stored::eta > selection.etaMin) &&                                                                         \
-    (femtobase::stored::eta < selection.etaMax) &&                                                                         \
-    (femtobase::stored::phi > selection.phiMin) &&                                                                         \
-    (femtobase::stored::phi < selection.phiMax) &&                                                                         \
-    (femtobase::stored::mass > selection.massMin) &&                                                                       \
-    (femtobase::stored::mass < selection.massMax) &&                                                                       \
-    ifnode(ncheckbit(femtotwotrackresonances::mask, selection.posDauBitForThres),                                          \
-           ncheckbit(femtotwotrackresonances::mask, selection.posDauMaskAboveThres),                                       \
-           ncheckbit(femtotwotrackresonances::mask, selection.posDauMaskBelowThres)) &&                                    \
-    ifnode(ncheckbit(femtotwotrackresonances::mask, selection.negDauBitForThres),                                          \
-           ncheckbit(femtotwotrackresonances::mask, selection.negDauMaskAboveThres),                                       \
-           ncheckbit(femtotwotrackresonances::mask, selection.negDauMaskBelowThres))
+#define MAKE_RESONANCE_1_PARTITON(selection)                                                                                                 \
+  ifnode(selection.sign.node() != 0,                                                                                                         \
+         ifnode(selection.sign.node() > 0, o2::aod::femtobase::stored::signedPt > 0.f, o2::aod::femtobase::stored::signedPt < 0.f), true) && \
+    (nabs(o2::aod::femtobase::stored::signedPt) > selection.ptMin) &&                                                                        \
+    (nabs(o2::aod::femtobase::stored::signedPt) < selection.ptMax) &&                                                                        \
+    (o2::aod::femtobase::stored::eta > selection.etaMin) &&                                                                                  \
+    (o2::aod::femtobase::stored::eta < selection.etaMax) &&                                                                                  \
+    (o2::aod::femtobase::stored::phi > selection.phiMin) &&                                                                                  \
+    (o2::aod::femtobase::stored::phi < selection.phiMax) &&                                                                                  \
+    (o2::aod::femtobase::stored::mass > selection.massMin) &&                                                                                \
+    (o2::aod::femtobase::stored::mass < selection.massMax) &&                                                                                \
+    ifnode(ncheckbit(o2::aod::femtotwotrackresonances::mask, selection.posDauBitForThres),                                                   \
+           ncheckbit(o2::aod::femtotwotrackresonances::mask, selection.posDauMaskAboveThres),                                                \
+           ncheckbit(o2::aod::femtotwotrackresonances::mask, selection.posDauMaskBelowThres)) &&                                             \
+    ifnode(ncheckbit(o2::aod::femtotwotrackresonances::mask, selection.negDauBitForThres),                                                   \
+           ncheckbit(o2::aod::femtotwotrackresonances::mask, selection.negDauMaskAboveThres),                                                \
+           ncheckbit(o2::aod::femtotwotrackresonances::mask, selection.negDauMaskBelowThres))
 
 // partition for lambdas
-#define MAKE_LAMBDA_PARTITION(selection)                                                                                   \
-  ifnode(selection.sign.node() != 0,                                                                                       \
-         ifnode(selection.sign.node() > 0, femtobase::stored::signedPt > 0.f, femtobase::stored::signedPt < 0.f), true) && \
-    (nabs(femtobase::stored::signedPt) > selection.ptMin) &&                                                               \
-    (nabs(femtobase::stored::signedPt) < selection.ptMax) &&                                                               \
-    (femtobase::stored::eta > selection.etaMin) &&                                                                         \
-    (femtobase::stored::eta < selection.etaMax) &&                                                                         \
-    (femtobase::stored::phi > selection.phiMin) &&                                                                         \
-    (femtobase::stored::phi < selection.phiMax) &&                                                                         \
-    (femtobase::stored::mass > selection.massMin) &&                                                                       \
-    (femtobase::stored::mass < selection.massMax) &&                                                                       \
-    ncheckbit(femtov0s::mask, selection.mask)
+#define MAKE_LAMBDA_PARTITION(selection)                                                                                                     \
+  ifnode(selection.sign.node() != 0,                                                                                                         \
+         ifnode(selection.sign.node() > 0, o2::aod::femtobase::stored::signedPt > 0.f, o2::aod::femtobase::stored::signedPt < 0.f), true) && \
+    (nabs(o2::aod::femtobase::stored::signedPt) > selection.ptMin) &&                                                                        \
+    (nabs(o2::aod::femtobase::stored::signedPt) < selection.ptMax) &&                                                                        \
+    (o2::aod::femtobase::stored::eta > selection.etaMin) &&                                                                                  \
+    (o2::aod::femtobase::stored::eta < selection.etaMax) &&                                                                                  \
+    (o2::aod::femtobase::stored::phi > selection.phiMin) &&                                                                                  \
+    (o2::aod::femtobase::stored::phi < selection.phiMax) &&                                                                                  \
+    (o2::aod::femtobase::stored::mass > selection.massMin) &&                                                                                \
+    (o2::aod::femtobase::stored::mass < selection.massMax) &&                                                                                \
+    ncheckbit(o2::aod::femtov0s::mask, selection.mask)
 
 // partition for k0shorts
 // need special partition since k0shorts have no antiparticle
-#define MAKE_K0SHORT_PARTITION(selection)            \
-  (femtobase::stored::pt > selection.ptMin) &&       \
-    (femtobase::stored::pt < selection.ptMax) &&     \
-    (femtobase::stored::eta > selection.etaMin) &&   \
-    (femtobase::stored::eta < selection.etaMax) &&   \
-    (femtobase::stored::phi > selection.phiMin) &&   \
-    (femtobase::stored::phi < selection.phiMax) &&   \
-    (femtobase::stored::mass > selection.massMin) && \
-    (femtobase::stored::mass < selection.massMax) && \
-    ncheckbit(femtov0s::mask, selection.mask)
+#define MAKE_K0SHORT_PARTITION(selection)                     \
+  (o2::aod::femtobase::stored::pt > selection.ptMin) &&       \
+    (o2::aod::femtobase::stored::pt < selection.ptMax) &&     \
+    (o2::aod::femtobase::stored::eta > selection.etaMin) &&   \
+    (o2::aod::femtobase::stored::eta < selection.etaMax) &&   \
+    (o2::aod::femtobase::stored::phi > selection.phiMin) &&   \
+    (o2::aod::femtobase::stored::phi < selection.phiMax) &&   \
+    (o2::aod::femtobase::stored::mass > selection.massMin) && \
+    (o2::aod::femtobase::stored::mass < selection.massMax) && \
+    ncheckbit(o2::aod::femtov0s::mask, selection.mask)
 
-#define MAKE_CASCADE_PARTITION(selection)                                                                                  \
-  ifnode(selection.sign.node() != 0,                                                                                       \
-         ifnode(selection.sign.node() > 0, femtobase::stored::signedPt > 0.f, femtobase::stored::signedPt < 0.f), true) && \
-    (nabs(femtobase::stored::signedPt) > selection.ptMin) &&                                                               \
-    (nabs(femtobase::stored::signedPt) < selection.ptMax) &&                                                               \
-    (femtobase::stored::eta > selection.etaMin) &&                                                                         \
-    (femtobase::stored::eta < selection.etaMax) &&                                                                         \
-    (femtobase::stored::phi > selection.phiMin) &&                                                                         \
-    (femtobase::stored::phi < selection.phiMax) &&                                                                         \
-    (femtobase::stored::mass > selection.massMin) &&                                                                       \
-    (femtobase::stored::mass < selection.massMax) &&                                                                       \
-    ncheckbit(femtocascades::mask, selection.mask)
+#define MAKE_CASCADE_PARTITION(selection)                                                                                                    \
+  ifnode(selection.sign.node() != 0,                                                                                                         \
+         ifnode(selection.sign.node() > 0, o2::aod::femtobase::stored::signedPt > 0.f, o2::aod::femtobase::stored::signedPt < 0.f), true) && \
+    (nabs(o2::aod::femtobase::stored::signedPt) > selection.ptMin) &&                                                                        \
+    (nabs(o2::aod::femtobase::stored::signedPt) < selection.ptMax) &&                                                                        \
+    (o2::aod::femtobase::stored::eta > selection.etaMin) &&                                                                                  \
+    (o2::aod::femtobase::stored::eta < selection.etaMax) &&                                                                                  \
+    (o2::aod::femtobase::stored::phi > selection.phiMin) &&                                                                                  \
+    (o2::aod::femtobase::stored::phi < selection.phiMax) &&                                                                                  \
+    (o2::aod::femtobase::stored::mass > selection.massMin) &&                                                                                \
+    (o2::aod::femtobase::stored::mass < selection.massMax) &&                                                                                \
+    ncheckbit(o2::aod::femtocascades::mask, selection.mask)
 
-#define MAKE_SIGMA_PARTITION(selection)                                                                                    \
-  ifnode(selection.sign.node() != 0,                                                                                       \
-         ifnode(selection.sign.node() > 0, femtobase::stored::signedPt > 0.f, femtobase::stored::signedPt < 0.f), true) && \
-    (nabs(femtobase::stored::signedPt) > selection.ptMin) &&                                                               \
-    (nabs(femtobase::stored::signedPt) < selection.ptMax) &&                                                               \
-    (femtobase::stored::eta > selection.etaMin) &&                                                                         \
-    (femtobase::stored::eta < selection.etaMax) &&                                                                         \
-    (femtobase::stored::phi > selection.phiMin) &&                                                                         \
-    (femtobase::stored::phi < selection.phiMax) &&                                                                         \
-    (femtobase::stored::mass > selection.massMin) &&                                                                       \
-    (femtobase::stored::mass < selection.massMax) &&                                                                       \
-    ncheckbit(femtokinks::mask, selection.mask)
+#define MAKE_SIGMA_PARTITION(selection)                                                                                                      \
+  ifnode(selection.sign.node() != 0,                                                                                                         \
+         ifnode(selection.sign.node() > 0, o2::aod::femtobase::stored::signedPt > 0.f, o2::aod::femtobase::stored::signedPt < 0.f), true) && \
+    (nabs(o2::aod::femtobase::stored::signedPt) > selection.ptMin) &&                                                                        \
+    (nabs(o2::aod::femtobase::stored::signedPt) < selection.ptMax) &&                                                                        \
+    (o2::aod::femtobase::stored::eta > selection.etaMin) &&                                                                                  \
+    (o2::aod::femtobase::stored::eta < selection.etaMax) &&                                                                                  \
+    (o2::aod::femtobase::stored::phi > selection.phiMin) &&                                                                                  \
+    (o2::aod::femtobase::stored::phi < selection.phiMax) &&                                                                                  \
+    (o2::aod::femtobase::stored::mass > selection.massMin) &&                                                                                \
+    (o2::aod::femtobase::stored::mass < selection.massMax) &&                                                                                \
+    ncheckbit(o2::aod::femtokinks::mask, selection.mask)
 
-#define MAKE_SIGMAPLUS_PARTITION(selection)                                                                                \
-  ifnode(selection.sign.node() != 0,                                                                                       \
-         ifnode(selection.sign.node() > 0, femtobase::stored::signedPt > 0.f, femtobase::stored::signedPt < 0.f), true) && \
-    (nabs(femtobase::stored::signedPt) > selection.ptMin) &&                                                               \
-    (nabs(femtobase::stored::signedPt) < selection.ptMax) &&                                                               \
-    (femtobase::stored::eta > selection.etaMin) &&                                                                         \
-    (femtobase::stored::eta < selection.etaMax) &&                                                                         \
-    (femtobase::stored::phi > selection.phiMin) &&                                                                         \
-    (femtobase::stored::phi < selection.phiMax) &&                                                                         \
-    (femtobase::stored::mass > selection.massMin) &&                                                                       \
-    (femtobase::stored::mass < selection.massMax) &&                                                                       \
-    ncheckbit(femtokinks::mask, selection.mask)
+#define MAKE_SIGMAPLUS_PARTITION(selection)                                                                                                  \
+  ifnode(selection.sign.node() != 0,                                                                                                         \
+         ifnode(selection.sign.node() > 0, o2::aod::femtobase::stored::signedPt > 0.f, o2::aod::femtobase::stored::signedPt < 0.f), true) && \
+    (nabs(o2::aod::femtobase::stored::signedPt) > selection.ptMin) &&                                                                        \
+    (nabs(o2::aod::femtobase::stored::signedPt) < selection.ptMax) &&                                                                        \
+    (o2::aod::femtobase::stored::eta > selection.etaMin) &&                                                                                  \
+    (o2::aod::femtobase::stored::eta < selection.etaMax) &&                                                                                  \
+    (o2::aod::femtobase::stored::phi > selection.phiMin) &&                                                                                  \
+    (o2::aod::femtobase::stored::phi < selection.phiMax) &&                                                                                  \
+    (o2::aod::femtobase::stored::mass > selection.massMin) &&                                                                                \
+    (o2::aod::femtobase::stored::mass < selection.massMax) &&                                                                                \
+    ncheckbit(o2::aod::femtokinks::mask, selection.mask)
 
 #endif // PWGCF_FEMTO_CORE_PARTITIONS_H_

--- a/PWGCF/Femto/Core/trackHistManager.h
+++ b/PWGCF/Femto/Core/trackHistManager.h
@@ -441,14 +441,14 @@ constexpr std::array<histmanager::HistInfo<TrackHist>, kTrackHistLast>
 template <typename T>
 auto makeTrackHistSpecMap(const T& confBinningAnalysis)
 {
-  return std::map<TrackHist, std::vector<framework::AxisSpec>>{
+  return std::map<TrackHist, std::vector<o2::framework::AxisSpec>>{
     TRACK_HIST_ANALYSIS_MAP(confBinningAnalysis)};
 }
 
 template <typename T>
 auto makeTrackMcHistSpecMap(T const& confBinningAnalysis)
 {
-  return std::map<TrackHist, std::vector<framework::AxisSpec>>{
+  return std::map<TrackHist, std::vector<o2::framework::AxisSpec>>{
     TRACK_HIST_ANALYSIS_MAP(confBinningAnalysis)
       TRACK_HIST_MC_MAP(confBinningAnalysis)};
 };
@@ -456,7 +456,7 @@ auto makeTrackMcHistSpecMap(T const& confBinningAnalysis)
 template <typename T1, typename T2>
 auto makeTrackQaHistSpecMap(T1 const& confBinningAnalysis, T2 const& confBinningQa)
 {
-  return std::map<TrackHist, std::vector<framework::AxisSpec>>{
+  return std::map<TrackHist, std::vector<o2::framework::AxisSpec>>{
     TRACK_HIST_ANALYSIS_MAP(confBinningAnalysis)
       TRACK_HIST_QA_MAP(confBinningAnalysis, confBinningQa)};
 }
@@ -464,7 +464,7 @@ auto makeTrackQaHistSpecMap(T1 const& confBinningAnalysis, T2 const& confBinning
 template <typename T1, typename T2>
 auto makeTrackMcQaHistSpecMap(T1 const& confBinningAnalysis, T2 const& confBinningQa)
 {
-  return std::map<TrackHist, std::vector<framework::AxisSpec>>{
+  return std::map<TrackHist, std::vector<o2::framework::AxisSpec>>{
     TRACK_HIST_ANALYSIS_MAP(confBinningAnalysis)
       TRACK_HIST_QA_MAP(confBinningAnalysis, confBinningQa)
         TRACK_HIST_MC_MAP(confBinningAnalysis)
@@ -744,7 +744,7 @@ class TrackHistManager
     mHistogramRegistry->add(mcDir + getHistNameV2(kTruePhiVsPhi, HistTable), getHistDesc(kTruePhiVsPhi, HistTable), getHistType(kTruePhiVsPhi, HistTable), {Specs.at(kTruePhiVsPhi)});
 
     // mc origin can be configured here
-    const framework::AxisSpec axisOrigin = {static_cast<int>(modes::McOrigin::kMcOriginLast), -0.5, static_cast<double>(modes::McOrigin::kMcOriginLast) - 0.5};
+    const o2::framework::AxisSpec axisOrigin = {static_cast<int>(modes::McOrigin::kMcOriginLast), -0.5, static_cast<double>(modes::McOrigin::kMcOriginLast) - 0.5};
     mHistogramRegistry->add(mcDir + getHistNameV2(kOrigin, HistTable), getHistDesc(kOrigin, HistTable), getHistType(kOrigin, HistTable), {axisOrigin});
     mHistogramRegistry->get<TH1>(HIST(prefix) + HIST(McDir) + HIST(histmanager::getHistName(kOrigin, HistTable)))->GetXaxis()->SetBinLabel(1 + static_cast<int>(modes::McOrigin::kNoMcParticle), modes::mcOriginToString(modes::McOrigin::kNoMcParticle));
     mHistogramRegistry->get<TH1>(HIST(prefix) + HIST(McDir) + HIST(histmanager::getHistName(kOrigin, HistTable)))->GetXaxis()->SetBinLabel(1 + static_cast<int>(modes::McOrigin::kFromWrongCollision), modes::mcOriginToString(modes::McOrigin::kFromWrongCollision));

--- a/PWGCF/Femto/Core/tripletCleaner.h
+++ b/PWGCF/Femto/Core/tripletCleaner.h
@@ -59,6 +59,46 @@ class TrackTrackTrackTripletCleaner : public paircleaner::BasePairCleaner
   }
 };
 
+class TrackTrackV0TripletCleaner : public paircleaner::BasePairCleaner
+{
+ public:
+  TrackTrackV0TripletCleaner() = default;
+  ~TrackTrackV0TripletCleaner() = default;
+
+  template <typename T1, typename T2, typename T3, typename T4>
+  bool isCleanTriplet(T1 const& track1, T2 const& track2, T3 const& v0, T4 const& trackTable) const
+  {
+    auto posDaughter = trackTable.rawIteratorAt(v0.posDauId() - trackTable.offset());
+    auto negDaughter = trackTable.rawIteratorAt(v0.negDauId() - trackTable.offset());
+    return this->isCleanTrackPair(track1, track2) &&
+           this->isCleanTrackPair(track1, posDaughter) &&
+           this->isCleanTrackPair(track1, negDaughter) &&
+           this->isCleanTrackPair(track2, posDaughter) &&
+           this->isCleanTrackPair(track2, negDaughter);
+  }
+
+  template <typename T1, typename T2, typename T3, typename T4, typename T5>
+  bool isCleanTriplet(T1 const& track1, T2 const& track2, T3 const& v0, T4 const& trackTable, T5 const& partonicMothers) const
+  {
+    if (!this->isCleanTriplet(track1, track2, v0, trackTable)) {
+      return false;
+    }
+    // pair is clean
+    // no check if we require common or non-common ancestry
+    if (mMixPairsWithCommonAncestor) {
+      return this->pairHasCommonAncestor(track1, track2, partonicMothers) &&
+             this->pairHasCommonAncestor(track1, v0, partonicMothers) &&
+             this->pairHasCommonAncestor(track2, v0, partonicMothers);
+    }
+    if (mMixPairsWithNonCommonAncestor) {
+      return this->pairHasNonCommonAncestor(track1, track2, partonicMothers) &&
+             this->pairHasNonCommonAncestor(track1, v0, partonicMothers) &&
+             this->pairHasNonCommonAncestor(track2, v0, partonicMothers);
+    }
+    return true;
+  }
+};
+
 } // namespace tripletcleaner
 } // namespace o2::analysis::femto
 

--- a/PWGCF/Femto/Core/tripletHistManager.h
+++ b/PWGCF/Femto/Core/tripletHistManager.h
@@ -177,14 +177,14 @@ constexpr std::array<histmanager::HistInfo<TripletHist>, kTripletHistogramLast>
 template <typename T>
 auto makeTripletHistSpecMap(const T& confPairBinning)
 {
-  return std::map<TripletHist, std::vector<framework::AxisSpec>>{
+  return std::map<TripletHist, std::vector<o2::framework::AxisSpec>>{
     TRIPLET_HIST_ANALYSIS_MAP(confPairBinning)};
 };
 
 template <typename T>
 auto makeTripletMcHistSpecMap(const T& confPairBinning)
 {
-  return std::map<TripletHist, std::vector<framework::AxisSpec>>{
+  return std::map<TripletHist, std::vector<o2::framework::AxisSpec>>{
     TRIPLET_HIST_ANALYSIS_MAP(confPairBinning)
       TRIPLET_HIST_MC_MAP(confPairBinning)};
 };
@@ -194,6 +194,9 @@ auto makeTripletMcHistSpecMap(const T& confPairBinning)
 
 constexpr char PrefixTrackTrackTrackSe[] = "TrackTrackTrack/SE/";
 constexpr char PrefixTrackTrackTrackMe[] = "TrackTrackTrack/ME/";
+
+constexpr char PrefixTrackTrackLambdaSe[] = "TrackTrackLambda/SE/";
+constexpr char PrefixTrackTrackLambdaMe[] = "TrackTrackLambda/ME/";
 
 constexpr std::string_view AnalysisDir = "Analysis/";
 constexpr std::string_view QaDir = "QA/";
@@ -282,7 +285,7 @@ class TripletHistManager
       mMass2 = particle2.mass();
     }
     if constexpr (modes::hasMass(particleType3)) {
-      mMass3 = particle2.mass();
+      mMass3 = particle3.mass();
     }
   }
 

--- a/PWGCF/Femto/Core/twoTrackResonanceHistManager.h
+++ b/PWGCF/Femto/Core/twoTrackResonanceHistManager.h
@@ -86,9 +86,9 @@ constexpr std::array<histmanager::HistInfo<TwoTrackResonanceHist>, kTwoTrackReso
    {kPtVsMass, o2::framework::kTH2F, "hPtVsMass", "p_{T} vs invariant mass; p_{T} (GeV/#it{c}); m (GeV/#it{c}^{2})"}}};
 
 template <typename T>
-std::map<TwoTrackResonanceHist, std::vector<framework::AxisSpec>> makeTwoTrackResonanceHistSpecMap(const T& confBinningAnalysis)
+std::map<TwoTrackResonanceHist, std::vector<o2::framework::AxisSpec>> makeTwoTrackResonanceHistSpecMap(const T& confBinningAnalysis)
 {
-  return std::map<TwoTrackResonanceHist, std::vector<framework::AxisSpec>>{
+  return std::map<TwoTrackResonanceHist, std::vector<o2::framework::AxisSpec>>{
     {kPt, {confBinningAnalysis.pt}},
     {kEta, {confBinningAnalysis.eta}},
     {kPhi, {confBinningAnalysis.phi}},
@@ -99,7 +99,7 @@ std::map<TwoTrackResonanceHist, std::vector<framework::AxisSpec>> makeTwoTrackRe
 template <typename T>
 auto makeTwoTrackResonanceQaHistSpecMap(const T& confBinningAnalysis)
 {
-  return std::map<TwoTrackResonanceHist, std::vector<framework::AxisSpec>>{
+  return std::map<TwoTrackResonanceHist, std::vector<o2::framework::AxisSpec>>{
     {kPt, {confBinningAnalysis.pt}},
     {kEta, {confBinningAnalysis.eta}},
     {kPhi, {confBinningAnalysis.phi}},

--- a/PWGCF/Femto/Core/v0HistManager.h
+++ b/PWGCF/Femto/Core/v0HistManager.h
@@ -232,30 +232,30 @@ constexpr std::array<histmanager::HistInfo<V0Hist>, kV0HistLast> HistTable = {
 template <typename T>
 auto makeV0HistSpecMap(const T& confBinningAnalysis)
 {
-  return std::map<V0Hist, std::vector<framework::AxisSpec>>{
+  return std::map<V0Hist, std::vector<o2::framework::AxisSpec>>{
     V0_HIST_ANALYSIS_MAP(confBinningAnalysis)};
 }
 
 template <typename T>
 auto makeV0McHistSpecMap(const T& confBinningAnalysis)
 {
-  return std::map<V0Hist, std::vector<framework::AxisSpec>>{
+  return std::map<V0Hist, std::vector<o2::framework::AxisSpec>>{
     V0_HIST_ANALYSIS_MAP(confBinningAnalysis)
       V0_HIST_MC_MAP(confBinningAnalysis)};
 }
 
 template <typename T1, typename T2>
-std::map<V0Hist, std::vector<framework::AxisSpec>> makeV0QaHistSpecMap(T1 const& confBinningAnalysis, T2 const& confBinningQa)
+std::map<V0Hist, std::vector<o2::framework::AxisSpec>> makeV0QaHistSpecMap(T1 const& confBinningAnalysis, T2 const& confBinningQa)
 {
-  return std::map<V0Hist, std::vector<framework::AxisSpec>>{
+  return std::map<V0Hist, std::vector<o2::framework::AxisSpec>>{
     V0_HIST_ANALYSIS_MAP(confBinningAnalysis)
       V0_HIST_QA_MAP(confBinningAnalysis, confBinningQa)};
 }
 
 template <typename T1, typename T2>
-std::map<V0Hist, std::vector<framework::AxisSpec>> makeV0McQaHistSpecMap(T1 const& confBinningAnalysis, T2 const& confBinningQa)
+std::map<V0Hist, std::vector<o2::framework::AxisSpec>> makeV0McQaHistSpecMap(T1 const& confBinningAnalysis, T2 const& confBinningQa)
 {
-  return std::map<V0Hist, std::vector<framework::AxisSpec>>{
+  return std::map<V0Hist, std::vector<o2::framework::AxisSpec>>{
     V0_HIST_ANALYSIS_MAP(confBinningAnalysis)
       V0_HIST_QA_MAP(confBinningAnalysis, confBinningQa)
         V0_HIST_MC_MAP(confBinningAnalysis)
@@ -486,7 +486,7 @@ class V0HistManager
     mHistogramRegistry->add(mcDir + getHistNameV2(kTruePhiVsPhi, HistTable), getHistDesc(kTruePhiVsPhi, HistTable), getHistType(kTruePhiVsPhi, HistTable), {V0Specs.at(kTruePhiVsPhi)});
 
     // mc origin can be configured here
-    const framework::AxisSpec axisOrigin = {static_cast<int>(modes::McOrigin::kMcOriginLast), -0.5, static_cast<double>(modes::McOrigin::kMcOriginLast) - 0.5};
+    const o2::framework::AxisSpec axisOrigin = {static_cast<int>(modes::McOrigin::kMcOriginLast), -0.5, static_cast<double>(modes::McOrigin::kMcOriginLast) - 0.5};
     mHistogramRegistry->add(mcDir + getHistNameV2(kOrigin, HistTable), getHistDesc(kOrigin, HistTable), getHistType(kOrigin, HistTable), {axisOrigin});
     mHistogramRegistry->get<TH1>(HIST(v0Prefix) + HIST(McDir) + HIST(histmanager::getHistName(kOrigin, HistTable)))->GetXaxis()->SetBinLabel(1 + static_cast<int>(modes::McOrigin::kNoMcParticle), modes::mcOriginToString(modes::McOrigin::kNoMcParticle));
     mHistogramRegistry->get<TH1>(HIST(v0Prefix) + HIST(McDir) + HIST(histmanager::getHistName(kOrigin, HistTable)))->GetXaxis()->SetBinLabel(1 + static_cast<int>(modes::McOrigin::kFromWrongCollision), modes::mcOriginToString(modes::McOrigin::kFromWrongCollision));

--- a/PWGCF/Femto/TableProducer/femtoProducer.cxx
+++ b/PWGCF/Femto/TableProducer/femtoProducer.cxx
@@ -46,38 +46,33 @@
 
 #include <chrono>
 #include <cstdint>
-#include <string>
 
-using namespace o2::aod;
-using namespace o2::soa;
-using namespace o2::framework;
-using namespace o2::framework::expressions;
 using namespace o2::analysis::femto;
 
 namespace o2::analysis::femto
 {
 namespace consumeddata
 {
-using Run3PpCollisions = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0As, aod::CentFT0Cs, aod::CentFT0Ms>;
-using Run3PpMcRecoCollisions = soa::Join<Run3PpCollisions, aod::McCollisionLabels>;
-using Run3PpMcGenCollisions = soa::Join<aod::McCollisions, aod::MultsExtraMC, aod::McCentFT0Ms>;
+using Run3PpCollisions = o2::soa::Join<o2::aod::Collisions, o2::aod::EvSels, o2::aod::Mults, o2::aod::CentFT0As, o2::aod::CentFT0Cs, o2::aod::CentFT0Ms>;
+using Run3PpMcRecoCollisions = o2::soa::Join<Run3PpCollisions, o2::aod::McCollisionLabels>;
+using Run3PpMcGenCollisions = o2::soa::Join<o2::aod::McCollisions, o2::aod::MultsExtraMC, o2::aod::McCentFT0Ms>;
 
 using Run3FullPidTracks =
-  soa::Join<Tracks, TracksExtra, TracksDCA,
-            pidTPCFullEl, pidTPCFullPi, pidTPCFullKa, pidTPCFullPr, pidTPCFullDe, pidTPCFullTr, pidTPCFullHe,
-            pidTOFFullEl, pidTOFFullPi, pidTOFFullKa, pidTOFFullPr, pidTOFFullDe, pidTOFFullTr, pidTOFFullHe,
-            pidTOFbeta, pidTOFmass>;
-using Run3McRecoTracks = soa::Join<Run3FullPidTracks, aod::McTrackLabels>;
+  soa::Join<o2::aod::Tracks, o2::aod::TracksExtra, o2::aod::TracksDCA,
+            o2::aod::pidTPCFullEl, o2::aod::pidTPCFullPi, o2::aod::pidTPCFullKa, o2::aod::pidTPCFullPr, o2::aod::pidTPCFullDe, o2::aod::pidTPCFullTr, o2::aod::pidTPCFullHe,
+            o2::aod::pidTOFFullEl, o2::aod::pidTOFFullPi, o2::aod::pidTOFFullKa, o2::aod::pidTOFFullPr, o2::aod::pidTOFFullDe, o2::aod::pidTOFFullTr, o2::aod::pidTOFFullHe,
+            o2::aod::pidTOFbeta, o2::aod::pidTOFmass>;
+using Run3McRecoTracks = soa::Join<Run3FullPidTracks, o2::aod::McTrackLabels>;
 
-using Run3Vzeros = aod::V0Datas;
-using Run3RecoVzeros = soa::Join<aod::V0Datas, aod::McV0Labels>;
+using Run3Vzeros = o2::aod::V0Datas;
+using Run3RecoVzeros = o2::soa::Join<o2::aod::V0Datas, o2::aod::McV0Labels>;
 
-using Run3Cascades = CascDatas;
-using Run3RecoCascades = soa::Join<CascDatas, aod::McCascLabels>;
+using Run3Cascades = o2::aod::CascDatas;
+using Run3RecoCascades = o2::soa::Join<Run3Cascades, o2::aod::McCascLabels>;
 
-using Run3Kinks = KinkCands;
+using Run3Kinks = o2::aod::KinkCands;
 
-using Run3McGenParticles = aod::McParticles;
+using Run3McGenParticles = o2::aod::McParticles;
 
 } // namespace consumeddata
 } // namespace o2::analysis::femto
@@ -138,12 +133,12 @@ struct FemtoProducer {
 
   // histogramming
   // add histograms in next iteration
-  HistogramRegistry hRegistry{"FemtoProducer", {}, OutputObjHandlingPolicy::AnalysisObject};
+  o2::framework::HistogramRegistry hRegistry{"FemtoProducer", {}, o2::framework::OutputObjHandlingPolicy::AnalysisObject};
 
   // data members
-  Service<o2::ccdb::BasicCCDBManager> ccdb; /// Accessing the CCDB
+  o2::framework::Service<o2::ccdb::BasicCCDBManager> ccdb; /// Accessing the CCDB
 
-  void init(InitContext& context)
+  void init(o2::framework::InitContext& context)
   {
     if ((xiBuilder.fillAnyTable() || omegaBuilder.fillAnyTable()) && (!doprocessTracksV0sCascadesRun3pp && !doprocessTracksV0sCascadesKinksRun3pp)) {
       LOG(fatal) << "At least one cascade table is enabled, but wrong process function is enabled. Breaking...";
@@ -281,29 +276,29 @@ struct FemtoProducer {
 
   // proccess functions
   void processTracksRun3pp(consumeddata::Run3PpCollisions::iterator const& col,
-                           BCsWithTimestamps const& bcs,
+                           o2::aod::BCsWithTimestamps const& bcs,
                            consumeddata::Run3FullPidTracks const& tracks)
   {
     if (!processCollisions<modes::System::kPP_Run3>(col, bcs, tracks)) {
       return;
     }
-    auto tracksWithItsPid = o2::soa::Attach<consumeddata::Run3FullPidTracks, pidits::ITSNSigmaEl, pidits::ITSNSigmaPi,
-                                            pidits::ITSNSigmaKa, pidits::ITSNSigmaPr, pidits::ITSNSigmaDe, pidits::ITSNSigmaTr, pidits::ITSNSigmaHe>(tracks);
+    auto tracksWithItsPid = o2::soa::Attach<consumeddata::Run3FullPidTracks, o2::aod::pidits::ITSNSigmaEl, o2::aod::pidits::ITSNSigmaPi, o2::aod::pidits::ITSNSigmaKa,
+                                            o2::aod::pidits::ITSNSigmaPr, o2::aod::pidits::ITSNSigmaDe, o2::aod::pidits::ITSNSigmaTr, o2::aod::pidits::ITSNSigmaHe>(tracks);
     processTracks<modes::System::kPP_Run3>(col, tracksWithItsPid);
   }
   PROCESS_SWITCH(FemtoProducer, processTracksRun3pp, "Process tracks", true);
 
   // process tracks and v0s
   void processTracksV0sRun3pp(consumeddata::Run3PpCollisions::iterator const& col,
-                              BCsWithTimestamps const& bcs,
+                              o2::aod::BCsWithTimestamps const& bcs,
                               consumeddata::Run3FullPidTracks const& tracks,
                               consumeddata::Run3Vzeros const& v0s)
   {
     if (!processCollisions<modes::System::kPP_Run3>(col, bcs, tracks)) {
       return;
     }
-    auto tracksWithItsPid = o2::soa::Attach<consumeddata::Run3FullPidTracks, pidits::ITSNSigmaEl, pidits::ITSNSigmaPi,
-                                            pidits::ITSNSigmaKa, pidits::ITSNSigmaPr, pidits::ITSNSigmaDe, pidits::ITSNSigmaTr, pidits::ITSNSigmaHe>(tracks);
+    auto tracksWithItsPid = o2::soa::Attach<consumeddata::Run3FullPidTracks, o2::aod::pidits::ITSNSigmaEl, o2::aod::pidits::ITSNSigmaPi, o2::aod::pidits::ITSNSigmaKa,
+                                            o2::aod::pidits::ITSNSigmaPr, o2::aod::pidits::ITSNSigmaDe, o2::aod::pidits::ITSNSigmaTr, o2::aod::pidits::ITSNSigmaHe>(tracks);
     processTracks<modes::System::kPP_Run3>(col, tracksWithItsPid);
     processV0s<modes::System::kPP_Run3>(col, tracks, tracksWithItsPid, v0s);
   };
@@ -311,15 +306,15 @@ struct FemtoProducer {
 
   // process tracks and kinks
   void processTracksKinksRun3pp(consumeddata::Run3PpCollisions::iterator const& col,
-                                BCsWithTimestamps const& bcs,
+                                o2::aod::BCsWithTimestamps const& bcs,
                                 consumeddata::Run3FullPidTracks const& tracks,
                                 consumeddata::Run3Kinks const& kinks)
   {
     if (!processCollisions<modes::System::kPP_Run3>(col, bcs, tracks)) {
       return;
     }
-    auto tracksWithItsPid = o2::soa::Attach<consumeddata::Run3FullPidTracks, pidits::ITSNSigmaEl, pidits::ITSNSigmaPi,
-                                            pidits::ITSNSigmaKa, pidits::ITSNSigmaPr, pidits::ITSNSigmaDe, pidits::ITSNSigmaTr, pidits::ITSNSigmaHe>(tracks);
+    auto tracksWithItsPid = o2::soa::Attach<consumeddata::Run3FullPidTracks, o2::aod::pidits::ITSNSigmaEl, o2::aod::pidits::ITSNSigmaPi, o2::aod::pidits::ITSNSigmaKa,
+                                            o2::aod::pidits::ITSNSigmaPr, o2::aod::pidits::ITSNSigmaDe, o2::aod::pidits::ITSNSigmaTr, o2::aod::pidits::ITSNSigmaHe>(tracks);
     processTracks<modes::System::kPP_Run3>(col, tracksWithItsPid);
     processKinks<modes::System::kPP_Run3>(col, tracks, tracksWithItsPid, kinks);
   }
@@ -327,7 +322,7 @@ struct FemtoProducer {
 
   // process tracks, v0s and cascades
   void processTracksV0sCascadesRun3pp(consumeddata::Run3PpCollisions::iterator const& col,
-                                      BCsWithTimestamps const& bcs,
+                                      o2::aod::BCsWithTimestamps const& bcs,
                                       consumeddata::Run3FullPidTracks const& tracks,
                                       consumeddata::Run3Vzeros const& v0s,
                                       consumeddata::Run3Cascades const& cascades)
@@ -335,8 +330,8 @@ struct FemtoProducer {
     if (!processCollisions<modes::System::kPP_Run3>(col, bcs, tracks)) {
       return;
     }
-    auto tracksWithItsPid = o2::soa::Attach<consumeddata::Run3FullPidTracks, pidits::ITSNSigmaEl, pidits::ITSNSigmaPi,
-                                            pidits::ITSNSigmaKa, pidits::ITSNSigmaPr, pidits::ITSNSigmaDe, pidits::ITSNSigmaTr, pidits::ITSNSigmaHe>(tracks);
+    auto tracksWithItsPid = o2::soa::Attach<consumeddata::Run3FullPidTracks, o2::aod::pidits::ITSNSigmaEl, o2::aod::pidits::ITSNSigmaPi, o2::aod::pidits::ITSNSigmaKa,
+                                            o2::aod::pidits::ITSNSigmaPr, o2::aod::pidits::ITSNSigmaDe, o2::aod::pidits::ITSNSigmaTr, o2::aod::pidits::ITSNSigmaHe>(tracks);
     processTracks<modes::System::kPP_Run3>(col, tracksWithItsPid);
     processV0s<modes::System::kPP_Run3>(col, tracks, tracksWithItsPid, v0s);
     processCascades<modes::System::kPP_Run3>(col, tracks, tracksWithItsPid, cascades);
@@ -345,7 +340,7 @@ struct FemtoProducer {
 
   // process tracks, v0s, cascades and kinks
   void processTracksV0sCascadesKinksRun3pp(consumeddata::Run3PpCollisions::iterator const& col,
-                                           BCsWithTimestamps const& bcs,
+                                           o2::aod::BCsWithTimestamps const& bcs,
                                            consumeddata::Run3FullPidTracks const& tracks,
                                            consumeddata::Run3Vzeros const& v0s,
                                            consumeddata::Run3Cascades const& cascades,
@@ -354,8 +349,8 @@ struct FemtoProducer {
     if (!processCollisions<modes::System::kPP_Run3>(col, bcs, tracks)) {
       return;
     }
-    auto tracksWithItsPid = o2::soa::Attach<consumeddata::Run3FullPidTracks, pidits::ITSNSigmaEl, pidits::ITSNSigmaPi,
-                                            pidits::ITSNSigmaKa, pidits::ITSNSigmaPr, pidits::ITSNSigmaDe, pidits::ITSNSigmaTr, pidits::ITSNSigmaHe>(tracks);
+    auto tracksWithItsPid = o2::soa::Attach<consumeddata::Run3FullPidTracks, o2::aod::pidits::ITSNSigmaEl, o2::aod::pidits::ITSNSigmaPi, o2::aod::pidits::ITSNSigmaKa,
+                                            o2::aod::pidits::ITSNSigmaPr, o2::aod::pidits::ITSNSigmaDe, o2::aod::pidits::ITSNSigmaTr, o2::aod::pidits::ITSNSigmaHe>(tracks);
     processTracks<modes::System::kPP_Run3>(col, tracksWithItsPid);
     processV0s<modes::System::kPP_Run3>(col, tracks, tracksWithItsPid, v0s);
     processKinks<modes::System::kPP_Run3>(col, tracks, tracksWithItsPid, kinks);
@@ -366,15 +361,15 @@ struct FemtoProducer {
   // process monte carlo tracks
   void processTracksRun3ppMc(consumeddata::Run3PpMcRecoCollisions::iterator const& col,
                              consumeddata::Run3PpMcGenCollisions const& mcCols,
-                             BCsWithTimestamps const& bcs,
+                             o2::aod::BCsWithTimestamps const& bcs,
                              consumeddata::Run3McRecoTracks const& tracks,
                              consumeddata::Run3McGenParticles const& mcParticles)
   {
     if (!processMcCollisions<modes::System::kPP_Run3_MC>(col, mcCols, bcs, tracks, mcParticles)) {
       return;
     }
-    auto tracksWithItsPid = o2::soa::Attach<consumeddata::Run3McRecoTracks, pidits::ITSNSigmaEl, pidits::ITSNSigmaPi,
-                                            pidits::ITSNSigmaKa, pidits::ITSNSigmaPr, pidits::ITSNSigmaDe, pidits::ITSNSigmaTr, pidits::ITSNSigmaHe>(tracks);
+    auto tracksWithItsPid = o2::soa::Attach<consumeddata::Run3McRecoTracks, o2::aod::pidits::ITSNSigmaEl, o2::aod::pidits::ITSNSigmaPi, o2::aod::pidits::ITSNSigmaKa,
+                                            o2::aod::pidits::ITSNSigmaPr, o2::aod::pidits::ITSNSigmaDe, o2::aod::pidits::ITSNSigmaTr, o2::aod::pidits::ITSNSigmaHe>(tracks);
     processMcTracks<modes::System::kPP_Run3_MC>(col, mcCols, tracks, tracksWithItsPid, mcParticles);
   }
   PROCESS_SWITCH(FemtoProducer, processTracksRun3ppMc, "Provide reconstructed and generated Tracks", false);
@@ -382,7 +377,7 @@ struct FemtoProducer {
   // process monte carlo tracks and v0s
   void processTracksV0sRun3ppMc(consumeddata::Run3PpMcRecoCollisions::iterator const& col,
                                 consumeddata::Run3PpMcGenCollisions const& mcCols,
-                                BCsWithTimestamps const& bcs,
+                                o2::aod::BCsWithTimestamps const& bcs,
                                 consumeddata::Run3McRecoTracks const& tracks,
                                 consumeddata::Run3RecoVzeros const& v0s,
                                 consumeddata::Run3McGenParticles const& mcParticles)
@@ -390,8 +385,8 @@ struct FemtoProducer {
     if (!processMcCollisions<modes::System::kPP_Run3_MC>(col, mcCols, bcs, tracks, mcParticles)) {
       return;
     }
-    auto tracksWithItsPid = o2::soa::Attach<consumeddata::Run3McRecoTracks, pidits::ITSNSigmaEl, pidits::ITSNSigmaPi,
-                                            pidits::ITSNSigmaKa, pidits::ITSNSigmaPr, pidits::ITSNSigmaDe, pidits::ITSNSigmaTr, pidits::ITSNSigmaHe>(tracks);
+    auto tracksWithItsPid = o2::soa::Attach<consumeddata::Run3McRecoTracks, o2::aod::pidits::ITSNSigmaEl, o2::aod::pidits::ITSNSigmaPi, o2::aod::pidits::ITSNSigmaKa,
+                                            o2::aod::pidits::ITSNSigmaPr, o2::aod::pidits::ITSNSigmaDe, o2::aod::pidits::ITSNSigmaTr, o2::aod::pidits::ITSNSigmaHe>(tracks);
     processMcTracks<modes::System::kPP_Run3_MC>(col, mcCols, tracks, tracksWithItsPid, mcParticles);
     processMcV0s<modes::System::kPP_Run3_MC>(col, mcCols, tracks, tracksWithItsPid, v0s, mcParticles);
   }
@@ -400,7 +395,7 @@ struct FemtoProducer {
   // process monte carlo tracks and kinks
   void processTracksKinksRun3ppMc(consumeddata::Run3PpMcRecoCollisions::iterator const& col,
                                   consumeddata::Run3PpMcGenCollisions const& mcCols,
-                                  BCsWithTimestamps const& bcs,
+                                  o2::aod::BCsWithTimestamps const& bcs,
                                   consumeddata::Run3McRecoTracks const& tracks,
                                   consumeddata::Run3Kinks const& kinks,
                                   consumeddata::Run3McGenParticles const& mcParticles)
@@ -408,8 +403,8 @@ struct FemtoProducer {
     if (!processMcCollisions<modes::System::kPP_Run3_MC>(col, mcCols, bcs, tracks, mcParticles)) {
       return;
     }
-    auto tracksWithItsPid = o2::soa::Attach<consumeddata::Run3McRecoTracks, pidits::ITSNSigmaEl, pidits::ITSNSigmaPi,
-                                            pidits::ITSNSigmaKa, pidits::ITSNSigmaPr, pidits::ITSNSigmaDe, pidits::ITSNSigmaTr, pidits::ITSNSigmaHe>(tracks);
+    auto tracksWithItsPid = o2::soa::Attach<consumeddata::Run3McRecoTracks, o2::aod::pidits::ITSNSigmaEl, o2::aod::pidits::ITSNSigmaPi, o2::aod::pidits::ITSNSigmaKa,
+                                            o2::aod::pidits::ITSNSigmaPr, o2::aod::pidits::ITSNSigmaDe, o2::aod::pidits::ITSNSigmaTr, o2::aod::pidits::ITSNSigmaHe>(tracks);
     processMcTracks<modes::System::kPP_Run3_MC>(col, mcCols, tracks, tracksWithItsPid, mcParticles);
     processMcKinks<modes::System::kPP_Run3_MC>(col, mcCols, tracks, tracksWithItsPid, kinks, mcParticles);
   }
@@ -418,7 +413,7 @@ struct FemtoProducer {
   // process monte carlo tracks and v0s and kinks (adding cascades later here)
   void processTracksV0sKinksRun3ppMc(consumeddata::Run3PpMcRecoCollisions::iterator const& col,
                                      consumeddata::Run3PpMcGenCollisions const& mcCols,
-                                     BCsWithTimestamps const& bcs,
+                                     o2::aod::BCsWithTimestamps const& bcs,
                                      consumeddata::Run3McRecoTracks const& tracks,
                                      consumeddata::Run3RecoVzeros const& v0s,
                                      consumeddata::Run3Kinks const& kinks,
@@ -427,8 +422,8 @@ struct FemtoProducer {
     if (!processMcCollisions<modes::System::kPP_Run3_MC>(col, mcCols, bcs, tracks, mcParticles)) {
       return;
     }
-    auto tracksWithItsPid = o2::soa::Attach<consumeddata::Run3McRecoTracks, pidits::ITSNSigmaEl, pidits::ITSNSigmaPi,
-                                            pidits::ITSNSigmaKa, pidits::ITSNSigmaPr, pidits::ITSNSigmaDe, pidits::ITSNSigmaTr, pidits::ITSNSigmaHe>(tracks);
+    auto tracksWithItsPid = o2::soa::Attach<consumeddata::Run3McRecoTracks, o2::aod::pidits::ITSNSigmaEl, o2::aod::pidits::ITSNSigmaPi, o2::aod::pidits::ITSNSigmaKa,
+                                            o2::aod::pidits::ITSNSigmaPr, o2::aod::pidits::ITSNSigmaDe, o2::aod::pidits::ITSNSigmaTr, o2::aod::pidits::ITSNSigmaHe>(tracks);
     processMcTracks<modes::System::kPP_Run3_MC>(col, mcCols, tracks, tracksWithItsPid, mcParticles);
     processMcV0s<modes::System::kPP_Run3_MC>(col, mcCols, tracks, tracksWithItsPid, v0s, mcParticles);
     processMcKinks<modes::System::kPP_Run3_MC>(col, mcCols, tracks, tracksWithItsPid, kinks, mcParticles);
@@ -438,7 +433,7 @@ struct FemtoProducer {
   // process monte carlo tracks and v0s
   void processTracksV0sCascadesRun3ppMc(consumeddata::Run3PpMcRecoCollisions::iterator const& col,
                                         consumeddata::Run3PpMcGenCollisions const& mcCols,
-                                        BCsWithTimestamps const& bcs,
+                                        o2::aod::BCsWithTimestamps const& bcs,
                                         consumeddata::Run3McRecoTracks const& tracks,
                                         consumeddata::Run3RecoVzeros const& v0s,
                                         consumeddata::Run3RecoCascades const& cascades,
@@ -447,8 +442,8 @@ struct FemtoProducer {
     if (!processMcCollisions<modes::System::kPP_Run3_MC>(col, mcCols, bcs, tracks, mcParticles)) {
       return;
     }
-    auto tracksWithItsPid = o2::soa::Attach<consumeddata::Run3McRecoTracks, pidits::ITSNSigmaEl, pidits::ITSNSigmaPi,
-                                            pidits::ITSNSigmaKa, pidits::ITSNSigmaPr, pidits::ITSNSigmaDe, pidits::ITSNSigmaTr, pidits::ITSNSigmaHe>(tracks);
+    auto tracksWithItsPid = o2::soa::Attach<consumeddata::Run3McRecoTracks, o2::aod::pidits::ITSNSigmaEl, o2::aod::pidits::ITSNSigmaPi, o2::aod::pidits::ITSNSigmaKa,
+                                            o2::aod::pidits::ITSNSigmaPr, o2::aod::pidits::ITSNSigmaDe, o2::aod::pidits::ITSNSigmaTr, o2::aod::pidits::ITSNSigmaHe>(tracks);
     processMcTracks<modes::System::kPP_Run3_MC>(col, mcCols, tracks, tracksWithItsPid, mcParticles);
     processMcV0s<modes::System::kPP_Run3_MC>(col, mcCols, tracks, tracksWithItsPid, v0s, mcParticles);
     processMcCascades<modes::System::kPP_Run3_MC>(col, mcCols, tracks, tracksWithItsPid, cascades, mcParticles);
@@ -456,8 +451,8 @@ struct FemtoProducer {
   PROCESS_SWITCH(FemtoProducer, processTracksV0sCascadesRun3ppMc, "Provide reconstructed and generated tracks and v0s", false);
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<FemtoProducer>(cfgc)};
+  o2::framework::WorkflowSpec workflow{adaptAnalysisTask<FemtoProducer>(cfgc)};
   return workflow;
 }

--- a/PWGCF/Femto/TableProducer/femtoProducerDerivedToDerived.cxx
+++ b/PWGCF/Femto/TableProducer/femtoProducerDerivedToDerived.cxx
@@ -27,32 +27,26 @@
 #include "Framework/InitContext.h"
 #include "Framework/runDataProcessing.h"
 
-#include <string>
-
-using namespace o2::aod;
-using namespace o2::soa;
-using namespace o2::framework;
-using namespace o2::framework::expressions;
 using namespace o2::analysis::femto;
 
 struct FemtoProducerDerivedToDerived {
 
   // setup tables
-  using Collisions = Join<FCols, FColMasks>;
+  using Collisions = o2::soa::Join<o2::aod::FCols, o2::aod::FColMasks>;
   using Collision = Collisions::iterator;
 
   using FilteredCollisions = o2::soa::Filtered<Collisions>;
   using FilteredCollision = FilteredCollisions::iterator;
 
-  using Tracks = o2::soa::Join<FTracks, FTrackMasks>;
-  using Lambdas = o2::soa::Join<FLambdas, FLambdaMasks>;
-  using K0shorts = o2::soa::Join<FK0shorts, FK0shortMasks>;
+  using Tracks = o2::soa::Join<o2::aod::FTracks, o2::aod::FTrackMasks>;
+  using Lambdas = o2::soa::Join<o2::aod::FLambdas, o2::aod::FLambdaMasks>;
+  using K0shorts = o2::soa::Join<o2::aod::FK0shorts, o2::aod::FK0shortMasks>;
 
-  SliceCache cache;
+  o2::framework::SliceCache cache;
 
   // collision builder
   collisionbuilder::ConfCollisionSelection collisionSelection;
-  Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
+  o2::framework::expressions::Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
   collisionbuilder::CollisionBuilderDerivedToDerivedProducts collisionBuilderProducts;
   collisionbuilder::CollisionBuilderDerivedToDerived collisionBuilder;
 
@@ -63,9 +57,9 @@ struct FemtoProducerDerivedToDerived {
   trackbuilder::ConfTrackSelection1 trackSelections1;
   trackbuilder::ConfTrackSelection2 trackSelections2;
 
-  Partition<Tracks> trackPartition1 = MAKE_TRACK_PARTITION(trackSelections1);
-  Partition<Tracks> trackPartition2 = MAKE_TRACK_PARTITION(trackSelections2);
-  Preslice<Tracks> perColTracks = femtobase::stored::fColId;
+  o2::framework::Partition<Tracks> trackPartition1 = MAKE_TRACK_PARTITION(trackSelections1);
+  o2::framework::Partition<Tracks> trackPartition2 = MAKE_TRACK_PARTITION(trackSelections2);
+  o2::framework::Preslice<Tracks> perColTracks = o2::aod::femtobase::stored::fColId;
 
   // v0 builder
   v0builder::V0BuilderDerivedToDerived v0Builder;
@@ -73,14 +67,14 @@ struct FemtoProducerDerivedToDerived {
   v0builder::ConfV0TablesDerivedToDerived confV0Builder;
 
   v0builder::ConfLambdaSelection1 lambdaSelection1;
-  Partition<Lambdas> lambdaPartition = MAKE_LAMBDA_PARTITION(lambdaSelection1);
-  Preslice<Lambdas> perColLambdas = femtobase::stored::fColId;
+  o2::framework::Partition<Lambdas> lambdaPartition = MAKE_LAMBDA_PARTITION(lambdaSelection1);
+  o2::framework::Preslice<Lambdas> perColLambdas = o2::aod::femtobase::stored::fColId;
 
   v0builder::ConfK0shortSelection1 k0shortSelection1;
-  Partition<K0shorts> k0shortPartition = MAKE_K0SHORT_PARTITION(k0shortSelection1);
-  Preslice<K0shorts> perColK0shorts = femtobase::stored::fColId;
+  o2::framework::Partition<K0shorts> k0shortPartition = MAKE_K0SHORT_PARTITION(k0shortSelection1);
+  o2::framework::Preslice<K0shorts> perColK0shorts = o2::aod::femtobase::stored::fColId;
 
-  void init(InitContext& /*context*/)
+  void init(o2::framework::InitContext& /*context*/)
   {
     trackBuilder.init(confTrackBuilder);
     v0Builder.init(confV0Builder);
@@ -128,8 +122,8 @@ struct FemtoProducerDerivedToDerived {
   PROCESS_SWITCH(FemtoProducerDerivedToDerived, processK0shorts, "Process k0short and tracks", false);
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{adaptAnalysisTask<FemtoProducerDerivedToDerived>(cfgc)};
+  o2::framework::WorkflowSpec workflow{adaptAnalysisTask<FemtoProducerDerivedToDerived>(cfgc)};
   return workflow;
 }

--- a/PWGCF/Femto/TableProducer/femtoProducerDerivedToDerived.cxx
+++ b/PWGCF/Femto/TableProducer/femtoProducerDerivedToDerived.cxx
@@ -27,9 +27,7 @@
 #include "Framework/InitContext.h"
 #include "Framework/runDataProcessing.h"
 
-#include <cstdint>
 #include <string>
-#include <unordered_map>
 
 using namespace o2::aod;
 using namespace o2::soa;

--- a/PWGCF/Femto/Tasks/CMakeLists.txt
+++ b/PWGCF/Femto/Tasks/CMakeLists.txt
@@ -68,3 +68,8 @@ o2physics_add_dpl_workflow(femto-triplet-track-track-track
 	  SOURCES femtoTripletTrackTrackTrack.cxx
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
           COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(femto-triplet-track-track-v0
+	  SOURCES femtoTripletTrackTrackV0.cxx
+          PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+          COMPONENT_NAME Analysis)

--- a/PWGCF/Femto/Tasks/femtoCascadeQa.cxx
+++ b/PWGCF/Femto/Tasks/femtoCascadeQa.cxx
@@ -33,6 +33,9 @@
 #include "Framework/OutputObjHeader.h"
 #include "Framework/runDataProcessing.h"
 
+#include <map>
+#include <vector>
+
 using namespace o2::analysis::femto;
 
 struct FemtoCascadeQa {

--- a/PWGCF/Femto/Tasks/femtoCascadeQa.cxx
+++ b/PWGCF/Femto/Tasks/femtoCascadeQa.cxx
@@ -33,38 +33,31 @@
 #include "Framework/OutputObjHeader.h"
 #include "Framework/runDataProcessing.h"
 
-#include <map>
-#include <string>
-#include <vector>
-
-using namespace o2::aod;
-using namespace o2::framework;
-using namespace o2::framework::expressions;
 using namespace o2::analysis::femto;
 
 struct FemtoCascadeQa {
 
-  using FemtoCollisions = o2::soa::Join<FCols, FColMasks, FColPos, FColSphericities, FColMults>;
+  using FemtoCollisions = o2::soa::Join<o2::aod::FCols, o2::aod::FColMasks, o2::aod::FColPos, o2::aod::FColSphericities, o2::aod::FColMults>;
   using FilteredFemtoCollisions = o2::soa::Filtered<FemtoCollisions>;
   using FilteredFemtoCollision = FilteredFemtoCollisions::iterator;
 
-  using FemtoCollisionsWithLabel = o2::soa::Join<FemtoCollisions, FColLabels>;
+  using FemtoCollisionsWithLabel = o2::soa::Join<FemtoCollisions, o2::aod::FColLabels>;
   using FilteredFemtoCollisionsWithLabel = o2::soa::Filtered<FemtoCollisionsWithLabel>;
   using FilteredFemtoCollisionWithLabel = FilteredFemtoCollisionsWithLabel::iterator;
 
-  using FemtoXis = o2::soa::Join<FXis, FXiMasks, FXiExtras>;
-  using FemtoOmegas = o2::soa::Join<FOmegas, FOmegaMasks, FOmegaExtras>;
-  using FemtoTracks = o2::soa::Join<FTracks, FTrackDcas, FTrackExtras, FTrackPids>;
+  using FemtoXis = o2::soa::Join<o2::aod::FXis, o2::aod::FXiMasks, o2::aod::FXiExtras>;
+  using FemtoOmegas = o2::soa::Join<o2::aod::FOmegas, o2::aod::FOmegaMasks, o2::aod::FOmegaExtras>;
+  using FemtoTracks = o2::soa::Join<o2::aod::FTracks, o2::aod::FTrackDcas, o2::aod::FTrackExtras, o2::aod::FTrackPids>;
 
-  using FemtoXisWithLabel = o2::soa::Join<FemtoXis, FXiLabels>;
-  using FemtoOmegasWithLabel = o2::soa::Join<FemtoOmegas, FOmegaLabels>;
-  using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, FTrackLabels>;
+  using FemtoXisWithLabel = o2::soa::Join<FemtoXis, o2::aod::FXiLabels>;
+  using FemtoOmegasWithLabel = o2::soa::Join<FemtoOmegas, o2::aod::FOmegaLabels>;
+  using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, o2::aod::FTrackLabels>;
 
-  SliceCache cache;
+  o2::framework::SliceCache cache;
 
   // setup collisions
   collisionbuilder::ConfCollisionSelection collisionSelection;
-  Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
+  o2::framework::expressions::Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
   colhistmanager::CollisionHistManager colHistManager;
   colhistmanager::ConfCollisionBinning confCollisionBinning;
   colhistmanager::ConfCollisionQaBinning confCollisionQaBinning;
@@ -75,11 +68,11 @@ struct FemtoCascadeQa {
   particlecleaner::ConfXiCleaner1 confXiCleaner;
   particlecleaner::ParticleCleaner xiCleaner;
 
-  Partition<FemtoXis> xiPartition = MAKE_CASCADE_PARTITION(confXiSelection);
-  Preslice<FemtoXis> preColXis = femtobase::stored::fColId;
+  o2::framework::Partition<FemtoXis> xiPartition = MAKE_CASCADE_PARTITION(confXiSelection);
+  o2::framework::Preslice<FemtoXis> preColXis = o2::aod::femtobase::stored::fColId;
 
-  Partition<FemtoXisWithLabel> xiWithLabelPartition = MAKE_CASCADE_PARTITION(confXiSelection);
-  Preslice<FemtoXisWithLabel> perColXisWithLabel = femtobase::stored::fColId;
+  o2::framework::Partition<FemtoXisWithLabel> xiWithLabelPartition = MAKE_CASCADE_PARTITION(confXiSelection);
+  o2::framework::Preslice<FemtoXisWithLabel> perColXisWithLabel = o2::aod::femtobase::stored::fColId;
 
   cascadehistmanager::ConfXiBinning confXiBinning;
   cascadehistmanager::ConfXiQaBinning confXiQaBinning;
@@ -97,11 +90,11 @@ struct FemtoCascadeQa {
   particlecleaner::ConfOmegaCleaner1 confOmegaCleaner;
   particlecleaner::ParticleCleaner omegaCleaner;
 
-  Partition<FemtoOmegas> omegaPartition = MAKE_CASCADE_PARTITION(confOmegaSelection);
-  Preslice<FemtoOmegas> preColOmegas = femtobase::stored::fColId;
+  o2::framework::Partition<FemtoOmegas> omegaPartition = MAKE_CASCADE_PARTITION(confOmegaSelection);
+  o2::framework::Preslice<FemtoOmegas> preColOmegas = o2::aod::femtobase::stored::fColId;
 
-  Partition<FemtoOmegasWithLabel> omegaWithLabelPartition = MAKE_CASCADE_PARTITION(confOmegaSelection);
-  Preslice<FemtoOmegasWithLabel> perColOmegasWithLabel = femtobase::stored::fColId;
+  o2::framework::Partition<FemtoOmegasWithLabel> omegaWithLabelPartition = MAKE_CASCADE_PARTITION(confOmegaSelection);
+  o2::framework::Preslice<FemtoOmegasWithLabel> perColOmegasWithLabel = o2::aod::femtobase::stored::fColId;
 
   cascadehistmanager::ConfOmegaBinning confOmegaBinning;
   cascadehistmanager::ConfOmegaQaBinning confOmegaQaBinning;
@@ -121,42 +114,51 @@ struct FemtoCascadeQa {
   trackhistmanager::ConfCascadeBachelorBinning confBachelorBinning;
   trackhistmanager::ConfCascadeBachelorQaBinning confBachelorQaBinning;
 
-  HistogramRegistry hRegistry{"FemtoCascadeQA", {}, OutputObjHandlingPolicy::AnalysisObject};
+  o2::framework::HistogramRegistry hRegistry{"FemtoCascadeQA", {}, o2::framework::OutputObjHandlingPolicy::AnalysisObject};
 
-  void init(InitContext&)
+  void init(o2::framework::InitContext&)
   {
     if ((doprocessXi + doprocessXiMc + doprocessOmega + doprocessOmegaMc) > 1) {
       LOG(fatal) << "Only one process can be activated";
     }
     bool processData = doprocessXi || doprocessOmega;
+
     xiCleaner.init(confXiCleaner);
     omegaCleaner.init(confOmegaCleaner);
+
+    std::map<colhistmanager::ColHist, std::vector<o2::framework::AxisSpec>> colHistSpec;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> bachelorHistSpec;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> posDaughterHistSpec;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> negDaughterHistSpec;
+    std::map<cascadehistmanager::CascadeHist, std::vector<o2::framework::AxisSpec>> xiHistSpec;
+    std::map<cascadehistmanager::CascadeHist, std::vector<o2::framework::AxisSpec>> omegaHistSpec;
+
     if (processData) {
-      auto colHistSpec = colhistmanager::makeColQaHistSpecMap(confCollisionBinning, confCollisionQaBinning);
+      colHistSpec = colhistmanager::makeColQaHistSpecMap(confCollisionBinning, confCollisionQaBinning);
       colHistManager.init<modes::Mode::kAnalysis_Qa>(&hRegistry, colHistSpec, confCollisionQaBinning);
-      auto bachelorHistSpec = trackhistmanager::makeTrackQaHistSpecMap(confBachelorBinning, confBachelorQaBinning);
-      auto posDaughterHistSpec = trackhistmanager::makeTrackQaHistSpecMap(confPosDaughterBinning, confPosDaughterQaBinning);
-      auto negDaughterHistSpec = trackhistmanager::makeTrackQaHistSpecMap(confNegDaughterBinning, confNegDaughterQaBinning);
+      bachelorHistSpec = trackhistmanager::makeTrackQaHistSpecMap(confBachelorBinning, confBachelorQaBinning);
+      posDaughterHistSpec = trackhistmanager::makeTrackQaHistSpecMap(confPosDaughterBinning, confPosDaughterQaBinning);
+      negDaughterHistSpec = trackhistmanager::makeTrackQaHistSpecMap(confNegDaughterBinning, confNegDaughterQaBinning);
       if (doprocessXi) {
-        auto xiHistSpec = cascadehistmanager::makeCascadeQaHistSpecMap(confXiBinning, confXiQaBinning);
+        xiHistSpec = cascadehistmanager::makeCascadeQaHistSpecMap(confXiBinning, confXiQaBinning);
         xiHistManager.init<modes::Mode::kAnalysis_Qa>(&hRegistry, xiHistSpec, confXiSelection, confXiQaBinning, bachelorHistSpec, confBachelorQaBinning, posDaughterHistSpec, confPosDaughterQaBinning, negDaughterHistSpec, confNegDaughterQaBinning);
       }
       if (doprocessOmega) {
-        auto omegaHistSpec = cascadehistmanager::makeCascadeQaHistSpecMap(confOmegaBinning, confOmegaQaBinning);
+        omegaHistSpec = cascadehistmanager::makeCascadeQaHistSpecMap(confOmegaBinning, confOmegaQaBinning);
         omegaHistManager.init<modes::Mode::kAnalysis_Qa>(&hRegistry, omegaHistSpec, confOmegaSelection, confOmegaQaBinning, bachelorHistSpec, confBachelorQaBinning, posDaughterHistSpec, confPosDaughterQaBinning, negDaughterHistSpec, confNegDaughterQaBinning);
       }
     } else {
-      auto colHistSpec = colhistmanager::makeColMcQaHistSpecMap(confCollisionBinning, confCollisionQaBinning);
+      colHistSpec = colhistmanager::makeColMcQaHistSpecMap(confCollisionBinning, confCollisionQaBinning);
       colHistManager.init<modes::Mode::kAnalysis_Qa_Mc>(&hRegistry, colHistSpec, confCollisionQaBinning);
-      auto bachelorHistSpec = trackhistmanager::makeTrackMcQaHistSpecMap(confBachelorBinning, confBachelorQaBinning);
-      auto posDaughterHistSpec = trackhistmanager::makeTrackMcQaHistSpecMap(confPosDaughterBinning, confPosDaughterQaBinning);
-      auto negDaughterHistSpec = trackhistmanager::makeTrackMcQaHistSpecMap(confNegDaughterBinning, confNegDaughterQaBinning);
+      bachelorHistSpec = trackhistmanager::makeTrackMcQaHistSpecMap(confBachelorBinning, confBachelorQaBinning);
+      posDaughterHistSpec = trackhistmanager::makeTrackMcQaHistSpecMap(confPosDaughterBinning, confPosDaughterQaBinning);
+      negDaughterHistSpec = trackhistmanager::makeTrackMcQaHistSpecMap(confNegDaughterBinning, confNegDaughterQaBinning);
       if (doprocessXiMc) {
-        auto xiHistSpec = cascadehistmanager::makeCascadeMcQaHistSpecMap(confXiBinning, confXiQaBinning);
+        xiHistSpec = cascadehistmanager::makeCascadeMcQaHistSpecMap(confXiBinning, confXiQaBinning);
         xiHistManager.init<modes::Mode::kAnalysis_Qa_Mc>(&hRegistry, xiHistSpec, confXiSelection, confXiQaBinning, bachelorHistSpec, confBachelorQaBinning, posDaughterHistSpec, confPosDaughterQaBinning, negDaughterHistSpec, confNegDaughterQaBinning);
       }
       if (doprocessOmegaMc) {
-        auto omegaHistSpec = cascadehistmanager::makeCascadeMcQaHistSpecMap(confOmegaBinning, confOmegaQaBinning);
+        omegaHistSpec = cascadehistmanager::makeCascadeMcQaHistSpecMap(confOmegaBinning, confOmegaQaBinning);
         omegaHistManager.init<modes::Mode::kAnalysis_Qa_Mc>(&hRegistry, omegaHistSpec, confOmegaSelection, confOmegaQaBinning, bachelorHistSpec, confBachelorQaBinning, posDaughterHistSpec, confPosDaughterQaBinning, negDaughterHistSpec, confNegDaughterQaBinning);
       }
     }
@@ -166,17 +168,17 @@ struct FemtoCascadeQa {
   void processXi(FilteredFemtoCollision const& col, FemtoXis const& /*xis*/, FemtoTracks const& tracks)
   {
     colHistManager.fill<modes::Mode::kAnalysis_Qa>(col);
-    auto xiSlice = xiPartition->sliceByCached(femtobase::stored::fColId, col.globalIndex(), cache);
+    auto xiSlice = xiPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
     for (auto const& xi : xiSlice) {
       xiHistManager.fill<modes::Mode::kAnalysis_Qa>(xi, tracks);
     }
   }
   PROCESS_SWITCH(FemtoCascadeQa, processXi, "Process Xis", true);
 
-  void processXiMc(FilteredFemtoCollisionWithLabel const& col, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& /*xis*/, FMcParticles const& mcParticles, FMcMothers const& mcMothers, FMcPartMoths const& mcPartonicMothers)
+  void processXiMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& /*xis*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     colHistManager.fill<modes::Mode::kAnalysis_Qa_Mc>(col, mcCols);
-    auto xiSlice = xiWithLabelPartition->sliceByCached(femtobase::stored::fColId, col.globalIndex(), cache);
+    auto xiSlice = xiWithLabelPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
     for (auto const& xi : xiSlice) {
       if (!xiCleaner.isClean(xi, mcParticles, mcMothers, mcPartonicMothers)) {
         continue;
@@ -189,17 +191,17 @@ struct FemtoCascadeQa {
   void processOmega(FilteredFemtoCollision const& col, FemtoOmegas const& /*omegas*/, FemtoTracks const& tracks)
   {
     colHistManager.fill<modes::Mode::kAnalysis_Qa>(col);
-    auto omegaSlice = omegaPartition->sliceByCached(femtobase::stored::fColId, col.globalIndex(), cache);
+    auto omegaSlice = omegaPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
     for (auto const& omega : omegaSlice) {
       omegaHistManager.fill<modes::Mode::kAnalysis_Qa>(omega, tracks);
     }
   }
   PROCESS_SWITCH(FemtoCascadeQa, processOmega, "Process Omegas", false);
 
-  void processOmegaMc(FilteredFemtoCollisionWithLabel const& col, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoOmegasWithLabel const& /*omegas*/, FMcParticles const& mcParticles, FMcMothers const& mcMothers, FMcPartMoths const& mcPartonicMothers)
+  void processOmegaMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoOmegasWithLabel const& /*omegas*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     colHistManager.fill<modes::Mode::kAnalysis_Qa_Mc>(col, mcCols);
-    auto omegaSlice = omegaWithLabelPartition->sliceByCached(femtobase::stored::fColId, col.globalIndex(), cache);
+    auto omegaSlice = omegaWithLabelPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
     for (auto const& omega : omegaSlice) {
       if (!omegaCleaner.isClean(omega, mcParticles, mcMothers, mcPartonicMothers)) {
         continue;
@@ -210,9 +212,9 @@ struct FemtoCascadeQa {
   PROCESS_SWITCH(FemtoCascadeQa, processOmegaMc, "Process Omegas with MC information", false);
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{
+  o2::framework::WorkflowSpec workflow{
     adaptAnalysisTask<FemtoCascadeQa>(cfgc),
   };
   return workflow;

--- a/PWGCF/Femto/Tasks/femtoKinkQa.cxx
+++ b/PWGCF/Femto/Tasks/femtoKinkQa.cxx
@@ -35,6 +35,9 @@
 #include "Framework/OutputObjHeader.h"
 #include "Framework/runDataProcessing.h"
 
+#include <map>
+#include <vector>
+
 using namespace o2::analysis::femto;
 
 struct FemtoKinkQa {

--- a/PWGCF/Femto/Tasks/femtoKinkQa.cxx
+++ b/PWGCF/Femto/Tasks/femtoKinkQa.cxx
@@ -35,39 +35,33 @@
 #include "Framework/OutputObjHeader.h"
 #include "Framework/runDataProcessing.h"
 
-#include <string>
-#include <vector>
-
-using namespace o2::aod;
-using namespace o2::framework;
-using namespace o2::framework::expressions;
 using namespace o2::analysis::femto;
 
 struct FemtoKinkQa {
 
   // setup tables
-  using FemtoCollisions = o2::soa::Join<FCols, FColMasks, FColPos, FColSphericities, FColMults>;
+  using FemtoCollisions = o2::soa::Join<o2::aod::FCols, o2::aod::FColMasks, o2::aod::FColPos, o2::aod::FColSphericities, o2::aod::FColMults>;
   using FilteredFemtoCollisions = o2::soa::Filtered<FemtoCollisions>;
   using FilteredFemtoCollision = FilteredFemtoCollisions::iterator;
 
-  using FemtoCollisionsWithLabel = o2::soa::Join<FemtoCollisions, FColLabels>;
+  using FemtoCollisionsWithLabel = o2::soa::Join<FemtoCollisions, o2::aod::FColLabels>;
   using FilteredFemtoCollisionsWithLabel = o2::soa::Filtered<FemtoCollisionsWithLabel>;
   using FilteredFemtoCollisionWithLabel = FilteredFemtoCollisionsWithLabel::iterator;
 
   // Define kink/sigma tables (joining tables for comprehensive information)
-  using FemtoSigmas = o2::soa::Join<FSigmas, FSigmaMasks, FSigmaExtras>;
-  using FemtoSigmaPlus = o2::soa::Join<FSigmaPlus, FSigmaPlusMasks, FSigmaPlusExtras>;
-  using FemtoTracks = o2::soa::Join<FTracks, FTrackDcas, FTrackExtras, FTrackPids>;
+  using FemtoSigmas = o2::soa::Join<o2::aod::FSigmas, o2::aod::FSigmaMasks, o2::aod::FSigmaExtras>;
+  using FemtoSigmaPlus = o2::soa::Join<o2::aod::FSigmaPlus, o2::aod::FSigmaPlusMasks, o2::aod::FSigmaPlusExtras>;
+  using FemtoTracks = o2::soa::Join<o2::aod::FTracks, o2::aod::FTrackDcas, o2::aod::FTrackExtras, o2::aod::FTrackPids>;
 
-  using FemtoSigmasWithLabel = o2::soa::Join<FemtoSigmas, FSigmaLabels>;
-  using FemtoSigmaPlusWithLabel = o2::soa::Join<FemtoSigmaPlus, FK0shortLabels>;
-  using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, FTrackLabels>;
+  using FemtoSigmasWithLabel = o2::soa::Join<FemtoSigmas, o2::aod::FSigmaLabels>;
+  using FemtoSigmaPlusWithLabel = o2::soa::Join<FemtoSigmaPlus, o2::aod::FSigmaPlusLabels>;
+  using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, o2::aod::FTrackLabels>;
 
-  SliceCache cache;
+  o2::framework::SliceCache cache;
 
   // setup for collisions
   collisionbuilder::ConfCollisionSelection collisionSelection;
-  Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
+  o2::framework::expressions::Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
 
   colhistmanager::CollisionHistManager colHistManager;
   colhistmanager::ConfCollisionBinning confCollisionBinning;
@@ -79,11 +73,11 @@ struct FemtoKinkQa {
   particlecleaner::ConfSigmaCleaner1 confSigmaCleaner;
   particlecleaner::ParticleCleaner sigmaCleaner;
 
-  Partition<FemtoSigmas> sigmaPartition = MAKE_SIGMA_PARTITION(confSigmaSelection);
-  Preslice<FemtoSigmas> perColSigmas = femtobase::stored::fColId;
+  o2::framework::Partition<FemtoSigmas> sigmaPartition = MAKE_SIGMA_PARTITION(confSigmaSelection);
+  o2::framework::Preslice<FemtoSigmas> perColSigmas = o2::aod::femtobase::stored::fColId;
 
-  Partition<FemtoSigmasWithLabel> sigmaWithLabelPartition = MAKE_SIGMA_PARTITION(confSigmaSelection);
-  Preslice<FemtoSigmasWithLabel> perColSigmasWithLabel = femtobase::stored::fColId;
+  o2::framework::Partition<FemtoSigmasWithLabel> sigmaWithLabelPartition = MAKE_SIGMA_PARTITION(confSigmaSelection);
+  o2::framework::Preslice<FemtoSigmasWithLabel> perColSigmasWithLabel = o2::aod::femtobase::stored::fColId;
 
   kinkhistmanager::ConfSigmaBinning1 confSigmaBinning;
   kinkhistmanager::ConfSigmaQaBinning1 confSigmaQaBinning;
@@ -99,11 +93,11 @@ struct FemtoKinkQa {
   particlecleaner::ConfSigmaPlusCleaner1 confSigmaPlusCleaner;
   particlecleaner::ParticleCleaner sigmaPlusCleaner;
 
-  Partition<FemtoSigmaPlus> sigmaPlusPartition = MAKE_SIGMAPLUS_PARTITION(confSigmaPlusSelection);
-  Preslice<FemtoSigmaPlus> perColSigmaPlus = femtobase::stored::fColId;
+  o2::framework::Partition<FemtoSigmaPlus> sigmaPlusPartition = MAKE_SIGMAPLUS_PARTITION(confSigmaPlusSelection);
+  o2::framework::Preslice<FemtoSigmaPlus> perColSigmaPlus = o2::aod::femtobase::stored::fColId;
 
-  Partition<FemtoSigmaPlusWithLabel> sigmaPlusWithLabelPartition = MAKE_SIGMAPLUS_PARTITION(confSigmaSelection);
-  Preslice<FemtoSigmaPlusWithLabel> perColSigmaPlussWithLabel = femtobase::stored::fColId;
+  o2::framework::Partition<FemtoSigmaPlusWithLabel> sigmaPlusWithLabelPartition = MAKE_SIGMAPLUS_PARTITION(confSigmaSelection);
+  o2::framework::Preslice<FemtoSigmaPlusWithLabel> perColSigmaPlussWithLabel = o2::aod::femtobase::stored::fColId;
 
   kinkhistmanager::ConfSigmaPlusBinning1 confSigmaPlusBinning;
   kinkhistmanager::ConfSigmaPlusQaBinning1 confSigmaPlusQaBinning;
@@ -117,39 +111,46 @@ struct FemtoKinkQa {
   trackhistmanager::ConfKinkChaDauBinning confKinkChaDaughterBinning;
   trackhistmanager::ConfKinkChaDauQaBinning confKinkChaDaughterQaBinning;
 
-  HistogramRegistry hRegistry{"FemtoKinkQa", {}, OutputObjHandlingPolicy::AnalysisObject};
+  o2::framework::HistogramRegistry hRegistry{"FemtoKinkQa", {}, o2::framework::OutputObjHandlingPolicy::AnalysisObject};
 
-  void init(InitContext&)
+  void init(o2::framework::InitContext&)
   {
     if ((doprocessSigma + doprocessSigmaMc + doprocessSigmaPlus + doprocessSigmaPlusMc) > 1) {
       LOG(fatal) << "Only one process can be activated";
     }
 
     bool processData = doprocessSigma || doprocessSigmaPlus;
+
     sigmaCleaner.init(confSigmaCleaner);
     sigmaPlusCleaner.init(confSigmaPlusCleaner);
+
+    std::map<colhistmanager::ColHist, std::vector<o2::framework::AxisSpec>> colHistSpec;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> chaDauHistSpec;
+    std::map<kinkhistmanager::KinkHist, std::vector<o2::framework::AxisSpec>> sigmaHistSpec;
+    std::map<kinkhistmanager::KinkHist, std::vector<o2::framework::AxisSpec>> sigmaPlusHistSpec;
+
     if (processData) {
-      auto colHistSpec = colhistmanager::makeColQaHistSpecMap(confCollisionBinning, confCollisionQaBinning);
+      colHistSpec = colhistmanager::makeColQaHistSpecMap(confCollisionBinning, confCollisionQaBinning);
       colHistManager.init<modes::Mode::kAnalysis_Qa>(&hRegistry, colHistSpec, confCollisionQaBinning);
-      auto chaDauHistSpec = trackhistmanager::makeTrackQaHistSpecMap(confKinkChaDaughterBinning, confKinkChaDaughterQaBinning);
+      chaDauHistSpec = trackhistmanager::makeTrackQaHistSpecMap(confKinkChaDaughterBinning, confKinkChaDaughterQaBinning);
       if (doprocessSigma) {
-        auto sigmaHistSpec = kinkhistmanager::makeKinkQaHistSpecMap(confSigmaBinning, confSigmaQaBinning);
+        sigmaHistSpec = kinkhistmanager::makeKinkQaHistSpecMap(confSigmaBinning, confSigmaQaBinning);
         sigmaHistManager.init<modes::Mode::kAnalysis_Qa>(&hRegistry, sigmaHistSpec, confSigmaSelection, confSigmaQaBinning, chaDauHistSpec, confKinkChaDaughterQaBinning);
       }
       if (doprocessSigmaPlus) {
-        auto sigmaPlusHistSpec = kinkhistmanager::makeKinkQaHistSpecMap(confSigmaPlusBinning, confSigmaPlusQaBinning);
+        sigmaPlusHistSpec = kinkhistmanager::makeKinkQaHistSpecMap(confSigmaPlusBinning, confSigmaPlusQaBinning);
         sigmaPlusHistManager.init<modes::Mode::kAnalysis_Qa>(&hRegistry, sigmaPlusHistSpec, confSigmaPlusSelection, confSigmaPlusQaBinning, chaDauHistSpec, confKinkChaDaughterQaBinning);
       }
     } else {
-      auto colHistSpec = colhistmanager::makeColMcQaHistSpecMap(confCollisionBinning, confCollisionQaBinning);
+      colHistSpec = colhistmanager::makeColMcQaHistSpecMap(confCollisionBinning, confCollisionQaBinning);
       colHistManager.init<modes::Mode::kAnalysis_Qa_Mc>(&hRegistry, colHistSpec, confCollisionQaBinning);
-      auto chaDauHistSpec = trackhistmanager::makeTrackMcQaHistSpecMap(confKinkChaDaughterBinning, confKinkChaDaughterQaBinning);
+      chaDauHistSpec = trackhistmanager::makeTrackMcQaHistSpecMap(confKinkChaDaughterBinning, confKinkChaDaughterQaBinning);
       if (doprocessSigmaMc) {
-        auto sigmaHistSpec = kinkhistmanager::makeKinkMcQaHistSpecMap(confSigmaBinning, confSigmaQaBinning);
+        sigmaHistSpec = kinkhistmanager::makeKinkMcQaHistSpecMap(confSigmaBinning, confSigmaQaBinning);
         sigmaHistManager.init<modes::Mode::kAnalysis_Qa_Mc>(&hRegistry, sigmaHistSpec, confSigmaSelection, confSigmaQaBinning, chaDauHistSpec, confKinkChaDaughterQaBinning);
       }
       if (doprocessSigmaPlusMc) {
-        auto sigmaPlusHistSpec = kinkhistmanager::makeKinkMcQaHistSpecMap(confSigmaPlusBinning, confSigmaPlusQaBinning);
+        sigmaPlusHistSpec = kinkhistmanager::makeKinkMcQaHistSpecMap(confSigmaPlusBinning, confSigmaPlusQaBinning);
         sigmaPlusHistManager.init<modes::Mode::kAnalysis_Qa_Mc>(&hRegistry, sigmaPlusHistSpec, confSigmaPlusSelection, confSigmaPlusQaBinning, chaDauHistSpec, confKinkChaDaughterQaBinning);
       }
     }
@@ -159,17 +160,17 @@ struct FemtoKinkQa {
   void processSigma(FilteredFemtoCollision const& col, FemtoSigmas const& /*sigmas*/, FemtoTracks const& tracks)
   {
     colHistManager.fill<modes::Mode::kAnalysis_Qa>(col);
-    auto sigmaSlice = sigmaPartition->sliceByCached(femtobase::stored::fColId, col.globalIndex(), cache);
+    auto sigmaSlice = sigmaPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
     for (auto const& sigma : sigmaSlice) {
       sigmaHistManager.fill<modes::Mode::kAnalysis_Qa>(sigma, tracks);
     }
   }
   PROCESS_SWITCH(FemtoKinkQa, processSigma, "Process sigmas", true);
 
-  void processSigmaMc(FilteredFemtoCollisionWithLabel const& col, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmasWithLabel const& /*sigmas*/, FMcParticles const& mcParticles, FMcMothers const& mcMothers, FMcPartMoths const& mcPartonicMothers)
+  void processSigmaMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmasWithLabel const& /*sigmas*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     colHistManager.fill<modes::Mode::kAnalysis_Qa_Mc>(col, mcCols);
-    auto sigmaSlice = sigmaWithLabelPartition->sliceByCached(femtobase::stored::fColId, col.globalIndex(), cache);
+    auto sigmaSlice = sigmaWithLabelPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
     for (auto const& sigma : sigmaSlice) {
       if (!sigmaCleaner.isClean(sigma, mcParticles, mcMothers, mcPartonicMothers)) {
         continue;
@@ -183,7 +184,7 @@ struct FemtoKinkQa {
   {
     colHistManager.fill<modes::Mode::kAnalysis_Qa>(col);
 
-    auto sigmaplusSlice = sigmaPlusPartition->sliceByCached(femtobase::stored::fColId, col.globalIndex(), cache);
+    auto sigmaplusSlice = sigmaPlusPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
 
     for (auto const& sp : sigmaplusSlice) {
       sigmaPlusHistManager.fill<modes::Mode::kAnalysis_Qa>(sp, tracks);
@@ -191,10 +192,10 @@ struct FemtoKinkQa {
   }
   PROCESS_SWITCH(FemtoKinkQa, processSigmaPlus, "Process sigma plus", false);
 
-  void processSigmaPlusMc(FilteredFemtoCollisionWithLabel const& col, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmaPlusWithLabel const& /*sigmaPlus*/, FMcParticles const& mcParticles, FMcMothers const& mcMothers, FMcPartMoths const& mcPartonicMothers)
+  void processSigmaPlusMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmaPlusWithLabel const& /*sigmaPlus*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     colHistManager.fill<modes::Mode::kAnalysis_Qa_Mc>(col, mcCols);
-    auto sigmaPlusSlice = sigmaPlusWithLabelPartition->sliceByCached(femtobase::stored::fColId, col.globalIndex(), cache);
+    auto sigmaPlusSlice = sigmaPlusWithLabelPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
     for (auto const& sigmaPlus : sigmaPlusSlice) {
       if (!sigmaPlusCleaner.isClean(sigmaPlus, mcParticles, mcMothers, mcPartonicMothers)) {
         continue;
@@ -205,9 +206,9 @@ struct FemtoKinkQa {
   PROCESS_SWITCH(FemtoKinkQa, processSigmaPlusMc, "Process sigmas", false);
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{
+  o2::framework::WorkflowSpec workflow{
     adaptAnalysisTask<FemtoKinkQa>(cfgc),
   };
   return workflow;

--- a/PWGCF/Femto/Tasks/femtoPairTrackCascade.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackCascade.cxx
@@ -38,39 +38,35 @@
 #include "Framework/OutputObjHeader.h"
 #include "Framework/runDataProcessing.h"
 
+#include <map>
 #include <vector>
 
-using namespace o2;
-using namespace o2::aod;
-using namespace o2::soa;
-using namespace o2::framework;
-using namespace o2::framework::expressions;
 using namespace o2::analysis::femto;
 
 struct FemtoPairTrackCascade {
 
   // setup tables
-  using FemtoCollisions = Join<FCols, FColMasks>;
+  using FemtoCollisions = o2::soa::Join<o2::aod::FCols, o2::aod::FColMasks>;
   using FilteredFemtoCollisions = o2::soa::Filtered<FemtoCollisions>;
   using FilteredFemtoCollision = FilteredFemtoCollisions::iterator;
 
-  using FemtoCollisionsWithLabel = o2::soa::Join<FemtoCollisions, FColLabels>;
+  using FemtoCollisionsWithLabel = o2::soa::Join<FemtoCollisions, o2::aod::FColLabels>;
   using FilteredFemtoCollisionsWithLabel = o2::soa::Filtered<FemtoCollisionsWithLabel>;
   using FilteredFemtoCollisionWithLabel = FilteredFemtoCollisionsWithLabel::iterator;
 
-  using FemtoTracks = o2::soa::Join<FTracks, FTrackMasks>;
-  using FemtoXis = o2::soa::Join<FXis, FXiMasks>;
-  using FemtoOmegas = o2::soa::Join<FOmegas, FOmegaMasks>;
+  using FemtoTracks = o2::soa::Join<o2::aod::FTracks, o2::aod::FTrackMasks>;
+  using FemtoXis = o2::soa::Join<o2::aod::FXis, o2::aod::FXiMasks>;
+  using FemtoOmegas = o2::soa::Join<o2::aod::FOmegas, o2::aod::FOmegaMasks>;
 
-  using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, FTrackLabels>;
-  using FemtoXisWithLabel = o2::soa::Join<FemtoXis, FLambdaLabels>;
-  using FemtoOmegasWithLabel = o2::soa::Join<FemtoOmegas, FK0shortLabels>;
+  using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, o2::aod::FTrackLabels>;
+  using FemtoXisWithLabel = o2::soa::Join<FemtoXis, o2::aod::FLambdaLabels>;
+  using FemtoOmegasWithLabel = o2::soa::Join<FemtoOmegas, o2::aod::FK0shortLabels>;
 
-  SliceCache cache;
+  o2::framework::SliceCache cache;
 
   // setup collisions
   collisionbuilder::ConfCollisionSelection collisionSelection;
-  Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
+  o2::framework::expressions::Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
   colhistmanager::ConfCollisionBinning confCollisionBinning;
 
   // setup tracks
@@ -78,11 +74,11 @@ struct FemtoPairTrackCascade {
   trackhistmanager::ConfTrackBinning1 confTrackBinning;
   particlecleaner::ConfTrackCleaner1 confTrackCleaner;
 
-  Partition<FemtoTracks> trackPartition = MAKE_TRACK_PARTITION(confTrackSelection);
-  Preslice<FemtoTracks> perColTracks = aod::femtobase::stored::fColId;
+  o2::framework::Partition<FemtoTracks> trackPartition = MAKE_TRACK_PARTITION(confTrackSelection);
+  o2::framework::Preslice<FemtoTracks> perColTracks = o2::aod::femtobase::stored::fColId;
 
-  Partition<FemtoTracksWithLabel> trackWithLabelPartition = MAKE_TRACK_PARTITION(confTrackSelection);
-  Preslice<FemtoTracksWithLabel> perColtracksWithLabel = aod::femtobase::stored::fColId;
+  o2::framework::Partition<FemtoTracksWithLabel> trackWithLabelPartition = MAKE_TRACK_PARTITION(confTrackSelection);
+  o2::framework::Preslice<FemtoTracksWithLabel> perColtracksWithLabel = o2::aod::femtobase::stored::fColId;
 
   // setup for daughters/bachelor
   trackhistmanager::ConfCascadePosDauBinning confPosDauBinning;
@@ -94,22 +90,22 @@ struct FemtoPairTrackCascade {
   cascadehistmanager::ConfXiBinning confXiBinning;
   particlecleaner::ConfXiCleaner1 confXiCleaner;
 
-  Partition<FemtoXis> xiPartition = MAKE_CASCADE_PARTITION(confXiSelection);
-  Preslice<FemtoXis> perColXis = aod::femtobase::stored::fColId;
+  o2::framework::Partition<FemtoXis> xiPartition = MAKE_CASCADE_PARTITION(confXiSelection);
+  o2::framework::Preslice<FemtoXis> perColXis = o2::aod::femtobase::stored::fColId;
 
-  Partition<FemtoXisWithLabel> xiWithLabelPartition = MAKE_CASCADE_PARTITION(confXiSelection);
-  Preslice<FemtoXisWithLabel> perColXisWithLabel = aod::femtobase::stored::fColId;
+  o2::framework::Partition<FemtoXisWithLabel> xiWithLabelPartition = MAKE_CASCADE_PARTITION(confXiSelection);
+  o2::framework::Preslice<FemtoXisWithLabel> perColXisWithLabel = o2::aod::femtobase::stored::fColId;
 
   // setup omegas
   cascadebuilder::ConfOmegaSelection confOmegaSelection;
   cascadehistmanager::ConfOmegaBinning confOmegaBinning;
   particlecleaner::ConfOmegaCleaner1 confOmegaCleaner;
 
-  Partition<FemtoOmegas> omegaPartition = MAKE_CASCADE_PARTITION(confOmegaSelection);
-  Preslice<FemtoOmegas> perColOmegas = aod::femtobase::stored::fColId;
+  o2::framework::Partition<FemtoOmegas> omegaPartition = MAKE_CASCADE_PARTITION(confOmegaSelection);
+  o2::framework::Preslice<FemtoOmegas> perColOmegas = o2::aod::femtobase::stored::fColId;
 
-  Partition<FemtoOmegasWithLabel> omegaWithLabelPartition = MAKE_CASCADE_PARTITION(confOmegaSelection);
-  Preslice<FemtoOmegasWithLabel> perColOmegasWithLabel = aod::femtobase::stored::fColId;
+  o2::framework::Partition<FemtoOmegasWithLabel> omegaWithLabelPartition = MAKE_CASCADE_PARTITION(confOmegaSelection);
+  o2::framework::Preslice<FemtoOmegasWithLabel> perColOmegasWithLabel = o2::aod::femtobase::stored::fColId;
 
   // setup pairs
   pairhistmanager::ConfPairBinning confPairBinning;
@@ -149,18 +145,18 @@ struct FemtoPairTrackCascade {
   std::vector<double> defaultVtxBins{10, -10, 10};
   std::vector<double> defaultMultBins{50, 0, 200};
   std::vector<double> defaultCentBins{10, 0, 100};
-  ColumnBinningPolicy<femtocollisions::PosZ, femtocollisions::Mult> mixBinsVtxMult{{defaultVtxBins, defaultMultBins}, true};
-  ColumnBinningPolicy<aod::femtocollisions::PosZ, aod::femtocollisions::Cent> mixBinsVtxCent{{defaultVtxBins, defaultCentBins}, true};
-  ColumnBinningPolicy<aod::femtocollisions::PosZ, aod::femtocollisions::Mult, aod::femtocollisions::Cent> mixBinsVtxMultCent{{defaultVtxBins, defaultMultBins, defaultCentBins}, true};
+  o2::framework::ColumnBinningPolicy<o2::aod::femtocollisions::PosZ, o2::aod::femtocollisions::Mult> mixBinsVtxMult{{defaultVtxBins, defaultMultBins}, true};
+  o2::framework::ColumnBinningPolicy<o2::aod::femtocollisions::PosZ, o2::aod::femtocollisions::Cent> mixBinsVtxCent{{defaultVtxBins, defaultCentBins}, true};
+  o2::framework::ColumnBinningPolicy<o2::aod::femtocollisions::PosZ, o2::aod::femtocollisions::Mult, o2::aod::femtocollisions::Cent> mixBinsVtxMultCent{{defaultVtxBins, defaultMultBins, defaultCentBins}, true};
   pairhistmanager::ConfMixing confMixing;
 
-  HistogramRegistry hRegistry{"FemtoTrackCascade", {}, OutputObjHandlingPolicy::AnalysisObject};
+  o2::framework::HistogramRegistry hRegistry{"FemtoTrackCascade", {}, o2::framework::OutputObjHandlingPolicy::AnalysisObject};
 
   // setup cpr
   closepairrejection::ConfCprTrackCascadeBachelor confCprBachelor;
   closepairrejection::ConfCprTrackV0Daughter confCprV0Daughter;
 
-  void init(InitContext&)
+  void init(o2::framework::InitContext&)
   {
     bool processData = doprocessXiSameEvent || doprocessXiMixedEvent || doprocessOmegaSameEvent || doprocessOmegaMixedEvent;
     bool processMc = doprocessXiSameEventMc || doprocessXiMixedEventMc || doprocessOmegaSameEventMc || doprocessOmegaMixedEventMc;
@@ -182,40 +178,49 @@ struct FemtoPairTrackCascade {
     mixBinsVtxCent = {{confMixing.vtxBins.value, confMixing.centBins.value}, true};
     mixBinsVtxMultCent = {{confMixing.vtxBins.value, confMixing.multBins.value, confMixing.centBins.value}, true};
 
-    auto cprHistSpecBachelor = closepairrejection::makeCprHistSpecMap(confCprBachelor);
-    auto cprHistSpecV0Daughter = closepairrejection::makeCprHistSpecMap(confCprV0Daughter);
+    std::map<colhistmanager::ColHist, std::vector<o2::framework::AxisSpec>> colHistSpec;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> trackHistSpec;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> bachelorHistSpec;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> posDauSpec;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> negDauSpec;
+    std::map<cascadehistmanager::CascadeHist, std::vector<o2::framework::AxisSpec>> xiHistSpec;
+    std::map<cascadehistmanager::CascadeHist, std::vector<o2::framework::AxisSpec>> omegaHistSpec;
+    std::map<pairhistmanager::PairHist, std::vector<o2::framework::AxisSpec>> pairTrackCascadeHistSpec;
+
+    std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpecBachelor = closepairrejection::makeCprHistSpecMap(confCprBachelor);
+    std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpecV0Daughter = closepairrejection::makeCprHistSpecMap(confCprV0Daughter);
 
     if (processData) {
-      auto colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
-      auto trackHistSpec = trackhistmanager::makeTrackHistSpecMap(confTrackBinning);
-      auto bachelorHistSpec = trackhistmanager::makeTrackHistSpecMap(confBachelorBinning);
-      auto posDauSpec = trackhistmanager::makeTrackHistSpecMap(confPosDauBinning);
-      auto negDauSpec = trackhistmanager::makeTrackHistSpecMap(confNegDauBinning);
-      auto pairHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning);
+      colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
+      trackHistSpec = trackhistmanager::makeTrackHistSpecMap(confTrackBinning);
+      bachelorHistSpec = trackhistmanager::makeTrackHistSpecMap(confBachelorBinning);
+      posDauSpec = trackhistmanager::makeTrackHistSpecMap(confPosDauBinning);
+      negDauSpec = trackhistmanager::makeTrackHistSpecMap(confNegDauBinning);
+      pairTrackCascadeHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning);
       if (processXi) {
-        auto xiHistSpec = cascadehistmanager::makeCascadeHistSpecMap(confXiBinning);
-        auto pairTrackXiHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning);
-        pairTrackXiBuilder.init<modes::Mode::kAnalysis>(&hRegistry, confTrackSelection, confTrackCleaner, confXiSelection, confXiCleaner, confCprBachelor, confCprV0Daughter, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, xiHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, pairTrackXiHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter);
+        xiHistSpec = cascadehistmanager::makeCascadeHistSpecMap(confXiBinning);
+        pairTrackCascadeHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning);
+        pairTrackXiBuilder.init<modes::Mode::kAnalysis>(&hRegistry, confTrackSelection, confTrackCleaner, confXiSelection, confXiCleaner, confCprBachelor, confCprV0Daughter, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, xiHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, pairTrackCascadeHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter);
       } else {
-        auto omegaHistSpec = cascadehistmanager::makeCascadeHistSpecMap(confOmegaBinning);
-        auto pairTrackOmegaHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning);
-        pairTrackOmegaBuilder.init<modes::Mode::kAnalysis>(&hRegistry, confTrackSelection, confTrackCleaner, confOmegaSelection, confOmegaCleaner, confCprBachelor, confCprV0Daughter, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, omegaHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, pairTrackOmegaHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter);
+        omegaHistSpec = cascadehistmanager::makeCascadeHistSpecMap(confOmegaBinning);
+        pairTrackCascadeHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning);
+        pairTrackOmegaBuilder.init<modes::Mode::kAnalysis>(&hRegistry, confTrackSelection, confTrackCleaner, confOmegaSelection, confOmegaCleaner, confCprBachelor, confCprV0Daughter, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, omegaHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, pairTrackCascadeHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter);
       }
     } else {
-      auto colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
-      auto trackHistSpec = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning);
-      auto bachelorHistSpec = trackhistmanager::makeTrackMcHistSpecMap(confBachelorBinning);
-      auto posDauSpec = trackhistmanager::makeTrackMcHistSpecMap(confPosDauBinning);
-      auto negDauSpec = trackhistmanager::makeTrackMcHistSpecMap(confNegDauBinning);
-      auto pairHistSpec = pairhistmanager::makePairMcHistSpecMap(confPairBinning);
+      colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
+      trackHistSpec = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning);
+      bachelorHistSpec = trackhistmanager::makeTrackMcHistSpecMap(confBachelorBinning);
+      posDauSpec = trackhistmanager::makeTrackMcHistSpecMap(confPosDauBinning);
+      negDauSpec = trackhistmanager::makeTrackMcHistSpecMap(confNegDauBinning);
+      pairTrackCascadeHistSpec = pairhistmanager::makePairMcHistSpecMap(confPairBinning);
       if (processXi) {
-        auto xiHistSpec = cascadehistmanager::makeCascadeMcHistSpecMap(confXiBinning);
-        auto pairTrackXiHistSpec = pairhistmanager::makePairMcHistSpecMap(confPairBinning);
-        pairTrackXiBuilder.init<modes::Mode::kAnalysis_Mc>(&hRegistry, confTrackSelection, confTrackCleaner, confXiSelection, confXiCleaner, confCprBachelor, confCprV0Daughter, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, xiHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, pairTrackXiHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter);
+        xiHistSpec = cascadehistmanager::makeCascadeMcHistSpecMap(confXiBinning);
+        pairTrackCascadeHistSpec = pairhistmanager::makePairMcHistSpecMap(confPairBinning);
+        pairTrackXiBuilder.init<modes::Mode::kAnalysis_Mc>(&hRegistry, confTrackSelection, confTrackCleaner, confXiSelection, confXiCleaner, confCprBachelor, confCprV0Daughter, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, xiHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, pairTrackCascadeHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter);
       } else {
-        auto omegaHistSpec = cascadehistmanager::makeCascadeMcHistSpecMap(confOmegaBinning);
-        auto pairTrackOmegaHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning);
-        pairTrackOmegaBuilder.init<modes::Mode::kAnalysis_Mc>(&hRegistry, confTrackSelection, confTrackCleaner, confOmegaSelection, confOmegaCleaner, confCprBachelor, confCprV0Daughter, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, omegaHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, pairTrackOmegaHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter);
+        omegaHistSpec = cascadehistmanager::makeCascadeMcHistSpecMap(confOmegaBinning);
+        pairTrackCascadeHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning);
+        pairTrackOmegaBuilder.init<modes::Mode::kAnalysis_Mc>(&hRegistry, confTrackSelection, confTrackCleaner, confOmegaSelection, confOmegaCleaner, confCprBachelor, confCprV0Daughter, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, omegaHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, pairTrackCascadeHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter);
       }
     }
   };
@@ -226,7 +231,7 @@ struct FemtoPairTrackCascade {
   }
   PROCESS_SWITCH(FemtoPairTrackCascade, processXiSameEvent, "Enable processing same event processing for tracks and xis", true);
 
-  void processXiSameEventMc(FilteredFemtoCollisionWithLabel const& col, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& xis, FMcParticles const& mcParticles, FMcMothers const& mcMothers, FMcPartMoths const& mcPartonicMothers)
+  void processXiSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& xis, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackXiBuilder.processSameEvent<modes::Mode::kAnalysis_Mc>(col, mcCols, tracks, trackWithLabelPartition, xis, xiWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -238,7 +243,7 @@ struct FemtoPairTrackCascade {
   }
   PROCESS_SWITCH(FemtoPairTrackCascade, processXiMixedEvent, "Enable processing mixed event processing for tracks and xis", true);
 
-  void processXiMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& /*xis*/, FMcParticles const& mcParticles, FMcMothers const& mcMothers, FMcPartMoths const& mcPartonicMothers)
+  void processXiMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& /*xis*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackXiBuilder.processMixedEvent<modes::Mode::kAnalysis_Mc>(cols, mcCols, tracks, trackWithLabelPartition, xiWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }
@@ -250,7 +255,7 @@ struct FemtoPairTrackCascade {
   }
   PROCESS_SWITCH(FemtoPairTrackCascade, processOmegaSameEvent, "Enable processing same event processing for tracks and omegas", false);
 
-  void processOmegaSameEventMc(FilteredFemtoCollisionWithLabel const& col, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoOmegasWithLabel const& omegas, FMcParticles const& mcParticles, FMcMothers const& mcMothers, FMcPartMoths const& mcPartonicMothers)
+  void processOmegaSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoOmegasWithLabel const& omegas, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackOmegaBuilder.processSameEvent<modes::Mode::kAnalysis_Mc>(col, mcCols, tracks, trackWithLabelPartition, omegas, omegaWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -262,16 +267,16 @@ struct FemtoPairTrackCascade {
   }
   PROCESS_SWITCH(FemtoPairTrackCascade, processOmegaMixedEvent, "Enable processing mixed event processing for tracks and omegas", false);
 
-  void processOmegaMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& /*xis*/, FMcParticles const& mcParticles, FMcMothers const& mcMothers, FMcPartMoths const& mcPartonicMothers)
+  void processOmegaMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& /*xis*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackOmegaBuilder.processMixedEvent<modes::Mode::kAnalysis_Mc>(cols, mcCols, tracks, trackWithLabelPartition, omegaWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }
   PROCESS_SWITCH(FemtoPairTrackCascade, processOmegaMixedEventMc, "Enable processing mixed event processing for tracks and omegas with mc information", false);
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{
+  o2::framework::WorkflowSpec workflow{
     adaptAnalysisTask<FemtoPairTrackCascade>(cfgc),
   };
   return workflow;

--- a/PWGCF/Femto/Tasks/femtoPairTrackKink.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackKink.cxx
@@ -39,6 +39,7 @@
 #include "Framework/OutputObjHeader.h"
 #include "Framework/runDataProcessing.h"
 
+#include <map>
 #include <vector>
 
 using namespace o2::analysis::femto;

--- a/PWGCF/Femto/Tasks/femtoPairTrackKink.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackKink.cxx
@@ -39,40 +39,34 @@
 #include "Framework/OutputObjHeader.h"
 #include "Framework/runDataProcessing.h"
 
-#include <string>
 #include <vector>
 
-using namespace o2;
-using namespace o2::aod;
-using namespace o2::soa;
-using namespace o2::framework;
-using namespace o2::framework::expressions;
 using namespace o2::analysis::femto;
 
 struct FemtoPairTrackKink {
 
   // setup tables
-  using FemtoCollisions = Join<FCols, FColMasks>;
+  using FemtoCollisions = o2::soa::Join<o2::aod::FCols, o2::aod::FColMasks>;
   using FilteredFemtoCollisions = o2::soa::Filtered<FemtoCollisions>;
   using FilteredFemtoCollision = FilteredFemtoCollisions::iterator;
 
-  using FemtoCollisionsWithLabel = o2::soa::Join<FemtoCollisions, FColLabels>;
+  using FemtoCollisionsWithLabel = o2::soa::Join<FemtoCollisions, o2::aod::FColLabels>;
   using FilteredFemtoCollisionsWithLabel = o2::soa::Filtered<FemtoCollisionsWithLabel>;
   using FilteredFemtoCollisionWithLabel = FilteredFemtoCollisionsWithLabel::iterator;
 
-  using FemtoTracks = o2::soa::Join<FTracks, FTrackMasks>;
-  using FemtoSigmas = o2::soa::Join<FSigmas, FSigmaMasks>;
-  using FemtoSigmaPlus = o2::soa::Join<FSigmaPlus, FSigmaPlusMasks>;
+  using FemtoTracks = o2::soa::Join<o2::aod::FTracks, o2::aod::FTrackMasks>;
+  using FemtoSigmas = o2::soa::Join<o2::aod::FSigmas, o2::aod::FSigmaMasks>;
+  using FemtoSigmaPlus = o2::soa::Join<o2::aod::FSigmaPlus, o2::aod::FSigmaPlusMasks>;
 
-  using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, FTrackLabels>;
-  using FemtoSigmasWithLabel = o2::soa::Join<FemtoSigmas, FSigmaLabels>;
-  using FemtoSigmaPlusWithLabel = o2::soa::Join<FemtoSigmaPlus, FSigmaPlusLabels>;
+  using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, o2::aod::FTrackLabels>;
+  using FemtoSigmasWithLabel = o2::soa::Join<FemtoSigmas, o2::aod::FSigmaLabels>;
+  using FemtoSigmaPlusWithLabel = o2::soa::Join<FemtoSigmaPlus, o2::aod::FSigmaPlusLabels>;
 
-  SliceCache cache;
+  o2::framework::SliceCache cache;
 
   // setup collisions
   collisionbuilder::ConfCollisionSelection collisionSelection;
-  Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
+  o2::framework::expressions::Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
   colhistmanager::ConfCollisionBinning confCollisionBinning;
 
   // setup tracks
@@ -80,11 +74,11 @@ struct FemtoPairTrackKink {
   trackhistmanager::ConfTrackBinning1 confTrackBinning;
   particlecleaner::ConfTrackCleaner1 confTrackCleaner;
 
-  Partition<FemtoTracks> trackPartition = MAKE_TRACK_PARTITION(confTrackSelection);
-  Preslice<FemtoTracks> perColTracks = aod::femtobase::stored::fColId;
+  o2::framework::Partition<FemtoTracks> trackPartition = MAKE_TRACK_PARTITION(confTrackSelection);
+  o2::framework::Preslice<FemtoTracks> perColTracks = o2::aod::femtobase::stored::fColId;
 
-  Partition<FemtoTracksWithLabel> trackWithLabelPartition = MAKE_TRACK_PARTITION(confTrackSelection);
-  Preslice<FemtoTracksWithLabel> perColtracksWithLabel = aod::femtobase::stored::fColId;
+  o2::framework::Partition<FemtoTracksWithLabel> trackWithLabelPartition = MAKE_TRACK_PARTITION(confTrackSelection);
+  o2::framework::Preslice<FemtoTracksWithLabel> perColtracksWithLabel = o2::aod::femtobase::stored::fColId;
 
   // setup for daughters
   trackhistmanager::ConfKinkChaDauBinning confChaDauBinning;
@@ -94,22 +88,22 @@ struct FemtoPairTrackKink {
   kinkhistmanager::ConfSigmaBinning1 confSigmaBinning;
   particlecleaner::ConfSigmaCleaner1 confSigmaCleaner;
 
-  Partition<FemtoSigmas> sigmaPartition = MAKE_SIGMA_PARTITION(confSigmaSelection);
-  Preslice<FemtoSigmas> perColSigmas = aod::femtobase::stored::fColId;
+  o2::framework::Partition<FemtoSigmas> sigmaPartition = MAKE_SIGMA_PARTITION(confSigmaSelection);
+  o2::framework::Preslice<FemtoSigmas> perColSigmas = o2::aod::femtobase::stored::fColId;
 
-  Partition<FemtoSigmasWithLabel> sigmaWithLabelPartition = MAKE_SIGMA_PARTITION(confSigmaSelection);
-  Preslice<FemtoSigmasWithLabel> perColSigmasWithLabel = aod::femtobase::stored::fColId;
+  o2::framework::Partition<FemtoSigmasWithLabel> sigmaWithLabelPartition = MAKE_SIGMA_PARTITION(confSigmaSelection);
+  o2::framework::Preslice<FemtoSigmasWithLabel> perColSigmasWithLabel = o2::aod::femtobase::stored::fColId;
 
   // setup for sigma plus
   kinkbuilder::ConfSigmaPlusSelection1 confSigmaPlusSelection;
   kinkhistmanager::ConfSigmaPlusBinning1 confSigmaPlusBinning;
   particlecleaner::ConfSigmaPlusCleaner1 confSigmaPlusCleaner;
 
-  Partition<FemtoSigmaPlus> sigmaPlusPartition = MAKE_SIGMAPLUS_PARTITION(confSigmaPlusSelection);
-  Preslice<FemtoSigmaPlus> perColSigmaPlus = aod::femtobase::stored::fColId;
+  o2::framework::Partition<FemtoSigmaPlus> sigmaPlusPartition = MAKE_SIGMAPLUS_PARTITION(confSigmaPlusSelection);
+  o2::framework::Preslice<FemtoSigmaPlus> perColSigmaPlus = o2::aod::femtobase::stored::fColId;
 
-  Partition<FemtoSigmaPlusWithLabel> sigmaPlusWithLabelPartition = MAKE_SIGMAPLUS_PARTITION(confSigmaPlusSelection);
-  Preslice<FemtoSigmaPlusWithLabel> perColSigmaPlusWithLabel = aod::femtobase::stored::fColId;
+  o2::framework::Partition<FemtoSigmaPlusWithLabel> sigmaPlusWithLabelPartition = MAKE_SIGMAPLUS_PARTITION(confSigmaPlusSelection);
+  o2::framework::Preslice<FemtoSigmaPlusWithLabel> perColSigmaPlusWithLabel = o2::aod::femtobase::stored::fColId;
 
   // setup pairs
   pairhistmanager::ConfPairBinning confPairBinning;
@@ -141,17 +135,17 @@ struct FemtoPairTrackKink {
   std::vector<double> defaultVtxBins{10, -10, 10};
   std::vector<double> defaultMultBins{50, 0, 200};
   std::vector<double> defaultCentBins{10, 0, 100};
-  ColumnBinningPolicy<femtocollisions::PosZ, femtocollisions::Mult> mixBinsVtxMult{{defaultVtxBins, defaultMultBins}, true};
-  ColumnBinningPolicy<aod::femtocollisions::PosZ, aod::femtocollisions::Cent> mixBinsVtxCent{{defaultVtxBins, defaultCentBins}, true};
-  ColumnBinningPolicy<aod::femtocollisions::PosZ, aod::femtocollisions::Mult, aod::femtocollisions::Cent> mixBinsVtxMultCent{{defaultVtxBins, defaultMultBins, defaultCentBins}, true};
+  o2::framework::ColumnBinningPolicy<o2::aod::femtocollisions::PosZ, o2::aod::femtocollisions::Mult> mixBinsVtxMult{{defaultVtxBins, defaultMultBins}, true};
+  o2::framework::ColumnBinningPolicy<o2::aod::femtocollisions::PosZ, o2::aod::femtocollisions::Cent> mixBinsVtxCent{{defaultVtxBins, defaultCentBins}, true};
+  o2::framework::ColumnBinningPolicy<o2::aod::femtocollisions::PosZ, o2::aod::femtocollisions::Mult, o2::aod::femtocollisions::Cent> mixBinsVtxMultCent{{defaultVtxBins, defaultMultBins, defaultCentBins}, true};
   pairhistmanager::ConfMixing confMixing;
 
-  HistogramRegistry hRegistry{"FemtoTrackKink", {}, OutputObjHandlingPolicy::AnalysisObject};
+  o2::framework::HistogramRegistry hRegistry{"FemtoTrackKink", {}, o2::framework::OutputObjHandlingPolicy::AnalysisObject};
 
   // setup cpr
   closepairrejection::ConfCprTrackKinkDaughter confCpr;
 
-  void init(InitContext&)
+  void init(o2::framework::InitContext&)
   {
     bool processData = doprocessSigmaSameEvent || doprocessSigmaMixedEvent || doprocessSigmaPlusSameEvent || doprocessSigmaPlusMixedEvent;
     bool processMc = doprocessSigmaSameEventMc || doprocessSigmaMixedEventMc || doprocessSigmaPlusSameEventMc || doprocessSigmaPlusMixedEventMc;
@@ -173,31 +167,37 @@ struct FemtoPairTrackKink {
     mixBinsVtxCent = {{confMixing.vtxBins.value, confMixing.centBins.value}, true};
     mixBinsVtxMultCent = {{confMixing.vtxBins.value, confMixing.multBins.value, confMixing.centBins.value}, true};
 
-    auto cprHistSpec = closepairrejection::makeCprHistSpecMap(confCpr);
+    std::map<colhistmanager::ColHist, std::vector<o2::framework::AxisSpec>> colHistSpec;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> trackHistSpec;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> chaDauSpec;
+    std::map<kinkhistmanager::KinkHist, std::vector<o2::framework::AxisSpec>> sigmaHistSpec;
+    std::map<kinkhistmanager::KinkHist, std::vector<o2::framework::AxisSpec>> sigmaPlusHistSpec;
+    std::map<pairhistmanager::PairHist, std::vector<o2::framework::AxisSpec>> pairTrackKinkHistSpec;
+    std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpec = closepairrejection::makeCprHistSpecMap(confCpr);
 
     if (processData) {
-      auto colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
-      auto trackHistSpec = trackhistmanager::makeTrackHistSpecMap(confTrackBinning);
-      auto chaDauSpec = trackhistmanager::makeTrackHistSpecMap(confChaDauBinning);
-      auto pairTrackKinkHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning);
+      colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
+      trackHistSpec = trackhistmanager::makeTrackHistSpecMap(confTrackBinning);
+      chaDauSpec = trackhistmanager::makeTrackHistSpecMap(confChaDauBinning);
+      pairTrackKinkHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning);
       if (processSigma) {
-        auto sigmaHistSpec = kinkhistmanager::makeKinkHistSpecMap(confSigmaBinning);
+        sigmaHistSpec = kinkhistmanager::makeKinkHistSpecMap(confSigmaBinning);
         pairTrackSigmaBuilder.init<modes::Mode::kAnalysis>(&hRegistry, confTrackSelection, confTrackCleaner, confSigmaSelection, confSigmaCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, sigmaHistSpec, chaDauSpec, pairTrackKinkHistSpec, cprHistSpec);
       } else {
-        auto sigmaplusHistSpec = kinkhistmanager::makeKinkHistSpecMap(confSigmaPlusBinning);
-        pairTrackSigmaPlusBuilder.init<modes::Mode::kAnalysis>(&hRegistry, confTrackSelection, confTrackCleaner, confSigmaPlusSelection, confSigmaPlusCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, sigmaplusHistSpec, chaDauSpec, pairTrackKinkHistSpec, cprHistSpec);
+        sigmaPlusHistSpec = kinkhistmanager::makeKinkHistSpecMap(confSigmaPlusBinning);
+        pairTrackSigmaPlusBuilder.init<modes::Mode::kAnalysis>(&hRegistry, confTrackSelection, confTrackCleaner, confSigmaPlusSelection, confSigmaPlusCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, sigmaPlusHistSpec, chaDauSpec, pairTrackKinkHistSpec, cprHistSpec);
       }
     } else {
-      auto colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
-      auto trackHistSpec = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning);
-      auto chaDauSpec = trackhistmanager::makeTrackMcHistSpecMap(confChaDauBinning);
-      auto pairTrackKinkHistSpec = pairhistmanager::makePairMcHistSpecMap(confPairBinning);
+      colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
+      trackHistSpec = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning);
+      chaDauSpec = trackhistmanager::makeTrackMcHistSpecMap(confChaDauBinning);
+      pairTrackKinkHistSpec = pairhistmanager::makePairMcHistSpecMap(confPairBinning);
       if (processSigma) {
-        auto sigmaHistSpec = kinkhistmanager::makeKinkMcHistSpecMap(confSigmaBinning);
+        sigmaHistSpec = kinkhistmanager::makeKinkMcHistSpecMap(confSigmaBinning);
         pairTrackSigmaBuilder.init<modes::Mode::kAnalysis_Mc>(&hRegistry, confTrackSelection, confTrackCleaner, confSigmaSelection, confSigmaCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, sigmaHistSpec, chaDauSpec, pairTrackKinkHistSpec, cprHistSpec);
       } else {
-        auto sigmaplusHistSpec = kinkhistmanager::makeKinkMcHistSpecMap(confSigmaPlusBinning);
-        pairTrackSigmaPlusBuilder.init<modes::Mode::kAnalysis_Mc>(&hRegistry, confTrackSelection, confTrackCleaner, confSigmaPlusSelection, confSigmaPlusCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, sigmaplusHistSpec, chaDauSpec, pairTrackKinkHistSpec, cprHistSpec);
+        sigmaPlusHistSpec = kinkhistmanager::makeKinkMcHistSpecMap(confSigmaPlusBinning);
+        pairTrackSigmaPlusBuilder.init<modes::Mode::kAnalysis_Mc>(&hRegistry, confTrackSelection, confTrackCleaner, confSigmaPlusSelection, confSigmaPlusCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, sigmaPlusHistSpec, chaDauSpec, pairTrackKinkHistSpec, cprHistSpec);
       }
     }
     hRegistry.print();
@@ -209,7 +209,7 @@ struct FemtoPairTrackKink {
   }
   PROCESS_SWITCH(FemtoPairTrackKink, processSigmaSameEvent, "Enable processing same event processing for tracks and sigmas", true);
 
-  void processSigmaSameEventMc(FilteredFemtoCollisionWithLabel const& col, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmasWithLabel const& sigmas, FMcParticles const& mcParticles, FMcMothers const& mcMothers, FMcPartMoths const& mcPartonicMothers)
+  void processSigmaSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmasWithLabel const& sigmas, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackSigmaBuilder.processSameEvent<modes::Mode::kAnalysis_Mc>(col, mcCols, tracks, trackWithLabelPartition, sigmas, sigmaWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -221,7 +221,7 @@ struct FemtoPairTrackKink {
   }
   PROCESS_SWITCH(FemtoPairTrackKink, processSigmaMixedEvent, "Enable processing mixed event processing for tracks and sigmas", true);
 
-  void processSigmaMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmasWithLabel const& /*sigmas*/, FMcParticles const& mcParticles, FMcMothers const& mcMothers, FMcPartMoths const& mcPartonicMothers)
+  void processSigmaMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmasWithLabel const& /*sigmas*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackSigmaBuilder.processMixedEvent<modes::Mode::kAnalysis_Mc>(cols, mcCols, tracks, trackWithLabelPartition, sigmaWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }
@@ -233,7 +233,7 @@ struct FemtoPairTrackKink {
   }
   PROCESS_SWITCH(FemtoPairTrackKink, processSigmaPlusSameEvent, "Enable processing same event processing for tracks and sigma plus", false);
 
-  void processSigmaPlusSameEventMc(FilteredFemtoCollisionWithLabel const& col, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmaPlusWithLabel const& sigmaplus, FMcParticles const& mcParticles, FMcMothers const& mcMothers, FMcPartMoths const& mcPartonicMothers)
+  void processSigmaPlusSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmaPlusWithLabel const& sigmaplus, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackSigmaPlusBuilder.processSameEvent<modes::Mode::kAnalysis_Mc>(col, mcCols, tracks, trackWithLabelPartition, sigmaplus, sigmaPlusWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -245,16 +245,16 @@ struct FemtoPairTrackKink {
   }
   PROCESS_SWITCH(FemtoPairTrackKink, processSigmaPlusMixedEvent, "Enable processing mixed event processing for tracks and sigma plus", false);
 
-  void processSigmaPlusMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmaPlusWithLabel const& /*sigmaplus*/, FMcParticles const& mcParticles, FMcMothers const& mcMothers, FMcPartMoths const& mcPartonicMothers)
+  void processSigmaPlusMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmaPlusWithLabel const& /*sigmaplus*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackSigmaPlusBuilder.processMixedEvent<modes::Mode::kAnalysis_Mc>(cols, mcCols, tracks, trackWithLabelPartition, sigmaPlusWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }
   PROCESS_SWITCH(FemtoPairTrackKink, processSigmaPlusMixedEventMc, "Enable processing mixed event processing for tracks and sigma plus with MC information", false);
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{
+  o2::framework::WorkflowSpec workflow{
     adaptAnalysisTask<FemtoPairTrackKink>(cfgc),
   };
   return workflow;

--- a/PWGCF/Femto/Tasks/femtoPairTrackTrack.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackTrack.cxx
@@ -36,6 +36,7 @@
 #include "Framework/OutputObjHeader.h"
 #include "Framework/runDataProcessing.h"
 
+#include <map>
 #include <vector>
 
 using namespace o2::analysis::femto;

--- a/PWGCF/Femto/Tasks/femtoPairTrackV0.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackV0.cxx
@@ -38,40 +38,34 @@
 #include "Framework/OutputObjHeader.h"
 #include "Framework/runDataProcessing.h"
 
-#include <string>
 #include <vector>
 
-using namespace o2;
-using namespace o2::aod;
-using namespace o2::soa;
-using namespace o2::framework;
-using namespace o2::framework::expressions;
 using namespace o2::analysis::femto;
 
 struct FemtoPairTrackV0 {
 
   // setup tables
-  using FemtoCollisions = Join<FCols, FColMasks>;
+  using FemtoCollisions = o2::soa::Join<o2::aod::FCols, o2::aod::FColMasks>;
   using FilteredFemtoCollisions = o2::soa::Filtered<FemtoCollisions>;
   using FilteredFemtoCollision = FilteredFemtoCollisions::iterator;
 
-  using FemtoCollisionsWithLabel = o2::soa::Join<FemtoCollisions, FColLabels>;
+  using FemtoCollisionsWithLabel = o2::soa::Join<FemtoCollisions, o2::aod::FColLabels>;
   using FilteredFemtoCollisionsWithLabel = o2::soa::Filtered<FemtoCollisionsWithLabel>;
   using FilteredFemtoCollisionWithLabel = FilteredFemtoCollisionsWithLabel::iterator;
 
-  using FemtoTracks = o2::soa::Join<FTracks, FTrackMasks>;
-  using FemtoLambdas = o2::soa::Join<FLambdas, FLambdaMasks>;
-  using FemtoK0shorts = o2::soa::Join<FK0shorts, FK0shortMasks>;
+  using FemtoTracks = o2::soa::Join<o2::aod::FTracks, o2::aod::FTrackMasks>;
+  using FemtoLambdas = o2::soa::Join<o2::aod::FLambdas, o2::aod::FLambdaMasks>;
+  using FemtoK0shorts = o2::soa::Join<o2::aod::FK0shorts, o2::aod::FK0shortMasks>;
 
-  using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, FTrackLabels>;
-  using FemtoLambdasWithLabel = o2::soa::Join<FemtoLambdas, FLambdaLabels>;
-  using FemtoK0shortsWithLabel = o2::soa::Join<FemtoK0shorts, FK0shortLabels>;
+  using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, o2::aod::FTrackLabels>;
+  using FemtoLambdasWithLabel = o2::soa::Join<FemtoLambdas, o2::aod::FLambdaLabels>;
+  using FemtoK0shortsWithLabel = o2::soa::Join<FemtoK0shorts, o2::aod::FK0shortLabels>;
 
-  SliceCache cache;
+  o2::framework::SliceCache cache;
 
   // setup collisions
   collisionbuilder::ConfCollisionSelection collisionSelection;
-  Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
+  o2::framework::expressions::Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
   colhistmanager::ConfCollisionBinning confCollisionBinning;
 
   // setup tracks
@@ -79,11 +73,11 @@ struct FemtoPairTrackV0 {
   trackhistmanager::ConfTrackBinning1 confTrackBinning;
   particlecleaner::ConfTrackCleaner1 confTrackCleaner;
 
-  Partition<FemtoTracks> trackPartition = MAKE_TRACK_PARTITION(confTrackSelection);
-  Preslice<FemtoTracks> perColTracks = aod::femtobase::stored::fColId;
+  o2::framework::Partition<FemtoTracks> trackPartition = MAKE_TRACK_PARTITION(confTrackSelection);
+  o2::framework::Preslice<FemtoTracks> perColTracks = o2::aod::femtobase::stored::fColId;
 
-  Partition<FemtoTracksWithLabel> trackWithLabelPartition = MAKE_TRACK_PARTITION(confTrackSelection);
-  Preslice<FemtoTracksWithLabel> perColtracksWithLabel = aod::femtobase::stored::fColId;
+  o2::framework::Partition<FemtoTracksWithLabel> trackWithLabelPartition = MAKE_TRACK_PARTITION(confTrackSelection);
+  o2::framework::Preslice<FemtoTracksWithLabel> perColtracksWithLabel = o2::aod::femtobase::stored::fColId;
 
   // setup for daughters
   trackhistmanager::ConfV0PosDauBinning confPosDauBinning;
@@ -94,22 +88,22 @@ struct FemtoPairTrackV0 {
   v0histmanager::ConfLambdaBinning1 confLambdaBinning;
   particlecleaner::ConfLambdaCleaner1 confLambdaCleaner;
 
-  Partition<FemtoLambdas> lambdaPartition = MAKE_LAMBDA_PARTITION(lambdaSelection);
-  Preslice<FemtoLambdas> perColLambdas = aod::femtobase::stored::fColId;
+  o2::framework::Partition<FemtoLambdas> lambdaPartition = MAKE_LAMBDA_PARTITION(lambdaSelection);
+  o2::framework::Preslice<FemtoLambdas> perColLambdas = o2::aod::femtobase::stored::fColId;
 
-  Partition<FemtoLambdasWithLabel> lambdaWithLabelPartition = MAKE_LAMBDA_PARTITION(lambdaSelection);
-  Preslice<FemtoLambdasWithLabel> perColLambdasWithLabel = aod::femtobase::stored::fColId;
+  o2::framework::Partition<FemtoLambdasWithLabel> lambdaWithLabelPartition = MAKE_LAMBDA_PARTITION(lambdaSelection);
+  o2::framework::Preslice<FemtoLambdasWithLabel> perColLambdasWithLabel = o2::aod::femtobase::stored::fColId;
 
   // setup k0shorts
   v0builder::ConfK0shortSelection1 k0shortSelection;
   v0histmanager::ConfK0shortBinning1 confK0shortBinning;
   particlecleaner::ConfK0shortCleaner1 confK0shortCleaner;
 
-  Partition<FemtoK0shorts> k0shortPartition = MAKE_K0SHORT_PARTITION(k0shortSelection);
-  Preslice<FemtoK0shorts> perColk0shorts = aod::femtobase::stored::fColId;
+  o2::framework::Partition<FemtoK0shorts> k0shortPartition = MAKE_K0SHORT_PARTITION(k0shortSelection);
+  o2::framework::Preslice<FemtoK0shorts> perColk0shorts = o2::aod::femtobase::stored::fColId;
 
-  Partition<FemtoK0shortsWithLabel> k0shortWithLabelPartition = MAKE_K0SHORT_PARTITION(k0shortSelection);
-  Preslice<FemtoK0shortsWithLabel> perColk0shortsWithLabel = aod::femtobase::stored::fColId;
+  o2::framework::Partition<FemtoK0shortsWithLabel> k0shortWithLabelPartition = MAKE_K0SHORT_PARTITION(k0shortSelection);
+  o2::framework::Preslice<FemtoK0shortsWithLabel> perColk0shortsWithLabel = o2::aod::femtobase::stored::fColId;
 
   // setup pairs
   pairhistmanager::ConfPairBinning confPairBinning;
@@ -143,17 +137,17 @@ struct FemtoPairTrackV0 {
   std::vector<double> defaultVtxBins{10, -10, 10};
   std::vector<double> defaultMultBins{50, 0, 200};
   std::vector<double> defaultCentBins{10, 0, 100};
-  ColumnBinningPolicy<femtocollisions::PosZ, femtocollisions::Mult> mixBinsVtxMult{{defaultVtxBins, defaultMultBins}, true};
-  ColumnBinningPolicy<aod::femtocollisions::PosZ, aod::femtocollisions::Cent> mixBinsVtxCent{{defaultVtxBins, defaultCentBins}, true};
-  ColumnBinningPolicy<aod::femtocollisions::PosZ, aod::femtocollisions::Mult, aod::femtocollisions::Cent> mixBinsVtxMultCent{{defaultVtxBins, defaultMultBins, defaultCentBins}, true};
+  o2::framework::ColumnBinningPolicy<o2::aod::femtocollisions::PosZ, o2::aod::femtocollisions::Mult> mixBinsVtxMult{{defaultVtxBins, defaultMultBins}, true};
+  o2::framework::ColumnBinningPolicy<o2::aod::femtocollisions::PosZ, o2::aod::femtocollisions::Cent> mixBinsVtxCent{{defaultVtxBins, defaultCentBins}, true};
+  o2::framework::ColumnBinningPolicy<o2::aod::femtocollisions::PosZ, o2::aod::femtocollisions::Mult, o2::aod::femtocollisions::Cent> mixBinsVtxMultCent{{defaultVtxBins, defaultMultBins, defaultCentBins}, true};
   pairhistmanager::ConfMixing confMixing;
 
-  HistogramRegistry hRegistry{"FemtoTrackV0", {}, OutputObjHandlingPolicy::AnalysisObject};
+  o2::framework::HistogramRegistry hRegistry{"FemtoTrackV0", {}, o2::framework::OutputObjHandlingPolicy::AnalysisObject};
 
   // setup cpr
   closepairrejection::ConfCprTrackV0Daughter confCpr;
 
-  void init(InitContext&)
+  void init(o2::framework::InitContext&)
   {
     bool processData = doprocessLambdaSameEvent || doprocessLambdaMixedEvent || doprocessK0shortSameEvent || doprocessK0shortMixedEvent;
     bool processMc = doprocessLambdaSameEventMc || doprocessLambdaMixedEventMc || doprocessK0shortSameEventMc || doprocessK0shortMixedEventMc;
@@ -175,32 +169,39 @@ struct FemtoPairTrackV0 {
     mixBinsVtxCent = {{confMixing.vtxBins.value, confMixing.centBins.value}, true};
     mixBinsVtxMultCent = {{confMixing.vtxBins.value, confMixing.multBins.value, confMixing.centBins.value}, true};
 
-    auto cprHistSpec = closepairrejection::makeCprHistSpecMap(confCpr);
+    std::map<colhistmanager::ColHist, std::vector<o2::framework::AxisSpec>> colHistSpec;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> trackHistSpec;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> posDauSpec;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> negDauSpec;
+    std::map<v0histmanager::V0Hist, std::vector<o2::framework::AxisSpec>> lambdaHistSpec;
+    std::map<v0histmanager::V0Hist, std::vector<o2::framework::AxisSpec>> k0shortHistSpec;
+    std::map<pairhistmanager::PairHist, std::vector<o2::framework::AxisSpec>> pairTrackV0HistSpec;
+    std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpec = closepairrejection::makeCprHistSpecMap(confCpr);
 
     if (processData) {
-      auto colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
-      auto trackHistSpec = trackhistmanager::makeTrackHistSpecMap(confTrackBinning);
-      auto posDauSpec = trackhistmanager::makeTrackHistSpecMap(confPosDauBinning);
-      auto negDauSpec = trackhistmanager::makeTrackHistSpecMap(confNegDauBinning);
-      auto pairTrackV0HistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning);
+      colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
+      trackHistSpec = trackhistmanager::makeTrackHistSpecMap(confTrackBinning);
+      posDauSpec = trackhistmanager::makeTrackHistSpecMap(confPosDauBinning);
+      negDauSpec = trackhistmanager::makeTrackHistSpecMap(confNegDauBinning);
+      pairTrackV0HistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning);
       if (processLambda) {
-        auto lambdaHistSpec = v0histmanager::makeV0HistSpecMap(confLambdaBinning);
+        lambdaHistSpec = v0histmanager::makeV0HistSpecMap(confLambdaBinning);
         pairTrackLambdaBuilder.init<modes::Mode::kAnalysis>(&hRegistry, confTrackSelection, confTrackCleaner, lambdaSelection, confLambdaCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, lambdaHistSpec, posDauSpec, negDauSpec, pairTrackV0HistSpec, cprHistSpec);
       } else {
-        auto k0shortHistSpec = v0histmanager::makeV0HistSpecMap(confK0shortBinning);
+        k0shortHistSpec = v0histmanager::makeV0HistSpecMap(confK0shortBinning);
         pairTrackK0shortBuilder.init<modes::Mode::kAnalysis>(&hRegistry, confTrackSelection, confTrackCleaner, lambdaSelection, confTrackCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, k0shortHistSpec, posDauSpec, negDauSpec, pairTrackV0HistSpec, cprHistSpec);
       }
     } else {
-      auto colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
-      auto trackHistSpec = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning);
-      auto posDauSpec = trackhistmanager::makeTrackMcHistSpecMap(confPosDauBinning);
-      auto negDauSpec = trackhistmanager::makeTrackMcHistSpecMap(confNegDauBinning);
-      auto pairTrackV0HistSpec = pairhistmanager::makePairMcHistSpecMap(confPairBinning);
+      colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
+      trackHistSpec = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning);
+      posDauSpec = trackhistmanager::makeTrackMcHistSpecMap(confPosDauBinning);
+      negDauSpec = trackhistmanager::makeTrackMcHistSpecMap(confNegDauBinning);
+      pairTrackV0HistSpec = pairhistmanager::makePairMcHistSpecMap(confPairBinning);
       if (processLambda) {
-        auto lambdaHistSpec = v0histmanager::makeV0McHistSpecMap(confLambdaBinning);
+        lambdaHistSpec = v0histmanager::makeV0McHistSpecMap(confLambdaBinning);
         pairTrackLambdaBuilder.init<modes::Mode::kAnalysis_Mc>(&hRegistry, confTrackSelection, confTrackCleaner, lambdaSelection, confLambdaCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, lambdaHistSpec, posDauSpec, negDauSpec, pairTrackV0HistSpec, cprHistSpec);
       } else {
-        auto k0shortHistSpec = v0histmanager::makeV0McHistSpecMap(confK0shortBinning);
+        k0shortHistSpec = v0histmanager::makeV0McHistSpecMap(confK0shortBinning);
         pairTrackK0shortBuilder.init<modes::Mode::kAnalysis_Mc>(&hRegistry, confTrackSelection, confTrackCleaner, lambdaSelection, confLambdaCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, k0shortHistSpec, posDauSpec, negDauSpec, pairTrackV0HistSpec, cprHistSpec);
       }
     }
@@ -213,7 +214,7 @@ struct FemtoPairTrackV0 {
   }
   PROCESS_SWITCH(FemtoPairTrackV0, processLambdaSameEvent, "Enable processing same event processing for tracks and lambdas", true);
 
-  void processLambdaSameEventMc(FilteredFemtoCollisionWithLabel const& col, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& lambdas, FMcParticles const& mcParticles, FMcMothers const& mcMothers, FMcPartMoths const& mcPartonicMothers)
+  void processLambdaSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& lambdas, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackLambdaBuilder.processSameEvent<modes::Mode::kAnalysis_Mc>(col, mcCols, tracks, trackWithLabelPartition, lambdas, lambdaWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -225,7 +226,7 @@ struct FemtoPairTrackV0 {
   }
   PROCESS_SWITCH(FemtoPairTrackV0, processLambdaMixedEvent, "Enable processing mixed event processing for tracks and lambdas", true);
 
-  void processLambdaMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& /*lambas*/, FMcParticles const& mcParticles, FMcMothers const& mcMothers, FMcPartMoths const& mcPartonicMothers)
+  void processLambdaMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& /*lambas*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackLambdaBuilder.processMixedEvent<modes::Mode::kAnalysis_Mc>(cols, mcCols, tracks, trackWithLabelPartition, lambdaWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }
@@ -237,7 +238,7 @@ struct FemtoPairTrackV0 {
   }
   PROCESS_SWITCH(FemtoPairTrackV0, processK0shortSameEvent, "Enable processing same event processing for tracks and k0shorts", false);
 
-  void processK0shortSameEventMc(FilteredFemtoCollisionWithLabel const& col, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& k0shorts, FMcParticles const& mcParticles, FMcMothers const& mcMothers, FMcPartMoths const& mcPartonicMothers)
+  void processK0shortSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& k0shorts, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackK0shortBuilder.processSameEvent<modes::Mode::kAnalysis_Mc>(col, mcCols, tracks, trackWithLabelPartition, k0shorts, k0shortWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -249,16 +250,16 @@ struct FemtoPairTrackV0 {
   }
   PROCESS_SWITCH(FemtoPairTrackV0, processK0shortMixedEvent, "Enable processing mixed event processing for tracks and k0shorts", false);
 
-  void processK0shortMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& /*k0shorts*/, FMcParticles const& mcParticles, FMcMothers const& mcMothers, FMcPartMoths const& mcPartonicMothers)
+  void processK0shortMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& /*k0shorts*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackK0shortBuilder.processMixedEvent<modes::Mode::kAnalysis_Mc>(cols, mcCols, tracks, trackWithLabelPartition, k0shortWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }
   PROCESS_SWITCH(FemtoPairTrackV0, processK0shortMixedEventMc, "Enable processing mixed event processing for tracks and k0shorts with mc information", false);
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{
+  o2::framework::WorkflowSpec workflow{
     adaptAnalysisTask<FemtoPairTrackV0>(cfgc),
   };
   return workflow;

--- a/PWGCF/Femto/Tasks/femtoPairTrackV0.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackV0.cxx
@@ -38,6 +38,7 @@
 #include "Framework/OutputObjHeader.h"
 #include "Framework/runDataProcessing.h"
 
+#include <map>
 #include <vector>
 
 using namespace o2::analysis::femto;

--- a/PWGCF/Femto/Tasks/femtoPairV0V0.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairV0V0.cxx
@@ -37,34 +37,35 @@
 #include "Framework/OutputObjHeader.h"
 #include "Framework/runDataProcessing.h"
 
-#include <string>
+#include <map>
 #include <vector>
 
-using namespace o2;
-using namespace o2::aod;
-using namespace o2::soa;
-using namespace o2::framework;
-using namespace o2::framework::expressions;
 using namespace o2::analysis::femto;
 
 struct FemtoPairV0V0 {
 
   // setup tables
-  using Collisions = Join<FCols, FColMasks>;
-  using Collision = Collisions::iterator;
+  using FemtoCollisions = o2::soa::Join<o2::aod::FCols, o2::aod::FColMasks>;
+  using FilteredFemtoCollisions = o2::soa::Filtered<FemtoCollisions>;
+  using FilteredFemtoCollision = FilteredFemtoCollisions::iterator;
 
-  using FilteredCollisions = o2::soa::Filtered<Collisions>;
-  using FilteredCollision = FilteredCollisions::iterator;
+  using FemtoCollisionsWithLabel = o2::soa::Join<FemtoCollisions, o2::aod::FColLabels>;
+  using FilteredFemtoCollisionsWithLabel = o2::soa::Filtered<FemtoCollisionsWithLabel>;
+  using FilteredFemtoCollisionWithLabel = FilteredFemtoCollisionsWithLabel::iterator;
 
-  using Tracks = o2::soa::Join<FTracks, FTrackMasks>;
-  using Lambdas = o2::soa::Join<FLambdas, FLambdaMasks>;
-  using K0shorts = o2::soa::Join<FK0shorts, FK0shortMasks>;
+  using FemtoTracks = o2::soa::Join<o2::aod::FTracks, o2::aod::FTrackMasks>;
+  using FemtoLambdas = o2::soa::Join<o2::aod::FLambdas, o2::aod::FLambdaMasks>;
+  using FemtoK0shorts = o2::soa::Join<o2::aod::FK0shorts, o2::aod::FK0shortMasks>;
 
-  SliceCache cache;
+  using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, o2::aod::FTrackLabels>;
+  using FemtoLambdasWithLabel = o2::soa::Join<FemtoLambdas, o2::aod::FLambdaLabels>;
+  using FemtoK0shortsWithLabel = o2::soa::Join<FemtoK0shorts, o2::aod::FK0shortLabels>;
+  //
+  o2::framework::SliceCache cache;
 
   // setup collisions
   collisionbuilder::ConfCollisionSelection collisionSelection;
-  Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
+  o2::framework::expressions::Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
   colhistmanager::ConfCollisionBinning confCollisionBinning;
 
   // setup for daughters
@@ -75,15 +76,23 @@ struct FemtoPairV0V0 {
   v0builder::ConfLambdaSelection1 confLambdaSelection;
   particlecleaner::ConfLambdaCleaner1 confLambdaCleaner;
   v0histmanager::ConfLambdaBinning1 confLambdaBinning;
-  Partition<Lambdas> lambdaPartition = MAKE_LAMBDA_PARTITION(confLambdaSelection);
-  Preslice<Lambdas> perColLambdas = aod::femtobase::stored::fColId;
+
+  o2::framework::Partition<FemtoLambdas> lambdaPartition = MAKE_LAMBDA_PARTITION(confLambdaSelection);
+  o2::framework::Preslice<FemtoLambdas> perColLambdas = o2::aod::femtobase::stored::fColId;
+
+  o2::framework::Partition<FemtoLambdasWithLabel> lambdaWithLabelPartition = MAKE_LAMBDA_PARTITION(confLambdaSelection);
+  o2::framework::Preslice<FemtoLambdasWithLabel> perCollambdasWithLabel = o2::aod::femtobase::stored::fColId;
 
   // setup k0shorts
   v0builder::ConfK0shortSelection1 confK0shortSelection;
   particlecleaner::ConfK0shortCleaner1 confK0shortCleaner;
   v0histmanager::ConfK0shortBinning1 confK0shortBinning;
-  Partition<K0shorts> k0shortPartition = MAKE_K0SHORT_PARTITION(confK0shortSelection);
-  Preslice<K0shorts> perColk0shorts = aod::femtobase::stored::fColId;
+
+  o2::framework::Partition<FemtoK0shorts> k0shortPartition = MAKE_K0SHORT_PARTITION(confK0shortSelection);
+  o2::framework::Preslice<FemtoK0shorts> perColk0shorts = o2::aod::femtobase::stored::fColId;
+
+  o2::framework::Partition<FemtoK0shortsWithLabel> k0shortWithLabelPartition = MAKE_K0SHORT_PARTITION(confK0shortSelection);
+  o2::framework::Preslice<FemtoK0shortsWithLabel> perColk0shortsWithLabel = o2::aod::femtobase::stored::fColId;
 
   // setup pairs
   pairhistmanager::ConfPairBinning confPairBinning;
@@ -127,22 +136,32 @@ struct FemtoPairV0V0 {
   std::vector<double> defaultVtxBins{10, -10, 10};
   std::vector<double> defaultMultBins{50, 0, 200};
   std::vector<double> defaultCentBins{10, 0, 100};
-  ColumnBinningPolicy<femtocollisions::PosZ, femtocollisions::Mult> mixBinsVtxMult{{defaultVtxBins, defaultMultBins}, true};
-  ColumnBinningPolicy<aod::femtocollisions::PosZ, aod::femtocollisions::Cent> mixBinsVtxCent{{defaultVtxBins, defaultCentBins}, true};
-  ColumnBinningPolicy<aod::femtocollisions::PosZ, aod::femtocollisions::Mult, aod::femtocollisions::Cent> mixBinsVtxMultCent{{defaultVtxBins, defaultMultBins, defaultCentBins}, true};
+  o2::framework::ColumnBinningPolicy<o2::aod::femtocollisions::PosZ, o2::aod::femtocollisions::Mult> mixBinsVtxMult{{defaultVtxBins, defaultMultBins}, true};
+  o2::framework::ColumnBinningPolicy<o2::aod::femtocollisions::PosZ, o2::aod::femtocollisions::Cent> mixBinsVtxCent{{defaultVtxBins, defaultCentBins}, true};
+  o2::framework::ColumnBinningPolicy<o2::aod::femtocollisions::PosZ, o2::aod::femtocollisions::Mult, o2::aod::femtocollisions::Cent> mixBinsVtxMultCent{{defaultVtxBins, defaultMultBins, defaultCentBins}, true};
   pairhistmanager::ConfMixing confMixing;
 
-  HistogramRegistry hRegistry{"FemtoV0V0", {}, OutputObjHandlingPolicy::AnalysisObject};
+  o2::framework::HistogramRegistry hRegistry{"FemtoV0V0", {}, o2::framework::OutputObjHandlingPolicy::AnalysisObject};
 
   // setup cpr
   closepairrejection::ConfCprV0DaugherV0DaughterPos confCprPos;
   closepairrejection::ConfCprV0DaugherV0DaughterNeg confCprNeg;
 
-  void init(InitContext&)
+  void init(o2::framework::InitContext&)
   {
+    // TODO: implement lambda-k0short
+    bool processData = doprocessLambdaLambdaSameEvent || doprocessLambdaLambdaSameEvent || doprocessK0shortK0shortSameEvent || doprocessK0shortK0shortSameEvent;
+    bool processMc = doprocessLambdaLambdaSameEventMc || doprocessLambdaLambdaSameEventMc || doprocessK0shortK0shortSameEventMc || doprocessK0shortK0shortSameEventMc;
 
-    if (((doprocessLambdaLambdaSameEvent || doprocessLambdaLambdaMixedEvent) + (doprocessK0shortK0shortSameEvent || doprocessK0shortK0shortMixedEvent)) > 1) {
-      LOG(fatal) << "Can only process lambda-tracks Or k0short-tracks";
+    if (processData && processMc) {
+      LOG(fatal) << "Both data and mc processing is enabled. Breaking...";
+    }
+
+    bool processLambdaLambda = doprocessLambdaLambdaSameEvent || doprocessLambdaLambdaMixedEvent || doprocessLambdaLambdaSameEventMc || doprocessLambdaLambdaMixedEventMc;
+    bool processK0shortK0short = doprocessK0shortK0shortSameEvent || doprocessK0shortK0shortMixedEvent || doprocessK0shortK0shortSameEventMc || doprocessK0shortK0shortMixedEventMc;
+
+    if (processLambdaLambda && processK0shortK0short) {
+      LOG(fatal) << "Both lambda-lambda and k0short-k0short processing is enabled. Breaking...";
     }
 
     // setup columnpolicy for binning
@@ -152,55 +171,103 @@ struct FemtoPairV0V0 {
     mixBinsVtxMultCent = {{confMixing.vtxBins.value, confMixing.multBins.value, confMixing.centBins.value}, true};
 
     // setup histograms
-    auto colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
-    auto posDauSpec = trackhistmanager::makeTrackHistSpecMap(confPosDauBinning);
-    auto negDauSpec = trackhistmanager::makeTrackHistSpecMap(confNegDauBinning);
-    auto cprHistSpecPos = closepairrejection::makeCprHistSpecMap(confCprPos);
-    auto cprHistSpecNeg = closepairrejection::makeCprHistSpecMap(confCprNeg);
+    std::map<colhistmanager::ColHist, std::vector<o2::framework::AxisSpec>> colHistSpec;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> trackHistSpec;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> posDauSpec;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> negDauSpec;
+    std::map<v0histmanager::V0Hist, std::vector<o2::framework::AxisSpec>> lambdaHistSpec;
+    std::map<v0histmanager::V0Hist, std::vector<o2::framework::AxisSpec>> k0shortHistSpec;
+    std::map<pairhistmanager::PairHist, std::vector<o2::framework::AxisSpec>> pairV0V0HistSpec;
+    std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpecPos = closepairrejection::makeCprHistSpecMap(confCprPos);
+    std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpecNeg = closepairrejection::makeCprHistSpecMap(confCprNeg);
 
-    // setup for lambda
-    if (doprocessLambdaLambdaSameEvent || doprocessLambdaLambdaMixedEvent) {
-      auto lambdaHistSpec = v0histmanager::makeV0HistSpecMap(confLambdaBinning);
-      auto pairLambdaLambdaHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning);
-      pairLambdaLambdaBuilder.init<modes::Mode::kAnalysis>(&hRegistry, confLambdaSelection, confLambdaSelection, confLambdaCleaner, confLambdaCleaner, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec, lambdaHistSpec, posDauSpec, negDauSpec, pairLambdaLambdaHistSpec, cprHistSpecPos, cprHistSpecNeg);
-    }
+    if (processData) {
+      colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
+      posDauSpec = trackhistmanager::makeTrackHistSpecMap(confPosDauBinning);
+      negDauSpec = trackhistmanager::makeTrackHistSpecMap(confNegDauBinning);
+      if (processLambdaLambda) {
+        lambdaHistSpec = v0histmanager::makeV0HistSpecMap(confLambdaBinning);
+        pairV0V0HistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning);
+        pairLambdaLambdaBuilder.init<modes::Mode::kAnalysis>(&hRegistry, confLambdaSelection, confLambdaSelection, confLambdaCleaner, confLambdaCleaner, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec, lambdaHistSpec, posDauSpec, negDauSpec, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg);
+      }
 
-    // setup for k0short
-    if (doprocessK0shortK0shortSameEvent || doprocessK0shortK0shortMixedEvent) {
-      auto k0shortHistSpec = v0histmanager::makeV0HistSpecMap(confK0shortBinning);
-      auto pairK0shortK0shortHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning);
-      pairK0shortK0shortBuilder.init<modes::Mode::kAnalysis>(&hRegistry, confK0shortSelection, confK0shortSelection, confK0shortCleaner, confK0shortCleaner, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, k0shortHistSpec, k0shortHistSpec, posDauSpec, negDauSpec, pairK0shortK0shortHistSpec, cprHistSpecPos, cprHistSpecNeg);
+      // setup for k0short
+      if (doprocessK0shortK0shortSameEvent || doprocessK0shortK0shortMixedEvent) {
+        k0shortHistSpec = v0histmanager::makeV0HistSpecMap(confK0shortBinning);
+        pairV0V0HistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning);
+        pairK0shortK0shortBuilder.init<modes::Mode::kAnalysis>(&hRegistry, confK0shortSelection, confK0shortSelection, confK0shortCleaner, confK0shortCleaner, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, k0shortHistSpec, k0shortHistSpec, posDauSpec, negDauSpec, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg);
+      }
+    } else {
+      colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
+      posDauSpec = trackhistmanager::makeTrackMcHistSpecMap(confPosDauBinning);
+      negDauSpec = trackhistmanager::makeTrackMcHistSpecMap(confNegDauBinning);
+      if (processLambdaLambda) {
+        lambdaHistSpec = v0histmanager::makeV0McHistSpecMap(confLambdaBinning);
+        pairV0V0HistSpec = pairhistmanager::makePairMcHistSpecMap(confPairBinning);
+        pairLambdaLambdaBuilder.init<modes::Mode::kAnalysis_Qa>(&hRegistry, confLambdaSelection, confLambdaSelection, confLambdaCleaner, confLambdaCleaner, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec, lambdaHistSpec, posDauSpec, negDauSpec, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg);
+      }
+
+      // setup for k0short
+      if (doprocessK0shortK0shortSameEvent || doprocessK0shortK0shortMixedEvent) {
+        k0shortHistSpec = v0histmanager::makeV0McHistSpecMap(confK0shortBinning);
+        pairV0V0HistSpec = pairhistmanager::makePairMcHistSpecMap(confPairBinning);
+        pairK0shortK0shortBuilder.init<modes::Mode::kAnalysis_Qa>(&hRegistry, confK0shortSelection, confK0shortSelection, confK0shortCleaner, confK0shortCleaner, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, k0shortHistSpec, k0shortHistSpec, posDauSpec, negDauSpec, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg);
+      }
     }
   };
 
-  void processLambdaLambdaSameEvent(FilteredCollision const& col, Tracks const& tracks, Lambdas const& lambdas)
+  void processLambdaLambdaSameEvent(FilteredFemtoCollision const& col, FemtoTracks const& tracks, FemtoLambdas const& lambdas)
   {
     pairLambdaLambdaBuilder.processSameEvent<modes::Mode::kAnalysis>(col, tracks, lambdas, lambdaPartition, lambdaPartition, cache);
   }
-  PROCESS_SWITCH(FemtoPairV0V0, processLambdaLambdaSameEvent, "Enable processing same event processing for lambdas", true);
+  PROCESS_SWITCH(FemtoPairV0V0, processLambdaLambdaSameEvent, "Enable processing same event processing for lambda-lambda", true);
 
-  void processLambdaLambdaMixedEvent(FilteredCollisions const& cols, Tracks const& tracks, Lambdas const& /*lambas*/)
+  void processLambdaLambdaSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& lambdas, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
-    pairLambdaLambdaBuilder.processMixedEvent<modes::Mode::kAnalysis>(cols, tracks, lambdaPartition, lambdaPartition, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
+    pairLambdaLambdaBuilder.processSameEvent<modes::Mode::kAnalysis_Mc>(col, mcCols, tracks, lambdas, lambdaWithLabelPartition, lambdaWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
-  PROCESS_SWITCH(FemtoPairV0V0, processLambdaLambdaMixedEvent, "Enable processing mixed event processing for lambdas", true);
+  PROCESS_SWITCH(FemtoPairV0V0, processLambdaLambdaSameEventMc, "Enable processing same event processing for lambda-lambda with mc information", false);
 
-  void processK0shortK0shortSameEvent(FilteredCollision const& col, Tracks const& tracks, K0shorts const& k0shorts)
+  void processLambdaLambdaMixedEvent(FilteredFemtoCollisions const& cols, FemtoTracks const& tracks, FemtoLambdas const& lambdas)
   {
-    pairK0shortK0shortBuilder.processSameEvent<modes::Mode::kAnalysis>(col, tracks, k0shorts, k0shortPartition, lambdaPartition, cache);
+    pairLambdaLambdaBuilder.processMixedEvent<modes::Mode::kAnalysis>(cols, tracks, lambdas, lambdaPartition, lambdaPartition, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }
-  PROCESS_SWITCH(FemtoPairV0V0, processK0shortK0shortSameEvent, "Enable processing same event processing for lambdas", false);
+  PROCESS_SWITCH(FemtoPairV0V0, processLambdaLambdaMixedEvent, "Enable processing mixed event processing for lambda-lambda", true);
 
-  void processK0shortK0shortMixedEvent(FilteredCollisions const& cols, Tracks const& tracks, K0shorts const& /*k0shorts*/)
+  void processLambdaLambdaMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& /*lambdas*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
-    pairK0shortK0shortBuilder.processMixedEvent<modes::Mode::kAnalysis>(cols, tracks, k0shortPartition, k0shortPartition, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
+    pairLambdaLambdaBuilder.processMixedEvent<modes::Mode::kAnalysis_Mc>(cols, mcCols, tracks, lambdaWithLabelPartition, lambdaWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }
-  PROCESS_SWITCH(FemtoPairV0V0, processK0shortK0shortMixedEvent, "Enable processing mixed event processing for lambdas", false);
+  PROCESS_SWITCH(FemtoPairV0V0, processLambdaLambdaMixedEventMc, "Enable processing mixed event processing for lambda-lambda with mc information", false);
+
+  void processK0shortK0shortSameEvent(FilteredFemtoCollision const& col, FemtoTracks const& tracks, FemtoK0shorts const& k0shorts)
+  {
+    pairK0shortK0shortBuilder.processSameEvent<modes::Mode::kAnalysis>(col, tracks, k0shorts, k0shortPartition, k0shortPartition, cache);
+  }
+  PROCESS_SWITCH(FemtoPairV0V0, processK0shortK0shortSameEvent, "Enable processing same event processing for k0short-k0short", false);
+
+  void processK0shortK0shortSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& k0shorts, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  {
+    pairK0shortK0shortBuilder.processSameEvent<modes::Mode::kAnalysis_Mc>(col, mcCols, tracks, k0shorts, k0shortWithLabelPartition, k0shortWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache);
+  }
+  PROCESS_SWITCH(FemtoPairV0V0, processK0shortK0shortSameEventMc, "Enable processing same event processing for k0short-k0short with mc information", false);
+
+  void processK0shortK0shortMixedEvent(FilteredFemtoCollisions const& cols, FemtoTracks const& tracks, FemtoK0shorts const& k0shorts)
+  {
+    pairK0shortK0shortBuilder.processMixedEvent<modes::Mode::kAnalysis>(cols, tracks, k0shorts, k0shortPartition, k0shortPartition, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
+  }
+  PROCESS_SWITCH(FemtoPairV0V0, processK0shortK0shortMixedEvent, "Enable processing mixed event processing for k0short-k0short", false);
+
+  void processK0shortK0shortMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& /*k0shorts*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  {
+    pairK0shortK0shortBuilder.processMixedEvent<modes::Mode::kAnalysis>(cols, mcCols, tracks, k0shortWithLabelPartition, k0shortWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
+  }
+  PROCESS_SWITCH(FemtoPairV0V0, processK0shortK0shortMixedEventMc, "Enable processing mixed event processing for k0short-k0short with mc information", false);
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{
+  o2::framework::WorkflowSpec workflow{
     adaptAnalysisTask<FemtoPairV0V0>(cfgc),
   };
   return workflow;

--- a/PWGCF/Femto/Tasks/femtoTrackQa.cxx
+++ b/PWGCF/Femto/Tasks/femtoTrackQa.cxx
@@ -31,6 +31,9 @@
 #include "Framework/OutputObjHeader.h"
 #include "Framework/runDataProcessing.h"
 
+#include <map>
+#include <vector>
+
 using namespace o2::analysis::femto;
 
 struct FemtoTrackQa {

--- a/PWGCF/Femto/Tasks/femtoTrackQa.cxx
+++ b/PWGCF/Femto/Tasks/femtoTrackQa.cxx
@@ -31,31 +31,28 @@
 #include "Framework/OutputObjHeader.h"
 #include "Framework/runDataProcessing.h"
 
-using namespace o2::aod;
-using namespace o2::framework;
-using namespace o2::framework::expressions;
 using namespace o2::analysis::femto;
 
 struct FemtoTrackQa {
 
   // setup tables
-  using FemtoCollisions = o2::soa::Join<FCols, FColMasks, FColPos, FColSphericities, FColMults>;
+  using FemtoCollisions = o2::soa::Join<o2::aod::FCols, o2::aod::FColMasks, o2::aod::FColPos, o2::aod::FColSphericities, o2::aod::FColMults>;
   using FilteredFemtoCollisions = o2::soa::Filtered<FemtoCollisions>;
   using FilteredFemtoCollision = FilteredFemtoCollisions::iterator;
 
-  using FemtoCollisionsWithLabel = o2::soa::Join<FemtoCollisions, FColLabels>;
+  using FemtoCollisionsWithLabel = o2::soa::Join<FemtoCollisions, o2::aod::FColLabels>;
   using FilteredFemtoCollisionsWithLabel = o2::soa::Filtered<FemtoCollisionsWithLabel>;
   using FilteredFemtoCollisionWithLabel = FilteredFemtoCollisionsWithLabel::iterator;
 
-  using FemtoTracks = o2::soa::Join<FTracks, FTrackMasks, FTrackDcas, FTrackExtras, FTrackPids>;
+  using FemtoTracks = o2::soa::Join<o2::aod::FTracks, o2::aod::FTrackMasks, o2::aod::FTrackDcas, o2::aod::FTrackExtras, o2::aod::FTrackPids>;
 
-  using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, FTrackLabels>;
+  using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, o2::aod::FTrackLabels>;
 
-  SliceCache cache;
+  o2::framework::SliceCache cache;
 
   // setup collisions
   collisionbuilder::ConfCollisionSelection collisionSelection;
-  Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
+  o2::framework::expressions::Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
   colhistmanager::ConfCollisionBinning confCollisionBinning;
   colhistmanager::ConfCollisionQaBinning confCollisionQaBinning;
   colhistmanager::CollisionHistManager colHistManager;
@@ -66,52 +63,37 @@ struct FemtoTrackQa {
   trackhistmanager::ConfTrackQaBinning1 confTrackQaBinning;
   trackhistmanager::TrackHistManager<trackhistmanager::PrefixTrackQa> trackHistManager;
 
-  Partition<FemtoTracks> trackPartition = MAKE_TRACK_PARTITION(confTrackSelection);
-  Preslice<FemtoTracks> perColReco = femtobase::stored::fColId;
+  o2::framework::Partition<FemtoTracks> trackPartition = MAKE_TRACK_PARTITION(confTrackSelection);
+  o2::framework::Preslice<FemtoTracks> perColReco = o2::aod::femtobase::stored::fColId;
 
   particlecleaner::ConfTrackCleaner1 confTrackCleaner;
   particlecleaner::ParticleCleaner trackCleaner;
 
-  Partition<FemtoTracksWithLabel> trackWithLabelPartition = MAKE_TRACK_PARTITION(confTrackSelection);
-  Preslice<FemtoTracksWithLabel> perColRecoWithLabel = femtobase::stored::fColId;
+  o2::framework::Partition<FemtoTracksWithLabel> trackWithLabelPartition = MAKE_TRACK_PARTITION(confTrackSelection);
+  o2::framework::Preslice<FemtoTracksWithLabel> perColRecoWithLabel = o2::aod::femtobase::stored::fColId;
 
-  HistogramRegistry hRegistry{"FemtoTrackQA", {}, OutputObjHandlingPolicy::AnalysisObject};
+  o2::framework::HistogramRegistry hRegistry{"FemtoTrackQA", {}, o2::framework::OutputObjHandlingPolicy::AnalysisObject};
 
-  template <modes::Mode mode,
-            typename MakeColSpec,
-            typename MakeTrackSpec>
-  void initMode(MakeColSpec&& makeColSpec,
-                MakeTrackSpec&& makeTrackSpec)
-  {
-    auto colHistSpec = makeColSpec(confCollisionBinning, confCollisionQaBinning);
-    colHistManager.init<mode>(&hRegistry, colHistSpec, confCollisionQaBinning);
-    auto trackHistSpec = makeTrackSpec(confTrackBinning, confTrackQaBinning);
-
-    trackHistManager.init<mode>(
-      &hRegistry,
-      trackHistSpec,
-      confTrackSelection.chargeAbs.value,
-      confTrackSelection.chargeSign.value,
-      confTrackSelection.pdgCodeAbs.value,
-      confTrackQaBinning);
-  }
-
-  void init(InitContext&)
+  void init(o2::framework::InitContext&)
   {
     if ((doprocessData + doprocessMc) > 1) {
       LOG(fatal) << "More than 1 process function is activated. Breaking...";
     }
     bool processData = doprocessData;
     trackCleaner.init(confTrackCleaner);
+
+    std::map<colhistmanager::ColHist, std::vector<o2::framework::AxisSpec>> colHistSpec;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> trackHistSpec;
+
     if (processData) {
-      auto colHistSpec = colhistmanager::makeColQaHistSpecMap(confCollisionBinning, confCollisionQaBinning);
+      colHistSpec = colhistmanager::makeColQaHistSpecMap(confCollisionBinning, confCollisionQaBinning);
       colHistManager.init<modes::Mode::kAnalysis_Qa>(&hRegistry, colHistSpec, confCollisionQaBinning);
-      auto trackHistSpec = trackhistmanager::makeTrackQaHistSpecMap(confTrackBinning, confTrackQaBinning);
+      trackHistSpec = trackhistmanager::makeTrackQaHistSpecMap(confTrackBinning, confTrackQaBinning);
       trackHistManager.init<modes::Mode::kAnalysis_Qa>(&hRegistry, trackHistSpec, confTrackSelection, confTrackQaBinning);
     } else {
-      auto colHistSpec = colhistmanager::makeColMcQaHistSpecMap(confCollisionBinning, confCollisionQaBinning);
+      colHistSpec = colhistmanager::makeColMcQaHistSpecMap(confCollisionBinning, confCollisionQaBinning);
       colHistManager.init<modes::Mode::kAnalysis_Qa_Mc>(&hRegistry, colHistSpec, confCollisionQaBinning);
-      auto trackHistSpec = trackhistmanager::makeTrackMcQaHistSpecMap(confTrackBinning, confTrackQaBinning);
+      trackHistSpec = trackhistmanager::makeTrackMcQaHistSpecMap(confTrackBinning, confTrackQaBinning);
       trackHistManager.init<modes::Mode::kAnalysis_Qa_Mc>(&hRegistry, trackHistSpec, confTrackSelection, confTrackQaBinning);
     }
     hRegistry.print();
@@ -120,18 +102,17 @@ struct FemtoTrackQa {
   void processData(FilteredFemtoCollision const& col, FemtoTracks const& tracks)
   {
     colHistManager.fill<modes::Mode::kAnalysis_Qa>(col);
-    auto trackSlice = trackPartition->sliceByCached(femtobase::stored::fColId, col.globalIndex(), cache);
+    auto trackSlice = trackPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
     for (auto const& track : trackSlice) {
       trackHistManager.fill<modes::Mode::kAnalysis_Qa>(track, tracks);
     }
   };
   PROCESS_SWITCH(FemtoTrackQa, processData, "Track QA in Data", true);
 
-  void processMc(FilteredFemtoCollisionWithLabel const& col, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FMcParticles const& mcParticles, FMcMothers const& mcMothers, FMcPartMoths const& mcPartonicMothers)
+  void processMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     colHistManager.fill<modes::Mode::kAnalysis_Qa_Mc>(col, mcCols);
-    auto trackSlice = trackWithLabelPartition->sliceByCached(femtobase::stored::fColId, col.globalIndex(), cache);
-
+    auto trackSlice = trackWithLabelPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
     for (auto const& track : trackSlice) {
       if (!trackCleaner.isClean(track, mcParticles, mcMothers, mcPartonicMothers)) {
         continue;
@@ -142,10 +123,10 @@ struct FemtoTrackQa {
   PROCESS_SWITCH(FemtoTrackQa, processMc, "Track QA in Monte Carlo", false);
 };
 
-WorkflowSpec
-  defineDataProcessing(ConfigContext const& cfgc)
+o2::framework::WorkflowSpec
+  defineDataProcessing(o2::framework::ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{
+  o2::framework::WorkflowSpec workflow{
     adaptAnalysisTask<FemtoTrackQa>(cfgc),
   };
   return workflow;

--- a/PWGCF/Femto/Tasks/femtoTripletTrackTrackTrack.cxx
+++ b/PWGCF/Femto/Tasks/femtoTripletTrackTrackTrack.cxx
@@ -10,7 +10,7 @@
 // or submit itself to any jurisdiction.
 
 /// \file femtoTripletTrackTrackTrack.cxx
-/// \brief Tasks that computes correlation between two tracks
+/// \brief Tasks that computes correlation between three tracks
 /// \author Anton Riedel, TU München, anton.riedel@cern.ch
 
 #include "PWGCF/Femto/Core/closeTripletRejection.h"
@@ -35,6 +35,7 @@
 #include "Framework/OutputObjHeader.h"
 #include "Framework/runDataProcessing.h"
 
+#include <map>
 #include <vector>
 
 using namespace o2::analysis::femto;

--- a/PWGCF/Femto/Tasks/femtoTripletTrackTrackV0.cxx
+++ b/PWGCF/Femto/Tasks/femtoTripletTrackTrackV0.cxx
@@ -22,6 +22,8 @@
 #include "PWGCF/Femto/Core/trackHistManager.h"
 #include "PWGCF/Femto/Core/tripletBuilder.h"
 #include "PWGCF/Femto/Core/tripletHistManager.h"
+#include "PWGCF/Femto/Core/v0Builder.h"
+#include "PWGCF/Femto/Core/v0HistManager.h"
 #include "PWGCF/Femto/DataModel/FemtoTables.h"
 
 #include "Framework/ASoA.h"
@@ -35,30 +37,40 @@
 #include "Framework/OutputObjHeader.h"
 #include "Framework/runDataProcessing.h"
 
+#include <string>
 #include <vector>
 
+using namespace o2;
+using namespace o2::aod;
+using namespace o2::soa;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
 using namespace o2::analysis::femto;
 
 struct FemtoTripletTrackTrackTrack {
 
   // setup tables
-  using FemtoCollisions = o2::soa::Join<o2::aod::FCols, o2::aod::FColMasks>;
+  using FemtoCollisions = Join<FCols, FColMasks>;
   using FilteredFemtoCollisions = o2::soa::Filtered<FemtoCollisions>;
   using FilteredFemtoCollision = FilteredFemtoCollisions::iterator;
 
-  using FemtoCollisionsWithLabel = o2::soa::Join<FemtoCollisions, o2::aod::FColLabels>;
+  using FemtoCollisionsWithLabel = o2::soa::Join<FemtoCollisions, FColLabels>;
   using FilteredFemtoCollisionsWithLabel = o2::soa::Filtered<FemtoCollisionsWithLabel>;
   using FilteredFemtoCollisionWithLabel = FilteredFemtoCollisionsWithLabel::iterator;
 
-  using FemtoTracks = o2::soa::Join<o2::aod::FTracks, o2::aod::FTrackMasks>;
+  using FemtoTracks = o2::soa::Join<FTracks, FTrackMasks>;
+  using FemtoLambdas = o2::soa::Join<FLambdas, FLambdaMasks>;
+  using FemtoK0shorts = o2::soa::Join<FK0shorts, FK0shortMasks>;
 
-  using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, o2::aod::FTrackLabels>;
+  using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, FTrackLabels>;
+  using FemtoLambdasWithLabel = o2::soa::Join<FemtoLambdas, FLambdaLabels>;
+  using FemtoK0shortsWithLabel = o2::soa::Join<FemtoK0shorts, FK0shortLabels>;
 
-  o2::framework::SliceCache cache;
+  SliceCache cache;
 
   // setup collisions
   collisionbuilder::ConfCollisionSelection collisionSelection;
-  o2::framework::expressions::Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
+  Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
   colhistmanager::ConfCollisionBinning confCollisionBinning;
 
   // setup tracks
@@ -69,15 +81,15 @@ struct FemtoTripletTrackTrackTrack {
   trackbuilder::ConfTrackSelection3 confTrackSelections3;
   trackhistmanager::ConfTrackBinning3 confTrackBinning3;
 
-  o2::framework::Partition<FemtoTracks> trackPartition1 = MAKE_TRACK_PARTITION(confTrackSelections1);
-  o2::framework::Partition<FemtoTracks> trackPartition2 = MAKE_TRACK_PARTITION(confTrackSelections2);
-  o2::framework::Partition<FemtoTracks> trackPartition3 = MAKE_TRACK_PARTITION(confTrackSelections3);
-  o2::framework::Preslice<FemtoTracks> perColtracks = o2::aod::femtobase::stored::fColId;
+  Partition<FemtoTracks> trackPartition1 = MAKE_TRACK_PARTITION(confTrackSelections1);
+  Partition<FemtoTracks> trackPartition2 = MAKE_TRACK_PARTITION(confTrackSelections2);
+  Partition<FemtoTracks> trackPartition3 = MAKE_TRACK_PARTITION(confTrackSelections3);
+  Preslice<FemtoTracks> perColtracks = aod::femtobase::stored::fColId;
 
-  o2::framework::Partition<FemtoTracksWithLabel> trackWithLabelPartition1 = MAKE_TRACK_PARTITION(confTrackSelections1);
-  o2::framework::Partition<FemtoTracksWithLabel> trackWithLabelPartition2 = MAKE_TRACK_PARTITION(confTrackSelections2);
-  o2::framework::Partition<FemtoTracksWithLabel> trackWithLabelPartition3 = MAKE_TRACK_PARTITION(confTrackSelections3);
-  o2::framework::Preslice<FemtoTracksWithLabel> perColtracksWithLabel = o2::aod::femtobase::stored::fColId;
+  Partition<FemtoTracksWithLabel> trackWithLabelPartition1 = MAKE_TRACK_PARTITION(confTrackSelections1);
+  Partition<FemtoTracksWithLabel> trackWithLabelPartition2 = MAKE_TRACK_PARTITION(confTrackSelections2);
+  Partition<FemtoTracksWithLabel> trackWithLabelPartition3 = MAKE_TRACK_PARTITION(confTrackSelections3);
+  Preslice<FemtoTracksWithLabel> perColtracksWithLabel = aod::femtobase::stored::fColId;
 
   // setup triplets
   triplethistmanager::ConfTripletBinning confTripletBinning;
@@ -103,14 +115,14 @@ struct FemtoTripletTrackTrackTrack {
   std::vector<double> defaultVtxBins{10, -10, 10};
   std::vector<double> defaultMultBins{50, 0, 200};
   std::vector<double> defaultCentBins{10, 0, 100};
-  o2::framework::ColumnBinningPolicy<o2::aod::femtocollisions::PosZ, o2::aod::femtocollisions::Mult> mixBinsVtxMult{{defaultVtxBins, defaultMultBins}, true};
-  o2::framework::ColumnBinningPolicy<o2::aod::femtocollisions::PosZ, o2::aod::femtocollisions::Cent> mixBinsVtxCent{{defaultVtxBins, defaultCentBins}, true};
-  o2::framework::ColumnBinningPolicy<o2::aod::femtocollisions::PosZ, o2::aod::femtocollisions::Mult, o2::aod::femtocollisions::Cent> mixBinsVtxMultCent{{defaultVtxBins, defaultMultBins, defaultCentBins}, true};
+  ColumnBinningPolicy<femtocollisions::PosZ, femtocollisions::Mult> mixBinsVtxMult{{defaultVtxBins, defaultMultBins}, true};
+  ColumnBinningPolicy<aod::femtocollisions::PosZ, aod::femtocollisions::Cent> mixBinsVtxCent{{defaultVtxBins, defaultCentBins}, true};
+  ColumnBinningPolicy<aod::femtocollisions::PosZ, aod::femtocollisions::Mult, aod::femtocollisions::Cent> mixBinsVtxMultCent{{defaultVtxBins, defaultMultBins, defaultCentBins}, true};
   triplethistmanager::ConfMixing confMixing;
 
-  o2::framework::HistogramRegistry hRegistry{"FemtoTrackTrackTrack", {}, o2::framework::OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry hRegistry{"FemtoTrackTrackTrack", {}, OutputObjHandlingPolicy::AnalysisObject};
 
-  void init(o2::framework::InitContext&)
+  void init(InitContext&)
   {
     if ((doprocessSameEvent + doprocessSameEventMc) > 1 || (doprocessMixedEvent + doprocessMixedEventMc) > 1) {
       LOG(fatal) << "More than 1 same or mixed event process function is activated. Breaking...";
@@ -128,27 +140,21 @@ struct FemtoTripletTrackTrackTrack {
     mixBinsVtxMultCent = {{confMixing.vtxBins.value, confMixing.multBins.value, confMixing.centBins.value}, true};
 
     // setup histogram specs
-
-    std::map<colhistmanager::ColHist, std::vector<o2::framework::AxisSpec>> colHistSpec;
-    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> trackHistSpec1;
-    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> trackHistSpec2;
-    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> trackHistSpec3;
-    std::map<triplethistmanager::TripletHist, std::vector<o2::framework::AxisSpec>> tripletHistSpec;
-    std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> ctrHistSpec = closepairrejection::makeCprHistSpecMap(confCtr);
+    auto ctrHistSpec = closepairrejection::makeCprHistSpecMap(confCtr);
 
     if (processData) {
-      colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
-      trackHistSpec1 = trackhistmanager::makeTrackHistSpecMap(confTrackBinning1);
-      trackHistSpec2 = trackhistmanager::makeTrackHistSpecMap(confTrackBinning2);
-      trackHistSpec3 = trackhistmanager::makeTrackHistSpecMap(confTrackBinning3);
-      tripletHistSpec = triplethistmanager::makeTripletHistSpecMap(confTripletBinning);
+      auto colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
+      auto trackHistSpec1 = trackhistmanager::makeTrackHistSpecMap(confTrackBinning1);
+      auto trackHistSpec2 = trackhistmanager::makeTrackHistSpecMap(confTrackBinning2);
+      auto trackHistSpec3 = trackhistmanager::makeTrackHistSpecMap(confTrackBinning3);
+      auto tripletHistSpec = triplethistmanager::makeTripletHistSpecMap(confTripletBinning);
       tripletTrackTrackTrackBuilder.init<modes::Mode::kAnalysis>(&hRegistry, confTrackSelections1, confTrackSelections2, confTrackSelections3, confCtr, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, trackHistSpec3, tripletHistSpec, ctrHistSpec);
     } else {
-      colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
-      trackHistSpec1 = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning1);
-      trackHistSpec2 = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning2);
-      trackHistSpec3 = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning3);
-      tripletHistSpec = triplethistmanager::makeTripletMcHistSpecMap(confTripletBinning);
+      auto colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
+      auto trackHistSpec1 = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning1);
+      auto trackHistSpec2 = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning2);
+      auto trackHistSpec3 = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning3);
+      auto tripletHistSpec = triplethistmanager::makeTripletMcHistSpecMap(confTripletBinning);
       tripletTrackTrackTrackBuilder.init<modes::Mode::kAnalysis_Mc>(&hRegistry, confTrackSelections1, confTrackSelections2, confTrackSelections3, confCtr, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, trackHistSpec3, tripletHistSpec, ctrHistSpec);
     }
     hRegistry.print();
@@ -160,7 +166,7 @@ struct FemtoTripletTrackTrackTrack {
   }
   PROCESS_SWITCH(FemtoTripletTrackTrackTrack, processSameEvent, "Enable processing same event processing", true);
 
-  void processSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processSameEventMc(FilteredFemtoCollisionWithLabel const& col, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FMcParticles const& mcParticles, FMcMothers const& mcMothers, FMcPartMoths const& mcPartonicMothers)
   {
     tripletTrackTrackTrackBuilder.processSameEvent<modes::Mode::kAnalysis_Mc>(col, mcCols, tracks, trackWithLabelPartition1, trackWithLabelPartition2, trackWithLabelPartition3, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -172,16 +178,16 @@ struct FemtoTripletTrackTrackTrack {
   }
   PROCESS_SWITCH(FemtoTripletTrackTrackTrack, processMixedEvent, "Enable processing mixed event processing", true);
 
-  void processMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, o2::aod::FMcParticles const& mcParticles)
+  void processMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FMcParticles const& mcParticles)
   {
     tripletTrackTrackTrackBuilder.processMixedEvent<modes::Mode::kAnalysis_Mc>(cols, mcCols, tracks, trackWithLabelPartition1, trackWithLabelPartition2, trackWithLabelPartition3, mcParticles, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }
   PROCESS_SWITCH(FemtoTripletTrackTrackTrack, processMixedEventMc, "Enable processing mixed event processing", false);
 };
 
-o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  o2::framework::WorkflowSpec workflow{
+  WorkflowSpec workflow{
     adaptAnalysisTask<FemtoTripletTrackTrackTrack>(cfgc),
   };
   return workflow;

--- a/PWGCF/Femto/Tasks/femtoTripletTrackTrackV0.cxx
+++ b/PWGCF/Femto/Tasks/femtoTripletTrackTrackV0.cxx
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file femtoTripletTrackTrackTrack.cxx
+/// \file femtoTripletTrackTrackV0.cxx
 /// \brief Tasks that computes correlation between two tracks
 /// \author Anton Riedel, TU München, anton.riedel@cern.ch
 
@@ -37,40 +37,36 @@
 #include "Framework/OutputObjHeader.h"
 #include "Framework/runDataProcessing.h"
 
-#include <string>
+#include <map>
 #include <vector>
 
-using namespace o2;
-using namespace o2::aod;
-using namespace o2::soa;
-using namespace o2::framework;
-using namespace o2::framework::expressions;
 using namespace o2::analysis::femto;
 
-struct FemtoTripletTrackTrackTrack {
+struct FemtoTripletTrackTrackV0 {
 
   // setup tables
-  using FemtoCollisions = Join<FCols, FColMasks>;
+  using FemtoCollisions = o2::soa::Join<o2::aod::FCols, o2::aod::FColMasks>;
   using FilteredFemtoCollisions = o2::soa::Filtered<FemtoCollisions>;
   using FilteredFemtoCollision = FilteredFemtoCollisions::iterator;
 
-  using FemtoCollisionsWithLabel = o2::soa::Join<FemtoCollisions, FColLabels>;
+  using FemtoCollisionsWithLabel = o2::soa::Join<FemtoCollisions, o2::aod::FColLabels>;
   using FilteredFemtoCollisionsWithLabel = o2::soa::Filtered<FemtoCollisionsWithLabel>;
   using FilteredFemtoCollisionWithLabel = FilteredFemtoCollisionsWithLabel::iterator;
 
-  using FemtoTracks = o2::soa::Join<FTracks, FTrackMasks>;
-  using FemtoLambdas = o2::soa::Join<FLambdas, FLambdaMasks>;
-  using FemtoK0shorts = o2::soa::Join<FK0shorts, FK0shortMasks>;
+  // TODO also implement K0shorts
+  using FemtoTracks = o2::soa::Join<o2::aod::FTracks, o2::aod::FTrackMasks>;
+  using FemtoLambdas = o2::soa::Join<o2::aod::FLambdas, o2::aod::FLambdaMasks>;
+  // using FemtoK0shorts = o2::soa::Join<o2::aod::FK0shorts, o2::aod::FK0shortMasks>;
 
-  using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, FTrackLabels>;
-  using FemtoLambdasWithLabel = o2::soa::Join<FemtoLambdas, FLambdaLabels>;
-  using FemtoK0shortsWithLabel = o2::soa::Join<FemtoK0shorts, FK0shortLabels>;
+  using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, o2::aod::FTrackLabels>;
+  using FemtoLambdasWithLabel = o2::soa::Join<FemtoLambdas, o2::aod::FLambdaLabels>;
+  // using FemtoK0shortsWithLabel = o2::soa::Join<FemtoK0shorts, o2::aod::FK0shortLabels>;
 
-  SliceCache cache;
+  o2::framework::SliceCache cache;
 
   // setup collisions
   collisionbuilder::ConfCollisionSelection collisionSelection;
-  Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
+  o2::framework::expressions::Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
   colhistmanager::ConfCollisionBinning confCollisionBinning;
 
   // setup tracks
@@ -78,18 +74,29 @@ struct FemtoTripletTrackTrackTrack {
   trackhistmanager::ConfTrackBinning1 confTrackBinning1;
   trackbuilder::ConfTrackSelection2 confTrackSelections2;
   trackhistmanager::ConfTrackBinning2 confTrackBinning2;
-  trackbuilder::ConfTrackSelection3 confTrackSelections3;
-  trackhistmanager::ConfTrackBinning3 confTrackBinning3;
 
-  Partition<FemtoTracks> trackPartition1 = MAKE_TRACK_PARTITION(confTrackSelections1);
-  Partition<FemtoTracks> trackPartition2 = MAKE_TRACK_PARTITION(confTrackSelections2);
-  Partition<FemtoTracks> trackPartition3 = MAKE_TRACK_PARTITION(confTrackSelections3);
-  Preslice<FemtoTracks> perColtracks = aod::femtobase::stored::fColId;
+  o2::framework::Partition<FemtoTracks> trackPartition1 = MAKE_TRACK_PARTITION(confTrackSelections1);
+  o2::framework::Partition<FemtoTracks> trackPartition2 = MAKE_TRACK_PARTITION(confTrackSelections2);
+  o2::framework::Preslice<FemtoTracks> perColtracks = o2::aod::femtobase::stored::fColId;
 
-  Partition<FemtoTracksWithLabel> trackWithLabelPartition1 = MAKE_TRACK_PARTITION(confTrackSelections1);
-  Partition<FemtoTracksWithLabel> trackWithLabelPartition2 = MAKE_TRACK_PARTITION(confTrackSelections2);
-  Partition<FemtoTracksWithLabel> trackWithLabelPartition3 = MAKE_TRACK_PARTITION(confTrackSelections3);
-  Preslice<FemtoTracksWithLabel> perColtracksWithLabel = aod::femtobase::stored::fColId;
+  o2::framework::Partition<FemtoTracksWithLabel> trackWithLabelPartition1 = MAKE_TRACK_PARTITION(confTrackSelections1);
+  o2::framework::Partition<FemtoTracksWithLabel> trackWithLabelPartition2 = MAKE_TRACK_PARTITION(confTrackSelections2);
+  o2::framework::Preslice<FemtoTracksWithLabel> perColtracksWithLabel = o2::aod::femtobase::stored::fColId;
+
+  // setup for daughters
+  trackhistmanager::ConfV0PosDauBinning confPosDauBinning;
+  trackhistmanager::ConfV0NegDauBinning confNegDauBinning;
+
+  // setup lambdas
+  v0builder::ConfLambdaSelection1 confLambdaSelection;
+  v0histmanager::ConfLambdaBinning1 confLambdaBinning;
+  particlecleaner::ConfLambdaCleaner1 confLambdaCleaner;
+
+  o2::framework::Partition<FemtoLambdas> lambdaPartition = MAKE_LAMBDA_PARTITION(confLambdaSelection);
+  o2::framework::Preslice<FemtoLambdas> perColLambdas = o2::aod::femtobase::stored::fColId;
+
+  o2::framework::Partition<FemtoLambdasWithLabel> lambdaWithLabelPartition = MAKE_LAMBDA_PARTITION(confLambdaSelection);
+  o2::framework::Preslice<FemtoLambdasWithLabel> perColLambdasWithLabel = o2::aod::femtobase::stored::fColId;
 
   // setup triplets
   triplethistmanager::ConfTripletBinning confTripletBinning;
@@ -97,32 +104,35 @@ struct FemtoTripletTrackTrackTrack {
 
   closetripletrejection::ConfCtrTrackTrackTrack confCtr;
 
-  tripletbuilder::TripletTrackTrackTrackBuilder<
+  tripletbuilder::TripletTrackTrackV0Builder<
+    modes::V0::kLambda,
     trackhistmanager::PrefixTrack1,
     trackhistmanager::PrefixTrack2,
-    trackhistmanager::PrefixTrack3,
-    triplethistmanager::PrefixTrackTrackTrackSe,
-    triplethistmanager::PrefixTrackTrackTrackMe,
+    v0histmanager::PrefixLambda1,
+    trackhistmanager::PrefixV01PosDaughter,
+    trackhistmanager::PrefixV02NegDaughter,
+    triplethistmanager::PrefixTrackTrackLambdaSe,
+    triplethistmanager::PrefixTrackTrackLambdaMe,
     closetripletrejection::PrefixTrack1Track2Se,
-    closetripletrejection::PrefixTrack2Track3Se,
-    closetripletrejection::PrefixTrack1Track3Se,
+    closetripletrejection::PrefixTrack1V0Se,
+    closetripletrejection::PrefixTrack2V0Se,
     closetripletrejection::PrefixTrack1Track2Me,
-    closetripletrejection::PrefixTrack2Track3Me,
-    closetripletrejection::PrefixTrack1Track3Me>
-    tripletTrackTrackTrackBuilder;
+    closetripletrejection::PrefixTrack1V0Me,
+    closetripletrejection::PrefixTrack2V0Me>
+    tripletTrackTrackLambdaBuilder;
 
   // setup mixing
   std::vector<double> defaultVtxBins{10, -10, 10};
   std::vector<double> defaultMultBins{50, 0, 200};
   std::vector<double> defaultCentBins{10, 0, 100};
-  ColumnBinningPolicy<femtocollisions::PosZ, femtocollisions::Mult> mixBinsVtxMult{{defaultVtxBins, defaultMultBins}, true};
-  ColumnBinningPolicy<aod::femtocollisions::PosZ, aod::femtocollisions::Cent> mixBinsVtxCent{{defaultVtxBins, defaultCentBins}, true};
-  ColumnBinningPolicy<aod::femtocollisions::PosZ, aod::femtocollisions::Mult, aod::femtocollisions::Cent> mixBinsVtxMultCent{{defaultVtxBins, defaultMultBins, defaultCentBins}, true};
+  o2::framework::ColumnBinningPolicy<o2::aod::femtocollisions::PosZ, o2::aod::femtocollisions::Mult> mixBinsVtxMult{{defaultVtxBins, defaultMultBins}, true};
+  o2::framework::ColumnBinningPolicy<o2::aod::femtocollisions::PosZ, o2::aod::femtocollisions::Cent> mixBinsVtxCent{{defaultVtxBins, defaultCentBins}, true};
+  o2::framework::ColumnBinningPolicy<o2::aod::femtocollisions::PosZ, o2::aod::femtocollisions::Mult, o2::aod::femtocollisions::Cent> mixBinsVtxMultCent{{defaultVtxBins, defaultMultBins, defaultCentBins}, true};
   triplethistmanager::ConfMixing confMixing;
 
-  HistogramRegistry hRegistry{"FemtoTrackTrackTrack", {}, OutputObjHandlingPolicy::AnalysisObject};
+  o2::framework::HistogramRegistry hRegistry{"FemtoTrackTrackTrack", {}, o2::framework::OutputObjHandlingPolicy::AnalysisObject};
 
-  void init(InitContext&)
+  void init(o2::framework::InitContext&)
   {
     if ((doprocessSameEvent + doprocessSameEventMc) > 1 || (doprocessMixedEvent + doprocessMixedEventMc) > 1) {
       LOG(fatal) << "More than 1 same or mixed event process function is activated. Breaking...";
@@ -140,55 +150,67 @@ struct FemtoTripletTrackTrackTrack {
     mixBinsVtxMultCent = {{confMixing.vtxBins.value, confMixing.multBins.value, confMixing.centBins.value}, true};
 
     // setup histogram specs
-    auto ctrHistSpec = closepairrejection::makeCprHistSpecMap(confCtr);
+    std::map<colhistmanager::ColHist, std::vector<o2::framework::AxisSpec>> colHistSpec;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> trackHistSpec1;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> trackHistSpec2;
+
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> posDauSpec;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> negDauSpec;
+    std::map<v0histmanager::V0Hist, std::vector<o2::framework::AxisSpec>> lambdaHistSpec;
+    std::map<triplethistmanager::TripletHist, std::vector<o2::framework::AxisSpec>> tripletHistSpec;
+    std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> ctrHistSpec = closepairrejection::makeCprHistSpecMap(confCtr);
 
     if (processData) {
-      auto colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
-      auto trackHistSpec1 = trackhistmanager::makeTrackHistSpecMap(confTrackBinning1);
-      auto trackHistSpec2 = trackhistmanager::makeTrackHistSpecMap(confTrackBinning2);
-      auto trackHistSpec3 = trackhistmanager::makeTrackHistSpecMap(confTrackBinning3);
-      auto tripletHistSpec = triplethistmanager::makeTripletHistSpecMap(confTripletBinning);
-      tripletTrackTrackTrackBuilder.init<modes::Mode::kAnalysis>(&hRegistry, confTrackSelections1, confTrackSelections2, confTrackSelections3, confCtr, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, trackHistSpec3, tripletHistSpec, ctrHistSpec);
+      colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
+      trackHistSpec1 = trackhistmanager::makeTrackHistSpecMap(confTrackBinning1);
+      trackHistSpec2 = trackhistmanager::makeTrackHistSpecMap(confTrackBinning2);
+      lambdaHistSpec = v0histmanager::makeV0HistSpecMap(confLambdaBinning);
+      posDauSpec = trackhistmanager::makeTrackHistSpecMap(confPosDauBinning);
+      negDauSpec = trackhistmanager::makeTrackHistSpecMap(confNegDauBinning);
+      tripletHistSpec = triplethistmanager::makeTripletHistSpecMap(confTripletBinning);
+      tripletTrackTrackLambdaBuilder.init<modes::Mode::kAnalysis>(&hRegistry, confTrackSelections1, confTrackSelections2, confLambdaSelection, confCtr, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, lambdaHistSpec, posDauSpec, negDauSpec, tripletHistSpec, ctrHistSpec);
     } else {
-      auto colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
-      auto trackHistSpec1 = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning1);
-      auto trackHistSpec2 = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning2);
-      auto trackHistSpec3 = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning3);
-      auto tripletHistSpec = triplethistmanager::makeTripletMcHistSpecMap(confTripletBinning);
-      tripletTrackTrackTrackBuilder.init<modes::Mode::kAnalysis_Mc>(&hRegistry, confTrackSelections1, confTrackSelections2, confTrackSelections3, confCtr, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, trackHistSpec3, tripletHistSpec, ctrHistSpec);
+      colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
+      trackHistSpec1 = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning1);
+      trackHistSpec2 = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning2);
+      lambdaHistSpec = v0histmanager::makeV0McHistSpecMap(confLambdaBinning);
+      posDauSpec = trackhistmanager::makeTrackMcHistSpecMap(confPosDauBinning);
+      negDauSpec = trackhistmanager::makeTrackMcHistSpecMap(confNegDauBinning);
+      tripletHistSpec = triplethistmanager::makeTripletMcHistSpecMap(confTripletBinning);
+      tripletTrackTrackLambdaBuilder.init<modes::Mode::kAnalysis_Mc>(&hRegistry, confTrackSelections1, confTrackSelections2, confLambdaSelection, confCtr, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, lambdaHistSpec, posDauSpec, negDauSpec, tripletHistSpec, ctrHistSpec);
     }
     hRegistry.print();
   };
 
-  void processSameEvent(FilteredFemtoCollision const& col, FemtoTracks const& tracks)
+  void processSameEvent(FilteredFemtoCollision const& col, FemtoTracks const& tracks, FemtoLambdas const& /*lambdas*/)
   {
-    tripletTrackTrackTrackBuilder.processSameEvent<modes::Mode::kAnalysis>(col, tracks, trackPartition1, trackPartition2, trackPartition3, cache);
+    tripletTrackTrackLambdaBuilder.processSameEvent<modes::Mode::kAnalysis>(col, tracks, trackPartition1, trackPartition2, lambdaPartition, cache);
   }
-  PROCESS_SWITCH(FemtoTripletTrackTrackTrack, processSameEvent, "Enable processing same event processing", true);
+  PROCESS_SWITCH(FemtoTripletTrackTrackV0, processSameEvent, "Enable processing same event processing", true);
 
-  void processSameEventMc(FilteredFemtoCollisionWithLabel const& col, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FMcParticles const& mcParticles, FMcMothers const& mcMothers, FMcPartMoths const& mcPartonicMothers)
+  void processSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdas const& /*lambdas*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
-    tripletTrackTrackTrackBuilder.processSameEvent<modes::Mode::kAnalysis_Mc>(col, mcCols, tracks, trackWithLabelPartition1, trackWithLabelPartition2, trackWithLabelPartition3, mcParticles, mcMothers, mcPartonicMothers, cache);
+    tripletTrackTrackLambdaBuilder.processSameEvent<modes::Mode::kAnalysis_Mc>(col, mcCols, tracks, trackWithLabelPartition1, trackWithLabelPartition2, lambdaWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
-  PROCESS_SWITCH(FemtoTripletTrackTrackTrack, processSameEventMc, "Enable processing same event processing", false);
+  PROCESS_SWITCH(FemtoTripletTrackTrackV0, processSameEventMc, "Enable processing same event processing", false);
 
-  void processMixedEvent(FilteredFemtoCollisions const& cols, FemtoTracks const& tracks)
+  void processMixedEvent(FilteredFemtoCollisions const& cols, FemtoTracks const& tracks, FemtoLambdas const& /*lambdas*/)
   {
-    tripletTrackTrackTrackBuilder.processMixedEvent<modes::Mode::kAnalysis>(cols, tracks, trackPartition1, trackPartition2, trackPartition3, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
+    tripletTrackTrackLambdaBuilder.processMixedEvent<modes::Mode::kAnalysis>(cols, tracks, trackPartition1, trackPartition2, lambdaPartition, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }
-  PROCESS_SWITCH(FemtoTripletTrackTrackTrack, processMixedEvent, "Enable processing mixed event processing", true);
+  PROCESS_SWITCH(FemtoTripletTrackTrackV0, processMixedEvent, "Enable processing mixed event processing", true);
 
-  void processMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FMcParticles const& mcParticles)
+  void processMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdas const& /*lambdas*/, o2::aod::FMcParticles const& mcParticles)
   {
-    tripletTrackTrackTrackBuilder.processMixedEvent<modes::Mode::kAnalysis_Mc>(cols, mcCols, tracks, trackWithLabelPartition1, trackWithLabelPartition2, trackWithLabelPartition3, mcParticles, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
+    tripletTrackTrackLambdaBuilder.processMixedEvent<modes::Mode::kAnalysis_Mc>(cols, mcCols, tracks, trackWithLabelPartition1, trackWithLabelPartition2, lambdaWithLabelPartition, mcParticles, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }
-  PROCESS_SWITCH(FemtoTripletTrackTrackTrack, processMixedEventMc, "Enable processing mixed event processing", false);
+  PROCESS_SWITCH(FemtoTripletTrackTrackV0, processMixedEventMc, "Enable processing mixed event processing", false);
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{
-    adaptAnalysisTask<FemtoTripletTrackTrackTrack>(cfgc),
+  o2::framework::WorkflowSpec workflow{
+    adaptAnalysisTask<FemtoTripletTrackTrackV0>(cfgc),
   };
   return workflow;
 }

--- a/PWGCF/Femto/Tasks/femtoV0Qa.cxx
+++ b/PWGCF/Femto/Tasks/femtoV0Qa.cxx
@@ -33,6 +33,9 @@
 #include "Framework/OutputObjHeader.h"
 #include "Framework/runDataProcessing.h"
 
+#include <map>
+#include <vector>
+
 using namespace o2::analysis::femto;
 
 struct FemtoV0Qa {

--- a/PWGCF/Femto/Tasks/femtoV0Qa.cxx
+++ b/PWGCF/Femto/Tasks/femtoV0Qa.cxx
@@ -33,38 +33,32 @@
 #include "Framework/OutputObjHeader.h"
 #include "Framework/runDataProcessing.h"
 
-#include <string>
-#include <vector>
-
-using namespace o2::aod;
-using namespace o2::framework;
-using namespace o2::framework::expressions;
 using namespace o2::analysis::femto;
 
 struct FemtoV0Qa {
 
   // setup tables
-  using FemtoCollisions = o2::soa::Join<FCols, FColMasks, FColPos, FColSphericities, FColMults>;
+  using FemtoCollisions = o2::soa::Join<o2::aod::FCols, o2::aod::FColMasks, o2::aod::FColPos, o2::aod::FColSphericities, o2::aod::FColMults>;
   using FilteredFemtoCollisions = o2::soa::Filtered<FemtoCollisions>;
   using FilteredFemtoCollision = FilteredFemtoCollisions::iterator;
 
-  using FemtoCollisionsWithLabel = o2::soa::Join<FemtoCollisions, FColLabels>;
+  using FemtoCollisionsWithLabel = o2::soa::Join<FemtoCollisions, o2::aod::FColLabels>;
   using FilteredFemtoCollisionsWithLabel = o2::soa::Filtered<FemtoCollisionsWithLabel>;
   using FilteredFemtoCollisionWithLabel = FilteredFemtoCollisionsWithLabel::iterator;
 
-  using FemtoLambdas = o2::soa::Join<FLambdas, FLambdaMasks, FLambdaExtras>;
-  using FemtoK0shorts = o2::soa::Join<FK0shorts, FK0shortMasks, FK0shortExtras>;
-  using FemtoTracks = o2::soa::Join<FTracks, FTrackDcas, FTrackExtras, FTrackPids>;
+  using FemtoLambdas = o2::soa::Join<o2::aod::FLambdas, o2::aod::FLambdaMasks, o2::aod::FLambdaExtras>;
+  using FemtoK0shorts = o2::soa::Join<o2::aod::FK0shorts, o2::aod::FK0shortMasks, o2::aod::FK0shortExtras>;
+  using FemtoTracks = o2::soa::Join<o2::aod::FTracks, o2::aod::FTrackDcas, o2::aod::FTrackExtras, o2::aod::FTrackPids>;
 
-  using FemtoLambdasWithLabel = o2::soa::Join<FemtoLambdas, FLambdaLabels>;
-  using FemtoK0shortsWithLabel = o2::soa::Join<FemtoK0shorts, FK0shortLabels>;
-  using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, FTrackLabels>;
+  using FemtoLambdasWithLabel = o2::soa::Join<FemtoLambdas, o2::aod::FLambdaLabels>;
+  using FemtoK0shortsWithLabel = o2::soa::Join<FemtoK0shorts, o2::aod::FK0shortLabels>;
+  using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, o2::aod::FTrackLabels>;
 
-  SliceCache cache;
+  o2::framework::SliceCache cache;
 
   // setup for collisions
   collisionbuilder::ConfCollisionSelection collisionSelection;
-  Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
+  o2::framework::expressions::Filter collisionFilter = MAKE_COLLISION_FILTER(collisionSelection);
   colhistmanager::CollisionHistManager colHistManager;
   colhistmanager::ConfCollisionBinning confCollisionBinning;
   colhistmanager::ConfCollisionQaBinning confCollisionQaBinning;
@@ -73,11 +67,11 @@ struct FemtoV0Qa {
   particlecleaner::ConfLambdaCleaner1 confLambdaCleaner;
   v0builder::ConfLambdaSelection1 confLambdaSelection;
 
-  Partition<FemtoLambdas> lambdaPartition = MAKE_LAMBDA_PARTITION(confLambdaSelection);
-  Preslice<FemtoLambdas> perColLambdas = femtobase::stored::fColId;
+  o2::framework::Partition<FemtoLambdas> lambdaPartition = MAKE_LAMBDA_PARTITION(confLambdaSelection);
+  o2::framework::Preslice<FemtoLambdas> perColLambdas = o2::aod::femtobase::stored::fColId;
 
-  Partition<FemtoLambdasWithLabel> lambdaWithLabelPartition = MAKE_LAMBDA_PARTITION(confLambdaSelection);
-  Preslice<FemtoLambdasWithLabel> perColLambdasWithLabel = femtobase::stored::fColId;
+  o2::framework::Partition<FemtoLambdasWithLabel> lambdaWithLabelPartition = MAKE_LAMBDA_PARTITION(confLambdaSelection);
+  o2::framework::Preslice<FemtoLambdasWithLabel> perColLambdasWithLabel = o2::aod::femtobase::stored::fColId;
 
   particlecleaner::ParticleCleaner lambdaCleaner;
 
@@ -94,11 +88,11 @@ struct FemtoV0Qa {
   particlecleaner::ConfK0shortCleaner1 confK0shortCleaner;
   v0builder::ConfK0shortSelection1 confK0shortSelection;
 
-  Partition<FemtoK0shorts> k0shortPartition = MAKE_K0SHORT_PARTITION(confK0shortSelection);
-  Preslice<FemtoK0shorts> perColK0shorts = femtobase::stored::fColId;
+  o2::framework::Partition<FemtoK0shorts> k0shortPartition = MAKE_K0SHORT_PARTITION(confK0shortSelection);
+  o2::framework::Preslice<FemtoK0shorts> perColK0shorts = o2::aod::femtobase::stored::fColId;
 
-  Partition<FemtoK0shortsWithLabel> k0shortWithLabelPartition = MAKE_K0SHORT_PARTITION(confK0shortSelection);
-  Preslice<FemtoK0shortsWithLabel> perColK0shortsWithLabel = femtobase::stored::fColId;
+  o2::framework::Partition<FemtoK0shortsWithLabel> k0shortWithLabelPartition = MAKE_K0SHORT_PARTITION(confK0shortSelection);
+  o2::framework::Preslice<FemtoK0shortsWithLabel> perColK0shortsWithLabel = o2::aod::femtobase::stored::fColId;
 
   particlecleaner::ParticleCleaner k0shortCleaner;
 
@@ -118,9 +112,9 @@ struct FemtoV0Qa {
   trackhistmanager::ConfV0NegDauBinning confV0NegDaughterBinning;
   trackhistmanager::ConfV0NegDauQaBinning confV0NegDaughterQaBinning;
 
-  HistogramRegistry hRegistry{"FemtoV0Qa", {}, OutputObjHandlingPolicy::AnalysisObject};
+  o2::framework::HistogramRegistry hRegistry{"FemtoV0Qa", {}, o2::framework::OutputObjHandlingPolicy::AnalysisObject};
 
-  void init(InitContext&)
+  void init(o2::framework::InitContext&)
   {
     if ((doprocessLambda + doprocessLambdaMc + doprocessK0short + doprocessK0shortMc) > 1) {
       LOG(fatal) << "Only one process can be activated";
@@ -129,30 +123,37 @@ struct FemtoV0Qa {
 
     lambdaCleaner.init(confLambdaCleaner);
     k0shortCleaner.init(confK0shortCleaner);
+
+    std::map<colhistmanager::ColHist, std::vector<o2::framework::AxisSpec>> colHistSpec;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> posDaughterHistSpec;
+    std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> negDaughterHistSpec;
+    std::map<v0histmanager::V0Hist, std::vector<o2::framework::AxisSpec>> lambdaHistSpec;
+    std::map<v0histmanager::V0Hist, std::vector<o2::framework::AxisSpec>> k0shortHistSpec;
+
     if (processData) {
-      auto colHistSpec = colhistmanager::makeColQaHistSpecMap(confCollisionBinning, confCollisionQaBinning);
+      colHistSpec = colhistmanager::makeColQaHistSpecMap(confCollisionBinning, confCollisionQaBinning);
       colHistManager.init<modes::Mode::kAnalysis_Qa>(&hRegistry, colHistSpec, confCollisionQaBinning);
-      auto posDaughterHistSpec = trackhistmanager::makeTrackQaHistSpecMap(confV0PosDaughterBinning, confV0PosDaughterQaBinning);
-      auto negDaughterHistSpec = trackhistmanager::makeTrackQaHistSpecMap(confV0NegDaughterBinning, confV0NegDaughterQaBinning);
+      posDaughterHistSpec = trackhistmanager::makeTrackQaHistSpecMap(confV0PosDaughterBinning, confV0PosDaughterQaBinning);
+      negDaughterHistSpec = trackhistmanager::makeTrackQaHistSpecMap(confV0NegDaughterBinning, confV0NegDaughterQaBinning);
       if (doprocessLambda) {
-        auto lambdaHistSpec = v0histmanager::makeV0QaHistSpecMap(confLambdaBinning, confLambdaQaBinning);
+        lambdaHistSpec = v0histmanager::makeV0QaHistSpecMap(confLambdaBinning, confLambdaQaBinning);
         lambdaHistManager.init<modes::Mode::kAnalysis_Qa>(&hRegistry, lambdaHistSpec, confLambdaSelection, confLambdaQaBinning, posDaughterHistSpec, confV0PosDaughterQaBinning, negDaughterHistSpec, confV0NegDaughterQaBinning);
       }
       if (doprocessK0short) {
-        auto k0shortHistSpec = v0histmanager::makeV0QaHistSpecMap(confK0shortBinning, confK0shortQaBinning);
+        k0shortHistSpec = v0histmanager::makeV0QaHistSpecMap(confK0shortBinning, confK0shortQaBinning);
         k0shortHistManager.init<modes::Mode::kAnalysis_Qa>(&hRegistry, k0shortHistSpec, confK0shortSelection, confK0shortQaBinning, posDaughterHistSpec, confV0PosDaughterQaBinning, negDaughterHistSpec, confV0NegDaughterQaBinning);
       }
     } else {
-      auto colHistSpec = colhistmanager::makeColMcQaHistSpecMap(confCollisionBinning, confCollisionQaBinning);
+      colHistSpec = colhistmanager::makeColMcQaHistSpecMap(confCollisionBinning, confCollisionQaBinning);
       colHistManager.init<modes::Mode::kAnalysis_Qa_Mc>(&hRegistry, colHistSpec, confCollisionQaBinning);
-      auto posDaughterHistSpec = trackhistmanager::makeTrackMcQaHistSpecMap(confV0PosDaughterBinning, confV0PosDaughterQaBinning);
-      auto negDaughterHistSpec = trackhistmanager::makeTrackMcQaHistSpecMap(confV0NegDaughterBinning, confV0NegDaughterQaBinning);
+      posDaughterHistSpec = trackhistmanager::makeTrackMcQaHistSpecMap(confV0PosDaughterBinning, confV0PosDaughterQaBinning);
+      negDaughterHistSpec = trackhistmanager::makeTrackMcQaHistSpecMap(confV0NegDaughterBinning, confV0NegDaughterQaBinning);
       if (doprocessLambdaMc) {
-        auto lambdaHistSpec = v0histmanager::makeV0McQaHistSpecMap(confLambdaBinning, confLambdaQaBinning);
+        lambdaHistSpec = v0histmanager::makeV0McQaHistSpecMap(confLambdaBinning, confLambdaQaBinning);
         lambdaHistManager.init<modes::Mode::kAnalysis_Qa_Mc>(&hRegistry, lambdaHistSpec, confLambdaSelection, confLambdaQaBinning, posDaughterHistSpec, confV0PosDaughterQaBinning, negDaughterHistSpec, confV0NegDaughterQaBinning);
       }
       if (doprocessK0shortMc) {
-        auto k0shortHistSpec = v0histmanager::makeV0McQaHistSpecMap(confK0shortBinning, confK0shortQaBinning);
+        k0shortHistSpec = v0histmanager::makeV0McQaHistSpecMap(confK0shortBinning, confK0shortQaBinning);
         k0shortHistManager.init<modes::Mode::kAnalysis_Qa_Mc>(&hRegistry, k0shortHistSpec, confK0shortSelection, confK0shortQaBinning, posDaughterHistSpec, confV0PosDaughterQaBinning, negDaughterHistSpec, confV0NegDaughterQaBinning);
       }
     }
@@ -162,17 +163,17 @@ struct FemtoV0Qa {
   void processK0short(FilteredFemtoCollision const& col, FemtoTracks const& tracks, FemtoK0shorts const& /*k0shorts*/)
   {
     colHistManager.fill<modes::Mode::kAnalysis_Qa>(col);
-    auto k0shortSlice = k0shortPartition->sliceByCached(femtobase::stored::fColId, col.globalIndex(), cache);
+    auto k0shortSlice = k0shortPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
     for (auto const& k0short : k0shortSlice) {
       k0shortHistManager.fill<modes::Mode::kAnalysis_Qa>(k0short, tracks);
     }
   }
   PROCESS_SWITCH(FemtoV0Qa, processK0short, "Process k0shorts", false);
 
-  void processK0shortMc(FilteredFemtoCollisionWithLabel const& col, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& /*k0shorts*/, FMcParticles const& mcParticles, FMcMothers const& mcMothers, FMcPartMoths const& mcPartonicMothers)
+  void processK0shortMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& /*k0shorts*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     colHistManager.fill<modes::Mode::kAnalysis_Qa_Mc>(col, mcCols);
-    auto k0shortSlice = k0shortWithLabelPartition->sliceByCached(femtobase::stored::fColId, col.globalIndex(), cache);
+    auto k0shortSlice = k0shortWithLabelPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
     for (auto const& k0short : k0shortSlice) {
       if (!k0shortCleaner.isClean(k0short, mcParticles, mcMothers, mcPartonicMothers)) {
         continue;
@@ -185,17 +186,17 @@ struct FemtoV0Qa {
   void processLambda(FilteredFemtoCollision const& col, FemtoTracks const& tracks, FemtoLambdas const& /*lambdas*/)
   {
     colHistManager.fill<modes::Mode::kAnalysis_Qa>(col);
-    auto lambdaSlice = lambdaPartition->sliceByCached(femtobase::stored::fColId, col.globalIndex(), cache);
+    auto lambdaSlice = lambdaPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
     for (auto const& lambda : lambdaSlice) {
       lambdaHistManager.fill<modes::Mode::kAnalysis_Qa>(lambda, tracks);
     }
   }
   PROCESS_SWITCH(FemtoV0Qa, processLambda, "Process lambdas", true);
 
-  void processLambdaMc(FilteredFemtoCollisionWithLabel const& col, FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& /*lambdas*/, FMcParticles const& mcParticles, FMcMothers const& mcMothers, FMcPartMoths const& mcPartonicMothers)
+  void processLambdaMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& /*lambdas*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     colHistManager.fill<modes::Mode::kAnalysis_Qa_Mc>(col, mcCols);
-    auto lambdaSlice = lambdaWithLabelPartition->sliceByCached(femtobase::stored::fColId, col.globalIndex(), cache);
+    auto lambdaSlice = lambdaWithLabelPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
     for (auto const& lambda : lambdaSlice) {
       if (!lambdaCleaner.isClean(lambda, mcParticles, mcMothers, mcPartonicMothers)) {
         continue;
@@ -206,9 +207,9 @@ struct FemtoV0Qa {
   PROCESS_SWITCH(FemtoV0Qa, processLambdaMc, "Process lambdas", false);
 };
 
-WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
 {
-  WorkflowSpec workflow{
+  o2::framework::WorkflowSpec workflow{
     adaptAnalysisTask<FemtoV0Qa>(cfgc),
   };
   return workflow;


### PR DESCRIPTION
The following changes are included
- global cleanup of namespaces. Only use our own namespace o2::analysis::femto in implementation files.
- small fixes in utilities of the triplet tracktracktrack task
- add MC processing to track-cascade task
- add triplet tracktrackv0 task and surrounding infrastructure