### PR TITLE
[PWGUD] Add ptSpectraInclusiveUpc.cxx

### DIFF
--- a/PWGUD/Tasks/CMakeLists.txt
+++ b/PWGUD/Tasks/CMakeLists.txt
@@ -293,3 +293,8 @@ o2physics_add_dpl_workflow(fitbit-mapping
 													 SOURCES upcTestFITBitMapping.cxx
 													 PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
 													 COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(pt-spectra-inclusive-upc
+													 SOURCES ptSpectraInclusiveUpc.cxx
+													 PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+													 COMPONENT_NAME Analysis)

--- a/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
+++ b/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
@@ -36,6 +36,7 @@
 #include <Math/GenVector/LorentzVector.h>
 #include <Math/GenVector/PxPyPzM4D.h>
 #include <TMCProcess.h>
+#include <TPDGCode.h>
 
 #include <cmath>
 #include <cstdlib>
@@ -63,9 +64,6 @@ struct PtSpectraInclusiveUpc {
   using TC = TCs::iterator;
   using LorentzVectorM = ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double>>;
 
-  double massPion = 0.;
-  double massKaon = 0.;
-  double massProton = 0.;
   const int codePion = 211;
   const int codeKaon = 321;
   const int codeProton = 2212;
@@ -79,11 +77,6 @@ struct PtSpectraInclusiveUpc {
 
   void init(InitContext const&)
   {
-
-    massPion = o2::constants::physics::MassPionCharged;
-    massKaon = o2::constants::physics::MassKaonCharged;
-    massProton = o2::constants::physics::MassProton;
-
     // axes
     const AxisSpec axisPt{nBinsPt, 0, 5, "#it{p}_{T} GeV/#it{c}"};
     const AxisSpec axisEventCounter{2, 0.5, 2.5, "Event type"};
@@ -130,7 +123,7 @@ struct PtSpectraInclusiveUpc {
       if (!mcParticle.isPhysicalPrimary())
         continue;
 
-      LorentzVectorM pMC(mcParticle.px(), mcParticle.py(), mcParticle.pz(), massPion);
+      LorentzVectorM pMC(mcParticle.px(), mcParticle.py(), mcParticle.pz(), o2::constants::physics::MassPionCharged);
 
       if (applyKineCutsInGen) {
         if (std::fabs(pMC.Eta()) > etaMax)
@@ -143,17 +136,17 @@ struct PtSpectraInclusiveUpc {
           continue;
       }
 
-      if (std::abs(mcParticle.pdgCode()) == codePion) {
+      if (std::abs(mcParticle.pdgCode()) == PDG_t::kPiPlus) {
         histos.fill(HIST("ptGeneratedPion"), pMC.Pt());
       }
 
-      if (std::abs(mcParticle.pdgCode()) == codeKaon) {
-        pMC.SetM(massKaon);
+      if (std::abs(mcParticle.pdgCode()) == PDG_t::kKPlus) {
+        pMC.SetM(o2::constants::physics::MassKaonCharged);
         histos.fill(HIST("ptGeneratedKaon"), pMC.Pt());
       }
 
-      if (std::abs(mcParticle.pdgCode()) == codeProton) {
-        pMC.SetM(massProton);
+      if (std::abs(mcParticle.pdgCode()) == PDG_t::kProton) {
+        pMC.SetM(o2::constants::physics::MassProton);
         histos.fill(HIST("ptGeneratedProton"), pMC.Pt());
       }
 
@@ -202,17 +195,17 @@ struct PtSpectraInclusiveUpc {
       pion->SetPx(track.px());
       pion->SetPy(track.py());
       pion->SetPz(track.pz());
-      pion->SetM(massPion);
+      pion->SetM(o2::constants::physics::MassPionCharged);
 
       kaon->SetPx(track.px());
       kaon->SetPy(track.py());
       kaon->SetPz(track.pz());
-      kaon->SetM(massKaon);
+      kaon->SetM(o2::constants::physics::MassKaonCharged);
 
       proton->SetPx(track.px());
       proton->SetPy(track.py());
       proton->SetPz(track.pz());
-      proton->SetM(massProton);
+      proton->SetM(o2::constants::physics::MassProton);
 
       if (!track.has_udMcParticle()) {
         continue;
@@ -369,17 +362,17 @@ struct PtSpectraInclusiveUpc {
       pion->SetPx(track.px());
       pion->SetPy(track.py());
       pion->SetPz(track.pz());
-      pion->SetM(massPion);
+      pion->SetM(o2::constants::physics::MassPionCharged);
 
       kaon->SetPx(track.px());
       kaon->SetPy(track.py());
       kaon->SetPz(track.pz());
-      kaon->SetM(massKaon);
+      kaon->SetM(o2::constants::physics::MassKaonCharged);
 
       proton->SetPx(track.px());
       proton->SetPy(track.py());
       proton->SetPz(track.pz());
-      proton->SetM(massProton);
+      proton->SetM(o2::constants::physics::MassProton);
 
       bool hasTpc = false;
       // TPC tracks

--- a/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
+++ b/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
@@ -123,7 +123,7 @@ struct PtSpectraInclusiveUpc {
     histos.add("DCAxy_data_protons", "DCAxy_data_protons", kTH1F, {axisDCAxy});
   }
 
-  void processSim(aod::UDMcCollisions::iterator const& mcCollision, aod::UDMcParticles const& mcParticles)
+  void processSim(aod::UDMcCollisions::iterator const&, aod::UDMcParticles const& mcParticles)
   {
 
     for (const auto& mcParticle : mcParticles) {
@@ -161,7 +161,7 @@ struct PtSpectraInclusiveUpc {
     }
   }
 
-  void processReco(CC const& collision, TCs const& tracks, aod::UDMcParticles const& mcParticles)
+  void processReco(CC const&, TCs const& tracks, aod::UDMcParticles const&)
   {
 
     Partition<TCs> pvContributors = aod::udtrack::isPVContributor == true;
@@ -328,7 +328,7 @@ struct PtSpectraInclusiveUpc {
     }
   }
 
-  void processData(CC const& collision, TCs const& tracks)
+  void processData(CC const&, TCs const& tracks)
   {
 
     Partition<TCs> pvContributors = aod::udtrack::isPVContributor == true;
@@ -339,9 +339,6 @@ struct PtSpectraInclusiveUpc {
     auto nSigmaPi = -999.;
     auto nSigmaKa = -999.;
     auto nSigmaPr = -999.;
-    auto nSigmaPiTOF = -999.;
-    auto nSigmaKaTOF = -999.;
-    auto nSigmaPrTOF = -999.;
 
     LorentzVectorM* pion = new LorentzVectorM();
     LorentzVectorM* kaon = new LorentzVectorM();

--- a/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
+++ b/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
@@ -153,9 +153,6 @@ struct PtSpectraInclusiveUpc {
   void processReco(CC const&, TCs const& tracks, aod::UDMcParticles const&)
   {
 
-    Partition<TCs> pvContributors = aod::udtrack::isPVContributor == true;
-    pvContributors.bindTable(tracks);
-
     double dcaXyLimit = 0;
 
     auto nSigmaPi = -999.;
@@ -319,9 +316,6 @@ struct PtSpectraInclusiveUpc {
 
   void processData(CC const&, TCs const& tracks)
   {
-
-    Partition<TCs> pvContributors = aod::udtrack::isPVContributor == true;
-    pvContributors.bindTable(tracks);
 
     double dcaXyLimit = 0;
 

--- a/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
+++ b/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
@@ -56,10 +56,8 @@ struct PtSpectraInclusiveUpc {
   Preslice<aod::Tracks> perCollision = aod::track::collisionId;
   Preslice<o2::aod::McParticles> perMcCollision = o2::aod::mcparticle::mcCollisionId;
   // define abbreviations
-  using BCs = soa::Join<aod::BCsWithTimestamps, aod::BcSels, aod::Run3MatchedToBCSparse>;
   using CCs = soa::Join<aod::UDCollisions, aod::UDCollisionsSels, aod::UDMcCollsLabels>;
   using CC = CCs::iterator;
-  using MCparticles = aod::UDMcParticles::iterator;
   using TCs = soa::Join<aod::UDTracks, aod::UDTracksPID, aod::UDTracksExtra, aod::UDTracksFlags, aod::UDTracksDCA, aod::UDMcTrackLabels>;
   using TC = TCs::iterator;
   using LorentzVectorM = ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double>>;
@@ -112,7 +110,7 @@ struct PtSpectraInclusiveUpc {
     histos.add("DCAxy_data_protons", "DCAxy_data_protons", kTH1F, {axisDCAxy});
   }
 
-  void processSim(aod::UDMcCollisions::iterator const&, aod::UDMcParticles const& mcParticles)
+  void processSim(aod::UDMcCollision const&, aod::UDMcParticles const& mcParticles)
   {
 
     for (const auto& mcParticle : mcParticles) {

--- a/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
+++ b/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
@@ -64,10 +64,6 @@ struct PtSpectraInclusiveUpc {
   using TC = TCs::iterator;
   using LorentzVectorM = ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double>>;
 
-  const int codePion = 211;
-  const int codeKaon = 321;
-  const int codeProton = 2212;
-
   const double etaMax = 0.9;
   const double yMax = 0.9;
   const double ptMin = 0.1;
@@ -442,11 +438,11 @@ struct PtSpectraInclusiveUpc {
     }
   }
 
-  PROCESS_SWITCH(PtSpectraInclusiveUpc, processSim, "processSim", true);
+  PROCESS_SWITCH(PtSpectraInclusiveUpc, processSim, "processSim", false);
 
   PROCESS_SWITCH(PtSpectraInclusiveUpc, processReco, "processReco", true);
 
-  PROCESS_SWITCH(PtSpectraInclusiveUpc, processData, "processData", true);
+  PROCESS_SWITCH(PtSpectraInclusiveUpc, processData, "processData", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
+++ b/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
@@ -18,11 +18,11 @@
 
 #include "PWGUD/DataModel/UDTables.h"
 
+#include "Common/Core/RecoDecay.h"
 #include "Common/DataModel/EventSelection.h"
 
 #include <CommonConstants/MathConstants.h>
 #include <CommonConstants/PhysicsConstants.h>
-#include "Common/Core/RecoDecay.h"
 #include <Framework/ASoA.h>
 #include <Framework/AnalysisDataModel.h>
 #include <Framework/AnalysisHelpers.h>
@@ -31,16 +31,16 @@
 #include <Framework/HistogramRegistry.h>
 #include <Framework/HistogramSpec.h>
 #include <Framework/InitContext.h>
+#include <Framework/O2DatabasePDGPlugin.h>
 #include <Framework/OutputObjHeader.h>
 #include <Framework/runDataProcessing.h>
-#include <Framework/O2DatabasePDGPlugin.h>
 
 #include <TMCProcess.h>
 #include <TPDGCode.h>
 
+#include <array>
 #include <cmath>
 #include <cstdlib>
-#include <array>
 
 using namespace o2;
 using namespace o2::framework;
@@ -73,7 +73,7 @@ struct PtSpectraInclusiveUpc {
 
   void init(InitContext const&)
   {
-    
+
     // axes
     const AxisSpec axisPt{nBinsPt, 0, 5, "#it{p}_{T} GeV/#it{c}"};
     const AxisSpec axisEventCounter{2, 0.5, 2.5, "Event type"};

--- a/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
+++ b/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
@@ -44,7 +44,7 @@ using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 
-struct ptSpectraInclusiveUpc {
+struct PtSpectraInclusiveUpc {
 
   HistogramRegistry histos{"histos", {}, OutputObjHandlingPolicy::AnalysisObject};
 
@@ -133,10 +133,10 @@ struct ptSpectraInclusiveUpc {
       LorentzVectorM pMC(mcParticle.px(), mcParticle.py(), mcParticle.pz(), massPion);
 
       if (applyKineCutsInGen) {
-        if (fabs(pMC.Eta()) > etaMax)
+        if (std::fabs(pMC.Eta()) > etaMax)
           continue;
 
-        if (fabs(pMC.Rapidity()) > yMax)
+        if (std::fabs(pMC.Rapidity()) > yMax)
           continue;
 
         if (pMC.Pt() < ptMin)
@@ -172,9 +172,6 @@ struct ptSpectraInclusiveUpc {
     auto nSigmaPi = -999.;
     auto nSigmaKa = -999.;
     auto nSigmaPr = -999.;
-    auto nSigmaPiTOF = -999.;
-    auto nSigmaKaTOF = -999.;
-    auto nSigmaPrTOF = -999.;
 
     LorentzVectorM* pion = new LorentzVectorM();
     LorentzVectorM* kaon = new LorentzVectorM();
@@ -222,10 +219,10 @@ struct ptSpectraInclusiveUpc {
       }
       auto mcParticle = track.udMcParticle();
 
-      bool has_tpc = false;
+      bool hasTpc = false;
       // TPC tracks
       if (track.hasTPC()) {
-        has_tpc = true;
+        hasTpc = true;
         nSigmaPi = track.tpcNSigmaPi();
         nSigmaKa = track.tpcNSigmaKa();
         nSigmaPr = track.tpcNSigmaPr();
@@ -286,10 +283,10 @@ struct ptSpectraInclusiveUpc {
 
           if (mcParticle.isPhysicalPrimary()) {
             histos.fill(HIST("ptReconstructedTOFPion"), pion->Pt());
-            if (!has_tpc)
+            if (!hasTpc)
               histos.fill(HIST("DCAxy_primary_pions"), track.dcaXY());
           } else {
-            if (!has_tpc)
+            if (!hasTpc)
               histos.fill(HIST("DCAxy_secondary_pions"), track.dcaXY());
           }
         }
@@ -300,10 +297,10 @@ struct ptSpectraInclusiveUpc {
 
           if (mcParticle.isPhysicalPrimary()) {
             histos.fill(HIST("ptReconstructedTOFKaon"), kaon->Pt());
-            if (!has_tpc)
+            if (!hasTpc)
               histos.fill(HIST("DCAxy_primary_kaons"), track.dcaXY());
           } else {
-            if (!has_tpc)
+            if (!hasTpc)
               histos.fill(HIST("DCAxy_secondary_kaons"), track.dcaXY());
           }
         }
@@ -315,10 +312,10 @@ struct ptSpectraInclusiveUpc {
 
           if (mcParticle.isPhysicalPrimary()) {
             histos.fill(HIST("ptReconstructedTOFProton"), proton->Pt());
-            if (!has_tpc)
+            if (!hasTpc)
               histos.fill(HIST("DCAxy_primary_protons"), track.dcaXY());
           } else {
-            if (!has_tpc) {
+            if (!hasTpc) {
               if (mcParticle.getProcess() == kPDecay) {
                 histos.fill(HIST("DCAxy_secondary_protons"), track.dcaXY());
               } else {
@@ -387,10 +384,10 @@ struct ptSpectraInclusiveUpc {
       proton->SetPz(track.pz());
       proton->SetM(massProton);
 
-      bool has_tpc = false;
+      bool hasTpc = false;
       // TPC tracks
       if (track.hasTPC()) {
-        has_tpc = true;
+        hasTpc = true;
         nSigmaPi = track.tpcNSigmaPi();
         nSigmaKa = track.tpcNSigmaKa();
         nSigmaPr = track.tpcNSigmaPr();
@@ -431,7 +428,7 @@ struct ptSpectraInclusiveUpc {
             continue;
           }
           histos.fill(HIST("ptDataTOFPion"), pion->Pt());
-          if (!has_tpc)
+          if (!hasTpc)
             histos.fill(HIST("DCAxy_data_pions"), track.dcaXY());
         }
         if (std::abs(nSigmaKa) < sigmaMax) {
@@ -439,7 +436,7 @@ struct ptSpectraInclusiveUpc {
             continue;
           }
           histos.fill(HIST("ptDataTOFKaon"), kaon->Pt());
-          if (!has_tpc)
+          if (!hasTpc)
             histos.fill(HIST("DCAxy_data_kaons"), track.dcaXY());
         }
 
@@ -448,22 +445,22 @@ struct ptSpectraInclusiveUpc {
             continue;
           }
           histos.fill(HIST("ptDataTOFProton"), proton->Pt());
-          if (!has_tpc)
+          if (!hasTpc)
             histos.fill(HIST("DCAxy_data_protons"), track.dcaXY());
         }
       }
     }
   }
 
-  PROCESS_SWITCH(ptSpectraInclusiveUpc, processSim, "processSim", true);
+  PROCESS_SWITCH(PtSpectraInclusiveUpc, processSim, "processSim", true);
 
-  PROCESS_SWITCH(ptSpectraInclusiveUpc, processReco, "processReco", true);
+  PROCESS_SWITCH(PtSpectraInclusiveUpc, processReco, "processReco", true);
 
-  PROCESS_SWITCH(ptSpectraInclusiveUpc, processData, "processData", true);
+  PROCESS_SWITCH(PtSpectraInclusiveUpc, processData, "processData", true);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<ptSpectraInclusiveUpc>(cfgc)};
+    adaptAnalysisTask<PtSpectraInclusiveUpc>(cfgc)};
 }

--- a/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
+++ b/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
@@ -22,6 +22,7 @@
 
 #include <CommonConstants/MathConstants.h>
 #include <CommonConstants/PhysicsConstants.h>
+#include "Common/Core/RecoDecay.h"
 #include <Framework/ASoA.h>
 #include <Framework/AnalysisDataModel.h>
 #include <Framework/AnalysisHelpers.h>
@@ -32,20 +33,22 @@
 #include <Framework/InitContext.h>
 #include <Framework/OutputObjHeader.h>
 #include <Framework/runDataProcessing.h>
+#include <Framework/O2DatabasePDGPlugin.h>
 
-#include <Math/GenVector/LorentzVector.h>
-#include <Math/GenVector/PxPyPzM4D.h>
 #include <TMCProcess.h>
 #include <TPDGCode.h>
 
 #include <cmath>
 #include <cstdlib>
+#include <array>
 
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 
 struct PtSpectraInclusiveUpc {
+
+  Service<o2::framework::O2DatabasePDG> pdg;
 
   HistogramRegistry histos{"histos", {}, OutputObjHandlingPolicy::AnalysisObject};
 
@@ -60,7 +63,6 @@ struct PtSpectraInclusiveUpc {
   using CC = CCs::iterator;
   using TCs = soa::Join<aod::UDTracks, aod::UDTracksPID, aod::UDTracksExtra, aod::UDTracksFlags, aod::UDTracksDCA, aod::UDMcTrackLabels>;
   using TC = TCs::iterator;
-  using LorentzVectorM = ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double>>;
 
   const double etaMax = 0.9;
   const double yMax = 0.9;
@@ -71,6 +73,7 @@ struct PtSpectraInclusiveUpc {
 
   void init(InitContext const&)
   {
+    
     // axes
     const AxisSpec axisPt{nBinsPt, 0, 5, "#it{p}_{T} GeV/#it{c}"};
     const AxisSpec axisEventCounter{2, 0.5, 2.5, "Event type"};
@@ -113,35 +116,37 @@ struct PtSpectraInclusiveUpc {
   void processSim(aod::UDMcCollision const&, aod::UDMcParticles const& mcParticles)
   {
 
+    std::array<float, 3> trackMomentum;
+
     for (const auto& mcParticle : mcParticles) {
       if (!mcParticle.isPhysicalPrimary())
         continue;
 
-      LorentzVectorM pMC(mcParticle.px(), mcParticle.py(), mcParticle.pz(), o2::constants::physics::MassPionCharged);
+      trackMomentum[0] = mcParticle.px();
+      trackMomentum[1] = mcParticle.py();
+      trackMomentum[2] = mcParticle.pz();
 
       if (applyKineCutsInGen) {
-        if (std::fabs(pMC.Eta()) > etaMax)
+        if (std::fabs(RecoDecay::eta(trackMomentum)) > etaMax)
           continue;
 
-        if (std::fabs(pMC.Rapidity()) > yMax)
+        if (std::fabs(RecoDecay::y(trackMomentum, pdg->Mass(mcParticle.pdgCode()))) > yMax)
           continue;
 
-        if (pMC.Pt() < ptMin)
+        if (RecoDecay::pt(trackMomentum) < ptMin)
           continue;
       }
 
       if (std::abs(mcParticle.pdgCode()) == PDG_t::kPiPlus) {
-        histos.fill(HIST("ptGeneratedPion"), pMC.Pt());
+        histos.fill(HIST("ptGeneratedPion"), RecoDecay::pt(trackMomentum));
       }
 
       if (std::abs(mcParticle.pdgCode()) == PDG_t::kKPlus) {
-        pMC.SetM(o2::constants::physics::MassKaonCharged);
-        histos.fill(HIST("ptGeneratedKaon"), pMC.Pt());
+        histos.fill(HIST("ptGeneratedKaon"), RecoDecay::pt(trackMomentum));
       }
 
       if (std::abs(mcParticle.pdgCode()) == PDG_t::kProton) {
-        pMC.SetM(o2::constants::physics::MassProton);
-        histos.fill(HIST("ptGeneratedProton"), pMC.Pt());
+        histos.fill(HIST("ptGeneratedProton"), RecoDecay::pt(trackMomentum));
       }
 
       histos.fill(HIST("myEventCounter"), 1); // gen event
@@ -157,9 +162,7 @@ struct PtSpectraInclusiveUpc {
     auto nSigmaKa = -999.;
     auto nSigmaPr = -999.;
 
-    LorentzVectorM* pion = new LorentzVectorM();
-    LorentzVectorM* kaon = new LorentzVectorM();
-    LorentzVectorM* proton = new LorentzVectorM();
+    std::array<float, 3> trackMomentum;
 
     for (const auto& track : tracks) {
       if (!track.isPVContributor()) {
@@ -183,20 +186,9 @@ struct PtSpectraInclusiveUpc {
         continue;
       }
 
-      pion->SetPx(track.px());
-      pion->SetPy(track.py());
-      pion->SetPz(track.pz());
-      pion->SetM(o2::constants::physics::MassPionCharged);
-
-      kaon->SetPx(track.px());
-      kaon->SetPy(track.py());
-      kaon->SetPz(track.pz());
-      kaon->SetM(o2::constants::physics::MassKaonCharged);
-
-      proton->SetPx(track.px());
-      proton->SetPy(track.py());
-      proton->SetPz(track.pz());
-      proton->SetM(o2::constants::physics::MassProton);
+      trackMomentum[0] = track.px();
+      trackMomentum[1] = track.py();
+      trackMomentum[2] = track.pz();
 
       if (!track.has_udMcParticle()) {
         continue;
@@ -212,24 +204,24 @@ struct PtSpectraInclusiveUpc {
         nSigmaPr = track.tpcNSigmaPr();
 
         if (std::abs(nSigmaPi) < sigmaMax) {
-          if (std::abs(pion->Rapidity()) > yMax) {
+          if (std::abs(RecoDecay::y(trackMomentum, o2::constants::physics::MassPionCharged)) > yMax) {
             continue;
           }
 
           if (mcParticle.isPhysicalPrimary()) {
-            histos.fill(HIST("ptReconstructedTPCPion"), pion->Pt());
+            histos.fill(HIST("ptReconstructedTPCPion"), track.pt());
             histos.fill(HIST("DCAxy_primary_pions"), track.dcaXY());
           } else {
             histos.fill(HIST("DCAxy_secondary_pions"), track.dcaXY());
           }
         }
         if (std::abs(nSigmaKa) < sigmaMax) {
-          if (std::abs(kaon->Rapidity()) > yMax) {
+          if (std::abs(RecoDecay::y(trackMomentum, o2::constants::physics::MassKaonCharged)) > yMax) {
             continue;
           }
 
           if (mcParticle.isPhysicalPrimary()) {
-            histos.fill(HIST("ptReconstructedTPCKaon"), kaon->Pt());
+            histos.fill(HIST("ptReconstructedTPCKaon"), track.pt());
             histos.fill(HIST("DCAxy_primary_kaons"), track.dcaXY());
           } else {
             histos.fill(HIST("DCAxy_secondary_kaons"), track.dcaXY());
@@ -237,12 +229,12 @@ struct PtSpectraInclusiveUpc {
         }
 
         if (std::abs(nSigmaPr) < sigmaMax) {
-          if (std::abs(proton->Rapidity()) > yMax) {
+          if (std::abs(RecoDecay::y(trackMomentum, o2::constants::physics::MassProton)) > yMax) {
             continue;
           }
 
           if (mcParticle.isPhysicalPrimary()) {
-            histos.fill(HIST("ptReconstructedTPCProton"), proton->Pt());
+            histos.fill(HIST("ptReconstructedTPCProton"), track.pt());
             histos.fill(HIST("DCAxy_primary_protons"), track.dcaXY());
           } else {
             if (mcParticle.getProcess() == kPDecay) {
@@ -261,12 +253,12 @@ struct PtSpectraInclusiveUpc {
         nSigmaPr = track.tofNSigmaPr();
 
         if (std::abs(nSigmaPi) < sigmaMax) {
-          if (std::abs(pion->Rapidity()) > yMax) {
+          if (std::abs(RecoDecay::y(trackMomentum, o2::constants::physics::MassPionCharged)) > yMax) {
             continue;
           }
 
           if (mcParticle.isPhysicalPrimary()) {
-            histos.fill(HIST("ptReconstructedTOFPion"), pion->Pt());
+            histos.fill(HIST("ptReconstructedTOFPion"), track.pt());
             if (!hasTpc)
               histos.fill(HIST("DCAxy_primary_pions"), track.dcaXY());
           } else {
@@ -275,12 +267,12 @@ struct PtSpectraInclusiveUpc {
           }
         }
         if (std::abs(nSigmaKa) < sigmaMax) {
-          if (std::abs(kaon->Rapidity()) > yMax) {
+          if (std::abs(RecoDecay::y(trackMomentum, o2::constants::physics::MassKaonCharged)) > yMax) {
             continue;
           }
 
           if (mcParticle.isPhysicalPrimary()) {
-            histos.fill(HIST("ptReconstructedTOFKaon"), kaon->Pt());
+            histos.fill(HIST("ptReconstructedTOFKaon"), track.pt());
             if (!hasTpc)
               histos.fill(HIST("DCAxy_primary_kaons"), track.dcaXY());
           } else {
@@ -290,12 +282,12 @@ struct PtSpectraInclusiveUpc {
         }
 
         if (std::abs(nSigmaPr) < sigmaMax) {
-          if (std::abs(proton->Rapidity()) > yMax) {
+          if (std::abs(RecoDecay::y(trackMomentum, o2::constants::physics::MassProton)) > yMax) {
             continue;
           }
 
           if (mcParticle.isPhysicalPrimary()) {
-            histos.fill(HIST("ptReconstructedTOFProton"), proton->Pt());
+            histos.fill(HIST("ptReconstructedTOFProton"), track.pt());
             if (!hasTpc)
               histos.fill(HIST("DCAxy_primary_protons"), track.dcaXY());
           } else {
@@ -321,9 +313,7 @@ struct PtSpectraInclusiveUpc {
     auto nSigmaKa = -999.;
     auto nSigmaPr = -999.;
 
-    LorentzVectorM* pion = new LorentzVectorM();
-    LorentzVectorM* kaon = new LorentzVectorM();
-    LorentzVectorM* proton = new LorentzVectorM();
+    std::array<float, 3> trackMomentum;
 
     for (const auto& track : tracks) {
       if (!track.isPVContributor()) {
@@ -347,20 +337,9 @@ struct PtSpectraInclusiveUpc {
         continue;
       }
 
-      pion->SetPx(track.px());
-      pion->SetPy(track.py());
-      pion->SetPz(track.pz());
-      pion->SetM(o2::constants::physics::MassPionCharged);
-
-      kaon->SetPx(track.px());
-      kaon->SetPy(track.py());
-      kaon->SetPz(track.pz());
-      kaon->SetM(o2::constants::physics::MassKaonCharged);
-
-      proton->SetPx(track.px());
-      proton->SetPy(track.py());
-      proton->SetPz(track.pz());
-      proton->SetM(o2::constants::physics::MassProton);
+      trackMomentum[0] = track.px();
+      trackMomentum[1] = track.py();
+      trackMomentum[2] = track.pz();
 
       bool hasTpc = false;
       // TPC tracks
@@ -371,26 +350,26 @@ struct PtSpectraInclusiveUpc {
         nSigmaPr = track.tpcNSigmaPr();
 
         if (std::abs(nSigmaPi) < sigmaMax) {
-          if (std::abs(pion->Rapidity()) > yMax) {
+          if (std::abs(RecoDecay::y(trackMomentum, o2::constants::physics::MassPionCharged)) > yMax) {
             continue;
           }
-          histos.fill(HIST("ptDataTPCPion"), pion->Pt());
+          histos.fill(HIST("ptDataTPCPion"), track.pt());
           histos.fill(HIST("DCAxy_data_pions"), track.dcaXY());
         }
 
         if (std::abs(nSigmaKa) < sigmaMax) {
-          if (std::abs(kaon->Rapidity()) > yMax) {
+          if (std::abs(RecoDecay::y(trackMomentum, o2::constants::physics::MassKaonCharged)) > yMax) {
             continue;
           }
-          histos.fill(HIST("ptDataTPCKaon"), kaon->Pt());
+          histos.fill(HIST("ptDataTPCKaon"), track.pt());
           histos.fill(HIST("DCAxy_data_kaons"), track.dcaXY());
         }
 
         if (std::abs(nSigmaPr) < sigmaMax) {
-          if (std::abs(proton->Rapidity()) > yMax) {
+          if (std::abs(RecoDecay::y(trackMomentum, o2::constants::physics::MassProton)) > yMax) {
             continue;
           }
-          histos.fill(HIST("ptDataTPCProton"), proton->Pt());
+          histos.fill(HIST("ptDataTPCProton"), track.pt());
           histos.fill(HIST("DCAxy_data_protons"), track.dcaXY());
         }
       }
@@ -402,27 +381,27 @@ struct PtSpectraInclusiveUpc {
         nSigmaPr = track.tofNSigmaPr();
 
         if (std::abs(nSigmaPi) < sigmaMax) {
-          if (std::abs(pion->Rapidity()) > yMax) {
+          if (std::abs(RecoDecay::y(trackMomentum, o2::constants::physics::MassPionCharged)) > yMax) {
             continue;
           }
-          histos.fill(HIST("ptDataTOFPion"), pion->Pt());
+          histos.fill(HIST("ptDataTOFPion"), track.pt());
           if (!hasTpc)
             histos.fill(HIST("DCAxy_data_pions"), track.dcaXY());
         }
         if (std::abs(nSigmaKa) < sigmaMax) {
-          if (std::abs(kaon->Rapidity()) > yMax) {
+          if (std::abs(RecoDecay::y(trackMomentum, o2::constants::physics::MassKaonCharged)) > yMax) {
             continue;
           }
-          histos.fill(HIST("ptDataTOFKaon"), kaon->Pt());
+          histos.fill(HIST("ptDataTOFKaon"), track.pt());
           if (!hasTpc)
             histos.fill(HIST("DCAxy_data_kaons"), track.dcaXY());
         }
 
         if (std::abs(nSigmaPr) < sigmaMax) {
-          if (std::abs(proton->Rapidity()) > yMax) {
+          if (std::abs(RecoDecay::y(trackMomentum, o2::constants::physics::MassProton)) > yMax) {
             continue;
           }
-          histos.fill(HIST("ptDataTOFProton"), proton->Pt());
+          histos.fill(HIST("ptDataTOFProton"), track.pt());
           if (!hasTpc)
             histos.fill(HIST("DCAxy_data_protons"), track.dcaXY());
         }

--- a/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
+++ b/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
@@ -8,8 +8,9 @@
 // In applying this license CERN does not waive the privileges and immunities
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
+///
 /// \file ptSpectraInclusiveUpc.cxx
-
+/// \executable o2-analysis-ud-pt-spectra-inclusive-upc
 /// \brief Task for the of pT spectra of pions, kaons and protons in inclusive UPC events.
 ///        Used to obtain the templates for the DCA_xy fits for the primary fractions
 ///
@@ -236,7 +237,6 @@ struct ptSpectraInclusiveUpc {
 
           if (mcParticle.isPhysicalPrimary()) {
             histos.fill(HIST("ptReconstructedTPCPion"), pion->Pt());
-            // selEv = true;
             histos.fill(HIST("DCAxy_primary_pions"), track.dcaXY());
           } else {
             histos.fill(HIST("DCAxy_secondary_pions"), track.dcaXY());
@@ -249,7 +249,6 @@ struct ptSpectraInclusiveUpc {
 
           if (mcParticle.isPhysicalPrimary()) {
             histos.fill(HIST("ptReconstructedTPCKaon"), kaon->Pt());
-            // selEv = true;
             histos.fill(HIST("DCAxy_primary_kaons"), track.dcaXY());
           } else {
             histos.fill(HIST("DCAxy_secondary_kaons"), track.dcaXY());
@@ -263,7 +262,6 @@ struct ptSpectraInclusiveUpc {
 
           if (mcParticle.isPhysicalPrimary()) {
             histos.fill(HIST("ptReconstructedTPCProton"), proton->Pt());
-            // selEv = true;
             histos.fill(HIST("DCAxy_primary_protons"), track.dcaXY());
           } else {
             if (mcParticle.getProcess() == kPDecay) {

--- a/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
+++ b/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
@@ -43,8 +43,8 @@ using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 
-struct ptSpectraInclusiveUpc{
-  
+struct ptSpectraInclusiveUpc {
+
   HistogramRegistry histos{"histos", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   Configurable<int> nBinsPt{"nBinsPt", 100, "N bins in pT histos"};
@@ -76,7 +76,8 @@ struct ptSpectraInclusiveUpc{
   const double sigmaMax = 3.;
   const double dcaZlimit = 2.;
 
-  void init(InitContext const&){
+  void init(InitContext const&)
+  {
 
     massPion = o2::constants::physics::MassPionCharged;
     massKaon = o2::constants::physics::MassKaonCharged;
@@ -88,48 +89,49 @@ struct ptSpectraInclusiveUpc{
     const AxisSpec axisDCAxy{nBinsDCAxy, -0.6, 0.6, "DCA_{xy} cm"};
 
     // histograms
-    histos.add("ptGeneratedPion",   "ptGeneratedPion",   kTH1F, {axisPt});
-    histos.add("ptGeneratedKaon",   "ptGeneratedKaon",   kTH1F, {axisPt});
+    histos.add("ptGeneratedPion", "ptGeneratedPion", kTH1F, {axisPt});
+    histos.add("ptGeneratedKaon", "ptGeneratedKaon", kTH1F, {axisPt});
     histos.add("ptGeneratedProton", "ptGeneratedProton", kTH1F, {axisPt});
 
-    histos.add("ptReconstructedTPCPion",   "ptReconstructedTPCPion",   kTH1F, {axisPt});
-    histos.add("ptReconstructedTPCKaon",   "ptReconstructedTPCKaon",   kTH1F, {axisPt});
+    histos.add("ptReconstructedTPCPion", "ptReconstructedTPCPion", kTH1F, {axisPt});
+    histos.add("ptReconstructedTPCKaon", "ptReconstructedTPCKaon", kTH1F, {axisPt});
     histos.add("ptReconstructedTPCProton", "ptReconstructedTPCProton", kTH1F, {axisPt});
 
-    histos.add("ptReconstructedTOFPion",   "ptReconstructedTOFPion",   kTH1F, {axisPt});
-    histos.add("ptReconstructedTOFKaon",   "ptReconstructedTOFKaon",   kTH1F, {axisPt});
+    histos.add("ptReconstructedTOFPion", "ptReconstructedTOFPion", kTH1F, {axisPt});
+    histos.add("ptReconstructedTOFKaon", "ptReconstructedTOFKaon", kTH1F, {axisPt});
     histos.add("ptReconstructedTOFProton", "ptReconstructedTOFProton", kTH1F, {axisPt});
 
-    histos.add("ptDataTPCPion",   "ptDataTPCPion",   kTH1F, {axisPt});
-    histos.add("ptDataTPCKaon",   "ptDataTPCKaon",   kTH1F, {axisPt});
+    histos.add("ptDataTPCPion", "ptDataTPCPion", kTH1F, {axisPt});
+    histos.add("ptDataTPCKaon", "ptDataTPCKaon", kTH1F, {axisPt});
     histos.add("ptDataTPCProton", "ptDataTPCProton", kTH1F, {axisPt});
 
-    histos.add("ptDataTOFPion",   "ptDataTOFPion",   kTH1F, {axisPt});
-    histos.add("ptDataTOFKaon",   "ptDataTOFKaon",   kTH1F, {axisPt});
+    histos.add("ptDataTOFPion", "ptDataTOFPion", kTH1F, {axisPt});
+    histos.add("ptDataTOFKaon", "ptDataTOFKaon", kTH1F, {axisPt});
     histos.add("ptDataTOFProton", "ptDataTOFProton", kTH1F, {axisPt});
 
     histos.add("myEventCounter", "myEventCounter", kTH1F, {axisEventCounter});
-    histos.add("DCAxy_primary_pions",   "DCAxy_primary_pions",   kTH1F, {axisDCAxy});
+    histos.add("DCAxy_primary_pions", "DCAxy_primary_pions", kTH1F, {axisDCAxy});
     histos.add("DCAxy_secondary_pions", "DCAxy_secondary_pions", kTH1F, {axisDCAxy});
-    histos.add("DCAxy_primary_kaons",   "DCAxy_primary_kaons",   kTH1F, {axisDCAxy});
+    histos.add("DCAxy_primary_kaons", "DCAxy_primary_kaons", kTH1F, {axisDCAxy});
     histos.add("DCAxy_secondary_kaons", "DCAxy_secondary_kaons", kTH1F, {axisDCAxy});
-    histos.add("DCAxy_primary_protons",   "DCAxy_primary_protons",   kTH1F, {axisDCAxy});
+    histos.add("DCAxy_primary_protons", "DCAxy_primary_protons", kTH1F, {axisDCAxy});
     histos.add("DCAxy_secondary_protons", "DCAxy_secondary_protons", kTH1F, {axisDCAxy});
     histos.add("DCAxy_material_protons", "DCAxy_material_protons", kTH1F, {axisDCAxy});
-    histos.add("DCAxy_data_pions",   "DCAxy_data_pions",   kTH1F, {axisDCAxy});
-    histos.add("DCAxy_data_kaons",   "DCAxy_data_kaons",   kTH1F, {axisDCAxy});
+    histos.add("DCAxy_data_pions", "DCAxy_data_pions", kTH1F, {axisDCAxy});
+    histos.add("DCAxy_data_kaons", "DCAxy_data_kaons", kTH1F, {axisDCAxy});
     histos.add("DCAxy_data_protons", "DCAxy_data_protons", kTH1F, {axisDCAxy});
   }
 
-  void processSim(aod::UDMcCollisions::iterator const& mcCollision, aod::UDMcParticles const& mcParticles){
+  void processSim(aod::UDMcCollisions::iterator const& mcCollision, aod::UDMcParticles const& mcParticles)
+  {
 
-    for (const auto& mcParticle : mcParticles){
+    for (const auto& mcParticle : mcParticles) {
       if (!mcParticle.isPhysicalPrimary())
         continue;
 
       LorentzVectorM pMC(mcParticle.px(), mcParticle.py(), mcParticle.pz(), massPion);
-      
-      if (applyKineCutsInGen){
+
+      if (applyKineCutsInGen) {
         if (fabs(pMC.Eta()) > etaMax)
           continue;
 
@@ -158,7 +160,8 @@ struct ptSpectraInclusiveUpc{
     }
   }
 
-  void processReco(CC const& collision, TCs const& tracks, aod::UDMcParticles const& mcParticles){
+  void processReco(CC const& collision, TCs const& tracks, aod::UDMcParticles const& mcParticles)
+  {
 
     Partition<TCs> pvContributors = aod::udtrack::isPVContributor == true;
     pvContributors.bindTable(tracks);
@@ -172,9 +175,9 @@ struct ptSpectraInclusiveUpc{
     auto nSigmaKaTOF = -999.;
     auto nSigmaPrTOF = -999.;
 
-    LorentzVectorM *pion = new LorentzVectorM();
-    LorentzVectorM *kaon = new LorentzVectorM();
-    LorentzVectorM *proton = new LorentzVectorM();
+    LorentzVectorM* pion = new LorentzVectorM();
+    LorentzVectorM* kaon = new LorentzVectorM();
+    LorentzVectorM* proton = new LorentzVectorM();
 
     for (const auto& track : tracks) {
       if (!track.isPVContributor()) {
@@ -186,7 +189,7 @@ struct ptSpectraInclusiveUpc{
       }
 
       if (track.pt() < ptMin) {
-          continue;
+        continue;
       }
 
       if (!(std::abs(track.dcaZ()) < dcaZlimit)) {
@@ -213,7 +216,7 @@ struct ptSpectraInclusiveUpc{
       proton->SetPz(track.pz());
       proton->SetM(massProton);
 
-      if (!track.has_udMcParticle()){
+      if (!track.has_udMcParticle()) {
         continue;
       }
       auto mcParticle = track.udMcParticle();
@@ -221,10 +224,10 @@ struct ptSpectraInclusiveUpc{
       bool has_tpc = false;
       // TPC tracks
       if (track.hasTPC()) {
-          has_tpc = true;
-          nSigmaPi = track.tpcNSigmaPi();
-          nSigmaKa = track.tpcNSigmaKa();
-          nSigmaPr = track.tpcNSigmaPr();
+        has_tpc = true;
+        nSigmaPi = track.tpcNSigmaPi();
+        nSigmaKa = track.tpcNSigmaKa();
+        nSigmaPr = track.tpcNSigmaPr();
 
         if (std::abs(nSigmaPi) < sigmaMax) {
           if (std::abs(pion->Rapidity()) > yMax) {
@@ -233,9 +236,9 @@ struct ptSpectraInclusiveUpc{
 
           if (mcParticle.isPhysicalPrimary()) {
             histos.fill(HIST("ptReconstructedTPCPion"), pion->Pt());
-            //selEv = true;
+            // selEv = true;
             histos.fill(HIST("DCAxy_primary_pions"), track.dcaXY());
-          }else{
+          } else {
             histos.fill(HIST("DCAxy_secondary_pions"), track.dcaXY());
           }
         }
@@ -246,9 +249,9 @@ struct ptSpectraInclusiveUpc{
 
           if (mcParticle.isPhysicalPrimary()) {
             histos.fill(HIST("ptReconstructedTPCKaon"), kaon->Pt());
-            //selEv = true;
+            // selEv = true;
             histos.fill(HIST("DCAxy_primary_kaons"), track.dcaXY());
-          }else{
+          } else {
             histos.fill(HIST("DCAxy_secondary_kaons"), track.dcaXY());
           }
         }
@@ -260,25 +263,23 @@ struct ptSpectraInclusiveUpc{
 
           if (mcParticle.isPhysicalPrimary()) {
             histos.fill(HIST("ptReconstructedTPCProton"), proton->Pt());
-            //selEv = true;
+            // selEv = true;
             histos.fill(HIST("DCAxy_primary_protons"), track.dcaXY());
-          }else{
+          } else {
             if (mcParticle.getProcess() == kPDecay) {
               histos.fill(HIST("DCAxy_secondary_protons"), track.dcaXY());
-            }
-            else{
+            } else {
               histos.fill(HIST("DCAxy_material_protons"), track.dcaXY());
             }
           }
         }
-
       }
 
       // TPC tracks
       if (track.hasTOF()) {
-          nSigmaPi = track.tofNSigmaPi();
-          nSigmaKa = track.tofNSigmaKa();
-          nSigmaPr = track.tofNSigmaPr();
+        nSigmaPi = track.tofNSigmaPi();
+        nSigmaKa = track.tofNSigmaKa();
+        nSigmaPr = track.tofNSigmaPr();
 
         if (std::abs(nSigmaPi) < sigmaMax) {
           if (std::abs(pion->Rapidity()) > yMax) {
@@ -287,9 +288,11 @@ struct ptSpectraInclusiveUpc{
 
           if (mcParticle.isPhysicalPrimary()) {
             histos.fill(HIST("ptReconstructedTOFPion"), pion->Pt());
-            if(!has_tpc) histos.fill(HIST("DCAxy_primary_pions"), track.dcaXY());
-          }else{
-            if(!has_tpc) histos.fill(HIST("DCAxy_secondary_pions"), track.dcaXY());
+            if (!has_tpc)
+              histos.fill(HIST("DCAxy_primary_pions"), track.dcaXY());
+          } else {
+            if (!has_tpc)
+              histos.fill(HIST("DCAxy_secondary_pions"), track.dcaXY());
           }
         }
         if (std::abs(nSigmaKa) < sigmaMax) {
@@ -299,9 +302,11 @@ struct ptSpectraInclusiveUpc{
 
           if (mcParticle.isPhysicalPrimary()) {
             histos.fill(HIST("ptReconstructedTOFKaon"), kaon->Pt());
-            if(!has_tpc) histos.fill(HIST("DCAxy_primary_kaons"), track.dcaXY());
-          }else{
-            if(!has_tpc) histos.fill(HIST("DCAxy_secondary_kaons"), track.dcaXY());
+            if (!has_tpc)
+              histos.fill(HIST("DCAxy_primary_kaons"), track.dcaXY());
+          } else {
+            if (!has_tpc)
+              histos.fill(HIST("DCAxy_secondary_kaons"), track.dcaXY());
           }
         }
 
@@ -312,24 +317,24 @@ struct ptSpectraInclusiveUpc{
 
           if (mcParticle.isPhysicalPrimary()) {
             histos.fill(HIST("ptReconstructedTOFProton"), proton->Pt());
-            if(!has_tpc) histos.fill(HIST("DCAxy_primary_protons"), track.dcaXY());
-          }else{
-            if(!has_tpc) {
+            if (!has_tpc)
+              histos.fill(HIST("DCAxy_primary_protons"), track.dcaXY());
+          } else {
+            if (!has_tpc) {
               if (mcParticle.getProcess() == kPDecay) {
                 histos.fill(HIST("DCAxy_secondary_protons"), track.dcaXY());
-              }
-              else{
+              } else {
                 histos.fill(HIST("DCAxy_material_protons"), track.dcaXY());
               }
             }
           }
         }
-
       }
     }
   }
 
-  void processData(CC const& collision, TCs const& tracks){
+  void processData(CC const& collision, TCs const& tracks)
+  {
 
     Partition<TCs> pvContributors = aod::udtrack::isPVContributor == true;
     pvContributors.bindTable(tracks);
@@ -343,9 +348,9 @@ struct ptSpectraInclusiveUpc{
     auto nSigmaKaTOF = -999.;
     auto nSigmaPrTOF = -999.;
 
-    LorentzVectorM *pion = new LorentzVectorM();
-    LorentzVectorM *kaon = new LorentzVectorM();
-    LorentzVectorM *proton = new LorentzVectorM();
+    LorentzVectorM* pion = new LorentzVectorM();
+    LorentzVectorM* kaon = new LorentzVectorM();
+    LorentzVectorM* proton = new LorentzVectorM();
 
     for (const auto& track : tracks) {
       if (!track.isPVContributor()) {
@@ -357,7 +362,7 @@ struct ptSpectraInclusiveUpc{
       }
 
       if (track.pt() < ptMin) {
-          continue;
+        continue;
       }
 
       if (!(std::abs(track.dcaZ()) < dcaZlimit)) {
@@ -387,10 +392,10 @@ struct ptSpectraInclusiveUpc{
       bool has_tpc = false;
       // TPC tracks
       if (track.hasTPC()) {
-          has_tpc = true;
-          nSigmaPi = track.tpcNSigmaPi();
-          nSigmaKa = track.tpcNSigmaKa();
-          nSigmaPr = track.tpcNSigmaPr();
+        has_tpc = true;
+        nSigmaPi = track.tpcNSigmaPi();
+        nSigmaKa = track.tpcNSigmaKa();
+        nSigmaPr = track.tpcNSigmaPr();
 
         if (std::abs(nSigmaPi) < sigmaMax) {
           if (std::abs(pion->Rapidity()) > yMax) {
@@ -415,28 +420,29 @@ struct ptSpectraInclusiveUpc{
           histos.fill(HIST("ptDataTPCProton"), proton->Pt());
           histos.fill(HIST("DCAxy_data_protons"), track.dcaXY());
         }
-
       }
 
       // TPC tracks
       if (track.hasTOF()) {
-          nSigmaPi = track.tofNSigmaPi();
-          nSigmaKa = track.tofNSigmaKa();
-          nSigmaPr = track.tofNSigmaPr();
+        nSigmaPi = track.tofNSigmaPi();
+        nSigmaKa = track.tofNSigmaKa();
+        nSigmaPr = track.tofNSigmaPr();
 
         if (std::abs(nSigmaPi) < sigmaMax) {
           if (std::abs(pion->Rapidity()) > yMax) {
             continue;
           }
           histos.fill(HIST("ptDataTOFPion"), pion->Pt());
-          if(!has_tpc) histos.fill(HIST("DCAxy_data_pions"), track.dcaXY());
+          if (!has_tpc)
+            histos.fill(HIST("DCAxy_data_pions"), track.dcaXY());
         }
         if (std::abs(nSigmaKa) < sigmaMax) {
           if (std::abs(kaon->Rapidity()) > yMax) {
             continue;
           }
           histos.fill(HIST("ptDataTOFKaon"), kaon->Pt());
-          if(!has_tpc) histos.fill(HIST("DCAxy_data_kaons"), track.dcaXY());
+          if (!has_tpc)
+            histos.fill(HIST("DCAxy_data_kaons"), track.dcaXY());
         }
 
         if (std::abs(nSigmaPr) < sigmaMax) {
@@ -444,20 +450,18 @@ struct ptSpectraInclusiveUpc{
             continue;
           }
           histos.fill(HIST("ptDataTOFProton"), proton->Pt());
-          if(!has_tpc) histos.fill(HIST("DCAxy_data_protons"), track.dcaXY());
+          if (!has_tpc)
+            histos.fill(HIST("DCAxy_data_protons"), track.dcaXY());
         }
-
       }
     }
   }
-
 
   PROCESS_SWITCH(ptSpectraInclusiveUpc, processSim, "processSim", true);
 
   PROCESS_SWITCH(ptSpectraInclusiveUpc, processReco, "processReco", true);
 
   PROCESS_SWITCH(ptSpectraInclusiveUpc, processData, "processData", true);
-
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
+++ b/PWGUD/Tasks/ptSpectraInclusiveUpc.cxx
@@ -1,0 +1,467 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+/// \file ptSpectraInclusiveUpc.cxx
+
+/// \brief Task for the of pT spectra of pions, kaons and protons in inclusive UPC events.
+///        Used to obtain the templates for the DCA_xy fits for the primary fractions
+///
+/// \author Andrea Giovanni Riffero andrea.giovanni.riffero@cern.ch
+
+#include "PWGUD/DataModel/UDTables.h"
+
+#include "Common/DataModel/EventSelection.h"
+
+#include <CommonConstants/MathConstants.h>
+#include <CommonConstants/PhysicsConstants.h>
+#include <Framework/ASoA.h>
+#include <Framework/AnalysisDataModel.h>
+#include <Framework/AnalysisHelpers.h>
+#include <Framework/AnalysisTask.h>
+#include <Framework/Configurable.h>
+#include <Framework/HistogramRegistry.h>
+#include <Framework/HistogramSpec.h>
+#include <Framework/InitContext.h>
+#include <Framework/OutputObjHeader.h>
+#include <Framework/runDataProcessing.h>
+
+#include <Math/GenVector/LorentzVector.h>
+#include <Math/GenVector/PxPyPzM4D.h>
+#include <TMCProcess.h>
+
+#include <cmath>
+#include <cstdlib>
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+struct ptSpectraInclusiveUpc{
+  
+  HistogramRegistry histos{"histos", {}, OutputObjHandlingPolicy::AnalysisObject};
+
+  Configurable<int> nBinsPt{"nBinsPt", 100, "N bins in pT histos"};
+  Configurable<int> nBinsDCAxy{"nBinsDCAxy", 100, "N bins in DCA_{xy} histos"};
+  Configurable<bool> applyKineCutsInGen{"applyKineCutsInGen", false, "Apply kinematic cuts in the generated level"};
+
+  Preslice<aod::Tracks> perCollision = aod::track::collisionId;
+  Preslice<o2::aod::McParticles> perMcCollision = o2::aod::mcparticle::mcCollisionId;
+  // define abbreviations
+  using BCs = soa::Join<aod::BCsWithTimestamps, aod::BcSels, aod::Run3MatchedToBCSparse>;
+  using CCs = soa::Join<aod::UDCollisions, aod::UDCollisionsSels, aod::UDMcCollsLabels>;
+  using CC = CCs::iterator;
+  using MCparticles = aod::UDMcParticles::iterator;
+  using TCs = soa::Join<aod::UDTracks, aod::UDTracksPID, aod::UDTracksExtra, aod::UDTracksFlags, aod::UDTracksDCA, aod::UDMcTrackLabels>;
+  using TC = TCs::iterator;
+  using LorentzVectorM = ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double>>;
+
+  double massPion = 0.;
+  double massKaon = 0.;
+  double massProton = 0.;
+  const int codePion = 211;
+  const int codeKaon = 321;
+  const int codeProton = 2212;
+
+  const double etaMax = 0.9;
+  const double yMax = 0.9;
+  const double ptMin = 0.1;
+  const int nFindableMin = 70;
+  const double sigmaMax = 3.;
+  const double dcaZlimit = 2.;
+
+  void init(InitContext const&){
+
+    massPion = o2::constants::physics::MassPionCharged;
+    massKaon = o2::constants::physics::MassKaonCharged;
+    massProton = o2::constants::physics::MassProton;
+
+    // axes
+    const AxisSpec axisPt{nBinsPt, 0, 5, "#it{p}_{T} GeV/#it{c}"};
+    const AxisSpec axisEventCounter{2, 0.5, 2.5, "Event type"};
+    const AxisSpec axisDCAxy{nBinsDCAxy, -0.6, 0.6, "DCA_{xy} cm"};
+
+    // histograms
+    histos.add("ptGeneratedPion",   "ptGeneratedPion",   kTH1F, {axisPt});
+    histos.add("ptGeneratedKaon",   "ptGeneratedKaon",   kTH1F, {axisPt});
+    histos.add("ptGeneratedProton", "ptGeneratedProton", kTH1F, {axisPt});
+
+    histos.add("ptReconstructedTPCPion",   "ptReconstructedTPCPion",   kTH1F, {axisPt});
+    histos.add("ptReconstructedTPCKaon",   "ptReconstructedTPCKaon",   kTH1F, {axisPt});
+    histos.add("ptReconstructedTPCProton", "ptReconstructedTPCProton", kTH1F, {axisPt});
+
+    histos.add("ptReconstructedTOFPion",   "ptReconstructedTOFPion",   kTH1F, {axisPt});
+    histos.add("ptReconstructedTOFKaon",   "ptReconstructedTOFKaon",   kTH1F, {axisPt});
+    histos.add("ptReconstructedTOFProton", "ptReconstructedTOFProton", kTH1F, {axisPt});
+
+    histos.add("ptDataTPCPion",   "ptDataTPCPion",   kTH1F, {axisPt});
+    histos.add("ptDataTPCKaon",   "ptDataTPCKaon",   kTH1F, {axisPt});
+    histos.add("ptDataTPCProton", "ptDataTPCProton", kTH1F, {axisPt});
+
+    histos.add("ptDataTOFPion",   "ptDataTOFPion",   kTH1F, {axisPt});
+    histos.add("ptDataTOFKaon",   "ptDataTOFKaon",   kTH1F, {axisPt});
+    histos.add("ptDataTOFProton", "ptDataTOFProton", kTH1F, {axisPt});
+
+    histos.add("myEventCounter", "myEventCounter", kTH1F, {axisEventCounter});
+    histos.add("DCAxy_primary_pions",   "DCAxy_primary_pions",   kTH1F, {axisDCAxy});
+    histos.add("DCAxy_secondary_pions", "DCAxy_secondary_pions", kTH1F, {axisDCAxy});
+    histos.add("DCAxy_primary_kaons",   "DCAxy_primary_kaons",   kTH1F, {axisDCAxy});
+    histos.add("DCAxy_secondary_kaons", "DCAxy_secondary_kaons", kTH1F, {axisDCAxy});
+    histos.add("DCAxy_primary_protons",   "DCAxy_primary_protons",   kTH1F, {axisDCAxy});
+    histos.add("DCAxy_secondary_protons", "DCAxy_secondary_protons", kTH1F, {axisDCAxy});
+    histos.add("DCAxy_material_protons", "DCAxy_material_protons", kTH1F, {axisDCAxy});
+    histos.add("DCAxy_data_pions",   "DCAxy_data_pions",   kTH1F, {axisDCAxy});
+    histos.add("DCAxy_data_kaons",   "DCAxy_data_kaons",   kTH1F, {axisDCAxy});
+    histos.add("DCAxy_data_protons", "DCAxy_data_protons", kTH1F, {axisDCAxy});
+  }
+
+  void processSim(aod::UDMcCollisions::iterator const& mcCollision, aod::UDMcParticles const& mcParticles){
+
+    for (const auto& mcParticle : mcParticles){
+      if (!mcParticle.isPhysicalPrimary())
+        continue;
+
+      LorentzVectorM pMC(mcParticle.px(), mcParticle.py(), mcParticle.pz(), massPion);
+      
+      if (applyKineCutsInGen){
+        if (fabs(pMC.Eta()) > etaMax)
+          continue;
+
+        if (fabs(pMC.Rapidity()) > yMax)
+          continue;
+
+        if (pMC.Pt() < ptMin)
+          continue;
+      }
+
+      if (std::abs(mcParticle.pdgCode()) == codePion) {
+        histos.fill(HIST("ptGeneratedPion"), pMC.Pt());
+      }
+
+      if (std::abs(mcParticle.pdgCode()) == codeKaon) {
+        pMC.SetM(massKaon);
+        histos.fill(HIST("ptGeneratedKaon"), pMC.Pt());
+      }
+
+      if (std::abs(mcParticle.pdgCode()) == codeProton) {
+        pMC.SetM(massProton);
+        histos.fill(HIST("ptGeneratedProton"), pMC.Pt());
+      }
+
+      histos.fill(HIST("myEventCounter"), 1); // gen event
+    }
+  }
+
+  void processReco(CC const& collision, TCs const& tracks, aod::UDMcParticles const& mcParticles){
+
+    Partition<TCs> pvContributors = aod::udtrack::isPVContributor == true;
+    pvContributors.bindTable(tracks);
+
+    double dcaXyLimit = 0;
+
+    auto nSigmaPi = -999.;
+    auto nSigmaKa = -999.;
+    auto nSigmaPr = -999.;
+    auto nSigmaPiTOF = -999.;
+    auto nSigmaKaTOF = -999.;
+    auto nSigmaPrTOF = -999.;
+
+    LorentzVectorM *pion = new LorentzVectorM();
+    LorentzVectorM *kaon = new LorentzVectorM();
+    LorentzVectorM *proton = new LorentzVectorM();
+
+    for (const auto& track : tracks) {
+      if (!track.isPVContributor()) {
+        continue;
+      }
+
+      if (track.tpcNClsFindable() < nFindableMin) {
+        continue;
+      }
+
+      if (track.pt() < ptMin) {
+          continue;
+      }
+
+      if (!(std::abs(track.dcaZ()) < dcaZlimit)) {
+        continue;
+      }
+
+      dcaXyLimit = 0.0105 + 0.035 / std::pow(track.pt(), 1.1);
+      if (!(std::abs(track.dcaXY()) < dcaXyLimit)) {
+        continue;
+      }
+
+      pion->SetPx(track.px());
+      pion->SetPy(track.py());
+      pion->SetPz(track.pz());
+      pion->SetM(massPion);
+
+      kaon->SetPx(track.px());
+      kaon->SetPy(track.py());
+      kaon->SetPz(track.pz());
+      kaon->SetM(massKaon);
+
+      proton->SetPx(track.px());
+      proton->SetPy(track.py());
+      proton->SetPz(track.pz());
+      proton->SetM(massProton);
+
+      if (!track.has_udMcParticle()){
+        continue;
+      }
+      auto mcParticle = track.udMcParticle();
+
+      bool has_tpc = false;
+      // TPC tracks
+      if (track.hasTPC()) {
+          has_tpc = true;
+          nSigmaPi = track.tpcNSigmaPi();
+          nSigmaKa = track.tpcNSigmaKa();
+          nSigmaPr = track.tpcNSigmaPr();
+
+        if (std::abs(nSigmaPi) < sigmaMax) {
+          if (std::abs(pion->Rapidity()) > yMax) {
+            continue;
+          }
+
+          if (mcParticle.isPhysicalPrimary()) {
+            histos.fill(HIST("ptReconstructedTPCPion"), pion->Pt());
+            //selEv = true;
+            histos.fill(HIST("DCAxy_primary_pions"), track.dcaXY());
+          }else{
+            histos.fill(HIST("DCAxy_secondary_pions"), track.dcaXY());
+          }
+        }
+        if (std::abs(nSigmaKa) < sigmaMax) {
+          if (std::abs(kaon->Rapidity()) > yMax) {
+            continue;
+          }
+
+          if (mcParticle.isPhysicalPrimary()) {
+            histos.fill(HIST("ptReconstructedTPCKaon"), kaon->Pt());
+            //selEv = true;
+            histos.fill(HIST("DCAxy_primary_kaons"), track.dcaXY());
+          }else{
+            histos.fill(HIST("DCAxy_secondary_kaons"), track.dcaXY());
+          }
+        }
+
+        if (std::abs(nSigmaPr) < sigmaMax) {
+          if (std::abs(proton->Rapidity()) > yMax) {
+            continue;
+          }
+
+          if (mcParticle.isPhysicalPrimary()) {
+            histos.fill(HIST("ptReconstructedTPCProton"), proton->Pt());
+            //selEv = true;
+            histos.fill(HIST("DCAxy_primary_protons"), track.dcaXY());
+          }else{
+            if (mcParticle.getProcess() == kPDecay) {
+              histos.fill(HIST("DCAxy_secondary_protons"), track.dcaXY());
+            }
+            else{
+              histos.fill(HIST("DCAxy_material_protons"), track.dcaXY());
+            }
+          }
+        }
+
+      }
+
+      // TPC tracks
+      if (track.hasTOF()) {
+          nSigmaPi = track.tofNSigmaPi();
+          nSigmaKa = track.tofNSigmaKa();
+          nSigmaPr = track.tofNSigmaPr();
+
+        if (std::abs(nSigmaPi) < sigmaMax) {
+          if (std::abs(pion->Rapidity()) > yMax) {
+            continue;
+          }
+
+          if (mcParticle.isPhysicalPrimary()) {
+            histos.fill(HIST("ptReconstructedTOFPion"), pion->Pt());
+            if(!has_tpc) histos.fill(HIST("DCAxy_primary_pions"), track.dcaXY());
+          }else{
+            if(!has_tpc) histos.fill(HIST("DCAxy_secondary_pions"), track.dcaXY());
+          }
+        }
+        if (std::abs(nSigmaKa) < sigmaMax) {
+          if (std::abs(kaon->Rapidity()) > yMax) {
+            continue;
+          }
+
+          if (mcParticle.isPhysicalPrimary()) {
+            histos.fill(HIST("ptReconstructedTOFKaon"), kaon->Pt());
+            if(!has_tpc) histos.fill(HIST("DCAxy_primary_kaons"), track.dcaXY());
+          }else{
+            if(!has_tpc) histos.fill(HIST("DCAxy_secondary_kaons"), track.dcaXY());
+          }
+        }
+
+        if (std::abs(nSigmaPr) < sigmaMax) {
+          if (std::abs(proton->Rapidity()) > yMax) {
+            continue;
+          }
+
+          if (mcParticle.isPhysicalPrimary()) {
+            histos.fill(HIST("ptReconstructedTOFProton"), proton->Pt());
+            if(!has_tpc) histos.fill(HIST("DCAxy_primary_protons"), track.dcaXY());
+          }else{
+            if(!has_tpc) {
+              if (mcParticle.getProcess() == kPDecay) {
+                histos.fill(HIST("DCAxy_secondary_protons"), track.dcaXY());
+              }
+              else{
+                histos.fill(HIST("DCAxy_material_protons"), track.dcaXY());
+              }
+            }
+          }
+        }
+
+      }
+    }
+  }
+
+  void processData(CC const& collision, TCs const& tracks){
+
+    Partition<TCs> pvContributors = aod::udtrack::isPVContributor == true;
+    pvContributors.bindTable(tracks);
+
+    double dcaXyLimit = 0;
+
+    auto nSigmaPi = -999.;
+    auto nSigmaKa = -999.;
+    auto nSigmaPr = -999.;
+    auto nSigmaPiTOF = -999.;
+    auto nSigmaKaTOF = -999.;
+    auto nSigmaPrTOF = -999.;
+
+    LorentzVectorM *pion = new LorentzVectorM();
+    LorentzVectorM *kaon = new LorentzVectorM();
+    LorentzVectorM *proton = new LorentzVectorM();
+
+    for (const auto& track : tracks) {
+      if (!track.isPVContributor()) {
+        continue;
+      }
+
+      if (track.tpcNClsFindable() < nFindableMin) {
+        continue;
+      }
+
+      if (track.pt() < ptMin) {
+          continue;
+      }
+
+      if (!(std::abs(track.dcaZ()) < dcaZlimit)) {
+        continue;
+      }
+
+      dcaXyLimit = 0.0105 + 0.035 / std::pow(track.pt(), 1.1);
+      if (!(std::abs(track.dcaXY()) < dcaXyLimit)) {
+        continue;
+      }
+
+      pion->SetPx(track.px());
+      pion->SetPy(track.py());
+      pion->SetPz(track.pz());
+      pion->SetM(massPion);
+
+      kaon->SetPx(track.px());
+      kaon->SetPy(track.py());
+      kaon->SetPz(track.pz());
+      kaon->SetM(massKaon);
+
+      proton->SetPx(track.px());
+      proton->SetPy(track.py());
+      proton->SetPz(track.pz());
+      proton->SetM(massProton);
+
+      bool has_tpc = false;
+      // TPC tracks
+      if (track.hasTPC()) {
+          has_tpc = true;
+          nSigmaPi = track.tpcNSigmaPi();
+          nSigmaKa = track.tpcNSigmaKa();
+          nSigmaPr = track.tpcNSigmaPr();
+
+        if (std::abs(nSigmaPi) < sigmaMax) {
+          if (std::abs(pion->Rapidity()) > yMax) {
+            continue;
+          }
+          histos.fill(HIST("ptDataTPCPion"), pion->Pt());
+          histos.fill(HIST("DCAxy_data_pions"), track.dcaXY());
+        }
+
+        if (std::abs(nSigmaKa) < sigmaMax) {
+          if (std::abs(kaon->Rapidity()) > yMax) {
+            continue;
+          }
+          histos.fill(HIST("ptDataTPCKaon"), kaon->Pt());
+          histos.fill(HIST("DCAxy_data_kaons"), track.dcaXY());
+        }
+
+        if (std::abs(nSigmaPr) < sigmaMax) {
+          if (std::abs(proton->Rapidity()) > yMax) {
+            continue;
+          }
+          histos.fill(HIST("ptDataTPCProton"), proton->Pt());
+          histos.fill(HIST("DCAxy_data_protons"), track.dcaXY());
+        }
+
+      }
+
+      // TPC tracks
+      if (track.hasTOF()) {
+          nSigmaPi = track.tofNSigmaPi();
+          nSigmaKa = track.tofNSigmaKa();
+          nSigmaPr = track.tofNSigmaPr();
+
+        if (std::abs(nSigmaPi) < sigmaMax) {
+          if (std::abs(pion->Rapidity()) > yMax) {
+            continue;
+          }
+          histos.fill(HIST("ptDataTOFPion"), pion->Pt());
+          if(!has_tpc) histos.fill(HIST("DCAxy_data_pions"), track.dcaXY());
+        }
+        if (std::abs(nSigmaKa) < sigmaMax) {
+          if (std::abs(kaon->Rapidity()) > yMax) {
+            continue;
+          }
+          histos.fill(HIST("ptDataTOFKaon"), kaon->Pt());
+          if(!has_tpc) histos.fill(HIST("DCAxy_data_kaons"), track.dcaXY());
+        }
+
+        if (std::abs(nSigmaPr) < sigmaMax) {
+          if (std::abs(proton->Rapidity()) > yMax) {
+            continue;
+          }
+          histos.fill(HIST("ptDataTOFProton"), proton->Pt());
+          if(!has_tpc) histos.fill(HIST("DCAxy_data_protons"), track.dcaXY());
+        }
+
+      }
+    }
+  }
+
+
+  PROCESS_SWITCH(ptSpectraInclusiveUpc, processSim, "processSim", true);
+
+  PROCESS_SWITCH(ptSpectraInclusiveUpc, processReco, "processReco", true);
+
+  PROCESS_SWITCH(ptSpectraInclusiveUpc, processData, "processData", true);
+
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<ptSpectraInclusiveUpc>(cfgc)};
+}


### PR DESCRIPTION
Add task to produce pT spectra and DCA_xy distributions of pion, kaon and protons in inclusive photonuclear events.