### PR TITLE
[PWGCF] FemtoUniverse Producer Task -- fixed mc collision check for V0's

### DIFF
--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -2303,7 +2303,7 @@ struct FemtoUniverseProducerTask {
 
   template <bool isMC, typename V0Type, typename TrackType,
             typename CollisionType>
-  void fillCollisionsAndTracksAndV0AndPhi(CollisionType const& col, TrackType const& tracks, V0Type const& fullV0s)
+  bool fillCollisionsAndTracksAndV0AndPhi(CollisionType const& col, TrackType const& tracks, V0Type const& fullV0s)
   {
     const auto colcheck = fillCollisions<isMC>(col, tracks);
     if (colcheck) {
@@ -2315,6 +2315,7 @@ struct FemtoUniverseProducerTask {
         fillPhi<isMC>(col, tracks);
       }
     }
+    return colcheck;
   }
 
   void processFullData(aod::FemtoFullCollision const& col,
@@ -2584,8 +2585,10 @@ struct FemtoUniverseProducerTask {
           fillCascade<true>(col, groupedStrageParts, groupedTracks);
         }
       } else {
-        mcColIds.insert(col.mcCollisionId());
-        fillCollisionsAndTracksAndV0AndPhi<true>(col, groupedTracks, groupedStrageParts);
+        const auto colcheck = fillCollisionsAndTracksAndV0AndPhi<true>(col, groupedTracks, groupedStrageParts);
+        if (colcheck) {
+          mcColIds.insert(col.mcCollisionId());
+        }
       }
       for (const auto& track : groupedTracks) {
         if (trackCuts.isSelectedMinimal(track))


### PR DESCRIPTION
- Previously 'colcheck' was not checked for V0s under 'else' loop: this incorrectly assigned collision IDs for V0s
- With the latest fix: taking 'colcheck' as a return value from 'fillCollisionsAndTracksAndV0AndPhi' is used to fix the problem 