### PR TITLE
[Common] Add EsE q-vectors to q-vector calibration task

### DIFF
--- a/Common/DataModel/Qvectors.h
+++ b/Common/DataModel/Qvectors.h
@@ -201,7 +201,7 @@ DECLARE_SOA_COLUMN(EseRedQFV0A, eseRedQFV0A, float);
 } // namespace ese_qvec
 
 DECLARE_SOA_TABLE(EseQvectors, "AOD", "ESEQVECTORDEVS", //! Table with all Qvectors.
-                  qvec::Cent, ese_qvec::IsCalibrated, ese_qvec::EseQvecRe, ese_qvec::EseQvecIm, ese_qvec::EseQvecAmp);
+                  qvec::Cent, ese_qvec::IsCalibrated, ese_qvec::EseQvecRe, ese_qvec::EseQvecIm, qvec::QvecAmp);
 using Qvector = Qvectors::iterator;
 
 DECLARE_SOA_TABLE(EseQvecFT0Cs, "AOD", "ESEQVECFT0C", ese_qvec::IsCalibrated, ese_qvec::EseQvecFT0CRe, ese_qvec::EseQvecFT0CIm, qvec::SumAmplFT0C);

--- a/Common/Tasks/qVectorsCorrection.cxx
+++ b/Common/Tasks/qVectorsCorrection.cxx
@@ -45,7 +45,8 @@
 using namespace o2;
 using namespace o2::framework;
 
-using MyCollisions = soa::Join<aod::Collisions, aod::EvSels, aod::Qvectors>;
+using MySpCollisions = soa::Join<aod::Collisions, aod::EvSels, aod::Qvectors>;
+using MyEseCollisions = soa::Join<aod::Collisions, aod::EvSels, aod::EseQvectors>;
 using MyTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TrackSelection, aod::TrackSelectionExtension>;
 
 struct qVectorsCorrection {
@@ -100,6 +101,26 @@ struct qVectorsCorrection {
   int DetId;
   int RefAId;
   int RefBId;
+
+  template <typename TColl>
+  float getQVecRe(TColl const& collision, int detId)
+  {
+    if constexpr (std::derived_from<TColl, MyEseCollisions::iterator>) {
+      return collision.eseQvecRe()[detId];
+    } else {
+      return collision.qvecRe()[detId];
+    }
+  }
+
+  template <typename TColl>
+  float getQVecIm(TColl const& collision, int detId)
+  {
+    if constexpr (std::derived_from<TColl, MyEseCollisions::iterator>) {
+      return collision.eseQvecIm()[detId];
+    } else {
+      return collision.qvecIm()[detId];
+    }
+  }
 
   template <typename T>
   int GetDetId(const T& name)
@@ -178,9 +199,9 @@ struct qVectorsCorrection {
     AxisSpec axisBasis = {20, 0, 20, "basis"};
     AxisSpec axisVertex = {220, -11, 11, "vertex"};
 
-    histosQA.add("histCentFull", "Centrality distribution for valid events", HistType::kTH1F, {axisCent});
-    histosQA.add("histCentSelected", "Centrality distribution for valid events", HistType::kTH1F, {axisCent});
-    histosQA.add("histVtxSelected", "Centrality distribution for valid events", HistType::kTH1F, {axisVertex});
+    histosQA.add("histCentFull", "Centrality distribution for all events", HistType::kTH1F, {axisCent});
+    histosQA.add("histCentSelected", "Centrality distribution for selected events", HistType::kTH1F, {axisCent});
+    histosQA.add("histVtxSelected", "Z vtx coordinate distribution for valid events", HistType::kTH1F, {axisVertex});
 
     for (uint i = 0; i < cfgnMods->size(); i++) {
       histosQA.add(Form("histQvecUncorV%d", cfgnMods->at(i)), "", {HistType::kTH3F, {axisQvecF, axisQvecF, axisCent}});
@@ -270,97 +291,42 @@ struct qVectorsCorrection {
       return;
     }
 
+    auto aTan2DetInd = TMath::ATan2(getQVecIm(vec, DetInd), getQVecRe(vec, DetInd));
+    auto aTan2RefAInd = TMath::ATan2(getQVecIm(vec, RefAInd), getQVecRe(vec, RefAInd));
+    auto aTan2RefBInd = TMath::ATan2(getQVecIm(vec, RefBInd), getQVecRe(vec, RefBInd));
+
     if (nmode == 2) {
       for (int ishift = 1; ishift <= 10; ishift++) {
-        histosQA.fill(HIST("histShiftV2"), vec.cent(), 2.0 * DetId + 0.5, ishift - 0.5, TMath::Sin(ishift * static_cast<float>(nmode) * TMath::ATan2(vec.qvecIm()[DetInd], vec.qvecRe()[DetInd]) / static_cast<float>(nmode)));
-        histosQA.fill(HIST("histShiftV2"), vec.cent(), 2.0 * DetId + 1.5, ishift - 0.5, TMath::Cos(ishift * static_cast<float>(nmode) * TMath::ATan2(vec.qvecIm()[DetInd], vec.qvecRe()[DetInd]) / static_cast<float>(nmode)));
+        histosQA.fill(HIST("histShiftV2"), vec.cent(), 2.0 * DetId + 0.5, ishift - 0.5, TMath::Sin(ishift * aTan2DetInd));
+        histosQA.fill(HIST("histShiftV2"), vec.cent(), 2.0 * DetId + 1.5, ishift - 0.5, TMath::Cos(ishift * aTan2DetInd));
 
-        histosQA.fill(HIST("histShiftV2"), vec.cent(), 2.0 * RefAId + 0.5, ishift - 0.5, TMath::Sin(ishift * static_cast<float>(nmode) * TMath::ATan2(vec.qvecIm()[RefAInd], vec.qvecRe()[RefAInd]) / static_cast<float>(nmode)));
-        histosQA.fill(HIST("histShiftV2"), vec.cent(), 2.0 * RefAId + 1.5, ishift - 0.5, TMath::Cos(ishift * static_cast<float>(nmode) * TMath::ATan2(vec.qvecIm()[RefAInd], vec.qvecRe()[RefAInd]) / static_cast<float>(nmode)));
+        histosQA.fill(HIST("histShiftV2"), vec.cent(), 2.0 * RefAId + 0.5, ishift - 0.5, TMath::Sin(ishift * aTan2RefAInd));
+        histosQA.fill(HIST("histShiftV2"), vec.cent(), 2.0 * RefAId + 1.5, ishift - 0.5, TMath::Cos(ishift * aTan2RefAInd));
 
-        histosQA.fill(HIST("histShiftV2"), vec.cent(), 2.0 * RefBId + 0.5, ishift - 0.5, TMath::Sin(ishift * static_cast<float>(nmode) * TMath::ATan2(vec.qvecIm()[RefBInd], vec.qvecRe()[RefBInd]) / static_cast<float>(nmode)));
-        histosQA.fill(HIST("histShiftV2"), vec.cent(), 2.0 * RefBId + 1.5, ishift - 0.5, TMath::Cos(ishift * static_cast<float>(nmode) * TMath::ATan2(vec.qvecIm()[RefBInd], vec.qvecRe()[RefBInd]) / static_cast<float>(nmode)));
+        histosQA.fill(HIST("histShiftV2"), vec.cent(), 2.0 * RefBId + 0.5, ishift - 0.5, TMath::Sin(ishift * aTan2RefBInd));
+        histosQA.fill(HIST("histShiftV2"), vec.cent(), 2.0 * RefBId + 1.5, ishift - 0.5, TMath::Cos(ishift * aTan2RefBInd));
       }
     } else if (nmode == 3) {
       for (int ishift = 1; ishift <= 10; ishift++) {
-        histosQA.fill(HIST("histShiftV3"), vec.cent(), 2.0 * DetId + 0.5, ishift - 0.5, TMath::Sin(ishift * static_cast<float>(nmode) * TMath::ATan2(vec.qvecIm()[DetInd], vec.qvecRe()[DetInd]) / static_cast<float>(nmode)));
-        histosQA.fill(HIST("histShiftV3"), vec.cent(), 2.0 * DetId + 1.5, ishift - 0.5, TMath::Cos(ishift * static_cast<float>(nmode) * TMath::ATan2(vec.qvecIm()[DetInd], vec.qvecRe()[DetInd]) / static_cast<float>(nmode)));
+        histosQA.fill(HIST("histShiftV3"), vec.cent(), 2.0 * DetId + 0.5, ishift - 0.5, TMath::Sin(ishift * aTan2DetInd));
+        histosQA.fill(HIST("histShiftV3"), vec.cent(), 2.0 * DetId + 1.5, ishift - 0.5, TMath::Cos(ishift * aTan2DetInd));
 
-        histosQA.fill(HIST("histShiftV3"), vec.cent(), 2.0 * RefAId + 0.5, ishift - 0.5, TMath::Sin(ishift * static_cast<float>(nmode) * TMath::ATan2(vec.qvecIm()[RefAInd], vec.qvecRe()[RefAInd]) / static_cast<float>(nmode)));
-        histosQA.fill(HIST("histShiftV3"), vec.cent(), 2.0 * RefAId + 1.5, ishift - 0.5, TMath::Cos(ishift * static_cast<float>(nmode) * TMath::ATan2(vec.qvecIm()[RefAInd], vec.qvecRe()[RefAInd]) / static_cast<float>(nmode)));
+        histosQA.fill(HIST("histShiftV3"), vec.cent(), 2.0 * RefAId + 0.5, ishift - 0.5, TMath::Sin(ishift * aTan2RefAInd));
+        histosQA.fill(HIST("histShiftV3"), vec.cent(), 2.0 * RefAId + 1.5, ishift - 0.5, TMath::Cos(ishift * aTan2RefAInd));
 
-        histosQA.fill(HIST("histShiftV3"), vec.cent(), 2.0 * RefBId + 0.5, ishift - 0.5, TMath::Sin(ishift * static_cast<float>(nmode) * TMath::ATan2(vec.qvecIm()[RefBInd], vec.qvecRe()[RefBInd]) / static_cast<float>(nmode)));
-        histosQA.fill(HIST("histShiftV3"), vec.cent(), 2.0 * RefBId + 1.5, ishift - 0.5, TMath::Cos(ishift * static_cast<float>(nmode) * TMath::ATan2(vec.qvecIm()[RefBInd], vec.qvecRe()[RefBInd]) / static_cast<float>(nmode)));
+        histosQA.fill(HIST("histShiftV3"), vec.cent(), 2.0 * RefBId + 0.5, ishift - 0.5, TMath::Sin(ishift * aTan2RefBInd));
+        histosQA.fill(HIST("histShiftV3"), vec.cent(), 2.0 * RefBId + 1.5, ishift - 0.5, TMath::Cos(ishift * aTan2RefBInd));
       }
     } else if (nmode == 4) {
       for (int ishift = 1; ishift <= 10; ishift++) {
-        histosQA.fill(HIST("histShiftV4"), vec.cent(), 2.0 * DetId + 0.5, ishift - 0.5, TMath::Sin(ishift * static_cast<float>(nmode) * TMath::ATan2(vec.qvecIm()[DetInd], vec.qvecRe()[DetInd]) / static_cast<float>(nmode)));
-        histosQA.fill(HIST("histShiftV4"), vec.cent(), 2.0 * DetId + 1.5, ishift - 0.5, TMath::Cos(ishift * static_cast<float>(nmode) * TMath::ATan2(vec.qvecIm()[DetInd], vec.qvecRe()[DetInd]) / static_cast<float>(nmode)));
+        histosQA.fill(HIST("histShiftV4"), vec.cent(), 2.0 * DetId + 0.5, ishift - 0.5, TMath::Sin(ishift * aTan2DetInd));
+        histosQA.fill(HIST("histShiftV4"), vec.cent(), 2.0 * DetId + 1.5, ishift - 0.5, TMath::Cos(ishift * aTan2DetInd));
 
-        histosQA.fill(HIST("histShiftV4"), vec.cent(), 2.0 * RefAId + 0.5, ishift - 0.5, TMath::Sin(ishift * static_cast<float>(nmode) * TMath::ATan2(vec.qvecIm()[RefAInd], vec.qvecRe()[RefAInd]) / static_cast<float>(nmode)));
-        histosQA.fill(HIST("histShiftV4"), vec.cent(), 2.0 * RefAId + 1.5, ishift - 0.5, TMath::Cos(ishift * static_cast<float>(nmode) * TMath::ATan2(vec.qvecIm()[RefAInd], vec.qvecRe()[RefAInd]) / static_cast<float>(nmode)));
+        histosQA.fill(HIST("histShiftV4"), vec.cent(), 2.0 * RefAId + 0.5, ishift - 0.5, TMath::Sin(ishift * aTan2RefAInd));
+        histosQA.fill(HIST("histShiftV4"), vec.cent(), 2.0 * RefAId + 1.5, ishift - 0.5, TMath::Cos(ishift * aTan2RefAInd));
 
-        histosQA.fill(HIST("histShiftV4"), vec.cent(), 2.0 * RefBId + 0.5, ishift - 0.5, TMath::Sin(ishift * static_cast<float>(nmode) * TMath::ATan2(vec.qvecIm()[RefBInd], vec.qvecRe()[RefBInd]) / static_cast<float>(nmode)));
-        histosQA.fill(HIST("histShiftV4"), vec.cent(), 2.0 * RefBId + 1.5, ishift - 0.5, TMath::Cos(ishift * static_cast<float>(nmode) * TMath::ATan2(vec.qvecIm()[RefBInd], vec.qvecRe()[RefBInd]) / static_cast<float>(nmode)));
-      }
-    }
-  }
-
-  template <typename CollType, typename TrackType>
-  void fillHistosFlowWithSC(const CollType& coll, const TrackType& track, int nmode)
-  {
-    int DetInd = DetId + cfgnTotalSystem * (nmode - 2);
-    int RefAInd = RefAId + cfgnTotalSystem * (nmode - 2);
-    int RefBInd = RefBId + cfgnTotalSystem * (nmode - 2);
-
-    if (coll.qvecAmp()[DetId] < 1e-8 || coll.qvecAmp()[RefAId] < 1e-8 || coll.qvecAmp()[RefBId] < 1e-8) {
-      return;
-    }
-
-    for (auto& trk : track) {
-      if (!SelTrack(trk)) {
-        continue;
-      }
-
-      if (std::abs(trk.eta()) > 0.8) {
-        continue;
-      }
-      if (nmode == 2) {
-        histosQA.fill(HIST("hist_EP_cos_Det_v2"), coll.cent(), trk.pt(), std::cos(2.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[DetInd], coll.qvecShiftedIm()[DetInd], nmode))));
-        histosQA.fill(HIST("hist_EP_sin_Det_v2"), coll.cent(), trk.pt(), std::sin(2.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[DetInd], coll.qvecShiftedIm()[DetInd], nmode))));
-        histosQA.fill(HIST("hist_EP_azimuth_Det_v2"), coll.cent(), trk.pt(), TVector2::Phi_0_2pi(2.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[DetInd], coll.qvecShiftedIm()[DetInd], nmode))));
-
-        histosQA.fill(HIST("hist_EP_cos_RefA_v2"), coll.cent(), trk.pt(), std::cos(2.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[RefAInd], coll.qvecShiftedIm()[RefAInd], nmode))));
-        histosQA.fill(HIST("hist_EP_sin_RefA_v2"), coll.cent(), trk.pt(), std::sin(2.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[RefAInd], coll.qvecShiftedIm()[RefAInd], nmode))));
-        histosQA.fill(HIST("hist_EP_azimuth_RefA_v2"), coll.cent(), trk.pt(), TVector2::Phi_0_2pi(2.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[RefAInd], coll.qvecShiftedIm()[RefAInd], nmode))));
-
-        histosQA.fill(HIST("hist_EP_cos_RefB_v2"), coll.cent(), trk.pt(), std::cos(2.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[RefBInd], coll.qvecShiftedIm()[RefBInd], nmode))));
-        histosQA.fill(HIST("hist_EP_sin_RefB_v2"), coll.cent(), trk.pt(), std::sin(2.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[RefBInd], coll.qvecShiftedIm()[RefBInd], nmode))));
-        histosQA.fill(HIST("hist_EP_azimuth_RefB_v2"), coll.cent(), trk.pt(), TVector2::Phi_0_2pi(2.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[RefBInd], coll.qvecShiftedIm()[RefBInd], nmode))));
-      } else if (nmode == 3) {
-        histosQA.fill(HIST("hist_EP_cos_Det_v3"), coll.cent(), trk.pt(), std::cos(3.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[DetInd], coll.qvecShiftedIm()[DetInd], nmode))));
-        histosQA.fill(HIST("hist_EP_sin_Det_v3"), coll.cent(), trk.pt(), std::sin(3.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[DetInd], coll.qvecShiftedIm()[DetInd], nmode))));
-        histosQA.fill(HIST("hist_EP_azimuth_Det_v3"), coll.cent(), trk.pt(), TVector2::Phi_0_2pi(3.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[DetInd], coll.qvecShiftedIm()[DetInd], nmode))));
-
-        histosQA.fill(HIST("hist_EP_cos_RefA_v3"), coll.cent(), trk.pt(), std::cos(3.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[RefAInd], coll.qvecShiftedIm()[RefAInd], nmode))));
-        histosQA.fill(HIST("hist_EP_sin_RefA_v3"), coll.cent(), trk.pt(), std::sin(3.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[RefAInd], coll.qvecShiftedIm()[RefAInd], nmode))));
-        histosQA.fill(HIST("hist_EP_azimuth_RefA_v3"), coll.cent(), trk.pt(), TVector2::Phi_0_2pi(3.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[RefAInd], coll.qvecShiftedIm()[RefAInd], nmode))));
-
-        histosQA.fill(HIST("hist_EP_cos_RefB_v3"), coll.cent(), trk.pt(), std::cos(3.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[RefBInd], coll.qvecShiftedIm()[RefBInd], nmode))));
-        histosQA.fill(HIST("hist_EP_sin_RefB_v3"), coll.cent(), trk.pt(), std::sin(3.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[RefBInd], coll.qvecShiftedIm()[RefBInd], nmode))));
-        histosQA.fill(HIST("hist_EP_azimuth_RefB_v3"), coll.cent(), trk.pt(), TVector2::Phi_0_2pi(3.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[RefBInd], coll.qvecShiftedIm()[RefBInd], nmode))));
-      } else if (nmode == 4) {
-        histosQA.fill(HIST("hist_EP_cos_Det_v4"), coll.cent(), trk.pt(), std::cos(4.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[DetInd], coll.qvecShiftedIm()[DetInd], nmode))));
-        histosQA.fill(HIST("hist_EP_sin_Det_v4"), coll.cent(), trk.pt(), std::sin(4.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[DetInd], coll.qvecShiftedIm()[DetInd], nmode))));
-        histosQA.fill(HIST("hist_EP_azimuth_Det_v4"), coll.cent(), trk.pt(), TVector2::Phi_0_2pi(4.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[DetInd], coll.qvecShiftedIm()[DetInd], nmode))));
-
-        histosQA.fill(HIST("hist_EP_cos_RefA_v4"), coll.cent(), trk.pt(), std::cos(4.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[RefAInd], coll.qvecShiftedIm()[RefAInd], nmode))));
-        histosQA.fill(HIST("hist_EP_sin_RefA_v4"), coll.cent(), trk.pt(), std::sin(4.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[RefAInd], coll.qvecShiftedIm()[RefAInd], nmode))));
-        histosQA.fill(HIST("hist_EP_azimuth_RefA_v4"), coll.cent(), trk.pt(), TVector2::Phi_0_2pi(4.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[RefAInd], coll.qvecShiftedIm()[RefAInd], nmode))));
-
-        histosQA.fill(HIST("hist_EP_cos_RefB_v4"), coll.cent(), trk.pt(), std::cos(4.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[RefBInd], coll.qvecShiftedIm()[RefBInd], nmode))));
-        histosQA.fill(HIST("hist_EP_sin_RefB_v4"), coll.cent(), trk.pt(), std::sin(4.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[RefBInd], coll.qvecShiftedIm()[RefBInd], nmode))));
-        histosQA.fill(HIST("hist_EP_azimuth_RefB_v4"), coll.cent(), trk.pt(), TVector2::Phi_0_2pi(4.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecShiftedRe()[RefBInd], coll.qvecShiftedIm()[RefBInd], nmode))));
+        histosQA.fill(HIST("histShiftV4"), vec.cent(), 2.0 * RefBId + 0.5, ishift - 0.5, TMath::Sin(ishift * aTan2RefBInd));
+        histosQA.fill(HIST("histShiftV4"), vec.cent(), 2.0 * RefBId + 1.5, ishift - 0.5, TMath::Cos(ishift * aTan2RefBInd));
       }
     }
   }
@@ -384,96 +350,50 @@ struct qVectorsCorrection {
         continue;
       }
 
+      auto trkPhi = trk.phi();
+      auto trkPt = trk.pt();
+      auto cent = coll.cent();
+      auto epDetInd = helperEP.GetEventPlane(getQVecRe(coll, DetInd + 3), getQVecIm(coll, DetInd + 3), nmode);
+      auto epRefAInd = helperEP.GetEventPlane(getQVecRe(coll, RefAInd + 3), getQVecIm(coll, RefAInd + 3), nmode);
+      auto epRefBInd = helperEP.GetEventPlane(getQVecRe(coll, RefBInd + 3), getQVecIm(coll, RefBInd + 3), nmode);
+
       if (nmode == 2) {
-        histosQA.fill(HIST("hist_EP_cos_Det_v2"), coll.cent(), trk.pt(), std::cos(2.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[DetInd + 3], coll.qvecIm()[DetInd + 3], nmode))));
-        histosQA.fill(HIST("hist_EP_sin_Det_v2"), coll.cent(), trk.pt(), std::sin(2.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[DetInd + 3], coll.qvecIm()[DetInd + 3], nmode))));
-        histosQA.fill(HIST("hist_EP_azimuth_Det_v2"), coll.cent(), trk.pt(), TVector2::Phi_0_2pi(2.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[DetInd + 3], coll.qvecIm()[DetInd + 3], nmode))));
+        histosQA.fill(HIST("hist_EP_cos_Det_v2"), cent, trkPt, std::cos(2.0 * (trkPhi - epDetInd)));
+        histosQA.fill(HIST("hist_EP_sin_Det_v2"), cent, trkPt, std::sin(2.0 * (trkPhi - epDetInd)));
+        histosQA.fill(HIST("hist_EP_azimuth_Det_v2"), cent, trkPt, TVector2::Phi_0_2pi(2.0 * (trkPhi - epDetInd)));
 
-        histosQA.fill(HIST("hist_EP_cos_RefA_v2"), coll.cent(), trk.pt(), std::cos(2.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[RefAInd + 3], coll.qvecIm()[RefAInd + 3], nmode))));
-        histosQA.fill(HIST("hist_EP_sin_RefA_v2"), coll.cent(), trk.pt(), std::sin(2.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[RefAInd + 3], coll.qvecIm()[RefAInd + 3], nmode))));
-        histosQA.fill(HIST("hist_EP_azimuth_RefA_v2"), coll.cent(), trk.pt(), TVector2::Phi_0_2pi(2.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[RefAInd + 3], coll.qvecIm()[RefAInd + 3], nmode))));
+        histosQA.fill(HIST("hist_EP_cos_RefA_v2"), cent, trkPt, std::cos(2.0 * (trkPhi - epRefAInd)));
+        histosQA.fill(HIST("hist_EP_sin_RefA_v2"), cent, trkPt, std::sin(2.0 * (trkPhi - epRefAInd)));
+        histosQA.fill(HIST("hist_EP_azimuth_RefA_v2"), cent, trkPt, TVector2::Phi_0_2pi(2.0 * (trkPhi - epRefAInd)));
 
-        histosQA.fill(HIST("hist_EP_cos_RefB_v2"), coll.cent(), trk.pt(), std::cos(2.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[RefBInd + 3], coll.qvecIm()[RefBInd + 3], nmode))));
-        histosQA.fill(HIST("hist_EP_sin_RefB_v2"), coll.cent(), trk.pt(), std::sin(2.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[RefBInd + 3], coll.qvecIm()[RefBInd + 3], nmode))));
-        histosQA.fill(HIST("hist_EP_azimuth_RefB_v2"), coll.cent(), trk.pt(), TVector2::Phi_0_2pi(2.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[RefBInd + 3], coll.qvecIm()[RefBInd + 3], nmode))));
+        histosQA.fill(HIST("hist_EP_cos_RefB_v2"), cent, trkPt, std::cos(2.0 * (trkPhi - epRefBInd)));
+        histosQA.fill(HIST("hist_EP_sin_RefB_v2"), cent, trkPt, std::sin(2.0 * (trkPhi - epRefBInd)));
+        histosQA.fill(HIST("hist_EP_azimuth_RefB_v2"), cent, trkPt, TVector2::Phi_0_2pi(2.0 * (trkPhi - epRefBInd)));
       } else if (nmode == 3) {
-        histosQA.fill(HIST("hist_EP_cos_Det_v3"), coll.cent(), trk.pt(), std::cos(3.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[DetInd + 3], coll.qvecIm()[DetInd + 3], nmode))));
-        histosQA.fill(HIST("hist_EP_sin_Det_v3"), coll.cent(), trk.pt(), std::sin(3.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[DetInd + 3], coll.qvecIm()[DetInd + 3], nmode))));
-        histosQA.fill(HIST("hist_EP_azimuth_Det_v3"), coll.cent(), trk.pt(), TVector2::Phi_0_2pi(3.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[DetInd + 3], coll.qvecIm()[DetInd + 3], nmode))));
+        histosQA.fill(HIST("hist_EP_cos_Det_v3"), cent, trkPt, std::cos(3.0 * (trkPhi - epDetInd)));
+        histosQA.fill(HIST("hist_EP_sin_Det_v3"), cent, trkPt, std::sin(3.0 * (trkPhi - epDetInd)));
+        histosQA.fill(HIST("hist_EP_azimuth_Det_v3"), cent, trkPt, TVector2::Phi_0_2pi(3.0 * (trkPhi - epDetInd)));
 
-        histosQA.fill(HIST("hist_EP_cos_RefA_v3"), coll.cent(), trk.pt(), std::cos(3.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[RefAInd + 3], coll.qvecIm()[RefAInd + 3], nmode))));
-        histosQA.fill(HIST("hist_EP_sin_RefA_v3"), coll.cent(), trk.pt(), std::sin(3.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[RefAInd + 3], coll.qvecIm()[RefAInd + 3], nmode))));
-        histosQA.fill(HIST("hist_EP_azimuth_RefA_v3"), coll.cent(), trk.pt(), TVector2::Phi_0_2pi(3.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[RefAInd + 3], coll.qvecIm()[RefAInd + 3], nmode))));
+        histosQA.fill(HIST("hist_EP_cos_RefA_v3"), cent, trkPt, std::cos(3.0 * (trkPhi - epRefAInd)));
+        histosQA.fill(HIST("hist_EP_sin_RefA_v3"), cent, trkPt, std::sin(3.0 * (trkPhi - epRefAInd)));
+        histosQA.fill(HIST("hist_EP_azimuth_RefA_v3"), cent, trkPt, TVector2::Phi_0_2pi(3.0 * (trkPhi - epRefAInd)));
 
-        histosQA.fill(HIST("hist_EP_cos_RefB_v3"), coll.cent(), trk.pt(), std::cos(3.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[RefBInd + 3], coll.qvecIm()[RefBInd + 3], nmode))));
-        histosQA.fill(HIST("hist_EP_sin_RefB_v3"), coll.cent(), trk.pt(), std::sin(3.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[RefBInd + 3], coll.qvecIm()[RefBInd + 3], nmode))));
-        histosQA.fill(HIST("hist_EP_azimuth_RefB_v3"), coll.cent(), trk.pt(), TVector2::Phi_0_2pi(3.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[RefBInd + 3], coll.qvecIm()[RefBInd + 3], nmode))));
+        histosQA.fill(HIST("hist_EP_cos_RefB_v3"), cent, trkPt, std::cos(3.0 * (trkPhi - epRefBInd)));
+        histosQA.fill(HIST("hist_EP_sin_RefB_v3"), cent, trkPt, std::sin(3.0 * (trkPhi - epRefBInd)));
+        histosQA.fill(HIST("hist_EP_azimuth_RefB_v3"), cent, trkPt, TVector2::Phi_0_2pi(3.0 * (trkPhi - epRefBInd)));
       } else if (nmode == 4) {
-        histosQA.fill(HIST("hist_EP_cos_Det_v4"), coll.cent(), trk.pt(), std::cos(4.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[DetInd + 3], coll.qvecIm()[DetInd + 3], nmode))));
-        histosQA.fill(HIST("hist_EP_sin_Det_v4"), coll.cent(), trk.pt(), std::sin(4.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[DetInd + 3], coll.qvecIm()[DetInd + 3], nmode))));
-        histosQA.fill(HIST("hist_EP_azimuth_Det_v4"), coll.cent(), trk.pt(), TVector2::Phi_0_2pi(4.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[DetInd + 3], coll.qvecIm()[DetInd + 3], nmode))));
+        histosQA.fill(HIST("hist_EP_cos_Det_v4"), cent, trkPt, std::cos(4.0 * (trkPhi - epDetInd)));
+        histosQA.fill(HIST("hist_EP_sin_Det_v4"), cent, trkPt, std::sin(4.0 * (trkPhi - epDetInd)));
+        histosQA.fill(HIST("hist_EP_azimuth_Det_v4"), cent, trkPt, TVector2::Phi_0_2pi(4.0 * (trkPhi - epDetInd)));
 
-        histosQA.fill(HIST("hist_EP_cos_RefA_v4"), coll.cent(), trk.pt(), std::cos(4.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[RefAInd + 3], coll.qvecIm()[RefAInd + 3], nmode))));
-        histosQA.fill(HIST("hist_EP_sin_RefA_v4"), coll.cent(), trk.pt(), std::sin(4.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[RefAInd + 3], coll.qvecIm()[RefAInd + 3], nmode))));
-        histosQA.fill(HIST("hist_EP_azimuth_RefA_v4"), coll.cent(), trk.pt(), TVector2::Phi_0_2pi(4.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[RefAInd + 3], coll.qvecIm()[RefAInd + 3], nmode))));
+        histosQA.fill(HIST("hist_EP_cos_RefA_v4"), cent, trkPt, std::cos(4.0 * (trkPhi - epRefAInd)));
+        histosQA.fill(HIST("hist_EP_sin_RefA_v4"), cent, trkPt, std::sin(4.0 * (trkPhi - epRefAInd)));
+        histosQA.fill(HIST("hist_EP_azimuth_RefA_v4"), cent, trkPt, TVector2::Phi_0_2pi(4.0 * (trkPhi - epRefAInd)));
 
-        histosQA.fill(HIST("hist_EP_cos_RefB_v4"), coll.cent(), trk.pt(), std::cos(4.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[RefBInd + 3], coll.qvecIm()[RefBInd + 3], nmode))));
-        histosQA.fill(HIST("hist_EP_sin_RefB_v4"), coll.cent(), trk.pt(), std::sin(4.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[RefBInd + 3], coll.qvecIm()[RefBInd + 3], nmode))));
-        histosQA.fill(HIST("hist_EP_azimuth_RefB_v4"), coll.cent(), trk.pt(), TVector2::Phi_0_2pi(4.0 * (trk.phi() - helperEP.GetEventPlane(coll.qvecRe()[RefBInd + 3], coll.qvecIm()[RefBInd + 3], nmode))));
+        histosQA.fill(HIST("hist_EP_cos_RefB_v4"), cent, trkPt, std::cos(4.0 * (trkPhi - epRefBInd)));
+        histosQA.fill(HIST("hist_EP_sin_RefB_v4"), cent, trkPt, std::sin(4.0 * (trkPhi - epRefBInd)));
+        histosQA.fill(HIST("hist_EP_azimuth_RefB_v4"), cent, trkPt, TVector2::Phi_0_2pi(4.0 * (trkPhi - epRefBInd)));
       }
-    }
-  }
-
-  template <typename T>
-  void fillHistosQvecWithSC(const T& vec, int nmode)
-  {
-    int DetInd = DetId + cfgnTotalSystem * (nmode - 2);
-    int RefAInd = RefAId + cfgnTotalSystem * (nmode - 2);
-    int RefBInd = RefBId + cfgnTotalSystem * (nmode - 2);
-
-    if (vec.qvecAmp()[DetId] < 1e-8 || vec.qvecAmp()[RefAId] < 1e-8 || vec.qvecAmp()[RefBId] < 1e-8) {
-      return;
-    }
-
-    if (nmode == 2) {
-      histosQA.fill(HIST("histQvecFinalV2"), vec.qvecShiftedRe()[DetInd], vec.qvecShiftedIm()[DetInd], vec.cent());
-      histosQA.fill(HIST("histEvtPlFinalV2"), helperEP.GetEventPlane(vec.qvecShiftedRe()[DetInd], vec.qvecShiftedIm()[DetInd], nmode), vec.cent());
-
-      histosQA.fill(HIST("histQvecRefAFinalV2"), vec.qvecShiftedRe()[RefAInd], vec.qvecShiftedIm()[RefAInd], vec.cent());
-      histosQA.fill(HIST("histEvtPlRefAFinalV2"), helperEP.GetEventPlane(vec.qvecShiftedRe()[RefAInd], vec.qvecShiftedIm()[RefAInd], nmode), vec.cent());
-
-      histosQA.fill(HIST("histQvecRefBFinalV2"), vec.qvecShiftedRe()[RefBInd], vec.qvecShiftedIm()[RefBInd], vec.cent());
-      histosQA.fill(HIST("histEvtPlRefBFinalV2"), helperEP.GetEventPlane(vec.qvecShiftedRe()[RefBInd], vec.qvecShiftedIm()[RefBInd], nmode), vec.cent());
-
-      histosQA.fill(HIST("histEvtPlRes_SigRefAV2"), helperEP.GetResolution(helperEP.GetEventPlane(vec.qvecShiftedRe()[DetInd], vec.qvecShiftedIm()[DetInd], nmode), helperEP.GetEventPlane(vec.qvecShiftedRe()[RefAInd], vec.qvecShiftedIm()[RefAInd], nmode), nmode), vec.cent());
-      histosQA.fill(HIST("histEvtPlRes_SigRefBV2"), helperEP.GetResolution(helperEP.GetEventPlane(vec.qvecShiftedRe()[DetInd], vec.qvecShiftedIm()[DetInd], nmode), helperEP.GetEventPlane(vec.qvecShiftedRe()[RefBInd], vec.qvecShiftedIm()[RefBInd], nmode), nmode), vec.cent());
-      histosQA.fill(HIST("histEvtPlRes_RefARefBV2"), helperEP.GetResolution(helperEP.GetEventPlane(vec.qvecShiftedRe()[RefAInd], vec.qvecShiftedIm()[RefAInd], nmode), helperEP.GetEventPlane(vec.qvecShiftedRe()[RefBInd], vec.qvecShiftedIm()[RefBInd], nmode), nmode), vec.cent());
-    } else if (nmode == 3) {
-      histosQA.fill(HIST("histQvecFinalV3"), vec.qvecShiftedRe()[DetInd], vec.qvecShiftedIm()[DetInd], vec.cent());
-      histosQA.fill(HIST("histEvtPlFinalV3"), helperEP.GetEventPlane(vec.qvecShiftedRe()[DetInd], vec.qvecShiftedIm()[DetInd], nmode), vec.cent());
-
-      histosQA.fill(HIST("histQvecRefAFinalV3"), vec.qvecShiftedRe()[RefAInd], vec.qvecShiftedIm()[RefAInd], vec.cent());
-      histosQA.fill(HIST("histEvtPlRefAFinalV3"), helperEP.GetEventPlane(vec.qvecShiftedRe()[RefAInd], vec.qvecShiftedIm()[RefAInd], nmode), vec.cent());
-
-      histosQA.fill(HIST("histQvecRefBFinalV3"), vec.qvecShiftedRe()[RefBInd], vec.qvecShiftedIm()[RefBInd], vec.cent());
-      histosQA.fill(HIST("histEvtPlRefBFinalV3"), helperEP.GetEventPlane(vec.qvecShiftedRe()[RefBInd], vec.qvecShiftedIm()[RefBInd], nmode), vec.cent());
-
-      histosQA.fill(HIST("histEvtPlRes_SigRefAV3"), helperEP.GetResolution(helperEP.GetEventPlane(vec.qvecShiftedRe()[DetInd], vec.qvecShiftedIm()[DetInd], nmode), helperEP.GetEventPlane(vec.qvecShiftedRe()[RefAInd], vec.qvecShiftedIm()[RefAInd], nmode), nmode), vec.cent());
-      histosQA.fill(HIST("histEvtPlRes_SigRefBV3"), helperEP.GetResolution(helperEP.GetEventPlane(vec.qvecShiftedRe()[DetInd], vec.qvecShiftedIm()[DetInd], nmode), helperEP.GetEventPlane(vec.qvecShiftedRe()[RefBInd], vec.qvecShiftedIm()[RefBInd], nmode), nmode), vec.cent());
-      histosQA.fill(HIST("histEvtPlRes_RefARefBV3"), helperEP.GetResolution(helperEP.GetEventPlane(vec.qvecShiftedRe()[RefAInd], vec.qvecShiftedIm()[RefAInd], nmode), helperEP.GetEventPlane(vec.qvecShiftedRe()[RefBInd], vec.qvecShiftedIm()[RefBInd], nmode), nmode), vec.cent());
-    } else if (nmode == 4) {
-      histosQA.fill(HIST("histQvecFinalV4"), vec.qvecShiftedRe()[DetInd], vec.qvecShiftedIm()[DetInd], vec.cent());
-      histosQA.fill(HIST("histEvtPlFinalV4"), helperEP.GetEventPlane(vec.qvecShiftedRe()[DetInd], vec.qvecShiftedIm()[DetInd], nmode), vec.cent());
-
-      histosQA.fill(HIST("histQvecRefAFinalV4"), vec.qvecShiftedRe()[RefAInd], vec.qvecShiftedIm()[RefAInd], vec.cent());
-      histosQA.fill(HIST("histEvtPlRefAFinalV4"), helperEP.GetEventPlane(vec.qvecShiftedRe()[RefAInd], vec.qvecShiftedIm()[RefAInd], nmode), vec.cent());
-
-      histosQA.fill(HIST("histQvecRefBFinalV4"), vec.qvecShiftedRe()[RefBInd], vec.qvecShiftedIm()[RefBInd], vec.cent());
-      histosQA.fill(HIST("histEvtPlRefBFinalV4"), helperEP.GetEventPlane(vec.qvecShiftedRe()[RefBInd], vec.qvecShiftedIm()[RefBInd], nmode), vec.cent());
-
-      histosQA.fill(HIST("histEvtPlRes_SigRefAV4"), helperEP.GetResolution(helperEP.GetEventPlane(vec.qvecShiftedRe()[DetInd], vec.qvecShiftedIm()[DetInd], nmode), helperEP.GetEventPlane(vec.qvecShiftedRe()[RefAInd], vec.qvecShiftedIm()[RefAInd], nmode), nmode), vec.cent());
-      histosQA.fill(HIST("histEvtPlRes_SigRefBV4"), helperEP.GetResolution(helperEP.GetEventPlane(vec.qvecShiftedRe()[DetInd], vec.qvecShiftedIm()[DetInd], nmode), helperEP.GetEventPlane(vec.qvecShiftedRe()[RefBInd], vec.qvecShiftedIm()[RefBInd], nmode), nmode), vec.cent());
-      histosQA.fill(HIST("histEvtPlRes_RefARefBV4"), helperEP.GetResolution(helperEP.GetEventPlane(vec.qvecShiftedRe()[RefAInd], vec.qvecShiftedIm()[RefAInd], nmode), helperEP.GetEventPlane(vec.qvecShiftedRe()[RefBInd], vec.qvecShiftedIm()[RefBInd], nmode), nmode), vec.cent());
     }
   }
 
@@ -484,275 +404,305 @@ struct qVectorsCorrection {
     int DetInd = DetId * 4 + cfgnTotalSystem * 4 * (nmode - 2);
     int RefAInd = RefAId * 4 + cfgnTotalSystem * 4 * (nmode - 2);
     int RefBInd = RefBId * 4 + cfgnTotalSystem * 4 * (nmode - 2);
+
+    auto epDetInd = helperEP.GetEventPlane(getQVecRe(vec, DetInd), getQVecIm(vec, DetInd), nmode);
+    auto epDetIndRectr = helperEP.GetEventPlane(getQVecRe(vec, DetInd + 1), getQVecIm(vec, DetInd + 1), nmode);
+    auto epDetIndTwist = helperEP.GetEventPlane(getQVecRe(vec, DetInd + 2), getQVecIm(vec, DetInd + 2), nmode);
+    auto epDetIndFinal = helperEP.GetEventPlane(getQVecRe(vec, DetInd + 3), getQVecIm(vec, DetInd + 3), nmode);
+    auto epRefAInd = helperEP.GetEventPlane(getQVecRe(vec, RefAInd), getQVecIm(vec, RefAInd), nmode);
+    auto epRefARectrInd = helperEP.GetEventPlane(getQVecRe(vec, RefAInd + 1), getQVecIm(vec, RefAInd + 1), nmode);
+    auto epRefATwistInd = helperEP.GetEventPlane(getQVecRe(vec, RefAInd + 2), getQVecIm(vec, RefAInd + 2), nmode);
+    auto epRefAFinalInd = helperEP.GetEventPlane(getQVecRe(vec, RefAInd + 3), getQVecIm(vec, RefAInd + 3), nmode);
+    auto epRefBInd = helperEP.GetEventPlane(getQVecRe(vec, RefBInd), getQVecIm(vec, RefBInd), nmode);
+    auto epRefBRectrInd = helperEP.GetEventPlane(getQVecRe(vec, RefBInd + 1), getQVecIm(vec, RefBInd + 1), nmode);
+    auto epRefBTwistInd = helperEP.GetEventPlane(getQVecRe(vec, RefBInd + 2), getQVecIm(vec, RefBInd + 2), nmode);
+    auto epRefBFinalInd = helperEP.GetEventPlane(getQVecRe(vec, RefBInd + 3), getQVecIm(vec, RefBInd + 3), nmode);
+
+    auto occ  = vec.trackOccupancyInTimeRange();
+    auto cent = vec.cent(); 
+
     if (nmode == 2) {
       if (vec.qvecAmp()[DetId] > 1e-8) {
-        histosQA.fill(HIST("histQvecUncorV2"), vec.qvecRe()[DetInd], vec.qvecIm()[DetInd], vec.cent());
-        histosQA.fill(HIST("histEvtPlUncorV2"), helperEP.GetEventPlane(vec.qvecRe()[DetInd], vec.qvecIm()[DetInd], nmode), vec.cent());
+        histosQA.fill(HIST("histQvecUncorV2"), getQVecRe(vec, DetInd), getQVecIm(vec, DetInd), cent);
+        histosQA.fill(HIST("histEvtPlUncorV2"), epDetInd, cent);
         if (cfgQAOccupancyStudy) {
-          histosQA.fill(HIST("histQvecOccUncorV2"), vec.qvecRe()[DetInd], vec.qvecIm()[DetInd], vec.cent(), vec.trackOccupancyInTimeRange());
+          histosQA.fill(HIST("histQvecOccUncorV2"), getQVecRe(vec, DetInd), getQVecIm(vec, DetInd), cent, occ);
         }
         if (cfgQAFinal) {
-          histosQA.fill(HIST("histQvecFinalV2"), vec.qvecRe()[DetInd + 3], vec.qvecIm()[DetInd + 3], vec.cent());
-          histosQA.fill(HIST("histEvtPlFinalV2"), helperEP.GetEventPlane(vec.qvecRe()[DetInd + 3], vec.qvecIm()[DetInd + 3], nmode), vec.cent());
+          histosQA.fill(HIST("histQvecFinalV2"), getQVecRe(vec, DetInd + 3), getQVecIm(vec, DetInd + 3), cent);
+          histosQA.fill(HIST("histEvtPlFinalV2"), epDetIndFinal, cent);
           if (cfgQAOccupancyStudy) {
-            histosQA.fill(HIST("histQvecOccFinalV2"), vec.qvecRe()[DetInd + 3], vec.qvecIm()[DetInd + 3], vec.cent(), vec.trackOccupancyInTimeRange());
+            histosQA.fill(HIST("histQvecOccFinalV2"), getQVecRe(vec, DetInd + 3), getQVecIm(vec, DetInd + 3), cent, occ);
           }
           if (cfgQAAll) {
-            histosQA.fill(HIST("histQvecRectrV2"), vec.qvecRe()[DetInd + 1], vec.qvecIm()[DetInd + 1], vec.cent());
-            histosQA.fill(HIST("histQvecTwistV2"), vec.qvecRe()[DetInd + 2], vec.qvecIm()[DetInd + 2], vec.cent());
+            histosQA.fill(HIST("histQvecRectrV2"), getQVecRe(vec, DetInd + 1), getQVecIm(vec, DetInd + 1), cent);
+            histosQA.fill(HIST("histQvecTwistV2"), getQVecRe(vec, DetInd + 2), getQVecIm(vec, DetInd + 2), cent);
 
-            histosQA.fill(HIST("histEvtPlRectrV2"), helperEP.GetEventPlane(vec.qvecRe()[DetInd + 1], vec.qvecIm()[DetInd + 1], nmode), vec.cent());
-            histosQA.fill(HIST("histEvtPlTwistV2"), helperEP.GetEventPlane(vec.qvecRe()[DetInd + 2], vec.qvecIm()[DetInd + 2], nmode), vec.cent());
+            histosQA.fill(HIST("histEvtPlRectrV2"), epDetIndRectr, cent);
+            histosQA.fill(HIST("histEvtPlTwistV2"), epDetIndTwist, cent);
           }
         }
       }
       if (vec.qvecAmp()[RefAId] > 1e-8) {
-        histosQA.fill(HIST("histQvecRefAUncorV2"), vec.qvecRe()[RefAInd], vec.qvecIm()[RefAInd], vec.cent());
-        histosQA.fill(HIST("histEvtPlRefAUncorV2"), helperEP.GetEventPlane(vec.qvecRe()[RefAInd], vec.qvecIm()[RefAInd], nmode), vec.cent());
+        histosQA.fill(HIST("histQvecRefAUncorV2"), getQVecRe(vec, RefAInd), getQVecIm(vec, RefAInd), cent);
+        histosQA.fill(HIST("histEvtPlRefAUncorV2"), epRefAInd, cent);
         if (cfgQAOccupancyStudy) {
-          histosQA.fill(HIST("histQvecRefAOccUncorV2"), vec.qvecRe()[RefAInd], vec.qvecIm()[RefAInd], vec.cent(), vec.trackOccupancyInTimeRange());
+          histosQA.fill(HIST("histQvecRefAOccUncorV2"), getQVecRe(vec, RefAInd), getQVecIm(vec, RefAInd), cent, occ);
         }
         if (cfgQAFinal) {
-          histosQA.fill(HIST("histQvecRefAFinalV2"), vec.qvecRe()[RefAInd + 3], vec.qvecIm()[RefAInd + 3], vec.cent());
-          histosQA.fill(HIST("histEvtPlRefAFinalV2"), helperEP.GetEventPlane(vec.qvecRe()[RefAInd + 3], vec.qvecIm()[RefAInd + 3], nmode), vec.cent());
+          histosQA.fill(HIST("histQvecRefAFinalV2"), getQVecRe(vec, RefAInd + 3), getQVecIm(vec, RefAInd + 3), cent);
+          histosQA.fill(HIST("histEvtPlRefAFinalV2"), epRefAFinalInd, cent);
           if (cfgQAOccupancyStudy) {
-            histosQA.fill(HIST("histQvecRefAOccFinalV2"), vec.qvecRe()[RefAInd + 3], vec.qvecIm()[RefAInd + 3], vec.cent(), vec.trackOccupancyInTimeRange());
+            histosQA.fill(HIST("histQvecRefAOccFinalV2"), getQVecRe(vec, RefAInd + 3), getQVecIm(vec, RefAInd + 3), cent, occ);
           }
           if (cfgQAAll) {
-            histosQA.fill(HIST("histQvecRefARectrV2"), vec.qvecRe()[RefAInd + 1], vec.qvecIm()[RefAInd + 1], vec.cent());
-            histosQA.fill(HIST("histQvecRefATwistV2"), vec.qvecRe()[RefAInd + 2], vec.qvecIm()[RefAInd + 2], vec.cent());
+            histosQA.fill(HIST("histQvecRefARectrV2"), getQVecRe(vec, RefAInd + 1), getQVecIm(vec, RefAInd + 1), cent);
+            histosQA.fill(HIST("histQvecRefATwistV2"), getQVecRe(vec, RefAInd + 2), getQVecIm(vec, RefAInd + 2), cent);
 
-            histosQA.fill(HIST("histEvtPlRefARectrV2"), helperEP.GetEventPlane(vec.qvecRe()[RefAInd + 1], vec.qvecIm()[RefAInd + 1], nmode), vec.cent());
-            histosQA.fill(HIST("histEvtPlRefATwistV2"), helperEP.GetEventPlane(vec.qvecRe()[RefAInd + 2], vec.qvecIm()[RefAInd + 2], nmode), vec.cent());
+            histosQA.fill(HIST("histEvtPlRefARectrV2"), epRefARectrInd, cent);
+            histosQA.fill(HIST("histEvtPlRefATwistV2"), epRefATwistInd, cent);
           }
         }
       }
       if (vec.qvecAmp()[RefBId] > 1e-8) {
-        histosQA.fill(HIST("histQvecRefBUncorV2"), vec.qvecRe()[RefBInd], vec.qvecIm()[RefBInd], vec.cent());
-        histosQA.fill(HIST("histEvtPlRefBUncorV2"), helperEP.GetEventPlane(vec.qvecRe()[RefBInd], vec.qvecIm()[RefBInd], nmode), vec.cent());
+        histosQA.fill(HIST("histQvecRefBUncorV2"), getQVecRe(vec, RefBInd), getQVecIm(vec, RefBInd), cent);
+        histosQA.fill(HIST("histEvtPlRefBUncorV2"), epRefBInd, cent);
         if (cfgQAOccupancyStudy) {
-          histosQA.fill(HIST("histQvecRefBOccUncorV2"), vec.qvecRe()[RefBInd], vec.qvecIm()[RefBInd], vec.cent(), vec.trackOccupancyInTimeRange());
+          histosQA.fill(HIST("histQvecRefBOccUncorV2"), getQVecRe(vec, RefBInd), getQVecIm(vec, RefBInd), cent, occ);
         }
         if (cfgQAFinal) {
-          histosQA.fill(HIST("histQvecRefBFinalV2"), vec.qvecRe()[RefBInd + 3], vec.qvecIm()[RefBInd + 3], vec.cent());
-          histosQA.fill(HIST("histEvtPlRefBFinalV2"), helperEP.GetEventPlane(vec.qvecRe()[RefBInd + 3], vec.qvecIm()[RefBInd + 3], nmode), vec.cent());
+          histosQA.fill(HIST("histQvecRefBFinalV2"), getQVecRe(vec, RefBInd + 3), getQVecIm(vec, RefBInd + 3), cent);
+          histosQA.fill(HIST("histEvtPlRefBFinalV2"), epRefBFinalInd, cent);
           if (cfgQAOccupancyStudy) {
-            histosQA.fill(HIST("histQvecRefBOccFinalV2"), vec.qvecRe()[RefBInd + 3], vec.qvecIm()[RefBInd + 3], vec.cent(), vec.trackOccupancyInTimeRange());
+            histosQA.fill(HIST("histQvecRefBOccFinalV2"), getQVecRe(vec, RefBInd + 3), getQVecIm(vec, RefBInd + 3), cent, occ);
           }
           if (cfgQAAll) {
-            histosQA.fill(HIST("histQvecRefBRectrV2"), vec.qvecRe()[RefBInd + 1], vec.qvecIm()[RefBInd + 1], vec.cent());
-            histosQA.fill(HIST("histQvecRefBTwistV2"), vec.qvecRe()[RefBInd + 2], vec.qvecIm()[RefBInd + 2], vec.cent());
+            histosQA.fill(HIST("histQvecRefBRectrV2"), getQVecRe(vec, RefBInd + 1), getQVecIm(vec, RefBInd + 1), cent);
+            histosQA.fill(HIST("histQvecRefBTwistV2"), getQVecRe(vec, RefBInd + 2), getQVecIm(vec, RefBInd + 2), cent);
 
-            histosQA.fill(HIST("histEvtPlRefBRectrV2"), helperEP.GetEventPlane(vec.qvecRe()[RefBInd + 1], vec.qvecIm()[RefBInd + 1], nmode), vec.cent());
-            histosQA.fill(HIST("histEvtPlRefBTwistV2"), helperEP.GetEventPlane(vec.qvecRe()[RefBInd + 2], vec.qvecIm()[RefBInd + 2], nmode), vec.cent());
+            histosQA.fill(HIST("histEvtPlRefBRectrV2"), epRefBRectrInd, cent);
+            histosQA.fill(HIST("histEvtPlRefBTwistV2"), epRefBTwistInd, cent);
           }
         }
       }
       if (vec.qvecAmp()[DetId] > 1e-8 && vec.qvecAmp()[RefAId] > 1e-8 && vec.qvecAmp()[RefBId] > 1e-8 && cfgQAFinal) {
-        histosQA.fill(HIST("histQvecRes_SigRefAV2"), vec.qvecRe()[DetInd + 3] * vec.qvecRe()[RefAInd + 3] + vec.qvecIm()[DetInd + 3] * vec.qvecIm()[RefAInd + 3], vec.cent());
-        histosQA.fill(HIST("histQvecRes_SigRefBV2"), vec.qvecRe()[DetInd + 3] * vec.qvecRe()[RefBInd + 3] + vec.qvecIm()[DetInd + 3] * vec.qvecIm()[RefBInd + 3], vec.cent());
-        histosQA.fill(HIST("histQvecRes_RefARefBV2"), vec.qvecRe()[RefAInd + 3] * vec.qvecRe()[RefBInd + 3] + vec.qvecIm()[RefAInd + 3] * vec.qvecIm()[RefBInd + 3], vec.cent());
+        histosQA.fill(HIST("histQvecRes_SigRefAV2"), getQVecRe(vec, DetInd + 3) * getQVecRe(vec, RefAInd + 3) + getQVecIm(vec, DetInd + 3) * getQVecIm(vec, RefAInd + 3), cent);
+        histosQA.fill(HIST("histQvecRes_SigRefBV2"), getQVecRe(vec, DetInd + 3) * getQVecRe(vec, RefBInd + 3) + getQVecIm(vec, DetInd + 3) * getQVecIm(vec, RefBInd + 3), cent);
+        histosQA.fill(HIST("histQvecRes_RefARefBV2"), getQVecRe(vec, RefAInd + 3) * getQVecRe(vec, RefBInd + 3) + getQVecIm(vec, RefAInd + 3) * getQVecIm(vec, RefBInd + 3), cent);
 
-        histosQA.fill(HIST("histEvtPlRes_SigRefAV2"), helperEP.GetResolution(helperEP.GetEventPlane(vec.qvecRe()[DetInd + 3], vec.qvecIm()[DetInd + 3], nmode), helperEP.GetEventPlane(vec.qvecRe()[RefAInd + 3], vec.qvecIm()[RefAInd + 3], nmode), nmode), vec.cent());
-        histosQA.fill(HIST("histEvtPlRes_SigRefBV2"), helperEP.GetResolution(helperEP.GetEventPlane(vec.qvecRe()[DetInd + 3], vec.qvecIm()[DetInd + 3], nmode), helperEP.GetEventPlane(vec.qvecRe()[RefBInd + 3], vec.qvecIm()[RefBInd + 3], nmode), nmode), vec.cent());
-        histosQA.fill(HIST("histEvtPlRes_RefARefBV2"), helperEP.GetResolution(helperEP.GetEventPlane(vec.qvecRe()[RefAInd + 3], vec.qvecIm()[RefAInd + 3], nmode), helperEP.GetEventPlane(vec.qvecRe()[RefBInd + 3], vec.qvecIm()[RefBInd + 3], nmode), nmode), vec.cent());
+        histosQA.fill(HIST("histEvtPlRes_SigRefAV2"), helperEP.GetResolution(epDetIndFinal, epRefAFinalInd, nmode), cent);
+        histosQA.fill(HIST("histEvtPlRes_SigRefBV2"), helperEP.GetResolution(epDetIndFinal, epRefBFinalInd, nmode), cent);
+        histosQA.fill(HIST("histEvtPlRes_RefARefBV2"), helperEP.GetResolution(epRefAFinalInd, epRefBFinalInd, nmode), cent);
       }
     } else if (nmode == 3) {
       if (vec.qvecAmp()[DetId] > 1e-8) {
-        histosQA.fill(HIST("histQvecUncorV3"), vec.qvecRe()[DetInd], vec.qvecIm()[DetInd], vec.cent());
-        histosQA.fill(HIST("histEvtPlUncorV3"), helperEP.GetEventPlane(vec.qvecRe()[DetInd], vec.qvecIm()[DetInd], nmode), vec.cent());
+        histosQA.fill(HIST("histQvecUncorV3"), getQVecRe(vec, DetInd), getQVecIm(vec, DetInd), cent);
+        histosQA.fill(HIST("histEvtPlUncorV3"), epDetInd, cent);
         if (cfgQAOccupancyStudy) {
-          histosQA.fill(HIST("histQvecOccUncorV3"), vec.qvecRe()[DetInd], vec.qvecIm()[DetInd], vec.cent(), vec.trackOccupancyInTimeRange());
+          histosQA.fill(HIST("histQvecOccUncorV3"), getQVecRe(vec, DetInd), getQVecIm(vec, DetInd), cent, occ);
         }
         if (cfgQAFinal) {
           if (cfgQAOccupancyStudy) {
-            histosQA.fill(HIST("histQvecOccFinalV3"), vec.qvecRe()[DetInd + 3], vec.qvecIm()[DetInd + 3], vec.cent(), vec.trackOccupancyInTimeRange());
+            histosQA.fill(HIST("histQvecOccFinalV3"), getQVecRe(vec, DetInd + 3), getQVecIm(vec, DetInd + 3), cent, occ);
           }
-          histosQA.fill(HIST("histQvecFinalV3"), vec.qvecRe()[DetInd + 3], vec.qvecIm()[DetInd + 3], vec.cent());
-          histosQA.fill(HIST("histEvtPlFinalV3"), helperEP.GetEventPlane(vec.qvecRe()[DetInd + 3], vec.qvecIm()[DetInd + 3], nmode), vec.cent());
+          histosQA.fill(HIST("histQvecFinalV3"), getQVecRe(vec, DetInd + 3), getQVecIm(vec, DetInd + 3), cent);
+          histosQA.fill(HIST("histEvtPlFinalV3"), epDetIndFinal, cent);
           if (cfgQAAll) {
-            histosQA.fill(HIST("histQvecRectrV3"), vec.qvecRe()[DetInd + 1], vec.qvecIm()[DetInd + 1], vec.cent());
-            histosQA.fill(HIST("histQvecTwistV3"), vec.qvecRe()[DetInd + 2], vec.qvecIm()[DetInd + 2], vec.cent());
+            histosQA.fill(HIST("histQvecRectrV3"), getQVecRe(vec, DetInd + 1), getQVecIm(vec, DetInd + 1), cent);
+            histosQA.fill(HIST("histQvecTwistV3"), getQVecRe(vec, DetInd + 2), getQVecIm(vec, DetInd + 2), cent);
 
-            histosQA.fill(HIST("histEvtPlRectrV3"), helperEP.GetEventPlane(vec.qvecRe()[DetInd + 1], vec.qvecIm()[DetInd + 1], nmode), vec.cent());
-            histosQA.fill(HIST("histEvtPlTwistV3"), helperEP.GetEventPlane(vec.qvecRe()[DetInd + 2], vec.qvecIm()[DetInd + 2], nmode), vec.cent());
+            histosQA.fill(HIST("histEvtPlRectrV3"), epDetIndRectr, cent);
+            histosQA.fill(HIST("histEvtPlTwistV3"), epDetIndTwist, cent);
           }
         }
       }
       if (vec.qvecAmp()[RefAId] > 1e-8) {
-        histosQA.fill(HIST("histQvecRefAUncorV3"), vec.qvecRe()[RefAInd], vec.qvecIm()[RefAInd], vec.cent());
-        histosQA.fill(HIST("histEvtPlRefAUncorV3"), helperEP.GetEventPlane(vec.qvecRe()[RefAInd], vec.qvecIm()[RefAInd], nmode), vec.cent());
+        histosQA.fill(HIST("histQvecRefAUncorV3"), getQVecRe(vec, RefAInd), getQVecIm(vec, RefAInd), cent);
+        histosQA.fill(HIST("histEvtPlRefAUncorV3"), epRefAInd, cent);
         if (cfgQAOccupancyStudy) {
-          histosQA.fill(HIST("histQvecRefAOccUncorV3"), vec.qvecRe()[RefAInd], vec.qvecIm()[RefAInd], vec.cent(), vec.trackOccupancyInTimeRange());
+          histosQA.fill(HIST("histQvecRefAOccUncorV3"), getQVecRe(vec, RefAInd), getQVecIm(vec, RefAInd), cent, occ);
         }
         if (cfgQAFinal) {
-          histosQA.fill(HIST("histQvecRefAFinalV3"), vec.qvecRe()[RefAInd + 3], vec.qvecIm()[RefAInd + 3], vec.cent());
-          histosQA.fill(HIST("histEvtPlRefAFinalV3"), helperEP.GetEventPlane(vec.qvecRe()[RefAInd + 3], vec.qvecIm()[RefAInd + 3], nmode), vec.cent());
+          histosQA.fill(HIST("histQvecRefAFinalV3"), getQVecRe(vec, RefAInd + 3), getQVecIm(vec, RefAInd + 3), cent);
+          histosQA.fill(HIST("histEvtPlRefAFinalV3"), epRefAFinalInd, cent);
           if (cfgQAOccupancyStudy) {
-            histosQA.fill(HIST("histQvecRefAOccFinalV3"), vec.qvecRe()[RefAInd + 3], vec.qvecIm()[RefAInd + 3], vec.cent(), vec.trackOccupancyInTimeRange());
+            histosQA.fill(HIST("histQvecRefAOccFinalV3"), getQVecRe(vec, RefAInd + 3), getQVecIm(vec, RefAInd + 3), cent, occ);
           }
           if (cfgQAAll) {
-            histosQA.fill(HIST("histQvecRefARectrV3"), vec.qvecRe()[RefAInd + 1], vec.qvecIm()[RefAInd + 1], vec.cent());
-            histosQA.fill(HIST("histQvecRefATwistV3"), vec.qvecRe()[RefAInd + 2], vec.qvecIm()[RefAInd + 2], vec.cent());
+            histosQA.fill(HIST("histQvecRefARectrV3"), getQVecRe(vec, RefAInd + 1), getQVecIm(vec, RefAInd + 1), cent);
+            histosQA.fill(HIST("histQvecRefATwistV3"), getQVecRe(vec, RefAInd + 2), getQVecIm(vec, RefAInd + 2), cent);
 
-            histosQA.fill(HIST("histEvtPlRefARectrV3"), helperEP.GetEventPlane(vec.qvecRe()[RefAInd + 1], vec.qvecIm()[RefAInd + 1], nmode), vec.cent());
-            histosQA.fill(HIST("histEvtPlRefATwistV3"), helperEP.GetEventPlane(vec.qvecRe()[RefAInd + 2], vec.qvecIm()[RefAInd + 2], nmode), vec.cent());
+            histosQA.fill(HIST("histEvtPlRefARectrV3"), epRefARectrInd, cent);
+            histosQA.fill(HIST("histEvtPlRefATwistV3"), epRefATwistInd, cent);
           }
         }
       }
       if (vec.qvecAmp()[RefBId] > 1e-8) {
-        histosQA.fill(HIST("histQvecRefBUncorV3"), vec.qvecRe()[RefBInd], vec.qvecIm()[RefBInd], vec.cent());
-        histosQA.fill(HIST("histEvtPlRefBUncorV3"), helperEP.GetEventPlane(vec.qvecRe()[RefBInd], vec.qvecIm()[RefBInd], nmode), vec.cent());
+        histosQA.fill(HIST("histQvecRefBUncorV3"), getQVecRe(vec, RefBInd), getQVecIm(vec, RefBInd), cent);
+        histosQA.fill(HIST("histEvtPlRefBUncorV3"), epRefBInd, cent);
         if (cfgQAOccupancyStudy) {
-          histosQA.fill(HIST("histQvecRefBOccUncorV3"), vec.qvecRe()[RefBInd], vec.qvecIm()[RefBInd], vec.cent(), vec.trackOccupancyInTimeRange());
+          histosQA.fill(HIST("histQvecRefBOccUncorV3"), getQVecRe(vec, RefBInd), getQVecIm(vec, RefBInd), cent, occ);
         }
         if (cfgQAFinal) {
-          histosQA.fill(HIST("histQvecRefBFinalV3"), vec.qvecRe()[RefBInd + 3], vec.qvecIm()[RefBInd + 3], vec.cent());
-          histosQA.fill(HIST("histEvtPlRefBFinalV3"), helperEP.GetEventPlane(vec.qvecRe()[RefBInd + 3], vec.qvecIm()[RefBInd + 3], nmode), vec.cent());
+          histosQA.fill(HIST("histQvecRefBFinalV3"), getQVecRe(vec, RefBInd + 3), getQVecIm(vec, RefBInd + 3), cent);
+          histosQA.fill(HIST("histEvtPlRefBFinalV3"), epRefBFinalInd, cent);
           if (cfgQAOccupancyStudy) {
-            histosQA.fill(HIST("histQvecRefBOccFinalV3"), vec.qvecRe()[RefBInd + 3], vec.qvecIm()[RefBInd + 3], vec.cent(), vec.trackOccupancyInTimeRange());
+            histosQA.fill(HIST("histQvecRefBOccFinalV3"), getQVecRe(vec, RefBInd + 3), getQVecIm(vec, RefBInd + 3), cent, occ);
           }
           if (cfgQAAll) {
-            histosQA.fill(HIST("histQvecRefBRectrV3"), vec.qvecRe()[RefBInd + 1], vec.qvecIm()[RefBInd + 1], vec.cent());
-            histosQA.fill(HIST("histQvecRefBTwistV3"), vec.qvecRe()[RefBInd + 2], vec.qvecIm()[RefBInd + 2], vec.cent());
+            histosQA.fill(HIST("histQvecRefBRectrV3"), getQVecRe(vec, RefBInd + 1), getQVecIm(vec, RefBInd + 1), cent);
+            histosQA.fill(HIST("histQvecRefBTwistV3"), getQVecRe(vec, RefBInd + 2), getQVecIm(vec, RefBInd + 2), cent);
 
-            histosQA.fill(HIST("histEvtPlRefBRectrV3"), helperEP.GetEventPlane(vec.qvecRe()[RefBInd + 1], vec.qvecIm()[RefBInd + 1], nmode), vec.cent());
-            histosQA.fill(HIST("histEvtPlRefBTwistV3"), helperEP.GetEventPlane(vec.qvecRe()[RefBInd + 2], vec.qvecIm()[RefBInd + 2], nmode), vec.cent());
+            histosQA.fill(HIST("histEvtPlRefBRectrV3"), epRefBRectrInd, cent);
+            histosQA.fill(HIST("histEvtPlRefBTwistV3"), epRefBTwistInd, cent);
           }
         }
       }
       if (vec.qvecAmp()[DetId] > 1e-8 && vec.qvecAmp()[RefAId] > 1e-8 && vec.qvecAmp()[RefBId] > 1e-8 && cfgQAFinal) {
-        histosQA.fill(HIST("histQvecRes_SigRefAV3"), vec.qvecRe()[DetInd + 3] * vec.qvecRe()[RefAInd + 3] + vec.qvecIm()[DetInd + 3] * vec.qvecIm()[RefAInd + 3], vec.cent());
-        histosQA.fill(HIST("histQvecRes_SigRefBV3"), vec.qvecRe()[DetInd + 3] * vec.qvecRe()[RefBInd + 3] + vec.qvecIm()[DetInd + 3] * vec.qvecIm()[RefBInd + 3], vec.cent());
-        histosQA.fill(HIST("histQvecRes_RefARefBV3"), vec.qvecRe()[RefAInd + 3] * vec.qvecRe()[RefBInd + 3] + vec.qvecIm()[RefAInd + 3] * vec.qvecIm()[RefBInd + 3], vec.cent());
+        histosQA.fill(HIST("histQvecRes_SigRefAV3"), getQVecRe(vec, DetInd + 3) * getQVecRe(vec, RefAInd + 3) + getQVecIm(vec, DetInd + 3) * getQVecIm(vec, RefAInd + 3), cent);
+        histosQA.fill(HIST("histQvecRes_SigRefBV3"), getQVecRe(vec, DetInd + 3) * getQVecRe(vec, RefBInd + 3) + getQVecIm(vec, DetInd + 3) * getQVecIm(vec, RefBInd + 3), cent);
+        histosQA.fill(HIST("histQvecRes_RefARefBV3"), getQVecRe(vec, RefAInd + 3) * getQVecRe(vec, RefBInd + 3) + getQVecIm(vec, RefAInd + 3) * getQVecIm(vec, RefBInd + 3), cent);
 
-        histosQA.fill(HIST("histEvtPlRes_SigRefAV3"), helperEP.GetResolution(helperEP.GetEventPlane(vec.qvecRe()[DetInd + 3], vec.qvecIm()[DetInd + 3], nmode), helperEP.GetEventPlane(vec.qvecRe()[RefAInd + 3], vec.qvecIm()[RefAInd + 3], nmode), nmode), vec.cent());
-        histosQA.fill(HIST("histEvtPlRes_SigRefBV3"), helperEP.GetResolution(helperEP.GetEventPlane(vec.qvecRe()[DetInd + 3], vec.qvecIm()[DetInd + 3], nmode), helperEP.GetEventPlane(vec.qvecRe()[RefBInd + 3], vec.qvecIm()[RefBInd + 3], nmode), nmode), vec.cent());
-        histosQA.fill(HIST("histEvtPlRes_RefARefBV3"), helperEP.GetResolution(helperEP.GetEventPlane(vec.qvecRe()[RefAInd + 3], vec.qvecIm()[RefAInd + 3], nmode), helperEP.GetEventPlane(vec.qvecRe()[RefBInd + 3], vec.qvecIm()[RefBInd + 3], nmode), nmode), vec.cent());
+        histosQA.fill(HIST("histEvtPlRes_SigRefAV3"), helperEP.GetResolution(epDetIndFinal, epRefAFinalInd, nmode), cent);
+        histosQA.fill(HIST("histEvtPlRes_SigRefBV3"), helperEP.GetResolution(epDetIndFinal, epRefBFinalInd, nmode), cent);
+        histosQA.fill(HIST("histEvtPlRes_RefARefBV3"), helperEP.GetResolution(epRefAFinalInd, epRefBFinalInd, nmode), cent);
       }
     } else if (nmode == 4) {
       if (vec.qvecAmp()[DetId] > 1e-8) {
-        histosQA.fill(HIST("histQvecUncorV4"), vec.qvecRe()[DetInd], vec.qvecIm()[DetInd], vec.cent());
-        histosQA.fill(HIST("histEvtPlUncorV4"), helperEP.GetEventPlane(vec.qvecRe()[DetInd], vec.qvecIm()[DetInd], nmode), vec.cent());
+        histosQA.fill(HIST("histQvecUncorV4"), getQVecRe(vec, DetInd), getQVecIm(vec, DetInd), cent);
+        histosQA.fill(HIST("histEvtPlUncorV4"), epDetInd, cent);
         if (cfgQAOccupancyStudy) {
-          histosQA.fill(HIST("histQvecOccUncorV4"), vec.qvecRe()[DetInd], vec.qvecIm()[DetInd], vec.cent(), vec.trackOccupancyInTimeRange());
+          histosQA.fill(HIST("histQvecOccUncorV4"), getQVecRe(vec, DetInd), getQVecIm(vec, DetInd), cent, occ);
         }
         if (cfgQAFinal) {
-          histosQA.fill(HIST("histQvecFinalV4"), vec.qvecRe()[DetInd + 3], vec.qvecIm()[DetInd + 3], vec.cent());
-          histosQA.fill(HIST("histEvtPlFinalV4"), helperEP.GetEventPlane(vec.qvecRe()[DetInd + 3], vec.qvecIm()[DetInd + 3], nmode), vec.cent());
+          histosQA.fill(HIST("histQvecFinalV4"), getQVecRe(vec, DetInd + 3), getQVecIm(vec, DetInd + 3), cent);
+          histosQA.fill(HIST("histEvtPlFinalV4"), epDetIndFinal, cent);
           if (cfgQAOccupancyStudy) {
-            histosQA.fill(HIST("histQvecOccFinalV4"), vec.qvecRe()[DetInd + 3], vec.qvecIm()[DetInd + 3], vec.cent(), vec.trackOccupancyInTimeRange());
+            histosQA.fill(HIST("histQvecOccFinalV4"), getQVecRe(vec, DetInd + 3), getQVecIm(vec, DetInd + 3), cent, occ);
           }
           if (cfgQAAll) {
-            histosQA.fill(HIST("histQvecRectrV4"), vec.qvecRe()[DetInd + 1], vec.qvecIm()[DetInd + 1], vec.cent());
-            histosQA.fill(HIST("histQvecTwistV4"), vec.qvecRe()[DetInd + 2], vec.qvecIm()[DetInd + 2], vec.cent());
+            histosQA.fill(HIST("histQvecRectrV4"), getQVecRe(vec, DetInd + 1), getQVecIm(vec, DetInd + 1), cent);
+            histosQA.fill(HIST("histQvecTwistV4"), getQVecRe(vec, DetInd + 2), getQVecIm(vec, DetInd + 2), cent);
 
-            histosQA.fill(HIST("histEvtPlRectrV4"), helperEP.GetEventPlane(vec.qvecRe()[DetInd + 1], vec.qvecIm()[DetInd + 1], nmode), vec.cent());
-            histosQA.fill(HIST("histEvtPlTwistV4"), helperEP.GetEventPlane(vec.qvecRe()[DetInd + 2], vec.qvecIm()[DetInd + 2], nmode), vec.cent());
+            histosQA.fill(HIST("histEvtPlRectrV4"), epDetIndRectr, cent);
+            histosQA.fill(HIST("histEvtPlTwistV4"), epDetIndTwist, cent);
           }
         }
       }
       if (vec.qvecAmp()[RefAId] > 1e-8) {
-        histosQA.fill(HIST("histQvecRefAUncorV4"), vec.qvecRe()[RefAInd], vec.qvecIm()[RefAInd], vec.cent());
-        histosQA.fill(HIST("histEvtPlRefAUncorV4"), helperEP.GetEventPlane(vec.qvecRe()[RefAInd], vec.qvecIm()[RefAInd], nmode), vec.cent());
+        histosQA.fill(HIST("histQvecRefAUncorV4"), getQVecRe(vec, RefAInd), getQVecIm(vec, RefAInd), cent);
+        histosQA.fill(HIST("histEvtPlRefAUncorV4"), epRefAInd, cent);
         if (cfgQAOccupancyStudy) {
-          histosQA.fill(HIST("histQvecRefAOccUncorV4"), vec.qvecRe()[RefAInd], vec.qvecIm()[RefAInd], vec.cent(), vec.trackOccupancyInTimeRange());
+          histosQA.fill(HIST("histQvecRefAOccUncorV4"), getQVecRe(vec, RefAInd), getQVecIm(vec, RefAInd), cent, occ);
         }
         if (cfgQAFinal) {
-          histosQA.fill(HIST("histQvecRefAFinalV4"), vec.qvecRe()[RefAInd + 3], vec.qvecIm()[RefAInd + 3], vec.cent());
-          histosQA.fill(HIST("histEvtPlRefAFinalV4"), helperEP.GetEventPlane(vec.qvecRe()[RefAInd + 3], vec.qvecIm()[RefAInd + 3], nmode), vec.cent());
+          histosQA.fill(HIST("histQvecRefAFinalV4"), getQVecRe(vec, RefAInd + 3), getQVecIm(vec, RefAInd + 3), cent);
+          histosQA.fill(HIST("histEvtPlRefAFinalV4"), epRefAFinalInd, cent);
           if (cfgQAOccupancyStudy) {
-            histosQA.fill(HIST("histQvecRefAOccFinalV4"), vec.qvecRe()[RefAInd + 3], vec.qvecIm()[RefAInd + 3], vec.cent(), vec.trackOccupancyInTimeRange());
+            histosQA.fill(HIST("histQvecRefAOccFinalV4"), getQVecRe(vec, RefAInd + 3), getQVecIm(vec, RefAInd + 3), cent, occ);
           }
           if (cfgQAAll) {
-            histosQA.fill(HIST("histQvecRefARectrV4"), vec.qvecRe()[RefAInd + 1], vec.qvecIm()[RefAInd + 1], vec.cent());
-            histosQA.fill(HIST("histQvecRefATwistV4"), vec.qvecRe()[RefAInd + 2], vec.qvecIm()[RefAInd + 2], vec.cent());
+            histosQA.fill(HIST("histQvecRefARectrV4"), getQVecRe(vec, RefAInd + 1), getQVecIm(vec, RefAInd + 1), cent);
+            histosQA.fill(HIST("histQvecRefATwistV4"), getQVecRe(vec, RefAInd + 2), getQVecIm(vec, RefAInd + 2), cent);
 
-            histosQA.fill(HIST("histEvtPlRefARectrV4"), helperEP.GetEventPlane(vec.qvecRe()[RefAInd + 1], vec.qvecIm()[RefAInd + 1], nmode), vec.cent());
-            histosQA.fill(HIST("histEvtPlRefATwistV4"), helperEP.GetEventPlane(vec.qvecRe()[RefAInd + 2], vec.qvecIm()[RefAInd + 2], nmode), vec.cent());
+            histosQA.fill(HIST("histEvtPlRefARectrV4"), epRefARectrInd, cent);
+            histosQA.fill(HIST("histEvtPlRefATwistV4"), epRefATwistInd, cent);
           }
         }
       }
       if (vec.qvecAmp()[RefBId] > 1e-8) {
-        histosQA.fill(HIST("histQvecRefBUncorV4"), vec.qvecRe()[RefBInd], vec.qvecIm()[RefBInd], vec.cent());
-        histosQA.fill(HIST("histEvtPlRefBUncorV4"), helperEP.GetEventPlane(vec.qvecRe()[RefBInd], vec.qvecIm()[RefBInd], nmode), vec.cent());
+        histosQA.fill(HIST("histQvecRefBUncorV4"), getQVecRe(vec, RefBInd), getQVecIm(vec, RefBInd), cent);
+        histosQA.fill(HIST("histEvtPlRefBUncorV4"), epRefBInd, cent);
         if (cfgQAOccupancyStudy) {
-          histosQA.fill(HIST("histQvecRefBOccUncorV4"), vec.qvecRe()[RefBInd], vec.qvecIm()[RefBInd], vec.cent(), vec.trackOccupancyInTimeRange());
+          histosQA.fill(HIST("histQvecRefBOccUncorV4"), getQVecRe(vec, RefBInd), getQVecIm(vec, RefBInd), cent, occ);
         }
         if (cfgQAFinal) {
-          histosQA.fill(HIST("histQvecRefBFinalV4"), vec.qvecRe()[RefBInd + 3], vec.qvecIm()[RefBInd + 3], vec.cent());
-          histosQA.fill(HIST("histEvtPlRefBFinalV4"), helperEP.GetEventPlane(vec.qvecRe()[RefBInd + 3], vec.qvecIm()[RefBInd + 3], nmode), vec.cent());
+          histosQA.fill(HIST("histQvecRefBFinalV4"), getQVecRe(vec, RefBInd + 3), getQVecIm(vec, RefBInd + 3), cent);
+          histosQA.fill(HIST("histEvtPlRefBFinalV4"), epRefBFinalInd, cent);
           if (cfgQAOccupancyStudy) {
-            histosQA.fill(HIST("histQvecRefBOccFinalV4"), vec.qvecRe()[RefBInd + 3], vec.qvecIm()[RefBInd + 3], vec.cent(), vec.trackOccupancyInTimeRange());
+            histosQA.fill(HIST("histQvecRefBOccFinalV4"), getQVecRe(vec, RefBInd + 3), getQVecIm(vec, RefBInd + 3), cent, occ);
           }
           if (cfgQAAll) {
-            histosQA.fill(HIST("histQvecRefBRectrV4"), vec.qvecRe()[RefBInd + 1], vec.qvecIm()[RefBInd + 1], vec.cent());
-            histosQA.fill(HIST("histQvecRefBTwistV4"), vec.qvecRe()[RefBInd + 2], vec.qvecIm()[RefBInd + 2], vec.cent());
+            histosQA.fill(HIST("histQvecRefBRectrV4"), getQVecRe(vec, RefBInd + 1), getQVecIm(vec, RefBInd + 1), cent);
+            histosQA.fill(HIST("histQvecRefBTwistV4"), getQVecRe(vec, RefBInd + 2), getQVecIm(vec, RefBInd + 2), cent);
 
-            histosQA.fill(HIST("histEvtPlRefBRectrV4"), helperEP.GetEventPlane(vec.qvecRe()[RefBInd + 1], vec.qvecIm()[RefBInd + 1], nmode), vec.cent());
-            histosQA.fill(HIST("histEvtPlRefBTwistV4"), helperEP.GetEventPlane(vec.qvecRe()[RefBInd + 2], vec.qvecIm()[RefBInd + 2], nmode), vec.cent());
+            histosQA.fill(HIST("histEvtPlRefBRectrV4"), epRefBRectrInd, cent);
+            histosQA.fill(HIST("histEvtPlRefBTwistV4"), epRefBTwistInd, cent);
           }
         }
       }
       if (vec.qvecAmp()[DetId] > 1e-8 && vec.qvecAmp()[RefAId] > 1e-8 && vec.qvecAmp()[RefBId] > 1e-8 && cfgQAFinal) {
-        histosQA.fill(HIST("histQvecRes_SigRefAV4"), vec.qvecRe()[DetInd + 3] * vec.qvecRe()[RefAInd + 3] + vec.qvecIm()[DetInd + 3] * vec.qvecIm()[RefAInd + 3], vec.cent());
-        histosQA.fill(HIST("histQvecRes_SigRefBV4"), vec.qvecRe()[DetInd + 3] * vec.qvecRe()[RefBInd + 3] + vec.qvecIm()[DetInd + 3] * vec.qvecIm()[RefBInd + 3], vec.cent());
-        histosQA.fill(HIST("histQvecRes_RefARefBV4"), vec.qvecRe()[RefAInd + 3] * vec.qvecRe()[RefBInd + 3] + vec.qvecIm()[RefAInd + 3] * vec.qvecIm()[RefBInd + 3], vec.cent());
+        histosQA.fill(HIST("histQvecRes_SigRefAV4"), getQVecRe(vec, DetInd + 3) * getQVecRe(vec, RefAInd + 3) + getQVecIm(vec, DetInd + 3) * getQVecIm(vec, RefAInd + 3), cent);
+        histosQA.fill(HIST("histQvecRes_SigRefBV4"), getQVecRe(vec, DetInd + 3) * getQVecRe(vec, RefBInd + 3) + getQVecIm(vec, DetInd + 3) * getQVecIm(vec, RefBInd + 3), cent);
+        histosQA.fill(HIST("histQvecRes_RefARefBV4"), getQVecRe(vec, RefAInd + 3) * getQVecRe(vec, RefBInd + 3) + getQVecIm(vec, RefAInd + 3) * getQVecIm(vec, RefBInd + 3), cent);
 
-        histosQA.fill(HIST("histEvtPlRes_SigRefAV4"), helperEP.GetResolution(helperEP.GetEventPlane(vec.qvecRe()[DetInd + 3], vec.qvecIm()[DetInd + 3], nmode), helperEP.GetEventPlane(vec.qvecRe()[RefAInd + 3], vec.qvecIm()[RefAInd + 3], nmode), nmode), vec.cent());
-        histosQA.fill(HIST("histEvtPlRes_SigRefBV4"), helperEP.GetResolution(helperEP.GetEventPlane(vec.qvecRe()[DetInd + 3], vec.qvecIm()[DetInd + 3], nmode), helperEP.GetEventPlane(vec.qvecRe()[RefBInd + 3], vec.qvecIm()[RefBInd + 3], nmode), nmode), vec.cent());
-        histosQA.fill(HIST("histEvtPlRes_RefARefBV4"), helperEP.GetResolution(helperEP.GetEventPlane(vec.qvecRe()[RefAInd + 3], vec.qvecIm()[RefAInd + 3], nmode), helperEP.GetEventPlane(vec.qvecRe()[RefBInd + 3], vec.qvecIm()[RefBInd + 3], nmode), nmode), vec.cent());
+        histosQA.fill(HIST("histEvtPlRes_SigRefAV4"), helperEP.GetResolution(epDetIndFinal, epRefAFinalInd, nmode), cent);
+        histosQA.fill(HIST("histEvtPlRes_SigRefBV4"), helperEP.GetResolution(epDetIndFinal, epRefBFinalInd, nmode), cent);
+        histosQA.fill(HIST("histEvtPlRes_RefARefBV4"), helperEP.GetResolution(epRefAFinalInd, epRefBFinalInd, nmode), cent);
       }
     }
   }
-  void processDefault(MyCollisions::iterator const& qVec, MyTracks const& tracks)
+
+  template<typename TCollision>
+  void processColls(TCollision const& flowQVec, MyTracks const& tracks)
   {
-    histosQA.fill(HIST("histCentFull"), qVec.cent());
+    histosQA.fill(HIST("histCentFull"), flowQVec.cent());
     if (cfgAddEvtSel) {
-      if (std::abs(qVec.posZ()) > 10.)
+      if (std::abs(flowQVec.posZ()) > 10.)
         return;
       switch (cfgEvtSel) {
         case 0: // Sel8
-          if (!qVec.sel8())
+          if (!flowQVec.sel8())
             return;
           break;
         case 1: // PbPb standard
-          if (!qVec.sel8() || !qVec.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV) || !qVec.selection_bit(aod::evsel::kNoSameBunchPileup))
+          if (!flowQVec.sel8() || !flowQVec.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV) || !flowQVec.selection_bit(aod::evsel::kNoSameBunchPileup))
             return;
           break;
         case 2: // PbPb with pileup
-          if (!qVec.sel8() || !qVec.selection_bit(o2::aod::evsel::kNoCollInTimeRangeStandard) ||
-              !qVec.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV) || !qVec.selection_bit(aod::evsel::kNoSameBunchPileup))
+          if (!flowQVec.sel8() || !flowQVec.selection_bit(o2::aod::evsel::kNoCollInTimeRangeStandard) ||
+              !flowQVec.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV) || !flowQVec.selection_bit(aod::evsel::kNoSameBunchPileup))
             return;
           break;
         case 3: // Small systems (OO, NeNe, pp)
-          if (!qVec.sel8() || !qVec.selection_bit(aod::evsel::kNoSameBunchPileup))
+          if (!flowQVec.sel8() || !flowQVec.selection_bit(aod::evsel::kNoSameBunchPileup))
             return;
           break;
         default:
           LOGF(warning, "Event selection flag was not found, continuing without basic event selections!\n");
       }
       // Check occupancy
-      if (qVec.trackOccupancyInTimeRange() > cfgMaxOccupancy || qVec.trackOccupancyInTimeRange() < cfgMinOccupancy)
+      if (flowQVec.trackOccupancyInTimeRange() > cfgMaxOccupancy || flowQVec.trackOccupancyInTimeRange() < cfgMinOccupancy)
         return;
     }
-    histosQA.fill(HIST("histCentSelected"), qVec.cent());
-    histosQA.fill(HIST("histVtxSelected"), qVec.posZ());
+    histosQA.fill(HIST("histCentSelected"), flowQVec.cent());
+    histosQA.fill(HIST("histVtxSelected"), flowQVec.posZ());
 
     if (cfgShiftCorPrep) {
       for (uint i = 0; i < cfgnMods->size(); i++) {
-        fillHistosShiftCor(qVec, cfgnMods->at(i));
+        fillHistosShiftCor(flowQVec, cfgnMods->at(i));
       }
     }
-
     for (uint i = 0; i < cfgnMods->size(); i++) {
-      fillHistosQvec(qVec, cfgnMods->at(i));
+      fillHistosQvec(flowQVec, cfgnMods->at(i));
       if (cfgQAFinal && cfgQAFlowStudy) {
-        fillHistosFlow(qVec, tracks, cfgnMods->at(i));
+        fillHistosFlow(flowQVec, tracks, cfgnMods->at(i));
       }
     }
   }
-  PROCESS_SWITCH(qVectorsCorrection, processDefault, "default process", true);
+
+  void processSp(MySpCollisions::iterator const& spQVec, MyTracks const& tracks)
+  {
+    processColls(spQVec, tracks);
+  }
+  PROCESS_SWITCH(qVectorsCorrection, processSp, "process SP", true);
+
+  void processEse(MyEseCollisions::iterator const& eseQVec, MyTracks const& tracks)
+  {
+    processColls(eseQVec, tracks);
+  }
+
+  PROCESS_SWITCH(qVectorsCorrection, processEse, "process Ese", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/Common/Tasks/qVectorsCorrection.cxx
+++ b/Common/Tasks/qVectorsCorrection.cxx
@@ -418,8 +418,8 @@ struct qVectorsCorrection {
     auto epRefBTwistInd = helperEP.GetEventPlane(getQVecRe(vec, RefBInd + 2), getQVecIm(vec, RefBInd + 2), nmode);
     auto epRefBFinalInd = helperEP.GetEventPlane(getQVecRe(vec, RefBInd + 3), getQVecIm(vec, RefBInd + 3), nmode);
 
-    auto occ  = vec.trackOccupancyInTimeRange();
-    auto cent = vec.cent(); 
+    auto occ = vec.trackOccupancyInTimeRange();
+    auto cent = vec.cent();
 
     if (nmode == 2) {
       if (vec.qvecAmp()[DetId] > 1e-8) {
@@ -643,7 +643,7 @@ struct qVectorsCorrection {
     }
   }
 
-  template<typename TCollision>
+  template <typename TCollision>
   void processColls(TCollision const& flowQVec, MyTracks const& tracks)
   {
     histosQA.fill(HIST("histCentFull"), flowQVec.cent());


### PR DESCRIPTION
@stefanopolitano @MaximVirta @jikim1290 

This PR adds the possibility to calibrate the q-vectors of the EsE-produced tables. I have removed the functions `fillHistosQvecWithSC` and `fillHistosFlowWithSC`, which were not called in the task, and templetized the current workflow. Please let me know if you have further ideas/suggestions, thanks in advance!