### PR TITLE
[PWGHF] Species-dependent minimum prong pt cut in skimming

### DIFF
--- a/PWGHF/Core/SelectorCuts.h
+++ b/PWGHF/Core/SelectorCuts.h
@@ -251,6 +251,17 @@ static const std::vector<std::string> labelsPt{};
 
 // column labels
 static const std::vector<std::string> labelsCutVar = {"massMin", "massMax", "cosp", "decL"};
+
+// Single prong min pt selection
+static constexpr int NSpecies3Prong = 8; // number of species for 3-prong candidates
+static const float cutsProngMinPt3Prong[NSpecies3Prong] = {0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4};
+
+// 3-prong species labels
+static const std::vector<std::string> labelsSpecies3Prong = {"Dplus", "Lc", "Ds", "Xic", "Cd", "Ct", "Ch", "Ca"};
+
+// column label
+static const std::vector<std::string> labelsMinPt = {"Minimum track transverse momentum (GeV/c)"};
+
 } // namespace hf_cuts_presel_3prong
 
 namespace hf_cuts_presel_ds

--- a/PWGHF/Core/SelectorCuts.h
+++ b/PWGHF/Core/SelectorCuts.h
@@ -254,10 +254,10 @@ static const std::vector<std::string> labelsCutVar = {"massMin", "massMax", "cos
 
 // Single prong min pt selection
 static constexpr int NSpecies3Prong = 8; // number of species for 3-prong candidates
-static const float cutsProngMinPt3Prong[NSpecies3Prong] = {0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4};
+static const float ptProngMin[NSpecies3Prong] = {0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4};
 
 // 3-prong species labels
-static const std::vector<std::string> labelsSpecies3Prong = {"Dplus", "Lc", "Ds", "Xic", "Cd", "Ct", "Ch", "Ca"};
+static const std::vector<std::string> labelsPtProngMin = {"Dplus", "Lc", "Ds", "Xic", "Cd", "Ct", "Ch", "Ca"};
 
 // column label
 static const std::vector<std::string> labelsMinPt = {"Minimum track transverse momentum (GeV/c)"};

--- a/PWGHF/Core/SelectorCuts.h
+++ b/PWGHF/Core/SelectorCuts.h
@@ -232,7 +232,7 @@ static const std::vector<std::string> labelsCutVar = {"massMin", "massMax", "cos
 namespace hf_cuts_presel_3prong
 {
 static constexpr int NBinsPt = 2;
-static constexpr int NCutVars = 4;
+static constexpr int NCutVars = 5;
 // default values for the pT bin edges (can be used to configure histogram axis)
 // common for any 3-prong candidate
 // offset by 1 from the bin numbers in cuts array
@@ -243,31 +243,21 @@ constexpr double BinsPt[NBinsPt + 1] = {
 const auto vecBinsPt = std::vector<double>{BinsPt, BinsPt + NBinsPt + 1};
 
 // default values for the cuts
-constexpr double Cuts[NBinsPt][NCutVars] = {{1.75, 2.05, 0.7, 0.02},  /* 1 < pt < 5 */
-                                            {1.75, 2.05, 0.5, 0.02}}; /* 5 < pt < 1000 */
+constexpr double Cuts[NBinsPt][NCutVars] = {{1.75, 2.05, 0.7, 0.02, 0.3},  /* 1 < pt < 5 */
+                                            {1.75, 2.05, 0.5, 0.02, 0.3}}; /* 5 < pt < 1000 */
 
 // row labels
 static const std::vector<std::string> labelsPt{};
 
 // column labels
-static const std::vector<std::string> labelsCutVar = {"massMin", "massMax", "cosp", "decL"};
-
-// Single prong min pt selection
-static constexpr int NSpecies = 8; // number of species for 3-prong candidates
-constexpr float PtProngMin[NSpecies][1] = {{0.4f}, {0.4f}, {0.4f}, {0.4f}, {0.4f}, {0.4f}, {0.4f}, {0.4f}};
-
-// 3-prong species labels
-static const std::vector<std::string> labelsSpecies = {"Dplus", "Lc", "Ds", "Xic", "Cd", "Ct", "Ch", "Ca"};
-
-// column label
-static const std::vector<std::string> labelsPtProngMin = {"Minimum pT (GeV/c)"};
+static const std::vector<std::string> labelsCutVar = {"massMin", "massMax", "cosp", "decL", "ptProngMin"};
 
 } // namespace hf_cuts_presel_3prong
 
 namespace hf_cuts_presel_ds
 {
 static constexpr int NBinsPt = 2;
-static constexpr int NCutVars = 5;
+static constexpr int NCutVars = 6;
 // default values for the pT bin edges (can be used to configure histogram axis)
 // offset by 1 from the bin numbers in cuts array
 constexpr double BinsPt[NBinsPt + 1] = {
@@ -277,14 +267,14 @@ constexpr double BinsPt[NBinsPt + 1] = {
 const auto vecBinsPt = std::vector<double>{BinsPt, BinsPt + NBinsPt + 1};
 
 // default values for the cuts
-constexpr double Cuts[NBinsPt][NCutVars] = {{1.70, 2.15, 0.7, 0.02, 0.02},  /* 1 < pt < 5 */
-                                            {1.70, 2.15, 0.5, 0.02, 0.02}}; /* 5 < pt < 1000 */
+constexpr double Cuts[NBinsPt][NCutVars] = {{1.70, 2.15, 0.7, 0.02, 0.3, 0.02},  /* 1 < pt < 5 */
+                                            {1.70, 2.15, 0.5, 0.02, 0.3, 0.02}}; /* 5 < pt < 1000 */
 
 // row labels
 static const std::vector<std::string> labelsPt{};
 
 // column labels
-static const std::vector<std::string> labelsCutVar = {"massMin", "massMax", "cosp", "decL", "deltaMassKK"};
+static const std::vector<std::string> labelsCutVar = {"massMin", "massMax", "cosp", "decL", "ptProngMin", "deltaMassKK"};
 } // namespace hf_cuts_presel_ds
 
 namespace hf_cuts_presel_dstar

--- a/PWGHF/Core/SelectorCuts.h
+++ b/PWGHF/Core/SelectorCuts.h
@@ -254,7 +254,7 @@ static const std::vector<std::string> labelsCutVar = {"massMin", "massMax", "cos
 
 // Single prong min pt selection
 static constexpr int NSpecies = 8; // number of species for 3-prong candidates
-static const float ptProngMin[NSpecies] = {0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4};
+static const float ptProngMin[NSpecies][1] = {{0.4}, {0.4}, {0.4}, {0.4}, {0.4}, {0.4}, {0.4}, {0.4}};
 
 // 3-prong species labels
 static const std::vector<std::string> labelsPtProngMin = {"Dplus", "Lc", "Ds", "Xic", "Cd", "Ct", "Ch", "Ca"};

--- a/PWGHF/Core/SelectorCuts.h
+++ b/PWGHF/Core/SelectorCuts.h
@@ -253,8 +253,8 @@ static const std::vector<std::string> labelsPt{};
 static const std::vector<std::string> labelsCutVar = {"massMin", "massMax", "cosp", "decL"};
 
 // Single prong min pt selection
-static constexpr int NSpecies3Prong = 8; // number of species for 3-prong candidates
-static const float ptProngMin[NSpecies3Prong] = {0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4};
+static constexpr int NSpecies = 8; // number of species for 3-prong candidates
+static const float ptProngMin[NSpecies] = {0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4};
 
 // 3-prong species labels
 static const std::vector<std::string> labelsPtProngMin = {"Dplus", "Lc", "Ds", "Xic", "Cd", "Ct", "Ch", "Ca"};

--- a/PWGHF/Core/SelectorCuts.h
+++ b/PWGHF/Core/SelectorCuts.h
@@ -254,13 +254,13 @@ static const std::vector<std::string> labelsCutVar = {"massMin", "massMax", "cos
 
 // Single prong min pt selection
 static constexpr int NSpecies = 8; // number of species for 3-prong candidates
-static const float ptProngMin[NSpecies][1] = {{0.4}, {0.4}, {0.4}, {0.4}, {0.4}, {0.4}, {0.4}, {0.4}};
+constexpr float ptProngMin[NSpecies][1] = {{0.4f}, {0.4f}, {0.4f}, {0.4f}, {0.4f}, {0.4f}, {0.4f}, {0.4f}};
 
 // 3-prong species labels
-static const std::vector<std::string> labelsPtProngMin = {"Dplus", "Lc", "Ds", "Xic", "Cd", "Ct", "Ch", "Ca"};
+static const std::vector<std::string> labelsSpecies = {"Dplus", "Lc", "Ds", "Xic", "Cd", "Ct", "Ch", "Ca"};
 
 // column label
-static const std::vector<std::string> labelsMinPt = {"Minimum prong transverse momentum (GeV/c)"};
+static const std::vector<std::string> labelsPtProngMin = {"Minimum pT (GeV/c)"};
 
 } // namespace hf_cuts_presel_3prong
 

--- a/PWGHF/Core/SelectorCuts.h
+++ b/PWGHF/Core/SelectorCuts.h
@@ -254,7 +254,7 @@ static const std::vector<std::string> labelsCutVar = {"massMin", "massMax", "cos
 
 // Single prong min pt selection
 static constexpr int NSpecies = 8; // number of species for 3-prong candidates
-constexpr float ptProngMin[NSpecies][1] = {{0.4f}, {0.4f}, {0.4f}, {0.4f}, {0.4f}, {0.4f}, {0.4f}, {0.4f}};
+constexpr float PtProngMin[NSpecies][1] = {{0.4f}, {0.4f}, {0.4f}, {0.4f}, {0.4f}, {0.4f}, {0.4f}, {0.4f}};
 
 // 3-prong species labels
 static const std::vector<std::string> labelsSpecies = {"Dplus", "Lc", "Ds", "Xic", "Cd", "Ct", "Ch", "Ca"};

--- a/PWGHF/Core/SelectorCuts.h
+++ b/PWGHF/Core/SelectorCuts.h
@@ -260,7 +260,7 @@ static const float ptProngMin[NSpecies] = {0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.
 static const std::vector<std::string> labelsPtProngMin = {"Dplus", "Lc", "Ds", "Xic", "Cd", "Ct", "Ch", "Ca"};
 
 // column label
-static const std::vector<std::string> labelsMinPt = {"Minimum track transverse momentum (GeV/c)"};
+static const std::vector<std::string> labelsMinPt = {"Minimum prong transverse momentum (GeV/c)"};
 
 } // namespace hf_cuts_presel_3prong
 

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1457,7 +1457,7 @@ struct HfTrackIndexSkimCreator {
     Configurable<LabeledArray<double>> cutsDstarToD0Pi{"cutsDstarToD0Pi", {hf_cuts_presel_dstar::Cuts[0], hf_cuts_presel_dstar::NBinsPt, hf_cuts_presel_dstar::NCutVars, hf_cuts_presel_dstar::labelsPt, hf_cuts_presel_dstar::labelsCutVar}, "D*+->D0pi selections per pT bin"};
 
     // Species-differential track min pT selection for 3-prong candidates
-    Configurable<LabeledArray<float>> ptProngMin3Prong{"ptProngMin3Prong", {hf_cuts_presel_3prong::ptProngMin[0], hf_cuts_presel_3prong::NSpecies, 1, hf_cuts_presel_3prong::labelsPtProngMin, hf_cuts_presel_3prong::labelsMinPt}, "Min pT selection for prongs of 3-prong candidates in GeV/c"};
+    Configurable<LabeledArray<float>> ptProngMin3Prong{"ptProngMin3Prong", {hf_cuts_presel_3prong::ptProngMin[0], hf_cuts_presel_3prong::NSpecies, 1, hf_cuts_presel_3prong::labelsSpecies, hf_cuts_presel_3prong::labelsPtProngMin}, "Min pT selection for prongs of 3-prong candidates in GeV/c"};
 
     // proton PID selections for Lc and Xic
     Configurable<bool> applyProtonPidForLcToPKPi{"applyProtonPidForLcToPKPi", false, "Apply proton PID for Lc->pKpi"};
@@ -1892,7 +1892,7 @@ struct HfTrackIndexSkimCreator {
       }
 
       // invariant mass
-      if ((config.debug || TESTBIT(isSelected, iDecay3P))) {
+      if (config.debug || TESTBIT(isSelected, iDecay3P)) {
         const double minMass = cut3Prong[iDecay3P].get(binPt, 0u);
         const double maxMass = cut3Prong[iDecay3P].get(binPt, 1u);
         if (minMass >= 0. && maxMass > 0.) { // no need to check isSelected but to avoid mistakes
@@ -2032,7 +2032,7 @@ struct HfTrackIndexSkimCreator {
         }
 
         // decay length
-        if ((config.debug || TESTBIT(isSelected, iDecay3P))) {
+        if (config.debug || TESTBIT(isSelected, iDecay3P)) {
           const auto decayLength = RecoDecay::distance(primVtx, secVtx);
           if (decayLength < cut3Prong[iDecay3P].get(binPt, 3u)) { // 3u == decLenIndex[iDecay3P]
             CLRBIT(isSelected, iDecay3P);
@@ -2043,7 +2043,7 @@ struct HfTrackIndexSkimCreator {
         }
 
         // prong daughter pT
-        if ((config.debug || TESTBIT(isSelected, iDecay3P))) {
+        if (config.debug || TESTBIT(isSelected, iDecay3P)) {
           const auto ptProngMin = config.ptProngMin3Prong->get(iDecay3P);
           if (ptProngs[0] < ptProngMin || ptProngs[1] < ptProngMin || ptProngs[2] < ptProngMin) {
             CLRBIT(isSelected, iDecay3P);

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -2798,7 +2798,7 @@ struct HfTrackIndexSkimCreator {
               const auto pVecCandProng3Pos = RecoDecay::pVec(pvec0, pvec1, pvec2);
 
               // 3-prong selections after secondary vertex
-              std::array ptProngs{trackPos1.pt(), trackNeg1.pt(), trackPos2.pt()};
+              const std::array ptProngs{trackPos1.pt(), trackNeg1.pt(), trackPos2.pt()};
               applySelection3Prong(pVecCandProng3Pos, ptProngs, secondaryVertex3, pvRefitCoord3Prong2Pos1Neg, cutStatus3Prong, isSelected3ProngCand);
 
               std::array<std::vector<float>, kN3ProngDecaysUsedMlForHfFilters> mlScores3Prongs;
@@ -3074,7 +3074,7 @@ struct HfTrackIndexSkimCreator {
               const auto pVecCandProng3Neg = RecoDecay::pVec(pvec0, pvec1, pvec2);
 
               // 3-prong selections after secondary vertex
-              std::array ptProngs{trackPos1.pt(), trackNeg1.pt(), trackNeg2.pt()};
+              const std::array ptProngs{trackPos1.pt(), trackNeg1.pt(), trackNeg2.pt()};
               applySelection3Prong(pVecCandProng3Neg, ptProngs, secondaryVertex3, pvRefitCoord3Prong1Pos2Neg, cutStatus3Prong, isSelected3ProngCand);
 
               std::array<std::vector<float>, kN3ProngDecaysUsedMlForHfFilters> mlScores3Prongs{};

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1457,7 +1457,7 @@ struct HfTrackIndexSkimCreator {
     Configurable<LabeledArray<double>> cutsDstarToD0Pi{"cutsDstarToD0Pi", {hf_cuts_presel_dstar::Cuts[0], hf_cuts_presel_dstar::NBinsPt, hf_cuts_presel_dstar::NCutVars, hf_cuts_presel_dstar::labelsPt, hf_cuts_presel_dstar::labelsCutVar}, "D*+->D0pi selections per pT bin"};
 
     // Species-differential track min pT selection for 3-prong candidates
-    Configurable<LabeledArray<float>> ptProngMin3Prong{"ptProngMin3Prong", {hf_cuts_presel_3prong::ptProngMin[0], hf_cuts_presel_3prong::NSpecies, 1, hf_cuts_presel_3prong::labelsSpecies, hf_cuts_presel_3prong::labelsPtProngMin}, "Min pT selection for prongs of 3-prong candidates in GeV/c"};
+    Configurable<LabeledArray<float>> ptProngMin3Prong{"ptProngMin3Prong", {hf_cuts_presel_3prong::PtProngMin[0], hf_cuts_presel_3prong::NSpecies, 1, hf_cuts_presel_3prong::labelsSpecies, hf_cuts_presel_3prong::labelsPtProngMin}, "Min pT selection for prongs of 3-prong candidates in GeV/c"};
 
     // proton PID selections for Lc and Xic
     Configurable<bool> applyProtonPidForLcToPKPi{"applyProtonPidForLcToPKPi", false, "Apply proton PID for Lc->pKpi"};

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1457,7 +1457,7 @@ struct HfTrackIndexSkimCreator {
     Configurable<LabeledArray<double>> cutsDstarToD0Pi{"cutsDstarToD0Pi", {hf_cuts_presel_dstar::Cuts[0], hf_cuts_presel_dstar::NBinsPt, hf_cuts_presel_dstar::NCutVars, hf_cuts_presel_dstar::labelsPt, hf_cuts_presel_dstar::labelsCutVar}, "D*+->D0pi selections per pT bin"};
 
     // Species-differential track min pT selection for 3-prong candidates
-    Configurable<LabeledArray<float>> ptProngMin3Prong{"ptProngMin3Prong", {hf_cuts_presel_3prong::ptProngMin, hf_cuts_presel_3prong::NSpecies3Prong, 1, hf_cuts_presel_3prong::labelsPtProngMin, hf_cuts_presel_3prong::labelsMinPt}, "Min pT selection for prongs of 3-prong candidates in GeV/c"};
+    Configurable<LabeledArray<float>> ptProngMin3Prong{"ptProngMin3Prong", {hf_cuts_presel_3prong::ptProngMin, hf_cuts_presel_3prong::NSpecies, 1, hf_cuts_presel_3prong::labelsPtProngMin, hf_cuts_presel_3prong::labelsMinPt}, "Min pT selection for prongs of 3-prong candidates in GeV/c"};
 
     // proton PID selections for Lc and Xic
     Configurable<bool> applyProtonPidForLcToPKPi{"applyProtonPidForLcToPKPi", false, "Apply proton PID for Lc->pKpi"};

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1457,7 +1457,7 @@ struct HfTrackIndexSkimCreator {
     Configurable<LabeledArray<double>> cutsDstarToD0Pi{"cutsDstarToD0Pi", {hf_cuts_presel_dstar::Cuts[0], hf_cuts_presel_dstar::NBinsPt, hf_cuts_presel_dstar::NCutVars, hf_cuts_presel_dstar::labelsPt, hf_cuts_presel_dstar::labelsCutVar}, "D*+->D0pi selections per pT bin"};
 
     // Species-differential track min pT selection for 3-prong candidates
-    Configurable<LabeledArray<float>> ptProngMin3Prong{"ptProngMin3Prong", {hf_cuts_presel_3prong::ptProngMin, hf_cuts_presel_3prong::NSpecies, 1, hf_cuts_presel_3prong::labelsPtProngMin, hf_cuts_presel_3prong::labelsMinPt}, "Min pT selection for prongs of 3-prong candidates in GeV/c"};
+    Configurable<LabeledArray<float>> ptProngMin3Prong{"ptProngMin3Prong", {hf_cuts_presel_3prong::ptProngMin[0], hf_cuts_presel_3prong::NSpecies, 1, hf_cuts_presel_3prong::labelsPtProngMin, hf_cuts_presel_3prong::labelsMinPt}, "Min pT selection for prongs of 3-prong candidates in GeV/c"};
 
     // proton PID selections for Lc and Xic
     Configurable<bool> applyProtonPidForLcToPKPi{"applyProtonPidForLcToPKPi", false, "Apply proton PID for Lc->pKpi"};

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1456,9 +1456,6 @@ struct HfTrackIndexSkimCreator {
     Configurable<std::vector<double>> binsPtDstarToD0Pi{"binsPtDstarToD0Pi", std::vector<double>{hf_cuts_presel_dstar::vecBinsPt}, "pT bin limits for D*+->D0pi pT-dependent cuts"};
     Configurable<LabeledArray<double>> cutsDstarToD0Pi{"cutsDstarToD0Pi", {hf_cuts_presel_dstar::Cuts[0], hf_cuts_presel_dstar::NBinsPt, hf_cuts_presel_dstar::NCutVars, hf_cuts_presel_dstar::labelsPt, hf_cuts_presel_dstar::labelsCutVar}, "D*+->D0pi selections per pT bin"};
 
-    // Species-differential track min pT selection for 3-prong candidates
-    Configurable<LabeledArray<float>> ptProngMin3Prong{"ptProngMin3Prong", {hf_cuts_presel_3prong::PtProngMin[0], hf_cuts_presel_3prong::NSpecies, 1, hf_cuts_presel_3prong::labelsSpecies, hf_cuts_presel_3prong::labelsPtProngMin}, "Min pT selection for prongs of 3-prong candidates in GeV/c"};
-
     // proton PID selections for Lc and Xic
     Configurable<bool> applyProtonPidForLcToPKPi{"applyProtonPidForLcToPKPi", false, "Apply proton PID for Lc->pKpi"};
     Configurable<bool> applyProtonPidForXicToPKPi{"applyProtonPidForXicToPKPi", false, "Apply proton PID for Xic->pKpi"};
@@ -1823,7 +1820,7 @@ struct HfTrackIndexSkimCreator {
   template <typename T1, typename T2, typename T3>
   void applyPreselectionPhiDecay(const int binPt, T1 const& pVecTrack0, T1 const& pVecTrack1, T1 const& pVecTrack2, T2& cutStatus, T3& whichHypo, auto& isSelected)
   {
-    const double deltaMassMax = cut3Prong[hf_cand_3prong::DecayType::DsToKKPi].get(binPt, 4u);
+    const double deltaMassMax = cut3Prong[hf_cand_3prong::DecayType::DsToKKPi].get(binPt, 5u);
     if (TESTBIT(whichHypo[hf_cand_3prong::DecayType::DsToKKPi], 0)) {
       const double mass2PhiKKPi = RecoDecay::m2(std::array{pVecTrack0, pVecTrack1}, std::array{arrMass3Prong[hf_cand_3prong::DecayType::DsToKKPi][0][0], arrMass3Prong[hf_cand_3prong::DecayType::DsToKKPi][0][1]});
       if (mass2PhiKKPi > (MassPhi + deltaMassMax) * (MassPhi + deltaMassMax) || mass2PhiKKPi < (MassPhi - deltaMassMax) * (MassPhi - deltaMassMax)) {
@@ -1839,7 +1836,7 @@ struct HfTrackIndexSkimCreator {
     if (whichHypo[hf_cand_3prong::DecayType::DsToKKPi] == 0) {
       CLRBIT(isSelected, hf_cand_3prong::DecayType::DsToKKPi);
       if (config.debug) {
-        cutStatus[hf_cand_3prong::DecayType::DsToKKPi][4] = false;
+        cutStatus[hf_cand_3prong::DecayType::DsToKKPi][5] = false;
       }
     }
   }
@@ -1874,6 +1871,7 @@ struct HfTrackIndexSkimCreator {
         if (whichHypo[iDecay3P] == 0) {
           CLRBIT(isSelected, iDecay3P);
           if (config.debug) {
+            LOG(info) << "Candidate rejected by PID for decay " << iDecay3P << ", setting " << hf_cuts_presel_3prong::NCutVars << "th bit of cutStatus to false";
             cutStatus[iDecay3P][hf_cuts_presel_3prong::NCutVars] = false; // PID
           }
           continue; // no need to check further for this particle hypothesis
@@ -2044,7 +2042,7 @@ struct HfTrackIndexSkimCreator {
 
         // prong daughter pT
         if (config.debug || TESTBIT(isSelected, iDecay3P)) {
-          const auto ptProngMin = config.ptProngMin3Prong->get(iDecay3P);
+          const auto ptProngMin = cut3Prong[iDecay3P].get(binPt, 4u); // 4u == ptProngMinIndex[iDecay3P]
           if (ptProngs[0] < ptProngMin || ptProngs[1] < ptProngMin || ptProngs[2] < ptProngMin) {
             CLRBIT(isSelected, iDecay3P);
             if (config.debug) {

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1457,7 +1457,7 @@ struct HfTrackIndexSkimCreator {
     Configurable<LabeledArray<double>> cutsDstarToD0Pi{"cutsDstarToD0Pi", {hf_cuts_presel_dstar::Cuts[0], hf_cuts_presel_dstar::NBinsPt, hf_cuts_presel_dstar::NCutVars, hf_cuts_presel_dstar::labelsPt, hf_cuts_presel_dstar::labelsCutVar}, "D*+->D0pi selections per pT bin"};
 
     // Species-differential track min pT selection for 3-prong candidates
-    Configurable<LabeledArray<float>> cutsProngPtMin{"cutsProngPtMin", {hf_cuts_presel_3prong::cutsProngMinPt3Prong, hf_cuts_presel_3prong::NSpecies3Prong, 1, hf_cuts_presel_3prong::labelsSpecies3Prong, hf_cuts_presel_3prong::labelsMinPt}, "Min pT selection for prongs of 3-prong candidates in GeV/c"};
+    Configurable<LabeledArray<float>> ptProngMin3Prong{"ptProngMin3Prong", {hf_cuts_presel_3prong::ptProngMin, hf_cuts_presel_3prong::NSpecies3Prong, 1, hf_cuts_presel_3prong::labelsPtProngMin, hf_cuts_presel_3prong::labelsMinPt}, "Min pT selection for prongs of 3-prong candidates in GeV/c"};
 
     // proton PID selections for Lc and Xic
     Configurable<bool> applyProtonPidForLcToPKPi{"applyProtonPidForLcToPKPi", false, "Apply proton PID for Lc->pKpi"};
@@ -2002,8 +2002,8 @@ struct HfTrackIndexSkimCreator {
   /// \param primVtx is the primary vertex
   /// \param cutStatus is a 2D array with outcome of each selection (filled only in debug mode)
   /// \param isSelected ia s bitmap with selection outcome
-  template <typename T1, typename T2, typename T3, typename T4, typename T5>
-  void applySelection3Prong(const T1& pVecCand, const T2& prongDaugsPt, const T3& secVtx, const T4& primVtx, T5& cutStatus, auto& isSelected)
+  template <typename T1, typename T2, typename T3, typename T4>
+  void applySelection3Prong(const T1& pVecCand, const std::array<float, 3>& ptProngs, const T2& secVtx, const T3& primVtx, T4& cutStatus, auto& isSelected)
   {
     if (config.debug || isSelected > 0) {
 
@@ -2044,8 +2044,8 @@ struct HfTrackIndexSkimCreator {
 
         // prong daughter pT
         if ((config.debug || TESTBIT(isSelected, iDecay3P))) {
-          const auto minPtDaug = config.cutsProngPtMin->get(iDecay3P);
-          if (prongDaugsPt[0] < minPtDaug || prongDaugsPt[1] < minPtDaug || prongDaugsPt[2] < minPtDaug) {
+          const auto ptProngMin = config.ptProngMin3Prong->get(iDecay3P);
+          if (ptProngs[0] < ptProngMin || ptProngs[1] < ptProngMin || ptProngs[2] < ptProngMin) {
             CLRBIT(isSelected, iDecay3P);
             if (config.debug) {
               cutStatus[iDecay3P][4] = false;
@@ -2657,7 +2657,7 @@ struct HfTrackIndexSkimCreator {
 
               auto trackParVarPos2 = getTrackParCov(trackPos2);
               std::array dcaInfoPos2{trackPos2.dcaXY(), trackPos2.dcaZ()};
-              std::array prongPtInfo{trackPos1.pt(), trackNeg1.pt(), trackPos2.pt()};
+              std::array ptProngs{trackPos1.pt(), trackNeg1.pt(), trackPos2.pt()};
 
               // preselection of 3-prong candidates
               if (isSelected3ProngCand) {
@@ -2799,7 +2799,7 @@ struct HfTrackIndexSkimCreator {
               const auto pVecCandProng3Pos = RecoDecay::pVec(pvec0, pvec1, pvec2);
 
               // 3-prong selections after secondary vertex
-              applySelection3Prong(pVecCandProng3Pos, prongPtInfo, secondaryVertex3, pvRefitCoord3Prong2Pos1Neg, cutStatus3Prong, isSelected3ProngCand);
+              applySelection3Prong(pVecCandProng3Pos, ptProngs, secondaryVertex3, pvRefitCoord3Prong2Pos1Neg, cutStatus3Prong, isSelected3ProngCand);
 
               std::array<std::vector<float>, kN3ProngDecaysUsedMlForHfFilters> mlScores3Prongs;
               if (config.applyMlForHfFilters) {
@@ -2932,7 +2932,7 @@ struct HfTrackIndexSkimCreator {
               auto trackNeg2 = trackIndexNeg2.template track_as<TTracks>();
               auto trackParVarNeg2 = getTrackParCov(trackNeg2);
               std::array dcaInfoNeg2{trackNeg2.dcaXY(), trackNeg2.dcaZ()};
-              std::array prongPtInfo{trackPos1.pt(), trackNeg1.pt(), trackNeg2.pt()};
+              std::array ptProngs{trackPos1.pt(), trackNeg1.pt(), trackNeg2.pt()};
 
               // preselection of 3-prong candidates
               if (isSelected3ProngCand) {
@@ -3075,7 +3075,7 @@ struct HfTrackIndexSkimCreator {
               const auto pVecCandProng3Neg = RecoDecay::pVec(pvec0, pvec1, pvec2);
 
               // 3-prong selections after secondary vertex
-              applySelection3Prong(pVecCandProng3Neg, prongPtInfo, secondaryVertex3, pvRefitCoord3Prong1Pos2Neg, cutStatus3Prong, isSelected3ProngCand);
+              applySelection3Prong(pVecCandProng3Neg, ptProngs, secondaryVertex3, pvRefitCoord3Prong1Pos2Neg, cutStatus3Prong, isSelected3ProngCand);
 
               std::array<std::vector<float>, kN3ProngDecaysUsedMlForHfFilters> mlScores3Prongs{};
               if (config.applyMlForHfFilters) {

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1871,7 +1871,6 @@ struct HfTrackIndexSkimCreator {
         if (whichHypo[iDecay3P] == 0) {
           CLRBIT(isSelected, iDecay3P);
           if (config.debug) {
-            LOG(info) << "Candidate rejected by PID for decay " << iDecay3P << ", setting " << hf_cuts_presel_3prong::NCutVars << "th bit of cutStatus to false";
             cutStatus[iDecay3P][hf_cuts_presel_3prong::NCutVars] = false; // PID
           }
           continue; // no need to check further for this particle hypothesis

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -2052,7 +2052,6 @@ struct HfTrackIndexSkimCreator {
             }
           }
         }
-
       }
     }
   }

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -2657,7 +2657,6 @@ struct HfTrackIndexSkimCreator {
 
               auto trackParVarPos2 = getTrackParCov(trackPos2);
               std::array dcaInfoPos2{trackPos2.dcaXY(), trackPos2.dcaZ()};
-              std::array ptProngs{trackPos1.pt(), trackNeg1.pt(), trackPos2.pt()};
 
               // preselection of 3-prong candidates
               if (isSelected3ProngCand) {
@@ -2799,6 +2798,7 @@ struct HfTrackIndexSkimCreator {
               const auto pVecCandProng3Pos = RecoDecay::pVec(pvec0, pvec1, pvec2);
 
               // 3-prong selections after secondary vertex
+              std::array ptProngs{trackPos1.pt(), trackNeg1.pt(), trackPos2.pt()};
               applySelection3Prong(pVecCandProng3Pos, ptProngs, secondaryVertex3, pvRefitCoord3Prong2Pos1Neg, cutStatus3Prong, isSelected3ProngCand);
 
               std::array<std::vector<float>, kN3ProngDecaysUsedMlForHfFilters> mlScores3Prongs;
@@ -2932,7 +2932,6 @@ struct HfTrackIndexSkimCreator {
               auto trackNeg2 = trackIndexNeg2.template track_as<TTracks>();
               auto trackParVarNeg2 = getTrackParCov(trackNeg2);
               std::array dcaInfoNeg2{trackNeg2.dcaXY(), trackNeg2.dcaZ()};
-              std::array ptProngs{trackPos1.pt(), trackNeg1.pt(), trackNeg2.pt()};
 
               // preselection of 3-prong candidates
               if (isSelected3ProngCand) {
@@ -3075,6 +3074,7 @@ struct HfTrackIndexSkimCreator {
               const auto pVecCandProng3Neg = RecoDecay::pVec(pvec0, pvec1, pvec2);
 
               // 3-prong selections after secondary vertex
+              std::array ptProngs{trackPos1.pt(), trackNeg1.pt(), trackNeg2.pt()};
               applySelection3Prong(pVecCandProng3Neg, ptProngs, secondaryVertex3, pvRefitCoord3Prong1Pos2Neg, cutStatus3Prong, isSelected3ProngCand);
 
               std::array<std::vector<float>, kN3ProngDecaysUsedMlForHfFilters> mlScores3Prongs{};

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -1456,6 +1456,9 @@ struct HfTrackIndexSkimCreator {
     Configurable<std::vector<double>> binsPtDstarToD0Pi{"binsPtDstarToD0Pi", std::vector<double>{hf_cuts_presel_dstar::vecBinsPt}, "pT bin limits for D*+->D0pi pT-dependent cuts"};
     Configurable<LabeledArray<double>> cutsDstarToD0Pi{"cutsDstarToD0Pi", {hf_cuts_presel_dstar::Cuts[0], hf_cuts_presel_dstar::NBinsPt, hf_cuts_presel_dstar::NCutVars, hf_cuts_presel_dstar::labelsPt, hf_cuts_presel_dstar::labelsCutVar}, "D*+->D0pi selections per pT bin"};
 
+    // Species-differential track min pT selection for 3-prong candidates
+    Configurable<LabeledArray<float>> cutsProngPtMin{"cutsProngPtMin", {hf_cuts_presel_3prong::cutsProngMinPt3Prong, hf_cuts_presel_3prong::NSpecies3Prong, 1, hf_cuts_presel_3prong::labelsSpecies3Prong, hf_cuts_presel_3prong::labelsMinPt}, "Min pT selection for prongs of 3-prong candidates in GeV/c"};
+
     // proton PID selections for Lc and Xic
     Configurable<bool> applyProtonPidForLcToPKPi{"applyProtonPidForLcToPKPi", false, "Apply proton PID for Lc->pKpi"};
     Configurable<bool> applyProtonPidForXicToPKPi{"applyProtonPidForXicToPKPi", false, "Apply proton PID for Xic->pKpi"};
@@ -1848,7 +1851,7 @@ struct HfTrackIndexSkimCreator {
   /// \param isIdentifiedPidTrack0 is the flag that tells if the track 0 has been tagged as a proton
   /// \param isIdentifiedPidTrack2 is the flag that tells if the track 2 has been tagged as a proton
   /// \param cutStatus is a 2D array with outcome of each selection (filled only in debug mode)
-  /// \param whichHypo information of the mass hypoteses that were selected
+  /// \param whichHypo information of the mass hypotheses that were selected
   /// \param isSelected is a bitmap with selection outcome
   template <typename T2, typename T3, typename T4>
   void applyPreselection3Prong(T2 const& pVecTrack0, T2 const& pVecTrack1, T2 const& pVecTrack2, const auto isIdentifiedPidTrack0, const auto isIdentifiedPidTrack2, T3& cutStatus, T4& whichHypo, auto& isSelected)
@@ -1999,8 +2002,8 @@ struct HfTrackIndexSkimCreator {
   /// \param primVtx is the primary vertex
   /// \param cutStatus is a 2D array with outcome of each selection (filled only in debug mode)
   /// \param isSelected ia s bitmap with selection outcome
-  template <typename T1, typename T2, typename T3, typename T4>
-  void applySelection3Prong(const T1& pVecCand, const T2& secVtx, const T3& primVtx, T4& cutStatus, auto& isSelected)
+  template <typename T1, typename T2, typename T3, typename T4, typename T5>
+  void applySelection3Prong(const T1& pVecCand, const T2& prongDaugsPt, const T3& secVtx, const T4& primVtx, T5& cutStatus, auto& isSelected)
   {
     if (config.debug || isSelected > 0) {
 
@@ -2038,6 +2041,18 @@ struct HfTrackIndexSkimCreator {
             }
           }
         }
+
+        // prong daughter pT
+        if ((config.debug || TESTBIT(isSelected, iDecay3P))) {
+          const auto minPtDaug = config.cutsProngPtMin->get(iDecay3P);
+          if (prongDaugsPt[0] < minPtDaug || prongDaugsPt[1] < minPtDaug || prongDaugsPt[2] < minPtDaug) {
+            CLRBIT(isSelected, iDecay3P);
+            if (config.debug) {
+              cutStatus[iDecay3P][4] = false;
+            }
+          }
+        }
+
       }
     }
   }
@@ -2643,6 +2658,7 @@ struct HfTrackIndexSkimCreator {
 
               auto trackParVarPos2 = getTrackParCov(trackPos2);
               std::array dcaInfoPos2{trackPos2.dcaXY(), trackPos2.dcaZ()};
+              std::array prongPtInfo{trackPos1.pt(), trackNeg1.pt(), trackPos2.pt()};
 
               // preselection of 3-prong candidates
               if (isSelected3ProngCand) {
@@ -2784,7 +2800,7 @@ struct HfTrackIndexSkimCreator {
               const auto pVecCandProng3Pos = RecoDecay::pVec(pvec0, pvec1, pvec2);
 
               // 3-prong selections after secondary vertex
-              applySelection3Prong(pVecCandProng3Pos, secondaryVertex3, pvRefitCoord3Prong2Pos1Neg, cutStatus3Prong, isSelected3ProngCand);
+              applySelection3Prong(pVecCandProng3Pos, prongPtInfo, secondaryVertex3, pvRefitCoord3Prong2Pos1Neg, cutStatus3Prong, isSelected3ProngCand);
 
               std::array<std::vector<float>, kN3ProngDecaysUsedMlForHfFilters> mlScores3Prongs;
               if (config.applyMlForHfFilters) {
@@ -2917,6 +2933,7 @@ struct HfTrackIndexSkimCreator {
               auto trackNeg2 = trackIndexNeg2.template track_as<TTracks>();
               auto trackParVarNeg2 = getTrackParCov(trackNeg2);
               std::array dcaInfoNeg2{trackNeg2.dcaXY(), trackNeg2.dcaZ()};
+              std::array prongPtInfo{trackPos1.pt(), trackNeg1.pt(), trackNeg2.pt()};
 
               // preselection of 3-prong candidates
               if (isSelected3ProngCand) {
@@ -3059,7 +3076,7 @@ struct HfTrackIndexSkimCreator {
               const auto pVecCandProng3Neg = RecoDecay::pVec(pvec0, pvec1, pvec2);
 
               // 3-prong selections after secondary vertex
-              applySelection3Prong(pVecCandProng3Neg, secondaryVertex3, pvRefitCoord3Prong1Pos2Neg, cutStatus3Prong, isSelected3ProngCand);
+              applySelection3Prong(pVecCandProng3Neg, prongPtInfo, secondaryVertex3, pvRefitCoord3Prong1Pos2Neg, cutStatus3Prong, isSelected3ProngCand);
 
               std::array<std::vector<float>, kN3ProngDecaysUsedMlForHfFilters> mlScores3Prongs{};
               if (config.applyMlForHfFilters) {

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -2039,7 +2039,7 @@ struct HfTrackIndexSkimCreator {
           }
         }
 
-        // prong daughter pT
+        // prong pT
         if (config.debug || TESTBIT(isSelected, iDecay3P)) {
           const auto ptProngMin = cut3Prong[iDecay3P].get(binPt, 4u); // 4u == ptProngMinIndex[iDecay3P]
           if (ptProngs[0] < ptProngMin || ptProngs[1] < ptProngMin || ptProngs[2] < ptProngMin) {


### PR DESCRIPTION
This PR implements the possibility to have different minimum prong pt selections for the HF 3 prong candidates in the `trackIndexSkimCreator` workflow.