### PR TITLE
[PWGLF] Fix Omega2012 input subscription

### DIFF
--- a/PWGLF/Tasks/Resonances/omega2012Analysis.cxx
+++ b/PWGLF/Tasks/Resonances/omega2012Analysis.cxx
@@ -698,6 +698,7 @@ struct Omega2012Analysis {
   PROCESS_SWITCH(Omega2012Analysis, processDummy, "Process Dummy", true);
 
   void processData(const aod::ResoCollision& collision,
+                   aod::ResoTracks const& /*resotracks*/,
                    aod::ResoCascades const& resocasc,
                    aod::ResoV0s const& resov0s)
   {


### PR DESCRIPTION
This patch adds ResoTracks as an unused input to Omega2012Analysis::processData.

The table is not used in the analysis logic, but subscribing to it aligns the process signature with the resonance daughter initializer output and avoids DPL input framing issues when running the task with ResoCascades and ResoV0s.