### PR TITLE
[PWGCF] Add mc3d femtodream

### DIFF
--- a/PWGCF/FemtoDream/Core/femtoDreamCollisionSelection.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamCollisionSelection.h
@@ -223,10 +223,10 @@ class FemtoDreamCollisionSelection
     mHistogramQn->add("Event/centVsqnVsSpher", "; cent; qn; Sphericity", kTH3F, {{10, 0, 100}, {100, 0, 1000}, {100, 0, 1}});
     mHistogramQn->add("Event/qnBin", "; qnBin; entries", kTH1F, {{20, 0, 20}});
     mHistogramQn->add("Event/psiEP", "; #Psi_{EP} (deg); entries", kTH1F, {{100, 0, 180}});
-    mHistogramQn->add("Event/epReso_FT0CTPC", "; cent; qnBin; reso_ft0c_tpc", kTH2F, {{10, 0, 100},{10,0,10}});
-    mHistogramQn->add("Event/epReso_FT0ATPC", "; cent; qnBin; reso_ft0a_tpc", kTH2F, {{10, 0, 100},{10,0,10}});
-    mHistogramQn->add("Event/epReso_FT0CFT0A", "; cent; qnBin; reso_ft0c_ft0a", kTH2F, {{10, 0, 100},{10,0,10}});
-    mHistogramQn->add("Event/epReso_count", "; cent; qnBin; count", kTH2F, {{10, 0, 100},{10,0,10}});
+    mHistogramQn->add("Event/epReso_FT0CTPC", "; cent; qnBin; reso_ft0c_tpc", kTH2F, {{10, 0, 100}, {10, 0, 10}});
+    mHistogramQn->add("Event/epReso_FT0ATPC", "; cent; qnBin; reso_ft0a_tpc", kTH2F, {{10, 0, 100}, {10, 0, 10}});
+    mHistogramQn->add("Event/epReso_FT0CFT0A", "; cent; qnBin; reso_ft0c_ft0a", kTH2F, {{10, 0, 100}, {10, 0, 10}});
+    mHistogramQn->add("Event/epReso_count", "; cent; qnBin; count", kTH2F, {{10, 0, 100}, {10, 0, 10}});
 
     return;
   }
@@ -337,13 +337,13 @@ class FemtoDreamCollisionSelection
   float computeqnVec(T const& col, int qvecMod = 0)
   {
     double qn = -999.f;
-    if (qvecMod == 0){
+    if (qvecMod == 0) {
       qn = std::sqrt(col.qvecFT0CReVec()[0] * col.qvecFT0CReVec()[0] + col.qvecFT0CImVec()[0] * col.qvecFT0CImVec()[0]) * std::sqrt(col.sumAmplFT0C());
-    } else if (qvecMod == 1){
+    } else if (qvecMod == 1) {
       qn = std::sqrt(col.qvecFT0AReVec()[0] * col.qvecFT0AReVec()[0] + col.qvecFT0AImVec()[0] * col.qvecFT0AImVec()[0]) * std::sqrt(col.sumAmplFT0A());
     } else {
-       LOGP(error, "no selected detector of Qvec for ESE ");  
-       return qn;   
+      LOGP(error, "no selected detector of Qvec for ESE ");
+      return qn;
     }
     return qn;
   }
@@ -357,20 +357,20 @@ class FemtoDreamCollisionSelection
   float computeEP(T const& col, int nmode, int qvecMod)
   {
     double EP = -999.f;
-    if (qvecMod == 0){
+    if (qvecMod == 0) {
       EP = ((1. / nmode) * (TMath::ATan2(col.qvecFT0CImVec()[0], col.qvecFT0CReVec()[0])));
     } else if (qvecMod == 1) {
-      EP = ((1. / nmode) * (TMath::ATan2(col.qvecFT0AImVec()[0], col.qvecFT0AReVec()[0])));      
+      EP = ((1. / nmode) * (TMath::ATan2(col.qvecFT0AImVec()[0], col.qvecFT0AReVec()[0])));
     } else if (qvecMod == 2) {
-      EP = ((1. / nmode) * (TMath::ATan2(col.qvecTPCallImVec()[0], col.qvecTPCallReVec()[0])));            
+      EP = ((1. / nmode) * (TMath::ATan2(col.qvecTPCallImVec()[0], col.qvecTPCallReVec()[0])));
     } else {
-       LOGP(error, "no selected detector of Qvec for EP");  
-       return EP;   
+      LOGP(error, "no selected detector of Qvec for EP");
+      return EP;
     }
-    
-    if (EP < 0){
+
+    if (EP < 0) {
       EP += TMath::Pi();
-    } // atan2 return in rad -pi/2-pi/2, then make it 0-pi   
+    } // atan2 return in rad -pi/2-pi/2, then make it 0-pi
     return EP;
   }
 
@@ -383,7 +383,7 @@ class FemtoDreamCollisionSelection
   {
     const float psi_ft0c = ((1. / nmode) * (TMath::ATan2(col.qvecFT0CImVec()[0], col.qvecFT0CReVec()[0])));
     const float psi_ft0a = ((1. / nmode) * (TMath::ATan2(col.qvecFT0AImVec()[0], col.qvecFT0AReVec()[0])));
-    const float psi_tpc = ((1. / nmode) * (TMath::ATan2(col.qvecTPCallImVec()[0], col.qvecTPCallReVec()[0]))); 
+    const float psi_tpc = ((1. / nmode) * (TMath::ATan2(col.qvecTPCallImVec()[0], col.qvecTPCallReVec()[0])));
 
     mHistogramQn->fill(HIST("Event/epReso_FT0CTPC"), centrality, mQnBin + 0.f, std::cos((psi_ft0c - psi_tpc) * nmode));
     mHistogramQn->fill(HIST("Event/epReso_FT0ATPC"), centrality, mQnBin + 0.f, std::cos((psi_ft0a - psi_tpc) * nmode));

--- a/PWGCF/FemtoDream/Core/femtoDreamContainer.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamContainer.h
@@ -225,24 +225,24 @@ class FemtoDreamContainer
 
   template <typename T>
   void init_3Dqn_MC(std::string folderName, std::string femtoDKout, std::string femtoDKside, std::string femtoDKlong,
-                    T& femtoDKoutAxis, T& femtoDKsideAxis, T& femtoDKlongAxis, bool smearingByOrigin=false)
+                    T& femtoDKoutAxis, T& femtoDKsideAxis, T& femtoDKlongAxis, bool smearingByOrigin = false)
   {
     mHistogramRegistry->add((folderName + "/hNoMCtruthPairsCounter").c_str(), "; Counter; Entries", kTH1I, {{1, 0, 1}});
     mHistogramRegistry->add((folderName + "/hFakePairsCounter").c_str(), "; Counter; Entries", kTH1I, {{1, 0, 1}});
     if (smearingByOrigin) {
       const int nOriginBins = o2::aod::femtodreamMCparticle::ParticleOriginMCTruth::kNOriginMCTruthTypes;
-      mHistogramRegistry->add((folderName + "/relPair3dresolution").c_str(), (";" + femtoDKout + "mctruth;" + femtoDKout + "_reco;" + femtoDKside + "mctruth;" + femtoDKside + "_reco;" +femtoDKlong + "mctruth;" +femtoDKlong + "_reco;" + "MC origin particle 1; MC origin particle 2;").c_str(), 
-                               kTHnSparseF, {femtoDKoutAxis, femtoDKoutAxis, femtoDKsideAxis, femtoDKsideAxis, femtoDKlongAxis, femtoDKlongAxis,
-                               {nOriginBins, 0, nOriginBins}, {nOriginBins, 0, nOriginBins}});
+      mHistogramRegistry->add((folderName + "/relPair3dresolution").c_str(), (";" + femtoDKout + "mctruth;" + femtoDKout + "_reco;" + femtoDKside + "mctruth;" + femtoDKside + "_reco;" + femtoDKlong + "mctruth;" + femtoDKlong + "_reco;" + "MC origin particle 1; MC origin particle 2;").c_str(),
+                              kTHnSparseF, {femtoDKoutAxis, femtoDKoutAxis, femtoDKsideAxis, femtoDKsideAxis, femtoDKlongAxis, femtoDKlongAxis, {nOriginBins, 0, nOriginBins}, {nOriginBins, 0, nOriginBins}});
     } else {
-      mHistogramRegistry->add((folderName + "/relPair3dresolution").c_str(), (";" + femtoDKout + "mctruth;" + femtoDKside + "mctruth;" +femtoDKlong + "mctruth;" + femtoDKout + "_reco;" + femtoDKside + "_reco;" +femtoDKlong + "_reco;").c_str(),
-                               kTHnSparseF, {femtoDKoutAxis, femtoDKoutAxis, femtoDKsideAxis, femtoDKsideAxis, femtoDKlongAxis, femtoDKlongAxis});    }
+      mHistogramRegistry->add((folderName + "/relPair3dresolution").c_str(), (";" + femtoDKout + "mctruth;" + femtoDKside + "mctruth;" + femtoDKlong + "mctruth;" + femtoDKout + "_reco;" + femtoDKside + "_reco;" + femtoDKlong + "_reco;").c_str(),
+                              kTHnSparseF, {femtoDKoutAxis, femtoDKoutAxis, femtoDKsideAxis, femtoDKsideAxis, femtoDKlongAxis, femtoDKlongAxis});
+    }
   }
 
   template <typename T>
   void init_3Dqn(HistogramRegistry* registry,
                  T& DKoutBins, T& DKsideBins, T& DKlongBins, T& mTBins4D, T& multPercentileBins4D,
-                 bool isMC, ConfigurableAxis qnBins = {"qnBins", {10, 0, 10}, "qn binning"}, ConfigurableAxis pairPhiBins = {"phiBins", {10, 0 - 0.05, TMath::Pi() + 0.05}, "pair phi binning"}, bool smearingByOrigin=false)
+                 bool isMC, ConfigurableAxis qnBins = {"qnBins", {10, 0, 10}, "qn binning"}, ConfigurableAxis pairPhiBins = {"phiBins", {10, 0 - 0.05, TMath::Pi() + 0.05}, "pair phi binning"}, bool smearingByOrigin = false)
   {
     mHistogramRegistry = registry;
 
@@ -268,7 +268,7 @@ class FemtoDreamContainer
       init_base_3Dqn(folderName, femtoObsDKout, femtoObsDKside, femtoObsDKlong,
                      DKoutAxis, DKsideAxis, DKlongAxis, mTAxis4D, multPercentileAxis4D, qnAxis, pairPhiAxis);
       init_3Dqn_MC(folderName, femtoObsDKout, femtoObsDKside, femtoObsDKlong,
-                    DKoutAxis, DKsideAxis, DKlongAxis, smearingByOrigin);
+                   DKoutAxis, DKsideAxis, DKlongAxis, smearingByOrigin);
     }
   }
 
@@ -511,7 +511,6 @@ class FemtoDreamContainer
     } else {
       mHistogramRegistry->fill(HIST(mFolderSuffix[mEventType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[o2::aod::femtodreamMCparticle::MCType::kTruth]) + HIST("_3Dqn") + HIST("/relPair3dresolution"), k3dMC[1], k3d[1], k3dMC[2], k3d[2], k3dMC[3], k3d[3]);
     }
-    
   }
 
   template <bool isMC, typename T1, typename T2>
@@ -519,8 +518,8 @@ class FemtoDreamContainer
   {
 
     std::vector<double> k3d = FemtoDreamMath::newpairfunc(part1, mMassOne, part2, mMassTwo, IsSameSpecies);
-    if (k3d.size()<4){
-      LOG(error)<<"newpairfunc returned size="<< k3d.size();
+    if (k3d.size() < 4) {
+      LOG(error) << "newpairfunc returned size=" << k3d.size();
       return;
     }
     float DKout = k3d[1];
@@ -538,8 +537,8 @@ class FemtoDreamContainer
         if (part1.has_fdMCParticle() && part2.has_fdMCParticle()) {
 
           std::vector<double> k3dMC = FemtoDreamMath::newpairfuncMC(part1.fdMCParticle(), mMassOne, part2.fdMCParticle(), mMassTwo, IsSameSpecies);
-          if (k3dMC.size()<4){
-            LOG(error)<<"newpairfunc returned size="<< k3d.size();
+          if (k3dMC.size() < 4) {
+            LOG(error) << "newpairfunc returned size=" << k3d.size();
             return;
           }
           const float mTMC = FemtoDreamMath::getmT(part1.fdMCParticle(), mMassOne, part2.fdMCParticle(), mMassTwo);
@@ -564,8 +563,8 @@ class FemtoDreamContainer
   {
 
     std::vector<double> k3d = FemtoDreamMath::newpairfunc(part1, mMassOne, part2, mMassTwo, IsSameSpecies);
-    if (k3d.size()<4){
-      LOG(error)<<"newpairfunc returned size="<< k3d.size();
+    if (k3d.size() < 4) {
+      LOG(error) << "newpairfunc returned size=" << k3d.size();
       return;
     }
     float DKout = k3d[1];
@@ -583,10 +582,10 @@ class FemtoDreamContainer
         if (part1.has_fdMCParticle() && part2.has_fdMCParticle()) {
 
           std::vector<double> k3dMC = FemtoDreamMath::newpairfuncMC(part1.fdMCParticle(), mMassOne, part2.fdMCParticle(), mMassTwo, IsSameSpecies);
-          if (k3dMC.size()<4){
-            LOG(error)<<"newpairfunc returned size="<< k3d.size();
+          if (k3dMC.size() < 4) {
+            LOG(error) << "newpairfunc returned size=" << k3d.size();
             return;
-          }          
+          }
           const float mTMC = FemtoDreamMath::getmT(part1.fdMCParticle(), mMassOne, part2.fdMCParticle(), mMassTwo);
           const float pairPhiEPMC = FemtoDreamMath::getPairPhiEP(part1.fdMCParticle(), mMassOne, part2.fdMCParticle(), mMassTwo, EP1, EP2);
 

--- a/PWGCF/FemtoDream/Core/femtoDreamContainer.h
+++ b/PWGCF/FemtoDream/Core/femtoDreamContainer.h
@@ -224,9 +224,25 @@ class FemtoDreamContainer
   }
 
   template <typename T>
+  void init_3Dqn_MC(std::string folderName, std::string femtoDKout, std::string femtoDKside, std::string femtoDKlong,
+                    T& femtoDKoutAxis, T& femtoDKsideAxis, T& femtoDKlongAxis, bool smearingByOrigin=false)
+  {
+    mHistogramRegistry->add((folderName + "/hNoMCtruthPairsCounter").c_str(), "; Counter; Entries", kTH1I, {{1, 0, 1}});
+    mHistogramRegistry->add((folderName + "/hFakePairsCounter").c_str(), "; Counter; Entries", kTH1I, {{1, 0, 1}});
+    if (smearingByOrigin) {
+      const int nOriginBins = o2::aod::femtodreamMCparticle::ParticleOriginMCTruth::kNOriginMCTruthTypes;
+      mHistogramRegistry->add((folderName + "/relPair3dresolution").c_str(), (";" + femtoDKout + "mctruth;" + femtoDKout + "_reco;" + femtoDKside + "mctruth;" + femtoDKside + "_reco;" +femtoDKlong + "mctruth;" +femtoDKlong + "_reco;" + "MC origin particle 1; MC origin particle 2;").c_str(), 
+                               kTHnSparseF, {femtoDKoutAxis, femtoDKoutAxis, femtoDKsideAxis, femtoDKsideAxis, femtoDKlongAxis, femtoDKlongAxis,
+                               {nOriginBins, 0, nOriginBins}, {nOriginBins, 0, nOriginBins}});
+    } else {
+      mHistogramRegistry->add((folderName + "/relPair3dresolution").c_str(), (";" + femtoDKout + "mctruth;" + femtoDKside + "mctruth;" +femtoDKlong + "mctruth;" + femtoDKout + "_reco;" + femtoDKside + "_reco;" +femtoDKlong + "_reco;").c_str(),
+                               kTHnSparseF, {femtoDKoutAxis, femtoDKoutAxis, femtoDKsideAxis, femtoDKsideAxis, femtoDKlongAxis, femtoDKlongAxis});    }
+  }
+
+  template <typename T>
   void init_3Dqn(HistogramRegistry* registry,
                  T& DKoutBins, T& DKsideBins, T& DKlongBins, T& mTBins4D, T& multPercentileBins4D,
-                 bool isMC, ConfigurableAxis qnBins = {"qnBins", {10, 0, 10}, "qn binning"}, ConfigurableAxis pairPhiBins = {"phiBins", {10, 0 - 0.05, TMath::Pi() + 0.05}, "pair phi binning"})
+                 bool isMC, ConfigurableAxis qnBins = {"qnBins", {10, 0, 10}, "qn binning"}, ConfigurableAxis pairPhiBins = {"phiBins", {10, 0 - 0.05, TMath::Pi() + 0.05}, "pair phi binning"}, bool smearingByOrigin=false)
   {
     mHistogramRegistry = registry;
 
@@ -251,6 +267,8 @@ class FemtoDreamContainer
       folderName = static_cast<std::string>(mFolderSuffix[mEventType]) + static_cast<std::string>(o2::aod::femtodreamMCparticle::MCTypeName[o2::aod::femtodreamMCparticle::MCType::kTruth]) + static_cast<std::string>("_3Dqn");
       init_base_3Dqn(folderName, femtoObsDKout, femtoObsDKside, femtoObsDKlong,
                      DKoutAxis, DKsideAxis, DKlongAxis, mTAxis4D, multPercentileAxis4D, qnAxis, pairPhiAxis);
+      init_3Dqn_MC(folderName, femtoObsDKout, femtoObsDKside, femtoObsDKlong,
+                    DKoutAxis, DKsideAxis, DKlongAxis, smearingByOrigin);
     }
   }
 
@@ -484,11 +502,27 @@ class FemtoDreamContainer
     mHistogramRegistry->fill(HIST(mFolderSuffix[mEventType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[mc]) + HIST("_3Dqn") + HIST("/relPair3dRmTMultPercentileQnPairphi"), femtoDKout, femtoDKside, femtoDKlong, mT, multPercentile, myQnBin, pairPhiEP);
   }
 
+  /// Called by setPair_3Dqn only in case of Monte Carlo truth
+  /// Fills resolution of DKout, DKside, DKlong
+  void setPair_3Dqn_MC(std::vector<double> k3dMC, std::vector<double> k3d, const int originPart1, const int originPart2, bool smearingByOrigin)
+  {
+    if (smearingByOrigin) {
+      mHistogramRegistry->fill(HIST(mFolderSuffix[mEventType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[o2::aod::femtodreamMCparticle::MCType::kTruth]) + HIST("_3Dqn") + HIST("/relPair3dresolution"), k3dMC[1], k3d[1], k3dMC[2], k3d[2], k3dMC[3], k3d[3], originPart1, originPart2);
+    } else {
+      mHistogramRegistry->fill(HIST(mFolderSuffix[mEventType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[o2::aod::femtodreamMCparticle::MCType::kTruth]) + HIST("_3Dqn") + HIST("/relPair3dresolution"), k3dMC[1], k3d[1], k3dMC[2], k3d[2], k3dMC[3], k3d[3]);
+    }
+    
+  }
+
   template <bool isMC, typename T1, typename T2>
-  void setPair_3Dqn(T1 const& part1, T2 const& part2, const float multPercentile, bool IsSameSpecies, const float myQnBin, const float eventPlane)
+  void setPair_3Dqn(T1 const& part1, T2 const& part2, const float multPercentile, bool IsSameSpecies, const float myQnBin, const float eventPlane, bool smearingByOrigin = false)
   {
 
     std::vector<double> k3d = FemtoDreamMath::newpairfunc(part1, mMassOne, part2, mMassTwo, IsSameSpecies);
+    if (k3d.size()<4){
+      LOG(error)<<"newpairfunc returned size="<< k3d.size();
+      return;
+    }
     float DKout = k3d[1];
     float DKside = k3d[2];
     float DKlong = k3d[3];
@@ -503,12 +537,17 @@ class FemtoDreamContainer
       if constexpr (isMC) {
         if (part1.has_fdMCParticle() && part2.has_fdMCParticle()) {
 
-          std::vector<double> k3dMC = FemtoDreamMath::newpairfunc(part1.fdMCParticle(), mMassOne, part2.fdMCParticle(), mMassTwo, IsSameSpecies);
+          std::vector<double> k3dMC = FemtoDreamMath::newpairfuncMC(part1.fdMCParticle(), mMassOne, part2.fdMCParticle(), mMassTwo, IsSameSpecies);
+          if (k3dMC.size()<4){
+            LOG(error)<<"newpairfunc returned size="<< k3d.size();
+            return;
+          }
           const float mTMC = FemtoDreamMath::getmT(part1.fdMCParticle(), mMassOne, part2.fdMCParticle(), mMassTwo);
           const float pairPhiEPMC = FemtoDreamMath::getPairPhiEP(part1.fdMCParticle(), mMassOne, part2.fdMCParticle(), mMassTwo, eventPlane);
 
           if (std::abs(part1.fdMCParticle().pdgMCTruth()) == mPDGOne && std::abs(part2.fdMCParticle().pdgMCTruth()) == mPDGTwo) { // Note: all pair-histogramms are filled with MC truth information ONLY in case of non-fake candidates
             setPair_3Dqn_base<o2::aod::femtodreamMCparticle::MCType::kTruth>(k3dMC[1], k3dMC[2], k3dMC[3], mTMC, multPercentile, myQnBin, pairPhiEPMC);
+            setPair_3Dqn_MC(k3dMC, k3d, part1.fdMCParticle().partOriginMCTruth(), part2.fdMCParticle().partOriginMCTruth(), smearingByOrigin);
           } else {
             mHistogramRegistry->fill(HIST(mFolderSuffix[mEventType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[o2::aod::femtodreamMCparticle::MCType::kTruth]) + HIST("/hFakePairsCounter"), 0);
           }
@@ -521,10 +560,14 @@ class FemtoDreamContainer
   }
 
   template <bool isMC, typename T1, typename T2>
-  void setPair_3Dqn(T1 const& part1, T2 const& part2, const float multPercentile, bool IsSameSpecies, const float myQnBin, const float EP1, const float EP2)
+  void setPair_3Dqn(T1 const& part1, T2 const& part2, const float multPercentile, bool IsSameSpecies, const float myQnBin, const float EP1, const float EP2, bool smearingByOrigin = false)
   {
 
     std::vector<double> k3d = FemtoDreamMath::newpairfunc(part1, mMassOne, part2, mMassTwo, IsSameSpecies);
+    if (k3d.size()<4){
+      LOG(error)<<"newpairfunc returned size="<< k3d.size();
+      return;
+    }
     float DKout = k3d[1];
     float DKside = k3d[2];
     float DKlong = k3d[3];
@@ -539,12 +582,17 @@ class FemtoDreamContainer
       if constexpr (isMC) {
         if (part1.has_fdMCParticle() && part2.has_fdMCParticle()) {
 
-          std::vector<double> k3dMC = FemtoDreamMath::newpairfunc(part1.fdMCParticle(), mMassOne, part2.fdMCParticle(), mMassTwo, IsSameSpecies);
+          std::vector<double> k3dMC = FemtoDreamMath::newpairfuncMC(part1.fdMCParticle(), mMassOne, part2.fdMCParticle(), mMassTwo, IsSameSpecies);
+          if (k3dMC.size()<4){
+            LOG(error)<<"newpairfunc returned size="<< k3d.size();
+            return;
+          }          
           const float mTMC = FemtoDreamMath::getmT(part1.fdMCParticle(), mMassOne, part2.fdMCParticle(), mMassTwo);
           const float pairPhiEPMC = FemtoDreamMath::getPairPhiEP(part1.fdMCParticle(), mMassOne, part2.fdMCParticle(), mMassTwo, EP1, EP2);
 
           if (std::abs(part1.fdMCParticle().pdgMCTruth()) == mPDGOne && std::abs(part2.fdMCParticle().pdgMCTruth()) == mPDGTwo) { // Note: all pair-histogramms are filled with MC truth information ONLY in case of non-fake candidates
             setPair_3Dqn_base<o2::aod::femtodreamMCparticle::MCType::kTruth>(k3dMC[1], k3dMC[2], k3dMC[3], mTMC, multPercentile, myQnBin, pairPhiEPMC);
+            setPair_3Dqn_MC(k3dMC, k3d, part1.fdMCParticle().partOriginMCTruth(), part2.fdMCParticle().partOriginMCTruth(), smearingByOrigin);
           } else {
             mHistogramRegistry->fill(HIST(mFolderSuffix[mEventType]) + HIST(o2::aod::femtodreamMCparticle::MCTypeName[o2::aod::femtodreamMCparticle::MCType::kTruth]) + HIST("/hFakePairsCounter"), 0);
           }

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
@@ -314,9 +314,7 @@ struct femtoDreamProducerTask {
     if (doprocessData == false && doprocessData_noCentrality == false && doprocessData_CentPbPb == false && doprocessData_CentPbPb_EP == false && doprocessMC == false && doprocessMC_noCentrality == false && doprocessMC_CentPbPb == false && doprocessMC_CentPbPb_EP == false) {
       LOGF(fatal, "Neither processData nor processMC enabled. Please choose one.");
     }
-    if ((doprocessData == true && doprocessMC == true) || (doprocessData == true && doprocessMC_noCentrality == true) || (doprocessMC == true && doprocessMC_noCentrality == true) || (doprocessData_noCentrality == true && doprocessData == true) || (doprocessData_noCentrality == true && doprocessMC == true) || (doprocessData_noCentrality == true && doprocessMC_noCentrality == true) || (doprocessData_CentPbPb == true && doprocessData == true) || (doprocessData_CentPbPb == true && doprocessData_noCentrality == true) || (doprocessData_CentPbPb == true && doprocessMC == true) || (doprocessData_CentPbPb == true && doprocessMC_noCentrality == true) || (doprocessData_CentPbPb == true && doprocessMC_CentPbPb == true) 
-        || (doprocessData_CentPbPb_EP == true && doprocessData == true) || (doprocessData_CentPbPb_EP == true && doprocessData_noCentrality == true) || (doprocessData_CentPbPb_EP == true && doprocessMC == true) || (doprocessData_CentPbPb_EP == true && doprocessMC_noCentrality == true) || (doprocessData_CentPbPb_EP == true && doprocessMC_CentPbPb == true) || (doprocessData_CentPbPb_EP == true && doprocessData_CentPbPb == true) || (doprocessData_CentPbPb_EP == true && doprocessMC_CentPbPb_EP == true)
-        || (doprocessMC_CentPbPb_EP == true && doprocessData == true) || (doprocessMC_CentPbPb_EP == true && doprocessData_noCentrality == true) || (doprocessMC_CentPbPb_EP == true && doprocessMC == true) || (doprocessMC_CentPbPb_EP == true && doprocessMC_noCentrality == true) || (doprocessMC_CentPbPb_EP == true && doprocessMC_CentPbPb == true) || (doprocessMC_CentPbPb_EP == true && doprocessData_CentPbPb == true)) {
+    if ((doprocessData == true && doprocessMC == true) || (doprocessData == true && doprocessMC_noCentrality == true) || (doprocessMC == true && doprocessMC_noCentrality == true) || (doprocessData_noCentrality == true && doprocessData == true) || (doprocessData_noCentrality == true && doprocessMC == true) || (doprocessData_noCentrality == true && doprocessMC_noCentrality == true) || (doprocessData_CentPbPb == true && doprocessData == true) || (doprocessData_CentPbPb == true && doprocessData_noCentrality == true) || (doprocessData_CentPbPb == true && doprocessMC == true) || (doprocessData_CentPbPb == true && doprocessMC_noCentrality == true) || (doprocessData_CentPbPb == true && doprocessMC_CentPbPb == true) || (doprocessData_CentPbPb_EP == true && doprocessData == true) || (doprocessData_CentPbPb_EP == true && doprocessData_noCentrality == true) || (doprocessData_CentPbPb_EP == true && doprocessMC == true) || (doprocessData_CentPbPb_EP == true && doprocessMC_noCentrality == true) || (doprocessData_CentPbPb_EP == true && doprocessMC_CentPbPb == true) || (doprocessData_CentPbPb_EP == true && doprocessData_CentPbPb == true) || (doprocessData_CentPbPb_EP == true && doprocessMC_CentPbPb_EP == true) || (doprocessMC_CentPbPb_EP == true && doprocessData == true) || (doprocessMC_CentPbPb_EP == true && doprocessData_noCentrality == true) || (doprocessMC_CentPbPb_EP == true && doprocessMC == true) || (doprocessMC_CentPbPb_EP == true && doprocessMC_noCentrality == true) || (doprocessMC_CentPbPb_EP == true && doprocessMC_CentPbPb == true) || (doprocessMC_CentPbPb_EP == true && doprocessData_CentPbPb == true)) {
       LOGF(fatal,
            "Cannot enable more than one process switch at the same time. "
            "Please choose one.");
@@ -1138,7 +1136,7 @@ struct femtoDreamProducerTask {
     float myqn = 0.f;
     float myEP = 0.f;
 
-    if (!isMC || epCal.ConfMCQvec){
+    if (!isMC || epCal.ConfMCQvec) {
       myqn = colCuts.computeqnVec(col, epCal.ConfQvecDetector);
       myEP = TMath::RadToDeg() * colCuts.computeEP(col, EPHarmonic, epCal.ConfEPDetector); // psi from rad(0-pi) to deg, in table psi would be in deg,from 0-180
     }
@@ -1288,16 +1286,16 @@ struct femtoDreamProducerTask {
   PROCESS_SWITCH(femtoDreamProducerTask, processMC_CentPbPb, "Provide MC data with centrality information for PbPb collisions", false);
 
   void processMC_CentPbPb_EP(aod::FemtoFullCollisionMC_CentPbPb_qvec const& col,
-                               aod::BCsWithTimestamps const&,
-                               soa::Join<aod::FemtoFullTracks, aod::McTrackLabels> const& tracks,
-                               aod::FemtoFullMCgenCollisions const&,
-                               aod::McParticles const&,                               
-                               soa::Join<o2::aod::V0Datas, aod::McV0Labels> const& fullV0s, /// \todo with FilteredFullV0s
-                               soa::Join<o2::aod::CascDatas, aod::McCascLabels> const& fullCascades)
+                             aod::BCsWithTimestamps const&,
+                             soa::Join<aod::FemtoFullTracks, aod::McTrackLabels> const& tracks,
+                             aod::FemtoFullMCgenCollisions const&,
+                             aod::McParticles const&,
+                             soa::Join<o2::aod::V0Datas, aod::McV0Labels> const& fullV0s, /// \todo with FilteredFullV0s
+                             soa::Join<o2::aod::CascDatas, aod::McCascLabels> const& fullCascades)
   {
     // get magnetic field for run
     initCCDB_Mag_Trig(col.bc_as<aod::BCsWithTimestamps>());
-    // fill the tables      
+    // fill the tables
     fillCollisionsAndTracksAndV0AndCascade<true, false, true, true, true>(col, tracks, tracks, fullV0s, fullCascades);
   }
   PROCESS_SWITCH(femtoDreamProducerTask, processMC_CentPbPb_EP, "Provide MC data with centrality and q-vector table for PbPb collisions", false);

--- a/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
+++ b/PWGCF/FemtoDream/TableProducer/femtoDreamProducerTask.cxx
@@ -61,10 +61,11 @@ namespace o2::aod
 using FemtoFullCollision = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Ms>::iterator;
 using FemtoFullCollision_noCent = soa::Join<aod::Collisions, aod::EvSels, aod::Mults>::iterator;
 using FemtoFullCollision_CentPbPb = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Cs>::iterator;
-using FemtoFullCollision_CentPbPb_qvec = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Cs, aod::CentFV0As, aod::QvectorFT0CVecs>::iterator;
+using FemtoFullCollision_CentPbPb_qvec = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Cs, aod::QvectorFT0CVecs, aod::CentFT0As, aod::QvectorFT0AVecs, aod::QvectorTPCallVecs>::iterator;
 using FemtoFullCollisionMC = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Ms, aod::McCollisionLabels>::iterator;
 using FemtoFullCollision_noCent_MC = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::McCollisionLabels>::iterator;
 using FemtoFullCollisionMC_CentPbPb = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Cs, aod::McCollisionLabels>::iterator;
+using FemtoFullCollisionMC_CentPbPb_qvec = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Cs, aod::QvectorFT0CVecs, aod::CentFT0As, aod::QvectorFT0AVecs, aod::QvectorTPCallVecs, aod::McCollisionLabels>::iterator;
 using FemtoFullMCgenCollisions = soa::Join<aod::McCollisions, MultsExtraMC>;
 using FemtoFullMCgenCollision = FemtoFullMCgenCollisions::iterator;
 
@@ -281,6 +282,9 @@ struct femtoDreamProducerTask {
     Configurable<float> ConfCentralityMax{"ConfCentralityMax", 100.f, "Evt sel: Maximum Centrality cut"};
     Configurable<float> ConfCentBinWidth{"ConfCentBinWidth", 1.f, "Centrality bin length for qn separator"};
     Configurable<int> ConfNumQnBins{"ConfNumQnBins", 10, "Number of qn bins"};
+    Configurable<bool> ConfMCQvec{"ConfMCQvec", false, "Enable Q vector table for Monte Carlo"};
+    Configurable<int> ConfQvecDetector{"ConfQvecDetector", 0, "Q-vec detector selection; 0 : FT0C; 1 : FT0A"};
+    Configurable<int> ConfEPDetector{"ConfEPDetector", 0, "Event-plane detector selection; 0 : FT0C; 1 : FT0A; 2 : TPC"};
   } epCal;
 
   struct : o2::framework::ConfigurableGroup {
@@ -307,10 +311,12 @@ struct femtoDreamProducerTask {
 
   void init(InitContext&)
   {
-    if (doprocessData == false && doprocessData_noCentrality == false && doprocessData_CentPbPb == false && doprocessData_CentPbPb_EP == false && doprocessMC == false && doprocessMC_noCentrality == false && doprocessMC_CentPbPb == false) {
+    if (doprocessData == false && doprocessData_noCentrality == false && doprocessData_CentPbPb == false && doprocessData_CentPbPb_EP == false && doprocessMC == false && doprocessMC_noCentrality == false && doprocessMC_CentPbPb == false && doprocessMC_CentPbPb_EP == false) {
       LOGF(fatal, "Neither processData nor processMC enabled. Please choose one.");
     }
-    if ((doprocessData == true && doprocessMC == true) || (doprocessData == true && doprocessMC_noCentrality == true) || (doprocessMC == true && doprocessMC_noCentrality == true) || (doprocessData_noCentrality == true && doprocessData == true) || (doprocessData_noCentrality == true && doprocessMC == true) || (doprocessData_noCentrality == true && doprocessMC_noCentrality == true) || (doprocessData_CentPbPb == true && doprocessData == true) || (doprocessData_CentPbPb == true && doprocessData_noCentrality == true) || (doprocessData_CentPbPb == true && doprocessMC == true) || (doprocessData_CentPbPb == true && doprocessMC_noCentrality == true) || (doprocessData_CentPbPb == true && doprocessMC_CentPbPb == true) || (doprocessData_CentPbPb_EP == true && doprocessData == true) || (doprocessData_CentPbPb_EP == true && doprocessData_noCentrality == true) || (doprocessData_CentPbPb_EP == true && doprocessMC == true) || (doprocessData_CentPbPb_EP == true && doprocessMC_noCentrality == true) || (doprocessData_CentPbPb_EP == true && doprocessMC_CentPbPb == true) || (doprocessData_CentPbPb_EP == true && doprocessData_CentPbPb == true)) {
+    if ((doprocessData == true && doprocessMC == true) || (doprocessData == true && doprocessMC_noCentrality == true) || (doprocessMC == true && doprocessMC_noCentrality == true) || (doprocessData_noCentrality == true && doprocessData == true) || (doprocessData_noCentrality == true && doprocessMC == true) || (doprocessData_noCentrality == true && doprocessMC_noCentrality == true) || (doprocessData_CentPbPb == true && doprocessData == true) || (doprocessData_CentPbPb == true && doprocessData_noCentrality == true) || (doprocessData_CentPbPb == true && doprocessMC == true) || (doprocessData_CentPbPb == true && doprocessMC_noCentrality == true) || (doprocessData_CentPbPb == true && doprocessMC_CentPbPb == true) 
+        || (doprocessData_CentPbPb_EP == true && doprocessData == true) || (doprocessData_CentPbPb_EP == true && doprocessData_noCentrality == true) || (doprocessData_CentPbPb_EP == true && doprocessMC == true) || (doprocessData_CentPbPb_EP == true && doprocessMC_noCentrality == true) || (doprocessData_CentPbPb_EP == true && doprocessMC_CentPbPb == true) || (doprocessData_CentPbPb_EP == true && doprocessData_CentPbPb == true) || (doprocessData_CentPbPb_EP == true && doprocessMC_CentPbPb_EP == true)
+        || (doprocessMC_CentPbPb_EP == true && doprocessData == true) || (doprocessMC_CentPbPb_EP == true && doprocessData_noCentrality == true) || (doprocessMC_CentPbPb_EP == true && doprocessMC == true) || (doprocessMC_CentPbPb_EP == true && doprocessMC_noCentrality == true) || (doprocessMC_CentPbPb_EP == true && doprocessMC_CentPbPb == true) || (doprocessMC_CentPbPb_EP == true && doprocessData_CentPbPb == true)) {
       LOGF(fatal,
            "Cannot enable more than one process switch at the same time. "
            "Please choose one.");
@@ -771,7 +777,7 @@ struct femtoDreamProducerTask {
     }
 
     if constexpr (doFlow) {
-      fillCollisionsFlow(col, tracks, mult, spher, epCal.ConfHarmonicOrder);
+      fillCollisionsFlow<isMC>(col, tracks, mult, spher, epCal.ConfHarmonicOrder);
     }
 
     std::vector<int> childIDs = {0, 0};           // these IDs are necessary to keep track of the children
@@ -1126,12 +1132,16 @@ struct femtoDreamProducerTask {
     }
   }
 
-  template <typename CollisionType, typename TrackType>
+  template <bool isMC, typename CollisionType, typename TrackType>
   void fillCollisionsFlow(CollisionType const& col, TrackType const& tracks, float mult, float spher, int EPHarmonic)
   {
-    float myqn = colCuts.computeqnVec(col);
-    float myEP = TMath::RadToDeg() * colCuts.computeEP(col, EPHarmonic);
-    // psi from rad(0-pi) to deg, in table psi would be in deg,from 0-180
+    float myqn = 0.f;
+    float myEP = 0.f;
+
+    if (!isMC || epCal.ConfMCQvec){
+      myqn = colCuts.computeqnVec(col, epCal.ConfQvecDetector);
+      myEP = TMath::RadToDeg() * colCuts.computeEP(col, EPHarmonic, epCal.ConfEPDetector); // psi from rad(0-pi) to deg, in table psi would be in deg,from 0-180
+    }
 
     if ((myqn >= 0 && myqn < 1e6) || (myEP >= 0 && myEP < 180)) {
       outputExtQnCollision(myqn, col.trackOccupancyInTimeRange());
@@ -1139,12 +1149,11 @@ struct femtoDreamProducerTask {
     }
 
     // Calculate flow via cumulant
-
-    if (epCal.ConfQnSeparation) {
+    if (epCal.ConfQnSeparation && (!isMC || epCal.ConfMCQvec)) {
       colCuts.myqnBin(mult, epCal.ConfCentralityMax, epCal.ConfFillFlowQA, epCal.ConfQnBinSeparator, myqn, epCal.ConfNumQnBins, epCal.ConfCentBinWidth);
     }
-    if (epCal.ConfFillFlowQA) {
-      colCuts.fillEPQA(mult, spher, myqn, myEP);
+    if (epCal.ConfFillFlowQA && (!isMC || epCal.ConfMCQvec)) {
+      colCuts.fillEPQA(col, mult, spher, myqn, myEP, EPHarmonic);
       if (epCal.ConfDoCumlant) {
         colCuts.doCumulants(col, tracks, trackCuts, mult, epCal.ConfQnSeparation);
       }
@@ -1277,6 +1286,21 @@ struct femtoDreamProducerTask {
     fillCollisionsAndTracksAndV0AndCascade<true, false, true, true, false>(col, tracks, tracks, fullV0s, fullCascades);
   }
   PROCESS_SWITCH(femtoDreamProducerTask, processMC_CentPbPb, "Provide MC data with centrality information for PbPb collisions", false);
+
+  void processMC_CentPbPb_EP(aod::FemtoFullCollisionMC_CentPbPb_qvec const& col,
+                               aod::BCsWithTimestamps const&,
+                               soa::Join<aod::FemtoFullTracks, aod::McTrackLabels> const& tracks,
+                               aod::FemtoFullMCgenCollisions const&,
+                               aod::McParticles const&,                               
+                               soa::Join<o2::aod::V0Datas, aod::McV0Labels> const& fullV0s, /// \todo with FilteredFullV0s
+                               soa::Join<o2::aod::CascDatas, aod::McCascLabels> const& fullCascades)
+  {
+    // get magnetic field for run
+    initCCDB_Mag_Trig(col.bc_as<aod::BCsWithTimestamps>());
+    // fill the tables      
+    fillCollisionsAndTracksAndV0AndCascade<true, false, true, true, true>(col, tracks, tracks, fullV0s, fullCascades);
+  }
+  PROCESS_SWITCH(femtoDreamProducerTask, processMC_CentPbPb_EP, "Provide MC data with centrality and q-vector table for PbPb collisions", false);
 };
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {

--- a/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
+++ b/PWGCF/FemtoDream/Tasks/femtoDreamPairTaskTrackTrack.cxx
@@ -713,7 +713,7 @@ struct femtoDreamPairTaskTrackTrack {
     float myEP = -999.f;
     int myqnBin = -999;
 
-    if (!isMC || EPCal.mcQvec){
+    if (!isMC || EPCal.mcQvec) {
       myEP = TMath::DegToRad() * col.eventPlane();
       if (EPCal.doQnSeparation || EPCal.do3DFemto) {
         myqnBin = epCalculator.myqnBin(col.multV0M(), EPCal.centMax, EPCal.fillFlowQA, EPCal.qnBinSeparator, col.qnVal(), EPCal.numQnBins, EPCal.centBinWidth);
@@ -748,7 +748,7 @@ struct femtoDreamPairTaskTrackTrack {
           }
           if (EPCal.do3DFemto) {
             sameEventQnCont.setPair_3Dqn<isMC>(p1, p2, col.multV0M(), Option.SameSpecies.value, myqnBin + 0.f, myEP, Option.SmearingByOrigin);
-          } 
+          }
         } else {
           if (EPCal.do1DFemto) {
             sameEventQnCont.setPair_EP<isMC>(p2, p1, col.multV0M(), EPCal.doQnSeparation, EPCal.doQnSeparation ? myqnBin + 0.f : myEP);
@@ -801,14 +801,14 @@ struct femtoDreamPairTaskTrackTrack {
   /// process function for to call doSameEventEP with MC Data
   /// \param col subscribe to the collision table (Data)
   /// \param parts subscribe to the femtoDreamParticleTable
-  void processSameEventEPMC(FilteredMCQnCollision& col, 
+  void processSameEventEPMC(FilteredMCQnCollision& col,
                             o2::aod::FDMCCollisions&,
                             soa::Join<o2::aod::FDParticles, o2::aod::FDMCLabels>& parts,
                             o2::aod::FDMCParticles&)
   {
     if (EPCal.storeEvtTrkInfo) {
       fillCollision<true>(col);
-    }    
+    }
     auto SliceTrk1 = PartitionMCTrk1->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     auto SliceTrk2 = PartitionMCTrk2->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
     if (SliceTrk1.size() == 0 && SliceTrk2.size() == 0) {
@@ -833,15 +833,13 @@ struct femtoDreamPairTaskTrackTrack {
       auto myEP_event1 = -999.f;
       auto myEP_event2 = -999.f;
 
-      if (!isMC || EPCal.mcQvec){
+      if (!isMC || EPCal.mcQvec) {
         myEP_event1 = TMath::DegToRad() * collision1.eventPlane();
         myEP_event2 = TMath::DegToRad() * collision2.eventPlane();
-      } 
-      else{
+      } else {
         myEP_event1 = 0.f;
         myEP_event2 = 0.f;
       }
-
 
       for (auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(SliceTrk1, SliceTrk2))) {
         if (Option.CPROn.value) {


### PR DESCRIPTION
This update introduces Monte Carlo support for the 3D femtoscopic analysis within the femtoDream framework and extends the configuration options for event-plane and Q-vector selections used in event-shape engineering (ESE). The detailed changes are summarised below.

1. Updates to detector selection configuration

- The event plane can now be reconstructed using FT0C, FT0A, or TPC detectors.
- Event-plane resolution is implemented and calculated consistently with respect to the corresponding flow observable.
- The Q-vector used for ESE can be selected from FT0A or FT0C, allowing flexible sub-event configurations.

2. Updates for Monte Carlo analysis

- A dedicated function for calculating the 3D relative momentum has been added to femtoDreamMath.h.
- Smearing histograms are filled for both generated and reconstructed MC particles, enabling momentum-resolution corrections.
- The corresponding processing functions have been updated to integrate these new MC-level calculations consistently within the femtoDream workflow.