### PR TITLE
[PWGDQ] make qaMatching AO2D index merger-safe

### DIFF
--- a/PWGDQ/Tasks/qaMatching.cxx
+++ b/PWGDQ/Tasks/qaMatching.cxx
@@ -121,12 +121,13 @@ DECLARE_SOA_TABLE(QaMatchingEvents, "AOD", "QAMEVT",
 
 namespace qamatching
 {
-DECLARE_SOA_INDEX_COLUMN_FULL(ReducedEvent, reducedEvent, int32_t, o2::aod::QaMatchingEvents, "");
+DECLARE_SOA_INDEX_COLUMN_FULL_CUSTOM(ReducedEvent, reducedEvent, int32_t, o2::aod::QaMatchingEvents, "QAMEVTs", "");
 } // namespace qamatching
 
 namespace o2::aod
 {
 DECLARE_SOA_TABLE(QaMatchingMCHTrack, "AOD", "QAMCHTRK",
+                  o2::soa::Index<>,
                   qamatching::ReducedEventId,
                   qamatching::TrackId,
                   qamatching::TrackType,
@@ -142,6 +143,7 @@ DECLARE_SOA_TABLE(QaMatchingMCHTrack, "AOD", "QAMCHTRK",
                   qamatching::PyAtVtx,
                   qamatching::PzAtVtx);
 DECLARE_SOA_TABLE(QaMatchingCandidates, "AOD", "QAMCAND",
+                  o2::soa::Index<>,
                   qamatching::ReducedEventId,
                   qamatching::MatchLabel,
                   qamatching::TrackId,


### PR DESCRIPTION
## Summary
- make the `qaMatching` event-reference column use a merger-safe custom index label
- preserve canonical AO2D tree naming for the qaMatching output tables

## Problem
The previous `qaMatching` AO2D output produced an event-reference branch that was not resolved correctly by `o2-aod-merger` and caused downstream Hyperloop issues.

