### PR TITLE
[PWGUD] Fix ambiguous-track BC handling in UPCCandProducer

### DIFF
--- a/PWGUD/TableProducer/UPCCandidateProducer.cxx
+++ b/PWGUD/TableProducer/UPCCandidateProducer.cxx
@@ -603,17 +603,25 @@ struct UpcCandProducer {
   // "uncorrected" bcs
   template <int32_t tracksSwitch, typename TBCs, typename TAmbTracks>
   void collectAmbTrackBCs(std::unordered_map<int64_t, uint64_t>& ambTrIds,
+                          TBCs const& bcs,
                           TAmbTracks ambTracks)
   {
     for (const auto& ambTrk : ambTracks) {
       auto trkId = getAmbTrackId<tracksSwitch>(ambTrk);
-      const auto& bcSlice = ambTrk.template bc_as<TBCs>();
-      uint64_t trackBC = -1;
-      if (bcSlice.size() != 0) {
-        auto first = bcSlice.begin();
-        trackBC = first.globalBC();
+
+      const auto& bcIds = ambTrk.bcIds();
+      if (bcIds.size() == 0)
+        continue;
+      
+      const auto firstBcId = static_cast<int64_t>(*bcIds.begin());
+      if (firstBcId < 0 || firstBcId >= static_cast<int64_t>(bcs.size())) {
+        LOGP(debug,
+             "Skipping ambiguous track {}: invalid first bcId {} (nBCs = {})",
+             trkId, firstBcId, bcs.size());
+        continue;
       }
-      ambTrIds[trkId] = trackBC;
+
+      ambTrIds[trkId] = bcs.iteratorAt(firstBcId).globalBC();
     }
   }
 
@@ -649,16 +657,22 @@ struct UpcCandProducer {
         continue;
       int64_t trkId = trk.globalIndex();
       int32_t nContrib = -1;
+      bool hasTrackBC = false;
       uint64_t trackBC = 0;
       if (trk.has_collision()) {
         const auto& col = trk.collision();
         nContrib = col.numContrib();
         trackBC = col.bc_as<TBCs>().globalBC();
+        hasTrackBC = true;
       } else {
         auto ambIter = ambBarrelTrBCs.find(trkId);
-        if (ambIter != ambBarrelTrBCs.end())
+        if (ambIter != ambBarrelTrBCs.end()) {
           trackBC = ambIter->second;
+          hasTrackBC = true;
+        }
       }
+      if (!hasTrackBC)
+        continue;
       int64_t tint = TMath::FloorNint(trk.trackTime() / o2::constants::lhc::LHCBunchSpacingNS + static_cast<float>(fBarrelTrackTShift));
       uint64_t bc = trackBC + tint;
       if (nContrib > upcCuts.getMaxNContrib())
@@ -683,15 +697,22 @@ struct UpcCandProducer {
         continue;
       int64_t trkId = trk.globalIndex();
       int32_t nContrib = -1;
+      bool hasTrackBC = false;
       uint64_t trackBC = 0;
       auto ambIter = ambFwdTrBCs.find(trkId);
       if (ambIter == ambFwdTrBCs.end()) {
+        if (!trk.has_collision())
+          continue;
         const auto& col = trk.collision();
         nContrib = col.numContrib();
         trackBC = col.bc_as<TBCs>().globalBC();
+        hasTrackBC = true;
       } else {
         trackBC = ambIter->second;
+        hasTrackBC = true;
       }
+      if (!hasTrackBC) 
+        continue;
       int64_t tint = TMath::FloorNint(trk.trackTime() / o2::constants::lhc::LHCBunchSpacingNS + static_cast<float>(fMuonTrackTShift));
       uint64_t bc = trackBC + tint;
       if (nContrib > upcCuts.getMaxNContrib())
@@ -716,9 +737,12 @@ struct UpcCandProducer {
         continue;
       int64_t trkId = trk.globalIndex();
       int32_t nContrib = -1;
+      bool hasTrackBC = false;
       uint64_t trackBC = 0;
       auto ambIter = ambFwdTrBCs.find(trkId);
       if (ambIter == ambFwdTrBCs.end()) {
+        if (!trk.has_collision())
+          continue;
         const auto& col = trk.collision();
         nContrib = col.numContrib();
         trackBC = col.bc_as<TBCs>().globalBC();
@@ -729,9 +753,13 @@ struct UpcCandProducer {
         if (fRequireNoITSROFrameBorder && !bc.selection_bit(o2::aod::evsel::kNoITSROFrameBorder)) {
           continue; // skip this track if the kNoITSROFrameBorder bit is required but not set
         }
+        hasTrackBC = true;
       } else {
         trackBC = ambIter->second;
+        hasTrackBC = true;
       }
+      if (!hasTrackBC) 
+        continue;
       int64_t tint = TMath::FloorNint(trk.trackTime() / o2::constants::lhc::LHCBunchSpacingNS + static_cast<float>(fMuonTrackTShift));
       uint64_t bc = trackBC + tint;
       if (nContrib > upcCuts.getMaxNContrib())
@@ -800,7 +828,7 @@ struct UpcCandProducer {
     // trackID -> index in amb. track table
     std::unordered_map<int64_t, uint64_t> ambBarrelTrBCs;
     if (upcCuts.getAmbigSwitch() != 1)
-      collectAmbTrackBCs<0, BCsWithBcSels>(ambBarrelTrBCs, ambBarrelTracks);
+      collectAmbTrackBCs<0, BCsWithBcSels>(ambBarrelTrBCs, bcs, ambBarrelTracks);
 
     collectBarrelTracks(bcsMatchedTrIdsTOF,
                         0,
@@ -1101,10 +1129,10 @@ struct UpcCandProducer {
 
     // trackID -> index in amb. track table
     std::unordered_map<int64_t, uint64_t> ambBarrelTrBCs;
-    collectAmbTrackBCs<0, BCsWithBcSels>(ambBarrelTrBCs, ambBarrelTracks);
+    collectAmbTrackBCs<0, BCsWithBcSels>(ambBarrelTrBCs, bcs, ambBarrelTracks);
 
     std::unordered_map<int64_t, uint64_t> ambFwdTrBCs;
-    collectAmbTrackBCs<1, BCsWithBcSels>(ambFwdTrBCs, ambFwdTracks);
+    collectAmbTrackBCs<1, BCsWithBcSels>(ambFwdTrBCs, bcs, ambFwdTracks);
 
     collectForwardTracks(bcsMatchedTrIdsMID,
                          o2::aod::fwdtrack::ForwardTrackTypeEnum::MuonStandaloneTrack,
@@ -1301,7 +1329,7 @@ struct UpcCandProducer {
 
     // trackID -> index in amb. track table
     std::unordered_map<int64_t, uint64_t> ambFwdTrBCs;
-    collectAmbTrackBCs<1, BCsWithBcSels>(ambFwdTrBCs, ambFwdTracks);
+    collectAmbTrackBCs<1, BCsWithBcSels>(ambFwdTrBCs, bcs, ambFwdTracks);
 
     collectForwardTracks(bcsMatchedTrIdsMID,
                          o2::aod::fwdtrack::ForwardTrackTypeEnum::MuonStandaloneTrack,
@@ -1556,7 +1584,7 @@ struct UpcCandProducer {
 
     // trackID -> index in amb. track table
     std::unordered_map<int64_t, uint64_t> ambFwdTrBCs;
-    collectAmbTrackBCs<1, BCsWithBcSels>(ambFwdTrBCs, ambFwdTracks);
+    collectAmbTrackBCs<1, BCsWithBcSels>(ambFwdTrBCs, bcs,ambFwdTracks);
 
     collectForwardTracks(bcsMatchedTrIdsMID,
                          o2::aod::fwdtrack::ForwardTrackTypeEnum::MuonStandaloneTrack,

--- a/PWGUD/TableProducer/UPCCandidateProducer.cxx
+++ b/PWGUD/TableProducer/UPCCandidateProducer.cxx
@@ -614,7 +614,7 @@ struct UpcCandProducer {
       const auto& bcIds = ambTrk.bcIds();
       if (bcIds.size() == 0)
         continue;
-      
+
       const auto firstBcId = static_cast<int64_t>(*bcIds.begin());
       if (firstBcId < 0 || firstBcId >= static_cast<int64_t>(bcs.size())) {
         LOGP(debug,
@@ -713,7 +713,7 @@ struct UpcCandProducer {
         trackBC = ambIter->second;
         hasTrackBC = true;
       }
-      if (!hasTrackBC) 
+      if (!hasTrackBC)
         continue;
       int64_t tint = TMath::FloorNint(trk.trackTime() / o2::constants::lhc::LHCBunchSpacingNS + static_cast<float>(fMuonTrackTShift));
       uint64_t bc = trackBC + tint;
@@ -760,7 +760,7 @@ struct UpcCandProducer {
         trackBC = ambIter->second;
         hasTrackBC = true;
       }
-      if (!hasTrackBC) 
+      if (!hasTrackBC)
         continue;
       int64_t tint = TMath::FloorNint(trk.trackTime() / o2::constants::lhc::LHCBunchSpacingNS + static_cast<float>(fMuonTrackTShift));
       uint64_t bc = trackBC + tint;
@@ -1586,7 +1586,7 @@ struct UpcCandProducer {
 
     // trackID -> index in amb. track table
     std::unordered_map<int64_t, uint64_t> ambFwdTrBCs;
-    collectAmbTrackBCs<1, BCsWithBcSels>(ambFwdTrBCs, bcs,ambFwdTracks);
+    collectAmbTrackBCs<1, BCsWithBcSels>(ambFwdTrBCs, bcs, ambFwdTracks);
 
     collectForwardTracks(bcsMatchedTrIdsMID,
                          o2::aod::fwdtrack::ForwardTrackTypeEnum::MuonStandaloneTrack,

--- a/PWGUD/TableProducer/UPCCandidateProducer.cxx
+++ b/PWGUD/TableProducer/UPCCandidateProducer.cxx
@@ -11,6 +11,8 @@
 /// \author Nazar Burmasov, nazar.burmasov@cern.ch
 /// \author Diana Krupova, diana.krupova@cern.ch
 /// \since 04.06.2024
+/// \author Andrea Riffero, andrea.giovanni.riffero@cern.ch
+/// \since 19.03.2026
 
 #include "PWGUD/Core/UPCCutparHolder.h"
 #include "PWGUD/Core/UPCHelpers.h"


### PR DESCRIPTION
Validate bcIds() before resolving ambiguous-track BCs, skip empty or out-of-range entries, and ignore tracks that have neither a valid ambiguous BC nor a valid collision association. This avoids crashes from invalid BC slices and from dereferencing missing collision links in forward-track processing.