### PR TITLE
[PWGHF] Apply UPC Lc ZDC timing cut online and simplify TTree

### DIFF
--- a/PWGHF/D2H/Tasks/taskUpcLc.cxx
+++ b/PWGHF/D2H/Tasks/taskUpcLc.cxx
@@ -17,7 +17,6 @@
 /// \author Ran Tu <ran.tu@cern.ch>, Fudan University
 
 #include "PWGHF/Core/CentralityEstimation.h"
-#include "PWGHF/Core/DecayChannels.h"
 #include "PWGHF/Core/HfHelper.h"
 #include "PWGHF/Core/SelectorCuts.h"
 #include "PWGHF/DataModel/AliasTables.h"
@@ -29,12 +28,11 @@
 #include "PWGUD/Core/SGSelector.h"
 #include "PWGUD/Core/UPCHelpers.h"
 
-#include "Common/Core/RecoDecay.h"
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/Multiplicity.h"
 
 #include <CCDB/BasicCCDBManager.h>
-#include <CommonConstants/PhysicsConstants.h>
+#include <CommonDataFormat/TimeStamp.h>
 #include <Framework/ASoA.h>
 #include <Framework/AnalysisDataModel.h>
 #include <Framework/AnalysisHelpers.h>
@@ -44,11 +42,8 @@
 #include <Framework/HistogramSpec.h>
 #include <Framework/InitContext.h>
 #include <Framework/Logger.h>
-#include <Framework/OutputObjHeader.h>
 #include <Framework/runDataProcessing.h>
 #include <ReconstructionDataFormats/Vertex.h>
-
-#include <TPDGCode.h>
 
 #include <array>
 #include <cmath>

--- a/PWGHF/D2H/Tasks/taskUpcLc.cxx
+++ b/PWGHF/D2H/Tasks/taskUpcLc.cxx
@@ -17,6 +17,7 @@
 /// \author Ran Tu <ran.tu@cern.ch>, Fudan University
 
 #include "PWGHF/Core/CentralityEstimation.h"
+#include "PWGHF/Core/DecayChannels.h"
 #include "PWGHF/Core/HfHelper.h"
 #include "PWGHF/Core/SelectorCuts.h"
 #include "PWGHF/DataModel/AliasTables.h"
@@ -28,11 +29,12 @@
 #include "PWGUD/Core/SGSelector.h"
 #include "PWGUD/Core/UPCHelpers.h"
 
+#include "Common/Core/RecoDecay.h"
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/Multiplicity.h"
 
 #include <CCDB/BasicCCDBManager.h>
-#include <CommonDataFormat/TimeStamp.h>
+#include <CommonConstants/PhysicsConstants.h>
 #include <Framework/ASoA.h>
 #include <Framework/AnalysisDataModel.h>
 #include <Framework/AnalysisHelpers.h>
@@ -42,8 +44,11 @@
 #include <Framework/HistogramSpec.h>
 #include <Framework/InitContext.h>
 #include <Framework/Logger.h>
+#include <Framework/OutputObjHeader.h>
 #include <Framework/runDataProcessing.h>
 #include <ReconstructionDataFormats/Vertex.h>
+
+#include <TPDGCode.h>
 
 #include <array>
 #include <cmath>
@@ -92,11 +97,7 @@ DECLARE_SOA_TABLE(HfUpcQa, "AOD", "HFUPCQA",
 DECLARE_SOA_TABLE(HfUpcLcBdtInfos, "AOD", "HFUPCLCBDTINFOS",
                   full::M,
                   full::Pt,
-                  full::BkgScore,
-                  full::AmpFT0A,
-                  full::AmpFT0C,
-                  full::ZdcTimeZNA,
-                  full::ZdcTimeZNC);
+                  full::BkgScore);
 
 DECLARE_SOA_TABLE(HfUpcLcInfos, "AOD", "HFUPCLCINFOS",
                   full::M,
@@ -106,11 +107,7 @@ DECLARE_SOA_TABLE(HfUpcLcInfos, "AOD", "HFUPCLCINFOS",
                   full::PtProng2,
                   full::Chi2PCA,
                   full::DecayLength,
-                  full::Cpa,
-                  full::AmpFT0A,
-                  full::AmpFT0C,
-                  full::ZdcTimeZNA,
-                  full::ZdcTimeZNC);
+                  full::Cpa);
 } // namespace o2::aod
 
 /// Λc± → p± K∓ π± analysis task
@@ -125,6 +122,7 @@ struct HfTaskUpcLc {
   Configurable<bool> fillTreeOnlySingleGap{"fillTreeOnlySingleGap", false, "Only fill the tree for candidates that pass the single-gap UPC events"};
   Configurable<bool> fillTreeUpcQa{"fillTreeUpcQa", false, "Fill Tree for UPC QA"};
   Configurable<bool> verticesWithUpc{"verticesWithUpc", false, "Consider vertices with UPC settings"};
+  Configurable<float> zdcTimeThreshold{"zdcTimeThreshold", 2., "Threshold for ZNA/ZNC time"};
   // CCDB configuration
   Configurable<std::string> ccdbUrl{"ccdbUrl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::string> ccdbPathGrp{"ccdbPathGrp", "GLO/GRP/GRP", "Path of the grp file (Run 2)"};
@@ -167,7 +165,7 @@ struct HfTaskUpcLc {
     registry.add("Data/hUpcGapAfterSelection", "UPC gap type after selection;Gap side;Counts", {HistType::kTH1F, {{7, -1.5, 5.5}}});
     registry.add("Data/hUpcMulti", "Multiplicity of UPC events;Multiplicity;Counts", {HistType::kTH1F, {{200, -0.5, 199.5}}});
     registry.add("Data/hUpcVtz", "Vertex Z position of UPC events;Vz (cm);Counts", {HistType::kTH1F, {{200, -10., 10.}}});
-
+    registry.add("Data/eta_vs_Multi", "Eta vs Multiplicity;Eta;Multiplicity", {HistType::kTH2F, {{20, -1., 1.}, {200, -0.5, 199.5}}});
     hfEvSel.addHistograms(registry);
     ccdb->setURL(ccdbUrl);
     ccdb->setCaching(true);
@@ -226,9 +224,13 @@ struct HfTaskUpcLc {
       float zdcEnergyZNC = -1.f;
       float zdcTimeZNA = -1.f;
       float zdcTimeZNC = -1.f;
+      bool gapA0nXn = false;
+      bool gapCXn0n = false;
+
       if (verticesWithUpc && !upcFlag) {
         continue;
       }
+
       if (hasZdc) {
         const auto zdc = bcForUPC.zdc();
         zdcEnergyZNA = zdc.energyCommonZNA();
@@ -240,12 +242,22 @@ struct HfTaskUpcLc {
         registry.fill(HIST("Data/zdc/timeZNA_vs_timeZNC"), zdcTimeZNA, zdcTimeZNC);
         registry.fill(HIST("Data/hUpcGapAfterSelection"), static_cast<int>(gap));
       }
-      if (gap == o2::aod::sgselector::TrueGap::SingleGapA || gap == o2::aod::sgselector::TrueGap::SingleGapC) {
-        registry.fill(HIST("Data/hUpcMulti"), collision.multNTracksPV());
-        registry.fill(HIST("Data/hUpcVtz"), collision.posZ());
-        if (fillTreeUpcQa) {
-          rowUpcQa(numPvContributors, collision.multNTracksPV(), collision.posZ(), fitInfo.ampFT0A, fitInfo.ampFT0C, zdcTimeZNA, zdcTimeZNC);
-        }
+      const bool ignoreZdcTime = (zdcTimeThreshold < 0.f);
+
+      if (gap == o2::aod::sgselector::TrueGap::SingleGapA && (ignoreZdcTime || (std::abs(zdcTimeZNA) > zdcTimeThreshold && std::abs(zdcTimeZNC) < zdcTimeThreshold))) {
+        gapA0nXn = true;
+      }
+      if (gap == o2::aod::sgselector::TrueGap::SingleGapC && (ignoreZdcTime || (std::abs(zdcTimeZNA) < zdcTimeThreshold && std::abs(zdcTimeZNC) > zdcTimeThreshold))) {
+        gapCXn0n = true;
+      }
+      if (fillTreeOnlySingleGap & !gapA0nXn & !gapCXn0n) {
+        continue;
+      }
+      registry.fill(HIST("Data/hUpcMulti"), collision.multNTracksPV());
+      registry.fill(HIST("Data/hUpcVtz"), collision.posZ());
+
+      if (fillTreeUpcQa) {
+        rowUpcQa(numPvContributors, collision.multNTracksPV(), collision.posZ(), fitInfo.ampFT0A, fitInfo.ampFT0C, zdcTimeZNA, zdcTimeZNC);
       }
 
       for (const auto& candidate : groupedLcCandidates) {
@@ -262,34 +274,23 @@ struct HfTaskUpcLc {
         const auto decayLength = candidate.decayLength();
         const auto chi2PCA = candidate.chi2PCA();
         const auto cpa = candidate.cpa();
+        const auto eta = candidate.eta();
 
         double outputBkg(-1);
 
         auto fillTHnData = [&](bool isPKPi) {
           const auto massLc = isPKPi ? HfHelper::invMassLcToPKPi(candidate) : HfHelper::invMassLcToPiKP(candidate);
-
+          registry.fill(HIST("Data/eta_vs_Multi"), eta, collision.multNTracksPV());
           if constexpr (FillMl) {
             const auto& mlProb = isPKPi ? candidate.mlProbLcToPKPi() : candidate.mlProbLcToPiKP();
             if (mlProb.size() == NumberOfMlClasses) {
               outputBkg = mlProb[MlClassBackground]; /// bkg score
             }
             /// Fill the ML outputScores and variables of candidate
-            if (fillTreeOnlySingleGap) {
-              if (gap == o2::aod::sgselector::TrueGap::SingleGapA || gap == o2::aod::sgselector::TrueGap::SingleGapC) {
-                rowCandUpcBdt(massLc, pt, outputBkg, fitInfo.ampFT0A, fitInfo.ampFT0C, zdcTimeZNA, zdcTimeZNC);
-              }
-            } else {
-              rowCandUpcBdt(massLc, pt, outputBkg, fitInfo.ampFT0A, fitInfo.ampFT0C, zdcTimeZNA, zdcTimeZNC);
-            }
+            rowCandUpcBdt(massLc, pt, outputBkg);
 
           } else {
-            if (fillTreeOnlySingleGap) {
-              if (gap == o2::aod::sgselector::TrueGap::SingleGapA || gap == o2::aod::sgselector::TrueGap::SingleGapC) {
-                rowCandUpc(massLc, pt, ptProng0, ptProng1, ptProng2, chi2PCA, decayLength, cpa, fitInfo.ampFT0A, fitInfo.ampFT0C, zdcTimeZNA, zdcTimeZNC);
-              }
-            } else {
-              rowCandUpc(massLc, pt, ptProng0, ptProng1, ptProng2, chi2PCA, decayLength, cpa, fitInfo.ampFT0A, fitInfo.ampFT0C, zdcTimeZNA, zdcTimeZNC);
-            }
+            rowCandUpc(massLc, pt, ptProng0, ptProng1, ptProng2, chi2PCA, decayLength, cpa);
           }
         };
 


### PR DESCRIPTION
This PR includes the following changes:
* Add eta vs. multiplicity QA plots.
* Apply the ZDC timing selection online to reduce the number of candidates filled.
* Remove detector-related information from the candidate TTree, since the ZDC timing cuts are now applied online.