### PR TITLE
[PWGCF] Fix MC processing, remove tmp histograms from registry

### DIFF
--- a/PWGCF/GenericFramework/Tasks/flowGenericFramework.cxx
+++ b/PWGCF/GenericFramework/Tasks/flowGenericFramework.cxx
@@ -181,16 +181,16 @@ struct FlowGenericFramework {
     O2_DEFINE_CONFIGURABLE(cfgTPCSectorCut, bool, false, "Cut on pt-phi distribution");
   } cfgTrackCuts;
   struct : ConfigurableGroup {
-    O2_DEFINE_CONFIGURABLE(cfgNoSameBunchPileupCut, bool, true, "kNoSameBunchPileupCut");
-    O2_DEFINE_CONFIGURABLE(cfgIsGoodZvtxFT0vsPV, bool, true, "kIsGoodZvtxFT0vsPV");
-    O2_DEFINE_CONFIGURABLE(cfgIsGoodITSLayersAll, bool, true, "kIsGoodITSLayersAll");
-    O2_DEFINE_CONFIGURABLE(cfgNoCollInTimeRangeStandard, bool, true, "kNoCollInTimeRangeStandard");
-    O2_DEFINE_CONFIGURABLE(cfgNoCollInRofStandard, bool, true, "kNoCollInRofStandard");
-    O2_DEFINE_CONFIGURABLE(cfgNoHighMultCollInPrevRof, bool, true, "kNoHighMultCollInPrevRof");
-    O2_DEFINE_CONFIGURABLE(cfgNoITSROFrameBorder, bool, true, "kNoITSROFrameBorder");
-    O2_DEFINE_CONFIGURABLE(cfgNoTimeFrameBorder, bool, true, "kNoTimeFrameBorder");
-    O2_DEFINE_CONFIGURABLE(cfgTVXinTRD, bool, true, "kTVXinTRD - Use kTVXinTRD (reject TRD triggered events)");
-    O2_DEFINE_CONFIGURABLE(cfgIsVertexITSTPC, bool, true, "kIsVertexITSTPC - Selects collisions with at least one ITS-TPC track");
+    O2_DEFINE_CONFIGURABLE(cfgNoSameBunchPileupCut, bool, true, "NoSameBunchPileupCut");
+    O2_DEFINE_CONFIGURABLE(cfgIsGoodZvtxFT0vsPV, bool, true, "IsGoodZvtxFT0vsPV");
+    O2_DEFINE_CONFIGURABLE(cfgIsGoodITSLayersAll, bool, true, "IsGoodITSLayersAll");
+    O2_DEFINE_CONFIGURABLE(cfgNoCollInTimeRangeStandard, bool, true, "NoCollInTimeRangeStandard");
+    O2_DEFINE_CONFIGURABLE(cfgNoCollInRofStandard, bool, true, "NoCollInRofStandard");
+    O2_DEFINE_CONFIGURABLE(cfgNoHighMultCollInPrevRof, bool, true, "NoHighMultCollInPrevRof");
+    O2_DEFINE_CONFIGURABLE(cfgNoITSROFrameBorder, bool, true, "NoITSROFrameBorder");
+    O2_DEFINE_CONFIGURABLE(cfgNoTimeFrameBorder, bool, true, "NoTimeFrameBorder");
+    O2_DEFINE_CONFIGURABLE(cfgTVXinTRD, bool, true, "TVXinTRD - Use TVXinTRD (reject TRD triggered events)");
+    O2_DEFINE_CONFIGURABLE(cfgIsVertexITSTPC, bool, true, "IsVertexITSTPC - Selects collisions with at least one ITS-TPC track");
   } cfgEventCutFlags;
   O2_DEFINE_CONFIGURABLE(cfgOccupancySelection, int, 2000, "Max occupancy selection, -999 to disable");
   O2_DEFINE_CONFIGURABLE(cfgDoOccupancySel, bool, true, "Bool for event selection on detector occupancy");
@@ -280,51 +280,51 @@ struct FlowGenericFramework {
   std::vector<std::unique_ptr<TH1>> histosNpt;
   std::vector<std::unique_ptr<TH1>> histosResoNpt;
   enum OutputTH1Names {
-    hPhi = 0,
-    hEta,
-    hVtxZ,
-    hMult,
-    hCent,
-    hEventSel,
-    kCount_TH1Names
+    Phi = 0,
+    Eta,
+    VtxZ,
+    Mult,
+    Cent,
+    EventSel,
+    TH1NameCount
   };
   // NUA outputs
   enum OutputTH3Names {
-    hNUAref = 0,
-    hNUAch,
-    hNUApi,
-    hNUAka,
-    hNUApr,
-    hPtPhiMult,
-    kCount_TH3Names
+    NUAref = 0,
+    NUAch,
+    NUApi,
+    NUAka,
+    NUApr,
+    PtPhiMult,
+    TH3NameCount
   };
   enum CentEstimators {
-    kCentFT0C = 0,
-    kCentFT0CVariant1,
-    kCentFT0M,
-    kCentFV0A,
-    kCentNTPV,
-    kCentNGlobal,
-    kCentMFT
+    CentFT0C = 0,
+    CentFT0CVariant1,
+    CentFT0M,
+    CentFV0A,
+    CentNTPV,
+    CentNGlobal,
+    CentMFT
   };
-  std::map<int, std::string> centNamesMap = {{kCentFT0C, "FT0C"}, {kCentFT0CVariant1, "FT0C variant1"}, {kCentFT0M, "FT0M"}, {kCentFV0A, "FV0A"}, {kCentNTPV, "NTPV"}, {kCentNGlobal, "NGlobal"}, {kCentMFT, "MFT"}};
+  std::map<int, std::string> centNamesMap = {{CentFT0C, "FT0C"}, {CentFT0CVariant1, "FT0C variant1"}, {CentFT0M, "FT0M"}, {CentFV0A, "FV0A"}, {CentNTPV, "NTPV"}, {CentNGlobal, "NGlobal"}, {CentMFT, "MFT"}};
 
   enum EventSelFlags {
-    kFilteredEvent = 1,
-    kSel8,
-    kOccupancy,
-    kTVXinTRD,
-    kNoSameBunchPileup,
-    kIsGoodZvtxFT0vsPV,
-    kNoCollInTimeRangeStandard,
-    kNoCollInRofStandard,
-    kNoHighMultCollInPrevRof,
-    kNoTimeFrameBorder,
-    kNoITSROFrameBorder,
-    kIsVertexITSTPC,
-    kIsGoodITSLayersAll,
-    kMultCuts,
-    kTrackCent
+    FilteredEvent = 1,
+    Sel8,
+    Occupancy,
+    TVXinTRD,
+    NoSameBunchPileup,
+    IsGoodZvtxFT0vsPV,
+    NoCollInTimeRangeStandard,
+    NoCollInRofStandard,
+    NoHighMultCollInPrevRof,
+    NoTimeFrameBorder,
+    NoITSROFrameBorder,
+    IsVertexITSTPC,
+    IsGoodITSLayersAll,
+    MultCuts,
+    TrackCent
   };
   struct EventCut {
     bool enabled;
@@ -333,73 +333,73 @@ struct FlowGenericFramework {
   };
   std::vector<EventCut> eventcutflags;
   enum Particles {
-    kPions,
-    kKaons,
-    kProtons
+    Pions,
+    Kaons,
+    Protons
   };
   enum ParticleIDs {
-    kChargedID = 0,
-    kPionID,
-    kKaonID,
-    kProtonID,
-    kSpeciesCount
+    ChargedID = 0,
+    PionID,
+    KaonID,
+    ProtonID,
+    SpeciesCount
   };
   enum ResoIDs {
-    kK0Sideband1 = 0,
-    kK0Signal,
-    kK0Sideband2,
-    kLambdaSideband1,
-    kLambdaSignal,
-    kLambdaSideband2,
-    kResonanceCount
+    K0Sideband1 = 0,
+    K0Signal,
+    K0Sideband2,
+    LambdaSideband1,
+    LambdaSignal,
+    LambdaSideband2,
+    ResonanceCount
   };
   enum OutputSpecies {
-    kK0 = 0,
-    kLambda = 1,
-    kPhi = 2,
-    kLambdaBar = 3,
-    kRef = 4,
-    kCountOutputSpecies
+    K0 = 0,
+    Lambda = 1,
+    PhiMeson = 2,
+    LambdaBar = 3,
+    RefParticle = 4,
+    OutputSpeciesCount
   };
   enum ParticleCuts {
-    kCosPA = 0,
-    kMassMin,
-    kMassMax,
-    kPosTrackPt,
-    kNegTrackPt,
-    kDCAPosToPVMin,
-    kDCANegToPVMin,
-    kDCAxDaughters,
-    kLifeTime,
-    kRadiusMin,
-    kRadiusMax,
-    kRapidity,
-    kArmPodMin,
-    kMassRejection
+    CosPA = 0,
+    MassMin,
+    MassMax,
+    PosTrackPt,
+    NegTrackPt,
+    DCAPosToPVMin,
+    DCANegToPVMin,
+    DCAxDaughters,
+    LifeTime,
+    RadiusMin,
+    RadiusMax,
+    Rapidity,
+    ArmPodMin,
+    MassRejection
   };
   enum ParticleSwitches {
-    kUseParticle = 0,
-    kUseCosPA,
-    kMassBins,
-    kUseDCAxDaughters,
-    kUseProperLifetime,
-    kUseV0Radius,
-    kUseArmPodCut,
-    kUseCompetingMassRejection
+    UseParticle = 0,
+    UseCosPA,
+    MassBins,
+    UseDCAxDaughters,
+    UseProperLifetime,
+    UseV0Radius,
+    UseArmPodCut,
+    UseCompetingMassRejection
   };
   enum V0Selection {
-    kFillCandidate = 1,
-    kFillDaughterPt,
-    kFillMassCut,
-    kFillRapidityCut,
-    kFillDCAtoPV,
-    kFillDCAxDaughters,
-    kFillV0Radius,
-    kFillCosPA,
-    kFillProperLifetime,
-    kFillArmPodCut,
-    kFillCompetingMass,
-    kFillDaughterTrackSelection
+    FillCandidate = 1,
+    FillDaughterPt,
+    FillMassCut,
+    FillRapidityCut,
+    FillDCAtoPV,
+    FillDCAxDaughters,
+    FillV0Radius,
+    FillCosPA,
+    FillProperLifetime,
+    FillArmPodCut,
+    FillCompetingMass,
+    FillDaughterTrackSelection
   };
 
   // Define global variables
@@ -500,7 +500,8 @@ struct FlowGenericFramework {
     readMatrix(cfgPIDCuts.resonanceSwitches->getData(), resoSwitchVals);
     printResoCuts();
 
-    for (int i = 0; i < 4; ++i) { // o2-linter: disable=magic-number (maximum of 4 subevents)
+    int nPtPtSubMax = 4;
+    for (int i = 0; i < nPtPtSubMax; ++i) {
       if (cfgPtPtGaps->getData()[i][0] < -1. || cfgPtPtGaps->getData()[i][1] < -1.)
         continue;
       o2::analysis::gfw::etagapsPtPt.push_back(std::make_pair(cfgPtPtGaps->getData()[i][0], cfgPtPtGaps->getData()[i][1]));
@@ -511,15 +512,15 @@ struct FlowGenericFramework {
     }
 
     // Setup event cuts
-    eventcutflags.push_back({cfgEventCutFlags.cfgNoSameBunchPileupCut, kNoSameBunchPileup, o2::aod::evsel::kNoSameBunchPileup});
-    eventcutflags.push_back({cfgEventCutFlags.cfgIsGoodZvtxFT0vsPV, kIsGoodZvtxFT0vsPV, o2::aod::evsel::kIsGoodZvtxFT0vsPV});
-    eventcutflags.push_back({cfgEventCutFlags.cfgNoCollInTimeRangeStandard, kNoCollInTimeRangeStandard, o2::aod::evsel::kNoCollInTimeRangeStandard});
-    eventcutflags.push_back({cfgEventCutFlags.cfgNoCollInRofStandard, kNoCollInRofStandard, o2::aod::evsel::kNoCollInRofStandard});
-    eventcutflags.push_back({cfgEventCutFlags.cfgNoHighMultCollInPrevRof, kNoHighMultCollInPrevRof, o2::aod::evsel::kNoHighMultCollInPrevRof});
-    eventcutflags.push_back({cfgEventCutFlags.cfgNoTimeFrameBorder, kNoTimeFrameBorder, o2::aod::evsel::kNoTimeFrameBorder});
-    eventcutflags.push_back({cfgEventCutFlags.cfgNoITSROFrameBorder, kNoITSROFrameBorder, o2::aod::evsel::kNoITSROFrameBorder});
-    eventcutflags.push_back({cfgEventCutFlags.cfgIsVertexITSTPC, kIsVertexITSTPC, o2::aod::evsel::kIsVertexITSTPC});
-    eventcutflags.push_back({cfgEventCutFlags.cfgIsGoodITSLayersAll, kIsGoodITSLayersAll, o2::aod::evsel::kIsGoodITSLayersAll});
+    eventcutflags.push_back({cfgEventCutFlags.cfgNoSameBunchPileupCut, NoSameBunchPileup, o2::aod::evsel::kNoSameBunchPileup});
+    eventcutflags.push_back({cfgEventCutFlags.cfgIsGoodZvtxFT0vsPV, IsGoodZvtxFT0vsPV, o2::aod::evsel::kIsGoodZvtxFT0vsPV});
+    eventcutflags.push_back({cfgEventCutFlags.cfgNoCollInTimeRangeStandard, NoCollInTimeRangeStandard, o2::aod::evsel::kNoCollInTimeRangeStandard});
+    eventcutflags.push_back({cfgEventCutFlags.cfgNoCollInRofStandard, NoCollInRofStandard, o2::aod::evsel::kNoCollInRofStandard});
+    eventcutflags.push_back({cfgEventCutFlags.cfgNoHighMultCollInPrevRof, NoHighMultCollInPrevRof, o2::aod::evsel::kNoHighMultCollInPrevRof});
+    eventcutflags.push_back({cfgEventCutFlags.cfgNoTimeFrameBorder, NoTimeFrameBorder, o2::aod::evsel::kNoTimeFrameBorder});
+    eventcutflags.push_back({cfgEventCutFlags.cfgNoITSROFrameBorder, NoITSROFrameBorder, o2::aod::evsel::kNoITSROFrameBorder});
+    eventcutflags.push_back({cfgEventCutFlags.cfgIsVertexITSTPC, IsVertexITSTPC, o2::aod::evsel::kIsVertexITSTPC});
+    eventcutflags.push_back({cfgEventCutFlags.cfgIsGoodITSLayersAll, IsGoodITSLayersAll, o2::aod::evsel::kIsGoodITSLayersAll});
     for (const auto& cut : eventcutflags) {
       LOGF(info, "Flag %d is %senabled", cut.histBin, (cut.enabled) ? "" : "not ");
     }
@@ -606,21 +607,21 @@ struct FlowGenericFramework {
       registryQA.add("eventQA/before/occ_mult_cent", "; occupancy; N_{ch}; centrality (%)", {HistType::kTH3D, {occAxis, nchAxis, centAxis}});
       registryQA.addClone("eventQA/before/", "eventQA/after/");
       registryQA.add("eventQA/eventSel", "Number of Events;; Counts", {HistType::kTH1D, {{15, 0.5, 15.5}}});
-      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(kFilteredEvent, "Filtered event");
-      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(kSel8, "sel8");
-      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(kOccupancy, "occupancy");
-      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(kTVXinTRD, "kTVXinTRD");
-      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(kNoSameBunchPileup, "kNoSameBunchPileup");
-      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(kIsGoodZvtxFT0vsPV, "kIsGoodZvtxFT0vsPV");
-      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(kNoCollInTimeRangeStandard, "kNoCollInTimeRangeStandard");
-      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(kNoCollInRofStandard, "kNoCollInRofStandard");
-      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(kNoHighMultCollInPrevRof, "kNoHighMultCollInPrevRof");
-      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(kNoTimeFrameBorder, "kNoTimeFrameBorder");
-      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(kNoITSROFrameBorder, "kNoITSROFrameBorder");
-      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(kIsVertexITSTPC, "kIsVertexITSTPC");
-      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(kIsGoodITSLayersAll, "kIsGoodITSLayersAll");
-      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(kMultCuts, "after Mult cuts");
-      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(kTrackCent, "has track + within cent");
+      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(FilteredEvent, "Filtered event");
+      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(Sel8, "sel8");
+      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(Occupancy, "occupancy");
+      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(TVXinTRD, "TVXinTRD");
+      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(NoSameBunchPileup, "NoSameBunchPileup");
+      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(IsGoodZvtxFT0vsPV, "IsGoodZvtxFT0vsPV");
+      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(NoCollInTimeRangeStandard, "NoCollInTimeRangeStandard");
+      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(NoCollInRofStandard, "NoCollInRofStandard");
+      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(NoHighMultCollInPrevRof, "NoHighMultCollInPrevRof");
+      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(NoTimeFrameBorder, "NoTimeFrameBorder");
+      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(NoITSROFrameBorder, "NoITSROFrameBorder");
+      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(IsVertexITSTPC, "IsVertexITSTPC");
+      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(IsGoodITSLayersAll, "IsGoodITSLayersAll");
+      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(MultCuts, "after Mult cuts");
+      registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(TrackCent, "has track + within cent");
 
       if (!cfgRunByRun) {
         if (cfgUsePID) {
@@ -634,11 +635,11 @@ struct FlowGenericFramework {
         }
       }
 
-      AxisSpec axisK0Mass = {resoSwitchVals[kMassBins][kK0], resoCutVals[kMassMin][kK0], resoCutVals[kMassMax][kK0]};
-      AxisSpec axisLambdaMass = {resoSwitchVals[kMassBins][kLambda], resoCutVals[kMassMin][kLambda], resoCutVals[kMassMax][kLambda]};
+      AxisSpec axisK0Mass = {resoSwitchVals[MassBins][K0], resoCutVals[MassMin][K0], resoCutVals[MassMax][K0]};
+      AxisSpec axisLambdaMass = {resoSwitchVals[MassBins][Lambda], resoCutVals[MassMin][Lambda], resoCutVals[MassMax][Lambda]};
 
       // QA histograms for V0s
-      if (resoSwitchVals[kUseParticle][kK0]) {
+      if (resoSwitchVals[UseParticle][K0]) {
         registryQA.add("K0/PiPlusTPC_K0", "", {HistType::kTH2D, {{ptAxis, axisNsigmaTPC}}});
         registryQA.add("K0/PiMinusTPC_K0", "", {HistType::kTH2D, {{ptAxis, axisNsigmaTPC}}});
         registryQA.add("K0/PiPlusTOF_K0", "", {HistType::kTH2D, {{ptAxis, axisNsigmaTOF}}});
@@ -650,21 +651,21 @@ struct FlowGenericFramework {
         registryQA.add("K0/hK0s_corrected", "", {HistType::kTH1D, {singleCount}});
 
         registryQA.add("K0/hK0Count", "Number of K0;; Count", {HistType::kTH1D, {{12, 0.5, 12.5}}});
-        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(kFillCandidate, "K0 candidates");
-        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(kFillDaughterPt, "Daughter pt");
-        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(kFillMassCut, "Mass cut");
-        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(kFillRapidityCut, "Rapidity cut");
-        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(kFillDCAtoPV, "DCA to PV");
-        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(kFillDCAxDaughters, "DCA between daughters");
-        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(kFillV0Radius, "V0radius");
-        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(kFillCosPA, "CosPA");
-        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(kFillProperLifetime, "Proper lifetime");
-        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(kFillArmPodCut, "Armenteros-Podolanski cut");
-        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(kFillCompetingMass, "Competing mass rejection");
-        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(kFillDaughterTrackSelection, "Daughter track selection");
+        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(FillCandidate, "K0 candidates");
+        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(FillDaughterPt, "Daughter pt");
+        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(FillMassCut, "Mass cut");
+        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(FillRapidityCut, "Rapidity cut");
+        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(FillDCAtoPV, "DCA to PV");
+        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(FillDCAxDaughters, "DCA between daughters");
+        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(FillV0Radius, "V0radius");
+        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(FillCosPA, "CosPA");
+        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(FillProperLifetime, "Proper lifetime");
+        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(FillArmPodCut, "Armenteros-Podolanski cut");
+        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(FillCompetingMass, "Competing mass rejection");
+        registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(FillDaughterTrackSelection, "Daughter track selection");
       }
 
-      if (resoSwitchVals[kUseParticle][kLambda]) {
+      if (resoSwitchVals[UseParticle][Lambda]) {
         registryQA.add("Lambda/PrPlusTPC_L", "", {HistType::kTH2D, {{ptAxis, axisNsigmaTPC}}});
         registryQA.add("Lambda/PiMinusTPC_L", "", {HistType::kTH2D, {{ptAxis, axisNsigmaTPC}}});
         registryQA.add("Lambda/PrPlusTOF_L", "", {HistType::kTH2D, {{ptAxis, axisNsigmaTOF}}});
@@ -683,18 +684,18 @@ struct FlowGenericFramework {
         registryQA.add("Lambda/hLambdas_corrected", "", {HistType::kTH1D, {singleCount}});
 
         registryQA.add("Lambda/hLambdaCount", "Number of Lambda;; Count", {HistType::kTH1D, {{12, 0.5, 12.5}}});
-        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(kFillCandidate, "Lambda candidates");
-        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(kFillDaughterPt, "Daughter pt");
-        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(kFillMassCut, "Mass cut");
-        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(kFillRapidityCut, "Rapidity cut");
-        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(kFillDCAtoPV, "DCA to PV");
-        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(kFillDCAxDaughters, "DCA between daughters");
-        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(kFillV0Radius, "V0radius");
-        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(kFillCosPA, "CosPA");
-        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(kFillProperLifetime, "Proper lifetime");
-        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(kFillArmPodCut, "Armenteros-Podolanski cut");
-        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(kFillCompetingMass, "Competing mass rejection");
-        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(kFillDaughterTrackSelection, "Daughter track selection");
+        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(FillCandidate, "Lambda candidates");
+        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(FillDaughterPt, "Daughter pt");
+        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(FillMassCut, "Mass cut");
+        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(FillRapidityCut, "Rapidity cut");
+        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(FillDCAtoPV, "DCA to PV");
+        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(FillDCAxDaughters, "DCA between daughters");
+        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(FillV0Radius, "V0radius");
+        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(FillCosPA, "CosPA");
+        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(FillProperLifetime, "Proper lifetime");
+        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(FillArmPodCut, "Armenteros-Podolanski cut");
+        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(FillCompetingMass, "Competing mass rejection");
+        registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(FillDaughterTrackSelection, "Daughter track selection");
       }
     }
 
@@ -709,18 +710,18 @@ struct FlowGenericFramework {
     registry.add("npt_Lambda_sb1", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
     registry.add("npt_Lambda_sb2", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
 
-    histosNpt.resize(kSpeciesCount);
-    histosNpt[kChargedID] = std::make_unique<TH1D>("nptCh", "; #it{p}_{T} (GeV/#it{c}; Count)", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data()); // registry.add<TH1>("nptCh", "; #it{p}_{T} (GeV/#it{c}; Count)", {HistType::kTH1D, {ptAxis}});
-    histosNpt[kPionID] = std::make_unique<TH1D>("nptPi", "; #it{p}_{T} (GeV/#it{c}; Count)", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data());    // registry.add<TH1>("nptPi", "; #it{p}_{T} (GeV/#it{c}; Count)", {HistType::kTH1D, {ptAxis}});
-    histosNpt[kKaonID] = std::make_unique<TH1D>("nptKa", "; #it{p}_{T} (GeV/#it{c}; Count)", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data());    // registry.add<TH1>("nptKa", "; #it{p}_{T} (GeV/#it{c}; Count)", {HistType::kTH1D, {ptAxis}});
-    histosNpt[kProtonID] = std::make_unique<TH1D>("nptPr", "; #it{p}_{T} (GeV/#it{c}; Count)", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data());  // registry.add<TH1>("nptPr", "; #it{p}_{T} (GeV/#it{c}; Count)", {HistType::kTH1D, {ptAxis}});
-    histosResoNpt.resize(kResonanceCount);
-    histosResoNpt[kK0Sideband1] = std::make_unique<TH1D>("nptK0SB1", "; #it{p}_{T} (GeV/#it{c}; Count", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data());         // registry.add<TH1>("nptK0SB1", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
-    histosResoNpt[kK0Signal] = std::make_unique<TH1D>("nptK0Sig", "; #it{p}_{T} (GeV/#it{c}; Count", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data());            // registry.add<TH1>("nptK0Sig", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
-    histosResoNpt[kK0Sideband2] = std::make_unique<TH1D>("nptK0SB2", "; #it{p}_{T} (GeV/#it{c}; Count", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data());         // registry.add<TH1>("nptK0SB2", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
-    histosResoNpt[kLambdaSideband1] = std::make_unique<TH1D>("nptLambdaSB1", "; #it{p}_{T} (GeV/#it{c}; Count", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data()); // registry.add<TH1>("nptLambdaSB1", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
-    histosResoNpt[kLambdaSignal] = std::make_unique<TH1D>("nptLambdaSig", "; #it{p}_{T} (GeV/#it{c}; Count", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data());    // registry.add<TH1>("nptLambdaSig", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
-    histosResoNpt[kLambdaSideband2] = std::make_unique<TH1D>("nptLambdaSB2", "; #it{p}_{T} (GeV/#it{c}; Count", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data()); // registry.add<TH1>("nptLambdaSB2", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
+    histosNpt.resize(SpeciesCount);
+    histosNpt[ChargedID] = std::make_unique<TH1D>("nptCh", "; #it{p}_{T} (GeV/#it{c}; Count)", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data()); // registry.add<TH1>("nptCh", "; #it{p}_{T} (GeV/#it{c}; Count)", {HistType::kTH1D, {ptAxis}});
+    histosNpt[PionID] = std::make_unique<TH1D>("nptPi", "; #it{p}_{T} (GeV/#it{c}; Count)", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data());    // registry.add<TH1>("nptPi", "; #it{p}_{T} (GeV/#it{c}; Count)", {HistType::kTH1D, {ptAxis}});
+    histosNpt[KaonID] = std::make_unique<TH1D>("nptKa", "; #it{p}_{T} (GeV/#it{c}; Count)", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data());    // registry.add<TH1>("nptKa", "; #it{p}_{T} (GeV/#it{c}; Count)", {HistType::kTH1D, {ptAxis}});
+    histosNpt[ProtonID] = std::make_unique<TH1D>("nptPr", "; #it{p}_{T} (GeV/#it{c}; Count)", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data());  // registry.add<TH1>("nptPr", "; #it{p}_{T} (GeV/#it{c}; Count)", {HistType::kTH1D, {ptAxis}});
+    histosResoNpt.resize(ResonanceCount);
+    histosResoNpt[K0Sideband1] = std::make_unique<TH1D>("nptK0SB1", "; #it{p}_{T} (GeV/#it{c}; Count", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data());         // registry.add<TH1>("nptK0SB1", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
+    histosResoNpt[K0Signal] = std::make_unique<TH1D>("nptK0Sig", "; #it{p}_{T} (GeV/#it{c}; Count", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data());            // registry.add<TH1>("nptK0Sig", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
+    histosResoNpt[K0Sideband2] = std::make_unique<TH1D>("nptK0SB2", "; #it{p}_{T} (GeV/#it{c}; Count", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data());         // registry.add<TH1>("nptK0SB2", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
+    histosResoNpt[LambdaSideband1] = std::make_unique<TH1D>("nptLambdaSB1", "; #it{p}_{T} (GeV/#it{c}; Count", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data()); // registry.add<TH1>("nptLambdaSB1", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
+    histosResoNpt[LambdaSignal] = std::make_unique<TH1D>("nptLambdaSig", "; #it{p}_{T} (GeV/#it{c}; Count", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data());    // registry.add<TH1>("nptLambdaSig", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
+    histosResoNpt[LambdaSideband2] = std::make_unique<TH1D>("nptLambdaSB2", "; #it{p}_{T} (GeV/#it{c}; Count", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data()); // registry.add<TH1>("nptLambdaSB2", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
 
     if (o2::analysis::gfw::regions.GetSize() < 0)
       LOGF(error, "Configuration contains vectors of different size - check the GFWRegions configurable");
@@ -906,8 +907,8 @@ struct FlowGenericFramework {
     printTable(cfgPIDCuts.resonanceSwitches.value, resoSwitchValsF, "Resonance Switches");
   }
   enum QAFillTime {
-    kBefore,
-    kAfter
+    Before,
+    After
   };
 
   void addConfigObjectsToObjArray(TObjArray* oba, const std::vector<GFW::CorrConfig>& configs)
@@ -1078,11 +1079,11 @@ struct FlowGenericFramework {
     }
 
     if (isPion) {
-      pid = kPions;
+      pid = Pions;
     } else if (isKaon) {
-      pid = kKaons;
+      pid = Kaons;
     } else if (isProton) {
-      pid = kProtons;
+      pid = Protons;
     } else {
       return 0; // no particle satisfies the criteria
     }
@@ -1095,14 +1096,14 @@ struct FlowGenericFramework {
   {
     // Cut on trigger alias
     if (cfgEventCutFlags.cfgTVXinTRD) {
-      if (collision.alias_bit(kTVXinTRD)) {
+      if (collision.alias_bit(TVXinTRD)) {
         // TRD triggered
         // "CMTVX-B-NOPF-TRD,minbias_TVX"
         return false;
       }
-      registryQA.fill(HIST("eventQA/eventSel"), kTVXinTRD);
+      registryQA.fill(HIST("eventQA/eventSel"), TVXinTRD);
       if (cfgRunByRun)
-        th1sList[run][hEventSel]->Fill(kTVXinTRD);
+        th1sList[run][EventSel]->Fill(TVXinTRD);
     }
     // Cut on event selection flags
     for (const auto& cut : eventcutflags) {
@@ -1112,7 +1113,7 @@ struct FlowGenericFramework {
         return false;
       registryQA.fill(HIST("eventQA/eventSel"), cut.histBin);
       if (cfgRunByRun)
-        th1sList[run][hEventSel]->Fill(cut.histBin);
+        th1sList[run][EventSel]->Fill(cut.histBin);
     }
     // Cut on vertex
     if (!selectVertex(collision))
@@ -1166,9 +1167,9 @@ struct FlowGenericFramework {
       return false;
     if (!(cfgMultCorrCuts.cfgMultGlobalASideCorrCutFunction->empty()) && static_cast<double>(collision.multFT0A()) > fMultGlobalT0ACutHigh->Eval(multTrk))
       return false;
-    registryQA.fill(HIST("eventQA/eventSel"), kMultCuts);
+    registryQA.fill(HIST("eventQA/eventSel"), MultCuts);
     if (cfgRunByRun)
-      th1sList[run][hEventSel]->Fill(kMultCuts);
+      th1sList[run][EventSel]->Fill(MultCuts);
     return true;
   }
 
@@ -1203,12 +1204,15 @@ struct FlowGenericFramework {
   {
     if (std::fabs(track.dcaXY()) > (0.0105f + 0.035f / std::pow(track.pt(), 1.1)))
       return false;
-    return ((track.tpcNClsCrossedRows() >= 70) && (track.tpcNClsFound() >= 50) && (track.itsNCls() >= 5)); // o2-linter: disable=magic-number (hard coded default cuts)
+    int tpcNClsCrossedRowsDefault = 70;
+    int tpcNClsFoundDefault = 50;
+    int itsNclsDefault = 5;
+    return ((track.tpcNClsCrossedRows() >= tpcNClsCrossedRowsDefault) && (track.tpcNClsFound() >= tpcNClsFoundDefault) && (track.itsNCls() >= itsNclsDefault));
   }
 
   enum DataType {
-    kReco,
-    kGen
+    Reco,
+    Gen
   };
 
   template <typename TTrack>
@@ -1221,9 +1225,9 @@ struct FlowGenericFramework {
       bool withinPtRef = (o2::analysis::gfw::ptreflow < track.pt()) && (track.pt() < o2::analysis::gfw::ptrefup); // within RF pT range
       if (cfgRunByRun) {
         if (withinPtRef && !pid_index)
-          th3sList[run][hNUAref]->Fill(track.phi(), track.eta(), vtxz); // pt-subset of charged particles for ref flow
+          th3sList[run][NUAref]->Fill(track.phi(), track.eta(), vtxz); // pt-subset of charged particles for ref flow
         if (withinPtPOI)
-          th3sList[run][hNUAch + pid_index]->Fill(track.phi(), track.eta(), vtxz); // charged and id'ed particle weights
+          th3sList[run][NUAch + pid_index]->Fill(track.phi(), track.eta(), vtxz); // charged and id'ed particle weights
       } else {
         if (withinPtRef && !pid_index)
           registryQA.fill(HIST("phi_eta_vtxz_ref"), track.phi(), track.eta(), vtxz); // pt-subset of charged particles for ref flow
@@ -1246,7 +1250,7 @@ struct FlowGenericFramework {
       }
     } else {
       if (cfgRunByRun)
-        th3sList[run][hNUAref]->Fill(track.phi(), track.eta(), vtxz);
+        th3sList[run][NUAref]->Fill(track.phi(), track.eta(), vtxz);
       else
         registryQA.fill(HIST("phi_eta_vtxz_ref"), track.phi(), track.eta(), vtxz);
     }
@@ -1262,36 +1266,36 @@ struct FlowGenericFramework {
     AxisSpec nchAxis = {o2::analysis::gfw::nchbins, o2::analysis::gfw::nchlow, o2::analysis::gfw::nchup, "N_{ch}"};
     AxisSpec centAxis = {o2::analysis::gfw::centbinning, "Centrality (%)"};
     AxisSpec ptAxis = {o2::analysis::gfw::ptbinning, "#it{p}_{T} GeV/#it{c}"};
-    std::vector<std::shared_ptr<TH1>> histos(kCount_TH1Names);
-    histos[hPhi] = registryQA.add<TH1>(Form("%d/phi", run), "", {HistType::kTH1D, {phiAxis}});
-    histos[hEta] = registryQA.add<TH1>(Form("%d/eta", run), "", {HistType::kTH1D, {etaAxis}});
-    histos[hVtxZ] = registryQA.add<TH1>(Form("%d/vtxz", run), "", {HistType::kTH1D, {vtxAxis}});
-    histos[hMult] = registryQA.add<TH1>(Form("%d/mult", run), "", {HistType::kTH1D, {nchAxis}});
-    histos[hCent] = registryQA.add<TH1>(Form("%d/cent", run), "", {HistType::kTH1D, {centAxis}});
-    histos[hEventSel] = registryQA.add<TH1>(Form("%d/eventSel", run), "Number of Events;; Counts", {HistType::kTH1D, {{11, 0, 11}}});
-    histos[hEventSel]->GetXaxis()->SetBinLabel(1, "Filtered event");
-    histos[hEventSel]->GetXaxis()->SetBinLabel(2, "sel8");
-    histos[hEventSel]->GetXaxis()->SetBinLabel(3, "occupancy");
-    histos[hEventSel]->GetXaxis()->SetBinLabel(4, "kTVXinTRD");
-    histos[hEventSel]->GetXaxis()->SetBinLabel(5, "kNoSameBunchPileup");
-    histos[hEventSel]->GetXaxis()->SetBinLabel(6, "kIsGoodZvtxFT0vsPV");
-    histos[hEventSel]->GetXaxis()->SetBinLabel(7, "kNoCollInTimeRangeStandard");
-    histos[hEventSel]->GetXaxis()->SetBinLabel(8, "kIsVertexITSTPC");
-    histos[hEventSel]->GetXaxis()->SetBinLabel(9, "kIsGoodITSLayersAll");
-    histos[hEventSel]->GetXaxis()->SetBinLabel(10, "after Mult cuts");
-    histos[hEventSel]->GetXaxis()->SetBinLabel(11, "has track + within cent");
+    std::vector<std::shared_ptr<TH1>> histos(TH1NameCount);
+    histos[Phi] = registryQA.add<TH1>(Form("%d/phi", run), "", {HistType::kTH1D, {phiAxis}});
+    histos[Eta] = registryQA.add<TH1>(Form("%d/eta", run), "", {HistType::kTH1D, {etaAxis}});
+    histos[VtxZ] = registryQA.add<TH1>(Form("%d/vtxz", run), "", {HistType::kTH1D, {vtxAxis}});
+    histos[Mult] = registryQA.add<TH1>(Form("%d/mult", run), "", {HistType::kTH1D, {nchAxis}});
+    histos[Cent] = registryQA.add<TH1>(Form("%d/cent", run), "", {HistType::kTH1D, {centAxis}});
+    histos[EventSel] = registryQA.add<TH1>(Form("%d/eventSel", run), "Number of Events;; Counts", {HistType::kTH1D, {{11, 0, 11}}});
+    histos[EventSel]->GetXaxis()->SetBinLabel(1, "Filtered event");
+    histos[EventSel]->GetXaxis()->SetBinLabel(2, "sel8");
+    histos[EventSel]->GetXaxis()->SetBinLabel(3, "occupancy");
+    histos[EventSel]->GetXaxis()->SetBinLabel(4, "TVXinTRD");
+    histos[EventSel]->GetXaxis()->SetBinLabel(5, "NoSameBunchPileup");
+    histos[EventSel]->GetXaxis()->SetBinLabel(6, "IsGoodZvtxFT0vsPV");
+    histos[EventSel]->GetXaxis()->SetBinLabel(7, "NoCollInTimeRangeStandard");
+    histos[EventSel]->GetXaxis()->SetBinLabel(8, "IsVertexITSTPC");
+    histos[EventSel]->GetXaxis()->SetBinLabel(9, "IsGoodITSLayersAll");
+    histos[EventSel]->GetXaxis()->SetBinLabel(10, "after Mult cuts");
+    histos[EventSel]->GetXaxis()->SetBinLabel(11, "has track + within cent");
     th1sList.insert(std::make_pair(run, histos));
-    std::vector<std::shared_ptr<TH3>> histos3d(kCount_TH3Names);
+    std::vector<std::shared_ptr<TH3>> histos3d(TH3NameCount);
     if (cfgUsePID) {
-      histos3d[hNUAref] = registryQA.add<TH3>(Form("%d/phi_eta_vtxz_ref", run), "", {HistType::kTH3D, {phiAxis, etaAxis, vtxAxis}});
-      histos3d[hNUAch] = registryQA.add<TH3>(Form("%d/phi_eta_vtxz_ch", run), "", {HistType::kTH3D, {phiAxis, etaAxis, vtxAxis}});
-      histos3d[hNUApi] = registryQA.add<TH3>(Form("%d/phi_eta_vtxz_pi", run), "", {HistType::kTH3D, {phiAxis, etaAxis, vtxAxis}});
-      histos3d[hNUAka] = registryQA.add<TH3>(Form("%d/phi_eta_vtxz_ka", run), "", {HistType::kTH3D, {phiAxis, etaAxis, vtxAxis}});
-      histos3d[hNUApr] = registryQA.add<TH3>(Form("%d/phi_eta_vtxz_pr", run), "", {HistType::kTH3D, {phiAxis, etaAxis, vtxAxis}});
+      histos3d[NUAref] = registryQA.add<TH3>(Form("%d/phi_eta_vtxz_ref", run), "", {HistType::kTH3D, {phiAxis, etaAxis, vtxAxis}});
+      histos3d[NUAch] = registryQA.add<TH3>(Form("%d/phi_eta_vtxz_ch", run), "", {HistType::kTH3D, {phiAxis, etaAxis, vtxAxis}});
+      histos3d[NUApi] = registryQA.add<TH3>(Form("%d/phi_eta_vtxz_pi", run), "", {HistType::kTH3D, {phiAxis, etaAxis, vtxAxis}});
+      histos3d[NUAka] = registryQA.add<TH3>(Form("%d/phi_eta_vtxz_ka", run), "", {HistType::kTH3D, {phiAxis, etaAxis, vtxAxis}});
+      histos3d[NUApr] = registryQA.add<TH3>(Form("%d/phi_eta_vtxz_pr", run), "", {HistType::kTH3D, {phiAxis, etaAxis, vtxAxis}});
     } else {
-      histos3d[hNUAref] = registryQA.add<TH3>(Form("%d/phi_eta_vtxz_ref", run), "", {HistType::kTH3D, {phiAxis, etaAxis, vtxAxis}});
+      histos3d[NUAref] = registryQA.add<TH3>(Form("%d/phi_eta_vtxz_ref", run), "", {HistType::kTH3D, {phiAxis, etaAxis, vtxAxis}});
     }
-    histos3d[hPtPhiMult] = registryQA.add<TH3>(Form("%d/pt_phi_mult", run), "", {HistType::kTH3D, {ptAxis, phiModAxis, (cfgUseNch) ? nchAxis : centAxis}});
+    histos3d[PtPhiMult] = registryQA.add<TH3>(Form("%d/pt_phi_mult", run), "", {HistType::kTH3D, {ptAxis, phiModAxis, (cfgUseNch) ? nchAxis : centAxis}});
     th3sList.insert(std::make_pair(run, histos3d));
     return;
   }
@@ -1320,7 +1324,7 @@ struct FlowGenericFramework {
           continue;
         auto val = fGFW->Calculate(corrconfigs.at(l_ind), 0, kFALSE).real() / dnx;
         if (std::abs(val) < 1) {
-          (dt == kGen) ? fFCgen->FillProfile(corrconfigs.at(l_ind).Head.c_str(), centmult, val, cfgUseMultiplicityFlowWeights ? dnx : 1.0, rndm) : fFC->FillProfile(corrconfigs.at(l_ind).Head.c_str(), centmult, val, cfgUseMultiplicityFlowWeights ? dnx : 1.0, rndm);
+          (dt == Gen) ? fFCgen->FillProfile(corrconfigs.at(l_ind).Head.c_str(), centmult, val, cfgUseMultiplicityFlowWeights ? dnx : 1.0, rndm) : fFC->FillProfile(corrconfigs.at(l_ind).Head.c_str(), centmult, val, cfgUseMultiplicityFlowWeights ? dnx : 1.0, rndm);
           if (cfgUseGapMethod) {
             fFCpt->fillVnPtProfiles(centmult, val, dnx, rndm, o2::analysis::gfw::configs.GetpTCorrMasks()[l_ind]);
           }
@@ -1333,51 +1337,51 @@ struct FlowGenericFramework {
           continue;
         auto val = fGFW->Calculate(corrconfigs.at(l_ind), i - 1, kFALSE).real() / dnx;
         if (std::abs(val) < 1)
-          (dt == kGen) ? fFCgen->FillProfile(Form("%s_pt_%i", corrconfigs.at(l_ind).Head.c_str(), i), centmult, val, cfgUseMultiplicityFlowWeights ? dnx : 1.0, rndm) : fFC->FillProfile(Form("%s_pt_%i", corrconfigs.at(l_ind).Head.c_str(), i), centmult, val, cfgUseMultiplicityFlowWeights ? dnx : 1.0, rndm);
+          (dt == Gen) ? fFCgen->FillProfile(Form("%s_pt_%i", corrconfigs.at(l_ind).Head.c_str(), i), centmult, val, cfgUseMultiplicityFlowWeights ? dnx : 1.0, rndm) : fFC->FillProfile(Form("%s_pt_%i", corrconfigs.at(l_ind).Head.c_str(), i), centmult, val, cfgUseMultiplicityFlowWeights ? dnx : 1.0, rndm);
       }
     }
 
-    if (histosNpt[kChargedID]->Integral() <= 0)
+    if (histosNpt[ChargedID]->Integral() <= 0)
       return;
 
-    double dnPi = histosNpt[kChargedID]->Integral();
-    double dnKa = histosNpt[kChargedID]->Integral();
-    double dnPr = histosNpt[kChargedID]->Integral();
+    double dnPi = histosNpt[ChargedID]->Integral();
+    double dnKa = histosNpt[ChargedID]->Integral();
+    double dnPr = histosNpt[ChargedID]->Integral();
 
     if (cfgUsePIDTotal) {
-      dnPi = histosNpt[kPionID]->Integral();
-      dnKa = histosNpt[kKaonID]->Integral();
-      dnPr = histosNpt[kProtonID]->Integral();
+      dnPi = histosNpt[PionID]->Integral();
+      dnKa = histosNpt[KaonID]->Integral();
+      dnPr = histosNpt[ProtonID]->Integral();
     }
 
     for (int i = 1; i <= fPtAxis->GetNbins(); ++i) {
-      registry.fill(HIST("npt_ch"), fPtAxis->GetBinCenter(i), centmult, histosNpt[kChargedID]->GetBinContent(i) / histosNpt[kChargedID]->Integral());
+      registry.fill(HIST("npt_ch"), fPtAxis->GetBinCenter(i), centmult, histosNpt[ChargedID]->GetBinContent(i) / histosNpt[ChargedID]->Integral());
       if (dnPi > 0)
-        registry.fill(HIST("npt_pi"), fPtAxis->GetBinCenter(i), centmult, histosNpt[kPionID]->GetBinContent(i) / dnPi);
+        registry.fill(HIST("npt_pi"), fPtAxis->GetBinCenter(i), centmult, histosNpt[PionID]->GetBinContent(i) / dnPi);
       if (dnKa > 0)
-        registry.fill(HIST("npt_ka"), fPtAxis->GetBinCenter(i), centmult, histosNpt[kKaonID]->GetBinContent(i) / dnKa);
+        registry.fill(HIST("npt_ka"), fPtAxis->GetBinCenter(i), centmult, histosNpt[KaonID]->GetBinContent(i) / dnKa);
       if (dnPr > 0)
-        registry.fill(HIST("npt_pr"), fPtAxis->GetBinCenter(i), centmult, histosNpt[kProtonID]->GetBinContent(i) / dnPr);
+        registry.fill(HIST("npt_pr"), fPtAxis->GetBinCenter(i), centmult, histosNpt[ProtonID]->GetBinContent(i) / dnPr);
     }
 
-    if (corrconfigsV02.size() < kSpeciesCount)
+    if (corrconfigsV02.size() < SpeciesCount)
       return;
 
     // For alternative normalisation with integrated pid spectra
-    std::vector<double> dns = {histosNpt[kChargedID]->Integral(), dnPi, dnKa, dnPr};
+    std::vector<double> dns = {histosNpt[ChargedID]->Integral(), dnPi, dnKa, dnPr};
 
-    for (uint l_ind = 0; l_ind < kSpeciesCount; ++l_ind) {
+    for (uint l_ind = 0; l_ind < SpeciesCount; ++l_ind) {
       for (int i = 1; i <= fPtAxis->GetNbins(); i++) {
         auto dnx = fGFW->Calculate(corrconfigsV02.at(l_ind), i - 1, kTRUE).real();
         if (dnx == 0)
           continue;
         auto val = fGFW->Calculate(corrconfigsV02.at(l_ind), i - 1, kFALSE).real() / dnx;
         if (std::abs(val) < 1 && dns[l_ind] > 0)
-          (dt == kGen) ? fFCgen->FillProfile(Form("%s_pt_%i", corrconfigsV02.at(l_ind).Head.c_str(), i), centmult, val * histosNpt[l_ind]->GetBinContent(i) / dns[l_ind], cfgUseMultiplicityFlowWeights ? dnx : 1.0, rndm) : fFC->FillProfile(Form("%s_pt_%i", corrconfigsV02.at(l_ind).Head.c_str(), i), centmult, val * histosNpt[l_ind]->GetBinContent(i) / dns[l_ind], cfgUseMultiplicityFlowWeights ? dnx : 1.0, rndm);
+          (dt == Gen) ? fFCgen->FillProfile(Form("%s_pt_%i", corrconfigsV02.at(l_ind).Head.c_str(), i), centmult, val * histosNpt[l_ind]->GetBinContent(i) / dns[l_ind], cfgUseMultiplicityFlowWeights ? dnx : 1.0, rndm) : fFC->FillProfile(Form("%s_pt_%i", corrconfigsV02.at(l_ind).Head.c_str(), i), centmult, val * histosNpt[l_ind]->GetBinContent(i) / dns[l_ind], cfgUseMultiplicityFlowWeights ? dnx : 1.0, rndm);
       }
     }
 
-    if (corrconfigsV0.size() < kSpeciesCount)
+    if (corrconfigsV0.size() < SpeciesCount)
       return;
 
     double mpt = 0;
@@ -1388,17 +1392,17 @@ struct FlowGenericFramework {
     } else {
       if (fFCpt->corrDenSub[0][1] == 0. || fFCpt->corrDenSub[1][1] == 0.)
         return;
-      double mpt_sub1 = fFCpt->corrNumSub[0][1] / fFCpt->corrDenSub[0][1];
-      double mpt_sub2 = fFCpt->corrNumSub[1][1] / fFCpt->corrDenSub[1][1];
-      mpt = 0.5 * (mpt_sub1 + mpt_sub2);
+      double mptSub1 = fFCpt->corrNumSub[0][1] / fFCpt->corrDenSub[0][1];
+      double mptSub2 = fFCpt->corrNumSub[1][1] / fFCpt->corrDenSub[1][1];
+      mpt = 0.5 * (mptSub1 + mptSub2);
     }
     if (std::isnan(mpt))
       return;
 
-    for (uint l_ind = 0; l_ind < kSpeciesCount; ++l_ind) {
+    for (uint l_ind = 0; l_ind < SpeciesCount; ++l_ind) {
       for (int i = 1; i <= fPtAxis->GetNbins(); i++) {
         if (dns[l_ind] > 0)
-          (dt == kGen) ? fFCgen->FillProfile(Form("%s_pt_%i", corrconfigsV0.at(l_ind).Head.c_str(), i), centmult, mpt * histosNpt[l_ind]->GetBinContent(i) / dns[l_ind], 1., rndm) : fFC->FillProfile(Form("%s_pt_%i", corrconfigsV0.at(l_ind).Head.c_str(), i), centmult, mpt * histosNpt[l_ind]->GetBinContent(i) / dns[l_ind], 1., rndm);
+          (dt == Gen) ? fFCgen->FillProfile(Form("%s_pt_%i", corrconfigsV0.at(l_ind).Head.c_str(), i), centmult, mpt * histosNpt[l_ind]->GetBinContent(i) / dns[l_ind], 1., rndm) : fFC->FillProfile(Form("%s_pt_%i", corrconfigsV0.at(l_ind).Head.c_str(), i), centmult, mpt * histosNpt[l_ind]->GetBinContent(i) / dns[l_ind], 1., rndm);
       }
     }
     return;
@@ -1409,18 +1413,18 @@ struct FlowGenericFramework {
   {
     if (tracks.size() < 1)
       return;
-    if (dt != kGen && (centrality < o2::analysis::gfw::centbinning.front() || centrality > o2::analysis::gfw::centbinning.back()))
+    if (dt != Gen && (centrality < o2::analysis::gfw::centbinning.front() || centrality > o2::analysis::gfw::centbinning.back()))
       return;
-    if (dt != kGen) {
-      registryQA.fill(HIST("eventQA/eventSel"), kTrackCent);
+    if (dt != Gen) {
+      registryQA.fill(HIST("eventQA/eventSel"), TrackCent);
       if (cfgRunByRun)
-        th1sList[run][hEventSel]->Fill(kTrackCent);
+        th1sList[run][EventSel]->Fill(TrackCent);
     }
     float vtxz = collision.posZ();
-    if (dt != kGen && cfgRunByRun) {
-      th1sList[run][hVtxZ]->Fill(vtxz);
-      th1sList[run][hMult]->Fill(tracks.size());
-      th1sList[run][hCent]->Fill(centrality);
+    if (dt != Gen && cfgRunByRun) {
+      th1sList[run][VtxZ]->Fill(vtxz);
+      th1sList[run][Mult]->Fill(tracks.size());
+      th1sList[run][Cent]->Fill(centrality);
     }
     fGFW->Clear();
     fFCpt->clearVector();
@@ -1468,7 +1472,7 @@ struct FlowGenericFramework {
     for (const auto& track : tracks) {
       processTrack(track, vtxz, field, run, densitycorrections, acceptedTracks);
     }
-    if (dt != kGen) {
+    if (dt != Gen) {
       registryQA.fill(HIST("trackQA/after/Nch_corrected"), acceptedTracks.total);
       registryQA.fill(HIST("trackQA/after/Nch_uncorrected"), acceptedTracks.totaluncorr);
     }
@@ -1499,28 +1503,28 @@ struct FlowGenericFramework {
       h->Reset("ICESM");
 
     // Process V0s only for reconstructed-track workflows.
-    if constexpr (dt != kGen) {
+    if constexpr (dt != Gen) {
       for (const auto& v0 : v0s) {
-        if (resoSwitchVals[kUseParticle][kK0]) {
+        if (resoSwitchVals[UseParticle][K0]) {
           double weff = 1;
           if (selectK0(collision, v0, tracks, centrality, weff)) {
             if (v0.mK0Short() > cfgPIDCuts.cfgK0SideBand1Min && v0.mK0Short() < cfgPIDCuts.cfgK0SideBand1Max)
-              histosResoNpt[kK0Sideband1]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+              histosResoNpt[K0Sideband1]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
             if (v0.mK0Short() > cfgPIDCuts.cfgK0SignalMin && v0.mK0Short() < cfgPIDCuts.cfgK0SignalMax)
-              histosResoNpt[kK0Signal]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+              histosResoNpt[K0Signal]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
             if (v0.mK0Short() > cfgPIDCuts.cfgK0SideBand2Min && v0.mK0Short() < cfgPIDCuts.cfgK0SideBand2Max)
-              histosResoNpt[kK0Sideband2]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+              histosResoNpt[K0Sideband2]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
           }
         }
-        if (resoSwitchVals[kUseParticle][kLambda]) {
+        if (resoSwitchVals[UseParticle][Lambda]) {
           double weff = 1.;
           if (selectLambda(collision, v0, tracks, centrality, weff)) {
             if (v0.mLambda() > cfgPIDCuts.cfgLambdaSideBand1Min && v0.mLambda() < cfgPIDCuts.cfgLambdaSideBand1Max)
-              histosResoNpt[kLambdaSideband1]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+              histosResoNpt[LambdaSideband1]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
             if (v0.mLambda() > cfgPIDCuts.cfgLambdaSignalMin && v0.mLambda() < cfgPIDCuts.cfgLambdaSignalMax)
-              histosResoNpt[kLambdaSignal]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+              histosResoNpt[LambdaSignal]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
             if (v0.mLambda() > cfgPIDCuts.cfgLambdaSideBand2Min && v0.mLambda() < cfgPIDCuts.cfgLambdaSideBand2Max)
-              histosResoNpt[kLambdaSideband2]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+              histosResoNpt[LambdaSideband2]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
           }
         }
       }
@@ -1536,9 +1540,9 @@ struct FlowGenericFramework {
           continue;
 
         if (isK0)
-          histosResoNpt[kK0Signal]->Fill(particle.pt(), 1.0);
+          histosResoNpt[K0Signal]->Fill(particle.pt(), 1.0);
         if (isLambda)
-          histosResoNpt[kLambdaSignal]->Fill(particle.pt(), 1.0);
+          histosResoNpt[LambdaSignal]->Fill(particle.pt(), 1.0);
 
         // For efficiency
         for (const auto& d : particle.template daughters_as<aod::McParticles>()) {
@@ -1555,38 +1559,38 @@ struct FlowGenericFramework {
       }
     }
 
-    if (histosNpt[kChargedID]->Integral() <= 0)
+    if (histosNpt[ChargedID]->Integral() <= 0)
       return;
 
-    double dnK0SB1 = histosNpt[kChargedID]->Integral();
-    double dnK0Sig = histosNpt[kChargedID]->Integral();
-    double dnK0SB2 = histosNpt[kChargedID]->Integral();
-    double dnLambdaSB1 = histosNpt[kChargedID]->Integral();
-    double dnLambdaSig = histosNpt[kChargedID]->Integral();
-    double dnLambdaSB2 = histosNpt[kChargedID]->Integral();
+    double dnK0SB1 = histosNpt[ChargedID]->Integral();
+    double dnK0Sig = histosNpt[ChargedID]->Integral();
+    double dnK0SB2 = histosNpt[ChargedID]->Integral();
+    double dnLambdaSB1 = histosNpt[ChargedID]->Integral();
+    double dnLambdaSig = histosNpt[ChargedID]->Integral();
+    double dnLambdaSB2 = histosNpt[ChargedID]->Integral();
 
     if (cfgUsePIDTotal) {
-      dnK0SB1 = histosResoNpt[kK0Sideband1]->Integral();
-      dnK0Sig = histosResoNpt[kK0Signal]->Integral();
-      dnK0SB2 = histosResoNpt[kK0Sideband2]->Integral();
-      dnLambdaSB1 = histosResoNpt[kLambdaSideband1]->Integral();
-      dnLambdaSig = histosResoNpt[kLambdaSignal]->Integral();
-      dnLambdaSB2 = histosResoNpt[kLambdaSideband2]->Integral();
+      dnK0SB1 = histosResoNpt[K0Sideband1]->Integral();
+      dnK0Sig = histosResoNpt[K0Signal]->Integral();
+      dnK0SB2 = histosResoNpt[K0Sideband2]->Integral();
+      dnLambdaSB1 = histosResoNpt[LambdaSideband1]->Integral();
+      dnLambdaSig = histosResoNpt[LambdaSignal]->Integral();
+      dnLambdaSB2 = histosResoNpt[LambdaSideband2]->Integral();
     }
 
     for (int i = 1; i <= fPtAxis->GetNbins(); ++i) {
       if (dnK0SB1 > 0)
-        registry.fill(HIST("npt_K0_sb1"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[kK0Sideband1]->GetBinContent(i) / dnK0SB1);
+        registry.fill(HIST("npt_K0_sb1"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[K0Sideband1]->GetBinContent(i) / dnK0SB1);
       if (dnK0Sig > 0)
-        registry.fill(HIST("npt_K0_sig"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[kK0Signal]->GetBinContent(i) / dnK0Sig);
+        registry.fill(HIST("npt_K0_sig"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[K0Signal]->GetBinContent(i) / dnK0Sig);
       if (dnK0SB2 > 0)
-        registry.fill(HIST("npt_K0_sb2"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[kK0Sideband2]->GetBinContent(i) / dnK0SB2);
+        registry.fill(HIST("npt_K0_sb2"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[K0Sideband2]->GetBinContent(i) / dnK0SB2);
       if (dnLambdaSB1 > 0)
-        registry.fill(HIST("npt_Lambda_sb1"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[kLambdaSideband1]->GetBinContent(i) / dnLambdaSB1);
+        registry.fill(HIST("npt_Lambda_sb1"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[LambdaSideband1]->GetBinContent(i) / dnLambdaSB1);
       if (dnLambdaSig > 0)
-        registry.fill(HIST("npt_Lambda_sig"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[kLambdaSignal]->GetBinContent(i) / dnLambdaSig);
+        registry.fill(HIST("npt_Lambda_sig"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[LambdaSignal]->GetBinContent(i) / dnLambdaSig);
       if (dnLambdaSB2 > 0)
-        registry.fill(HIST("npt_Lambda_sb2"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[kLambdaSideband2]->GetBinContent(i) / dnLambdaSB2);
+        registry.fill(HIST("npt_Lambda_sb2"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[LambdaSideband2]->GetBinContent(i) / dnLambdaSB2);
     }
 
     std::vector<double> dns = {dnK0SB1, dnK0Sig, dnK0SB2, dnLambdaSB1, dnLambdaSig, dnLambdaSB2};
@@ -1598,7 +1602,7 @@ struct FlowGenericFramework {
           continue;
         auto val = fGFW->Calculate(corrconfigsV02.at(l_ind), i - 1, kFALSE).real() / dnx;
         if (std::abs(val) < 1 && dns[l_ind - 4] > 0)
-          (dt == kGen) ? fFCgen->FillProfile(Form("%s_pt_%i", corrconfigsV02.at(l_ind).Head.c_str(), i), centrality, val * histosResoNpt[l_ind - 4]->GetBinContent(i) / dns[l_ind - 4], cfgUseMultiplicityFlowWeights ? dnx : 1.0, lRandom) : fFC->FillProfile(Form("%s_pt_%i", corrconfigsV02.at(l_ind).Head.c_str(), i), centrality, val * histosResoNpt[l_ind - 4]->GetBinContent(i) / dns[l_ind - 4], cfgUseMultiplicityFlowWeights ? dnx : 1.0, lRandom);
+          (dt == Gen) ? fFCgen->FillProfile(Form("%s_pt_%i", corrconfigsV02.at(l_ind).Head.c_str(), i), centrality, val * histosResoNpt[l_ind - 4]->GetBinContent(i) / dns[l_ind - 4], cfgUseMultiplicityFlowWeights ? dnx : 1.0, lRandom) : fFC->FillProfile(Form("%s_pt_%i", corrconfigsV02.at(l_ind).Head.c_str(), i), centrality, val * histosResoNpt[l_ind - 4]->GetBinContent(i) / dns[l_ind - 4], cfgUseMultiplicityFlowWeights ? dnx : 1.0, lRandom);
       }
     }
 
@@ -1613,9 +1617,9 @@ struct FlowGenericFramework {
     } else {
       if (fFCpt->corrDenSub[0][1] == 0. || fFCpt->corrDenSub[1][1] == 0.)
         return;
-      double mpt_sub1 = fFCpt->corrNumSub[0][1] / fFCpt->corrDenSub[0][1];
-      double mpt_sub2 = fFCpt->corrNumSub[1][1] / fFCpt->corrDenSub[1][1];
-      mpt = 0.5 * (mpt_sub1 + mpt_sub2);
+      double mptSub1 = fFCpt->corrNumSub[0][1] / fFCpt->corrDenSub[0][1];
+      double mptSub2 = fFCpt->corrNumSub[1][1] / fFCpt->corrDenSub[1][1];
+      mpt = 0.5 * (mptSub1 + mptSub2);
     }
 
     if (std::isnan(mpt))
@@ -1624,7 +1628,7 @@ struct FlowGenericFramework {
     for (uint l_ind = 4; l_ind < corrconfigsV0.size(); ++l_ind) {
       for (int i = 1; i <= fPtAxis->GetNbins(); i++) {
         if (dns[l_ind] > 0)
-          (dt == kGen) ? fFCgen->FillProfile(Form("%s_pt_%i", corrconfigsV0.at(l_ind).Head.c_str(), i), centrality, mpt * histosResoNpt[l_ind - 4]->GetBinContent(i) / dns[l_ind - 4], 1.0, lRandom) : fFC->FillProfile(Form("%s_pt_%i", corrconfigsV0.at(l_ind).Head.c_str(), i), centrality, mpt * histosResoNpt[l_ind - 4]->GetBinContent(i) / dns[l_ind - 4], 1.0, lRandom);
+          (dt == Gen) ? fFCgen->FillProfile(Form("%s_pt_%i", corrconfigsV0.at(l_ind).Head.c_str(), i), centrality, mpt * histosResoNpt[l_ind - 4]->GetBinContent(i) / dns[l_ind - 4], 1.0, lRandom) : fFC->FillProfile(Form("%s_pt_%i", corrconfigsV0.at(l_ind).Head.c_str(), i), centrality, mpt * histosResoNpt[l_ind - 4]->GetBinContent(i) / dns[l_ind - 4], 1.0, lRandom);
       }
     }
   }
@@ -1640,7 +1644,7 @@ struct FlowGenericFramework {
       if (!mcParticle.isPhysicalPrimary())
         return;
       if (cfgFillQA)
-        fillTrackQA<kReco, kBefore>(track, vtxz);
+        fillTrackQA<Reco, Before>(track, vtxz);
 
       if (mcParticle.eta() < o2::analysis::gfw::etalow || mcParticle.eta() > o2::analysis::gfw::etaup || mcParticle.pt() < o2::analysis::gfw::ptlow || mcParticle.pt() > o2::analysis::gfw::ptup)
         return;
@@ -1661,37 +1665,37 @@ struct FlowGenericFramework {
 
       int pidIndex = 0;
       if (std::abs(mcParticle.pdgCode()) == kPiPlus)
-        pidIndex = kPionID;
+        pidIndex = PionID;
       if (std::abs(mcParticle.pdgCode()) == kKPlus)
-        pidIndex = kKaonID;
+        pidIndex = KaonID;
       if (std::abs(mcParticle.pdgCode()) == kProton)
-        pidIndex = kProtonID;
+        pidIndex = ProtonID;
 
       if (track.eta() > cfgEtaNch->first && track.eta() < cfgEtaNch->second) {
         double weff = getEfficiency(track, pidIndex);
 
         if (weffCh > 0)
-          histosNpt[kChargedID]->Fill(track.pt(), (cfgUseNchCorrection) ? weffCh : 1.0);
-        if (pidIndex == kPionID && weff > 0)
-          histosNpt[kPionID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
-        if (pidIndex == kKaonID && weff > 0)
-          histosNpt[kKaonID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
-        if (pidIndex == kProtonID && weff > 0)
-          histosNpt[kProtonID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+          histosNpt[ChargedID]->Fill(track.pt(), (cfgUseNchCorrection) ? weffCh : 1.0);
+        if (pidIndex == PionID && weff > 0)
+          histosNpt[PionID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+        if (pidIndex == KaonID && weff > 0)
+          histosNpt[KaonID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+        if (pidIndex == ProtonID && weff > 0)
+          histosNpt[ProtonID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
       }
 
       if (cfgFillWeights) {
         fillWeights(mcParticle, vtxz, 0, run);
       } else {
-        fillPtSums<kReco>(track, vtxz);
-        fillGFW<kReco>(mcParticle, vtxz, pidIndex, densitycorrections);
+        fillPtSums<Reco>(track, vtxz);
+        fillGFW<Reco>(mcParticle, vtxz, pidIndex, densitycorrections);
       }
 
       if (cfgFillQA) {
-        fillTrackQA<kReco, kAfter>(track, vtxz);
+        fillTrackQA<Reco, After>(track, vtxz);
         if (cfgRunByRun) {
-          th1sList[run][hPhi]->Fill(track.phi());
-          th1sList[run][hEta]->Fill(track.eta());
+          th1sList[run][Phi]->Fill(track.phi());
+          th1sList[run][Eta]->Fill(track.eta());
         }
       }
 
@@ -1699,38 +1703,38 @@ struct FlowGenericFramework {
       if (!track.isPhysicalPrimary())
         return;
       if (cfgFillQA)
-        fillTrackQA<kGen, kBefore>(track, vtxz);
+        fillTrackQA<Gen, Before>(track, vtxz);
       if (track.eta() < o2::analysis::gfw::etalow || track.eta() > o2::analysis::gfw::etaup || track.pt() < o2::analysis::gfw::ptlow || track.pt() > o2::analysis::gfw::ptup)
         return;
       int pidIndex = 0;
       if (std::abs(track.pdgCode()) == kPiPlus)
-        pidIndex = kPionID;
+        pidIndex = PionID;
       if (std::abs(track.pdgCode()) == kKPlus)
-        pidIndex = kKaonID;
+        pidIndex = KaonID;
       if (std::abs(track.pdgCode()) == kProton)
-        pidIndex = kProtonID;
+        pidIndex = ProtonID;
 
       if (track.eta() > cfgEtaNch->first && track.eta() < cfgEtaNch->second) {
         ++acceptedTracks.total;
         ++acceptedTracks.totaluncorr;
 
-        histosNpt[kChargedID]->Fill(track.pt());
-        if (pidIndex == kPionID)
-          histosNpt[kPionID]->Fill(track.pt());
-        if (pidIndex == kKaonID)
-          histosNpt[kKaonID]->Fill(track.pt());
-        if (pidIndex == kProtonID)
-          histosNpt[kProtonID]->Fill(track.pt());
+        histosNpt[ChargedID]->Fill(track.pt());
+        if (pidIndex == PionID)
+          histosNpt[PionID]->Fill(track.pt());
+        if (pidIndex == KaonID)
+          histosNpt[KaonID]->Fill(track.pt());
+        if (pidIndex == ProtonID)
+          histosNpt[ProtonID]->Fill(track.pt());
       }
 
-      fillPtSums<kGen>(track, vtxz);
-      fillGFW<kGen>(track, vtxz, pidIndex, densitycorrections);
+      fillPtSums<Gen>(track, vtxz);
+      fillGFW<Gen>(track, vtxz, pidIndex, densitycorrections);
       if (cfgFillQA)
-        fillTrackQA<kGen, kAfter>(track, vtxz);
+        fillTrackQA<Gen, After>(track, vtxz);
 
     } else {
       if (cfgFillQA)
-        fillTrackQA<kReco, kBefore>(track, vtxz);
+        fillTrackQA<Reco, Before>(track, vtxz);
       // Select tracks with nominal cuts always
       if (!nchSelected(track))
         return;
@@ -1752,26 +1756,26 @@ struct FlowGenericFramework {
         double weff = getEfficiency(track, pidIndex);
 
         if (weffCh > 0)
-          histosNpt[kChargedID]->Fill(track.pt(), (cfgUseNchCorrection) ? weffCh : 1.0);
-        if (pidIndex == kPionID && weff > 0)
-          histosNpt[kPionID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
-        if (pidIndex == kKaonID && weff > 0)
-          histosNpt[kKaonID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
-        if (pidIndex == kProtonID && weff > 0)
-          histosNpt[kProtonID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+          histosNpt[ChargedID]->Fill(track.pt(), (cfgUseNchCorrection) ? weffCh : 1.0);
+        if (pidIndex == PionID && weff > 0)
+          histosNpt[PionID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+        if (pidIndex == KaonID && weff > 0)
+          histosNpt[KaonID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+        if (pidIndex == ProtonID && weff > 0)
+          histosNpt[ProtonID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
       }
 
       if (cfgFillWeights) {
         fillWeights(track, vtxz, pidIndex, run);
       } else {
-        fillPtSums<kReco>(track, vtxz);
-        fillGFW<kReco>(track, vtxz, pidIndex, densitycorrections);
+        fillPtSums<Reco>(track, vtxz);
+        fillGFW<Reco>(track, vtxz, pidIndex, densitycorrections);
       }
       if (cfgFillQA) {
-        fillTrackQA<kReco, kAfter>(track, vtxz);
+        fillTrackQA<Reco, After>(track, vtxz);
         if (cfgRunByRun) {
-          th1sList[run][hPhi]->Fill(track.phi());
-          th1sList[run][hEta]->Fill(track.eta());
+          th1sList[run][Phi]->Fill(track.phi());
+          th1sList[run][Eta]->Fill(track.eta());
         }
       }
     }
@@ -1790,11 +1794,11 @@ struct FlowGenericFramework {
       return 0;
 
     if (cfgPIDCuts.cfgUseOnlyTPC) {
-      if (pid == kPions && std::abs(track.tpcNSigmaPi()) > cfgPIDCuts.cfgTPCNsigmaCut)
+      if (pid == Pions && std::abs(track.tpcNSigmaPi()) > cfgPIDCuts.cfgTPCNsigmaCut)
         return false;
-      if (pid == kKaons && std::abs(track.tpcNSigmaKa()) > cfgPIDCuts.cfgTPCNsigmaCut)
+      if (pid == Kaons && std::abs(track.tpcNSigmaKa()) > cfgPIDCuts.cfgTPCNsigmaCut)
         return false;
-      if (pid == kProtons && std::abs(track.tpcNSigmaPr()) > cfgPIDCuts.cfgTPCNsigmaCut)
+      if (pid == Protons && std::abs(track.tpcNSigmaPr()) > cfgPIDCuts.cfgTPCNsigmaCut)
         return false;
     } else {
       int partIndex = cfgPIDCuts.cfgUseAsymmetricPID ? getNsigmaPIDAssymmetric(track) : getNsigmaPID(track);
@@ -1820,50 +1824,50 @@ struct FlowGenericFramework {
     auto postrack = v0.template posTrack_as<V0TrackTable>();
     auto negtrack = v0.template negTrack_as<V0TrackTable>();
 
-    registryQA.fill(HIST("K0/hK0Count"), kFillCandidate);
-    if (postrack.pt() < resoCutVals[kPosTrackPt][kK0] || negtrack.pt() < resoCutVals[kNegTrackPt][kK0])
+    registryQA.fill(HIST("K0/hK0Count"), FillCandidate);
+    if (postrack.pt() < resoCutVals[PosTrackPt][K0] || negtrack.pt() < resoCutVals[NegTrackPt][K0])
       return false;
-    registryQA.fill(HIST("K0/hK0Count"), kFillDaughterPt);
-    if (massK0s < resoCutVals[kMassMin][kK0] && massK0s > resoCutVals[kMassMax][kK0])
+    registryQA.fill(HIST("K0/hK0Count"), FillDaughterPt);
+    if (massK0s < resoCutVals[MassMin][K0] && massK0s > resoCutVals[MassMax][K0])
       return false;
-    registryQA.fill(HIST("K0/hK0Count"), kFillMassCut);
+    registryQA.fill(HIST("K0/hK0Count"), FillMassCut);
     // Rapidity correction
-    if (v0.yK0Short() > resoCutVals[kRapidity][kK0])
+    if (v0.yK0Short() > resoCutVals[Rapidity][K0])
       return false;
-    registryQA.fill(HIST("K0/hK0Count"), kFillRapidityCut);
+    registryQA.fill(HIST("K0/hK0Count"), FillRapidityCut);
     // DCA cuts for K0short
-    if (std::abs(v0.dcapostopv()) < resoCutVals[kDCAPosToPVMin][kK0] || std::abs(v0.dcanegtopv()) < resoCutVals[kDCANegToPVMin][kK0])
+    if (std::abs(v0.dcapostopv()) < resoCutVals[DCAPosToPVMin][K0] || std::abs(v0.dcanegtopv()) < resoCutVals[DCANegToPVMin][K0])
       return false;
-    registryQA.fill(HIST("K0/hK0Count"), kFillDCAtoPV);
-    if (resoSwitchVals[kUseDCAxDaughters][kK0] && std::abs(v0.dcaV0daughters()) > resoCutVals[kDCAxDaughters][kK0])
+    registryQA.fill(HIST("K0/hK0Count"), FillDCAtoPV);
+    if (resoSwitchVals[UseDCAxDaughters][K0] && std::abs(v0.dcaV0daughters()) > resoCutVals[DCAxDaughters][K0])
       return false;
-    registryQA.fill(HIST("K0/hK0Count"), kFillDCAxDaughters);
+    registryQA.fill(HIST("K0/hK0Count"), FillDCAxDaughters);
     // v0 radius cuts
-    if (resoSwitchVals[kUseV0Radius][kK0] && (v0.v0radius() < resoCutVals[kRadiusMin][kK0] || v0.v0radius() > resoCutVals[kRadiusMax][kK0]))
+    if (resoSwitchVals[UseV0Radius][K0] && (v0.v0radius() < resoCutVals[RadiusMin][K0] || v0.v0radius() > resoCutVals[RadiusMax][K0]))
       return false;
-    registryQA.fill(HIST("K0/hK0Count"), kFillV0Radius);
+    registryQA.fill(HIST("K0/hK0Count"), FillV0Radius);
     // cosine pointing angle cuts
-    if (v0.v0cosPA() < resoCutVals[kCosPA][kK0])
+    if (v0.v0cosPA() < resoCutVals[CosPA][K0])
       return false;
-    registryQA.fill(HIST("K0/hK0Count"), kFillCosPA);
+    registryQA.fill(HIST("K0/hK0Count"), FillCosPA);
     // Proper lifetime
-    if (resoSwitchVals[kUseProperLifetime][kK0] && v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * massK0Short > resoCutVals[kLifeTime][kK0])
+    if (resoSwitchVals[UseProperLifetime][K0] && v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * massK0Short > resoCutVals[LifeTime][K0])
       return false;
-    registryQA.fill(HIST("K0/hK0Count"), kFillProperLifetime);
+    registryQA.fill(HIST("K0/hK0Count"), FillProperLifetime);
     // ArmenterosPodolanskiCut
-    if (resoSwitchVals[kUseArmPodCut][kK0] && (v0.qtarm() / std::abs(v0.alpha())) < resoCutVals[kArmPodMin][kK0])
+    if (resoSwitchVals[UseArmPodCut][K0] && (v0.qtarm() / std::abs(v0.alpha())) < resoCutVals[ArmPodMin][K0])
       return false;
-    registryQA.fill(HIST("K0/hK0Count"), kFillArmPodCut);
-    if (resoSwitchVals[kUseCompetingMassRejection][kK0]) {
-      if (std::abs(v0.mLambda() - o2::constants::physics::MassLambda0) < resoCutVals[kMassRejection][kK0])
+    registryQA.fill(HIST("K0/hK0Count"), FillArmPodCut);
+    if (resoSwitchVals[UseCompetingMassRejection][K0]) {
+      if (std::abs(v0.mLambda() - o2::constants::physics::MassLambda0) < resoCutVals[MassRejection][K0])
         return false;
-      if (std::abs(v0.mAntiLambda() - o2::constants::physics::MassLambda0) < resoCutVals[kMassRejection][kK0])
+      if (std::abs(v0.mAntiLambda() - o2::constants::physics::MassLambda0) < resoCutVals[MassRejection][K0])
         return false;
     }
-    registryQA.fill(HIST("K0/hK0Count"), kFillCompetingMass);
-    if (!selectionV0Daughter(postrack, kPions) || !selectionV0Daughter(negtrack, kPions))
+    registryQA.fill(HIST("K0/hK0Count"), FillCompetingMass);
+    if (!selectionV0Daughter(postrack, Pions) || !selectionV0Daughter(negtrack, Pions))
       return false;
-    registryQA.fill(HIST("K0/hK0Count"), kFillDaughterTrackSelection);
+    registryQA.fill(HIST("K0/hK0Count"), FillDaughterTrackSelection);
 
     registryQA.fill(HIST("K0/hK0Mass_sparse"), massK0s, v0.pt(), centrality);
     registryQA.fill(HIST("K0/hK0Phi"), v0.phi());
@@ -1906,68 +1910,68 @@ struct FlowGenericFramework {
     auto postrack = v0.template posTrack_as<V0TrackTable>();
     auto negtrack = v0.template negTrack_as<V0TrackTable>();
 
-    registryQA.fill(HIST("Lambda/hLambdaCount"), kFillCandidate);
-    if (postrack.pt() < resoCutVals[kPosTrackPt][kLambda] || negtrack.pt() < resoCutVals[kNegTrackPt][kLambda])
+    registryQA.fill(HIST("Lambda/hLambdaCount"), FillCandidate);
+    if (postrack.pt() < resoCutVals[PosTrackPt][Lambda] || negtrack.pt() < resoCutVals[NegTrackPt][Lambda])
       return false;
 
-    registryQA.fill(HIST("Lambda/hLambdaCount"), kFillDaughterPt);
-    if (mlambda > resoCutVals[kMassMin][kLambda] && mlambda < resoCutVals[kMassMax][kLambda])
+    registryQA.fill(HIST("Lambda/hLambdaCount"), FillDaughterPt);
+    if (mlambda > resoCutVals[MassMin][Lambda] && mlambda < resoCutVals[MassMax][Lambda])
       isL = true;
-    if (mantilambda > resoCutVals[kMassMin][kLambda] && mantilambda < resoCutVals[kMassMax][kLambda])
+    if (mantilambda > resoCutVals[MassMin][Lambda] && mantilambda < resoCutVals[MassMax][Lambda])
       isAL = true;
 
     if (!isL && !isAL) {
       return false;
     }
-    registryQA.fill(HIST("Lambda/hLambdaCount"), kFillMassCut);
+    registryQA.fill(HIST("Lambda/hLambdaCount"), FillMassCut);
 
     // Rapidity correction
-    if (v0.yLambda() > resoCutVals[kRapidity][kLambda])
+    if (v0.yLambda() > resoCutVals[Rapidity][Lambda])
       return false;
-    registryQA.fill(HIST("Lambda/hLambdaCount"), kFillRapidityCut);
+    registryQA.fill(HIST("Lambda/hLambdaCount"), FillRapidityCut);
     // DCA cuts for lambda and antilambda
     if (isL) {
-      if (std::abs(v0.dcapostopv()) < resoCutVals[kDCAPosToPVMin][kLambda] || std::abs(v0.dcanegtopv()) < resoCutVals[kDCANegToPVMin][kLambda])
+      if (std::abs(v0.dcapostopv()) < resoCutVals[DCAPosToPVMin][Lambda] || std::abs(v0.dcanegtopv()) < resoCutVals[DCANegToPVMin][Lambda])
         return false;
     }
     if (isAL) {
-      if (std::abs(v0.dcapostopv()) < resoCutVals[kDCANegToPVMin][kLambda] || std::abs(v0.dcanegtopv()) < resoCutVals[kDCAPosToPVMin][kLambda])
+      if (std::abs(v0.dcapostopv()) < resoCutVals[DCANegToPVMin][Lambda] || std::abs(v0.dcanegtopv()) < resoCutVals[DCAPosToPVMin][Lambda])
         return false;
     }
-    registryQA.fill(HIST("Lambda/hLambdaCount"), kFillDCAtoPV);
-    if (resoSwitchVals[kUseDCAxDaughters][kLambda] && std::abs(v0.dcaV0daughters()) > resoCutVals[kDCAxDaughters][kLambda])
+    registryQA.fill(HIST("Lambda/hLambdaCount"), FillDCAtoPV);
+    if (resoSwitchVals[UseDCAxDaughters][Lambda] && std::abs(v0.dcaV0daughters()) > resoCutVals[DCAxDaughters][Lambda])
       return false;
-    registryQA.fill(HIST("Lambda/hLambdaCount"), kFillDCAxDaughters);
+    registryQA.fill(HIST("Lambda/hLambdaCount"), FillDCAxDaughters);
     // v0 radius cuts
-    if (resoSwitchVals[kUseV0Radius][kLambda] && (v0.v0radius() < resoCutVals[kRadiusMin][kLambda] || v0.v0radius() > resoCutVals[kRadiusMax][kLambda]))
+    if (resoSwitchVals[UseV0Radius][Lambda] && (v0.v0radius() < resoCutVals[RadiusMin][Lambda] || v0.v0radius() > resoCutVals[RadiusMax][Lambda]))
       return false;
-    registryQA.fill(HIST("Lambda/hLambdaCount"), kFillV0Radius);
+    registryQA.fill(HIST("Lambda/hLambdaCount"), FillV0Radius);
     // cosine pointing angle cuts
-    if (v0.v0cosPA() < resoCutVals[kCosPA][kLambda])
+    if (v0.v0cosPA() < resoCutVals[CosPA][Lambda])
       return false;
-    registryQA.fill(HIST("Lambda/hLambdaCount"), kFillCosPA);
+    registryQA.fill(HIST("Lambda/hLambdaCount"), FillCosPA);
     // Proper lifetime
-    if (resoSwitchVals[kUseProperLifetime][kLambda] && v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * massLambda > resoCutVals[kLifeTime][kLambda])
+    if (resoSwitchVals[UseProperLifetime][Lambda] && v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * massLambda > resoCutVals[LifeTime][Lambda])
       return false;
-    registryQA.fill(HIST("Lambda/hLambdaCount"), kFillProperLifetime);
+    registryQA.fill(HIST("Lambda/hLambdaCount"), FillProperLifetime);
     // ArmenterosPodolanskiCut
-    if (resoSwitchVals[kUseArmPodCut][kLambda] && (v0.qtarm() / std::abs(v0.alpha())) < resoCutVals[kArmPodMin][kLambda])
+    if (resoSwitchVals[UseArmPodCut][Lambda] && (v0.qtarm() / std::abs(v0.alpha())) < resoCutVals[ArmPodMin][Lambda])
       return false;
-    registryQA.fill(HIST("Lambda/hLambdaCount"), kFillArmPodCut);
-    if (resoSwitchVals[kUseCompetingMassRejection][kLambda]) {
-      if (std::abs(v0.mK0Short() - o2::constants::physics::MassK0Short) < resoCutVals[kMassRejection][kLambda])
+    registryQA.fill(HIST("Lambda/hLambdaCount"), FillArmPodCut);
+    if (resoSwitchVals[UseCompetingMassRejection][Lambda]) {
+      if (std::abs(v0.mK0Short() - o2::constants::physics::MassK0Short) < resoCutVals[MassRejection][Lambda])
         return false;
     }
-    registryQA.fill(HIST("Lambda/hLambdaCount"), kFillCompetingMass);
+    registryQA.fill(HIST("Lambda/hLambdaCount"), FillCompetingMass);
     if (isL) {
-      if (!selectionV0Daughter(postrack, kProtons) || !selectionV0Daughter(negtrack, kPions))
+      if (!selectionV0Daughter(postrack, Protons) || !selectionV0Daughter(negtrack, Pions))
         return false;
     }
     if (isAL) {
-      if (!selectionV0Daughter(postrack, kPions) || !selectionV0Daughter(negtrack, kProtons))
+      if (!selectionV0Daughter(postrack, Pions) || !selectionV0Daughter(negtrack, Protons))
         return false;
     }
-    registryQA.fill(HIST("Lambda/hLambdaCount"), kFillDaughterTrackSelection);
+    registryQA.fill(HIST("Lambda/hLambdaCount"), FillDaughterTrackSelection);
 
     if (isL) {
       registryQA.fill(HIST("Lambda/hLambdaMass_sparse"), mlambda, v0.pt(), centrality);
@@ -2022,8 +2026,8 @@ struct FlowGenericFramework {
   template <DataType dt, typename TTrack>
   inline void fillPtSums(TTrack track, const double& vtxz)
   {
-    double wacc = (dt == kGen) ? 1. : getAcceptance(track, vtxz, 0);
-    double weff = (dt == kGen) ? 1. : getEfficiency(track);
+    double wacc = (dt == Gen) ? 1. : getAcceptance(track, vtxz, 0);
+    double weff = (dt == Gen) ? 1. : getEfficiency(track);
     if (weff < 0)
       return;
 
@@ -2059,9 +2063,9 @@ struct FlowGenericFramework {
       if (!withinPtPOI && !withinPtRef)
         return;
 
-      double waccRef = (dt == kGen) ? 1. : getAcceptance(track, vtxz, 0);
-      double waccPOI = (dt == kGen) ? 1. : withinPtPOI ? getAcceptance(track, vtxz, pid_index + 1)
-                                                       : getAcceptance(track, vtxz, 0); //
+      double waccRef = (dt == Gen) ? 1. : getAcceptance(track, vtxz, 0);
+      double waccPOI = (dt == Gen) ? 1. : withinPtPOI ? getAcceptance(track, vtxz, pid_index + 1)
+                                                      : getAcceptance(track, vtxz, 0); //
       if (withinPtRef && withinPtPOI && pid_index)
         waccRef = waccPOI; // if particle is both (then it's overlap), override ref with POI
       if (withinPtRef)
@@ -2079,10 +2083,10 @@ struct FlowGenericFramework {
       bool withinPtPOI = (track.pt() > o2::analysis::gfw::ptpoilow && track.pt() < o2::analysis::gfw::ptpoiup);
       if (!withinPtPOI && !withinPtRef)
         return;
-      double weff = (dt == kGen) ? 1. : getEfficiency(track, 0);
+      double weff = (dt == Gen) ? 1. : getEfficiency(track, 0);
       if (weff < 0)
         return;
-      if (cfgUseDensityDependentCorrection && withinPtRef && dt != kGen) {
+      if (cfgUseDensityDependentCorrection && withinPtRef && dt != Gen) {
         double fphi = densitycorrections.v2 * std::cos(2 * (track.phi() - densitycorrections.psi2Est)) + densitycorrections.v3 * std::cos(3 * (track.phi() - densitycorrections.psi3Est)) + densitycorrections.v4 * std::cos(4 * (track.phi() - densitycorrections.psi4Est));
         fphi = (1 + 2 * fphi);
         int pTBinForEff = hFindPtBin->FindBin(track.pt());
@@ -2094,7 +2098,7 @@ struct FlowGenericFramework {
           }
         }
       }
-      double wacc = (dt == kGen) ? 1. : getAcceptance(track, vtxz, 0);
+      double wacc = (dt == Gen) ? 1. : getAcceptance(track, vtxz, 0);
       if (withinPtRef)
         fGFW->Fill(track.eta(), fPtAxis->FindBin(track.pt()) - 1, track.phi(), weff * wacc, 1);
       if (withinPtPOI)
@@ -2108,12 +2112,12 @@ struct FlowGenericFramework {
   template <DataType dt, QAFillTime ft, typename TTrack>
   inline void fillTrackQA(TTrack track, const float vtxz)
   {
-    if constexpr (dt == kGen) {
+    if constexpr (dt == Gen) {
       registryQA.fill(HIST("MCGen/") + HIST(FillTimeName[ft]) + HIST("phi_eta_vtxZ_gen"), track.phi(), track.eta(), vtxz);
       registryQA.fill(HIST("MCGen/") + HIST(FillTimeName[ft]) + HIST("pt_gen"), track.pt());
     } else {
       double wacc = getAcceptance(track, vtxz, 0);
-      registryQA.fill(HIST("trackQA/") + HIST(FillTimeName[ft]) + HIST("phi_eta_vtxZ"), track.phi(), track.eta(), vtxz, (ft == kAfter) ? wacc : 1.0);
+      registryQA.fill(HIST("trackQA/") + HIST(FillTimeName[ft]) + HIST("phi_eta_vtxZ"), track.phi(), track.eta(), vtxz, (ft == After) ? wacc : 1.0);
       registryQA.fill(HIST("trackQA/") + HIST(FillTimeName[ft]) + HIST("pt_dcaXY_dcaZ"), track.pt(), track.dcaXY(), track.dcaZ());
 
       registryQA.fill(HIST("trackQA/") + HIST(FillTimeName[ft]) + HIST("chi2prTPCcls"), track.tpcChi2NCl());
@@ -2122,7 +2126,7 @@ struct FlowGenericFramework {
       registryQA.fill(HIST("trackQA/") + HIST(FillTimeName[ft]) + HIST("nITSClusters"), track.itsNCls());
       registryQA.fill(HIST("trackQA/") + HIST(FillTimeName[ft]) + HIST("nTPCCrossedRows"), track.tpcNClsCrossedRows());
 
-      if (ft == kAfter) {
+      if (ft == After) {
         registryQA.fill(HIST("trackQA/") + HIST(FillTimeName[ft]) + HIST("pt_ref"), track.pt());
         registryQA.fill(HIST("trackQA/") + HIST(FillTimeName[ft]) + HIST("pt_poi"), track.pt());
 
@@ -2138,19 +2142,19 @@ struct FlowGenericFramework {
   float getCentrality(TCollision collision)
   {
     switch (cfgCentEstimator) {
-      case kCentFT0C:
+      case CentFT0C:
         return collision.centFT0C();
-      case kCentFT0CVariant1:
+      case CentFT0CVariant1:
         return collision.centFT0CVariant1();
-      case kCentFT0M:
+      case CentFT0M:
         return collision.centFT0M();
-      case kCentFV0A:
+      case CentFV0A:
         return collision.centFV0A();
-      case kCentNTPV:
+      case CentNTPV:
         return collision.centNTPV();
-      case kCentNGlobal:
+      case CentNGlobal:
         return collision.centNGlobal();
-      case kCentMFT:
+      case CentMFT:
         return collision.centMFT();
       default:
         return collision.centFT0C();
@@ -2209,12 +2213,12 @@ struct FlowGenericFramework {
       loadCorrections(bc);
     registryQA.fill(HIST("eventQA/eventSel"), 0.5);
     if (cfgRunByRun)
-      th1sList[run][hEventSel]->Fill(0.5);
+      th1sList[run][EventSel]->Fill(0.5);
     if (!collision.sel8())
       return;
     registryQA.fill(HIST("eventQA/eventSel"), 1.5);
     if (cfgRunByRun)
-      th1sList[run][hEventSel]->Fill(1.5);
+      th1sList[run][EventSel]->Fill(1.5);
 
     float centrality = getCentrality(collision);
     if (cfgDoOccupancySel) {
@@ -2226,21 +2230,22 @@ struct FlowGenericFramework {
     }
     registryQA.fill(HIST("eventQA/eventSel"), 2.5);
     if (cfgRunByRun)
-      th1sList[run][hEventSel]->Fill(2.5);
+      th1sList[run][EventSel]->Fill(2.5);
     if (cfgFillQA)
-      fillEventQA<kBefore>(collision, tracks);
+      fillEventQA<Before>(collision, tracks);
     registryQA.fill(HIST("eventQA/before/centrality"), centrality);
     registryQA.fill(HIST("eventQA/before/multiplicity"), tracks.size());
     if (!eventSelected(collision, tracks.size(), centrality, run))
       return;
     if (cfgFillQA)
-      fillEventQA<kAfter>(collision, tracks);
+      fillEventQA<After>(collision, tracks);
     registryQA.fill(HIST("eventQA/after/centrality"), centrality);
     registryQA.fill(HIST("eventQA/after/multiplicity"), tracks.size());
     // Get magnetic field polarity
-    auto field = (cfgMagField == 99999) ? getMagneticField(bc.timestamp()) : cfgMagField; // o2-linter: disable=magic-number (hard coded default cut)
+    int defaultMagCut = 99999;
+    auto field = (cfgMagField == defaultMagCut) ? getMagneticField(bc.timestamp()) : cfgMagField;
 
-    processCollision<kReco>(collision, tracks, v0s, centrality, field, run);
+    processCollision<Reco>(collision, tracks, v0s, centrality, field, run);
   }
   PROCESS_SWITCH(FlowGenericFramework, processData, "Process analysis for non-derived data", true);
 
@@ -2256,14 +2261,14 @@ struct FlowGenericFramework {
 
     registryQA.fill(HIST("eventQA/eventSel"), 0.5);
     if (cfgRunByRun)
-      th1sList[run][hEventSel]->Fill(0.5);
+      th1sList[run][EventSel]->Fill(0.5);
 
     if (!collision.sel8())
       return;
 
     registryQA.fill(HIST("eventQA/eventSel"), 1.5);
     if (cfgRunByRun)
-      th1sList[run][hEventSel]->Fill(1.5);
+      th1sList[run][EventSel]->Fill(1.5);
 
     const auto centrality = getCentrality(collision);
 
@@ -2276,20 +2281,20 @@ struct FlowGenericFramework {
     }
     registryQA.fill(HIST("eventQA/eventSel"), 2.5);
     if (cfgRunByRun)
-      th1sList[run][hEventSel]->Fill(2.5);
+      th1sList[run][EventSel]->Fill(2.5);
 
     if (cfgFillQA)
-      fillEventQA<kBefore>(collision, tracks);
+      fillEventQA<Before>(collision, tracks);
     if (!eventSelected(collision, tracks.size(), centrality, run))
       return;
     if (cfgFillQA)
-      fillEventQA<kAfter>(collision, tracks);
+      fillEventQA<After>(collision, tracks);
 
     if (!cfgFillWeights)
       loadCorrections(bc);
-
-    auto field = (cfgMagField == 99999) ? getMagneticField(bc.timestamp()) : cfgMagField; // o2-linter: disable=magic-number (hard coded default cut)
-    processCollision<kReco>(collision, tracks, v0s, centrality, field, run);
+    int defaultMagCut = 99999;
+    auto field = (cfgMagField == defaultMagCut) ? getMagneticField(bc.timestamp()) : cfgMagField;
+    processCollision<Reco>(collision, tracks, v0s, centrality, field, run);
   }
   PROCESS_SWITCH(FlowGenericFramework, processMCReco, "Process analysis for MC reconstructed events", false);
 
@@ -2303,7 +2308,7 @@ struct FlowGenericFramework {
       centrality = getCentrality(collision);
     }
     int run = 0;
-    processCollision<kGen>(mcCollision, particles, v0s, centrality, -999, run);
+    processCollision<Gen>(mcCollision, particles, v0s, centrality, -999, run);
   }
   PROCESS_SWITCH(FlowGenericFramework, processMCGen, "Process analysis for MC generated events", false);
 
@@ -2311,7 +2316,7 @@ struct FlowGenericFramework {
   {
     int run = 0;
     registryQA.fill(HIST("MCGen/impactParameter"), mcCollision.impactParameter(), mcParticles.size());
-    processCollision<kGen>(mcCollision, mcParticles, v0s, mcCollision.impactParameter(), -999, run);
+    processCollision<Gen>(mcCollision, mcParticles, v0s, mcCollision.impactParameter(), -999, run);
   }
   PROCESS_SWITCH(FlowGenericFramework, processOnTheFly, "Process analysis for MC on-the-fly generated events", false);
 
@@ -2329,9 +2334,9 @@ struct FlowGenericFramework {
     const auto centrality = collision.centRun2V0M();
     if (!cfgFillWeights)
       loadCorrections(bc);
-
-    auto field = (cfgMagField == 99999) ? getMagneticField(bc.timestamp()) : cfgMagField; // o2-linter: disable=magic-number (hard coded default cut)
-    processCollision<kReco>(collision, tracks, v0s, centrality, field, run);
+    int defaultMagCut = 99999;
+    auto field = (cfgMagField == defaultMagCut) ? getMagneticField(bc.timestamp()) : cfgMagField;
+    processCollision<Reco>(collision, tracks, v0s, centrality, field, run);
   }
   PROCESS_SWITCH(FlowGenericFramework, processRun2, "Process analysis for Run 2 converted data", false);
 };

--- a/PWGCF/GenericFramework/Tasks/flowGenericFramework.cxx
+++ b/PWGCF/GenericFramework/Tasks/flowGenericFramework.cxx
@@ -76,6 +76,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -276,8 +277,8 @@ struct FlowGenericFramework {
   // QA outputs
   std::map<int, std::vector<std::shared_ptr<TH1>>> th1sList;
   std::map<int, std::vector<std::shared_ptr<TH3>>> th3sList;
-  std::vector<std::shared_ptr<TH1>> histosNpt;
-  std::vector<std::shared_ptr<TH1>> histosResoNpt;
+  std::vector<std::unique_ptr<TH1>> histosNpt;
+  std::vector<std::unique_ptr<TH1>> histosResoNpt;
   enum OutputTH1Names {
     hPhi = 0,
     hEta,
@@ -332,33 +333,33 @@ struct FlowGenericFramework {
   };
   std::vector<EventCut> eventcutflags;
   enum Particles {
-    PIONS,
-    KAONS,
-    PROTONS
+    kPions,
+    kKaons,
+    kProtons
   };
   enum ParticleIDs {
-    CHARGEDID = 0,
-    PIONID,
-    KAONID,
-    PROTONID,
-    SPECIESCOUNT
+    kChargedID = 0,
+    kPionID,
+    kKaonID,
+    kProtonID,
+    kSpeciesCount
   };
   enum ResoIDs {
-    K0SIDEBAND1 = 0,
-    K0SIGNAL,
-    K0SIDEBAND2,
-    LAMBDASIDEBAND1,
-    LAMBDASIGNAL,
-    LAMBDASIDEBAND2,
-    RESOCOUNT
+    kK0Sideband1 = 0,
+    kK0Signal,
+    kK0Sideband2,
+    kLambdaSideband1,
+    kLambdaSignal,
+    kLambdaSideband2,
+    kResonanceCount
   };
   enum OutputSpecies {
-    K0 = 0,
-    LAMBDA = 1,
-    PHI = 2,
-    ANLAMBDA = 3,
-    REF = 4,
-    kCount_OutputSpecies
+    kK0 = 0,
+    kLambda = 1,
+    kPhi = 2,
+    kLambdaBar = 3,
+    kRef = 4,
+    kCountOutputSpecies
   };
   enum ParticleCuts {
     kCosPA = 0,
@@ -561,6 +562,10 @@ struct FlowGenericFramework {
       registryQA.add("MCGen/before/pt_gen", "", {HistType::kTH1D, {ptAxis}});
       registryQA.add("MCGen/before/phi_eta_vtxZ_gen", "", {HistType::kTH3D, {phiAxis, etaAxis, vtxAxis}});
       registryQA.addClone("MCGen/before/", "MCGen/after/");
+      registry.add("MCGen/after/pt_centrality_K0_pion_gen", "; #it{p}_{T}; Centrality (%)", {HistType::kTH2D, {ptAxis, centAxis}});
+      registry.add("MCGen/after/pt_centrality_Lambda_pion_gen", "; #it{p}_{T}; Centrality (%)", {HistType::kTH2D, {ptAxis, centAxis}});
+      registry.add("MCGen/after/pt_centrality_pion_gen", "; #it{p}_{T}; Centrality (%)", {HistType::kTH2D, {ptAxis, centAxis}});
+      registry.add("MCGen/after/pt_centrality_proton_gen", "; #it{p}_{T}; Centrality (%)", {HistType::kTH2D, {ptAxis, centAxis}});
       if (doprocessOnTheFly)
         registryQA.add("MCGen/impactParameter", "", {HistType::kTH2D, {{bAxis, nchAxis}}});
     }
@@ -582,19 +587,12 @@ struct FlowGenericFramework {
       registryQA.add("trackQA/after/etaNch", "; #eta; Counts", {HistType::kTH1D, {etaAxis}});
       registryQA.add("trackQA/after/etaPtPt", "; #eta; Counts", {HistType::kTH1D, {etaAxis}});
       registryQA.add("trackQA/after/etaV0Daughters", "; #eta; Counts", {HistType::kTH1D, {etaAxis}});
-
-      histosNpt.resize(SPECIESCOUNT);
-      histosNpt[CHARGEDID] = registry.add<TH1>("nptCh", "; #it{p}_{T} (GeV/#it{c}; Count)", {HistType::kTH1D, {ptAxis}});
-      histosNpt[PIONID] = registry.add<TH1>("nptPi", "; #it{p}_{T} (GeV/#it{c}; Count)", {HistType::kTH1D, {ptAxis}});
-      histosNpt[KAONID] = registry.add<TH1>("nptKa", "; #it{p}_{T} (GeV/#it{c}; Count)", {HistType::kTH1D, {ptAxis}});
-      histosNpt[PROTONID] = registry.add<TH1>("nptPr", "; #it{p}_{T} (GeV/#it{c}; Count)", {HistType::kTH1D, {ptAxis}});
-      histosResoNpt.resize(RESOCOUNT);
-      histosResoNpt[K0SIDEBAND1] = registry.add<TH1>("nptK0SB1", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
-      histosResoNpt[K0SIGNAL] = registry.add<TH1>("nptK0Sig", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
-      histosResoNpt[K0SIDEBAND2] = registry.add<TH1>("nptK0SB2", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
-      histosResoNpt[LAMBDASIDEBAND1] = registry.add<TH1>("nptLambdaSB1", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
-      histosResoNpt[LAMBDASIGNAL] = registry.add<TH1>("nptLambdaSig", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
-      histosResoNpt[LAMBDASIDEBAND2] = registry.add<TH1>("nptLambdaSB2", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
+      if (doprocessMCReco) {
+        registry.add("trackQA/after/pt_centrality_K0_pion", "; #it{p}_{T}; Centrality (%)", {HistType::kTH2D, {ptAxis, centAxis}});
+        registry.add("trackQA/after/pt_centrality_Lambda_pion", "; #it{p}_{T}; Centrality (%)", {HistType::kTH2D, {ptAxis, centAxis}});
+        registry.add("trackQA/after/pt_centrality_pion", "; #it{p}_{T}; Centrality (%)", {HistType::kTH2D, {ptAxis, centAxis}});
+        registry.add("trackQA/after/pt_centrality_proton", "; #it{p}_{T}; Centrality (%)", {HistType::kTH2D, {ptAxis, centAxis}});
+      }
 
       registryQA.add("eventQA/before/centrality", "; centrality (%); Counts", {HistType::kTH1D, {centAxis}});
       registryQA.add("eventQA/before/multiplicity", "; N_{ch}; Counts", {HistType::kTH1D, {nchAxis}});
@@ -624,17 +622,6 @@ struct FlowGenericFramework {
       registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(kMultCuts, "after Mult cuts");
       registryQA.get<TH1>(HIST("eventQA/eventSel"))->GetXaxis()->SetBinLabel(kTrackCent, "has track + within cent");
 
-      registry.add("npt_ch", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
-      registry.add("npt_pi", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
-      registry.add("npt_ka", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
-      registry.add("npt_pr", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
-      registry.add("npt_K0_sig", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
-      registry.add("npt_K0_sb1", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
-      registry.add("npt_K0_sb2", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
-      registry.add("npt_Lambda_sig", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
-      registry.add("npt_Lambda_sb1", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
-      registry.add("npt_Lambda_sb2", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
-
       if (!cfgRunByRun) {
         if (cfgUsePID) {
           registryQA.add<TH3>("phi_eta_vtxz_ref", "", {HistType::kTH3D, {phiAxis, etaAxis, vtxAxis}});
@@ -647,11 +634,11 @@ struct FlowGenericFramework {
         }
       }
 
-      AxisSpec axisK0Mass = {resoSwitchVals[kMassBins][K0], resoCutVals[kMassMin][K0], resoCutVals[kMassMax][K0]};
-      AxisSpec axisLambdaMass = {resoSwitchVals[kMassBins][LAMBDA], resoCutVals[kMassMin][LAMBDA], resoCutVals[kMassMax][LAMBDA]};
+      AxisSpec axisK0Mass = {resoSwitchVals[kMassBins][kK0], resoCutVals[kMassMin][kK0], resoCutVals[kMassMax][kK0]};
+      AxisSpec axisLambdaMass = {resoSwitchVals[kMassBins][kLambda], resoCutVals[kMassMin][kLambda], resoCutVals[kMassMax][kLambda]};
 
       // QA histograms for V0s
-      if (resoSwitchVals[kUseParticle][K0]) {
+      if (resoSwitchVals[kUseParticle][kK0]) {
         registryQA.add("K0/PiPlusTPC_K0", "", {HistType::kTH2D, {{ptAxis, axisNsigmaTPC}}});
         registryQA.add("K0/PiMinusTPC_K0", "", {HistType::kTH2D, {{ptAxis, axisNsigmaTPC}}});
         registryQA.add("K0/PiPlusTOF_K0", "", {HistType::kTH2D, {{ptAxis, axisNsigmaTOF}}});
@@ -677,7 +664,7 @@ struct FlowGenericFramework {
         registryQA.get<TH1>(HIST("K0/hK0Count"))->GetXaxis()->SetBinLabel(kFillDaughterTrackSelection, "Daughter track selection");
       }
 
-      if (resoSwitchVals[kUseParticle][LAMBDA]) {
+      if (resoSwitchVals[kUseParticle][kLambda]) {
         registryQA.add("Lambda/PrPlusTPC_L", "", {HistType::kTH2D, {{ptAxis, axisNsigmaTPC}}});
         registryQA.add("Lambda/PiMinusTPC_L", "", {HistType::kTH2D, {{ptAxis, axisNsigmaTPC}}});
         registryQA.add("Lambda/PrPlusTOF_L", "", {HistType::kTH2D, {{ptAxis, axisNsigmaTOF}}});
@@ -710,6 +697,30 @@ struct FlowGenericFramework {
         registryQA.get<TH1>(HIST("Lambda/hLambdaCount"))->GetXaxis()->SetBinLabel(kFillDaughterTrackSelection, "Daughter track selection");
       }
     }
+
+    registry.add("npt_ch", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
+    registry.add("npt_pi", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
+    registry.add("npt_ka", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
+    registry.add("npt_pr", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
+    registry.add("npt_K0_sig", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
+    registry.add("npt_K0_sb1", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
+    registry.add("npt_K0_sb2", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
+    registry.add("npt_Lambda_sig", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
+    registry.add("npt_Lambda_sb1", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
+    registry.add("npt_Lambda_sb2", "; #it{p}_{T} (GeV/#it{c}; ; centrality (%); fraction)", {HistType::kTProfile2D, {ptAxis, centAxis}});
+
+    histosNpt.resize(kSpeciesCount);
+    histosNpt[kChargedID] = std::make_unique<TH1D>("nptCh", "; #it{p}_{T} (GeV/#it{c}; Count)", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data()); // registry.add<TH1>("nptCh", "; #it{p}_{T} (GeV/#it{c}; Count)", {HistType::kTH1D, {ptAxis}});
+    histosNpt[kPionID] = std::make_unique<TH1D>("nptPi", "; #it{p}_{T} (GeV/#it{c}; Count)", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data());    // registry.add<TH1>("nptPi", "; #it{p}_{T} (GeV/#it{c}; Count)", {HistType::kTH1D, {ptAxis}});
+    histosNpt[kKaonID] = std::make_unique<TH1D>("nptKa", "; #it{p}_{T} (GeV/#it{c}; Count)", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data());    // registry.add<TH1>("nptKa", "; #it{p}_{T} (GeV/#it{c}; Count)", {HistType::kTH1D, {ptAxis}});
+    histosNpt[kProtonID] = std::make_unique<TH1D>("nptPr", "; #it{p}_{T} (GeV/#it{c}; Count)", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data());  // registry.add<TH1>("nptPr", "; #it{p}_{T} (GeV/#it{c}; Count)", {HistType::kTH1D, {ptAxis}});
+    histosResoNpt.resize(kResonanceCount);
+    histosResoNpt[kK0Sideband1] = std::make_unique<TH1D>("nptK0SB1", "; #it{p}_{T} (GeV/#it{c}; Count", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data());         // registry.add<TH1>("nptK0SB1", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
+    histosResoNpt[kK0Signal] = std::make_unique<TH1D>("nptK0Sig", "; #it{p}_{T} (GeV/#it{c}; Count", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data());            // registry.add<TH1>("nptK0Sig", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
+    histosResoNpt[kK0Sideband2] = std::make_unique<TH1D>("nptK0SB2", "; #it{p}_{T} (GeV/#it{c}; Count", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data());         // registry.add<TH1>("nptK0SB2", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
+    histosResoNpt[kLambdaSideband1] = std::make_unique<TH1D>("nptLambdaSB1", "; #it{p}_{T} (GeV/#it{c}; Count", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data()); // registry.add<TH1>("nptLambdaSB1", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
+    histosResoNpt[kLambdaSignal] = std::make_unique<TH1D>("nptLambdaSig", "; #it{p}_{T} (GeV/#it{c}; Count", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data());    // registry.add<TH1>("nptLambdaSig", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
+    histosResoNpt[kLambdaSideband2] = std::make_unique<TH1D>("nptLambdaSB2", "; #it{p}_{T} (GeV/#it{c}; Count", ptAxis.binEdges.size() - 1, ptAxis.binEdges.data()); // registry.add<TH1>("nptLambdaSB2", "; #it{p}_{T} (GeV/#it{c}; Count", {HistType::kTH1D, {ptAxis}});
 
     if (o2::analysis::gfw::regions.GetSize() < 0)
       LOGF(error, "Configuration contains vectors of different size - check the GFWRegions configurable");
@@ -949,6 +960,9 @@ struct FlowGenericFramework {
         cfg.mAcceptance.push_back(ccdb->getForTimeStamp<GFWWeights>(cfgAcceptance.value + runstr, timestamp));
       }
     }
+    // Run-by-run efficiencies are not supported at the moment
+    if (cfg.correctionsLoaded)
+      return;
     if (!cfgEfficiency.value.empty()) {
       if (!cfgUsePIDEfficiencies) {
         cfg.mEfficiency = ccdb->getForTimeStamp<TH1D>(cfgEfficiency, timestamp);
@@ -1064,11 +1078,11 @@ struct FlowGenericFramework {
     }
 
     if (isPion) {
-      pid = PIONS;
+      pid = kPions;
     } else if (isKaon) {
-      pid = KAONS;
+      pid = kKaons;
     } else if (isProton) {
-      pid = PROTONS;
+      pid = kProtons;
     } else {
       return 0; // no particle satisfies the criteria
     }
@@ -1323,36 +1337,36 @@ struct FlowGenericFramework {
       }
     }
 
-    if (histosNpt[CHARGEDID]->Integral() <= 0)
+    if (histosNpt[kChargedID]->Integral() <= 0)
       return;
 
-    double dnPi = histosNpt[CHARGEDID]->Integral();
-    double dnKa = histosNpt[CHARGEDID]->Integral();
-    double dnPr = histosNpt[CHARGEDID]->Integral();
+    double dnPi = histosNpt[kChargedID]->Integral();
+    double dnKa = histosNpt[kChargedID]->Integral();
+    double dnPr = histosNpt[kChargedID]->Integral();
 
     if (cfgUsePIDTotal) {
-      dnPi = histosNpt[PIONID]->Integral();
-      dnKa = histosNpt[KAONID]->Integral();
-      dnPr = histosNpt[PROTONID]->Integral();
+      dnPi = histosNpt[kPionID]->Integral();
+      dnKa = histosNpt[kKaonID]->Integral();
+      dnPr = histosNpt[kProtonID]->Integral();
     }
 
     for (int i = 1; i <= fPtAxis->GetNbins(); ++i) {
-      registry.fill(HIST("npt_ch"), fPtAxis->GetBinCenter(i), centmult, histosNpt[CHARGEDID]->GetBinContent(i) / histosNpt[CHARGEDID]->Integral());
+      registry.fill(HIST("npt_ch"), fPtAxis->GetBinCenter(i), centmult, histosNpt[kChargedID]->GetBinContent(i) / histosNpt[kChargedID]->Integral());
       if (dnPi > 0)
-        registry.fill(HIST("npt_pi"), fPtAxis->GetBinCenter(i), centmult, histosNpt[PIONID]->GetBinContent(i) / dnPi);
+        registry.fill(HIST("npt_pi"), fPtAxis->GetBinCenter(i), centmult, histosNpt[kPionID]->GetBinContent(i) / dnPi);
       if (dnKa > 0)
-        registry.fill(HIST("npt_ka"), fPtAxis->GetBinCenter(i), centmult, histosNpt[KAONID]->GetBinContent(i) / dnKa);
+        registry.fill(HIST("npt_ka"), fPtAxis->GetBinCenter(i), centmult, histosNpt[kKaonID]->GetBinContent(i) / dnKa);
       if (dnPr > 0)
-        registry.fill(HIST("npt_pr"), fPtAxis->GetBinCenter(i), centmult, histosNpt[PROTONID]->GetBinContent(i) / dnPr);
+        registry.fill(HIST("npt_pr"), fPtAxis->GetBinCenter(i), centmult, histosNpt[kProtonID]->GetBinContent(i) / dnPr);
     }
 
-    if (corrconfigsV02.size() < SPECIESCOUNT)
+    if (corrconfigsV02.size() < kSpeciesCount)
       return;
 
     // For alternative normalisation with integrated pid spectra
-    std::vector<double> dns = {histosNpt[CHARGEDID]->Integral(), dnPi, dnKa, dnPr};
+    std::vector<double> dns = {histosNpt[kChargedID]->Integral(), dnPi, dnKa, dnPr};
 
-    for (uint l_ind = 0; l_ind < SPECIESCOUNT; ++l_ind) {
+    for (uint l_ind = 0; l_ind < kSpeciesCount; ++l_ind) {
       for (int i = 1; i <= fPtAxis->GetNbins(); i++) {
         auto dnx = fGFW->Calculate(corrconfigsV02.at(l_ind), i - 1, kTRUE).real();
         if (dnx == 0)
@@ -1363,7 +1377,7 @@ struct FlowGenericFramework {
       }
     }
 
-    if (corrconfigsV0.size() < SPECIESCOUNT)
+    if (corrconfigsV0.size() < kSpeciesCount)
       return;
 
     double mpt = 0;
@@ -1380,7 +1394,8 @@ struct FlowGenericFramework {
     }
     if (std::isnan(mpt))
       return;
-    for (uint l_ind = 0; l_ind < SPECIESCOUNT; ++l_ind) {
+
+    for (uint l_ind = 0; l_ind < kSpeciesCount; ++l_ind) {
       for (int i = 1; i <= fPtAxis->GetNbins(); i++) {
         if (dns[l_ind] > 0)
           (dt == kGen) ? fFCgen->FillProfile(Form("%s_pt_%i", corrconfigsV0.at(l_ind).Head.c_str(), i), centmult, mpt * histosNpt[l_ind]->GetBinContent(i) / dns[l_ind], 1., rndm) : fFC->FillProfile(Form("%s_pt_%i", corrconfigsV0.at(l_ind).Head.c_str(), i), centmult, mpt * histosNpt[l_ind]->GetBinContent(i) / dns[l_ind], 1., rndm);
@@ -1453,8 +1468,10 @@ struct FlowGenericFramework {
     for (const auto& track : tracks) {
       processTrack(track, vtxz, field, run, densitycorrections, acceptedTracks);
     }
-    registryQA.fill(HIST("trackQA/after/Nch_corrected"), acceptedTracks.total);
-    registryQA.fill(HIST("trackQA/after/Nch_uncorrected"), acceptedTracks.totaluncorr);
+    if (dt != kGen) {
+      registryQA.fill(HIST("trackQA/after/Nch_corrected"), acceptedTracks.total);
+      registryQA.fill(HIST("trackQA/after/Nch_uncorrected"), acceptedTracks.totaluncorr);
+    }
 
     int multiplicity = 0;
     switch (cfgUseNchCorrection) {
@@ -1481,64 +1498,95 @@ struct FlowGenericFramework {
     for (const auto& h : histosResoNpt)
       h->Reset("ICESM");
 
-    // Process V0s
-    for (const auto& v0 : v0s) {
-      if (resoSwitchVals[kUseParticle][K0]) {
-        double weff = 1;
-        if (selectK0(collision, v0, centrality, weff)) {
-          if (v0.mK0Short() > cfgPIDCuts.cfgK0SideBand1Min && v0.mK0Short() < cfgPIDCuts.cfgK0SideBand1Max)
-            histosResoNpt[K0SIDEBAND1]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
-          if (v0.mK0Short() > cfgPIDCuts.cfgK0SignalMin && v0.mK0Short() < cfgPIDCuts.cfgK0SignalMax)
-            histosResoNpt[K0SIGNAL]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
-          if (v0.mK0Short() > cfgPIDCuts.cfgK0SideBand2Min && v0.mK0Short() < cfgPIDCuts.cfgK0SideBand2Max)
-            histosResoNpt[K0SIDEBAND2]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+    // Process V0s only for reconstructed-track workflows.
+    if constexpr (dt != kGen) {
+      for (const auto& v0 : v0s) {
+        if (resoSwitchVals[kUseParticle][kK0]) {
+          double weff = 1;
+          if (selectK0(collision, v0, tracks, centrality, weff)) {
+            if (v0.mK0Short() > cfgPIDCuts.cfgK0SideBand1Min && v0.mK0Short() < cfgPIDCuts.cfgK0SideBand1Max)
+              histosResoNpt[kK0Sideband1]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+            if (v0.mK0Short() > cfgPIDCuts.cfgK0SignalMin && v0.mK0Short() < cfgPIDCuts.cfgK0SignalMax)
+              histosResoNpt[kK0Signal]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+            if (v0.mK0Short() > cfgPIDCuts.cfgK0SideBand2Min && v0.mK0Short() < cfgPIDCuts.cfgK0SideBand2Max)
+              histosResoNpt[kK0Sideband2]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+          }
+        }
+        if (resoSwitchVals[kUseParticle][kLambda]) {
+          double weff = 1.;
+          if (selectLambda(collision, v0, tracks, centrality, weff)) {
+            if (v0.mLambda() > cfgPIDCuts.cfgLambdaSideBand1Min && v0.mLambda() < cfgPIDCuts.cfgLambdaSideBand1Max)
+              histosResoNpt[kLambdaSideband1]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+            if (v0.mLambda() > cfgPIDCuts.cfgLambdaSignalMin && v0.mLambda() < cfgPIDCuts.cfgLambdaSignalMax)
+              histosResoNpt[kLambdaSignal]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+            if (v0.mLambda() > cfgPIDCuts.cfgLambdaSideBand2Min && v0.mLambda() < cfgPIDCuts.cfgLambdaSideBand2Max)
+              histosResoNpt[kLambdaSideband2]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+          }
         }
       }
-      if (resoSwitchVals[kUseParticle][LAMBDA]) {
-        double weff = 1.;
-        if (selectLambda(collision, v0, centrality, weff)) {
-          if (v0.mLambda() > cfgPIDCuts.cfgLambdaSideBand1Min && v0.mLambda() < cfgPIDCuts.cfgLambdaSideBand1Max)
-            histosResoNpt[LAMBDASIDEBAND1]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
-          if (v0.mLambda() > cfgPIDCuts.cfgLambdaSignalMin && v0.mLambda() < cfgPIDCuts.cfgLambdaSignalMax)
-            histosResoNpt[LAMBDASIGNAL]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
-          if (v0.mLambda() > cfgPIDCuts.cfgLambdaSideBand2Min && v0.mLambda() < cfgPIDCuts.cfgLambdaSideBand2Max)
-            histosResoNpt[LAMBDASIDEBAND2]->Fill(v0.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+    } else {
+      for (const auto& particle : tracks) {
+        if (!particle.has_daughters())
+          continue;
+
+        bool isK0 = (particle.pdgCode() == PDG_t::kK0Short);
+        bool isLambda = (particle.pdgCode() == PDG_t::kLambda0);
+
+        if (!isK0 && !isLambda)
+          continue;
+
+        if (isK0)
+          histosResoNpt[kK0Signal]->Fill(particle.pt(), 1.0);
+        if (isLambda)
+          histosResoNpt[kLambdaSignal]->Fill(particle.pt(), 1.0);
+
+        // For efficiency
+        for (const auto& d : particle.template daughters_as<aod::McParticles>()) {
+          if (std::abs(d.pdgCode()) == PDG_t::kPiPlus) {
+            if (isK0)
+              registry.fill(HIST("MCGen/after/pt_centrality_K0_pion_gen"), d.pt(), centrality);
+            if (isLambda)
+              registry.fill(HIST("MCGen/after/pt_centrality_Lambda_pion_gen"), d.pt(), centrality);
+            registry.fill(HIST("MCGen/after/pt_centrality_pion_gen"), d.pt(), centrality);
+          }
+          if (std::abs(d.pdgCode()) == PDG_t::kProton)
+            registry.fill(HIST("MCGen/after/pt_centrality_proton_gen"), d.pt(), centrality);
         }
       }
     }
 
-    if (histosNpt[CHARGEDID]->Integral() <= 0)
+    if (histosNpt[kChargedID]->Integral() <= 0)
       return;
 
-    double dnK0SB1 = histosNpt[CHARGEDID]->Integral();
-    double dnK0Sig = histosNpt[CHARGEDID]->Integral();
-    double dnK0SB2 = histosNpt[CHARGEDID]->Integral();
-    double dnLambdaSB1 = histosNpt[CHARGEDID]->Integral();
-    double dnLambdaSig = histosNpt[CHARGEDID]->Integral();
-    double dnLambdaSB2 = histosNpt[CHARGEDID]->Integral();
+    double dnK0SB1 = histosNpt[kChargedID]->Integral();
+    double dnK0Sig = histosNpt[kChargedID]->Integral();
+    double dnK0SB2 = histosNpt[kChargedID]->Integral();
+    double dnLambdaSB1 = histosNpt[kChargedID]->Integral();
+    double dnLambdaSig = histosNpt[kChargedID]->Integral();
+    double dnLambdaSB2 = histosNpt[kChargedID]->Integral();
 
     if (cfgUsePIDTotal) {
-      dnK0SB1 = histosResoNpt[K0SIDEBAND1]->Integral();
-      dnK0Sig = histosResoNpt[K0SIGNAL]->Integral();
-      dnK0SB2 = histosResoNpt[K0SIDEBAND2]->Integral();
-      dnLambdaSB1 = histosResoNpt[LAMBDASIDEBAND1]->Integral();
-      dnLambdaSig = histosResoNpt[LAMBDASIGNAL]->Integral();
-      dnLambdaSB2 = histosResoNpt[LAMBDASIDEBAND2]->Integral();
+      dnK0SB1 = histosResoNpt[kK0Sideband1]->Integral();
+      dnK0Sig = histosResoNpt[kK0Signal]->Integral();
+      dnK0SB2 = histosResoNpt[kK0Sideband2]->Integral();
+      dnLambdaSB1 = histosResoNpt[kLambdaSideband1]->Integral();
+      dnLambdaSig = histosResoNpt[kLambdaSignal]->Integral();
+      dnLambdaSB2 = histosResoNpt[kLambdaSideband2]->Integral();
     }
 
     for (int i = 1; i <= fPtAxis->GetNbins(); ++i) {
       if (dnK0SB1 > 0)
-        registry.fill(HIST("npt_K0_sb1"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[K0SIDEBAND1]->GetBinContent(i) / dnK0SB1);
+        registry.fill(HIST("npt_K0_sb1"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[kK0Sideband1]->GetBinContent(i) / dnK0SB1);
       if (dnK0Sig > 0)
-        registry.fill(HIST("npt_K0_sig"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[K0SIGNAL]->GetBinContent(i) / dnK0Sig);
+        registry.fill(HIST("npt_K0_sig"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[kK0Signal]->GetBinContent(i) / dnK0Sig);
       if (dnK0SB2 > 0)
-        registry.fill(HIST("npt_K0_sb2"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[K0SIDEBAND2]->GetBinContent(i) / dnK0SB2);
+        registry.fill(HIST("npt_K0_sb2"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[kK0Sideband2]->GetBinContent(i) / dnK0SB2);
       if (dnLambdaSB1 > 0)
-        registry.fill(HIST("npt_Lambda_sb1"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[LAMBDASIDEBAND1]->GetBinContent(i) / dnLambdaSB1);
+        registry.fill(HIST("npt_Lambda_sb1"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[kLambdaSideband1]->GetBinContent(i) / dnLambdaSB1);
       if (dnLambdaSig > 0)
-        registry.fill(HIST("npt_Lambda_sig"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[LAMBDASIGNAL]->GetBinContent(i) / dnLambdaSig);
+        registry.fill(HIST("npt_Lambda_sig"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[kLambdaSignal]->GetBinContent(i) / dnLambdaSig);
       if (dnLambdaSB2 > 0)
-        registry.fill(HIST("npt_Lambda_sb2"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[LAMBDASIDEBAND2]->GetBinContent(i) / dnLambdaSB2);
+        registry.fill(HIST("npt_Lambda_sb2"), fPtAxis->GetBinCenter(i), centrality, histosResoNpt[kLambdaSideband2]->GetBinContent(i) / dnLambdaSB2);
     }
 
     std::vector<double> dns = {dnK0SB1, dnK0Sig, dnK0SB2, dnLambdaSB1, dnLambdaSig, dnLambdaSB2};
@@ -1557,9 +1605,19 @@ struct FlowGenericFramework {
     if (fFCpt->corrDenSub[0][1] == 0. || fFCpt->corrDenSub[1][1] == 0.)
       return;
 
-    double mpt_sub1 = fFCpt->corrNumSub[0][1] / fFCpt->corrDenSub[0][1];
-    double mpt_sub2 = fFCpt->corrNumSub[1][1] / fFCpt->corrDenSub[1][1];
-    double mpt = 0.5 * (mpt_sub1 + mpt_sub2);
+    double mpt = 0;
+    if (cfgEtaPtPt->first * cfgEtaPtPt->second >= 0) {
+      if (fFCpt->corrDen[1] == 0.)
+        return;
+      mpt = fFCpt->corrNum[1] / fFCpt->corrDen[1];
+    } else {
+      if (fFCpt->corrDenSub[0][1] == 0. || fFCpt->corrDenSub[1][1] == 0.)
+        return;
+      double mpt_sub1 = fFCpt->corrNumSub[0][1] / fFCpt->corrDenSub[0][1];
+      double mpt_sub2 = fFCpt->corrNumSub[1][1] / fFCpt->corrDenSub[1][1];
+      mpt = 0.5 * (mpt_sub1 + mpt_sub2);
+    }
+
     if (std::isnan(mpt))
       return;
 
@@ -1602,26 +1660,24 @@ struct FlowGenericFramework {
         return;
 
       int pidIndex = 0;
-      if (cfgUsePID) {
-        if (std::abs(mcParticle.pdgCode()) == kPiPlus)
-          pidIndex = PIONID;
-        if (std::abs(mcParticle.pdgCode()) == kKPlus)
-          pidIndex = KAONID;
-        if (std::abs(mcParticle.pdgCode()) == kProton)
-          pidIndex = PROTONID;
-      }
+      if (std::abs(mcParticle.pdgCode()) == kPiPlus)
+        pidIndex = kPionID;
+      if (std::abs(mcParticle.pdgCode()) == kKPlus)
+        pidIndex = kKaonID;
+      if (std::abs(mcParticle.pdgCode()) == kProton)
+        pidIndex = kProtonID;
 
       if (track.eta() > cfgEtaNch->first && track.eta() < cfgEtaNch->second) {
         double weff = getEfficiency(track, pidIndex);
 
         if (weffCh > 0)
-          histosNpt[CHARGEDID]->Fill(track.pt(), (cfgUseNchCorrection) ? weffCh : 1.0);
-        if (pidIndex == PIONID && weff > 0)
-          histosNpt[PIONID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
-        if (pidIndex == KAONID && weff > 0)
-          histosNpt[KAONID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
-        if (pidIndex == PROTONID && weff > 0)
-          histosNpt[PROTONID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+          histosNpt[kChargedID]->Fill(track.pt(), (cfgUseNchCorrection) ? weffCh : 1.0);
+        if (pidIndex == kPionID && weff > 0)
+          histosNpt[kPionID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+        if (pidIndex == kKaonID && weff > 0)
+          histosNpt[kKaonID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+        if (pidIndex == kProtonID && weff > 0)
+          histosNpt[kProtonID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
       }
 
       if (cfgFillWeights) {
@@ -1644,38 +1700,34 @@ struct FlowGenericFramework {
         return;
       if (cfgFillQA)
         fillTrackQA<kGen, kBefore>(track, vtxz);
-
       if (track.eta() < o2::analysis::gfw::etalow || track.eta() > o2::analysis::gfw::etaup || track.pt() < o2::analysis::gfw::ptlow || track.pt() > o2::analysis::gfw::ptup)
         return;
-
       int pidIndex = 0;
-      if (cfgUsePID) {
-        if (std::abs(track.pdgCode()) == kPiPlus)
-          pidIndex = 1;
-        if (std::abs(track.pdgCode()) == kKPlus)
-          pidIndex = 2;
-        if (std::abs(track.pdgCode()) == kProton)
-          pidIndex = 3;
-      }
+      if (std::abs(track.pdgCode()) == kPiPlus)
+        pidIndex = kPionID;
+      if (std::abs(track.pdgCode()) == kKPlus)
+        pidIndex = kKaonID;
+      if (std::abs(track.pdgCode()) == kProton)
+        pidIndex = kProtonID;
 
       if (track.eta() > cfgEtaNch->first && track.eta() < cfgEtaNch->second) {
         ++acceptedTracks.total;
         ++acceptedTracks.totaluncorr;
 
-        histosNpt[CHARGEDID]->Fill(track.pt());
-        if (pidIndex == PIONID)
-          histosNpt[PIONID]->Fill(track.pt());
-        if (pidIndex == KAONID)
-          histosNpt[KAONID]->Fill(track.pt());
-        if (pidIndex == PROTONID)
-          histosNpt[PROTONID]->Fill(track.pt());
+        histosNpt[kChargedID]->Fill(track.pt());
+        if (pidIndex == kPionID)
+          histosNpt[kPionID]->Fill(track.pt());
+        if (pidIndex == kKaonID)
+          histosNpt[kKaonID]->Fill(track.pt());
+        if (pidIndex == kProtonID)
+          histosNpt[kProtonID]->Fill(track.pt());
       }
 
       fillPtSums<kGen>(track, vtxz);
       fillGFW<kGen>(track, vtxz, pidIndex, densitycorrections);
-
       if (cfgFillQA)
         fillTrackQA<kGen, kAfter>(track, vtxz);
+
     } else {
       if (cfgFillQA)
         fillTrackQA<kReco, kBefore>(track, vtxz);
@@ -1700,13 +1752,13 @@ struct FlowGenericFramework {
         double weff = getEfficiency(track, pidIndex);
 
         if (weffCh > 0)
-          histosNpt[CHARGEDID]->Fill(track.pt(), (cfgUseNchCorrection) ? weffCh : 1.0);
-        if (pidIndex == PIONID && weff > 0)
-          histosNpt[PIONID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
-        if (pidIndex == KAONID && weff > 0)
-          histosNpt[KAONID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
-        if (pidIndex == PROTONID && weff > 0)
-          histosNpt[PROTONID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+          histosNpt[kChargedID]->Fill(track.pt(), (cfgUseNchCorrection) ? weffCh : 1.0);
+        if (pidIndex == kPionID && weff > 0)
+          histosNpt[kPionID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+        if (pidIndex == kKaonID && weff > 0)
+          histosNpt[kKaonID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
+        if (pidIndex == kProtonID && weff > 0)
+          histosNpt[kProtonID]->Fill(track.pt(), (cfgUseNchCorrection) ? weff : 1.0);
       }
 
       if (cfgFillWeights) {
@@ -1738,11 +1790,11 @@ struct FlowGenericFramework {
       return 0;
 
     if (cfgPIDCuts.cfgUseOnlyTPC) {
-      if (pid == PIONS && std::abs(track.tpcNSigmaPi()) > cfgPIDCuts.cfgTPCNsigmaCut)
+      if (pid == kPions && std::abs(track.tpcNSigmaPi()) > cfgPIDCuts.cfgTPCNsigmaCut)
         return false;
-      if (pid == KAONS && std::abs(track.tpcNSigmaKa()) > cfgPIDCuts.cfgTPCNsigmaCut)
+      if (pid == kKaons && std::abs(track.tpcNSigmaKa()) > cfgPIDCuts.cfgTPCNsigmaCut)
         return false;
-      if (pid == PROTONS && std::abs(track.tpcNSigmaPr()) > cfgPIDCuts.cfgTPCNsigmaCut)
+      if (pid == kProtons && std::abs(track.tpcNSigmaPr()) > cfgPIDCuts.cfgTPCNsigmaCut)
         return false;
     } else {
       int partIndex = cfgPIDCuts.cfgUseAsymmetricPID ? getNsigmaPIDAssymmetric(track) : getNsigmaPID(track);
@@ -1758,57 +1810,58 @@ struct FlowGenericFramework {
     return true;
   }
 
-  template <typename TCollision, typename TV0>
-  bool selectK0(TCollision const& collision, TV0 const& v0, const double& centrality, double& weff)
+  template <typename TCollision, typename TV0, typename TTracks>
+  bool selectK0(TCollision const& collision, TV0 const& v0, TTracks const&, const double& centrality, double& weff)
   {
+    using V0TrackTable = std::decay_t<TTracks>;
 
     double massK0s = v0.mK0Short();
 
-    auto postrack = v0.template posTrack_as<GFWTracks>();
-    auto negtrack = v0.template negTrack_as<GFWTracks>();
+    auto postrack = v0.template posTrack_as<V0TrackTable>();
+    auto negtrack = v0.template negTrack_as<V0TrackTable>();
 
     registryQA.fill(HIST("K0/hK0Count"), kFillCandidate);
-    if (postrack.pt() < resoCutVals[kPosTrackPt][K0] || negtrack.pt() < resoCutVals[kNegTrackPt][K0])
+    if (postrack.pt() < resoCutVals[kPosTrackPt][kK0] || negtrack.pt() < resoCutVals[kNegTrackPt][kK0])
       return false;
     registryQA.fill(HIST("K0/hK0Count"), kFillDaughterPt);
-    if (massK0s < resoCutVals[kMassMin][K0] && massK0s > resoCutVals[kMassMax][K0])
+    if (massK0s < resoCutVals[kMassMin][kK0] && massK0s > resoCutVals[kMassMax][kK0])
       return false;
     registryQA.fill(HIST("K0/hK0Count"), kFillMassCut);
     // Rapidity correction
-    if (v0.yK0Short() > resoCutVals[kRapidity][K0])
+    if (v0.yK0Short() > resoCutVals[kRapidity][kK0])
       return false;
     registryQA.fill(HIST("K0/hK0Count"), kFillRapidityCut);
     // DCA cuts for K0short
-    if (std::abs(v0.dcapostopv()) < resoCutVals[kDCAPosToPVMin][K0] || std::abs(v0.dcanegtopv()) < resoCutVals[kDCANegToPVMin][K0])
+    if (std::abs(v0.dcapostopv()) < resoCutVals[kDCAPosToPVMin][kK0] || std::abs(v0.dcanegtopv()) < resoCutVals[kDCANegToPVMin][kK0])
       return false;
     registryQA.fill(HIST("K0/hK0Count"), kFillDCAtoPV);
-    if (resoSwitchVals[kUseDCAxDaughters][K0] && std::abs(v0.dcaV0daughters()) > resoCutVals[kDCAxDaughters][K0])
+    if (resoSwitchVals[kUseDCAxDaughters][kK0] && std::abs(v0.dcaV0daughters()) > resoCutVals[kDCAxDaughters][kK0])
       return false;
     registryQA.fill(HIST("K0/hK0Count"), kFillDCAxDaughters);
     // v0 radius cuts
-    if (resoSwitchVals[kUseV0Radius][K0] && (v0.v0radius() < resoCutVals[kRadiusMin][K0] || v0.v0radius() > resoCutVals[kRadiusMax][K0]))
+    if (resoSwitchVals[kUseV0Radius][kK0] && (v0.v0radius() < resoCutVals[kRadiusMin][kK0] || v0.v0radius() > resoCutVals[kRadiusMax][kK0]))
       return false;
     registryQA.fill(HIST("K0/hK0Count"), kFillV0Radius);
     // cosine pointing angle cuts
-    if (v0.v0cosPA() < resoCutVals[kCosPA][K0])
+    if (v0.v0cosPA() < resoCutVals[kCosPA][kK0])
       return false;
     registryQA.fill(HIST("K0/hK0Count"), kFillCosPA);
     // Proper lifetime
-    if (resoSwitchVals[kUseProperLifetime][K0] && v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * massK0Short > resoCutVals[kLifeTime][K0])
+    if (resoSwitchVals[kUseProperLifetime][kK0] && v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * massK0Short > resoCutVals[kLifeTime][kK0])
       return false;
     registryQA.fill(HIST("K0/hK0Count"), kFillProperLifetime);
     // ArmenterosPodolanskiCut
-    if (resoSwitchVals[kUseArmPodCut][K0] && (v0.qtarm() / std::abs(v0.alpha())) < resoCutVals[kArmPodMin][K0])
+    if (resoSwitchVals[kUseArmPodCut][kK0] && (v0.qtarm() / std::abs(v0.alpha())) < resoCutVals[kArmPodMin][kK0])
       return false;
     registryQA.fill(HIST("K0/hK0Count"), kFillArmPodCut);
-    if (resoSwitchVals[kUseCompetingMassRejection][K0]) {
-      if (std::abs(v0.mLambda() - o2::constants::physics::MassLambda0) < resoCutVals[kMassRejection][K0])
+    if (resoSwitchVals[kUseCompetingMassRejection][kK0]) {
+      if (std::abs(v0.mLambda() - o2::constants::physics::MassLambda0) < resoCutVals[kMassRejection][kK0])
         return false;
-      if (std::abs(v0.mAntiLambda() - o2::constants::physics::MassLambda0) < resoCutVals[kMassRejection][K0])
+      if (std::abs(v0.mAntiLambda() - o2::constants::physics::MassLambda0) < resoCutVals[kMassRejection][kK0])
         return false;
     }
     registryQA.fill(HIST("K0/hK0Count"), kFillCompetingMass);
-    if (!selectionV0Daughter(postrack, PIONS) || !selectionV0Daughter(negtrack, PIONS))
+    if (!selectionV0Daughter(postrack, kPions) || !selectionV0Daughter(negtrack, kPions))
       return false;
     registryQA.fill(HIST("K0/hK0Count"), kFillDaughterTrackSelection);
 
@@ -1829,12 +1882,20 @@ struct FlowGenericFramework {
         registryQA.fill(HIST("K0/hK0s_corrected"), 0.5, weff);
     }
 
+    if (doprocessMCReco) {
+      registry.fill(HIST("trackQA/after/pt_centrality_K0_pion"), postrack.pt(), centrality);
+      registry.fill(HIST("trackQA/after/pt_centrality_pion"), postrack.pt(), centrality);
+      registry.fill(HIST("trackQA/after/pt_centrality_K0_pion"), negtrack.pt(), centrality);
+      registry.fill(HIST("trackQA/after/pt_centrality_pion"), negtrack.pt(), centrality);
+    }
+
     return true;
   }
 
-  template <typename TCollision, typename TV0>
-  bool selectLambda(TCollision const& collision, TV0 const& v0, const double& centrality, double& weff)
+  template <typename TCollision, typename TV0, typename TTracks>
+  bool selectLambda(TCollision const& collision, TV0 const& v0, TTracks const&, const double& centrality, double& weff)
   {
+    using V0TrackTable = std::decay_t<TTracks>;
     bool isL = false;  // Is lambda candidate
     bool isAL = false; // Is anti-lambda candidate
 
@@ -1842,17 +1903,17 @@ struct FlowGenericFramework {
     double mantilambda = v0.mAntiLambda();
 
     // separate the positive and negative V0 daughters
-    auto postrack = v0.template posTrack_as<GFWTracks>();
-    auto negtrack = v0.template negTrack_as<GFWTracks>();
+    auto postrack = v0.template posTrack_as<V0TrackTable>();
+    auto negtrack = v0.template negTrack_as<V0TrackTable>();
 
     registryQA.fill(HIST("Lambda/hLambdaCount"), kFillCandidate);
-    if (postrack.pt() < resoCutVals[kPosTrackPt][LAMBDA] || negtrack.pt() < resoCutVals[kNegTrackPt][LAMBDA])
+    if (postrack.pt() < resoCutVals[kPosTrackPt][kLambda] || negtrack.pt() < resoCutVals[kNegTrackPt][kLambda])
       return false;
 
     registryQA.fill(HIST("Lambda/hLambdaCount"), kFillDaughterPt);
-    if (mlambda > resoCutVals[kMassMin][LAMBDA] && mlambda < resoCutVals[kMassMax][LAMBDA])
+    if (mlambda > resoCutVals[kMassMin][kLambda] && mlambda < resoCutVals[kMassMax][kLambda])
       isL = true;
-    if (mantilambda > resoCutVals[kMassMin][LAMBDA] && mantilambda < resoCutVals[kMassMax][LAMBDA])
+    if (mantilambda > resoCutVals[kMassMin][kLambda] && mantilambda < resoCutVals[kMassMax][kLambda])
       isAL = true;
 
     if (!isL && !isAL) {
@@ -1861,49 +1922,49 @@ struct FlowGenericFramework {
     registryQA.fill(HIST("Lambda/hLambdaCount"), kFillMassCut);
 
     // Rapidity correction
-    if (v0.yLambda() > resoCutVals[kRapidity][LAMBDA])
+    if (v0.yLambda() > resoCutVals[kRapidity][kLambda])
       return false;
     registryQA.fill(HIST("Lambda/hLambdaCount"), kFillRapidityCut);
     // DCA cuts for lambda and antilambda
     if (isL) {
-      if (std::abs(v0.dcapostopv()) < resoCutVals[kDCAPosToPVMin][LAMBDA] || std::abs(v0.dcanegtopv()) < resoCutVals[kDCANegToPVMin][LAMBDA])
+      if (std::abs(v0.dcapostopv()) < resoCutVals[kDCAPosToPVMin][kLambda] || std::abs(v0.dcanegtopv()) < resoCutVals[kDCANegToPVMin][kLambda])
         return false;
     }
     if (isAL) {
-      if (std::abs(v0.dcapostopv()) < resoCutVals[kDCANegToPVMin][LAMBDA] || std::abs(v0.dcanegtopv()) < resoCutVals[kDCAPosToPVMin][LAMBDA])
+      if (std::abs(v0.dcapostopv()) < resoCutVals[kDCANegToPVMin][kLambda] || std::abs(v0.dcanegtopv()) < resoCutVals[kDCAPosToPVMin][kLambda])
         return false;
     }
     registryQA.fill(HIST("Lambda/hLambdaCount"), kFillDCAtoPV);
-    if (resoSwitchVals[kUseDCAxDaughters][LAMBDA] && std::abs(v0.dcaV0daughters()) > resoCutVals[kDCAxDaughters][LAMBDA])
+    if (resoSwitchVals[kUseDCAxDaughters][kLambda] && std::abs(v0.dcaV0daughters()) > resoCutVals[kDCAxDaughters][kLambda])
       return false;
     registryQA.fill(HIST("Lambda/hLambdaCount"), kFillDCAxDaughters);
     // v0 radius cuts
-    if (resoSwitchVals[kUseV0Radius][LAMBDA] && (v0.v0radius() < resoCutVals[kRadiusMin][LAMBDA] || v0.v0radius() > resoCutVals[kRadiusMax][LAMBDA]))
+    if (resoSwitchVals[kUseV0Radius][kLambda] && (v0.v0radius() < resoCutVals[kRadiusMin][kLambda] || v0.v0radius() > resoCutVals[kRadiusMax][kLambda]))
       return false;
     registryQA.fill(HIST("Lambda/hLambdaCount"), kFillV0Radius);
     // cosine pointing angle cuts
-    if (v0.v0cosPA() < resoCutVals[kCosPA][LAMBDA])
+    if (v0.v0cosPA() < resoCutVals[kCosPA][kLambda])
       return false;
     registryQA.fill(HIST("Lambda/hLambdaCount"), kFillCosPA);
     // Proper lifetime
-    if (resoSwitchVals[kUseProperLifetime][LAMBDA] && v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * massLambda > resoCutVals[kLifeTime][LAMBDA])
+    if (resoSwitchVals[kUseProperLifetime][kLambda] && v0.distovertotmom(collision.posX(), collision.posY(), collision.posZ()) * massLambda > resoCutVals[kLifeTime][kLambda])
       return false;
     registryQA.fill(HIST("Lambda/hLambdaCount"), kFillProperLifetime);
     // ArmenterosPodolanskiCut
-    if (resoSwitchVals[kUseArmPodCut][LAMBDA] && (v0.qtarm() / std::abs(v0.alpha())) < resoCutVals[kArmPodMin][LAMBDA])
+    if (resoSwitchVals[kUseArmPodCut][kLambda] && (v0.qtarm() / std::abs(v0.alpha())) < resoCutVals[kArmPodMin][kLambda])
       return false;
     registryQA.fill(HIST("Lambda/hLambdaCount"), kFillArmPodCut);
-    if (resoSwitchVals[kUseCompetingMassRejection][LAMBDA]) {
-      if (std::abs(v0.mK0Short() - o2::constants::physics::MassK0Short) < resoCutVals[kMassRejection][LAMBDA])
+    if (resoSwitchVals[kUseCompetingMassRejection][kLambda]) {
+      if (std::abs(v0.mK0Short() - o2::constants::physics::MassK0Short) < resoCutVals[kMassRejection][kLambda])
         return false;
     }
     registryQA.fill(HIST("Lambda/hLambdaCount"), kFillCompetingMass);
     if (isL) {
-      if (!selectionV0Daughter(postrack, PROTONS) || !selectionV0Daughter(negtrack, PIONS))
+      if (!selectionV0Daughter(postrack, kProtons) || !selectionV0Daughter(negtrack, kPions))
         return false;
     }
     if (isAL) {
-      if (!selectionV0Daughter(postrack, PIONS) || !selectionV0Daughter(negtrack, PROTONS))
+      if (!selectionV0Daughter(postrack, kPions) || !selectionV0Daughter(negtrack, kProtons))
         return false;
     }
     registryQA.fill(HIST("Lambda/hLambdaCount"), kFillDaughterTrackSelection);
@@ -1925,6 +1986,11 @@ struct FlowGenericFramework {
         if (weff > 0)
           registryQA.fill(HIST("Lambda/hLambdas_corrected"), 0.5, weff);
       }
+      if (doprocessMCReco) {
+        registry.fill(HIST("trackQA/after/pt_centrality_Lambda_pion"), negtrack.pt(), centrality);
+        registry.fill(HIST("trackQA/after/pt_centrality_pion"), negtrack.pt(), centrality);
+        registry.fill(HIST("trackQA/after/pt_centrality_proton"), postrack.pt(), centrality);
+      }
     }
     if (isAL) {
       registryQA.fill(HIST("Lambda/hAntiLambdaMass_sparse"), mantilambda, v0.pt(), centrality);
@@ -1943,7 +2009,13 @@ struct FlowGenericFramework {
         if (weff > 0)
           registryQA.fill(HIST("Lambda/hLambdas_corrected"), 0.5, weff);
       }
+      if (doprocessMCReco) {
+        registry.fill(HIST("trackQA/after/pt_centrality_Lambda_pion"), postrack.pt(), centrality);
+        registry.fill(HIST("trackQA/after/pt_centrality_pion"), postrack.pt(), centrality);
+        registry.fill(HIST("trackQA/after/pt_centrality_proton"), negtrack.pt(), centrality);
+      }
     }
+
     return true;
   }
 
@@ -2104,6 +2176,7 @@ struct FlowGenericFramework {
   using GFWCollisions = soa::Filtered<soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Cs, aod::CentFT0CVariant1s, aod::CentFT0Ms, aod::CentFV0As, aod::CentNTPVs, aod::CentNGlobals, aod::CentMFTs>>;
   // using GFWTracks = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection, aod::TracksDCA, aod::pidTOFPi, aod::pidTPCPi, aod::pidTOFKa, aod::pidTPCKa, aod::pidTOFPr, aod::pidTPCPr>>;
   using GFWTracks = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection, aod::TracksDCA, aod::pidTPCFullPi, aod::pidTPCFullKa, aod::pidTPCFullPr, aod::pidTOFbeta, aod::pidTOFFullPi, aod::pidTOFFullKa, aod::pidTOFFullPr>>;
+  using GFWMCTracks = soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection, aod::TracksDCA, aod::pidTPCFullPi, aod::pidTPCFullKa, aod::pidTPCFullPr, aod::pidTOFbeta, aod::pidTOFFullPi, aod::pidTOFFullKa, aod::pidTOFFullPr, aod::McTrackLabels>>;
 
   SliceCache cache;
   Partition<GFWTracks> posTracks = aod::track::signed1Pt > 0.0f;
@@ -2171,7 +2244,7 @@ struct FlowGenericFramework {
   }
   PROCESS_SWITCH(FlowGenericFramework, processData, "Process analysis for non-derived data", true);
 
-  void processMCReco(GFWCollisions::iterator const& collision, aod::BCsWithTimestamps const&, soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection, aod::TracksDCA, aod::McTrackLabels>> const& tracks, aod::McParticles const&, aod::V0Datas const& v0s)
+  void processMCReco(GFWCollisions::iterator const& collision, aod::BCsWithTimestamps const&, GFWMCTracks const& tracks, aod::McParticles const&, aod::V0Datas const& v0s)
   {
     auto bc = collision.bc_as<aod::BCsWithTimestamps>();
     int run = bc.runNumber();


### PR DESCRIPTION
- Fix to MC reco and MC gen processing for radial and elliptic flow-spectra correlations
- Temporary histograms for tracking EbyE spectra have been removed from the histogram registry to remove clutter in the output
- Some changes to enum names to conform to coding guidellines
- Proper use of subevent-averaged mean pt for v0