### PR TITLE
[PWGEM] Revert "[PWGEM] LMee: Adding more DCA correlation histograms to various signals."

### DIFF
--- a/PWGEM/Dilepton/Core/DileptonMC.h
+++ b/PWGEM/Dilepton/Core/DileptonMC.h
@@ -525,14 +525,6 @@ struct DileptonMC {
         fRegistry.add(std::format("Pair/sm/NonPromptPi0/{0}hDeltaPtvsDCA", strSign), "#Delta p_{T,1}^{gen-rec} + #Delta p_{T,2}^{gen-rec} vs. DCA_{ee}", o2::framework::kTH2F, {axis_dca_narrow, axis_dpt}, true);
         fRegistry.add(std::format("Pair/sm/NonPromptPi0/{0}hDCAz1vsDCAz2", strSign), "DCA_{z,1} vs DCA_{z,2}", o2::framework::kTH2F, {axis_dca_track1, axis_dca_track2}, true);
 
-        fRegistry.add(std::format("Pair/sm/Eta/{0}hDCAz1vsDCAz2", strSign), "DCA_{z,1} vs DCA_{z,2}", o2::framework::kTH2F, {axis_dca_track1, axis_dca_track2}, true);
-        // fRegistry.add(std::format("Pair/sm/EtaPrime/{0}hDCAz1vsDCAz2", strSign), "DCA_{z,1} vs DCA_{z,2}", o2::framework::kTH2F, {axis_dca_track1, axis_dca_track2}, true);
-        // fRegistry.add(std::format("Pair/sm/Rho/{0}hDCAz1vsDCAz2", strSign), "DCA_{z,1} vs DCA_{z,2}", o2::framework::kTH2F, {axis_dca_track1, axis_dca_track2}, true);
-        fRegistry.add(std::format("Pair/sm/Omega/{0}hDCAz1vsDCAz2", strSign), "DCA_{z,1} vs DCA_{z,2}", o2::framework::kTH2F, {axis_dca_track1, axis_dca_track2}, true);
-        fRegistry.add(std::format("Pair/sm/Omega2ll/{0}hDCAz1vsDCAz2", strSign), "DCA_{z,1} vs DCA_{z,2}", o2::framework::kTH2F, {axis_dca_track1, axis_dca_track2}, true);
-        fRegistry.add(std::format("Pair/sm/Phi/{0}hDCAz1vsDCAz2", strSign), "DCA_{z,1} vs DCA_{z,2}", o2::framework::kTH2F, {axis_dca_track1, axis_dca_track2}, true);
-        fRegistry.add(std::format("Pair/sm/Phi2ll/{0}hDCAz1vsDCAz2", strSign), "DCA_{z,1} vs DCA_{z,2}", o2::framework::kTH2F, {axis_dca_track1, axis_dca_track2}, true);
-
         fRegistry.add(std::format("Pair/sm/PromptJPsi/{0}hDeltaPtvsDCA", strSign), "#Delta p_{T,1}^{gen-rec} + #Delta p_{T,2}^{gen-rec} vs. DCA_{ee}", o2::framework::kTH2F, {axis_dca_narrow, axis_dpt}, true);
         fRegistry.add(std::format("Pair/sm/PromptJPsi/{0}hDCAz1vsDCAz2", strSign), "DCA_{z,1} vs DCA_{z,2}", o2::framework::kTH2F, {axis_dca_track1, axis_dca_track2}, true);
         fRegistry.add(std::format("Pair/sm/NonPromptJPsi/{0}hDeltaPtvsDCA", strSign), "#Delta p_{T,1}^{gen-rec} + #Delta p_{T,2}^{gen-rec} vs. DCA_{ee}", o2::framework::kTH2F, {axis_dca_narrow, axis_dpt}, true);
@@ -543,12 +535,6 @@ struct DileptonMC {
     fRegistry.add("Pair/ccbar/c2l_c2l/uls/hs", "rec. dilepton", o2::framework::kTHnSparseD, {axis_mass, axis_pt, axis_y, axis_dphi_ee, axis_deta_ee, axis_cos_theta_pol, axis_phi_pol, axis_quadmom, axis_aco, axis_asym_pt, axis_dphi_e_ee, axis_dca}, true);
     fRegistry.addClone("Pair/ccbar/c2l_c2l/uls/", "Pair/ccbar/c2l_c2l/lspp/");
     fRegistry.addClone("Pair/ccbar/c2l_c2l/uls/", "Pair/ccbar/c2l_c2l/lsmm/");
-
-    if constexpr (pairtype == o2::aod::pwgem::dilepton::utils::pairutil::DileptonPairType::kDielectron) {
-      for (const auto& strSign : pair_sign_types) {
-        fRegistry.add(std::format("Pair/ccbar/c2l_c2l/{0}hDCAz1vsDCAz2", strSign), "DCA_{z,1} vs DCA_{z,2}", o2::framework::kTH2F, {axis_dca_track1, axis_dca_track2}, true);
-      }
-    }
 
     fRegistry.addClone("Pair/ccbar/c2l_c2l/", "Pair/bbbar/b2l_b2l/");
     fRegistry.addClone("Pair/ccbar/c2l_c2l/", "Pair/bbbar/b2c2l_b2c2l/");
@@ -576,15 +562,6 @@ struct DileptonMC {
         for (int ib = 0; ib < nb; ib++) {
           fRegistry.addClone("Pair/ccbar/c2l_c2l/", Form("Pair/ccbar/%s_%s/", sum_charmed_mesons[im].data(), sum_charmed_baryons[ib].data()));
         }
-      }
-    }
-
-    if constexpr (pairtype == o2::aod::pwgem::dilepton::utils::pairutil::DileptonPairType::kDielectron) {
-      for (const auto& strSign : pair_sign_types) {
-        fRegistry.add(std::format("Pair/bbbar/b2l_b2l/{0}hDCAz1vsDCAz2", strSign), "DCA_{z,1} vs DCA_{z,2}", o2::framework::kTH2F, {axis_dca_track1, axis_dca_track2}, true);
-        fRegistry.add(std::format("Pair/bbbar/b2c2l_b2c2l/{0}hDCAz1vsDCAz2", strSign), "DCA_{z,1} vs DCA_{z,2}", o2::framework::kTH2F, {axis_dca_track1, axis_dca_track2}, true);
-        fRegistry.add(std::format("Pair/bbbar/b2c2l_b2l_sameb/{0}hDCAz1vsDCAz2", strSign), "DCA_{z,1} vs DCA_{z,2}", o2::framework::kTH2F, {axis_dca_track1, axis_dca_track2}, true);
-        fRegistry.add(std::format("Pair/bbbar/b2c2l_b2l_diffb/{0}hDCAz1vsDCAz2", strSign), "DCA_{z,1} vs DCA_{z,2}", o2::framework::kTH2F, {axis_dca_track1, axis_dca_track2}, true);
       }
     }
 


### PR DESCRIPTION
Reverts AliceO2Group/O2Physics#15602

The above PR seems to break the MC analysis as the beauty histograms are defined twice:
Error from the HY test
```
[ERROR] SEVERE: Device dielectron-mc (561166) had at least one message above severity 7: Hash collision in HistogramRegistry "output"! Please rename histogram "Pair/bbbar/b2l_b2l/uls/hDCAz1vsDCAz2" or "Pair/bbbar/b2l_b2l/uls/hDCAz1vsDCAz2".
```

This can be traced back to
This defines the histogram for charm:
https://github.com/AliceO2Group/O2Physics/blob/ed0e19a5906721268d2ccea1c8882d04e4c2a3e6/PWGEM/Dilepton/Core/DileptonMC.h#L549

Then here the charm histograms are copied to the beauty histograms:
https://github.com/AliceO2Group/O2Physics/blob/ed0e19a5906721268d2ccea1c8882d04e4c2a3e6/PWGEM/Dilepton/Core/DileptonMC.h#L553

and here it is defined again:
https://github.com/AliceO2Group/O2Physics/blob/ed0e19a5906721268d2ccea1c8882d04e4c2a3e6/PWGEM/Dilepton/Core/DileptonMC.h#L584