### PR TITLE
[PWGHF] Improve tasks for B to JPsi analyses

### DIFF
--- a/PWGHF/Core/HfHelper.h
+++ b/PWGHF/Core/HfHelper.h
@@ -937,7 +937,7 @@ struct HfHelper {
     }
 
     // J/Psi mass
-    if (std::abs(candJpsi.m() - o2::constants::physics::MassJPsi) < cuts->get(binPt, "DeltaM J/Psi")) {
+    if (std::abs(candJpsi.m() - o2::constants::physics::MassJPsi) > cuts->get(binPt, "DeltaM J/Psi")) {
       return false;
     }
 
@@ -1127,12 +1127,12 @@ struct HfHelper {
     }
 
     // phi mass
-    if (std::abs(mCandPhi - o2::constants::physics::MassPhi) < cuts->get(binPt, "DeltaM phi")) {
+    if (std::abs(mCandPhi - o2::constants::physics::MassPhi) > cuts->get(binPt, "DeltaM phi")) {
       return false;
     }
 
     // J/Psi mass
-    if (std::abs(candJpsi.m() - o2::constants::physics::MassJPsi) < cuts->get(binPt, "DeltaM J/Psi")) {
+    if (std::abs(candJpsi.m() - o2::constants::physics::MassJPsi) > cuts->get(binPt, "DeltaM J/Psi")) {
       return false;
     }
 

--- a/PWGHF/Core/HfHelper.h
+++ b/PWGHF/Core/HfHelper.h
@@ -174,16 +174,16 @@ struct HfHelper {
   template <typename T>
   static auto invMassBplusToJpsiK(const T& candidate, const bool useJpsiPdgMass)
   {
-    const std::array pVecMuPos{candidate.pxProng0(), candidate.pyProng0(), candidate.pzProng0()};
-    const std::array pVecMuNeg{candidate.pxProng1(), candidate.pyProng1(), candidate.pzProng1()};
-    const std::array pVecKa{candidate.pxProng2(), candidate.pyProng2(), candidate.pzProng2()};
+    auto const pVecMuPos = candidate.pVectorProng0();
+    auto const pVecMuNeg = candidate.pVectorProng1();
+    auto const pVecKa = candidate.pVectorProng2();
     if (useJpsiPdgMass) {
       return RecoDecay::m(std::array{RecoDecay::pVec(pVecMuPos, pVecMuNeg), pVecKa},
                           std::array{o2::constants::physics::MassJPsi, o2::constants::physics::MassKPlus});
-    } else {
-      return RecoDecay::m(std::array{pVecMuPos, pVecMuNeg, pVecKa},
-                          std::array{o2::constants::physics::MassMuon, o2::constants::physics::MassMuon, o2::constants::physics::MassKPlus});
     }
+    // Do not use PDG mass for J/psi
+    return RecoDecay::m(std::array{pVecMuPos, pVecMuNeg, pVecKa},
+                        std::array{o2::constants::physics::MassMuon, o2::constants::physics::MassMuon, o2::constants::physics::MassKPlus});
   }
 
   template <typename T>
@@ -695,23 +695,25 @@ struct HfHelper {
   template <typename T>
   static auto invMassBsToJpsiPhi(const T& candidate, const bool useJpsiPdgMass, const bool usePhiPdgMass)
   {
-    const std::array pVecMuPos{candidate.pxProng0(), candidate.pyProng0(), candidate.pzProng0()};
-    const std::array pVecMuNeg{candidate.pxProng1(), candidate.pyProng1(), candidate.pzProng1()};
-    const std::array pVecKaPos{candidate.pxProng2(), candidate.pyProng2(), candidate.pzProng2()};
-    const std::array pVecKaNeg{candidate.pxProng3(), candidate.pyProng3(), candidate.pzProng3()};
+    auto const pVecMuPos = candidate.pVectorProng0();
+    auto const pVecMuNeg = candidate.pVectorProng1();
+    auto const pVecKaPos = candidate.pVectorProng2();
+    auto const pVecKaNeg = candidate.pVectorProng3();
     if (useJpsiPdgMass && usePhiPdgMass) {
       return RecoDecay::m(std::array{RecoDecay::pVec(pVecMuPos, pVecMuNeg), RecoDecay::pVec(pVecKaPos, pVecKaNeg)},
                           std::array{o2::constants::physics::MassJPsi, o2::constants::physics::MassPhi});
-    } else if (useJpsiPdgMass && !usePhiPdgMass) {
+    }
+    if (useJpsiPdgMass && !usePhiPdgMass) {
       return RecoDecay::m(std::array{RecoDecay::pVec(pVecMuPos, pVecMuNeg), pVecKaPos, pVecKaNeg},
                           std::array{o2::constants::physics::MassJPsi, o2::constants::physics::MassKPlus, o2::constants::physics::MassKPlus});
-    } else if (!useJpsiPdgMass && usePhiPdgMass) {
+    }
+    if (!useJpsiPdgMass && usePhiPdgMass) {
       return RecoDecay::m(std::array{pVecMuPos, pVecMuNeg, RecoDecay::pVec(pVecKaPos, pVecKaNeg)},
                           std::array{o2::constants::physics::MassMuon, o2::constants::physics::MassMuon, o2::constants::physics::MassPhi});
-    } else {
-      return RecoDecay::m(std::array{pVecMuPos, pVecMuNeg, pVecKaPos, pVecKaNeg},
-                          std::array{o2::constants::physics::MassMuon, o2::constants::physics::MassMuon, o2::constants::physics::MassKPlus, o2::constants::physics::MassKPlus});
     }
+    // Do not use PDG mass for either J/psi or phi
+    return RecoDecay::m(std::array{pVecMuPos, pVecMuNeg, pVecKaPos, pVecKaNeg},
+                        std::array{o2::constants::physics::MassMuon, o2::constants::physics::MassMuon, o2::constants::physics::MassKPlus, o2::constants::physics::MassKPlus});
   }
 
   template <typename T>
@@ -937,9 +939,9 @@ struct HfHelper {
   {
     auto ptCandBp = candBp.pt();
     auto mCandBp = invMassBplusToJpsiK(candBp, useJpsiPdgMass);
-    std::array<float, 3> const pVecMu0 = {candBp.pxProng0(), candBp.pyProng0(), candBp.pzProng0()};
-    std::array<float, 3> const pVecMu1 = {candBp.pxProng1(), candBp.pyProng1(), candBp.pzProng1()};
-    std::array<float, 3> const pVecKa = {candBp.pxProng2(), candBp.pyProng2(), candBp.pzProng2()};
+    auto const pVecMu0 = candBp.pVectorProng0();
+    auto const pVecMu1 = candBp.pVectorProng1();
+    auto const pVecKa = candBp.pVectorProng2();
     auto ptJpsi = RecoDecay::pt(pVecMu0, pVecMu1);
     auto ptKa = RecoDecay::pt(pVecKa);
     auto candJpsi = candBp.jpsi();
@@ -1127,10 +1129,10 @@ struct HfHelper {
   {
     auto ptCandBs = candBs.pt();
     auto mCandBs = invMassBsToJpsiPhi(candBs, useJpsiPdgMass, usePhiPdgMass);
-    std::array<float, 3> const pVecMu0 = {candBs.pxProng0(), candBs.pyProng0(), candBs.pzProng0()};
-    std::array<float, 3> const pVecMu1 = {candBs.pxProng1(), candBs.pyProng1(), candBs.pzProng1()};
-    std::array<float, 3> const pVecKa0 = {candBs.pxProng2(), candBs.pyProng2(), candBs.pzProng2()};
-    std::array<float, 3> const pVecKa1 = {candBs.pxProng3(), candBs.pyProng3(), candBs.pzProng3()};
+    auto const pVecMu0 = candBs.pVectorProng0();
+    auto const pVecMu1 = candBs.pVectorProng1();
+    auto const pVecKa0 = candBs.pVectorProng2();
+    auto const pVecKa1 = candBs.pVectorProng3();
     auto mCandPhi = RecoDecay::m(std::array{pVecKa0, pVecKa1}, std::array{o2::constants::physics::MassKPlus, o2::constants::physics::MassKPlus});
     auto ptJpsi = RecoDecay::pt(pVecMu0, pVecMu1);
     auto ptKa0 = RecoDecay::pt(pVecKa0);

--- a/PWGHF/Core/HfHelper.h
+++ b/PWGHF/Core/HfHelper.h
@@ -172,9 +172,18 @@ struct HfHelper {
   }
 
   template <typename T>
-  static auto invMassBplusToJpsiK(const T& candidate)
+  static auto invMassBplusToJpsiK(const T& candidate, const bool useJpsiPdgMass)
   {
-    return candidate.m(std::array{o2::constants::physics::MassMuon, o2::constants::physics::MassMuon, o2::constants::physics::MassKPlus});
+    const std::array pVecMuPos{candidate.pxProng0(), candidate.pyProng0(), candidate.pzProng0()};
+    const std::array pVecMuNeg{candidate.pxProng1(), candidate.pyProng1(), candidate.pzProng1()};
+    const std::array pVecKa{candidate.pxProng2(), candidate.pyProng2(), candidate.pzProng2()};
+    if (useJpsiPdgMass) {
+      return RecoDecay::m(std::array{RecoDecay::pVec(pVecMuPos, pVecMuNeg), pVecKa},
+                          std::array{o2::constants::physics::MassJPsi, o2::constants::physics::MassKPlus});
+    } else {
+      return RecoDecay::m(std::array{pVecMuPos, pVecMuNeg, pVecKa},
+                          std::array{o2::constants::physics::MassMuon, o2::constants::physics::MassMuon, o2::constants::physics::MassKPlus});
+    }
   }
 
   template <typename T>
@@ -684,9 +693,25 @@ struct HfHelper {
   }
 
   template <typename T>
-  static auto invMassBsToJpsiPhi(const T& candidate)
+  static auto invMassBsToJpsiPhi(const T& candidate, const bool useJpsiPdgMass, const bool usePhiPdgMass)
   {
-    return candidate.m(std::array{o2::constants::physics::MassMuon, o2::constants::physics::MassMuon, o2::constants::physics::MassKPlus, o2::constants::physics::MassKPlus});
+    const std::array pVecMuPos{candidate.pxProng0(), candidate.pyProng0(), candidate.pzProng0()};
+    const std::array pVecMuNeg{candidate.pxProng1(), candidate.pyProng1(), candidate.pzProng1()};
+    const std::array pVecKaPos{candidate.pxProng2(), candidate.pyProng2(), candidate.pzProng2()};
+    const std::array pVecKaNeg{candidate.pxProng3(), candidate.pyProng3(), candidate.pzProng3()};
+    if (useJpsiPdgMass && usePhiPdgMass) {
+      return RecoDecay::m(std::array{RecoDecay::pVec(pVecMuPos, pVecMuNeg), RecoDecay::pVec(pVecKaPos, pVecKaNeg)},
+                          std::array{o2::constants::physics::MassJPsi, o2::constants::physics::MassPhi});
+    } else if (useJpsiPdgMass && !usePhiPdgMass) {
+      return RecoDecay::m(std::array{RecoDecay::pVec(pVecMuPos, pVecMuNeg), pVecKaPos, pVecKaNeg},
+                          std::array{o2::constants::physics::MassJPsi, o2::constants::physics::MassKPlus, o2::constants::physics::MassKPlus});
+    } else if (!useJpsiPdgMass && usePhiPdgMass) {
+      return RecoDecay::m(std::array{pVecMuPos, pVecMuNeg, RecoDecay::pVec(pVecKaPos, pVecKaNeg)},
+                          std::array{o2::constants::physics::MassMuon, o2::constants::physics::MassMuon, o2::constants::physics::MassPhi});
+    } else {
+      return RecoDecay::m(std::array{pVecMuPos, pVecMuNeg, pVecKaPos, pVecKaNeg},
+                          std::array{o2::constants::physics::MassMuon, o2::constants::physics::MassMuon, o2::constants::physics::MassKPlus, o2::constants::physics::MassKPlus});
+    }
   }
 
   template <typename T>
@@ -905,14 +930,18 @@ struct HfHelper {
   /// \param candBp B+ candidate
   /// \param cuts B+ candidate selection per pT bin
   /// \param binsPt pT bin limits
+  /// \param useJpsiPdgMass Use PDG mass for J/psi when calculating Bs candidate mass
   /// \return true if candidate passes all selections
   template <typename T1, typename T2, typename T3>
-  static bool selectionBplusToJpsiKTopol(const T1& candBp, const T2& cuts, const T3& binsPt)
+  static bool selectionBplusToJpsiKTopol(const T1& candBp, const T2& cuts, const T3& binsPt, const bool useJpsiPdgMass)
   {
     auto ptCandBp = candBp.pt();
-    auto mCandBp = invMassBplusToJpsiK(candBp);
-    auto ptJpsi = RecoDecay::pt(candBp.pxProng0(), candBp.pyProng0());
-    auto ptKa = RecoDecay::pt(candBp.pxProng1(), candBp.pyProng1());
+    auto mCandBp = invMassBplusToJpsiK(candBp, useJpsiPdgMass);
+    std::array<float, 3> const pVecMu0 = {candBp.pxProng0(), candBp.pyProng0(), candBp.pzProng0()};
+    std::array<float, 3> const pVecMu1 = {candBp.pxProng1(), candBp.pyProng1(), candBp.pzProng1()};
+    std::array<float, 3> const pVecKa = {candBp.pxProng2(), candBp.pyProng2(), candBp.pzProng2()};
+    auto ptJpsi = RecoDecay::pt(pVecMu0, pVecMu1);
+    auto ptKa = RecoDecay::pt(pVecKa);
     auto candJpsi = candBp.jpsi();
     float pseudoPropDecLen = candBp.decayLengthXY() * mCandBp / ptCandBp;
 
@@ -1088,20 +1117,24 @@ struct HfHelper {
 
   // Apply topological cuts as defined in SelectorCuts.h
   /// \param candBs Bs candidate
-  /// \param candKa0 kaon candidate 0 (phi daughter)
-  /// \param candKa1 kaon candidate 1 (phi daughter)
   /// \param cuts Bs candidate selection per pT bin
   /// \param binsPt pT bin limits
+  /// \param useJpsiPdgMass Use PDG mass for J/psi when calculating Bs candidate mass
+  /// \param usePhiPdgMass Use PDG mass for phi when calculating Bs candidate mass
   /// \return true if candidate passes all selections
-  template <typename T1, typename T2, typename T3, typename T4, typename T5>
-  static bool selectionBsToJpsiPhiTopol(const T1& candBs, const T2& candKa0, const T3& candKa1, const T4& cuts, const T5& binsPt)
+  template <typename T1, typename T2, typename T3>
+  static bool selectionBsToJpsiPhiTopol(const T1& candBs, const T2& cuts, const T3& binsPt, const bool useJpsiPdgMass, const bool usePhiPdgMass)
   {
     auto ptCandBs = candBs.pt();
-    auto mCandBs = invMassBsToJpsiPhi(candBs);
-    std::array<float, 3> pVecKa0 = candKa0.pVector();
-    std::array<float, 3> pVecKa1 = candKa1.pVector();
+    auto mCandBs = invMassBsToJpsiPhi(candBs, useJpsiPdgMass, usePhiPdgMass);
+    std::array<float, 3> const pVecMu0 = {candBs.pxProng0(), candBs.pyProng0(), candBs.pzProng0()};
+    std::array<float, 3> const pVecMu1 = {candBs.pxProng1(), candBs.pyProng1(), candBs.pzProng1()};
+    std::array<float, 3> const pVecKa0 = {candBs.pxProng2(), candBs.pyProng2(), candBs.pzProng2()};
+    std::array<float, 3> const pVecKa1 = {candBs.pxProng3(), candBs.pyProng3(), candBs.pzProng3()};
     auto mCandPhi = RecoDecay::m(std::array{pVecKa0, pVecKa1}, std::array{o2::constants::physics::MassKPlus, o2::constants::physics::MassKPlus});
-    auto ptJpsi = RecoDecay::pt(candBs.pxProng0(), candBs.pyProng0());
+    auto ptJpsi = RecoDecay::pt(pVecMu0, pVecMu1);
+    auto ptKa0 = RecoDecay::pt(pVecKa0);
+    auto ptKa1 = RecoDecay::pt(pVecKa1);
     auto candJpsi = candBs.jpsi();
     float pseudoPropDecLen = candBs.decayLengthXY() * mCandBs / ptCandBs;
 
@@ -1116,8 +1149,8 @@ struct HfHelper {
     }
 
     // kaon pt
-    if (candKa0.pt() < cuts->get(binPt, "pT K") &&
-        candKa1.pt() < cuts->get(binPt, "pT K")) {
+    if (ptKa0 < cuts->get(binPt, "pT K") &&
+        ptKa1 < cuts->get(binPt, "pT K")) {
       return false;
     }
 

--- a/PWGHF/D2H/TableProducer/candidateCreatorBToJpsiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/candidateCreatorBToJpsiReduced.cxx
@@ -343,9 +343,9 @@ struct HfCandidateCreatorBToJpsiReduced {
                                errorDecayLength, errorDecayLengthXY,
                                chi2PCA,
                                pVecDauPos[0], pVecDauPos[1], pVecDauPos[2],
-                               pVecDauNeg[0], pVecDauNeg[1], pVecDauPos[2],
+                               pVecDauNeg[0], pVecDauNeg[1], pVecDauNeg[2],
                                pVecTrackLf0[0], pVecTrackLf0[1], pVecTrackLf0[2],
-                               pVecTrackLf1[0], pVecTrackLf1[1], pVecTrackLf0[2],
+                               pVecTrackLf1[0], pVecTrackLf1[1], pVecTrackLf1[2],
                                dcaDauPos.getY(), dcaDauNeg.getY(), dcaTrackLf0.getY(), dcaTrackLf1.getY(),
                                std::sqrt(dcaDauPos.getSigmaY2()), std::sqrt(dcaDauNeg.getSigmaY2()), std::sqrt(dcaTrackLf0.getSigmaY2()), std::sqrt(dcaTrackLf1.getSigmaY2()));
             rowCandidateBsProngs(candJpsi.globalIndex(), trackLf0.globalIndex(), trackLf1.globalIndex());

--- a/PWGHF/D2H/Tasks/taskBplusToJpsiKReduced.cxx
+++ b/PWGHF/D2H/Tasks/taskBplusToJpsiKReduced.cxx
@@ -343,8 +343,8 @@ struct HfTaskBplusToJpsiKReduced {
     auto invMassBplus = HfHelper::invMassBplusToJpsiK(candidate, useJpsiPdgMass);
     auto candJpsi = candidate.template jpsi_as<aod::HfRedJpsis>();
     auto candKa = candidate.template bachKa_as<aod::HfRedBach0Tracks>();
-    std::array<float, 3> const pVecMu0 = {candidate.pxProng0(), candidate.pyProng0(), candidate.pzProng0()};
-    std::array<float, 3> const pVecMu1 = {candidate.pxProng1(), candidate.pyProng1(), candidate.pzProng1()};
+    auto const pVecMu0 = candidate.pVectorProng0();
+    auto const pVecMu1 = candidate.pVectorProng1();
     auto ptJpsi = RecoDecay::pt(pVecMu0, pVecMu1);
     auto invMassJpsi = RecoDecay::m(std::array{pVecMu0, pVecMu1}, std::array{o2::constants::physics::MassMuonPlus, o2::constants::physics::MassMuonMinus});
     uint8_t statusBplus = 0;

--- a/PWGHF/D2H/Tasks/taskBplusToJpsiKReduced.cxx
+++ b/PWGHF/D2H/Tasks/taskBplusToJpsiKReduced.cxx
@@ -141,7 +141,6 @@ DECLARE_SOA_TABLE(HfRedCandBpLites, "AOD", "HFREDCANDBPLITE", //! Table with som
                   hf_cand_bplustojpsik_lite::PtJpsi,
                   hf_cand_bplustojpsik_lite::ImpactParameterJpsiDauPos,
                   hf_cand_bplustojpsik_lite::ImpactParameterJpsiDauNeg,
-                  hf_cand_bplustojpsik_lite::ImpactParameterLfTrack0,
                   // Jpsi daughter features
                   hf_cand_bplustojpsik_lite::ItsNClsJpsiDauPos,
                   hf_cand_bplustojpsik_lite::TpcNClsCrossedRowsJpsiDauPos,
@@ -155,6 +154,7 @@ DECLARE_SOA_TABLE(HfRedCandBpLites, "AOD", "HFREDCANDBPLITE", //! Table with som
                   hf_cand_bplustojpsik_lite::AbsEtaJpsiDauNeg,
                   // kaon features
                   hf_cand_bplustojpsik_lite::PtBach,
+                  hf_cand_bplustojpsik_lite::ImpactParameterLfTrack0,
                   hf_cand_bplustojpsik_lite::ItsNClsLfTrack0,
                   hf_cand_bplustojpsik_lite::TpcNClsCrossedRowsLfTrack0,
                   hf_cand_bplustojpsik_lite::ItsChi2NClLfTrack0,
@@ -207,6 +207,7 @@ struct HfTaskBplusToJpsiKReduced {
   Configurable<bool> fillBackground{"fillBackground", false, "Flag to enable filling of background histograms/sparses/tree (only MC)"};
   Configurable<float> downSampleBkgFactor{"downSampleBkgFactor", 1., "Fraction of background candidates to keep for ML trainings"};
   Configurable<float> ptMaxForDownSample{"ptMaxForDownSample", 10., "Maximum pt for the application of the downsampling factor"};
+  Configurable<bool> useJpsiPdgMass{"useJpsiPdgMass", true, "Whether to use J/Psi PDG mass for B+ candidate mass evaluation or to use the invariant mass of the two prongs"};
   // topological cuts
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_bplus_to_jpsi_k::vecBinsPt}, "pT bin limits"};
   Configurable<LabeledArray<double>> cuts{"cuts", {hf_cuts_bplus_to_jpsi_k::Cuts[0], hf_cuts_bplus_to_jpsi_k::NBinsPt, hf_cuts_bplus_to_jpsi_k::NCutVars, hf_cuts_bplus_to_jpsi_k::labelsPt, hf_cuts_bplus_to_jpsi_k::labelsCutVar}, "B+ candidate selection per pT bin"};
@@ -339,11 +340,13 @@ struct HfTaskBplusToJpsiKReduced {
                 aod::HfRedBach0Tracks const&)
   {
     auto ptCandBplus = candidate.pt();
-    auto invMassBplus = HfHelper::invMassBplusToJpsiK(candidate);
+    auto invMassBplus = HfHelper::invMassBplusToJpsiK(candidate, useJpsiPdgMass);
     auto candJpsi = candidate.template jpsi_as<aod::HfRedJpsis>();
     auto candKa = candidate.template bachKa_as<aod::HfRedBach0Tracks>();
-    auto ptJpsi = candidate.ptProng0();
-    auto invMassJpsi = candJpsi.m();
+    std::array<float, 3> const pVecMu0 = {candidate.pxProng0(), candidate.pyProng0(), candidate.pzProng0()};
+    std::array<float, 3> const pVecMu1 = {candidate.pxProng1(), candidate.pyProng1(), candidate.pzProng1()};
+    auto ptJpsi = RecoDecay::pt(pVecMu0, pVecMu1);
+    auto invMassJpsi = RecoDecay::m(std::array{pVecMu0, pVecMu1}, std::array{o2::constants::physics::MassMuonPlus, o2::constants::physics::MassMuonMinus});
     uint8_t statusBplus = 0;
 
     int8_t flagMcMatchRec{0}, flagMcDecayChanRec{0}, flagWrongCollision{0};
@@ -356,7 +359,7 @@ struct HfTaskBplusToJpsiKReduced {
     }
 
     SETBIT(statusBplus, SelectionStep::RecoSkims);
-    if (HfHelper::selectionBplusToJpsiKTopol(candidate, cuts, binsPt)) {
+    if (HfHelper::selectionBplusToJpsiKTopol(candidate, cuts, binsPt, useJpsiPdgMass)) {
       SETBIT(statusBplus, SelectionStep::RecoTopol);
     } else if (selectionFlagBplus >= BIT(SelectionStep::RecoTopol) * 2 - 1) {
       return;
@@ -391,17 +394,17 @@ struct HfTaskBplusToJpsiKReduced {
     }
 
     registry.fill(HIST("hMass"), invMassBplus, ptCandBplus);
-    registry.fill(HIST("hMassJpsi"), invMassJpsi, candidate.ptProng0());
-    registry.fill(HIST("hd0K"), candidate.impactParameter1(), candidate.ptProng1());
+    registry.fill(HIST("hMassJpsi"), invMassJpsi, ptJpsi);
+    registry.fill(HIST("hd0K"), candidate.impactParameter2(), candidate.ptProng2());
     if constexpr (DoMc) {
       if (isSignal) {
         registry.fill(HIST("hMassRecSig"), invMassBplus, ptCandBplus);
-        registry.fill(HIST("hMassJpsiRecSig"), invMassJpsi, candidate.ptProng0());
-        registry.fill(HIST("hd0KRecSig"), candidate.impactParameter1(), candidate.ptProng1());
+        registry.fill(HIST("hMassJpsiRecSig"), invMassJpsi, ptJpsi);
+        registry.fill(HIST("hd0KRecSig"), candidate.impactParameter2(), candidate.ptProng2());
       } else if (fillBackground) {
         registry.fill(HIST("hMassRecBg"), invMassBplus, ptCandBplus);
-        registry.fill(HIST("hMassJpsiRecBg"), invMassJpsi, candidate.ptProng0());
-        registry.fill(HIST("hd0KRecBg"), candidate.impactParameter1(), candidate.ptProng1());
+        registry.fill(HIST("hMassJpsiRecBg"), invMassJpsi, ptJpsi);
+        registry.fill(HIST("hd0KRecBg"), candidate.impactParameter2(), candidate.ptProng2());
       }
     }
 
@@ -436,7 +439,6 @@ struct HfTaskBplusToJpsiKReduced {
         ptJpsi,
         candidate.impactParameter0(),
         candidate.impactParameter1(),
-        candidate.impactParameter2(),
         candJpsi.itsNClsDauPos(),
         candJpsi.tpcNClsCrossedRowsDauPos(),
         candJpsi.itsChi2NClDauPos(),
@@ -448,7 +450,8 @@ struct HfTaskBplusToJpsiKReduced {
         candJpsi.tpcChi2NClDauNeg(),
         absEta(candJpsi.tglDauNeg()),
         // kaon features
-        candidate.ptProng1(),
+        candidate.ptProng2(),
+        candidate.impactParameter2(),
         candKa.itsNCls(),
         candKa.tpcNClsCrossedRows(),
         candKa.itsChi2NCl(),

--- a/PWGHF/D2H/Tasks/taskBsToJpsiPhiReduced.cxx
+++ b/PWGHF/D2H/Tasks/taskBsToJpsiPhiReduced.cxx
@@ -232,6 +232,8 @@ struct HfTaskBsToJpsiPhiReduced {
   Configurable<bool> fillBackground{"fillBackground", false, "Flag to enable filling of background histograms/sparses/tree (only MC)"};
   Configurable<float> downSampleBkgFactor{"downSampleBkgFactor", 1., "Fraction of background candidates to keep for ML trainings"};
   Configurable<float> ptMaxForDownSample{"ptMaxForDownSample", 10., "Maximum pt for the application of the downsampling factor"};
+  Configurable<bool> useJpsiPdgMass{"useJpsiPdgMass", true, "Whether to use J/Psi PDG mass for B+ candidate mass evaluation or to use the invariant mass of the two prongs"};
+  Configurable<bool> usePhiPdgMass{"usePhiPdgMass", true, "Whether to use Phi PDG mass for B+ candidate mass evaluation or to use the invariant mass of the two prongs"};
   // topological cuts
   Configurable<std::vector<double>> binsPt{"binsPt", std::vector<double>{hf_cuts_bs_to_jpsi_phi::vecBinsPt}, "pT bin limits"};
   Configurable<LabeledArray<double>> cuts{"cuts", {hf_cuts_bs_to_jpsi_phi::Cuts[0], hf_cuts_bs_to_jpsi_phi::NBinsPt, hf_cuts_bs_to_jpsi_phi::NCutVars, hf_cuts_bs_to_jpsi_phi::labelsPt, hf_cuts_bs_to_jpsi_phi::labelsCutVar}, "Bs candidate selection per pT bin"};
@@ -310,7 +312,6 @@ struct HfTaskBsToJpsiPhiReduced {
     registry.add("hMass", bSCandTitle + "inv. mass J/#Psi K^{+} (GeV/#it{c}^{2});" + stringPt, {HistType::kTH2F, {axisMassBs, axisPtB}});
     registry.add("hMassJpsi", bSCandTitle + "inv. mass #mu^{+}#mu^{#minus} (GeV/#it{c}^{2});" + stringPt, {HistType::kTH2F, {axisMassJpsi, axisPtJpsi}});
     registry.add("hMassPhi", bSCandTitle + "inv. mass K^{+}K^{#minus} (GeV/#it{c}^{2});" + stringPt, {HistType::kTH2F, {axisMassPhi, axisPtPhi}});
-    registry.add("hd0K", bSCandTitle + "Kaon DCAxy to prim. vertex (cm);" + stringPt, {HistType::kTH2F, {axisImpactPar, axisPtKa}});
 
     // histograms processMC
     if (doprocessMc || doprocessMcWithBsMl) {
@@ -321,11 +322,9 @@ struct HfTaskBsToJpsiPhiReduced {
       registry.add("hMassRecSig", bSCandMatch + "inv. mass J/#Psi K^{+} (GeV/#it{c}^{2}); B_{s}^{0} " + stringPt, {HistType::kTH2F, {axisMassBs, axisPtB}});
       registry.add("hMassJpsiRecSig", bSCandMatch + "inv. mass #mu^{+}#mu^{#minus} (GeV/#it{c}^{2}); J/#Psi " + stringPt, {HistType::kTH2F, {axisMassJpsi, axisPtJpsi}});
       registry.add("hMassPhiRecSig", bSCandMatch + "inv. mass K^{+}K^{#minus} (GeV/#it{c}^{2}); #phi " + stringPt, {HistType::kTH2F, {axisMassPhi, axisPtPhi}});
-      registry.add("hd0KRecSig", bSCandMatch + "Kaon DCAxy to prim. vertex (cm); K^{+} " + stringPt, {HistType::kTH2F, {axisImpactPar, axisPtKa}});
       registry.add("hMassRecBg", bSCandUnmatch + "inv. mass J/#Psi K^{+} (GeV/#it{c}^{2}); B_{s}^{0} " + stringPt, {HistType::kTH2F, {axisMassBs, axisPtB}});
       registry.add("hMassJpsiRecBg", bSCandUnmatch + "inv. mass #mu^{+}#mu^{#minus} (GeV/#it{c}^{2}); J/#Psi " + stringPt, {HistType::kTH2F, {axisMassJpsi, axisPtJpsi}});
       registry.add("hMassPhiRecBg", bSCandMatch + "inv. mass K^{+}K^{#minus} (GeV/#it{c}^{2}); #phi " + stringPt, {HistType::kTH2F, {axisMassPhi, axisPtPhi}});
-      registry.add("hd0KRecBg", bSCandMatch + "Kaon DCAxy to prim. vertex (cm); K^{+} " + stringPt, {HistType::kTH2F, {axisImpactPar, axisPtKa}});
     }
 
     if (doprocessDataWithBsMl || doprocessMcWithBsMl) {
@@ -371,14 +370,17 @@ struct HfTaskBsToJpsiPhiReduced {
                 aod::HfRedBach1Tracks const&)
   {
     auto ptCandBs = candidate.pt();
-    auto invMassBs = HfHelper::invMassBsToJpsiPhi(candidate);
+    auto invMassBs = HfHelper::invMassBsToJpsiPhi(candidate, useJpsiPdgMass, usePhiPdgMass);
     auto candJpsi = candidate.template jpsi_as<aod::HfRedJpsis>();
     auto candKa0 = candidate.template prong0Phi_as<aod::HfRedBach0Tracks>();
     auto candKa1 = candidate.template prong1Phi_as<aod::HfRedBach1Tracks>();
-    std::array<float, 3> const pVecKa0 = {candKa0.px(), candKa0.py(), candKa0.pz()};
-    std::array<float, 3> const pVecKa1 = {candKa1.px(), candKa1.py(), candKa1.pz()};
-    auto ptJpsi = candidate.ptProng0();
-    auto invMassJpsi = candJpsi.m();
+    std::array<float, 3> const pVecMu0 = {candidate.pxProng0(), candidate.pyProng0(), candidate.pzProng0()};
+    std::array<float, 3> const pVecMu1 = {candidate.pxProng1(), candidate.pyProng1(), candidate.pzProng1()};
+    std::array<float, 3> const pVecKa0 = {candidate.pxProng2(), candidate.pyProng2(), candidate.pzProng2()};
+    std::array<float, 3> const pVecKa1 = {candidate.pxProng3(), candidate.pyProng3(), candidate.pzProng3()};
+    auto ptJpsi = RecoDecay::pt(pVecMu0, pVecMu1);
+    auto ptPhi = RecoDecay::pt(pVecKa0, pVecKa1);
+    auto invMassJpsi = RecoDecay::m(std::array{pVecMu0, pVecMu1}, std::array{o2::constants::physics::MassMuonPlus, o2::constants::physics::MassMuonMinus});
     auto invMassPhi = RecoDecay::m(std::array{pVecKa0, pVecKa1}, std::array{o2::constants::physics::MassKPlus, o2::constants::physics::MassKPlus});
     uint8_t statusBs = 0;
 
@@ -393,7 +395,7 @@ struct HfTaskBsToJpsiPhiReduced {
     }
 
     SETBIT(statusBs, SelectionStep::RecoSkims);
-    if (HfHelper::selectionBsToJpsiPhiTopol(candidate, candKa0, candKa1, cuts, binsPt)) {
+    if (HfHelper::selectionBsToJpsiPhiTopol(candidate, cuts, binsPt, useJpsiPdgMass, usePhiPdgMass)) {
       SETBIT(statusBs, SelectionStep::RecoTopol);
     } else if (selectionFlagBs >= BIT(SelectionStep::RecoTopol) * 2 - 1) {
       return;
@@ -432,18 +434,15 @@ struct HfTaskBsToJpsiPhiReduced {
     }
 
     registry.fill(HIST("hMass"), invMassBs, ptCandBs);
-    registry.fill(HIST("hMassJpsi"), invMassJpsi, candidate.ptProng0());
-    registry.fill(HIST("hMassPhi"), invMassPhi, candidate.ptProng0());
-    registry.fill(HIST("hd0K"), candidate.impactParameter1(), candidate.ptProng1());
+    registry.fill(HIST("hMassJpsi"), invMassJpsi, ptJpsi);
+    registry.fill(HIST("hMassPhi"), invMassPhi, ptPhi);
     if constexpr (DoMc) {
       if (isSignal) {
         registry.fill(HIST("hMassRecSig"), invMassBs, ptCandBs);
-        registry.fill(HIST("hMassJpsiRecSig"), invMassJpsi, candidate.ptProng0());
-        registry.fill(HIST("hd0KRecSig"), candidate.impactParameter1(), candidate.ptProng1());
+        registry.fill(HIST("hMassJpsiRecSig"), invMassJpsi, ptJpsi);
       } else if (fillBackground) {
         registry.fill(HIST("hMassRecBg"), invMassBs, ptCandBs);
-        registry.fill(HIST("hMassJpsiRecBg"), invMassJpsi, candidate.ptProng0());
-        registry.fill(HIST("hd0KRecBg"), candidate.impactParameter1(), candidate.ptProng1());
+        registry.fill(HIST("hMassJpsiRecBg"), invMassJpsi, ptJpsi);
       }
     }
 

--- a/PWGHF/D2H/Tasks/taskBsToJpsiPhiReduced.cxx
+++ b/PWGHF/D2H/Tasks/taskBsToJpsiPhiReduced.cxx
@@ -374,10 +374,10 @@ struct HfTaskBsToJpsiPhiReduced {
     auto candJpsi = candidate.template jpsi_as<aod::HfRedJpsis>();
     auto candKa0 = candidate.template prong0Phi_as<aod::HfRedBach0Tracks>();
     auto candKa1 = candidate.template prong1Phi_as<aod::HfRedBach1Tracks>();
-    std::array<float, 3> const pVecMu0 = {candidate.pxProng0(), candidate.pyProng0(), candidate.pzProng0()};
-    std::array<float, 3> const pVecMu1 = {candidate.pxProng1(), candidate.pyProng1(), candidate.pzProng1()};
-    std::array<float, 3> const pVecKa0 = {candidate.pxProng2(), candidate.pyProng2(), candidate.pzProng2()};
-    std::array<float, 3> const pVecKa1 = {candidate.pxProng3(), candidate.pyProng3(), candidate.pzProng3()};
+    auto const pVecMu0 = candidate.pVectorProng0();
+    auto const pVecMu1 = candidate.pVectorProng1();
+    auto const pVecKa0 = candidate.pVectorProng2();
+    auto const pVecKa1 = candidate.pVectorProng3();
     auto ptJpsi = RecoDecay::pt(pVecMu0, pVecMu1);
     auto ptPhi = RecoDecay::pt(pVecKa0, pVecKa1);
     auto invMassJpsi = RecoDecay::m(std::array{pVecMu0, pVecMu1}, std::array{o2::constants::physics::MassMuonPlus, o2::constants::physics::MassMuonMinus});


### PR DESCRIPTION
I have spotted a few bugs that were preventing the signals to be observed, and added a configurable to use J/Psi PDG mass instead of the reconstructed one when computing the B meson mass. (tagging @fgrosa)
- Fix selection on invariant mass of J/Psi and phi
- Fix filling of Bs table