### PR TITLE
[PWGLF] Correction for pT extrapolation

### DIFF
--- a/PWGLF/Tasks/GlobalEventProperties/studyPnch.cxx
+++ b/PWGLF/Tasks/GlobalEventProperties/studyPnch.cxx
@@ -113,6 +113,7 @@ struct StudyPnch {
   Configurable<float> maxPhi{"maxPhi", 6.283185f, "Maximum phi value for track selection"};
   Configurable<bool> isPtincrease{"isPtincrease", false, "Varies low pT particles by a conservative amount of +100%"};
   Configurable<bool> isPtdecrease{"isPtdecrease", false, "Varies low pT particles by a conservative amount of -50%"};
+  Configurable<bool> cPrint{"cPrint", false, "Enable printing information for debugging"};
   Configurable<bool> isApplyStrangenessSysUncert{"isApplyStrangenessSysUncert", false, "Enable the evaluation of systematics due to strange particle contribution"};
 
   void init(InitContext const&)
@@ -359,6 +360,7 @@ struct StudyPnch {
   float countTracksPtCut(countTrk const& tracks, McColType const& McCol)
   {
     float nTrk = 0.0;
+    auto count = 0;
     for (const auto& track : tracks) {
       if (!isGenTrackSelected(track)) {
         continue;
@@ -366,13 +368,23 @@ struct StudyPnch {
       if (track.mcCollisionId() != McCol.mcCollisionId()) {
         continue;
       }
-      if (track.pt() > pTminCut)
+      if (track.pt() > pTminCut) {
+        count++;
         continue;
-      if (isPtincrease) {
-        nTrk += 2 - 10 * track.pt();
-      } else {
-        nTrk += 0.5 + 5 * track.pt();
       }
+      if (isPtincrease) {
+        nTrk += 2 - 10 * track.pt() - 1;
+      } else {
+        nTrk += 0.5 + 5 * track.pt() - 1;
+      }
+      if (cPrint) {
+        LOG(info) << "nTrk: " << nTrk;
+        LOG(info) << "low pT = " << track.pt();
+      }
+    }
+    if (nTrk != 0 && cPrint) {
+      LOG(info) << "counts standard pT: " << count;
+      LOG(info) << "Result of the function: " << nTrk;
     }
     return nTrk;
   }
@@ -429,10 +441,13 @@ struct StudyPnch {
       auto multrec = countNTracksMcCol(recTracksPart, RecCol);
       histos.fill(HIST("hMultiplicityMCrec"), multrec);
       float multgen = countGenTracks(GenParticles, RecCol);
+      LOG(info) << "Generated Particles with standard pT:" << multgen;
       histos.fill(HIST("hMultiplicityMCgen"), multgen);
       histos.fill(HIST("hResponseMatrix"), multrec, multgen);
       float nTrkPtCut = countTracksPtCut(GenParticles, RecCol);
       nTrkPtCut = multgen + nTrkPtCut;
+      LOG(info) << "After Counting low pT: " << nTrkPtCut;
+      LOG(info) << "########################";
       histos.fill(HIST("hMultiplicityMCgenPtCut"), nTrkPtCut);
       histos.fill(HIST("hResponseMatrixPtCut"), multrec, nTrkPtCut);
       if (isApplyStrangenessSysUncert) {

--- a/PWGLF/Tasks/GlobalEventProperties/studyPnch.cxx
+++ b/PWGLF/Tasks/GlobalEventProperties/studyPnch.cxx
@@ -441,13 +441,17 @@ struct StudyPnch {
       auto multrec = countNTracksMcCol(recTracksPart, RecCol);
       histos.fill(HIST("hMultiplicityMCrec"), multrec);
       float multgen = countGenTracks(GenParticles, RecCol);
-      LOG(info) << "Generated Particles with standard pT:" << multgen;
+      if (cPrint) {
+        LOG(info) << "Generated Particles with standard pT:" << multgen;
+      }
       histos.fill(HIST("hMultiplicityMCgen"), multgen);
       histos.fill(HIST("hResponseMatrix"), multrec, multgen);
       float nTrkPtCut = countTracksPtCut(GenParticles, RecCol);
       nTrkPtCut = multgen + nTrkPtCut;
-      LOG(info) << "After Counting low pT: " << nTrkPtCut;
-      LOG(info) << "########################";
+      if (cPrint) {
+        LOG(info) << "After Counting low pT: " << nTrkPtCut;
+        LOG(info) << "########################";
+      }
       histos.fill(HIST("hMultiplicityMCgenPtCut"), nTrkPtCut);
       histos.fill(HIST("hResponseMatrixPtCut"), multrec, nTrkPtCut);
       if (isApplyStrangenessSysUncert) {


### PR DESCRIPTION
When evaluating pT extrapolation, the generated counts were bin double-counted. This correction properly deals with this issue and also displays the count of tracks for debugging