### PR TITLE
[PWGLF] Added the LambdaStar configurables

### DIFF
--- a/PWGLF/DataModel/LFSigmaTables.h
+++ b/PWGLF/DataModel/LFSigmaTables.h
@@ -84,6 +84,11 @@ DECLARE_SOA_DYNAMIC_COLUMN(Sigma0Y, sigma0Y,
                              return RecoDecay::y(std::array{photonPx + lambdaPx, photonPy + lambdaPy, photonPz + lambdaPz}, o2::constants::physics::MassSigma0);
                            });
 
+DECLARE_SOA_DYNAMIC_COLUMN(LambdaStarY, lambdaStarY,
+                           [](float photonPx, float photonPy, float photonPz, float lambdaPx, float lambdaPy, float lambdaPz) -> float {
+                             return RecoDecay::y(std::array{photonPx + lambdaPx, photonPy + lambdaPy, photonPz + lambdaPz}, o2::constants::physics::MassLambda1520);
+                           });
+
 DECLARE_SOA_DYNAMIC_COLUMN(Phi, phi, //! Phi in the range [0, 2pi)
                            [](float photonPx, float photonPy, float lambdaPx, float lambdaPy) -> float { return RecoDecay::phi(photonPx + lambdaPx, photonPy + lambdaPy); });
 
@@ -169,6 +174,7 @@ DECLARE_SOA_TABLE(Sigma0Cores, "AOD", "SIGMA0CORES",
                   sigma0Core::P<sigma0Core::PhotonPx, sigma0Core::PhotonPy, sigma0Core::PhotonPz, sigma0Core::LambdaPx, sigma0Core::LambdaPy, sigma0Core::LambdaPz>,
                   sigma0Core::Sigma0Mass<sigma0Core::PhotonPx, sigma0Core::PhotonPy, sigma0Core::PhotonPz, sigma0Core::LambdaPx, sigma0Core::LambdaPy, sigma0Core::LambdaPz>,
                   sigma0Core::Sigma0Y<sigma0Core::PhotonPx, sigma0Core::PhotonPy, sigma0Core::PhotonPz, sigma0Core::LambdaPx, sigma0Core::LambdaPy, sigma0Core::LambdaPz>,
+                  sigma0Core::LambdaStarY<sigma0Core::PhotonPx, sigma0Core::PhotonPy, sigma0Core::PhotonPz, sigma0Core::LambdaPx, sigma0Core::LambdaPy, sigma0Core::LambdaPz>,
                   sigma0Core::Phi<sigma0Core::PhotonPx, sigma0Core::PhotonPy, sigma0Core::LambdaPx, sigma0Core::LambdaPy>,
                   sigma0Core::Eta<sigma0Core::PhotonPx, sigma0Core::PhotonPy, sigma0Core::PhotonPz, sigma0Core::LambdaPx, sigma0Core::LambdaPy, sigma0Core::LambdaPz>,
                   sigma0Core::Radius<sigma0Core::X, sigma0Core::Y>,

--- a/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigma0builder.cxx
@@ -121,6 +121,9 @@ struct sigma0builder {
   // Histogram registry
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
 
+  // Species selection
+  Configurable<bool> doLambdaStar{"doLambdaStar", false, "Build Lambda(1520) instead of Sigma0"};
+
   Configurable<bool> fFillV03DPositionHistos{"fFillV03DPositionHistos", false, "Fill XYZ histo for Photons and Lambdas."};
   Configurable<bool> fFillNoSelV0Histos{"fFillNoSelV0Histos", false, "Fill QA histos for input V0s."};
   Configurable<bool> fFillSelPhotonHistos{"fFillSelPhotonHistos", true, "Fill QA histos for sel photons."};
@@ -2293,14 +2296,15 @@ struct sigma0builder {
     auto arrMom = std::array{pVecPhotons, pVecLambda};
     float sigmaMass = RecoDecay::m(arrMom, std::array{o2::constants::physics::MassPhoton, o2::constants::physics::MassLambda0});
     float sigmaY = -999.f;
+    float TheoreticalMass = doLambdaStar ? o2::constants::physics::MassLambda1520 : o2::constants::physics::MassSigma0;
 
     if constexpr (requires { gamma.pxMC(); lambda.pxMC(); }) // If MC
-      sigmaY = RecoDecay::y(std::array{gamma.pxMC() + lambda.pxMC(), gamma.pyMC() + lambda.pyMC(), gamma.pzMC() + lambda.pzMC()}, o2::constants::physics::MassSigma0);
+      sigmaY = RecoDecay::y(std::array{gamma.pxMC() + lambda.pxMC(), gamma.pyMC() + lambda.pyMC(), gamma.pzMC() + lambda.pzMC()}, TheoreticalMass);
     else // If DATA
-      sigmaY = RecoDecay::y(std::array{gamma.px() + lambda.px(), gamma.py() + lambda.py(), gamma.pz() + lambda.pz()}, o2::constants::physics::MassSigma0);
+      sigmaY = RecoDecay::y(std::array{gamma.px() + lambda.px(), gamma.py() + lambda.py(), gamma.pz() + lambda.pz()}, TheoreticalMass);
 
     histos.fill(HIST("SigmaSel/hSelectionStatistics"), 1.);
-    if (TMath::Abs(sigmaMass - o2::constants::physics::MassSigma0) > Sigma0Window)
+    if (TMath::Abs(sigmaMass - TheoreticalMass) > Sigma0Window)
       return false;
 
     histos.fill(HIST("SigmaSel/hSelectionStatistics"), 2.);
@@ -2415,14 +2419,15 @@ struct sigma0builder {
 
     auto arrMom = std::array{pVecPhotons, pVecLambda};
     float sigmaMass = RecoDecay::m(arrMom, std::array{o2::constants::physics::MassPhoton, o2::constants::physics::MassLambda0});
+    float TheoreticalMass = doLambdaStar ? o2::constants::physics::MassLambda1520 : o2::constants::physics::MassSigma0;
 
     // N.B. At this stage, we are only using the reconstructed rapidity (ideally with a very loose cut)
     // A proper selection should be done in the sigmaanalysis
-    float sigmaY = RecoDecay::y(std::array{gammapx + lambda.px(), gammapy + lambda.py(), gammapz + lambda.pz()}, o2::constants::physics::MassSigma0);
+    float sigmaY = RecoDecay::y(std::array{gammapx + lambda.px(), gammapy + lambda.py(), gammapz + lambda.pz()}, TheoreticalMass);
 
     histos.fill(HIST("SigmaSel/hSelectionStatistics"), 1.);
     histos.fill(HIST("SigmaSel/hSigmaMassBeforeSel"), sigmaMass);
-    if (TMath::Abs(sigmaMass - o2::constants::physics::MassSigma0) > Sigma0Window)
+    if (TMath::Abs(sigmaMass - TheoreticalMass) > Sigma0Window)
       return false;
 
     histos.fill(HIST("SigmaSel/hSelectionStatistics"), 2.);

--- a/PWGLF/Tasks/Strangeness/sigmaanalysis.cxx
+++ b/PWGLF/Tasks/Strangeness/sigmaanalysis.cxx
@@ -89,6 +89,9 @@ struct sigmaanalysis {
   //__________________________________________________
   HistogramRegistry histos{"Histos", {}, OutputObjHandlingPolicy::AnalysisObject};
 
+  // Species
+  Configurable<bool> doLambdaStar{"doLambdaStar", false, "Build Lambda(1520) instead of Sigma0"};
+
   // Event level
   Configurable<bool> doPPAnalysis{"doPPAnalysis", true, "if in pp, set to true"};
   Configurable<int> centralityEstimator{"centralityEstimator", kCentFT0C, "Run 3 centrality estimator (0:CentFT0C, 1:CentFT0M, 2:CentFT0CVariant1, 3:CentMFT, 4:CentNGlobal, 5:CentFV0A)"};
@@ -1616,13 +1619,13 @@ struct sigmaanalysis {
       return false;
 
     // Sigma0 specific selections
-    float sigma0Y = cand.sigma0Y();
+    float rapidity = doLambdaStar ? cand.lambdaStarY() : cand.sigma0Y();
     if constexpr (requires { cand.sigma0MCY(); }) { // If MC
-      sigma0Y = cand.sigma0MCY();
+      rapidity = cand.sigma0MCY();
     }
 
     // Rapidity
-    if ((sigma0Y < sigma0Selections.Sigma0MinRapidity) || (sigma0Y > sigma0Selections.Sigma0MaxRapidity))
+    if ((rapidity < sigma0Selections.Sigma0MinRapidity) || (rapidity > sigma0Selections.Sigma0MaxRapidity))
       return false;
 
     // V0Pair Radius


### PR DESCRIPTION
I added a configurable "doLambdaStar" which allows us to analyse the LambdaStar using both the sigma0builder and sigmaanalysis.cxx task, since the Lambda1520 has the same decay products as the sigma0.

Changes include using a different mass hypothesis for the rapidity and mass window cuts, if doLambdaStar is True.

For your information @gianniliveraro @ddobrigk @DelloStritto 