### PR TITLE
[PWGDQ] Add globalBc to DQ MC data model for MC truth BC checks

### DIFF
--- a/PWGDQ/Core/VarManager.cxx
+++ b/PWGDQ/Core/VarManager.cxx
@@ -756,12 +756,8 @@ void VarManager::SetDefaultVarNames()
   fgVariableUnits[kMultMCNParticlesEta05] = "Multiplicity_eta05";
   fgVariableUnits[kMultMCNParticlesEta08] = "Multiplicity_eta08";
   fgVariableUnits[kMultMCNParticlesEta10] = "Multiplicity_eta10";
-  fgVariableNames[kMCIsNoTFBorder] = "MC Is not TF border";
-  fgVariableUnits[kMCIsNoTFBorder] = "";
   fgVariableNames[kMCIsNoTFBorderRecomputed] = "MC Is not TF border";
   fgVariableUnits[kMCIsNoTFBorderRecomputed] = "";
-  fgVariableNames[kMCIsNoITSROFBorder] = "MC Is not ITS ROF border";
-  fgVariableUnits[kMCIsNoITSROFBorder] = "";
   fgVariableNames[kMCIsNoITSROFBorderRecomputed] = "MC Is not ITS ROF border";
   fgVariableUnits[kMCIsNoITSROFBorderRecomputed] = "";
   fgVariableNames[kTwoEvPosZ1] = "vtx-z_{1}";
@@ -1927,6 +1923,8 @@ void VarManager::SetDefaultVarNames()
   fgVarNamesMap["kIsNoTFBorderRecomputed"] = kIsNoTFBorderRecomputed;
   fgVarNamesMap["kIsNoITSROFBorder"] = kIsNoITSROFBorder;
   fgVarNamesMap["kIsNoITSROFBorderRecomputed"] = kIsNoITSROFBorderRecomputed;
+  fgVarNamesMap["kMCIsNoTFBorderRecomputed"] = kMCIsNoTFBorderRecomputed;
+  fgVarNamesMap["kMCIsNoITSROFBorderRecomputed"] = kMCIsNoITSROFBorderRecomputed;
   fgVarNamesMap["kIsNoSameBunch"] = kIsNoSameBunch;
   fgVarNamesMap["kIsGoodZvtxFT0vsPV"] = kIsGoodZvtxFT0vsPV;
   fgVarNamesMap["kIsVertexITSTPC"] = kIsVertexITSTPC;

--- a/PWGDQ/Core/VarManager.cxx
+++ b/PWGDQ/Core/VarManager.cxx
@@ -60,6 +60,10 @@ int VarManager::fgITSROFbias = 0;
 int VarManager::fgITSROFlength = 100;
 int VarManager::fgITSROFBorderMarginLow = 0;
 int VarManager::fgITSROFBorderMarginHigh = 0;
+int64_t VarManager::fgBCSOR = -1;
+int64_t VarManager::fgNBCsPerTF = -1;
+int VarManager::fgTFBorderMarginLow = 300;
+int VarManager::fgTFBorderMarginHigh = 4000;
 uint64_t VarManager::fgSOR = 0;
 uint64_t VarManager::fgEOR = 0;
 ROOT::Math::PxPyPzEVector VarManager::fgBeamA(0, 0, 6799.99, 6800);  // GeV, beam from A-side 4-momentum vector
@@ -718,6 +722,14 @@ void VarManager::SetDefaultVarNames()
   fgVariableUnits[kMultDimuonsME] = "";
   fgVariableNames[kCentFT0C] = "Centrality FT0C";
   fgVariableUnits[kCentFT0C] = "%";
+  fgVariableNames[kIsNoTFBorder] = "Is not TF border";
+  fgVariableUnits[kIsNoTFBorder] = "";
+  fgVariableNames[kIsNoTFBorderRecomputed] = "Is not TF border";
+  fgVariableUnits[kIsNoTFBorderRecomputed] = "";
+  fgVariableNames[kIsNoITSROFBorder] = "Is not ITS ROF border";
+  fgVariableUnits[kIsNoITSROFBorder] = "";
+  fgVariableNames[kIsNoITSROFBorderRecomputed] = "Is not ITS ROF border";
+  fgVariableUnits[kIsNoITSROFBorderRecomputed] = "";
   fgVariableNames[kMCEventGeneratorId] = "MC Generator ID";
   fgVariableNames[kMCEventSubGeneratorId] = "MC SubGenerator ID";
   fgVariableNames[kMCVtxX] = "MC Vtx X";
@@ -1912,6 +1924,7 @@ void VarManager::SetDefaultVarNames()
   fgVarNamesMap["kIsPhysicsSelection"] = kIsPhysicsSelection;
   fgVarNamesMap["kIsTVXTriggered"] = kIsTVXTriggered;
   fgVarNamesMap["kIsNoTFBorder"] = kIsNoTFBorder;
+  fgVarNamesMap["kIsNoTFBorderRecomputed"] = kIsNoTFBorderRecomputed;
   fgVarNamesMap["kIsNoITSROFBorder"] = kIsNoITSROFBorder;
   fgVarNamesMap["kIsNoITSROFBorderRecomputed"] = kIsNoITSROFBorderRecomputed;
   fgVarNamesMap["kIsNoSameBunch"] = kIsNoSameBunch;

--- a/PWGDQ/Core/VarManager.cxx
+++ b/PWGDQ/Core/VarManager.cxx
@@ -744,6 +744,14 @@ void VarManager::SetDefaultVarNames()
   fgVariableUnits[kMultMCNParticlesEta05] = "Multiplicity_eta05";
   fgVariableUnits[kMultMCNParticlesEta08] = "Multiplicity_eta08";
   fgVariableUnits[kMultMCNParticlesEta10] = "Multiplicity_eta10";
+  fgVariableNames[kMCIsNoTFBorder] = "MC Is not TF border";
+  fgVariableUnits[kMCIsNoTFBorder] = "";
+  fgVariableNames[kMCIsNoTFBorderRecomputed] = "MC Is not TF border";
+  fgVariableUnits[kMCIsNoTFBorderRecomputed] = "";
+  fgVariableNames[kMCIsNoITSROFBorder] = "MC Is not ITS ROF border";
+  fgVariableUnits[kMCIsNoITSROFBorder] = "";
+  fgVariableNames[kMCIsNoITSROFBorderRecomputed] = "MC Is not ITS ROF border";
+  fgVariableUnits[kMCIsNoITSROFBorderRecomputed] = "";
   fgVariableNames[kTwoEvPosZ1] = "vtx-z_{1}";
   fgVariableUnits[kTwoEvPosZ1] = "cm";
   fgVariableNames[kTwoEvPosZ2] = "vtx-z_{2}";

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -342,6 +342,8 @@ class VarManager : public TObject
     kMultMCNParticlesEta10,
     kMultMCNParticlesEta08,
     kMultMCNParticlesEta05,
+    kMCIsNoITSROFBorderRecomputed,
+    kMCIsNoTFBorderRecomputed,
     kQ1ZNAX,
     kQ1ZNAY,
     kQ1ZNCX,
@@ -2384,6 +2386,14 @@ void VarManager::FillEvent(T const& event, float* values)
     values[kMultMCNParticlesEta05] = event.multMCNParticlesEta05();
     values[kMultMCNParticlesEta08] = event.multMCNParticlesEta08();
     values[kMultMCNParticlesEta10] = event.multMCNParticlesEta10();
+    if (fgUsedVars[kMCIsNoITSROFBorderRecomputed]) {
+      uint16_t bcInITSROF = (event.globalBC() + o2::constants::lhc::LHCMaxBunches - fgITSROFbias) % fgITSROFlength;
+      values[kMCIsNoITSROFBorderRecomputed] = bcInITSROF > fgITSROFBorderMarginLow && bcInITSROF < fgITSROFlength - fgITSROFBorderMarginHigh ? 1.0 : 0.0;
+    }
+    if (fgUsedVars[kMCIsNoTFBorderRecomputed]) {
+      int64_t bcInTF = (event.globalBC() - fgBCSOR) % fgNBCsPerTF;
+      values[kMCIsNoTFBorderRecomputed] = bcInTF > fgTFBorderMarginLow && bcInTF < fgNBCsPerTF - fgTFBorderMarginHigh ? 1.0 : 0.0;
+    }
   }
 
   if constexpr ((fillMap & EventFilter) > 0 || (fillMap & RapidityGapFilter) > 0) {

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -218,7 +218,8 @@ class VarManager : public TObject
     kCollisionRandom, // random number generated per collision (if required, can be used to perform random selections at the collision level)
     kIsPhysicsSelection,
     kIsTVXTriggered,             // Is trigger TVX
-    kIsNoTFBorder,               // No time frame border
+    kIsNoTFBorder,               // No time frame border (from event selection)
+    kIsNoTFBorderRecomputed,     // No time frame border, computed here
     kIsNoITSROFBorder,           // No ITS read out frame border (from event selection)
     kIsNoITSROFBorderRecomputed, // No ITS read out frame border, computed here
     kIsNoSameBunch,              // No collisions with same T0 BC
@@ -1506,6 +1507,14 @@ class VarManager : public TObject
     fgITSROFBorderMarginHigh = marginHigh;
   }
 
+  static void SetTFBorderselection(int64_t bcSOR, int64_t nBCsPerTF, int marginLow, int marginHigh)
+  {
+    fgBCSOR = bcSOR;
+    fgNBCsPerTF = nBCsPerTF;
+    fgTFBorderMarginLow = marginLow;
+    fgTFBorderMarginHigh = marginHigh;
+  }
+
   static void SetSORandEOR(uint64_t sor, uint64_t eor)
   {
     fgSOR = sor;
@@ -1535,6 +1544,10 @@ class VarManager : public TObject
   static int fgITSROFlength;                // ITS ROF length (from ALPIDE parameters)
   static int fgITSROFBorderMarginLow;       // ITS ROF border low margin
   static int fgITSROFBorderMarginHigh;      // ITS ROF border high margin
+  static int64_t fgBCSOR;                   // BC for start of run
+  static int64_t fgNBCsPerTF;               // duration of TF in bcs, should be 128*3564 or 32*3564 
+  static int fgTFBorderMarginLow;           // TF border low margin
+  static int fgTFBorderMarginHigh;          // TF border high margin
   static uint64_t fgSOR;                    // Timestamp for start of run
   static uint64_t fgEOR;                    // Timestamp for end of run
   static ROOT::Math::PxPyPzEVector fgBeamA; // beam from A-side 4-momentum vector
@@ -2118,7 +2131,7 @@ void VarManager::FillEvent(T const& event, float* values)
     values[kCentVZERO] = event.centRun2V0M();
     values[kCentFT0C] = event.centFT0C();
     if (fgUsedVars[kIsNoITSROFBorderRecomputed]) {
-      uint16_t bcInITSROF = (event.globalBC() + 3564 - fgITSROFbias) % fgITSROFlength;
+      uint16_t bcInITSROF = (event.globalBC() + o2::constants::lhc::LHCMaxBunches - fgITSROFbias) % fgITSROFlength;
       values[kIsNoITSROFBorderRecomputed] = bcInITSROF > fgITSROFBorderMarginLow && bcInITSROF < fgITSROFlength - fgITSROFBorderMarginHigh ? 1.0 : 0.0;
     }
     if (fgUsedVars[kIsNoITSROFBorder]) {
@@ -2126,6 +2139,10 @@ void VarManager::FillEvent(T const& event, float* values)
     }
     if (fgUsedVars[kIsTVXTriggered]) {
       values[kIsTVXTriggered] = (event.selection_bit(o2::aod::evsel::kIsTriggerTVX) > 0);
+    }
+    if (fgUsedVars[kIsNoTFBorderRecomputed]) {
+      int64_t bcInTF = (event.globalBC() - fgBCSOR) % fgNBCsPerTF;
+      values[kIsNoTFBorderRecomputed] = bcInTF > fgTFBorderMarginLow && bcInTF < fgNBCsPerTF - fgTFBorderMarginHigh ? 1.0 : 0.0;
     }
     if (fgUsedVars[kIsNoTFBorder]) {
       values[kIsNoTFBorder] = (event.selection_bit(o2::aod::evsel::kNoTimeFrameBorder) > 0);

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -1545,7 +1545,7 @@ class VarManager : public TObject
   static int fgITSROFBorderMarginLow;       // ITS ROF border low margin
   static int fgITSROFBorderMarginHigh;      // ITS ROF border high margin
   static int64_t fgBCSOR;                   // BC for start of run
-  static int64_t fgNBCsPerTF;               // duration of TF in bcs, should be 128*3564 or 32*3564 
+  static int64_t fgNBCsPerTF;               // duration of TF in bcs, should be 128*3564 or 32*3564
   static int fgTFBorderMarginLow;           // TF border low margin
   static int fgTFBorderMarginHigh;          // TF border high margin
   static uint64_t fgSOR;                    // Timestamp for start of run
@@ -2403,14 +2403,10 @@ void VarManager::FillEvent(T const& event, float* values)
     values[kMultMCNParticlesEta05] = event.multMCNParticlesEta05();
     values[kMultMCNParticlesEta08] = event.multMCNParticlesEta08();
     values[kMultMCNParticlesEta10] = event.multMCNParticlesEta10();
-    if (fgUsedVars[kMCIsNoITSROFBorderRecomputed]) {
-      uint16_t bcInITSROF = (event.globalBC() + o2::constants::lhc::LHCMaxBunches - fgITSROFbias) % fgITSROFlength;
-      values[kMCIsNoITSROFBorderRecomputed] = bcInITSROF > fgITSROFBorderMarginLow && bcInITSROF < fgITSROFlength - fgITSROFBorderMarginHigh ? 1.0 : 0.0;
-    }
-    if (fgUsedVars[kMCIsNoTFBorderRecomputed]) {
-      int64_t bcInTF = (event.globalBC() - fgBCSOR) % fgNBCsPerTF;
-      values[kMCIsNoTFBorderRecomputed] = bcInTF > fgTFBorderMarginLow && bcInTF < fgNBCsPerTF - fgTFBorderMarginHigh ? 1.0 : 0.0;
-    }
+    uint16_t bcInITSROF = (event.globalBC() + o2::constants::lhc::LHCMaxBunches - fgITSROFbias) % fgITSROFlength;
+    values[kMCIsNoITSROFBorderRecomputed] = bcInITSROF > fgITSROFBorderMarginLow && bcInITSROF < fgITSROFlength - fgITSROFBorderMarginHigh ? 1.0 : 0.0;
+    int64_t bcInTF = (event.globalBC() - fgBCSOR) % fgNBCsPerTF;
+    values[kMCIsNoTFBorderRecomputed] = bcInTF > fgTFBorderMarginLow && bcInTF < fgNBCsPerTF - fgTFBorderMarginHigh ? 1.0 : 0.0;
   }
 
   if constexpr ((fillMap & EventFilter) > 0 || (fillMap & RapidityGapFilter) > 0) {

--- a/PWGDQ/DataModel/ReducedInfoTables.h
+++ b/PWGDQ/DataModel/ReducedInfoTables.h
@@ -252,7 +252,14 @@ DECLARE_SOA_TABLE_VERSIONED(ReducedMCEvents_001, "AOD", "REDUCEDMCEVENT", 1, //!
                             mccollision::T, mccollision::Weight, mccollision::ImpactParameter, cent::CentFT0C,
                             mult::MultMCNParticlesEta05, mult::MultMCNParticlesEta08, mult::MultMCNParticlesEta10);
 
-using ReducedMCEvents = ReducedMCEvents_001;
+DECLARE_SOA_TABLE_VERSIONED(ReducedMCEvents_002, "AOD", "REDUCEDMCEVENT", 2, //!   Event level MC truth information
+                            o2::soa::Index<>,
+                            bc::GlobalBC,
+                            mccollision::GeneratorsID, reducedevent::MCPosX, reducedevent::MCPosY, reducedevent::MCPosZ,
+                            mccollision::T, mccollision::Weight, mccollision::ImpactParameter, cent::CentFT0C,
+                            mult::MultMCNParticlesEta05, mult::MultMCNParticlesEta08, mult::MultMCNParticlesEta10);
+
+using ReducedMCEvents = ReducedMCEvents_002;
 
 using ReducedEvent = ReducedEvents::iterator;
 using StoredReducedEvent = StoredReducedEvents::iterator;

--- a/PWGDQ/TableProducer/tableMakerMC.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC.cxx
@@ -474,7 +474,8 @@ struct TableMakerMC {
       eventInfo(collision.globalIndex());
       // make an entry for this MC event only if it was not already added to the table
       if (!(fEventLabels.find(mcCollision.globalIndex()) != fEventLabels.end())) {
-        eventMC(mcCollision.generatorsID(), mcCollision.posX(), mcCollision.posY(), mcCollision.posZ(),
+        auto mcBc = mcCollision.template bc_as<aod::BCsWithTimestamps>();
+        eventMC(mcBc.globalBC(), mcCollision.generatorsID(), mcCollision.posX(), mcCollision.posY(), mcCollision.posZ(),
                 mcCollision.t(), mcCollision.weight(), mcCollision.impactParameter(), 1, 1, 1, 1);
         fEventLabels[mcCollision.globalIndex()] = fCounters[1];
         fCounters[1]++;
@@ -1109,7 +1110,8 @@ struct TableMakerMC {
       eventInfo(collision.globalIndex());
       // make an entry for this MC event only if it was not already added to the table
       if (!(fEventLabels.find(mcCollision.globalIndex()) != fEventLabels.end())) {
-        eventMC(mcCollision.generatorsID(), mcCollision.posX(), mcCollision.posY(), mcCollision.posZ(),
+        auto mcBc = mcCollision.template bc_as<aod::BCsWithTimestamps>();
+        eventMC(mcBc.globalBC(), mcCollision.generatorsID(), mcCollision.posX(), mcCollision.posY(), mcCollision.posZ(),
                 mcCollision.t(), mcCollision.weight(), mcCollision.impactParameter(), 1, 1, 1, 1);
         fEventLabels[mcCollision.globalIndex()] = fCounters[1];
         fCounters[1]++;

--- a/PWGDQ/TableProducer/tableMakerMC_withAssoc.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC_withAssoc.cxx
@@ -526,7 +526,7 @@ struct TableMakerMC {
 
     // Loop over MC collisions
     for (auto& mcCollision : mcCollisions) {
-      auto bc = mcCollision.template bc_as<TBCs>();
+      auto bc = mcCollision.template bc_as<BCsWithTimestamps>();
       // Get MC collision information into the VarManager
       VarManager::FillEvent<gkEventMcFillMapWithCent>(mcCollision);
       // Fill histograms

--- a/PWGDQ/TableProducer/tableMakerMC_withAssoc.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC_withAssoc.cxx
@@ -526,12 +526,13 @@ struct TableMakerMC {
 
     // Loop over MC collisions
     for (auto& mcCollision : mcCollisions) {
+      auto bc = mcCollision.template bc_as<TBCs>();
       // Get MC collision information into the VarManager
       VarManager::FillEvent<gkEventMcFillMapWithCent>(mcCollision);
       // Fill histograms
       fHistMan->FillHistClass("Event_MCTruth", VarManager::fgValues);
       // Create the skimmed table entry for this collision
-      eventMC(mcCollision.generatorsID(), mcCollision.posX(), mcCollision.posY(), mcCollision.posZ(),
+      eventMC(bc.globalBC(), mcCollision.generatorsID(), mcCollision.posX(), mcCollision.posY(), mcCollision.posZ(),
               mcCollision.t(), mcCollision.weight(), mcCollision.impactParameter(), mcCollision.bestCollisionCentFT0C(),
               mcCollision.multMCNParticlesEta05(), mcCollision.multMCNParticlesEta08(), mcCollision.multMCNParticlesEta10());
     }

--- a/PWGDQ/Tasks/CMakeLists.txt
+++ b/PWGDQ/Tasks/CMakeLists.txt
@@ -144,6 +144,11 @@ o2physics_add_dpl_workflow(model-converter-mc-reduced-event
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::PWGDQCore
                     COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(model-converter-mc-reduced-event-002
+                    SOURCES ModelConverterReducedMCEventsV002.cxx
+                    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::PWGDQCore
+                    COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(tag-and-probe
                     SOURCES TagAndProbe.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2::DetectorsBase O2Physics::AnalysisCore O2Physics::AnalysisCCDB O2Physics::PWGDQCore

--- a/PWGDQ/Tasks/CMakeLists.txt
+++ b/PWGDQ/Tasks/CMakeLists.txt
@@ -145,7 +145,7 @@ o2physics_add_dpl_workflow(model-converter-mc-reduced-event
                     COMPONENT_NAME Analysis)
 
 o2physics_add_dpl_workflow(model-converter-mc-reduced-event-002
-                    SOURCES ModelConverterReducedMCEventsV002.cxx
+                    SOURCES ModelConverterReducedMCEvents002.cxx
                     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore O2Physics::PWGDQCore
                     COMPONENT_NAME Analysis)
 

--- a/PWGDQ/Tasks/ModelConverterReducedMCEvents002.cxx
+++ b/PWGDQ/Tasks/ModelConverterReducedMCEvents002.cxx
@@ -20,7 +20,6 @@
 #include <Framework/AnalysisHelpers.h>
 #include <Framework/AnalysisTask.h>
 #include <Framework/runDataProcessing.h>
-#include <sys/types.h>
 
 using namespace o2;
 using namespace o2::framework;

--- a/PWGDQ/Tasks/ModelConverterReducedMCEventsV002.cxx
+++ b/PWGDQ/Tasks/ModelConverterReducedMCEventsV002.cxx
@@ -1,0 +1,70 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+// Contact: iarsene@cern.ch, i.c.arsene@fys.uio.no
+//
+// Task used to convert the data model from the old format to the new format. To avoid
+// the conflict with the old data model.
+
+#include "PWGDQ/DataModel/ReducedInfoTables.h"
+
+#include <Framework/AnalysisDataModel.h>
+#include <Framework/AnalysisHelpers.h>
+#include <Framework/AnalysisTask.h>
+#include <Framework/runDataProcessing.h>
+#include <sys/types.h>
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using namespace o2::aod;
+
+struct reducedMCeventConverter002 {
+  Produces<aod::ReducedMCEvents_002> reducedMCevent_002;
+
+  void init(InitContext const&)
+  {
+    if (doprocessV000ToV002 == false && doprocessV001ToV002 == false) {
+      LOGF(fatal, "Neither processV000ToV002 nor processV001ToV002 is enabled. Please choose one!");
+    }
+    if (doprocessV000ToV002 == true && doprocessV001ToV002 == true) {
+      LOGF(fatal, "Both processV000ToV002 and processV001ToV002 are enabled. Please choose only one!");
+    }
+  }
+
+  void processV000ToV002(aod::ReducedMCEvents_000 const& events)
+  {
+    for (const auto& event : events) {
+      uint64_t globalBc = 0;
+      reducedMCevent_002(globalBc, event.generatorsID(), event.mcPosX(), event.mcPosY(), event.mcPosZ(),
+                         event.t(), event.weight(), event.impactParameter(),
+                         -1.0f, -1.0f, -1.0f, -1.0f);
+    }
+  }
+  PROCESS_SWITCH(reducedMCeventConverter002, processV000ToV002, "process v000-to-v002 conversion", false);
+
+  void processV001ToV002(aod::ReducedMCEvents_001 const& events)
+  {
+    for (const auto& event : events) {
+      uint64_t globalBc = 0;
+      reducedMCevent_002(globalBc, event.generatorsID(), event.mcPosX(), event.mcPosY(), event.mcPosZ(),
+                         event.t(), event.weight(), event.impactParameter(),
+                         event.centFT0C(), event.multMCNParticlesEta05(), event.multMCNParticlesEta08(), event.multMCNParticlesEta10());
+    }
+  }
+  PROCESS_SWITCH(reducedMCeventConverter002, processV001ToV002, "process v001-to-v002 conversion", true);
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<reducedMCeventConverter002>(cfgc)};
+}

--- a/PWGDQ/Tasks/dqEfficiency_withAssoc.cxx
+++ b/PWGDQ/Tasks/dqEfficiency_withAssoc.cxx
@@ -28,6 +28,8 @@
 
 #include <CCDB/BasicCCDBManager.h>
 #include <CCDB/CcdbApi.h>
+#include <DataFormatsITSMFT/DPLAlpideParam.h>
+#include <DataFormatsParameters/AggregatedRunInfo.h>
 #include <DataFormatsParameters/GRPMagField.h>
 #include <DetectorsBase/GeometryManager.h>
 #include <DetectorsBase/MatLayerCylSet.h>
@@ -297,6 +299,12 @@ struct AnalysisEventSelection {
   Configurable<std::string> fConfigAddEventMCHistogram{"cfgAddEventMCHistogram", "generator", "Comma separated list of histograms"};
   Configurable<std::string> fConfigAddJSONHistograms{"cfgAddJSONHistograms", "", "Add event histograms defined via JSON formatting (see HistogramsLibrary)"};
 
+  Configurable<int> fConfigITSROFrameStartBorderMargin{"cfgITSROFrameStartBorderMargin", -1, "Number of bcs at the start of ITS RO Frame border. Take from CCDB if -1"};
+  Configurable<int> fConfigITSROFrameEndBorderMargin{"cfgITSROFrameEndBorderMargin", -1, "Number of bcs at the end of ITS RO Frame border. Take from CCDB if -1"};
+  Configurable<int> fConfigTFStartBorderMargin{"cfgTFStartBorderMargin", -1, "Number of bcs at the start of TF border. Take from CCDB if -1"};
+  Configurable<int> fConfigTFEndBorderMargin{"cfgTFEndBorderMargin", -1, "Number of bcs at the end of TF border. Take from CCDB if -1"};
+  Configurable<int> fConfigNumberOfOrbitsPerTF{"cfgNumberOfOrbitsPerTF", -1, "Number of orbits per Time Frame. Take from CCDB if -1"};
+
   Configurable<float> fConfigSplitCollisionsDeltaZ{"splitCollisionsDeltaZ", 1.0, "maximum delta-z (cm) between two collisions to consider them as split candidates"};
   Configurable<unsigned int> fConfigSplitCollisionsDeltaBC{"splitCollisionsDeltaBC", 100, "maximum delta-BC between two collisions to consider them as split candidates; do not apply if value is negative"};
   Configurable<bool> fConfigCheckSplitCollisions{"checkSplitCollisions", false, "If true, run the split collision check and fill histograms"};
@@ -383,6 +391,21 @@ struct AnalysisEventSelection {
       uint64_t sor = std::atol(fHeader["SOR"].c_str());
       uint64_t eor = std::atol(fHeader["EOR"].c_str());
       VarManager::SetSORandEOR(sor, eor);
+
+      auto alppar = fCCDB->getForTimeStamp<o2::itsmft::DPLAlpideParam<0>>("ITS/Config/AlpideParam", events.begin().timestamp());
+      EventSelectionParams* par = fCCDB->getForTimeStamp<EventSelectionParams>("EventSelection/EventSelectionParams", events.begin().timestamp());
+      int itsROFrameStartBorderMargin = fConfigITSROFrameStartBorderMargin < 0 ? par->fITSROFrameStartBorderMargin : fConfigITSROFrameStartBorderMargin;
+      int itsROFrameEndBorderMargin = fConfigITSROFrameEndBorderMargin < 0 ? par->fITSROFrameEndBorderMargin : fConfigITSROFrameEndBorderMargin;
+      VarManager::SetITSROFBorderselection(alppar->roFrameBiasInBC, alppar->roFrameLengthInBC, itsROFrameStartBorderMargin, itsROFrameEndBorderMargin);
+
+      int timeFrameStartBorderMargin = fConfigTFStartBorderMargin < 0 ? par->fTimeFrameStartBorderMargin : fConfigTFStartBorderMargin;
+      int timeFrameEndBorderMargin = fConfigTFEndBorderMargin < 0 ? par->fTimeFrameEndBorderMargin : fConfigTFEndBorderMargin;
+      auto runInfo = o2::parameters::AggregatedRunInfo::buildAggregatedRunInfo(o2::ccdb::BasicCCDBManager::instance(), events.begin().runNumber());
+      int64_t bcSOR = runInfo.orbitSOR * o2::constants::lhc::LHCMaxBunches;
+      int64_t nBCsPerTF = fConfigNumberOfOrbitsPerTF < 0 ? runInfo.orbitsPerTF * o2::constants::lhc::LHCMaxBunches : fConfigNumberOfOrbitsPerTF * o2::constants::lhc::LHCMaxBunches;
+      VarManager::SetTFBorderselection(bcSOR, nBCsPerTF, timeFrameStartBorderMargin, timeFrameEndBorderMargin);
+
+      fCurrentRun = events.begin().runNumber();
     }
 
     fSelMap.clear();

--- a/PWGDQ/Tasks/dqEfficiency_withAssoc.cxx
+++ b/PWGDQ/Tasks/dqEfficiency_withAssoc.cxx
@@ -79,6 +79,8 @@ using namespace o2::framework::expressions;
 using namespace o2::aod;
 using namespace o2::common::core;
 
+o2::common::core::MetadataHelper metadataInfo;
+
 // Some definitions
 namespace o2::aod
 {
@@ -400,7 +402,7 @@ struct AnalysisEventSelection {
 
       int timeFrameStartBorderMargin = fConfigTFStartBorderMargin < 0 ? par->fTimeFrameStartBorderMargin : fConfigTFStartBorderMargin;
       int timeFrameEndBorderMargin = fConfigTFEndBorderMargin < 0 ? par->fTimeFrameEndBorderMargin : fConfigTFEndBorderMargin;
-      auto runInfo = o2::parameters::AggregatedRunInfo::buildAggregatedRunInfo(o2::ccdb::BasicCCDBManager::instance(), events.begin().runNumber());
+      auto runInfo = o2::parameters::AggregatedRunInfo::buildAggregatedRunInfo(o2::ccdb::BasicCCDBManager::instance(), events.begin().runNumber(), metadataInfo.get("LPMProductionTag"));
       int64_t bcSOR = runInfo.orbitSOR * o2::constants::lhc::LHCMaxBunches;
       int64_t nBCsPerTF = fConfigNumberOfOrbitsPerTF < 0 ? runInfo.orbitsPerTF * o2::constants::lhc::LHCMaxBunches : fConfigNumberOfOrbitsPerTF * o2::constants::lhc::LHCMaxBunches;
       VarManager::SetTFBorderselection(bcSOR, nBCsPerTF, timeFrameStartBorderMargin, timeFrameEndBorderMargin);
@@ -3187,6 +3189,13 @@ struct AnalysisAsymmetricPairing {
   std::vector<TString> fCommonCutNames;
   std::vector<TString> fRecMCSignalNames;
 
+  // Parameters for TF and ITSROF border checks to be fetched from the event selection task
+  int fITSROFrameStartBorderMargin;
+  int fITSROFrameEndBorderMargin;
+  int fTFStartBorderMargin;
+  int fTFEndBorderMargin;
+  int fNumberOfOrbitsPerTF;
+
   Filter eventFilter = aod::dqanalysisflags::isEventSelected > static_cast<uint32_t>(0);
 
   Preslice<soa::Join<aod::ReducedTracksAssoc, aod::BarrelTrackCuts>> trackAssocsPerCollision = aod::reducedtrack_association::reducedeventId;
@@ -3210,6 +3219,12 @@ struct AnalysisAsymmetricPairing {
     fHistMan = new HistogramManager("analysisHistos", "aa", VarManager::kNVars);
     fHistMan->SetUseDefaultVariableNames(kTRUE);
     fHistMan->SetDefaultVarNames(VarManager::fgVariableNames, VarManager::fgVariableUnits);
+
+    getTaskOptionValue<int>(context, "analysis-event-selection", "cfgITSROFrameStartBorderMargin", fITSROFrameStartBorderMargin, false);
+    getTaskOptionValue<int>(context, "analysis-event-selection", "cfgITSROFrameEndBorderMargin", fITSROFrameEndBorderMargin, false);
+    getTaskOptionValue<int>(context, "analysis-event-selection", "cfgTFStartBorderMargin", fTFStartBorderMargin, false);
+    getTaskOptionValue<int>(context, "analysis-event-selection", "cfgTFEndBorderMargin", fTFEndBorderMargin, false);
+    getTaskOptionValue<int>(context, "analysis-event-selection", "cfgNumberOfOrbitsPerTF", fNumberOfOrbitsPerTF, false);
 
     // Get the leg cut filter masks
     fLegAFilterMask = fConfigLegAFilterMask.value;
@@ -3592,6 +3607,24 @@ struct AnalysisAsymmetricPairing {
   template <bool TTwoProngFitter, int TPairType, uint32_t TEventFillMap, uint32_t TTrackFillMap, typename TEvents, typename TTrackAssocs, typename TTracks>
   void runAsymmetricPairing(TEvents const& events, Preslice<TTrackAssocs>& preslice, TTrackAssocs const& /*assocs*/, TTracks const& /*tracks*/, ReducedMCEvents const& /*mcEvents*/, ReducedMCTracks const& /*mcTracks*/)
   {
+    if (events.size() > 0 && events.begin().runNumber() != fCurrentRun) {
+      // Set the TF and ITSROF border configuration to the same values used in the event selection task
+      auto alppar = fCCDB->getForTimeStamp<o2::itsmft::DPLAlpideParam<0>>("ITS/Config/AlpideParam", events.begin().timestamp());
+      EventSelectionParams* par = fCCDB->getForTimeStamp<EventSelectionParams>("EventSelection/EventSelectionParams", events.begin().timestamp());
+      int itsROFrameStartBorderMargin = fITSROFrameStartBorderMargin < 0 ? par->fITSROFrameStartBorderMargin : fITSROFrameStartBorderMargin;
+      int itsROFrameEndBorderMargin = fITSROFrameEndBorderMargin < 0 ? par->fITSROFrameEndBorderMargin : fITSROFrameEndBorderMargin;
+      VarManager::SetITSROFBorderselection(alppar->roFrameBiasInBC, alppar->roFrameLengthInBC, itsROFrameStartBorderMargin, itsROFrameEndBorderMargin);
+
+      int timeFrameStartBorderMargin = fTFStartBorderMargin < 0 ? par->fTimeFrameStartBorderMargin : fTFStartBorderMargin;
+      int timeFrameEndBorderMargin = fTFEndBorderMargin < 0 ? par->fTimeFrameEndBorderMargin : fTFEndBorderMargin;
+      auto runInfo = o2::parameters::AggregatedRunInfo::buildAggregatedRunInfo(o2::ccdb::BasicCCDBManager::instance(), events.begin().runNumber(), metadataInfo.get("LPMProductionTag"));
+      int64_t bcSOR = runInfo.orbitSOR * o2::constants::lhc::LHCMaxBunches;
+      int64_t nBCsPerTF = fNumberOfOrbitsPerTF < 0 ? runInfo.orbitsPerTF * o2::constants::lhc::LHCMaxBunches : fNumberOfOrbitsPerTF * o2::constants::lhc::LHCMaxBunches;
+      VarManager::SetTFBorderselection(bcSOR, nBCsPerTF, timeFrameStartBorderMargin, timeFrameEndBorderMargin);
+
+      fCurrentRun = events.begin().runNumber();
+    }
+
     fPairCount.clear();
 
     if (events.size() > 0) { // Additional protection to avoid crashing of events.begin().runNumber()
@@ -5153,6 +5186,7 @@ struct AnalysisDileptonTrack {
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
+  metadataInfo.initMetadata(cfgc);
   return WorkflowSpec{
     adaptAnalysisTask<AnalysisEventSelection>(cfgc),
     adaptAnalysisTask<AnalysisTrackSelection>(cfgc),

--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -31,6 +31,7 @@
 #include <CCDB/CcdbApi.h>
 #include <CommonConstants/MathConstants.h>
 #include <DataFormatsITSMFT/DPLAlpideParam.h>
+#include <DataFormatsParameters/AggregatedRunInfo.h>
 #include <DataFormatsParameters/GRPLHCIFData.h>
 #include <DataFormatsParameters/GRPMagField.h>
 #include <DetectorsBase/GeometryManager.h>
@@ -314,6 +315,9 @@ struct AnalysisEventSelection {
 
   Configurable<int> fConfigITSROFrameStartBorderMargin{"cfgITSROFrameStartBorderMargin", -1, "Number of bcs at the start of ITS RO Frame border. Take from CCDB if -1"};
   Configurable<int> fConfigITSROFrameEndBorderMargin{"cfgITSROFrameEndBorderMargin", -1, "Number of bcs at the end of ITS RO Frame border. Take from CCDB if -1"};
+  Configurable<int> fConfigTFStartBorderMargin{"cfgTFStartBorderMargin", -1, "Number of bcs at the start of TF border. Take from CCDB if -1"};
+  Configurable<int> fConfigTFEndBorderMargin{"cfgTFEndBorderMargin", -1, "Number of bcs at the end of TF border. Take from CCDB if -1"};
+  Configurable<int> fConfigNumberOfOrbitsPerTF{"cfgNumberOfOrbitsPerTF", -1, "Number of orbits per Time Frame. Take from CCDB if -1"};
 
   Configurable<float> fConfigSplitCollisionsDeltaZ{"cfgSplitCollisionsDeltaZ", 1.0, "maximum delta-z (cm) between two collisions to consider them as split candidates"};
   Configurable<unsigned int> fConfigSplitCollisionsDeltaBC{"cfgSplitCollisionsDeltaBC", 100, "maximum delta-BC between two collisions to consider them as split candidates; do not apply if value is negative"};
@@ -424,6 +428,14 @@ struct AnalysisEventSelection {
       int itsROFrameStartBorderMargin = fConfigITSROFrameStartBorderMargin < 0 ? par->fITSROFrameStartBorderMargin : fConfigITSROFrameStartBorderMargin;
       int itsROFrameEndBorderMargin = fConfigITSROFrameEndBorderMargin < 0 ? par->fITSROFrameEndBorderMargin : fConfigITSROFrameEndBorderMargin;
       VarManager::SetITSROFBorderselection(alppar->roFrameBiasInBC, alppar->roFrameLengthInBC, itsROFrameStartBorderMargin, itsROFrameEndBorderMargin);
+
+      int timeFrameStartBorderMargin = fConfigTFStartBorderMargin < 0 ? par->fTimeFrameStartBorderMargin : fConfigTFStartBorderMargin;
+      int timeFrameEndBorderMargin = fConfigTFEndBorderMargin < 0 ? par->fTimeFrameEndBorderMargin : fConfigTFEndBorderMargin;
+      auto runInfo = o2::parameters::AggregatedRunInfo::buildAggregatedRunInfo(o2::ccdb::BasicCCDBManager::instance(), events.begin().runNumber());
+      int64_t bcSOR = runInfo.orbitSOR * o2::constants::lhc::LHCMaxBunches;
+      int64_t nBCsPerTF = fConfigNumberOfOrbitsPerTF < 0 ? runInfo.orbitsPerTF * o2::constants::lhc::LHCMaxBunches : fConfigNumberOfOrbitsPerTF * o2::constants::lhc::LHCMaxBunches;
+      VarManager::SetTFBorderselection(bcSOR, nBCsPerTF, timeFrameStartBorderMargin, timeFrameEndBorderMargin);
+
       fCurrentRun = events.begin().runNumber();
     }
 


### PR DESCRIPTION
- Add globalBc to reducedMcEvents, in order to calculate MC truth TF and ITSROF border checks
- New column is filled in tableMakerMc(_withAssoc), passing the globalBc from central data model McCollisions
- Add converter to fill 'globalBc' column with dummy 0
- Implement calculation of MC IsTFBorder and IsITSROFBorder variables in the VarManager
- New helper function to set TF border calculation configurables and metadata
- The TF border calculation ('recomputed') is also implemented for the real data case, akin to the existing ITSROFBorderRecomputed variable. The initialization of metadata and configurables are added to tableReader_withAssoc
- All TFBorder and ITSROFBorder variables given names and units in the VarManager 
- The asymmetric-pairing task in MC (used for the UPC D0 analysis) also gets access to the MC TFBorder and ITSROFBorder calculations, by fetching the configurables from analysis-event-selection

https://indico.cern.ch/event/1688270/#11-update-of-the-reducedmceven