### PR TITLE
[PWGHF] Add filter to only fill Xic0 MC candidates in the tree

### DIFF
--- a/PWGHF/TableProducer/treeCreatorXic0ToXiPiKf.cxx
+++ b/PWGHF/TableProducer/treeCreatorXic0ToXiPiKf.cxx
@@ -38,6 +38,7 @@
 
 using namespace o2;
 using namespace o2::framework;
+using namespace o2::framework::expressions;
 
 namespace o2::aod
 {
@@ -134,7 +135,7 @@ DECLARE_SOA_TABLE(HfKfXicFulls, "AOD", "HFKFXICFULL",
 } // namespace o2::aod
 
 /// Writes the full information in an output TTree
-struct HfTreeCreatorXic0ToXiPiKf {
+struct TreeCreatorXic0ToXiPiKf {
 
   Produces<o2::aod::HfKfXicFulls> rowKfCandidate;
 
@@ -145,6 +146,9 @@ struct HfTreeCreatorXic0ToXiPiKf {
   using MyEventTableWithFT0C = soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Cs>;
   using MyEventTableWithFT0M = soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Ms>;
   using MyEventTableWithNTracksPV = soa::Join<aod::Collisions, aod::EvSels, aod::CentNTPVs>;
+  using MyMcCandidates = soa::Filtered<soa::Join<aod::HfCandToXiPiKf, aod::HfSelToXiPiKf, aod::HfXicToXiPiMCRec>>;
+
+  Filter mcFilter = aod::hf_cand_mc_flag::originMcRec == 1;
 
   HistogramRegistry registry{"registry"}; // for QA of selections
 
@@ -276,7 +280,7 @@ struct HfTreeCreatorXic0ToXiPiKf {
   PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processDataLiteWithNTracksPV, "Process KF data with Ntracks", false);
 
   void processKfMcXic0(MyTrackTable const&,
-                       soa::Join<aod::HfCandToXiPiKf, aod::HfSelToXiPiKf, aod::HfXicToXiPiMCRec> const& candidates)
+                       MyMcCandidates const& candidates)
   {
     rowKfCandidate.reserve(candidates.size());
     for (const auto& candidate : candidates) {
@@ -286,7 +290,7 @@ struct HfTreeCreatorXic0ToXiPiKf {
   PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processKfMcXic0, "Process MC with information for xic0", false);
 
   void processKfMCWithFT0C(MyTrackTable const&,
-                           soa::Join<aod::HfCandToXiPiKf, aod::HfSelToXiPiKf, aod::HfXicToXiPiMCRec> const& candidates)
+                           MyMcCandidates const& candidates)
   {
     rowKfCandidate.reserve(candidates.size());
     for (const auto& candidate : candidates) {
@@ -296,7 +300,7 @@ struct HfTreeCreatorXic0ToXiPiKf {
   PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processKfMCWithFT0C, "Process MC with information for xic0 at FT0C", false);
 
   void processKfMCWithFT0M(MyTrackTable const&,
-                           soa::Join<aod::HfCandToXiPiKf, aod::HfSelToXiPiKf, aod::HfXicToXiPiMCRec> const& candidates)
+                           MyMcCandidates const& candidates)
   {
     rowKfCandidate.reserve(candidates.size());
     for (const auto& candidate : candidates) {
@@ -306,7 +310,7 @@ struct HfTreeCreatorXic0ToXiPiKf {
   PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processKfMCWithFT0M, "Process MC with information for xic0 at FT0M", false);
 
   void processMCLiteWithNTracksPV(MyTrackTable const&,
-                                  soa::Join<aod::HfCandToXiPiKf, aod::HfSelToXiPiKf, aod::HfXicToXiPiMCRec> const& candidates)
+                                  MyMcCandidates const& candidates)
   {
     rowKfCandidate.reserve(candidates.size());
     for (const auto& candidate : candidates) {

--- a/PWGHF/TableProducer/treeCreatorXic0ToXiPiKf.cxx
+++ b/PWGHF/TableProducer/treeCreatorXic0ToXiPiKf.cxx
@@ -148,7 +148,7 @@ struct TreeCreatorXic0ToXiPiKf {
   using MyEventTableWithNTracksPV = soa::Join<aod::Collisions, aod::EvSels, aod::CentNTPVs>;
   using MyMcCandidates = soa::Filtered<soa::Join<aod::HfCandToXiPiKf, aod::HfSelToXiPiKf, aod::HfXicToXiPiMCRec>>;
 
-  Filter mcFilter = aod::hf_cand_mc_flag::originMcRec == 1;
+  Filter mcFilter = aod::hf_cand_mc_flag::originMcRec == RecoDecay::OriginType::NonPrompt || aod::hf_cand_mc_flag::originMcRec == RecoDecay::OriginType::Prompt;
 
   HistogramRegistry registry{"registry"}; // for QA of selections
 
@@ -247,7 +247,7 @@ struct TreeCreatorXic0ToXiPiKf {
       fillKfCandidate<false, MyEventTable>(candidate, -7, -7, RecoDecay::OriginType::None, false);
     }
   }
-  PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processKfData, "Process KF data", false);
+  PROCESS_SWITCH(TreeCreatorXic0ToXiPiKf, processKfData, "Process KF data", false);
 
   void processKfDataWithFT0C(MyTrackTable const&, MyEventTableWithFT0C const&,
                              soa::Join<aod::HfCandToXiPiKf, aod::HfSelToXiPiKf> const& candidates)
@@ -257,7 +257,7 @@ struct TreeCreatorXic0ToXiPiKf {
       fillKfCandidate<true, MyEventTableWithFT0C>(candidate, -7, -7, RecoDecay::OriginType::None, false);
     }
   }
-  PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processKfDataWithFT0C, "Process KF data with FT0C", false);
+  PROCESS_SWITCH(TreeCreatorXic0ToXiPiKf, processKfDataWithFT0C, "Process KF data with FT0C", false);
 
   void processKfDataWithFT0M(MyTrackTable const&, MyEventTableWithFT0M const&,
                              soa::Join<aod::HfCandToXiPiKf, aod::HfSelToXiPiKf> const& candidates)
@@ -267,7 +267,7 @@ struct TreeCreatorXic0ToXiPiKf {
       fillKfCandidate<true, MyEventTableWithFT0M>(candidate, -7, -7, RecoDecay::OriginType::None, false);
     }
   }
-  PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processKfDataWithFT0M, "Process KF data with FT0M", false);
+  PROCESS_SWITCH(TreeCreatorXic0ToXiPiKf, processKfDataWithFT0M, "Process KF data with FT0M", false);
 
   void processDataLiteWithNTracksPV(MyTrackTable const&,
                                     soa::Join<aod::HfCandToXiPiKf, aod::HfSelToXiPiKf> const& candidates)
@@ -277,7 +277,7 @@ struct TreeCreatorXic0ToXiPiKf {
       fillKfCandidate<true, MyEventTableWithNTracksPV>(candidate, -7, -7, RecoDecay::OriginType::None, false);
     }
   }
-  PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processDataLiteWithNTracksPV, "Process KF data with Ntracks", false);
+  PROCESS_SWITCH(TreeCreatorXic0ToXiPiKf, processDataLiteWithNTracksPV, "Process KF data with Ntracks", false);
 
   void processKfMcXic0(MyTrackTable const&,
                        MyMcCandidates const& candidates)
@@ -287,7 +287,7 @@ struct TreeCreatorXic0ToXiPiKf {
       fillKfCandidate<false, MyEventTable>(candidate, candidate.flagMcMatchRec(), candidate.debugMcRec(), candidate.originMcRec(), candidate.collisionMatched());
     }
   }
-  PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processKfMcXic0, "Process MC with information for xic0", false);
+  PROCESS_SWITCH(TreeCreatorXic0ToXiPiKf, processKfMcXic0, "Process MC with information for xic0", false);
 
   void processKfMCWithFT0C(MyTrackTable const&,
                            MyMcCandidates const& candidates)
@@ -297,7 +297,7 @@ struct TreeCreatorXic0ToXiPiKf {
       fillKfCandidate<true, MyEventTableWithFT0C>(candidate, candidate.flagMcMatchRec(), candidate.debugMcRec(), candidate.originMcRec(), candidate.collisionMatched());
     }
   }
-  PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processKfMCWithFT0C, "Process MC with information for xic0 at FT0C", false);
+  PROCESS_SWITCH(TreeCreatorXic0ToXiPiKf, processKfMCWithFT0C, "Process MC with information for xic0 at FT0C", false);
 
   void processKfMCWithFT0M(MyTrackTable const&,
                            MyMcCandidates const& candidates)
@@ -307,7 +307,7 @@ struct TreeCreatorXic0ToXiPiKf {
       fillKfCandidate<true, MyEventTableWithFT0M>(candidate, candidate.flagMcMatchRec(), candidate.debugMcRec(), candidate.originMcRec(), candidate.collisionMatched());
     }
   }
-  PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processKfMCWithFT0M, "Process MC with information for xic0 at FT0M", false);
+  PROCESS_SWITCH(TreeCreatorXic0ToXiPiKf, processKfMCWithFT0M, "Process MC with information for xic0 at FT0M", false);
 
   void processMCLiteWithNTracksPV(MyTrackTable const&,
                                   MyMcCandidates const& candidates)
@@ -317,11 +317,11 @@ struct TreeCreatorXic0ToXiPiKf {
       fillKfCandidate<true, MyEventTableWithNTracksPV>(candidate, candidate.flagMcMatchRec(), candidate.debugMcRec(), candidate.originMcRec(), candidate.collisionMatched());
     }
   }
-  PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processMCLiteWithNTracksPV, "Process MC with information for xic0 at Ntrack", false);
+  PROCESS_SWITCH(TreeCreatorXic0ToXiPiKf, processMCLiteWithNTracksPV, "Process MC with information for xic0 at Ntrack", false);
 }; // end of struct
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<HfTreeCreatorXic0ToXiPiKf>(cfgc)};
+    adaptAnalysisTask<TreeCreatorXic0ToXiPiKf>(cfgc)};
 }

--- a/PWGHF/TableProducer/treeCreatorXic0ToXiPiKf.cxx
+++ b/PWGHF/TableProducer/treeCreatorXic0ToXiPiKf.cxx
@@ -135,7 +135,7 @@ DECLARE_SOA_TABLE(HfKfXicFulls, "AOD", "HFKFXICFULL",
 } // namespace o2::aod
 
 /// Writes the full information in an output TTree
-struct TreeCreatorXic0ToXiPiKf {
+struct HfTreeCreatorXic0ToXiPiKf {
 
   Produces<o2::aod::HfKfXicFulls> rowKfCandidate;
 
@@ -246,7 +246,7 @@ struct TreeCreatorXic0ToXiPiKf {
       fillKfCandidate<false, MyEventTable>(candidate, -7, -7, RecoDecay::OriginType::None, false);
     }
   }
-  PROCESS_SWITCH(TreeCreatorXic0ToXiPiKf, processKfData, "Process KF data", false);
+  PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processKfData, "Process KF data", false);
 
   void processKfDataWithFT0C(MyTrackTable const&, MyEventTableWithFT0C const&,
                              soa::Join<aod::HfCandToXiPiKf, aod::HfSelToXiPiKf> const& candidates)
@@ -256,7 +256,7 @@ struct TreeCreatorXic0ToXiPiKf {
       fillKfCandidate<true, MyEventTableWithFT0C>(candidate, -7, -7, RecoDecay::OriginType::None, false);
     }
   }
-  PROCESS_SWITCH(TreeCreatorXic0ToXiPiKf, processKfDataWithFT0C, "Process KF data with FT0C", false);
+  PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processKfDataWithFT0C, "Process KF data with FT0C", false);
 
   void processKfDataWithFT0M(MyTrackTable const&, MyEventTableWithFT0M const&,
                              soa::Join<aod::HfCandToXiPiKf, aod::HfSelToXiPiKf> const& candidates)
@@ -266,7 +266,7 @@ struct TreeCreatorXic0ToXiPiKf {
       fillKfCandidate<true, MyEventTableWithFT0M>(candidate, -7, -7, RecoDecay::OriginType::None, false);
     }
   }
-  PROCESS_SWITCH(TreeCreatorXic0ToXiPiKf, processKfDataWithFT0M, "Process KF data with FT0M", false);
+  PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processKfDataWithFT0M, "Process KF data with FT0M", false);
 
   void processDataLiteWithNTracksPV(MyTrackTable const&,
                                     soa::Join<aod::HfCandToXiPiKf, aod::HfSelToXiPiKf> const& candidates)
@@ -276,7 +276,7 @@ struct TreeCreatorXic0ToXiPiKf {
       fillKfCandidate<true, MyEventTableWithNTracksPV>(candidate, -7, -7, RecoDecay::OriginType::None, false);
     }
   }
-  PROCESS_SWITCH(TreeCreatorXic0ToXiPiKf, processDataLiteWithNTracksPV, "Process KF data with Ntracks", false);
+  PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processDataLiteWithNTracksPV, "Process KF data with Ntracks", false);
 
   void processKfMcXic0(MyTrackTable const&,
                        MyMcCandidates const& candidates)
@@ -286,7 +286,7 @@ struct TreeCreatorXic0ToXiPiKf {
       fillKfCandidate<false, MyEventTable>(candidate, candidate.flagMcMatchRec(), candidate.debugMcRec(), candidate.originMcRec(), candidate.collisionMatched());
     }
   }
-  PROCESS_SWITCH(TreeCreatorXic0ToXiPiKf, processKfMcXic0, "Process MC with information for xic0", false);
+  PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processKfMcXic0, "Process MC with information for xic0", false);
 
   void processKfMCWithFT0C(MyTrackTable const&,
                            MyMcCandidates const& candidates)
@@ -296,7 +296,7 @@ struct TreeCreatorXic0ToXiPiKf {
       fillKfCandidate<true, MyEventTableWithFT0C>(candidate, candidate.flagMcMatchRec(), candidate.debugMcRec(), candidate.originMcRec(), candidate.collisionMatched());
     }
   }
-  PROCESS_SWITCH(TreeCreatorXic0ToXiPiKf, processKfMCWithFT0C, "Process MC with information for xic0 at FT0C", false);
+  PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processKfMCWithFT0C, "Process MC with information for xic0 at FT0C", false);
 
   void processKfMCWithFT0M(MyTrackTable const&,
                            MyMcCandidates const& candidates)
@@ -306,7 +306,7 @@ struct TreeCreatorXic0ToXiPiKf {
       fillKfCandidate<true, MyEventTableWithFT0M>(candidate, candidate.flagMcMatchRec(), candidate.debugMcRec(), candidate.originMcRec(), candidate.collisionMatched());
     }
   }
-  PROCESS_SWITCH(TreeCreatorXic0ToXiPiKf, processKfMCWithFT0M, "Process MC with information for xic0 at FT0M", false);
+  PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processKfMCWithFT0M, "Process MC with information for xic0 at FT0M", false);
 
   void processMCLiteWithNTracksPV(MyTrackTable const&,
                                   MyMcCandidates const& candidates)
@@ -316,11 +316,11 @@ struct TreeCreatorXic0ToXiPiKf {
       fillKfCandidate<true, MyEventTableWithNTracksPV>(candidate, candidate.flagMcMatchRec(), candidate.debugMcRec(), candidate.originMcRec(), candidate.collisionMatched());
     }
   }
-  PROCESS_SWITCH(TreeCreatorXic0ToXiPiKf, processMCLiteWithNTracksPV, "Process MC with information for xic0 at Ntrack", false);
+  PROCESS_SWITCH(HfTreeCreatorXic0ToXiPiKf, processMCLiteWithNTracksPV, "Process MC with information for xic0 at Ntrack", false);
 }; // end of struct
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<TreeCreatorXic0ToXiPiKf>(cfgc)};
+    adaptAnalysisTask<HfTreeCreatorXic0ToXiPiKf>(cfgc)};
 }

--- a/PWGHF/TableProducer/treeCreatorXic0ToXiPiKf.cxx
+++ b/PWGHF/TableProducer/treeCreatorXic0ToXiPiKf.cxx
@@ -148,8 +148,7 @@ struct TreeCreatorXic0ToXiPiKf {
   using MyEventTableWithNTracksPV = soa::Join<aod::Collisions, aod::EvSels, aod::CentNTPVs>;
   using MyMcCandidates = soa::Filtered<soa::Join<aod::HfCandToXiPiKf, aod::HfSelToXiPiKf, aod::HfXicToXiPiMCRec>>;
 
-  Filter mcFilter = aod::hf_cand_mc_flag::originMcRec == RecoDecay::OriginType::NonPrompt || aod::hf_cand_mc_flag::originMcRec == RecoDecay::OriginType::Prompt;
-
+  Filter mcFilter = (aod::hf_cand_mc_flag::originMcRec == static_cast<int>(RecoDecay::OriginType::NonPrompt)) || (aod::hf_cand_mc_flag::originMcRec == static_cast<int>(RecoDecay::OriginType::Prompt));
   HistogramRegistry registry{"registry"}; // for QA of selections
 
   void init(InitContext const&)


### PR DESCRIPTION
Previously, background candidates were filled in the MC tree creator. 
This PR introduces a filter (mcFilter) to keep only Xic0 candidates in the tree.