### PR TITLE
[PWGJE] Removed collisionId criteria for processMcTrackLabelsWithCollisionAssociator in derivedDataProducer.cxx

### DIFF
--- a/PWGJE/Core/JetTaggingUtilities.h
+++ b/PWGJE/Core/JetTaggingUtilities.h
@@ -997,7 +997,8 @@ int vertexClustering(AnyCollision const& collision, AnalysisJet const& jet, AnyT
         trkLabels["trkOrigin"].push_back(0); // mismatched coll track
       } else {
         int orig = RecoDecay::getParticleOrigin(particles, particle, searchUpToQuark);
-        trkLabels["trkOrigin"].push_back((orig != RecoDecay::OriginType::None) ? static_cast<int>(orig) : (trkLabels["trkVtxIndex"][trkIdx] == 0) ? 3 : 4); // 1: charm, 2: beauty, 3: primary, 4: other secondary
+        trkLabels["trkOrigin"].push_back((orig != RecoDecay::OriginType::None) ? static_cast<int>(orig) : (trkLabels["trkVtxIndex"][trkIdx] == 0) ? 3
+                                                                                                                                                  : 4); // 1: charm, 2: beauty, 3: primary, 4: other secondary
       }
     }
 

--- a/PWGJE/Core/JetTaggingUtilities.h
+++ b/PWGJE/Core/JetTaggingUtilities.h
@@ -997,8 +997,7 @@ int vertexClustering(AnyCollision const& collision, AnalysisJet const& jet, AnyT
         trkLabels["trkOrigin"].push_back(0); // mismatched coll track
       } else {
         int orig = RecoDecay::getParticleOrigin(particles, particle, searchUpToQuark);
-        trkLabels["trkOrigin"].push_back((orig > 0) ? orig : (trkLabels["trkVtxIndex"][trkIdx] == 0) ? 3
-                                                                                                     : 4); // 1: charm, 2: beauty, 3: primary, 4: other secondary
+        trkLabels["trkOrigin"].push_back((orig != RecoDecay::OriginType::None) ? static_cast<int>(orig) : (trkLabels["trkVtxIndex"][trkIdx] == 0) ? 3 : 4); // 1: charm, 2: beauty, 3: primary, 4: other secondary
       }
     }
 

--- a/PWGJE/Core/JetTaggingUtilities.h
+++ b/PWGJE/Core/JetTaggingUtilities.h
@@ -990,12 +990,15 @@ int vertexClustering(AnyCollision const& collision, AnalysisJet const& jet, AnyT
   int trkIdx = 0;
   for (auto const& constituent : jet.template tracks_as<AnyTracks>()) {
     if (!constituent.has_mcParticle() || !constituent.template mcParticle_as<AnyParticles>().isPhysicalPrimary() || constituent.pt() < trackPtMin) {
-      trkLabels["trkOrigin"].push_back(0);
+      trkLabels["trkOrigin"].push_back(0); // fake track, non-physical primary track
     } else {
       const auto& particle = constituent.template mcParticle_as<AnyParticles>();
-      int orig = RecoDecay::getParticleOrigin(particles, particle, searchUpToQuark);
-      trkLabels["trkOrigin"].push_back((orig > 0) ? orig : (trkLabels["trkVtxIndex"][trkIdx] == 0) ? 3
-                                                                                                   : 4);
+      if (particle.mcCollisionId() != collision.globalIndex()) {
+        trkLabels["trkOrigin"].push_back(0); // mismatched coll track
+      } else {
+        int orig = RecoDecay::getParticleOrigin(particles, particle, searchUpToQuark);
+        trkLabels["trkOrigin"].push_back((orig > 0) ? orig : (trkLabels["trkVtxIndex"][trkIdx] == 0) ? 3 : 4); // 1: charm, 2: beauty, 3: primary, 4: other secondary
+      }
     }
 
     trkIdx++;

--- a/PWGJE/Core/JetTaggingUtilities.h
+++ b/PWGJE/Core/JetTaggingUtilities.h
@@ -997,7 +997,8 @@ int vertexClustering(AnyCollision const& collision, AnalysisJet const& jet, AnyT
         trkLabels["trkOrigin"].push_back(0); // mismatched coll track
       } else {
         int orig = RecoDecay::getParticleOrigin(particles, particle, searchUpToQuark);
-        trkLabels["trkOrigin"].push_back((orig > 0) ? orig : (trkLabels["trkVtxIndex"][trkIdx] == 0) ? 3 : 4); // 1: charm, 2: beauty, 3: primary, 4: other secondary
+        trkLabels["trkOrigin"].push_back((orig > 0) ? orig : (trkLabels["trkVtxIndex"][trkIdx] == 0) ? 3
+                                                                                                     : 4); // 1: charm, 2: beauty, 3: primary, 4: other secondary
       }
     }
 

--- a/PWGJE/TableProducer/derivedDataProducer.cxx
+++ b/PWGJE/TableProducer/derivedDataProducer.cxx
@@ -582,7 +582,7 @@ struct JetDerivedDataProducerTask {
       auto collisionTrackIndices = assocCollisions.sliceBy(preslices.perCollisionTrackIndices, collision.globalIndex());
       for (auto const& collisionTrackIndex : collisionTrackIndices) {
         auto track = collisionTrackIndex.track_as<soa::Join<aod::Tracks, aod::McTrackLabels>>();
-        if (track.collisionId() == collision.globalIndex() && track.has_mcParticle()) {
+        if (track.has_mcParticle()) {
           products.jMcTracksLabelTable(track.mcParticleId());
         } else {
           products.jMcTracksLabelTable(-1);


### PR DESCRIPTION
- PWGJE/TableProducer/derivedDataProducer.cxx
Removed collisionId criteria for `processMcTrackLabelsWithCollisionAssociator` to enable access to mcParticle information of reassociated tracks.

- PWGJE/Core/JetTaggingUtilities.h
Redefined the track origin prediction labels for GNN method.
0: background track (mismatched coll, non-physical primary, fake tracks)
1: charm origin track
2: beauty origin track
3: primary vertex track
4: other secondary vertex track