### PR TITLE
[PWGEM] Fix TTCA weights when using cfgRequireTrueAssociation in PWGEM/Dilepton tasks

### DIFF
--- a/PWGEM/Dilepton/Core/DileptonMC.h
+++ b/PWGEM/Dilepton/Core/DileptonMC.h
@@ -2222,6 +2222,9 @@ struct DileptonMC {
         if (cfgEventGeneratorType >= 0 && mccollision_from_neg.getSubGeneratorId() != cfgEventGeneratorType) {
           continue;
         }
+        if (cfgRequireTrueAssociation && (mcpos.emmceventId() != collision.emmceventId() || mcneg.emmceventId() != collision.emmceventId())) {
+          continue;
+        }
 
         if (isPairOK(pos, neg, cut, tracks)) {
           passed_pairIds.emplace_back(std::make_pair(pos.globalIndex(), neg.globalIndex()));
@@ -2238,6 +2241,9 @@ struct DileptonMC {
         if (cfgEventGeneratorType >= 0 && mccollision_from_pos2.getSubGeneratorId() != cfgEventGeneratorType) {
           continue;
         }
+        if (cfgRequireTrueAssociation && (mcpos1.emmceventId() != collision.emmceventId() || mcpos2.emmceventId() != collision.emmceventId())) {
+          continue;
+        }
 
         if (isPairOK(pos1, pos2, cut, tracks)) {
           passed_pairIds.emplace_back(std::make_pair(pos1.globalIndex(), pos2.globalIndex()));
@@ -2252,6 +2258,9 @@ struct DileptonMC {
         auto mcneg2 = mcparticles.iteratorAt(neg2.emmcparticleId());
         auto mccollision_from_neg2 = mcneg2.template emmcevent_as<TMCCollisions>();
         if (cfgEventGeneratorType >= 0 && mccollision_from_neg2.getSubGeneratorId() != cfgEventGeneratorType) {
+          continue;
+        }
+        if (cfgRequireTrueAssociation && (mcneg1.emmceventId() != collision.emmceventId() || mcneg2.emmceventId() != collision.emmceventId())) {
           continue;
         }
         if (isPairOK(neg1, neg2, cut, tracks)) {

--- a/PWGEM/Dilepton/Core/SingleTrackQCMC.h
+++ b/PWGEM/Dilepton/Core/SingleTrackQCMC.h
@@ -1055,6 +1055,9 @@ struct SingleTrackQCMC {
           if (cfgEventGeneratorType >= 0 && mccollision_from_track.getSubGeneratorId() != cfgEventGeneratorType) {
             continue;
           }
+          if (cfgRequireTrueAssociation && (mctrack.emmceventId() != collision.emmceventId())) {
+            continue;
+          }
 
           if (dielectroncuts.cfg_pid_scheme == static_cast<int>(DielectronCut::PIDSchemes::kPIDML)) {
             if (!cut.template IsSelectedTrack<false>(track)) {
@@ -1072,6 +1075,9 @@ struct SingleTrackQCMC {
           auto mctrack = track.template emmcparticle_as<TMCParticles>();
           auto mccollision_from_track = mctrack.template emmcevent_as<TMCCollisions>();
           if (cfgEventGeneratorType >= 0 && mccollision_from_track.getSubGeneratorId() != cfgEventGeneratorType) {
+            continue;
+          }
+          if (cfgRequireTrueAssociation && (mctrack.emmceventId() != collision.emmceventId())) {
             continue;
           }
           if (!cut.template IsSelectedTrack<false>(track)) {

--- a/PWGEM/Dilepton/Tasks/checkMCPairTemplate.cxx
+++ b/PWGEM/Dilepton/Tasks/checkMCPairTemplate.cxx
@@ -2804,6 +2804,9 @@ struct checkMCPairTemplate {
         if (cfgEventGeneratorType >= 0 && mccollision_from_neg.getSubGeneratorId() != cfgEventGeneratorType) {
           continue;
         }
+        if (cfgRequireTrueAssociation && (mcpos.emmceventId() != collision.emmceventId() || mcneg.emmceventId() != collision.emmceventId())) {
+          continue;
+        }
 
         if (isPairOK(pos, neg, cut, tracks)) {
           passed_pairIds.emplace_back(std::make_pair(pos.globalIndex(), neg.globalIndex()));
@@ -2820,6 +2823,9 @@ struct checkMCPairTemplate {
         if (cfgEventGeneratorType >= 0 && mccollision_from_pos2.getSubGeneratorId() != cfgEventGeneratorType) {
           continue;
         }
+        if (cfgRequireTrueAssociation && (mcpos1.emmceventId() != collision.emmceventId() || mcpos2.emmceventId() != collision.emmceventId())) {
+          continue;
+        }
 
         if (isPairOK(pos1, pos2, cut, tracks)) {
           passed_pairIds.emplace_back(std::make_pair(pos1.globalIndex(), pos2.globalIndex()));
@@ -2834,6 +2840,9 @@ struct checkMCPairTemplate {
         auto mcneg2 = mcparticles.iteratorAt(neg2.emmcparticleId());
         auto mccollision_from_neg2 = mcneg2.template emmcevent_as<TMCCollisions>();
         if (cfgEventGeneratorType >= 0 && mccollision_from_neg2.getSubGeneratorId() != cfgEventGeneratorType) {
+          continue;
+        }
+        if (cfgRequireTrueAssociation && (mcneg1.emmceventId() != collision.emmceventId() || mcneg2.emmceventId() != collision.emmceventId())) {
           continue;
         }
         if (isPairOK(neg1, neg2, cut, tracks)) {


### PR DESCRIPTION
When `cfgRequireTrueAssociation = true`, tracks/pairs failing the MC collision association check were correctly rejected during histogram filling, but still counted in the TTCA weight denominator — causing weights of `1/N` instead of `1/1` and under-filled histograms.

## Affected files

- **`PWGEM/Dilepton/Core/SingleTrackQCMC.h`** — `fillTrackWeightMap()`: missing check for both electron and muon loops
- **`PWGEM/Dilepton/Core/DileptonMC.h`** — `fillPairWeightMap()`: missing check for ULS, LS++, and LS-- combination loops
- **`PWGEM/Dilepton/Tasks/checkMCPairTemplate.cxx`** — `fillPairWeightMap()`: same as above

## Fix

Added `cfgRequireTrueAssociation` guard in each weight-building loop to mirror the filter already applied at fill time:

```cpp
// fillPairWeightMap — now consistent with fillPairInfo
if (cfgRequireTrueAssociation &&
    (mcpos.emmceventId() != collision.emmceventId() ||
     mcneg.emmceventId() != collision.emmceventId())) {
  continue;  // skip pairs that would be rejected at fill time
}
```

This ensures only tracks/pairs that actually enter histograms are counted in `N`, keeping `weight = 1/N` correct under all configurations.