### PR TITLE
[PWGHF] Add centrality branch to Lc candidate tree

### DIFF
--- a/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
@@ -263,7 +263,7 @@ DECLARE_SOA_TABLE(HfCandLcLites, "AOD", "HFCANDLCLITE",
                   full::MlScoreFirstClass,
                   full::MlScoreSecondClass,
                   full::MlScoreThirdClass,
-                  full::CentFT0C); 
+                  full::CentFT0C);
 
 DECLARE_SOA_TABLE(HfCollIdLCLite, "AOD", "HFCOLLIDLCLITE",
                   full::CollisionId);
@@ -635,7 +635,7 @@ struct HfTreeCreatorLcToPKPi {
     if (applyMl) {
       assignMlScores(candidateMlScore, mlScoreFirstClass, mlScoreSecondClass, mlScoreThirdClass, candFlag);
     }
-    
+
     float centFT0C = -1.f;
     if constexpr (UseCentrality) {
       centFT0C = collision.centFT0C();
@@ -728,7 +728,7 @@ struct HfTreeCreatorLcToPKPi {
     if (applyMl) {
       assignMlScores(candidateMlScore, mlScoreFirstClass, mlScoreSecondClass, mlScoreThirdClass, candFlag);
     }
-    
+
     float centFT0C = -1.f;
     if constexpr (UseCentrality) {
       centFT0C = collision.centFT0C();

--- a/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
@@ -262,7 +262,8 @@ DECLARE_SOA_TABLE(HfCandLcLites, "AOD", "HFCANDLCLITE",
                   full::MassKPi,
                   full::MlScoreFirstClass,
                   full::MlScoreSecondClass,
-                  full::MlScoreThirdClass);
+                  full::MlScoreThirdClass,
+                  full::CentFT0C); 
 
 DECLARE_SOA_TABLE(HfCollIdLCLite, "AOD", "HFCOLLIDLCLITE",
                   full::CollisionId);
@@ -343,7 +344,8 @@ DECLARE_SOA_TABLE(HfCandLcFulls, "AOD", "HFCANDLCFULL",
                   full::MassKPi,
                   full::MlScoreFirstClass,
                   full::MlScoreSecondClass,
-                  full::MlScoreThirdClass);
+                  full::MlScoreThirdClass,
+                  full::CentFT0C);
 
 DECLARE_SOA_TABLE(HfCandLcFullEvs, "AOD", "HFCANDLCFULLEV",
                   full::CollisionId,
@@ -607,8 +609,8 @@ struct HfTreeCreatorLcToPKPi {
   /// \param candidate candidate instance
   /// \param candidateMlScore instance of handler of vectors with ML scores associated with the current candidate
   /// \param candFlag flag indicating if PKPi (0) or PiKP (1) hypothesis is used
-  template <bool IsMc, typename CandType>
-  void fillLiteTable(CandType const& candidate, aod::HfMlLcToPKPi::iterator const& candidateMlScore, int candFlag)
+  template <bool UseCentrality, bool IsMc, typename CandType, typename CollType>
+  void fillLiteTable(CandType const& candidate, CollType const& collision, aod::HfMlLcToPKPi::iterator const& candidateMlScore, int candFlag)
   {
     auto [functionInvMass, functionInvMassKPi] = evaluateInvariantMassesDCAFitter(candidate, candFlag);
     const float functionCt = HfHelper::ctLc(candidate);
@@ -632,6 +634,11 @@ struct HfTreeCreatorLcToPKPi {
 
     if (applyMl) {
       assignMlScores(candidateMlScore, mlScoreFirstClass, mlScoreSecondClass, mlScoreThirdClass, candFlag);
+    }
+    
+    float centFT0C = -1.f;
+    if constexpr (UseCentrality) {
+      centFT0C = collision.centFT0C();
     }
 
     rowCandidateLite(
@@ -681,7 +688,8 @@ struct HfTreeCreatorLcToPKPi {
       functionInvMassKPi,
       mlScoreFirstClass,
       mlScoreSecondClass,
-      mlScoreThirdClass);
+      mlScoreThirdClass,
+      centFT0C);
 
     if (fillCollIdTable) {
       /// save also candidate collision indices
@@ -693,8 +701,8 @@ struct HfTreeCreatorLcToPKPi {
   /// \param candidate candidate instance
   /// \param candidateMlScore instance of handler of vectors with ML scores associated with the current candidate
   /// \param candFlag flag indicating if PKPi (0) or PiKP (1) hypothesis is used
-  template <bool IsMc, typename CandType>
-  void fillFullTable(CandType const& candidate, aod::HfMlLcToPKPi::iterator const& candidateMlScore, int candFlag)
+  template <bool UseCentrality, bool IsMc, typename CandType, typename CollType>
+  void fillFullTable(CandType const& candidate, CollType const& collision, aod::HfMlLcToPKPi::iterator const& candidateMlScore, int candFlag)
   {
     auto [functionInvMass, functionInvMassKPi] = evaluateInvariantMassesDCAFitter(candidate, candFlag);
     const float functionCt = HfHelper::ctLc(candidate);
@@ -719,6 +727,11 @@ struct HfTreeCreatorLcToPKPi {
 
     if (applyMl) {
       assignMlScores(candidateMlScore, mlScoreFirstClass, mlScoreSecondClass, mlScoreThirdClass, candFlag);
+    }
+    
+    float centFT0C = -1.f;
+    if constexpr (UseCentrality) {
+      centFT0C = collision.centFT0C();
     }
 
     rowCandidateFull(
@@ -797,7 +810,8 @@ struct HfTreeCreatorLcToPKPi {
       functionInvMassKPi,
       mlScoreFirstClass,
       mlScoreSecondClass,
-      mlScoreThirdClass);
+      mlScoreThirdClass,
+      centFT0C);
   }
 
   /// \brief function to fill lite table
@@ -944,9 +958,9 @@ struct HfTreeCreatorLcToPKPi {
         const bool notSkippedBkg = isMcCandidateSignal || candidate.pt() > downSampleBkgPtMax || pseudoRndm < downSampleBkgFactor;
         if (passSelection && notSkippedBkg && (keepAll || (keepSignalMc && isMcCandidateSignal) || (keepBkgMc && !isMcCandidateSignal) || (keepCorrBkgMC && isCorrBkg))) {
           if (fillCandidateLiteTable) {
-            fillLiteTable<IsMc>(candidate, candidateMlScore, candFlag);
+            fillLiteTable<UseCentrality, IsMc>(candidate, collision, candidateMlScore, candFlag);
           } else {
-            fillFullTable<IsMc>(candidate, candidateMlScore, candFlag);
+            fillFullTable<UseCentrality, IsMc>(candidate, collision, candidateMlScore, candFlag);
           }
 
           if constexpr (ReconstructionType == aod::hf_cand::VertexerType::KfParticle) {
@@ -1126,9 +1140,9 @@ struct HfTreeCreatorLcToPKPi {
         const int functionSelection = candFlag == 0 ? candidate.isSelLcToPKPi() : candidate.isSelLcToPiKP();
         if (functionSelection >= selectionFlagLc && (candidate.pt() > downSampleBkgPtMax || (pseudoRndm < downSampleBkgFactor && candidate.pt() < downSampleBkgPtMax))) {
           if (fillCandidateLiteTable) {
-            fillLiteTable<IsMc>(candidate, candidateMlScore, candFlag);
+            fillLiteTable<UseCentrality, IsMc>(candidate, collision, candidateMlScore, candFlag);
           } else {
-            fillFullTable<IsMc>(candidate, candidateMlScore, candFlag);
+            fillFullTable<UseCentrality, IsMc>(candidate, collision, candidateMlScore, candFlag);
           }
 
           if constexpr (ReconstructionType == aod::hf_cand::VertexerType::KfParticle) {


### PR DESCRIPTION
Add centrality (CentFT0C) branch to the candidate tables 
(HfCandLcLites and HfCandLcFulls) in the Lc->pKpi tree creator.
Centrality is propagated from the collision to each candidate 
via fillLiteTable and fillFullTable, consistent with how it is 
already filled in the event table.