### PR TITLE
[PWGCF] FemtoUniverse: Fix in processFractionsSingleTruth

### DIFF
--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackV0Extended.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackV0Extended.cxx
@@ -1690,7 +1690,7 @@ struct FemtoUniversePairTaskTrackV0Extended {
   }
   PROCESS_SWITCH(FemtoUniversePairTaskTrackV0Extended, processFractionsSingleReco, "Process MC data to obtain fractions for V0 and protons particles", false);
 
-  void processFractionsSingleTruth(FilteredFDCollision const& col, FemtoRecoParticles const&)
+  void processFractionsSingleTruth(FilteredFDCollision const& col, FemtoFullParticles const&)
   {
     auto groupPartsOne = partsOneMCFull->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
     auto groupPartsTwo = partsTwoMCFull->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);


### PR DESCRIPTION
`PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackV0Extended.cxx`:
Fix a bug  in _processFractionsSingleTruth_ that caused a segmentation fault.
_FemtoRecoParticles_->_FemtoFullParticles_