### PR TITLE
[PWGHF] [xic0omegac0] Updated candidate creator & candidate selector

### DIFF
--- a/PWGHF/TableProducer/candidateCreatorXic0Omegac0Qa.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXic0Omegac0Qa.cxx
@@ -258,15 +258,15 @@ struct HfCandidateCreatorXic0Omegac0Qa {
   HfEventSelection hfEvSel;
 
   // PDG Id of daughter tracks & V0s & cascades & charm baryons - Used in KFParticle
-  int pdgIdOfV0DauPos, pdgIdOfV0DauNeg, pdgIdOfBach, pdgIdOfCharmBach;
-  int pdgIdOfV0, pdgIdOfCascade, pdgIdOfCharmBaryon;
+  int pdgIdOfV0DauPos{}, pdgIdOfV0DauNeg{}, pdgIdOfBach{}, pdgIdOfCharmBach{};
+  int pdgIdOfV0{}, pdgIdOfCascade{}, pdgIdOfCharmBaryon{};
 
   // Track PID - Used in DCAFitter
-  int trackPidOfCascade;
+  int trackPidOfCascade{};
 
   // Mass of daughter tracks & V0s & cascades & charm baryons;
-  float massOfV0DauPos, massOfV0DauNeg, massOfCharmBach;
-  float massOfV0, massOfCascade;
+  float massOfV0DauPos{}, massOfV0DauNeg{}, massOfCharmBach{};
+  float massOfV0{}, massOfCascade{};
 
   // Pointer of histograms for QA
   std::shared_ptr<TH1> hInvMassCharmBaryonToXiPi, hInvMassCharmBaryonToOmegaPi, hInvMassCharmBaryonToOmegaKa;

--- a/PWGHF/TableProducer/candidateCreatorXic0Omegac0Qa.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXic0Omegac0Qa.cxx
@@ -512,12 +512,6 @@ struct HfCandidateCreatorXic0Omegac0Qa {
 
   } // end of initialization
 
-  ////////////////////////////////////////////////////////////
-  //                                                        //
-  //         Candidate reconstruction with DCAFitter        //
-  //                                                        //
-  ////////////////////////////////////////////////////////////
-
   // template function for running charm baryon reconstruction with DCAFitter
   /// \brief centEstimator is for different centrality estimators
   /// \brief decayChannel is for different decay channels. 0 for XiczeroOmegaczeroToXiPi, 1 for OmegaczeroToOmegaPi, 2 for OmegaczeroToOmeagaK
@@ -962,10 +956,10 @@ struct HfCandidateCreatorXic0Omegac0Qa {
 
       bool isAnti = (bachTrack.signed1Pt() > 0 ? true : false);
 
-      KFParticle kfPos(kfTrack0, (isAnti ? pdgIdOfAntiV0DauPos : pdgIdOfV0DauPos));
-      KFParticle kfNeg(kfTrack1, (isAnti ? pdgIdOfAntiV0DauNeg : pdgIdOfV0DauNeg));
-      KFParticle kfBach(kfTrackBach, (isAnti ? pdgIdOfAntiBach : pdgIdOfBach));
-      KFParticle kfBachRej(kfTrackBach, (isAnti ? pdgIdOfAntiBach : pdgIdOfBach)); // Rej -> Used for Omegac0->OmegaPi only
+      KFParticle kfPos(kfTrack0, (isAnti ? -pdgIdOfV0DauNeg : pdgIdOfV0DauPos));
+      KFParticle kfNeg(kfTrack1, (isAnti ? -pdgIdOfV0DauPos : pdgIdOfV0DauNeg));
+      KFParticle kfBach(kfTrackBach, (isAnti ? -pdgIdOfBach : pdgIdOfBach));
+      KFParticle kfBachRej(kfTrackBach, (isAnti ? -pdgIdOfBach : pdgIdOfBach)); // Rej -> Used for Omegac0->OmegaPi only
 
       // ~~~~~~~Construct V0 with KF~~~~~~~
       const KFParticle* v0Daughters[2] = {&kfPos, &kfNeg};
@@ -1049,7 +1043,7 @@ struct HfCandidateCreatorXic0Omegac0Qa {
       //~~~~~~~Construct Charm Baryon with KF~~~~~~~
       auto trackCharmBachelor = tracks.rawIteratorAt(cand.prong0Id());
       const KFPTrack kfTrackCharmBach = createKFPTrackFromTrack(trackCharmBachelor);
-      const KFParticle kfCharmBach(kfTrackCharmBach, (isAnti ? pdgIdOfAntiCharmBach : pdgIdOfCharmBach));
+      const KFParticle kfCharmBach(kfTrackCharmBach, (isAnti ? -pdgIdOfCharmBach : pdgIdOfCharmBach));
       const KFParticle* charmBaryonDaughters[2] = {&kfCharmBach, &kfCasc};
 
       KFParticle kfCharmBaryon;

--- a/PWGHF/TableProducer/candidateCreatorXic0Omegac0Qa.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXic0Omegac0Qa.cxx
@@ -259,15 +259,14 @@ struct HfCandidateCreatorXic0Omegac0Qa {
 
   // PDG Id of daughter tracks & V0s & cascades & charm baryons - Used in KFParticle
   int pdgIdOfV0DauPos, pdgIdOfV0DauNeg, pdgIdOfBach, pdgIdOfCharmBach;
-  int pdgIdOfAntiV0DauPos, pdgIdOfAntiV0DauNeg, pdgIdOfAntiBach, pdgIdOfAntiCharmBach;
   int pdgIdOfV0, pdgIdOfCascade, pdgIdOfCharmBaryon;
 
   // Track PID - Used in DCAFitter
   int trackPidOfCascade;
 
   // Mass of daughter tracks & V0s & cascades & charm baryons;
-  float massOfV0DauPos, massOfV0DauNeg, massOfBach, massOfCharmBach;
-  float massOfV0, massOfCascade, massOfCharmBaryon;
+  float massOfV0DauPos, massOfV0DauNeg, massOfCharmBach;
+  float massOfV0, massOfCascade;
 
   // Pointer of histograms for QA
   std::shared_ptr<TH1> hInvMassCharmBaryonToXiPi, hInvMassCharmBaryonToOmegaPi, hInvMassCharmBaryonToOmegaKa;
@@ -317,11 +316,6 @@ struct HfCandidateCreatorXic0Omegac0Qa {
       pdgIdOfBach = kPiMinus;
       pdgIdOfCharmBach = kPiPlus;
 
-      pdgIdOfAntiV0DauPos = kPiPlus;
-      pdgIdOfAntiV0DauNeg = kProton;
-      pdgIdOfAntiBach = kPiPlus;
-      pdgIdOfAntiCharmBach = kPiMinus;
-
       pdgIdOfV0 = kLambda0;
       pdgIdOfCascade = kXiMinus;
       pdgIdOfCharmBaryon = kXiC0;
@@ -338,11 +332,6 @@ struct HfCandidateCreatorXic0Omegac0Qa {
       pdgIdOfV0DauNeg = kPiMinus;
       pdgIdOfBach = kKMinus;
       pdgIdOfCharmBach = kPiPlus;
-
-      pdgIdOfAntiV0DauPos = kPiPlus;
-      pdgIdOfAntiV0DauNeg = kProton;
-      pdgIdOfAntiBach = kKPlus;
-      pdgIdOfAntiCharmBach = kPiMinus;
 
       pdgIdOfV0 = kLambda0;
       pdgIdOfCascade = kOmegaMinus;
@@ -361,11 +350,6 @@ struct HfCandidateCreatorXic0Omegac0Qa {
       pdgIdOfBach = kKMinus;
       pdgIdOfCharmBach = kKPlus;
 
-      pdgIdOfAntiV0DauPos = kPiPlus;
-      pdgIdOfAntiV0DauNeg = kProton;
-      pdgIdOfAntiBach = kKPlus;
-      pdgIdOfAntiCharmBach = kKMinus;
-
       pdgIdOfV0 = kLambda0;
       pdgIdOfCascade = kOmegaMinus;
       pdgIdOfCharmBaryon = kOmegaC0;
@@ -383,11 +367,6 @@ struct HfCandidateCreatorXic0Omegac0Qa {
     LOGF(info, "PDG ID of V0 negative daughter: %d", pdgIdOfV0DauNeg);
     LOGF(info, "PDG ID of Bachelor: %d", pdgIdOfBach);
     LOGF(info, "PDG ID of Charm Bachelor: %d", pdgIdOfCharmBach);
-    LOGF(info, "-------------------------------------------");
-    LOGF(info, "PDG ID of anti V0 positive daughter: %d", pdgIdOfAntiV0DauPos);
-    LOGF(info, "PDG ID of anti V0 negative daughter: %d", pdgIdOfAntiV0DauNeg);
-    LOGF(info, "PDG ID of anti Bachelor: %d", pdgIdOfAntiBach);
-    LOGF(info, "PDG ID of anti Charm Bachelor: %d", pdgIdOfAntiCharmBach);
     LOGF(info, "-------------------------------------------");
     LOGF(info, "PDG ID of V0: %d", pdgIdOfV0);
     LOGF(info, "PDG ID of Cascade: %d", pdgIdOfCascade);

--- a/PWGHF/TableProducer/candidateSelectorToXiPiQa.cxx
+++ b/PWGHF/TableProducer/candidateSelectorToXiPiQa.cxx
@@ -295,7 +295,7 @@ struct HfCandidateSelectorToXiPiQa {
   // Selection on LF related informations
   // returns true if all cuts are passed
   template <int svReco, typename T>
-  bool SelectOnLF(const T& candidate, const int& inputPtBin)
+  bool selectOnLf(const T& candidate, const int& inputPtBin)
   {
 
     registry.fill(HIST("hSelStatusLf"), 0.0);
@@ -442,7 +442,7 @@ struct HfCandidateSelectorToXiPiQa {
   // Apply cuts with charm baryon & charm bachelor related informations
   // returns true if all cuts are passed
   template <int svReco, typename T>
-  bool SelectOnHF(const T& candidate, const int& inputPtBin)
+  bool selectOnHf(const T& candidate, const int& inputPtBin)
   {
 
     registry.fill(HIST("hSelStatusHf"), 0.0);
@@ -561,8 +561,8 @@ struct HfCandidateSelectorToXiPiQa {
       }
 
       // Topological selection
-      const bool selectionResOnLF = SelectOnLF<svReco>(candidate, pTBin);
-      const bool selectionResOnHF = SelectOnHF<svReco>(candidate, pTBin);
+      const bool selectionResOnLF = selectOnLf<svReco>(candidate, pTBin);
+      const bool selectionResOnHF = selectOnHf<svReco>(candidate, pTBin);
       if (!selectionResOnLF || !selectionResOnHF) {
         resultSelections = false;
       }

--- a/PWGHF/TableProducer/candidateSelectorToXiPiQa.cxx
+++ b/PWGHF/TableProducer/candidateSelectorToXiPiQa.cxx
@@ -730,7 +730,7 @@ struct HfCandidateSelectorToXiPiQa {
         hfMlToXiPi(outputMlXic0ToXiPi);
 
         if (!isSelectedMlXic0) {
-          continue;    
+          continue;
         }
       }
 

--- a/PWGHF/TableProducer/candidateSelectorToXiPiQa.cxx
+++ b/PWGHF/TableProducer/candidateSelectorToXiPiQa.cxx
@@ -710,9 +710,6 @@ struct HfCandidateSelectorToXiPiQa {
           inputFeaturesXic0 = hfMlResponseKf.getInputFeatures(candidate, trackPiFromLam, trackPiFromCasc, trackPiFromCharm);
           isSelectedMlXic0 = hfMlResponseKf.isSelectedMl(inputFeaturesXic0, ptCandXic0, outputMlXic0ToXiPi);
         }
-        if (!isSelectedMlXic0) {
-          continue;
-        }
         hfMlToXiPi(outputMlXic0ToXiPi);
       }
 

--- a/PWGHF/TableProducer/candidateSelectorToXiPiQa.cxx
+++ b/PWGHF/TableProducer/candidateSelectorToXiPiQa.cxx
@@ -699,20 +699,6 @@ struct HfCandidateSelectorToXiPiQa {
         statusInvMassCharmBaryon = true;
       }
 
-      // ML BDT selection
-      if (applyMl) {
-        bool isSelectedMlXic0 = false;
-        std::vector<float> inputFeaturesXic0 = {};
-        if constexpr (svReco == doDcaFitter) {
-          inputFeaturesXic0 = hfMlResponseDca.getInputFeatures(candidate, trackPiFromLam, trackPiFromCasc, trackPiFromCharm);
-          isSelectedMlXic0 = hfMlResponseDca.isSelectedMl(inputFeaturesXic0, ptCandXic0, outputMlXic0ToXiPi);
-        } else {
-          inputFeaturesXic0 = hfMlResponseKf.getInputFeatures(candidate, trackPiFromLam, trackPiFromCasc, trackPiFromCharm);
-          isSelectedMlXic0 = hfMlResponseKf.isSelectedMl(inputFeaturesXic0, ptCandXic0, outputMlXic0ToXiPi);
-        }
-        hfMlToXiPi(outputMlXic0ToXiPi);
-      }
-
       // Fill in selection result
       if constexpr (svReco == doDcaFitter) {
         hfSelToXiPi(statusPidLambda, statusPidCascade, statusPidCharmBaryon, statusInvMassLambda, statusInvMassCascade, statusInvMassCharmBaryon, resultSelections, infoTpcStored, infoTofStored,
@@ -727,6 +713,25 @@ struct HfCandidateSelectorToXiPiQa {
         hfSelToXiPiKf(resultSelections,
                       trackPiFromCharm.tpcNSigmaPi(), trackPiFromCasc.tpcNSigmaPi(), trackPiFromLam.tpcNSigmaPi(), trackPrFromLam.tpcNSigmaPr(),
                       trackPiFromCharm.tofNSigmaPi(), trackPiFromCasc.tofNSigmaPi(), trackPiFromLam.tofNSigmaPi(), trackPrFromLam.tofNSigmaPr());
+      }
+
+      // ML BDT selection if required
+      if (applyMl) {
+        bool isSelectedMlXic0 = false;
+        std::vector<float> inputFeaturesXic0 = {};
+        if constexpr (svReco == doDcaFitter) {
+          inputFeaturesXic0 = hfMlResponseDca.getInputFeatures(candidate, trackPiFromLam, trackPiFromCasc, trackPiFromCharm);
+          isSelectedMlXic0 = hfMlResponseDca.isSelectedMl(inputFeaturesXic0, ptCandXic0, outputMlXic0ToXiPi);
+        } else {
+          inputFeaturesXic0 = hfMlResponseKf.getInputFeatures(candidate, trackPiFromLam, trackPiFromCasc, trackPiFromCharm);
+          isSelectedMlXic0 = hfMlResponseKf.isSelectedMl(inputFeaturesXic0, ptCandXic0, outputMlXic0ToXiPi);
+        }
+
+        hfMlToXiPi(outputMlXic0ToXiPi);
+
+        if (!isSelectedMlXic0) {
+          continue;    
+        }
       }
 
       // Fill in invariant mass histogram


### PR DESCRIPTION
candidateCreatorXic0Omegac0Qa:
- Removed unused configurables `massOfBach`, `massOfCharmBaryon`
- Removed unnecessary configurables for storing pdg Id of final state hadrons in case of anti-Xic0

candidateSelectorToXiPiQa:
- Removed `continue` statement inside candidate loop