### PR TITLE
[PWGHF] Fix PID assignment in Xic0 and Omegac0 candidate creator

### DIFF
--- a/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
@@ -96,25 +96,25 @@ enum McMatchFlag : uint8_t {
   V0Unmatched
 };
 
-// Convert the KFParticle PDG code to the O2 track PID enum needed by getTrackParCovFromKFP()
+// Convert the absolute KFParticle PDG code to the O2 track PID enum needed by getTrackParCovFromKFP()
 o2::track::PID::ID getTrackPIDFromPDG(const int pdg)
 {
   switch (std::abs(pdg)) {
-    case 211:
+    case kPiPlus:
       return o2::track::PID::Pion;
-    case 321:
+    case kKPlus:
       return o2::track::PID::Kaon;
-    case 2212:
+    case kProton:
       return o2::track::PID::Proton;
-    case 3122:
+    case kLambda0:
       return o2::track::PID::Lambda;
-    case 3312:
+    case kXiMinus:
       return o2::track::PID::XiMinus;
-    case 3334:
+    case kOmegaMinus:
       return o2::track::PID::OmegaMinus;
     default:
       LOGF(fatal, "Unsupported PDG code %d in getTrackPIDFromPDG()", pdg);
-      return o2::track::PID::Pion; 
+      return o2::track::PID::Pion;
   }
 }
 

--- a/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
@@ -97,7 +97,7 @@ enum McMatchFlag : uint8_t {
 };
 
 // Convert the KFParticle PDG code to the O2 track PID enum needed by getTrackParCovFromKFP()
-o2::track::PID getTrackPIDFromPDG(const int pdg)
+o2::track::PID::ID getTrackPIDFromPDG(const int pdg)
 {
   switch (std::abs(pdg)) {
     case 211:
@@ -106,13 +106,15 @@ o2::track::PID getTrackPIDFromPDG(const int pdg)
       return o2::track::PID::Kaon;
     case 2212:
       return o2::track::PID::Proton;
+    case 3122:
+      return o2::track::PID::Lambda;
     case 3312:
       return o2::track::PID::XiMinus;
     case 3334:
       return o2::track::PID::OmegaMinus;
     default:
       LOGF(fatal, "Unsupported PDG code %d in getTrackPIDFromPDG()", pdg);
-      return static_cast<o2::track::PID>(-1);
+      return o2::track::PID::Pion; 
   }
 }
 
@@ -979,15 +981,15 @@ struct HfCandidateCreatorXic0Omegac0 {
 
       omegaDauChargedTrackParCov = getTrackParCovFromKFP(kfBachKaonToOmega, o2::track::PID::Kaon, bachCharge); // Cascade bach kaon
       omegaDauChargedTrackParCov.setAbsCharge(1);
-      auto pidCasc = getTrackPIDFromPDG(kfOmegaToOmegaC.GetPDG());
+      o2::track::PID::ID pidCasc = getTrackPIDFromPDG(kfOmegaToOmegaC.GetPDG());
       o2::track::TrackParCov trackCasc = getTrackParCovFromKFP(kfOmegaToOmegaC, pidCasc, bachCharge);
       trackCasc.setAbsCharge(1);
 
-      auto pidV0Dau0 = getTrackPIDFromPDG(kfPos.GetPDG());
+      o2::track::PID::ID pidV0Dau0 = getTrackPIDFromPDG(kfPos.GetPDG());
       trackParCovV0Dau0 = getTrackParCovFromKFP(kfPos, pidV0Dau0, +1); // V0 postive daughter
       trackParCovV0Dau0.setAbsCharge(1);
 
-      auto pidV0Dau1 = getTrackPIDFromPDG(kfNeg.GetPDG());
+      o2::track::PID::ID pidV0Dau1 = getTrackPIDFromPDG(kfNeg.GetPDG());
       trackParCovV0Dau1 = getTrackParCovFromKFP(kfNeg, pidV0Dau1, -1); // V0 negative daughter
       trackParCovV0Dau1.setAbsCharge(1);
 
@@ -1477,15 +1479,15 @@ struct HfCandidateCreatorXic0Omegac0 {
       xiDauChargedTrackParCov = getTrackParCovFromKFP(kfBachPionToXi, o2::track::PID::Pion, bachCharge); // Cascade bach pion
       xiDauChargedTrackParCov.setAbsCharge(1);
 
-      auto pidCasc = getTrackPIDFromPDG(kfXiToXiC.GetPDG());
+      o2::track::PID::ID pidCasc = getTrackPIDFromPDG(kfXiToXiC.GetPDG());
       o2::track::TrackParCov trackCasc = getTrackParCovFromKFP(kfXiToXiC, pidCasc, bachCharge);
       trackCasc.setAbsCharge(1);
 
-      auto pidV0Dau0 = getTrackPIDFromPDG(kfPos.GetPDG());
+      o2::track::PID::ID pidV0Dau0 = getTrackPIDFromPDG(kfPos.GetPDG());
       trackParCovV0Dau0 = getTrackParCovFromKFP(kfPos, pidV0Dau0, +1); // V0 postive daughter
       trackParCovV0Dau0.setAbsCharge(1);
 
-      auto pidV0Dau1 = getTrackPIDFromPDG(kfNeg.GetPDG());
+      o2::track::PID::ID pidV0Dau1 = getTrackPIDFromPDG(kfNeg.GetPDG());
       trackParCovV0Dau1 = getTrackParCovFromKFP(kfNeg, pidV0Dau1, -1); // V0 negative daughter
       trackParCovV0Dau1.setAbsCharge(1);
 

--- a/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
@@ -96,6 +96,26 @@ enum McMatchFlag : uint8_t {
   V0Unmatched
 };
 
+// Convert the KFParticle PDG code to the O2 track PID enum needed by getTrackParCovFromKFP()
+o2::track::PID getTrackPIDFromPDG(const int pdg)
+{
+  switch (std::abs(pdg)) {
+    case 211:
+      return o2::track::PID::Pion;
+    case 321:
+      return o2::track::PID::Kaon;
+    case 2212:
+      return o2::track::PID::Proton;
+    case 3312:
+      return o2::track::PID::XiMinus;
+    case 3334:
+      return o2::track::PID::OmegaMinus;
+    default:
+      LOGF(fatal, "Unsupported PDG code %d in getTrackPIDFromPDG()", pdg);
+      return static_cast<o2::track::PID>(-1);
+  }
+}
+
 // Reconstruction of omegac0 and xic0 candidates
 struct HfCandidateCreatorXic0Omegac0 {
   Produces<aod::HfCandToXiPi> rowCandToXiPi;
@@ -959,12 +979,16 @@ struct HfCandidateCreatorXic0Omegac0 {
 
       omegaDauChargedTrackParCov = getTrackParCovFromKFP(kfBachKaonToOmega, o2::track::PID::Kaon, bachCharge); // Cascade bach kaon
       omegaDauChargedTrackParCov.setAbsCharge(1);
-      o2::track::TrackParCov trackCasc = getTrackParCovFromKFP(kfOmegaToOmegaC, kfOmegaToOmegaC.GetPDG(), bachCharge);
+      auto pidCasc = getTrackPIDFromPDG(kfOmegaToOmegaC.GetPDG());
+      o2::track::TrackParCov trackCasc = getTrackParCovFromKFP(kfOmegaToOmegaC, pidCasc, bachCharge);
       trackCasc.setAbsCharge(1);
 
-      trackParCovV0Dau0 = getTrackParCovFromKFP(kfPos, kfPos.GetPDG(), 1); // V0 postive daughter
+      auto pidV0Dau0 = getTrackPIDFromPDG(kfPos.GetPDG());
+      trackParCovV0Dau0 = getTrackParCovFromKFP(kfPos, pidV0Dau0, +1); // V0 postive daughter
       trackParCovV0Dau0.setAbsCharge(1);
-      trackParCovV0Dau1 = getTrackParCovFromKFP(kfNeg, kfNeg.GetPDG(), -1); // V0 negtive daughter
+
+      auto pidV0Dau1 = getTrackPIDFromPDG(kfNeg.GetPDG());
+      trackParCovV0Dau1 = getTrackParCovFromKFP(kfNeg, pidV0Dau1, -1); // V0 negative daughter
       trackParCovV0Dau1.setAbsCharge(1);
 
       //-------------------------- V0 info---------------------------
@@ -1452,12 +1476,17 @@ struct HfCandidateCreatorXic0Omegac0 {
 
       xiDauChargedTrackParCov = getTrackParCovFromKFP(kfBachPionToXi, o2::track::PID::Pion, bachCharge); // Cascade bach pion
       xiDauChargedTrackParCov.setAbsCharge(1);
-      o2::track::TrackParCov trackCasc = getTrackParCovFromKFP(kfXiToXiC, kfXiToXiC.GetPDG(), bachCharge);
+
+      auto pidCasc = getTrackPIDFromPDG(kfXiToXiC.GetPDG());
+      o2::track::TrackParCov trackCasc = getTrackParCovFromKFP(kfXiToXiC, pidCasc, bachCharge);
       trackCasc.setAbsCharge(1);
 
-      trackParCovV0Dau0 = getTrackParCovFromKFP(kfPos, kfPos.GetPDG(), 1); // V0 postive daughter
+      auto pidV0Dau0 = getTrackPIDFromPDG(kfPos.GetPDG());
+      trackParCovV0Dau0 = getTrackParCovFromKFP(kfPos, pidV0Dau0, +1); // V0 postive daughter
       trackParCovV0Dau0.setAbsCharge(1);
-      trackParCovV0Dau1 = getTrackParCovFromKFP(kfNeg, kfNeg.GetPDG(), -1); // V0 negtive daughter
+
+      auto pidV0Dau1 = getTrackPIDFromPDG(kfNeg.GetPDG());
+      trackParCovV0Dau1 = getTrackParCovFromKFP(kfNeg, pidV0Dau1, -1); // V0 negative daughter
       trackParCovV0Dau1.setAbsCharge(1);
 
       //-------------------------- V0 info---------------------------


### PR DESCRIPTION
This PR fixes the PID assignment passed to getTrackParCovFromKFP() in candidateCreatorXic0Omegac0.cxx.

KFParticle::GetPDG() returns a PDG code, while getTrackParCovFromKFP() expects an o2::track::PID enum. This PR adds a helper function to convert the PDG code to the corresponding PID enum before calling getTrackParCovFromKFP().

@fcatalan92 @jinhyunni 