### PR TITLE
[PWGJE] update the jet v2 in-plane and out-of-plane selection, fix several issue

### DIFF
--- a/PWGJE/Tasks/jetChargedV2.cxx
+++ b/PWGJE/Tasks/jetChargedV2.cxx
@@ -58,24 +58,27 @@ struct JetChargedV2 {
   using ChargedMCPMatchedJets = soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents, aod::ChargedMCParticleLevelJetsMatchedToChargedMCDetectorLevelJets>;
   using ChargedMCDMatchedJetsWeighted = soa::Join<aod::ChargedMCDetectorLevelJets, aod::ChargedMCDetectorLevelJetConstituents, aod::ChargedMCDetectorLevelJetsMatchedToChargedMCParticleLevelJets, aod::ChargedMCDetectorLevelJetEventWeights>;
   using ChargedMCPMatchedJetsWeighted = soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents, aod::ChargedMCParticleLevelJetsMatchedToChargedMCDetectorLevelJets, aod::ChargedMCParticleLevelJetEventWeights>;
+  using JetParticlesWithOriginal = soa::Join<aod::JetParticles, aod::JMcParticlePIs>;
 
   HistogramRegistry registry;
   HistogramRegistry histosQA{"histosQA", {}, OutputObjHandlingPolicy::AnalysisObject, false, false};
 
-  Configurable<int> centralityMode{"centralityMode", 0, "0 = FT0C (default), 1 = FT0M, 2 = FT0A"};
   Configurable<std::string> eventSelections{"eventSelections", "sel8", "choose event selection"};
-  Configurable<std::string> trackSelections{"trackSelections", "globalTracks", "set track selections"};
-  Configurable<std::vector<double>> jetRadii{"jetRadii", std::vector<double>{0.4}, "jet resolution parameters"};
-
   Configurable<float> vertexZCut{"vertexZCut", 10.0f, "Accepted z-vertex range"};
-  Configurable<float> trackDcaZmax{"trackDcaZmax", 99, "additional cut on dcaZ to PV for tracks; uniformTracks in particular don't cut on this at all"};
+  Configurable<int> centralityMode{"centralityMode", 0, "0 = FT0C (default), 1 = FT0M, 2 = FT0A"};
   Configurable<float> centralityMin{"centralityMin", -999.0, "minimum centrality"};
   Configurable<float> centralityMax{"centralityMax", 999.0, "maximum centrality"};
+
+  Configurable<std::string> trackSelections{"trackSelections", "globalTracks", "set track selections"};
+  Configurable<float> trackDcaZmax{"trackDcaZmax", 99, "additional cut on dcaZ to PV for tracks; uniformTracks in particular don't cut on this at all"};
+  Configurable<int> trackOccupancyInTimeRangeMax{"trackOccupancyInTimeRangeMax", 999999, "maximum occupancy of tracks in neighbouring collisions in a given time range; only applied to reconstructed collisions (data and mcd jets), not mc collisions (mcp jets)"};
+  Configurable<int> trackOccupancyInTimeRangeMin{"trackOccupancyInTimeRangeMin", -999999, "minimum occupancy of tracks in neighbouring collisions in a given time range; only applied to reconstructed collisions (data and mcd jets), not mc collisions (mcp jets)"};
   Configurable<float> trackPtMin{"trackPtMin", 0.15, "minimum pT acceptance for tracks"};
   Configurable<float> trackPtMax{"trackPtMax", 1000., "maximum pT acceptance for tracks"};
   Configurable<float> trackEtaMin{"trackEtaMin", -0.9, "minimum eta acceptance for tracks"};
   Configurable<float> trackEtaMax{"trackEtaMax", 0.9, "maximum eta acceptance for tracks"};
 
+  Configurable<float> selectedJetsRadius{"selectedJetsRadius", 0.2, "resolution parameter for histograms without radius"};
   Configurable<float> jetAreaFractionMin{"jetAreaFractionMin", -99.0, "used to make a cut on the jet areas"};
   Configurable<float> leadingConstituentPtMin{"leadingConstituentPtMin", -99.0, "minimum pT selection on jet constituent"};
   Configurable<float> leadingConstituentPtMax{"leadingConstituentPtMax", 9999.0, "maximum pT selection on jet constituent"};
@@ -84,18 +87,20 @@ struct JetChargedV2 {
   Configurable<float> jetEtaMin{"jetEtaMin", -0.9, "minimum eta acceptance for jets"};
   Configurable<float> jetEtaMax{"jetEtaMax", 0.9, "maximum eta acceptance for jets"};
   Configurable<int> nBinsEta{"nBinsEta", 200, "number of bins for eta axes"};
-  Configurable<float> jetRadius{"jetRadius", 0.2, "jet resolution parameters"};
   Configurable<float> randomConeLeadJetDeltaR{"randomConeLeadJetDeltaR", -99.0, "min distance between leading jet axis and random cone (RC) axis; if negative, min distance is set to automatic value of R_leadJet+R_RC "};
-
-  Configurable<float> localRhoFitPtMin{"localRhoFitPtMin", 0.2, "Minimum track pT used for local rho fluctuation fit"};
-  Configurable<float> localRhoFitPtMax{"localRhoFitPtMax", 5, "Maximum track pT used for local rho fluctuation fit"};
-
   Configurable<float> randomConeR{"randomConeR", 0.4, "size of random Cone for estimating background fluctuations"};
-  Configurable<int> trackOccupancyInTimeRangeMax{"trackOccupancyInTimeRangeMax", 999999, "maximum occupancy of tracks in neighbouring collisions in a given time range; only applied to reconstructed collisions (data and mcd jets), not mc collisions (mcp jets)"};
-  Configurable<int> trackOccupancyInTimeRangeMin{"trackOccupancyInTimeRangeMin", -999999, "minimum occupancy of tracks in neighbouring collisions in a given time range; only applied to reconstructed collisions (data and mcd jets), not mc collisions (mcp jets)"};
+
+  //=====================< tracking efficiency >=====================//
+  // Configurable<bool> checkCentrality{"checkCentrality", false, ""};
+  // Configurable<bool> checkOccupancy{"checkOccupancy", false, "check occupancy only in general purpose Pb-Pb MC, default as false"};
+  // Configurable<bool> getPtHatFromHepMCXSection{"getPtHatFromHepMCXSection", true, "test configurable, configurable should be removed once well tested"};
+
+  // Configurable<float> ptHatMin{"ptHatMin", 5, "min pT hat of collisions"};
+  // Configurable<float> ptHatMax{"ptHatMax", 300, "max pT hat of collisions"};
+  Configurable<float> pTHatExponent{"pTHatExponent", 6.0, "exponent of the event weight for the calculation of pTHat"};
+  // Configurable<float> pTHatMaxFractionMCD{"pTHatMaxFractionMCD", 999.0, "maximum fraction of hard scattering for reconstructed track acceptance in MC"};
 
   //=====================< evt pln >=====================//
-  Configurable<bool> cfgAddEvtSel{"cfgAddEvtSel", true, "event selection"};
   Configurable<std::vector<int>> cfgnMods{"cfgnMods", {2}, "Modulation of interest"};
   Configurable<int> cfgnTotalSystem{"cfgnTotalSystem", 7, "total qvector number"};
   Configurable<std::string> cfgDetName{"cfgDetName", "FT0M", "The name of detector to be analyzed"};
@@ -115,11 +120,10 @@ struct JetChargedV2 {
   int refBId;
 
   //=====================< jetSpectraConfig to this analysis >=====================//
-  Configurable<float> pTHatExponent{"pTHatExponent", 6.0, "exponent of the event weight for the calculation of pTHat"};
   Configurable<int> acceptSplitCollisions{"acceptSplitCollisions", 0, "0: only look at mcCollisions that are not split; 1: accept split mcCollisions, 2: accept split mcCollisions but only look at the first reco collision associated with it"};
   Configurable<float> pTHatAbsoluteMin{"pTHatAbsoluteMin", -99.0, "minimum value of pTHat"};
+  Configurable<bool> applyRCTSelections{"applyRCTSelections", true, "decide to apply RCT selections"};
   Configurable<bool> skipMBGapEvents{"skipMBGapEvents", false, "flag to choose to reject min. bias gap events; jet-level rejection can also be applied at the jet finder level for jets only, here rejection is applied for collision and track process functions for the first time, and on jets in case it was set to false at the jet finder level"};
-  Configurable<bool> checkMcCollisionIsMatched{"checkMcCollisionIsMatched", false, "0: count whole MCcollisions, 1: select MCcollisions which only have their correspond collisions"};
   Configurable<float> pTHatMaxMCD{"pTHatMaxMCD", 999.0, "maximum fraction of hard scattering for jet acceptance in detector MC"};
   Configurable<float> pTHatMaxMCP{"pTHatMaxMCP", 999.0, "maximum fraction of hard scattering for jet acceptance in particle MC"};
   Configurable<bool> checkLeadConstituentPtForMcpJets{"checkLeadConstituentPtForMcpJets", false, "flag to choose whether particle level jets should have their lead track pt above leadingConstituentPtMin to be accepted; off by default, as leadingConstituentPtMin cut is only applied on MCD jets for the Pb-Pb analysis using pp MC anchored to Pb-Pb for the response matrix"};
@@ -127,9 +131,8 @@ struct JetChargedV2 {
   Configurable<bool> subtractMCPBackground{"subtractMCPBackground", true, "subtract MCP Background with General Purpose anchored MC"};
   Configurable<bool> useMedianRho{"useMedianRho", false, "use median rho for subtract MCP Background"};
   Configurable<bool> useLocalRho{"useLocalRho", false, "use local rho for subtract MCP Background"};
+  Configurable<bool> isMCGenOnly{"isMCGenOnly", false, "analysis is run over mcGen only"};
 
-  float configSwitchLow = -98.0;
-  float configSwitchHigh = 9998.0;
   enum AcceptSplitCollisionsOptions {
     NonSplitOnly = 0,
     SplitOkCheckAnyAssocColl,      // 1
@@ -161,17 +164,12 @@ struct JetChargedV2 {
     }
   }
   //=====================< evt p615ln | end >=====================//
-
-  Configurable<float> selectedJetsRadius{"selectedJetsRadius", 0.2, "resolution parameter for histograms without radius"};
-
   std::vector<double> jetPtBins;
   std::vector<double> jetPtBinsRhoAreaSub;
 
   std::vector<int> eventSelectionBits;
   int trackSelection = -1;
   double evtnum = 0;
-  double accptTrack = 0;
-  double fitTrack = 0;
   float collQvecAmpDetId = 1e-8;
   TH1F* hPtsumSumptFit = nullptr;
   TH1F* hPtsumSumptFitMCP = nullptr;
@@ -179,6 +177,7 @@ struct JetChargedV2 {
   TF1* fFitModulationV2v3P = 0x0;
   TH1F* hPtsumSumptFitRM = nullptr;
   TF1* fFitModulationRM = 0x0;
+  TRandom3 randomNumber{};
 
   void init(o2::framework::InitContext&)
   {
@@ -190,12 +189,6 @@ struct JetChargedV2 {
       detId = 0;
       refAId = 4;
       refBId = 5;
-    }
-    auto jetRadiiBins = (std::vector<double>)jetRadii;
-    if (jetRadiiBins.size() > 1) {
-      jetRadiiBins.push_back(jetRadiiBins[jetRadiiBins.size() - 1] + (std::abs(jetRadiiBins[jetRadiiBins.size() - 1] - jetRadiiBins[jetRadiiBins.size() - 2])));
-    } else {
-      jetRadiiBins.push_back(jetRadiiBins[jetRadiiBins.size() - 1] + 0.1);
     }
 
     auto jetPtTemp = 0.0;
@@ -240,6 +233,7 @@ struct JetChargedV2 {
 
     eventSelectionBits = jetderiveddatautilities::initialiseEventSelectionBits(static_cast<std::string>(eventSelections));
     trackSelection = jetderiveddatautilities::initialiseTrackSelection(static_cast<std::string>(trackSelections));
+    randomNumber.SetSeed(0);
 
     if (doprocessCollisions || doprocessCollisionsWeighted) {
       registry.add("h_collisions", "number of events;event status;entries", {HistType::kTH1F, {{4, 0.0, 4.0}}});
@@ -336,8 +330,11 @@ struct JetChargedV2 {
       registry.add("h_fitparaPsi2_evtnum", "fitparameter #Psi_{2} vs evtnum ; #eventnumber", {HistType::kTH1F, {{1000, 0.0, 1000}}});
       registry.add("h_fitparaPsi3_evtnum", "fitparameter #Psi_{3} vs evtnum ; #eventnumber", {HistType::kTH1F, {{1000, 0.0, 1000}}});
       registry.add("h_evtnum_centrlity", "eventNumber vs centrality ; #eventNumber", {HistType::kTH1F, {{1000, 0.0, 1000}}});
+      registry.add("h_badfit_counter", "bad fit para[1] count; #eventNumber", {HistType::kTH1F, {{5, 0.0, 5}}});
 
       registry.add("h2_phi_rholocal", "#varphi vs #rho(#varphi); #varphi - #Psi_{EP,2};  #rho(#varphi) ", {HistType::kTH2F, {{40, 0., o2::constants::math::TwoPI}, {210, -10.0, 200.0}}});
+      registry.add("h2_phi_rholocal_absDelta", "#varphi vs #rho(#varphi), absDelta; #varphi - #Psi_{EP,2};  #rho(#varphi) ", {HistType::kTH2F, {{40, 0., o2::constants::math::TwoPI}, {210, -10.0, 200.0}}});
+
       registry.add("h2_rholocal_cent", "#varphi vs #rho(#varphi); #cent;  #rho(#varphi) ", {HistType::kTH2F, {{100, 0., 100}, {210, -10.0, 200.0}}});
       //< \sigma p_T at local rho test plot | end >
 
@@ -352,6 +349,11 @@ struct JetChargedV2 {
       registry.add("h3_centrality_deltapT_RandomCornPhi_localrhovsphi", "centrality; #it{p}_{T,random cone} - #it{area, random cone} * #it{rho}; #Delta#varphi_{jet}", {HistType::kTH3F, {{100, 0.0, 100.0}, {400, -200.0, 200.0}, {100, 0., o2::constants::math::TwoPI}}});
 
       registry.add("h3_centrality_deltapT_RandomCornPhi_localrhovsphiwithoutleadingjet", "centrality; #it{p}_{T,random cone} - #it{area, random cone} * #it{rho}(#varphi); #Delta#varphi_{jet}", {HistType::kTH3F, {{100, 0.0, 100.0}, {400, -200.0, 200.0}, {100, 0., o2::constants::math::TwoPI}}});
+
+      registry.add("h1_distribution_RC", "RC #phi-#Psi_{2}", {HistType::kTH1F, {{72, 0.0, o2::constants::math::TwoPI}}});
+      registry.add("h1_distribution_random", "RC #phi-#Psi_{2}", {HistType::kTH1F, {{72, 0.0, o2::constants::math::TwoPI}}});
+      registry.add("h3_randomizedPhi_check", "centrality; #it{p}_{T,random cone} - #it{area, random cone} * #it{rho}(#varphi); #Delta#varphi_{jet}", {HistType::kTH3F, {{100, 0.0, 100.0}, {400, -200.0, 200.0}, {100, 0., o2::constants::math::TwoPI}}});
+
       //< bkg sub plot | end >//
       //< median rho >//
       registry.add("h_jet_pt_in_plane_v2", "jet pT;#it{p}^{in-plane}_{T,jet} (GeV/#it{c});entries", {HistType::kTH1F, {jetPtAxisRhoAreaSub}});
@@ -378,6 +380,7 @@ struct JetChargedV2 {
     }
 
     if (doprocessSigmaPtMCP || doprocessSigmaPtAreaSubMCP) {
+      registry.add("h_mccollisions_zvertex_mcp", "position of mc collision in mcp process ;#it{Z} (cm)", {HistType::kTH1F, {{300, -15.0, 15.0}}});
       registry.add("h_jet_pt_part", "partvjet pT;#it{p}_{T,jet}^{part} (GeV/#it{c}); counts", {HistType::kTH1F, {jetPtAxis}});
       registry.add("h_jet_eta_part", "part jet #eta;#eta^{part}; counts", {HistType::kTH1F, {jetEtaAxis}});
       registry.add("h_jet_phi_part", "part jet #varphi;#phi^{part}; counts", {HistType::kTH1F, {phiAxis}});
@@ -570,7 +573,7 @@ struct JetChargedV2 {
         registry.fill(HIST("h_collisions_weighted"), 0.5, eventWeight);
     }
 
-    if (!jetderiveddatautilities::selectCollision(collision, eventSelectionBits, skipMBGapEvents)) {
+    if (!jetderiveddatautilities::selectCollision(collision, eventSelectionBits, skipMBGapEvents, applyRCTSelections)) {
       return false;
     }
     if (fillHistograms) {
@@ -606,6 +609,13 @@ struct JetChargedV2 {
   template <typename TMCColl, typename TCollisions>
   bool applyMCCollisionCuts(TMCColl const& mccollision, TCollisions const& collisions, bool fillHistograms = false, bool isWeighted = false, float eventWeight = 1.0)
   {
+    if (isMCGenOnly) {
+      if (fillHistograms) {
+        registry.fill(HIST("h_mccollisions"), 0.5);
+      }
+      return true;
+    } // if isMCGenOnly is true, skip MC selection and accept all of them
+
     float centrality = -1.0;
     centrality = mccollision.centFT0M();
 
@@ -640,7 +650,7 @@ struct JetChargedV2 {
     bool centralityIsGood = false;
     bool occupancyIsGood = false;
     if (acceptSplitCollisions == SplitOkCheckFirstAssocCollOnly) {
-      if (jetderiveddatautilities::selectCollision(collisions.begin(), eventSelectionBits, skipMBGapEvents)) {
+      if (jetderiveddatautilities::selectCollision(collisions.begin(), eventSelectionBits, skipMBGapEvents, applyRCTSelections)) {
         hasSel8Coll = true;
       }
       if ((trackOccupancyInTimeRangeMin < collisions.begin().trackOccupancyInTimeRange()) && (collisions.begin().trackOccupancyInTimeRange() < trackOccupancyInTimeRangeMax)) {
@@ -652,7 +662,7 @@ struct JetChargedV2 {
       }
     } else {
       for (auto const& collision : collisions) {
-        if (jetderiveddatautilities::selectCollision(collision, eventSelectionBits, skipMBGapEvents)) {
+        if (jetderiveddatautilities::selectCollision(collision, eventSelectionBits, skipMBGapEvents, applyRCTSelections)) {
           hasSel8Coll = true;
         }
         if ((trackOccupancyInTimeRangeMin < collision.trackOccupancyInTimeRange()) && (collision.trackOccupancyInTimeRange() < trackOccupancyInTimeRangeMax)) {
@@ -738,13 +748,14 @@ struct JetChargedV2 {
 
   // leading jet fill
   template <typename T>
-  void fillLeadingJetQA(T const& jets, double& leadingJetPt, double& leadingJetPhi, double& leadingJetEta)
+  void fillLeadingJetQA(T const& jets, double& leadingJetPt, double& leadingJetPhi, double& leadingJetEta, double& leadingJetR)
   {
     for (const auto& jet : jets) {
       if (jet.pt() > leadingJetPt) {
         leadingJetPt = jet.pt();
         leadingJetEta = jet.eta();
         leadingJetPhi = jet.phi();
+        leadingJetR = jet.r() / 100.0;
       }
     }
     registry.fill(HIST("leadJetPt"), leadingJetPt);
@@ -758,7 +769,9 @@ struct JetChargedV2 {
   {
     if (jets.size() > 0) {
       for (auto const& track : tracks) {
-        if (jetderiveddatautilities::selectTrack(track, trackSelection) && (std::fabs(track.eta() - leadingJetEta) > jetRadius) && track.pt() >= localRhoFitPtMin && track.pt() <= localRhoFitPtMax) {
+        double localRhoFitPtMin = 0.2;
+        double localRhoFitPtMax = 5;
+        if (jetderiveddatautilities::selectTrack(track, trackSelection) && (std::fabs(track.eta() - leadingJetEta) > selectedJetsRadius) && track.pt() >= localRhoFitPtMin && track.pt() <= localRhoFitPtMax) {
           registry.fill(HIST("h_accept_Track"), 4.5);
           nTrk += 1;
         }
@@ -772,16 +785,18 @@ struct JetChargedV2 {
   void fillNtrkCheck(U const& tracks, J const& jets, TH1F* hPtsumSumptFit, double& leadingJetEta)
   {
     if (jets.size() > 0) {
+      double localRhoFitPtMin = 0.2;
+      double localRhoFitPtMax = 5;
       for (auto const& trackfit : tracks) {
         registry.fill(HIST("h_accept_Track"), 0.5);
-        if (jetderiveddatautilities::selectTrack(trackfit, trackSelection) && (std::fabs(trackfit.eta() - leadingJetEta) > jetRadius) && trackfit.pt() >= localRhoFitPtMin && trackfit.pt() <= localRhoFitPtMax) {
+        if (jetderiveddatautilities::selectTrack(trackfit, trackSelection) && (std::fabs(trackfit.eta() - leadingJetEta) > selectedJetsRadius) && trackfit.pt() >= localRhoFitPtMin && trackfit.pt() <= localRhoFitPtMax) {
           registry.fill(HIST("h_accept_Track"), 1.5);
         }
       }
 
       for (auto const& track : tracks) {
         registry.fill(HIST("h_accept_Track"), 2.5);
-        if (jetderiveddatautilities::selectTrack(track, trackSelection) && (std::fabs(track.eta() - leadingJetEta) > jetRadius) && track.pt() >= localRhoFitPtMin && track.pt() <= localRhoFitPtMax) {
+        if (jetderiveddatautilities::selectTrack(track, trackSelection) && (std::fabs(track.eta() - leadingJetEta) > selectedJetsRadius) && track.pt() >= localRhoFitPtMin && track.pt() <= localRhoFitPtMax) {
           registry.fill(HIST("h_accept_Track"), 3.5);
           hPtsumSumptFit->Fill(track.phi(), track.pt());
         }
@@ -875,7 +890,7 @@ struct JetChargedV2 {
     temppara[3] = fFitModulationV2v3P->GetParameter(3);
     temppara[4] = fFitModulationV2v3P->GetParameter(4);
     if (temppara[0] == 0) {
-      return;
+      registry.fill(HIST("h_badfit_counter"), 1);
     }
     registry.fill(HIST("h_mcp_fitparaRho_evtnum"), evtnum, temppara[0]);
     registry.fill(HIST("h_mcp_fitparaPsi2_evtnum"), evtnum, temppara[2]);
@@ -899,8 +914,8 @@ struct JetChargedV2 {
           continue;
         }
 
-        double integralValue = fFitModulationV2v3P->Integral(jet.phi() - jetRadius, jet.phi() + jetRadius);
-        double rholocal = collision.rho() / (2 * jetRadius * temppara[0]) * integralValue;
+        double integralValue = fFitModulationV2v3P->Integral(jet.phi() - selectedJetsRadius, jet.phi() + selectedJetsRadius);
+        double rholocal = collision.rho() / (2 * selectedJetsRadius * temppara[0]) * integralValue;
         registry.fill(HIST("h2_mcp_phi_rholocal"), jet.phi() - ep2, rholocal, weight);
         registry.fill(HIST("h2_mcp_centrality_rholocal"), centrality, rholocal, weight);
         if (nmode == cfgNmodA) {
@@ -910,8 +925,10 @@ struct JetChargedV2 {
           if (collision.qvecAmp()[detId] < collQvecAmpDetId) {
             continue;
           }
-          phiMinusPsi2 = jet.phi() - ep2;
-          if ((phiMinusPsi2 < o2::constants::math::PIQuarter) || (phiMinusPsi2 >= evtPlnAngleA * o2::constants::math::PIQuarter) || (phiMinusPsi2 >= evtPlnAngleB * o2::constants::math::PIQuarter && phiMinusPsi2 < evtPlnAngleC * o2::constants::math::PIQuarter)) {
+          // phiMinusPsi2 = jet.phi() - ep2;
+          phiMinusPsi2 = RecoDecay::constrainAngle(jet.phi() - ep2, -o2::constants::math::PI);
+          float absDelta = std::abs(phiMinusPsi2);
+          if ((absDelta < o2::constants::math::PIQuarter) || (absDelta >= evtPlnAngleA * o2::constants::math::PIQuarter) || (absDelta >= evtPlnAngleB * o2::constants::math::PIQuarter && absDelta < evtPlnAngleC * o2::constants::math::PIQuarter)) {
             registry.fill(HIST("h_mcp_jet_pt_in_plane_v2_rho"), jet.pt() - (rholocal * jet.area()), weight);
             registry.fill(HIST("h2_mcp_centrality_jet_pt_in_plane_v2_rho"), centrality, jet.pt() - (rholocal * jet.area()), weight);
           } else {
@@ -920,96 +937,20 @@ struct JetChargedV2 {
           }
         } else if (nmode == cfgNmodB) {
           double phiMinusPsi3;
+
           if (collision.qvecAmp()[detId] < collQvecAmpDetId) {
             continue;
           }
           ep3 = helperEP.GetEventPlane(collision.qvecRe()[detInd], collision.qvecIm()[detInd], nmode);
-          phiMinusPsi3 = jet.phi() - ep3;
-
-          if ((phiMinusPsi3 < o2::constants::math::PIQuarter) || (phiMinusPsi3 >= evtPlnAngleA * o2::constants::math::PIQuarter) || (phiMinusPsi3 >= evtPlnAngleB * o2::constants::math::PIQuarter && phiMinusPsi3 < evtPlnAngleC * o2::constants::math::PIQuarter)) {
+          // phiMinusPsi3 = jet.phi() - ep3;
+          phiMinusPsi3 = RecoDecay::constrainAngle(jet.phi() - ep3, -o2::constants::math::PI);
+          float absDelta3 = std::abs(phiMinusPsi3);
+          if ((absDelta3 < o2::constants::math::PIQuarter) || (absDelta3 >= evtPlnAngleA * o2::constants::math::PIQuarter) || (absDelta3 >= evtPlnAngleB * o2::constants::math::PIQuarter && absDelta3 < evtPlnAngleC * o2::constants::math::PIQuarter)) {
             registry.fill(HIST("h_mcp_jet_pt_in_plane_v3_rho"), jet.pt() - (rholocal * jet.area()), weight);
             registry.fill(HIST("h2_mcp_centrality_jet_pt_in_plane_v3_rho"), centrality, jet.pt() - (rholocal * jet.area()), weight);
           } else {
             registry.fill(HIST("h_mcp_jet_pt_out_of_plane_v3_rho"), jet.pt() - (rholocal * jet.area()), weight);
             registry.fill(HIST("h2_mcp_centrality_jet_pt_out_of_plane_v3_rho"), centrality, jet.pt() - (rholocal * jet.area()), weight);
-          }
-        }
-      }
-    }
-  }
-
-  // Run jet-jet MC MCP leading jet fill
-  template <typename U, typename J>
-  void fitFncMCP(U const& collision, J const& jets, bool mcLevelIsParticleLevel, float weight = 1.0)
-  {
-    double ep2 = 0.;
-    double ep3 = 0.;
-    int cfgNmodA = 2;
-    int cfgNmodB = 3;
-    int evtPlnAngleA = 7;
-    int evtPlnAngleB = 3;
-    int evtPlnAngleC = 5;
-    for (uint i = 0; i < cfgnMods->size(); i++) {
-      int nmode = cfgnMods->at(i);
-      int detInd = detId * 4 + cfgnTotalSystem * 4 * (nmode - 2);
-      if (nmode == cfgNmodA) {
-        if (collision.qvecAmp()[detId] > collQvecAmpDetId) {
-          ep2 = helperEP.GetEventPlane(collision.qvecRe()[detInd + 3], collision.qvecIm()[detInd + 3], nmode);
-        }
-      } else if (nmode == cfgNmodB) {
-        if (collision.qvecAmp()[detId] > collQvecAmpDetId) {
-          ep3 = helperEP.GetEventPlane(collision.qvecRe()[detInd + 3], collision.qvecIm()[detInd + 3], nmode);
-        }
-      }
-    }
-    registry.fill(HIST("h_mcp_evtnum_centrlity"), evtnum, collision.centFT0M());
-    registry.fill(HIST("h_ep2_evtnum"), evtnum, ep2);
-    registry.fill(HIST("h_ep3_evtnum"), evtnum, ep3);
-
-    for (uint i = 0; i < cfgnMods->size(); i++) {
-      int nmode = cfgnMods->at(i);
-      int detInd = detId * 4 + cfgnTotalSystem * 4 * (nmode - 2);
-
-      for (auto const& jet : jets) {
-        if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
-          continue;
-        }
-        if (!isAcceptedJet<aod::JetParticles>(jet, mcLevelIsParticleLevel)) {
-          continue;
-        }
-        if (jet.r() != round(selectedJetsRadius * 100.0f)) {
-          continue;
-        }
-
-        if (nmode == cfgNmodA) {
-          registry.fill(HIST("h_mcp_jet_pt_rhoareasubtracted"), jet.pt(), weight);
-
-          double phiMinusPsi2;
-          if (collision.qvecAmp()[detId] < collQvecAmpDetId) {
-            continue;
-          }
-          phiMinusPsi2 = jet.phi() - ep2;
-          if ((phiMinusPsi2 < o2::constants::math::PIQuarter) || (phiMinusPsi2 >= evtPlnAngleA * o2::constants::math::PIQuarter) || (phiMinusPsi2 >= evtPlnAngleB * o2::constants::math::PIQuarter && phiMinusPsi2 < evtPlnAngleC * o2::constants::math::PIQuarter)) {
-            registry.fill(HIST("h_mcp_jet_pt_in_plane_v2_rho"), jet.pt(), weight);
-            registry.fill(HIST("h2_mcp_centrality_jet_pt_in_plane_v2_rho"), collision.centFT0M(), jet.pt(), weight);
-          } else {
-            registry.fill(HIST("h_mcp_jet_pt_out_of_plane_v2_rho"), jet.pt(), weight);
-            registry.fill(HIST("h2_mcp_centrality_jet_pt_out_of_plane_v2_rho"), collision.centFT0M(), jet.pt(), weight);
-          }
-        } else if (nmode == cfgNmodB) {
-          double phiMinusPsi3;
-          if (collision.qvecAmp()[detId] < collQvecAmpDetId) {
-            continue;
-          }
-          ep3 = helperEP.GetEventPlane(collision.qvecRe()[detInd], collision.qvecIm()[detInd], nmode);
-          phiMinusPsi3 = jet.phi() - ep3;
-
-          if ((phiMinusPsi3 < o2::constants::math::PIQuarter) || (phiMinusPsi3 >= evtPlnAngleA * o2::constants::math::PIQuarter) || (phiMinusPsi3 >= evtPlnAngleB * o2::constants::math::PIQuarter && phiMinusPsi3 < evtPlnAngleC * o2::constants::math::PIQuarter)) {
-            registry.fill(HIST("h_mcp_jet_pt_in_plane_v3_rho"), jet.pt(), weight);
-            registry.fill(HIST("h2_mcp_centrality_jet_pt_in_plane_v3_rho"), collision.centFT0M(), jet.pt(), weight);
-          } else {
-            registry.fill(HIST("h_mcp_jet_pt_out_of_plane_v3_rho"), jet.pt(), weight);
-            registry.fill(HIST("h2_mcp_centrality_jet_pt_out_of_plane_v3_rho"), collision.centFT0M(), jet.pt(), weight);
           }
         }
       }
@@ -1054,13 +995,6 @@ struct JetChargedV2 {
     }
   }
 
-  template <typename TTracks>
-  void fillTrackHistograms(TTracks const& track, float weight = 1.0)
-  {
-    registry.fill(HIST("h_track_pt"), track.pt(), weight);
-    registry.fill(HIST("h2_track_eta_track_phi"), track.eta(), track.phi(), weight);
-  }
-
   template <typename TBase, typename TTag>
   void fillGeoMatchedHistograms(TBase const& jetMCD, double ep2, float rho, float mcrho = 0.0, float weight = 1.0)
   {
@@ -1077,14 +1011,17 @@ struct JetChargedV2 {
           int evtPlnAngleA = 7;
           int evtPlnAngleB = 3;
           int evtPlnAngleC = 5;
-          double phiMinusPsi2 = jetMCD.phi() - ep2;
+          double phiMinusPsi2;
+          // double phiMinusPsi2 = jetMCD.phi() - ep2;
+          phiMinusPsi2 = RecoDecay::constrainAngle(jetMCD.phi() - ep2, -o2::constants::math::PI);
+          float absDelta = std::abs(phiMinusPsi2);
           double corrTagjetpt = jetMCP.pt() - (mcrho * jetMCP.area());
           double corrBasejetpt = jetMCD.pt() - (rho * jetMCD.area());
           double dcorrpt = corrTagjetpt - corrBasejetpt;
           if (jetfindingutilities::isInEtaAcceptance(jetMCD, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
             registry.fill(HIST("h2_jet_pt_mcd_jet_pt_mcp_matchedgeo_mcdetaconstraint"), corrBasejetpt, corrTagjetpt, weight);
             registry.fill(HIST("h2_jet_pt_mcd_jet_pt_diff_matchedgeo"), corrBasejetpt, dcorrpt / corrBasejetpt, weight);
-            if ((phiMinusPsi2 < o2::constants::math::PIQuarter) || (phiMinusPsi2 >= evtPlnAngleA * o2::constants::math::PIQuarter) || (phiMinusPsi2 >= evtPlnAngleB * o2::constants::math::PIQuarter && phiMinusPsi2 < evtPlnAngleC * o2::constants::math::PIQuarter)) {
+            if ((absDelta < o2::constants::math::PIQuarter) || (absDelta >= evtPlnAngleA * o2::constants::math::PIQuarter) || (absDelta >= evtPlnAngleB * o2::constants::math::PIQuarter && absDelta < evtPlnAngleC * o2::constants::math::PIQuarter)) {
               registry.fill(HIST("h2_jet_pt_mcd_jet_pt_mcp_matchedgeo_in_mcdetaconstraint"), corrBasejetpt, corrTagjetpt, weight);
               registry.fill(HIST("h2_jet_pt_mcd_jet_pt_diff_matchedgeo_in"), corrBasejetpt, dcorrpt / corrBasejetpt, weight);
             } else {
@@ -1096,7 +1033,7 @@ struct JetChargedV2 {
             registry.fill(HIST("h2_jet_pt_mcd_jet_pt_mcp_matchedgeo_mcpetaconstraint"), corrBasejetpt, corrTagjetpt, weight);
             registry.fill(HIST("h2_jet_pt_mcp_jet_pt_diff_matchedgeo"), corrTagjetpt, dcorrpt / corrTagjetpt, weight);
             registry.fill(HIST("h2_jet_pt_mcp_jet_pt_ratio_matchedgeo"), corrTagjetpt, corrBasejetpt / corrTagjetpt, weight);
-            if ((phiMinusPsi2 < o2::constants::math::PIQuarter) || (phiMinusPsi2 >= evtPlnAngleA * o2::constants::math::PIQuarter) || (phiMinusPsi2 >= evtPlnAngleB * o2::constants::math::PIQuarter && phiMinusPsi2 < evtPlnAngleC * o2::constants::math::PIQuarter)) {
+            if ((absDelta < o2::constants::math::PIQuarter) || (absDelta >= evtPlnAngleA * o2::constants::math::PIQuarter) || (absDelta >= evtPlnAngleB * o2::constants::math::PIQuarter && absDelta < evtPlnAngleC * o2::constants::math::PIQuarter)) {
               registry.fill(HIST("h2_jet_pt_mcd_jet_pt_mcp_matchedgeo_in_mcpetaconstraint"), corrBasejetpt, corrTagjetpt, weight);
               registry.fill(HIST("h2_jet_pt_mcp_jet_pt_diff_matchedgeo_in"), corrTagjetpt, dcorrpt / corrTagjetpt, weight);
               registry.fill(HIST("h2_jet_pt_mcp_jet_pt_ratio_matchedgeo_in"), corrTagjetpt, corrBasejetpt / corrTagjetpt, weight);
@@ -1139,23 +1076,26 @@ struct JetChargedV2 {
           int evtPlnAngleA = 7;
           int evtPlnAngleB = 3;
           int evtPlnAngleC = 5;
-          double integralValue = fFitModulationRM->Integral(jetMCD.phi() - jetRadius, jetMCD.phi() + jetRadius);
-          double rholocal = rho / (2 * jetRadius * tempparaA) * integralValue;
+          double integralValue = fFitModulationRM->Integral(jetMCD.phi() - selectedJetsRadius, jetMCD.phi() + selectedJetsRadius);
+          double rholocal = rho / (2 * selectedJetsRadius * tempparaA) * integralValue;
           double corrBasejetpt = jetMCD.pt() - (rholocal * jetMCD.area());
           double corrTagjetpt;
           if (subtractMCPBackground) {
-            double integralValueMCP = fFitModulationRM->Integral(jetMCP.phi() - jetRadius, jetMCP.phi() + jetRadius);
-            double rholocalMCP = mcrho / (2 * jetRadius * tempparaA) * integralValueMCP;
+            double integralValueMCP = fFitModulationRM->Integral(jetMCP.phi() - selectedJetsRadius, jetMCP.phi() + selectedJetsRadius);
+            double rholocalMCP = mcrho / (2 * selectedJetsRadius * tempparaA) * integralValueMCP;
             corrTagjetpt = jetMCP.pt() - (rholocalMCP * jetMCP.area());
           } else {
             corrTagjetpt = jetMCP.pt() - (mcrho * jetMCP.area());
           }
           double dcorrpt = corrTagjetpt - corrBasejetpt;
-          double phiMinusPsi2 = jetMCD.phi() - ep2;
+          double phiMinusPsi2;
+          // double phiMinusPsi2 = jetMCD.phi() - ep2;
+          phiMinusPsi2 = RecoDecay::constrainAngle(jetMCD.phi() - ep2, -o2::constants::math::PI);
+          float absDelta = std::abs(phiMinusPsi2);
           if (jetfindingutilities::isInEtaAcceptance(jetMCD, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
             registry.fill(HIST("h2_jet_pt_mcd_jet_pt_mcp_matchedgeo_incl_rhoareasubtracted_mcdetaconstraint"), corrBasejetpt, corrTagjetpt, weight);
             registry.fill(HIST("h2_jet_pt_mcd_jet_pt_diff_matchedgeo_incl_rhoareasubtracted"), corrBasejetpt, dcorrpt / corrBasejetpt, weight);
-            if ((phiMinusPsi2 < o2::constants::math::PIQuarter) || (phiMinusPsi2 >= evtPlnAngleA * o2::constants::math::PIQuarter) || (phiMinusPsi2 >= evtPlnAngleB * o2::constants::math::PIQuarter && phiMinusPsi2 < evtPlnAngleC * o2::constants::math::PIQuarter)) {
+            if ((absDelta < o2::constants::math::PIQuarter) || (absDelta >= evtPlnAngleA * o2::constants::math::PIQuarter) || (absDelta >= evtPlnAngleB * o2::constants::math::PIQuarter && absDelta < evtPlnAngleC * o2::constants::math::PIQuarter)) {
               registry.fill(HIST("h2_jet_pt_mcd_jet_pt_mcp_matchedgeo_in_rhoareasubtracted_mcdetaconstraint"), corrBasejetpt, corrTagjetpt, weight);
               registry.fill(HIST("h2_jet_pt_mcd_jet_pt_diff_matchedgeo_in_rhoareasubtracted"), corrBasejetpt, dcorrpt / corrBasejetpt, weight);
             } else {
@@ -1167,7 +1107,7 @@ struct JetChargedV2 {
             registry.fill(HIST("h2_jet_pt_mcd_jet_pt_mcp_matchedgeo_incl_rhoareasubtracted_mcpetaconstraint"), corrBasejetpt, corrTagjetpt, weight);
             registry.fill(HIST("h2_jet_pt_mcp_jet_pt_diff_matchedgeo_incl_rhoareasubtracted"), corrTagjetpt, dcorrpt / corrTagjetpt, weight);
             registry.fill(HIST("h2_jet_pt_mcp_jet_pt_ratio_matchedgeo_incl_rhoareasubtracted"), corrTagjetpt, corrBasejetpt / corrTagjetpt, weight);
-            if ((phiMinusPsi2 < o2::constants::math::PIQuarter) || (phiMinusPsi2 >= evtPlnAngleA * o2::constants::math::PIQuarter) || (phiMinusPsi2 >= evtPlnAngleB * o2::constants::math::PIQuarter && phiMinusPsi2 < evtPlnAngleC * o2::constants::math::PIQuarter)) {
+            if ((absDelta < o2::constants::math::PIQuarter) || (absDelta >= evtPlnAngleA * o2::constants::math::PIQuarter) || (absDelta >= evtPlnAngleB * o2::constants::math::PIQuarter && absDelta < evtPlnAngleC * o2::constants::math::PIQuarter)) {
               registry.fill(HIST("h2_jet_pt_mcd_jet_pt_mcp_matchedgeo_in_rhoareasubtracted_mcpetaconstraint"), corrBasejetpt, corrTagjetpt, weight);
               registry.fill(HIST("h2_jet_pt_mcp_jet_pt_diff_matchedgeo_in_rhoareasubtracted"), corrTagjetpt, dcorrpt / corrTagjetpt, weight);
               registry.fill(HIST("h2_jet_pt_mcp_jet_pt_ratio_matchedgeo_in_rhoareasubtracted"), corrTagjetpt, corrBasejetpt / corrTagjetpt, weight);
@@ -1290,13 +1230,6 @@ struct JetChargedV2 {
         continue;
       }
     }
-
-    if (collision.trackOccupancyInTimeRange() < trackOccupancyInTimeRangeMin || trackOccupancyInTimeRangeMax < collision.trackOccupancyInTimeRange()) {
-      return;
-    }
-    if (!jetderiveddatautilities::selectCollision(collision, eventSelectionBits)) {
-      return;
-    }
     //=====================< evt pln [n=2->\Psi_2, n=3->\Psi_3] >=====================//
     histosQA.fill(HIST("histCent"), collision.cent());
 
@@ -1310,7 +1243,7 @@ struct JetChargedV2 {
       int refBInd = refBId * 4 + cfgnTotalSystem * 4 * (nmode - 2);
 
       if (nmode == cfgNmodA) {
-        if (collision.qvecAmp()[detId] > collQvecAmpDetId || collision.qvecAmp()[refAId] < collQvecAmpDetId || collision.qvecAmp()[refBId] < collQvecAmpDetId) {
+        if (collision.qvecAmp()[detId] > collQvecAmpDetId && collision.qvecAmp()[refAId] > collQvecAmpDetId && collision.qvecAmp()[refBId] > collQvecAmpDetId) {
           histosQA.fill(HIST("histQvecUncorV2"), collision.qvecRe()[detInd], collision.qvecIm()[detInd], collision.cent());
           histosQA.fill(HIST("histQvecRectrV2"), collision.qvecRe()[detInd + 1], collision.qvecIm()[detInd + 1], collision.cent());
           histosQA.fill(HIST("histQvecTwistV2"), collision.qvecRe()[detInd + 2], collision.qvecIm()[detInd + 2], collision.cent());
@@ -1379,8 +1312,10 @@ struct JetChargedV2 {
           }
           registry.fill(HIST("h_jet_pt_rhoareasubtracted"), jet.pt() - (collision.rho() * jet.area()), 1.0);
 
-          phiMinusPsi2 = jet.phi() - ep2;
-          if ((phiMinusPsi2 < o2::constants::math::PIQuarter) || (phiMinusPsi2 >= evtPlnAngleA * o2::constants::math::PIQuarter) || (phiMinusPsi2 >= evtPlnAngleB * o2::constants::math::PIQuarter && phiMinusPsi2 < evtPlnAngleC * o2::constants::math::PIQuarter)) {
+          // phiMinusPsi2 = jet.phi() - ep2;
+          phiMinusPsi2 = RecoDecay::constrainAngle(jet.phi() - ep2, -o2::constants::math::PI);
+          float absDelta = std::abs(phiMinusPsi2);
+          if ((absDelta < o2::constants::math::PIQuarter) || (absDelta >= evtPlnAngleA * o2::constants::math::PIQuarter) || (absDelta >= evtPlnAngleB * o2::constants::math::PIQuarter && absDelta < evtPlnAngleC * o2::constants::math::PIQuarter)) {
             registry.fill(HIST("h_jet_pt_in_plane_v2"), jet.pt() - (collision.rho() * jet.area()), 1.0);
             registry.fill(HIST("h2_centrality_jet_pt_in_plane_v2"), centrality, jet.pt() - (collision.rho() * jet.area()), 1.0);
           } else {
@@ -1401,9 +1336,10 @@ struct JetChargedV2 {
           if (jet.r() != round(selectedJetsRadius * 100.0f)) {
             continue;
           }
-          phiMinusPsi3 = jet.phi() - ep3;
-
-          if ((phiMinusPsi3 < o2::constants::math::PIQuarter) || (phiMinusPsi3 >= evtPlnAngleA * o2::constants::math::PIQuarter) || (phiMinusPsi3 >= evtPlnAngleB * o2::constants::math::PIQuarter && phiMinusPsi3 < evtPlnAngleC * o2::constants::math::PIQuarter)) {
+          // phiMinusPsi3 = jet.phi() - ep3;
+          phiMinusPsi3 = RecoDecay::constrainAngle(jet.phi() - ep3, -o2::constants::math::PI);
+          float absDelta3 = std::abs(phiMinusPsi3);
+          if ((absDelta3 < o2::constants::math::PIQuarter) || (absDelta3 >= evtPlnAngleA * o2::constants::math::PIQuarter) || (absDelta3 >= evtPlnAngleB * o2::constants::math::PIQuarter && absDelta3 < evtPlnAngleC * o2::constants::math::PIQuarter)) {
             registry.fill(HIST("h_jet_pt_in_plane_v3"), jet.pt() - (collision.rho() * jet.area()), 1.0);
           } else {
             registry.fill(HIST("h_jet_pt_out_of_plane_v3"), jet.pt() - (collision.rho() * jet.area()), 1.0);
@@ -1441,7 +1377,7 @@ struct JetChargedV2 {
       int refBInd = refBId * 4 + cfgnTotalSystem * 4 * (nmode - 2);
 
       if (nmode == cfgNmodA) {
-        if (collision.qvecAmp()[detId] > collQvecAmpDetId || collision.qvecAmp()[refAId] < collQvecAmpDetId || collision.qvecAmp()[refBId] < collQvecAmpDetId) {
+        if (collision.qvecAmp()[detId] > collQvecAmpDetId && collision.qvecAmp()[refAId] > collQvecAmpDetId && collision.qvecAmp()[refBId] > collQvecAmpDetId) {
           histosQA.fill(HIST("histQvecUncorV2"), collision.qvecRe()[detInd], collision.qvecIm()[detInd], collision.cent());
           histosQA.fill(HIST("histQvecRectrV2"), collision.qvecRe()[detInd + 1], collision.qvecIm()[detInd + 1], collision.cent());
           histosQA.fill(HIST("histQvecTwistV2"), collision.qvecRe()[detInd + 2], collision.qvecIm()[detInd + 2], collision.cent());
@@ -1510,8 +1446,10 @@ struct JetChargedV2 {
           }
           registry.fill(HIST("h_jet_pt_rhoareasubtracted"), jet.pt() - (collision.rho() * jet.area()), 1.0);
 
-          phiMinusPsi2 = jet.phi() - ep2;
-          if ((phiMinusPsi2 < o2::constants::math::PIQuarter) || (phiMinusPsi2 >= evtPlnAngleA * o2::constants::math::PIQuarter) || (phiMinusPsi2 >= evtPlnAngleB * o2::constants::math::PIQuarter && phiMinusPsi2 < evtPlnAngleC * o2::constants::math::PIQuarter)) {
+          // phiMinusPsi2 = jet.phi() - ep2;
+          phiMinusPsi2 = RecoDecay::constrainAngle(jet.phi() - ep2, -o2::constants::math::PI);
+          float absDelta = std::abs(phiMinusPsi2);
+          if ((absDelta < o2::constants::math::PIQuarter) || (absDelta >= evtPlnAngleA * o2::constants::math::PIQuarter) || (absDelta >= evtPlnAngleB * o2::constants::math::PIQuarter && absDelta < evtPlnAngleC * o2::constants::math::PIQuarter)) {
             registry.fill(HIST("h_jet_pt_in_plane_v2"), jet.pt() - (collision.rho() * jet.area()), 1.0);
             registry.fill(HIST("h2_centrality_jet_pt_in_plane_v2"), centrality, jet.pt() - (collision.rho() * jet.area()), 1.0);
           } else {
@@ -1532,9 +1470,11 @@ struct JetChargedV2 {
           if (jet.r() != round(selectedJetsRadius * 100.0f)) {
             continue;
           }
-          phiMinusPsi3 = jet.phi() - ep3;
+          // phiMinusPsi3 = jet.phi() - ep3;
+          phiMinusPsi3 = RecoDecay::constrainAngle(jet.phi() - ep3, -o2::constants::math::PI);
+          float absDelta3 = std::abs(phiMinusPsi3);
 
-          if ((phiMinusPsi3 < o2::constants::math::PIQuarter) || (phiMinusPsi3 >= evtPlnAngleA * o2::constants::math::PIQuarter) || (phiMinusPsi3 >= evtPlnAngleB * o2::constants::math::PIQuarter && phiMinusPsi3 < evtPlnAngleC * o2::constants::math::PIQuarter)) {
+          if ((absDelta3 < o2::constants::math::PIQuarter) || (absDelta3 >= evtPlnAngleA * o2::constants::math::PIQuarter) || (absDelta3 >= evtPlnAngleB * o2::constants::math::PIQuarter && absDelta3 < evtPlnAngleC * o2::constants::math::PIQuarter)) {
             registry.fill(HIST("h_jet_pt_in_plane_v3"), jet.pt() - (collision.rho() * jet.area()), 1.0);
           } else {
             registry.fill(HIST("h_jet_pt_out_of_plane_v3"), jet.pt() - (collision.rho() * jet.area()), 1.0);
@@ -1577,7 +1517,8 @@ struct JetChargedV2 {
     double leadingJetPt = -1;
     double leadingJetPhi = -1;
     double leadingJetEta = -1;
-    fillLeadingJetQA(jets, leadingJetPt, leadingJetPhi, leadingJetEta);
+    double leadingJetR = -1;
+    fillLeadingJetQA(jets, leadingJetPt, leadingJetPhi, leadingJetEta, leadingJetR);
 
     int nTrk = 0;
     getNtrk(tracks, jets, nTrk, evtnum, leadingJetEta);
@@ -1649,7 +1590,7 @@ struct JetChargedV2 {
     registry.fill(HIST("h_evtnum_centrlity"), evtnum, centrality);
 
     if (temppara[0] == 0) {
-      return;
+      registry.fill(HIST("h_badfit_counter"), 1);
     }
 
     int nDF = 1;
@@ -1709,8 +1650,8 @@ struct JetChargedV2 {
           continue;
         }
 
-        double integralValue = fFitModulationV2v3->Integral(jet.phi() - jetRadius, jet.phi() + jetRadius);
-        double rholocal = collision.rho() / (2 * jetRadius * temppara[0]) * integralValue;
+        double integralValue = fFitModulationV2v3->Integral(jet.phi() - selectedJetsRadius, jet.phi() + selectedJetsRadius);
+        double rholocal = collision.rho() / (2 * selectedJetsRadius * temppara[0]) * integralValue;
         registry.fill(HIST("h2_rholocal_cent"), centrality, rholocal, 1.0);
 
         if (nmode == cfgNmodA) {
@@ -1718,12 +1659,13 @@ struct JetChargedV2 {
           if (collision.qvecAmp()[detId] < collQvecAmpDetId) {
             continue;
           }
-          phiMinusPsi2 = jet.phi() - ep2;
-
+          // phiMinusPsi2 = jet.phi() - ep2;
+          phiMinusPsi2 = RecoDecay::constrainAngle(jet.phi() - ep2, -o2::constants::math::PI);
+          float absDelta = std::abs(phiMinusPsi2);
           registry.fill(HIST("h2_phi_rholocal"), jet.phi() - ep2, rholocal, 1.0);
+          registry.fill(HIST("h2_phi_rholocal_absDelta"), absDelta, rholocal, 1.0);
           registry.fill(HIST("h_jet_pt_inclusive_v2_rho"), jet.pt() - (rholocal * jet.area()), 1.0);
-
-          if ((phiMinusPsi2 < o2::constants::math::PIQuarter) || (phiMinusPsi2 >= evtPlnAngleA * o2::constants::math::PIQuarter) || (phiMinusPsi2 >= evtPlnAngleB * o2::constants::math::PIQuarter && phiMinusPsi2 < evtPlnAngleC * o2::constants::math::PIQuarter)) {
+          if ((absDelta < o2::constants::math::PIQuarter) || (absDelta >= evtPlnAngleA * o2::constants::math::PIQuarter) || (absDelta >= evtPlnAngleB * o2::constants::math::PIQuarter && absDelta < evtPlnAngleC * o2::constants::math::PIQuarter)) {
             registry.fill(HIST("h_jet_pt_in_plane_v2_rho"), jet.pt() - (rholocal * jet.area()), 1.0);
             registry.fill(HIST("h2_centrality_jet_pt_in_plane_v2_rho"), centrality, jet.pt() - (rholocal * jet.area()), 1.0);
           } else {
@@ -1736,9 +1678,11 @@ struct JetChargedV2 {
             continue;
           }
           ep3 = helperEP.GetEventPlane(collision.qvecRe()[detInd], collision.qvecIm()[detInd], nmode);
-          phiMinusPsi3 = jet.phi() - ep3;
+          // phiMinusPsi3 = jet.phi() - ep3;
+          phiMinusPsi3 = RecoDecay::constrainAngle(jet.phi() - ep3, -o2::constants::math::PI);
+          float absDelta3 = std::abs(phiMinusPsi3);
 
-          if ((phiMinusPsi3 < o2::constants::math::PIQuarter) || (phiMinusPsi3 >= evtPlnAngleA * o2::constants::math::PIQuarter) || (phiMinusPsi3 >= evtPlnAngleB * o2::constants::math::PIQuarter && phiMinusPsi3 < evtPlnAngleC * o2::constants::math::PIQuarter)) {
+          if ((absDelta3 < o2::constants::math::PIQuarter) || (absDelta3 >= evtPlnAngleA * o2::constants::math::PIQuarter) || (absDelta3 >= evtPlnAngleB * o2::constants::math::PIQuarter && absDelta3 < evtPlnAngleC * o2::constants::math::PIQuarter)) {
             registry.fill(HIST("h_jet_pt_in_plane_v3_rho"), jet.pt() - (rholocal * jet.area()), 1.0);
           } else {
             registry.fill(HIST("h_jet_pt_out_of_plane_v3_rho"), jet.pt() - (rholocal * jet.area()), 1.0);
@@ -1748,7 +1692,7 @@ struct JetChargedV2 {
     }
     // RCpT
     for (uint i = 0; i < cfgnMods->size(); i++) {
-      TRandom3 randomNumber(0);
+      // TRandom3 randomNumber(0);
       float randomConeEta = randomNumber.Uniform(trackEtaMin + randomConeR, trackEtaMax - randomConeR);
       float randomConePhi = randomNumber.Uniform(0.0, o2::constants::math::TwoPI);
       float randomConePt = 0;
@@ -1758,36 +1702,78 @@ struct JetChargedV2 {
       int nmode = cfgnMods->at(i);
       if (nmode == cfgNmodA) {
         double rcPhiPsi2;
-        rcPhiPsi2 = randomConePhi - ep2;
+        double rcPhiPsi2Rand;
+
+        // randomized φ check test
+        float randomPhiTest = randomNumber.Uniform(0.0, o2::constants::math::TwoPI);
+        float randomEtaTest = randomNumber.Uniform(trackEtaMin + randomConeR, trackEtaMax - randomConeR);
+        float randomConePtTest = 0.0;
+        // randomized φ check test end
+
+        // rcPhiPsi2 = randomConePhi - ep2;
+        rcPhiPsi2 = RecoDecay::constrainAngle(randomConePhi - ep2, -o2::constants::math::PI);
+        // if (rcPhiPsi2 < 0) rcPhiPsi2 += o2::constants::math::TwoPI;
+        if (rcPhiPsi2 < 0) {
+          rcPhiPsi2 = RecoDecay::constrainAngle(rcPhiPsi2, 0.0F);
+        }
+
+        rcPhiPsi2Rand = RecoDecay::constrainAngle(randomPhiTest - ep2, -o2::constants::math::PI);
+        // if (rcPhiPsi2Rand < 0) rcPhiPsi2Rand += o2::constants::math::TwoPI;
+        if (rcPhiPsi2Rand < 0) {
+          rcPhiPsi2Rand = RecoDecay::constrainAngle(rcPhiPsi2Rand, 0.0F);
+        }
 
         for (auto const& track : tracks) {
           if (jetderiveddatautilities::selectTrack(track, trackSelection)) {
+            // float dPhi = RecoDecay::constrainAngle(track.phi() - randomConePhi, static_cast<float>(-o2::constants::math::PI));
+            // float dEta = track.eta() - randomConeEta;
+            // if (std::sqrt(dEta * dEta + dPhi * dPhi) < randomConeR) {
+            //   randomConePt += track.pt();
+            // }
             float dPhi = RecoDecay::constrainAngle(track.phi() - randomConePhi, static_cast<float>(-o2::constants::math::PI));
             float dEta = track.eta() - randomConeEta;
             if (std::sqrt(dEta * dEta + dPhi * dPhi) < randomConeR) {
               randomConePt += track.pt();
             }
+
+            float dPhiTest = RecoDecay::constrainAngle(track.phi() - randomPhiTest, static_cast<float>(-o2::constants::math::PI));
+            float dEtaTest = track.eta() - randomEtaTest;
+            if (std::sqrt(dEtaTest * dEtaTest + dPhiTest * dPhiTest) < randomConeR) {
+              randomConePtTest += track.pt();
+            }
           }
         }
+        registry.fill(HIST("h1_distribution_RC"), rcPhiPsi2);
+        registry.fill(HIST("h1_distribution_random"), rcPhiPsi2Rand);
+        registry.fill(HIST("h3_randomizedPhi_check"), centrality, randomConePtTest - o2::constants::math::PI * randomConeR * randomConeR * collision.rho(), rcPhiPsi2Rand, 1.0);
         registry.fill(HIST("h3_centrality_deltapT_RandomCornPhi_localrhovsphi"), centrality, randomConePt - o2::constants::math::PI * randomConeR * randomConeR * rholocalRC, rcPhiPsi2, 1.0);
 
         // removing the leading jet from the random cone
         if (jets.size() > 0) { // if there are no jets in the acceptance (from the jetfinder cuts) then there can be no leading jet
-          float dPhiLeadingJet = RecoDecay::constrainAngle(jets.iteratorAt(0).phi() - randomConePhi, static_cast<float>(-o2::constants::math::PI));
-          float dEtaLeadingJet = jets.iteratorAt(0).eta() - randomConeEta;
+          // float dPhiLeadingJet = RecoDecay::constrainAngle(jets.iteratorAt(0).phi() - randomConePhi, static_cast<float>(-o2::constants::math::PI));
+          // float dEtaLeadingJet = jets.iteratorAt(0).eta() - randomConeEta;
+          float dPhiLeadingJet = RecoDecay::constrainAngle(leadingJetPhi - randomConePhi, static_cast<float>(-o2::constants::math::PI));
+          float dEtaLeadingJet = leadingJetEta - randomConeEta;
 
           bool jetWasInCone = false;
-          while ((randomConeLeadJetDeltaR <= 0 && (std::sqrt(dEtaLeadingJet * dEtaLeadingJet + dPhiLeadingJet * dPhiLeadingJet) < jets.iteratorAt(0).r() / 100.0 + randomConeR)) || (randomConeLeadJetDeltaR > 0 && (std::sqrt(dEtaLeadingJet * dEtaLeadingJet + dPhiLeadingJet * dPhiLeadingJet) < randomConeLeadJetDeltaR))) {
+          // while ((randomConeLeadJetDeltaR <= 0 && (std::sqrt(dEtaLeadingJet * dEtaLeadingJet + dPhiLeadingJet * dPhiLeadingJet) < jets.iteratorAt(0).r() / 100.0 + randomConeR)) || (randomConeLeadJetDeltaR > 0 && (std::sqrt(dEtaLeadingJet * dEtaLeadingJet + dPhiLeadingJet * dPhiLeadingJet) < randomConeLeadJetDeltaR))) {
+          while ((randomConeLeadJetDeltaR <= 0 && (std::sqrt(dEtaLeadingJet * dEtaLeadingJet + dPhiLeadingJet * dPhiLeadingJet) < leadingJetR + randomConeR)) || (randomConeLeadJetDeltaR > 0 && (std::sqrt(dEtaLeadingJet * dEtaLeadingJet + dPhiLeadingJet * dPhiLeadingJet) < randomConeLeadJetDeltaR))) {
             jetWasInCone = true;
             randomConeEta = randomNumber.Uniform(trackEtaMin + randomConeR, trackEtaMax - randomConeR);
             randomConePhi = randomNumber.Uniform(0.0, o2::constants::math::TwoPI);
-            dPhiLeadingJet = RecoDecay::constrainAngle(jets.iteratorAt(0).phi() - randomConePhi, static_cast<float>(-o2::constants::math::PI));
-            dEtaLeadingJet = jets.iteratorAt(0).eta() - randomConeEta;
+            dPhiLeadingJet = RecoDecay::constrainAngle(leadingJetPhi - randomConePhi, static_cast<float>(-o2::constants::math::PI));
+            dEtaLeadingJet = leadingJetEta - randomConeEta;
           }
           if (jetWasInCone) {
             randomConePt = 0.0;
             for (auto const& track : tracks) {
-              if (jetderiveddatautilities::selectTrack(track, trackSelection) && (std::fabs(track.eta() - leadingJetEta) > randomConeR)) { // if track selection is uniformTrack, dcaXY and dcaZ cuts need to be added as they aren't in the selection so that they can be studied here
+              // if (jetderiveddatautilities::selectTrack(track, trackSelection) && (std::fabs(track.eta() - leadingJetEta) > randomConeR)) { // if track selection is uniformTrack, dcaXY and dcaZ cuts need to be added as they aren't in the selection so that they can be studied here
+              //   float dPhi = RecoDecay::constrainAngle(track.phi() - randomConePhi, static_cast<float>(-o2::constants::math::PI));
+              //   float dEta = track.eta() - randomConeEta;
+              //   if (std::sqrt(dEta * dEta + dPhi * dPhi) < randomConeR) {
+              //     randomConePt += track.pt();
+              //   }
+              if (jetderiveddatautilities::selectTrack(track, trackSelection)) { // if track selection is uniformTrack, dcaXY and dcaZ cuts need to be added as they aren't in the selection so that they can be studied here
                 float dPhi = RecoDecay::constrainAngle(track.phi() - randomConePhi, static_cast<float>(-o2::constants::math::PI));
                 float dEta = track.eta() - randomConeEta;
                 if (std::sqrt(dEta * dEta + dPhi * dPhi) < randomConeR) {
@@ -1875,7 +1861,8 @@ struct JetChargedV2 {
     double leadingJetPt = -1;
     double leadingJetPhi = -1;
     double leadingJetEta = -1;
-    fillLeadingJetQA(jets, leadingJetPt, leadingJetPhi, leadingJetEta);
+    double leadingJetR = -1;
+    fillLeadingJetQA(jets, leadingJetPt, leadingJetPhi, leadingJetEta, leadingJetR);
 
     int nTrk = 0;
     getNtrk(tracks, jets, nTrk, evtnum, leadingJetEta);
@@ -1947,7 +1934,7 @@ struct JetChargedV2 {
     registry.fill(HIST("h_evtnum_centrlity"), evtnum, centrality);
 
     if (temppara[0] == 0) {
-      return;
+      registry.fill(HIST("h_badfit_counter"), 1);
     }
 
     int nDF = 1;
@@ -2003,8 +1990,8 @@ struct JetChargedV2 {
           registry.fill(HIST("h_mcd_pt_before_matching_mcdprocess"), corrBasejetpt);
         }
 
-        double integralValue = fFitModulationV2v3->Integral(jet.phi() - jetRadius, jet.phi() + jetRadius);
-        double rholocal = collision.rho() / (2 * jetRadius * temppara[0]) * integralValue;
+        double integralValue = fFitModulationV2v3->Integral(jet.phi() - selectedJetsRadius, jet.phi() + selectedJetsRadius);
+        double rholocal = collision.rho() / (2 * selectedJetsRadius * temppara[0]) * integralValue;
         registry.fill(HIST("h2_rholocal_cent"), centrality, rholocal, 1.0);
 
         if (nmode == cfgNmodA) {
@@ -2012,11 +1999,13 @@ struct JetChargedV2 {
           if (collision.qvecAmp()[detId] < collQvecAmpDetId) {
             continue;
           }
-          phiMinusPsi2 = jet.phi() - ep2;
+          // phiMinusPsi2 = jet.phi() - ep2;
+          phiMinusPsi2 = RecoDecay::constrainAngle(jet.phi() - ep2, -o2::constants::math::PI);
+          float absDelta = std::abs(phiMinusPsi2);
           registry.fill(HIST("h2_phi_rholocal"), jet.phi() - ep2, rholocal, 1.0);
           registry.fill(HIST("h_jet_pt_inclusive_v2_rho"), jet.pt() - (rholocal * jet.area()), 1.0);
 
-          if ((phiMinusPsi2 < o2::constants::math::PIQuarter) || (phiMinusPsi2 >= evtPlnAngleA * o2::constants::math::PIQuarter) || (phiMinusPsi2 >= evtPlnAngleB * o2::constants::math::PIQuarter && phiMinusPsi2 < evtPlnAngleC * o2::constants::math::PIQuarter)) {
+          if ((absDelta < o2::constants::math::PIQuarter) || (absDelta >= evtPlnAngleA * o2::constants::math::PIQuarter) || (absDelta >= evtPlnAngleB * o2::constants::math::PIQuarter && absDelta < evtPlnAngleC * o2::constants::math::PIQuarter)) {
             registry.fill(HIST("h_jet_pt_in_plane_v2_rho"), jet.pt() - (rholocal * jet.area()), 1.0);
             registry.fill(HIST("h2_centrality_jet_pt_in_plane_v2_rho"), centrality, jet.pt() - (rholocal * jet.area()), 1.0);
           } else {
@@ -2029,9 +2018,11 @@ struct JetChargedV2 {
             continue;
           }
           ep3 = helperEP.GetEventPlane(collision.qvecRe()[detInd], collision.qvecIm()[detInd], nmode);
-          phiMinusPsi3 = jet.phi() - ep3;
+          // phiMinusPsi3 = jet.phi() - ep3;
+          phiMinusPsi3 = RecoDecay::constrainAngle(jet.phi() - ep3, -o2::constants::math::PI);
+          float absDelta3 = std::abs(phiMinusPsi3);
 
-          if ((phiMinusPsi3 < o2::constants::math::PIQuarter) || (phiMinusPsi3 >= evtPlnAngleA * o2::constants::math::PIQuarter) || (phiMinusPsi3 >= evtPlnAngleB * o2::constants::math::PIQuarter && phiMinusPsi3 < evtPlnAngleC * o2::constants::math::PIQuarter)) {
+          if ((absDelta3 < o2::constants::math::PIQuarter) || (absDelta3 >= evtPlnAngleA * o2::constants::math::PIQuarter) || (absDelta3 >= evtPlnAngleB * o2::constants::math::PIQuarter && absDelta3 < evtPlnAngleC * o2::constants::math::PIQuarter)) {
             registry.fill(HIST("h_jet_pt_in_plane_v3_rho"), jet.pt() - (rholocal * jet.area()), 1.0);
           } else {
             registry.fill(HIST("h_jet_pt_out_of_plane_v3_rho"), jet.pt() - (rholocal * jet.area()), 1.0);
@@ -2041,7 +2032,7 @@ struct JetChargedV2 {
     }
     // RCpT
     for (uint i = 0; i < cfgnMods->size(); i++) {
-      TRandom3 randomNumber(0);
+      // TRandom3 randomNumber(0);
       float randomConeEta = randomNumber.Uniform(trackEtaMin + randomConeR, trackEtaMax - randomConeR);
       float randomConePhi = randomNumber.Uniform(0.0, o2::constants::math::TwoPI);
       float randomConePt = 0;
@@ -2051,7 +2042,8 @@ struct JetChargedV2 {
       int nmode = cfgnMods->at(i);
       if (nmode == cfgNmodA) {
         double rcPhiPsi2;
-        rcPhiPsi2 = randomConePhi - ep2;
+        // rcPhiPsi2 = randomConePhi - ep2;
+        rcPhiPsi2 = RecoDecay::constrainAngle(randomConePhi - ep2, -o2::constants::math::PI);
 
         for (auto const& track : tracks) {
           if (jetderiveddatautilities::selectTrack(track, trackSelection)) {
@@ -2066,11 +2058,14 @@ struct JetChargedV2 {
 
         // removing the leading jet from the random cone
         if (jets.size() > 0) { // if there are no jets in the acceptance (from the jetfinder cuts) then there can be no leading jet
-          float dPhiLeadingJet = RecoDecay::constrainAngle(jets.iteratorAt(0).phi() - randomConePhi, static_cast<float>(-o2::constants::math::PI));
-          float dEtaLeadingJet = jets.iteratorAt(0).eta() - randomConeEta;
+          // float dPhiLeadingJet = RecoDecay::constrainAngle(jets.iteratorAt(0).phi() - randomConePhi, static_cast<float>(-o2::constants::math::PI));
+          // float dEtaLeadingJet = jets.iteratorAt(0).eta() - randomConeEta;
+          float dPhiLeadingJet = RecoDecay::constrainAngle(leadingJetPhi - randomConePhi, static_cast<float>(-o2::constants::math::PI));
+          float dEtaLeadingJet = leadingJetEta - randomConeEta;
 
           bool jetWasInCone = false;
-          while ((randomConeLeadJetDeltaR <= 0 && (std::sqrt(dEtaLeadingJet * dEtaLeadingJet + dPhiLeadingJet * dPhiLeadingJet) < jets.iteratorAt(0).r() / 100.0 + randomConeR)) || (randomConeLeadJetDeltaR > 0 && (std::sqrt(dEtaLeadingJet * dEtaLeadingJet + dPhiLeadingJet * dPhiLeadingJet) < randomConeLeadJetDeltaR))) {
+          // while ((randomConeLeadJetDeltaR <= 0 && (std::sqrt(dEtaLeadingJet * dEtaLeadingJet + dPhiLeadingJet * dPhiLeadingJet) < jets.iteratorAt(0).r() / 100.0 + randomConeR)) || (randomConeLeadJetDeltaR > 0 && (std::sqrt(dEtaLeadingJet * dEtaLeadingJet + dPhiLeadingJet * dPhiLeadingJet) < randomConeLeadJetDeltaR))) {
+          while ((randomConeLeadJetDeltaR <= 0 && (std::sqrt(dEtaLeadingJet * dEtaLeadingJet + dPhiLeadingJet * dPhiLeadingJet) < leadingJetR + randomConeR)) || (randomConeLeadJetDeltaR > 0 && (std::sqrt(dEtaLeadingJet * dEtaLeadingJet + dPhiLeadingJet * dPhiLeadingJet) < randomConeLeadJetDeltaR))) {
             jetWasInCone = true;
             randomConeEta = randomNumber.Uniform(trackEtaMin + randomConeR, trackEtaMax - randomConeR);
             randomConePhi = randomNumber.Uniform(0.0, o2::constants::math::TwoPI);
@@ -2080,7 +2075,14 @@ struct JetChargedV2 {
           if (jetWasInCone) {
             randomConePt = 0.0;
             for (auto const& track : tracks) {
-              if (jetderiveddatautilities::selectTrack(track, trackSelection) && (std::fabs(track.eta() - leadingJetEta) > randomConeR)) { // if track selection is uniformTrack, dcaXY and dcaZ cuts need to be added as they aren't in the selection so that they can be studied here
+              // if (jetderiveddatautilities::selectTrack(track, trackSelection) && (std::fabs(track.eta() - leadingJetEta) > randomConeR)) { // if track selection is uniformTrack, dcaXY and dcaZ cuts need to be added as they aren't in the selection so that they can be studied here
+              //   float dPhi = RecoDecay::constrainAngle(track.phi() - randomConePhi, static_cast<float>(-o2::constants::math::PI));
+              //   float dEta = track.eta() - randomConeEta;
+              //   if (std::sqrt(dEta * dEta + dPhi * dPhi) < randomConeR) {
+              //     randomConePt += track.pt();
+              //   }
+              // }
+              if (jetderiveddatautilities::selectTrack(track, trackSelection)) { // if track selection is uniformTrack, dcaXY and dcaZ cuts need to be added as they aren't in the selection so that they can be studied here
                 float dPhi = RecoDecay::constrainAngle(track.phi() - randomConePhi, static_cast<float>(-o2::constants::math::PI));
                 float dEta = track.eta() - randomConeEta;
                 if (std::sqrt(dEta * dEta + dPhi * dPhi) < randomConeR) {
@@ -2112,7 +2114,7 @@ struct JetChargedV2 {
     if (!applyMCCollisionCuts(mccollision, collisions)) {
       return;
     }
-    registry.fill(HIST("h_mccollisions_zvertex"), mccollision.posZ());
+    registry.fill(HIST("h_mccollisions_zvertex_mcp"), mccollision.posZ());
 
     for (auto const& jet : jets) {
       if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
@@ -2137,6 +2139,7 @@ struct JetChargedV2 {
     if (!applyMCCollisionCuts(mccollision, collisions)) {
       return;
     }
+    registry.fill(HIST("h_mccollisions_zvertex_mcp"), mccollision.posZ());
 
     for (auto const& jet : jets) {
       if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
@@ -2156,9 +2159,11 @@ struct JetChargedV2 {
       auto collTracks = tracks.sliceBy(tracksPerJCollision, collision.globalIndex());
       fillLeadingJetQAMCP(jets, leadingJetPt, leadingJetPhi, leadingJetEta);
 
+      double localRhoFitPtMin = 0.2;
+      double localRhoFitPtMax = 5;
       if (jets.size() > 0) {
         for (auto const& track : collTracks) {
-          if (jetderiveddatautilities::selectTrack(track, trackSelection) && (std::fabs(track.eta() - leadingJetEta) > jetRadius) && track.pt() >= localRhoFitPtMin && track.pt() <= localRhoFitPtMax) {
+          if (jetderiveddatautilities::selectTrack(track, trackSelection) && (std::fabs(track.eta() - leadingJetEta) > selectedJetsRadius) && track.pt() >= localRhoFitPtMin && track.pt() <= localRhoFitPtMax) {
             nTrk += 1;
           }
         }
@@ -2170,16 +2175,15 @@ struct JetChargedV2 {
 
       if (jets.size() > 0) {
         for (auto const& track : collTracks) {
-          if (jetderiveddatautilities::selectTrack(track, trackSelection) && (std::fabs(track.eta() - leadingJetEta) > jetRadius) && track.pt() >= localRhoFitPtMin && track.pt() <= localRhoFitPtMax) {
+          if (jetderiveddatautilities::selectTrack(track, trackSelection) && (std::fabs(track.eta() - leadingJetEta) > selectedJetsRadius) && track.pt() >= localRhoFitPtMin && track.pt() <= localRhoFitPtMax) {
             hPtsumSumptFitMCP->Fill(track.phi(), track.pt());
           }
         }
       }
       fitFncAreaSubMCP(collision, jets, hPtsumSumptFitMCP, mcLevelIsParticleLevel);
+      delete hPtsumSumptFitMCP;
+      delete fFitModulationV2v3P;
     }
-
-    delete hPtsumSumptFitMCP;
-    delete fFitModulationV2v3P;
     evtnum += 1;
   }
   PROCESS_SWITCH(JetChargedV2, processSigmaPtAreaSubMCP, "jet spectra with area-based subtraction for MC particle level", false);
@@ -2236,6 +2240,7 @@ struct JetChargedV2 {
     double mcrho = collision.has_mcCollision() ? collision.mcCollision_as<JetBkgRhoMcCollisions>().rho() : -1;
     registry.fill(HIST("h_mc_rho_matched"), mcrho);
 
+    auto collTracks = tracks.sliceBy(tracksPerJCollision, collision.globalIndex());
     for (const auto& mcdjet : mcdjets) {
       if (!isAcceptedJet<aod::JetTracks>(mcdjet)) {
         continue;
@@ -2249,20 +2254,20 @@ struct JetChargedV2 {
         leadingJetEta = mcdjet.eta();
       }
       int nTrk = 0;
-      if (mcdjet.size() > 0) {
-        for (auto const& track : tracks) {
-          if (jetderiveddatautilities::selectTrack(track, trackSelection) && (std::fabs(track.eta() - leadingJetEta) > jetRadius) && track.pt() >= localRhoFitPtMin && track.pt() <= localRhoFitPtMax) {
-            registry.fill(HIST("h_accept_Track"), 4.5);
-            nTrk += 1;
-          }
+      double localRhoFitPtMin = 0.2;
+      double localRhoFitPtMax = 5;
+      for (auto const& track : collTracks) {
+        if (jetderiveddatautilities::selectTrack(track, trackSelection) && (std::fabs(track.eta() - leadingJetEta) > selectedJetsRadius) && track.pt() >= localRhoFitPtMin && track.pt() <= localRhoFitPtMax) {
+          registry.fill(HIST("h_accept_Track"), 4.5);
+          nTrk += 1;
         }
       }
       if (nTrk <= 0) {
         return;
       }
       hPtsumSumptFitRM = new TH1F("h_ptsum_sumpt_fit_RM", "h_ptsum_sumpt_RM fit use", TMath::CeilNint(std::sqrt(nTrk)), 0., o2::constants::math::TwoPI);
-      for (auto const& track : tracks) {
-        if (jetderiveddatautilities::selectTrack(track, trackSelection) && (std::fabs(track.eta() - leadingJetEta) > jetRadius) && track.pt() >= localRhoFitPtMin && track.pt() <= localRhoFitPtMax) {
+      for (auto const& track : collTracks) {
+        if (jetderiveddatautilities::selectTrack(track, trackSelection) && (std::fabs(track.eta() - leadingJetEta) > selectedJetsRadius) && track.pt() >= localRhoFitPtMin && track.pt() <= localRhoFitPtMax) {
           registry.fill(HIST("h_accept_Track_Match"), 0.5);
           hPtsumSumptFitRM->Fill(track.phi(), track.pt());
         }
@@ -2330,24 +2335,6 @@ struct JetChargedV2 {
     }
   }
   PROCESS_SWITCH(JetChargedV2, processJetsMatchedSubtracted, "matched mcp and mcd jets", false);
-
-  void processTracksQA(soa::Filtered<soa::Join<aod::JetCollisions, aod::BkgChargedRhos, aod::Qvectors>>::iterator const& collision,
-                       soa::Filtered<soa::Join<aod::JetTracks, aod::JTrackExtras>> const& tracks)
-  {
-    if (!jetderiveddatautilities::selectCollision(collision, eventSelectionBits)) {
-      return;
-    }
-    if (collision.trackOccupancyInTimeRange() < trackOccupancyInTimeRangeMin || trackOccupancyInTimeRangeMax < collision.trackOccupancyInTimeRange()) {
-      return;
-    }
-    for (auto const& track : tracks) {
-      if (!jetderiveddatautilities::selectTrack(track, trackSelection)) {
-        continue;
-      }
-      fillTrackHistograms(track);
-    }
-  }
-  PROCESS_SWITCH(JetChargedV2, processTracksQA, "QA for charged tracks", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)


### PR DESCRIPTION
1. Fixed event-plane validity checks (changed || to &&)
2. Wrapped raw angle differences into the (0 \sim 2\pi) interval
3. Fixed random cone RNG seeding (removed repeated SetSeed(0) in init{})
4. Resolved memory leak in if (temppara[0] == 0) (added a histogram and replaced return;)
5. Moved fitting plot and function cleanup inside the loop in processSigmaPtAreaSubMCP
6. Removed mcdjet.size() issue
7. Removed extra occupancy and event selection in processInOutJetV2MCD
8. Added skipMBGapEvents in jetderiveddatautilities::selectCollision()
9. Removed old function fitFncMCP()
10. Fixed inconsistency in leading jet usage: fillLeadingJetQA assumes the highest-pT jet, 
    while RC veto used jets.iteratorAt(0). Now both use the same leading jet definition