### PR TITLE
[Common] Add run 3 hyperfine percentiling

### DIFF
--- a/Common/Tasks/centralityStudypp.cxx
+++ b/Common/Tasks/centralityStudypp.cxx
@@ -263,6 +263,7 @@ struct centralityStudypp {
 
     histPointers.insert({histPath + "hFDDA_Collisions", histos.add((histPath + "hFDDA_Collisions").c_str(), "hFDDA_Collisions", {kTH1D, {{axisMultUltraFineFDDA}}})});
     histPointers.insert({histPath + "hFDDC_Collisions", histos.add((histPath + "hFDDC_Collisions").c_str(), "hFDDC_Collisions", {kTH1D, {{axisMultUltraFineFDDC}}})});
+    histPointers.insert({histPath + "hFDDM_Collisions", histos.add((histPath + "hFDDM_Collisions").c_str(), "hFDDM_Collisions", {kTH1D, {{axisMultUltraFineFDDC}}})});
 
     histPointers.insert({histPath + "hFV0A_Collisions", histos.add((histPath + "hFV0A_Collisions").c_str(), "hFV0A_Collisions", {kTH1D, {{axisMultUltraFineFV0A}}})});
     histPointers.insert({histPath + "hNGlobalTracks", histos.add((histPath + "hNGlobalTracks").c_str(), "hNGlobalTracks", {kTH1D, {{axisMultUltraFineGlobalTracks}}})});
@@ -276,6 +277,7 @@ struct centralityStudypp {
 
       histPointers.insert({histPath + "hFDDA_Collisions_Unequalized", histos.add((histPath + "hFDDA_Collisions_Unequalized").c_str(), "hFDDA_Collisions_Unequalized", {kTH1D, {{axisMultUltraFineFDDA}}})});
       histPointers.insert({histPath + "hFDDC_Collisions_Unequalized", histos.add((histPath + "hFDDC_Collisions_Unequalized").c_str(), "hFDDC_Collisions_Unequalized", {kTH1D, {{axisMultUltraFineFDDC}}})});
+      histPointers.insert({histPath + "hFDDM_Collisions_Unequalized", histos.add((histPath + "hFDDM_Collisions_Unequalized").c_str(), "hFDDM_Collisions_Unequalized", {kTH1D, {{axisMultUltraFineFDDC}}})});
 
       histPointers.insert({histPath + "hFV0A_Collisions_Unequalized", histos.add((histPath + "hFV0A_Collisions_Unequalized").c_str(), "hFV0A_Collisions_Unequalized", {kTH1D, {{axisMultUltraFineFV0A}}})});
       histPointers.insert({histPath + "hNGlobalTracks_Unequalized", histos.add((histPath + "hNGlobalTracks_Unequalized").c_str(), "hNGlobalTracks_Unequalized", {kTH1D, {{axisMultUltraFineGlobalTracks}}})});
@@ -456,13 +458,13 @@ struct centralityStudypp {
     getHist(TH1, histPath + "hCollisionSelection")->Fill(11);
 
     // if we got here, we also finally fill the FT0C histogram, please
-    histos.fill(HIST("hNPVContributors"), collision.multNTracksPV());
-    histos.fill(HIST("hFT0A_Collisions"), collision.multFT0A());
-    histos.fill(HIST("hFT0C_Collisions"), collision.multFT0C());
-    histos.fill(HIST("hFT0M_Collisions"), (collision.multFT0A() + collision.multFT0C()));
-    histos.fill(HIST("hFDDA_Collisions"), collision.multFDDA());
-    histos.fill(HIST("hFDDC_Collisions"), collision.multFDDC());
-    histos.fill(HIST("hFV0A_Collisions"), collision.multFV0A());
+    histos.fill(HIST("hNPVContributors"), multNTracksPV);
+    histos.fill(HIST("hFT0A_Collisions"), multFT0A);
+    histos.fill(HIST("hFT0C_Collisions"), multFT0C);
+    histos.fill(HIST("hFT0M_Collisions"), multFT0A + multFT0C);
+    histos.fill(HIST("hFDDA_Collisions"), multFDDA);
+    histos.fill(HIST("hFDDC_Collisions"), multFDDC);
+    histos.fill(HIST("hFV0A_Collisions"), multFV0A);
     histos.fill(HIST("hNGlobalTracks"), collision.multNTracksGlobal());
     histos.fill(HIST("hNMFTTracks"), collision.mftNtracks());
 
@@ -473,6 +475,7 @@ struct centralityStudypp {
     getHist(TH1, histPath + "hFT0M_Collisions")->Fill((multFT0A + multFT0C));
     getHist(TH1, histPath + "hFDDA_Collisions")->Fill(multFDDA);
     getHist(TH1, histPath + "hFDDC_Collisions")->Fill(multFDDC);
+    getHist(TH1, histPath + "hFDDM_Collisions")->Fill(multFDDA+multFDDC);
     getHist(TH1, histPath + "hFV0A_Collisions")->Fill(multFV0A);
     getHist(TH1, histPath + "hNGlobalTracks")->Fill(multNTracksGlobal);
     getHist(TH1, histPath + "hNMFTTracks")->Fill(mftNtracks);

--- a/Common/Tasks/centralityStudypp.cxx
+++ b/Common/Tasks/centralityStudypp.cxx
@@ -475,7 +475,7 @@ struct centralityStudypp {
     getHist(TH1, histPath + "hFT0M_Collisions")->Fill((multFT0A + multFT0C));
     getHist(TH1, histPath + "hFDDA_Collisions")->Fill(multFDDA);
     getHist(TH1, histPath + "hFDDC_Collisions")->Fill(multFDDC);
-    getHist(TH1, histPath + "hFDDM_Collisions")->Fill(multFDDA+multFDDC);
+    getHist(TH1, histPath + "hFDDM_Collisions")->Fill(multFDDA + multFDDC);
     getHist(TH1, histPath + "hFV0A_Collisions")->Fill(multFV0A);
     getHist(TH1, histPath + "hNGlobalTracks")->Fill(multNTracksGlobal);
     getHist(TH1, histPath + "hNMFTTracks")->Fill(mftNtracks);

--- a/Common/Tools/Multiplicity/multCalibrator.cxx
+++ b/Common/Tools/Multiplicity/multCalibrator.cxx
@@ -40,7 +40,7 @@ const TString multCalibrator::fCentEstimName[kNCentEstim] = {
 multCalibrator::multCalibrator() : TNamed(),
                                    lDesiredBoundaries(0),
                                    lNDesiredBoundaries(0),
-                                   fkPrecisionWarningThreshold(1.0),
+                                   fkPrecisionWarningThreshold(1000.0),
                                    fInputFileName("AnalysisResults.root"),
                                    fOutputFileName("CCDB-objects.root"),
                                    fAnchorPointValue(-1),
@@ -57,7 +57,7 @@ multCalibrator::multCalibrator() : TNamed(),
 multCalibrator::multCalibrator(const char* name, const char* title) : TNamed(name, title),
                                                                       lDesiredBoundaries(0),
                                                                       lNDesiredBoundaries(0),
-                                                                      fkPrecisionWarningThreshold(1.0),
+                                                                      fkPrecisionWarningThreshold(1000.0),
                                                                       fInputFileName("AnalysisResults.root"),
                                                                       fOutputFileName("CCDB-objects.root"),
                                                                       fAnchorPointValue(-1),
@@ -231,6 +231,54 @@ void multCalibrator::SetStandardAdaptiveBoundaries()
 }
 
 //________________________________________________________________
+void multCalibrator::SetRun3AdaptiveBoundaries()
+{
+  // Function to set standard adaptive boundaries
+  // Run 3 exclusive: goes to 0.00001% binning for highest multiplicity
+  // Warning: this setting requires well filled input histograms
+  // 
+  // -> at 0.00001%, one needs 10 million events to get a single one in the highest 
+  // category. In Run 3, at 500 kHz, this corresponds to 20 seconds of dataking; 
+  // any run lasting over 5 minutes should have enough to calibrate to the highest 
+  // boundary. 
+  // 
+  // QA when using hyperfine binning is still advised: 
+  // Selecting very fine percentages may select on spurious situations 
+  // such as beam-background, pileup, etc. 
+
+  lNDesiredBoundaries = 0;
+  lDesiredBoundaries = new Double_t[1100];
+  lDesiredBoundaries[0] = 100;
+  // From Low To High Multiplicity
+  for (Int_t ib = 1; ib < 91; ib++) {
+    lNDesiredBoundaries++;
+    lDesiredBoundaries[lNDesiredBoundaries] = lDesiredBoundaries[lNDesiredBoundaries - 1] - 1.0;
+  }
+  for (Int_t ib = 1; ib < 91; ib++) {
+    lNDesiredBoundaries++;
+    lDesiredBoundaries[lNDesiredBoundaries] = lDesiredBoundaries[lNDesiredBoundaries - 1] - 0.1;
+  }
+  for (Int_t ib = 1; ib < 91; ib++) {
+    lNDesiredBoundaries++;
+    lDesiredBoundaries[lNDesiredBoundaries] = lDesiredBoundaries[lNDesiredBoundaries - 1] - 0.01;
+  }
+  for (Int_t ib = 1; ib < 91; ib++) {
+    lNDesiredBoundaries++;
+    lDesiredBoundaries[lNDesiredBoundaries] = lDesiredBoundaries[lNDesiredBoundaries - 1] - 0.001;
+  }
+  for (Int_t ib = 1; ib < 91; ib++) {
+    lNDesiredBoundaries++;
+    lDesiredBoundaries[lNDesiredBoundaries] = lDesiredBoundaries[lNDesiredBoundaries - 1] - 0.0001;
+  }
+  for (Int_t ib = 1; ib < 101; ib++) {
+    lNDesiredBoundaries++;
+    lDesiredBoundaries[lNDesiredBoundaries] = lDesiredBoundaries[lNDesiredBoundaries - 1] - 0.00001;
+  }
+  lNDesiredBoundaries++;
+  cout << "Set run 3 adaptive percentile boundaries! Nboundaries: " << lNDesiredBoundaries << endl;
+}
+
+//________________________________________________________________
 void multCalibrator::SetStandardOnePercentBoundaries()
 {
   // Function to set standard adaptive boundaries
@@ -242,6 +290,32 @@ void multCalibrator::SetStandardOnePercentBoundaries()
   for (Int_t ib = 1; ib < 101; ib++)
     lDesiredBoundaries[ib] = lDesiredBoundaries[ib - 1] - 1.0;
   cout << "Set standard 1%-wide percentile boundaries! Nboundaries: " << lNDesiredBoundaries << endl;
+}
+
+//________________________________________________________________
+bool multCalibrator::IsBinningSane(TH1 *histogram)
+{
+  // check if binning that will be attempted is too fine for this histogram
+  double minimumBinWidth = 1000.0f; 
+  for(int ib = 0; ib<lNDesiredBoundaries-1; ib++){
+    if(std::abs(lDesiredBoundaries[ib+1]-lDesiredBoundaries[ib])<minimumBinWidth){
+      minimumBinWidth = std::abs(lDesiredBoundaries[ib+1]-lDesiredBoundaries[ib]); 
+    }
+  }
+  if(minimumBinWidth<1e-9){
+    cout << "Excessively fine binning requested: minimum bin width registers as "<< minimumBinWidth << endl;
+    return false; // not reasonable 
+  }
+  if(histogram->GetEntries() < 1000.0/minimumBinWidth){ 
+    cout << "Histogram "<<histogram->GetName()<<" does not have enough entries ("<<histogram->GetEntries()<<") to calibrate!" << endl;
+    return false; 
+  }
+  if(std::abs(histogram->GetMean())<1e-9){ 
+    cout << "Histogram "<<histogram->GetName()<<" has suspicious mean: "<<histogram->GetMean()<<endl; 
+    return false; 
+  }
+  cout << "Sanity check: " << histogram->GetName() << ", entries = " << histogram->GetEntries() << ", 1/(min bin width) = " <<100.0/minimumBinWidth << " -> OK ! " << endl;
+  return true;
 }
 
 //________________________________________________________________
@@ -258,6 +332,19 @@ TH1F* multCalibrator::GetCalibrationHistogram(TH1* histoRaw, TString lHistoName)
     cout << "PROBLEM WITH ANCHOR POINT SETTINGS! " << endl;
     cout << "Anchor point percentage requested: " << fAnchorPointPercentage << endl;
     cout << "Last boundary: " << lDesiredBoundaries[0] << endl;
+  }
+
+  // binning check 
+  if(!IsBinningSane(histoRaw)){ 
+    cout << "Requested binning is not viable for input histogram named "<<histoRaw->GetName()<<"! Will return 100.5 for all requests." <<endl; 
+    Double_t lDummyBounds[2]; 
+    lDummyBounds[0] = 0;
+    lDummyBounds[1] = 1.0;
+    TH1F *hCalib = new TH1F(lHistoName.Data(), "", 1, lDummyBounds); 
+    hCalib->SetBinContent(0, 100.5);
+    hCalib->SetBinContent(1, 100.5);
+    hCalib->SetBinContent(2, 100.5);
+    return hCalib;
   }
 
   // Aux vars
@@ -278,15 +365,22 @@ TH1F* multCalibrator::GetCalibrationHistogram(TH1* histoRaw, TString lHistoName)
     if (fAnchorPointValue > 0)
       lDisplacedii++;
     lBounds[lDisplacedii] = GetBoundaryForPercentile(histoRaw, lDesiredBoundaries[ii], lPrecision[ii]);
+    bool warnUser = false;
     TString lPrecisionString = "(Precision OK)";
     if (ii != 0 && ii != lNDesiredBoundaries - 1) {
       // check precision, please
-      if (lPrecision[ii] / TMath::Abs(lDesiredBoundaries[ii + 1] - lDesiredBoundaries[ii]) > fkPrecisionWarningThreshold)
+      if ((lPrecision[ii] / TMath::Abs(lDesiredBoundaries[ii + 1] - lDesiredBoundaries[ii])) > fkPrecisionWarningThreshold){
         lPrecisionString = "(WARNING: BINNING MAY LEAD TO IMPRECISION!)";
-      if (lPrecision[ii] / TMath::Abs(lDesiredBoundaries[ii - 1] - lDesiredBoundaries[ii]) > fkPrecisionWarningThreshold)
+        warnUser = true;
+      }
+      if ((lPrecision[ii] / TMath::Abs(lDesiredBoundaries[ii - 1] - lDesiredBoundaries[ii])) > fkPrecisionWarningThreshold){
         lPrecisionString = "(WARNING: BINNING MAY LEAD TO IMPRECISION!)";
+        warnUser = true;
+      }
     }
-    cout << histoRaw->GetName() << " boundaries, percentile: " << lDesiredBoundaries[ii] << "%\t Signal value = " << lBounds[lDisplacedii] << "\tprecision = " << lPrecision[ii] << "% " << lPrecisionString.Data() << endl;
+    if(warnUser){
+      cout << histoRaw->GetName() << " boundaries, percentile: " << lDesiredBoundaries[ii] << "%\t Signal value = " << lBounds[lDisplacedii] << "\tprecision = " << lPrecision[ii] << "% " << lPrecisionString.Data() << endl;
+    }
   }
   TH1F* hCalib = new TH1F(lHistoName.Data(), "", fAnchorPointValue < 0 ? lNDesiredBoundaries - 1 : lNDesiredBoundaries, lBounds);
   hCalib->SetDirectory(0);
@@ -311,7 +405,6 @@ void multCalibrator::ResetPrecisionHistogram()
     Double_t lInverseDesiredBoundaries[1100];
     for (Int_t ii = 0; ii < lNDesiredBoundaries; ii++) {
       lInverseDesiredBoundaries[ii] = lDesiredBoundaries[lNDesiredBoundaries - (ii + 1)];
-      cout << "Boundary " << ii << " is " << lInverseDesiredBoundaries[ii] << endl;
     }
     fPrecisionHistogram = new TH1D("hPrecisionHistogram", "", lNDesiredBoundaries - 1, lInverseDesiredBoundaries);
   }

--- a/Common/Tools/Multiplicity/multCalibrator.cxx
+++ b/Common/Tools/Multiplicity/multCalibrator.cxx
@@ -236,15 +236,15 @@ void multCalibrator::SetRun3AdaptiveBoundaries()
   // Function to set standard adaptive boundaries
   // Run 3 exclusive: goes to 0.00001% binning for highest multiplicity
   // Warning: this setting requires well filled input histograms
-  // 
-  // -> at 0.00001%, one needs 10 million events to get a single one in the highest 
-  // category. In Run 3, at 500 kHz, this corresponds to 20 seconds of dataking; 
-  // any run lasting over 5 minutes should have enough to calibrate to the highest 
-  // boundary. 
-  // 
-  // QA when using hyperfine binning is still advised: 
-  // Selecting very fine percentages may select on spurious situations 
-  // such as beam-background, pileup, etc. 
+  //
+  // -> at 0.00001%, one needs 10 million events to get a single one in the highest
+  // category. In Run 3, at 500 kHz, this corresponds to 20 seconds of dataking;
+  // any run lasting over 5 minutes should have enough to calibrate to the highest
+  // boundary.
+  //
+  // QA when using hyperfine binning is still advised:
+  // Selecting very fine percentages may select on spurious situations
+  // such as beam-background, pileup, etc.
 
   lNDesiredBoundaries = 0;
   lDesiredBoundaries = new Double_t[1100];
@@ -293,28 +293,28 @@ void multCalibrator::SetStandardOnePercentBoundaries()
 }
 
 //________________________________________________________________
-bool multCalibrator::IsBinningSane(TH1 *histogram)
+bool multCalibrator::IsBinningSane(TH1* histogram)
 {
   // check if binning that will be attempted is too fine for this histogram
-  double minimumBinWidth = 1000.0f; 
-  for(int ib = 0; ib<lNDesiredBoundaries-1; ib++){
-    if(std::abs(lDesiredBoundaries[ib+1]-lDesiredBoundaries[ib])<minimumBinWidth){
-      minimumBinWidth = std::abs(lDesiredBoundaries[ib+1]-lDesiredBoundaries[ib]); 
+  double minimumBinWidth = 1000.0f;
+  for (int ib = 0; ib < lNDesiredBoundaries - 1; ib++) {
+    if (std::abs(lDesiredBoundaries[ib + 1] - lDesiredBoundaries[ib]) < minimumBinWidth) {
+      minimumBinWidth = std::abs(lDesiredBoundaries[ib + 1] - lDesiredBoundaries[ib]);
     }
   }
-  if(minimumBinWidth<1e-9){
-    cout << "Excessively fine binning requested: minimum bin width registers as "<< minimumBinWidth << endl;
-    return false; // not reasonable 
+  if (minimumBinWidth < 1e-9) {
+    cout << "Excessively fine binning requested: minimum bin width registers as " << minimumBinWidth << endl;
+    return false; // not reasonable
   }
-  if(histogram->GetEntries() < 1000.0/minimumBinWidth){ 
-    cout << "Histogram "<<histogram->GetName()<<" does not have enough entries ("<<histogram->GetEntries()<<") to calibrate!" << endl;
-    return false; 
+  if (histogram->GetEntries() < 1000.0 / minimumBinWidth) {
+    cout << "Histogram " << histogram->GetName() << " does not have enough entries (" << histogram->GetEntries() << ") to calibrate!" << endl;
+    return false;
   }
-  if(std::abs(histogram->GetMean())<1e-9){ 
-    cout << "Histogram "<<histogram->GetName()<<" has suspicious mean: "<<histogram->GetMean()<<endl; 
-    return false; 
+  if (std::abs(histogram->GetMean()) < 1e-9) {
+    cout << "Histogram " << histogram->GetName() << " has suspicious mean: " << histogram->GetMean() << endl;
+    return false;
   }
-  cout << "Sanity check: " << histogram->GetName() << ", entries = " << histogram->GetEntries() << ", 1/(min bin width) = " <<100.0/minimumBinWidth << " -> OK ! " << endl;
+  cout << "Sanity check: " << histogram->GetName() << ", entries = " << histogram->GetEntries() << ", 1/(min bin width) = " << 100.0 / minimumBinWidth << " -> OK ! " << endl;
   return true;
 }
 
@@ -334,13 +334,13 @@ TH1F* multCalibrator::GetCalibrationHistogram(TH1* histoRaw, TString lHistoName)
     cout << "Last boundary: " << lDesiredBoundaries[0] << endl;
   }
 
-  // binning check 
-  if(!IsBinningSane(histoRaw)){ 
-    cout << "Requested binning is not viable for input histogram named "<<histoRaw->GetName()<<"! Will return 100.5 for all requests." <<endl; 
-    Double_t lDummyBounds[2]; 
+  // binning check
+  if (!IsBinningSane(histoRaw)) {
+    cout << "Requested binning is not viable for input histogram named " << histoRaw->GetName() << "! Will return 100.5 for all requests." << endl;
+    Double_t lDummyBounds[2];
     lDummyBounds[0] = 0;
     lDummyBounds[1] = 1.0;
-    TH1F *hCalib = new TH1F(lHistoName.Data(), "", 1, lDummyBounds); 
+    TH1F* hCalib = new TH1F(lHistoName.Data(), "", 1, lDummyBounds);
     hCalib->SetBinContent(0, 100.5);
     hCalib->SetBinContent(1, 100.5);
     hCalib->SetBinContent(2, 100.5);
@@ -369,16 +369,16 @@ TH1F* multCalibrator::GetCalibrationHistogram(TH1* histoRaw, TString lHistoName)
     TString lPrecisionString = "(Precision OK)";
     if (ii != 0 && ii != lNDesiredBoundaries - 1) {
       // check precision, please
-      if ((lPrecision[ii] / TMath::Abs(lDesiredBoundaries[ii + 1] - lDesiredBoundaries[ii])) > fkPrecisionWarningThreshold){
+      if ((lPrecision[ii] / TMath::Abs(lDesiredBoundaries[ii + 1] - lDesiredBoundaries[ii])) > fkPrecisionWarningThreshold) {
         lPrecisionString = "(WARNING: BINNING MAY LEAD TO IMPRECISION!)";
         warnUser = true;
       }
-      if ((lPrecision[ii] / TMath::Abs(lDesiredBoundaries[ii - 1] - lDesiredBoundaries[ii])) > fkPrecisionWarningThreshold){
+      if ((lPrecision[ii] / TMath::Abs(lDesiredBoundaries[ii - 1] - lDesiredBoundaries[ii])) > fkPrecisionWarningThreshold) {
         lPrecisionString = "(WARNING: BINNING MAY LEAD TO IMPRECISION!)";
         warnUser = true;
       }
     }
-    if(warnUser){
+    if (warnUser) {
       cout << histoRaw->GetName() << " boundaries, percentile: " << lDesiredBoundaries[ii] << "%\t Signal value = " << lBounds[lDisplacedii] << "\tprecision = " << lPrecision[ii] << "% " << lPrecisionString.Data() << endl;
     }
   }

--- a/Common/Tools/Multiplicity/multCalibrator.h
+++ b/Common/Tools/Multiplicity/multCalibrator.h
@@ -62,8 +62,8 @@ class multCalibrator : public TNamed
   void SetStandardAdaptiveBoundaries();   // standard adaptive (pp-like)
   void SetRun3AdaptiveBoundaries();       // Run 3 adaptive (down to 0.00001%)
   void SetStandardOnePercentBoundaries(); // standard 1% (Pb-Pb like)
-  bool IsBinningSane(TH1 *histogram);     // for safety
-  
+  bool IsBinningSane(TH1* histogram);     // for safety
+
   // Master Function in this Class: To be called once filenames are set
   Bool_t Calibrate();
 

--- a/Common/Tools/Multiplicity/multCalibrator.h
+++ b/Common/Tools/Multiplicity/multCalibrator.h
@@ -60,8 +60,10 @@ class multCalibrator : public TNamed
   void SetAnchorPointPercentage(Float_t lPer) { fAnchorPointPercentage = lPer; }
 
   void SetStandardAdaptiveBoundaries();   // standard adaptive (pp-like)
+  void SetRun3AdaptiveBoundaries();       // Run 3 adaptive (down to 0.00001%)
   void SetStandardOnePercentBoundaries(); // standard 1% (Pb-Pb like)
-
+  bool IsBinningSane(TH1 *histogram);     // for safety
+  
   // Master Function in this Class: To be called once filenames are set
   Bool_t Calibrate();
 


### PR DESCRIPTION
* adds an adaptive percentiling setting in which 0.00001% is viable, which should be fine in any run with well over 10 million events. Based on inspecting the typical signals, a very high multiplicity selection is likely to be fine with midrapidity counters but caution should be exercised with FIT signals, as these have a tail that is likely beam-background or otherwise spurious: QA is always needed!
* adds sanity checks to capture problematic calibration situations and issue an invalid (but mathematically functional) calibration in that case. Checks include excessively fine binning requested for the input information as well as situations in which the detector signal is zero (e.g. no MFT in datataking). 
* N.B.: the calibrator that is touched in this PR is legacy code (it's very old...) and thus spawns several linter warnings: will be fixed in a future PR.