### PR TITLE
[PWGEM] remove unnecessary variables in EMTrack

### DIFF
--- a/PWGEM/Dilepton/Tasks/dileptonPolarization.cxx
+++ b/PWGEM/Dilepton/Tasks/dileptonPolarization.cxx
@@ -377,7 +377,7 @@ struct DileptonPolarization {
     fRegistry.addClone("Pair/same/uls/", "Pair/same/lsmm/");
     fRegistry.addClone("Pair/same/", "Pair/mix/");
     fRegistry.add("Pair/same/uls/hEta", "#eta_{ll}", kTH1D, {{2000, -10, 10}}, true);
-    fRegistry.add("Pair/mix/uls/hBeta", "#beta for Lorentz boost;#beta^{same};(#beta^{mix} - #beta^{same})/#beta^{same}", kTH2D, {{100, 0, 1}, {400, -0.2, 0.2}}, true);
+    // fRegistry.add("Pair/mix/uls/hBeta", "#beta for Lorentz boost;#beta^{same};(#beta^{mix} - #beta^{same})/#beta^{same}", kTH2D, {{100, 0, 1}, {400, -0.2, 0.2}}, true);
   }
 
   template <typename TCollision, typename TDilepton, typename TMixingBin>
@@ -483,7 +483,7 @@ struct DileptonPolarization {
           phiPol = std::fabs(phiPol);
         }
         fRegistry.fill(HIST("Pair/mix/") + HIST(pair_sign_types[signType]) + HIST("hs"), empair1.mass(), empair1.pt(), empair1.getPairDCA(), empair1.rapidity(), cos_thetaPol, phiPol, quadmom, weight);
-        fRegistry.fill(HIST("Pair/mix/") + HIST(pair_sign_types[signType]) + HIST("hBeta"), empair1.p() / empair1.e(), (empair2.p() / empair2.e() - empair1.p() / empair1.e()) / (empair1.p() / empair1.e()));
+        // fRegistry.fill(HIST("Pair/mix/") + HIST(pair_sign_types[signType]) + HIST("hBeta"), empair1.p() / empair1.e(), (empair2.p() / empair2.e() - empair1.p() / empair1.e()) / (empair1.p() / empair1.e()));
 
       } // end of pair2 loop
     } // end of pair1 loop

--- a/PWGEM/Dilepton/Utils/EMFwdTrack.h
+++ b/PWGEM/Dilepton/Utils/EMFwdTrack.h
@@ -25,11 +25,9 @@ class EMFwdTrack
  public:
   EMFwdTrack(float pt, float eta, float phi, float mass, int8_t charge, float dcaX, float dcaY, float cXX, float cXY, float cYY)
   {
-    fPt = pt;
+    fSigned1Pt = static_cast<float>(charge) / pt;
     fEta = eta;
     fPhi = phi;
-    fMass = mass;
-    fCharge = charge;
     fDCAx = dcaX;
     fDCAy = dcaY;
     fCXX = cXX;
@@ -39,31 +37,28 @@ class EMFwdTrack
 
   ~EMFwdTrack() {}
 
-  float pt() const { return fPt; }
+  float pt() const { return 1.f / std::fabs(fSigned1Pt); }
   float eta() const { return fEta; }
   float phi() const { return fPhi; }
-  float mass() const { return fMass; }
-  int8_t sign() const { return fCharge; }
+  int8_t sign() const { return (fSigned1Pt > 0 ? +1 : -1); }
   float fwdDcaX() const { return fDCAx; }
   float fwdDcaY() const { return fDCAy; }
   float fwdDcaXY() const { return std::sqrt(std::pow(fDCAx, 2) + std::pow(fDCAy, 2)); }
-  float p() const { return fPt * std::cosh(fEta); }
-  float px() const { return fPt * std::cos(fPhi); }
-  float py() const { return fPt * std::sin(fPhi); }
-  float pz() const { return fPt * std::sinh(fEta); }
-  float e() const { return std::hypot(fPt * std::cosh(fEta), fMass); } // e2 = p2 + m2
-  float signed1Pt() const { return fCharge * 1.f / fPt; }
+  float p() const { return 1.f / std::fabs(fSigned1Pt) * std::cosh(fEta); }
+  float px() const { return 1.f / std::fabs(fSigned1Pt) * std::cos(fPhi); }
+  float py() const { return 1.f / std::fabs(fSigned1Pt) * std::sin(fPhi); }
+  float pz() const { return 1.f / std::fabs(fSigned1Pt) * std::sinh(fEta); }
+  // float e(const float mass) const { return std::hypot(fPt * std::cosh(fEta), mass); } // e2 = p2 + m2
+  float signed1Pt() const { return fSigned1Pt; }
 
   float cXX() const { return fCXX; }
   float cXY() const { return fCXY; }
   float cYY() const { return fCYY; }
 
  protected:
-  float fPt;
+  float fSigned1Pt;
   float fEta;
   float fPhi;
-  float fMass;
-  int8_t fCharge;
   float fDCAx;
   float fDCAy;
   float fCXX;

--- a/PWGEM/Dilepton/Utils/EMFwdTrack.h
+++ b/PWGEM/Dilepton/Utils/EMFwdTrack.h
@@ -23,7 +23,7 @@ namespace o2::aod::pwgem::dilepton::utils
 class EMFwdTrack
 {
  public:
-  EMFwdTrack(float pt, float eta, float phi, float /*mass*/, int8_t /*charge*/, float dcaX, float dcaY, float cXX, float cXY, float cYY)
+  EMFwdTrack(float pt, float eta, float phi, float /*mass*/, int8_t charge, float dcaX, float dcaY, float cXX, float cXY, float cYY)
   {
     fSigned1Pt = static_cast<float>(charge) / pt;
     fEta = eta;

--- a/PWGEM/Dilepton/Utils/EMFwdTrack.h
+++ b/PWGEM/Dilepton/Utils/EMFwdTrack.h
@@ -23,7 +23,7 @@ namespace o2::aod::pwgem::dilepton::utils
 class EMFwdTrack
 {
  public:
-  EMFwdTrack(float pt, float eta, float phi, float mass, int8_t charge, float dcaX, float dcaY, float cXX, float cXY, float cYY)
+  EMFwdTrack(float pt, float eta, float phi, float /*mass*/, int8_t /*charge*/, float dcaX, float dcaY, float cXX, float cXY, float cYY)
   {
     fSigned1Pt = static_cast<float>(charge) / pt;
     fEta = eta;

--- a/PWGEM/Dilepton/Utils/EMTrack.h
+++ b/PWGEM/Dilepton/Utils/EMTrack.h
@@ -30,11 +30,9 @@ class EMTrack
  public:
   EMTrack(float pt, float eta, float phi, float mass, int8_t charge = 0, float dcaXY = 0.f, float dcaZ = 0.f, float CYY = 0, float CZY = 0, float CZZ = 0)
   {
-    fPt = pt;
+    fSigned1Pt = static_cast<float>(charge) / pt;
     fEta = eta;
     fPhi = phi;
-    fMass = mass;
-    fCharge = charge;
     fDCAxy = dcaXY;
     fDCAz = dcaZ;
     fCYY = CYY;
@@ -44,11 +42,10 @@ class EMTrack
 
   ~EMTrack() {}
 
-  float pt() const { return fPt; }
+  float pt() const { return 1.f / std::fabs(fSigned1Pt); }
   float eta() const { return fEta; }
   float phi() const { return fPhi; }
-  float mass() const { return fMass; }
-  int8_t sign() const { return fCharge; }
+  int8_t sign() const { return (fSigned1Pt > 0 ? +1 : -1); }
   float dcaXY() const { return fDCAxy; }
   float dcaZ() const { return fDCAz; }
 
@@ -56,20 +53,17 @@ class EMTrack
   float cZY() const { return fCZY; }
   float cZZ() const { return fCZZ; }
 
-  float rapidity() const { return std::log((std::sqrt(std::pow(fMass, 2) + std::pow(fPt * std::cosh(fEta), 2)) + fPt * std::sinh(fEta)) / std::sqrt(std::pow(fMass, 2) + std::pow(fPt, 2))); }
-  float p() const { return fPt * std::cosh(fEta); }
-  float px() const { return fPt * std::cos(fPhi); }
-  float py() const { return fPt * std::sin(fPhi); }
-  float pz() const { return fPt * std::sinh(fEta); }
-  float e() const { return std::hypot(fPt * std::cosh(fEta), fMass); } // e2 = p2 + m2
-  float signed1Pt() const { return fCharge * 1.f / fPt; }
+  float p() const { return  1.f / std::fabs(fSigned1Pt) * std::cosh(fEta); }
+  float px() const { return 1.f / std::fabs(fSigned1Pt) * std::cos(fPhi); }
+  float py() const { return 1.f / std::fabs(fSigned1Pt) * std::sin(fPhi); }
+  float pz() const { return 1.f / std::fabs(fSigned1Pt) * std::sinh(fEta); }
+  // float e() const { return std::hypot(fPt * std::cosh(fEta), fMass); } // e2 = p2 + m2
+  float signed1Pt() const { return fSigned1Pt; }
 
  protected:
-  float fPt;
+  float fSigned1Pt;
   float fEta;
   float fPhi;
-  float fMass;
-  int8_t fCharge;
   float fDCAxy;
   float fDCAz;
   float fCYY;
@@ -158,6 +152,7 @@ class EMPair : public EMTrack
  public:
   EMPair(float pt, float eta, float phi, float mass, int8_t charge = 0) : EMTrack(pt, eta, phi, mass, charge, 0, 0, 0, 0, 0)
   {
+    fMass = mass;
     fPairDCA = 999.f;
     fVPos = ROOT::Math::PtEtaPhiMVector(0, 0, 0, 0);
     fVNeg = ROOT::Math::PtEtaPhiMVector(0, 0, 0, 0);
@@ -167,6 +162,8 @@ class EMPair : public EMTrack
   }
 
   ~EMPair() {}
+  float mass() const { return fMass; }
+  float rapidity() const { return std::log((std::sqrt(std::pow(fMass, 2) + std::pow(1.f/ std::fabs(fSigned1Pt) * std::cosh(fEta), 2)) + 1.f/ std::fabs(fSigned1Pt) * std::sinh(fEta)) / std::sqrt(std::pow(fMass, 2) + std::pow(1.f/ std::fabs(fSigned1Pt), 2))); }
 
   void setPairDCA(float dca) { fPairDCA = dca; }
   float getPairDCA() const { return fPairDCA; }
@@ -232,6 +229,7 @@ class EMPair : public EMTrack
   float phi_cp() const { return std::atan2(fVy, fVx); }
 
  protected:
+  float fMass;
   float fPairDCA;
   ROOT::Math::PtEtaPhiMVector fVPos;
   ROOT::Math::PtEtaPhiMVector fVNeg;

--- a/PWGEM/Dilepton/Utils/EMTrack.h
+++ b/PWGEM/Dilepton/Utils/EMTrack.h
@@ -53,7 +53,7 @@ class EMTrack
   float cZY() const { return fCZY; }
   float cZZ() const { return fCZZ; }
 
-  float p() const { return  1.f / std::fabs(fSigned1Pt) * std::cosh(fEta); }
+  float p() const { return 1.f / std::fabs(fSigned1Pt) * std::cosh(fEta); }
   float px() const { return 1.f / std::fabs(fSigned1Pt) * std::cos(fPhi); }
   float py() const { return 1.f / std::fabs(fSigned1Pt) * std::sin(fPhi); }
   float pz() const { return 1.f / std::fabs(fSigned1Pt) * std::sinh(fEta); }
@@ -163,7 +163,7 @@ class EMPair : public EMTrack
 
   ~EMPair() {}
   float mass() const { return fMass; }
-  float rapidity() const { return std::log((std::sqrt(std::pow(fMass, 2) + std::pow(1.f/ std::fabs(fSigned1Pt) * std::cosh(fEta), 2)) + 1.f/ std::fabs(fSigned1Pt) * std::sinh(fEta)) / std::sqrt(std::pow(fMass, 2) + std::pow(1.f/ std::fabs(fSigned1Pt), 2))); }
+  float rapidity() const { return std::log((std::sqrt(std::pow(fMass, 2) + std::pow(1.f / std::fabs(fSigned1Pt) * std::cosh(fEta), 2)) + 1.f / std::fabs(fSigned1Pt) * std::sinh(fEta)) / std::sqrt(std::pow(fMass, 2) + std::pow(1.f / std::fabs(fSigned1Pt), 2))); }
 
   void setPairDCA(float dca) { fPairDCA = dca; }
   float getPairDCA() const { return fPairDCA; }

--- a/PWGEM/Dilepton/Utils/EMTrack.h
+++ b/PWGEM/Dilepton/Utils/EMTrack.h
@@ -28,7 +28,7 @@ namespace o2::aod::pwgem::dilepton::utils
 class EMTrack
 {
  public:
-  EMTrack(float pt, float eta, float phi, float mass, int8_t charge = 0, float dcaXY = 0.f, float dcaZ = 0.f, float CYY = 0, float CZY = 0, float CZZ = 0)
+  EMTrack(float pt, float eta, float phi, float /*mass*/, int8_t charge = 0, float dcaXY = 0.f, float dcaZ = 0.f, float CYY = 0, float CZY = 0, float CZZ = 0)
   {
     fSigned1Pt = static_cast<float>(charge) / pt;
     fEta = eta;

--- a/PWGEM/PhotonMeson/Core/Pi0EtaToGammaGamma.h
+++ b/PWGEM/PhotonMeson/Core/Pi0EtaToGammaGamma.h
@@ -24,11 +24,11 @@
 #include "PWGEM/PhotonMeson/Core/V0PhotonCut.h"
 #include "PWGEM/PhotonMeson/DataModel/EventTables.h"
 #include "PWGEM/PhotonMeson/DataModel/gammaTables.h"
+#include "PWGEM/PhotonMeson/Utils/EMPhoton.h"
 #include "PWGEM/PhotonMeson/Utils/EventHistograms.h"
 #include "PWGEM/PhotonMeson/Utils/NMHistograms.h"
 #include "PWGEM/PhotonMeson/Utils/PairUtilities.h"
 // Dilepton headers
-#include "PWGEM/Dilepton/Utils/EMTrack.h"
 #include "PWGEM/Dilepton/Utils/EventMixingHandler.h"
 
 #include "Common/CCDB/TriggerAliases.h"
@@ -249,8 +249,8 @@ struct Pi0EtaToGammaGamma {
   o2::framework::Partition<o2::soa::Filtered<o2::soa::Join<o2::aod::EMPrimaryElectronsFromDalitz, o2::aod::EMPrimaryElectronDaEMEventIds, o2::aod::EMPrimaryElectronsPrefilterBitDerived>>> positrons = o2::aod::emprimaryelectron::sign > int8_t(0) && dileptoncuts.cfg_min_pt_track < o2::aod::track::pt&& nabs(o2::aod::track::eta) < dileptoncuts.cfg_max_eta_track;
   o2::framework::Partition<o2::soa::Filtered<o2::soa::Join<o2::aod::EMPrimaryElectronsFromDalitz, o2::aod::EMPrimaryElectronDaEMEventIds, o2::aod::EMPrimaryElectronsPrefilterBitDerived>>> electrons = o2::aod::emprimaryelectron::sign < int8_t(0) && dileptoncuts.cfg_min_pt_track < o2::aod::track::pt && nabs(o2::aod::track::eta) < dileptoncuts.cfg_max_eta_track;
 
-  o2::aod::pwgem::dilepton::utils::EventMixingHandler<std::tuple<int, int, int, int>, std::pair<int, int>, o2::aod::pwgem::dilepton::utils::EMTrack>* emh1 = nullptr;
-  o2::aod::pwgem::dilepton::utils::EventMixingHandler<std::tuple<int, int, int, int>, std::pair<int, int>, o2::aod::pwgem::dilepton::utils::EMTrack>* emh2 = nullptr;
+  o2::aod::pwgem::dilepton::utils::EventMixingHandler<std::tuple<int, int, int, int>, std::pair<int, int>, o2::aod::pwgem::photonmeson::utils::EMPhoton>* emh1 = nullptr;
+  o2::aod::pwgem::dilepton::utils::EventMixingHandler<std::tuple<int, int, int, int>, std::pair<int, int>, o2::aod::pwgem::photonmeson::utils::EMPhoton>* emh2 = nullptr;
   //---------------------------------------------------------------------------
 
   std::vector<int> used_photonIds_per_col;                   // <ndf, trackId>
@@ -383,8 +383,8 @@ struct Pi0EtaToGammaGamma {
     occ_bin_edges = std::vector<float>(ConfOccupancyBins.value.begin(), ConfOccupancyBins.value.end());
     occ_bin_edges.erase(occ_bin_edges.begin());
 
-    emh1 = new o2::aod::pwgem::dilepton::utils::EventMixingHandler<std::tuple<int, int, int, int>, std::pair<int, int>, o2::aod::pwgem::dilepton::utils::EMTrack>(ndepth);
-    emh2 = new o2::aod::pwgem::dilepton::utils::EventMixingHandler<std::tuple<int, int, int, int>, std::pair<int, int>, o2::aod::pwgem::dilepton::utils::EMTrack>(ndepth);
+    emh1 = new o2::aod::pwgem::dilepton::utils::EventMixingHandler<std::tuple<int, int, int, int>, std::pair<int, int>, o2::aod::pwgem::photonmeson::utils::EMPhoton>(ndepth);
+    emh2 = new o2::aod::pwgem::dilepton::utils::EventMixingHandler<std::tuple<int, int, int, int>, std::pair<int, int>, o2::aod::pwgem::photonmeson::utils::EMPhoton>(ndepth);
 
     o2::aod::pwgem::photonmeson::utils::eventhistogram::addEventHistograms(&fRegistry);
     if constexpr (pairtype == o2::aod::pwgem::photonmeson::photonpair::PairType::kPCMDalitzEE) {
@@ -843,11 +843,11 @@ struct Pi0EtaToGammaGamma {
 
             std::pair<int, int> tuple_tmp_id2 = std::make_pair(pos2.trackId(), ele2.trackId());
             if (std::find(used_photonIds_per_col.begin(), used_photonIds_per_col.end(), g1.globalIndex()) == used_photonIds_per_col.end()) {
-              emh1->AddTrackToEventPool(key_df_collision, o2::aod::pwgem::dilepton::utils::EMTrack(g1.pt(), g1.eta(), g1.phi(), 0));
+              emh1->AddTrackToEventPool(key_df_collision, o2::aod::pwgem::photonmeson::utils::EMPhoton(g1.pt(), g1.eta(), g1.phi(), 0));
               used_photonIds_per_col.emplace_back(g1.globalIndex());
             }
             if (std::find(used_dileptonIds_per_col.begin(), used_dileptonIds_per_col.end(), tuple_tmp_id2) == used_dileptonIds_per_col.end()) {
-              emh2->AddTrackToEventPool(key_df_collision, o2::aod::pwgem::dilepton::utils::EMTrack(v_ee.Pt(), v_ee.Eta(), v_ee.Phi(), v_ee.M()));
+              emh2->AddTrackToEventPool(key_df_collision, o2::aod::pwgem::photonmeson::utils::EMPhoton(v_ee.Pt(), v_ee.Eta(), v_ee.Phi(), v_ee.M()));
               used_dileptonIds_per_col.emplace_back(tuple_tmp_id2);
             }
             ndiphoton++;
@@ -922,11 +922,11 @@ struct Pi0EtaToGammaGamma {
           fRegistry.fill(HIST("Pair/same/hs"), v12.M(), v12.Pt(), wpair);
 
           if (std::find(used_photonIds_per_col.begin(), used_photonIds_per_col.end(), g1.globalIndex()) == used_photonIds_per_col.end()) {
-            emh1->AddTrackToEventPool(key_df_collision, o2::aod::pwgem::dilepton::utils::EMTrack(g1.pt(), g1.eta(), g1.phi(), 0));
+            emh1->AddTrackToEventPool(key_df_collision, o2::aod::pwgem::photonmeson::utils::EMPhoton(g1.pt(), g1.eta(), g1.phi(), 0));
             used_photonIds_per_col.emplace_back(g1.globalIndex());
           }
           if (std::find(used_photonIds_per_col.begin(), used_photonIds_per_col.end(), g2.globalIndex()) == used_photonIds_per_col.end()) {
-            emh2->AddTrackToEventPool(key_df_collision, o2::aod::pwgem::dilepton::utils::EMTrack(g2.pt(), g2.eta(), g2.phi(), 0));
+            emh2->AddTrackToEventPool(key_df_collision, o2::aod::pwgem::photonmeson::utils::EMPhoton(g2.pt(), g2.eta(), g2.phi(), 0));
             used_photonIds_per_col.emplace_back(g2.globalIndex());
           }
           ndiphoton++;

--- a/PWGEM/PhotonMeson/Core/TaggingPi0.h
+++ b/PWGEM/PhotonMeson/Core/TaggingPi0.h
@@ -22,10 +22,10 @@
 #include "PWGEM/PhotonMeson/Core/V0PhotonCut.h"
 #include "PWGEM/PhotonMeson/DataModel/EventTables.h"
 #include "PWGEM/PhotonMeson/DataModel/gammaTables.h"
+#include "PWGEM/PhotonMeson/Utils/EMPhoton.h"
 #include "PWGEM/PhotonMeson/Utils/EventHistograms.h"
 #include "PWGEM/PhotonMeson/Utils/PairUtilities.h"
 //
-#include "PWGEM/Dilepton/Utils/EMTrack.h"
 #include "PWGEM/Dilepton/Utils/EventMixingHandler.h"
 
 #include "Common/DataModel/Centrality.h"
@@ -104,7 +104,7 @@ struct TaggingPi0 {
   o2::framework::ConfigurableAxis ConfOccupancyBins{"ConfOccupancyBins", {o2::framework::VARIABLE_WIDTH, -1, 1e+10}, "Mixing bins - occupancy"};
   o2::framework::ConfigurableAxis ConfPtBins{"ConfPtBins", {100, 0, 10}, "pT bins for output histograms"};
 
-  using MyEMH = o2::aod::pwgem::dilepton::utils::EventMixingHandler<std::tuple<int, int, int, int>, std::pair<int, int>, o2::aod::pwgem::dilepton::utils::EMTrack>;
+  using MyEMH = o2::aod::pwgem::dilepton::utils::EventMixingHandler<std::tuple<int, int, int, int>, std::pair<int, int>, o2::aod::pwgem::photonmeson::utils::EMPhoton>;
 
   EMPhotonEventCut fEMEventCut;
   struct : o2::framework::ConfigurableGroup {
@@ -565,11 +565,11 @@ struct TaggingPi0 {
 
             std::pair<int, int> tuple_tmp_id2 = std::make_pair(pos2.trackId(), ele2.trackId());
             if (std::find(used_photonIds_per_col.begin(), used_photonIds_per_col.end(), g1.globalIndex()) == used_photonIds_per_col.end()) {
-              emh1->AddTrackToEventPool(key_df_collision, o2::aod::pwgem::dilepton::utils::EMTrack(g1.pt(), g1.eta(), g1.phi(), 0));
+              emh1->AddTrackToEventPool(key_df_collision, o2::aod::pwgem::photonmeson::utils::EMPhoton(g1.pt(), g1.eta(), g1.phi(), 0));
               used_photonIds_per_col.emplace_back(g1.globalIndex());
             }
             if (std::find(used_dileptonIds_per_col.begin(), used_dileptonIds_per_col.end(), tuple_tmp_id2) == used_dileptonIds_per_col.end()) {
-              emh2->AddTrackToEventPool(key_df_collision, o2::aod::pwgem::dilepton::utils::EMTrack(v_ee.Pt(), v_ee.Eta(), v_ee.Phi(), v_ee.M()));
+              emh2->AddTrackToEventPool(key_df_collision, o2::aod::pwgem::photonmeson::utils::EMPhoton(v_ee.Pt(), v_ee.Eta(), v_ee.Phi(), v_ee.M()));
               used_dileptonIds_per_col.emplace_back(tuple_tmp_id2);
             }
             ndiphoton++;
@@ -590,11 +590,11 @@ struct TaggingPi0 {
           fRegistry.fill(HIST("Pair/same/hMvsPt"), v12.M(), v1.Pt(), weight);
 
           if (std::find(used_photonIds_per_col.begin(), used_photonIds_per_col.end(), g1.globalIndex()) == used_photonIds_per_col.end()) {
-            emh1->AddTrackToEventPool(key_df_collision, o2::aod::pwgem::dilepton::utils::EMTrack(g1.pt(), g1.eta(), g1.phi(), 0));
+            emh1->AddTrackToEventPool(key_df_collision, o2::aod::pwgem::photonmeson::utils::EMPhoton(g1.pt(), g1.eta(), g1.phi(), 0));
             used_photonIds_per_col.emplace_back(g1.globalIndex());
           }
           if (std::find(used_photonIds_per_col.begin(), used_photonIds_per_col.end(), g2.globalIndex()) == used_photonIds_per_col.end()) {
-            emh2->AddTrackToEventPool(key_df_collision, o2::aod::pwgem::dilepton::utils::EMTrack(g2.pt(), g2.eta(), g2.phi(), 0));
+            emh2->AddTrackToEventPool(key_df_collision, o2::aod::pwgem::photonmeson::utils::EMPhoton(g2.pt(), g2.eta(), g2.phi(), 0));
             used_photonIds_per_col.emplace_back(g2.globalIndex());
           }
           ndiphoton++;

--- a/PWGEM/PhotonMeson/Utils/EMPhoton.h
+++ b/PWGEM/PhotonMeson/Utils/EMPhoton.h
@@ -42,7 +42,7 @@ class EMPhoton
   float eta() const { return fEta; }
   float phi() const { return fPhi; }
 
-  float p() const { return  fPt * std::cosh(fEta); }
+  float p() const { return fPt * std::cosh(fEta); }
   float px() const { return fPt * std::cos(fPhi); }
   float py() const { return fPt * std::sin(fPhi); }
   float pz() const { return fPt * std::sinh(fEta); }

--- a/PWGEM/PhotonMeson/Utils/EMPhoton.h
+++ b/PWGEM/PhotonMeson/Utils/EMPhoton.h
@@ -12,8 +12,8 @@
 /// \class to store minimal photon info
 /// \author daiki.sekihata@cern.ch
 
-#ifndef PWGEM_DILEPTON_UTILS_EMPHOTON_H_
-#define PWGEM_DILEPTON_UTILS_EMPHOTON_H_
+#ifndef PWGEM_PHOTONMESON_UTILS_EMPHOTON_H_
+#define PWGEM_PHOTONMESON_UTILS_EMPHOTON_H_
 
 #include <Math/Vector4D.h> // IWYU pragma: keep (do not replace with Math/Vector4Dfwd.h)
 #include <Math/Vector4Dfwd.h>
@@ -57,4 +57,4 @@ class EMPhoton
 };
 
 } // namespace o2::aod::pwgem::photonmeson::utils
-#endif // PWGEM_DILEPTON_UTILS_EMPHOTON_H_
+#endif // PWGEM_PHOTONMESON_UTILS_EMPHOTON_H_

--- a/PWGEM/PhotonMeson/Utils/EMPhoton.h
+++ b/PWGEM/PhotonMeson/Utils/EMPhoton.h
@@ -1,0 +1,60 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \class to store minimal photon info
+/// \author daiki.sekihata@cern.ch
+
+#ifndef PWGEM_DILEPTON_UTILS_EMPHOTON_H_
+#define PWGEM_DILEPTON_UTILS_EMPHOTON_H_
+
+#include <Math/Vector4D.h> // IWYU pragma: keep (do not replace with Math/Vector4Dfwd.h)
+#include <Math/Vector4Dfwd.h>
+
+#include <cmath>
+#include <cstdint>
+
+#include <math.h>
+
+namespace o2::aod::pwgem::photonmeson::utils
+{
+class EMPhoton
+{
+ public:
+  EMPhoton(float pt, float eta, float phi, float mass)
+  {
+    fPt = pt;
+    fEta = eta;
+    fPhi = phi;
+    fMass = mass;
+  }
+
+  ~EMPhoton() {}
+
+  float pt() const { return fPt; }
+  float eta() const { return fEta; }
+  float phi() const { return fPhi; }
+
+  float p() const { return  fPt * std::cosh(fEta); }
+  float px() const { return fPt * std::cos(fPhi); }
+  float py() const { return fPt * std::sin(fPhi); }
+  float pz() const { return fPt * std::sinh(fEta); }
+  float mass() const { return fMass; }
+  float rapidity() const { return std::log((std::sqrt(std::pow(fMass, 2) + std::pow(fPt * std::cosh(fEta), 2)) + fPt * std::sinh(fEta)) / std::sqrt(std::pow(fMass, 2) + std::pow(fPt, 2))); }
+
+ protected:
+  float fPt;
+  float fEta;
+  float fPhi;
+  float fMass;
+};
+
+} // namespace o2::aod::pwgem::photonmeson::utils
+#endif // PWGEM_DILEPTON_UTILS_EMPHOTON_H_


### PR DESCRIPTION
Remove unnecessary variables in EMTrack for dilepton PAG.
Add EMPhoton for photon PAG.
This PR should reduce memory in event mixing for both dilepton and photon PAG.