### PR TITLE
[PWGDQ] added alignment corrections for MFT and MCH in global alignment task

### DIFF
--- a/PWGDQ/Tasks/CMakeLists.txt
+++ b/PWGDQ/Tasks/CMakeLists.txt
@@ -156,5 +156,5 @@ o2physics_add_dpl_workflow(mft-mch-matcher
 
 o2physics_add_dpl_workflow(muon-global-alignment
                     SOURCES muonGlobalAlignment.cxx
-                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::PWGDQCore
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::PWGDQCore O2::MCHGeometryTransformer
                     COMPONENT_NAME Analysis)


### PR DESCRIPTION
MFT: only global alignment corrections are implemented, in the form of configurable rotations and translations of the top and bottom halves

MCH: the re-alignment and re-fitting of the MCH clusters and tracks is fully implemented, inspired from the muon QA task

Both can be enabled/disabled individually via configration options, and are disabled by default.