### PR TITLE
[PWGJE] hfFragmentationFunction: MC truth decay classification fix and cleanup

### DIFF
--- a/PWGJE/Tasks/hfFragmentationFunction.cxx
+++ b/PWGJE/Tasks/hfFragmentationFunction.cxx
@@ -21,6 +21,7 @@
 #include "PWGJE/Core/JetDerivedDataUtilities.h"
 #include "PWGJE/Core/JetHFUtilities.h"
 #include "PWGJE/Core/JetUtilities.h"
+#include "PWGJE/Core/JetHFUtilities.h"
 #include "PWGJE/DataModel/Jet.h"
 #include "PWGJE/DataModel/JetReducedData.h"
 
@@ -464,6 +465,28 @@ struct HfFragmentationFunction {
               selectedAs = -1;
             }
 
+            // reflection information for storage: HF = +1, HFbar = -1, neither = 0
+            int matchedFrom = 0;
+            int decayChannel = 0;
+            if (jethfutilities::isD0Table<TCandidatesMCD>()) {
+              decayChannel = o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK;
+            } else if (jethfutilities::isLcTable<TCandidatesMCD>()) {
+              decayChannel = o2::hf_decay::hf_cand_3prong::DecayChannelMain::LcToPKPi;
+            }
+            int selectedAs = 0;
+
+            if (mcdcand.flagMcMatchRec() == decayChannel) { // matched to HF on truth level
+              matchedFrom = 1;
+            } else if (mcdcand.flagMcMatchRec() == -decayChannel) { // matched to HFbar on truth level
+              matchedFrom = -1;
+            }
+            // bitwise AND operation: Checks whether BIT(i) is set, regardless of other bits
+            if (mcdcand.candidateSelFlag() & BIT(0)) { // CandidateSelFlag == BIT(0) -> selected as HF
+              selectedAs = 1;
+            } else if (mcdcand.candidateSelFlag() & BIT(1)) { // CandidateSelFlag == BIT(1) -> selected as HFbar
+              selectedAs = -1;
+            }
+            
             // store matched particle and detector level data in one single table (calculate angular distance in eta-phi plane on the fly)
             matchJetTable(jetutilities::deltaR(mcpjet, mcpcand), mcpjet.pt(), mcpjet.eta(), mcpjet.phi(), mcpjet.template tracks_as<aod::JetParticles>().size() + mcpjet.template candidates_as<TCandidatesMCP>().size(), // particle level jet
                           mcpcand.pt(), mcpcand.eta(), mcpcand.phi(), mcpcand.y(), (mcpcand.originMcGen() == RecoDecay::OriginType::Prompt),                                                                              // particle level HF

--- a/PWGJE/Tasks/hfFragmentationFunction.cxx
+++ b/PWGJE/Tasks/hfFragmentationFunction.cxx
@@ -443,7 +443,7 @@ struct HfFragmentationFunction {
             } else if (mcdcand.candidateSelFlag() & BIT(1)) { // CandidateSelFlag == BIT(1) -> selected as HFbar
               selectedAs = -1;
             }
-            
+
             // store matched particle and detector level data in one single table (calculate angular distance in eta-phi plane on the fly)
             matchJetTable(jetutilities::deltaR(mcpjet, mcpcand), mcpjet.pt(), mcpjet.eta(), mcpjet.phi(), mcpjet.template tracks_as<aod::JetParticles>().size() + mcpjet.template candidates_as<TCandidatesMCP>().size(), // particle level jet
                           mcpcand.pt(), mcpcand.eta(), mcpcand.phi(), mcpcand.y(), (mcpcand.originMcGen() == RecoDecay::OriginType::Prompt),                                                                              // particle level HF
@@ -455,11 +455,11 @@ struct HfFragmentationFunction {
         } else {
           // store matched particle and detector level data in one single table (calculate angular distance in eta-phi plane on the fly)
           matchJetTable(jetutilities::deltaR(mcpjet, mcpcand), mcpjet.pt(), mcpjet.eta(), mcpjet.phi(), mcpjet.template tracks_as<aod::JetParticles>().size() + mcpjet.template candidates_as<TCandidatesMCP>().size(), // particle level jet
-                        mcpcand.pt(), mcpcand.eta(), mcpcand.phi(), mcpcand.y(), (mcpcand.originMcGen() == RecoDecay::OriginType::Prompt),                                                                               // particle level HF
-                        -2, -2, -2, -2, -2,                                                                                                                                                                              // no detector-level jet found
-                        -2, -2, -2, -2, -2, -2,                                                                                                                                                                          // no detector-level jet found
-                        -2, -2, -2,                                                                                                                                                                                      // no detector-level jet found
-                        -2, -2);                                                                                                                                                                                         // no detector-level jet found
+                        mcpcand.pt(), mcpcand.eta(), mcpcand.phi(), mcpcand.y(), (mcpcand.originMcGen() == RecoDecay::OriginType::Prompt),                                                                              // particle level HF
+                        -2, -2, -2, -2, -2,                                                                                                                                                                             // no detector-level jet found
+                        -2, -2, -2, -2, -2, -2,                                                                                                                                                                         // no detector-level jet found
+                        -2, -2, -2,                                                                                                                                                                                     // no detector-level jet found
+                        -2, -2);                                                                                                                                                                                        // no detector-level jet found
         }
       } // end of mcpjets loop
     } // end of mccollisions loop

--- a/PWGJE/Tasks/hfFragmentationFunction.cxx
+++ b/PWGJE/Tasks/hfFragmentationFunction.cxx
@@ -196,7 +196,6 @@ struct HfFragmentationFunction {
 
   Configurable<float> vertexZCut{"vertexZCut", 10.0f, "Accepted z-vertex range"};
   Configurable<std::string> eventSelections{"eventSelections", "sel8", "choose event selection"};
-  Configurable<std::string> chosenHadron{"chosenHadron", "D0", "choose hadron for analysis: D0 or Lc"};
 
   std::vector<int> eventSelectionBits;
 

--- a/PWGJE/Tasks/hfFragmentationFunction.cxx
+++ b/PWGJE/Tasks/hfFragmentationFunction.cxx
@@ -21,8 +21,6 @@
 #include "PWGJE/Core/JetDerivedDataUtilities.h"
 #include "PWGJE/Core/JetHFUtilities.h"
 #include "PWGJE/Core/JetUtilities.h"
-#include "PWGJE/Core/JetHFUtilities.h"
-#include "PWGJE/Core/JetUtilities.h"
 #include "PWGJE/DataModel/Jet.h"
 #include "PWGJE/DataModel/JetReducedData.h"
 
@@ -92,7 +90,7 @@ DECLARE_SOA_COLUMN(McJetHfDist, mcJetHfDist, float);
 DECLARE_SOA_COLUMN(McJetPt, mcJetPt, float);
 DECLARE_SOA_COLUMN(McJetEta, mcJetEta, float);
 DECLARE_SOA_COLUMN(McJetPhi, mcJetPhi, float);
-DECLARE_SOA_COLUMN(McJetNConst, mcJetNConst, float);
+DECLARE_SOA_COLUMN(McJetNConst, mcJetNConst, int);
 DECLARE_SOA_COLUMN(McHfPt, mcHfPt, float);
 DECLARE_SOA_COLUMN(McHfEta, mcHfEta, float);
 DECLARE_SOA_COLUMN(McHfPhi, mcHfPhi, float);
@@ -350,15 +348,8 @@ struct HfFragmentationFunction {
           }
 
           // reflection information for storage: D0 = +1, D0bar = -1, neither = 0
-          int matchedFrom = 0;
-          int decayChannel = o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK;
           int selectedAs = 0;
 
-          if (mcdd0cand.flagMcMatchRec() == decayChannel) { // matched to D0 on truth level
-            matchedFrom = 1;
-          } else if (mcdd0cand.flagMcMatchRec() == -decayChannel) { // matched to D0bar on truth level
-            matchedFrom = -1;
-          }
           // bitwise AND operation: Checks whether BIT(i) is set, regardless of other bits
           if (mcdd0cand.candidateSelFlag() & BIT(0)) { // CandidateSelFlag == BIT(0) -> selected as D0
             selectedAs = 1;
@@ -370,8 +361,8 @@ struct HfFragmentationFunction {
           mcddistJetTable(jetutilities::deltaR(mcdjet, mcdd0cand),
                           mcdjet.pt(), mcdjet.eta(), mcdjet.phi(), mcdjet.tracks_as<aod::JetTracks>().size() + mcdjet.candidates_as<aod::CandidatesD0MCD>().size(),   // detector level jet
                           mcdd0cand.pt(), mcdd0cand.eta(), mcdd0cand.phi(), mcdd0cand.m(), mcdd0cand.y(), (mcdd0cand.originMcRec() == RecoDecay::OriginType::Prompt), // detector level D0 candidate
-                          mcdjet.has_matchedJetCand(), mcdd0cand.mlScores()[0], mcdd0cand.mlScores()[1], mcdd0cand.mlScores()[2],                                     // // Machine Learning PID scores: background, prompt, non-prompt
-                          matchedFrom, selectedAs);                                                                                                                   // D0 = +1, D0bar = -1, neither = 0
+                          mcdjet.has_matchedJetCand(), mcdd0cand.mlScores()[0], mcdd0cand.mlScores()[1], mcdd0cand.mlScores()[2],                                     // Machine Learning PID scores: background, prompt, non-prompt
+                          static_cast<int>(mcdd0cand.flagMcMatchRec()), selectedAs);                                                                                  // +1/-1 = D0(bar)→Kπ, ±2..5 = other D0 channels, 0 = no match
         }
       }
 
@@ -444,21 +435,8 @@ struct HfFragmentationFunction {
             // obtain leading HF candidate in jet
             auto mcdcand = mcdjet.template candidates_first_as<TCandidatesMCD>();
 
-            // reflection information for storage: HF = +1, HFbar = -1, neither = 0
-            int matchedFrom = 0;
-            int decayChannel = 0;
-            if (jethfutilities::isD0Table<TCandidatesMCD>()) {
-              decayChannel = o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK;
-            } else if (jethfutilities::isLcTable<TCandidatesMCD>()) {
-              decayChannel = o2::hf_decay::hf_cand_3prong::DecayChannelMain::LcToPKPi;
-            }
             int selectedAs = 0;
 
-            if (mcdcand.flagMcMatchRec() == decayChannel) { // matched to HF on truth level
-              matchedFrom = 1;
-            } else if (mcdcand.flagMcMatchRec() == -decayChannel) { // matched to HFbar on truth level
-              matchedFrom = -1;
-            }
             // bitwise AND operation: Checks whether BIT(i) is set, regardless of other bits
             if (mcdcand.candidateSelFlag() & BIT(0)) { // CandidateSelFlag == BIT(0) -> selected as HF
               selectedAs = 1;
@@ -469,19 +447,19 @@ struct HfFragmentationFunction {
             // store matched particle and detector level data in one single table (calculate angular distance in eta-phi plane on the fly)
             matchJetTable(jetutilities::deltaR(mcpjet, mcpcand), mcpjet.pt(), mcpjet.eta(), mcpjet.phi(), mcpjet.template tracks_as<aod::JetParticles>().size() + mcpjet.template candidates_as<TCandidatesMCP>().size(), // particle level jet
                           mcpcand.pt(), mcpcand.eta(), mcpcand.phi(), mcpcand.y(), (mcpcand.originMcGen() == RecoDecay::OriginType::Prompt),                                                                              // particle level HF
-                          jetutilities::deltaR(mcdjet, mcdcand), mcdjet.pt(), mcdjet.eta(), mcdjet.phi(), mcdjet.template tracks_as<aod::JetTracks>().size() + +mcdjet.template candidates_as<TCandidatesMCD>().size(),   // detector level jet
+                          jetutilities::deltaR(mcdjet, mcdcand), mcdjet.pt(), mcdjet.eta(), mcdjet.phi(), mcdjet.template tracks_as<aod::JetTracks>().size() + mcdjet.template candidates_as<TCandidatesMCD>().size(),    // detector level jet
                           mcdcand.pt(), mcdcand.eta(), mcdcand.phi(), mcdcand.m(), mcdcand.y(), (mcdcand.originMcRec() == RecoDecay::OriginType::Prompt),                                                                 // detector level HF
                           mcdcand.mlScores()[0], mcdcand.mlScores()[1], mcdcand.mlScores()[2],                                                                                                                            // Machine Learning PID scores: background, prompt, non-prompt
-                          matchedFrom, selectedAs);                                                                                                                                                                       // HF = +1, HFbar = -1, neither = 0
+                          static_cast<int>(mcdcand.flagMcMatchRec()), selectedAs);                                                                                                                                        // HF = +1, HFbar = -1, neither = 0
           }
         } else {
           // store matched particle and detector level data in one single table (calculate angular distance in eta-phi plane on the fly)
-          matchJetTable(jetutilities::deltaR(mcpjet, mcpcand), mcpjet.pt(), mcpjet.eta(), mcpjet.phi(), mcpjet.template tracks_as<aod::JetParticles>().size() + +mcpjet.template candidates_as<TCandidatesMCP>().size(), // particle level jet
+          matchJetTable(jetutilities::deltaR(mcpjet, mcpcand), mcpjet.pt(), mcpjet.eta(), mcpjet.phi(), mcpjet.template tracks_as<aod::JetParticles>().size() + mcpjet.template candidates_as<TCandidatesMCP>().size(), // particle level jet
                         mcpcand.pt(), mcpcand.eta(), mcpcand.phi(), mcpcand.y(), (mcpcand.originMcGen() == RecoDecay::OriginType::Prompt),                                                                               // particle level HF
-                        -2, -2, -2, -2, -2,                                                                                                                                                                              // detector level jet
-                        -2, -2, -2, -2, -2, -2,                                                                                                                                                                          // detector level HF
-                        -2, -2, -2,                                                                                                                                                                                      // Machine Learning PID scores: background, prompt, non-prompt
-                        -2, -2);                                                                                                                                                                                         // HF = +1, HFbar = -1, neither = 0
+                        -2, -2, -2, -2, -2,                                                                                                                                                                              // no detector-level jet found
+                        -2, -2, -2, -2, -2, -2,                                                                                                                                                                          // no detector-level jet found
+                        -2, -2, -2,                                                                                                                                                                                      // no detector-level jet found
+                        -2, -2);                                                                                                                                                                                         // no detector-level jet found
         }
       } // end of mcpjets loop
     } // end of mccollisions loop

--- a/PWGJE/Tasks/hfFragmentationFunction.cxx
+++ b/PWGJE/Tasks/hfFragmentationFunction.cxx
@@ -25,15 +25,7 @@
 #include "PWGJE/Core/JetUtilities.h"
 #include "PWGJE/DataModel/Jet.h"
 #include "PWGJE/DataModel/JetReducedData.h"
-<<<<<<< HEAD
-=======
 
-<<<<<<< HEAD
-#include "PWGHF/Core/DecayChannels.h"
->>>>>>> 8fcbef4d9 (Fix: clang-formatting done manually)
-
-=======
->>>>>>> ee38d6bf6 (Fix: formatting with automatic git-clang-format feature)
 #include "Common/Core/RecoDecay.h"
 
 #include <CommonConstants/MathConstants.h>
@@ -451,28 +443,6 @@ struct HfFragmentationFunction {
 
             // obtain leading HF candidate in jet
             auto mcdcand = mcdjet.template candidates_first_as<TCandidatesMCD>();
-
-            // reflection information for storage: HF = +1, HFbar = -1, neither = 0
-            int matchedFrom = 0;
-            int decayChannel = 0;
-            if (jethfutilities::isD0Table<TCandidatesMCD>()) {
-              decayChannel = o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK;
-            } else if (jethfutilities::isLcTable<TCandidatesMCD>()) {
-              decayChannel = o2::hf_decay::hf_cand_3prong::DecayChannelMain::LcToPKPi;
-            }
-            int selectedAs = 0;
-
-            if (mcdcand.flagMcMatchRec() == decayChannel) { // matched to HF on truth level
-              matchedFrom = 1;
-            } else if (mcdcand.flagMcMatchRec() == -decayChannel) { // matched to HFbar on truth level
-              matchedFrom = -1;
-            }
-            // bitwise AND operation: Checks whether BIT(i) is set, regardless of other bits
-            if (mcdcand.candidateSelFlag() & BIT(0)) { // CandidateSelFlag == BIT(0) -> selected as HF
-              selectedAs = 1;
-            } else if (mcdcand.candidateSelFlag() & BIT(1)) { // CandidateSelFlag == BIT(1) -> selected as HFbar
-              selectedAs = -1;
-            }
 
             // reflection information for storage: HF = +1, HFbar = -1, neither = 0
             int matchedFrom = 0;

--- a/PWGJE/Tasks/hfFragmentationFunction.cxx
+++ b/PWGJE/Tasks/hfFragmentationFunction.cxx
@@ -196,6 +196,7 @@ struct HfFragmentationFunction {
 
   Configurable<float> vertexZCut{"vertexZCut", 10.0f, "Accepted z-vertex range"};
   Configurable<std::string> eventSelections{"eventSelections", "sel8", "choose event selection"};
+  Configurable<std::string> chosenHadron{"chosenHadron", "D0", "choose hadron for analysis: D0 or Lc"};
 
   std::vector<int> eventSelectionBits;
 

--- a/PWGJE/Tasks/hfFragmentationFunction.cxx
+++ b/PWGJE/Tasks/hfFragmentationFunction.cxx
@@ -19,11 +19,8 @@
 
 #include "PWGHF/Core/DecayChannels.h"
 #include "PWGJE/Core/JetDerivedDataUtilities.h"
-<<<<<<< HEAD
 #include "PWGJE/Core/JetHFUtilities.h"
 #include "PWGJE/Core/JetUtilities.h"
-=======
->>>>>>> 8fcbef4d9 (Fix: clang-formatting done manually)
 #include "PWGJE/Core/JetHFUtilities.h"
 #include "PWGJE/Core/JetUtilities.h"
 #include "PWGJE/DataModel/Jet.h"
@@ -31,9 +28,12 @@
 <<<<<<< HEAD
 =======
 
+<<<<<<< HEAD
 #include "PWGHF/Core/DecayChannels.h"
 >>>>>>> 8fcbef4d9 (Fix: clang-formatting done manually)
 
+=======
+>>>>>>> ee38d6bf6 (Fix: formatting with automatic git-clang-format feature)
 #include "Common/Core/RecoDecay.h"
 
 #include <CommonConstants/MathConstants.h>

--- a/PWGJE/Tasks/hfFragmentationFunction.cxx
+++ b/PWGJE/Tasks/hfFragmentationFunction.cxx
@@ -19,11 +19,20 @@
 
 #include "PWGHF/Core/DecayChannels.h"
 #include "PWGJE/Core/JetDerivedDataUtilities.h"
+<<<<<<< HEAD
 #include "PWGJE/Core/JetHFUtilities.h"
 #include "PWGJE/Core/JetUtilities.h"
+=======
+>>>>>>> 8fcbef4d9 (Fix: clang-formatting done manually)
 #include "PWGJE/Core/JetHFUtilities.h"
+#include "PWGJE/Core/JetUtilities.h"
 #include "PWGJE/DataModel/Jet.h"
 #include "PWGJE/DataModel/JetReducedData.h"
+<<<<<<< HEAD
+=======
+
+#include "PWGHF/Core/DecayChannels.h"
+>>>>>>> 8fcbef4d9 (Fix: clang-formatting done manually)
 
 #include "Common/Core/RecoDecay.h"
 


### PR DESCRIPTION
### Minor changes:
- excluded duplicated includes at the beginning of file
- changed number of jet constituents from `float` to `int` type

### Small but more significant change:
- storage of original decay information
- no need for usage of `matchedFrom` variable anymore

This is necessary in order to describe correlated background during the side-band subtraction method.