### PR TITLE
[PWGDQ] Add track-rotation option for dielectron pair filling

### DIFF
--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -64,7 +64,6 @@
 #include <TObject.h>
 #include <TRandom.h>
 #include <TString.h>
-
 #include <KFPTrack.h>
 #include <KFPVertex.h>
 #include <KFParticle.h>
@@ -1363,6 +1362,8 @@ class VarManager : public TObject
   static void FillGlobalMuonRefitCov(T1 const& muontrack, T2 const& mfttrack, const C& collision, C2 const& mftcov, float* values = nullptr);
   template <int pairType, uint32_t fillMap, typename T1, typename T2>
   static void FillPair(T1 const& t1, T2 const& t2, float* values = nullptr);
+  template <int pairType, uint32_t fillMap, typename T1, typename T2>        
+  static void FillPairRotation(T1 const& t1, T2 const& t2, float* values = nullptr);
   template <int pairType, uint32_t fillMap, typename C, typename T1, typename T2>
   static void FillPairCollision(C const& collision, T1 const& t1, T2 const& t2, float* values = nullptr);
   template <int pairType, uint32_t fillMap, typename C, typename T1, typename T2, typename M, typename P>
@@ -3710,6 +3711,69 @@ void VarManager::FillPair(T1 const& t1, T2 const& t2, float* values)
     values[kPairPhiv] = calculatePhiV<pairType>(t1, t2);
   }
 }
+
+//change_start: rotation pair
+template <int pairType, uint32_t fillMap, typename T1, typename T2>
+void VarManager::FillPairRotation(T1 const& t1, T2 const& t2, float* values)
+{
+  if (!values) {
+    values = fgValues;
+  }
+
+  float m1 = o2::constants::physics::MassElectron;
+  float m2 = o2::constants::physics::MassElectron;
+  if constexpr (pairType == kDecayToMuMu) {
+    m1 = o2::constants::physics::MassMuon;
+    m2 = o2::constants::physics::MassMuon;
+  }
+
+  if constexpr (pairType == kDecayToPiPi) {
+    m1 = o2::constants::physics::MassPionCharged;
+    m2 = o2::constants::physics::MassPionCharged;
+  }
+
+  if constexpr (pairType == kDecayToKPi) {
+    m1 = o2::constants::physics::MassKaonCharged;
+    m2 = o2::constants::physics::MassPionCharged;
+    // Make the TPC information of the kaon available for pair histograms
+    values[kPin_leg1] = t1.tpcInnerParam();
+    values[kTPCnSigmaKa_leg1] = t1.tpcNSigmaKa();
+  }
+
+  if constexpr (pairType == kElectronMuon) {
+    m2 = o2::constants::physics::MassMuon;
+  }
+
+  double dphi = gRandom->Uniform(0., 2. * TMath::Pi());
+  double rotationphi2 = t2.phi() + dphi;
+
+  if (rotationphi2 > 2. * TMath::Pi()) rotationphi2 -= 2. * TMath::Pi();
+
+  values[kCharge] = t1.sign() + t2.sign();
+  values[kCharge1] = t1.sign();
+  values[kCharge2] = t2.sign();
+  ROOT::Math::PtEtaPhiMVector v1(t1.pt(), t1.eta(), t1.phi(), m1);
+  ROOT::Math::PtEtaPhiMVector v2(t2.pt(), t2.eta(), rotationphi2, m2);
+  ROOT::Math::PtEtaPhiMVector v12 = v1 + v2;
+  values[kMass] = v12.M();
+  values[kPt] = v12.Pt();
+  values[kEta] = v12.Eta();
+  // values[kPhi] = v12.Phi();
+  values[kPhi] = v12.Phi() > 0 ? v12.Phi() : v12.Phi() + 2. * M_PI;
+  values[kRap] = -v12.Rapidity();
+  double Ptot1 = TMath::Sqrt(v1.Px() * v1.Px() + v1.Py() * v1.Py() + v1.Pz() * v1.Pz());
+  double Ptot2 = TMath::Sqrt(v2.Px() * v2.Px() + v2.Py() * v2.Py() + v2.Pz() * v2.Pz());
+  values[kDeltaPtotTracks] = Ptot1 - Ptot2;
+
+  values[kPt1] = t1.pt();
+  values[kEta1] = t1.eta();
+  values[kPhi1] = t1.phi();
+  values[kPt2] = t2.pt();
+  values[kEta2] = t2.eta();
+  values[kPhi2] = rotationphi2;
+
+}
+
 
 template <int pairType, uint32_t fillMap, typename C, typename T1, typename T2>
 void VarManager::FillPairCollision(const C& collision, T1 const& t1, T2 const& t2, float* values)

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -64,6 +64,7 @@
 #include <TObject.h>
 #include <TRandom.h>
 #include <TString.h>
+
 #include <KFPTrack.h>
 #include <KFPVertex.h>
 #include <KFParticle.h>
@@ -1362,7 +1363,7 @@ class VarManager : public TObject
   static void FillGlobalMuonRefitCov(T1 const& muontrack, T2 const& mfttrack, const C& collision, C2 const& mftcov, float* values = nullptr);
   template <int pairType, uint32_t fillMap, typename T1, typename T2>
   static void FillPair(T1 const& t1, T2 const& t2, float* values = nullptr);
-  template <int pairType, uint32_t fillMap, typename T1, typename T2>        
+  template <int pairType, uint32_t fillMap, typename T1, typename T2>
   static void FillPairRotation(T1 const& t1, T2 const& t2, float* values = nullptr);
   template <int pairType, uint32_t fillMap, typename C, typename T1, typename T2>
   static void FillPairCollision(C const& collision, T1 const& t1, T2 const& t2, float* values = nullptr);
@@ -3712,7 +3713,7 @@ void VarManager::FillPair(T1 const& t1, T2 const& t2, float* values)
   }
 }
 
-//change_start: rotation pair
+// change_start: rotation pair
 template <int pairType, uint32_t fillMap, typename T1, typename T2>
 void VarManager::FillPairRotation(T1 const& t1, T2 const& t2, float* values)
 {
@@ -3747,7 +3748,8 @@ void VarManager::FillPairRotation(T1 const& t1, T2 const& t2, float* values)
   double dphi = gRandom->Uniform(0., 2. * TMath::Pi());
   double rotationphi2 = t2.phi() + dphi;
 
-  if (rotationphi2 > 2. * TMath::Pi()) rotationphi2 -= 2. * TMath::Pi();
+  if (rotationphi2 > 2. * TMath::Pi())
+    rotationphi2 -= 2. * TMath::Pi();
 
   values[kCharge] = t1.sign() + t2.sign();
   values[kCharge1] = t1.sign();
@@ -3771,9 +3773,7 @@ void VarManager::FillPairRotation(T1 const& t1, T2 const& t2, float* values)
   values[kPt2] = t2.pt();
   values[kEta2] = t2.eta();
   values[kPhi2] = rotationphi2;
-
 }
-
 
 template <int pairType, uint32_t fillMap, typename C, typename T1, typename T2>
 void VarManager::FillPairCollision(const C& collision, T1 const& t1, T2 const& t2, float* values)

--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -1476,19 +1476,22 @@ struct AnalysisSameEventPairing {
               // change define histname
               Form("PairsBarrelSEPM_%s", objArray->At(icut)->GetName()),
               Form("PairsBarrelSEPP_%s", objArray->At(icut)->GetName()),
-              Form("PairsBarrelSEMM_%s", objArray->At(icut)->GetName()),
-              Form("PairsBarrelTRPM_%s", objArray->At(icut)->GetName())};
-            histNames += Form("%s;%s;%s;%s;", names[0].Data(), names[1].Data(), names[2].Data(), names[3].Data());
+              Form("PairsBarrelSEMM_%s", objArray->At(icut)->GetName())};
+            histNames += Form("%s;%s;%s;", names[0].Data(), names[1].Data(), names[2].Data());
             names.push_back(Form("PairsBarrelSEPM_ambiguousextra_%s", objArray->At(icut)->GetName()));
             names.push_back(Form("PairsBarrelSEPP_ambiguousextra_%s", objArray->At(icut)->GetName()));
             names.push_back(Form("PairsBarrelSEMM_ambiguousextra_%s", objArray->At(icut)->GetName()));
-            names.push_back(Form("PairsBarrelTRPM_ambiguousextra_%s", objArray->At(icut)->GetName()));
-            histNames += Form("%s;%s;%s;%s;", names[4].Data(), names[5].Data(), names[6].Data(), names[7].Data());
+            histNames += Form("%s;%s;%s;", names[3].Data(), names[4].Data(), names[5].Data());
+            if (fConfigTRPairs) {
+              names.push_back(Form("PairsBarrelTRPM_%s", objArray->At(icut)->GetName()));
+              names.push_back(Form("PairsBarrelTRPM_ambiguousextra_%s", objArray->At(icut)->GetName()));
+              histNames += Form("%s;%s;", names[6].Data(), names[7].Data());
+            }
             if (fEnableBarrelMixingHistos) {
               names.push_back(Form("PairsBarrelMEPM_%s", objArray->At(icut)->GetName()));
               names.push_back(Form("PairsBarrelMEPP_%s", objArray->At(icut)->GetName()));
               names.push_back(Form("PairsBarrelMEMM_%s", objArray->At(icut)->GetName()));
-              histNames += Form("%s;%s;%s;", names[8].Data(), names[9].Data(), names[10].Data());
+              histNames += Form("%s;%s;%s;", names[(fConfigTRPairs ? 8 : 6)].Data(), names[(fConfigTRPairs ? 9 : 7)].Data(), names[(fConfigTRPairs ? 10 : 8)].Data());
             }
             fTrackHistNames[icut] = names;
 

--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -1469,7 +1469,7 @@ struct AnalysisSameEventPairing {
 
           if (fEnableBarrelHistos) {
             names = {
-              //change define histname
+              // change define histname
               Form("PairsBarrelSEPM_%s", objArray->At(icut)->GetName()),
               Form("PairsBarrelSEPP_%s", objArray->At(icut)->GetName()),
               Form("PairsBarrelSEMM_%s", objArray->At(icut)->GetName()),
@@ -2131,8 +2131,8 @@ struct AnalysisSameEventPairing {
           }
         } // end loop (cuts)
 
-        //edit
-        //rotation 20 times
+        // edit
+        // rotation 20 times
         if constexpr (TPairType == VarManager::kDecayToEE) {
           twoTrackFilter = a1.isBarrelSelected_raw() & a2.isBarrelSelected_raw() & a1.isBarrelSelectedPrefilter_raw() & a2.isBarrelSelectedPrefilter_raw() & fTrackFilterMask;
 
@@ -2144,8 +2144,6 @@ struct AnalysisSameEventPairing {
           auto t2 = a2.template reducedtrack_as<TTracks>();
           sign1 = t1.sign();
           sign2 = t2.sign();
-          // store the ambiguity number of the two dilepton legs in the last 4 digits of the two-track filter
-          // TODO: Make sure that we do not work with more than 28 track bits
           if (t1.barrelAmbiguityInBunch() > 1) {
             twoTrackFilter |= (static_cast<uint32_t>(1) << 28);
           }
@@ -2158,43 +2156,43 @@ struct AnalysisSameEventPairing {
           if (t2.barrelAmbiguityOutOfBunch() > 1) {
             twoTrackFilter |= (static_cast<uint32_t>(1) << 31);
           }
-          
-        for (int icut = 0; icut < ncuts; icut++) {
-          if (twoTrackFilter & (static_cast<uint32_t>(1) << icut)) {
-            isAmbiInBunch = (twoTrackFilter & (static_cast<uint32_t>(1) << 28)) || (twoTrackFilter & (static_cast<uint32_t>(1) << 29));
-            isAmbiOutOfBunch = (twoTrackFilter & (static_cast<uint32_t>(1) << 30)) || (twoTrackFilter & (static_cast<uint32_t>(1) << 31));
-            isUnambiguous = !(isAmbiInBunch || isAmbiOutOfBunch);
-            isLeg1Ambi = (twoTrackFilter & (static_cast<uint32_t>(1) << 28) || (twoTrackFilter & (static_cast<uint32_t>(1) << 30)));
-            isLeg2Ambi = (twoTrackFilter & (static_cast<uint32_t>(1) << 29) || (twoTrackFilter & (static_cast<uint32_t>(1) << 31)));
-            if constexpr (TPairType == VarManager::kDecayToEE) {
-              if (isLeg1Ambi && isLeg2Ambi) {
-                std::pair<uint32_t, uint32_t> iPair(a1.reducedtrackId(), a2.reducedtrackId());
-                if (fAmbiguousPairs.find(iPair) != fAmbiguousPairs.end()) {
-                  if (fAmbiguousPairs[iPair] & (static_cast<uint32_t>(1) << icut)) { // if this pair is already stored with this cut
-                    isAmbiExtra = true;
+
+          for (int icut = 0; icut < ncuts; icut++) {
+            if (twoTrackFilter & (static_cast<uint32_t>(1) << icut)) {
+              isAmbiInBunch = (twoTrackFilter & (static_cast<uint32_t>(1) << 28)) || (twoTrackFilter & (static_cast<uint32_t>(1) << 29));
+              isAmbiOutOfBunch = (twoTrackFilter & (static_cast<uint32_t>(1) << 30)) || (twoTrackFilter & (static_cast<uint32_t>(1) << 31));
+              isUnambiguous = !(isAmbiInBunch || isAmbiOutOfBunch);
+              isLeg1Ambi = (twoTrackFilter & (static_cast<uint32_t>(1) << 28) || (twoTrackFilter & (static_cast<uint32_t>(1) << 30)));
+              isLeg2Ambi = (twoTrackFilter & (static_cast<uint32_t>(1) << 29) || (twoTrackFilter & (static_cast<uint32_t>(1) << 31)));
+              if constexpr (TPairType == VarManager::kDecayToEE) {
+                if (isLeg1Ambi && isLeg2Ambi) {
+                  std::pair<uint32_t, uint32_t> iPair(a1.reducedtrackId(), a2.reducedtrackId());
+                  if (fAmbiguousPairs.find(iPair) != fAmbiguousPairs.end()) {
+                    if (fAmbiguousPairs[iPair] & (static_cast<uint32_t>(1) << icut)) { // if this pair is already stored with this cut
+                      isAmbiExtra = true;
+                    } else {
+                      fAmbiguousPairs[iPair] |= static_cast<uint32_t>(1) << icut;
+                    }
                   } else {
-                    fAmbiguousPairs[iPair] |= static_cast<uint32_t>(1) << icut;
+                    fAmbiguousPairs[iPair] = static_cast<uint32_t>(1) << icut;
                   }
-                } else {
-                  fAmbiguousPairs[iPair] = static_cast<uint32_t>(1) << icut;
                 }
               }
-            }
-            if (sign1 * sign2 < 0) {
-              for (int i = 0; i < 20; i++) {
+              if (sign1 * sign2 < 0) {
+                for (int i = 0; i < 20; i++) {
                   VarManager::FillPairRotation<TPairType, TTrackFillMap>(t1, t2);
                   if constexpr (TPairType == VarManager::kDecayToEE) {
-                  fHistMan->FillHistClass(Form("PairsBarrelTRPM_%s", fTrackCuts[icut].Data()), VarManager::fgValues);
-                  if (isAmbiExtra) {
-                    fHistMan->FillHistClass(Form("PairsBarrelTRPM_ambiguousextra_%s", fTrackCuts[icut].Data()), VarManager::fgValues);
+                    fHistMan->FillHistClass(Form("PairsBarrelTRPM_%s", fTrackCuts[icut].Data()), VarManager::fgValues);
+                    if (isAmbiExtra) {
+                      fHistMan->FillHistClass(Form("PairsBarrelTRPM_ambiguousextra_%s", fTrackCuts[icut].Data()), VarManager::fgValues);
+                    }
                   }
                 }
               }
             }
           }
         }
-        }
-//end
+        // end
       } // end loop over pairs of track associations
       VarManager::fgValues[VarManager::kNPairsPerEvent] = fNPairPerEvent;
       if (fEnableBarrelHistos && fConfigQA) {

--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -1280,6 +1280,10 @@ struct AnalysisSameEventPairing {
   Configurable<std::string> fConfigAddJSONHistograms{"cfgAddJSONHistograms", "", "Histograms in JSON format"};
   Configurable<bool> fConfigQA{"cfgQA", true, "If true, fill output histograms"};
   Configurable<bool> fConfigAmbiguousMuonHistograms{"cfgAmbiguousMuonHistograms", true, "If true, fill ambiguous histograms"};
+  
+  //option for TR pair fill
+  Configurable<bool> fConfigTRPairs{"cfgFillTRPairs", false, "If true, fill Track rotation pairs"};
+  Configurable<int> fConfigNRotations{"cfgNRotations", 20, "Number of rotations for track rotation method"};
 
   struct : ConfigurableGroup {
     Configurable<std::string> url{"ccdb-url", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
@@ -2133,6 +2137,7 @@ struct AnalysisSameEventPairing {
 
         // edit
         // rotation 20 times
+      if (fConfigTRPairs) {
         if constexpr (TPairType == VarManager::kDecayToEE) {
           twoTrackFilter = a1.isBarrelSelected_raw() & a2.isBarrelSelected_raw() & a1.isBarrelSelectedPrefilter_raw() & a2.isBarrelSelectedPrefilter_raw() & fTrackFilterMask;
 
@@ -2179,7 +2184,7 @@ struct AnalysisSameEventPairing {
                 }
               }
               if (sign1 * sign2 < 0) {
-                for (int i = 0; i < 20; i++) {
+                for (int i = 0; i < fConfigNRotations.value; i++) {
                   VarManager::FillPairRotation<TPairType, TTrackFillMap>(t1, t2);
                   if constexpr (TPairType == VarManager::kDecayToEE) {
                     fHistMan->FillHistClass(Form("PairsBarrelTRPM_%s", fTrackCuts[icut].Data()), VarManager::fgValues);
@@ -2192,6 +2197,7 @@ struct AnalysisSameEventPairing {
             }
           }
         }
+      }
         // end
       } // end loop over pairs of track associations
       VarManager::fgValues[VarManager::kNPairsPerEvent] = fNPairPerEvent;

--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -1469,19 +1469,22 @@ struct AnalysisSameEventPairing {
 
           if (fEnableBarrelHistos) {
             names = {
+              //change define histname
               Form("PairsBarrelSEPM_%s", objArray->At(icut)->GetName()),
               Form("PairsBarrelSEPP_%s", objArray->At(icut)->GetName()),
-              Form("PairsBarrelSEMM_%s", objArray->At(icut)->GetName())};
-            histNames += Form("%s;%s;%s;", names[0].Data(), names[1].Data(), names[2].Data());
+              Form("PairsBarrelSEMM_%s", objArray->At(icut)->GetName()),
+              Form("PairsBarrelTRPM_%s", objArray->At(icut)->GetName())};
+            histNames += Form("%s;%s;%s;%s;", names[0].Data(), names[1].Data(), names[2].Data(), names[3].Data());
             names.push_back(Form("PairsBarrelSEPM_ambiguousextra_%s", objArray->At(icut)->GetName()));
             names.push_back(Form("PairsBarrelSEPP_ambiguousextra_%s", objArray->At(icut)->GetName()));
             names.push_back(Form("PairsBarrelSEMM_ambiguousextra_%s", objArray->At(icut)->GetName()));
-            histNames += Form("%s;%s;%s;", names[3].Data(), names[4].Data(), names[5].Data());
+            names.push_back(Form("PairsBarrelTRPM_ambiguousextra_%s", objArray->At(icut)->GetName()));
+            histNames += Form("%s;%s;%s;%s;", names[4].Data(), names[5].Data(), names[6].Data(), names[7].Data());
             if (fEnableBarrelMixingHistos) {
               names.push_back(Form("PairsBarrelMEPM_%s", objArray->At(icut)->GetName()));
               names.push_back(Form("PairsBarrelMEPP_%s", objArray->At(icut)->GetName()));
               names.push_back(Form("PairsBarrelMEMM_%s", objArray->At(icut)->GetName()));
-              histNames += Form("%s;%s;%s;", names[6].Data(), names[7].Data(), names[8].Data());
+              histNames += Form("%s;%s;%s;", names[8].Data(), names[9].Data(), names[10].Data());
             }
             fTrackHistNames[icut] = names;
 
@@ -2127,6 +2130,71 @@ struct AnalysisSameEventPairing {
             } // end loop (pair cuts)
           }
         } // end loop (cuts)
+
+        //edit
+        //rotation 20 times
+        if constexpr (TPairType == VarManager::kDecayToEE) {
+          twoTrackFilter = a1.isBarrelSelected_raw() & a2.isBarrelSelected_raw() & a1.isBarrelSelectedPrefilter_raw() & a2.isBarrelSelectedPrefilter_raw() & fTrackFilterMask;
+
+          if (!twoTrackFilter) { // the tracks must have at least one filter bit in common to continue
+            continue;
+          }
+
+          auto t1 = a1.template reducedtrack_as<TTracks>();
+          auto t2 = a2.template reducedtrack_as<TTracks>();
+          sign1 = t1.sign();
+          sign2 = t2.sign();
+          // store the ambiguity number of the two dilepton legs in the last 4 digits of the two-track filter
+          // TODO: Make sure that we do not work with more than 28 track bits
+          if (t1.barrelAmbiguityInBunch() > 1) {
+            twoTrackFilter |= (static_cast<uint32_t>(1) << 28);
+          }
+          if (t2.barrelAmbiguityInBunch() > 1) {
+            twoTrackFilter |= (static_cast<uint32_t>(1) << 29);
+          }
+          if (t1.barrelAmbiguityOutOfBunch() > 1) {
+            twoTrackFilter |= (static_cast<uint32_t>(1) << 30);
+          }
+          if (t2.barrelAmbiguityOutOfBunch() > 1) {
+            twoTrackFilter |= (static_cast<uint32_t>(1) << 31);
+          }
+          
+        for (int icut = 0; icut < ncuts; icut++) {
+          if (twoTrackFilter & (static_cast<uint32_t>(1) << icut)) {
+            isAmbiInBunch = (twoTrackFilter & (static_cast<uint32_t>(1) << 28)) || (twoTrackFilter & (static_cast<uint32_t>(1) << 29));
+            isAmbiOutOfBunch = (twoTrackFilter & (static_cast<uint32_t>(1) << 30)) || (twoTrackFilter & (static_cast<uint32_t>(1) << 31));
+            isUnambiguous = !(isAmbiInBunch || isAmbiOutOfBunch);
+            isLeg1Ambi = (twoTrackFilter & (static_cast<uint32_t>(1) << 28) || (twoTrackFilter & (static_cast<uint32_t>(1) << 30)));
+            isLeg2Ambi = (twoTrackFilter & (static_cast<uint32_t>(1) << 29) || (twoTrackFilter & (static_cast<uint32_t>(1) << 31)));
+            if constexpr (TPairType == VarManager::kDecayToEE) {
+              if (isLeg1Ambi && isLeg2Ambi) {
+                std::pair<uint32_t, uint32_t> iPair(a1.reducedtrackId(), a2.reducedtrackId());
+                if (fAmbiguousPairs.find(iPair) != fAmbiguousPairs.end()) {
+                  if (fAmbiguousPairs[iPair] & (static_cast<uint32_t>(1) << icut)) { // if this pair is already stored with this cut
+                    isAmbiExtra = true;
+                  } else {
+                    fAmbiguousPairs[iPair] |= static_cast<uint32_t>(1) << icut;
+                  }
+                } else {
+                  fAmbiguousPairs[iPair] = static_cast<uint32_t>(1) << icut;
+                }
+              }
+            }
+            if (sign1 * sign2 < 0) {
+              for (int i = 0; i < 20; i++) {
+                  VarManager::FillPairRotation<TPairType, TTrackFillMap>(t1, t2);
+                  if constexpr (TPairType == VarManager::kDecayToEE) {
+                  fHistMan->FillHistClass(Form("PairsBarrelTRPM_%s", fTrackCuts[icut].Data()), VarManager::fgValues);
+                  if (isAmbiExtra) {
+                    fHistMan->FillHistClass(Form("PairsBarrelTRPM_ambiguousextra_%s", fTrackCuts[icut].Data()), VarManager::fgValues);
+                  }
+                }
+              }
+            }
+          }
+        }
+        }
+//end
       } // end loop over pairs of track associations
       VarManager::fgValues[VarManager::kNPairsPerEvent] = fNPairPerEvent;
       if (fEnableBarrelHistos && fConfigQA) {

--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -1280,8 +1280,8 @@ struct AnalysisSameEventPairing {
   Configurable<std::string> fConfigAddJSONHistograms{"cfgAddJSONHistograms", "", "Histograms in JSON format"};
   Configurable<bool> fConfigQA{"cfgQA", true, "If true, fill output histograms"};
   Configurable<bool> fConfigAmbiguousMuonHistograms{"cfgAmbiguousMuonHistograms", true, "If true, fill ambiguous histograms"};
-  
-  //option for TR pair fill
+
+  // option for TR pair fill
   Configurable<bool> fConfigTRPairs{"cfgFillTRPairs", false, "If true, fill Track rotation pairs"};
   Configurable<int> fConfigNRotations{"cfgNRotations", 20, "Number of rotations for track rotation method"};
 
@@ -2137,59 +2137,60 @@ struct AnalysisSameEventPairing {
 
         // edit
         // rotation 20 times
-      if (fConfigTRPairs) {
-        if constexpr (TPairType == VarManager::kDecayToEE) {
-          twoTrackFilter = a1.isBarrelSelected_raw() & a2.isBarrelSelected_raw() & a1.isBarrelSelectedPrefilter_raw() & a2.isBarrelSelectedPrefilter_raw() & fTrackFilterMask;
+        if (fConfigTRPairs) {
+          if constexpr (TPairType == VarManager::kDecayToEE) {
+            twoTrackFilter = a1.isBarrelSelected_raw() & a2.isBarrelSelected_raw() & a1.isBarrelSelectedPrefilter_raw() & a2.isBarrelSelectedPrefilter_raw() & fTrackFilterMask;
 
-          if (!twoTrackFilter) { // the tracks must have at least one filter bit in common to continue
-            continue;
-          }
+            if (!twoTrackFilter) { // the tracks must have at least one filter bit in common to continue
+              continue;
+            }
 
-          auto t1 = a1.template reducedtrack_as<TTracks>();
-          auto t2 = a2.template reducedtrack_as<TTracks>();
-          sign1 = t1.sign();
-          sign2 = t2.sign();
-          if (t1.barrelAmbiguityInBunch() > 1) {
-            twoTrackFilter |= (static_cast<uint32_t>(1) << 28);
-          }
-          if (t2.barrelAmbiguityInBunch() > 1) {
-            twoTrackFilter |= (static_cast<uint32_t>(1) << 29);
-          }
-          if (t1.barrelAmbiguityOutOfBunch() > 1) {
-            twoTrackFilter |= (static_cast<uint32_t>(1) << 30);
-          }
-          if (t2.barrelAmbiguityOutOfBunch() > 1) {
-            twoTrackFilter |= (static_cast<uint32_t>(1) << 31);
-          }
+            auto t1 = a1.template reducedtrack_as<TTracks>();
+            auto t2 = a2.template reducedtrack_as<TTracks>();
+            sign1 = t1.sign();
+            sign2 = t2.sign();
+            if (t1.barrelAmbiguityInBunch() > 1) {
+              twoTrackFilter |= (static_cast<uint32_t>(1) << 28);
+            }
+            if (t2.barrelAmbiguityInBunch() > 1) {
+              twoTrackFilter |= (static_cast<uint32_t>(1) << 29);
+            }
+            if (t1.barrelAmbiguityOutOfBunch() > 1) {
+              twoTrackFilter |= (static_cast<uint32_t>(1) << 30);
+            }
+            if (t2.barrelAmbiguityOutOfBunch() > 1) {
+              twoTrackFilter |= (static_cast<uint32_t>(1) << 31);
+            }
 
-          for (int icut = 0; icut < ncuts; icut++) {
-            if (twoTrackFilter & (static_cast<uint32_t>(1) << icut)) {
-              isAmbiInBunch = (twoTrackFilter & (static_cast<uint32_t>(1) << 28)) || (twoTrackFilter & (static_cast<uint32_t>(1) << 29));
-              isAmbiOutOfBunch = (twoTrackFilter & (static_cast<uint32_t>(1) << 30)) || (twoTrackFilter & (static_cast<uint32_t>(1) << 31));
-              isUnambiguous = !(isAmbiInBunch || isAmbiOutOfBunch);
-              isLeg1Ambi = (twoTrackFilter & (static_cast<uint32_t>(1) << 28) || (twoTrackFilter & (static_cast<uint32_t>(1) << 30)));
-              isLeg2Ambi = (twoTrackFilter & (static_cast<uint32_t>(1) << 29) || (twoTrackFilter & (static_cast<uint32_t>(1) << 31)));
-              if constexpr (TPairType == VarManager::kDecayToEE) {
-                if (isLeg1Ambi && isLeg2Ambi) {
-                  std::pair<uint32_t, uint32_t> iPair(a1.reducedtrackId(), a2.reducedtrackId());
-                  if (fAmbiguousPairs.find(iPair) != fAmbiguousPairs.end()) {
-                    if (fAmbiguousPairs[iPair] & (static_cast<uint32_t>(1) << icut)) { // if this pair is already stored with this cut
-                      isAmbiExtra = true;
+            for (int icut = 0; icut < ncuts; icut++) {
+              if (twoTrackFilter & (static_cast<uint32_t>(1) << icut)) {
+                isAmbiInBunch = (twoTrackFilter & (static_cast<uint32_t>(1) << 28)) || (twoTrackFilter & (static_cast<uint32_t>(1) << 29));
+                isAmbiOutOfBunch = (twoTrackFilter & (static_cast<uint32_t>(1) << 30)) || (twoTrackFilter & (static_cast<uint32_t>(1) << 31));
+                isUnambiguous = !(isAmbiInBunch || isAmbiOutOfBunch);
+                isLeg1Ambi = (twoTrackFilter & (static_cast<uint32_t>(1) << 28) || (twoTrackFilter & (static_cast<uint32_t>(1) << 30)));
+                isLeg2Ambi = (twoTrackFilter & (static_cast<uint32_t>(1) << 29) || (twoTrackFilter & (static_cast<uint32_t>(1) << 31)));
+                if constexpr (TPairType == VarManager::kDecayToEE) {
+                  if (isLeg1Ambi && isLeg2Ambi) {
+                    std::pair<uint32_t, uint32_t> iPair(a1.reducedtrackId(), a2.reducedtrackId());
+                    if (fAmbiguousPairs.find(iPair) != fAmbiguousPairs.end()) {
+                      if (fAmbiguousPairs[iPair] & (static_cast<uint32_t>(1) << icut)) { // if this pair is already stored with this cut
+                        isAmbiExtra = true;
+                      } else {
+                        fAmbiguousPairs[iPair] |= static_cast<uint32_t>(1) << icut;
+                      }
                     } else {
-                      fAmbiguousPairs[iPair] |= static_cast<uint32_t>(1) << icut;
+                      fAmbiguousPairs[iPair] = static_cast<uint32_t>(1) << icut;
                     }
-                  } else {
-                    fAmbiguousPairs[iPair] = static_cast<uint32_t>(1) << icut;
                   }
                 }
-              }
-              if (sign1 * sign2 < 0) {
-                for (int i = 0; i < fConfigNRotations.value; i++) {
-                  VarManager::FillPairRotation<TPairType, TTrackFillMap>(t1, t2);
-                  if constexpr (TPairType == VarManager::kDecayToEE) {
-                    fHistMan->FillHistClass(Form("PairsBarrelTRPM_%s", fTrackCuts[icut].Data()), VarManager::fgValues);
-                    if (isAmbiExtra) {
-                      fHistMan->FillHistClass(Form("PairsBarrelTRPM_ambiguousextra_%s", fTrackCuts[icut].Data()), VarManager::fgValues);
+                if (sign1 * sign2 < 0) {
+                  for (int i = 0; i < fConfigNRotations.value; i++) {
+                    VarManager::FillPairRotation<TPairType, TTrackFillMap>(t1, t2);
+                    if constexpr (TPairType == VarManager::kDecayToEE) {
+                      fHistMan->FillHistClass(Form("PairsBarrelTRPM_%s", fTrackCuts[icut].Data()), VarManager::fgValues);
+                      if (isAmbiExtra) {
+                        fHistMan->FillHistClass(Form("PairsBarrelTRPM_ambiguousextra_%s", fTrackCuts[icut].Data()), VarManager::fgValues);
+                      }
                     }
                   }
                 }
@@ -2197,7 +2198,6 @@ struct AnalysisSameEventPairing {
             }
           }
         }
-      }
         // end
       } // end loop over pairs of track associations
       VarManager::fgValues[VarManager::kNPairsPerEvent] = fNPairPerEvent;


### PR DESCRIPTION
This PR adds a track-rotation method to fill electron pairs in PWGDQ.No changes are made to the existing pair-filling workflow