### PR TITLE
[Common,PWGCF] EventPlaneHelper: invoke geometry invariant helper once

### DIFF
--- a/Common/Core/EventPlaneHelper.cxx
+++ b/Common/Core/EventPlaneHelper.cxx
@@ -74,7 +74,6 @@ double EventPlaneHelper::GetPhiFT0(int chno, const o2::ft0::Geometry& ft0geom)
     offsetY = mOffsetFT0AY;
   }
 
-  ft0geom.calculateChannelCenter();
   auto chPos = ft0geom.getChannelCenter(chno);
 
   return TMath::ATan2(chPos.Y() + offsetY, chPos.X() + offsetX);

--- a/Common/Core/EventPlaneHelper.cxx
+++ b/Common/Core/EventPlaneHelper.cxx
@@ -61,7 +61,7 @@ double EventPlaneHelper::GetPhiFV0(int chno, o2::fv0::Geometry* fv0geom)
   return TMath::ATan2(chPos.y + offsetY, chPos.x + offsetX);
 }
 
-double EventPlaneHelper::GetPhiFT0(int chno, o2::ft0::Geometry ft0geom)
+double EventPlaneHelper::GetPhiFT0(int chno, const o2::ft0::Geometry& ft0geom)
 {
   /* Calculate the azimuthal angle in FT0 for the channel number 'chno'. The offset
     of FT0-A is taken into account if chno is between 0 and 95. */
@@ -76,12 +76,11 @@ double EventPlaneHelper::GetPhiFT0(int chno, o2::ft0::Geometry ft0geom)
 
   ft0geom.calculateChannelCenter();
   auto chPos = ft0geom.getChannelCenter(chno);
-  /// printf("Channel id: %d X: %.3f Y: %.3f\n", chno, chPos.X(), chPos.Y());
 
   return TMath::ATan2(chPos.Y() + offsetY, chPos.X() + offsetX);
 }
 
-void EventPlaneHelper::SumQvectors(int det, int chno, float ampl, int nmod, TComplex& Qvec, float& sum, o2::ft0::Geometry ft0geom, o2::fv0::Geometry* fv0geom)
+void EventPlaneHelper::SumQvectors(int det, int chno, float ampl, int nmod, TComplex& Qvec, float& sum, const o2::ft0::Geometry& ft0geom, o2::fv0::Geometry* fv0geom)
 {
   /* Calculate the complex Q-vector for the provided detector and channel number,
     before adding it to the total Q-vector given as argument. */

--- a/Common/Core/EventPlaneHelper.h
+++ b/Common/Core/EventPlaneHelper.h
@@ -60,12 +60,12 @@ class EventPlaneHelper
   }
 
   // Methods to calculate the azimuthal angles for each part of FIT, given the channel number.
-  double GetPhiFT0(int chno, o2::ft0::Geometry ft0geom);
+  double GetPhiFT0(int chno, const o2::ft0::Geometry& ft0geom);
   double GetPhiFV0(int chno, o2::fv0::Geometry* fv0geom);
 
   // Method to get the Q-vector and sum of amplitudes for any channel in FIT, given
   // the detector and amplitude.
-  void SumQvectors(int det, int chno, float ampl, int nmod, TComplex& Qvec, float& sum, o2::ft0::Geometry ft0geom, o2::fv0::Geometry* fv0geom);
+  void SumQvectors(int det, int chno, float ampl, int nmod, TComplex& Qvec, float& sum, const o2::ft0::Geometry& ft0geom, o2::fv0::Geometry* fv0geom);
 
   // Method to get the bin corresponding to a centrality percentile, according to the
   // centClasses[] array defined in Tasks/qVectorsQA.cxx.

--- a/Common/TableProducer/qVectorsTable.cxx
+++ b/Common/TableProducer/qVectorsTable.cxx
@@ -256,6 +256,7 @@ struct qVectorsTable {
     AxisSpec axisChID = {220, 0, 220};
 
     fv0geom = o2::fv0::Geometry::instance(o2::fv0::Geometry::eUninitialized);
+    ft0geom.calculateChannelCenter();
 
     histosQA.add("ChTracks", "", {HistType::kTHnSparseF, {axisPt, axisEta, axisPhi, axixCent}});
     histosQA.add("FT0Amp", "", {HistType::kTH2F, {axisFITamp, axisChID}});

--- a/PWGCF/JCorran/Tasks/jEPFlowAnalysis.cxx
+++ b/PWGCF/JCorran/Tasks/jEPFlowAnalysis.cxx
@@ -444,6 +444,7 @@ struct JEPFlowAnalysis {
     ccdb->setCreatedNotAfter(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
 
     fv0geom = o2::fv0::Geometry::instance(o2::fv0::Geometry::eUninitialized);
+    ft0geom.calculateChannelCenter();
 
     detId = getdetId(cfgDetName);
     refAId = getdetId(cfgRefAName);


### PR DESCRIPTION

calculateChannelCenter() was called inside
GetPhiFT0 on every channel, recomputing all 208 channel
positions from scratch each time despite the geometry being
constant.
