### PR TITLE
[Common] Add zdc-extra-table-reader task

### DIFF
--- a/Common/Tasks/CMakeLists.txt
+++ b/Common/Tasks/CMakeLists.txt
@@ -98,3 +98,8 @@ o2physics_add_dpl_workflow(zdc-table-reader
                     SOURCES zdcTableReader.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
                     COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(zdc-extra-table-reader
+                    SOURCES zdcExtraTableReader.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)

--- a/Common/Tasks/zdcExtraTableReader.cxx
+++ b/Common/Tasks/zdcExtraTableReader.cxx
@@ -746,7 +746,6 @@ struct ZdcExtraTableReader {
     }
     //
 
-
     bool isZNASpDeterminable = false;
     bool isZNCSpDeterminable = false;
 
@@ -755,13 +754,15 @@ struct ZdcExtraTableReader {
     if (isZNAhit) {
       int activeTowersZNA = (zdc.znaTow1() > 0.) + (zdc.znaTow2() > 0.) + (zdc.znaTow3() > 0.) + (zdc.znaTow4() > 0.);
       float znaSum = zdc.znaTow1() + zdc.znaTow2() + zdc.znaTow3() + zdc.znaTow4();
-      if (activeTowersZNA >= nTowersFired && znaSum > 0 && zdc.znaQx() < QvectorMaxValue) isZNASpDeterminable = true;
+      if (activeTowersZNA >= nTowersFired && znaSum > 0 && zdc.znaQx() < QvectorMaxValue)
+        isZNASpDeterminable = true;
     }
 
     if (isZNChit) {
       int activeTowersZNC = (zdc.zncTow1() > 0.) + (zdc.zncTow2() > 0.) + (zdc.zncTow3() > 0.) + (zdc.zncTow4() > 0.);
       float zncSum = zdc.zncTow1() + zdc.zncTow2() + zdc.zncTow3() + zdc.zncTow4();
-      if (activeTowersZNC >= nTowersFired && zncSum > 0 && zdc.zncQx() < QvectorMaxValue) isZNCSpDeterminable = true;
+      if (activeTowersZNC >= nTowersFired && zncSum > 0 && zdc.zncQx() < QvectorMaxValue)
+        isZNCSpDeterminable = true;
     }
 
     if (plotPMs) {

--- a/Common/Tasks/zdcExtraTableReader.cxx
+++ b/Common/Tasks/zdcExtraTableReader.cxx
@@ -181,10 +181,10 @@ double getMeanQFromMap(THn* h, double cent, double vx, double vy, double vz)
     return 0.0;
   }
 
-  int binCent = axCent->FindBin(cent);
-  int binVx = axVx->FindBin(vx);
-  int binVy = axVy->FindBin(vy);
-  int binVz = axVz->FindBin(vz);
+  int binCent = axCent->FindFixBin(cent);
+  int binVx = axVx->FindFixBin(vx);
+  int binVy = axVy->FindFixBin(vy);
+  int binVz = axVz->FindFixBin(vz);
 
   int idx[4] = {binCent, binVx, binVy, binVz};
   double meanQ = h->GetBinContent(idx);
@@ -199,7 +199,7 @@ double getMeanQ1D(TH1* h, double x)
   if (!h) {
     return 0.0;
   }
-  int bin = h->FindBin(x);
+  int bin = h->FindFixBin(x);
   if (bin < 1 || bin > h->GetNbinsX()) {
     return 0.0;
   }
@@ -236,6 +236,8 @@ struct ZdcExtraTableReader {
   Configurable<float> centMax{"centMax", 80.0f, "Centrality upper edge"};
 
   Configurable<int> phiNbins{"phiNbins", 60, "Bins in phi"};
+
+  Configurable<int> nTowersFired{"nTowersFired", 2, "Minimum number of towers fired for Q-vector determination"};
 
   Configurable<int> qNbins5D{"qNbins5D", 4, "Bins in each dimension for 5D histograms"};
   Configurable<bool> plot5D{"plot5D", false, "Flag to plot 5D histograms"};
@@ -301,8 +303,8 @@ struct ZdcExtraTableReader {
   TH1* hMeanVy{nullptr};
 
   // Phase shift correction cache
-  TProfile3D* hShiftZNA{nullptr};
-  TProfile3D* hShiftZNC{nullptr};
+  TProfile3D* mShiftProfileZNA{nullptr};
+  TProfile3D* mShiftProfileZNC{nullptr};
 
   HistogramRegistry histos{
     "histos",
@@ -377,13 +379,13 @@ struct ZdcExtraTableReader {
       delete step.hMeanQxVyZNC;
       delete step.hMeanQyVyZNC;
 
-      if (hShiftZNA) {
-        delete hShiftZNA;
-        hShiftZNA = nullptr;
+      if (mShiftProfileZNA) {
+        delete mShiftProfileZNA;
+        mShiftProfileZNA = nullptr;
       }
-      if (hShiftZNC) {
-        delete hShiftZNC;
-        hShiftZNC = nullptr;
+      if (mShiftProfileZNC) {
+        delete mShiftProfileZNC;
+        mShiftProfileZNC = nullptr;
       }
     }
     mCalibCache.clear();
@@ -611,21 +613,21 @@ struct ZdcExtraTableReader {
 
       if (lst) {
         // Important: Object names must match exactly what was saved
-        hShiftZNA = safeClone<TProfile3D>(lst->FindObject("hShiftZNA"));
-        hShiftZNC = safeClone<TProfile3D>(lst->FindObject("hShiftZNC"));
+        mShiftProfileZNA = safeClone<TProfile3D>(lst->FindObject("ShiftProfileZNA"));
+        mShiftProfileZNC = safeClone<TProfile3D>(lst->FindObject("ShiftProfileZNC"));
 
-        if (hShiftZNA) {
-          hShiftZNA->SetDirectory(nullptr); // Detach from file
+        if (mShiftProfileZNA) {
+          mShiftProfileZNA->SetDirectory(nullptr); // Detach from file
           LOGF(info, "  >> ShiftProfileZNA found! Entries: %.0f, Mean: %f",
-               hShiftZNA->GetEntries(), hShiftZNA->GetMean());
+               mShiftProfileZNA->GetEntries(), mShiftProfileZNA->GetMean());
         } else {
           LOGF(error, "  >> ShiftProfileZNA NOT found in TList! Content follows:");
           lst->Print();
         }
 
-        if (hShiftZNC) {
-          hShiftZNC->SetDirectory(nullptr);
-          LOGF(info, "  >> ShiftProfileZNC found! Entries: %.0f", hShiftZNC->GetEntries());
+        if (mShiftProfileZNC) {
+          mShiftProfileZNC->SetDirectory(nullptr);
+          LOGF(info, "  >> ShiftProfileZNC found! Entries: %.0f", mShiftProfileZNC->GetEntries());
         } else {
           LOGF(error, "  >> ShiftProfileZNC NOT found in TList!");
         }
@@ -744,6 +746,22 @@ struct ZdcExtraTableReader {
     }
     //
 
+
+    bool isZNASpDeterminable = false;
+    bool isZNCSpDeterminable = false;
+
+    if (isZNAhit) {
+      int activeTowersZNA = (zdc.znaTow1() > 0.) + (zdc.znaTow2() > 0.) + (zdc.znaTow3() > 0.) + (zdc.znaTow4() > 0.);
+      float znaSum = zdc.znaTow1() + zdc.znaTow2() + zdc.znaTow3() + zdc.znaTow4();
+      if (activeTowersZNA >= nTowersFired && znaSum > 0 && zdc.znaQx() < 990.0f) isZNASpDeterminable = true;
+    }
+
+    if (isZNChit) {
+      int activeTowersZNC = (zdc.zncTow1() > 0.) + (zdc.zncTow2() > 0.) + (zdc.zncTow3() > 0.) + (zdc.zncTow4() > 0.);
+      float zncSum = zdc.zncTow1() + zdc.zncTow2() + zdc.zncTow3() + zdc.zncTow4();
+      if (activeTowersZNC >= nTowersFired && zncSum > 0 && zdc.zncQx() < 990.0f) isZNCSpDeterminable = true;
+    }
+
     if (plotPMs) {
       if (isZNAhit) {
         gCurrentPmcZNA->Fill(zdc.znaTowC());
@@ -789,7 +807,7 @@ struct ZdcExtraTableReader {
     }
 
     // -------- ZNA --------
-    if (isZNAhit) {
+    if (isZNASpDeterminable) {
       double qx = zdc.znaQx();
       double qy = zdc.znaQy();
 
@@ -856,7 +874,7 @@ struct ZdcExtraTableReader {
 
       // Apply Correction (Read Mode)
       // Checks if correction is enabled AND if the map from CCDB was loaded successfully
-      if (ifShiftCorrection && hShiftZNA) {
+      if (ifShiftCorrection && mShiftProfileZNA) {
         double deltaPsi = 0.0;
 
         // Loop over harmonics (usually 1 to 10)
@@ -867,11 +885,11 @@ struct ZdcExtraTableReader {
           // Y: Type (0.5 for Sin, 1.5 for Cos)
           // Z: Harmonic index (ishift - 0.5 maps to bin 1, 2, etc.)
 
-          int binSin = hShiftZNA->FindBin(cent, 0.5, static_cast<double>(ishift) - 0.5);
-          int binCos = hShiftZNA->FindBin(cent, 1.5, static_cast<double>(ishift) - 0.5);
+          int binSin = mShiftProfileZNA->FindFixBin(cent, 0.5, static_cast<double>(ishift) - 0.5);
+          int binCos = mShiftProfileZNA->FindFixBin(cent, 1.5, static_cast<double>(ishift) - 0.5);
 
-          double coeffSin = hShiftZNA->GetBinContent(binSin);
-          double coeffCos = hShiftZNA->GetBinContent(binCos);
+          double coeffSin = mShiftProfileZNA->GetBinContent(binSin);
+          double coeffCos = mShiftProfileZNA->GetBinContent(binCos);
 
           // Fourier flattening formula:
           // DeltaPsi = sum( (2/k) * ( <cos>*sin(k*psi) - <sin>*cos(k*psi) ) )
@@ -912,7 +930,7 @@ struct ZdcExtraTableReader {
     }
 
     // -------- ZNC --------
-    if (isZNChit) {
+    if (isZNCSpDeterminable) {
       double qx = zdc.zncQx();
       double qy = zdc.zncQy();
 
@@ -990,7 +1008,7 @@ struct ZdcExtraTableReader {
 
       // Apply Correction (Read Mode)
       // Checks if correction is enabled AND if the map from CCDB was loaded successfully
-      if (ifShiftCorrection && hShiftZNC) {
+      if (ifShiftCorrection && mShiftProfileZNC) {
         double deltaPsi = 0.0;
 
         // Loop over harmonics (usually 1 to 10)
@@ -1001,11 +1019,11 @@ struct ZdcExtraTableReader {
           // Y: Type (0.5 for Sin, 1.5 for Cos)
           // Z: Harmonic index (ishift - 0.5 maps to bin 1, 2, etc.)
 
-          int binSin = hShiftZNC->FindBin(cent, 0.5, static_cast<double>(ishift) - 0.5);
-          int binCos = hShiftZNC->FindBin(cent, 1.5, static_cast<double>(ishift) - 0.5);
+          int binSin = mShiftProfileZNC->FindFixBin(cent, 0.5, static_cast<double>(ishift) - 0.5);
+          int binCos = mShiftProfileZNC->FindFixBin(cent, 1.5, static_cast<double>(ishift) - 0.5);
 
-          double coeffSin = hShiftZNC->GetBinContent(binSin);
-          double coeffCos = hShiftZNC->GetBinContent(binCos);
+          double coeffSin = mShiftProfileZNC->GetBinContent(binSin);
+          double coeffCos = mShiftProfileZNC->GetBinContent(binCos);
 
           // Fourier flattening formula:
           // DeltaPsi = sum( (2/k) * ( <cos>*sin(k*psi) - <sin>*cos(k*psi) ) )
@@ -1035,7 +1053,7 @@ struct ZdcExtraTableReader {
       gCurrentPsiZNC->Fill(psiZNC);
     }
 
-    if (isZNAhit && isZNChit) {
+    if (isZNASpDeterminable && isZNCSpDeterminable) {
       gCurrentQxQyVsCent->Fill(cent, qxZNArec * qyZNCrec);
       gCurrentQyQxVsCent->Fill(cent, qyZNArec * qxZNCrec);
       gCurrentQxQxVsCent->Fill(cent, qxZNArec * qxZNCrec);

--- a/Common/Tasks/zdcExtraTableReader.cxx
+++ b/Common/Tasks/zdcExtraTableReader.cxx
@@ -1,0 +1,1056 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file zdcExtraTableReader.cxx
+/// \brief Task reading AOD/ZDCEXTRA table
+/// \author Uliana Dmitrieva <uliana.dmitrieva@cern.ch>, INFN Torino
+
+#include "Common/CCDB/EventSelectionParams.h"
+#include "Common/Core/RecoDecay.h"
+#include "Common/DataModel/Centrality.h"
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/ZDCExtra.h"
+
+#include <CCDB/BasicCCDBManager.h>
+#include <CCDB/CcdbApi.h>
+#include <CommonConstants/MathConstants.h>
+#include <Framework/AnalysisDataModel.h>
+#include <Framework/AnalysisHelpers.h>
+#include <Framework/AnalysisTask.h>
+#include <Framework/Configurable.h>
+#include <Framework/HistogramRegistry.h>
+#include <Framework/HistogramSpec.h>
+#include <Framework/InitContext.h>
+#include <Framework/OutputObjHeader.h>
+#include <Framework/runDataProcessing.h>
+
+#include <TFile.h>
+#include <TH1.h>
+#include <TH2.h>
+#include <THn.h>
+#include <TList.h>
+#include <TMath.h>
+#include <TProfile3D.h>
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+using namespace o2;
+using namespace o2::framework;
+
+namespace
+{
+
+std::unordered_map<int, TH1*> gEventCounter;
+std::unordered_map<int, TH2*> gCentroidZNA;
+std::unordered_map<int, TH2*> gCentroidZNC;
+std::unordered_map<int, TH1*> gPmcZNA;
+std::unordered_map<int, TH1*> gPm1ZNA;
+std::unordered_map<int, TH1*> gPm2ZNA;
+std::unordered_map<int, TH1*> gPm3ZNA;
+std::unordered_map<int, TH1*> gPm4ZNA;
+std::unordered_map<int, TH1*> gSumZNA;
+std::unordered_map<int, TH1*> gPmcZNC;
+std::unordered_map<int, TH1*> gPm1ZNC;
+std::unordered_map<int, TH1*> gPm2ZNC;
+std::unordered_map<int, TH1*> gPm3ZNC;
+std::unordered_map<int, TH1*> gPm4ZNC;
+std::unordered_map<int, TH1*> gSumZNC;
+std::unordered_map<int, TH2*> gQxVsCentZNA;
+std::unordered_map<int, TH2*> gQyVsCentZNA;
+std::unordered_map<int, TH2*> gQxVsVxZNA;
+std::unordered_map<int, TH2*> gQyVsVxZNA;
+std::unordered_map<int, TH2*> gQxVsVyZNA;
+std::unordered_map<int, TH2*> gQyVsVyZNA;
+std::unordered_map<int, TH2*> gQxVsVzZNA;
+std::unordered_map<int, TH2*> gQyVsVzZNA;
+std::unordered_map<int, TH2*> gQxVsCentZNC;
+std::unordered_map<int, TH2*> gQyVsCentZNC;
+std::unordered_map<int, TH2*> gQxVsVxZNC;
+std::unordered_map<int, TH2*> gQyVsVxZNC;
+std::unordered_map<int, TH2*> gQxVsVyZNC;
+std::unordered_map<int, TH2*> gQyVsVyZNC;
+std::unordered_map<int, TH2*> gQxVsVzZNC;
+std::unordered_map<int, TH2*> gQyVsVzZNC;
+std::unordered_map<int, TH2*> gQxQyVsCent;
+std::unordered_map<int, TH2*> gQyQxVsCent;
+std::unordered_map<int, TH2*> gQxQxVsCent;
+std::unordered_map<int, TH2*> gQyQyVsCent;
+
+std::unordered_map<int, THn*> gQx5DZNA;
+std::unordered_map<int, THn*> gQy5DZNA;
+std::unordered_map<int, THn*> gQx5DZNC;
+std::unordered_map<int, THn*> gQy5DZNC;
+
+std::unordered_map<int, TH1*> gPsiZNA;
+std::unordered_map<int, TH1*> gPsiZNC;
+
+std::unordered_map<int, TH1*> gVx;
+std::unordered_map<int, TH1*> gVy;
+
+// centroid stability vs timestamp
+std::unordered_map<int, TH2*> gQxVsTimeZNA;
+std::unordered_map<int, TH2*> gQyVsTimeZNA;
+std::unordered_map<int, TH2*> gQxVsTimeZNC;
+std::unordered_map<int, TH2*> gQyVsTimeZNC;
+
+std::unordered_map<int, TProfile3D*> gShiftProfileZNA;
+std::unordered_map<int, TProfile3D*> gShiftProfileZNC;
+
+TH1* gCurrentEventCounter;
+TH2* gCurrentCentroidZNA;
+TH2* gCurrentCentroidZNC;
+TH1* gCurrentPmcZNA;
+TH1* gCurrentPm1ZNA;
+TH1* gCurrentPm2ZNA;
+TH1* gCurrentPm3ZNA;
+TH1* gCurrentPm4ZNA;
+TH1* gCurrentSumZNA;
+TH1* gCurrentPmcZNC;
+TH1* gCurrentPm1ZNC;
+TH1* gCurrentPm2ZNC;
+TH1* gCurrentPm3ZNC;
+TH1* gCurrentPm4ZNC;
+TH1* gCurrentSumZNC;
+TH2* gCurrentQxVsCentZNA;
+TH2* gCurrentQyVsCentZNA;
+TH2* gCurrentQxVsVxZNA;
+TH2* gCurrentQyVsVxZNA;
+TH2* gCurrentQxVsVyZNA;
+TH2* gCurrentQyVsVyZNA;
+TH2* gCurrentQxVsVzZNA;
+TH2* gCurrentQyVsVzZNA;
+TH2* gCurrentQxVsCentZNC;
+TH2* gCurrentQyVsCentZNC;
+TH2* gCurrentQxVsVxZNC;
+TH2* gCurrentQyVsVxZNC;
+TH2* gCurrentQxVsVyZNC;
+TH2* gCurrentQyVsVyZNC;
+TH2* gCurrentQxVsVzZNC;
+TH2* gCurrentQyVsVzZNC;
+TH2* gCurrentQxQyVsCent;
+TH2* gCurrentQyQxVsCent;
+TH2* gCurrentQxQxVsCent;
+TH2* gCurrentQyQyVsCent;
+
+THn* gCurrentQxZNA;
+THn* gCurrentQyZNA;
+THn* gCurrentQxZNC;
+THn* gCurrentQyZNC;
+
+TH1* gCurrentPsiZNA;
+TH1* gCurrentPsiZNC;
+
+TH1* gCurrentVx;
+TH1* gCurrentVy;
+
+TH2* gCurrentQxVsTimeZNA;
+TH2* gCurrentQyVsTimeZNA;
+TH2* gCurrentQxVsTimeZNC;
+TH2* gCurrentQyVsTimeZNC;
+
+TProfile3D* gCurrentShiftProfileZNA;
+TProfile3D* gCurrentShiftProfileZNC;
+
+} // namespace
+
+double getMeanQFromMap(THn* h, double cent, double vx, double vy, double vz)
+{
+  if (!h) {
+    // Commented out to reduce log spam in case of missing maps, enable for debugging
+    // std::cerr << "[MeanQ] Null THn pointer (cent=" << cent << ", vx=" << vx << ", vy=" << vy << ", vz=" << vz << ")" << std::endl;
+    return 0.0;
+  }
+
+  TAxis* axCent = h->GetAxis(0);
+  TAxis* axVx = h->GetAxis(1);
+  TAxis* axVy = h->GetAxis(2);
+  TAxis* axVz = h->GetAxis(3);
+
+  if (!axCent || !axVx || !axVy || !axVz) {
+    std::cerr << "[MeanQ] One of THn axes is null" << std::endl;
+    return 0.0;
+  }
+
+  int binCent = axCent->FindBin(cent);
+  int binVx = axVx->FindBin(vx);
+  int binVy = axVy->FindBin(vy);
+  int binVz = axVz->FindBin(vz);
+
+  int idx[4] = {binCent, binVx, binVy, binVz};
+  double meanQ = h->GetBinContent(idx);
+
+  return meanQ;
+}
+
+// Helper for 1D recentering maps: returns mean Q for coordinate x.
+// If histogram is missing or bin out of range, returns 0.0.
+double getMeanQ1D(TH1* h, double x)
+{
+  if (!h) {
+    return 0.0;
+  }
+  int bin = h->FindBin(x);
+  if (bin < 1 || bin > h->GetNbinsX()) {
+    return 0.0;
+  }
+  return h->GetBinContent(bin);
+}
+
+struct ZdcExtraTableReader {
+
+  Configurable<int> nBinsZN{"nBinsZN", 2000, "n bins for ZN histograms"};
+  Configurable<float> maxZN{"maxZN", 399.5, "Max ZN signal"};
+  Configurable<bool> tdcCut{"tdcCut", true, "Flag for TDC cut"};
+  Configurable<float> tdcZNmincut{"tdcZNmincut", -2.5, "Min ZN TDC cut"};
+  Configurable<float> tdcZNmaxcut{"tdcZNmaxcut", 2.5, "Max ZN TDC cut"};
+  Configurable<bool> plotPMs{"plotPMs", false, "Flag to plot individual PMs"};
+
+  Configurable<int> qxyNbins{"qxyNbins", 100, "Number of bins in QxQy histograms"};
+  Configurable<float> qxyMin{"qxyMin", -2.0f, "Lower edge for QxQy histograms"};
+  Configurable<float> qxyMax{"qxyMax", 2.0f, "Upper edge for QxQy histograms"};
+
+  Configurable<int> vxNbins{"vxNbins", 50, "Bins in Vx"};
+  Configurable<float> vxMin{"vxMin", -0.1f, "Vx lower edge"};
+  Configurable<float> vxMax{"vxMax", 0.1f, "Vx upper edge"};
+
+  Configurable<int> vyNbins{"vyNbins", 50, "Bins in Vy"};
+  Configurable<float> vyMin{"vyMin", -0.1f, "Vy lower edge"};
+  Configurable<float> vyMax{"vyMax", 0.1f, "Vy upper edge"};
+
+  Configurable<int> vzNbins{"vzNbins", 50, "Bins in Vz"};
+  Configurable<float> vzMin{"vzMin", -10.0f, "Vz lower edge"};
+  Configurable<float> vzMax{"vzMax", 10.0f, "Vz upper edge"};
+
+  Configurable<int> centNbins{"centNbins", 16, "Bins in centrality"};
+  Configurable<float> centMin{"centMin", 0.0f, "Centrality lower edge"};
+  Configurable<float> centMax{"centMax", 80.0f, "Centrality upper edge"};
+
+  Configurable<int> phiNbins{"phiNbins", 60, "Bins in phi"};
+
+  Configurable<int> qNbins5D{"qNbins5D", 4, "Bins in each dimension for 5D histograms"};
+  Configurable<bool> plot5D{"plot5D", false, "Flag to plot 5D histograms"};
+
+  Configurable<int> calibrationStep{"calibrationStep", 1, "Calibration step"};
+  Configurable<bool> ifFineCalibration{"ifFineCalibration", false, "Calibration: base  or refine"};
+
+  Configurable<bool> ifBeamSpotCorrection{"ifBeamSpotCorrection", true, "Beam spot correction"};
+
+  Configurable<bool> ifSel8{"ifSel8", true, "Event selection: sel8"};
+  Configurable<bool> ifVtxZle10{"ifVtxZle10", true, "Event selection: zVtx < 10 cm"};
+  Configurable<bool> ifOccupancyCut{"ifOccupancyCut", false, "Event selection: occupancy cut"};
+  Configurable<bool> ifNoSameBunchPileup{"ifNoSameBunchPileup", false, "Event selection: no same bunch pileup"};
+  Configurable<bool> ifIsGoodZvtxFT0vsPV{"ifIsGoodZvtxFT0vsPV", false, "Event selection: good Zvtx FT0 vs PV"};
+  Configurable<bool> ifNoCollInTimeRangeStandard{"ifNoCollInTimeRangeStandard", false, "Event selection: no collision in time range standard"};
+  Configurable<bool> ifIsVertexITSTPC{"ifIsVertexITSTPC", false, "Event selection: vertex ITS TPC"};
+  Configurable<bool> ifIsGoodITSLayersAll{"ifIsGoodITSLayersAll", false, "Event selection: good ITS layers all"};
+
+  Configurable<bool> ifShiftCorrection{"ifShiftCorrection", false, "Apply shift correction (Read from CCDB)"};
+  Configurable<bool> fillShiftHistos{"fillShiftHistos", true, "Fill shift profiles (Write to output)"};
+  Configurable<int> nShift{"nShift", 10, "Number of harmonics"};
+
+  Configurable<std::string> qRecenteringCcdb{"qRecenteringCcdb", "Users/u/udmitrie/ZDC/LHC24ar_apass2", "Recentering maps containing step folder"};
+
+  // CCDB
+  Service<o2::ccdb::BasicCCDBManager> ccdb;
+
+  // Struct to hold calibration data for a single step
+  struct CalibStepData {
+    // 5D maps (Base)
+    THn* hMeanQxZNA{nullptr};
+    THn* hMeanQyZNA{nullptr};
+    THn* hMeanQxZNC{nullptr};
+    THn* hMeanQyZNC{nullptr};
+
+    // 1D maps (Refine)
+    TH1* hMeanQxCentZNA{nullptr};
+    TH1* hMeanQyCentZNA{nullptr};
+    TH1* hMeanQxCentZNC{nullptr};
+    TH1* hMeanQyCentZNC{nullptr};
+
+    TH1* hMeanQxVzZNA{nullptr};
+    TH1* hMeanQyVzZNA{nullptr};
+    TH1* hMeanQxVzZNC{nullptr};
+    TH1* hMeanQyVzZNC{nullptr};
+
+    TH1* hMeanQxVxZNA{nullptr};
+    TH1* hMeanQyVxZNA{nullptr};
+    TH1* hMeanQxVxZNC{nullptr};
+    TH1* hMeanQyVxZNC{nullptr};
+
+    TH1* hMeanQxVyZNA{nullptr};
+    TH1* hMeanQyVyZNA{nullptr};
+    TH1* hMeanQxVyZNC{nullptr};
+    TH1* hMeanQyVyZNC{nullptr};
+  };
+
+  // Cache container: Vector index = Step index (0-based, so step 1 is at index 0)
+  std::vector<CalibStepData> mCalibCache;
+
+  // Vertex correction cache
+  TH1* hMeanVx{nullptr};
+  TH1* hMeanVy{nullptr};
+
+  // Phase shift correction cache
+  TProfile3D* hShiftZNA{nullptr};
+  TProfile3D* hShiftZNC{nullptr};
+
+  HistogramRegistry histos{
+    "histos",
+    {},
+    OutputObjHandlingPolicy::AnalysisObject};
+
+  enum EvSelBits { // TO DO: move to a common header file
+    evSel_zvtx,
+    evSel_sel8,
+    evSel_occupancy,
+    evSel_kNoSameBunchPileup,
+    evSel_kIsGoodZvtxFT0vsPV,
+    evSel_kNoCollInTimeRangeStandard,
+    evSel_kIsVertexITSTPC,
+    evSel_kIsGoodITSLayersAll,
+    evSel_allEvents,
+    nEventSelections
+  };
+
+  int mCurrentRunNumber{-1};
+
+  // Helper to safely clone a histogram and detach from file
+  template <typename T>
+  T* safeClone(TObject* obj)
+  {
+    if (!obj)
+      return nullptr;
+    T* cloned = dynamic_cast<T*>(obj->Clone());
+    if (cloned) {
+
+      if (dynamic_cast<TH1*>(cloned)) {
+        dynamic_cast<TH1*>(cloned)->SetDirectory(nullptr);
+      }
+    }
+    return cloned;
+  }
+
+  void clearCache()
+  {
+    if (hMeanVx) {
+      delete hMeanVx;
+      hMeanVx = nullptr;
+    }
+    if (hMeanVy) {
+      delete hMeanVy;
+      hMeanVy = nullptr;
+    }
+
+    for (const auto& step : mCalibCache) {
+      delete step.hMeanQxZNA;
+      delete step.hMeanQyZNA;
+      delete step.hMeanQxZNC;
+      delete step.hMeanQyZNC;
+
+      delete step.hMeanQxCentZNA;
+      delete step.hMeanQyCentZNA;
+      delete step.hMeanQxCentZNC;
+      delete step.hMeanQyCentZNC;
+
+      delete step.hMeanQxVzZNA;
+      delete step.hMeanQyVzZNA;
+      delete step.hMeanQxVzZNC;
+      delete step.hMeanQyVzZNC;
+
+      delete step.hMeanQxVxZNA;
+      delete step.hMeanQyVxZNA;
+      delete step.hMeanQxVxZNC;
+      delete step.hMeanQyVxZNC;
+
+      delete step.hMeanQxVyZNA;
+      delete step.hMeanQyVyZNA;
+      delete step.hMeanQxVyZNC;
+      delete step.hMeanQyVyZNC;
+
+      if (hShiftZNA) {
+        delete hShiftZNA;
+        hShiftZNA = nullptr;
+      }
+      if (hShiftZNC) {
+        delete hShiftZNC;
+        hShiftZNC = nullptr;
+      }
+    }
+    mCalibCache.clear();
+  }
+
+  void initHistos(const int& mRunNumber)
+  {
+    if (mRunNumber == mCurrentRunNumber) {
+      return;
+    }
+    mCurrentRunNumber = mRunNumber;
+
+    if (gEventCounter.find(mRunNumber) == gEventCounter.end()) {
+      // if new run, initialize histograms
+
+      const AxisSpec axisCounter{1, 0, +1, ""};
+      const AxisSpec axisZN{nBinsZN, -0.5, maxZN, "(a.u.)"};
+      const AxisSpec axisCent = {centNbins, centMin, centMax, "Centrality (%)"};
+      const AxisSpec axisVx = {vxNbins, vxMin, vxMax, "V_{x} (cm)"};
+      const AxisSpec axisVy = {vyNbins, vyMin, vyMax, "V_{y} (cm)"};
+      const AxisSpec axisVz = {vzNbins, vzMin, vzMax, "V_{z} (cm)"};
+
+      const AxisSpec axisCent5D = {qNbins5D, centMin, centMax, "Centrality (%)"};
+      const AxisSpec axisVx5D = {qNbins5D, vxMin, vxMax, "V_{x} (cm)"};
+      const AxisSpec axisVy5D = {qNbins5D, vyMin, vyMax, "V_{y} (cm)"};
+      const AxisSpec axisVz5D = {qNbins5D, vzMin, vzMax, "V_{z} (cm)"};
+
+      const AxisSpec axisQx = {qxyNbins, qxyMin, qxyMax, "Q_{x}"};
+      const AxisSpec axisQy = {qxyNbins, qxyMin, qxyMax, "Q_{y}"};
+
+      const AxisSpec axisQxQy = {qxyNbins, qxyMin, qxyMax, ""};
+      const AxisSpec axisPhi = {phiNbins, -1.0f * o2::constants::math::PI, 1.0f * o2::constants::math::PI, "#phi"};
+
+      const AxisSpec axisTime = {90, 0, 90, "Time (minutes)"}; // 90 minutes
+
+      gEventCounter[mRunNumber] = histos.add<TH1>(Form("%i/eventCounter", mRunNumber), "Number of Event; ; #Events Passed Cut", kTH1D, {{nEventSelections, 0, nEventSelections}}).get();
+      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(evSel_allEvents + 1, "All events");
+      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(evSel_zvtx + 1, "vtxZ");
+      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(evSel_sel8 + 1, "Sel8");
+      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(evSel_occupancy + 1, "kOccupancy");
+      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(evSel_kNoSameBunchPileup + 1, "kNoSameBunchPileup");
+      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(evSel_kIsGoodZvtxFT0vsPV + 1, "kIsGoodZvtxFT0vsPV");
+      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(evSel_kNoCollInTimeRangeStandard + 1, "kNoCollInTimeRangeStandard");
+      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(evSel_kIsVertexITSTPC + 1, "kIsVertexITSTPC");
+      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(evSel_kIsGoodITSLayersAll + 1, "kIsGoodITSLayersAll");
+
+      gCentroidZNA[mRunNumber] = histos.add<TH2>(Form("%i/CentroidZNA", mRunNumber), "ZNA Centroid; Q_{X}; Q_{Y}", kTH2F, {{50, -1.5, 1.5}, {50, -1.5, 1.5}}).get();
+      gCentroidZNC[mRunNumber] = histos.add<TH2>(Form("%i/CentroidZNC", mRunNumber), "ZNC Centroid; Q_{X}; Q_{Y}", kTH2F, {{50, -1.5, 1.5}, {50, -1.5, 1.5}}).get();
+      gPmcZNA[mRunNumber] = histos.add<TH1>(Form("%i/pmcZNA", mRunNumber), "; E_{PMC}^{ZNA} (TeV);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gPm1ZNA[mRunNumber] = histos.add<TH1>(Form("%i/pm1ZNA", mRunNumber), "; E_{PM1}^{ZNA} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gPm2ZNA[mRunNumber] = histos.add<TH1>(Form("%i/pm2ZNA", mRunNumber), "; E_{PM2}^{ZNA} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gPm3ZNA[mRunNumber] = histos.add<TH1>(Form("%i/pm3ZNA", mRunNumber), "; E_{PM3}^{ZNA} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gPm4ZNA[mRunNumber] = histos.add<TH1>(Form("%i/pm4ZNA", mRunNumber), "; E_{PM4}^{ZNA} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gSumZNA[mRunNumber] = histos.add<TH1>(Form("%i/sumZNA", mRunNumber), "; E_{sum PMs}^{ZNA} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gPmcZNC[mRunNumber] = histos.add<TH1>(Form("%i/pmcZNC", mRunNumber), "; E_{PMC}^{ZNC} (TeV);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gPm1ZNC[mRunNumber] = histos.add<TH1>(Form("%i/pm1ZNC", mRunNumber), "; E_{PM1}^{ZNC} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gPm2ZNC[mRunNumber] = histos.add<TH1>(Form("%i/pm2ZNC", mRunNumber), "; E_{PM2}^{ZNC} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gPm3ZNC[mRunNumber] = histos.add<TH1>(Form("%i/pm3ZNC", mRunNumber), "; E_{PM3}^{ZNC} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gPm4ZNC[mRunNumber] = histos.add<TH1>(Form("%i/pm4ZNC", mRunNumber), "; E_{PM4}^{ZNC} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gSumZNC[mRunNumber] = histos.add<TH1>(Form("%i/sumZNC", mRunNumber), "; E_{sum PMs}^{ZNC} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gQxVsCentZNA[mRunNumber] = histos.add<TH2>(Form("%i/QxVsCentZNA", mRunNumber), "Q_{x}^{ZNA} vs Centrality", kTH2F, {axisCent, axisQx}).get();
+      gQyVsCentZNA[mRunNumber] = histos.add<TH2>(Form("%i/QyVsCentZNA", mRunNumber), "Q_{y}^{ZNA} vs Centrality", kTH2F, {axisCent, axisQy}).get();
+      gQxVsVxZNA[mRunNumber] = histos.add<TH2>(Form("%i/QxVsVxZNA", mRunNumber), "Q_{x}^{ZNA} vs V_{x}; V_{x} (cm); Q_{x}", kTH2F, {axisVx, axisQx}).get();
+      gQyVsVxZNA[mRunNumber] = histos.add<TH2>(Form("%i/QyVsVxZNA", mRunNumber), "Q_{y}^{ZNA} vs V_{x}; V_{x} (cm); Q_{y}", kTH2F, {axisVx, axisQy}).get();
+      gQxVsVyZNA[mRunNumber] = histos.add<TH2>(Form("%i/QxVsVyZNA", mRunNumber), "Q_{x}^{ZNA} vs V_{y}; V_{y} (cm); Q_{x}", kTH2F, {axisVy, axisQx}).get();
+      gQyVsVyZNA[mRunNumber] = histos.add<TH2>(Form("%i/QyVsVyZNA", mRunNumber), "Q_{y}^{ZNA} vs V_{y}; V_{y} (cm); Q_{y}", kTH2F, {axisVy, axisQy}).get();
+      gQxVsVzZNA[mRunNumber] = histos.add<TH2>(Form("%i/QxVsVzZNA", mRunNumber), "Q_{x}^{ZNA} vs V_{z}; V_{z} (cm); Q_{x}", kTH2F, {axisVz, axisQx}).get();
+      gQyVsVzZNA[mRunNumber] = histos.add<TH2>(Form("%i/QyVsVzZNA", mRunNumber), "Q_{y}^{ZNA} vs V_{z}; V_{z} (cm); Q_{y}", kTH2F, {axisVz, axisQy}).get();
+      gQxVsCentZNC[mRunNumber] = histos.add<TH2>(Form("%i/QxVsCentZNC", mRunNumber), "Q_{x}^{ZNC} vs Centrality; Centrality (%); Q_{x}", kTH2F, {axisCent, axisQx}).get();
+      gQyVsCentZNC[mRunNumber] = histos.add<TH2>(Form("%i/QyVsCentZNC", mRunNumber), "Q_{y}^{ZNC} vs Centrality; Centrality (%); Q_{y}", kTH2F, {axisCent, axisQy}).get();
+      gQxVsVxZNC[mRunNumber] = histos.add<TH2>(Form("%i/QxVsVxZNC", mRunNumber), "Q_{x}^{ZNC} vs V_{x}; V_{x} (cm); Q_{x}", kTH2F, {axisVx, axisQx}).get();
+      gQyVsVxZNC[mRunNumber] = histos.add<TH2>(Form("%i/QyVsVxZNC", mRunNumber), "Q_{y}^{ZNC} vs V_{x}; V_{x} (cm); Q_{y}", kTH2F, {axisVx, axisQy}).get();
+      gQxVsVyZNC[mRunNumber] = histos.add<TH2>(Form("%i/QxVsVyZNC", mRunNumber), "Q_{x}^{ZNC} vs V_{y}; V_{y} (cm); Q_{x}", kTH2F, {axisVy, axisQx}).get();
+      gQyVsVyZNC[mRunNumber] = histos.add<TH2>(Form("%i/QyVsVyZNC", mRunNumber), "Q_{y}^{ZNC} vs V_{y}; V_{y} (cm); Q_{y}", kTH2F, {axisVy, axisQy}).get();
+      gQxVsVzZNC[mRunNumber] = histos.add<TH2>(Form("%i/QxVsVzZNC", mRunNumber), "Q_{x}^{ZNC} vs V_{z}; V_{z} (cm); Q_{x}", kTH2F, {axisVz, axisQx}).get();
+      gQyVsVzZNC[mRunNumber] = histos.add<TH2>(Form("%i/QyVsVzZNC", mRunNumber), "Q_{y}^{ZNC} vs V_{z}; V_{z} (cm); Q_{y}", kTH2F, {axisVz, axisQy}).get();
+      gQxQyVsCent[mRunNumber] = histos.add<TH2>(Form("%i/QxQyVsCent", mRunNumber), "Q_{x}^{ZNC}Q_{y}^{ZNC} vs Centrality; Centrality (%); Q_{x}^{ZNA}Q_{y}^{ZNC}", kTH2F, {axisCent, {50, -1.5, 1.5}}).get();
+      gQyQxVsCent[mRunNumber] = histos.add<TH2>(Form("%i/QyQxVsCent", mRunNumber), "Q_{y}^{ZNC}Q_{x}^{ZNC} vs Centrality; Centrality (%); Q_{y}^{ZNA}Q_{x}^{ZNC}", kTH2F, {axisCent, {50, -1.5, 1.5}}).get();
+      gQxQxVsCent[mRunNumber] = histos.add<TH2>(Form("%i/QxQxVsCent", mRunNumber), "Q_{x}^{ZNC}Q_{x}^{ZNC} vs Centrality; Centrality (%); Q_{x}^{ZNA}Q_{x}^{ZNC}", kTH2F, {axisCent, {50, -1.5, 1.5}}).get();
+      gQyQyVsCent[mRunNumber] = histos.add<TH2>(Form("%i/QyQyVsCent", mRunNumber), "Q_{y}^{ZNC}Q_{y}^{ZNC} vs Centrality; Centrality (%); Q_{y}^{ZNA}Q_{y}^{ZNC}", kTH2F, {axisCent, {50, -1.5, 1.5}}).get();
+
+      gQx5DZNA[mRunNumber] = histos.add<THn>(Form("%i/Qx5DZNA", mRunNumber), "Qx recenter map ZNA", kTHnF, {axisCent5D, axisVx5D, axisVy5D, axisVz5D, axisQx}, true).get();
+      gQy5DZNA[mRunNumber] = histos.add<THn>(Form("%i/Qy5DZNA", mRunNumber), "Qy recenter map ZNA", kTHnF, {axisCent5D, axisVx5D, axisVy5D, axisVz5D, axisQy}, true).get();
+      gQx5DZNC[mRunNumber] = histos.add<THn>(Form("%i/Qx5DZNC", mRunNumber), "Qx recenter map ZNC", kTHnF, {axisCent5D, axisVx5D, axisVy5D, axisVz5D, axisQx}, true).get();
+      gQy5DZNC[mRunNumber] = histos.add<THn>(Form("%i/Qy5DZNC", mRunNumber), "Qy recenter map ZNC", kTHnF, {axisCent5D, axisVx5D, axisVy5D, axisVz5D, axisQy}, true).get();
+
+      gPsiZNA[mRunNumber] = histos.add<TH1>(Form("%i/PsiZNA", mRunNumber), ";#Phi_{ZNA} (rad)", kTH1F, {axisPhi}).get();
+      gPsiZNC[mRunNumber] = histos.add<TH1>(Form("%i/PsiZNC", mRunNumber), ";#Phi_{ZNC} (rad)", kTH1F, {axisPhi}).get();
+
+      gVx[mRunNumber] = histos.add<TH1>(Form("%i/Vx", mRunNumber), "V_{x} distribution; V_{x} (cm); Entries", kTH1F, {axisVx}).get();
+      gVy[mRunNumber] = histos.add<TH1>(Form("%i/Vy", mRunNumber), "V_{y} distribution; V_{y} (cm); Entries", kTH1F, {axisVy}).get();
+
+      gQxVsTimeZNA[mRunNumber] = histos.add<TH2>(Form("%i/QxVsTimeZNA", mRunNumber), "Q_{x}^{ZNA} vs Time; Time (minutes); Q_{x}", kTH2F, {axisTime, axisQx}).get();
+      gQyVsTimeZNA[mRunNumber] = histos.add<TH2>(Form("%i/QyVsTimeZNA", mRunNumber), "Q_{y}^{ZNA} vs Time; Time (minutes); Q_{y}", kTH2F, {axisTime, axisQy}).get();
+      gQxVsTimeZNC[mRunNumber] = histos.add<TH2>(Form("%i/QxVsTimeZNC", mRunNumber), "Q_{x}^{ZNC} vs Time; Time (minutes); Q_{x}", kTH2F, {axisTime, axisQx}).get();
+      gQyVsTimeZNC[mRunNumber] = histos.add<TH2>(Form("%i/QyVsTimeZNC", mRunNumber), "Q_{y}^{ZNC} vs Time; Time (minutes); Q_{y}", kTH2F, {axisTime, axisQy}).get();
+
+      gShiftProfileZNA[mRunNumber] = histos.add<TProfile3D>(Form("%i/ShiftProfileZNA", mRunNumber), "ZNA Shift Coeffs;Cent;Type;Harmonic", kTProfile3D, {axisCent, {2, 0, 2}, {nShift, 0, static_cast<double>(nShift)}}).get();
+      gShiftProfileZNC[mRunNumber] = histos.add<TProfile3D>(Form("%i/ShiftProfileZNC", mRunNumber), "ZNC Shift Coeffs;Cent;Type;Harmonic", kTProfile3D, {axisCent, {2, 0, 2}, {nShift, 0, static_cast<double>(nShift)}}).get();
+    }
+
+    gCurrentEventCounter = gEventCounter[mCurrentRunNumber];
+    gCurrentCentroidZNA = gCentroidZNA[mCurrentRunNumber];
+    gCurrentCentroidZNC = gCentroidZNC[mCurrentRunNumber];
+    gCurrentPmcZNA = gPmcZNA[mCurrentRunNumber];
+    gCurrentPm1ZNA = gPm1ZNA[mCurrentRunNumber];
+    gCurrentPm2ZNA = gPm2ZNA[mCurrentRunNumber];
+    gCurrentPm3ZNA = gPm3ZNA[mCurrentRunNumber];
+    gCurrentPm4ZNA = gPm4ZNA[mCurrentRunNumber];
+    gCurrentSumZNA = gSumZNA[mCurrentRunNumber];
+    gCurrentPmcZNC = gPmcZNC[mCurrentRunNumber];
+    gCurrentPm1ZNC = gPm1ZNC[mCurrentRunNumber];
+    gCurrentPm2ZNC = gPm2ZNC[mCurrentRunNumber];
+    gCurrentPm3ZNC = gPm3ZNC[mCurrentRunNumber];
+    gCurrentPm4ZNC = gPm4ZNC[mCurrentRunNumber];
+    gCurrentSumZNC = gSumZNC[mCurrentRunNumber];
+    gCurrentQxVsCentZNA = gQxVsCentZNA[mCurrentRunNumber];
+    gCurrentQyVsCentZNA = gQyVsCentZNA[mCurrentRunNumber];
+    gCurrentQxVsVxZNA = gQxVsVxZNA[mCurrentRunNumber];
+    gCurrentQyVsVxZNA = gQyVsVxZNA[mCurrentRunNumber];
+    gCurrentQxVsVyZNA = gQxVsVyZNA[mCurrentRunNumber];
+    gCurrentQyVsVyZNA = gQyVsVyZNA[mCurrentRunNumber];
+    gCurrentQxVsVzZNA = gQxVsVzZNA[mCurrentRunNumber];
+    gCurrentQyVsVzZNA = gQyVsVzZNA[mCurrentRunNumber];
+    gCurrentQxVsCentZNC = gQxVsCentZNC[mCurrentRunNumber];
+    gCurrentQyVsCentZNC = gQyVsCentZNC[mCurrentRunNumber];
+    gCurrentQxVsVxZNC = gQxVsVxZNC[mCurrentRunNumber];
+    gCurrentQyVsVxZNC = gQyVsVxZNC[mCurrentRunNumber];
+    gCurrentQxVsVyZNC = gQxVsVyZNC[mCurrentRunNumber];
+    gCurrentQyVsVyZNC = gQyVsVyZNC[mCurrentRunNumber];
+    gCurrentQxVsVzZNC = gQxVsVzZNC[mCurrentRunNumber];
+    gCurrentQyVsVzZNC = gQyVsVzZNC[mCurrentRunNumber];
+    gCurrentQxQyVsCent = gQxQyVsCent[mCurrentRunNumber];
+    gCurrentQyQxVsCent = gQyQxVsCent[mCurrentRunNumber];
+    gCurrentQxQxVsCent = gQxQxVsCent[mCurrentRunNumber];
+    gCurrentQyQyVsCent = gQyQyVsCent[mCurrentRunNumber];
+
+    gCurrentQxZNA = gQx5DZNA[mCurrentRunNumber];
+    gCurrentQyZNA = gQy5DZNA[mCurrentRunNumber];
+    gCurrentQxZNC = gQx5DZNC[mCurrentRunNumber];
+    gCurrentQyZNC = gQy5DZNC[mCurrentRunNumber];
+
+    gCurrentPsiZNA = gPsiZNA[mCurrentRunNumber];
+    gCurrentPsiZNC = gPsiZNC[mCurrentRunNumber];
+
+    gCurrentVx = gVx[mCurrentRunNumber];
+    gCurrentVy = gVy[mCurrentRunNumber];
+
+    gCurrentQxVsTimeZNA = gQxVsTimeZNA[mCurrentRunNumber];
+    gCurrentQyVsTimeZNA = gQyVsTimeZNA[mCurrentRunNumber];
+    gCurrentQxVsTimeZNC = gQxVsTimeZNC[mCurrentRunNumber];
+    gCurrentQyVsTimeZNC = gQyVsTimeZNC[mCurrentRunNumber];
+
+    gCurrentShiftProfileZNA = gShiftProfileZNA[mCurrentRunNumber];
+    gCurrentShiftProfileZNC = gShiftProfileZNC[mCurrentRunNumber];
+  }
+
+  // Optimized method to load ALL calibrations for the new run at once
+  void loadCalibrations(int run)
+  {
+    clearCache();
+
+    // Vertex Calibration
+    if (ifBeamSpotCorrection) {
+      std::string folder = Form("%s/step0", qRecenteringCcdb.value.c_str());
+      TList* lst = ccdb->getForRun<TList>(folder, run);
+      if (lst) {
+        hMeanVx = safeClone<TH1>(lst->FindObject("hMeanVx"));
+        hMeanVy = safeClone<TH1>(lst->FindObject("hMeanVy"));
+      }
+    }
+
+    // Step Calibrations
+    std::size_t targetSteps = (calibrationStep > 0) ? static_cast<std::size_t>(calibrationStep.value) : 0;
+    mCalibCache.resize(targetSteps);
+
+    for (std::size_t stepIdx = 0; stepIdx < targetSteps; ++stepIdx) {
+      int step = static_cast<int>(stepIdx + 1);
+
+      // Load 5D (Base)
+      std::string folderBase = Form("%s/step%d_base", qRecenteringCcdb.value.c_str(), step);
+      TList* lstBase = ccdb->getForRun<TList>(folderBase, run);
+      if (lstBase) {
+        mCalibCache[stepIdx].hMeanQxZNA = safeClone<THn>(lstBase->FindObject("hMeanQxZNA"));
+        mCalibCache[stepIdx].hMeanQyZNA = safeClone<THn>(lstBase->FindObject("hMeanQyZNA"));
+        mCalibCache[stepIdx].hMeanQxZNC = safeClone<THn>(lstBase->FindObject("hMeanQxZNC"));
+        mCalibCache[stepIdx].hMeanQyZNC = safeClone<THn>(lstBase->FindObject("hMeanQyZNC"));
+      }
+
+      // Load 1D (Refine)
+      if ((step != calibrationStep) || ifFineCalibration) {
+        std::string folderRefine = Form("%s/step%d_refine", qRecenteringCcdb.value.c_str(), step);
+        TList* lstRefine = ccdb->getForRun<TList>(folderRefine, run);
+        if (lstRefine) {
+          mCalibCache[stepIdx].hMeanQxCentZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQxCentZNA"));
+          mCalibCache[stepIdx].hMeanQyCentZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQyCentZNA"));
+          mCalibCache[stepIdx].hMeanQxCentZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQxCentZNC"));
+          mCalibCache[stepIdx].hMeanQyCentZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQyCentZNC"));
+
+          mCalibCache[stepIdx].hMeanQxVzZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQxVzZNA"));
+          mCalibCache[stepIdx].hMeanQyVzZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQyVzZNA"));
+          mCalibCache[stepIdx].hMeanQxVzZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQxVzZNC"));
+          mCalibCache[stepIdx].hMeanQyVzZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQyVzZNC"));
+
+          mCalibCache[stepIdx].hMeanQxVxZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQxVxZNA"));
+          mCalibCache[stepIdx].hMeanQyVxZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQyVxZNA"));
+          mCalibCache[stepIdx].hMeanQxVxZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQxVxZNC"));
+          mCalibCache[stepIdx].hMeanQyVxZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQyVxZNC"));
+
+          mCalibCache[stepIdx].hMeanQxVyZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQxVyZNA"));
+          mCalibCache[stepIdx].hMeanQyVyZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQyVyZNA"));
+          mCalibCache[stepIdx].hMeanQxVyZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQxVyZNC"));
+          mCalibCache[stepIdx].hMeanQyVyZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQyVyZNC"));
+        }
+      }
+    } // end of step loop
+
+    if (ifShiftCorrection) {
+      std::string folder = Form("%s/psiShift", qRecenteringCcdb.value.c_str());
+
+      LOGF(info, "ZDC Analysis: Loading Shift Correction from %s for run %d", folder.c_str(), run);
+
+      // Attempt to fetch TList from CCDB
+      auto* lst = ccdb->getForRun<TList>(folder, run);
+
+      if (lst) {
+        // Important: Object names must match exactly what was saved
+        hShiftZNA = safeClone<TProfile3D>(lst->FindObject("hShiftZNA"));
+        hShiftZNC = safeClone<TProfile3D>(lst->FindObject("hShiftZNC"));
+
+        if (hShiftZNA) {
+          hShiftZNA->SetDirectory(nullptr); // Detach from file
+          LOGF(info, "  >> ShiftProfileZNA found! Entries: %.0f, Mean: %f",
+               hShiftZNA->GetEntries(), hShiftZNA->GetMean());
+        } else {
+          LOGF(error, "  >> ShiftProfileZNA NOT found in TList! Content follows:");
+          lst->Print();
+        }
+
+        if (hShiftZNC) {
+          hShiftZNC->SetDirectory(nullptr);
+          LOGF(info, "  >> ShiftProfileZNC found! Entries: %.0f", hShiftZNC->GetEntries());
+        } else {
+          LOGF(error, "  >> ShiftProfileZNC NOT found in TList!");
+        }
+
+      } else {
+        LOGF(error, "  >> CCDB TList is NULL for path: %s. Check object type (TList vs TFile).", folder.c_str());
+      }
+    }
+  } // end of loadCalibrations()
+
+  ~ZdcExtraTableReader()
+  {
+    clearCache();
+  }
+
+  /// Initializes histograms and other resources before event processing.
+  void init(InitContext&)
+  {
+    const AxisSpec axisCounter{1, 0, +1, ""};
+    histos.add("eventCounter", "eventCounter", kTH1F, {axisCounter});
+
+    // CCDB
+    ccdb->setURL("http://alice-ccdb.cern.ch");
+    ccdb->setFatalWhenNull(false);
+  } // end of init()
+
+  void process(aod::ZdcExtras::iterator const& zdc /*collision*/)
+  {
+
+    // Apply event selection
+
+    if (ifSel8 && !(zdc.selectionBits() & (1 << evSel_sel8))) {
+      return;
+    }
+    if (ifVtxZle10 && !(zdc.selectionBits() & (1 << evSel_zvtx))) {
+      return;
+    }
+    if (ifOccupancyCut && !(zdc.selectionBits() & (1 << evSel_occupancy))) {
+      return;
+    }
+    if (ifNoSameBunchPileup && !(zdc.selectionBits() & (1 << evSel_kNoSameBunchPileup))) {
+      return;
+    }
+    if (ifIsGoodZvtxFT0vsPV && !(zdc.selectionBits() & (1 << evSel_kIsGoodZvtxFT0vsPV))) {
+      return;
+    }
+    if (ifNoCollInTimeRangeStandard && !(zdc.selectionBits() & (1 << evSel_kNoCollInTimeRangeStandard))) {
+      return;
+    }
+    if (ifIsVertexITSTPC && !(zdc.selectionBits() & (1 << evSel_kIsVertexITSTPC))) {
+      return;
+    }
+    if (ifIsGoodITSLayersAll && !(zdc.selectionBits() & (1 << evSel_kIsGoodITSLayersAll))) {
+      return;
+    }
+
+    //  LOGF(info, "zvtx       = %d", (zdc.selectionBits() & (1 << evSel_zvtx)) > 0);
+    //  LOGF(info, "sel8       = %d", (zdc.selectionBits() & (1 << evSel_sel8)) > 0);
+    //  LOGF(info, "occupancy  = %d", (zdc.selectionBits() & (1 << evSel_occupancy)) > 0);
+    //  LOGF(info, "noSameBC   = %d", (zdc.selectionBits() & (1 << evSel_kNoSameBunchPileup)) > 0);
+    //  LOGF(info, "FT0vsPV    = %d", (zdc.selectionBits() & (1 << evSel_kIsGoodZvtxFT0vsPV)) > 0);
+    //  LOGF(info, "noCollTR   = %d", (zdc.selectionBits() & (1 << evSel_kNoCollInTimeRangeStandard)) > 0);
+    //  LOGF(info, "vtxITSTPC  = %d", (zdc.selectionBits() & (1 << evSel_kIsVertexITSTPC)) > 0);
+    //  LOGF(info, "ITS layers = %d", (zdc.selectionBits() & (1 << evSel_kIsGoodITSLayersAll)) > 0);
+
+    const int mRunNumber = zdc.runNumber();
+
+    const uint64_t timestamp = zdc.timestamp(); // in milliseconds
+
+    // Convert timestamp to hours from run start (approximate)
+    // Store first timestamp of run to calculate relative time
+    static std::unordered_map<int, uint64_t> runStartTime;
+    if (runStartTime.find(mRunNumber) == runStartTime.end()) {
+      runStartTime[mRunNumber] = timestamp;
+    }
+
+    double timeInMinutes = (timestamp - runStartTime[mRunNumber]) / 60000.0; // ms -> minutes
+
+    // Initialization block if Run Number changes
+    if (mRunNumber != mCurrentRunNumber) {
+      initHistos(mRunNumber);       // Init output histograms
+      loadCalibrations(mRunNumber); // Load all steps from CCDB once
+      mCurrentRunNumber = mRunNumber;
+    }
+
+    histos.fill(HIST("eventCounter"), 0.5);
+
+    gCurrentEventCounter->Fill(evSel_allEvents);
+
+    // Fill histogram for all bits that passed
+    for (int bit = 0; bit < nEventSelections + 1; bit++) {
+      if (zdc.selectionBits() & (1 << bit)) {
+        gCurrentEventCounter->Fill(bit);
+      }
+    }
+
+    bool isZNChit = false, isZNAhit = false;
+    //
+    double tdcZNC = zdc.zncTdc();
+    double tdcZNA = zdc.znaTdc();
+
+    if (tdcCut) { // TDC window is set
+      if ((tdcZNC >= tdcZNmincut) && (tdcZNC <= tdcZNmaxcut)) {
+        isZNChit = true;
+      }
+      if ((tdcZNA >= tdcZNmincut) && (tdcZNA <= tdcZNmaxcut)) {
+        isZNAhit = true;
+      }
+    } else { // if no window on TDC is set
+      if (zdc.zncTowC() > -1.) {
+        isZNChit = true;
+      }
+      if (zdc.znaTowC() > -1.) {
+        isZNAhit = true;
+      }
+    }
+    //
+
+    if (plotPMs) {
+      if (isZNAhit) {
+        gCurrentPmcZNA->Fill(zdc.znaTowC());
+        gCurrentPm1ZNA->Fill(zdc.znaTow1());
+        gCurrentPm2ZNA->Fill(zdc.znaTow2());
+        gCurrentPm3ZNA->Fill(zdc.znaTow3());
+        gCurrentPm4ZNA->Fill(zdc.znaTow4());
+
+        float znaSum = zdc.znaTow1() + zdc.znaTow2() + zdc.znaTow3() + zdc.znaTow4();
+        gCurrentSumZNA->Fill(znaSum);
+      }
+
+      if (isZNChit) {
+        gCurrentPmcZNC->Fill(zdc.zncTowC());
+        gCurrentPm1ZNC->Fill(zdc.zncTow1());
+        gCurrentPm2ZNC->Fill(zdc.zncTow2());
+        gCurrentPm3ZNC->Fill(zdc.zncTow3());
+        gCurrentPm4ZNC->Fill(zdc.zncTow4());
+
+        float zncSum = zdc.zncTow1() + zdc.zncTow2() + zdc.zncTow3() + zdc.zncTow4();
+        gCurrentSumZNC->Fill(zncSum);
+      }
+    } // end of if (plotPMs)
+
+    double qxZNArec = 0., qyZNArec = 0.;
+    double qxZNCrec = 0., qyZNCrec = 0.;
+
+    //
+    double cent = zdc.centrality();
+    double vx = zdc.vx();
+    double vy = zdc.vy();
+    double vz = zdc.vz();
+
+    //   double vx_corrected = vx;
+    // double vy_corrected = vy;
+
+    if (ifBeamSpotCorrection) {
+      // Use cached vertex pointers
+      if (hMeanVx && hMeanVy) {
+        vx -= hMeanVx->GetBinContent(1);
+        vy -= hMeanVy->GetBinContent(1);
+      }
+    }
+
+    // -------- ZNA --------
+    if (isZNAhit) {
+      double qx = zdc.znaQx();
+      double qy = zdc.znaQy();
+
+      qxZNArec = qx;
+      qyZNArec = qy;
+
+      //
+      for (int step = 1; step <= calibrationStep; step++) {
+
+        int cacheIdx = step - 1;
+        // Check if index is valid within cached vector
+        if (cacheIdx >= static_cast<int>(mCalibCache.size()))
+          continue;
+
+        const auto& calib = mCalibCache[cacheIdx];
+
+        // Apply 5D Base calibration
+        if (calib.hMeanQxZNA && calib.hMeanQyZNA) {
+          qxZNArec -= getMeanQFromMap(calib.hMeanQxZNA, cent, vx, vy, vz);
+          qyZNArec -= getMeanQFromMap(calib.hMeanQyZNA, cent, vx, vy, vz);
+        }
+
+        if ((step != calibrationStep) || ifFineCalibration) {
+          // Apply 1D Refine calibration
+          qxZNArec -= getMeanQ1D(calib.hMeanQxCentZNA, cent);
+          qyZNArec -= getMeanQ1D(calib.hMeanQyCentZNA, cent);
+
+          qxZNArec -= getMeanQ1D(calib.hMeanQxVzZNA, vz);
+          qyZNArec -= getMeanQ1D(calib.hMeanQyVzZNA, vz);
+
+          qxZNArec -= getMeanQ1D(calib.hMeanQxVxZNA, vx);
+          qyZNArec -= getMeanQ1D(calib.hMeanQyVxZNA, vx);
+
+          qxZNArec -= getMeanQ1D(calib.hMeanQxVyZNA, vy);
+          qyZNArec -= getMeanQ1D(calib.hMeanQyVyZNA, vy);
+        }
+      }
+
+      double valuesQxZNA[5] = {cent, vx, vy, vz, qxZNArec};
+      double valuesQyZNA[5] = {cent, vx, vy, vz, qyZNArec};
+
+      gCurrentCentroidZNA->Fill(qxZNArec, qyZNArec);
+
+      gCurrentQxVsCentZNA->Fill(cent, qxZNArec);
+      gCurrentQyVsCentZNA->Fill(cent, qyZNArec);
+      gCurrentQxVsVxZNA->Fill(vx, qxZNArec);
+      gCurrentQyVsVxZNA->Fill(vx, qyZNArec);
+      gCurrentQxVsVyZNA->Fill(vy, qxZNArec);
+      gCurrentQyVsVyZNA->Fill(vy, qyZNArec);
+      gCurrentQxVsVzZNA->Fill(vz, qxZNArec);
+      gCurrentQyVsVzZNA->Fill(vz, qyZNArec);
+
+      // Fill time-dependent plots
+      gCurrentQxVsTimeZNA->Fill(timeInMinutes, qxZNArec);
+      gCurrentQyVsTimeZNA->Fill(timeInMinutes, qyZNArec);
+
+      if (plot5D) {
+        gCurrentQxZNA->Fill(valuesQxZNA);
+        gCurrentQyZNA->Fill(valuesQyZNA);
+      }
+
+      //  Calculate raw/recentered angle
+      double psiZNA = TMath::ATan2(qyZNArec, qxZNArec);
+
+      // Apply Correction (Read Mode)
+      // Checks if correction is enabled AND if the map from CCDB was loaded successfully
+      if (ifShiftCorrection && hShiftZNA) {
+        double deltaPsi = 0.0;
+
+        // Loop over harmonics (usually 1 to 10)
+        for (int ishift = 1; ishift <= nShift; ishift++) {
+          // Retrieve coefficients from TProfile3D
+          // Axis mapping:
+          // X: Centrality
+          // Y: Type (0.5 for Sin, 1.5 for Cos)
+          // Z: Harmonic index (ishift - 0.5 maps to bin 1, 2, etc.)
+
+          int binSin = hShiftZNA->FindBin(cent, 0.5, static_cast<double>(ishift) - 0.5);
+          int binCos = hShiftZNA->FindBin(cent, 1.5, static_cast<double>(ishift) - 0.5);
+
+          double coeffSin = hShiftZNA->GetBinContent(binSin);
+          double coeffCos = hShiftZNA->GetBinContent(binCos);
+
+          // Fourier flattening formula:
+          // DeltaPsi = sum( (2/k) * ( <cos>*sin(k*psi) - <sin>*cos(k*psi) ) )
+          // Note: signs depend on definition, this matches the standard correction logic
+          deltaPsi += (2.0 / ishift) * (-coeffSin * TMath::Cos(ishift * psiZNA) + coeffCos * TMath::Sin(ishift * psiZNA));
+        }
+
+        // DEBUG: Print only if shift is actually happening for first few events
+        static int debugPrintCount = 0;
+        constexpr int maxDebugPrints = 10;
+        constexpr double psiTolerance = 1e-6;
+
+        if (debugPrintCount < maxDebugPrints && std::abs(deltaPsi) > psiTolerance) {
+          LOGF(info, "ZNA Shift: Cent %.1f, Raw %.3f (Delta %.4f)", cent, psiZNA, deltaPsi);
+          debugPrintCount++;
+        }
+
+        // Apply the calculated shift
+        psiZNA += deltaPsi;
+
+        // Wrap angle to [-pi, pi] range
+        psiZNA = RecoDecay::constrainAngle(psiZNA, -o2::constants::math::PI);
+      }
+
+      // Fill Shift Profiles (Write Mode)
+      // Used to generate calibration for the next step or to verify correction (QA)
+      if (fillShiftHistos && gCurrentShiftProfileZNA) {
+        for (int ishift = 1; ishift <= nShift; ishift++) {
+          // Fill Sin component (Y = 0.5)
+          gCurrentShiftProfileZNA->Fill(cent, 0.5, static_cast<double>(ishift) - 0.5, TMath::Sin(ishift * psiZNA));
+          // Fill Cos component (Y = 1.5)
+          gCurrentShiftProfileZNA->Fill(cent, 1.5, static_cast<double>(ishift) - 0.5, TMath::Cos(ishift * psiZNA));
+        }
+      }
+
+      // Fill final analysis histogram with the best available Psi (Raw or Corrected)
+      gCurrentPsiZNA->Fill(psiZNA);
+    }
+
+    // -------- ZNC --------
+    if (isZNChit) {
+      double qx = zdc.zncQx();
+      double qy = zdc.zncQy();
+
+      qxZNCrec = qx;
+      qyZNCrec = qy;
+
+      //   LOGF(info, "Qx init = %f", qxZNCrec);
+
+      // Iterate through steps using cached vector
+      for (int step = 1; step <= calibrationStep; step++) {
+
+        int cacheIdx = step - 1;
+        if (cacheIdx >= static_cast<int>(mCalibCache.size()))
+          continue;
+
+        //     LOGF(info, "Go to step = %d", step);
+
+        const auto& calib = mCalibCache[cacheIdx];
+
+        // Apply 5D Base calibration
+        if (calib.hMeanQxZNC && calib.hMeanQyZNC) {
+          qxZNCrec -= getMeanQFromMap(calib.hMeanQxZNC, cent, vx, vy, vz);
+          qyZNCrec -= getMeanQFromMap(calib.hMeanQyZNC, cent, vx, vy, vz);
+
+          //  LOGF(info, "Go to base calibration step = %d", step);
+          //  LOGF(info, "Qx after base calibration step %d = %f", step, qxZNCrec);
+        }
+
+        if ((step != calibrationStep) || ifFineCalibration) {
+
+          // Apply 1D Refine calibration
+          qxZNCrec -= getMeanQ1D(calib.hMeanQxCentZNC, cent);
+          qyZNCrec -= getMeanQ1D(calib.hMeanQyCentZNC, cent);
+
+          qxZNCrec -= getMeanQ1D(calib.hMeanQxVzZNC, vz);
+          qyZNCrec -= getMeanQ1D(calib.hMeanQyVzZNC, vz);
+
+          qxZNCrec -= getMeanQ1D(calib.hMeanQxVxZNC, vx);
+          qyZNCrec -= getMeanQ1D(calib.hMeanQyVxZNC, vx);
+
+          qxZNCrec -= getMeanQ1D(calib.hMeanQxVyZNC, vy);
+          qyZNCrec -= getMeanQ1D(calib.hMeanQyVyZNC, vy);
+          // LOGF(info, "Go to refine calibration step = %d", step);
+          //   LOGF(info, "Qx after fine calibration step %d = %f", step, qxZNCrec);
+        }
+      }
+
+      double valuesQxZNC[5] = {cent, vx, vy, vz, qxZNCrec};
+      double valuesQyZNC[5] = {cent, vx, vy, vz, qyZNCrec};
+
+      //    LOGF(info, "Qx cal = %f", qxZNCrec);
+
+      gCurrentCentroidZNC->Fill(qxZNCrec, qyZNCrec);
+
+      gCurrentQxVsCentZNC->Fill(cent, qxZNCrec);
+      gCurrentQyVsCentZNC->Fill(cent, qyZNCrec);
+      gCurrentQxVsVxZNC->Fill(vx, qxZNCrec);
+      gCurrentQyVsVxZNC->Fill(vx, qyZNCrec);
+      gCurrentQxVsVyZNC->Fill(vy, qxZNCrec);
+      gCurrentQyVsVyZNC->Fill(vy, qyZNCrec);
+      gCurrentQxVsVzZNC->Fill(vz, qxZNCrec);
+      gCurrentQyVsVzZNC->Fill(vz, qyZNCrec);
+
+      // Fill time-dependent plots
+      gCurrentQxVsTimeZNC->Fill(timeInMinutes, qxZNCrec);
+      gCurrentQyVsTimeZNC->Fill(timeInMinutes, qyZNCrec);
+
+      if (plot5D) {
+        gCurrentQxZNC->Fill(valuesQxZNC);
+        gCurrentQyZNC->Fill(valuesQyZNC);
+      }
+
+      //  Calculate raw/recentered angle
+      double psiZNC = TMath::ATan2(qyZNCrec, qxZNCrec);
+
+      // Apply Correction (Read Mode)
+      // Checks if correction is enabled AND if the map from CCDB was loaded successfully
+      if (ifShiftCorrection && hShiftZNC) {
+        double deltaPsi = 0.0;
+
+        // Loop over harmonics (usually 1 to 10)
+        for (int ishift = 1; ishift <= nShift; ishift++) {
+          // Retrieve coefficients from TProfile3D
+          // Axis mapping:
+          // X: Centrality
+          // Y: Type (0.5 for Sin, 1.5 for Cos)
+          // Z: Harmonic index (ishift - 0.5 maps to bin 1, 2, etc.)
+
+          int binSin = hShiftZNC->FindBin(cent, 0.5, static_cast<double>(ishift) - 0.5);
+          int binCos = hShiftZNC->FindBin(cent, 1.5, static_cast<double>(ishift) - 0.5);
+
+          double coeffSin = hShiftZNC->GetBinContent(binSin);
+          double coeffCos = hShiftZNC->GetBinContent(binCos);
+
+          // Fourier flattening formula:
+          // DeltaPsi = sum( (2/k) * ( <cos>*sin(k*psi) - <sin>*cos(k*psi) ) )
+          // Note: signs depend on definition, this matches the standard correction logic
+          deltaPsi += (2.0 / ishift) * (-coeffSin * TMath::Cos(ishift * psiZNC) + coeffCos * TMath::Sin(ishift * psiZNC));
+        }
+
+        // Apply the calculated shift
+        psiZNC += deltaPsi;
+
+        // Wrap angle to [-pi, pi] range
+        psiZNC = RecoDecay::constrainAngle(psiZNC, -o2::constants::math::PI);
+      }
+
+      // Fill Shift Profiles (Write Mode)
+      // Used to generate calibration for the next step or to verify correction (QA)
+      if (fillShiftHistos && gCurrentShiftProfileZNC) {
+        for (int ishift = 1; ishift <= nShift; ishift++) {
+          // Fill Sin component (Y = 0.5)
+          gCurrentShiftProfileZNC->Fill(cent, 0.5, static_cast<double>(ishift) - 0.5, TMath::Sin(ishift * psiZNC));
+          // Fill Cos component (Y = 1.5)
+          gCurrentShiftProfileZNC->Fill(cent, 1.5, static_cast<double>(ishift) - 0.5, TMath::Cos(ishift * psiZNC));
+        }
+      }
+
+      // Fill final analysis histogram with the best available Psi (Raw or Corrected)
+      gCurrentPsiZNC->Fill(psiZNC);
+    }
+
+    if (isZNAhit && isZNChit) {
+      gCurrentQxQyVsCent->Fill(cent, qxZNArec * qyZNCrec);
+      gCurrentQyQxVsCent->Fill(cent, qyZNArec * qxZNCrec);
+      gCurrentQxQxVsCent->Fill(cent, qxZNArec * qxZNCrec);
+      gCurrentQyQyVsCent->Fill(cent, qyZNArec * qyZNCrec);
+    }
+
+    gCurrentVx->Fill(vx);
+    gCurrentVy->Fill(vy);
+
+  } // end of process() (= end of loop through collisions with ZDC)
+}; // end of struct ZdcExtraTableReader
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{adaptAnalysisTask<ZdcExtraTableReader>(cfgc)};
+}

--- a/Common/Tasks/zdcExtraTableReader.cxx
+++ b/Common/Tasks/zdcExtraTableReader.cxx
@@ -40,7 +40,6 @@
 #include <TMath.h>
 #include <TProfile3D.h>
 
-#include <iostream>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -168,8 +167,7 @@ TProfile3D* gCurrentShiftProfileZNC;
 double getMeanQFromMap(THn* h, double cent, double vx, double vy, double vz)
 {
   if (!h) {
-    // Commented out to reduce log spam in case of missing maps, enable for debugging
-    // std::cerr << "[MeanQ] Null THn pointer (cent=" << cent << ", vx=" << vx << ", vy=" << vy << ", vz=" << vz << ")" << std::endl;
+    // LOGF(error, "[MeanQ] Null THn pointer");
     return 0.0;
   }
 
@@ -179,7 +177,7 @@ double getMeanQFromMap(THn* h, double cent, double vx, double vy, double vz)
   TAxis* axVz = h->GetAxis(3);
 
   if (!axCent || !axVx || !axVy || !axVz) {
-    std::cerr << "[MeanQ] One of THn axes is null" << std::endl;
+    LOGF(error, "[MeanQ] One of THn axes is null");
     return 0.0;
   }
 
@@ -883,10 +881,10 @@ struct ZdcExtraTableReader {
 
         // DEBUG: Print only if shift is actually happening for first few events
         static int debugPrintCount = 0;
-        constexpr int maxDebugPrints = 10;
-        constexpr double psiTolerance = 1e-6;
+        constexpr int MaxDebugPrints = 10;
+        constexpr double PsiTolerance = 1e-6;
 
-        if (debugPrintCount < maxDebugPrints && std::abs(deltaPsi) > psiTolerance) {
+        if (debugPrintCount < MaxDebugPrints && std::abs(deltaPsi) > PsiTolerance) {
           LOGF(info, "ZNA Shift: Cent %.1f, Raw %.3f (Delta %.4f)", cent, psiZNA, deltaPsi);
           debugPrintCount++;
         }

--- a/Common/Tasks/zdcExtraTableReader.cxx
+++ b/Common/Tasks/zdcExtraTableReader.cxx
@@ -750,16 +750,18 @@ struct ZdcExtraTableReader {
     bool isZNASpDeterminable = false;
     bool isZNCSpDeterminable = false;
 
+    constexpr float QvectorMaxValue = 990.0;
+
     if (isZNAhit) {
       int activeTowersZNA = (zdc.znaTow1() > 0.) + (zdc.znaTow2() > 0.) + (zdc.znaTow3() > 0.) + (zdc.znaTow4() > 0.);
       float znaSum = zdc.znaTow1() + zdc.znaTow2() + zdc.znaTow3() + zdc.znaTow4();
-      if (activeTowersZNA >= nTowersFired && znaSum > 0 && zdc.znaQx() < 990.0f) isZNASpDeterminable = true;
+      if (activeTowersZNA >= nTowersFired && znaSum > 0 && zdc.znaQx() < QvectorMaxValue) isZNASpDeterminable = true;
     }
 
     if (isZNChit) {
       int activeTowersZNC = (zdc.zncTow1() > 0.) + (zdc.zncTow2() > 0.) + (zdc.zncTow3() > 0.) + (zdc.zncTow4() > 0.);
       float zncSum = zdc.zncTow1() + zdc.zncTow2() + zdc.zncTow3() + zdc.zncTow4();
-      if (activeTowersZNC >= nTowersFired && zncSum > 0 && zdc.zncQx() < 990.0f) isZNCSpDeterminable = true;
+      if (activeTowersZNC >= nTowersFired && zncSum > 0 && zdc.zncQx() < QvectorMaxValue) isZNCSpDeterminable = true;
     }
 
     if (plotPMs) {

--- a/Common/Tasks/zdcExtraTableReader.cxx
+++ b/Common/Tasks/zdcExtraTableReader.cxx
@@ -32,13 +32,14 @@
 #include <Framework/OutputObjHeader.h>
 #include <Framework/runDataProcessing.h>
 
-#include <TFile.h>
 #include <TH1.h>
 #include <TH2.h>
 #include <THn.h>
 #include <TList.h>
 #include <TMath.h>
 #include <TProfile3D.h>
+
+#include <Rtypes.h>
 
 #include <memory>
 #include <string>
@@ -247,9 +248,9 @@ struct ZdcExtraTableReader {
 
   Configurable<bool> ifBeamSpotCorrection{"ifBeamSpotCorrection", true, "Beam spot correction"};
 
-  Configurable<bool> ifSel8{"ifSel8", true, "Event selection: sel8"};
-  Configurable<bool> ifVtxZle10{"ifVtxZle10", true, "Event selection: zVtx < 10 cm"};
-  Configurable<bool> ifOccupancyCut{"ifOccupancyCut", false, "Event selection: occupancy cut"};
+  Configurable<bool> ifSel8{"ifSel8", true, "Event selection: Sel8"};
+  Configurable<bool> ifZVtxCut{"ifZVtxCut", true, "Event selection: zVtx cut set in producer (tipically < 10 cm)"};
+  Configurable<bool> ifOccupancyCut{"ifOccupancyCut", false, "Event selection: occupancy cut set in producer"};
   Configurable<bool> ifNoSameBunchPileup{"ifNoSameBunchPileup", false, "Event selection: no same bunch pileup"};
   Configurable<bool> ifIsGoodZvtxFT0vsPV{"ifIsGoodZvtxFT0vsPV", false, "Event selection: good Zvtx FT0 vs PV"};
   Configurable<bool> ifNoCollInTimeRangeStandard{"ifNoCollInTimeRangeStandard", false, "Event selection: no collision in time range standard"};
@@ -293,6 +294,34 @@ struct ZdcExtraTableReader {
     TH1* hMeanQyVyZNA{nullptr};
     TH1* hMeanQxVyZNC{nullptr};
     TH1* hMeanQyVyZNC{nullptr};
+    
+    // Destructor to handle cleanup automatically
+    ~CalibStepData() {
+      delete hMeanQxZNA;
+      delete hMeanQyZNA;
+      delete hMeanQxZNC;
+      delete hMeanQyZNC;
+
+      delete hMeanQxCentZNA;
+      delete hMeanQyCentZNA;
+      delete hMeanQxCentZNC;
+      delete hMeanQyCentZNC;
+
+      delete hMeanQxVzZNA;
+      delete hMeanQyVzZNA;
+      delete hMeanQxVzZNC;
+      delete hMeanQyVzZNC;
+
+      delete hMeanQxVxZNA;
+      delete hMeanQyVxZNA;
+      delete hMeanQxVxZNC;
+      delete hMeanQyVxZNC;
+
+      delete hMeanQxVyZNA;
+      delete hMeanQyVyZNA;
+      delete hMeanQxVyZNC;
+      delete hMeanQyVyZNC;
+    }
   };
 
   // Cache container: Vector index = Step index (0-based, so step 1 is at index 0)
@@ -306,22 +335,19 @@ struct ZdcExtraTableReader {
   TProfile3D* mShiftProfileZNA{nullptr};
   TProfile3D* mShiftProfileZNC{nullptr};
 
-  HistogramRegistry histos{
-    "histos",
-    {},
-    OutputObjHandlingPolicy::AnalysisObject};
+  HistogramRegistry histos{"histos"};
 
-  enum EvSelBits { // TO DO: move to a common header file
-    evSel_zvtx,
-    evSel_sel8,
-    evSel_occupancy,
-    evSel_kNoSameBunchPileup,
-    evSel_kIsGoodZvtxFT0vsPV,
-    evSel_kNoCollInTimeRangeStandard,
-    evSel_kIsVertexITSTPC,
-    evSel_kIsGoodITSLayersAll,
-    evSel_allEvents,
-    nEventSelections
+  enum EvSelBits { // same bits as in zdcExtraTableProducer.cxx 
+    ZVtxCut,
+    Sel8,
+    OccupancyCut,
+    NoSameBunchPileup,
+    IsGoodZvtxFT0vsPV,
+    NoCollInTimeRangeStandard,
+    IsVertexITSTPC,
+    IsGoodITSLayersAll,
+    AllEvents,
+    NEventSelections
   };
 
   int mCurrentRunNumber{-1};
@@ -344,50 +370,18 @@ struct ZdcExtraTableReader {
 
   void clearCache()
   {
-    if (hMeanVx) {
-      delete hMeanVx;
-      hMeanVx = nullptr;
-    }
-    if (hMeanVy) {
-      delete hMeanVy;
-      hMeanVy = nullptr;
-    }
+    delete hMeanVx;
+    hMeanVx = nullptr;
+    
+    delete hMeanVy;
+    hMeanVy = nullptr;
 
-    for (const auto& step : mCalibCache) {
-      delete step.hMeanQxZNA;
-      delete step.hMeanQyZNA;
-      delete step.hMeanQxZNC;
-      delete step.hMeanQyZNC;
-
-      delete step.hMeanQxCentZNA;
-      delete step.hMeanQyCentZNA;
-      delete step.hMeanQxCentZNC;
-      delete step.hMeanQyCentZNC;
-
-      delete step.hMeanQxVzZNA;
-      delete step.hMeanQyVzZNA;
-      delete step.hMeanQxVzZNC;
-      delete step.hMeanQyVzZNC;
-
-      delete step.hMeanQxVxZNA;
-      delete step.hMeanQyVxZNA;
-      delete step.hMeanQxVxZNC;
-      delete step.hMeanQyVxZNC;
-
-      delete step.hMeanQxVyZNA;
-      delete step.hMeanQyVyZNA;
-      delete step.hMeanQxVyZNC;
-      delete step.hMeanQyVyZNC;
-
-      if (mShiftProfileZNA) {
-        delete mShiftProfileZNA;
-        mShiftProfileZNA = nullptr;
-      }
-      if (mShiftProfileZNC) {
-        delete mShiftProfileZNC;
-        mShiftProfileZNC = nullptr;
-      }
-    }
+    delete mShiftProfileZNA;
+    mShiftProfileZNA = nullptr;
+    
+    delete mShiftProfileZNC;
+    mShiftProfileZNC = nullptr;
+    
     mCalibCache.clear();
   }
 
@@ -398,7 +392,7 @@ struct ZdcExtraTableReader {
     }
     mCurrentRunNumber = mRunNumber;
 
-    if (gEventCounter.find(mRunNumber) == gEventCounter.end()) {
+    if (!gEventCounter.contains(mRunNumber)) {
       // if new run, initialize histograms
 
       const AxisSpec axisCounter{1, 0, +1, ""};
@@ -421,16 +415,16 @@ struct ZdcExtraTableReader {
 
       const AxisSpec axisTime = {90, 0, 90, "Time (minutes)"}; // 90 minutes
 
-      gEventCounter[mRunNumber] = histos.add<TH1>(Form("%i/eventCounter", mRunNumber), "Number of Event; ; #Events Passed Cut", kTH1D, {{nEventSelections, 0, nEventSelections}}).get();
-      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(evSel_allEvents + 1, "All events");
-      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(evSel_zvtx + 1, "vtxZ");
-      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(evSel_sel8 + 1, "Sel8");
-      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(evSel_occupancy + 1, "kOccupancy");
-      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(evSel_kNoSameBunchPileup + 1, "kNoSameBunchPileup");
-      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(evSel_kIsGoodZvtxFT0vsPV + 1, "kIsGoodZvtxFT0vsPV");
-      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(evSel_kNoCollInTimeRangeStandard + 1, "kNoCollInTimeRangeStandard");
-      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(evSel_kIsVertexITSTPC + 1, "kIsVertexITSTPC");
-      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(evSel_kIsGoodITSLayersAll + 1, "kIsGoodITSLayersAll");
+      gEventCounter[mRunNumber] = histos.add<TH1>(Form("%i/eventCounter", mRunNumber), "Number of Event; ; #Events Passed Cut", kTH1D, {{NEventSelections, 0, NEventSelections}}).get();
+      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(AllEvents + 1, "allEvents");
+      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(ZVtxCut + 1, "zVtxCut");
+      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(Sel8 + 1, "Sel8");
+      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(OccupancyCut + 1, "occupancyCut");
+      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(NoSameBunchPileup + 1, "NoSameBunchPileup");
+      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(IsGoodZvtxFT0vsPV + 1, "isGoodZvtxFT0vsPV");
+      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(NoCollInTimeRangeStandard + 1, "noCollInTimeRangeStandard");
+      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(IsVertexITSTPC + 1, "isVertexITSTPC");
+      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(IsGoodITSLayersAll + 1, "isGoodITSLayersAll");
 
       gCentroidZNA[mRunNumber] = histos.add<TH2>(Form("%i/CentroidZNA", mRunNumber), "ZNA Centroid; Q_{X}; Q_{Y}", kTH2F, {{50, -1.5, 1.5}, {50, -1.5, 1.5}}).get();
       gCentroidZNC[mRunNumber] = histos.add<TH2>(Form("%i/CentroidZNC", mRunNumber), "ZNC Centroid; Q_{X}; Q_{Y}", kTH2F, {{50, -1.5, 1.5}, {50, -1.5, 1.5}}).get();
@@ -551,7 +545,7 @@ struct ZdcExtraTableReader {
     // Vertex Calibration
     if (ifBeamSpotCorrection) {
       std::string folder = Form("%s/step0", qRecenteringCcdb.value.c_str());
-      TList* lst = ccdb->getForRun<TList>(folder, run);
+      auto* lst = ccdb->getForRun<TList>(folder, run);
       if (lst) {
         hMeanVx = safeClone<TH1>(lst->FindObject("hMeanVx"));
         hMeanVy = safeClone<TH1>(lst->FindObject("hMeanVy"));
@@ -567,7 +561,7 @@ struct ZdcExtraTableReader {
 
       // Load 5D (Base)
       std::string folderBase = Form("%s/step%d_base", qRecenteringCcdb.value.c_str(), step);
-      TList* lstBase = ccdb->getForRun<TList>(folderBase, run);
+      auto* lstBase = ccdb->getForRun<TList>(folderBase, run);
       if (lstBase) {
         mCalibCache[stepIdx].hMeanQxZNA = safeClone<THn>(lstBase->FindObject("hMeanQxZNA"));
         mCalibCache[stepIdx].hMeanQyZNA = safeClone<THn>(lstBase->FindObject("hMeanQyZNA"));
@@ -578,7 +572,7 @@ struct ZdcExtraTableReader {
       // Load 1D (Refine)
       if ((step != calibrationStep) || ifFineCalibration) {
         std::string folderRefine = Form("%s/step%d_refine", qRecenteringCcdb.value.c_str(), step);
-        TList* lstRefine = ccdb->getForRun<TList>(folderRefine, run);
+        auto* lstRefine = ccdb->getForRun<TList>(folderRefine, run);
         if (lstRefine) {
           mCalibCache[stepIdx].hMeanQxCentZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQxCentZNA"));
           mCalibCache[stepIdx].hMeanQyCentZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQyCentZNA"));
@@ -611,15 +605,18 @@ struct ZdcExtraTableReader {
       // Attempt to fetch TList from CCDB
       auto* lst = ccdb->getForRun<TList>(folder, run);
 
-      if (lst) {
+      if (!lst) {
+        LOGF(error, "  >> CCDB TList is NULL for path: %s. Check object type (TList vs TFile).", folder.c_str());
+        return; 
+      }
+
         // Important: Object names must match exactly what was saved
         mShiftProfileZNA = safeClone<TProfile3D>(lst->FindObject("ShiftProfileZNA"));
         mShiftProfileZNC = safeClone<TProfile3D>(lst->FindObject("ShiftProfileZNC"));
 
         if (mShiftProfileZNA) {
           mShiftProfileZNA->SetDirectory(nullptr); // Detach from file
-          LOGF(info, "  >> ShiftProfileZNA found! Entries: %.0f, Mean: %f",
-               mShiftProfileZNA->GetEntries(), mShiftProfileZNA->GetMean());
+        //  LOGF(info, "  >> ShiftProfileZNA found! Entries: %.0f, Mean: %f", mShiftProfileZNA->GetEntries(), mShiftProfileZNA->GetMean());
         } else {
           LOGF(error, "  >> ShiftProfileZNA NOT found in TList! Content follows:");
           lst->Print();
@@ -627,14 +624,11 @@ struct ZdcExtraTableReader {
 
         if (mShiftProfileZNC) {
           mShiftProfileZNC->SetDirectory(nullptr);
-          LOGF(info, "  >> ShiftProfileZNC found! Entries: %.0f", mShiftProfileZNC->GetEntries());
+         // LOGF(info, "  >> ShiftProfileZNC found! Entries: %.0f", mShiftProfileZNC->GetEntries());
         } else {
           LOGF(error, "  >> ShiftProfileZNC NOT found in TList!");
         }
 
-      } else {
-        LOGF(error, "  >> CCDB TList is NULL for path: %s. Check object type (TList vs TFile).", folder.c_str());
-      }
     }
   } // end of loadCalibrations()
 
@@ -659,39 +653,39 @@ struct ZdcExtraTableReader {
 
     // Apply event selection
 
-    if (ifSel8 && !(zdc.selectionBits() & (1 << evSel_sel8))) {
+    if (ifSel8 && !TESTBIT(zdc.selectionBits(), Sel8)) {
       return;
     }
-    if (ifVtxZle10 && !(zdc.selectionBits() & (1 << evSel_zvtx))) {
+    if (ifZVtxCut && !TESTBIT(zdc.selectionBits(), ZVtxCut)) {
       return;
     }
-    if (ifOccupancyCut && !(zdc.selectionBits() & (1 << evSel_occupancy))) {
+    if (ifOccupancyCut && !TESTBIT(zdc.selectionBits(), OccupancyCut)) {
       return;
     }
-    if (ifNoSameBunchPileup && !(zdc.selectionBits() & (1 << evSel_kNoSameBunchPileup))) {
+    if (ifNoSameBunchPileup && !TESTBIT(zdc.selectionBits(), NoSameBunchPileup)) {
       return;
     }
-    if (ifIsGoodZvtxFT0vsPV && !(zdc.selectionBits() & (1 << evSel_kIsGoodZvtxFT0vsPV))) {
+    if (ifIsGoodZvtxFT0vsPV && !TESTBIT(zdc.selectionBits(), IsGoodZvtxFT0vsPV)) {
       return;
     }
-    if (ifNoCollInTimeRangeStandard && !(zdc.selectionBits() & (1 << evSel_kNoCollInTimeRangeStandard))) {
+    if (ifNoCollInTimeRangeStandard && !TESTBIT(zdc.selectionBits(), NoCollInTimeRangeStandard)) {
       return;
     }
-    if (ifIsVertexITSTPC && !(zdc.selectionBits() & (1 << evSel_kIsVertexITSTPC))) {
+    if (ifIsVertexITSTPC && !TESTBIT(zdc.selectionBits(), IsVertexITSTPC)) {
       return;
     }
-    if (ifIsGoodITSLayersAll && !(zdc.selectionBits() & (1 << evSel_kIsGoodITSLayersAll))) {
+    if (ifIsGoodITSLayersAll && !TESTBIT(zdc.selectionBits(), IsGoodITSLayersAll)) {
       return;
     }
 
-    //  LOGF(info, "zvtx       = %d", (zdc.selectionBits() & (1 << evSel_zvtx)) > 0);
-    //  LOGF(info, "sel8       = %d", (zdc.selectionBits() & (1 << evSel_sel8)) > 0);
-    //  LOGF(info, "occupancy  = %d", (zdc.selectionBits() & (1 << evSel_occupancy)) > 0);
-    //  LOGF(info, "noSameBC   = %d", (zdc.selectionBits() & (1 << evSel_kNoSameBunchPileup)) > 0);
-    //  LOGF(info, "FT0vsPV    = %d", (zdc.selectionBits() & (1 << evSel_kIsGoodZvtxFT0vsPV)) > 0);
-    //  LOGF(info, "noCollTR   = %d", (zdc.selectionBits() & (1 << evSel_kNoCollInTimeRangeStandard)) > 0);
-    //  LOGF(info, "vtxITSTPC  = %d", (zdc.selectionBits() & (1 << evSel_kIsVertexITSTPC)) > 0);
-    //  LOGF(info, "ITS layers = %d", (zdc.selectionBits() & (1 << evSel_kIsGoodITSLayersAll)) > 0);
+    //  LOGF(info, "zvtx       = %d", TESTBIT(zdc.selectionBits(), ZVtxCut));
+    //  LOGF(info, "Sel8       = %d", TESTBIT(zdc.selectionBits(), Sel8));
+    //  LOGF(info, "occupancy  = %d", TESTBIT(zdc.selectionBits(), OccupancyCut));
+    //  LOGF(info, "noSameBC   = %d", TESTBIT(zdc.selectionBits(), NoSameBunchPileup));
+    //  LOGF(info, "FT0vsPV    = %d", TESTBIT(zdc.selectionBits(), IsGoodZvtxFT0vsPV));
+    //  LOGF(info, "noCollTR   = %d", TESTBIT(zdc.selectionBits(), NoCollInTimeRangeStandard));
+    //  LOGF(info, "vtxITSTPC  = %d", TESTBIT(zdc.selectionBits(), IsVertexITSTPC));
+    //  LOGF(info, "ITS layers = %d", TESTBIT(zdc.selectionBits(), IsGoodITSLayersAll));
 
     const int mRunNumber = zdc.runNumber();
 
@@ -700,7 +694,7 @@ struct ZdcExtraTableReader {
     // Convert timestamp to hours from run start (approximate)
     // Store first timestamp of run to calculate relative time
     static std::unordered_map<int, uint64_t> runStartTime;
-    if (runStartTime.find(mRunNumber) == runStartTime.end()) {
+    if (!runStartTime.contains(mRunNumber)) {
       runStartTime[mRunNumber] = timestamp;
     }
 
@@ -715,11 +709,11 @@ struct ZdcExtraTableReader {
 
     histos.fill(HIST("eventCounter"), 0.5);
 
-    gCurrentEventCounter->Fill(evSel_allEvents);
+    gCurrentEventCounter->Fill(AllEvents);
 
     // Fill histogram for all bits that passed
-    for (int bit = 0; bit < nEventSelections + 1; bit++) {
-      if (zdc.selectionBits() & (1 << bit)) {
+    for (int bit = 0; bit < NEventSelections + 1; bit++) {
+      if (TESTBIT(zdc.selectionBits(), bit)) {
         gCurrentEventCounter->Fill(bit);
       }
     }

--- a/Common/Tasks/zdcExtraTableReader.cxx
+++ b/Common/Tasks/zdcExtraTableReader.cxx
@@ -165,11 +165,11 @@ TProfile3D* gCurrentShiftProfileZNC;
 
 } // namespace
 
+// Helper for 4D recentering maps
 double getMeanQFromMap(THn* h, double cent, double vx, double vy, double vz)
 {
   if (!h) {
-    // LOGF(error, "[MeanQ] Null THn pointer");
-    return 0.0;
+    LOGF(fatal, "[MeanQ] Null THn pointer");
   }
 
   TAxis* axCent = h->GetAxis(0);
@@ -178,8 +178,7 @@ double getMeanQFromMap(THn* h, double cent, double vx, double vy, double vz)
   TAxis* axVz = h->GetAxis(3);
 
   if (!axCent || !axVx || !axVy || !axVz) {
-    LOGF(error, "[MeanQ] One of THn axes is null");
-    return 0.0;
+    LOGF(fatal, "[MeanQ] One of THn axes is null");
   }
 
   int binCent = axCent->FindFixBin(cent);
@@ -188,17 +187,16 @@ double getMeanQFromMap(THn* h, double cent, double vx, double vy, double vz)
   int binVz = axVz->FindFixBin(vz);
 
   int idx[4] = {binCent, binVx, binVy, binVz};
-  double meanQ = h->GetBinContent(idx);
+  return h->GetBinContent(idx);
 
-  return meanQ;
 }
 
-// Helper for 1D recentering maps: returns mean Q for coordinate x.
-// If histogram is missing or bin out of range, returns 0.0.
+// Helper for 1D recentering maps: returns mean Q for coordinate x
+// If bin out of range, returns 0.0
 double getMeanQ1D(TH1* h, double x)
 {
   if (!h) {
-    return 0.0;
+    LOGF(fatal, "[MeanQ1D] Null TH1 pointer");
   }
   int bin = h->FindFixBin(x);
   if (bin < 1 || bin > h->GetNbinsX()) {
@@ -211,9 +209,9 @@ struct ZdcExtraTableReader {
 
   Configurable<int> nBinsZN{"nBinsZN", 2000, "n bins for ZN histograms"};
   Configurable<float> maxZN{"maxZN", 399.5, "Max ZN signal"};
-  Configurable<bool> tdcCut{"tdcCut", true, "Flag for TDC cut"};
-  Configurable<float> tdcZNmincut{"tdcZNmincut", -2.5, "Min ZN TDC cut"};
-  Configurable<float> tdcZNmaxcut{"tdcZNmaxcut", 2.5, "Max ZN TDC cut"};
+  Configurable<bool> applyTdcCut{"applyTdcCut", true, "Flag for TDC cut"};
+  Configurable<float> tdcZnMin{"tdcZnMin", -2.5, "Min ZN TDC cut"};
+  Configurable<float> tdcZnMax{"tdcZnMax", 2.5, "Max ZN TDC cut"};
   Configurable<bool> plotPMs{"plotPMs", false, "Flag to plot individual PMs"};
 
   Configurable<int> qxyNbins{"qxyNbins", 100, "Number of bins in QxQy histograms"};
@@ -238,28 +236,28 @@ struct ZdcExtraTableReader {
 
   Configurable<int> phiNbins{"phiNbins", 60, "Bins in phi"};
 
-  Configurable<int> nTowersFired{"nTowersFired", 2, "Minimum number of towers fired for Q-vector determination"};
+  Configurable<int> minNTowersFired{"minNTowersFired", 2, "Minimum number of towers fired for Q-vector determination"};
 
   Configurable<int> qNbins5D{"qNbins5D", 4, "Bins in each dimension for 5D histograms"};
   Configurable<bool> plot5D{"plot5D", false, "Flag to plot 5D histograms"};
 
   Configurable<int> calibrationStep{"calibrationStep", 1, "Calibration step"};
-  Configurable<bool> ifFineCalibration{"ifFineCalibration", false, "Calibration: base  or refine"};
+  Configurable<bool> isFineCalibrationStep{"isFineCalibrationStep", false, "Calibration: base  or refine"};
 
-  Configurable<bool> ifBeamSpotCorrection{"ifBeamSpotCorrection", true, "Beam spot correction"};
+  Configurable<bool> applyBeamSpotCorrection{"applyBeamSpotCorrection", true, "Beam spot correction"};
 
-  Configurable<bool> ifSel8{"ifSel8", true, "Event selection: Sel8"};
-  Configurable<bool> ifZVtxCut{"ifZVtxCut", true, "Event selection: zVtx cut set in producer (tipically < 10 cm)"};
-  Configurable<bool> ifOccupancyCut{"ifOccupancyCut", false, "Event selection: occupancy cut set in producer"};
-  Configurable<bool> ifNoSameBunchPileup{"ifNoSameBunchPileup", false, "Event selection: no same bunch pileup"};
-  Configurable<bool> ifIsGoodZvtxFT0vsPV{"ifIsGoodZvtxFT0vsPV", false, "Event selection: good Zvtx FT0 vs PV"};
-  Configurable<bool> ifNoCollInTimeRangeStandard{"ifNoCollInTimeRangeStandard", false, "Event selection: no collision in time range standard"};
-  Configurable<bool> ifIsVertexITSTPC{"ifIsVertexITSTPC", false, "Event selection: vertex ITS TPC"};
-  Configurable<bool> ifIsGoodITSLayersAll{"ifIsGoodITSLayersAll", false, "Event selection: good ITS layers all"};
+  Configurable<bool> applySel8{"applySel8", true, "Event selection: Sel8"};
+  Configurable<bool> applyZVtxCut{"applyZVtxCut", true, "Event selection: zVtx cut set in producer (tipically < 10 cm)"};
+  Configurable<bool> applyOccupancyCut{"applyOccupancyCut", false, "Event selection: occupancy cut set in producer"};
+  Configurable<bool> selectNoSameBunchPileupEvents{"selectNoSameBunchPileupEvents", false, "Event selection: no same bunch pileup"};
+  Configurable<bool> selectGoodZvtxFT0vsPV{"selectGoodZvtxFT0vsPV", false, "Event selection: good Zvtx FT0 vs PV"};
+  Configurable<bool> applyNoCollInTimeRangeStandard{"applyNoCollInTimeRangeStandard", false, "Event selection: no collision in time range standard"};
+  Configurable<bool> selectVertexITSTPC{"selectVertexITSTPC", false, "Event selection: vertex ITS TPC"};
+  Configurable<bool> selectGoodITSLayersAll{"selectGoodITSLayersAll", false, "Event selection: good ITS layers all"};
 
-  Configurable<bool> ifShiftCorrection{"ifShiftCorrection", false, "Apply shift correction (Read from CCDB)"};
-  Configurable<bool> fillShiftHistos{"fillShiftHistos", true, "Fill shift profiles (Write to output)"};
-  Configurable<int> nShift{"nShift", 10, "Number of harmonics"};
+  Configurable<bool> applyShiftCorrection{"applyShiftCorrection", false, "Apply shift correction (Read from CCDB)"};
+  Configurable<bool> fillShiftHistos{"fillShiftHistos", false, "Fill shift profiles (Write to output)"};
+  Configurable<int> nHarmonics{"nHarmonics", 10, "Number of harmonics"};
 
   Configurable<std::string> qRecenteringCcdb{"qRecenteringCcdb", "Users/u/udmitrie/ZDC/LHC24ar_apass2", "Recentering maps containing step folder"};
 
@@ -326,15 +324,15 @@ struct ZdcExtraTableReader {
   };
 
   // Cache container: Vector index = Step index (0-based, so step 1 is at index 0)
-  std::vector<CalibStepData> mCalibCache;
+  std::vector<CalibStepData> calibCache;
 
   // Vertex correction cache
   TH1* hMeanVx{nullptr};
   TH1* hMeanVy{nullptr};
 
   // Phase shift correction cache
-  TProfile3D* mShiftProfileZNA{nullptr};
-  TProfile3D* mShiftProfileZNC{nullptr};
+  TProfile3D* shiftProfileZNA{nullptr};
+  TProfile3D* shiftProfileZNC{nullptr};
 
   HistogramRegistry histos{"histos"};
 
@@ -351,7 +349,7 @@ struct ZdcExtraTableReader {
     NEventSelections
   };
 
-  int mCurrentRunNumber{-1};
+  int currentRunNumber{-1};
 
   // Helper to safely clone a histogram and detach from file
   template <typename T>
@@ -377,23 +375,23 @@ struct ZdcExtraTableReader {
     delete hMeanVy;
     hMeanVy = nullptr;
 
-    delete mShiftProfileZNA;
-    mShiftProfileZNA = nullptr;
+    delete shiftProfileZNA;
+    shiftProfileZNA = nullptr;
 
-    delete mShiftProfileZNC;
-    mShiftProfileZNC = nullptr;
+    delete shiftProfileZNC;
+    shiftProfileZNC = nullptr;
 
-    mCalibCache.clear();
+    calibCache.clear();
   }
 
-  void initHistos(const int& mRunNumber)
+  void initHistos(const int& runNumber)
   {
-    if (mRunNumber == mCurrentRunNumber) {
+    if (runNumber == currentRunNumber) {
       return;
     }
-    mCurrentRunNumber = mRunNumber;
+    currentRunNumber = runNumber;
 
-    if (!gEventCounter.contains(mRunNumber)) {
+    if (!gEventCounter.contains(runNumber)) {
       // if new run, initialize histograms
 
       const AxisSpec axisCounter{1, 0, +1, ""};
@@ -416,126 +414,126 @@ struct ZdcExtraTableReader {
 
       const AxisSpec axisTime = {90, 0, 90, "Time (minutes)"}; // 90 minutes
 
-      gEventCounter[mRunNumber] = histos.add<TH1>(Form("%i/eventCounter", mRunNumber), "Number of Event; ; #Events Passed Cut", kTH1D, {{NEventSelections, 0, NEventSelections}}).get();
-      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(AllEvents + 1, "allEvents");
-      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(ZVtxCut + 1, "zVtxCut");
-      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(Sel8 + 1, "Sel8");
-      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(OccupancyCut + 1, "occupancyCut");
-      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(NoSameBunchPileup + 1, "NoSameBunchPileup");
-      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(IsGoodZvtxFT0vsPV + 1, "isGoodZvtxFT0vsPV");
-      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(NoCollInTimeRangeStandard + 1, "noCollInTimeRangeStandard");
-      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(IsVertexITSTPC + 1, "isVertexITSTPC");
-      gEventCounter[mRunNumber]->GetXaxis()->SetBinLabel(IsGoodITSLayersAll + 1, "isGoodITSLayersAll");
+      gEventCounter[runNumber] = histos.add<TH1>(Form("%i/eventCounter", runNumber), "Number of Event; ; #Events Passed Cut", kTH1D, {{NEventSelections, 0, NEventSelections}}).get();
+      gEventCounter[runNumber]->GetXaxis()->SetBinLabel(AllEvents + 1, "allEvents");
+      gEventCounter[runNumber]->GetXaxis()->SetBinLabel(ZVtxCut + 1, "zVtxCut");
+      gEventCounter[runNumber]->GetXaxis()->SetBinLabel(Sel8 + 1, "Sel8");
+      gEventCounter[runNumber]->GetXaxis()->SetBinLabel(OccupancyCut + 1, "occupancyCut");
+      gEventCounter[runNumber]->GetXaxis()->SetBinLabel(NoSameBunchPileup + 1, "NoSameBunchPileup");
+      gEventCounter[runNumber]->GetXaxis()->SetBinLabel(IsGoodZvtxFT0vsPV + 1, "isGoodZvtxFT0vsPV");
+      gEventCounter[runNumber]->GetXaxis()->SetBinLabel(NoCollInTimeRangeStandard + 1, "noCollInTimeRangeStandard");
+      gEventCounter[runNumber]->GetXaxis()->SetBinLabel(IsVertexITSTPC + 1, "isVertexITSTPC");
+      gEventCounter[runNumber]->GetXaxis()->SetBinLabel(IsGoodITSLayersAll + 1, "isGoodITSLayersAll");
 
-      gCentroidZNA[mRunNumber] = histos.add<TH2>(Form("%i/CentroidZNA", mRunNumber), "ZNA Centroid; Q_{X}; Q_{Y}", kTH2F, {{50, -1.5, 1.5}, {50, -1.5, 1.5}}).get();
-      gCentroidZNC[mRunNumber] = histos.add<TH2>(Form("%i/CentroidZNC", mRunNumber), "ZNC Centroid; Q_{X}; Q_{Y}", kTH2F, {{50, -1.5, 1.5}, {50, -1.5, 1.5}}).get();
-      gPmcZNA[mRunNumber] = histos.add<TH1>(Form("%i/pmcZNA", mRunNumber), "; E_{PMC}^{ZNA} (TeV);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
-      gPm1ZNA[mRunNumber] = histos.add<TH1>(Form("%i/pm1ZNA", mRunNumber), "; E_{PM1}^{ZNA} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
-      gPm2ZNA[mRunNumber] = histos.add<TH1>(Form("%i/pm2ZNA", mRunNumber), "; E_{PM2}^{ZNA} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
-      gPm3ZNA[mRunNumber] = histos.add<TH1>(Form("%i/pm3ZNA", mRunNumber), "; E_{PM3}^{ZNA} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
-      gPm4ZNA[mRunNumber] = histos.add<TH1>(Form("%i/pm4ZNA", mRunNumber), "; E_{PM4}^{ZNA} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
-      gSumZNA[mRunNumber] = histos.add<TH1>(Form("%i/sumZNA", mRunNumber), "; E_{sum PMs}^{ZNA} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
-      gPmcZNC[mRunNumber] = histos.add<TH1>(Form("%i/pmcZNC", mRunNumber), "; E_{PMC}^{ZNC} (TeV);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
-      gPm1ZNC[mRunNumber] = histos.add<TH1>(Form("%i/pm1ZNC", mRunNumber), "; E_{PM1}^{ZNC} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
-      gPm2ZNC[mRunNumber] = histos.add<TH1>(Form("%i/pm2ZNC", mRunNumber), "; E_{PM2}^{ZNC} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
-      gPm3ZNC[mRunNumber] = histos.add<TH1>(Form("%i/pm3ZNC", mRunNumber), "; E_{PM3}^{ZNC} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
-      gPm4ZNC[mRunNumber] = histos.add<TH1>(Form("%i/pm4ZNC", mRunNumber), "; E_{PM4}^{ZNC} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
-      gSumZNC[mRunNumber] = histos.add<TH1>(Form("%i/sumZNC", mRunNumber), "; E_{sum PMs}^{ZNC} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
-      gQxVsCentZNA[mRunNumber] = histos.add<TH2>(Form("%i/QxVsCentZNA", mRunNumber), "Q_{x}^{ZNA} vs Centrality", kTH2F, {axisCent, axisQx}).get();
-      gQyVsCentZNA[mRunNumber] = histos.add<TH2>(Form("%i/QyVsCentZNA", mRunNumber), "Q_{y}^{ZNA} vs Centrality", kTH2F, {axisCent, axisQy}).get();
-      gQxVsVxZNA[mRunNumber] = histos.add<TH2>(Form("%i/QxVsVxZNA", mRunNumber), "Q_{x}^{ZNA} vs V_{x}; V_{x} (cm); Q_{x}", kTH2F, {axisVx, axisQx}).get();
-      gQyVsVxZNA[mRunNumber] = histos.add<TH2>(Form("%i/QyVsVxZNA", mRunNumber), "Q_{y}^{ZNA} vs V_{x}; V_{x} (cm); Q_{y}", kTH2F, {axisVx, axisQy}).get();
-      gQxVsVyZNA[mRunNumber] = histos.add<TH2>(Form("%i/QxVsVyZNA", mRunNumber), "Q_{x}^{ZNA} vs V_{y}; V_{y} (cm); Q_{x}", kTH2F, {axisVy, axisQx}).get();
-      gQyVsVyZNA[mRunNumber] = histos.add<TH2>(Form("%i/QyVsVyZNA", mRunNumber), "Q_{y}^{ZNA} vs V_{y}; V_{y} (cm); Q_{y}", kTH2F, {axisVy, axisQy}).get();
-      gQxVsVzZNA[mRunNumber] = histos.add<TH2>(Form("%i/QxVsVzZNA", mRunNumber), "Q_{x}^{ZNA} vs V_{z}; V_{z} (cm); Q_{x}", kTH2F, {axisVz, axisQx}).get();
-      gQyVsVzZNA[mRunNumber] = histos.add<TH2>(Form("%i/QyVsVzZNA", mRunNumber), "Q_{y}^{ZNA} vs V_{z}; V_{z} (cm); Q_{y}", kTH2F, {axisVz, axisQy}).get();
-      gQxVsCentZNC[mRunNumber] = histos.add<TH2>(Form("%i/QxVsCentZNC", mRunNumber), "Q_{x}^{ZNC} vs Centrality; Centrality (%); Q_{x}", kTH2F, {axisCent, axisQx}).get();
-      gQyVsCentZNC[mRunNumber] = histos.add<TH2>(Form("%i/QyVsCentZNC", mRunNumber), "Q_{y}^{ZNC} vs Centrality; Centrality (%); Q_{y}", kTH2F, {axisCent, axisQy}).get();
-      gQxVsVxZNC[mRunNumber] = histos.add<TH2>(Form("%i/QxVsVxZNC", mRunNumber), "Q_{x}^{ZNC} vs V_{x}; V_{x} (cm); Q_{x}", kTH2F, {axisVx, axisQx}).get();
-      gQyVsVxZNC[mRunNumber] = histos.add<TH2>(Form("%i/QyVsVxZNC", mRunNumber), "Q_{y}^{ZNC} vs V_{x}; V_{x} (cm); Q_{y}", kTH2F, {axisVx, axisQy}).get();
-      gQxVsVyZNC[mRunNumber] = histos.add<TH2>(Form("%i/QxVsVyZNC", mRunNumber), "Q_{x}^{ZNC} vs V_{y}; V_{y} (cm); Q_{x}", kTH2F, {axisVy, axisQx}).get();
-      gQyVsVyZNC[mRunNumber] = histos.add<TH2>(Form("%i/QyVsVyZNC", mRunNumber), "Q_{y}^{ZNC} vs V_{y}; V_{y} (cm); Q_{y}", kTH2F, {axisVy, axisQy}).get();
-      gQxVsVzZNC[mRunNumber] = histos.add<TH2>(Form("%i/QxVsVzZNC", mRunNumber), "Q_{x}^{ZNC} vs V_{z}; V_{z} (cm); Q_{x}", kTH2F, {axisVz, axisQx}).get();
-      gQyVsVzZNC[mRunNumber] = histos.add<TH2>(Form("%i/QyVsVzZNC", mRunNumber), "Q_{y}^{ZNC} vs V_{z}; V_{z} (cm); Q_{y}", kTH2F, {axisVz, axisQy}).get();
-      gQxQyVsCent[mRunNumber] = histos.add<TH2>(Form("%i/QxQyVsCent", mRunNumber), "Q_{x}^{ZNC}Q_{y}^{ZNC} vs Centrality; Centrality (%); Q_{x}^{ZNA}Q_{y}^{ZNC}", kTH2F, {axisCent, {50, -1.5, 1.5}}).get();
-      gQyQxVsCent[mRunNumber] = histos.add<TH2>(Form("%i/QyQxVsCent", mRunNumber), "Q_{y}^{ZNC}Q_{x}^{ZNC} vs Centrality; Centrality (%); Q_{y}^{ZNA}Q_{x}^{ZNC}", kTH2F, {axisCent, {50, -1.5, 1.5}}).get();
-      gQxQxVsCent[mRunNumber] = histos.add<TH2>(Form("%i/QxQxVsCent", mRunNumber), "Q_{x}^{ZNC}Q_{x}^{ZNC} vs Centrality; Centrality (%); Q_{x}^{ZNA}Q_{x}^{ZNC}", kTH2F, {axisCent, {50, -1.5, 1.5}}).get();
-      gQyQyVsCent[mRunNumber] = histos.add<TH2>(Form("%i/QyQyVsCent", mRunNumber), "Q_{y}^{ZNC}Q_{y}^{ZNC} vs Centrality; Centrality (%); Q_{y}^{ZNA}Q_{y}^{ZNC}", kTH2F, {axisCent, {50, -1.5, 1.5}}).get();
+      gCentroidZNA[runNumber] = histos.add<TH2>(Form("%i/CentroidZNA", runNumber), "ZNA Centroid; Q_{X}; Q_{Y}", kTH2F, {{50, -1.5, 1.5}, {50, -1.5, 1.5}}).get();
+      gCentroidZNC[runNumber] = histos.add<TH2>(Form("%i/CentroidZNC", runNumber), "ZNC Centroid; Q_{X}; Q_{Y}", kTH2F, {{50, -1.5, 1.5}, {50, -1.5, 1.5}}).get();
+      gPmcZNA[runNumber] = histos.add<TH1>(Form("%i/pmcZNA", runNumber), "; E_{PMC}^{ZNA} (TeV);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gPm1ZNA[runNumber] = histos.add<TH1>(Form("%i/pm1ZNA", runNumber), "; E_{PM1}^{ZNA} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gPm2ZNA[runNumber] = histos.add<TH1>(Form("%i/pm2ZNA", runNumber), "; E_{PM2}^{ZNA} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gPm3ZNA[runNumber] = histos.add<TH1>(Form("%i/pm3ZNA", runNumber), "; E_{PM3}^{ZNA} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gPm4ZNA[runNumber] = histos.add<TH1>(Form("%i/pm4ZNA", runNumber), "; E_{PM4}^{ZNA} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gSumZNA[runNumber] = histos.add<TH1>(Form("%i/sumZNA", runNumber), "; E_{sum PMs}^{ZNA} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gPmcZNC[runNumber] = histos.add<TH1>(Form("%i/pmcZNC", runNumber), "; E_{PMC}^{ZNC} (TeV);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gPm1ZNC[runNumber] = histos.add<TH1>(Form("%i/pm1ZNC", runNumber), "; E_{PM1}^{ZNC} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gPm2ZNC[runNumber] = histos.add<TH1>(Form("%i/pm2ZNC", runNumber), "; E_{PM2}^{ZNC} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gPm3ZNC[runNumber] = histos.add<TH1>(Form("%i/pm3ZNC", runNumber), "; E_{PM3}^{ZNC} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gPm4ZNC[runNumber] = histos.add<TH1>(Form("%i/pm4ZNC", runNumber), "; E_{PM4}^{ZNC} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gSumZNC[runNumber] = histos.add<TH1>(Form("%i/sumZNC", runNumber), "; E_{sum PMs}^{ZNC} (a.u.);", kTH1F, {{nBinsZN, -0.5, maxZN}}).get();
+      gQxVsCentZNA[runNumber] = histos.add<TH2>(Form("%i/QxVsCentZNA", runNumber), "Q_{x}^{ZNA} vs Centrality", kTH2F, {axisCent, axisQx}).get();
+      gQyVsCentZNA[runNumber] = histos.add<TH2>(Form("%i/QyVsCentZNA", runNumber), "Q_{y}^{ZNA} vs Centrality", kTH2F, {axisCent, axisQy}).get();
+      gQxVsVxZNA[runNumber] = histos.add<TH2>(Form("%i/QxVsVxZNA", runNumber), "Q_{x}^{ZNA} vs V_{x}; V_{x} (cm); Q_{x}", kTH2F, {axisVx, axisQx}).get();
+      gQyVsVxZNA[runNumber] = histos.add<TH2>(Form("%i/QyVsVxZNA", runNumber), "Q_{y}^{ZNA} vs V_{x}; V_{x} (cm); Q_{y}", kTH2F, {axisVx, axisQy}).get();
+      gQxVsVyZNA[runNumber] = histos.add<TH2>(Form("%i/QxVsVyZNA", runNumber), "Q_{x}^{ZNA} vs V_{y}; V_{y} (cm); Q_{x}", kTH2F, {axisVy, axisQx}).get();
+      gQyVsVyZNA[runNumber] = histos.add<TH2>(Form("%i/QyVsVyZNA", runNumber), "Q_{y}^{ZNA} vs V_{y}; V_{y} (cm); Q_{y}", kTH2F, {axisVy, axisQy}).get();
+      gQxVsVzZNA[runNumber] = histos.add<TH2>(Form("%i/QxVsVzZNA", runNumber), "Q_{x}^{ZNA} vs V_{z}; V_{z} (cm); Q_{x}", kTH2F, {axisVz, axisQx}).get();
+      gQyVsVzZNA[runNumber] = histos.add<TH2>(Form("%i/QyVsVzZNA", runNumber), "Q_{y}^{ZNA} vs V_{z}; V_{z} (cm); Q_{y}", kTH2F, {axisVz, axisQy}).get();
+      gQxVsCentZNC[runNumber] = histos.add<TH2>(Form("%i/QxVsCentZNC", runNumber), "Q_{x}^{ZNC} vs Centrality; Centrality (%); Q_{x}", kTH2F, {axisCent, axisQx}).get();
+      gQyVsCentZNC[runNumber] = histos.add<TH2>(Form("%i/QyVsCentZNC", runNumber), "Q_{y}^{ZNC} vs Centrality; Centrality (%); Q_{y}", kTH2F, {axisCent, axisQy}).get();
+      gQxVsVxZNC[runNumber] = histos.add<TH2>(Form("%i/QxVsVxZNC", runNumber), "Q_{x}^{ZNC} vs V_{x}; V_{x} (cm); Q_{x}", kTH2F, {axisVx, axisQx}).get();
+      gQyVsVxZNC[runNumber] = histos.add<TH2>(Form("%i/QyVsVxZNC", runNumber), "Q_{y}^{ZNC} vs V_{x}; V_{x} (cm); Q_{y}", kTH2F, {axisVx, axisQy}).get();
+      gQxVsVyZNC[runNumber] = histos.add<TH2>(Form("%i/QxVsVyZNC", runNumber), "Q_{x}^{ZNC} vs V_{y}; V_{y} (cm); Q_{x}", kTH2F, {axisVy, axisQx}).get();
+      gQyVsVyZNC[runNumber] = histos.add<TH2>(Form("%i/QyVsVyZNC", runNumber), "Q_{y}^{ZNC} vs V_{y}; V_{y} (cm); Q_{y}", kTH2F, {axisVy, axisQy}).get();
+      gQxVsVzZNC[runNumber] = histos.add<TH2>(Form("%i/QxVsVzZNC", runNumber), "Q_{x}^{ZNC} vs V_{z}; V_{z} (cm); Q_{x}", kTH2F, {axisVz, axisQx}).get();
+      gQyVsVzZNC[runNumber] = histos.add<TH2>(Form("%i/QyVsVzZNC", runNumber), "Q_{y}^{ZNC} vs V_{z}; V_{z} (cm); Q_{y}", kTH2F, {axisVz, axisQy}).get();
+      gQxQyVsCent[runNumber] = histos.add<TH2>(Form("%i/QxQyVsCent", runNumber), "Q_{x}^{ZNC}Q_{y}^{ZNC} vs Centrality; Centrality (%); Q_{x}^{ZNA}Q_{y}^{ZNC}", kTH2F, {axisCent, {50, -1.5, 1.5}}).get();
+      gQyQxVsCent[runNumber] = histos.add<TH2>(Form("%i/QyQxVsCent", runNumber), "Q_{y}^{ZNC}Q_{x}^{ZNC} vs Centrality; Centrality (%); Q_{y}^{ZNA}Q_{x}^{ZNC}", kTH2F, {axisCent, {50, -1.5, 1.5}}).get();
+      gQxQxVsCent[runNumber] = histos.add<TH2>(Form("%i/QxQxVsCent", runNumber), "Q_{x}^{ZNC}Q_{x}^{ZNC} vs Centrality; Centrality (%); Q_{x}^{ZNA}Q_{x}^{ZNC}", kTH2F, {axisCent, {50, -1.5, 1.5}}).get();
+      gQyQyVsCent[runNumber] = histos.add<TH2>(Form("%i/QyQyVsCent", runNumber), "Q_{y}^{ZNC}Q_{y}^{ZNC} vs Centrality; Centrality (%); Q_{y}^{ZNA}Q_{y}^{ZNC}", kTH2F, {axisCent, {50, -1.5, 1.5}}).get();
 
-      gQx5DZNA[mRunNumber] = histos.add<THn>(Form("%i/Qx5DZNA", mRunNumber), "Qx recenter map ZNA", kTHnF, {axisCent5D, axisVx5D, axisVy5D, axisVz5D, axisQx}, true).get();
-      gQy5DZNA[mRunNumber] = histos.add<THn>(Form("%i/Qy5DZNA", mRunNumber), "Qy recenter map ZNA", kTHnF, {axisCent5D, axisVx5D, axisVy5D, axisVz5D, axisQy}, true).get();
-      gQx5DZNC[mRunNumber] = histos.add<THn>(Form("%i/Qx5DZNC", mRunNumber), "Qx recenter map ZNC", kTHnF, {axisCent5D, axisVx5D, axisVy5D, axisVz5D, axisQx}, true).get();
-      gQy5DZNC[mRunNumber] = histos.add<THn>(Form("%i/Qy5DZNC", mRunNumber), "Qy recenter map ZNC", kTHnF, {axisCent5D, axisVx5D, axisVy5D, axisVz5D, axisQy}, true).get();
+      gQx5DZNA[runNumber] = histos.add<THn>(Form("%i/Qx5DZNA", runNumber), "Qx recenter map ZNA", kTHnF, {axisCent5D, axisVx5D, axisVy5D, axisVz5D, axisQx}, true).get();
+      gQy5DZNA[runNumber] = histos.add<THn>(Form("%i/Qy5DZNA", runNumber), "Qy recenter map ZNA", kTHnF, {axisCent5D, axisVx5D, axisVy5D, axisVz5D, axisQy}, true).get();
+      gQx5DZNC[runNumber] = histos.add<THn>(Form("%i/Qx5DZNC", runNumber), "Qx recenter map ZNC", kTHnF, {axisCent5D, axisVx5D, axisVy5D, axisVz5D, axisQx}, true).get();
+      gQy5DZNC[runNumber] = histos.add<THn>(Form("%i/Qy5DZNC", runNumber), "Qy recenter map ZNC", kTHnF, {axisCent5D, axisVx5D, axisVy5D, axisVz5D, axisQy}, true).get();
 
-      gPsiZNA[mRunNumber] = histos.add<TH1>(Form("%i/PsiZNA", mRunNumber), ";#Phi_{ZNA} (rad)", kTH1F, {axisPhi}).get();
-      gPsiZNC[mRunNumber] = histos.add<TH1>(Form("%i/PsiZNC", mRunNumber), ";#Phi_{ZNC} (rad)", kTH1F, {axisPhi}).get();
+      gPsiZNA[runNumber] = histos.add<TH1>(Form("%i/PsiZNA", runNumber), ";#Phi_{ZNA} (rad)", kTH1F, {axisPhi}).get();
+      gPsiZNC[runNumber] = histos.add<TH1>(Form("%i/PsiZNC", runNumber), ";#Phi_{ZNC} (rad)", kTH1F, {axisPhi}).get();
 
-      gVx[mRunNumber] = histos.add<TH1>(Form("%i/Vx", mRunNumber), "V_{x} distribution; V_{x} (cm); Entries", kTH1F, {axisVx}).get();
-      gVy[mRunNumber] = histos.add<TH1>(Form("%i/Vy", mRunNumber), "V_{y} distribution; V_{y} (cm); Entries", kTH1F, {axisVy}).get();
+      gVx[runNumber] = histos.add<TH1>(Form("%i/Vx", runNumber), "V_{x} distribution; V_{x} (cm); Entries", kTH1F, {axisVx}).get();
+      gVy[runNumber] = histos.add<TH1>(Form("%i/Vy", runNumber), "V_{y} distribution; V_{y} (cm); Entries", kTH1F, {axisVy}).get();
 
-      gQxVsTimeZNA[mRunNumber] = histos.add<TH2>(Form("%i/QxVsTimeZNA", mRunNumber), "Q_{x}^{ZNA} vs Time; Time (minutes); Q_{x}", kTH2F, {axisTime, axisQx}).get();
-      gQyVsTimeZNA[mRunNumber] = histos.add<TH2>(Form("%i/QyVsTimeZNA", mRunNumber), "Q_{y}^{ZNA} vs Time; Time (minutes); Q_{y}", kTH2F, {axisTime, axisQy}).get();
-      gQxVsTimeZNC[mRunNumber] = histos.add<TH2>(Form("%i/QxVsTimeZNC", mRunNumber), "Q_{x}^{ZNC} vs Time; Time (minutes); Q_{x}", kTH2F, {axisTime, axisQx}).get();
-      gQyVsTimeZNC[mRunNumber] = histos.add<TH2>(Form("%i/QyVsTimeZNC", mRunNumber), "Q_{y}^{ZNC} vs Time; Time (minutes); Q_{y}", kTH2F, {axisTime, axisQy}).get();
+      gQxVsTimeZNA[runNumber] = histos.add<TH2>(Form("%i/QxVsTimeZNA", runNumber), "Q_{x}^{ZNA} vs Time; Time (minutes); Q_{x}", kTH2F, {axisTime, axisQx}).get();
+      gQyVsTimeZNA[runNumber] = histos.add<TH2>(Form("%i/QyVsTimeZNA", runNumber), "Q_{y}^{ZNA} vs Time; Time (minutes); Q_{y}", kTH2F, {axisTime, axisQy}).get();
+      gQxVsTimeZNC[runNumber] = histos.add<TH2>(Form("%i/QxVsTimeZNC", runNumber), "Q_{x}^{ZNC} vs Time; Time (minutes); Q_{x}", kTH2F, {axisTime, axisQx}).get();
+      gQyVsTimeZNC[runNumber] = histos.add<TH2>(Form("%i/QyVsTimeZNC", runNumber), "Q_{y}^{ZNC} vs Time; Time (minutes); Q_{y}", kTH2F, {axisTime, axisQy}).get();
 
-      gShiftProfileZNA[mRunNumber] = histos.add<TProfile3D>(Form("%i/ShiftProfileZNA", mRunNumber), "ZNA Shift Coeffs;Cent;Type;Harmonic", kTProfile3D, {axisCent, {2, 0, 2}, {nShift, 0, static_cast<double>(nShift)}}).get();
-      gShiftProfileZNC[mRunNumber] = histos.add<TProfile3D>(Form("%i/ShiftProfileZNC", mRunNumber), "ZNC Shift Coeffs;Cent;Type;Harmonic", kTProfile3D, {axisCent, {2, 0, 2}, {nShift, 0, static_cast<double>(nShift)}}).get();
+      gShiftProfileZNA[runNumber] = histos.add<TProfile3D>(Form("%i/ShiftProfileZNA", runNumber), "ZNA Shift Coeffs;Cent;Type;Harmonic", kTProfile3D, {axisCent, {2, 0, 2}, {nHarmonics, 0, static_cast<double>(nHarmonics)}}).get();
+      gShiftProfileZNC[runNumber] = histos.add<TProfile3D>(Form("%i/ShiftProfileZNC", runNumber), "ZNC Shift Coeffs;Cent;Type;Harmonic", kTProfile3D, {axisCent, {2, 0, 2}, {nHarmonics, 0, static_cast<double>(nHarmonics)}}).get();
     }
 
-    gCurrentEventCounter = gEventCounter[mCurrentRunNumber];
-    gCurrentCentroidZNA = gCentroidZNA[mCurrentRunNumber];
-    gCurrentCentroidZNC = gCentroidZNC[mCurrentRunNumber];
-    gCurrentPmcZNA = gPmcZNA[mCurrentRunNumber];
-    gCurrentPm1ZNA = gPm1ZNA[mCurrentRunNumber];
-    gCurrentPm2ZNA = gPm2ZNA[mCurrentRunNumber];
-    gCurrentPm3ZNA = gPm3ZNA[mCurrentRunNumber];
-    gCurrentPm4ZNA = gPm4ZNA[mCurrentRunNumber];
-    gCurrentSumZNA = gSumZNA[mCurrentRunNumber];
-    gCurrentPmcZNC = gPmcZNC[mCurrentRunNumber];
-    gCurrentPm1ZNC = gPm1ZNC[mCurrentRunNumber];
-    gCurrentPm2ZNC = gPm2ZNC[mCurrentRunNumber];
-    gCurrentPm3ZNC = gPm3ZNC[mCurrentRunNumber];
-    gCurrentPm4ZNC = gPm4ZNC[mCurrentRunNumber];
-    gCurrentSumZNC = gSumZNC[mCurrentRunNumber];
-    gCurrentQxVsCentZNA = gQxVsCentZNA[mCurrentRunNumber];
-    gCurrentQyVsCentZNA = gQyVsCentZNA[mCurrentRunNumber];
-    gCurrentQxVsVxZNA = gQxVsVxZNA[mCurrentRunNumber];
-    gCurrentQyVsVxZNA = gQyVsVxZNA[mCurrentRunNumber];
-    gCurrentQxVsVyZNA = gQxVsVyZNA[mCurrentRunNumber];
-    gCurrentQyVsVyZNA = gQyVsVyZNA[mCurrentRunNumber];
-    gCurrentQxVsVzZNA = gQxVsVzZNA[mCurrentRunNumber];
-    gCurrentQyVsVzZNA = gQyVsVzZNA[mCurrentRunNumber];
-    gCurrentQxVsCentZNC = gQxVsCentZNC[mCurrentRunNumber];
-    gCurrentQyVsCentZNC = gQyVsCentZNC[mCurrentRunNumber];
-    gCurrentQxVsVxZNC = gQxVsVxZNC[mCurrentRunNumber];
-    gCurrentQyVsVxZNC = gQyVsVxZNC[mCurrentRunNumber];
-    gCurrentQxVsVyZNC = gQxVsVyZNC[mCurrentRunNumber];
-    gCurrentQyVsVyZNC = gQyVsVyZNC[mCurrentRunNumber];
-    gCurrentQxVsVzZNC = gQxVsVzZNC[mCurrentRunNumber];
-    gCurrentQyVsVzZNC = gQyVsVzZNC[mCurrentRunNumber];
-    gCurrentQxQyVsCent = gQxQyVsCent[mCurrentRunNumber];
-    gCurrentQyQxVsCent = gQyQxVsCent[mCurrentRunNumber];
-    gCurrentQxQxVsCent = gQxQxVsCent[mCurrentRunNumber];
-    gCurrentQyQyVsCent = gQyQyVsCent[mCurrentRunNumber];
+    gCurrentEventCounter = gEventCounter[currentRunNumber];
+    gCurrentCentroidZNA = gCentroidZNA[currentRunNumber];
+    gCurrentCentroidZNC = gCentroidZNC[currentRunNumber];
+    gCurrentPmcZNA = gPmcZNA[currentRunNumber];
+    gCurrentPm1ZNA = gPm1ZNA[currentRunNumber];
+    gCurrentPm2ZNA = gPm2ZNA[currentRunNumber];
+    gCurrentPm3ZNA = gPm3ZNA[currentRunNumber];
+    gCurrentPm4ZNA = gPm4ZNA[currentRunNumber];
+    gCurrentSumZNA = gSumZNA[currentRunNumber];
+    gCurrentPmcZNC = gPmcZNC[currentRunNumber];
+    gCurrentPm1ZNC = gPm1ZNC[currentRunNumber];
+    gCurrentPm2ZNC = gPm2ZNC[currentRunNumber];
+    gCurrentPm3ZNC = gPm3ZNC[currentRunNumber];
+    gCurrentPm4ZNC = gPm4ZNC[currentRunNumber];
+    gCurrentSumZNC = gSumZNC[currentRunNumber];
+    gCurrentQxVsCentZNA = gQxVsCentZNA[currentRunNumber];
+    gCurrentQyVsCentZNA = gQyVsCentZNA[currentRunNumber];
+    gCurrentQxVsVxZNA = gQxVsVxZNA[currentRunNumber];
+    gCurrentQyVsVxZNA = gQyVsVxZNA[currentRunNumber];
+    gCurrentQxVsVyZNA = gQxVsVyZNA[currentRunNumber];
+    gCurrentQyVsVyZNA = gQyVsVyZNA[currentRunNumber];
+    gCurrentQxVsVzZNA = gQxVsVzZNA[currentRunNumber];
+    gCurrentQyVsVzZNA = gQyVsVzZNA[currentRunNumber];
+    gCurrentQxVsCentZNC = gQxVsCentZNC[currentRunNumber];
+    gCurrentQyVsCentZNC = gQyVsCentZNC[currentRunNumber];
+    gCurrentQxVsVxZNC = gQxVsVxZNC[currentRunNumber];
+    gCurrentQyVsVxZNC = gQyVsVxZNC[currentRunNumber];
+    gCurrentQxVsVyZNC = gQxVsVyZNC[currentRunNumber];
+    gCurrentQyVsVyZNC = gQyVsVyZNC[currentRunNumber];
+    gCurrentQxVsVzZNC = gQxVsVzZNC[currentRunNumber];
+    gCurrentQyVsVzZNC = gQyVsVzZNC[currentRunNumber];
+    gCurrentQxQyVsCent = gQxQyVsCent[currentRunNumber];
+    gCurrentQyQxVsCent = gQyQxVsCent[currentRunNumber];
+    gCurrentQxQxVsCent = gQxQxVsCent[currentRunNumber];
+    gCurrentQyQyVsCent = gQyQyVsCent[currentRunNumber];
 
-    gCurrentQxZNA = gQx5DZNA[mCurrentRunNumber];
-    gCurrentQyZNA = gQy5DZNA[mCurrentRunNumber];
-    gCurrentQxZNC = gQx5DZNC[mCurrentRunNumber];
-    gCurrentQyZNC = gQy5DZNC[mCurrentRunNumber];
+    gCurrentQxZNA = gQx5DZNA[currentRunNumber];
+    gCurrentQyZNA = gQy5DZNA[currentRunNumber];
+    gCurrentQxZNC = gQx5DZNC[currentRunNumber];
+    gCurrentQyZNC = gQy5DZNC[currentRunNumber];
 
-    gCurrentPsiZNA = gPsiZNA[mCurrentRunNumber];
-    gCurrentPsiZNC = gPsiZNC[mCurrentRunNumber];
+    gCurrentPsiZNA = gPsiZNA[currentRunNumber];
+    gCurrentPsiZNC = gPsiZNC[currentRunNumber];
 
-    gCurrentVx = gVx[mCurrentRunNumber];
-    gCurrentVy = gVy[mCurrentRunNumber];
+    gCurrentVx = gVx[currentRunNumber];
+    gCurrentVy = gVy[currentRunNumber];
 
-    gCurrentQxVsTimeZNA = gQxVsTimeZNA[mCurrentRunNumber];
-    gCurrentQyVsTimeZNA = gQyVsTimeZNA[mCurrentRunNumber];
-    gCurrentQxVsTimeZNC = gQxVsTimeZNC[mCurrentRunNumber];
-    gCurrentQyVsTimeZNC = gQyVsTimeZNC[mCurrentRunNumber];
+    gCurrentQxVsTimeZNA = gQxVsTimeZNA[currentRunNumber];
+    gCurrentQyVsTimeZNA = gQyVsTimeZNA[currentRunNumber];
+    gCurrentQxVsTimeZNC = gQxVsTimeZNC[currentRunNumber];
+    gCurrentQyVsTimeZNC = gQyVsTimeZNC[currentRunNumber];
 
-    gCurrentShiftProfileZNA = gShiftProfileZNA[mCurrentRunNumber];
-    gCurrentShiftProfileZNC = gShiftProfileZNC[mCurrentRunNumber];
+    gCurrentShiftProfileZNA = gShiftProfileZNA[currentRunNumber];
+    gCurrentShiftProfileZNC = gShiftProfileZNC[currentRunNumber];
   }
 
   // Optimized method to load ALL calibrations for the new run at once
@@ -544,18 +542,21 @@ struct ZdcExtraTableReader {
     clearCache();
 
     // Vertex Calibration
-    if (ifBeamSpotCorrection) {
+    if (applyBeamSpotCorrection) {
       std::string folder = Form("%s/step0", qRecenteringCcdb.value.c_str());
       auto* lst = ccdb->getForRun<TList>(folder, run);
       if (lst) {
         hMeanVx = safeClone<TH1>(lst->FindObject("hMeanVx"));
         hMeanVy = safeClone<TH1>(lst->FindObject("hMeanVy"));
+      } else
+      {
+        LOGF(error, "  >> CCDB TList is NULL for path: %s. Check object type (TList vs TFile).", folder.c_str());
       }
     }
 
     // Step Calibrations
     std::size_t targetSteps = (calibrationStep > 0) ? static_cast<std::size_t>(calibrationStep.value) : 0;
-    mCalibCache.resize(targetSteps);
+    calibCache.resize(targetSteps);
 
     for (std::size_t stepIdx = 0; stepIdx < targetSteps; ++stepIdx) {
       int step = static_cast<int>(stepIdx + 1);
@@ -563,43 +564,52 @@ struct ZdcExtraTableReader {
       // Load 5D (Base)
       std::string folderBase = Form("%s/step%d_base", qRecenteringCcdb.value.c_str(), step);
       auto* lstBase = ccdb->getForRun<TList>(folderBase, run);
-      if (lstBase) {
-        mCalibCache[stepIdx].hMeanQxZNA = safeClone<THn>(lstBase->FindObject("hMeanQxZNA"));
-        mCalibCache[stepIdx].hMeanQyZNA = safeClone<THn>(lstBase->FindObject("hMeanQyZNA"));
-        mCalibCache[stepIdx].hMeanQxZNC = safeClone<THn>(lstBase->FindObject("hMeanQxZNC"));
-        mCalibCache[stepIdx].hMeanQyZNC = safeClone<THn>(lstBase->FindObject("hMeanQyZNC"));
+
+      if (!lstBase) {
+        LOGF(error, "  >> CCDB TList is NULL for path: %s. Check object type (TList vs TFile).", folderBase.c_str());
+        continue;
       }
 
+      calibCache[stepIdx].hMeanQxZNA = safeClone<THn>(lstBase->FindObject("hMeanQxZNA"));
+      calibCache[stepIdx].hMeanQyZNA = safeClone<THn>(lstBase->FindObject("hMeanQyZNA"));
+      calibCache[stepIdx].hMeanQxZNC = safeClone<THn>(lstBase->FindObject("hMeanQxZNC"));
+      calibCache[stepIdx].hMeanQyZNC = safeClone<THn>(lstBase->FindObject("hMeanQyZNC"));
+      
+
       // Load 1D (Refine)
-      if ((step != calibrationStep) || ifFineCalibration) {
+      if ((step != calibrationStep) || isFineCalibrationStep) {
         std::string folderRefine = Form("%s/step%d_refine", qRecenteringCcdb.value.c_str(), step);
         auto* lstRefine = ccdb->getForRun<TList>(folderRefine, run);
-        if (lstRefine) {
-          mCalibCache[stepIdx].hMeanQxCentZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQxCentZNA"));
-          mCalibCache[stepIdx].hMeanQyCentZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQyCentZNA"));
-          mCalibCache[stepIdx].hMeanQxCentZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQxCentZNC"));
-          mCalibCache[stepIdx].hMeanQyCentZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQyCentZNC"));
 
-          mCalibCache[stepIdx].hMeanQxVzZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQxVzZNA"));
-          mCalibCache[stepIdx].hMeanQyVzZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQyVzZNA"));
-          mCalibCache[stepIdx].hMeanQxVzZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQxVzZNC"));
-          mCalibCache[stepIdx].hMeanQyVzZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQyVzZNC"));
-
-          mCalibCache[stepIdx].hMeanQxVxZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQxVxZNA"));
-          mCalibCache[stepIdx].hMeanQyVxZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQyVxZNA"));
-          mCalibCache[stepIdx].hMeanQxVxZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQxVxZNC"));
-          mCalibCache[stepIdx].hMeanQyVxZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQyVxZNC"));
-
-          mCalibCache[stepIdx].hMeanQxVyZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQxVyZNA"));
-          mCalibCache[stepIdx].hMeanQyVyZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQyVyZNA"));
-          mCalibCache[stepIdx].hMeanQxVyZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQxVyZNC"));
-          mCalibCache[stepIdx].hMeanQyVyZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQyVyZNC"));
+        if (!lstRefine) {
+          LOGF(error, "  >> CCDB TList is NULL for path: %s. Check object type (TList vs TFile).", folderRefine.c_str());
+          continue;
         }
+
+        calibCache[stepIdx].hMeanQxCentZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQxCentZNA"));
+        calibCache[stepIdx].hMeanQyCentZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQyCentZNA"));
+        calibCache[stepIdx].hMeanQxCentZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQxCentZNC"));
+        calibCache[stepIdx].hMeanQyCentZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQyCentZNC"));
+
+        calibCache[stepIdx].hMeanQxVzZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQxVzZNA"));
+        calibCache[stepIdx].hMeanQyVzZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQyVzZNA"));
+        calibCache[stepIdx].hMeanQxVzZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQxVzZNC"));
+        calibCache[stepIdx].hMeanQyVzZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQyVzZNC"));
+
+        calibCache[stepIdx].hMeanQxVxZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQxVxZNA"));
+        calibCache[stepIdx].hMeanQyVxZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQyVxZNA"));
+        calibCache[stepIdx].hMeanQxVxZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQxVxZNC"));
+        calibCache[stepIdx].hMeanQyVxZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQyVxZNC"));
+
+        calibCache[stepIdx].hMeanQxVyZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQxVyZNA"));
+        calibCache[stepIdx].hMeanQyVyZNA = safeClone<TH1>(lstRefine->FindObject("hMeanQyVyZNA"));
+        calibCache[stepIdx].hMeanQxVyZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQxVyZNC"));
+        calibCache[stepIdx].hMeanQyVyZNC = safeClone<TH1>(lstRefine->FindObject("hMeanQyVyZNC"));
       }
     } // end of step loop
 
-    if (ifShiftCorrection) {
-      std::string folder = Form("%s/psiShift", qRecenteringCcdb.value.c_str());
+    if (applyShiftCorrection) {
+      std::string folder = Form("%s/psiHarm", qRecenteringCcdb.value.c_str());
 
       LOGF(info, "ZDC Analysis: Loading Shift Correction from %s for run %d", folder.c_str(), run);
 
@@ -612,20 +622,20 @@ struct ZdcExtraTableReader {
       }
 
       // Important: Object names must match exactly what was saved
-      mShiftProfileZNA = safeClone<TProfile3D>(lst->FindObject("ShiftProfileZNA"));
-      mShiftProfileZNC = safeClone<TProfile3D>(lst->FindObject("ShiftProfileZNC"));
+      shiftProfileZNA = safeClone<TProfile3D>(lst->FindObject("ShiftProfileZNA"));
+      shiftProfileZNC = safeClone<TProfile3D>(lst->FindObject("ShiftProfileZNC"));
 
-      if (mShiftProfileZNA) {
-        mShiftProfileZNA->SetDirectory(nullptr); // Detach from file
-        //  LOGF(info, "  >> ShiftProfileZNA found! Entries: %.0f, Mean: %f", mShiftProfileZNA->GetEntries(), mShiftProfileZNA->GetMean());
+      if (shiftProfileZNA) {
+        shiftProfileZNA->SetDirectory(nullptr); // Detach from file
+        //  LOGF(info, "  >> ShiftProfileZNA found! Entries: %.0f, Mean: %f", shiftProfileZNA->GetEntries(), shiftProfileZNA->GetMean());
       } else {
         LOGF(error, "  >> ShiftProfileZNA NOT found in TList! Content follows:");
         lst->Print();
       }
 
-      if (mShiftProfileZNC) {
-        mShiftProfileZNC->SetDirectory(nullptr);
-        // LOGF(info, "  >> ShiftProfileZNC found! Entries: %.0f", mShiftProfileZNC->GetEntries());
+      if (shiftProfileZNC) {
+        shiftProfileZNC->SetDirectory(nullptr);
+        // LOGF(info, "  >> ShiftProfileZNC found! Entries: %.0f", shiftProfileZNC->GetEntries());
       } else {
         LOGF(error, "  >> ShiftProfileZNC NOT found in TList!");
       }
@@ -653,28 +663,28 @@ struct ZdcExtraTableReader {
 
     // Apply event selection
 
-    if (ifSel8 && !TESTBIT(zdc.selectionBits(), Sel8)) {
+    if (applySel8 && !TESTBIT(zdc.selectionBits(), Sel8)) {
       return;
     }
-    if (ifZVtxCut && !TESTBIT(zdc.selectionBits(), ZVtxCut)) {
+    if (applyZVtxCut && !TESTBIT(zdc.selectionBits(), ZVtxCut)) {
       return;
     }
-    if (ifOccupancyCut && !TESTBIT(zdc.selectionBits(), OccupancyCut)) {
+    if (applyOccupancyCut && !TESTBIT(zdc.selectionBits(), OccupancyCut)) {
       return;
     }
-    if (ifNoSameBunchPileup && !TESTBIT(zdc.selectionBits(), NoSameBunchPileup)) {
+    if (selectNoSameBunchPileupEvents && !TESTBIT(zdc.selectionBits(), NoSameBunchPileup)) {
       return;
     }
-    if (ifIsGoodZvtxFT0vsPV && !TESTBIT(zdc.selectionBits(), IsGoodZvtxFT0vsPV)) {
+    if (selectGoodZvtxFT0vsPV && !TESTBIT(zdc.selectionBits(), IsGoodZvtxFT0vsPV)) {
       return;
     }
-    if (ifNoCollInTimeRangeStandard && !TESTBIT(zdc.selectionBits(), NoCollInTimeRangeStandard)) {
+    if (applyNoCollInTimeRangeStandard && !TESTBIT(zdc.selectionBits(), NoCollInTimeRangeStandard)) {
       return;
     }
-    if (ifIsVertexITSTPC && !TESTBIT(zdc.selectionBits(), IsVertexITSTPC)) {
+    if (selectVertexITSTPC && !TESTBIT(zdc.selectionBits(), IsVertexITSTPC)) {
       return;
     }
-    if (ifIsGoodITSLayersAll && !TESTBIT(zdc.selectionBits(), IsGoodITSLayersAll)) {
+    if (selectGoodITSLayersAll && !TESTBIT(zdc.selectionBits(), IsGoodITSLayersAll)) {
       return;
     }
 
@@ -687,24 +697,24 @@ struct ZdcExtraTableReader {
     //  LOGF(info, "vtxITSTPC  = %d", TESTBIT(zdc.selectionBits(), IsVertexITSTPC));
     //  LOGF(info, "ITS layers = %d", TESTBIT(zdc.selectionBits(), IsGoodITSLayersAll));
 
-    const int mRunNumber = zdc.runNumber();
+    const int runNumber = zdc.runNumber();
 
     const uint64_t timestamp = zdc.timestamp(); // in milliseconds
 
     // Convert timestamp to hours from run start (approximate)
     // Store first timestamp of run to calculate relative time
     static std::unordered_map<int, uint64_t> runStartTime;
-    if (!runStartTime.contains(mRunNumber)) {
-      runStartTime[mRunNumber] = timestamp;
+    if (!runStartTime.contains(runNumber)) {
+      runStartTime[runNumber] = timestamp;
     }
 
-    double timeInMinutes = (timestamp - runStartTime[mRunNumber]) / 60000.0; // ms -> minutes
+    double timeInMinutes = (timestamp - runStartTime[runNumber]) / 60000.0; // ms -> minutes
 
     // Initialization block if Run Number changes
-    if (mRunNumber != mCurrentRunNumber) {
-      initHistos(mRunNumber);       // Init output histograms
-      loadCalibrations(mRunNumber); // Load all steps from CCDB once
-      mCurrentRunNumber = mRunNumber;
+    if (runNumber != currentRunNumber) {
+      initHistos(runNumber);       // Init output histograms
+      loadCalibrations(runNumber); // Load all steps from CCDB once
+      currentRunNumber = runNumber;
     }
 
     histos.fill(HIST("eventCounter"), 0.5);
@@ -723,11 +733,11 @@ struct ZdcExtraTableReader {
     double tdcZNC = zdc.zncTdc();
     double tdcZNA = zdc.znaTdc();
 
-    if (tdcCut) { // TDC window is set
-      if ((tdcZNC >= tdcZNmincut) && (tdcZNC <= tdcZNmaxcut)) {
+    if (applyTdcCut) { // TDC window is set
+      if ((tdcZNC >= tdcZnMin) && (tdcZNC <= tdcZnMax)) {
         isZNChit = true;
       }
-      if ((tdcZNA >= tdcZNmincut) && (tdcZNA <= tdcZNmaxcut)) {
+      if ((tdcZNA >= tdcZnMin) && (tdcZNA <= tdcZnMax)) {
         isZNAhit = true;
       }
     } else { // if no window on TDC is set
@@ -748,14 +758,14 @@ struct ZdcExtraTableReader {
     if (isZNAhit) {
       int activeTowersZNA = (zdc.znaTow1() > 0.) + (zdc.znaTow2() > 0.) + (zdc.znaTow3() > 0.) + (zdc.znaTow4() > 0.);
       float znaSum = zdc.znaTow1() + zdc.znaTow2() + zdc.znaTow3() + zdc.znaTow4();
-      if (activeTowersZNA >= nTowersFired && znaSum > 0 && zdc.znaQx() < QvectorMaxValue)
+      if (activeTowersZNA >= minNTowersFired && znaSum > 0 && zdc.znaQx() < QvectorMaxValue)
         isZNASpDeterminable = true;
     }
 
     if (isZNChit) {
       int activeTowersZNC = (zdc.zncTow1() > 0.) + (zdc.zncTow2() > 0.) + (zdc.zncTow3() > 0.) + (zdc.zncTow4() > 0.);
       float zncSum = zdc.zncTow1() + zdc.zncTow2() + zdc.zncTow3() + zdc.zncTow4();
-      if (activeTowersZNC >= nTowersFired && zncSum > 0 && zdc.zncQx() < QvectorMaxValue)
+      if (activeTowersZNC >= minNTowersFired && zncSum > 0 && zdc.zncQx() < QvectorMaxValue)
         isZNCSpDeterminable = true;
     }
 
@@ -795,7 +805,7 @@ struct ZdcExtraTableReader {
     //   double vx_corrected = vx;
     // double vy_corrected = vy;
 
-    if (ifBeamSpotCorrection) {
+    if (applyBeamSpotCorrection) {
       // Use cached vertex pointers
       if (hMeanVx && hMeanVy) {
         vx -= hMeanVx->GetBinContent(1);
@@ -816,10 +826,10 @@ struct ZdcExtraTableReader {
 
         int cacheIdx = step - 1;
         // Check if index is valid within cached vector
-        if (cacheIdx >= static_cast<int>(mCalibCache.size()))
+        if (cacheIdx >= static_cast<int>(calibCache.size()))
           continue;
 
-        const auto& calib = mCalibCache[cacheIdx];
+        const auto& calib = calibCache[cacheIdx];
 
         // Apply 5D Base calibration
         if (calib.hMeanQxZNA && calib.hMeanQyZNA) {
@@ -827,7 +837,7 @@ struct ZdcExtraTableReader {
           qyZNArec -= getMeanQFromMap(calib.hMeanQyZNA, cent, vx, vy, vz);
         }
 
-        if ((step != calibrationStep) || ifFineCalibration) {
+        if ((step != calibrationStep) || isFineCalibrationStep) {
           // Apply 1D Refine calibration
           qxZNArec -= getMeanQ1D(calib.hMeanQxCentZNA, cent);
           qyZNArec -= getMeanQ1D(calib.hMeanQyCentZNA, cent);
@@ -871,27 +881,27 @@ struct ZdcExtraTableReader {
 
       // Apply Correction (Read Mode)
       // Checks if correction is enabled AND if the map from CCDB was loaded successfully
-      if (ifShiftCorrection && mShiftProfileZNA) {
+      if (applyShiftCorrection && shiftProfileZNA) {
         double deltaPsi = 0.0;
 
         // Loop over harmonics (usually 1 to 10)
-        for (int ishift = 1; ishift <= nShift; ishift++) {
+        for (int iHarm = 1; iHarm <= nHarmonics; iHarm++) {
           // Retrieve coefficients from TProfile3D
           // Axis mapping:
           // X: Centrality
           // Y: Type (0.5 for Sin, 1.5 for Cos)
-          // Z: Harmonic index (ishift - 0.5 maps to bin 1, 2, etc.)
+          // Z: Harmonic index (iHarm - 0.5 maps to bin 1, 2, etc.)
 
-          int binSin = mShiftProfileZNA->FindFixBin(cent, 0.5, static_cast<double>(ishift) - 0.5);
-          int binCos = mShiftProfileZNA->FindFixBin(cent, 1.5, static_cast<double>(ishift) - 0.5);
+          int binSin = shiftProfileZNA->FindFixBin(cent, 0.5, static_cast<double>(iHarm) - 0.5);
+          int binCos = shiftProfileZNA->FindFixBin(cent, 1.5, static_cast<double>(iHarm) - 0.5);
 
-          double coeffSin = mShiftProfileZNA->GetBinContent(binSin);
-          double coeffCos = mShiftProfileZNA->GetBinContent(binCos);
+          double coeffSin = shiftProfileZNA->GetBinContent(binSin);
+          double coeffCos = shiftProfileZNA->GetBinContent(binCos);
 
           // Fourier flattening formula:
           // DeltaPsi = sum( (2/k) * ( <cos>*sin(k*psi) - <sin>*cos(k*psi) ) )
           // Note: signs depend on definition, this matches the standard correction logic
-          deltaPsi += (2.0 / ishift) * (-coeffSin * TMath::Cos(ishift * psiZNA) + coeffCos * TMath::Sin(ishift * psiZNA));
+          deltaPsi += (2.0 / iHarm) * (-coeffSin * TMath::Cos(iHarm * psiZNA) + coeffCos * TMath::Sin(iHarm * psiZNA));
         }
 
         // DEBUG: Print only if shift is actually happening for first few events
@@ -914,11 +924,11 @@ struct ZdcExtraTableReader {
       // Fill Shift Profiles (Write Mode)
       // Used to generate calibration for the next step or to verify correction (QA)
       if (fillShiftHistos && gCurrentShiftProfileZNA) {
-        for (int ishift = 1; ishift <= nShift; ishift++) {
+        for (int iHarm = 1; iHarm <= nHarmonics; iHarm++) {
           // Fill Sin component (Y = 0.5)
-          gCurrentShiftProfileZNA->Fill(cent, 0.5, static_cast<double>(ishift) - 0.5, TMath::Sin(ishift * psiZNA));
+          gCurrentShiftProfileZNA->Fill(cent, 0.5, static_cast<double>(iHarm) - 0.5, TMath::Sin(iHarm * psiZNA));
           // Fill Cos component (Y = 1.5)
-          gCurrentShiftProfileZNA->Fill(cent, 1.5, static_cast<double>(ishift) - 0.5, TMath::Cos(ishift * psiZNA));
+          gCurrentShiftProfileZNA->Fill(cent, 1.5, static_cast<double>(iHarm) - 0.5, TMath::Cos(iHarm * psiZNA));
         }
       }
 
@@ -940,12 +950,12 @@ struct ZdcExtraTableReader {
       for (int step = 1; step <= calibrationStep; step++) {
 
         int cacheIdx = step - 1;
-        if (cacheIdx >= static_cast<int>(mCalibCache.size()))
+        if (cacheIdx >= static_cast<int>(calibCache.size()))
           continue;
 
         //     LOGF(info, "Go to step = %d", step);
 
-        const auto& calib = mCalibCache[cacheIdx];
+        const auto& calib = calibCache[cacheIdx];
 
         // Apply 5D Base calibration
         if (calib.hMeanQxZNC && calib.hMeanQyZNC) {
@@ -956,7 +966,7 @@ struct ZdcExtraTableReader {
           //  LOGF(info, "Qx after base calibration step %d = %f", step, qxZNCrec);
         }
 
-        if ((step != calibrationStep) || ifFineCalibration) {
+        if ((step != calibrationStep) || isFineCalibrationStep) {
 
           // Apply 1D Refine calibration
           qxZNCrec -= getMeanQ1D(calib.hMeanQxCentZNC, cent);
@@ -1005,27 +1015,27 @@ struct ZdcExtraTableReader {
 
       // Apply Correction (Read Mode)
       // Checks if correction is enabled AND if the map from CCDB was loaded successfully
-      if (ifShiftCorrection && mShiftProfileZNC) {
+      if (applyShiftCorrection && shiftProfileZNC) {
         double deltaPsi = 0.0;
 
         // Loop over harmonics (usually 1 to 10)
-        for (int ishift = 1; ishift <= nShift; ishift++) {
+        for (int iHarm = 1; iHarm <= nHarmonics; iHarm++) {
           // Retrieve coefficients from TProfile3D
           // Axis mapping:
           // X: Centrality
           // Y: Type (0.5 for Sin, 1.5 for Cos)
-          // Z: Harmonic index (ishift - 0.5 maps to bin 1, 2, etc.)
+          // Z: Harmonic index (iHarm - 0.5 maps to bin 1, 2, etc.)
 
-          int binSin = mShiftProfileZNC->FindFixBin(cent, 0.5, static_cast<double>(ishift) - 0.5);
-          int binCos = mShiftProfileZNC->FindFixBin(cent, 1.5, static_cast<double>(ishift) - 0.5);
+          int binSin = shiftProfileZNC->FindFixBin(cent, 0.5, static_cast<double>(iHarm) - 0.5);
+          int binCos = shiftProfileZNC->FindFixBin(cent, 1.5, static_cast<double>(iHarm) - 0.5);
 
-          double coeffSin = mShiftProfileZNC->GetBinContent(binSin);
-          double coeffCos = mShiftProfileZNC->GetBinContent(binCos);
+          double coeffSin = shiftProfileZNC->GetBinContent(binSin);
+          double coeffCos = shiftProfileZNC->GetBinContent(binCos);
 
           // Fourier flattening formula:
           // DeltaPsi = sum( (2/k) * ( <cos>*sin(k*psi) - <sin>*cos(k*psi) ) )
           // Note: signs depend on definition, this matches the standard correction logic
-          deltaPsi += (2.0 / ishift) * (-coeffSin * TMath::Cos(ishift * psiZNC) + coeffCos * TMath::Sin(ishift * psiZNC));
+          deltaPsi += (2.0 / iHarm) * (-coeffSin * TMath::Cos(iHarm * psiZNC) + coeffCos * TMath::Sin(iHarm * psiZNC));
         }
 
         // Apply the calculated shift
@@ -1038,11 +1048,11 @@ struct ZdcExtraTableReader {
       // Fill Shift Profiles (Write Mode)
       // Used to generate calibration for the next step or to verify correction (QA)
       if (fillShiftHistos && gCurrentShiftProfileZNC) {
-        for (int ishift = 1; ishift <= nShift; ishift++) {
+        for (int iHarm = 1; iHarm <= nHarmonics; iHarm++) {
           // Fill Sin component (Y = 0.5)
-          gCurrentShiftProfileZNC->Fill(cent, 0.5, static_cast<double>(ishift) - 0.5, TMath::Sin(ishift * psiZNC));
+          gCurrentShiftProfileZNC->Fill(cent, 0.5, static_cast<double>(iHarm) - 0.5, TMath::Sin(iHarm * psiZNC));
           // Fill Cos component (Y = 1.5)
-          gCurrentShiftProfileZNC->Fill(cent, 1.5, static_cast<double>(ishift) - 0.5, TMath::Cos(ishift * psiZNC));
+          gCurrentShiftProfileZNC->Fill(cent, 1.5, static_cast<double>(iHarm) - 0.5, TMath::Cos(iHarm * psiZNC));
         }
       }
 

--- a/Common/Tasks/zdcExtraTableReader.cxx
+++ b/Common/Tasks/zdcExtraTableReader.cxx
@@ -188,7 +188,6 @@ double getMeanQFromMap(THn* h, double cent, double vx, double vy, double vz)
 
   int idx[4] = {binCent, binVx, binVy, binVz};
   return h->GetBinContent(idx);
-
 }
 
 // Helper for 1D recentering maps: returns mean Q for coordinate x
@@ -548,8 +547,7 @@ struct ZdcExtraTableReader {
       if (lst) {
         hMeanVx = safeClone<TH1>(lst->FindObject("hMeanVx"));
         hMeanVy = safeClone<TH1>(lst->FindObject("hMeanVy"));
-      } else
-      {
+      } else {
         LOGF(error, "  >> CCDB TList is NULL for path: %s. Check object type (TList vs TFile).", folder.c_str());
       }
     }
@@ -574,7 +572,6 @@ struct ZdcExtraTableReader {
       calibCache[stepIdx].hMeanQyZNA = safeClone<THn>(lstBase->FindObject("hMeanQyZNA"));
       calibCache[stepIdx].hMeanQxZNC = safeClone<THn>(lstBase->FindObject("hMeanQxZNC"));
       calibCache[stepIdx].hMeanQyZNC = safeClone<THn>(lstBase->FindObject("hMeanQyZNC"));
-      
 
       // Load 1D (Refine)
       if ((step != calibrationStep) || isFineCalibrationStep) {

--- a/Common/Tasks/zdcExtraTableReader.cxx
+++ b/Common/Tasks/zdcExtraTableReader.cxx
@@ -27,15 +27,15 @@
 #include <Framework/InitContext.h>
 #include <Framework/runDataProcessing.h>
 
+#include <TAxis.h>
 #include <TH1.h>
 #include <TH2.h>
 #include <THn.h>
 #include <TList.h>
 #include <TProfile3D.h>
+#include <TString.h>
 
 #include <Rtypes.h>
-#include <TAxis.h>
-#include <TString.h>
 
 #include <array>
 #include <cmath>

--- a/Common/Tasks/zdcExtraTableReader.cxx
+++ b/Common/Tasks/zdcExtraTableReader.cxx
@@ -36,7 +36,6 @@
 #include <TH2.h>
 #include <THn.h>
 #include <TList.h>
-#include <TMath.h>
 #include <TProfile3D.h>
 
 #include <Rtypes.h>
@@ -874,7 +873,7 @@ struct ZdcExtraTableReader {
       }
 
       //  Calculate raw/recentered angle
-      double psiZNA = TMath::ATan2(qyZNArec, qxZNArec);
+      double psiZNA = std::atan2(qyZNArec, qxZNArec);
 
       // Apply Correction (Read Mode)
       // Checks if correction is enabled AND if the map from CCDB was loaded successfully
@@ -898,7 +897,7 @@ struct ZdcExtraTableReader {
           // Fourier flattening formula:
           // DeltaPsi = sum( (2/k) * ( <cos>*sin(k*psi) - <sin>*cos(k*psi) ) )
           // Note: signs depend on definition, this matches the standard correction logic
-          deltaPsi += (2.0 / iHarm) * (-coeffSin * TMath::Cos(iHarm * psiZNA) + coeffCos * TMath::Sin(iHarm * psiZNA));
+          deltaPsi += (2.0 / iHarm) * (-coeffSin * std::cos(iHarm * psiZNA) + coeffCos * std::sin(iHarm * psiZNA));
         }
 
         // DEBUG: Print only if shift is actually happening for first few events
@@ -923,9 +922,9 @@ struct ZdcExtraTableReader {
       if (fillShiftHistos && gCurrentShiftProfileZNA) {
         for (int iHarm = 1; iHarm <= nHarmonics; iHarm++) {
           // Fill Sin component (Y = 0.5)
-          gCurrentShiftProfileZNA->Fill(cent, 0.5, static_cast<double>(iHarm) - 0.5, TMath::Sin(iHarm * psiZNA));
+          gCurrentShiftProfileZNA->Fill(cent, 0.5, static_cast<double>(iHarm) - 0.5, std::sin(iHarm * psiZNA));
           // Fill Cos component (Y = 1.5)
-          gCurrentShiftProfileZNA->Fill(cent, 1.5, static_cast<double>(iHarm) - 0.5, TMath::Cos(iHarm * psiZNA));
+          gCurrentShiftProfileZNA->Fill(cent, 1.5, static_cast<double>(iHarm) - 0.5, std::cos(iHarm * psiZNA));
         }
       }
 
@@ -1008,7 +1007,7 @@ struct ZdcExtraTableReader {
       }
 
       //  Calculate raw/recentered angle
-      double psiZNC = TMath::ATan2(qyZNCrec, qxZNCrec);
+      double psiZNC = std::atan2(qyZNCrec, qxZNCrec);
 
       // Apply Correction (Read Mode)
       // Checks if correction is enabled AND if the map from CCDB was loaded successfully
@@ -1032,7 +1031,7 @@ struct ZdcExtraTableReader {
           // Fourier flattening formula:
           // DeltaPsi = sum( (2/k) * ( <cos>*sin(k*psi) - <sin>*cos(k*psi) ) )
           // Note: signs depend on definition, this matches the standard correction logic
-          deltaPsi += (2.0 / iHarm) * (-coeffSin * TMath::Cos(iHarm * psiZNC) + coeffCos * TMath::Sin(iHarm * psiZNC));
+          deltaPsi += (2.0 / iHarm) * (-coeffSin * std::cos(iHarm * psiZNC) + coeffCos * std::sin(iHarm * psiZNC));
         }
 
         // Apply the calculated shift
@@ -1047,9 +1046,9 @@ struct ZdcExtraTableReader {
       if (fillShiftHistos && gCurrentShiftProfileZNC) {
         for (int iHarm = 1; iHarm <= nHarmonics; iHarm++) {
           // Fill Sin component (Y = 0.5)
-          gCurrentShiftProfileZNC->Fill(cent, 0.5, static_cast<double>(iHarm) - 0.5, TMath::Sin(iHarm * psiZNC));
+          gCurrentShiftProfileZNC->Fill(cent, 0.5, static_cast<double>(iHarm) - 0.5, std::sin(iHarm * psiZNC));
           // Fill Cos component (Y = 1.5)
-          gCurrentShiftProfileZNC->Fill(cent, 1.5, static_cast<double>(iHarm) - 0.5, TMath::Cos(iHarm * psiZNC));
+          gCurrentShiftProfileZNC->Fill(cent, 1.5, static_cast<double>(iHarm) - 0.5, std::cos(iHarm * psiZNC));
         }
       }
 

--- a/Common/Tasks/zdcExtraTableReader.cxx
+++ b/Common/Tasks/zdcExtraTableReader.cxx
@@ -13,14 +13,10 @@
 /// \brief Task reading AOD/ZDCEXTRA table
 /// \author Uliana Dmitrieva <uliana.dmitrieva@cern.ch>, INFN Torino
 
-#include "Common/CCDB/EventSelectionParams.h"
 #include "Common/Core/RecoDecay.h"
-#include "Common/DataModel/Centrality.h"
-#include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/ZDCExtra.h"
 
 #include <CCDB/BasicCCDBManager.h>
-#include <CCDB/CcdbApi.h>
 #include <CommonConstants/MathConstants.h>
 #include <Framework/AnalysisDataModel.h>
 #include <Framework/AnalysisHelpers.h>
@@ -29,7 +25,6 @@
 #include <Framework/HistogramRegistry.h>
 #include <Framework/HistogramSpec.h>
 #include <Framework/InitContext.h>
-#include <Framework/OutputObjHeader.h>
 #include <Framework/runDataProcessing.h>
 
 #include <TH1.h>
@@ -39,7 +34,13 @@
 #include <TProfile3D.h>
 
 #include <Rtypes.h>
+#include <TAxis.h>
+#include <TString.h>
 
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -185,8 +186,8 @@ double getMeanQFromMap(THn* h, double cent, double vx, double vy, double vz)
   int binVy = axVy->FindFixBin(vy);
   int binVz = axVz->FindFixBin(vz);
 
-  int idx[4] = {binCent, binVx, binVy, binVz};
-  return h->GetBinContent(idx);
+  std::array<int, 4> idx = {binCent, binVx, binVy, binVz};
+  return h->GetBinContent(idx.data());
 }
 
 // Helper for 1D recentering maps: returns mean Q for coordinate x
@@ -258,7 +259,7 @@ struct ZdcExtraTableReader {
   Configurable<std::string> qRecenteringCcdb{"qRecenteringCcdb", "Users/u/udmitrie/ZDC/LHC24ar_apass2", "Recentering maps containing step folder"};
 
   // CCDB
-  Service<o2::ccdb::BasicCCDBManager> ccdb;
+  Service<o2::ccdb::BasicCCDBManager> ccdb{};
 
   // Struct to hold calibration data for a single step
   struct CalibStepData {
@@ -351,8 +352,9 @@ struct ZdcExtraTableReader {
   template <typename T>
   T* safeClone(TObject* obj)
   {
-    if (!obj)
+    if (!obj) {
       return nullptr;
+    }
     T* cloned = dynamic_cast<T*>(obj->Clone());
     if (cloned) {
 
@@ -740,17 +742,19 @@ struct ZdcExtraTableReader {
     constexpr float QvectorMaxValue = 990.0;
 
     if (isZNAhit) {
-      int activeTowersZNA = (zdc.znaTow1() > 0.) + (zdc.znaTow2() > 0.) + (zdc.znaTow3() > 0.) + (zdc.znaTow4() > 0.);
+      int activeTowersZNA = static_cast<int>(zdc.znaTow1() > 0.) + static_cast<int>(zdc.znaTow2() > 0.) + static_cast<int>(zdc.znaTow3() > 0.) + static_cast<int>(zdc.znaTow4() > 0.);
       float znaSum = zdc.znaTow1() + zdc.znaTow2() + zdc.znaTow3() + zdc.znaTow4();
-      if (activeTowersZNA >= minNTowersFired && znaSum > 0 && zdc.znaQx() < QvectorMaxValue)
+      if (activeTowersZNA >= minNTowersFired && znaSum > 0 && zdc.znaQx() < QvectorMaxValue) {
         isZNASpDeterminable = true;
+      }
     }
 
     if (isZNChit) {
-      int activeTowersZNC = (zdc.zncTow1() > 0.) + (zdc.zncTow2() > 0.) + (zdc.zncTow3() > 0.) + (zdc.zncTow4() > 0.);
+      int activeTowersZNC = static_cast<int>(zdc.zncTow1() > 0.) + static_cast<int>(zdc.zncTow2() > 0.) + static_cast<int>(zdc.zncTow3() > 0.) + static_cast<int>(zdc.zncTow4() > 0.);
       float zncSum = zdc.zncTow1() + zdc.zncTow2() + zdc.zncTow3() + zdc.zncTow4();
-      if (activeTowersZNC >= minNTowersFired && zncSum > 0 && zdc.zncQx() < QvectorMaxValue)
+      if (activeTowersZNC >= minNTowersFired && zncSum > 0 && zdc.zncQx() < QvectorMaxValue) {
         isZNCSpDeterminable = true;
+      }
     }
 
     if (plotPMs) {
@@ -805,8 +809,9 @@ struct ZdcExtraTableReader {
 
         int cacheIdx = step - 1;
         // Check if index is valid within cached vector
-        if (cacheIdx >= static_cast<int>(calibCache.size()))
+        if (cacheIdx >= static_cast<int>(calibCache.size())) {
           continue;
+        }
 
         const auto& calib = calibCache[cacheIdx];
 
@@ -832,8 +837,8 @@ struct ZdcExtraTableReader {
         }
       }
 
-      double valuesQxZNA[5] = {cent, vx, vy, vz, qxZNArec};
-      double valuesQyZNA[5] = {cent, vx, vy, vz, qyZNArec};
+      std::array<double, 5> valuesQxZNA = {cent, vx, vy, vz, qxZNArec};
+      std::array<double, 5> valuesQyZNA = {cent, vx, vy, vz, qyZNArec};
 
       gCurrentCentroidZNA->Fill(qxZNArec, qyZNArec);
 
@@ -851,8 +856,8 @@ struct ZdcExtraTableReader {
       gCurrentQyVsTimeZNA->Fill(timeInMinutes, qyZNArec);
 
       if (plot5D) {
-        gCurrentQxZNA->Fill(valuesQxZNA);
-        gCurrentQyZNA->Fill(valuesQyZNA);
+        gCurrentQxZNA->Fill(valuesQxZNA.data());
+        gCurrentQyZNA->Fill(valuesQyZNA.data());
       }
 
       //  Calculate raw/recentered angle
@@ -955,8 +960,8 @@ struct ZdcExtraTableReader {
         }
       }
 
-      double valuesQxZNC[5] = {cent, vx, vy, vz, qxZNCrec};
-      double valuesQyZNC[5] = {cent, vx, vy, vz, qyZNCrec};
+      std::array<double, 5> valuesQxZNC = {cent, vx, vy, vz, qxZNCrec};
+      std::array<double, 5> valuesQyZNC = {cent, vx, vy, vz, qyZNCrec};
 
       gCurrentCentroidZNC->Fill(qxZNCrec, qyZNCrec);
 
@@ -974,8 +979,8 @@ struct ZdcExtraTableReader {
       gCurrentQyVsTimeZNC->Fill(timeInMinutes, qyZNCrec);
 
       if (plot5D) {
-        gCurrentQxZNC->Fill(valuesQxZNC);
-        gCurrentQyZNC->Fill(valuesQyZNC);
+        gCurrentQxZNC->Fill(valuesQxZNC.data());
+        gCurrentQyZNC->Fill(valuesQyZNC.data());
       }
 
       //  Calculate raw/recentered angle

--- a/Common/Tasks/zdcExtraTableReader.cxx
+++ b/Common/Tasks/zdcExtraTableReader.cxx
@@ -294,9 +294,10 @@ struct ZdcExtraTableReader {
     TH1* hMeanQyVyZNA{nullptr};
     TH1* hMeanQxVyZNC{nullptr};
     TH1* hMeanQyVyZNC{nullptr};
-    
+
     // Destructor to handle cleanup automatically
-    ~CalibStepData() {
+    ~CalibStepData()
+    {
       delete hMeanQxZNA;
       delete hMeanQyZNA;
       delete hMeanQxZNC;
@@ -337,7 +338,7 @@ struct ZdcExtraTableReader {
 
   HistogramRegistry histos{"histos"};
 
-  enum EvSelBits { // same bits as in zdcExtraTableProducer.cxx 
+  enum EvSelBits { // same bits as in zdcExtraTableProducer.cxx
     ZVtxCut,
     Sel8,
     OccupancyCut,
@@ -372,16 +373,16 @@ struct ZdcExtraTableReader {
   {
     delete hMeanVx;
     hMeanVx = nullptr;
-    
+
     delete hMeanVy;
     hMeanVy = nullptr;
 
     delete mShiftProfileZNA;
     mShiftProfileZNA = nullptr;
-    
+
     delete mShiftProfileZNC;
     mShiftProfileZNC = nullptr;
-    
+
     mCalibCache.clear();
   }
 
@@ -607,28 +608,27 @@ struct ZdcExtraTableReader {
 
       if (!lst) {
         LOGF(error, "  >> CCDB TList is NULL for path: %s. Check object type (TList vs TFile).", folder.c_str());
-        return; 
+        return;
       }
 
-        // Important: Object names must match exactly what was saved
-        mShiftProfileZNA = safeClone<TProfile3D>(lst->FindObject("ShiftProfileZNA"));
-        mShiftProfileZNC = safeClone<TProfile3D>(lst->FindObject("ShiftProfileZNC"));
+      // Important: Object names must match exactly what was saved
+      mShiftProfileZNA = safeClone<TProfile3D>(lst->FindObject("ShiftProfileZNA"));
+      mShiftProfileZNC = safeClone<TProfile3D>(lst->FindObject("ShiftProfileZNC"));
 
-        if (mShiftProfileZNA) {
-          mShiftProfileZNA->SetDirectory(nullptr); // Detach from file
+      if (mShiftProfileZNA) {
+        mShiftProfileZNA->SetDirectory(nullptr); // Detach from file
         //  LOGF(info, "  >> ShiftProfileZNA found! Entries: %.0f, Mean: %f", mShiftProfileZNA->GetEntries(), mShiftProfileZNA->GetMean());
-        } else {
-          LOGF(error, "  >> ShiftProfileZNA NOT found in TList! Content follows:");
-          lst->Print();
-        }
+      } else {
+        LOGF(error, "  >> ShiftProfileZNA NOT found in TList! Content follows:");
+        lst->Print();
+      }
 
-        if (mShiftProfileZNC) {
-          mShiftProfileZNC->SetDirectory(nullptr);
-         // LOGF(info, "  >> ShiftProfileZNC found! Entries: %.0f", mShiftProfileZNC->GetEntries());
-        } else {
-          LOGF(error, "  >> ShiftProfileZNC NOT found in TList!");
-        }
-
+      if (mShiftProfileZNC) {
+        mShiftProfileZNC->SetDirectory(nullptr);
+        // LOGF(info, "  >> ShiftProfileZNC found! Entries: %.0f", mShiftProfileZNC->GetEntries());
+      } else {
+        LOGF(error, "  >> ShiftProfileZNC NOT found in TList!");
+      }
     }
   } // end of loadCalibrations()
 

--- a/Common/Tasks/zdcExtraTableReader.cxx
+++ b/Common/Tasks/zdcExtraTableReader.cxx
@@ -148,7 +148,7 @@ THn* gCurrentQyZNA{nullptr};
 THn* gCurrentQxZNC{nullptr};
 THn* gCurrentQyZNC{nullptr};
 
-TH1* gCurrentPsiZNA{nullptr} ;
+TH1* gCurrentPsiZNA{nullptr};
 TH1* gCurrentPsiZNC{nullptr};
 
 TH1* gCurrentVx{nullptr};
@@ -605,7 +605,7 @@ struct ZdcExtraTableReader {
     if (applyShiftCorrection) {
       std::string folder = Form("%s/psiHarm", qRecenteringCcdb.value.c_str());
 
-      //LOGF(info, "Loading Shift Correction from %s for runNumber %d", folder.c_str(), runNumber);
+      // LOGF(info, "Loading Shift Correction from %s for runNumber %d", folder.c_str(), runNumber);
 
       // Attempt to fetch TList from CCDB
       auto* lst = ccdb->getForRun<TList>(folder, runNumber);
@@ -714,7 +714,7 @@ struct ZdcExtraTableReader {
     }
 
     bool isZNChit = false, isZNAhit = false;
-    
+
     double tdcZNC = zdc.zncTdc();
     double tdcZNA = zdc.znaTdc();
 
@@ -733,7 +733,7 @@ struct ZdcExtraTableReader {
         isZNAhit = true;
       }
     }
-    
+
     bool isZNASpDeterminable = false;
     bool isZNCSpDeterminable = false;
 
@@ -779,12 +779,11 @@ struct ZdcExtraTableReader {
 
     double qxZNArec = 0., qyZNArec = 0.;
     double qxZNCrec = 0., qyZNCrec = 0.;
-    
+
     double cent = zdc.centrality();
     double vx = zdc.vx();
     double vy = zdc.vy();
     double vz = zdc.vz();
-
 
     if (applyBeamSpotCorrection) {
       // Use cached vertex pointers
@@ -801,7 +800,7 @@ struct ZdcExtraTableReader {
 
       qxZNArec = qx;
       qyZNArec = qy;
-      
+
       for (int step = 1; step <= calibrationStep; step++) {
 
         int cacheIdx = step - 1;
@@ -923,14 +922,14 @@ struct ZdcExtraTableReader {
 
       qxZNCrec = qx;
       qyZNCrec = qy;
-      
+
       // Iterate through steps using cached vector
       for (int step = 1; step <= calibrationStep; step++) {
 
         int cacheIdx = step - 1;
         if (cacheIdx >= static_cast<int>(calibCache.size()))
           continue;
-        
+
         const auto& calib = calibCache[cacheIdx];
 
         // Apply 5D Base calibration
@@ -958,7 +957,7 @@ struct ZdcExtraTableReader {
 
       double valuesQxZNC[5] = {cent, vx, vy, vz, qxZNCrec};
       double valuesQyZNC[5] = {cent, vx, vy, vz, qyZNCrec};
-      
+
       gCurrentCentroidZNC->Fill(qxZNCrec, qyZNCrec);
 
       gCurrentQxVsCentZNC->Fill(cent, qxZNCrec);

--- a/Common/Tasks/zdcExtraTableReader.cxx
+++ b/Common/Tasks/zdcExtraTableReader.cxx
@@ -107,60 +107,60 @@ std::unordered_map<int, TH2*> gQyVsTimeZNC;
 std::unordered_map<int, TProfile3D*> gShiftProfileZNA;
 std::unordered_map<int, TProfile3D*> gShiftProfileZNC;
 
-TH1* gCurrentEventCounter;
-TH2* gCurrentCentroidZNA;
-TH2* gCurrentCentroidZNC;
-TH1* gCurrentPmcZNA;
-TH1* gCurrentPm1ZNA;
-TH1* gCurrentPm2ZNA;
-TH1* gCurrentPm3ZNA;
-TH1* gCurrentPm4ZNA;
-TH1* gCurrentSumZNA;
-TH1* gCurrentPmcZNC;
-TH1* gCurrentPm1ZNC;
-TH1* gCurrentPm2ZNC;
-TH1* gCurrentPm3ZNC;
-TH1* gCurrentPm4ZNC;
-TH1* gCurrentSumZNC;
-TH2* gCurrentQxVsCentZNA;
-TH2* gCurrentQyVsCentZNA;
-TH2* gCurrentQxVsVxZNA;
-TH2* gCurrentQyVsVxZNA;
-TH2* gCurrentQxVsVyZNA;
-TH2* gCurrentQyVsVyZNA;
-TH2* gCurrentQxVsVzZNA;
-TH2* gCurrentQyVsVzZNA;
-TH2* gCurrentQxVsCentZNC;
-TH2* gCurrentQyVsCentZNC;
-TH2* gCurrentQxVsVxZNC;
-TH2* gCurrentQyVsVxZNC;
-TH2* gCurrentQxVsVyZNC;
-TH2* gCurrentQyVsVyZNC;
-TH2* gCurrentQxVsVzZNC;
-TH2* gCurrentQyVsVzZNC;
-TH2* gCurrentQxQyVsCent;
-TH2* gCurrentQyQxVsCent;
-TH2* gCurrentQxQxVsCent;
-TH2* gCurrentQyQyVsCent;
+TH1* gCurrentEventCounter{nullptr};
+TH2* gCurrentCentroidZNA{nullptr};
+TH2* gCurrentCentroidZNC{nullptr};
+TH1* gCurrentPmcZNA{nullptr};
+TH1* gCurrentPm1ZNA{nullptr};
+TH1* gCurrentPm2ZNA{nullptr};
+TH1* gCurrentPm3ZNA{nullptr};
+TH1* gCurrentPm4ZNA{nullptr};
+TH1* gCurrentSumZNA{nullptr};
+TH1* gCurrentPmcZNC{nullptr};
+TH1* gCurrentPm1ZNC{nullptr};
+TH1* gCurrentPm2ZNC{nullptr};
+TH1* gCurrentPm3ZNC{nullptr};
+TH1* gCurrentPm4ZNC{nullptr};
+TH1* gCurrentSumZNC{nullptr};
+TH2* gCurrentQxVsCentZNA{nullptr};
+TH2* gCurrentQyVsCentZNA{nullptr};
+TH2* gCurrentQxVsVxZNA{nullptr};
+TH2* gCurrentQyVsVxZNA{nullptr};
+TH2* gCurrentQxVsVyZNA{nullptr};
+TH2* gCurrentQyVsVyZNA{nullptr};
+TH2* gCurrentQxVsVzZNA{nullptr};
+TH2* gCurrentQyVsVzZNA{nullptr};
+TH2* gCurrentQxVsCentZNC{nullptr};
+TH2* gCurrentQyVsCentZNC{nullptr};
+TH2* gCurrentQxVsVxZNC{nullptr};
+TH2* gCurrentQyVsVxZNC{nullptr};
+TH2* gCurrentQxVsVyZNC{nullptr};
+TH2* gCurrentQyVsVyZNC{nullptr};
+TH2* gCurrentQxVsVzZNC{nullptr};
+TH2* gCurrentQyVsVzZNC{nullptr};
+TH2* gCurrentQxQyVsCent{nullptr};
+TH2* gCurrentQyQxVsCent{nullptr};
+TH2* gCurrentQxQxVsCent{nullptr};
+TH2* gCurrentQyQyVsCent{nullptr};
 
-THn* gCurrentQxZNA;
-THn* gCurrentQyZNA;
-THn* gCurrentQxZNC;
-THn* gCurrentQyZNC;
+THn* gCurrentQxZNA{nullptr};
+THn* gCurrentQyZNA{nullptr};
+THn* gCurrentQxZNC{nullptr};
+THn* gCurrentQyZNC{nullptr};
 
-TH1* gCurrentPsiZNA;
-TH1* gCurrentPsiZNC;
+TH1* gCurrentPsiZNA{nullptr} ;
+TH1* gCurrentPsiZNC{nullptr};
 
-TH1* gCurrentVx;
-TH1* gCurrentVy;
+TH1* gCurrentVx{nullptr};
+TH1* gCurrentVy{nullptr};
 
-TH2* gCurrentQxVsTimeZNA;
-TH2* gCurrentQyVsTimeZNA;
-TH2* gCurrentQxVsTimeZNC;
-TH2* gCurrentQyVsTimeZNC;
+TH2* gCurrentQxVsTimeZNA{nullptr};
+TH2* gCurrentQyVsTimeZNA{nullptr};
+TH2* gCurrentQxVsTimeZNC{nullptr};
+TH2* gCurrentQyVsTimeZNC{nullptr};
 
-TProfile3D* gCurrentShiftProfileZNA;
-TProfile3D* gCurrentShiftProfileZNC;
+TProfile3D* gCurrentShiftProfileZNA{nullptr};
+TProfile3D* gCurrentShiftProfileZNC{nullptr};
 
 } // namespace
 
@@ -380,7 +380,7 @@ struct ZdcExtraTableReader {
     calibCache.clear();
   }
 
-  void initHistos(const int& runNumber)
+  void initHistos(const int runNumber)
   {
     if (runNumber == currentRunNumber) {
       return;
@@ -533,14 +533,14 @@ struct ZdcExtraTableReader {
   }
 
   // Optimized method to load ALL calibrations for the new run at once
-  void loadCalibrations(int run)
+  void loadCalibrations(int runNumber)
   {
     clearCache();
 
     // Vertex Calibration
     if (applyBeamSpotCorrection) {
       std::string folder = Form("%s/step0", qRecenteringCcdb.value.c_str());
-      auto* lst = ccdb->getForRun<TList>(folder, run);
+      auto* lst = ccdb->getForRun<TList>(folder, runNumber);
       if (lst) {
         hMeanVx = safeClone<TH1>(lst->FindObject("hMeanVx"));
         hMeanVy = safeClone<TH1>(lst->FindObject("hMeanVy"));
@@ -558,7 +558,7 @@ struct ZdcExtraTableReader {
 
       // Load 5D (Base)
       std::string folderBase = Form("%s/step%d_base", qRecenteringCcdb.value.c_str(), step);
-      auto* lstBase = ccdb->getForRun<TList>(folderBase, run);
+      auto* lstBase = ccdb->getForRun<TList>(folderBase, runNumber);
 
       if (!lstBase) {
         LOGF(error, "  >> CCDB TList is NULL for path: %s. Check object type (TList vs TFile).", folderBase.c_str());
@@ -573,7 +573,7 @@ struct ZdcExtraTableReader {
       // Load 1D (Refine)
       if ((step != calibrationStep) || isFineCalibrationStep) {
         std::string folderRefine = Form("%s/step%d_refine", qRecenteringCcdb.value.c_str(), step);
-        auto* lstRefine = ccdb->getForRun<TList>(folderRefine, run);
+        auto* lstRefine = ccdb->getForRun<TList>(folderRefine, runNumber);
 
         if (!lstRefine) {
           LOGF(error, "  >> CCDB TList is NULL for path: %s. Check object type (TList vs TFile).", folderRefine.c_str());
@@ -605,10 +605,10 @@ struct ZdcExtraTableReader {
     if (applyShiftCorrection) {
       std::string folder = Form("%s/psiHarm", qRecenteringCcdb.value.c_str());
 
-      LOGF(info, "ZDC Analysis: Loading Shift Correction from %s for run %d", folder.c_str(), run);
+      //LOGF(info, "Loading Shift Correction from %s for runNumber %d", folder.c_str(), runNumber);
 
       // Attempt to fetch TList from CCDB
-      auto* lst = ccdb->getForRun<TList>(folder, run);
+      auto* lst = ccdb->getForRun<TList>(folder, runNumber);
 
       if (!lst) {
         LOGF(error, "  >> CCDB TList is NULL for path: %s. Check object type (TList vs TFile).", folder.c_str());
@@ -652,7 +652,7 @@ struct ZdcExtraTableReader {
     ccdb->setFatalWhenNull(false);
   } // end of init()
 
-  void process(aod::ZdcExtras::iterator const& zdc /*collision*/)
+  void process(aod::ZdcExtras::iterator const& zdc)
   {
 
     // Apply event selection
@@ -681,15 +681,6 @@ struct ZdcExtraTableReader {
     if (selectGoodITSLayersAll && !TESTBIT(zdc.selectionBits(), IsGoodITSLayersAll)) {
       return;
     }
-
-    //  LOGF(info, "zvtx       = %d", TESTBIT(zdc.selectionBits(), ZVtxCut));
-    //  LOGF(info, "Sel8       = %d", TESTBIT(zdc.selectionBits(), Sel8));
-    //  LOGF(info, "occupancy  = %d", TESTBIT(zdc.selectionBits(), OccupancyCut));
-    //  LOGF(info, "noSameBC   = %d", TESTBIT(zdc.selectionBits(), NoSameBunchPileup));
-    //  LOGF(info, "FT0vsPV    = %d", TESTBIT(zdc.selectionBits(), IsGoodZvtxFT0vsPV));
-    //  LOGF(info, "noCollTR   = %d", TESTBIT(zdc.selectionBits(), NoCollInTimeRangeStandard));
-    //  LOGF(info, "vtxITSTPC  = %d", TESTBIT(zdc.selectionBits(), IsVertexITSTPC));
-    //  LOGF(info, "ITS layers = %d", TESTBIT(zdc.selectionBits(), IsGoodITSLayersAll));
 
     const int runNumber = zdc.runNumber();
 
@@ -723,7 +714,7 @@ struct ZdcExtraTableReader {
     }
 
     bool isZNChit = false, isZNAhit = false;
-    //
+    
     double tdcZNC = zdc.zncTdc();
     double tdcZNA = zdc.znaTdc();
 
@@ -742,8 +733,7 @@ struct ZdcExtraTableReader {
         isZNAhit = true;
       }
     }
-    //
-
+    
     bool isZNASpDeterminable = false;
     bool isZNCSpDeterminable = false;
 
@@ -789,15 +779,12 @@ struct ZdcExtraTableReader {
 
     double qxZNArec = 0., qyZNArec = 0.;
     double qxZNCrec = 0., qyZNCrec = 0.;
-
-    //
+    
     double cent = zdc.centrality();
     double vx = zdc.vx();
     double vy = zdc.vy();
     double vz = zdc.vz();
 
-    //   double vx_corrected = vx;
-    // double vy_corrected = vy;
 
     if (applyBeamSpotCorrection) {
       // Use cached vertex pointers
@@ -814,8 +801,7 @@ struct ZdcExtraTableReader {
 
       qxZNArec = qx;
       qyZNArec = qy;
-
-      //
+      
       for (int step = 1; step <= calibrationStep; step++) {
 
         int cacheIdx = step - 1;
@@ -937,27 +923,20 @@ struct ZdcExtraTableReader {
 
       qxZNCrec = qx;
       qyZNCrec = qy;
-
-      //   LOGF(info, "Qx init = %f", qxZNCrec);
-
+      
       // Iterate through steps using cached vector
       for (int step = 1; step <= calibrationStep; step++) {
 
         int cacheIdx = step - 1;
         if (cacheIdx >= static_cast<int>(calibCache.size()))
           continue;
-
-        //     LOGF(info, "Go to step = %d", step);
-
+        
         const auto& calib = calibCache[cacheIdx];
 
         // Apply 5D Base calibration
         if (calib.hMeanQxZNC && calib.hMeanQyZNC) {
           qxZNCrec -= getMeanQFromMap(calib.hMeanQxZNC, cent, vx, vy, vz);
           qyZNCrec -= getMeanQFromMap(calib.hMeanQyZNC, cent, vx, vy, vz);
-
-          //  LOGF(info, "Go to base calibration step = %d", step);
-          //  LOGF(info, "Qx after base calibration step %d = %f", step, qxZNCrec);
         }
 
         if ((step != calibrationStep) || isFineCalibrationStep) {
@@ -974,16 +953,12 @@ struct ZdcExtraTableReader {
 
           qxZNCrec -= getMeanQ1D(calib.hMeanQxVyZNC, vy);
           qyZNCrec -= getMeanQ1D(calib.hMeanQyVyZNC, vy);
-          // LOGF(info, "Go to refine calibration step = %d", step);
-          //   LOGF(info, "Qx after fine calibration step %d = %f", step, qxZNCrec);
         }
       }
 
       double valuesQxZNC[5] = {cent, vx, vy, vz, qxZNCrec};
       double valuesQyZNC[5] = {cent, vx, vy, vz, qyZNCrec};
-
-      //    LOGF(info, "Qx cal = %f", qxZNCrec);
-
+      
       gCurrentCentroidZNC->Fill(qxZNCrec, qyZNCrec);
 
       gCurrentQxVsCentZNC->Fill(cent, qxZNCrec);

--- a/Common/Tasks/zdcExtraTableReader.cxx
+++ b/Common/Tasks/zdcExtraTableReader.cxx
@@ -212,9 +212,7 @@ struct ZdcExtraTableReader {
   Configurable<float> tdcZnMax{"tdcZnMax", 2.5, "Max ZN TDC cut"};
   Configurable<bool> plotPMs{"plotPMs", false, "Flag to plot individual PMs"};
 
-  Configurable<int> qxyNbins{"qxyNbins", 100, "Number of bins in QxQy histograms"};
-  Configurable<float> qxyMin{"qxyMin", -2.0f, "Lower edge for QxQy histograms"};
-  Configurable<float> qxyMax{"qxyMax", 2.0f, "Upper edge for QxQy histograms"};
+  ConfigurableAxis qxyAxis{"qxyAxis", {100, -2.0f, 2.0f}, ""};
 
   Configurable<int> vxNbins{"vxNbins", 50, "Bins in Vx"};
   Configurable<float> vxMin{"vxMin", -0.1f, "Vx lower edge"};
@@ -404,10 +402,10 @@ struct ZdcExtraTableReader {
       const AxisSpec axisVy5D = {qNbins5D, vyMin, vyMax, "V_{y} (cm)"};
       const AxisSpec axisVz5D = {qNbins5D, vzMin, vzMax, "V_{z} (cm)"};
 
-      const AxisSpec axisQx = {qxyNbins, qxyMin, qxyMax, "Q_{x}"};
-      const AxisSpec axisQy = {qxyNbins, qxyMin, qxyMax, "Q_{y}"};
+      const AxisSpec axisQx{qxyAxis, "Q_{x}"};
+      const AxisSpec axisQy{qxyAxis, "Q_{y}"};
+      const AxisSpec axisQxQy = {qxyAxis, ""};
 
-      const AxisSpec axisQxQy = {qxyNbins, qxyMin, qxyMax, ""};
       const AxisSpec axisPhi = {phiNbins, -1.0f * o2::constants::math::PI, 1.0f * o2::constants::math::PI, "#phi"};
 
       const AxisSpec axisTime = {90, 0, 90, "Time (minutes)"}; // 90 minutes


### PR DESCRIPTION
zdc-extra-table-reader is needed to read AOD/ZDCEXTRA derived data and proceed with multi-step calibration (Q-vectors recentering) of ZDC data