### PR TITLE
[PWGHF] Set cascade PDG codes in Xic0/Omegac0 candidate creator

### DIFF
--- a/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXic0Omegac0.cxx
@@ -832,7 +832,7 @@ struct HfCandidateCreatorXic0Omegac0 {
       KFParticle const kfNegKa(kfTrackBach, kKMinus);
       KFParticle const kfNegPiRej(kfTrackBach, kPiMinus); // rej
       KFParticle const kfPosPi(kfTrack0, kPiPlus);
-      KFParticle const kfNegPr(kfTrack1, kProton);
+      KFParticle const kfNegPr(kfTrack1, kProtonBar);
       KFParticle const kfPosKa(kfTrackBach, kKPlus);
       KFParticle const kfPosPiRej(kfTrackBach, kPiPlus); // rej
 
@@ -890,6 +890,8 @@ struct HfCandidateCreatorXic0Omegac0 {
       // construct cascade
       KFParticle kfOmega;
       KFParticle kfOmegarej; // rej
+      kfOmega.SetPDG(bachCharge < 0 ? kOmegaMinus : kOmegaPlusBar);
+      kfOmegarej.SetPDG(bachCharge < 0 ? kOmegaMinus : kOmegaPlusBar);
       kfOmega.SetConstructMethod(kfConstructMethod);
       kfOmegarej.SetConstructMethod(kfConstructMethod); // rej
       try {
@@ -1325,7 +1327,7 @@ struct HfCandidateCreatorXic0Omegac0 {
       KFParticle const kfNegPi(kfTrack1, kPiMinus);
       KFParticle const kfNegBachPi(kfTrackBach, kPiMinus);
       KFParticle const kfPosPi(kfTrack0, kPiPlus);
-      KFParticle const kfNegPr(kfTrack1, kProton);
+      KFParticle const kfNegPr(kfTrack1, kProtonBar);
       KFParticle const kfPosBachPi(kfTrackBach, kPiPlus);
 
       KFParticle kfBachPion;
@@ -1383,6 +1385,7 @@ struct HfCandidateCreatorXic0Omegac0 {
       const KFParticle* xiDaugthers[2] = {&kfBachPion, &kfV0};
       // construct cascade
       KFParticle kfXi;
+      kfXi.SetPDG(bachCharge < 0 ? kXiMinus : kXiPlusBar);
       kfXi.SetConstructMethod(kfConstructMethod);
       try {
         kfXi.Construct(xiDaugthers, 2);


### PR DESCRIPTION
This PR explicitly sets the PDG code of Xi and Omega in the Xic0/Omegac0 candidate creator. 
In addition, this PR fixes the anti-Lambda daughter assignment by using kProtonBar for the negative daughter in the charge-conjugate case.

@fcatalan92 @jinhyunni 