### PR TITLE
[PWGHF] treeCreatorLcToPKPi: check the size of HfMlLcToPKPi

### DIFF
--- a/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
@@ -478,6 +478,21 @@ struct HfTreeCreatorLcToPKPi {
     }
   }
 
+  /// \brief function to check when applyMl == true if the HfMlLcToPKPi size is equal to that of the table with candidates
+  /// \param candidates Lc->pKpi candidate table
+  /// \param candidateMlScores ML scores table
+  template <typename CandType>
+  void checkHfMlLcToPKPiSize(CandType const& candidates, aod::HfMlLcToPKPi const& candidateMlScores)
+  {
+    if (applyMl) {
+      const auto candidatesSize = candidates.size();
+      const auto candidateMlScoresSize = candidateMlScores.size();
+      if (candidatesSize != candidateMlScoresSize) {
+        LOG(fatal) << "Tables with candidates and ML scores have different sizes (" << candidatesSize << " vs " << candidateMlScoresSize << ") while applyMl == true. Check if applyMl is enabled in the candidateSelectorLc";
+      }
+    }
+  }
+
   /// \brief function to fill event properties
   /// \param collisions Collision table
   template <bool UseCentrality, bool IsMc, typename Colls>
@@ -918,6 +933,7 @@ struct HfTreeCreatorLcToPKPi {
                     soa::Join<aod::McParticles, aod::HfCand3ProngMcGen> const& particles,
                     soa::Join<TracksWPid, o2::aod::McTrackLabels> const&, aod::BCs const&)
   {
+    checkHfMlLcToPKPiSize(candidates, candidateMlScores);
 
     constexpr bool IsMc = true;
 
@@ -1105,6 +1121,7 @@ struct HfTreeCreatorLcToPKPi {
                       aod::HfMlLcToPKPi const& candidateMlScores,
                       TracksWPid const&, aod::BCs const&)
   {
+    checkHfMlLcToPKPiSize(candidates, candidateMlScores);
 
     constexpr bool IsMc = false;
 


### PR DESCRIPTION
In the current implementation of the code if `applyMl` == **true** and the sizes of tables with candidates and the `aod::HfMlLcToPKPi ` are not equal (e.g. `applyMl` was not enabled in the `candidateSelectorLc`), the code crashes via segmentation error because of dereferencing the **nullptr**. (The reason why mentioned tables are not joined is discussed [here](https://github.com/AliceO2Group/O2Physics/pull/11489/files#diff-91a82c5ec6b79a5d6848f5b02dccbe397a73d99818d07f48f797c6c2b74d8ef8R1026)).

This PR adds a function which checks the mentioned sizes for equality and throws a `fatal` error in case of fail.