### PR TITLE
[PWGDQ] fixed match type assignment

### DIFF
--- a/PWGDQ/Tasks/qaMatching.cxx
+++ b/PWGDQ/Tasks/qaMatching.cxx
@@ -139,6 +139,7 @@ struct QaMatching {
   static constexpr int ExtrapolationMethodMftFirstPoint = 2;
   static constexpr int ExtrapolationMethodVertex = 3;
   static constexpr int ExtrapolationMethodMftDca = 4;
+  static constexpr int DecayRankingDirect = 2;
 
   struct MatchingCandidate {
     int64_t collisionId{-1};
@@ -1675,7 +1676,7 @@ struct QaMatching {
 
   template <class TMUON, class TMUONS, class TMFTS>
   MuonMatchType getMatchType(const TMUON& muonTrack,
-                             TMUONS const& muonTracks,
+                             TMUONS const& /*muonTracks*/,
                              TMFTS const& mftTracks,
                              const std::vector<std::pair<int64_t, int64_t>>& matchablePairs,
                              int ranking)
@@ -1685,18 +1686,18 @@ struct QaMatching {
 
     auto const& mchTrack = muonTrack.template matchMCHTrack_as<TMUONS>();
 
-    bool isPaired = isMatchableMch(mchTrack.globalIndex(), matchablePairs);
-    bool isMuon = IsMuon(muonTrack, muonTracks, mftTracks);
+    bool isPairable = isMatchableMch(mchTrack.globalIndex(), matchablePairs);
+    bool isTrueMatch = isTrueGlobalMatching(muonTrack, matchablePairs);
     int decayRanking = getDecayRanking(mchTrack, mftTracks);
 
     MuonMatchType result{kMatchTypeUndefined};
-    if (isPaired) {
-      if (isMuon) {
+    if (isPairable) {
+      if (isTrueMatch) {
         result = (ranking == 1) ? kMatchTypeTrueLeading : kMatchTypeTrueNonLeading;
       } else {
         result = (ranking == 1) ? kMatchTypeWrongLeading : kMatchTypeWrongNonLeading;
       }
-    } else if (decayRanking == 1) {
+    } else if (decayRanking == DecayRankingDirect) {
       result = (ranking == 1) ? kMatchTypeDecayLeading : kMatchTypeDecayNonLeading;
     } else {
       result = (ranking == 1) ? kMatchTypeFakeLeading : kMatchTypeFakeNonLeading;


### PR DESCRIPTION
Removed condition requiring that a true match must correspond to a muon particle crossing both MFT and MCH.
The condition is relaxed to require only that MFT and MCH are crossed by the same particle, regardless of its PDG code.