### PR TITLE
[PWGHF] Extending derived data for D+-h correl

### DIFF
--- a/PWGHF/HFC/DataModel/DerivedDataCorrelationTables.h
+++ b/PWGHF/HFC/DataModel/DerivedDataCorrelationTables.h
@@ -53,22 +53,22 @@ DECLARE_SOA_COLUMN(Prong2Id, prong2Id, int);                //! Prong2 index
 DECLARE_SOA_COLUMN(PhiCand, phiCand, float);                //! Phi of the candidate
 DECLARE_SOA_COLUMN(EtaCand, etaCand, float);                //! Eta of the candidate
 DECLARE_SOA_COLUMN(PtCand, ptCand, float);                  //! Pt of the candidate
-DECLARE_SOA_COLUMN(InvMassDs, invMassDs, float);            //! Invariant mass of Ds candidate
+DECLARE_SOA_COLUMN(InvMass, invMass, float);                //! Invariant mass of charm candidate
 DECLARE_SOA_COLUMN(BdtScorePrompt, bdtScorePrompt, float);  //! BDT output score for prompt hypothesis
 DECLARE_SOA_COLUMN(BdtScoreBkg, bdtScoreBkg, float);        //! BDT output score for background hypothesis
 } // namespace hf_candidate_reduced
-DECLARE_SOA_TABLE(DsCandReduceds, "AOD", "DSCANDREDUCED", //! Table with Ds candidate info
+DECLARE_SOA_TABLE(HcCandReduceds, "AOD", "HCCANDREDUCED", //! Table with charm hadron candidate info
                   soa::Index<>,
                   aod::hf_candidate_reduced::HfcRedCollisionId,
                   aod::hf_candidate_reduced::PhiCand,
                   aod::hf_candidate_reduced::EtaCand,
                   aod::hf_candidate_reduced::PtCand,
-                  aod::hf_candidate_reduced::InvMassDs,
+                  aod::hf_candidate_reduced::InvMass,
                   aod::hf_candidate_reduced::Prong0Id,
                   aod::hf_candidate_reduced::Prong1Id,
                   aod::hf_candidate_reduced::Prong2Id);
 
-DECLARE_SOA_TABLE(DsCandSelInfos, "AOD", "DSCANDSELINFO", //! Table with Ds candidate selection info
+DECLARE_SOA_TABLE(HcCandSelInfos, "AOD", "HCCANDSELINFO", //! Table with charm hadron candidate selection info
                   soa::Index<>,
                   aod::hf_candidate_reduced::HfcRedCollisionId,
                   aod::hf_candidate_reduced::BdtScorePrompt,

--- a/PWGHF/HFC/TableProducer/correlatorDplusHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDplusHadrons.cxx
@@ -21,6 +21,7 @@
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
 #include "PWGHF/DataModel/TrackIndexSkimmingTables.h"
 #include "PWGHF/HFC/DataModel/CorrelationTables.h"
+#include "PWGHF/HFC/DataModel/DerivedDataCorrelationTables.h"
 #include "PWGHF/Utils/utilsAnalysis.h"
 
 #include "Common/CCDB/EventSelectionParams.h"
@@ -181,6 +182,12 @@ struct HfCorrelatorDplusHadrons {
   Produces<aod::TrkRecInfoDplus> entryTrackRecoInfo;
   Produces<aod::Dplus> entryDplus;
   Produces<aod::Hadron> entryHadron;
+  Produces<aod::HfcRedCollisions> collReduced;
+  Produces<aod::HcCandReduceds> candReduced;
+  Produces<aod::HcCandSelInfos> candSelInfo;
+  Produces<aod::AssocTrackReds> assocTrackReduced;
+  Produces<aod::AssocTrackSels> assocTrackSelInfo;
+
   static constexpr std::size_t NDaughters{3u};
   static constexpr float EtaDaughtersMax = 0.8f; // Eta cut on daughters of D+ meson as Run2
 
@@ -231,10 +238,13 @@ struct HfCorrelatorDplusHadrons {
   // filter on selection of Dplus meson and decay channel Dplus->KPiPi
   Filter dplusFilter = ((o2::aod::hf_track_index::hfflag & static_cast<uint8_t>(1 << aod::hf_cand_3prong::DecayType::DplusToPiKPi)) != static_cast<uint8_t>(0)) && aod::hf_sel_candidate_dplus::isSelDplusToPiKPi >= selectionFlagDplus;
   Filter trackFilter = (nabs(aod::track::eta) < etaTrackMax) && (nabs(aod::track::pt) > ptTrackMin) && (nabs(aod::track::dcaXY) < dcaXYTrackMax) && (nabs(aod::track::dcaZ) < dcaZTrackMax);
+  // Filter particlesFilter = nabs(aod::mcparticle::pdgCode) == 411 || ((aod::mcparticle::flags & (uint8_t)o2::aod::mcparticle::enums::PhysicalPrimary) == (uint8_t)o2::aod::mcparticle::enums::PhysicalPrimary);
   Preslice<aod::McParticles> presliceMc{aod::mcparticle::mcCollisionId};
   Preslice<CandDplusMcGen> candMcGenPerMcCollision = o2::aod::mcparticle::mcCollisionId;
   PresliceUnsorted<soa::Join<aod::Collisions, aod::FT0Mults, aod::EvSels, aod::McCollisionLabels>> recoCollisionsPerMcCollision = o2::aod::mccollisionlabel::mcCollisionId;
-  // Filter particlesFilter = nabs(aod::mcparticle::pdgCode) == 411 || ((aod::mcparticle::flags & (uint8_t)o2::aod::mcparticle::enums::PhysicalPrimary) == (uint8_t)o2::aod::mcparticle::enums::PhysicalPrimary);
+  Preslice<CandidatesDplusData> candsDplusPerCollision = aod::hf_cand::collisionId;
+  Preslice<TracksData> trackIndicesPerCollision = aod::track::collisionId;
+
   ConfigurableAxis binsMultiplicity{"binsMultiplicity", {VARIABLE_WIDTH, 0.0f, 2000.0f, 6000.0f, 100000.0f}, "Mixing bins - multiplicity"};
   ConfigurableAxis binsZVtx{"binsZVtx", {VARIABLE_WIDTH, -10.0f, -2.5f, 2.5f, 10.0f}, "Mixing bins - z-vertex"};
   ConfigurableAxis binsMultiplicityMc{"binsMultiplicityMc", {VARIABLE_WIDTH, 0.0f, 20.0f, 50.0f, 500.0f}, "Mixing bins - MC multiplicity"}; // In MCGen multiplicity is defined by counting tracks
@@ -527,6 +537,46 @@ struct HfCorrelatorDplusHadrons {
     }
   }
   PROCESS_SWITCH(HfCorrelatorDplusHadrons, processData, "Process data", false);
+
+  void processDerivedDataDplus(SelCollisionsWithDplus const& collisions,
+                               CandidatesDplusData const& candidates,
+                               TracksData const& tracks)
+  {
+
+    for (const auto& collision : collisions) {
+      auto thisCollId = collision.globalIndex();
+      auto candsDplusThisColl = candidates.sliceBy(candsDplusPerCollision, thisCollId);
+      auto tracksThisColl = tracks.sliceBy(trackIndicesPerCollision, thisCollId);
+
+      int indexHfcReducedCollision = collReduced.lastIndex() + 1;
+
+      // Ds fill histograms and Dplus candidates information stored
+      for (const auto& candidate : candsDplusThisColl) {
+        std::vector<float> outputMl = {-1., -1., -1.};
+        // candidate selected
+        if (candidate.isSelDplusToPiKPi() >= selectionFlagDplus) {
+          for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
+            outputMl[iclass] = candidate.mlProbDplusToPiKPi()[classMl->at(iclass)];
+          }
+          candReduced(indexHfcReducedCollision, candidate.phi(), candidate.eta(), candidate.pt(), HfHelper::invMassDplusToPiKPi(candidate), candidate.prong0Id(), candidate.prong1Id(), candidate.prong2Id());
+          candSelInfo(indexHfcReducedCollision, outputMl[0], outputMl[2]);
+        }
+      }
+
+      // tracks information
+      for (const auto& track : tracksThisColl) {
+        if (!track.isGlobalTrackWoDCA()) {
+          continue;
+        }
+        registry.fill(HIST("hDcaXYVsPt"), track.dcaXY(), track.pt());
+        assocTrackReduced(indexHfcReducedCollision, track.globalIndex(), track.phi(), track.eta(), track.pt());
+        assocTrackSelInfo(indexHfcReducedCollision, track.tpcNClsCrossedRows(), track.itsClusterMap(), track.itsNCls(), track.dcaXY(), track.dcaZ());
+      }
+
+      collReduced(collision.multFT0M(), collision.numContrib(), collision.posZ());
+    }
+  }
+  PROCESS_SWITCH(HfCorrelatorDplusHadrons, processDerivedDataDplus, "Process derived data D+", false);
 
   /// Dplus-Hadron correlation pair builder - for MC reco-level analysis (candidates matched to true signal only, but also the various bkg sources are studied)
   void processMcRec(SelCollisionsWithDplus::iterator const& collision,

--- a/PWGHF/HFC/TableProducer/correlatorDplusHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDplusHadrons.cxx
@@ -241,9 +241,9 @@ struct HfCorrelatorDplusHadrons {
   // Filter particlesFilter = nabs(aod::mcparticle::pdgCode) == 411 || ((aod::mcparticle::flags & (uint8_t)o2::aod::mcparticle::enums::PhysicalPrimary) == (uint8_t)o2::aod::mcparticle::enums::PhysicalPrimary);
   Preslice<aod::McParticles> presliceMc{aod::mcparticle::mcCollisionId};
   Preslice<CandDplusMcGen> candMcGenPerMcCollision = o2::aod::mcparticle::mcCollisionId;
-  PresliceUnsorted<soa::Join<aod::Collisions, aod::FT0Mults, aod::EvSels, aod::McCollisionLabels>> recoCollisionsPerMcCollision = o2::aod::mccollisionlabel::mcCollisionId;
   Preslice<CandidatesDplusData> candsDplusPerCollision = aod::hf_cand::collisionId;
   Preslice<TracksData> trackIndicesPerCollision = aod::track::collisionId;
+  PresliceUnsorted<soa::Join<aod::Collisions, aod::FT0Mults, aod::EvSels, aod::McCollisionLabels>> recoCollisionsPerMcCollision = o2::aod::mccollisionlabel::mcCollisionId;
 
   ConfigurableAxis binsMultiplicity{"binsMultiplicity", {VARIABLE_WIDTH, 0.0f, 2000.0f, 6000.0f, 100000.0f}, "Mixing bins - multiplicity"};
   ConfigurableAxis binsZVtx{"binsZVtx", {VARIABLE_WIDTH, -10.0f, -2.5f, 2.5f, 10.0f}, "Mixing bins - z-vertex"};

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -173,8 +173,8 @@ struct HfCorrelatorDsHadrons {
   Produces<aod::DsCandGenInfo> entryDsCandGenInfo;
   Produces<aod::TrackRecoInfo> entryTrackRecoInfo;
   Produces<aod::HfcRedCollisions> collReduced;
-  Produces<aod::DsCandReduceds> candReduced;
-  Produces<aod::DsCandSelInfos> candSelInfo;
+  Produces<aod::HcCandReduceds> candReduced;
+  Produces<aod::HcCandSelInfos> candSelInfo;
   Produces<aod::AssocTrackReds> assocTrackReduced;
   Produces<aod::AssocTrackSels> assocTrackSelInfo;
   Produces<aod::AssocTrackPids> assocTrackPidInfo;

--- a/PWGHF/HFC/TableProducer/correlatorDsHadronsReduced.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadronsReduced.cxx
@@ -69,7 +69,7 @@ struct HfCorrelatorDsHadronsReduced {
 
   // Preslice<aod::AssocTrackReds> tracksPerCol = aod::hf_assoc_track_reduced::hfcRedCollisionId;
   Preslice<aod::AssocTrackReds> tracksPerCol = aod::hf_candidate_reduced::hfcRedCollisionId;
-  Preslice<aod::DsCandReduceds> candPerCol = aod::hf_candidate_reduced::hfcRedCollisionId;
+  Preslice<aod::HcCandReduceds> candPerCol = aod::hf_candidate_reduced::hfcRedCollisionId;
 
   ConfigurableAxis zPoolBins{"zPoolBins", {VARIABLE_WIDTH, -10.0, -2.5, 2.5, 10.0}, "z vertex position pools"};
   ConfigurableAxis multPoolBins{"multPoolBins", {VARIABLE_WIDTH, 0., 900., 1800., 6000.}, "event multiplicity pools (FT0M)"};
@@ -106,7 +106,7 @@ struct HfCorrelatorDsHadronsReduced {
   }
 
   void processDerivedData(aod::HfcRedCollisions const& collisions,
-                          soa::Join<aod::DsCandReduceds, aod::DsCandSelInfos> const& candidates,
+                          soa::Join<aod::HcCandReduceds, aod::HcCandSelInfos> const& candidates,
                           soa::Join<aod::AssocTrackReds, aod::AssocTrackSels> const& tracks)
   {
 
@@ -126,7 +126,7 @@ struct HfCorrelatorDsHadronsReduced {
         registry.fill(HIST("hDsPoolBin"), poolBin);
         registry.fill(HIST("hPhiVsPtCand"), RecoDecay::constrainAngle(candidate.phiCand(), -PIHalf), candidate.ptCand());
         registry.fill(HIST("hEtaVsPtCand"), candidate.etaCand(), candidate.ptCand());
-        entryDsCandRecoInfo(candidate.invMassDs(), candidate.ptCand(), candidate.bdtScorePrompt(), candidate.bdtScoreBkg(), collision.numPvContrib());
+        entryDsCandRecoInfo(candidate.invMass(), candidate.ptCand(), candidate.bdtScorePrompt(), candidate.bdtScoreBkg(), collision.numPvContrib());
         for (const auto& track : tracksThisColl) {
           // Removing Ds daughters by checking track indices
           if ((candidate.prong0Id() == track.originTrackId()) || (candidate.prong1Id() == track.originTrackId()) || (candidate.prong2Id() == track.originTrackId())) {
@@ -142,7 +142,7 @@ struct HfCorrelatorDsHadronsReduced {
                             track.ptAssocTrack(),
                             poolBin,
                             collision.numPvContrib());
-          entryDsHadronRecoInfo(candidate.invMassDs(), false, false);
+          entryDsHadronRecoInfo(candidate.invMass(), false, false);
           entryDsHadronMlInfo(candidate.bdtScorePrompt(), candidate.bdtScoreBkg());
           entryTrackRecoInfo(track.dcaXY(), track.dcaZ(), track.nTpcCrossedRows());
         }
@@ -152,7 +152,7 @@ struct HfCorrelatorDsHadronsReduced {
   PROCESS_SWITCH(HfCorrelatorDsHadronsReduced, processDerivedData, "Process Derived Data", true);
 
   void processDerivedDataME(aod::HfcRedCollisions const& collisions,
-                            aod::DsCandReduceds const& candidates,
+                            aod::HcCandReduceds const& candidates,
                             aod::AssocTrackReds const& tracks)
   {
 
@@ -182,7 +182,7 @@ struct HfCorrelatorDsHadronsReduced {
 
     auto tracksTuple = std::make_tuple(candidates, tracks);
 
-    Pair<aod::HfcRedCollisions, aod::DsCandReduceds, aod::AssocTrackReds, BinningTypeDerived> const pairData{corrBinning, numberEventsMixed, -1, collisions, tracksTuple, &cache};
+    Pair<aod::HfcRedCollisions, aod::HcCandReduceds, aod::AssocTrackReds, BinningTypeDerived> const pairData{corrBinning, numberEventsMixed, -1, collisions, tracksTuple, &cache};
 
     for (const auto& [c1, tracks1, c2, tracks2] : pairData) {
       if (tracks1.size() == 0) {
@@ -205,7 +205,7 @@ struct HfCorrelatorDsHadronsReduced {
                           pAssoc.ptAssocTrack(),
                           poolBin,
                           c1.numPvContrib());
-        entryDsHadronRecoInfo(cand.invMassDs(), false, false);
+        entryDsHadronRecoInfo(cand.invMass(), false, false);
         // entryDsHadronGenInfo(false, false, 0);
       }
     }


### PR DESCRIPTION
Hello @scattaru,
I generalised the Derived data Model (just the naming), to avoid confusion if used for other charm hadrons.
The Ds-h correlations related classes have been changed accordingly.