### PR TITLE
[PWGDQ] Fill q-vector tables for all PbPb process functions in tableMaker_withAssoc

### DIFF
--- a/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
+++ b/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
@@ -295,10 +295,10 @@ struct TableMaker {
     Configurable<bool> fConfigSaveElectronSample{"cfgSaveElectronSample", false, "If true, only save electron sample"};
   } fConfigPostCalibTPC;
 
-  // 
+  //
   struct : ConfigurableGroup {
     Configurable<bool> fConfigFT0CCumulant{"cfgFT0CCumulant", false,
-    "If true, compute RefFlow cumulants from FT0C amplitudes (requires FT0s subscription)"};
+                                           "If true, compute RefFlow cumulants from FT0C amplitudes (requires FT0s subscription)"};
   } fConfigQvector;
 
   struct : ConfigurableGroup {
@@ -1192,7 +1192,7 @@ struct TableMaker {
 
       if constexpr ((TEventFillMap & VarManager::ObjTypes::CollisionQvectCentr) > 0) {
         qvecGroup.eventQvectorCentr(collision.qvecFT0ARe(), collision.qvecFT0AIm(), collision.qvecFT0CRe(), collision.qvecFT0CIm(), collision.qvecFT0MRe(), collision.qvecFT0MIm(), collision.qvecFV0ARe(), collision.qvecFV0AIm(), collision.qvecTPCposRe(), collision.qvecTPCposIm(), collision.qvecTPCnegRe(), collision.qvecTPCnegIm(),
-                          collision.sumAmplFT0A(), collision.sumAmplFT0C(), collision.sumAmplFT0M(), collision.sumAmplFV0A(), collision.nTrkTPCpos(), collision.nTrkTPCneg());
+                                    collision.sumAmplFT0A(), collision.sumAmplFT0C(), collision.sumAmplFT0M(), collision.sumAmplFV0A(), collision.nTrkTPCpos(), collision.nTrkTPCneg());
         qvecGroup.eventQvectorCentrExtra(collision.qvecTPCallRe(), collision.qvecTPCallIm(), collision.nTrkTPCall());
 
         if (fConfigQvector.fConfigFT0CCumulant) {
@@ -1213,7 +1213,7 @@ struct TableMaker {
           float M11REF = S21C - S12C;
           std::complex<double> Q21C(collision.qvecFT0CRe() * S11C, collision.qvecFT0CIm() * S11C);
           float CORR2REF = (std::norm(Q21C) - S12C) / M11REF;
-        
+
           if (std::isnan(M11REF) || std::isinf(M11REF) || std::isnan(CORR2REF) || std::isinf(CORR2REF)) {
             M11REF = 0.f;
             CORR2REF = 0.f;
@@ -1978,8 +1978,8 @@ struct TableMaker {
 
   // produce the barrel only DQ skimmed data model typically for Pb-Pb (with centrality), no subscribtion to the DQ event filter
   void processPbPbBarrelOnlyWithQvect(MyEventsWithCentAndMultsQvect const& collisions, MyBCs const& bcs,
-                             MyBarrelTracksWithCov const& tracksBarrel,
-                             TrackAssoc const& trackAssocs, aod::FT0s& ft0s)
+                                      MyBarrelTracksWithCov const& tracksBarrel,
+                                      TrackAssoc const& trackAssocs, aod::FT0s& ft0s)
   {
     computeOccupancyEstimators(collisions, tracksPosWithCov, tracksNegWithCov, presliceWithCov, bcs);
     computeCollMergingTag(collisions, tracksBarrel, presliceWithCov);

--- a/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
+++ b/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
@@ -295,10 +295,10 @@ struct TableMaker {
     Configurable<bool> fConfigSaveElectronSample{"cfgSaveElectronSample", false, "If true, only save electron sample"};
   } fConfigPostCalibTPC;
 
-  //
+  // 
   struct : ConfigurableGroup {
-    Configurable<bool> fConfigFT0CCumulant{"cfgFT0CCumulant", false,
-                                           "If true, compute RefFlow cumulants from FT0C amplitudes (requires FT0s subscription)"};
+    Configurable<bool> fConfigFT0CCumulant{"cfgFT0CCumulant", false, "If true, compute RefFlow cumulants from FT0C amplitudes (requires FT0s subscription)"};
+    Configurable<std::string> fConfigQvecCalibPath{"cfgQvecCalibPath","Analysis/EventPlane/QVecCorrections","CCDB path for qvector calibration objects; used only to check availability per run"};
   } fConfigQvector;
 
   struct : ConfigurableGroup {
@@ -336,6 +336,7 @@ struct TableMaker {
 
   bool fDoDetailedQA = false; // Bool to set detailed QA true, if QA is set true
   int fCurrentRun;            // needed to detect if the run changed and trigger update of calibrations etc.
+  bool fQvectCalibAvailable = false; // Whether the Q-vector calibration is available for the current run 
 
   // maps used to store index info; NOTE: std::map are sorted in ascending order by default (needed for track to collision indices)
   std::map<uint32_t, uint32_t> fCollIndexMap;             // key: old collision index, value: skimmed collision index
@@ -480,7 +481,11 @@ struct TableMaker {
     }
 
     // Check whether we have to define barrel or muon histograms
+<<<<<<< HEAD
     bool enableBarrelHistos = (context.mOptions.get<bool>("processPP") || context.mOptions.get<bool>("processPPWithFilter") || context.mOptions.get<bool>("processPPWithFilterBarrelOnly") || context.mOptions.get<bool>("processPPBarrelOnly") ||
+=======
+    bool enableBarrelHistos = (context.mOptions.get<bool>("processPPWithFilter") || context.mOptions.get<bool>("processPPWithFilterBarrelOnly") || context.mOptions.get<bool>("processPPBarrelOnly") ||
+>>>>>>> daa02bd72 (Qvector-tables shall be filled for all PbPb processes (except for processPbPbWithFilterBarrelOnly). Added a configurable for Qvector calibration path. The tables shall only be filled if the calibrations are available)
                                context.mOptions.get<bool>("processPbPb") || context.mOptions.get<bool>("processPbPbBarrelOnly") || context.mOptions.get<bool>("processPbPbBarrelOnlyWithV0Bits") || context.mOptions.get<bool>("processPbPbBarrelOnlyWithV0BitsNoTOF")) ||
                               context.mOptions.get<bool>("processPbPbWithFilterBarrelOnly") || context.mOptions.get<bool>("processPPBarrelOnlyWithV0s") || context.mOptions.get<bool>("processPbPbBarrelOnlyNoTOF");
 
@@ -1191,38 +1196,39 @@ struct TableMaker {
       eventInfo(collision.globalIndex());
 
       if constexpr ((TEventFillMap & VarManager::ObjTypes::CollisionQvectCentr) > 0) {
-        qvecGroup.eventQvectorCentr(collision.qvecFT0ARe(), collision.qvecFT0AIm(), collision.qvecFT0CRe(), collision.qvecFT0CIm(), collision.qvecFT0MRe(), collision.qvecFT0MIm(), collision.qvecFV0ARe(), collision.qvecFV0AIm(), collision.qvecTPCposRe(), collision.qvecTPCposIm(), collision.qvecTPCnegRe(), collision.qvecTPCnegIm(),
-                                    collision.sumAmplFT0A(), collision.sumAmplFT0C(), collision.sumAmplFT0M(), collision.sumAmplFV0A(), collision.nTrkTPCpos(), collision.nTrkTPCneg());
-        qvecGroup.eventQvectorCentrExtra(collision.qvecTPCallRe(), collision.qvecTPCallIm(), collision.nTrkTPCall());
+        if (fQvectCalibAvailable) {
+          qvecGroup.eventQvectorCentr(collision.qvecFT0ARe(), collision.qvecFT0AIm(), collision.qvecFT0CRe(), collision.qvecFT0CIm(), collision.qvecFT0MRe(), collision.qvecFT0MIm(), collision.qvecFV0ARe(), collision.qvecFV0AIm(), collision.qvecTPCposRe(), collision.qvecTPCposIm(), collision.qvecTPCnegRe(), collision.qvecTPCnegIm(),
+                          collision.sumAmplFT0A(), collision.sumAmplFT0C(), collision.sumAmplFT0M(), collision.sumAmplFV0A(), collision.nTrkTPCpos(), collision.nTrkTPCneg());
+          qvecGroup.eventQvectorCentrExtra(collision.qvecTPCallRe(), collision.qvecTPCallIm(), collision.nTrkTPCall());
 
-        if (fConfigQvector.fConfigFT0CCumulant) {
-          // FT0C cumulants for RefFlow and QvectorExtra
-          float S11C = collision.sumAmplFT0C();
-          float S12C = 0.f;
-          if constexpr (!std::is_same_v<std::decay_t<TFt0s>, std::nullptr_t>) {
-            if (collision.has_foundFT0()) {
-              auto ft0 = collision.foundFT0();
-              for (auto amp : ft0.amplitudeC()) {
-                if (amp > 0.f) {
-                  S12C += amp * amp;
+          if (fConfigQvector.fConfigFT0CCumulant) {
+            // FT0C cumulants for RefFlow and QvectorExtra
+            float S11C = collision.sumAmplFT0C();
+            float S12C = 0.f;
+            if constexpr (!std::is_same_v<std::decay_t<TFt0s>, std::nullptr_t>) {
+              if (collision.has_foundFT0()) {
+                auto ft0 = collision.foundFT0();
+                for (auto amp : ft0.amplitudeC()) {
+                  if (amp > 0.f) {
+                    S12C += amp * amp;
+                  }
                 }
               }
             }
+            float S21C = S11C * S11C;
+            float M11REF = S21C - S12C;
+            std::complex<double> Q21C(collision.qvecFT0CRe() * S11C, collision.qvecFT0CIm() * S11C);
+            float CORR2REF = (std::norm(Q21C) - S12C) / M11REF;
+        
+            if (std::isnan(M11REF) || std::isinf(M11REF) || std::isnan(CORR2REF) || std::isinf(CORR2REF)) {
+              M11REF = 0.f;
+              CORR2REF = 0.f;
+            }
+            qvecGroup.eventRefFlow(M11REF, -9999, -9999, CORR2REF, -9999, -9999, VarManager::fgValues[VarManager::kCentFT0C]);
+            qvecGroup.eventQvectorExtra(-9999, -9999, -9999, -9999, S11C, S12C, -9999, -9999);
           }
-          float S21C = S11C * S11C;
-          float M11REF = S21C - S12C;
-          std::complex<double> Q21C(collision.qvecFT0CRe() * S11C, collision.qvecFT0CIm() * S11C);
-          float CORR2REF = (std::norm(Q21C) - S12C) / M11REF;
-
-          if (std::isnan(M11REF) || std::isinf(M11REF) || std::isnan(CORR2REF) || std::isinf(CORR2REF)) {
-            M11REF = 0.f;
-            CORR2REF = 0.f;
-          }
-          qvecGroup.eventRefFlow(M11REF, -9999, -9999, CORR2REF, -9999, -9999, VarManager::fgValues[VarManager::kCentFT0C]);
-          qvecGroup.eventQvectorExtra(-9999, -9999, -9999, -9999, S11C, S12C, -9999, -9999);
         }
       }
-
       if constexpr ((TEventFillMap & VarManager::ObjTypes::Zdc) > 0) {
         if constexpr ((TEventFillMap & VarManager::ObjTypes::RapidityGapFilter) > 0) {
           // The DQRapidityGapFilter contains the index of the bc we want to get ZDC info from
@@ -1772,6 +1778,29 @@ struct TableMaker {
       }
       std::map<std::string, std::string> metadataRCT, header;
       header = fCCDBApi.retrieveHeaders(Form("RCT/Info/RunInformation/%i", bcs.begin().runNumber()), metadataRCT, -1);
+      
+      // Check if qvector calibration objects are available in CCDB for this run
+      if constexpr ((TEventFillMap & VarManager::ObjTypes::CollisionQvectCentr) > 0) {
+        std::map<std::string, std::string> metadataQvect;
+        const std::array<std::string, 3> subfolders = {"v2", "v3", "v4"};
+        bool anyFound = false;
+        for (const auto& sub : subfolders) {
+          std::string fullPath = fConfigQvector.fConfigQvecCalibPath.value + "/" + sub;
+          auto headers = fCCDBApi.retrieveHeaders(fullPath, metadataQvect, bcs.begin().timestamp());
+            if (headers.empty()) {
+              LOG(warn) << "Qvector calibration not found at CCDB path '" << fullPath
+                        << "' for run " << bcs.begin().runNumber();
+            } else {
+            anyFound = true;
+          }
+        }
+        fQvectCalibAvailable = anyFound;
+        if (!fQvectCalibAvailable) {
+          LOG(warn) << "No qvector calibration found in any subfolder under '"
+                    << fConfigQvector.fConfigQvecCalibPath.value
+                    << "' — qvector tables will not be filled for this run.";
+        }
+      }
       uint64_t sor = std::atol(header["SOR"].c_str());
       uint64_t eor = std::atol(header["EOR"].c_str());
       VarManager::SetSORandEOR(sor, eor);
@@ -1957,43 +1986,33 @@ struct TableMaker {
   }
 
   // produce the full DQ skimmed data model typically for Pb-Pb (with centrality), no subscribtion to the DQ event filter
-  void processPbPb(MyEventsWithCentAndMults const& collisions, MyBCs const& bcs,
+  void processPbPb(MyEventsWithCentAndMultsQvect const& collisions, MyBCs const& bcs,
                    MyBarrelTracksWithCov const& tracksBarrel,
                    MyMuonsWithCov const& muons, MFTTracks const& mftTracks,
                    TrackAssoc const& trackAssocs, FwdTrackAssoc const& fwdTrackAssocs,
-                   MFTTrackAssoc const& mftAssocs)
+                   MFTTrackAssoc const& mftAssocs, aod::FT0s& ft0s, aod::FV0As& fv0as, aod::FDDs& fdds)
   {
-    fullSkimming<gkEventFillMapWithCentAndMults, gkTrackFillMapWithCov, gkMuonFillMapWithCov, gkMFTFillMap>(collisions, bcs, nullptr, tracksBarrel, muons, mftTracks, trackAssocs, fwdTrackAssocs, mftAssocs, nullptr, nullptr, nullptr, nullptr);
+    fullSkimming<gkEventFillMapWithCentAndMultsQvect, gkTrackFillMapWithCov, gkMuonFillMapWithCov, gkMFTFillMap>(collisions, bcs, nullptr, tracksBarrel, muons, mftTracks, trackAssocs, fwdTrackAssocs, mftAssocs, nullptr, ft0s, fv0as, fdds);
   }
 
   // produce the barrel only DQ skimmed data model typically for Pb-Pb (with centrality), no subscribtion to the DQ event filter
-  void processPbPbBarrelOnly(MyEventsWithCentAndMults const& collisions, MyBCs const& bcs,
+  void processPbPbBarrelOnly(MyEventsWithCentAndMultsQvect const& collisions, MyBCs const& bcs,
                              MyBarrelTracksWithCov const& tracksBarrel,
-                             TrackAssoc const& trackAssocs)
+                             TrackAssoc const& trackAssocs, aod::FT0s& ft0s, aod::FV0As& fv0as, aod::FDDs& fdds)
   {
     computeOccupancyEstimators(collisions, tracksPosWithCov, tracksNegWithCov, presliceWithCov, bcs);
     computeCollMergingTag(collisions, tracksBarrel, presliceWithCov);
-    fullSkimming<gkEventFillMapWithCentAndMults, gkTrackFillMapWithCov, 0u, 0u>(collisions, bcs, nullptr, tracksBarrel, nullptr, nullptr, trackAssocs, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
-  }
-
-  // produce the barrel only DQ skimmed data model typically for Pb-Pb (with centrality), no subscribtion to the DQ event filter
-  void processPbPbBarrelOnlyWithQvect(MyEventsWithCentAndMultsQvect const& collisions, MyBCs const& bcs,
-                                      MyBarrelTracksWithCov const& tracksBarrel,
-                                      TrackAssoc const& trackAssocs, aod::FT0s& ft0s)
-  {
-    computeOccupancyEstimators(collisions, tracksPosWithCov, tracksNegWithCov, presliceWithCov, bcs);
-    computeCollMergingTag(collisions, tracksBarrel, presliceWithCov);
-    fullSkimming<gkEventFillMapWithCentAndMultsQvect, gkTrackFillMapWithCov, 0u, 0u>(collisions, bcs, nullptr, tracksBarrel, nullptr, nullptr, trackAssocs, nullptr, nullptr, nullptr, ft0s, nullptr, nullptr);
+    fullSkimming<gkEventFillMapWithCentAndMultsQvect, gkTrackFillMapWithCov, 0u, 0u>(collisions, bcs, nullptr, tracksBarrel, nullptr, nullptr, trackAssocs, nullptr, nullptr, nullptr, ft0s, fv0as, fdds);
   }
 
   // produce the barrel only DQ skimmed data model typically for Pb-Pb (with centrality), no TOF
-  void processPbPbBarrelOnlyNoTOF(MyEventsWithCentAndMults const& collisions, MyBCs const& bcs,
+  void processPbPbBarrelOnlyNoTOF(MyEventsWithCentAndMultsQvect const& collisions, MyBCs const& bcs,
                                   MyBarrelTracksWithCovNoTOF const& tracksBarrel,
-                                  TrackAssoc const& trackAssocs)
+                                  TrackAssoc const& trackAssocs, aod::FT0s& ft0s, aod::FV0As& fv0as, aod::FDDs& fdds)
   {
     computeOccupancyEstimators(collisions, tracksPosWithCovNoTOF, tracksNegWithCovNoTOF, presliceWithCovNoTOF, bcs);
     computeCollMergingTag(collisions, tracksBarrel, presliceWithCovNoTOF);
-    fullSkimming<gkEventFillMapWithCentAndMults, gkTrackFillMapNoTOF, 0u, 0u>(collisions, bcs, nullptr, tracksBarrel, nullptr, nullptr, trackAssocs, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+    fullSkimming<gkEventFillMapWithCentAndMultsQvect, gkTrackFillMapNoTOF, 0u, 0u>(collisions, bcs, nullptr, tracksBarrel, nullptr, nullptr, trackAssocs, nullptr, nullptr, nullptr, ft0s, fv0as, fdds);
   }
 
   // produce the barrel-only DQ skimmed data model typically for UPC Pb-Pb (no centrality), subscribe to the DQ rapidity gap event filter (filter-PbPb)
@@ -2007,23 +2026,23 @@ struct TableMaker {
   }
 
   // produce the barrel only DQ skimmed data model typically for Pb-Pb (with centrality), no subscribtion to the DQ event filter
-  void processPbPbBarrelOnlyWithV0Bits(MyEventsWithCentAndMults const& collisions, MyBCs const& bcs,
+  void processPbPbBarrelOnlyWithV0Bits(MyEventsWithCentAndMultsQvect const& collisions, MyBCs const& bcs,
                                        MyBarrelTracksWithV0Bits const& tracksBarrel,
-                                       TrackAssoc const& trackAssocs)
+                                       TrackAssoc const& trackAssocs, aod::FT0s& ft0s, aod::FV0As& fv0as, aod::FDDs& fdds)
   {
     computeOccupancyEstimators(collisions, tracksPos, tracksNeg, preslice, bcs);
     computeCollMergingTag(collisions, tracksBarrel, preslice);
-    fullSkimming<gkEventFillMapWithCentAndMults, gkTrackFillMapWithV0Bits, 0u, 0u>(collisions, bcs, nullptr, tracksBarrel, nullptr, nullptr, trackAssocs, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+    fullSkimming<gkEventFillMapWithCentAndMultsQvect, gkTrackFillMapWithV0Bits, 0u, 0u>(collisions, bcs, nullptr, tracksBarrel, nullptr, nullptr, trackAssocs, nullptr, nullptr, nullptr, ft0s, fv0as, fdds);
   }
 
   // produce the barrel only DQ skimmed data model typically for Pb-Pb (with centrality), no subscribtion to the DQ event filter
-  void processPbPbBarrelOnlyWithV0BitsNoTOF(MyEventsWithCentAndMults const& collisions, MyBCs const& bcs,
+  void processPbPbBarrelOnlyWithV0BitsNoTOF(MyEventsWithCentAndMultsQvect const& collisions, MyBCs const& bcs,
                                             MyBarrelTracksWithV0BitsNoTOF const& tracksBarrel,
-                                            TrackAssoc const& trackAssocs)
+                                            TrackAssoc const& trackAssocs, aod::FT0s& ft0s, aod::FV0As& fv0as, aod::FDDs& fdds)
   {
     computeOccupancyEstimators(collisions, tracksPosNoTOF, tracksNegNoTOF, presliceNoTOF, bcs);
     computeCollMergingTag(collisions, tracksBarrel, presliceNoTOF);
-    fullSkimming<gkEventFillMapWithCentAndMults, gkTrackFillMapWithV0BitsNoTOF, 0u, 0u>(collisions, bcs, nullptr, tracksBarrel, nullptr, nullptr, trackAssocs, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+    fullSkimming<gkEventFillMapWithCentAndMultsQvect, gkTrackFillMapWithV0BitsNoTOF, 0u, 0u>(collisions, bcs, nullptr, tracksBarrel, nullptr, nullptr, trackAssocs, nullptr, nullptr, nullptr, ft0s, fv0as, fdds);
   }
 
   // produce the muon only DQ skimmed data model typically for Pb-Pb (with centrality), no subscribtion to the DQ event filter
@@ -2089,7 +2108,6 @@ struct TableMaker {
   PROCESS_SWITCH(TableMaker, processPPMuonMFTWithMultsExtra, "Build muon + mft DQ skimmed data model typically for pp/p-Pb and UPC Pb-Pb", false);
   PROCESS_SWITCH(TableMaker, processPbPb, "Build full DQ skimmed data model typically for Pb-Pb, w/o event filtering", false);
   PROCESS_SWITCH(TableMaker, processPbPbBarrelOnly, "Build barrel only DQ skimmed data model typically for Pb-Pb, w/o event filtering", false);
-  PROCESS_SWITCH(TableMaker, processPbPbBarrelOnlyWithQvect, "Build barrel only DQ skimmed data model typically for Pb-Pb, w/o event filtering with event properties and flow", false);
   PROCESS_SWITCH(TableMaker, processPbPbBarrelOnlyNoTOF, "Build barrel only DQ skimmed data model typically for Pb-Pb, w/o event filtering, no TOF", false);
   PROCESS_SWITCH(TableMaker, processPbPbWithFilterBarrelOnly, "Build barrel only DQ skimmed data model typically for UPC Pb-Pb, w/ event filtering", false);
   PROCESS_SWITCH(TableMaker, processPbPbBarrelOnlyWithV0Bits, "Build barrel only DQ skimmed data model typically for Pb-Pb, w/ V0 bits, w/o event filtering", false);

--- a/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
+++ b/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
@@ -211,8 +211,6 @@ struct TableMaker {
   struct : ProducesGroup {
     Produces<ReducedEventsQvectorCentr> eventQvectorCentr;
     Produces<ReducedEventsQvectorCentrExtra> eventQvectorCentrExtra;
-    Produces<ReducedEventsQvectorExtra> eventQvectorExtra;
-    Produces<ReducedEventsRefFlow> eventRefFlow;
   } qvecGroup;
 
   OutputObj<THashList> fOutputList{"output"}; //! the histogram manager output list
@@ -297,7 +295,6 @@ struct TableMaker {
 
   //
   struct : ConfigurableGroup {
-    Configurable<bool> fConfigFT0CCumulant{"cfgFT0CCumulant", false, "If true, compute RefFlow cumulants from FT0C amplitudes (requires FT0s subscription)"};
     Configurable<bool> fConfigQvectCalibAvailable{"cfgQvectCalibAvailable", false, "If true, qvector calibration objects are available in CCDB for this run"};
   } fConfigQvector;
 
@@ -480,11 +477,7 @@ struct TableMaker {
     }
 
     // Check whether we have to define barrel or muon histograms
-<<<<<<< HEAD
     bool enableBarrelHistos = (context.mOptions.get<bool>("processPP") || context.mOptions.get<bool>("processPPWithFilter") || context.mOptions.get<bool>("processPPWithFilterBarrelOnly") || context.mOptions.get<bool>("processPPBarrelOnly") ||
-=======
-    bool enableBarrelHistos = (context.mOptions.get<bool>("processPPWithFilter") || context.mOptions.get<bool>("processPPWithFilterBarrelOnly") || context.mOptions.get<bool>("processPPBarrelOnly") ||
->>>>>>> daa02bd72 (Qvector-tables shall be filled for all PbPb processes (except for processPbPbWithFilterBarrelOnly). Added a configurable for Qvector calibration path. The tables shall only be filled if the calibrations are available)
                                context.mOptions.get<bool>("processPbPb") || context.mOptions.get<bool>("processPbPbBarrelOnly") || context.mOptions.get<bool>("processPbPbBarrelOnlyWithV0Bits") || context.mOptions.get<bool>("processPbPbBarrelOnlyWithV0BitsNoTOF")) ||
                               context.mOptions.get<bool>("processPbPbWithFilterBarrelOnly") || context.mOptions.get<bool>("processPPBarrelOnlyWithV0s") || context.mOptions.get<bool>("processPbPbBarrelOnlyNoTOF");
 
@@ -1199,33 +1192,6 @@ struct TableMaker {
           qvecGroup.eventQvectorCentr(collision.qvecFT0ARe(), collision.qvecFT0AIm(), collision.qvecFT0CRe(), collision.qvecFT0CIm(), collision.qvecFT0MRe(), collision.qvecFT0MIm(), collision.qvecFV0ARe(), collision.qvecFV0AIm(), collision.qvecTPCposRe(), collision.qvecTPCposIm(), collision.qvecTPCnegRe(), collision.qvecTPCnegIm(),
                                       collision.sumAmplFT0A(), collision.sumAmplFT0C(), collision.sumAmplFT0M(), collision.sumAmplFV0A(), collision.nTrkTPCpos(), collision.nTrkTPCneg());
           qvecGroup.eventQvectorCentrExtra(collision.qvecTPCallRe(), collision.qvecTPCallIm(), collision.nTrkTPCall());
-
-          if (fConfigQvector.fConfigFT0CCumulant) {
-            // FT0C cumulants for RefFlow and QvectorExtra
-            float S11C = collision.sumAmplFT0C();
-            float S12C = 0.f;
-            if constexpr (!std::is_same_v<std::decay_t<TFt0s>, std::nullptr_t>) {
-              if (collision.has_foundFT0()) {
-                auto ft0 = collision.foundFT0();
-                for (auto amp : ft0.amplitudeC()) {
-                  if (amp > 0.f) {
-                    S12C += amp * amp;
-                  }
-                }
-              }
-            }
-            float S21C = S11C * S11C;
-            float M11REF = S21C - S12C;
-            std::complex<double> Q21C(collision.qvecFT0CRe() * S11C, collision.qvecFT0CIm() * S11C);
-            float CORR2REF = (std::norm(Q21C) - S12C) / M11REF;
-
-            if (std::isnan(M11REF) || std::isinf(M11REF) || std::isnan(CORR2REF) || std::isinf(CORR2REF)) {
-              M11REF = 0.f;
-              CORR2REF = 0.f;
-            }
-            qvecGroup.eventRefFlow(M11REF, -9999, -9999, CORR2REF, -9999, -9999, VarManager::fgValues[VarManager::kCentFT0C]);
-            qvecGroup.eventQvectorExtra(-9999, -9999, -9999, -9999, S11C, S12C, -9999, -9999);
-          }
         }
       }
       if constexpr ((TEventFillMap & VarManager::ObjTypes::Zdc) > 0) {

--- a/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
+++ b/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
@@ -298,7 +298,7 @@ struct TableMaker {
   //
   struct : ConfigurableGroup {
     Configurable<bool> fConfigFT0CCumulant{"cfgFT0CCumulant", false, "If true, compute RefFlow cumulants from FT0C amplitudes (requires FT0s subscription)"};
-    Configurable<std::string> fConfigQvecCalibPath{"cfgQvecCalibPath", "Analysis/EventPlane/QVecCorrections", "CCDB path for qvector calibration objects; used only to check availability per run"};
+    Configurable<bool> fConfigQvectCalibAvailable{"cfgQvectCalibAvailable", false, "If true, qvector calibration objects are available in CCDB for this run"};
   } fConfigQvector;
 
   struct : ConfigurableGroup {
@@ -336,7 +336,6 @@ struct TableMaker {
 
   bool fDoDetailedQA = false; // Bool to set detailed QA true, if QA is set true
   int fCurrentRun;            // needed to detect if the run changed and trigger update of calibrations etc.
-  bool fQvectCalibAvailable = false; // Whether the Q-vector calibration is available for the current run
 
   // maps used to store index info; NOTE: std::map are sorted in ascending order by default (needed for track to collision indices)
   std::map<uint32_t, uint32_t> fCollIndexMap;             // key: old collision index, value: skimmed collision index
@@ -1196,7 +1195,7 @@ struct TableMaker {
       eventInfo(collision.globalIndex());
 
       if constexpr ((TEventFillMap & VarManager::ObjTypes::CollisionQvectCentr) > 0) {
-        if (fQvectCalibAvailable) {
+        if (fConfigQvector.fConfigQvectCalibAvailable) {
           qvecGroup.eventQvectorCentr(collision.qvecFT0ARe(), collision.qvecFT0AIm(), collision.qvecFT0CRe(), collision.qvecFT0CIm(), collision.qvecFT0MRe(), collision.qvecFT0MIm(), collision.qvecFV0ARe(), collision.qvecFV0AIm(), collision.qvecTPCposRe(), collision.qvecTPCposIm(), collision.qvecTPCnegRe(), collision.qvecTPCnegIm(),
                                       collision.sumAmplFT0A(), collision.sumAmplFT0C(), collision.sumAmplFT0M(), collision.sumAmplFV0A(), collision.nTrkTPCpos(), collision.nTrkTPCneg());
           qvecGroup.eventQvectorCentrExtra(collision.qvecTPCallRe(), collision.qvecTPCallIm(), collision.nTrkTPCall());
@@ -1778,29 +1777,6 @@ struct TableMaker {
       }
       std::map<std::string, std::string> metadataRCT, header;
       header = fCCDBApi.retrieveHeaders(Form("RCT/Info/RunInformation/%i", bcs.begin().runNumber()), metadataRCT, -1);
-
-      // Check if qvector calibration objects are available in CCDB for this run
-      if constexpr ((TEventFillMap & VarManager::ObjTypes::CollisionQvectCentr) > 0) {
-        std::map<std::string, std::string> metadataQvect;
-        const std::array<std::string, 3> subfolders = {"v2", "v3", "v4"};
-        bool anyFound = false;
-        for (const auto& sub : subfolders) {
-          std::string fullPath = fConfigQvector.fConfigQvecCalibPath.value + "/" + sub;
-          auto headers = fCCDBApi.retrieveHeaders(fullPath, metadataQvect, bcs.begin().timestamp());
-          if (headers.empty()) {
-            LOG(warn) << "Qvector calibration not found at CCDB path '" << fullPath
-                      << "' for run " << bcs.begin().runNumber();
-          } else {
-            anyFound = true;
-          }
-        }
-        fQvectCalibAvailable = anyFound;
-        if (!fQvectCalibAvailable) {
-          LOG(warn) << "No qvector calibration found in any subfolder under '"
-                    << fConfigQvector.fConfigQvecCalibPath.value
-                    << "' — qvector tables will not be filled for this run.";
-        }
-      }
       uint64_t sor = std::atol(header["SOR"].c_str());
       uint64_t eor = std::atol(header["EOR"].c_str());
       VarManager::SetSORandEOR(sor, eor);

--- a/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
+++ b/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
@@ -187,8 +187,6 @@ struct TableMaker {
   Produces<ReducedEventsExtended> eventExtended;
   Produces<ReducedEventsVtxCov> eventVtxCov;
   Produces<ReducedEventsInfo> eventInfo;
-  Produces<ReducedEventsQvectorCentr> eventQvectorCentr;
-  Produces<ReducedEventsQvectorCentrExtra> eventQvectorCentrExtra;
   Produces<ReducedZdcs> zdc;
   Produces<ReducedFITs> fit;
   Produces<ReducedEventsMultPV> multPV;
@@ -208,6 +206,14 @@ struct TableMaker {
   Produces<ReducedMFTs> mftTrack;
   Produces<ReducedMFTsExtra> mftTrackExtra;
   Produces<ReducedMFTAssoc> mftAssoc;
+
+  // Q-vector related tables, to be filled only if the user selects the corresponding option; since they are not needed for the skimming, we keep them in a separate group to avoid filling them when not needed
+  struct : ProducesGroup {
+    Produces<ReducedEventsQvectorCentr> eventQvectorCentr;
+    Produces<ReducedEventsQvectorCentrExtra> eventQvectorCentrExtra;
+    Produces<ReducedEventsQvectorExtra> eventQvectorExtra;
+    Produces<ReducedEventsRefFlow> eventRefFlow;
+  } qvecGroup;
 
   OutputObj<THashList> fOutputList{"output"}; //! the histogram manager output list
   OutputObj<TList> fStatsList{"Statistics"};  //! skimming statistics
@@ -288,6 +294,12 @@ struct TableMaker {
     Configurable<bool> fConfigIsOnlyforMaps{"cfgIsforMaps", false, "If true, run for postcalibration maps only"};
     Configurable<bool> fConfigSaveElectronSample{"cfgSaveElectronSample", false, "If true, only save electron sample"};
   } fConfigPostCalibTPC;
+
+  // 
+  struct : ConfigurableGroup {
+    Configurable<bool> fConfigFT0CCumulant{"cfgFT0CCumulant", false,
+    "If true, compute RefFlow cumulants from FT0C amplitudes (requires FT0s subscription)"};
+  } fConfigQvector;
 
   struct : ConfigurableGroup {
     // Track related options
@@ -1179,9 +1191,36 @@ struct TableMaker {
       eventInfo(collision.globalIndex());
 
       if constexpr ((TEventFillMap & VarManager::ObjTypes::CollisionQvectCentr) > 0) {
-        eventQvectorCentr(collision.qvecFT0ARe(), collision.qvecFT0AIm(), collision.qvecFT0CRe(), collision.qvecFT0CIm(), collision.qvecFT0MRe(), collision.qvecFT0MIm(), collision.qvecFV0ARe(), collision.qvecFV0AIm(), collision.qvecTPCposRe(), collision.qvecTPCposIm(), collision.qvecTPCnegRe(), collision.qvecTPCnegIm(),
+        qvecGroup.eventQvectorCentr(collision.qvecFT0ARe(), collision.qvecFT0AIm(), collision.qvecFT0CRe(), collision.qvecFT0CIm(), collision.qvecFT0MRe(), collision.qvecFT0MIm(), collision.qvecFV0ARe(), collision.qvecFV0AIm(), collision.qvecTPCposRe(), collision.qvecTPCposIm(), collision.qvecTPCnegRe(), collision.qvecTPCnegIm(),
                           collision.sumAmplFT0A(), collision.sumAmplFT0C(), collision.sumAmplFT0M(), collision.sumAmplFV0A(), collision.nTrkTPCpos(), collision.nTrkTPCneg());
-        eventQvectorCentrExtra(collision.qvecTPCallRe(), collision.qvecTPCallIm(), collision.nTrkTPCall());
+        qvecGroup.eventQvectorCentrExtra(collision.qvecTPCallRe(), collision.qvecTPCallIm(), collision.nTrkTPCall());
+
+        if (fConfigQvector.fConfigFT0CCumulant) {
+          // FT0C cumulants for RefFlow and QvectorExtra
+          float S11C = collision.sumAmplFT0C();
+          float S12C = 0.f;
+          if constexpr (!std::is_same_v<std::decay_t<TFt0s>, std::nullptr_t>) {
+            if (collision.has_foundFT0()) {
+              auto ft0 = collision.foundFT0();
+              for (auto amp : ft0.amplitudeC()) {
+                if (amp > 0.f) {
+                  S12C += amp * amp;
+                }
+              }
+            }
+          }
+          float S21C = S11C * S11C;
+          float M11REF = S21C - S12C;
+          std::complex<double> Q21C(collision.qvecFT0CRe() * S11C, collision.qvecFT0CIm() * S11C);
+          float CORR2REF = (std::norm(Q21C) - S12C) / M11REF;
+        
+          if (std::isnan(M11REF) || std::isinf(M11REF) || std::isnan(CORR2REF) || std::isinf(CORR2REF)) {
+            M11REF = 0.f;
+            CORR2REF = 0.f;
+          }
+          qvecGroup.eventRefFlow(M11REF, -9999, -9999, CORR2REF, -9999, -9999, VarManager::fgValues[VarManager::kCentFT0C]);
+          qvecGroup.eventQvectorExtra(-9999, -9999, -9999, -9999, S11C, S12C, -9999, -9999);
+        }
       }
 
       if constexpr ((TEventFillMap & VarManager::ObjTypes::Zdc) > 0) {
@@ -1937,6 +1976,16 @@ struct TableMaker {
     fullSkimming<gkEventFillMapWithCentAndMults, gkTrackFillMapWithCov, 0u, 0u>(collisions, bcs, nullptr, tracksBarrel, nullptr, nullptr, trackAssocs, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
   }
 
+  // produce the barrel only DQ skimmed data model typically for Pb-Pb (with centrality), no subscribtion to the DQ event filter
+  void processPbPbBarrelOnlyWithQvect(MyEventsWithCentAndMultsQvect const& collisions, MyBCs const& bcs,
+                             MyBarrelTracksWithCov const& tracksBarrel,
+                             TrackAssoc const& trackAssocs, aod::FT0s& ft0s)
+  {
+    computeOccupancyEstimators(collisions, tracksPosWithCov, tracksNegWithCov, presliceWithCov, bcs);
+    computeCollMergingTag(collisions, tracksBarrel, presliceWithCov);
+    fullSkimming<gkEventFillMapWithCentAndMultsQvect, gkTrackFillMapWithCov, 0u, 0u>(collisions, bcs, nullptr, tracksBarrel, nullptr, nullptr, trackAssocs, nullptr, nullptr, nullptr, ft0s, nullptr, nullptr);
+  }
+
   // produce the barrel only DQ skimmed data model typically for Pb-Pb (with centrality), no TOF
   void processPbPbBarrelOnlyNoTOF(MyEventsWithCentAndMults const& collisions, MyBCs const& bcs,
                                   MyBarrelTracksWithCovNoTOF const& tracksBarrel,
@@ -2040,6 +2089,7 @@ struct TableMaker {
   PROCESS_SWITCH(TableMaker, processPPMuonMFTWithMultsExtra, "Build muon + mft DQ skimmed data model typically for pp/p-Pb and UPC Pb-Pb", false);
   PROCESS_SWITCH(TableMaker, processPbPb, "Build full DQ skimmed data model typically for Pb-Pb, w/o event filtering", false);
   PROCESS_SWITCH(TableMaker, processPbPbBarrelOnly, "Build barrel only DQ skimmed data model typically for Pb-Pb, w/o event filtering", false);
+  PROCESS_SWITCH(TableMaker, processPbPbBarrelOnlyWithQvect, "Build barrel only DQ skimmed data model typically for Pb-Pb, w/o event filtering with event properties and flow", false);
   PROCESS_SWITCH(TableMaker, processPbPbBarrelOnlyNoTOF, "Build barrel only DQ skimmed data model typically for Pb-Pb, w/o event filtering, no TOF", false);
   PROCESS_SWITCH(TableMaker, processPbPbWithFilterBarrelOnly, "Build barrel only DQ skimmed data model typically for UPC Pb-Pb, w/ event filtering", false);
   PROCESS_SWITCH(TableMaker, processPbPbBarrelOnlyWithV0Bits, "Build barrel only DQ skimmed data model typically for Pb-Pb, w/ V0 bits, w/o event filtering", false);

--- a/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
+++ b/PWGDQ/TableProducer/tableMaker_withAssoc.cxx
@@ -295,10 +295,10 @@ struct TableMaker {
     Configurable<bool> fConfigSaveElectronSample{"cfgSaveElectronSample", false, "If true, only save electron sample"};
   } fConfigPostCalibTPC;
 
-  // 
+  //
   struct : ConfigurableGroup {
     Configurable<bool> fConfigFT0CCumulant{"cfgFT0CCumulant", false, "If true, compute RefFlow cumulants from FT0C amplitudes (requires FT0s subscription)"};
-    Configurable<std::string> fConfigQvecCalibPath{"cfgQvecCalibPath","Analysis/EventPlane/QVecCorrections","CCDB path for qvector calibration objects; used only to check availability per run"};
+    Configurable<std::string> fConfigQvecCalibPath{"cfgQvecCalibPath", "Analysis/EventPlane/QVecCorrections", "CCDB path for qvector calibration objects; used only to check availability per run"};
   } fConfigQvector;
 
   struct : ConfigurableGroup {
@@ -336,7 +336,7 @@ struct TableMaker {
 
   bool fDoDetailedQA = false; // Bool to set detailed QA true, if QA is set true
   int fCurrentRun;            // needed to detect if the run changed and trigger update of calibrations etc.
-  bool fQvectCalibAvailable = false; // Whether the Q-vector calibration is available for the current run 
+  bool fQvectCalibAvailable = false; // Whether the Q-vector calibration is available for the current run
 
   // maps used to store index info; NOTE: std::map are sorted in ascending order by default (needed for track to collision indices)
   std::map<uint32_t, uint32_t> fCollIndexMap;             // key: old collision index, value: skimmed collision index
@@ -1198,7 +1198,7 @@ struct TableMaker {
       if constexpr ((TEventFillMap & VarManager::ObjTypes::CollisionQvectCentr) > 0) {
         if (fQvectCalibAvailable) {
           qvecGroup.eventQvectorCentr(collision.qvecFT0ARe(), collision.qvecFT0AIm(), collision.qvecFT0CRe(), collision.qvecFT0CIm(), collision.qvecFT0MRe(), collision.qvecFT0MIm(), collision.qvecFV0ARe(), collision.qvecFV0AIm(), collision.qvecTPCposRe(), collision.qvecTPCposIm(), collision.qvecTPCnegRe(), collision.qvecTPCnegIm(),
-                          collision.sumAmplFT0A(), collision.sumAmplFT0C(), collision.sumAmplFT0M(), collision.sumAmplFV0A(), collision.nTrkTPCpos(), collision.nTrkTPCneg());
+                                      collision.sumAmplFT0A(), collision.sumAmplFT0C(), collision.sumAmplFT0M(), collision.sumAmplFV0A(), collision.nTrkTPCpos(), collision.nTrkTPCneg());
           qvecGroup.eventQvectorCentrExtra(collision.qvecTPCallRe(), collision.qvecTPCallIm(), collision.nTrkTPCall());
 
           if (fConfigQvector.fConfigFT0CCumulant) {
@@ -1219,7 +1219,7 @@ struct TableMaker {
             float M11REF = S21C - S12C;
             std::complex<double> Q21C(collision.qvecFT0CRe() * S11C, collision.qvecFT0CIm() * S11C);
             float CORR2REF = (std::norm(Q21C) - S12C) / M11REF;
-        
+
             if (std::isnan(M11REF) || std::isinf(M11REF) || std::isnan(CORR2REF) || std::isinf(CORR2REF)) {
               M11REF = 0.f;
               CORR2REF = 0.f;
@@ -1778,7 +1778,7 @@ struct TableMaker {
       }
       std::map<std::string, std::string> metadataRCT, header;
       header = fCCDBApi.retrieveHeaders(Form("RCT/Info/RunInformation/%i", bcs.begin().runNumber()), metadataRCT, -1);
-      
+
       // Check if qvector calibration objects are available in CCDB for this run
       if constexpr ((TEventFillMap & VarManager::ObjTypes::CollisionQvectCentr) > 0) {
         std::map<std::string, std::string> metadataQvect;
@@ -1787,10 +1787,10 @@ struct TableMaker {
         for (const auto& sub : subfolders) {
           std::string fullPath = fConfigQvector.fConfigQvecCalibPath.value + "/" + sub;
           auto headers = fCCDBApi.retrieveHeaders(fullPath, metadataQvect, bcs.begin().timestamp());
-            if (headers.empty()) {
-              LOG(warn) << "Qvector calibration not found at CCDB path '" << fullPath
-                        << "' for run " << bcs.begin().runNumber();
-            } else {
+          if (headers.empty()) {
+            LOG(warn) << "Qvector calibration not found at CCDB path '" << fullPath
+                      << "' for run " << bcs.begin().runNumber();
+          } else {
             anyFound = true;
           }
         }

--- a/PWGDQ/Tasks/dqFlow.cxx
+++ b/PWGDQ/Tasks/dqFlow.cxx
@@ -354,6 +354,53 @@ struct DQEventQvector {
   }
 
   // Templated function instantianed for all of the process functions
+  template <uint32_t TEventFillMap, typename TEvent, typename TFT0s>
+  void runFillQvectorFromCentralFWWithFT0CCumulants(TEvent const& collision, TFT0s const& /*ft0s*/)
+  {
+    VarManager::ResetValues(0, VarManager::kNVars);
+    VarManager::FillEvent<TEventFillMap>(collision);
+
+    float S11C = collision.sumAmplFT0C();
+    float S12C = 0.f;
+    float S21C = S11C * S11C;
+
+    // Compute sum of squares of amplitudes from FT0C for flow analysis
+    if (collision.has_foundFT0()) {
+      auto ft0 = collision.foundFT0();
+      auto const& ampC = ft0.amplitudeC();
+      for (auto amp : ampC) {
+        if (amp > 0.f) {
+          S12C += amp * amp;
+        }
+      }
+    }
+    VarManager::FillQVectorFromCentralFW(collision);
+    std::complex<double> Q21C(collision.qvecFT0CRe() * S11C, collision.qvecFT0CIm() * S11C);
+
+    // Fill necessary quantities for cumulant calculations with weighted Q-vectors
+    float M11REF = S21C - S12C;
+    float CORR2REF = (norm(Q21C) - S12C) / M11REF;
+    CORR2REF = std::isnan(M11REF) || std::isinf(M11REF) || std::isnan(CORR2REF) || std::isinf(CORR2REF) ? 0 : CORR2REF;
+    M11REF = std::isnan(M11REF) || std::isinf(M11REF) || std::isnan(CORR2REF) || std::isinf(CORR2REF) ? 0 : M11REF;
+
+    if (fConfigQA) {
+      fHistMan->FillHistClass("Event_BeforeCuts_centralFW", VarManager::fgValues);
+      if (fEventCut->IsSelected(VarManager::fgValues)) {
+        fHistMan->FillHistClass("Event_AfterCuts_centralFW", VarManager::fgValues);
+      }
+    }
+
+    if (fEventCut->IsSelected(VarManager::fgValues)) {
+      // temporarily removed --> this table is filled in the table-maker directly
+      // eventQvectorCentr(collision.qvecFT0ARe(), collision.qvecFT0AIm(), collision.qvecFT0CRe(), collision.qvecFT0CIm(), collision.qvecFT0MRe(), collision.qvecFT0MIm(), collision.qvecFV0ARe(), collision.qvecFV0AIm(), collision.qvecTPCposRe(), collision.qvecTPCposIm(), collision.qvecTPCnegRe(), collision.qvecTPCnegIm(),
+      //                  collision.sumAmplFT0A(), collision.sumAmplFT0C(), collision.sumAmplFT0M(), collision.sumAmplFV0A(), collision.nTrkTPCpos(), collision.nTrkTPCneg());
+      // eventQvectorCentrExtra(collision.qvecTPCallRe(), collision.qvecTPCallIm(), collision.nTrkTPCall());
+      eventRefFlow(M11REF, -9999, -9999, CORR2REF, -9999, -9999, VarManager::fgValues[VarManager::kCentFT0C]);
+      eventQvectorExtra(-9999, -9999, -9999, -9999, S11C, S12C, -9999, -9999);
+    }
+  }
+
+  // Templated function instantianed for all of the process functions
   template <uint32_t TEventFillMap, uint32_t TTrackFillMap, typename TEvent, typename TTracks>
   void runFillQvector(TEvent const& collision, MyBcs const&, TTracks const& tracks1, aod::Zdcs const&)
   {
@@ -576,6 +623,12 @@ struct DQEventQvector {
     runFillQvectorFromCentralFW<gkEventFillMapRun3>(collisions);
   }
 
+  // Process to fill Q vector using barrel tracks in a reduced event table for barrel/muon tracks flow related analyses Run 3
+  void processCentralQvectorWithFT0CCumulants(MyEventsWithCentQvectRun3::iterator const& collision, aod::FT0s const& ft0s)
+  {
+    runFillQvectorFromCentralFWWithFT0CCumulants<gkEventFillMapRun3>(collision, ft0s);
+  }
+
   // Process to fill Q vector using forward tracks in a reduced event table for barrel/muon tracks flow related analyses Run 3
   void processForwardQvector(MyEventsWithCentRun3::iterator const& collisions, MyBcs const& bcs, soa::Filtered<aod::MFTTracks> const& tracks, aod::Zdcs const& zdcs)
   {
@@ -592,6 +645,7 @@ struct DQEventQvector {
   PROCESS_SWITCH(DQEventQvector, processBarrelQvector, "Run q-vector task on barrel tracks for Run3", false);
   PROCESS_SWITCH(DQEventQvector, processAllQvector, "Run q-vector task on barrel tracks for Run3 and using central q-vector", false);
   PROCESS_SWITCH(DQEventQvector, processCentralQvector, "Run q-vector task using central q-vector", false);
+  PROCESS_SWITCH(DQEventQvector, processCentralQvectorWithFT0CCumulants, "Run q-vector task using central q-vector with FT0C cumulants", false);
   PROCESS_SWITCH(DQEventQvector, processForwardQvector, "Run q-vector task on forward tracks for Run3", false);
   PROCESS_SWITCH(DQEventQvector, processDummy, "Dummy function", false);
 };


### PR DESCRIPTION
Q-vector tables are to be filled in tableMaker_withAssoc now rather than using dqFlow to save memory. For all PbPb barrel processes, q-vector tables are filled now except for processPbPbWithFilterBarrelOnly. Added a cofigurable to check if q-vector calibrations exist.
For flow analysis using 2 particle correlations at midrapidity, one needs the RefFlow table filled with sum of squares of amplitude from FT0C. These are now filled in dqFlow. Switched to using a Produces group for all q-vector related tables