### PR TITLE
[PWGLF] use reconstructed eventType in cascade analysis

### DIFF
--- a/PWGLF/TableProducer/Strangeness/cascqaanalysis.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascqaanalysis.cxx
@@ -44,6 +44,8 @@
 #include <Framework/runDataProcessing.h>
 
 #include <TH1.h>
+#include <TH2.h>
+#include <TH3.h>
 #include <TPDGCode.h>
 #include <TRandom2.h>
 #include <TString.h>
@@ -194,6 +196,15 @@ struct Cascqaanalysis {
             o2::constants::physics::MassOmegaMinus * decayLength * invMomentum};
   }
 
+  template <typename TAxisType>
+  static void setEventTypeAxisLabels(TAxisType* axis)
+  {
+    const char* labels[3] = {"INEL", "INEL>0", "INEL>1"};
+    for (int i = 0; i < 3; ++i) {
+      axis->SetBinLabel(i + 1, labels[i]);
+    }
+  }
+
   void init(InitContext const&)
   {
     TString hCandidateCounterLabels[4] = {"All candidates", "passed topo cuts", "has associated MC particle", "associated with Xi(Omega)"};
@@ -220,15 +231,25 @@ struct Cascqaanalysis {
         registry.get<TH1>(HIST("hNEventsMC"))->GetXaxis()->SetBinLabel(n, hNEventsMCLabels[n - 1]);
       }
       registry.add("hZCollisionGen", "hZCollisionGen", {HistType::kTH1D, {{200, -20.f, 20.f}}});
+      registry.add("hZCollisionRecVsGen", "hZCollisionRecVsGen", {HistType::kTH2D, {{100, -10.f, 10.f, "z_{vtx}^{rec} (cm)"}, {100, -10.f, 10.f, "z_{vtx}^{gen} (cm)"}}});
+      registry.add("hEventTypeRecVsGen", "hEventTypeRecVsGen", {HistType::kTH2D, {eventTypeAxis, eventTypeAxis}});
       registry.add("hNchFT0MNAssocMCCollisions", "hNchFT0MNAssocMCCollisions", {HistType::kTH3D, {nChargedFT0MGenAxis, nAssocCollAxis, eventTypeAxis}});
       registry.add("hNchFT0MNAssocMCCollisionsSameType", "hNchFT0MNAssocMCCollisionsSameType", {HistType::kTH3D, {nChargedFT0MGenAxis, nAssocCollAxis, eventTypeAxis}});
       registry.add("hNContributorsCorrelation", "hNContributorsCorrelation", {HistType::kTH2F, {{250, -0.5f, 249.5f, "Secondary Contributor"}, {250, -0.5f, 249.5f, "Main Contributor"}}});
       registry.add("hNchFT0MGenEvType", "hNchFT0MGenEvType", {HistType::kTH2D, {nChargedFT0MGenAxis, eventTypeAxis}});
       registry.add("hNchFV0AGenEvType", "hNchFV0AGenEvType", {HistType::kTH2D, {nChargedFV0AGenAxis, eventTypeAxis}});
       registry.add("hCentFT0M_genMC", "hCentFT0M_genMC", {HistType::kTH2D, {centFT0MAxis, eventTypeAxis}});
+      setEventTypeAxisLabels(registry.get<TH2>(HIST("hEventTypeRecVsGen"))->GetXaxis());
+      setEventTypeAxisLabels(registry.get<TH2>(HIST("hEventTypeRecVsGen"))->GetYaxis());
+      setEventTypeAxisLabels(registry.get<TH3>(HIST("hNchFT0MNAssocMCCollisions"))->GetZaxis());
+      setEventTypeAxisLabels(registry.get<TH3>(HIST("hNchFT0MNAssocMCCollisionsSameType"))->GetZaxis());
+      setEventTypeAxisLabels(registry.get<TH2>(HIST("hNchFT0MGenEvType"))->GetYaxis());
+      setEventTypeAxisLabels(registry.get<TH2>(HIST("hNchFV0AGenEvType"))->GetYaxis());
+      setEventTypeAxisLabels(registry.get<TH2>(HIST("hCentFT0M_genMC"))->GetYaxis());
     }
 
     registry.add("hCentFT0M_rec", "hCentFT0M_rec", {HistType::kTH2D, {centFT0MAxis, eventTypeAxis}});
+    setEventTypeAxisLabels(registry.get<TH2>(HIST("hCentFT0M_rec"))->GetYaxis());
 
     if (candidateQA) {
       registry.add("hNcandidates", "hNcandidates", {HistType::kTH3D, {nCandidates, centFT0MAxis, {2, -0.5f, 1.5f}}});
@@ -242,6 +263,9 @@ struct Cascqaanalysis {
         registry.add("hNchFT0Mglobal", "hNchFT0Mglobal", {HistType::kTH3D, {nChargedFT0MGenAxis, multNTracksAxis, eventTypeAxis}});
         registry.add("hNchFT0MPVContr", "hNchFT0MPVContr", {HistType::kTH3D, {nChargedFT0MGenAxis, multNTracksAxis, eventTypeAxis}});
         registry.add("hNchFV0APVContr", "hNchFV0APVContr", {HistType::kTH3D, {nChargedFV0AGenAxis, multNTracksAxis, eventTypeAxis}});
+        setEventTypeAxisLabels(registry.get<TH3>(HIST("hNchFT0Mglobal"))->GetZaxis());
+        setEventTypeAxisLabels(registry.get<TH3>(HIST("hNchFT0MPVContr"))->GetZaxis());
+        setEventTypeAxisLabels(registry.get<TH3>(HIST("hNchFV0APVContr"))->GetZaxis());
       }
       registry.add("hFT0MpvContr", "hFT0MpvContr", {HistType::kTH3D, {centFT0MAxis, multNTracksAxis, eventTypeAxis}});
       registry.add("hFV0ApvContr", "hFV0ApvContr", {HistType::kTH3D, {centFV0AAxis, multNTracksAxis, eventTypeAxis}});
@@ -249,6 +273,11 @@ struct Cascqaanalysis {
       registry.add("hFV0AFT0M", "hFV0AFT0M", {HistType::kTH3D, {centFV0AAxis, centFT0MAxis, eventTypeAxis}});
       registry.add("hFT0MFV0Asignal", "hFT0MFV0Asignal", {HistType::kTH2D, {signalFT0MAxis, signalFV0AAxis}});
       registry.add("hFT0MsignalPVContr", "hFT0MsignalPVContr", {HistType::kTH3D, {signalFT0MAxis, multNTracksAxis, eventTypeAxis}});
+      setEventTypeAxisLabels(registry.get<TH3>(HIST("hFT0MpvContr"))->GetZaxis());
+      setEventTypeAxisLabels(registry.get<TH3>(HIST("hFV0ApvContr"))->GetZaxis());
+      setEventTypeAxisLabels(registry.get<TH3>(HIST("hFT0Mglobal"))->GetZaxis());
+      setEventTypeAxisLabels(registry.get<TH3>(HIST("hFV0AFT0M"))->GetZaxis());
+      setEventTypeAxisLabels(registry.get<TH3>(HIST("hFT0MsignalPVContr"))->GetZaxis());
     }
 
     rctChecker.init(cfgEvtRCTFlagCheckerLabel, cfgEvtRCTFlagCheckerZDCCheck, cfgEvtRCTFlagCheckerLimitAcceptAsBad);
@@ -549,31 +578,30 @@ struct Cascqaanalysis {
     uint16_t nchFT0 = getGenNchInFT0Mregion(mcPartSlice);
     uint16_t nchFV0 = getGenNchInFV0Aregion(mcPartSlice);
 
-    int evType = 0;
-    registry.fill(HIST("hNEvents"), 11.5); // INEL
-    // Rec. collision associated with INEL>0 gen. one
+    int genEvType = 0;
     if (pwglf::isINELgtNmc(mcPartSlice, 0, pdgDB)) {
-      registry.fill(HIST("hNEvents"), 12.5); // INEL
-      evType++;
+      genEvType++;
     }
-    // Rec. collision associated with INEL>1 gen. one
     if (pwglf::isINELgtNmc(mcPartSlice, 1, pdgDB)) {
-      registry.fill(HIST("hNEvents"), 13.5); // INEL
-      evType++;
+      genEvType++;
     }
 
-    registry.fill(HIST("hCentFT0M_rec"), mcCollision.centFT0M(), evType);
+    const int recoEvType = getEventTypeFlag(collision);
+
+    registry.fill(HIST("hCentFT0M_rec"), mcCollision.centFT0M(), recoEvType);
+    registry.fill(HIST("hZCollisionRecVsGen"), collision.posZ(), mcCollision.posZ());
+    registry.fill(HIST("hEventTypeRecVsGen"), recoEvType, genEvType);
 
     if (multQA) {
-      registry.fill(HIST("hNchFT0MPVContr"), nchFT0, nTracksPVcontr, evType);
-      registry.fill(HIST("hNchFV0APVContr"), nchFV0, nTracksPVcontr, evType);
-      registry.fill(HIST("hFT0MpvContr"), mcCollision.centFT0M(), nTracksPVcontr, evType);
-      registry.fill(HIST("hFV0ApvContr"), 0, nTracksPVcontr, evType); // mcCollision.centFV0A() to be added
-      registry.fill(HIST("hFT0Mglobal"), mcCollision.centFT0M(), nTracksGlobal, evType);
-      registry.fill(HIST("hFV0AFT0M"), 0, mcCollision.centFT0M(), evType); // mcCollision.centFV0A() to be added
-      registry.fill(HIST("hNchFT0Mglobal"), nchFT0, nTracksGlobal, evType);
+      registry.fill(HIST("hNchFT0MPVContr"), nchFT0, nTracksPVcontr, recoEvType);
+      registry.fill(HIST("hNchFV0APVContr"), nchFV0, nTracksPVcontr, recoEvType);
+      registry.fill(HIST("hFT0MpvContr"), mcCollision.centFT0M(), nTracksPVcontr, recoEvType);
+      registry.fill(HIST("hFV0ApvContr"), 0, nTracksPVcontr, recoEvType); // mcCollision.centFV0A() to be added
+      registry.fill(HIST("hFT0Mglobal"), mcCollision.centFT0M(), nTracksGlobal, recoEvType);
+      registry.fill(HIST("hFV0AFT0M"), 0, mcCollision.centFT0M(), recoEvType); // mcCollision.centFV0A() to be added
+      registry.fill(HIST("hNchFT0Mglobal"), nchFT0, nTracksGlobal, recoEvType);
       registry.fill(HIST("hFT0MFV0Asignal"), collision.multFT0A() + collision.multFT0C(), collision.multFV0A());
-      registry.fill(HIST("hFT0MsignalPVContr"), collision.multFT0A() + collision.multFT0C(), nTracksPVcontr, evType);
+      registry.fill(HIST("hFT0MsignalPVContr"), collision.multFT0A() + collision.multFT0C(), nTracksPVcontr, recoEvType);
     }
 
     float lEventScale = scalefactor;

--- a/PWGLF/TableProducer/Strangeness/cascqaanalysis.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascqaanalysis.cxx
@@ -51,6 +51,7 @@
 #include <TString.h>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
@@ -76,6 +77,19 @@ struct Cascqaanalysis {
 
   HistogramRegistry registry{"registry"};
 
+  enum EventTypeBin {
+    kINEL = 0,
+    kINELgt0,
+    kINELgt1,
+    kNEventTypeBins
+  };
+
+  static constexpr std::array<std::pair<EventTypeBin, const char*>, kNEventTypeBins> EventTypeBinLabels{{
+    {kINEL, "INEL"},
+    {kINELgt0, "INEL>0"},
+    {kINELgt1, "INEL>1"},
+  }};
+
   // Axes
   ConfigurableAxis ptAxis{"ptAxis", {200, 0.0f, 10.0f}, "#it{p}_{T} (GeV/#it{c})"};
   ConfigurableAxis rapidityAxis{"rapidityAxis", {200, -2.0f, 2.0f}, "y"};
@@ -85,7 +99,7 @@ struct Cascqaanalysis {
   ConfigurableAxis centFV0AAxis{"centFV0AAxis",
                                 {VARIABLE_WIDTH, 0., 0.01, 0.05, 0.1, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 105.5},
                                 "FV0A (%)"};
-  ConfigurableAxis eventTypeAxis{"eventTypeAxis", {3, -0.5f, 2.5f}, "Event Type"};
+  ConfigurableAxis eventTypeAxis{"eventTypeAxis", {kNEventTypeBins, -0.5f, static_cast<float>(kNEventTypeBins) - 0.5f}, "Event Type"};
 
   ConfigurableAxis nAssocCollAxis{"nAssocCollAxis", {5, -0.5f, 4.5f}, "N_{assoc.}"};
   ConfigurableAxis nChargedFT0MGenAxis{"nChargedFT0MGenAxis", {300, 0, 300}, "N_{FT0M, gen.}"};
@@ -199,9 +213,8 @@ struct Cascqaanalysis {
   template <typename TAxisType>
   static void setEventTypeAxisLabels(TAxisType* axis)
   {
-    const char* labels[] = {"INEL", "INEL>0", "INEL>1"};
-    for (int i = 0; i < static_cast<int>(sizeof(labels) / sizeof(labels[0])); ++i) {
-      axis->SetBinLabel(i + 1, labels[i]);
+    for (const auto& [bin, label] : EventTypeBinLabels) {
+      axis->SetBinLabel(static_cast<int>(bin) + 1, label);
     }
   }
 
@@ -363,20 +376,19 @@ struct Cascqaanalysis {
   }
 
   template <typename TCollision>
-  int getEventTypeFlag(TCollision const& collision)
+  EventTypeBin getEventTypeBin(TCollision const& collision)
   {
-    // 0 - INEL, 1 - INEL>0, 2 - INEL>1
-    int evFlag = 0;
+    EventTypeBin evTypeBin = kINEL;
     registry.fill(HIST("hNEvents"), 11.5); // INEL
     if (collision.isInelGt0()) {
-      evFlag += 1;
+      evTypeBin = kINELgt0;
       registry.fill(HIST("hNEvents"), 12.5); // INEL>0
     }
     if (collision.isInelGt1()) {
-      evFlag += 1;
+      evTypeBin = kINELgt1;
       registry.fill(HIST("hNEvents"), 13.5); // INEL>1
     }
-    return evFlag;
+    return evTypeBin;
   }
 
   template <typename TCollision>
@@ -480,7 +492,7 @@ struct Cascqaanalysis {
       return;
     }
 
-    int evType = getEventTypeFlag(collision);
+    EventTypeBin evType = getEventTypeBin(collision);
 
     auto tracksGroupedPVcontr = pvContribTracksIUEta1->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
     int nTracksPVcontr = tracksGroupedPVcontr.size();
@@ -578,15 +590,15 @@ struct Cascqaanalysis {
     uint16_t nchFT0 = getGenNchInFT0Mregion(mcPartSlice);
     uint16_t nchFV0 = getGenNchInFV0Aregion(mcPartSlice);
 
-    int genEvType = 0;
+    EventTypeBin genEvType = kINEL;
     if (pwglf::isINELgtNmc(mcPartSlice, 0, pdgDB)) {
-      genEvType++;
+      genEvType = kINELgt0;
     }
     if (pwglf::isINELgtNmc(mcPartSlice, 1, pdgDB)) {
-      genEvType++;
+      genEvType = kINELgt1;
     }
 
-    const int recoEvType = getEventTypeFlag(collision);
+    const EventTypeBin recoEvType = getEventTypeBin(collision);
 
     registry.fill(HIST("hCentFT0M_rec"), mcCollision.centFT0M(), recoEvType);
     registry.fill(HIST("hZCollisionRecVsGen"), collision.posZ(), mcCollision.posZ());
@@ -682,20 +694,20 @@ struct Cascqaanalysis {
     registry.fill(HIST("hNEventsMC"), 1.5);
 
     // Define the type of generated MC collision
-    int evType = 0;
+    EventTypeBin evType = kINEL;
     uint8_t flagsGen = 0;
     flagsGen |= o2::aod::myMCcascades::EvFlags::EvINEL;
     registry.fill(HIST("hNEventsMC"), 2.5);
     // Generated collision is INEL>0
     if (pwglf::isINELgtNmc(mcParticles, 0, pdgDB)) {
       flagsGen |= o2::aod::myMCcascades::EvFlags::EvINELgt0;
-      evType++;
+      evType = kINELgt0;
       registry.fill(HIST("hNEventsMC"), 3.5);
     }
     // Generated collision is INEL>1
     if (pwglf::isINELgtNmc(mcParticles, 1, pdgDB)) {
       flagsGen |= o2::aod::myMCcascades::EvFlags::EvINELgt1;
-      evType++;
+      evType = kINELgt1;
       registry.fill(HIST("hNEventsMC"), 4.5);
     }
 
@@ -751,15 +763,15 @@ struct Cascqaanalysis {
     const auto evtReconstructedAndINELgt1 = std::count_if(selectedEvents.begin(), selectedEvents.end(), isAssocToINELgt1);
 
     switch (evType) {
-      case 0: {
+      case kINEL: {
         registry.fill(HIST("hNchFT0MNAssocMCCollisionsSameType"), nchFT0, evtReconstructedAndINEL, evType);
         break;
       }
-      case 1: {
+      case kINELgt0: {
         registry.fill(HIST("hNchFT0MNAssocMCCollisionsSameType"), nchFT0, evtReconstructedAndINELgt0, evType);
         break;
       }
-      case 2: {
+      case kINELgt1: {
         registry.fill(HIST("hNchFT0MNAssocMCCollisionsSameType"), nchFT0, evtReconstructedAndINELgt1, evType);
         break;
       }

--- a/PWGLF/TableProducer/Strangeness/cascqaanalysis.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascqaanalysis.cxx
@@ -199,8 +199,8 @@ struct Cascqaanalysis {
   template <typename TAxisType>
   static void setEventTypeAxisLabels(TAxisType* axis)
   {
-    const char* labels[3] = {"INEL", "INEL>0", "INEL>1"};
-    for (int i = 0; i < 3; ++i) {
+    const char* labels[] = {"INEL", "INEL>0", "INEL>1"};
+    for (int i = 0; i < static_cast<int>(sizeof(labels) / sizeof(labels[0])); ++i) {
       axis->SetBinLabel(i + 1, labels[i]);
     }
   }


### PR DESCRIPTION
The reconstructed event type is used for MC.
Several QA hists, and eventType labels are added.