### PR TITLE
[PWGCF] FemtoUniverse: Add debug histogram with TPC momentum

### DIFF
--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackSpherHarMultKtExtended.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackSpherHarMultKtExtended.cxx
@@ -490,7 +490,7 @@ struct FemtoUniversePairTaskTrackTrackSpherHarMultKtExtended {
 
     trackHistoPartTwo.init(&qaRegistry, confTempFitVarpTBins, confTempFitVarBins, twotracksconfigs.confIsMC, tracktwofilter.confPDGCodePartTwo, true);
 
-    mixQaRegistry.add("MixingQA/hSECollisionBins", ";bin;Entries", kTH1F, {{120, 0, 119.5}});
+    mixQaRegistry.add("MixingQA/hSECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
     mixQaRegistry.add("MixingQA/hMECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
 
     if (twotracksconfigs.confIsDebug) {

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackSpherHarMultKtExtended.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackSpherHarMultKtExtended.cxx
@@ -166,6 +166,7 @@ struct FemtoUniversePairTaskTrackTrackSpherHarMultKtExtended {
 
     ConfigurableAxis confDeltaEtaAxis{"confDeltaEtaAxis", {100, -0.15, 0.15}, "DeltaEta"};
     ConfigurableAxis confDeltaPhiStarAxis{"confDeltaPhiStarAxis", {100, -0.15, 0.15}, "DeltaPhiStar"};
+    Configurable<bool> confIsDebug{"confIsDebug", true, "Fill additional histograms"};
   } twotracksconfigs;
 
   using FemtoFullParticles = soa::Join<aod::FDParticles, aod::FDExtParticles>;
@@ -489,8 +490,13 @@ struct FemtoUniversePairTaskTrackTrackSpherHarMultKtExtended {
 
     trackHistoPartTwo.init(&qaRegistry, confTempFitVarpTBins, confTempFitVarBins, twotracksconfigs.confIsMC, tracktwofilter.confPDGCodePartTwo, true);
 
-    mixQaRegistry.add("MixingQA/hSECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
+    mixQaRegistry.add("MixingQA/hSECollisionBins", ";bin;Entries", kTH1F, {{120, 0, 119.5}});
     mixQaRegistry.add("MixingQA/hMECollisionBins", ";bin;Entries", kTH1F, {{120, -0.5, 119.5}});
+
+    if (twotracksconfigs.confIsDebug) {
+      qaRegistry.add("Tracks_one/hPtpcVsP", ";p GeV/c; (p_{TPC}-p)/p", kTH2F, {{800, 0, 4}, {400, -1, 1}});
+      qaRegistry.add("Tracks_two/hPtpcVsP", ";p GeV/c; (p_{TPC}-p)/p", kTH2F, {{800, 0, 4}, {400, -1, 1}});
+    }
 
     mass1 = pdg->Mass(trackonefilter.confPDGCodePartOne);
     mass2 = pdg->Mass(tracktwofilter.confPDGCodePartTwo);
@@ -582,6 +588,9 @@ struct FemtoUniversePairTaskTrackTrackSpherHarMultKtExtended {
         }
         trackHistoPartOne.fillQA<isMC, true>(part);
         trackHistoPartOne.fillQAMisIden<isMC, true>(part, trackonefilter.confPDGCodePartOne);
+        if (twotracksconfigs.confIsDebug) {
+          qaRegistry.fill(HIST("Tracks_one/hPtpcVsP"), part.p(), (part.tpcInnerParam() - part.p()) / part.p());
+        }
       }
     }
 
@@ -591,6 +600,9 @@ struct FemtoUniversePairTaskTrackTrackSpherHarMultKtExtended {
           continue;
         }
         trackHistoPartTwo.fillQA<isMC, true>(part);
+        if (twotracksconfigs.confIsDebug) {
+          qaRegistry.fill(HIST("Tracks_two/hPtpcVsP"), part.p(), (part.tpcInnerParam() - part.p()) / part.p());
+        }
       }
     }
 


### PR DESCRIPTION
`PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackSpherHarMultKtExtended.cxx`:
Add a debug histogram _hPtpcVsP_ comparing TPC momentum and general momentum for both tracks. Those histograms are created and filled only when the _confIsDebug_ is set to true.