### PR TITLE
[Infrastructure] Bump oxsecurity/megalinter from 9.4.0 to 9.5.0

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -38,7 +38,7 @@ jobs:
         id: ml
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.io/flavors/
-        uses: oxsecurity/megalinter@v9.4.0
+        uses: oxsecurity/megalinter@v9.5.0
         env:
           # All available variables are described in documentation:
           # https://megalinter.io/configuration/

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -21,11 +21,13 @@ DISABLE_LINTERS:
   - REPOSITORY_DEVSKIM
   - REPOSITORY_GITLEAKS
   - REPOSITORY_KICS
+  - REPOSITORY_OSV_SCANNER
   - REPOSITORY_SECRETLINT
   - REPOSITORY_TRIVY
   - YAML_PRETTIER
   - YAML_V8R
 DISABLE_ERRORS_LINTERS: # If errors are found by these linters, they will be considered as non blocking.
+  - ACTION_ZIZMOR
   - PYTHON_BANDIT # The bandit check is overly broad and complains about subprocess usage.
 SHOW_ELAPSED_TIME: true
 FILEIO_REPORTER: false
@@ -42,3 +44,4 @@ CPP_CLANG_FORMAT_FILE_EXTENSIONS: [".C", ".c", ".c++", ".cc", ".cl", ".cpp", ".c
 CPP_CPPCHECK_FILE_EXTENSIONS: [".C", ".c", ".c++", ".cc", ".cl", ".cpp", ".cu", ".cuh", ".cxx", ".cxx.in", ".h", ".h++", ".hh", ".h.in", ".hpp", ".hxx", ".inc", ".inl", ".macro"]
 CPP_CPPCHECK_ARGUMENTS: --language=c++ --std=c++20 --check-level=exhaustive --suppressions-list=cppcheck_config
 REPOSITORY_GITLEAKS_PR_COMMITS_SCAN: true
+ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES: [GITHUB_TOKEN]


### PR DESCRIPTION
Contains additional configuration adjustment on top of https://github.com/AliceO2Group/O2Physics/pull/16280 to make sure that the new tools don't break the checks.