### PR TITLE
[PWGHF] Add forceTOF option in CharmReso bach selections

### DIFF
--- a/PWGHF/D2H/Core/DataCreationCharmReso.h
+++ b/PWGHF/D2H/Core/DataCreationCharmReso.h
@@ -743,9 +743,9 @@ bool isTrackSelected(const Tr& track, const std::array<int, 3>& dDaughtersIds, c
   bool isProtonTOF = hasTOF ? std::abs(track.tofNSigmaPr()) < cfgSingleTrackCuts.maxNsigmaTofPr.value : false;
 
   // --- Combined logic ---
-  bool isPion = isPionTPC && (!cfgSingleTrackCuts.forceTOF || isPionTOF);
-  bool isKaon = isKaonTPC && (!cfgSingleTrackCuts.forceTOF || isKaonTOF);
-  bool isProton = isProtonTPC && (!cfgSingleTrackCuts.forceTOF || isProtonTOF);
+  bool isPion = isPionTPC && (!cfgSingleTrackCuts.forceTOF.value || isPionTOF);
+  bool isKaon = isKaonTPC && (!cfgSingleTrackCuts.forceTOF.value || isKaonTOF);
+  bool isProton = isProtonTPC && (!cfgSingleTrackCuts.forceTOF.value || isProtonTOF);
 
   return (isPion || isKaon || isProton); // we keep the track if is it compatible with at least one of the PID hypotheses selected
 }

--- a/PWGHF/D2H/Core/DataCreationCharmReso.h
+++ b/PWGHF/D2H/Core/DataCreationCharmReso.h
@@ -732,19 +732,19 @@ bool isTrackSelected(const Tr& track, const std::array<int, 3>& dDaughtersIds, c
     return false;
   }
   // --- TPC PID ---
-  bool isPionTPC   = std::abs(track.tpcNSigmaPi()) < cfgSingleTrackCuts.maxNsigmaTpcPi.value;
-  bool isKaonTPC   = std::abs(track.tpcNSigmaKa()) < cfgSingleTrackCuts.maxNsigmaTpcKa.value;
+  bool isPionTPC = std::abs(track.tpcNSigmaPi()) < cfgSingleTrackCuts.maxNsigmaTpcPi.value;
+  bool isKaonTPC = std::abs(track.tpcNSigmaKa()) < cfgSingleTrackCuts.maxNsigmaTpcKa.value;
   bool isProtonTPC = std::abs(track.tpcNSigmaPr()) < cfgSingleTrackCuts.maxNsigmaTpcPr.value;
 
   // --- TOF PID ---
   bool hasTOF = track.hasTOF();
-  bool isPionTOF   = hasTOF ? std::abs(track.tofNSigmaPi()) < cfgSingleTrackCuts.maxNsigmaTofPi.value : false;
-  bool isKaonTOF   = hasTOF ? std::abs(track.tofNSigmaKa()) < cfgSingleTrackCuts.maxNsigmaTofKa.value : false;
+  bool isPionTOF = hasTOF ? std::abs(track.tofNSigmaPi()) < cfgSingleTrackCuts.maxNsigmaTofPi.value : false;
+  bool isKaonTOF = hasTOF ? std::abs(track.tofNSigmaKa()) < cfgSingleTrackCuts.maxNsigmaTofKa.value : false;
   bool isProtonTOF = hasTOF ? std::abs(track.tofNSigmaPr()) < cfgSingleTrackCuts.maxNsigmaTofPr.value : false;
 
   // --- Combined logic ---
-  bool isPion   = isPionTPC   && (!forceTOF || isPionTOF);
-  bool isKaon   = isKaonTPC   && (!forceTOF || isKaonTOF);
+  bool isPion = isPionTPC && (!forceTOF || isPionTOF);
+  bool isKaon = isKaonTPC && (!forceTOF || isKaonTOF);
   bool isProton = isProtonTPC && (!forceTOF || isProtonTOF);
 
   return (isPion || isKaon || isProton); // we keep the track if is it compatible with at least one of the PID hypotheses selected

--- a/PWGHF/D2H/Core/DataCreationCharmReso.h
+++ b/PWGHF/D2H/Core/DataCreationCharmReso.h
@@ -197,7 +197,7 @@ struct HfResoConfigSingleTrackCuts : o2::framework::ConfigurableGroup {
   o2::framework::Configurable<int> setTrackSelections{"setTrackSelections", 2, "flag to apply track selections: 0=none; 1=global track w/o DCA selection; 2=global track; 3=only ITS quality"};
   o2::framework::Configurable<float> maxEta{"maxEta", 0.8, "maximum pseudorapidity for single tracks to be paired with D mesons"};
   o2::framework::Configurable<float> minPt{"minPt", 0.1, "minimum pT for single tracks to be paired with D mesons"};
-  o2::framework::Configurable<bool> forceTOF{"forceTOF", false, "minimum pT for single tracks to be paired with D mesons"};
+  o2::framework::Configurable<bool> forceTOF{"forceTOF", false, "force TOF for single tracks to be paired with D mesons"};
   o2::framework::Configurable<float> maxNsigmaTpcPi{"maxNsigmaTpcPi", -1., "maximum pion NSigma in TPC for single tracks to be paired with D mesons; set negative to reject"};
   o2::framework::Configurable<float> maxNsigmaTpcKa{"maxNsigmaTpcKa", -1., "maximum kaon NSigma in TPC for single tracks to be paired with D mesons; set negative to reject"};
   o2::framework::Configurable<float> maxNsigmaTpcPr{"maxNsigmaTpcPr", 3., "maximum proton NSigma in TPC for single tracks to be paired with D mesons; set negative to reject"};

--- a/PWGHF/D2H/Core/DataCreationCharmReso.h
+++ b/PWGHF/D2H/Core/DataCreationCharmReso.h
@@ -197,7 +197,7 @@ struct HfResoConfigSingleTrackCuts : o2::framework::ConfigurableGroup {
   o2::framework::Configurable<int> setTrackSelections{"setTrackSelections", 2, "flag to apply track selections: 0=none; 1=global track w/o DCA selection; 2=global track; 3=only ITS quality"};
   o2::framework::Configurable<float> maxEta{"maxEta", 0.8, "maximum pseudorapidity for single tracks to be paired with D mesons"};
   o2::framework::Configurable<float> minPt{"minPt", 0.1, "minimum pT for single tracks to be paired with D mesons"};
-  o2::framework::Configurable<float> forceTOF{"forceTOF", 0.1, "minimum pT for single tracks to be paired with D mesons"};
+  o2::framework::Configurable<bool> forceTOF{"forceTOF", false, "minimum pT for single tracks to be paired with D mesons"};
   o2::framework::Configurable<float> maxNsigmaTpcPi{"maxNsigmaTpcPi", -1., "maximum pion NSigma in TPC for single tracks to be paired with D mesons; set negative to reject"};
   o2::framework::Configurable<float> maxNsigmaTpcKa{"maxNsigmaTpcKa", -1., "maximum kaon NSigma in TPC for single tracks to be paired with D mesons; set negative to reject"};
   o2::framework::Configurable<float> maxNsigmaTpcPr{"maxNsigmaTpcPr", 3., "maximum proton NSigma in TPC for single tracks to be paired with D mesons; set negative to reject"};
@@ -743,9 +743,9 @@ bool isTrackSelected(const Tr& track, const std::array<int, 3>& dDaughtersIds, c
   bool isProtonTOF = hasTOF ? std::abs(track.tofNSigmaPr()) < cfgSingleTrackCuts.maxNsigmaTofPr.value : false;
 
   // --- Combined logic ---
-  bool isPion = isPionTPC && (!forceTOF || isPionTOF);
-  bool isKaon = isKaonTPC && (!forceTOF || isKaonTOF);
-  bool isProton = isProtonTPC && (!forceTOF || isProtonTOF);
+  bool isPion = isPionTPC && (!cfgSingleTrackCuts.forceTOF || isPionTOF);
+  bool isKaon = isKaonTPC && (!cfgSingleTrackCuts.forceTOF || isKaonTOF);
+  bool isProton = isProtonTPC && (!cfgSingleTrackCuts.forceTOF || isProtonTOF);
 
   return (isPion || isKaon || isProton); // we keep the track if is it compatible with at least one of the PID hypotheses selected
 }

--- a/PWGHF/D2H/Core/DataCreationCharmReso.h
+++ b/PWGHF/D2H/Core/DataCreationCharmReso.h
@@ -197,9 +197,13 @@ struct HfResoConfigSingleTrackCuts : o2::framework::ConfigurableGroup {
   o2::framework::Configurable<int> setTrackSelections{"setTrackSelections", 2, "flag to apply track selections: 0=none; 1=global track w/o DCA selection; 2=global track; 3=only ITS quality"};
   o2::framework::Configurable<float> maxEta{"maxEta", 0.8, "maximum pseudorapidity for single tracks to be paired with D mesons"};
   o2::framework::Configurable<float> minPt{"minPt", 0.1, "minimum pT for single tracks to be paired with D mesons"};
+  o2::framework::Configurable<float> forceTOF{"forceTOF", 0.1, "minimum pT for single tracks to be paired with D mesons"};
   o2::framework::Configurable<float> maxNsigmaTpcPi{"maxNsigmaTpcPi", -1., "maximum pion NSigma in TPC for single tracks to be paired with D mesons; set negative to reject"};
   o2::framework::Configurable<float> maxNsigmaTpcKa{"maxNsigmaTpcKa", -1., "maximum kaon NSigma in TPC for single tracks to be paired with D mesons; set negative to reject"};
   o2::framework::Configurable<float> maxNsigmaTpcPr{"maxNsigmaTpcPr", 3., "maximum proton NSigma in TPC for single tracks to be paired with D mesons; set negative to reject"};
+  o2::framework::Configurable<float> maxNsigmaTofPi{"maxNsigmaTofPi", -1., "maximum pion NSigma in TOF for single tracks to be paired with D mesons; set negative to reject"};
+  o2::framework::Configurable<float> maxNsigmaTofKa{"maxNsigmaTofKa", -1., "maximum kaon NSigma in TOF for single tracks to be paired with D mesons; set negative to reject"};
+  o2::framework::Configurable<float> maxNsigmaTofPr{"maxNsigmaTofPr", -1., "maximum proton NSigma in TOF for single tracks to be paired with D mesons; set negative to reject"};
 };
 
 struct HfResoConfigQaPlots : o2::framework::ConfigurableGroup {
@@ -727,9 +731,22 @@ bool isTrackSelected(const Tr& track, const std::array<int, 3>& dDaughtersIds, c
   if (!track.hasTPC()) {
     return false;
   }
-  bool const isPion = std::abs(track.tpcNSigmaPi()) < cfgSingleTrackCuts.maxNsigmaTpcPi.value;
-  bool const isKaon = std::abs(track.tpcNSigmaKa()) < cfgSingleTrackCuts.maxNsigmaTpcKa.value;
-  bool const isProton = std::abs(track.tpcNSigmaPr()) < cfgSingleTrackCuts.maxNsigmaTpcPr.value;
+  // --- TPC PID ---
+  bool isPionTPC   = std::abs(track.tpcNSigmaPi()) < cfgSingleTrackCuts.maxNsigmaTpcPi.value;
+  bool isKaonTPC   = std::abs(track.tpcNSigmaKa()) < cfgSingleTrackCuts.maxNsigmaTpcKa.value;
+  bool isProtonTPC = std::abs(track.tpcNSigmaPr()) < cfgSingleTrackCuts.maxNsigmaTpcPr.value;
+
+  // --- TOF PID ---
+  bool hasTOF = track.hasTOF();
+  bool isPionTOF   = hasTOF ? std::abs(track.tofNSigmaPi()) < cfgSingleTrackCuts.maxNsigmaTofPi.value : false;
+  bool isKaonTOF   = hasTOF ? std::abs(track.tofNSigmaKa()) < cfgSingleTrackCuts.maxNsigmaTofKa.value : false;
+  bool isProtonTOF = hasTOF ? std::abs(track.tofNSigmaPr()) < cfgSingleTrackCuts.maxNsigmaTofPr.value : false;
+
+  // --- Combined logic ---
+  bool isPion   = isPionTPC   && (!forceTOF || isPionTOF);
+  bool isKaon   = isKaonTPC   && (!forceTOF || isKaonTOF);
+  bool isProton = isProtonTPC && (!forceTOF || isProtonTOF);
+
   return (isPion || isKaon || isProton); // we keep the track if is it compatible with at least one of the PID hypotheses selected
 }
 


### PR DESCRIPTION
@Luca610 @fgrosa @zhangbiao-phy
Bachelor PID selection modified in the helper class to account for the possibility of forcing TOF at the candidate creator level:
 - match trigger channel conditions to avoid unnecessary background stored in derived data