### PR TITLE
[PWGHF/D2H] removing di-quark contribution from non-prompt Dstar

### DIFF
--- a/PWGHF/D2H/Tasks/taskDstarToD0Pi.cxx
+++ b/PWGHF/D2H/Tasks/taskDstarToD0Pi.cxx
@@ -555,6 +555,11 @@ struct HfTaskDstarToD0Pi {
         auto indexMother = RecoDecay::getMother(rowsMcPartilces, prong0.template mcParticle_as<CandDstarMcGen>(), o2::constants::physics::Pdg::kDStar, true, &signDstar, 2);
         auto particleMother = rowsMcPartilces.rawIteratorAt(indexMother); // What is difference between rawIterator() or iteratorAt() methods?
         auto ptMother = particleMother.pt();
+        int const pdgBhadMother = candDstarMcRec.pdgBhadMotherPart();
+        // For unknown reasons there are charm hadrons coming directly from beauty diquarks without an intermediate B-hadron which have an unreasonable correlation between the pT of the charm hadron and the beauty mother. We also remove charm hadrons from quarkonia.
+        if (candDstarMcRec.originMcRec() == RecoDecay::OriginType::NonPrompt && (pdgBhadMother == 5101 || pdgBhadMother == 5103 || pdgBhadMother == 5201 || pdgBhadMother == 5203 || pdgBhadMother == 5301 || pdgBhadMother == 5303 || pdgBhadMother == 5401 || pdgBhadMother == 5403 || pdgBhadMother == 5503 || pdgBhadMother == 553 || pdgBhadMother == 555 || pdgBhadMother == 557)) { // o2-linter: disable=pdg/explicit-code, magic-number (constants not in the PDG header)
+          continue;
+        }
         if (qaEnabled) {
           registry.fill(HIST("QA/hPtSkimDstarGenSig"), ptMother); // generator level pt
           registry.fill(HIST("QA/hPtVsCentSkimDstarGenSig"), ptMother, centrality);
@@ -745,6 +750,12 @@ struct HfTaskDstarToD0Pi {
         auto idxBhadMotherPart = mcParticle.idxBhadMotherPart();
         auto bMother = rowsMcPartilces.rawIteratorAt(idxBhadMotherPart);
         auto ptBMother = bMother.pt();
+        int const pdgBhadMother = std::abs(bMother.pdgCode());
+
+        // For unknown reasons there are charm hadrons coming directly from beauty diquarks without an intermediate B-hadron which have an unreasonable correlation between the pT of the charm hadron and the beauty mother. We also remove charm hadrons from quarkonia.
+        if (mcParticle.originMcGen() == RecoDecay::OriginType::NonPrompt && (pdgBhadMother == 5101 || pdgBhadMother == 5103 || pdgBhadMother == 5201 || pdgBhadMother == 5203 || pdgBhadMother == 5301 || pdgBhadMother == 5303 || pdgBhadMother == 5401 || pdgBhadMother == 5403 || pdgBhadMother == 5503 || pdgBhadMother == 553 || pdgBhadMother == 555 || pdgBhadMother == 557)) { // o2-linter: disable=pdg/explicit-code, magic-number (constants not in the PDG header)
+          continue;
+        }
 
         auto yGen = RecoDecay::y(mcParticle.pVector(), o2::constants::physics::MassDStar);
         if (yCandDstarGenMax >= 0. && std::abs(yGen) > yCandDstarGenMax) {


### PR DESCRIPTION
Hi @fgrosa, @xinyepeng, @zhangbiao-phy, @stefanopolitano, and @Jessica

I am making changes in [D2H task](https://github.com/AliceO2Group/O2Physics/blob/master/PWGHF/D2H/Tasks/taskDstarToD0Pi.cxx) in order to remove contribution from beauty diquark into non-prompt D*.

The reference for these changes is taken from the [line](https://github.com/AliceO2Group/O2Physics/blob/2d99f6ce65475ec88a7325da0dbf29465de0c1e6/PWGHF/D2H/Tasks/taskCharmPolarisation.cxx#L2608) in [polarisation task](https://github.com/AliceO2Group/O2Physics/blob/2d99f6ce65475ec88a7325da0dbf29465de0c1e6/PWGHF/D2H/Tasks/taskCharmPolarisation.cxx).

I have the following doubt...
At the [line](https://github.com/AliceO2Group/O2Physics/blob/806303380c92a06c43fd4c220a6ff8d5bb2c4607/PWGHF/TableProducer/candidateCreatorDstar.cxx#L724), we have 

`originDstar = RecoDecay::getCharmHadronOrigin(mcParticles, particleDstar, false, &idxBhadMothers);`

argument for `const bool searchUpToQuark` is set to `false`. So, is it searching up to di-quark level? Or Can it not assign particle as Prompt (=1) if beauty hadron mother not found or assign None (=0)?

Thanks & let me know if further modification is required.

