### PR TITLE
[Common,PWGDQ,PWGJE,PWGLF] Preslice requires table type rather than iterator type

### DIFF
--- a/Common/TableProducer/mcCollsExtra.cxx
+++ b/Common/TableProducer/mcCollsExtra.cxx
@@ -50,7 +50,7 @@ struct mcCollisionExtra {
   Configurable<float> poiEtaWindow{"poiEtaWindow", 0.8, "PDG code requirement within this eta window"};
 
   // For manual sliceBy
-  Preslice<aod::McParticle> perMcCollision = aod::mcparticle::mcCollisionId;
+  Preslice<aod::McParticles> perMcCollision = aod::mcparticle::mcCollisionId;
 
   template <typename T>
   std::vector<std::size_t> sort_indices(const std::vector<T>& v)

--- a/Common/TableProducer/muonRealignment.cxx
+++ b/Common/TableProducer/muonRealignment.cxx
@@ -104,7 +104,7 @@ struct MuonRealignment {
   TGeoManager* geoNew = nullptr;
   TGeoManager* geoRef = nullptr;
 
-  Preslice<aod::FwdTrkCl> perMuon = aod::fwdtrkcl::fwdtrackId;
+  Preslice<aod::FwdTrkCls> perMuon = aod::fwdtrkcl::fwdtrackId;
 
   int GetDetElemId(int iDetElemNumber)
   {

--- a/Common/Tasks/qaMuon.cxx
+++ b/Common/Tasks/qaMuon.cxx
@@ -278,7 +278,7 @@ struct muonQa {
   TGeoManager* geoNew = nullptr;
   TGeoManager* geoRef = nullptr;
 
-  Preslice<aod::FwdTrkCl> perMuon = aod::fwdtrkcl::fwdtrackId;
+  Preslice<aod::FwdTrkCls> perMuon = aod::fwdtrkcl::fwdtrackId;
   Preslice<MyMuonsWithCov> fwdtracksPerCollision = aod::fwdtrack::collisionId;
   Preslice<MyMFTs> mftPerCollision = aod::fwdtrack::collisionId;
 

--- a/PWGDQ/Tasks/mchAlignRecord.cxx
+++ b/PWGDQ/Tasks/mchAlignRecord.cxx
@@ -113,7 +113,7 @@ struct mchAlignRecordTask {
                                               "List of param mask for d.o.f to be fixed"};
   } fFixDetElem;
 
-  Preslice<aod::FwdTrkCl> perMuon = aod::fwdtrkcl::fwdtrackId;
+  Preslice<aod::FwdTrkCls> perMuon = aod::fwdtrkcl::fwdtrackId;
 
   void init(InitContext& ic)
   {

--- a/PWGDQ/Tasks/muonGlobalAlignment.cxx
+++ b/PWGDQ/Tasks/muonGlobalAlignment.cxx
@@ -237,7 +237,7 @@ struct muonGlobalAlignment {
   };
   std::map<int, AlignmentCorrections> mMchAlignmentCorrections;
 
-  Preslice<aod::FwdTrkCl> perMuon = aod::fwdtrkcl::fwdtrackId;
+  Preslice<aod::FwdTrkCls> perMuon = aod::fwdtrkcl::fwdtrackId;
 
   o2::aod::rctsel::RCTFlagsChecker rctChecker{"CBT_muon_glo", false, false, true};
 

--- a/PWGJE/TableProducer/jetTrackDerived.cxx
+++ b/PWGJE/TableProducer/jetTrackDerived.cxx
@@ -159,7 +159,7 @@ struct jetspectraDerivedMaker {
     return true;
   }
 
-  Preslice<aod::Track> trackPerColl = aod::track::collisionId;
+  Preslice<aod::Tracks> trackPerColl = aod::track::collisionId;
   Produces<o2::aod::JeTracks> tableTrack;
   Produces<o2::aod::JeColls> tableColl;
   using CollisionCandidate = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs>;

--- a/PWGJE/Tasks/trackJetQA.cxx
+++ b/PWGJE/Tasks/trackJetQA.cxx
@@ -350,7 +350,7 @@ struct TrackJetQa {
     histos.fill(HIST("TPC/tpcChi2NCl"), track.pt(), track.sigma1Pt() * track.pt(), track.tpcChi2NCl(), collision.centFT0A(), collision.centFT0C());
   }
 
-  Preslice<aod::Track> trackPerColl = aod::track::collisionId;
+  Preslice<aod::Tracks> trackPerColl = aod::track::collisionId;
   using CollisionCandidate = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs>;
   using TrackCandidates = soa::Join<aod::FullTracks, aod::TracksDCA, aod::TrackSelection, aod::TracksCov>;
 

--- a/PWGLF/TableProducer/Nuspex/threebodymcfinder.cxx
+++ b/PWGLF/TableProducer/Nuspex/threebodymcfinder.cxx
@@ -59,7 +59,7 @@ struct threebodymcfinder {
 
   Configurable<bool> requireITS{"requireITS", false, "require ITS information used in tracks"};
 
-  Preslice<aod::McParticle> perMcCollision = aod::mcparticle::mcCollisionId;
+  Preslice<aod::McParticles> perMcCollision = aod::mcparticle::mcCollisionId;
 
   std::vector<int> d3bcollisionId;
   std::vector<int> d3bprong0Index;

--- a/PWGLF/TableProducer/Strangeness/cascademcfinder.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascademcfinder.cxx
@@ -67,7 +67,7 @@ struct cascademcfinder {
   Configurable<bool> doQA{"doQA", true, "do qa plots"};
 
   // For manual sliceBy
-  Preslice<aod::McParticle> perMcCollision = aod::mcparticle::mcCollisionId;
+  Preslice<aod::McParticles> perMcCollision = aod::mcparticle::mcCollisionId;
 
   std::vector<int> casccollisionId;
   std::vector<int> cascv0Index;


### PR DESCRIPTION
`Preslice` declaration is designed to take table type, previously this code worked by accident and will no longer work with the upcoming changes. The changed lines, anyway, look like typos, where the `s` from table types was simply missed. This change can be merged directly, as it does not change the actual behavior of the tasks.

@dsekihat could you please merge this directly? It would take too much time to wait for individual approvals and the change does not require any extra validation other than the CI. 