### PR TITLE
[DPG] tpcSkimsTableCreator: add RCT check, minor refactory

### DIFF
--- a/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
+++ b/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
@@ -864,10 +864,11 @@ struct TreeWriterTpcTof {
         }
 
         for (const auto& tofTrack : {&tofTriton, &tofDeuteron, &tofProton, &tofKaon, &tofPion}) {
-          if ((!tofTrack->isApplyHardCutOnly || trk.tpcInnerParam() < tofTrack->maxMomHardCutOnly) &&
-              ((trk.tpcInnerParam() <= tofTrack->maxMomTPCOnly && std::fabs(tofTrack->tpcNSigma) < tofTrack->nSigmaTPCOnly) ||
-               (trk.tpcInnerParam() > tofTrack->maxMomTPCOnly && std::fabs(tofTrack->tofNSigma) < tofTrack->nSigmaTofTpctof && std::fabs(tofTrack->tpcNSigma) < tofTrack->nSigmaTpcTpctof)) &&
-              downsampleTsalisCharged(fRndm, trk.pt(), tofTrack->downsamplingTsalis, tofTrack->mass, sqrtSNN)) {
+          const bool passMomHardCut = !tofTrack->isApplyHardCutOnly || trk.tpcInnerParam() < tofTrack->maxMomHardCutOnly;
+          const bool passMomTpcOnly = trk.tpcInnerParam() <= tofTrack->maxMomTPCOnly && std::fabs(tofTrack->tpcNSigma) < tofTrack->nSigmaTPCOnly;
+          const bool passMomTpcTof = trk.tpcInnerParam() > tofTrack->maxMomTPCOnly && std::fabs(tofTrack->tofNSigma) < tofTrack->nSigmaTofTpctof && std::fabs(tofTrack->tpcNSigma) < tofTrack->nSigmaTpcTpctof;
+          const bool passDownsamplig = downsampleTsalisCharged(fRndm, trk.pt(), tofTrack->downsamplingTsalis, tofTrack->mass, sqrtSNN);
+          if (passMomHardCut && (passMomTpcOnly || passMomTpcTof) && passDownsamplig) {
             fillSkimmedTpcTofTable<IsCorrectedDeDx, ModeId>(trk, trackQA, existTrkQA, collision, tofTrack->tpcNSigma, tofTrack->tofNSigma, tofTrack->itsNSigma, tofTrack->tpcExpSignal, tofTrack->pid, runnumber, tofTrack->dwnSmplFactor, hadronicRate, bcGlobalIndex, bcTimeFrameId, bcBcInTimeFrame, occValues, isGoodRctEvent);
           }
         }

--- a/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
+++ b/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
@@ -25,6 +25,7 @@
 #include "PWGLF/DataModel/LFStrangenessPIDTables.h"
 #include "PWGLF/DataModel/LFStrangenessTables.h"
 
+#include "Common/CCDB/RCTSelectionFlags.h"
 #include "Common/CCDB/ctpRateFetcher.h"
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/Multiplicity.h"
@@ -101,6 +102,11 @@ struct TreeWriterTpcV0 {
   Configurable<float> maxPt4dwnsmplTsalisProtons{"maxPt4dwnsmplTsalisProtons", 100., "Maximum Pt for applying downsampling factor of protons"};
   Configurable<float> maxPt4dwnsmplTsalisElectrons{"maxPt4dwnsmplTsalisElectrons", 100., "Maximum Pt for applying  downsampling factor of electrons"};
   Configurable<float> maxPt4dwnsmplTsalisKaons{"maxPt4dwnsmplTsalisKaons", 100., "Maximum Pt for applying  downsampling factor of kaons"};
+  // Configurables for run condtion table
+  Configurable<std::string> rctLabel{"rctLabel", "CBT_hadronPID", "select 1 [CBT, CBT_hadronPID, CBT_muon_glo] see O2Physics/Common/CCDB/RCTSelectionFlags.h"};
+  Configurable<bool> checkZdc{"checkZdc", false, "set ZDC flag for PbPb"};
+  Configurable<bool> treatLimitedAcceptanceAsBad{"treatLimitedAcceptanceAsBad", false, "reject all events where the detectors relevant for the specified Runlist are flagged as LimitedAcceptance"};
+  Configurable<bool> requireGoodRct{"requireGoodRct", false, "require good detector flag in run condtion table"};
 
   // an arbitrary value of N sigma TOF assigned by TOF task to tracks which are not matched to TOF hits
   constexpr static float NSigmaTofUnmatched{o2::aod::v0data::kNoTOFValue};
@@ -149,6 +155,8 @@ struct TreeWriterTpcV0 {
 
   ctpRateFetcher mRateFetcher;
 
+  o2::aod::rctsel::RCTFlagsChecker rctChecker;
+
   TRandom3* fRndm = new TRandom3(0);
 
   using Trks = soa::Join<aod::Tracks, aod::V0Bits, aod::TracksExtra, aod::pidTPCFullEl, aod::pidTPCFullPi, aod::pidTPCFullKa, aod::pidTPCFullPr, aod::pidTOFFullEl, aod::pidTOFFullPi, aod::pidTOFFullKa, aod::pidTOFFullPr, aod::TrackSelection>;
@@ -171,6 +179,8 @@ struct TreeWriterTpcV0 {
     ccdb->setURL("http://alice-ccdb.cern.ch");
     ccdb->setCaching(true);
     ccdb->setFatalWhenNull(false);
+
+    rctChecker.init(rctLabel, checkZdc, treatLimitedAcceptanceAsBad);
   }
 
   template <bool IsCorrectedDeDx, typename V0Casc, typename T>
@@ -413,6 +423,11 @@ struct TreeWriterTpcV0 {
       if (!isEventSelected(collision, applyEvSel)) {
         continue;
       }
+      const bool isGoodRctEvent = rctChecker.checkTable(collision);
+      if (requireGoodRct && !isGoodRctEvent) {
+        continue;
+      }
+
       const auto& v0s = myV0s.sliceBy(perCollisionV0s, static_cast<int>(collision.globalIndex()));
       const auto& cascs = myCascs.sliceBy(perCollisionCascs, static_cast<int>(collision.globalIndex()));
       const auto& bc = collision.bc_as<BCType>();
@@ -614,6 +629,11 @@ struct TreeWriterTpcTof {
   Configurable<float> downsamplingTsalisProtons{"downsamplingTsalisProtons", -1., "Downsampling factor to reduce the number of protons"};
   Configurable<float> downsamplingTsalisKaons{"downsamplingTsalisKaons", -1., "Downsampling factor to reduce the number of kaons"};
   Configurable<float> downsamplingTsalisPions{"downsamplingTsalisPions", -1., "Downsampling factor to reduce the number of pions"};
+  // Configurables for run condtion table
+  Configurable<std::string> rctLabel{"rctLabel", "CBT_hadronPID", "select 1 [CBT, CBT_hadronPID, CBT_muon_glo] see O2Physics/Common/CCDB/RCTSelectionFlags.h"};
+  Configurable<bool> checkZdc{"checkZdc", false, "set ZDC flag for PbPb"};
+  Configurable<bool> treatLimitedAcceptanceAsBad{"treatLimitedAcceptanceAsBad", false, "reject all events where the detectors relevant for the specified Runlist are flagged as LimitedAcceptance"};
+  Configurable<bool> requireGoodRct{"requireGoodRct", false, "require good detector flag in run condtion table"};
 
   struct TofTrack {
     bool isApplyHardCutOnly;
@@ -635,6 +655,8 @@ struct TreeWriterTpcTof {
   Service<o2::ccdb::BasicCCDBManager> ccdb;
 
   ctpRateFetcher mRateFetcher;
+
+  o2::aod::rctsel::RCTFlagsChecker rctChecker;
 
   TRandom3* fRndm = new TRandom3(0);
 
@@ -665,6 +687,8 @@ struct TreeWriterTpcTof {
     ccdb->setURL("http://alice-ccdb.cern.ch");
     ccdb->setCaching(true);
     ccdb->setFatalWhenNull(false);
+
+    rctChecker.init(rctLabel, checkZdc, treatLimitedAcceptanceAsBad);
   }
 
   template <bool DoCorrectDeDx, int ModeId, typename T, typename C>
@@ -779,6 +803,11 @@ struct TreeWriterTpcTof {
       if (!isEventSelected(collision, applyEvSel)) {
         continue;
       }
+      const bool isGoodRctEvent = rctChecker.checkTable(collision);
+      if (requireGoodRct && !isGoodRctEvent) {
+        continue;
+      }
+
       auto tracksWithITSPid = soa::Attach<TrksType,
                                           aod::pidits::ITSNSigmaPi, aod::pidits::ITSNSigmaKa, aod::pidits::ITSNSigmaPr,
                                           aod::pidits::ITSNSigmaDe, aod::pidits::ITSNSigmaTr>(tracks);

--- a/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
+++ b/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
@@ -151,11 +151,11 @@ struct TreeWriterTpcV0 {
     int negDaughterId{UndefValueInt};
   };
 
-  Service<o2::ccdb::BasicCCDBManager> ccdb;
+  Service<o2::ccdb::BasicCCDBManager> ccdb{};
 
-  ctpRateFetcher mRateFetcher;
+  ctpRateFetcher mRateFetcher{};
 
-  o2::aod::rctsel::RCTFlagsChecker rctChecker;
+  o2::aod::rctsel::RCTFlagsChecker rctChecker{};
 
   TRandom3* fRndm = new TRandom3(0);
 
@@ -654,11 +654,11 @@ struct TreeWriterTpcTof {
     double nSigmaTpcTpctof;
   };
 
-  Service<o2::ccdb::BasicCCDBManager> ccdb;
+  Service<o2::ccdb::BasicCCDBManager> ccdb{};
 
-  ctpRateFetcher mRateFetcher;
+  ctpRateFetcher mRateFetcher{};
 
-  o2::aod::rctsel::RCTFlagsChecker rctChecker;
+  o2::aod::rctsel::RCTFlagsChecker rctChecker{};
 
   TRandom3* fRndm = new TRandom3(0);
 
@@ -858,7 +858,7 @@ struct TreeWriterTpcTof {
 
         TofTrack tofPion(false, UndefValueDouble, maxMomTPCOnlyPi, trk.tpcNSigmaPi(), nSigmaTPCOnlyPi, downsamplingTsalisPions, MassPiPlus, trk.tofNSigmaPi(), trk.itsNSigmaPi(), trk.tpcExpSignalPi(tpcSignalGeneric<IsCorrectedDeDx>(trk)), PidPion, dwnSmplFactorPi, nSigmaTofTpctofPi, nSigmaTpcTpctofPi);
 
-        OccupancyValues occValues;
+        OccupancyValues occValues{};
         if constexpr (ModeId == ModeWithTrkQA) {
           evaluateOccupancyVariables(trk, occValues);
         }

--- a/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
+++ b/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
@@ -417,9 +417,9 @@ struct TreeWriterTpcV0 {
       }
     }
 
-    const auto& tracksWithITSPid = soa::Attach<TrksType,
-                                               aod::pidits::ITSNSigmaEl, aod::pidits::ITSNSigmaPi,
-                                               aod::pidits::ITSNSigmaKa, aod::pidits::ITSNSigmaPr>(myTracks);
+    const auto tracksWithITSPid = soa::Attach<TrksType,
+                                              aod::pidits::ITSNSigmaEl, aod::pidits::ITSNSigmaPi,
+                                              aod::pidits::ITSNSigmaKa, aod::pidits::ITSNSigmaPr>(myTracks);
 
     for (const auto& collision : collisions) {
       if (!isEventSelected(collision, applyEvSel)) {
@@ -430,9 +430,9 @@ struct TreeWriterTpcV0 {
         continue;
       }
 
-      const auto& v0s = myV0s.sliceBy(perCollisionV0s, static_cast<int>(collision.globalIndex()));
-      const auto& cascs = myCascs.sliceBy(perCollisionCascs, static_cast<int>(collision.globalIndex()));
-      const auto& bc = collision.bc_as<BCType>();
+      const auto v0s = myV0s.sliceBy(perCollisionV0s, static_cast<int>(collision.globalIndex()));
+      const auto cascs = myCascs.sliceBy(perCollisionCascs, static_cast<int>(collision.globalIndex()));
+      const auto bc = collision.bc_as<BCType>();
       const int runnumber = bc.runNumber();
       const auto hadronicRate = mRateFetcher.fetch(ccdb.service, bc.timestamp(), runnumber, irSource) * OneToKilo;
       const int bcGlobalIndex = bc.globalIndex();
@@ -464,7 +464,7 @@ struct TreeWriterTpcV0 {
       auto fillDaughterTrack = [&](const auto& mother, const TrksType::iterator& dauTrack, const auto& v0, const bool isPositive) {
         const auto [trackQAInstance, existTrkQA] = getTrackQA(dauTrack);
         const auto trackId = dauTrack.globalIndex();
-        const auto& dauTrackWithITSPid = tracksWithITSPid.rawIteratorAt(trackId);
+        const auto dauTrackWithITSPid = tracksWithITSPid.rawIteratorAt(trackId);
         const auto v0Id = getAddId(v0);
         const V0Mother v0Mother = createV0Mother(v0Id);
         const auto daughterId = isPositive ? v0Mother.posDaughterId : v0Mother.negDaughterId;
@@ -489,8 +489,8 @@ struct TreeWriterTpcV0 {
         if (v0Id == MotherUndef) {
           continue;
         }
-        const auto& posTrack = v0.posTrack_as<TrksType>();
-        const auto& negTrack = v0.negTrack_as<TrksType>();
+        const auto posTrack = v0.posTrack_as<TrksType>();
+        const auto negTrack = v0.negTrack_as<TrksType>();
 
         fillDaughterTrack(v0, posTrack, v0, true);
         fillDaughterTrack(v0, negTrack, v0, false);
@@ -502,7 +502,7 @@ struct TreeWriterTpcV0 {
         if (cascId == MotherUndef) {
           continue;
         }
-        const auto& bachTrack = casc.bachelor_as<TrksType>();
+        const auto bachTrack = casc.bachelor_as<TrksType>();
         // Omega and antiomega
         const auto isDaughterPositive = cascId == MotherAntiOmega ? true : false;
         fillDaughterTrack(casc, bachTrack, casc, isDaughterPositive);
@@ -803,7 +803,7 @@ struct TreeWriterTpcTof {
       }
     }
     for (const auto& collision : collisions) {
-      const auto& tracks = myTracks.sliceBy(perCollisionTracksType, collision.globalIndex());
+      const auto tracks = myTracks.sliceBy(perCollisionTracksType, collision.globalIndex());
       if (!isEventSelected(collision, applyEvSel)) {
         continue;
       }
@@ -820,7 +820,7 @@ struct TreeWriterTpcTof {
         tracksWithITSPid.bindExternalIndices(&trackMeanOccs);
       }
 
-      const auto& bc = collision.bc_as<BCType>();
+      const auto bc = collision.bc_as<BCType>();
       const int runnumber = bc.runNumber();
       const auto hadronicRate = mRateFetcher.fetch(ccdb.service, bc.timestamp(), runnumber, irSource) * OneToKilo;
       const int bcGlobalIndex = bc.globalIndex();

--- a/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
+++ b/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
@@ -259,7 +259,7 @@ struct TreeWriterTpcV0 {
   }
 
   template <bool DoUseCorrectedDeDx, int ModeId, typename T, typename C, typename V0Casc>
-  void fillSkimmedV0Table(V0Casc const& v0casc, T const& track, aod::TracksQA const& trackQA, const bool existTrkQA, C const& collision, const float nSigmaTPC, const float nSigmaTOF, const float nSigmaITS, const float dEdxExp, const o2::track::PID::ID id, const int runnumber, const double dwnSmplFactor, const float hadronicRate, const int bcGlobalIndex, const int bcTimeFrameId, const int bcBcInTimeFrame, const OccupancyValues& occValues)
+  void fillSkimmedV0Table(V0Casc const& v0casc, T const& track, aod::TracksQA const& trackQA, const bool existTrkQA, C const& collision, const float nSigmaTPC, const float nSigmaTOF, const float nSigmaITS, const float dEdxExp, const o2::track::PID::ID id, const int runnumber, const double dwnSmplFactor, const float hadronicRate, const int bcGlobalIndex, const int bcTimeFrameId, const int bcBcInTimeFrame, const OccupancyValues& occValues, const bool isGoodRctEvent)
   {
     const double ncl = track.tpcNClsFound();
     const double nclPID = track.tpcNClsFindableMinusPID();
@@ -286,7 +286,8 @@ struct TreeWriterTpcV0 {
         tpcdEdxNorm = existTrkQA ? trackQA.tpcdEdxNorm() : UndefValueFloat;
       }
       if constexpr (ModeId == ModeStandard || ModeId == ModeWithdEdxTrkQA) {
-        rowTPCTree(usedDedx,
+        rowTPCTree(isGoodRctEvent,
+                   usedDedx,
                    1. / dEdxExp,
                    track.tpcInnerParam(),
                    track.tgl(),
@@ -316,7 +317,8 @@ struct TreeWriterTpcV0 {
                    v0radius,
                    gammapsipair);
       } else {
-        rowTPCTreeWithTrkQA(usedDedx,
+        rowTPCTreeWithTrkQA(isGoodRctEvent,
+                            usedDedx,
                             1. / dEdxExp,
                             track.tpcInnerParam(),
                             track.tgl(),
@@ -477,7 +479,7 @@ struct TreeWriterTpcV0 {
           if constexpr (ModeId == ModeWithTrkQA) {
             evaluateOccupancyVariables(dauTrack, occValues);
           }
-          fillSkimmedV0Table<IsCorrectedDeDx, ModeId>(mother, dauTrack, trackQAInstance, existTrkQA, collision, daughter.tpcNSigma, daughter.tofNSigma, daughter.itsNSigma, daughter.tpcExpSignal, daughter.id, runnumber, daughter.dwnSmplFactor, hadronicRate, bcGlobalIndex, bcTimeFrameId, bcBcInTimeFrame, occValues);
+          fillSkimmedV0Table<IsCorrectedDeDx, ModeId>(mother, dauTrack, trackQAInstance, existTrkQA, collision, daughter.tpcNSigma, daughter.tofNSigma, daughter.itsNSigma, daughter.tpcExpSignal, daughter.id, runnumber, daughter.dwnSmplFactor, hadronicRate, bcGlobalIndex, bcTimeFrameId, bcBcInTimeFrame, occValues, isGoodRctEvent);
         }
       };
 
@@ -692,7 +694,7 @@ struct TreeWriterTpcTof {
   }
 
   template <bool DoCorrectDeDx, int ModeId, typename T, typename C>
-  void fillSkimmedTpcTofTable(T const& track, aod::TracksQA const& trackQA, const bool existTrkQA, C const& collision, const float nSigmaTPC, const float nSigmaTOF, const float nSigmaITS, const float dEdxExp, const o2::track::PID::ID id, const int runnumber, const double dwnSmplFactor, const double hadronicRate, const int bcGlobalIndex, const int bcTimeFrameId, const int bcBcInTimeFrame, const OccupancyValues& occValues)
+  void fillSkimmedTpcTofTable(T const& track, aod::TracksQA const& trackQA, const bool existTrkQA, C const& collision, const float nSigmaTPC, const float nSigmaTOF, const float nSigmaITS, const float dEdxExp, const o2::track::PID::ID id, const int runnumber, const double dwnSmplFactor, const double hadronicRate, const int bcGlobalIndex, const int bcTimeFrameId, const int bcBcInTimeFrame, const OccupancyValues& occValues, const bool isGoodRctEvent)
   {
     const double ncl = track.tpcNClsFound();
     const double nclPID = track.tpcNClsFindableMinusPID();
@@ -712,7 +714,8 @@ struct TreeWriterTpcTof {
         tpcdEdxNorm = existTrkQA ? trackQA.tpcdEdxNorm() : UndefValueFloat;
       }
       if (ModeId == ModeStandard || ModeId == ModeWithdEdxTrkQA) {
-        rowTPCTOFTree(usedEdx,
+        rowTPCTOFTree(isGoodRctEvent,
+                      usedEdx,
                       1. / dEdxExp,
                       track.tpcInnerParam(),
                       track.tgl(),
@@ -736,7 +739,8 @@ struct TreeWriterTpcTof {
                       hadronicRate,
                       tpcdEdxNorm);
       } else {
-        rowTPCTOFTreeWithTrkQA(usedEdx,
+        rowTPCTOFTreeWithTrkQA(isGoodRctEvent,
+                               usedEdx,
                                1. / dEdxExp,
                                track.tpcInnerParam(),
                                track.tgl(),
@@ -864,7 +868,7 @@ struct TreeWriterTpcTof {
               ((trk.tpcInnerParam() <= tofTrack->maxMomTPCOnly && std::fabs(tofTrack->tpcNSigma) < tofTrack->nSigmaTPCOnly) ||
                (trk.tpcInnerParam() > tofTrack->maxMomTPCOnly && std::fabs(tofTrack->tofNSigma) < tofTrack->nSigmaTofTpctof && std::fabs(tofTrack->tpcNSigma) < tofTrack->nSigmaTpcTpctof)) &&
               downsampleTsalisCharged(fRndm, trk.pt(), tofTrack->downsamplingTsalis, tofTrack->mass, sqrtSNN)) {
-            fillSkimmedTpcTofTable<IsCorrectedDeDx, ModeId>(trk, trackQA, existTrkQA, collision, tofTrack->tpcNSigma, tofTrack->tofNSigma, tofTrack->itsNSigma, tofTrack->tpcExpSignal, tofTrack->pid, runnumber, tofTrack->dwnSmplFactor, hadronicRate, bcGlobalIndex, bcTimeFrameId, bcBcInTimeFrame, occValues);
+            fillSkimmedTpcTofTable<IsCorrectedDeDx, ModeId>(trk, trackQA, existTrkQA, collision, tofTrack->tpcNSigma, tofTrack->tofNSigma, tofTrack->itsNSigma, tofTrack->tpcExpSignal, tofTrack->pid, runnumber, tofTrack->dwnSmplFactor, hadronicRate, bcGlobalIndex, bcTimeFrameId, bcBcInTimeFrame, occValues, isGoodRctEvent);
           }
         }
       } /// Loop tracks

--- a/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
+++ b/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
@@ -467,8 +467,8 @@ struct TreeWriterTpcV0 {
         const auto& dauTrackWithITSPid = tracksWithITSPid.rawIteratorAt(trackId);
         const auto v0Id = getAddId(v0);
         const V0Mother v0Mother = createV0Mother(v0Id);
-        const auto daighterId = isPositive ? v0Mother.posDaughterId : v0Mother.negDaughterId;
-        const V0Daughter daughter = createV0Daughter<IsCorrectedDeDx>(v0, dauTrackWithITSPid, v0Id, daighterId, isPositive);
+        const auto daughterId = isPositive ? v0Mother.posDaughterId : v0Mother.negDaughterId;
+        const V0Daughter daughter = createV0Daughter<IsCorrectedDeDx>(v0, dauTrackWithITSPid, v0Id, daughterId, isPositive);
 
         const bool passTrackSelection = isTrackSelected(dauTrack, trackSelection);
         const bool passDownsamplig = downsampleTsalisCharged(fRndm, dauTrack.pt(), daughter.downsamplingTsalis, daughter.mass, sqrtSNN, daughter.maxPt4dwnsmplTsalis);

--- a/DPG/Tasks/TPC/tpcSkimsTableCreator.h
+++ b/DPG/Tasks/TPC/tpcSkimsTableCreator.h
@@ -32,6 +32,7 @@ namespace o2::aod
 {
 namespace tpcskims
 {
+DECLARE_SOA_COLUMN(IsGoodRct, isGoodRct, bool);
 DECLARE_SOA_COLUMN(InvDeDxExpTPC, invDeDxExpTPC, float);
 DECLARE_SOA_COLUMN(Mass, mass, float);
 DECLARE_SOA_COLUMN(BetaGamma, betaGamma, float);
@@ -59,7 +60,8 @@ DECLARE_SOA_COLUMN(BcBcInTimeFrame, bcBcInTimeFrame, int);
 } // namespace tpcskims
 
 #define TPCSKIMS_COLUMNS_BASE      \
-  o2::aod::track::TPCSignal,       \
+  tpcskims::IsGoodRct,             \
+    o2::aod::track::TPCSignal,     \
     tpcskims::InvDeDxExpTPC,       \
     o2::aod::track::TPCInnerParam, \
     o2::aod::track::Tgl,           \

--- a/DPG/Tasks/TPC/utilsTpcSkimsTableCreator.h
+++ b/DPG/Tasks/TPC/utilsTpcSkimsTableCreator.h
@@ -132,7 +132,7 @@ void evaluateOccupancyVariables(const TrkType& track, OccupancyValues& occValues
   if (track.tmoId() == -1) {
     return;
   }
-  const auto& tmoFromTrack = track.template tmo_as<TrackMeanOccs>();
+  const auto tmoFromTrack = track.template tmo_as<TrackMeanOccs>();
   occValues.tmoPrimUnfm80 = tmoFromTrack.tmoPrimUnfm80();
   occValues.tmoFV0AUnfm80 = tmoFromTrack.tmoFV0AUnfm80();
   occValues.tmoFT0AUnfm80 = tmoFromTrack.tmoFT0AUnfm80();

--- a/DPG/Tasks/TPC/utilsTpcSkimsTableCreator.h
+++ b/DPG/Tasks/TPC/utilsTpcSkimsTableCreator.h
@@ -47,7 +47,7 @@ enum {
 
 /// Event selection
 template <typename CollisionType>
-inline bool isEventSelected(const CollisionType& collision, const int applyEvSel)
+bool isEventSelected(const CollisionType& collision, const int applyEvSel)
 {
   if ((applyEvSel == EventSelectionRun2 && !collision.sel7()) || (applyEvSel == EventSelectionRun3 && !collision.sel8())) {
     return false;
@@ -86,7 +86,7 @@ inline bool downsampleTsalisCharged(TRandom3* fRndm, const double pt, const doub
 
 // Track selection
 template <typename TrackType>
-inline bool isTrackSelected(const TrackType& track, const int trackSelection)
+bool isTrackSelected(const TrackType& track, const int trackSelection)
 {
   bool isSelected{false};
   isSelected |= trackSelection == TrackSelectionNoCut;
@@ -101,7 +101,7 @@ inline bool isTrackSelected(const TrackType& track, const int trackSelection)
 
 /// Evaluate tpcSignal with or without dEdx correction
 template <bool IsCorrectedDeDx, typename TrkType>
-inline double tpcSignalGeneric(const TrkType& track)
+double tpcSignalGeneric(const TrkType& track)
 {
   if constexpr (IsCorrectedDeDx) {
     return track.tpcSignalCorrected();
@@ -127,7 +127,7 @@ using TrackMeanOccs = soa::Join<aod::TmoTrackIds, aod::TmoToTrackQA, aod::TmoPri
 
 /// Evaluate occupancy-related variables
 template <typename TrkType>
-inline void evaluateOccupancyVariables(const TrkType& track, OccupancyValues& occValues)
+void evaluateOccupancyVariables(const TrkType& track, OccupancyValues& occValues)
 {
   if (track.tmoId() == -1) {
     return;


### PR DESCRIPTION
**Major:**
Enabled selection of tracks by Run Condition Table (for details see [Common/CCDB/RCTSelectionFlags.h](https://github.com/AliceO2Group/O2Physics/blob/a930c3b95d30f755906a2af9219c8ed17cc7d1b4/Common/CCDB/RCTSelectionFlags.h)). The boolean column is added to each track, showing whether the latter belongs to "good" or "bad" event. Upon user's request tracks from "bad" events can be rejected.

**Minor refactory:**
Fixed typo; removed **inline** specifier from **template** functions; value-initialized uninitialized objects; removed redundant `&` when r.h.s. is an rvalue; **if**-condition with complicated logic made more reading-friendly.

Tagging @amaringarcia 