### PR TITLE
[Tools] MlResponse: assure equality of number of checked features to that in the .onnx file

### DIFF
--- a/Tools/ML/MlResponse.h
+++ b/Tools/ML/MlResponse.h
@@ -151,8 +151,13 @@ class MlResponse
   void init(bool enableOptimizations = false, int threads = 0)
   {
     uint8_t counterModel{0};
+    const int numCachedIndices = static_cast<int>(mCachedIndices.size());
     for (const auto& path : mPaths) {
       mModels[counterModel].initModel(path, enableOptimizations, threads);
+      const int numInputNodes = mModels[counterModel].getNumInputNodes();
+      if (numInputNodes != numCachedIndices) {
+        LOG(fatal) << "Number of input nodes in the model " << path << " is different from the number of input features indices (" << numInputNodes << " vs " << numCachedIndices << ")";
+      }
       ++counterModel;
     }
   }

--- a/Tools/ML/MlResponse.h
+++ b/Tools/ML/MlResponse.h
@@ -157,6 +157,7 @@ class MlResponse
       const int numInputNodes = mModels[counterModel].getNumInputNodes();
       if (numInputNodes != numCachedIndices) {
         LOG(fatal) << "Number of input nodes in the model " << path << " is different from the number of input features indices (" << numInputNodes << " vs " << numCachedIndices << ")";
+        return;
       }
       ++counterModel;
     }


### PR DESCRIPTION
In the current implementation of the code, if the number of features to be checked ([`mCachedIndices`](https://github.com/AliceO2Group/O2Physics/blob/33bb1c03b51405a28a5e33db96cd81360deb7f14/Tools/ML/MlResponse.h#L280) size) is not equal to the number of features stored in the .onnx file (accessible by [`OnnxModel::getNumInputNodes()`](https://github.com/AliceO2Group/O2Physics/blob/33bb1c03b51405a28a5e33db96cd81360deb7f14/Tools/ML/model.h#L141)), then:
* if the former is less than the latter, the code crashes at the moment of model application in [`OnnxModel::evalModel()`](https://github.com/AliceO2Group/O2Physics/blob/33bb1c03b51405a28a5e33db96cd81360deb7f14/Tools/ML/model.h#L55) via handling an exception thrown deeper in the stack;
* if the former is greater than the latter, the code does not crash at all.

This PR proposes to check the mentioned sizes before model application, while model is initialized and throw a `fatal` error if the sizes are not equal.