### PR TITLE
[PWGHF] feat(taskLcToK0sP): add THnSparse with ML scores, align with taskLc patterns

### DIFF
--- a/PWGHF/D2H/Tasks/taskLcToK0sP.cxx
+++ b/PWGHF/D2H/Tasks/taskLcToK0sP.cxx
@@ -18,9 +18,9 @@
 ///
 /// \note based on taskD0.cxx, taskLc.cxx
 
+#include "PWGHF/Core/CentralityEstimation.h"
 #include "PWGHF/Core/HfHelper.h"
 #include "PWGHF/Core/SelectorCuts.h"
-#include "PWGHF/Core/CentralityEstimation.h"
 #include "PWGHF/DataModel/AliasTables.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
@@ -37,12 +37,12 @@
 #include <Framework/InitContext.h>
 #include <Framework/runDataProcessing.h>
 
-#include <cstdlib>
-#include <vector>
-#include <string>
-#include <numeric>
-
 #include <THnSparse.h>
+
+#include <cstdlib>
+#include <numeric>
+#include <string>
+#include <vector>
 
 using namespace o2;
 using namespace o2::analysis;
@@ -258,19 +258,19 @@ struct HfTaskLcToK0sP {
       // Data with ML: {mass, pt, centrality, bkg, prompt, non-prompt, numPvContr}
       if (doprocessDataWithMl || doprocessDataWithMlWithFT0C || doprocessDataWithMlWithFT0M) {
         registry.add("hnLcK0sPDataWithBdt", "THn for Lc->K0sP data with BDT", HistType::kTHnSparseF,
-          {thnAxisMass, thnAxisPt, thnAxisCentrality, thnAxisBdtScoreBkg, thnAxisBdtScorePrompt, thnAxisBdtScoreNonPrompt, thnAxisNumPvContr});
+                     {thnAxisMass, thnAxisPt, thnAxisCentrality, thnAxisBdtScoreBkg, thnAxisBdtScorePrompt, thnAxisBdtScoreNonPrompt, thnAxisNumPvContr});
       }
 
       // MC Rec with ML: {mass, pt, centrality, bkg, prompt, non-prompt, numPvContr, origin}
       if (doprocessMcWithMl || doprocessMcWithMlWithFT0C || doprocessMcWithMlWithFT0M) {
         registry.add("hnLcK0sPRecMcWithBdt", "THn for Lc->K0sP MC rec with BDT", HistType::kTHnSparseF,
-          {thnAxisMass, thnAxisPt, thnAxisCentrality, thnAxisBdtScoreBkg, thnAxisBdtScorePrompt, thnAxisBdtScoreNonPrompt, thnAxisNumPvContr, thnAxisOrigin});
+                     {thnAxisMass, thnAxisPt, thnAxisCentrality, thnAxisBdtScoreBkg, thnAxisBdtScorePrompt, thnAxisBdtScoreNonPrompt, thnAxisNumPvContr, thnAxisOrigin});
       }
 
       // MC Gen: {pt, centrality, rapidity, numPvContr, ptB, origin}
       if (doprocessMcWithMl || doprocessMcWithMlWithFT0C || doprocessMcWithMlWithFT0M) {
         registry.add("hnLcK0sPGenMc", "THn for Lc->K0sP MC gen", HistType::kTHnSparseF,
-          {thnAxisPt, thnAxisCentrality, thnAxisY, thnAxisNumPvContr, thnAxisPtB, thnAxisOrigin});
+                     {thnAxisPt, thnAxisCentrality, thnAxisY, thnAxisNumPvContr, thnAxisPtB, thnAxisOrigin});
       }
     }
   }
@@ -518,18 +518,18 @@ struct HfTaskLcToK0sP {
   }
 
   void processDataStd(Collisions const& collisions,
-              FilteredCandLcToPK0SWSelFlag const& candidates,
-              TracksWPid const&)
+                      FilteredCandLcToPK0SWSelFlag const& candidates,
+                      TracksWPid const&)
   {
     runAnalysisPerCollisionData<false>(collisions, candidates);
   }
   PROCESS_SWITCH(HfTaskLcToK0sP, processDataStd, "Process Data", false);
 
   void processMcStd(CollisionsMc const& collisions,
-                 FilteredCandLcToPK0SWSelFlagAndMc const& candidates,
-                 soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& mcParticles,
-                 aod::TracksWMc const&,
-                 TracksWPid const&)
+                    FilteredCandLcToPK0SWSelFlagAndMc const& candidates,
+                    soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& mcParticles,
+                    aod::TracksWMc const&,
+                    TracksWPid const&)
   {
     runAnalysisPerCollisionMc<false>(collisions, candidates, mcParticles);
   }
@@ -537,8 +537,8 @@ struct HfTaskLcToK0sP {
 
   // Data with ML
   void processDataWithMl(Collisions const& collisions,
-                        FilteredCandLcToPK0SWSelFlagAndMl const& candidates,
-                        TracksWPid const&)
+                         FilteredCandLcToPK0SWSelFlagAndMl const& candidates,
+                         TracksWPid const&)
   {
     runAnalysisPerCollisionData<true>(collisions, candidates);
   }
@@ -546,10 +546,10 @@ struct HfTaskLcToK0sP {
 
   // MC Rec and Gen with ML
   void processMcWithMl(CollisionsMc const& collisions,
-                          FilteredCandLcToPK0SWSelFlagAndMcAndMl const& candidates,
-                          soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& mcParticles,
-                          aod::TracksWMc const&,
-                          TracksWPid const&)
+                       FilteredCandLcToPK0SWSelFlagAndMcAndMl const& candidates,
+                       soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& mcParticles,
+                       aod::TracksWMc const&,
+                       TracksWPid const&)
   {
     runAnalysisPerCollisionMc<true>(collisions, candidates, mcParticles);
   }
@@ -604,10 +604,10 @@ struct HfTaskLcToK0sP {
 
   // MC Std with FT0M centrality
   void processMcStdWithFT0M(CollisionsMcWithFT0M const& collisions,
-                             FilteredCandLcToPK0SWSelFlagAndMc const& candidates,
-                             soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& mcParticles,
-                             aod::TracksWMc const&,
-                             TracksWPid const&)
+                            FilteredCandLcToPK0SWSelFlagAndMc const& candidates,
+                            soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& mcParticles,
+                            aod::TracksWMc const&,
+                            TracksWPid const&)
   {
     runAnalysisPerCollisionMc<false>(collisions, candidates, mcParticles);
   }
@@ -615,10 +615,10 @@ struct HfTaskLcToK0sP {
 
   // MC with ML + FT0C centrality
   void processMcWithMlWithFT0C(CollisionsMcWithFT0C const& collisions,
-                                FilteredCandLcToPK0SWSelFlagAndMcAndMl const& candidates,
-                                soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& mcParticles,
-                                aod::TracksWMc const&,
-                                TracksWPid const&)
+                               FilteredCandLcToPK0SWSelFlagAndMcAndMl const& candidates,
+                               soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& mcParticles,
+                               aod::TracksWMc const&,
+                               TracksWPid const&)
   {
     runAnalysisPerCollisionMc<true>(collisions, candidates, mcParticles);
   }

--- a/PWGHF/D2H/Tasks/taskLcToK0sP.cxx
+++ b/PWGHF/D2H/Tasks/taskLcToK0sP.cxx
@@ -14,11 +14,13 @@
 ///
 /// \author Chiara Zampolli, <Chiara.Zampolli@cern.ch>, CERN
 ///         Paul Buehler, <paul.buehler@oeaw.ac.at>, Vienna
+///         Xufei Xue, <xufei.xue@cern.ch>, CUG
 ///
 /// \note based on taskD0.cxx, taskLc.cxx
 
 #include "PWGHF/Core/HfHelper.h"
 #include "PWGHF/Core/SelectorCuts.h"
+#include "PWGHF/Core/CentralityEstimation.h"
 #include "PWGHF/DataModel/AliasTables.h"
 #include "PWGHF/DataModel/CandidateReconstructionTables.h"
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
@@ -37,29 +39,83 @@
 
 #include <cstdlib>
 #include <vector>
+#include <string>
+#include <numeric>
+
+#include <THnSparse.h>
 
 using namespace o2;
 using namespace o2::analysis;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
+using namespace o2::hf_centrality;
 
 /// LcToK0sp analysis task
 struct HfTaskLcToK0sP {
+  Configurable<bool> fillTHn{"fillTHn", true, "fill THnSparse"};
   Configurable<int> selectionFlagLcToK0sP{"selectionFlagLcToK0sP", 1, "Selection Flag for Lc"};
-  Configurable<int> selectionFlagLcbarToK0sP{"selectionFlagLcbarToK0sP", 1, "Selection Flag for Lcbar"};
   Configurable<double> etaCandMax{"etaCandMax", -1., "max. cand. pseudorapidity"};
   Configurable<double> yCandGenMax{"yCandGenMax", 0.5, "max. gen particle rapidity"};
   Configurable<double> yCandRecoMax{"yCandRecoMax", 0.8, "max. cand. rapidity"};
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_lc_to_k0s_p::vecBinsPt}, "pT bin limits"};
 
+  SliceCache cache;
+
+  using FilteredCandLcToPK0SWSelFlag = soa::Filtered<soa::Join<aod::HfCandCascade, aod::HfSelLcToK0sP>>;
+  using FilteredCandLcToPK0SWSelFlagAndMl = soa::Filtered<soa::Join<aod::HfCandCascade, aod::HfSelLcToK0sP, aod::HfMlLcToK0sP>>;
+  using FilteredCandLcToPK0SWSelFlagAndMc = soa::Filtered<soa::Join<aod::HfCandCascade, aod::HfSelLcToK0sP, aod::HfCandCascadeMcRec>>;
+  using FilteredCandLcToPK0SWSelFlagAndMcAndMl = soa::Filtered<soa::Join<aod::HfCandCascade, aod::HfSelLcToK0sP, aod::HfCandCascadeMcRec, aod::HfMlLcToK0sP>>;
+
   using TracksWPid = soa::Join<aod::TracksWExtra, aod::TracksPidPr>;
 
-  Filter filterSelectCandidates = (aod::hf_sel_candidate_lc_to_k0s_p::isSelLcToK0sP >= selectionFlagLcToK0sP || aod::hf_sel_candidate_lc_to_k0s_p::isSelLcToK0sP >= selectionFlagLcbarToK0sP);
+  using Collisions = soa::Join<aod::Collisions, aod::EvSels>;
+  using CollisionsMc = soa::Join<aod::Collisions, aod::McCollisionLabels, aod::EvSels>;
+  using CollisionsWithFT0C = soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Cs>;
+  using CollisionsMcWithFT0C = soa::Join<aod::Collisions, aod::McCollisionLabels, aod::EvSels, aod::CentFT0Cs>;
+  using CollisionsWithFT0M = soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Ms>;
+  using CollisionsMcWithFT0M = soa::Join<aod::Collisions, aod::McCollisionLabels, aod::EvSels, aod::CentFT0Ms>;
+
+  Filter filterSelectCandidates = aod::hf_sel_candidate_lc_to_k0s_p::isSelLcToK0sP >= selectionFlagLcToK0sP;
+
+  Preslice<aod::HfCandCascade> lcToPK0SPerCollision = aod::hf_cand::collisionId;
+  PresliceUnsorted<aod::McCollisionLabels> colPerMcCollision = aod::mcparticle::mcCollisionId;
+
+  // THnSparse configurable axes
+  ConfigurableAxis thnConfigAxisMass{"thnConfigAxisMass", {300, 2.0, 2.6}, ""};
+  ConfigurableAxis thnConfigAxisPt{"thnConfigAxisPt", {360, 0., 36.}, ""};
+  ConfigurableAxis thnConfigAxisBdtScoreBkg{"thnConfigAxisBdtScoreBkg", {100, 0., 1.}, ""};
+  ConfigurableAxis thnConfigAxisBdtScorePrompt{"thnConfigAxisBdtScorePrompt", {100, 0., 1.}, ""};
+  ConfigurableAxis thnConfigAxisBdtScoreNonPrompt{"thnConfigAxisBdtScoreNonPrompt", {100, 0., 1.}, ""};
+  ConfigurableAxis thnConfigAxisPtB{"thnConfigAxisPtB", {3000, 0., 300.}, ""};
+  ConfigurableAxis thnConfigAxisOrigin{"thnConfigAxisOrigin", {2, -0.5, 1.5}, ""};
+  ConfigurableAxis thnConfigAxisCentrality{"thnConfigAxisCentrality", {100, 0., 100.}, ""};
+  ConfigurableAxis thnConfigAxisNumPvContr{"thnConfigAxisNumPvContr", {200, -0.5, 199.5}, "Number of PV contributors"};
+  ConfigurableAxis thnConfigAxisY{"thnConfigAxisY", {20, -1., 1.}, "candidate rapidity"};
 
   HistogramRegistry registry{"registry"};
 
-  void init(InitContext& context)
+  // ML class indices
+  enum MlClasses : int {
+    MlClassBackground = 0,
+    MlClassPrompt,
+    MlClassNonPrompt,
+    NumberOfMlClasses
+  };
+
+  static constexpr int KDecayChannelLcToK0sP = 1;
+
+  void init(InitContext&)
   {
+    // Check that only one process function is enabled
+    std::array<bool, 12> processFlags{
+      doprocessDataStd, doprocessDataStdWithFT0C, doprocessDataStdWithFT0M,
+      doprocessDataWithMl, doprocessDataWithMlWithFT0C, doprocessDataWithMlWithFT0M,
+      doprocessMcStd, doprocessMcStdWithFT0C, doprocessMcStdWithFT0M,
+      doprocessMcWithMl, doprocessMcWithMlWithFT0C, doprocessMcWithMlWithFT0M};
+    if ((std::accumulate(processFlags.begin(), processFlags.end(), 0)) != 1) {
+      LOGP(fatal, "no or more than one process function enabled! Please check your configuration!");
+    }
+
     // axes
     AxisSpec const axisBinsPt = {binsPt, "#it{p}_{T} (GeV/#it{c})"};
     AxisSpec const axisPt = {300, 0.0f, 30.0f, "#it{p}_{T} (GeV/#it{c})"};
@@ -80,176 +136,94 @@ struct HfTaskLcToK0sP {
     AxisSpec const axisProperLifetimeV0 = {1000, 0.f, 80.f, "#it{c#tau} (cm)"};
     AxisSpec const axisNSigma = {100, -6.f, 6.f, "n#it{#sigma}_{p}"};
     AxisSpec const axisPidP = {100, 0.f, 10.0f, "#it{p} (GeV/#it{c})"};
-    // data
-    registry.add("hPtCand", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-    registry.add("hEtaCand", "cascade candidates;candidate #it{#eta};entries", {HistType::kTH1F, {axisEta}});
-    registry.add("hEtaCandVsPtCand", "cascade candidates;candidate #it{#eta};p_{T}", {HistType::kTH2F, {axisEta, axisBinsPt}});
-    registry.add("hPhiCand", "cascade candidates;candidate #it{#phi};entries", {HistType::kTH1F, {axisPhi}});
-    registry.add("hPhiCandVsPtCand", "cascade candidates;candidate #it{#phi};p_{T}", {HistType::kTH2F, {axisPhi, axisBinsPt}});
-    registry.add("hMass", "cascade candidates;inv. mass (p K_{S}^{0}) (GeV/#it{c}^{2});entries", {HistType::kTH1F, {axisMassCand}});
-    registry.add("hMassVsPtCand", "cascade candidates;inv. mass (p K_{S}^{0}) (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {axisMassCand, axisBinsPt}});
-    registry.add("hPtBach", "cascade candidates;bachelor #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-    registry.add("hPtBachVsPtCand", "cascade candidates;bachelor #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {axisPt, axisBinsPt}});
-    registry.add("hPtV0", "cascade candidates;v0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-    registry.add("hPtV0VsPtCand", "cascade candidates;v0 #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {axisPt, axisBinsPt}});
-    registry.add("hd0Bach", "cascade candidates;bachelor DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {axisd0}});
-    registry.add("hd0BachVsPtCand", "cascade candidates;bachelor DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {axisd0, axisBinsPt}});
-    registry.add("hd0V0", "cascade candidates;V0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {axisd0}});
-    registry.add("hd0V0VsPtCand", "cascade candidates;V0 DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {axisd0, axisBinsPt}});
-    registry.add("hd0V0pos", "cascade candidates;pos daugh v0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {axisd0V0Daughters}});
-    registry.add("hd0V0posVsPtCand", "cascade candidates;pos daugh v0 DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {axisd0V0Daughters, axisBinsPt}});
-    registry.add("hd0V0neg", "cascade candidates;neg daugh v0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {axisd0V0Daughters}});
-    registry.add("hd0V0negVsPtCand", "cascade candidates;neg daugh v0 DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {axisd0V0Daughters, axisBinsPt}});
-    registry.add("hPtV0pos", "cascade candidates;pos daugh v0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-    registry.add("hPtV0posVsPtCand", "cascade candidates;pos daugh v0 #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {axisPt, axisBinsPt}});
-    registry.add("hPtV0neg", "cascade candidates;neg daugh v0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-    registry.add("hPtV0negVsPtCand", "cascade candidates;neg daugh v0 #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {axisPt, axisBinsPt}});
-    registry.add("hV0CPA", "cascade candidates;v0 cosine of pointing angle;entries", {HistType::kTH1F, {axisV0CPA}});
-    registry.add("hV0CPAVsPtCand", "cascade candidates;v0 cosine of pointing angle;p_{T}", {HistType::kTH2F, {axisV0CPA, axisBinsPt}});
-    registry.add("hV0Radius", "cascade candidates;v0 radius (cm);entries", {HistType::kTH1F, {axisV0Radius}});
-    registry.add("hV0RadiusVsPtCand", "cascade candidates;v0 radius (cm);p_{T}", {HistType::kTH2F, {axisV0Radius, axisBinsPt}});
-    registry.add("hV0DCADaughters", "cascade candidates;v0 dca daughters (cm);entries", {HistType::kTH1F, {axisV0DCADaughters}});
-    registry.add("hV0DCADaughtersVsPtCand", "cascade candidates;v0 dca daughters (cm);p_{T}", {HistType::kTH2F, {axisV0DCADaughters, axisBinsPt}});
-    registry.add("hV0MK0Short", "cascade candidates;v0 mass K0s (GeV/#it{c}^{2});entries", {HistType::kTH1F, {axisMassK0Short}});
-    registry.add("hV0MK0ShortVsPtCand", "cascade candidates;v0 mass K0s (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {axisMassK0Short, axisBinsPt}});
-    registry.add("hV0MLambda", "cascade candidates;v0 mass Lambda (GeV/#it{c}^{2});entries", {HistType::kTH1F, {axisMassLambda}});
-    registry.add("hV0MLambdaVsPtCand", "cascade candidates;v0 mass Lambda (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {axisMassLambda, axisBinsPt}});
-    registry.add("hV0MAntiLambda", "cascade candidates;v0 mass AntiLambda (GeV/#it{c}^{2});entries", {HistType::kTH1F, {axisMassLambda}});
-    registry.add("hV0MAntiLambdaVsPtCand", "cascade candidates;v0 mass AntiLambda (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {axisMassLambda, axisBinsPt}});
-    registry.add("hV0MGamma", "cascade candidates;v0 mass Gamma (GeV/#it{c}^{2});entries", {HistType::kTH1F, {axisMassGamma}});
-    registry.add("hV0MGammaVsPtCand", "cascade candidates;v0 mass Gamma (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {axisMassGamma, axisBinsPt}});
-    registry.add("hCtV0K0Short", "cascade candidates;proper lifetime (V0) * #it{c} (cm);entries", {HistType::kTH1F, {axisProperLifetimeV0}});
-    registry.add("hCtV0K0ShortVsPtCand", "cascade candidates;proper lifetime (V0) * #it{c} (cm);p_{T}", {HistType::kTH2F, {axisProperLifetimeV0, axisBinsPt}});
-    registry.add("hCtV0Lambda", "cascade candidates;proper lifetime (V0) * #it{c} (cm);entries", {HistType::kTH1F, {axisProperLifetimeV0}});
-    registry.add("hCtV0LambdaVsPtCand", "cascade candidates;proper lifetime (V0) * #it{c} (cm);p_{T}", {HistType::kTH2F, {axisProperLifetimeV0, axisBinsPt}});
-    registry.add("hCPACand", "cascade candidates;cosine pointing angle;entries", {HistType::kTH1F, {axisCPACand}});
-    registry.add("hCPACandVsPtCand", "cascade candidates;cosine pointing angle;p_{T}", {HistType::kTH2F, {axisCPACand, axisBinsPt}});
-    registry.add("hCPAxyCand", "cascade candidates;cosine pointing angle xy;entries", {HistType::kTH1F, {axisCPACand}});
-    registry.add("hCPAxyCandVsPtCand", "cascade candidates;cosine pointing angle xy;p_{T}", {HistType::kTH2F, {axisCPACand, axisBinsPt}});
-    registry.add("hDecLengthCand", "cascade candidates;decay length (cm);entries", {HistType::kTH1F, {axisDecLength}});
-    registry.add("hDecLengthCandVsPtCand", "cascade candidates;decay length (cm);p_{T}", {HistType::kTH2F, {axisDecLength, axisBinsPt}});
-    registry.add("hDecLengthXYCand", "cascade candidates;decay length xy (cm);entries", {HistType::kTH1F, {axisDecLength}});
-    registry.add("hDecLengthXYCandVsPtCand", "cascade candidates;decay length xy (cm);p_{T}", {HistType::kTH2F, {axisDecLength, axisBinsPt}});
-    registry.add("hCtCand", "cascade candidates;proper lifetime (#Lambda_{c}) * #it{c} (cm);entries", {HistType::kTH1F, {axisProperLifetime}});
-    registry.add("hCtCandVsPtCand", "cascade candidates;proper lifetime (#Lambda_{c}) * #it{c} (cm);p_{T}", {HistType::kTH2F, {axisProperLifetime, axisBinsPt}});
-    registry.add("hTPCNSigmaPrBach", "cascade candidates;n#it{#sigma}_{p} TPC;entries", {HistType::kTH1F, {axisNSigma}});
-    registry.add("hPBachVsTPCNSigmaPrBach", "cascade candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TPC", {HistType::kTH2F, {axisPidP, axisNSigma}});
-    registry.add("hTOFNSigmaPrBach", "cascade candidates;n#it{#sigma}_{p} TOF;entries", {HistType::kTH1F, {axisNSigma}});
-    registry.add("hPBachVsTOFNSigmaPrBach", "cascade candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TOF", {HistType::kTH2F, {axisPidP, axisNSigma}});
+    // data - helper lambda: adds 1D histogram and its VsPtCand 2D variant
+    auto addHistosData = [&](const std::string& name, const std::string& title, const AxisSpec& axis) {
+      registry.add(("Data/h" + name).c_str(), ("cascade candidates;" + title + ";entries").c_str(), {HistType::kTH1F, {axis}});
+      registry.add(("Data/h" + name + "VsPtCand").c_str(), ("cascade candidates;" + title + ";p_{T}").c_str(), {HistType::kTH2F, {axis, axisBinsPt}});
+    };
+
+    addHistosData("PtCand", "candidate #it{p}_{T} (GeV/#it{c})", axisPt);
+    addHistosData("EtaCand", "candidate #it{#eta}", axisEta);
+    addHistosData("PhiCand", "candidate #it{#phi}", axisPhi);
+    addHistosData("Mass", "inv. mass (p K_{S}^{0}) (GeV/#it{c}^{2})", axisMassCand);
+    addHistosData("PtBach", "bachelor #it{p}_{T} (GeV/#it{c})", axisPt);
+    addHistosData("PtV0", "v0 #it{p}_{T} (GeV/#it{c})", axisPt);
+    addHistosData("d0Bach", "bachelor DCAxy to prim. vertex (cm)", axisd0);
+    addHistosData("d0V0", "V0 DCAxy to prim. vertex (cm)", axisd0);
+    addHistosData("d0V0pos", "pos daugh v0 DCAxy to prim. vertex (cm)", axisd0V0Daughters);
+    addHistosData("d0V0neg", "neg daugh v0 DCAxy to prim. vertex (cm)", axisd0V0Daughters);
+    addHistosData("PtV0pos", "pos daugh v0 #it{p}_{T} (GeV/#it{c})", axisPt);
+    addHistosData("PtV0neg", "neg daugh v0 #it{p}_{T} (GeV/#it{c})", axisPt);
+    addHistosData("V0CPA", "v0 cosine of pointing angle", axisV0CPA);
+    addHistosData("V0Radius", "V0 radius (cm)", axisV0Radius);
+    addHistosData("V0DCADaughters", "v0 dca daughters (cm)", axisV0DCADaughters);
+    addHistosData("V0MK0Short", "v0 mass K0s (GeV/#it{c}^{2})", axisMassK0Short);
+    addHistosData("V0MLambda", "v0 mass #Lambda (GeV/#it{c}^{2})", axisMassLambda);
+    addHistosData("V0MAntiLambda", "v0 mass Anti#Lambda (GeV/#it{c}^{2})", axisMassLambda);
+    addHistosData("V0MGamma", "v0 mass #gamma (GeV/#it{c}^{2})", axisMassGamma);
+    addHistosData("CtV0K0Short", "proper lifetime (V0) * #it{c} (cm)", axisProperLifetimeV0);
+    addHistosData("CtV0Lambda", "proper lifetime (V0) * #it{c} (cm)", axisProperLifetimeV0);
+    addHistosData("CPACand", "cosine pointing angle", axisCPACand);
+    addHistosData("CPAxyCand", "cosine pointing angle xy", axisCPACand);
+    addHistosData("DecLengthCand", "decay length (cm)", axisDecLength);
+    addHistosData("DecLengthXYCand", "decay length xy (cm)", axisDecLength);
+    addHistosData("CtCand", "proper lifetime (#Lambda_{c}) * #it{c} (cm)", axisProperLifetime);
+
+    // PID histograms (non-standard axis pattern)
+    registry.add("Data/hTPCNSigmaPrBach", "cascade candidates;n#it{#sigma}_{p} TPC;entries", {HistType::kTH1F, {axisNSigma}});
+    registry.add("Data/hPBachVsTPCNSigmaPrBach", "cascade candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TPC", {HistType::kTH2F, {axisPidP, axisNSigma}});
+    registry.add("Data/hTOFNSigmaPrBach", "cascade candidates;n#it{#sigma}_{p} TOF;entries", {HistType::kTH1F, {axisNSigma}});
+    registry.add("Data/hPBachVsTOFNSigmaPrBach", "cascade candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TOF", {HistType::kTH2F, {axisPidP, axisNSigma}});
 
     // add MC histograms
-    if (context.mOptions.get<bool>("processMc")) {
+    bool const isMc = doprocessMcStd || doprocessMcStdWithFT0C || doprocessMcStdWithFT0M ||
+                      doprocessMcWithMl || doprocessMcWithMlWithFT0C || doprocessMcWithMlWithFT0M;
+    if (isMc) {
+      // MC helper lambdas
+      auto addHistosMcRec = [&](const std::string& name, const std::string& title, const AxisSpec& axis) {
+        registry.add(("MC/Rec/h" + name + "RecSig").c_str(), ("cascade candidates;" + title + ";entries").c_str(), {HistType::kTH1F, {axis}});
+        registry.add(("MC/Rec/h" + name + "VsPtCandRecSig").c_str(), ("cascade candidates;" + title + ";p_{T}").c_str(), {HistType::kTH2F, {axis, axisBinsPt}});
+        registry.add(("MC/Rec/h" + name + "RecBg").c_str(), ("cascade candidates;" + title + ";entries").c_str(), {HistType::kTH1F, {axis}});
+        registry.add(("MC/Rec/h" + name + "VsPtCandRecBg").c_str(), ("cascade candidates;" + title + ";p_{T}").c_str(), {HistType::kTH2F, {axis, axisBinsPt}});
+      };
+      auto addHistosMcGen = [&](const std::string& name, const std::string& title, const AxisSpec& axis) {
+        registry.add(("MC/Gen/h" + name + "Gen").c_str(), ("cascade candidates;" + title + ";entries").c_str(), {HistType::kTH1F, {axis}});
+        registry.add(("MC/Gen/h" + name + "VsPtCandGen").c_str(), ("cascade candidates;" + title + ";p_{T}").c_str(), {HistType::kTH2F, {axis, axisBinsPt}});
+      };
+
+      // MC Rec: PtCand has extra Prompt/NonPrompt variants
       registry.add("MC/Rec/hPtCandRecSig", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
       registry.add("MC/Rec/hPtCandRecSigPrompt", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
       registry.add("MC/Rec/hPtCandRecSigNonPrompt", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
       registry.add("MC/Rec/hPtCandRecBg", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-      registry.add("MC/Rec/hEtaCandRecSig", "cascade candidates;candidate #it{#eta};entries", {HistType::kTH1F, {axisEta}});
-      registry.add("MC/Rec/hEtaCandVsPtCandRecSig", "cascade candidates;candidate #it{#eta};p_{T}", {HistType::kTH2F, {axisEta, axisBinsPt}});
-      registry.add("MC/Rec/hEtaCandRecBg", "cascade candidates;candidate #it{#eta};entries", {HistType::kTH1F, {axisEta}});
-      registry.add("MC/Rec/hEtaCandVsPtCandRecBg", "cascade candidates;candidate #it{#eta};p_{T}", {HistType::kTH2F, {axisEta, axisBinsPt}});
-      registry.add("MC/Rec/hPhiCandRecSig", "cascade candidates;candidate #it{#phi};entries", {HistType::kTH1F, {axisPhi}});
-      registry.add("MC/Rec/hPhiCandVsPtCandRecSig", "cascade candidates;candidate #it{#phi};p_{T}", {HistType::kTH2F, {axisPhi, axisBinsPt}});
-      registry.add("MC/Rec/hPhiCandRecBg", "cascade candidates;candidate #it{#phi};entries", {HistType::kTH1F, {axisPhi}});
-      registry.add("MC/Rec/hPhiCandVsPtCandRecBg", "cascade candidates;candidate #it{#phi};p_{T}", {HistType::kTH2F, {axisPhi, axisBinsPt}});
-      registry.add("MC/Gen/hPtCandGen", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-      registry.add("MC/Gen/hPtCandGenPrompt", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-      registry.add("MC/Gen/hPtCandGenNonPrompt", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-      registry.add("MC/Gen/hEtaCandGen", "cascade candidates;candidate #it{#eta};entries", {HistType::kTH1F, {axisEta}});
-      registry.add("MC/Gen/hEtaCandVsPtCandGen", "cascade candidates;candidate #it{#eta};p_{T}", {HistType::kTH2F, {axisEta, axisBinsPt}});
-      registry.add("MC/Gen/hPhiCandGen", "cascade candidates;candidate #it{#phi};entries", {HistType::kTH1F, {axisPhi}});
-      registry.add("MC/Gen/hPhiCandVsPtCandGen", "cascade candidates;candidate #it{#phi};p_{T}", {HistType::kTH2F, {axisPhi, axisBinsPt}});
-      registry.add("MC/Rec/hMassRecSig", "cascade candidates;inv. mass (p K_{S}^{0}) (GeV/#it{c}^{2});p_{T}", {HistType::kTH1F, {axisMassCand}});
-      registry.add("MC/Rec/hMassVsPtCandRecSig", "cascade candidates;inv. mass (p K_{S}^{0}) (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {axisMassCand, axisBinsPt}});
-      registry.add("MC/Rec/hMassRecBg", "cascade candidates;inv. mass (p K_{S}^{0}) (GeV/#it{c}^{2});p_{T}", {HistType::kTH1F, {axisMassCand}});
-      registry.add("MC/Rec/hMassVsPtCandRecBg", "cascade candidates;inv. mass (p K_{S}^{0}) (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {axisMassCand, axisBinsPt}});
-      registry.add("MC/Rec/hPtBachRecSig", "cascade candidates;bachelor #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-      registry.add("MC/Rec/hPtBachVsPtCandRecSig", "cascade candidates;bachelor #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {axisPt, axisBinsPt}});
-      registry.add("MC/Rec/hPtBachRecBg", "cascade candidates;bachelor #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-      registry.add("MC/Rec/hPtBachVsPtCandRecBg", "cascade candidates;bachelor #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {axisPt, axisBinsPt}});
-      registry.add("MC/Rec/hPtV0RecSig", "cascade candidates;v0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-      registry.add("MC/Rec/hPtV0VsPtCandRecSig", "cascade candidates;v0 #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {axisPt, axisBinsPt}});
-      registry.add("MC/Rec/hPtV0RecBg", "cascade candidates;v0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-      registry.add("MC/Rec/hPtV0VsPtCandRecBg", "cascade candidates;v0 #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {axisPt, axisBinsPt}});
-      registry.add("MC/Rec/hd0BachRecSig", "cascade candidates;bachelor DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {axisd0}});
-      registry.add("MC/Rec/hd0BachVsPtCandRecSig", "cascade candidates;bachelor DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {axisd0, axisBinsPt}});
-      registry.add("MC/Rec/hd0BachRecBg", "cascade candidates;bachelor DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {axisd0}});
-      registry.add("MC/Rec/hd0BachVsPtCandRecBg", "cascade candidates;bachelor DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {axisd0, axisBinsPt}});
-      registry.add("MC/Rec/hd0V0RecSig", "cascade candidates;V0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {axisd0}});
-      registry.add("MC/Rec/hd0V0VsPtCandRecSig", "cascade candidates;V0 DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {axisd0, axisBinsPt}});
-      registry.add("MC/Rec/hd0V0RecBg", "cascade candidates;V0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {axisd0}});
-      registry.add("MC/Rec/hd0V0VsPtCandRecBg", "cascade candidates;V0 DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {axisd0, axisBinsPt}});
-      registry.add("MC/Rec/hd0V0posRecSig", "cascade candidates;pos daugh v0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {axisd0V0Daughters}});
-      registry.add("MC/Rec/hd0V0posVsPtCandRecSig", "cascade candidates;pos daugh v0 DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {axisd0V0Daughters, axisBinsPt}});
-      registry.add("MC/Rec/hd0V0posRecBg", "cascade candidates;pos daugh v0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {axisd0V0Daughters}});
-      registry.add("MC/Rec/hd0V0posVsPtCandRecBg", "cascade candidates;pos daugh v0 DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {axisd0V0Daughters, axisBinsPt}});
-      registry.add("MC/Rec/hd0V0negRecSig", "cascade candidates;neg daugh v0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {axisd0V0Daughters}});
-      registry.add("MC/Rec/hd0V0negVsPtCandRecSig", "cascade candidates;neg daugh v0 DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {axisd0V0Daughters, axisBinsPt}});
-      registry.add("MC/Rec/hd0V0negRecBg", "cascade candidates;neg daugh v0 DCAxy to prim. vertex (cm);entries", {HistType::kTH1F, {axisd0V0Daughters}});
-      registry.add("MC/Rec/hd0V0negVsPtCandRecBg", "cascade candidates;neg daugh v0 DCAxy to prim. vertex (cm);p_{T}", {HistType::kTH2F, {axisd0V0Daughters, axisBinsPt}});
-      registry.add("MC/Rec/hPtV0posRecSig", "cascade candidates;pos daugh v0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-      registry.add("MC/Rec/hPtV0posVsPtCandRecSig", "cascade candidates;pos daugh v0 #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {axisPt, axisBinsPt}});
-      registry.add("MC/Rec/hPtV0posRecBg", "cascade candidates;pos daugh v0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-      registry.add("MC/Rec/hPtV0posVsPtCandRecBg", "cascade candidates;pos daugh v0 #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {axisPt, axisBinsPt}});
-      registry.add("MC/Rec/hPtV0negRecSig", "cascade candidates;neg daugh v0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-      registry.add("MC/Rec/hPtV0negVsPtCandRecSig", "cascade candidates;neg daugh v0 #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {axisPt, axisBinsPt}});
-      registry.add("MC/Rec/hPtV0negRecBg", "cascade candidates;neg daugh v0 #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-      registry.add("MC/Rec/hPtV0negVsPtCandRecBg", "cascade candidates;neg daugh v0 #it{p}_{T} (GeV/#it{c});p_{T}", {HistType::kTH2F, {axisPt, axisBinsPt}});
-      registry.add("MC/Rec/hV0CPARecSig", "cascade candidates;v0 cosine of pointing angle;entries", {HistType::kTH1F, {axisV0CPA}});
-      registry.add("MC/Rec/hV0CPAVsPtCandRecSig", "cascade candidates;v0 cosine of pointing angle;p_{T}", {HistType::kTH2F, {axisV0CPA, axisBinsPt}});
-      registry.add("MC/Rec/hV0CPARecBg", "cascade candidates;v0 cosine of pointing angle;entries", {HistType::kTH1F, {axisV0CPA}});
-      registry.add("MC/Rec/hV0CPAVsPtCandRecBg", "cascade candidates;v0 cosine of pointing angle;p_{T}", {HistType::kTH2F, {axisV0CPA, axisBinsPt}});
-      registry.add("MC/Rec/hV0RadiusRecSig", "cascade candidates;v0 radius (cm);entries", {HistType::kTH1F, {axisV0Radius}});
-      registry.add("MC/Rec/hV0RadiusVsPtCandRecSig", "cascade candidates;v0 radius (cm);p_{T}", {HistType::kTH2F, {axisV0Radius, axisBinsPt}});
-      registry.add("MC/Rec/hV0RadiusRecBg", "cascade candidates;v0 radius (cm);entries", {HistType::kTH1F, {axisV0Radius}});
-      registry.add("MC/Rec/hV0RadiusVsPtCandRecBg", "cascade candidates;v0 radius (cm);p_{T}", {HistType::kTH2F, {axisV0Radius, axisBinsPt}});
-      registry.add("MC/Rec/hV0DCADaughtersRecSig", "cascade candidates;v0 dca daughters (cm);entries", {HistType::kTH1F, {axisV0DCADaughters}});
-      registry.add("MC/Rec/hV0DCADaughtersVsPtCandRecSig", "cascade candidates;v0 dca daughters (cm);p_{T}", {HistType::kTH2F, {axisV0DCADaughters, axisBinsPt}});
-      registry.add("MC/Rec/hV0DCADaughtersRecBg", "cascade candidates;v0 dca daughters (cm);entries", {HistType::kTH1F, {axisV0DCADaughters}});
-      registry.add("MC/Rec/hV0DCADaughtersVsPtCandRecBg", "cascade candidates;v0 dca daughters (cm);p_{T}", {HistType::kTH2F, {axisV0DCADaughters, axisBinsPt}});
-      registry.add("MC/Rec/hV0MK0ShortRecSig", "cascade candidates;v0 mass K0s (GeV/#it{c}^{2});entries", {HistType::kTH1F, {axisMassK0Short}});
-      registry.add("MC/Rec/hV0MK0ShortVsPtCandRecSig", "cascade candidates;v0 mass K0s (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {axisMassK0Short, axisBinsPt}});
-      registry.add("MC/Rec/hV0MK0ShortRecBg", "cascade candidates;v0 mass K0s (GeV/#it{c}^{2});entries", {HistType::kTH1F, {axisMassK0Short}});
-      registry.add("MC/Rec/hV0MK0ShortVsPtCandRecBg", "cascade candidates;v0 mass K0s (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {axisMassK0Short, axisBinsPt}});
-      registry.add("MC/Rec/hV0MLambdaRecSig", "cascade candidates;v0 mass Lambda (GeV/#it{c}^{2});entries", {HistType::kTH1F, {axisMassLambda}});
-      registry.add("MC/Rec/hV0MLambdaVsPtCandRecSig", "cascade candidates;v0 mass Lambda (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {axisMassLambda, axisBinsPt}});
-      registry.add("MC/Rec/hV0MLambdaRecBg", "cascade candidates;v0 mass Lambda (GeV/#it{c}^{2});entries", {HistType::kTH1F, {axisMassLambda}});
-      registry.add("MC/Rec/hV0MLambdaVsPtCandRecBg", "cascade candidates;v0 mass Lambda (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {axisMassLambda, axisBinsPt}});
-      registry.add("MC/Rec/hV0MAntiLambdaRecSig", "cascade candidates;v0 mass AntiLambda (GeV/#it{c}^{2});entries", {HistType::kTH1F, {axisMassLambda}});
-      registry.add("MC/Rec/hV0MAntiLambdaVsPtCandRecSig", "cascade candidates;v0 mass AntiLambda (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {axisMassLambda, axisBinsPt}});
-      registry.add("MC/Rec/hV0MAntiLambdaRecBg", "cascade candidates;v0 mass AntiLambda (GeV/#it{c}^{2});entries", {HistType::kTH1F, {axisMassLambda}});
-      registry.add("MC/Rec/hV0MAntiLambdaVsPtCandRecBg", "cascade candidates;v0 mass AntiLambda (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {axisMassLambda, axisBinsPt}});
-      registry.add("MC/Rec/hV0MGammaRecSig", "cascade candidates;v0 mass Gamma (GeV/#it{c}^{2});entries", {HistType::kTH1F, {axisMassGamma}});
-      registry.add("MC/Rec/hV0MGammaVsPtCandRecSig", "cascade candidates;v0 mass Gamma (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {axisMassGamma, axisBinsPt}});
-      registry.add("MC/Rec/hV0MGammaRecBg", "cascade candidates;v0 mass Gamma (GeV/#it{c}^{2});entries", {HistType::kTH1F, {axisMassGamma}});
-      registry.add("MC/Rec/hV0MGammaVsPtCandRecBg", "cascade candidates;v0 mass Gamma (GeV/#it{c}^{2});p_{T}", {HistType::kTH2F, {axisMassGamma, axisBinsPt}});
-      registry.add("MC/Rec/hCtV0K0ShortRecSig", "cascade candidates;proper lifetime (V0) * #it{c} (cm);entries", {HistType::kTH1F, {axisProperLifetimeV0}});
-      registry.add("MC/Rec/hCtV0K0ShortVsPtCandRecSig", "cascade candidates;proper lifetime (V0) * #it{c} (cm);p_{T}", {HistType::kTH2F, {axisProperLifetimeV0, axisBinsPt}});
-      registry.add("MC/Rec/hCtV0K0ShortRecBg", "cascade candidates;proper lifetime (V0) * #it{c} (cm);entries", {HistType::kTH1F, {axisProperLifetimeV0}});
-      registry.add("MC/Rec/hCtV0K0ShortVsPtCandRecBg", "cascade candidates;proper lifetime (V0) * #it{c} (cm);p_{T}", {HistType::kTH2F, {axisProperLifetimeV0, axisBinsPt}});
-      registry.add("MC/Rec/hCtV0LambdaRecSig", "cascade candidates;proper lifetime (V0) * #it{c} (cm);entries", {HistType::kTH1F, {axisProperLifetimeV0}});
-      registry.add("MC/Rec/hCtV0LambdaVsPtCandRecSig", "cascade candidates;proper lifetime (V0) * #it{c} (cm);p_{T}", {HistType::kTH2F, {axisProperLifetimeV0, axisBinsPt}});
-      registry.add("MC/Rec/hCtV0LambdaRecBg", "cascade candidates;proper lifetime (V0) * #it{c} (cm);entries", {HistType::kTH1F, {axisProperLifetimeV0}});
-      registry.add("MC/Rec/hCtV0LambdaVsPtCandRecBg", "cascade candidates;proper lifetime (V0) * #it{c} (cm);p_{T}", {HistType::kTH2F, {axisProperLifetimeV0, axisBinsPt}});
-      registry.add("MC/Rec/hCPACandRecSig", "cascade candidates;cosine pointing angle;entries", {HistType::kTH1F, {axisCPACand}});
-      registry.add("MC/Rec/hCPACandVsPtCandRecSig", "cascade candidates;cosine pointing angle;p_{T}", {HistType::kTH2F, {axisCPACand, axisBinsPt}});
-      registry.add("MC/Rec/hCPACandRecBg", "cascade candidates;cosine pointing angle;entries", {HistType::kTH1F, {axisCPACand}});
-      registry.add("MC/Rec/hCPACandVsPtCandRecBg", "cascade candidates;cosine pointing angle;p_{T}", {HistType::kTH2F, {axisCPACand, axisBinsPt}});
-      registry.add("MC/Rec/hCPAxyCandRecSig", "cascade candidates;cosine pointing angle xy;entries", {HistType::kTH1F, {axisCPACand}});
-      registry.add("MC/Rec/hCPAxyCandVsPtCandRecSig", "cascade candidates;cosine pointing angle xy;p_{T}", {HistType::kTH2F, {axisCPACand, axisBinsPt}});
-      registry.add("MC/Rec/hCPAxyCandRecBg", "cascade candidates;cosine pointing angle xy;entries", {HistType::kTH1F, {axisCPACand}});
-      registry.add("MC/Rec/hCPAxyCandVsPtCandRecBg", "cascade candidates;cosine pointing angle xy;p_{T}", {HistType::kTH2F, {axisCPACand, axisBinsPt}});
-      registry.add("MC/Rec/hDecLengthCandRecSig", "cascade candidates;decay length (cm);entries", {HistType::kTH1F, {axisDecLength}});
-      registry.add("MC/Rec/hDecLengthCandVsPtCandRecSig", "cascade candidates;decay length (cm);p_{T}", {HistType::kTH2F, {axisDecLength, axisBinsPt}});
-      registry.add("MC/Rec/hDecLengthCandRecBg", "cascade candidates;decay length (cm);entries", {HistType::kTH1F, {axisDecLength}});
-      registry.add("MC/Rec/hDecLengthCandVsPtCandRecBg", "cascade candidates;decay length (cm);p_{T}", {HistType::kTH2F, {axisDecLength, axisBinsPt}});
-      registry.add("MC/Rec/hDecLengthXYCandRecSig", "cascade candidates;decay length xy (cm);entries", {HistType::kTH1F, {axisDecLength}});
-      registry.add("MC/Rec/hDecLengthXYCandVsPtCandRecSig", "cascade candidates;decay length xy (cm);p_{T}", {HistType::kTH2F, {axisDecLength, axisBinsPt}});
-      registry.add("MC/Rec/hDecLengthXYCandRecBg", "cascade candidates;decay length xy (cm);entries", {HistType::kTH1F, {axisDecLength}});
-      registry.add("MC/Rec/hDecLengthXYCandVsPtCandRecBg", "cascade candidates;decay length xy (cm);p_{T}", {HistType::kTH2F, {axisDecLength, axisBinsPt}});
-      registry.add("MC/Rec/hCtCandRecSig", "cascade candidates;proper lifetime (#Lambda_{c}) * #it{c} (cm);entries", {HistType::kTH1F, {axisProperLifetime}});
-      registry.add("MC/Rec/hCtCandVsPtCandRecSig", "cascade candidates;proper lifetime (#Lambda_{c}) * #it{c} (cm);p_{T}", {HistType::kTH2F, {axisProperLifetime, axisBinsPt}});
-      registry.add("MC/Rec/hCtCandRecBg", "cascade candidates;proper lifetime (#Lambda_{c}) * #it{c} (cm);entries", {HistType::kTH1F, {axisProperLifetime}});
-      registry.add("MC/Rec/hCtCandVsPtCandRecBg", "cascade candidates;proper lifetime (#Lambda_{c}) * #it{c} (cm);p_{T}", {HistType::kTH2F, {axisProperLifetime, axisBinsPt}});
+
+      addHistosMcRec("EtaCand", "candidate #it{#eta}", axisEta);
+      addHistosMcRec("PhiCand", "candidate #it{#phi}", axisPhi);
+      addHistosMcRec("Mass", "inv. mass (p K_{S}^{0}) (GeV/#it{c}^{2})", axisMassCand);
+      addHistosMcRec("PtBach", "bachelor #it{p}_{T} (GeV/#it{c})", axisPt);
+      addHistosMcRec("PtV0", "v0 #it{p}_{T} (GeV/#it{c})", axisPt);
+      addHistosMcRec("d0Bach", "bachelor DCAxy to prim. vertex (cm)", axisd0);
+      addHistosMcRec("d0V0", "V0 DCAxy to prim. vertex (cm)", axisd0);
+      addHistosMcRec("d0V0pos", "pos daugh v0 DCAxy to prim. vertex (cm)", axisd0V0Daughters);
+      addHistosMcRec("d0V0neg", "neg daugh v0 DCAxy to prim. vertex (cm)", axisd0V0Daughters);
+      addHistosMcRec("PtV0pos", "pos daugh v0 #it{p}_{T} (GeV/#it{c})", axisPt);
+      addHistosMcRec("PtV0neg", "neg daugh v0 #it{p}_{T} (GeV/#it{c})", axisPt);
+      addHistosMcRec("V0CPA", "v0 cosine of pointing angle", axisV0CPA);
+      addHistosMcRec("V0Radius", "V0 radius (cm)", axisV0Radius);
+      addHistosMcRec("V0DCADaughters", "v0 dca daughters (cm)", axisV0DCADaughters);
+      addHistosMcRec("V0MK0Short", "v0 mass K0s (GeV/#it{c}^{2})", axisMassK0Short);
+      addHistosMcRec("V0MLambda", "v0 mass #Lambda (GeV/#it{c}^{2})", axisMassLambda);
+      addHistosMcRec("V0MAntiLambda", "v0 mass Anti#Lambda (GeV/#it{c}^{2})", axisMassLambda);
+      addHistosMcRec("V0MGamma", "v0 mass #gamma (GeV/#it{c}^{2})", axisMassGamma);
+      addHistosMcRec("CtV0K0Short", "proper lifetime (V0) * #it{c} (cm)", axisProperLifetimeV0);
+      addHistosMcRec("CtV0Lambda", "proper lifetime (V0) * #it{c} (cm)", axisProperLifetimeV0);
+      addHistosMcRec("CPACand", "cosine pointing angle", axisCPACand);
+      addHistosMcRec("CPAxyCand", "cosine pointing angle xy", axisCPACand);
+      addHistosMcRec("DecLengthCand", "decay length (cm)", axisDecLength);
+      addHistosMcRec("DecLengthXYCand", "decay length xy (cm)", axisDecLength);
+      addHistosMcRec("CtCand", "proper lifetime (#Lambda_{c}) * #it{c} (cm)", axisProperLifetime);
+
+      // MC Rec PID
       registry.add("MC/Rec/hTPCNSigmaPrBachRecSig", "cascade candidates;n#it{#sigma}_{p} TPC;entries", {HistType::kTH1F, {axisNSigma}});
       registry.add("MC/Rec/hPBachVsTPCNSigmaPrBachRecSig", "cascade candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TPC", {HistType::kTH2F, {axisPidP, axisNSigma}});
       registry.add("MC/Rec/hTPCNSigmaPrBachRecBg", "cascade candidates;n#it{#sigma}_{p} TPC;entries", {HistType::kTH1F, {axisNSigma}});
@@ -258,319 +232,411 @@ struct HfTaskLcToK0sP {
       registry.add("MC/Rec/hPBachVsTOFNSigmaPrBachRecSig", "cascade candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TOF", {HistType::kTH2F, {axisPidP, axisNSigma}});
       registry.add("MC/Rec/hTOFNSigmaPrBachRecBg", "cascade candidates;n#it{#sigma}_{p} TOF;entries", {HistType::kTH1F, {axisNSigma}});
       registry.add("MC/Rec/hPBachVsTOFNSigmaPrBachRecBg", "cascade candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TOF", {HistType::kTH2F, {axisPidP, axisNSigma}});
+
+      // MC Gen
+      registry.add("MC/Gen/hPtCandGen", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
+      registry.add("MC/Gen/hPtCandGenPrompt", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
+      registry.add("MC/Gen/hPtCandGenNonPrompt", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
+
+      addHistosMcGen("EtaCand", "candidate #it{#eta}", axisEta);
+      addHistosMcGen("PhiCand", "candidate #it{#phi}", axisPhi);
+    }
+
+    // THnSparse for ML analysis
+    if (fillTHn) {
+      const AxisSpec thnAxisMass{thnConfigAxisMass, "inv. mass (p K_{S}^{0}) (GeV/#it{c}^{2})"};
+      const AxisSpec thnAxisPt{thnConfigAxisPt, "#it{p}_{T} (GeV/#it{c})"};
+      const AxisSpec thnAxisBdtScoreBkg{thnConfigAxisBdtScoreBkg, "BDT bkg score"};
+      const AxisSpec thnAxisBdtScorePrompt{thnConfigAxisBdtScorePrompt, "BDT prompt score"};
+      const AxisSpec thnAxisBdtScoreNonPrompt{thnConfigAxisBdtScoreNonPrompt, "BDT non-prompt score"};
+      const AxisSpec thnAxisCentrality{thnConfigAxisCentrality, "centrality (FT0C)"};
+      const AxisSpec thnAxisNumPvContr{thnConfigAxisNumPvContr, "Number of PV contributors"};
+      const AxisSpec thnAxisPtB{thnConfigAxisPtB, "#it{p}_{T}^{B} (GeV/#it{c})"};
+      const AxisSpec thnAxisOrigin{thnConfigAxisOrigin, "origin"};
+      const AxisSpec thnAxisY{thnConfigAxisY, "rapidity"};
+
+      // Data with ML: {mass, pt, centrality, bkg, prompt, non-prompt, numPvContr}
+      if (doprocessDataWithMl || doprocessDataWithMlWithFT0C || doprocessDataWithMlWithFT0M) {
+        registry.add("hnLcK0sPDataWithBdt", "THn for Lc->K0sP data with BDT", HistType::kTHnSparseF,
+          {thnAxisMass, thnAxisPt, thnAxisCentrality, thnAxisBdtScoreBkg, thnAxisBdtScorePrompt, thnAxisBdtScoreNonPrompt, thnAxisNumPvContr});
+      }
+
+      // MC Rec with ML: {mass, pt, centrality, bkg, prompt, non-prompt, numPvContr, origin}
+      if (doprocessMcWithMl || doprocessMcWithMlWithFT0C || doprocessMcWithMlWithFT0M) {
+        registry.add("hnLcK0sPRecMcWithBdt", "THn for Lc->K0sP MC rec with BDT", HistType::kTHnSparseF,
+          {thnAxisMass, thnAxisPt, thnAxisCentrality, thnAxisBdtScoreBkg, thnAxisBdtScorePrompt, thnAxisBdtScoreNonPrompt, thnAxisNumPvContr, thnAxisOrigin});
+      }
+
+      // MC Gen: {pt, centrality, rapidity, numPvContr, ptB, origin}
+      if (doprocessMcWithMl || doprocessMcWithMlWithFT0C || doprocessMcWithMlWithFT0M) {
+        registry.add("hnLcK0sPGenMc", "THn for Lc->K0sP MC gen", HistType::kTHnSparseF,
+          {thnAxisPt, thnAxisCentrality, thnAxisY, thnAxisNumPvContr, thnAxisPtB, thnAxisOrigin});
+      }
     }
   }
 
-  void process(soa::Filtered<soa::Join<aod::HfCandCascExt, aod::HfSelLcToK0sP>> const& candidates,
-               TracksWPid const&)
+  /// Evaluate centrality/multiplicity percentile
+  /// \param collision is collision
+  /// \return centrality/multiplicity percentile of the collision
+  template <typename Coll>
+  float evaluateCentralityColl(const Coll& collision)
   {
-    for (const auto& candidate : candidates) {
+    return o2::hf_centrality::getCentralityColl<Coll>(collision);
+  }
+
+  /// Helper function to fill candidate histograms
+  /// \param candidate is the candidate
+  template <typename CandType>
+  void fillCandHistograms(CandType const& candidate)
+  {
+    auto ptCand = candidate.pt();
+    auto eta = candidate.eta();
+    auto phi = candidate.phi();
+    auto invMassLcToK0sP = HfHelper::invMassLcToK0sP(candidate);
+    auto ptProng0 = candidate.ptProng0();
+    auto ptProng1 = candidate.ptProng1();
+    auto impactParameter0 = candidate.impactParameter0();
+    auto impactParameter1 = candidate.impactParameter1();
+    auto dcaPosToPV = candidate.dcapostopv();
+    auto dcaNegToPV = candidate.dcanegtopv();
+    auto ptV0Pos = candidate.ptV0Pos();
+    auto ptV0Neg = candidate.ptV0Neg();
+    auto v0CosPA = candidate.v0cosPA();
+    auto v0Radius = candidate.v0radius();
+    auto dcaV0Daughters = candidate.dcaV0daughters();
+    auto mK0Short = candidate.mK0Short();
+    auto mLambda = candidate.mLambda();
+    auto mAntiLambda = candidate.mAntiLambda();
+    auto mGamma = candidate.mGamma();
+    auto ctV0K0Short = HfHelper::ctV0K0s(candidate);
+    auto ctV0Lambda = HfHelper::ctV0Lambda(candidate);
+    auto cpa = candidate.cpa();
+    auto cpaXY = candidate.cpaXY();
+    auto decayLength = candidate.decayLength();
+    auto decayLengthXY = candidate.decayLengthXY();
+    auto ctLc = HfHelper::ctLc(candidate);
+
+    registry.fill(HIST("Data/hPtCand"), ptCand);
+    registry.fill(HIST("Data/hEtaCand"), eta);
+    registry.fill(HIST("Data/hEtaCandVsPtCand"), eta, ptCand);
+    registry.fill(HIST("Data/hPhiCand"), phi);
+    registry.fill(HIST("Data/hPhiCandVsPtCand"), phi, ptCand);
+    registry.fill(HIST("Data/hMass"), invMassLcToK0sP);
+    registry.fill(HIST("Data/hMassVsPtCand"), invMassLcToK0sP, ptCand);
+    registry.fill(HIST("Data/hPtBach"), ptProng0);
+    registry.fill(HIST("Data/hPtBachVsPtCand"), ptProng0, ptCand);
+    registry.fill(HIST("Data/hPtV0"), ptProng1);
+    registry.fill(HIST("Data/hPtV0VsPtCand"), ptProng1, ptCand);
+    registry.fill(HIST("Data/hd0Bach"), impactParameter0);
+    registry.fill(HIST("Data/hd0BachVsPtCand"), impactParameter0, ptCand);
+    registry.fill(HIST("Data/hd0V0"), impactParameter1);
+    registry.fill(HIST("Data/hd0V0VsPtCand"), impactParameter1, ptCand);
+    registry.fill(HIST("Data/hd0V0pos"), dcaPosToPV);
+    registry.fill(HIST("Data/hd0V0posVsPtCand"), dcaPosToPV, ptCand);
+    registry.fill(HIST("Data/hd0V0neg"), dcaNegToPV);
+    registry.fill(HIST("Data/hd0V0negVsPtCand"), dcaNegToPV, ptCand);
+    registry.fill(HIST("Data/hPtV0pos"), ptV0Pos);
+    registry.fill(HIST("Data/hPtV0posVsPtCand"), ptV0Pos, ptCand);
+    registry.fill(HIST("Data/hPtV0neg"), ptV0Neg);
+    registry.fill(HIST("Data/hPtV0negVsPtCand"), ptV0Neg, ptCand);
+    registry.fill(HIST("Data/hV0CPA"), v0CosPA);
+    registry.fill(HIST("Data/hV0CPAVsPtCand"), v0CosPA, ptCand);
+    registry.fill(HIST("Data/hV0Radius"), v0Radius);
+    registry.fill(HIST("Data/hV0RadiusVsPtCand"), v0Radius, ptCand);
+    registry.fill(HIST("Data/hV0DCADaughters"), dcaV0Daughters);
+    registry.fill(HIST("Data/hV0DCADaughtersVsPtCand"), dcaV0Daughters, ptCand);
+    registry.fill(HIST("Data/hV0MK0Short"), mK0Short);
+    registry.fill(HIST("Data/hV0MK0ShortVsPtCand"), mK0Short, ptCand);
+    registry.fill(HIST("Data/hV0MLambda"), mLambda);
+    registry.fill(HIST("Data/hV0MLambdaVsPtCand"), mLambda, ptCand);
+    registry.fill(HIST("Data/hV0MAntiLambda"), mAntiLambda);
+    registry.fill(HIST("Data/hV0MAntiLambdaVsPtCand"), mAntiLambda, ptCand);
+    registry.fill(HIST("Data/hV0MGamma"), mGamma);
+    registry.fill(HIST("Data/hV0MGammaVsPtCand"), mGamma, ptCand);
+    registry.fill(HIST("Data/hCtV0K0Short"), ctV0K0Short);
+    registry.fill(HIST("Data/hCtV0K0ShortVsPtCand"), ctV0K0Short, ptCand);
+    registry.fill(HIST("Data/hCtV0Lambda"), ctV0Lambda);
+    registry.fill(HIST("Data/hCtV0LambdaVsPtCand"), ctV0Lambda, ptCand);
+    registry.fill(HIST("Data/hCPACand"), cpa);
+    registry.fill(HIST("Data/hCPACandVsPtCand"), cpa, ptCand);
+    registry.fill(HIST("Data/hCPAxyCand"), cpaXY);
+    registry.fill(HIST("Data/hCPAxyCandVsPtCand"), cpaXY, ptCand);
+    registry.fill(HIST("Data/hDecLengthCand"), decayLength);
+    registry.fill(HIST("Data/hDecLengthCandVsPtCand"), decayLength, ptCand);
+    registry.fill(HIST("Data/hDecLengthXYCand"), decayLengthXY);
+    registry.fill(HIST("Data/hDecLengthXYCandVsPtCand"), decayLengthXY, ptCand);
+    registry.fill(HIST("Data/hCtCand"), ctLc);
+    registry.fill(HIST("Data/hCtCandVsPtCand"), ctLc, ptCand);
+  }
+
+  /// Data processing template
+  /// \tparam FillMl switch to fill ML histograms
+  template <bool FillMl, typename CollType, typename CandType>
+  void runAnalysisPerCollisionData(CollType const& collisions, CandType const& candidates)
+  {
+    for (const auto& collision : collisions) {
+      fillHistosData<FillMl>(collision, candidates);
+    }
+  }
+
+  /// Helper function to fill data histograms
+  /// \tparam FillMl switch to fill ML histograms
+  template <bool FillMl, typename CollType, typename CandType>
+  void fillHistosData(CollType const& collision, CandType const& candidates)
+  {
+    const auto thisCollId = collision.globalIndex();
+    const auto& groupedCandidates = candidates.sliceBy(lcToPK0SPerCollision, thisCollId);
+
+    for (const auto& candidate : groupedCandidates) {
       if (etaCandMax >= 0. && std::abs(candidate.eta()) > etaCandMax) {
         continue;
       }
       if (yCandRecoMax >= 0. && std::abs(HfHelper::yLc(candidate)) > yCandRecoMax) {
         continue;
       }
+      if (candidate.isSelLcToK0sP() < selectionFlagLcToK0sP) {
+        continue;
+      }
 
-      auto ptCand = candidate.pt();
-      auto eta = candidate.eta();
-      auto phi = candidate.phi();
-      auto invMassLcToK0sP = HfHelper::invMassLcToK0sP(candidate);
-      auto ptProng0 = candidate.ptProng0();
-      auto ptProng1 = candidate.ptProng1();
-      auto impactParameter0 = candidate.impactParameter0();
-      auto impactParameter1 = candidate.impactParameter1();
-      auto dcaPosToPV = candidate.dcapostopv();
-      auto dcaNegToPV = candidate.dcanegtopv();
-      auto ptV0Pos = candidate.ptV0Pos();
-      auto ptV0Neg = candidate.ptV0Neg();
-      auto v0CosPA = candidate.v0cosPA();
-      auto v0Radius = candidate.v0radius();
-      auto dcaV0Daughters = candidate.dcaV0daughters();
-      auto mK0Short = candidate.mK0Short();
-      auto mLambda = candidate.mLambda();
-      auto mAntiLambda = candidate.mAntiLambda();
-      auto mGamma = candidate.mGamma();
-      auto ctV0K0Short = HfHelper::ctV0K0s(candidate);
-      auto ctV0Lambda = HfHelper::ctV0Lambda(candidate);
-      auto cpa = candidate.cpa();
-      auto cpaXY = candidate.cpaXY();
-      auto decayLength = candidate.decayLength();
-      auto decayLengthXY = candidate.decayLengthXY();
-      auto ctLc = HfHelper::ctLc(candidate);
+      fillCandHistograms(candidate);
 
-      registry.fill(HIST("hPtCand"), ptCand);
-      registry.fill(HIST("hEtaCand"), eta);
-      registry.fill(HIST("hEtaCandVsPtCand"), eta, ptCand);
-      registry.fill(HIST("hPhiCand"), phi);
-      registry.fill(HIST("hPhiCandVsPtCand"), phi, ptCand);
-      registry.fill(HIST("hMass"), invMassLcToK0sP);
-      registry.fill(HIST("hMassVsPtCand"), invMassLcToK0sP, ptCand);
-      registry.fill(HIST("hPtBach"), ptProng0);
-      registry.fill(HIST("hPtBachVsPtCand"), ptProng0, ptCand);
-      registry.fill(HIST("hPtV0"), ptProng1);
-      registry.fill(HIST("hPtV0VsPtCand"), ptProng1, ptCand);
-      registry.fill(HIST("hd0Bach"), impactParameter0);
-      registry.fill(HIST("hd0BachVsPtCand"), impactParameter0, ptCand);
-      registry.fill(HIST("hd0V0"), impactParameter1);
-      registry.fill(HIST("hd0V0VsPtCand"), impactParameter1, ptCand);
-      registry.fill(HIST("hd0V0pos"), dcaPosToPV);
-      registry.fill(HIST("hd0V0posVsPtCand"), dcaPosToPV, ptCand);
-      registry.fill(HIST("hd0V0neg"), dcaNegToPV);
-      registry.fill(HIST("hd0V0negVsPtCand"), dcaNegToPV, ptCand);
-      registry.fill(HIST("hPtV0pos"), ptV0Pos);
-      registry.fill(HIST("hPtV0posVsPtCand"), ptV0Pos, ptCand);
-      registry.fill(HIST("hPtV0neg"), ptV0Neg);
-      registry.fill(HIST("hPtV0negVsPtCand"), ptV0Neg, ptCand);
-      registry.fill(HIST("hV0CPA"), v0CosPA);
-      registry.fill(HIST("hV0CPAVsPtCand"), v0CosPA, ptCand);
-      registry.fill(HIST("hV0Radius"), v0Radius);
-      registry.fill(HIST("hV0RadiusVsPtCand"), v0Radius, ptCand);
-      registry.fill(HIST("hV0DCADaughters"), dcaV0Daughters);
-      registry.fill(HIST("hV0DCADaughtersVsPtCand"), dcaV0Daughters, ptCand);
-      registry.fill(HIST("hV0MK0Short"), mK0Short);
-      registry.fill(HIST("hV0MK0ShortVsPtCand"), mK0Short, ptCand);
-      registry.fill(HIST("hV0MLambda"), mLambda);
-      registry.fill(HIST("hV0MLambdaVsPtCand"), mLambda, ptCand);
-      registry.fill(HIST("hV0MAntiLambda"), mAntiLambda);
-      registry.fill(HIST("hV0MAntiLambdaVsPtCand"), mAntiLambda, ptCand);
-      registry.fill(HIST("hV0MGamma"), mGamma);
-      registry.fill(HIST("hV0MGammaVsPtCand"), mGamma, ptCand);
-      registry.fill(HIST("hCtV0K0Short"), ctV0K0Short);
-      registry.fill(HIST("hCtV0K0ShortVsPtCand"), ctV0K0Short, ptCand);
-      registry.fill(HIST("hCtV0Lambda"), ctV0Lambda);
-      registry.fill(HIST("hCtV0LambdaVsPtCand"), ctV0Lambda, ptCand);
-      registry.fill(HIST("hCPACand"), cpa);
-      registry.fill(HIST("hCPACandVsPtCand"), cpa, ptCand);
-      registry.fill(HIST("hCPAxyCand"), cpaXY);
-      registry.fill(HIST("hCPAxyCandVsPtCand"), cpaXY, ptCand);
-      registry.fill(HIST("hDecLengthCand"), decayLength);
-      registry.fill(HIST("hDecLengthCandVsPtCand"), decayLength, ptCand);
-      registry.fill(HIST("hDecLengthXYCand"), decayLengthXY);
-      registry.fill(HIST("hDecLengthXYCandVsPtCand"), decayLengthXY, ptCand);
-      registry.fill(HIST("hCtCand"), ctLc);
-      registry.fill(HIST("hCtCandVsPtCand"), ctLc, ptCand);
-
-      const auto& bach = candidate.prong0_as<TracksWPid>(); // bachelor track
+      // PID histograms
+      const auto& bach = candidate.template prong0_as<TracksWPid>();
       auto tpcNSigmaPr = bach.tpcNSigmaPr();
       auto pBach = bach.p();
-      registry.fill(HIST("hTPCNSigmaPrBach"), tpcNSigmaPr);
-      registry.fill(HIST("hPBachVsTPCNSigmaPrBach"), pBach, tpcNSigmaPr);
+      registry.fill(HIST("Data/hTPCNSigmaPrBach"), tpcNSigmaPr);
+      registry.fill(HIST("Data/hPBachVsTPCNSigmaPrBach"), pBach, tpcNSigmaPr);
       if (bach.hasTOF()) {
-        auto tofNSigmaPr = bach.tofNSigmaPr();
-        registry.fill(HIST("hTOFNSigmaPrBach"), tofNSigmaPr);
-        registry.fill(HIST("hPBachVsTOFNSigmaPrBach"), pBach, tofNSigmaPr);
+        registry.fill(HIST("Data/hTOFNSigmaPrBach"), bach.tofNSigmaPr());
+        registry.fill(HIST("Data/hPBachVsTOFNSigmaPrBach"), pBach, bach.tofNSigmaPr());
+      }
+
+      if (fillTHn && FillMl) {
+        if constexpr (CandType::template contains<aod::HfMlLcToK0sP>()) {
+          if (candidate.mlProbLcToK0sP().size() == NumberOfMlClasses) {
+            float ml0 = candidate.mlProbLcToK0sP()[MlClassBackground];
+            float ml1 = candidate.mlProbLcToK0sP()[MlClassPrompt];
+            float ml2 = candidate.mlProbLcToK0sP()[MlClassNonPrompt];
+            if (ml0 >= 0.f && ml1 >= 0.f && ml2 >= 0.f) {
+              float cent = evaluateCentralityColl(collision);
+              int numPvContr = collision.numContrib();
+              registry.get<THnSparse>(HIST("hnLcK0sPDataWithBdt"))->Fill(HfHelper::invMassLcToK0sP(candidate), candidate.pt(), cent, ml0, ml1, ml2, static_cast<double>(numPvContr));
+            }
+          }
+        }
       }
     }
   }
 
-  void processMc(soa::Filtered<soa::Join<aod::HfCandCascExt, aod::HfSelLcToK0sP, aod::HfCandCascadeMcRec>> const& candidates,
-                 soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& mcParticles,
-                 aod::TracksWMc const&,
-                 TracksWPid const&)
+  /// MC processing template
+  /// \tparam FillMl switch to fill ML histograms
+  template <bool FillMl, typename CollType, typename CandType, typename CandMcGen>
+  void runAnalysisPerCollisionMc(CollType const& collisions,
+                                 CandType const& candidates,
+                                 CandMcGen const& mcParticles)
   {
-    // MC rec.
-    for (const auto& candidate : candidates) {
+    for (const auto& collision : collisions) {
+      fillHistosMcRec<FillMl>(collision, candidates, mcParticles);
+    }
+    fillHistosMcGen(mcParticles, collisions);
+  }
+
+  /// Helper function to fill MC reconstructed histograms
+  /// \tparam FillMl switch to fill ML histograms
+  template <bool FillMl, typename CollType, typename CandType, typename CandMcGen>
+  void fillHistosMcRec(CollType const& collision, CandType const& candidates, CandMcGen const&)
+  {
+    const auto thisCollId = collision.globalIndex();
+    const auto& groupedCandidates = candidates.sliceBy(lcToPK0SPerCollision, thisCollId);
+
+    for (const auto& candidate : groupedCandidates) {
       if (etaCandMax >= 0. && std::abs(candidate.eta()) > etaCandMax) {
         continue;
       }
-
       if (yCandRecoMax >= 0. && std::abs(HfHelper::yLc(candidate)) > yCandRecoMax) {
         continue;
       }
 
-      auto ptCand = candidate.pt();
-      auto eta = candidate.eta();
-      auto phi = candidate.phi();
-      auto invMassLcToK0sP = HfHelper::invMassLcToK0sP(candidate);
-      auto ptProng0 = candidate.ptProng0();
-      auto ptProng1 = candidate.ptProng1();
-      auto impactParameter0 = candidate.impactParameter0();
-      auto impactParameter1 = candidate.impactParameter1();
-      auto dcaPosToPV = candidate.dcapostopv();
-      auto dcaNegToPV = candidate.dcanegtopv();
-      auto ptV0Pos = candidate.ptV0Pos();
-      auto ptV0Neg = candidate.ptV0Neg();
-      auto v0CosPA = candidate.v0cosPA();
-      auto v0Radius = candidate.v0radius();
-      auto dcaV0Daughters = candidate.dcaV0daughters();
-      auto mK0Short = candidate.mK0Short();
-      auto mLambda = candidate.mLambda();
-      auto mAntiLambda = candidate.mAntiLambda();
-      auto mGamma = candidate.mGamma();
-      auto ctV0K0Short = HfHelper::ctV0K0s(candidate);
-      auto ctV0Lambda = HfHelper::ctV0Lambda(candidate);
-      auto cpa = candidate.cpa();
-      auto cpaXY = candidate.cpaXY();
-      auto decayLength = candidate.decayLength();
-      auto decayLengthXY = candidate.decayLengthXY();
-      auto ctLc = HfHelper::ctLc(candidate);
+      if (std::abs(candidate.flagMcMatchRec()) == KDecayChannelLcToK0sP) {
+        fillCandHistograms(candidate);
 
-      const auto& bach = candidate.prong0_as<TracksWPid>(); // bachelor track
-      auto tpcNSigmaPr = bach.tpcNSigmaPr();
-      auto pBach = bach.p();
-
-      if (std::abs(candidate.flagMcMatchRec()) == 1) {
-        if (candidate.originMcRec() == RecoDecay::OriginType::Prompt) {
-          registry.fill(HIST("MC/Rec/hPtCandRecSigPrompt"), ptCand);
-        } else if (candidate.originMcRec() == RecoDecay::OriginType::NonPrompt) {
-          registry.fill(HIST("MC/Rec/hPtCandRecSigNonPrompt"), ptCand);
-        }
-        registry.fill(HIST("MC/Rec/hPtCandRecSig"), ptCand);
-        registry.fill(HIST("MC/Rec/hEtaCandRecSig"), eta);
-        registry.fill(HIST("MC/Rec/hEtaCandVsPtCandRecSig"), eta, ptCand);
-        registry.fill(HIST("MC/Rec/hPhiCandRecSig"), phi);
-        registry.fill(HIST("MC/Rec/hPhiCandVsPtCandRecSig"), phi, ptCand);
-        registry.fill(HIST("MC/Rec/hMassRecSig"), invMassLcToK0sP);
-        registry.fill(HIST("MC/Rec/hMassVsPtCandRecSig"), invMassLcToK0sP, ptCand);
-        registry.fill(HIST("MC/Rec/hPtBachRecSig"), ptProng0);
-        registry.fill(HIST("MC/Rec/hPtBachVsPtCandRecSig"), ptProng0, ptCand);
-        registry.fill(HIST("MC/Rec/hPtV0RecSig"), ptProng1);
-        registry.fill(HIST("MC/Rec/hPtV0VsPtCandRecSig"), ptProng1, ptCand);
-        registry.fill(HIST("MC/Rec/hd0BachRecSig"), impactParameter0);
-        registry.fill(HIST("MC/Rec/hd0BachVsPtCandRecSig"), impactParameter0, ptCand);
-        registry.fill(HIST("MC/Rec/hd0V0RecSig"), impactParameter1);
-        registry.fill(HIST("MC/Rec/hd0V0VsPtCandRecSig"), impactParameter1, ptCand);
-        registry.fill(HIST("MC/Rec/hd0V0posRecSig"), dcaPosToPV);
-        registry.fill(HIST("MC/Rec/hd0V0posVsPtCandRecSig"), dcaPosToPV, ptCand);
-        registry.fill(HIST("MC/Rec/hd0V0negRecSig"), dcaNegToPV);
-        registry.fill(HIST("MC/Rec/hd0V0negVsPtCandRecSig"), dcaNegToPV, ptCand);
-        registry.fill(HIST("MC/Rec/hPtV0posRecSig"), ptV0Pos);
-        registry.fill(HIST("MC/Rec/hPtV0posVsPtCandRecSig"), ptV0Pos, ptCand);
-        registry.fill(HIST("MC/Rec/hPtV0negRecSig"), ptV0Neg);
-        registry.fill(HIST("MC/Rec/hPtV0negVsPtCandRecSig"), ptV0Neg, ptCand);
-        registry.fill(HIST("MC/Rec/hV0CPARecSig"), v0CosPA);
-        registry.fill(HIST("MC/Rec/hV0CPAVsPtCandRecSig"), v0CosPA, ptCand);
-        registry.fill(HIST("MC/Rec/hV0RadiusRecSig"), v0Radius);
-        registry.fill(HIST("MC/Rec/hV0RadiusVsPtCandRecSig"), v0Radius, ptCand);
-        registry.fill(HIST("MC/Rec/hV0DCADaughtersRecSig"), dcaV0Daughters);
-        registry.fill(HIST("MC/Rec/hV0DCADaughtersVsPtCandRecSig"), dcaV0Daughters, ptCand);
-        registry.fill(HIST("MC/Rec/hV0MK0ShortRecSig"), mK0Short);
-        registry.fill(HIST("MC/Rec/hV0MK0ShortVsPtCandRecSig"), mK0Short, ptCand);
-        registry.fill(HIST("MC/Rec/hV0MLambdaRecSig"), mLambda);
-        registry.fill(HIST("MC/Rec/hV0MLambdaVsPtCandRecSig"), mLambda, ptCand);
-        registry.fill(HIST("MC/Rec/hV0MAntiLambdaRecSig"), mAntiLambda);
-        registry.fill(HIST("MC/Rec/hV0MAntiLambdaVsPtCandRecSig"), mAntiLambda, ptCand);
-        registry.fill(HIST("MC/Rec/hV0MGammaRecSig"), mGamma);
-        registry.fill(HIST("MC/Rec/hV0MGammaVsPtCandRecSig"), mGamma, ptCand);
-        registry.fill(HIST("MC/Rec/hCtV0K0ShortRecSig"), ctV0K0Short);
-        registry.fill(HIST("MC/Rec/hCtV0K0ShortVsPtCandRecSig"), ctV0K0Short, ptCand);
-        registry.fill(HIST("MC/Rec/hCtV0LambdaRecSig"), ctV0Lambda);
-        registry.fill(HIST("MC/Rec/hCtV0LambdaVsPtCandRecSig"), ctV0Lambda, ptCand);
-        registry.fill(HIST("MC/Rec/hCPACandRecSig"), cpa);
-        registry.fill(HIST("MC/Rec/hCPACandVsPtCandRecSig"), cpa, ptCand);
-        registry.fill(HIST("MC/Rec/hCPAxyCandRecSig"), cpaXY);
-        registry.fill(HIST("MC/Rec/hCPAxyCandVsPtCandRecSig"), cpaXY, ptCand);
-        registry.fill(HIST("MC/Rec/hDecLengthCandRecSig"), decayLength);
-        registry.fill(HIST("MC/Rec/hDecLengthCandVsPtCandRecSig"), decayLength, ptCand);
-        registry.fill(HIST("MC/Rec/hDecLengthXYCandRecSig"), decayLengthXY);
-        registry.fill(HIST("MC/Rec/hDecLengthXYCandVsPtCandRecSig"), decayLengthXY, ptCand);
-        registry.fill(HIST("MC/Rec/hCtCandRecSig"), ctLc);
-        registry.fill(HIST("MC/Rec/hCtCandVsPtCandRecSig"), ctLc, ptCand);
-        registry.fill(HIST("MC/Rec/hTPCNSigmaPrBachRecSig"), tpcNSigmaPr);
-        registry.fill(HIST("MC/Rec/hPBachVsTPCNSigmaPrBachRecSig"), pBach, tpcNSigmaPr);
-        if (bach.hasTOF()) {
-          auto tofNSigmaPr = bach.tofNSigmaPr();
-          registry.fill(HIST("MC/Rec/hTOFNSigmaPrBachRecSig"), tofNSigmaPr);
-          registry.fill(HIST("MC/Rec/hPBachVsTOFNSigmaPrBachRecSig"), pBach, tofNSigmaPr);
-        }
-      } else {
-        registry.fill(HIST("MC/Rec/hPtCandRecBg"), ptCand);
-        registry.fill(HIST("MC/Rec/hEtaCandRecBg"), eta);
-        registry.fill(HIST("MC/Rec/hEtaCandVsPtCandRecBg"), eta, ptCand);
-        registry.fill(HIST("MC/Rec/hPhiCandRecBg"), phi);
-        registry.fill(HIST("MC/Rec/hPhiCandVsPtCandRecBg"), phi, ptCand);
-        registry.fill(HIST("MC/Rec/hMassRecBg"), invMassLcToK0sP);
-        registry.fill(HIST("MC/Rec/hMassVsPtCandRecBg"), invMassLcToK0sP, ptCand);
-        registry.fill(HIST("MC/Rec/hPtBachRecBg"), ptProng0);
-        registry.fill(HIST("MC/Rec/hPtBachVsPtCandRecBg"), ptProng0, ptCand);
-        registry.fill(HIST("MC/Rec/hPtV0RecBg"), ptProng1);
-        registry.fill(HIST("MC/Rec/hPtV0VsPtCandRecBg"), ptProng1, ptCand);
-        registry.fill(HIST("MC/Rec/hd0BachRecBg"), impactParameter0);
-        registry.fill(HIST("MC/Rec/hd0BachVsPtCandRecBg"), impactParameter0, ptCand);
-        registry.fill(HIST("MC/Rec/hd0V0RecBg"), impactParameter1);
-        registry.fill(HIST("MC/Rec/hd0V0VsPtCandRecBg"), impactParameter1, ptCand);
-        registry.fill(HIST("MC/Rec/hd0V0posRecBg"), dcaPosToPV);
-        registry.fill(HIST("MC/Rec/hd0V0posVsPtCandRecBg"), dcaPosToPV, ptCand);
-        registry.fill(HIST("MC/Rec/hd0V0negRecBg"), dcaNegToPV);
-        registry.fill(HIST("MC/Rec/hd0V0negVsPtCandRecBg"), dcaNegToPV, ptCand);
-        registry.fill(HIST("MC/Rec/hPtV0posRecBg"), ptV0Pos);
-        registry.fill(HIST("MC/Rec/hPtV0posVsPtCandRecBg"), ptV0Pos, ptCand);
-        registry.fill(HIST("MC/Rec/hPtV0negRecBg"), ptV0Neg);
-        registry.fill(HIST("MC/Rec/hPtV0negVsPtCandRecBg"), ptV0Neg, ptCand);
-        registry.fill(HIST("MC/Rec/hV0CPARecBg"), v0CosPA);
-        registry.fill(HIST("MC/Rec/hV0CPAVsPtCandRecBg"), v0CosPA, ptCand);
-        registry.fill(HIST("MC/Rec/hV0RadiusRecBg"), v0Radius);
-        registry.fill(HIST("MC/Rec/hV0RadiusVsPtCandRecBg"), v0Radius, ptCand);
-        registry.fill(HIST("MC/Rec/hV0DCADaughtersRecBg"), dcaV0Daughters);
-        registry.fill(HIST("MC/Rec/hV0DCADaughtersVsPtCandRecBg"), dcaV0Daughters, ptCand);
-        registry.fill(HIST("MC/Rec/hV0MK0ShortRecBg"), mK0Short);
-        registry.fill(HIST("MC/Rec/hV0MK0ShortVsPtCandRecBg"), mK0Short, ptCand);
-        registry.fill(HIST("MC/Rec/hV0MLambdaRecBg"), mLambda);
-        registry.fill(HIST("MC/Rec/hV0MLambdaVsPtCandRecBg"), mLambda, ptCand);
-        registry.fill(HIST("MC/Rec/hV0MAntiLambdaRecBg"), mAntiLambda);
-        registry.fill(HIST("MC/Rec/hV0MAntiLambdaVsPtCandRecBg"), mAntiLambda, ptCand);
-        registry.fill(HIST("MC/Rec/hV0MGammaRecBg"), mGamma);
-        registry.fill(HIST("MC/Rec/hV0MGammaVsPtCandRecBg"), mGamma, ptCand);
-        registry.fill(HIST("MC/Rec/hCtV0K0ShortRecBg"), ctV0K0Short);
-        registry.fill(HIST("MC/Rec/hCtV0K0ShortVsPtCandRecBg"), ctV0K0Short, ptCand);
-        registry.fill(HIST("MC/Rec/hCtV0LambdaRecBg"), ctV0Lambda);
-        registry.fill(HIST("MC/Rec/hCtV0LambdaVsPtCandRecBg"), ctV0Lambda, ptCand);
-        registry.fill(HIST("MC/Rec/hCPACandRecBg"), cpa);
-        registry.fill(HIST("MC/Rec/hCPACandVsPtCandRecBg"), cpa, ptCand);
-        registry.fill(HIST("MC/Rec/hCPAxyCandRecBg"), cpaXY);
-        registry.fill(HIST("MC/Rec/hCPAxyCandVsPtCandRecBg"), cpaXY, ptCand);
-        registry.fill(HIST("MC/Rec/hDecLengthCandRecBg"), decayLength);
-        registry.fill(HIST("MC/Rec/hDecLengthCandVsPtCandRecBg"), decayLength, ptCand);
-        registry.fill(HIST("MC/Rec/hDecLengthXYCandRecBg"), decayLengthXY);
-        registry.fill(HIST("MC/Rec/hDecLengthXYCandVsPtCandRecBg"), decayLengthXY, ptCand);
-        registry.fill(HIST("MC/Rec/hCtCandRecBg"), ctLc);
-        registry.fill(HIST("MC/Rec/hCtCandVsPtCandRecBg"), ctLc, ptCand);
-        registry.fill(HIST("MC/Rec/hTPCNSigmaPrBachRecBg"), tpcNSigmaPr);
-        registry.fill(HIST("MC/Rec/hPBachVsTPCNSigmaPrBachRecBg"), pBach, tpcNSigmaPr);
-        if (bach.hasTOF()) {
-          auto tofNSigmaPr = bach.tofNSigmaPr();
-          registry.fill(HIST("MC/Rec/hTOFNSigmaPrBachRecBg"), tofNSigmaPr);
-          registry.fill(HIST("MC/Rec/hPBachVsTOFNSigmaPrBachRecBg"), pBach, tofNSigmaPr);
+        if (fillTHn && FillMl) {
+          float mass = HfHelper::invMassLcToK0sP(candidate);
+          float pt = candidate.pt();
+          std::array<float, 3> mlScores{-1.f, -1.f, -1.f};
+          if constexpr (CandType::template contains<aod::HfMlLcToK0sP>()) {
+            if (candidate.mlProbLcToK0sP().size() == NumberOfMlClasses) {
+              mlScores = {candidate.mlProbLcToK0sP()[MlClassBackground],
+                          candidate.mlProbLcToK0sP()[MlClassPrompt],
+                          candidate.mlProbLcToK0sP()[MlClassNonPrompt]};
+            }
+          }
+          float cent = evaluateCentralityColl(collision);
+          int numPvContr = collision.numContrib();
+          int8_t origin = candidate.originMcRec();
+          registry.get<THnSparse>(HIST("hnLcK0sPRecMcWithBdt"))->Fill(mass, pt, cent, mlScores[0], mlScores[1], mlScores[2], static_cast<double>(numPvContr), origin);
         }
       }
     }
-    // MC gen.
+  }
+
+  /// Helper function to fill MC generated histograms
+  template <typename CandMcGen, typename Coll>
+  void fillHistosMcGen(CandMcGen const& mcParticles, Coll const& recoCollisions)
+  {
     for (const auto& particle : mcParticles) {
-      if (etaCandMax >= 0. && std::abs(particle.eta()) > etaCandMax) {
-        continue;
-      }
-
-      if (std::abs(particle.flagMcMatchGen()) == 1) {
-
+      // if (etaCandMax >= 0. && std::abs(particle.eta()) > etaCandMax) {
+      //   continue;
+      // }
+      if (std::abs(particle.flagMcMatchGen()) == KDecayChannelLcToK0sP) {
         auto yGen = RecoDecay::y(particle.pVector(), o2::constants::physics::MassLambdaCPlus);
         if (yCandGenMax >= 0. && std::abs(yGen) > yCandGenMax) {
           continue;
         }
-        auto ptCand = particle.pt();
-        auto eta = particle.eta();
-        auto phi = particle.phi();
-        registry.fill(HIST("MC/Gen/hPtCandGen"), ptCand);
-        registry.fill(HIST("MC/Gen/hEtaCandGen"), eta);
-        registry.fill(HIST("MC/Gen/hEtaCandVsPtCandGen"), eta, ptCand);
-        registry.fill(HIST("MC/Gen/hPhiCandGen"), phi);
-        registry.fill(HIST("MC/Gen/hPhiCandVsPtCandGen"), phi, ptCand);
-
+        registry.fill(HIST("MC/Gen/hPtCandGen"), particle.pt());
+        registry.fill(HIST("MC/Gen/hEtaCandGen"), particle.eta());
+        registry.fill(HIST("MC/Gen/hPhiCandGen"), particle.phi());
         if (particle.originMcGen() == RecoDecay::OriginType::Prompt) {
-          registry.fill(HIST("MC/Gen/hPtCandGenPrompt"), ptCand);
+          registry.fill(HIST("MC/Gen/hPtCandGenPrompt"), particle.pt());
         } else if (particle.originMcGen() == RecoDecay::OriginType::NonPrompt) {
-          registry.fill(HIST("MC/Gen/hPtCandGenNonPrompt"), ptCand);
+          registry.fill(HIST("MC/Gen/hPtCandGenNonPrompt"), particle.pt());
+        }
+
+        if (fillTHn) {
+          int8_t origin = particle.originMcGen();
+          float ptB = (origin == RecoDecay::OriginType::NonPrompt) ? mcParticles.rawIteratorAt(particle.idxBhadMotherPart()).pt() : -1.;
+          const auto& recoCollsPerMcColl = recoCollisions.sliceBy(colPerMcCollision, particle.mcCollision().globalIndex());
+          int numPvContr = 0;
+          for (const auto& recCol : recoCollsPerMcColl) {
+            numPvContr = recCol.numContrib() > numPvContr ? recCol.numContrib() : numPvContr;
+          }
+          float cent = o2::hf_centrality::getCentralityGenColl(recoCollsPerMcColl);
+          registry.get<THnSparse>(HIST("hnLcK0sPGenMc"))->Fill(particle.pt(), cent, yGen, static_cast<double>(numPvContr), ptB, origin);
         }
       }
     }
   }
 
-  PROCESS_SWITCH(HfTaskLcToK0sP, processMc, "Process MC data", false);
+  void processDataStd(Collisions const& collisions,
+              FilteredCandLcToPK0SWSelFlag const& candidates,
+              TracksWPid const&)
+  {
+    runAnalysisPerCollisionData<false>(collisions, candidates);
+  }
+  PROCESS_SWITCH(HfTaskLcToK0sP, processDataStd, "Process Data", false);
+
+  void processMcStd(CollisionsMc const& collisions,
+                 FilteredCandLcToPK0SWSelFlagAndMc const& candidates,
+                 soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& mcParticles,
+                 aod::TracksWMc const&,
+                 TracksWPid const&)
+  {
+    runAnalysisPerCollisionMc<false>(collisions, candidates, mcParticles);
+  }
+  PROCESS_SWITCH(HfTaskLcToK0sP, processMcStd, "Process MC data", false);
+
+  // Data with ML
+  void processDataWithMl(Collisions const& collisions,
+                        FilteredCandLcToPK0SWSelFlagAndMl const& candidates,
+                        TracksWPid const&)
+  {
+    runAnalysisPerCollisionData<true>(collisions, candidates);
+  }
+  PROCESS_SWITCH(HfTaskLcToK0sP, processDataWithMl, "Process Data with ML", false);
+
+  // MC Rec and Gen with ML
+  void processMcWithMl(CollisionsMc const& collisions,
+                          FilteredCandLcToPK0SWSelFlagAndMcAndMl const& candidates,
+                          soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& mcParticles,
+                          aod::TracksWMc const&,
+                          TracksWPid const&)
+  {
+    runAnalysisPerCollisionMc<true>(collisions, candidates, mcParticles);
+  }
+  PROCESS_SWITCH(HfTaskLcToK0sP, processMcWithMl, "Process MC with ML", false);
+
+  // Data with FT0C centrality
+  void processDataStdWithFT0C(CollisionsWithFT0C const& collisions,
+                              FilteredCandLcToPK0SWSelFlag const& candidates,
+                              TracksWPid const&)
+  {
+    runAnalysisPerCollisionData<false>(collisions, candidates);
+  }
+  PROCESS_SWITCH(HfTaskLcToK0sP, processDataStdWithFT0C, "Process Data with FT0C centrality", false);
+
+  // Data with FT0M centrality
+  void processDataStdWithFT0M(CollisionsWithFT0M const& collisions,
+                              FilteredCandLcToPK0SWSelFlag const& candidates,
+                              TracksWPid const&)
+  {
+    runAnalysisPerCollisionData<false>(collisions, candidates);
+  }
+  PROCESS_SWITCH(HfTaskLcToK0sP, processDataStdWithFT0M, "Process Data with FT0M centrality", false);
+
+  // Data with ML + FT0C centrality
+  void processDataWithMlWithFT0C(CollisionsWithFT0C const& collisions,
+                                 FilteredCandLcToPK0SWSelFlagAndMl const& candidates,
+                                 TracksWPid const&)
+  {
+    runAnalysisPerCollisionData<true>(collisions, candidates);
+  }
+  PROCESS_SWITCH(HfTaskLcToK0sP, processDataWithMlWithFT0C, "Process Data with ML and FT0C centrality", false);
+
+  // Data with ML + FT0M centrality
+  void processDataWithMlWithFT0M(CollisionsWithFT0M const& collisions,
+                                 FilteredCandLcToPK0SWSelFlagAndMl const& candidates,
+                                 TracksWPid const&)
+  {
+    runAnalysisPerCollisionData<true>(collisions, candidates);
+  }
+  PROCESS_SWITCH(HfTaskLcToK0sP, processDataWithMlWithFT0M, "Process Data with ML and FT0M centrality", false);
+
+  // MC Std with FT0C centrality
+  void processMcStdWithFT0C(CollisionsMcWithFT0C const& collisions,
+                            FilteredCandLcToPK0SWSelFlagAndMc const& candidates,
+                            soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& mcParticles,
+                            aod::TracksWMc const&,
+                            TracksWPid const&)
+  {
+    runAnalysisPerCollisionMc<false>(collisions, candidates, mcParticles);
+  }
+  PROCESS_SWITCH(HfTaskLcToK0sP, processMcStdWithFT0C, "Process MC with FT0C centrality", false);
+
+  // MC Std with FT0M centrality
+  void processMcStdWithFT0M(CollisionsMcWithFT0M const& collisions,
+                             FilteredCandLcToPK0SWSelFlagAndMc const& candidates,
+                             soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& mcParticles,
+                             aod::TracksWMc const&,
+                             TracksWPid const&)
+  {
+    runAnalysisPerCollisionMc<false>(collisions, candidates, mcParticles);
+  }
+  PROCESS_SWITCH(HfTaskLcToK0sP, processMcStdWithFT0M, "Process MC with FT0M centrality", false);
+
+  // MC with ML + FT0C centrality
+  void processMcWithMlWithFT0C(CollisionsMcWithFT0C const& collisions,
+                                FilteredCandLcToPK0SWSelFlagAndMcAndMl const& candidates,
+                                soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& mcParticles,
+                                aod::TracksWMc const&,
+                                TracksWPid const&)
+  {
+    runAnalysisPerCollisionMc<true>(collisions, candidates, mcParticles);
+  }
+  PROCESS_SWITCH(HfTaskLcToK0sP, processMcWithMlWithFT0C, "Process MC with ML and FT0C centrality", false);
+
+  // MC with ML + FT0M centrality
+  void processMcWithMlWithFT0M(CollisionsMcWithFT0M const& collisions,
+                               FilteredCandLcToPK0SWSelFlagAndMcAndMl const& candidates,
+                               soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& mcParticles,
+                               aod::TracksWMc const&,
+                               TracksWPid const&)
+  {
+    runAnalysisPerCollisionMc<true>(collisions, candidates, mcParticles);
+  }
+  PROCESS_SWITCH(HfTaskLcToK0sP, processMcWithMlWithFT0M, "Process MC with ML and FT0M centrality", false);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
-  return WorkflowSpec{
-    adaptAnalysisTask<HfTaskLcToK0sP>(cfgc),
-  };
+  return WorkflowSpec{adaptAnalysisTask<HfTaskLcToK0sP>(cfgc)};
 }

--- a/PWGHF/HFC/TableProducer/derivedDataCreatorCorrelationsReduced.cxx
+++ b/PWGHF/HFC/TableProducer/derivedDataCreatorCorrelationsReduced.cxx
@@ -551,8 +551,8 @@ struct HfDerivedDataCreatorCorrelationsReduced {
 
   // Lc with ML selections
   void processLcSameEvent(CollsWithCentMult::iterator const& coll,
-                           TracksData const& tracks,
-                           CandLcData const&)
+                          TracksData const& tracks,
+                          CandLcData const&)
   {
     auto candsLcToPKPi = selectedLcToPKPi->sliceByCached(aod::hf_cand::collisionId, coll.globalIndex(), cache);
     if (forceCharmInCollision && candsLcToPKPi.size() < 1) {

--- a/PWGHF/HFC/TableProducer/derivedDataCreatorCorrelationsReduced.cxx
+++ b/PWGHF/HFC/TableProducer/derivedDataCreatorCorrelationsReduced.cxx
@@ -63,6 +63,7 @@ enum CandidateType {
   DsToPiKK,
   D0ToPiK,
   D0ToKPi,
+  LcToPKPi,
   Hadron
 };
 
@@ -103,7 +104,7 @@ struct HfDerivedDataCreatorCorrelationsReduced {
   Configurable<std::vector<double>> binsPtAssoc{"binsPtAssoc", std::vector<double>{0.2, 1., 2., 50.}, "pT bin limits for associated particles"};
 
   HfEventSelection hfEvSel; // event selection and monitoring
-  o2::framework::Service<o2::ccdb::BasicCCDBManager> ccdb{};
+  o2::framework::Service<o2::ccdb::BasicCCDBManager> ccdb;
   SliceCache cache;
 
   double massCharm{0.};
@@ -113,22 +114,26 @@ struct HfDerivedDataCreatorCorrelationsReduced {
   using CandDsData = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi, aod::HfMlDsToKKPi>>;
   using CandDplusData = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDplusToPiKPi, aod::HfMlDplusToPiKPi>>;
   using CandD0Data = soa::Filtered<soa::Join<aod::HfCand2Prong, aod::HfSelD0, aod::HfMlD0>>;
+  using CandLcData = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelLc, aod::HfMlLcToPKPi>>;
   using TracksData = soa::Filtered<soa::Join<aod::TracksWDca, aod::TrackSelection, aod::TracksExtra>>;
 
   Filter filterSelectDsCandidates = aod::hf_sel_candidate_ds::isSelDsToKKPi >= selectionFlag || aod::hf_sel_candidate_ds::isSelDsToPiKK >= selectionFlag;
   Filter filterSelectDplusCandidates = aod::hf_sel_candidate_dplus::isSelDplusToPiKPi >= selectionFlag;
   Filter filterSelectD0Candidates = aod::hf_sel_candidate_d0::isSelD0 >= selectionFlag || aod::hf_sel_candidate_d0::isSelD0bar >= selectionFlag;
+  Filter filterSelectLcCandidates = aod::hf_sel_candidate_lc::isSelLcToPKPi >= selectionFlag;
   Filter filterSelectTrkData = (nabs(aod::track::eta) < etaTrkMax) && (aod::track::pt > ptTrkMin) && (aod::track::pt < ptTrkMax) && (nabs(aod::track::dcaXY) < dcaXYTrkMax) && (nabs(aod::track::dcaZ) < dcaZTrkMax);
 
   Preslice<CandDsData> candsDsPerColl = aod::hf_cand::collisionId;
   Preslice<CandDplusData> candsDplusPerColl = aod::hf_cand::collisionId;
   Preslice<CandD0Data> candsD0PerColl = aod::hf_cand::collisionId;
+  Preslice<CandLcData> candsLcPerColl = aod::hf_cand::collisionId;
   Preslice<TracksData> trackIndicesPerColl = aod::track::collisionId;
 
   Partition<CandDsData> selectedDsToKKPi = aod::hf_sel_candidate_ds::isSelDsToKKPi >= selectionFlag;
   Partition<CandDsData> selectedDsToPiKK = aod::hf_sel_candidate_ds::isSelDsToPiKK >= selectionFlag;
   Partition<CandD0Data> selectedD0ToPiK = aod::hf_sel_candidate_d0::isSelD0 >= selectionFlag;
   Partition<CandD0Data> selectedD0ToKPi = aod::hf_sel_candidate_d0::isSelD0bar >= selectionFlag;
+  Partition<CandLcData> selectedLcToPKPi = aod::hf_sel_candidate_lc::isSelLcToPKPi >= selectionFlag;
 
   ConfigurableAxis binsInvMass{"binsInvMass", {300, 1.6, 2.2}, ""};
   ConfigurableAxis binsMultFT0M{"binsMultFT0M", {100, 0., 10000.}, "Multiplicity as FT0M signal amplitude"};
@@ -152,6 +157,8 @@ struct HfDerivedDataCreatorCorrelationsReduced {
       massCharm = o2::constants::physics::MassDS;
     } else if (doprocessD0SameEvent || doprocessD0MixedEvent) {
       massCharm = o2::constants::physics::MassD0;
+    } else if (doprocessLcSameEvent || doprocessLcMixedEvent) {
+      massCharm = o2::constants::physics::MassLambdaCPlus;
     } else if (doprocessHadronHadronSameEvent || doprocessHadronHadronMixedEvent) {
       LOG(info) << "Charm mass not set, processing Hadron-Hadron case";
     } else {
@@ -211,6 +218,9 @@ struct HfDerivedDataCreatorCorrelationsReduced {
     if constexpr (CandType == CandidateType::D0ToKPi) {
       return HfHelper::invMassD0barToKPi(candidate);
     }
+    if constexpr (CandType == CandidateType::LcToPKPi) {
+      return HfHelper::invMassLcToPKPi(candidate);
+    }
     return -1.;
   }
 
@@ -243,6 +253,11 @@ struct HfDerivedDataCreatorCorrelationsReduced {
     if constexpr (CandType == CandidateType::D0ToKPi) {
       for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
         outputMl[iclass] = candidate.mlProbD0bar()[classMl->at(iclass)];
+      }
+    }
+    if constexpr (CandType == CandidateType::LcToPKPi) {
+      for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
+        outputMl[iclass] = candidate.mlProbLcToPKPi()[classMl->at(iclass)];
       }
     }
     return outputMl;
@@ -533,6 +548,43 @@ struct HfDerivedDataCreatorCorrelationsReduced {
     fillTrkMixedEvent(tracks, cent);
   }
   PROCESS_SWITCH(HfDerivedDataCreatorCorrelationsReduced, processD0MixedEvent, "Process Mixed Event for D0 candidates", false);
+
+  // Lc with ML selections
+  void processLcSameEvent(CollsWithCentMult::iterator const& coll,
+                           TracksData const& tracks,
+                           CandLcData const&)
+  {
+    auto candsLcToPKPi = selectedLcToPKPi->sliceByCached(aod::hf_cand::collisionId, coll.globalIndex(), cache);
+    if (forceCharmInCollision && candsLcToPKPi.size() < 1) {
+      return;
+    }
+    float cent{-1.}, mult{-1.};
+    if (!checkCollision(coll, cent, mult)) {
+      return;
+    }
+    rowCollisions(mult, coll.numContrib(), cent, coll.posZ());
+    fillSameEvent<CandidateType::LcToPKPi>(candsLcToPKPi, tracks, cent);
+  }
+  PROCESS_SWITCH(HfDerivedDataCreatorCorrelationsReduced, processLcSameEvent, "Process Same Event for Lc candidates", false);
+
+  // Lc with ML selections
+  void processLcMixedEvent(CollsWithCentMult::iterator const& coll,
+                           TracksData const& tracks,
+                           CandLcData const&)
+  {
+    auto candsLcToPKPi = selectedLcToPKPi->sliceByCached(aod::hf_cand::collisionId, coll.globalIndex(), cache);
+    if (forceCharmInCollision && candsLcToPKPi.size() < 1) {
+      return;
+    }
+    float cent{-1.}, mult{-1.};
+    if (!checkCollision(coll, cent, mult)) {
+      return;
+    }
+    rowCollisions(mult, coll.numContrib(), cent, coll.posZ());
+    fillCharmMixedEvent<CandidateType::LcToPKPi>(candsLcToPKPi);
+    fillTrkMixedEvent(tracks, cent);
+  }
+  PROCESS_SWITCH(HfDerivedDataCreatorCorrelationsReduced, processLcMixedEvent, "Process Mixed Event for Lc candidates", false);
 
   // Hadron Hadron Same Event
   void processHadronHadronSameEvent(CollsWithCentMult::iterator const& coll,

--- a/PWGHF/TableProducer/candidateCreatorCascade.cxx
+++ b/PWGHF/TableProducer/candidateCreatorCascade.cxx
@@ -233,7 +233,9 @@ struct HfCandidateCreatorCascade {
           covV[i] = v0row.positionCovMat()[i];
         }
       } else {
-        LOGF(warning, "V0Data not there for V0 %d in HF cascade %d. Skipping candidate.", casc.v0Id(), casc.globalIndex());
+        if (!silenceV0DataWarning) {
+            LOGF(warning, "V0Data not there for V0 %d in HF cascade %d. Skipping candidate.", casc.v0Id(), casc.globalIndex());
+        }
         continue; // this was inadequately linked, should not happen
       }
 

--- a/PWGHF/TableProducer/candidateCreatorCascade.cxx
+++ b/PWGHF/TableProducer/candidateCreatorCascade.cxx
@@ -234,7 +234,7 @@ struct HfCandidateCreatorCascade {
         }
       } else {
         if (!silenceV0DataWarning) {
-            LOGF(warning, "V0Data not there for V0 %d in HF cascade %d. Skipping candidate.", casc.v0Id(), casc.globalIndex());
+          LOGF(warning, "V0Data not there for V0 %d in HF cascade %d. Skipping candidate.", casc.v0Id(), casc.globalIndex());
         }
         continue; // this was inadequately linked, should not happen
       }


### PR DESCRIPTION
Add THnSparse support for Λc→K0sP analysis with BDT scores (Data, MC Rec, MC Gen). Add process functions for standard/ML with FT0C/FT0M centrality estimators. Refactor code structure to align with taskLc.cxx."