### PR TITLE
[PWGEM,PWGEM-36] Fix flow reso task

### DIFF
--- a/PWGEM/PhotonMeson/Tasks/taskFlowReso.cxx
+++ b/PWGEM/PhotonMeson/Tasks/taskFlowReso.cxx
@@ -164,12 +164,13 @@ struct TaskFlowReso {
       registry.add("spReso/hSpResoFT0cTPCtot", "hSpResoFT0cTPCtot; centrality; Q_{FT0c} #bullet Q_{TPCtot}", HistType::kTProfile, {thnAxisCent});
       registry.add("spReso/hSpResoFT0aTPCpos", "hSpResoFT0aTPCpos; centrality; Q_{FT0a} #bullet Q_{TPCpos}", HistType::kTProfile, {thnAxisCent});
       registry.add("spReso/hSpResoFT0aTPCneg", "hSpResoFT0aTPCneg; centrality; Q_{FT0a} #bullet Q_{TPCneg}", HistType::kTProfile, {thnAxisCent});
-      registry.add("spReso/hSpResoFT0aTPCtot", "hSpResoFT0aTPCtot; centrality; Q_{FT0m} #bullet Q_{TPCtot}", HistType::kTProfile, {thnAxisCent});
+      registry.add("spReso/hSpResoFT0aTPCtot", "hSpResoFT0aTPCtot; centrality; Q_{FT0a} #bullet Q_{TPCtot}", HistType::kTProfile, {thnAxisCent});
       registry.add("spReso/hSpResoFT0mTPCpos", "hSpResoFT0mTPCpos; centrality; Q_{FT0m} #bullet Q_{TPCpos}", HistType::kTProfile, {thnAxisCent});
       registry.add("spReso/hSpResoFT0mTPCneg", "hSpResoFT0mTPCneg; centrality; Q_{FT0m} #bullet Q_{TPCneg}", HistType::kTProfile, {thnAxisCent});
       registry.add("spReso/hSpResoFT0mTPCtot", "hSpResoFT0mTPCtot; centrality; Q_{FT0m} #bullet Q_{TPCtot}", HistType::kTProfile, {thnAxisCent});
       registry.add("spReso/hSpResoTPCposTPCneg", "hSpResoTPCposTPCneg; centrality; Q_{TPCpos} #bullet Q_{TPCneg}", HistType::kTProfile, {thnAxisCent});
       registry.add("spReso/hSpResoFV0aFT0c", "hSpResoFV0aFT0c; centrality; Q_{FV0a} #bullet Q_{FT0c}", HistType::kTProfile, {thnAxisCent});
+      registry.add("spReso/hSpResoFV0aFT0a", "hSpResoFV0aFT0a; centrality; Q_{FV0a} #bullet Q_{FT0a}", HistType::kTProfile, {thnAxisCent});
       registry.add("spReso/hSpResoFV0aTPCpos", "hSpResoFV0aTPCpos; centrality; Q_{FV0a} #bullet Q_{TPCpos}", HistType::kTProfile, {thnAxisCent});
       registry.add("spReso/hSpResoFV0aTPCneg", "hSpResoFV0aTPCneg; centrality; Q_{FV0a} #bullet Q_{TPCneg}", HistType::kTProfile, {thnAxisCent});
       registry.add("spReso/hSpResoFV0aTPCtot", "hSpResoFV0aTPCtot; centrality; Q_{FV0a} #bullet Q_{TPCtot}", HistType::kTProfile, {thnAxisCent});
@@ -451,6 +452,7 @@ struct TaskFlowReso {
       registry.fill(HIST("spReso/hSpResoFT0mTPCtot"), centrality, xQVecFT0m * xQVecBTot + yQVecFT0m * yQVecBTot);
       registry.fill(HIST("spReso/hSpResoTPCposTPCneg"), centrality, xQVecBPos * xQVecBNeg + yQVecBPos * yQVecBNeg);
       registry.fill(HIST("spReso/hSpResoFV0aFT0c"), centrality, xQVecFV0a * xQVecFT0c + yQVecFV0a * yQVecFT0c);
+      registry.fill(HIST("spReso/hSpResoFV0aFT0a"), centrality, xQVecFV0a * xQVecFT0a + yQVecFV0a * yQVecFT0a);
       registry.fill(HIST("spReso/hSpResoFV0aTPCpos"), centrality, xQVecFV0a * xQVecBPos + yQVecFV0a * yQVecBPos);
       registry.fill(HIST("spReso/hSpResoFV0aTPCneg"), centrality, xQVecFV0a * xQVecBNeg + yQVecFV0a * yQVecBNeg);
       registry.fill(HIST("spReso/hSpResoFV0aTPCtot"), centrality, xQVecFV0a * xQVecBTot + yQVecFV0a * yQVecBTot);
@@ -466,8 +468,8 @@ struct TaskFlowReso {
       float epFV0a = epHelper.GetEventPlane(xQVecFV0a, yQVecFV0a, harmonic);
 
       registry.fill(HIST("hEventPlaneAngleFT0M"), centrality, epFT0m);
-      registry.fill(HIST("hEventPlaneAngleFT0A"), centrality, epFT0c);
-      registry.fill(HIST("hEventPlaneAngleFT0C"), centrality, epFT0a);
+      registry.fill(HIST("hEventPlaneAngleFT0A"), centrality, epFT0a);
+      registry.fill(HIST("hEventPlaneAngleFT0C"), centrality, epFT0c);
       registry.fill(HIST("hEventPlaneAngleTPCpos"), centrality, epBPoss);
       registry.fill(HIST("hEventPlaneAngleTPCneg"), centrality, epBNegs);
       registry.fill(HIST("hEventPlaneAngleFV0A"), centrality, epFV0a);


### PR DESCRIPTION
- Fix swapped FT0A and FT0C event plane histogram
- Add `hSpResoFV0aFT0a`. This is experimental, since they have large overlap in pseudorapidity!
- Fix title string in `hSpResoFT0aTPCtot`