### PR TITLE
[PWGLF] Feat/antin cex hist update

### DIFF
--- a/PWGLF/DataModel/LFAntinCexTables.h
+++ b/PWGLF/DataModel/LFAntinCexTables.h
@@ -18,8 +18,9 @@
 #ifndef PWGLF_DATAMODEL_LFANTINCEXTABLES_H_
 #define PWGLF_DATAMODEL_LFANTINCEXTABLES_H_
 
-#include "Framework/ASoAHelpers.h"
-#include "Framework/AnalysisDataModel.h"
+#include <Framework/AnalysisDataModel.h>
+
+#include <cstdint>
 
 namespace o2::aod
 {

--- a/PWGLF/DataModel/LFAntinCexTables.h
+++ b/PWGLF/DataModel/LFAntinCexTables.h
@@ -18,21 +18,20 @@
 #ifndef PWGLF_DATAMODEL_LFANTINCEXTABLES_H_
 #define PWGLF_DATAMODEL_LFANTINCEXTABLES_H_
 
-#include <Framework/AnalysisDataModel.h>
-
-#include <cstdint>
+#include "Framework/ASoAHelpers.h"
+#include "Framework/AnalysisDataModel.h"
 
 namespace o2::aod
 {
 namespace antin_cex
 {
 // Metadata
-DECLARE_SOA_COLUMN(IsCex, isCex, bool);              // 1=CEX (from antin), 0=BG
-DECLARE_SOA_COLUMN(MotherPdg, motherPdg, int32_t);   // mother PDG
-DECLARE_SOA_COLUMN(MotherNHitIB, motherNHitIB, int); // mother IB Hits
-DECLARE_SOA_COLUMN(ColId, colId, int32_t);           // mcCollisionId
-DECLARE_SOA_COLUMN(PId, pId, int32_t);               // proton MC id
-DECLARE_SOA_COLUMN(AntipId, antipId, int32_t);       // antiproton MC id
+DECLARE_SOA_COLUMN(IsCex, isCex, bool);            // 1=CEX (from antin), 0=BG
+DECLARE_SOA_COLUMN(MotherPdg, motherPdg, int32_t); // mother PDG
+DECLARE_SOA_COLUMN(MotherP, motherP, float);        // mother P
+DECLARE_SOA_COLUMN(ColId, colId, int32_t);         // mcCollisionId
+DECLARE_SOA_COLUMN(PId, pId, int32_t);             // proton MC id
+DECLARE_SOA_COLUMN(AntipId, antipId, int32_t);     // antiproton MC id
 
 // MC (pair)
 DECLARE_SOA_COLUMN(McPairP, mcPairP, float);
@@ -43,12 +42,6 @@ DECLARE_SOA_COLUMN(McAngleDeg, mcAngleDeg, float);
 DECLARE_SOA_COLUMN(McVtxX, mcVtxX, float);
 DECLARE_SOA_COLUMN(McVtxY, mcVtxY, float);
 DECLARE_SOA_COLUMN(McVtxZ, mcVtxZ, float);
-DECLARE_SOA_COLUMN(VtxNAll, vtxNAll, int16_t);
-DECLARE_SOA_COLUMN(VtxNCh, vtxNCh, int16_t);
-DECLARE_SOA_COLUMN(VtxNNeut, vtxNNeut, int16_t);
-DECLARE_SOA_COLUMN(VtxNPi0, vtxNPi0, int16_t);
-DECLARE_SOA_COLUMN(VtxNGamma, vtxNGamma, int16_t);
-DECLARE_SOA_COLUMN(VtxNN, vtxNN, int16_t);
 
 // Tracks (pair, fitter)
 DECLARE_SOA_COLUMN(TrkPairP, trkPairP, float);
@@ -109,8 +102,6 @@ DECLARE_SOA_COLUMN(SVDeltaRToLayer, svDeltaRToLayer, float);
 
 DECLARE_SOA_COLUMN(PTrkItsHitMap, pTrkItsHitMap, uint16_t);
 DECLARE_SOA_COLUMN(APTrkItsHitMap, apTrkItsHitMap, uint16_t);
-DECLARE_SOA_COLUMN(PLayersOk, pLayersOk, int8_t);
-DECLARE_SOA_COLUMN(APLayersOk, apLayersOk, int8_t);
 
 DECLARE_SOA_COLUMN(PVtxZ, pVtxZ, float);
 
@@ -128,10 +119,9 @@ DECLARE_SOA_COLUMN(AntipTrkTgl, antipTrkTgl, float);
 // Table
 DECLARE_SOA_TABLE(AntinCexPairs, "AOD", "ANTINCEX",
                   antin_cex::IsCex,
-                  antin_cex::MotherPdg, antin_cex::MotherNHitIB, antin_cex::ColId, antin_cex::PId, antin_cex::AntipId,
+                  antin_cex::MotherPdg, antin_cex::MotherP, antin_cex::ColId, antin_cex::PId, antin_cex::AntipId,
                   antin_cex::McPairP, antin_cex::McPairPt, antin_cex::McPairPz,
                   antin_cex::McDplane, antin_cex::McAngleDeg, antin_cex::McVtxX, antin_cex::McVtxY, antin_cex::McVtxZ,
-                  antin_cex::VtxNAll, antin_cex::VtxNCh, antin_cex::VtxNNeut, antin_cex::VtxNPi0, antin_cex::VtxNGamma, antin_cex::VtxNN,
                   antin_cex::TrkPairP, antin_cex::TrkPairPt, antin_cex::TrkPairPz, antin_cex::TrkAngleDeg,
                   antin_cex::TrkVtxfitDcaPair, antin_cex::TrkVtxfitR, antin_cex::TrkVtxfitDistToPv,
                   antin_cex::TrkVtxfitSecVtxX, antin_cex::TrkVtxfitSecVtxY, antin_cex::TrkVtxfitSecVtxZ,
@@ -143,7 +133,7 @@ DECLARE_SOA_TABLE(AntinCexPairs, "AOD", "ANTINCEX",
                   antin_cex::PairPointingAngleDeg, antin_cex::PvsvThetaDeg, antin_cex::PvsvPhiDeg, antin_cex::PairPBalance, antin_cex::PairPtBalance, antin_cex::PairQ,
                   antin_cex::DPairP, antin_cex::DPairPt, antin_cex::DPairPz, antin_cex::DOpenAngle,
                   antin_cex::SVNearestLayerId, antin_cex::SVDeltaRToLayer,
-                  antin_cex::PTrkItsHitMap, antin_cex::APTrkItsHitMap, antin_cex::PLayersOk, antin_cex::APLayersOk,
+                  antin_cex::PTrkItsHitMap, antin_cex::APTrkItsHitMap,
                   antin_cex::PVtxZ,
                   antin_cex::PTrkItsNSigmaPr, antin_cex::PTrkItsPidValid, antin_cex::PTrkTgl,
                   antin_cex::AntipTrkItsNSigmaPr, antin_cex::AntipTrkItsPidValid, antin_cex::AntipTrkTgl);

--- a/PWGLF/DataModel/LFAntinCexTables.h
+++ b/PWGLF/DataModel/LFAntinCexTables.h
@@ -28,7 +28,7 @@ namespace antin_cex
 // Metadata
 DECLARE_SOA_COLUMN(IsCex, isCex, bool);            // 1=CEX (from antin), 0=BG
 DECLARE_SOA_COLUMN(MotherPdg, motherPdg, int32_t); // mother PDG
-DECLARE_SOA_COLUMN(MotherP, motherP, float);        // mother P
+DECLARE_SOA_COLUMN(MotherP, motherP, float);       // mother P
 DECLARE_SOA_COLUMN(ColId, colId, int32_t);         // mcCollisionId
 DECLARE_SOA_COLUMN(PId, pId, int32_t);             // proton MC id
 DECLARE_SOA_COLUMN(AntipId, antipId, int32_t);     // antiproton MC id

--- a/PWGLF/TableProducer/Nuspex/nucleiAntineutronCex.cxx
+++ b/PWGLF/TableProducer/Nuspex/nucleiAntineutronCex.cxx
@@ -14,16 +14,17 @@
 /// \brief Analysis task for antineutron detection through cex interactions
 /// \author Fabiola Lugo
 ///
+#include <PWGLF/DataModel/LFAntinCexTables.h>
+
+#include <Common/DataModel/PIDResponseITS.h>
+
+#include <CommonConstants/MathConstants.h>
+#include <DCAFitter/DCAFitterN.h>
+#include <DetectorsBase/Propagator.h>
 #include <Framework/AnalysisDataModel.h>
 #include <Framework/AnalysisTask.h>
 #include <Framework/Logger.h>
 #include <Framework/runDataProcessing.h>
-
-#include <PWGLF/DataModel/LFAntinCexTables.h>
-#include <Common/DataModel/PIDResponseITS.h>
-#include <CommonConstants/MathConstants.h>
-#include <DCAFitter/DCAFitterN.h>
-#include <DetectorsBase/Propagator.h>
 #include <ReconstructionDataFormats/TrackParametrization.h>
 
 #include <TMCProcess.h>
@@ -43,7 +44,7 @@ using o2::constants::math::Rad2Deg;
 struct NucleiAntineutronCex {
   // Slicing per colision
   Preslice<aod::McParticles> perMcByColl = aod::mcparticle::mcCollisionId;
-  
+
   using TracksWCovMc = soa::Join<aod::TracksIU, aod::TracksExtra, aod::McTrackLabels, o2::aod::TracksCovIU>;
 
   // === Cut values ===
@@ -99,11 +100,11 @@ struct NucleiAntineutronCex {
     histos.add("pPz", "p_{z};p_{z} (GeV/c);Entries", kTH1F, {{100, -10., 10.}});
     histos.add("pEta", "Pseudorapidity;#eta;Entries", kTH1F, {{100, -10., 10.}});
     histos.add("pP_ITScuts", "Momentum with ITS cuts;|p| (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
-    
+
     // Process enum breakdown (secondary antiproton that anchors the SV)
     histos.add("hProcEnumAP_CEX", "procEnum of secondary #bar{p} (CEX);procEnum;Entries", kTH1I, {{100, -0.5, 99.5}});
-    histos.add("hProcEnumAP_BG",  "procEnum of secondary #bar{p} (BG);procEnum;Entries",  kTH1I, {{100, -0.5, 99.5}});
-    
+    histos.add("hProcEnumAP_BG", "procEnum of secondary #bar{p} (BG);procEnum;Entries", kTH1I, {{100, -0.5, 99.5}});
+
     // CEX pair from antineutron (MC)
     histos.add("cexPairMcP", "CEX pair total momentum;|p| (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
     histos.add("cexPairMcPt", "CEX pair p_{T};p_{T} (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
@@ -128,8 +129,8 @@ struct NucleiAntineutronCex {
     histos.add("cexbg_pairmc_vtx", "Background pair vertex;X (cm);Y (cm)", kTH2F, {{200, -60., 60.}, {200, -60., 60.}});
     histos.add("cexbg_pairmc_vtxz", "Background secondary vertex Z;Z (cm);Entries", kTH1F, {{200, -60., 60.}});
     histos.add("cexbg_pairmc_pITScuts", "Background momentum (ITS cuts);|p| (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
-    
-    //Pi0 events
+
+    // Pi0 events
     histos.add("cexn_pairmc_p_pi0", "Pair p / antineutron p for CEX + #pi^{0};p/p_{#bar{n}};Entries", kTH1F, {{100, 0., 2.}});
 
     // CEX pair from antineutron (TRK)
@@ -359,10 +360,10 @@ struct NucleiAntineutronCex {
             break;
           }
         }
-        
+
         if (pionPlus || pionMinus)
           continue;
-        
+
         // Check for neutral pion at the same secondary vertex
         bool pion0 = false;
         for (const auto& particle4 : mcPartsThis) {
@@ -721,7 +722,7 @@ struct NucleiAntineutronCex {
 
               const TVector3 pv2sv(secX - pvtxX, secY - pvtxY, secZ - pvtxZ);
               const double pairPointingAngleDeg = pv2sv.Angle(total_trk_pVec) * Rad2Deg;
-              
+
               const double pvsvThetaDeg = pv2sv.Theta() * Rad2Deg;
 
               double pvsvPhiDeg = pv2sv.Phi() * Rad2Deg;
@@ -790,14 +791,14 @@ struct NucleiAntineutronCex {
               histos.fill(HIST("vtxfit_mc_d3D"), d3d);
 
               const bool isCex = (motherPdg == -kNeutron);
-              
+
               // Nature of the process
               if (isCex) {
                 histos.fill(HIST("hProcEnumAP_CEX"), static_cast<int>(procEnum));
               } else {
                 histos.fill(HIST("hProcEnumAP_BG"), static_cast<int>(procEnum));
               }
-                      
+
               const float vtxfitDX = secX - antipVx;
               const float vtxfitDY = secY - antipVy;
               const float vtxfitDZ = secZ - antipVz;
@@ -884,8 +885,7 @@ struct NucleiAntineutronCex {
 
                 antipTrkItsNSigmaPr,
                 antipTrkItsPidValid,
-                antipTrkTgl
-                );
+                antipTrkTgl);
             }
           }
           // ==== end DCAFitter2 ====

--- a/PWGLF/TableProducer/Nuspex/nucleiAntineutronCex.cxx
+++ b/PWGLF/TableProducer/Nuspex/nucleiAntineutronCex.cxx
@@ -14,34 +14,26 @@
 /// \brief Analysis task for antineutron detection through cex interactions
 /// \author Fabiola Lugo
 ///
+#include <Framework/AnalysisDataModel.h>
+#include <Framework/AnalysisTask.h>
+#include <Framework/Logger.h>
+#include <Framework/runDataProcessing.h>
 
-#include "PWGLF/DataModel/LFAntinCexTables.h"
-
-#include "Common/DataModel/PIDResponseITS.h"
-
+#include <PWGLF/DataModel/LFAntinCexTables.h>
+#include <Common/DataModel/PIDResponseITS.h>
 #include <CommonConstants/MathConstants.h>
 #include <DCAFitter/DCAFitterN.h>
-#include <Framework/AnalysisDataModel.h>
-#include <Framework/AnalysisHelpers.h>
-#include <Framework/AnalysisTask.h>
-#include <Framework/HistogramRegistry.h>
-#include <Framework/HistogramSpec.h>
-#include <Framework/InitContext.h>
-#include <Framework/OutputObjHeader.h>
-#include <Framework/runDataProcessing.h>
-#include <ReconstructionDataFormats/PID.h>
-#include <ReconstructionDataFormats/Track.h>
+#include <DetectorsBase/Propagator.h>
 #include <ReconstructionDataFormats/TrackParametrization.h>
 
-#include <TDatabasePDG.h>
 #include <TMCProcess.h>
+#include <TMath.h>
 #include <TPDGCode.h>
 #include <TVector3.h>
 
 #include <algorithm>
 #include <array>
 #include <cmath>
-#include <cstdint>
 #include <optional>
 
 using namespace o2;
@@ -51,15 +43,15 @@ using o2::constants::math::Rad2Deg;
 struct NucleiAntineutronCex {
   // Slicing per colision
   Preslice<aod::McParticles> perMcByColl = aod::mcparticle::mcCollisionId;
-  // Check available tables in the AOD, specifically TracksIU, TracksCovIU
+  
   using TracksWCovMc = soa::Join<aod::TracksIU, aod::TracksExtra, aod::McTrackLabels, o2::aod::TracksCovIU>;
 
   // === Cut values ===
   static constexpr double kIts2MinR = 4.5;    // ITS2 min radius (exluding IB) [cm]
   static constexpr double kIts2MaxR = 48.0;   // ITS2 max radius [cm]
   static constexpr double kIts2MaxVz = 39.0;  // ITS2 max |vz| [cm]
-  static constexpr double kAccMaxEta = 1.2;   // acceptance |eta|
-  static constexpr double kAccMaxVz = 10.0;   // acceptance |vz| [cm]
+  static constexpr double kAccMaxEta = 1.2;   // acceptance |eta| (primary particles)
+  static constexpr double kAccMaxVz = 10.0;   // acceptance |vz| (primary particles) [cm]
   static constexpr double kStrictEta = 0.9;   // tighter eta cut
   static constexpr double kInitDplane = 10.0; // init dplane
   static constexpr double kHuge = 1e9;        // fallback for bad denom
@@ -107,33 +99,18 @@ struct NucleiAntineutronCex {
     histos.add("pPz", "p_{z};p_{z} (GeV/c);Entries", kTH1F, {{100, -10., 10.}});
     histos.add("pEta", "Pseudorapidity;#eta;Entries", kTH1F, {{100, -10., 10.}});
     histos.add("pP_ITScuts", "Momentum with ITS cuts;|p| (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
-
+    
     // Process enum breakdown (secondary antiproton that anchors the SV)
     histos.add("hProcEnumAP_CEX", "procEnum of secondary #bar{p} (CEX);procEnum;Entries", kTH1I, {{100, -0.5, 99.5}});
-    histos.add("hProcEnumAP_BG", "procEnum of secondary #bar{p} (BG);procEnum;Entries", kTH1I, {{100, -0.5, 99.5}});
-
-    // Multiplicity/composition at the SV (MC truth, for FINAL selected candidates)
-    histos.add("hVtxNAll_CEX", "N(all) secondaries at SV (CEX);N;Entries", kTH1I, {{60, -0.5, 59.5}});
-    histos.add("hVtxNAll_BG", "N(all) secondaries at SV (BG);N;Entries", kTH1I, {{60, -0.5, 59.5}});
-    histos.add("hVtxNCh_CEX", "N(charged) secondaries at SV (CEX);N;Entries", kTH1I, {{60, -0.5, 59.5}});
-    histos.add("hVtxNCh_BG", "N(charged) secondaries at SV (BG);N;Entries", kTH1I, {{60, -0.5, 59.5}});
-    histos.add("hVtxNNeut_CEX", "N(neutral) secondaries at SV (CEX);N;Entries", kTH1I, {{60, -0.5, 59.5}});
-    histos.add("hVtxNNeut_BG", "N(neutral) secondaries at SV (BG);N;Entries", kTH1I, {{60, -0.5, 59.5}});
-
-    histos.add("hVtxNPi0_CEX", "N(#pi^{0}) at SV (CEX);N;Entries", kTH1I, {{40, -0.5, 39.5}});
-    histos.add("hVtxNPi0_BG", "N(#pi^{0}) at SV (BG);N;Entries", kTH1I, {{40, -0.5, 39.5}});
-    histos.add("hVtxNGamma_CEX", "N(#gamma) at SV (CEX);N;Entries", kTH1I, {{60, -0.5, 59.5}});
-    histos.add("hVtxNGamma_BG", "N(#gamma) at SV (BG);N;Entries", kTH1I, {{60, -0.5, 59.5}});
-    histos.add("hVtxNN_CEX", "N(n) at SV (CEX);N;Entries", kTH1I, {{40, -0.5, 39.5}});
-    histos.add("hVtxNN_BG", "N(n) at SV (BG);N;Entries", kTH1I, {{40, -0.5, 39.5}});
-
+    histos.add("hProcEnumAP_BG",  "procEnum of secondary #bar{p} (BG);procEnum;Entries",  kTH1I, {{100, -0.5, 99.5}});
+    
     // CEX pair from antineutron (MC)
     histos.add("cexPairMcP", "CEX pair total momentum;|p| (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
     histos.add("cexPairMcPt", "CEX pair p_{T};p_{T} (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
     histos.add("cexPairMcPz", "CEX pair p_{z};p_{z} (GeV/c);Entries", kTH1F, {{100, -10., 10.}});
     histos.add("cex_pairmcDplane", "CEX pair d_{plane};d_{plane} (cm);Entries", kTH1F, {{100, 0., 10.}});
     histos.add("cex_pairmc_angle", "Pair opening angle;Angle (°);Entries", kTH1F, {{180, 0., 180.}});
-    histos.add("cex_pairmc_vtx", "MC CEX pair vertex;X (cm);Y (cm)", kTH2F, {{100, -50., 50.}, {100, -50., 50.}});
+    histos.add("cex_pairmc_vtx", "MC CEX pair vertex;X (cm);Y (cm)", kTH2F, {{200, -60., 60.}, {200, -60., 60.}});
     histos.add("cex_pairmc_vtxz", "MC secondary vertex Z;Z (cm);Entries", kTH1F, {{200, -60., 60.}});
     histos.add("cexPairMcPITScuts", "CEX pair momentum (ITS cuts);|p| (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
 
@@ -148,16 +125,12 @@ struct NucleiAntineutronCex {
     histos.add("cexbg_pairmc_pz", "Background pair p_{z};p_{z} (GeV/c);Entries", kTH1F, {{100, -10., 10.}});
     histos.add("cexbg_pairmcDplane", "Background d_{plane};d_{plane} (cm);Entries", kTH1F, {{100, 0., 10.}});
     histos.add("cexbg_pairmc_angle", "Background opening angle;Angle (°);Entries", kTH1F, {{180, 0., 180.}});
-    histos.add("cexbg_pairmc_vtx", "Background pair vertex;X (cm);Y (cm)", kTH2F, {{100, -50., 50.}, {100, -50., 50.}});
+    histos.add("cexbg_pairmc_vtx", "Background pair vertex;X (cm);Y (cm)", kTH2F, {{200, -60., 60.}, {200, -60., 60.}});
     histos.add("cexbg_pairmc_vtxz", "Background secondary vertex Z;Z (cm);Entries", kTH1F, {{200, -60., 60.}});
     histos.add("cexbg_pairmc_pITScuts", "Background momentum (ITS cuts);|p| (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
-
-    histos.add("hDeltaP_CEX", "|p_{mother}-Σp_{SV}| (CEX);Δp (GeV/c);Entries", kTH1F, {{200, 0., 10.}});
-    histos.add("hDeltaP_BG", "|p_{mother}-Σp_{SV}| (BG);Δp (GeV/c);Entries", kTH1F, {{200, 0., 10.}});
-
-    // Mother IB hits
-    histos.add("hMotherNHitIB_CEX", "Mother IB hit layers (L0-L2) (CEX);N_{IB layers};Entries", kTH1I, {{5, -1.5, 4.5}});
-    histos.add("hMotherNHitIB_BG", "Mother IB hit layers (L0-L2) (BG);N_{IB layers};Entries", kTH1I, {{5, -1.5, 4.5}});
+    
+    //Pi0 events
+    histos.add("cexn_pairmc_p_pi0", "Pair p / antineutron p for CEX + #pi^{0};p/p_{#bar{n}};Entries", kTH1F, {{100, 0., 2.}});
 
     // CEX pair from antineutron (TRK)
     histos.add("cex_pairtrk_angle", "Pair opening angle (tracks);Angle (°);Entries", kTH1F, {{180, 0., 180.}});
@@ -329,7 +302,7 @@ struct NucleiAntineutronCex {
         double antipE = particle.e();
         int antipId = particle.globalIndex();
 
-        // Selection conditions: Produced in the ITS
+        // Selection conditions: Produced in the ITS IB
         const double r = std::sqrt(antipVx * antipVx + antipVy * antipVy);
         // Config for ITS
         // if(3.9<=r && r<=43.0 && std::abs(antipVz)<=48.9){
@@ -392,9 +365,36 @@ struct NucleiAntineutronCex {
             break;
           }
         }
-
+        
         if (pionPlus || pionMinus)
           continue;
+        
+        // Check for neutral pion at the same secondary vertex
+        bool pion0 = false;
+        for (const auto& particle4 : mcPartsThis) {
+          if (particle4.mcCollisionId() != colId)
+            continue;
+          const auto proc4Enum = particle4.getProcess();
+          const bool isSecondaryFromMaterial4 = (!particle4.producedByGenerator()) && (proc4Enum == kPHadronic || proc4Enum == kPHInhelastic);
+          if (particle4.pdgCode() != kPi0 || !isSecondaryFromMaterial4 || particle4.mothersIds().empty())
+            continue;
+          bool hasPrimaryMotherPi0 = false;
+          for (const auto& mother : particle4.mothers_as<aod::McParticles>()) {
+            if (mother.isPhysicalPrimary()) {
+              hasPrimaryMotherPi0 = true;
+              break;
+            }
+          }
+          if (!hasPrimaryMotherPi0)
+            continue;
+          double pi0Vx = particle4.vx();
+          double pi0Vy = particle4.vy();
+          double pi0Vz = particle4.vz();
+          if (std::abs(pi0Vx - antipVx) < kVtxTol && std::abs(pi0Vy - antipVy) < kVtxTol && std::abs(pi0Vz - antipVz) < kVtxTol) {
+            pion0 = true;
+            break;
+          }
+        }
 
         // CEX selection
         double dplane = kInitDplane;
@@ -453,7 +453,6 @@ struct NucleiAntineutronCex {
               continue;
 
             // CEX proton selection
-            // dplaneTmp = (pPy*antipPz - pPz*antipPy)*(pvtxX-antipVx) + (pPz*antipPx - pPx*antipPz)*(pvtxY-antipVy) + (pPx*antipPy - pPy*antipPx)*(pvtxZ-antipVz);
             double nx = (pPy * antipPz - pPz * antipPy);
             double ny = (pPz * antipPx - pPx * antipPz);
             double nz = (pPx * antipPy - pPy * antipPx);
@@ -518,6 +517,8 @@ struct NucleiAntineutronCex {
               histos.fill(HIST("cexn_pairmc_pt"), cexPairMcPt / motherPt);
             if (motherPz != 0)
               histos.fill(HIST("cexn_pairmc_pz"), cexPairMcPz / motherPz);
+            if (motherP != 0 && pion0)
+              histos.fill(HIST("cexPairMcP_pi0"), cexPairMcP / motherP);
           }
           // BG mother
           if (motherPdg != -kNeutron) {
@@ -533,8 +534,8 @@ struct NucleiAntineutronCex {
               histos.fill(HIST("cexbg_pairmc_pITScuts"), cexPairMcP);
           }
 
-          // Detector signal
-          bool antipLayers = false;
+          // Reconstructed data
+          bool antipLayers_condition = false;
           bool antipHasTrack = false;
           double antipTrkPx = 0.;
           double antipTrkPy = 0.;
@@ -549,7 +550,7 @@ struct NucleiAntineutronCex {
           int8_t pTrkItsPidValid = 0;
           float pTrkTgl = 0.f;
 
-          bool pLayers = false;
+          bool pLayers_condition = false;
           bool pHasTrack = false;
           double pTrkPx = 0.;
           double pTrkPy = 0.;
@@ -563,9 +564,6 @@ struct NucleiAntineutronCex {
           float antipTrkItsNSigmaPr = -999.f;
           int8_t antipTrkItsPidValid = 0;
           float antipTrkTgl = 0.f;
-
-          bool motherHasTrack = false;
-          int motherNHitIB = -1; // number of hits in IB (L0-L2)
 
           o2::aod::ITSResponse itsResponse;
 
@@ -594,11 +592,6 @@ struct NucleiAntineutronCex {
             int nITS = track.itsNCls();
             bool layerCondition = (!hitIB) && hitOuter && (nITS >= kMinItsHits);
 
-            if (mc.globalIndex() == motherId) {
-              motherHasTrack = true;
-              motherNHitIB = static_cast<int>(hitL0) + static_cast<int>(hitL1) + static_cast<int>(hitL2);
-            }
-
             if (mc.globalIndex() == antipId) {
               antipTrkP = track.p();
               antipTrkPx = track.px();
@@ -614,9 +607,8 @@ struct NucleiAntineutronCex {
               antipTrkItsPidValid = std::isfinite(nsigmaITSantip) ? 1 : 0;
               antipHasTrack = true;
               apItsMap = static_cast<uint16_t>(track.itsClusterMap());
-              antipLayers = (apItsMap != 0);
               if (layerCondition)
-                antipLayers = true;
+                antipLayers_condition = true;
               if (motherPdg == -kNeutron) {
                 histos.fill(HIST("apItsNsigmaPr"), antipTrkItsNSigmaPr);
                 histos.fill(HIST("apItsPidValid"), antipTrkItsPidValid);
@@ -643,9 +635,8 @@ struct NucleiAntineutronCex {
               pTrkItsPidValid = std::isfinite(nsigmaITSp) ? 1 : 0;
               pHasTrack = true;
               pItsMap = static_cast<uint16_t>(track.itsClusterMap());
-              pLayers = (pItsMap != 0);
               if (layerCondition)
-                pLayers = true;
+                pLayers_condition = true;
               if (motherPdg == -kNeutron) {
                 histos.fill(HIST("pItsNsigmaPr"), pTrkItsNSigmaPr);
                 histos.fill(HIST("pItsPidValid"), pTrkItsPidValid);
@@ -723,7 +714,7 @@ struct NucleiAntineutronCex {
               if (motherPdg != -kNeutron)
                 histos.fill(HIST("cexbg_pairtrkVtxfitDcaPair"), dcaPair);
 
-              if (!(antipLayers && pLayers))
+              if (!(antipLayers_condition && pLayers_condition))
                 continue;
               double cexPairTrkP = total_trk_pVec.Mag();
               double cexPairTrkPt = total_trk_pVec.Pt();
@@ -736,7 +727,7 @@ struct NucleiAntineutronCex {
 
               const TVector3 pv2sv(secX - pvtxX, secY - pvtxY, secZ - pvtxZ);
               const double pairPointingAngleDeg = pv2sv.Angle(total_trk_pVec) * Rad2Deg;
-
+              
               const double pvsvThetaDeg = pv2sv.Theta() * Rad2Deg;
 
               double pvsvPhiDeg = pv2sv.Phi() * Rad2Deg;
@@ -805,113 +796,24 @@ struct NucleiAntineutronCex {
               histos.fill(HIST("vtxfit_mc_d3D"), d3d);
 
               const bool isCex = (motherPdg == -kNeutron);
-
+              
               // Nature of the process
               if (isCex) {
                 histos.fill(HIST("hProcEnumAP_CEX"), static_cast<int>(procEnum));
               } else {
                 histos.fill(HIST("hProcEnumAP_BG"), static_cast<int>(procEnum));
               }
-
-              // Count material secondaries produced at the same SV as the selected secondary antiproton.
-              int vtxNAll = 0;
-              int vtxNCh = 0;
-              int vtxNNeut = 0;
-              int vtxNPi0 = 0;
-              int vtxNGamma = 0;
-              int vtxNN = 0;
-              double sumPx_vtx = 0.0;
-              double sumPy_vtx = 0.0;
-              double sumPz_vtx = 0.0;
-              auto* pdgDB = TDatabasePDG::Instance();
-
-              for (const auto& particle5 : mcPartsThis) {
-                if (particle5.mcCollisionId() != colId) {
-                  continue;
-                }
-                // Same SV (use the SV of the selected secondary antiproton)
-                if (std::abs(particle5.vx() - antipVx) >= kVtxTol || std::abs(particle5.vy() - antipVy) >= kVtxTol || std::abs(particle5.vz() - antipVz) >= kVtxTol) {
-                  continue;
-                }
-                const auto proc5Enum = particle5.getProcess();
-                const bool isSecondaryFromMaterial5 =
-                  (!particle5.producedByGenerator()) && (proc5Enum == kPHadronic || proc5Enum == kPHInhelastic);
-                if (!isSecondaryFromMaterial5) {
-                  continue;
-                }
-                ++vtxNAll;
-                sumPx_vtx += particle5.px();
-                sumPy_vtx += particle5.py();
-                sumPz_vtx += particle5.pz();
-                const int pdg = particle5.pdgCode();
-                if (pdg == kPi0) {
-                  ++vtxNPi0;
-                }
-                if (pdg == kGamma) {
-                  ++vtxNGamma;
-                }
-                if (pdg == kNeutron) {
-                  ++vtxNN;
-                }
-                // Charged vs neutral via PDG database (Charge() is in units of e/3)
-                double q = 0.0;
-                if (auto* part = pdgDB->GetParticle(pdg)) {
-                  q = part->Charge() / 3.0;
-                }
-                if (std::abs(q) > 0.0) {
-                  ++vtxNCh;
-                } else {
-                  ++vtxNNeut;
-                }
-              }
-
-              // Fill histos (final selected candidates only)
-              if (isCex) {
-                histos.fill(HIST("hVtxNAll_CEX"), vtxNAll);
-                histos.fill(HIST("hVtxNCh_CEX"), vtxNCh);
-                histos.fill(HIST("hVtxNNeut_CEX"), vtxNNeut);
-                histos.fill(HIST("hVtxNPi0_CEX"), vtxNPi0);
-                histos.fill(HIST("hVtxNGamma_CEX"), vtxNGamma);
-                histos.fill(HIST("hVtxNN_CEX"), vtxNN);
-              } else {
-                histos.fill(HIST("hVtxNAll_BG"), vtxNAll);
-                histos.fill(HIST("hVtxNCh_BG"), vtxNCh);
-                histos.fill(HIST("hVtxNNeut_BG"), vtxNNeut);
-                histos.fill(HIST("hVtxNPi0_BG"), vtxNPi0);
-                histos.fill(HIST("hVtxNGamma_BG"), vtxNGamma);
-                histos.fill(HIST("hVtxNN_BG"), vtxNN);
-              }
-
+                      
               const float vtxfitDX = secX - antipVx;
               const float vtxfitDY = secY - antipVy;
               const float vtxfitDZ = secZ - antipVz;
               const float vtxfitD3D = std::sqrt(vtxfitDX * vtxfitDX + vtxfitDY * vtxfitDY + vtxfitDZ * vtxfitDZ);
-
-              const double dPx = motherPx - sumPx_vtx;
-              const double dPy = motherPy - sumPy_vtx;
-              const double dPz = motherPz - sumPz_vtx;
-              const double deltaP = std::sqrt(dPx * dPx + dPy * dPy + dPz * dPz);
-
-              if (isCex) {
-                histos.fill(HIST("hDeltaP_CEX"), deltaP);
-              } else {
-                histos.fill(HIST("hDeltaP_BG"), deltaP);
-              }
-
-              if (motherHasTrack) {
-                if (isCex) {
-                  histos.fill(HIST("hMotherNHitIB_CEX"), motherNHitIB);
-                } else {
-                  histos.fill(HIST("hMotherNHitIB_BG"), motherNHitIB);
-                }
-              }
-
               const uint32_t selMask = 0u;
 
               outPairs(
                 isCex,
                 motherPdg,
-                motherNHitIB,
+                motherP,
                 colId,
                 pId,
                 antipId,
@@ -924,13 +826,6 @@ struct NucleiAntineutronCex {
                 antipVx,
                 antipVy,
                 antipVz,
-
-                static_cast<int16_t>(vtxNAll),
-                static_cast<int16_t>(vtxNCh),
-                static_cast<int16_t>(vtxNNeut),
-                static_cast<int16_t>(vtxNPi0),
-                static_cast<int16_t>(vtxNGamma),
-                static_cast<int16_t>(vtxNN),
 
                 cexPairTrkP,
                 cexPairTrkPt,
@@ -986,8 +881,6 @@ struct NucleiAntineutronCex {
 
                 pItsMap,
                 apItsMap,
-                static_cast<int8_t>(pLayers ? 1 : 0),
-                static_cast<int8_t>(antipLayers ? 1 : 0),
 
                 pvtxZ,
 
@@ -997,7 +890,8 @@ struct NucleiAntineutronCex {
 
                 antipTrkItsNSigmaPr,
                 antipTrkItsPidValid,
-                antipTrkTgl);
+                antipTrkTgl
+                );
             }
           }
           // ==== end DCAFitter2 ====

--- a/PWGLF/TableProducer/Nuspex/nucleiAntineutronCex.cxx
+++ b/PWGLF/TableProducer/Nuspex/nucleiAntineutronCex.cxx
@@ -14,27 +14,33 @@
 /// \brief Analysis task for antineutron detection through cex interactions
 /// \author Fabiola Lugo
 ///
-#include <PWGLF/DataModel/LFAntinCexTables.h>
+#include "PWGLF/DataModel/LFAntinCexTables.h"
 
-#include <Common/DataModel/PIDResponseITS.h>
+#include "Common/DataModel/PIDResponseITS.h"
 
 #include <CommonConstants/MathConstants.h>
 #include <DCAFitter/DCAFitterN.h>
 #include <DetectorsBase/Propagator.h>
 #include <Framework/AnalysisDataModel.h>
+#include <Framework/AnalysisHelpers.h>
 #include <Framework/AnalysisTask.h>
-#include <Framework/Logger.h>
+#include <Framework/HistogramRegistry.h>
+#include <Framework/HistogramSpec.h>
+#include <Framework/InitContext.h>
+#include <Framework/OutputObjHeader.h>
 #include <Framework/runDataProcessing.h>
+#include <ReconstructionDataFormats/PID.h>
+#include <ReconstructionDataFormats/Track.h>
 #include <ReconstructionDataFormats/TrackParametrization.h>
 
 #include <TMCProcess.h>
-#include <TMath.h>
 #include <TPDGCode.h>
 #include <TVector3.h>
 
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstdint>
 #include <optional>
 
 using namespace o2;
@@ -44,7 +50,7 @@ using o2::constants::math::Rad2Deg;
 struct NucleiAntineutronCex {
   // Slicing per colision
   Preslice<aod::McParticles> perMcByColl = aod::mcparticle::mcCollisionId;
-
+  
   using TracksWCovMc = soa::Join<aod::TracksIU, aod::TracksExtra, aod::McTrackLabels, o2::aod::TracksCovIU>;
 
   // === Cut values ===
@@ -100,11 +106,11 @@ struct NucleiAntineutronCex {
     histos.add("pPz", "p_{z};p_{z} (GeV/c);Entries", kTH1F, {{100, -10., 10.}});
     histos.add("pEta", "Pseudorapidity;#eta;Entries", kTH1F, {{100, -10., 10.}});
     histos.add("pP_ITScuts", "Momentum with ITS cuts;|p| (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
-
+    
     // Process enum breakdown (secondary antiproton that anchors the SV)
     histos.add("hProcEnumAP_CEX", "procEnum of secondary #bar{p} (CEX);procEnum;Entries", kTH1I, {{100, -0.5, 99.5}});
-    histos.add("hProcEnumAP_BG", "procEnum of secondary #bar{p} (BG);procEnum;Entries", kTH1I, {{100, -0.5, 99.5}});
-
+    histos.add("hProcEnumAP_BG",  "procEnum of secondary #bar{p} (BG);procEnum;Entries",  kTH1I, {{100, -0.5, 99.5}});
+    
     // CEX pair from antineutron (MC)
     histos.add("cexPairMcP", "CEX pair total momentum;|p| (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
     histos.add("cexPairMcPt", "CEX pair p_{T};p_{T} (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
@@ -129,8 +135,8 @@ struct NucleiAntineutronCex {
     histos.add("cexbg_pairmc_vtx", "Background pair vertex;X (cm);Y (cm)", kTH2F, {{200, -60., 60.}, {200, -60., 60.}});
     histos.add("cexbg_pairmc_vtxz", "Background secondary vertex Z;Z (cm);Entries", kTH1F, {{200, -60., 60.}});
     histos.add("cexbg_pairmc_pITScuts", "Background momentum (ITS cuts);|p| (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
-
-    // Pi0 events
+    
+    //Pi0 events
     histos.add("cexn_pairmc_p_pi0", "Pair p / antineutron p for CEX + #pi^{0};p/p_{#bar{n}};Entries", kTH1F, {{100, 0., 2.}});
 
     // CEX pair from antineutron (TRK)
@@ -360,10 +366,10 @@ struct NucleiAntineutronCex {
             break;
           }
         }
-
+        
         if (pionPlus || pionMinus)
           continue;
-
+        
         // Check for neutral pion at the same secondary vertex
         bool pion0 = false;
         for (const auto& particle4 : mcPartsThis) {
@@ -722,7 +728,7 @@ struct NucleiAntineutronCex {
 
               const TVector3 pv2sv(secX - pvtxX, secY - pvtxY, secZ - pvtxZ);
               const double pairPointingAngleDeg = pv2sv.Angle(total_trk_pVec) * Rad2Deg;
-
+              
               const double pvsvThetaDeg = pv2sv.Theta() * Rad2Deg;
 
               double pvsvPhiDeg = pv2sv.Phi() * Rad2Deg;
@@ -791,14 +797,14 @@ struct NucleiAntineutronCex {
               histos.fill(HIST("vtxfit_mc_d3D"), d3d);
 
               const bool isCex = (motherPdg == -kNeutron);
-
+              
               // Nature of the process
               if (isCex) {
                 histos.fill(HIST("hProcEnumAP_CEX"), static_cast<int>(procEnum));
               } else {
                 histos.fill(HIST("hProcEnumAP_BG"), static_cast<int>(procEnum));
               }
-
+                      
               const float vtxfitDX = secX - antipVx;
               const float vtxfitDY = secY - antipVy;
               const float vtxfitDZ = secZ - antipVz;
@@ -885,7 +891,8 @@ struct NucleiAntineutronCex {
 
                 antipTrkItsNSigmaPr,
                 antipTrkItsPidValid,
-                antipTrkTgl);
+                antipTrkTgl
+                );
             }
           }
           // ==== end DCAFitter2 ====

--- a/PWGLF/TableProducer/Nuspex/nucleiAntineutronCex.cxx
+++ b/PWGLF/TableProducer/Nuspex/nucleiAntineutronCex.cxx
@@ -50,7 +50,7 @@ using o2::constants::math::Rad2Deg;
 struct NucleiAntineutronCex {
   // Slicing per colision
   Preslice<aod::McParticles> perMcByColl = aod::mcparticle::mcCollisionId;
-  
+
   using TracksWCovMc = soa::Join<aod::TracksIU, aod::TracksExtra, aod::McTrackLabels, o2::aod::TracksCovIU>;
 
   // === Cut values ===
@@ -106,11 +106,11 @@ struct NucleiAntineutronCex {
     histos.add("pPz", "p_{z};p_{z} (GeV/c);Entries", kTH1F, {{100, -10., 10.}});
     histos.add("pEta", "Pseudorapidity;#eta;Entries", kTH1F, {{100, -10., 10.}});
     histos.add("pP_ITScuts", "Momentum with ITS cuts;|p| (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
-    
+
     // Process enum breakdown (secondary antiproton that anchors the SV)
     histos.add("hProcEnumAP_CEX", "procEnum of secondary #bar{p} (CEX);procEnum;Entries", kTH1I, {{100, -0.5, 99.5}});
-    histos.add("hProcEnumAP_BG",  "procEnum of secondary #bar{p} (BG);procEnum;Entries",  kTH1I, {{100, -0.5, 99.5}});
-    
+    histos.add("hProcEnumAP_BG", "procEnum of secondary #bar{p} (BG);procEnum;Entries", kTH1I, {{100, -0.5, 99.5}});
+
     // CEX pair from antineutron (MC)
     histos.add("cexPairMcP", "CEX pair total momentum;|p| (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
     histos.add("cexPairMcPt", "CEX pair p_{T};p_{T} (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
@@ -135,8 +135,8 @@ struct NucleiAntineutronCex {
     histos.add("cexbg_pairmc_vtx", "Background pair vertex;X (cm);Y (cm)", kTH2F, {{200, -60., 60.}, {200, -60., 60.}});
     histos.add("cexbg_pairmc_vtxz", "Background secondary vertex Z;Z (cm);Entries", kTH1F, {{200, -60., 60.}});
     histos.add("cexbg_pairmc_pITScuts", "Background momentum (ITS cuts);|p| (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
-    
-    //Pi0 events
+
+    // Pi0 events
     histos.add("cexn_pairmc_p_pi0", "Pair p / antineutron p for CEX + #pi^{0};p/p_{#bar{n}};Entries", kTH1F, {{100, 0., 2.}});
 
     // CEX pair from antineutron (TRK)
@@ -366,10 +366,10 @@ struct NucleiAntineutronCex {
             break;
           }
         }
-        
+
         if (pionPlus || pionMinus)
           continue;
-        
+
         // Check for neutral pion at the same secondary vertex
         bool pion0 = false;
         for (const auto& particle4 : mcPartsThis) {
@@ -728,7 +728,7 @@ struct NucleiAntineutronCex {
 
               const TVector3 pv2sv(secX - pvtxX, secY - pvtxY, secZ - pvtxZ);
               const double pairPointingAngleDeg = pv2sv.Angle(total_trk_pVec) * Rad2Deg;
-              
+
               const double pvsvThetaDeg = pv2sv.Theta() * Rad2Deg;
 
               double pvsvPhiDeg = pv2sv.Phi() * Rad2Deg;
@@ -797,14 +797,14 @@ struct NucleiAntineutronCex {
               histos.fill(HIST("vtxfit_mc_d3D"), d3d);
 
               const bool isCex = (motherPdg == -kNeutron);
-              
+
               // Nature of the process
               if (isCex) {
                 histos.fill(HIST("hProcEnumAP_CEX"), static_cast<int>(procEnum));
               } else {
                 histos.fill(HIST("hProcEnumAP_BG"), static_cast<int>(procEnum));
               }
-                      
+
               const float vtxfitDX = secX - antipVx;
               const float vtxfitDY = secY - antipVy;
               const float vtxfitDZ = secZ - antipVz;
@@ -891,8 +891,7 @@ struct NucleiAntineutronCex {
 
                 antipTrkItsNSigmaPr,
                 antipTrkItsPidValid,
-                antipTrkTgl
-                );
+                antipTrkTgl);
             }
           }
           // ==== end DCAFitter2 ====

--- a/PWGLF/TableProducer/Nuspex/nucleiAntineutronCex.cxx
+++ b/PWGLF/TableProducer/Nuspex/nucleiAntineutronCex.cxx
@@ -14,17 +14,16 @@
 /// \brief Analysis task for antineutron detection through cex interactions
 /// \author Fabiola Lugo
 ///
-#include <PWGLF/DataModel/LFAntinCexTables.h>
-
-#include <Common/DataModel/PIDResponseITS.h>
-
-#include <CommonConstants/MathConstants.h>
-#include <DCAFitter/DCAFitterN.h>
-#include <DetectorsBase/Propagator.h>
 #include <Framework/AnalysisDataModel.h>
 #include <Framework/AnalysisTask.h>
 #include <Framework/Logger.h>
 #include <Framework/runDataProcessing.h>
+
+#include <PWGLF/DataModel/LFAntinCexTables.h>
+#include <Common/DataModel/PIDResponseITS.h>
+#include <CommonConstants/MathConstants.h>
+#include <DCAFitter/DCAFitterN.h>
+#include <DetectorsBase/Propagator.h>
 #include <ReconstructionDataFormats/TrackParametrization.h>
 
 #include <TMCProcess.h>
@@ -44,7 +43,7 @@ using o2::constants::math::Rad2Deg;
 struct NucleiAntineutronCex {
   // Slicing per colision
   Preslice<aod::McParticles> perMcByColl = aod::mcparticle::mcCollisionId;
-
+  
   using TracksWCovMc = soa::Join<aod::TracksIU, aod::TracksExtra, aod::McTrackLabels, o2::aod::TracksCovIU>;
 
   // === Cut values ===
@@ -100,11 +99,11 @@ struct NucleiAntineutronCex {
     histos.add("pPz", "p_{z};p_{z} (GeV/c);Entries", kTH1F, {{100, -10., 10.}});
     histos.add("pEta", "Pseudorapidity;#eta;Entries", kTH1F, {{100, -10., 10.}});
     histos.add("pP_ITScuts", "Momentum with ITS cuts;|p| (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
-
+    
     // Process enum breakdown (secondary antiproton that anchors the SV)
     histos.add("hProcEnumAP_CEX", "procEnum of secondary #bar{p} (CEX);procEnum;Entries", kTH1I, {{100, -0.5, 99.5}});
-    histos.add("hProcEnumAP_BG", "procEnum of secondary #bar{p} (BG);procEnum;Entries", kTH1I, {{100, -0.5, 99.5}});
-
+    histos.add("hProcEnumAP_BG",  "procEnum of secondary #bar{p} (BG);procEnum;Entries",  kTH1I, {{100, -0.5, 99.5}});
+    
     // CEX pair from antineutron (MC)
     histos.add("cexPairMcP", "CEX pair total momentum;|p| (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
     histos.add("cexPairMcPt", "CEX pair p_{T};p_{T} (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
@@ -129,8 +128,8 @@ struct NucleiAntineutronCex {
     histos.add("cexbg_pairmc_vtx", "Background pair vertex;X (cm);Y (cm)", kTH2F, {{200, -60., 60.}, {200, -60., 60.}});
     histos.add("cexbg_pairmc_vtxz", "Background secondary vertex Z;Z (cm);Entries", kTH1F, {{200, -60., 60.}});
     histos.add("cexbg_pairmc_pITScuts", "Background momentum (ITS cuts);|p| (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
-
-    // Pi0 events
+    
+    //Pi0 events
     histos.add("cexn_pairmc_p_pi0", "Pair p / antineutron p for CEX + #pi^{0};p/p_{#bar{n}};Entries", kTH1F, {{100, 0., 2.}});
 
     // CEX pair from antineutron (TRK)
@@ -267,27 +266,21 @@ struct NucleiAntineutronCex {
         // Primary mother
         bool hasPrimaryMotherAntip = false;
         double motherPt = 0.0;
-        double motherPx = 0.0;
-        double motherPy = 0.0;
         double motherPz = 0.0;
         double motherVz = 0.0;
         double motherP = 0.0;
         double motherEta = 0.0;
         int motherPdg = 0;
-        int motherId = -1;
 
         for (const auto& mother : particle.mothers_as<aod::McParticles>()) {
           if (mother.isPhysicalPrimary()) {
             hasPrimaryMotherAntip = true;
             motherPt = mother.pt();
-            motherPx = mother.px();
-            motherPy = mother.py();
             motherPz = mother.pz();
             motherVz = mother.vz();
             motherP = mother.p();
             motherEta = mother.eta();
             motherPdg = mother.pdgCode();
-            motherId = mother.globalIndex();
             break;
           }
         }
@@ -366,10 +359,10 @@ struct NucleiAntineutronCex {
             break;
           }
         }
-
+        
         if (pionPlus || pionMinus)
           continue;
-
+        
         // Check for neutral pion at the same secondary vertex
         bool pion0 = false;
         for (const auto& particle4 : mcPartsThis) {
@@ -728,7 +721,7 @@ struct NucleiAntineutronCex {
 
               const TVector3 pv2sv(secX - pvtxX, secY - pvtxY, secZ - pvtxZ);
               const double pairPointingAngleDeg = pv2sv.Angle(total_trk_pVec) * Rad2Deg;
-
+              
               const double pvsvThetaDeg = pv2sv.Theta() * Rad2Deg;
 
               double pvsvPhiDeg = pv2sv.Phi() * Rad2Deg;
@@ -797,14 +790,14 @@ struct NucleiAntineutronCex {
               histos.fill(HIST("vtxfit_mc_d3D"), d3d);
 
               const bool isCex = (motherPdg == -kNeutron);
-
+              
               // Nature of the process
               if (isCex) {
                 histos.fill(HIST("hProcEnumAP_CEX"), static_cast<int>(procEnum));
               } else {
                 histos.fill(HIST("hProcEnumAP_BG"), static_cast<int>(procEnum));
               }
-
+                      
               const float vtxfitDX = secX - antipVx;
               const float vtxfitDY = secY - antipVy;
               const float vtxfitDZ = secZ - antipVz;
@@ -891,7 +884,8 @@ struct NucleiAntineutronCex {
 
                 antipTrkItsNSigmaPr,
                 antipTrkItsPidValid,
-                antipTrkTgl);
+                antipTrkTgl
+                );
             }
           }
           // ==== end DCAFitter2 ====

--- a/PWGLF/TableProducer/Nuspex/nucleiAntineutronCex.cxx
+++ b/PWGLF/TableProducer/Nuspex/nucleiAntineutronCex.cxx
@@ -14,16 +14,17 @@
 /// \brief Analysis task for antineutron detection through cex interactions
 /// \author Fabiola Lugo
 ///
+#include <PWGLF/DataModel/LFAntinCexTables.h>
+
+#include <Common/DataModel/PIDResponseITS.h>
+
+#include <CommonConstants/MathConstants.h>
+#include <DCAFitter/DCAFitterN.h>
+#include <DetectorsBase/Propagator.h>
 #include <Framework/AnalysisDataModel.h>
 #include <Framework/AnalysisTask.h>
 #include <Framework/Logger.h>
 #include <Framework/runDataProcessing.h>
-
-#include <PWGLF/DataModel/LFAntinCexTables.h>
-#include <Common/DataModel/PIDResponseITS.h>
-#include <CommonConstants/MathConstants.h>
-#include <DCAFitter/DCAFitterN.h>
-#include <DetectorsBase/Propagator.h>
 #include <ReconstructionDataFormats/TrackParametrization.h>
 
 #include <TMCProcess.h>
@@ -43,7 +44,7 @@ using o2::constants::math::Rad2Deg;
 struct NucleiAntineutronCex {
   // Slicing per colision
   Preslice<aod::McParticles> perMcByColl = aod::mcparticle::mcCollisionId;
-  
+
   using TracksWCovMc = soa::Join<aod::TracksIU, aod::TracksExtra, aod::McTrackLabels, o2::aod::TracksCovIU>;
 
   // === Cut values ===
@@ -99,11 +100,11 @@ struct NucleiAntineutronCex {
     histos.add("pPz", "p_{z};p_{z} (GeV/c);Entries", kTH1F, {{100, -10., 10.}});
     histos.add("pEta", "Pseudorapidity;#eta;Entries", kTH1F, {{100, -10., 10.}});
     histos.add("pP_ITScuts", "Momentum with ITS cuts;|p| (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
-    
+
     // Process enum breakdown (secondary antiproton that anchors the SV)
     histos.add("hProcEnumAP_CEX", "procEnum of secondary #bar{p} (CEX);procEnum;Entries", kTH1I, {{100, -0.5, 99.5}});
-    histos.add("hProcEnumAP_BG",  "procEnum of secondary #bar{p} (BG);procEnum;Entries",  kTH1I, {{100, -0.5, 99.5}});
-    
+    histos.add("hProcEnumAP_BG", "procEnum of secondary #bar{p} (BG);procEnum;Entries", kTH1I, {{100, -0.5, 99.5}});
+
     // CEX pair from antineutron (MC)
     histos.add("cexPairMcP", "CEX pair total momentum;|p| (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
     histos.add("cexPairMcPt", "CEX pair p_{T};p_{T} (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
@@ -128,8 +129,8 @@ struct NucleiAntineutronCex {
     histos.add("cexbg_pairmc_vtx", "Background pair vertex;X (cm);Y (cm)", kTH2F, {{200, -60., 60.}, {200, -60., 60.}});
     histos.add("cexbg_pairmc_vtxz", "Background secondary vertex Z;Z (cm);Entries", kTH1F, {{200, -60., 60.}});
     histos.add("cexbg_pairmc_pITScuts", "Background momentum (ITS cuts);|p| (GeV/c);Entries", kTH1F, {{100, 0., 10.}});
-    
-    //Pi0 events
+
+    // Pi0 events
     histos.add("cexn_pairmc_p_pi0", "Pair p / antineutron p for CEX + #pi^{0};p/p_{#bar{n}};Entries", kTH1F, {{100, 0., 2.}});
 
     // CEX pair from antineutron (TRK)
@@ -365,10 +366,10 @@ struct NucleiAntineutronCex {
             break;
           }
         }
-        
+
         if (pionPlus || pionMinus)
           continue;
-        
+
         // Check for neutral pion at the same secondary vertex
         bool pion0 = false;
         for (const auto& particle4 : mcPartsThis) {
@@ -727,7 +728,7 @@ struct NucleiAntineutronCex {
 
               const TVector3 pv2sv(secX - pvtxX, secY - pvtxY, secZ - pvtxZ);
               const double pairPointingAngleDeg = pv2sv.Angle(total_trk_pVec) * Rad2Deg;
-              
+
               const double pvsvThetaDeg = pv2sv.Theta() * Rad2Deg;
 
               double pvsvPhiDeg = pv2sv.Phi() * Rad2Deg;
@@ -796,14 +797,14 @@ struct NucleiAntineutronCex {
               histos.fill(HIST("vtxfit_mc_d3D"), d3d);
 
               const bool isCex = (motherPdg == -kNeutron);
-              
+
               // Nature of the process
               if (isCex) {
                 histos.fill(HIST("hProcEnumAP_CEX"), static_cast<int>(procEnum));
               } else {
                 histos.fill(HIST("hProcEnumAP_BG"), static_cast<int>(procEnum));
               }
-                      
+
               const float vtxfitDX = secX - antipVx;
               const float vtxfitDY = secY - antipVy;
               const float vtxfitDZ = secZ - antipVz;
@@ -890,8 +891,7 @@ struct NucleiAntineutronCex {
 
                 antipTrkItsNSigmaPr,
                 antipTrkItsPidValid,
-                antipTrkTgl
-                );
+                antipTrkTgl);
             }
           }
           // ==== end DCAFitter2 ====

--- a/PWGLF/TableProducer/Nuspex/nucleiAntineutronCex.cxx
+++ b/PWGLF/TableProducer/Nuspex/nucleiAntineutronCex.cxx
@@ -20,7 +20,6 @@
 
 #include <CommonConstants/MathConstants.h>
 #include <DCAFitter/DCAFitterN.h>
-#include <DetectorsBase/Propagator.h>
 #include <Framework/AnalysisDataModel.h>
 #include <Framework/AnalysisHelpers.h>
 #include <Framework/AnalysisTask.h>
@@ -536,7 +535,7 @@ struct NucleiAntineutronCex {
           }
 
           // Reconstructed data
-          bool antipLayers_condition = false;
+          bool antipLayersCondition = false;
           bool antipHasTrack = false;
           double antipTrkPx = 0.;
           double antipTrkPy = 0.;
@@ -551,7 +550,7 @@ struct NucleiAntineutronCex {
           int8_t pTrkItsPidValid = 0;
           float pTrkTgl = 0.f;
 
-          bool pLayers_condition = false;
+          bool pLayersCondition = false;
           bool pHasTrack = false;
           double pTrkPx = 0.;
           double pTrkPy = 0.;
@@ -609,7 +608,7 @@ struct NucleiAntineutronCex {
               antipHasTrack = true;
               apItsMap = static_cast<uint16_t>(track.itsClusterMap());
               if (layerCondition)
-                antipLayers_condition = true;
+                antipLayersCondition = true;
               if (motherPdg == -kNeutron) {
                 histos.fill(HIST("apItsNsigmaPr"), antipTrkItsNSigmaPr);
                 histos.fill(HIST("apItsPidValid"), antipTrkItsPidValid);
@@ -637,7 +636,7 @@ struct NucleiAntineutronCex {
               pHasTrack = true;
               pItsMap = static_cast<uint16_t>(track.itsClusterMap());
               if (layerCondition)
-                pLayers_condition = true;
+                pLayersCondition = true;
               if (motherPdg == -kNeutron) {
                 histos.fill(HIST("pItsNsigmaPr"), pTrkItsNSigmaPr);
                 histos.fill(HIST("pItsPidValid"), pTrkItsPidValid);
@@ -715,7 +714,7 @@ struct NucleiAntineutronCex {
               if (motherPdg != -kNeutron)
                 histos.fill(HIST("cexbg_pairtrkVtxfitDcaPair"), dcaPair);
 
-              if (!(antipLayers_condition && pLayers_condition))
+              if (!(antipLayersCondition && pLayersCondition))
                 continue;
               double cexPairTrkP = total_trk_pVec.Mag();
               double cexPairTrkPt = total_trk_pVec.Pt();


### PR DESCRIPTION
This PR updates the antineutron CEX analysis task and corresponding data model.

Main changes:

Removed obsolete histograms.
Added new histograms for updated analysis studies.
Updated the content of LFAntinCexTables.
Minor cleanup and consistency updates in the task output.

The task was rebuilt and tested successfully in a fresh O2Physics installation.