### PR TITLE
[PWGDQ] Adding functionality for event mixing across TFs

### DIFF
--- a/PWGDQ/Core/MixingHandler.cxx
+++ b/PWGDQ/Core/MixingHandler.cxx
@@ -134,7 +134,7 @@ int MixingHandler::FindEventCategory(float* values)
       return -1; // all variables must be inside limits
     }
     bin.push_back(binValue - 1);
-  } 
+  }
 
   // Hash the bin values to define a unique category
   // The hashing is done such that the original bin values can be retrieved from the category

--- a/PWGDQ/Core/MixingHandler.cxx
+++ b/PWGDQ/Core/MixingHandler.cxx
@@ -27,9 +27,11 @@ ClassImp(MixingHandler);
 
 //_________________________________________________________________________
 MixingHandler::MixingHandler() : TNamed(),
-                                 fIsInitialized(kFALSE),
+                                 fIsInitialized(false),
                                  fVariableLimits(),
-                                 fVariables()
+                                 fVariables(),
+                                 fPoolDepth(0),
+                                 fPools()
 {
   //
   // default constructor
@@ -38,9 +40,11 @@ MixingHandler::MixingHandler() : TNamed(),
 
 //_________________________________________________________________________
 MixingHandler::MixingHandler(const char* name, const char* title) : TNamed(name, title),
-                                                                    fIsInitialized(kFALSE),
+                                                                    fIsInitialized(false),
                                                                     fVariableLimits(),
-                                                                    fVariables()
+                                                                    fVariables(),
+                                                                    fPoolDepth(0),
+                                                                    fPools()
 {
   //
   // Named constructor
@@ -56,29 +60,13 @@ MixingHandler::~MixingHandler()
 }
 
 //_________________________________________________________________________
-void MixingHandler::AddMixingVariable(int var, int nBins, float* binLims)
+void MixingHandler::AddMixingVariable(int var, std::vector<float> binLims)
 {
-  //
-  // add a mixing variable
-  //
-  fVariables.push_back(var);
-  TArrayF varBins;
-  varBins.Set(nBins, binLims);
-  fVariableLimits.push_back(varBins);
-  VarManager::SetUseVariable(var);
+  fVariables[var] = fVariableLimits.size();
+  fVariableLimits.push_back(binLims);
 }
 
-//_________________________________________________________________________
-void MixingHandler::AddMixingVariable(int var, int nBins, std::vector<float> binLims)
-{
-
-  float* bins = new float[nBins];
-  for (int i = 0; i < nBins; ++i) {
-    bins[i] = binLims[i];
-  }
-  AddMixingVariable(var, nBins, bins);
-}
-
+/*
 //_________________________________________________________________________
 int MixingHandler::GetMixingVariable(VarManager::Variables var)
 {
@@ -90,7 +78,9 @@ int MixingHandler::GetMixingVariable(VarManager::Variables var)
   }
   return -1;
 }
+*/
 
+/*
 //_________________________________________________________________________
 std::vector<float> MixingHandler::GetMixingVariableLimits(VarManager::Variables var)
 {
@@ -105,21 +95,21 @@ std::vector<float> MixingHandler::GetMixingVariableLimits(VarManager::Variables 
     }
   }
   return binLimits;
-}
+}*/
 
 //_________________________________________________________________________
 void MixingHandler::Init()
 {
-  //
-  // Initialization of pools
-  //       The correct event category will be retrieved using the function FindEventCategory()
-  //
-  int size = 1;
-  for (auto v : fVariableLimits) {
-    size *= (v.GetSize() - 1);
+  // loop over all variables and create a mixing pool for each category defined by the binning of the variables
+  int nCategories = 1;
+  for (auto& var : fVariables) {
+    nCategories *= (fVariableLimits[var.second].size() - 1);
   }
-  (void)size;
-  fIsInitialized = kTRUE;
+  // add elements in the map for each category (the key is the category and the value is an empty pool)
+  for (int i = 0; i < nCategories; i++) {
+    fPools[i] = MixingPool();
+  }
+  fIsInitialized = true;
 }
 
 //_________________________________________________________________________
@@ -135,16 +125,21 @@ int MixingHandler::FindEventCategory(float* values)
     Init();
   }
 
+  // loop over the variables and find out in which bin the value of the variable for the event is located
   std::vector<int> bin;
-  int iVar = 0;
-  for (auto v = fVariableLimits.begin(); v != fVariableLimits.end(); v++, iVar++) {
-    int binValue = TMath::BinarySearch((*v).GetSize(), (*v).GetArray(), values[fVariables[iVar]]);
-    bin.push_back(binValue);
-    if (bin[iVar] == -1 || bin[iVar] == (*v).GetSize() - 1) {
+  for (auto [var, pos] : fVariables) {
+    // check that the value is within limits, if not return -1 to exclude the event from mixing
+    size_t binValue = std::distance(fVariableLimits[pos].begin(), std::upper_bound(fVariableLimits[pos].begin(), fVariableLimits[pos].end(), values[var]));
+    if (binValue == 0 || binValue == fVariableLimits[pos].size()) {
       return -1; // all variables must be inside limits
     }
-  }
+    bin.push_back(binValue - 1);
+  } 
 
+  // Hash the bin values to define a unique category
+  // The hashing is done such that the original bin values can be retrieved from the category
+  // For example, for 3 variables with n1, n2, n3 bins respectively, the category for bin values (b1, b2, b3) would be:
+  // category = b1*(n2*n3) + b2*(n3) + b3
   int category = 0;
   int tempCategory = 1;
   int iv1 = 0;
@@ -156,7 +151,7 @@ int MixingHandler::FindEventCategory(float* values)
       if (iv2 == iv1) {
         tempCategory *= bin[iv2];
       } else {
-        tempCategory *= (fVariableLimits[iv2].GetSize() - 1);
+        tempCategory *= (fVariableLimits[iv2].size() - 1);
       }
     }
     category += tempCategory;
@@ -175,19 +170,14 @@ int MixingHandler::GetBinFromCategory(VarManager::Variables var, int category) c
   }
 
   // Search for the position of the variable "var" in the internal variable list of the handler
-  int tempVar = 0;
-  for (auto v = fVariables.begin(); v != fVariables.end(); v++, tempVar++) {
-    if (*v == var) {
-      break;
-    }
-  }
+  int ivar = fVariables.at(var);
 
   // extract the bin position in variable "var" from the category
   int norm = 1;
-  for (int i = fVariables.size() - 1; i > tempVar; --i) {
-    norm *= (fVariableLimits[i].GetSize() - 1);
+  for (int i = fVariables.size() - 1; i > ivar; --i) {
+    norm *= (fVariableLimits[i].size() - 1);
   }
   int truncatedCategory = category - (category % norm);
   truncatedCategory /= norm;
-  return truncatedCategory % (fVariableLimits[tempVar].GetSize() - 1);
+  return truncatedCategory % (fVariableLimits[ivar].size() - 1);
 }

--- a/PWGDQ/Core/MixingHandler.h
+++ b/PWGDQ/Core/MixingHandler.h
@@ -24,16 +24,15 @@
 
 #include <Rtypes.h>
 
-#include <vector>
-#include <map>
 #include <array>
 #include <iostream>
+#include <map>
+#include <vector>
 
 class MixingHandler : public TNamed
 {
 
  public:
-
   // Struct to define track properties relevant for mixing and few utility functions
   struct MixingTrack {
     float pt;
@@ -41,15 +40,16 @@ class MixingHandler : public TNamed
     float phi;
     uint32_t filteringFlags;
     // flip a bit to zero (needed when a track was already used in mixing for that bit for the required pool depth)
-    void FlipBit(int64_t mask) { filteringFlags ^= mask;}
-    void Print() const {
+    void FlipBit(int64_t mask) { filteringFlags ^= mask; }
+    void Print() const
+    {
       std::cout << "pt: " << pt << ", eta: " << eta << ", phi: " << phi << ", filteringFlags: " << filteringFlags << std::endl;
     }
   };
 
   // Struct to define events used in mixing and few utility functions.
-  // An event is defined as two vectors of tracks (typically the legs of a two-body 
-  //decay or the two-particles in a correlation analysis)
+  // An event is defined as two vectors of tracks (typically the legs of a two-body
+  // decay or the two-particles in a correlation analysis)
   struct MixingEvent {
     std::vector<MixingTrack> tracks1;
     std::vector<MixingTrack> tracks2;
@@ -58,20 +58,23 @@ class MixingHandler : public TNamed
     // counters to keep track of how many times the event was used for mixing (for each track cut separately)
     std::array<short, 64> counters = {0};
     // add a track to the event and update the filtering mask accordingly
-    void AddTrack1(const MixingTrack& track) {
+    void AddTrack1(const MixingTrack& track)
+    {
       tracks1.push_back(track);
       filteringMask |= track.filteringFlags;
     }
-    void AddTrack2(const MixingTrack& track) {
+    void AddTrack2(const MixingTrack& track)
+    {
       tracks2.push_back(track);
       filteringMask |= track.filteringFlags;
     }
     // flip bits in the filtering mask
     void FlipFilteringMask(int64_t mask) { filteringMask ^= mask; }
-    // 1) increment the counters for a given track cut bit mask and if the counters reached the pool depth, 
+    // 1) increment the counters for a given track cut bit mask and if the counters reached the pool depth,
     // 2) flip the corresponding bit in the tracks filtering flags to exclude them from further mixing
     // 3) for each track, if there are no more active bits in the filtering mask, then remove the track from the event
-    void IncrementCounters(uint32_t mask, short poolDepth) {
+    void IncrementCounters(uint32_t mask, short poolDepth)
+    {
       for (int i = 0; i < 32; i++) {
         if (mask & (1ULL << i)) {
           counters[i]++;
@@ -95,7 +98,8 @@ class MixingHandler : public TNamed
         }
       }
     }
-    void Print() const {
+    void Print() const
+    {
       std::cout << "Event filtering mask: ";
       for (int i = 0; i < 32; i++) {
         if (filteringMask & (1ULL << i)) {
@@ -123,16 +127,18 @@ class MixingHandler : public TNamed
 
   struct MixingPool {
     std::vector<MixingEvent> events;
-    
+
     // check which events in the pool are empty (i.e. no active tracks for mixing) and remove them from the pool
-    void CleanPool() {
+    void CleanPool()
+    {
       events.erase(std::remove_if(events.begin(), events.end(),
                                   [](const MixingEvent& event) { return event.tracks1.empty() && event.tracks2.empty(); }),
                    events.end());
     }
-    // The function that performs the mixing is called outside this class, but the pool provides the events and tracks to be mixed and takes care of updating the events after mixing 
+    // The function that performs the mixing is called outside this class, but the pool provides the events and tracks to be mixed and takes care of updating the events after mixing
     // (e.g. incrementing the counters and removing the tracks that reached the pool depth for a given cut)
-    void UpdatePool(const MixingEvent& event, short poolDepth) {
+    void UpdatePool(const MixingEvent& event, short poolDepth)
+    {
       for (auto& event : events) {
         event.IncrementCounters(event.filteringMask, poolDepth);
       }
@@ -142,14 +148,15 @@ class MixingHandler : public TNamed
     // getter for the events in the pool
     const std::vector<MixingEvent>& GetEvents() const { return events; }
 
-    void Print() const {
+    void Print() const
+    {
       std::cout << "Mixing pool with " << events.size() << " events:" << std::endl;
       for (const auto& event : events) {
         event.Print();
       }
     }
   };
-  
+
   MixingHandler();
   MixingHandler(const char* name, const char* title);
   virtual ~MixingHandler();
@@ -159,9 +166,9 @@ class MixingHandler : public TNamed
   void SetPoolDepth(short depth) { fPoolDepth = depth; }
 
   // getters
-  //int GetNMixingVariables() const { return fVariables.size(); }
-  //int GetMixingVariable(VarManager::Variables var); // returns the position in the internal varible list of the handler. Useful for checks, mostly
-  //std::vector<float> GetMixingVariableLimits(VarManager::Variables var);
+  // int GetNMixingVariables() const { return fVariables.size(); }
+  // int GetMixingVariable(VarManager::Variables var); // returns the position in the internal varible list of the handler. Useful for checks, mostly
+  // std::vector<float> GetMixingVariableLimits(VarManager::Variables var);
   MixingPool& GetPool(int category) { return fPools[category]; }
   short GetPoolDepth() const { return fPoolDepth; }
 
@@ -178,10 +185,10 @@ class MixingHandler : public TNamed
 
   // bin limits for the variables used for mixing, the number of vectors corresponds to the number of variables and the content of each vector corresponds to the bin limits for that variable
   std::vector<std::vector<float>> fVariableLimits;
-  std::map<int, int> fVariables;  // key: variable, value: position in the internal variable list of the handler (used to map the variables to the values passed to FindEventCategory)
+  std::map<int, int> fVariables; // key: variable, value: position in the internal variable list of the handler (used to map the variables to the values passed to FindEventCategory)
 
-  short fPoolDepth; // number of events to be kept in each pool
-  std::map<int, MixingPool> fPools;  // key: category, value: pool of events corresponding to that category
+  short fPoolDepth;                 // number of events to be kept in each pool
+  std::map<int, MixingPool> fPools; // key: category, value: pool of events corresponding to that category
 
   ClassDef(MixingHandler, 2);
 };

--- a/PWGDQ/Core/MixingHandler.h
+++ b/PWGDQ/Core/MixingHandler.h
@@ -25,23 +25,145 @@
 #include <Rtypes.h>
 
 #include <vector>
+#include <map>
+#include <array>
+#include <iostream>
 
 class MixingHandler : public TNamed
 {
 
  public:
+
+  // Struct to define track properties relevant for mixing and few utility functions
+  struct MixingTrack {
+    float pt;
+    float eta;
+    float phi;
+    uint32_t filteringFlags;
+    // flip a bit to zero (needed when a track was already used in mixing for that bit for the required pool depth)
+    void FlipBit(int64_t mask) { filteringFlags ^= mask;}
+    void Print() const {
+      std::cout << "pt: " << pt << ", eta: " << eta << ", phi: " << phi << ", filteringFlags: " << filteringFlags << std::endl;
+    }
+  };
+
+  // Struct to define events used in mixing and few utility functions.
+  // An event is defined as two vectors of tracks (typically the legs of a two-body 
+  //decay or the two-particles in a correlation analysis)
+  struct MixingEvent {
+    std::vector<MixingTrack> tracks1;
+    std::vector<MixingTrack> tracks2;
+    // bit map for active filtering bits of all the tracks
+    uint32_t filteringMask = 0;
+    // counters to keep track of how many times the event was used for mixing (for each track cut separately)
+    std::array<short, 64> counters = {0};
+    // add a track to the event and update the filtering mask accordingly
+    void AddTrack1(const MixingTrack& track) {
+      tracks1.push_back(track);
+      filteringMask |= track.filteringFlags;
+    }
+    void AddTrack2(const MixingTrack& track) {
+      tracks2.push_back(track);
+      filteringMask |= track.filteringFlags;
+    }
+    // flip bits in the filtering mask
+    void FlipFilteringMask(int64_t mask) { filteringMask ^= mask; }
+    // 1) increment the counters for a given track cut bit mask and if the counters reached the pool depth, 
+    // 2) flip the corresponding bit in the tracks filtering flags to exclude them from further mixing
+    // 3) for each track, if there are no more active bits in the filtering mask, then remove the track from the event
+    void IncrementCounters(uint32_t mask, short poolDepth) {
+      for (int i = 0; i < 32; i++) {
+        if (mask & (1ULL << i)) {
+          counters[i]++;
+          if (counters[i] >= poolDepth) {
+            for (auto& track : tracks1) {
+              track.FlipBit(1ULL << i);
+              if (track.filteringFlags == 0) {
+                track = tracks1.back();
+                tracks1.pop_back();
+              }
+            }
+            for (auto& track : tracks2) {
+              track.FlipBit(1ULL << i);
+              if (track.filteringFlags == 0) {
+                track = tracks2.back();
+                tracks2.pop_back();
+              }
+            }
+            FlipFilteringMask(1ULL << i);
+          }
+        }
+      }
+    }
+    void Print() const {
+      std::cout << "Event filtering mask: ";
+      for (int i = 0; i < 32; i++) {
+        if (filteringMask & (1ULL << i)) {
+          std::cout << "1";
+        } else {
+          std::cout << "0";
+        }
+      }
+      std::cout << std::endl;
+      for (int i = 0; i < 32; i++) {
+        if (filteringMask & (1ULL << i)) {
+          std::cout << "Counter " << i << ": " << counters[i] << std::endl;
+        }
+      }
+      std::cout << "Tracks 1: " << std::endl;
+      for (const auto& track : tracks1) {
+        track.Print();
+      }
+      std::cout << "Tracks 2: " << std::endl;
+      for (const auto& track : tracks2) {
+        track.Print();
+      }
+    }
+  };
+
+  struct MixingPool {
+    std::vector<MixingEvent> events;
+    
+    // check which events in the pool are empty (i.e. no active tracks for mixing) and remove them from the pool
+    void CleanPool() {
+      events.erase(std::remove_if(events.begin(), events.end(),
+                                  [](const MixingEvent& event) { return event.tracks1.empty() && event.tracks2.empty(); }),
+                   events.end());
+    }
+    // The function that performs the mixing is called outside this class, but the pool provides the events and tracks to be mixed and takes care of updating the events after mixing 
+    // (e.g. incrementing the counters and removing the tracks that reached the pool depth for a given cut)
+    void UpdatePool(const MixingEvent& event, short poolDepth) {
+      for (auto& event : events) {
+        event.IncrementCounters(event.filteringMask, poolDepth);
+      }
+      CleanPool();
+      events.push_back(event);
+    }
+    // getter for the events in the pool
+    const std::vector<MixingEvent>& GetEvents() const { return events; }
+
+    void Print() const {
+      std::cout << "Mixing pool with " << events.size() << " events:" << std::endl;
+      for (const auto& event : events) {
+        event.Print();
+      }
+    }
+  };
+  
   MixingHandler();
   MixingHandler(const char* name, const char* title);
   virtual ~MixingHandler();
 
   // setters
-  void AddMixingVariable(int var, int nBins, float* binLims);
-  void AddMixingVariable(int var, int nBins, std::vector<float> binLims);
+  void AddMixingVariable(int var, std::vector<float> binLims);
+  void SetPoolDepth(short depth) { fPoolDepth = depth; }
 
   // getters
-  int GetNMixingVariables() const { return fVariables.size(); }
-  int GetMixingVariable(VarManager::Variables var); // returns the position in the internal varible list of the handler. Useful for checks, mostly
-  std::vector<float> GetMixingVariableLimits(VarManager::Variables var);
+  //int GetNMixingVariables() const { return fVariables.size(); }
+  //int GetMixingVariable(VarManager::Variables var); // returns the position in the internal varible list of the handler. Useful for checks, mostly
+  //std::vector<float> GetMixingVariableLimits(VarManager::Variables var);
+  MixingPool& GetPool(int category) { return fPools[category]; }
+  short GetPoolDepth() const { return fPoolDepth; }
 
   void Init();
   int FindEventCategory(float* values);
@@ -54,10 +176,14 @@ class MixingHandler : public TNamed
   // User options
   bool fIsInitialized; // check if the mixing handler is initialized
 
-  std::vector<TArrayF> fVariableLimits;
-  std::vector<int> fVariables;
+  // bin limits for the variables used for mixing, the number of vectors corresponds to the number of variables and the content of each vector corresponds to the bin limits for that variable
+  std::vector<std::vector<float>> fVariableLimits;
+  std::map<int, int> fVariables;  // key: variable, value: position in the internal variable list of the handler (used to map the variables to the values passed to FindEventCategory)
 
-  ClassDef(MixingHandler, 1);
+  short fPoolDepth; // number of events to be kept in each pool
+  std::map<int, MixingPool> fPools;  // key: category, value: pool of events corresponding to that category
+
+  ClassDef(MixingHandler, 2);
 };
 
 #endif // PWGDQ_CORE_MIXINGHANDLER_H_

--- a/PWGDQ/Core/MixingLibrary.cxx
+++ b/PWGDQ/Core/MixingLibrary.cxx
@@ -31,183 +31,183 @@ void o2::aod::dqmixing::SetUpMixing(MixingHandler* mh, const char* mixingVarible
   std::string nameStr = mixingVarible;
   if (!nameStr.compare("Centrality1")) {
     std::vector<float> fCentLimsHashing = {0.0f, 20.0f, 40.0f, 60.0f, 90.0f};
-    mh->AddMixingVariable(VarManager::kCentVZERO, fCentLimsHashing.size(), fCentLimsHashing);
+    mh->AddMixingVariable(VarManager::kCentVZERO, fCentLimsHashing);
   }
   if (!nameStr.compare("Centrality2")) {
     std::vector<float> fCentLimsHashing = {0.0f, 10.0f, 20.0f, 40.0f, 60.0f, 90.0f};
-    mh->AddMixingVariable(VarManager::kCentVZERO, fCentLimsHashing.size(), fCentLimsHashing);
+    mh->AddMixingVariable(VarManager::kCentVZERO, fCentLimsHashing);
   }
   if (!nameStr.compare("Centrality3")) {
     std::vector<float> fCentLimsHashing = {0.0f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 70.0f, 90.0f};
-    mh->AddMixingVariable(VarManager::kCentVZERO, fCentLimsHashing.size(), fCentLimsHashing);
+    mh->AddMixingVariable(VarManager::kCentVZERO, fCentLimsHashing);
   }
   if (!nameStr.compare("Centrality4")) {
     std::vector<float> fCentLimsHashing = {0.0f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f, 70.0f, 80.0f, 90.0f};
-    mh->AddMixingVariable(VarManager::kCentVZERO, fCentLimsHashing.size(), fCentLimsHashing);
+    mh->AddMixingVariable(VarManager::kCentVZERO, fCentLimsHashing);
   }
   if (!nameStr.compare("Centrality5")) {
     std::vector<float> fCentLimsHashing = {0.0f, 5.0f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f, 70.0f, 80.0f, 90.0f};
-    mh->AddMixingVariable(VarManager::kCentVZERO, fCentLimsHashing.size(), fCentLimsHashing);
+    mh->AddMixingVariable(VarManager::kCentVZERO, fCentLimsHashing);
   }
   if (!nameStr.compare("Centrality6")) {
     std::vector<float> fCentLimsHashing = {0.0f, 2.5f, 5.0f, 7.5f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f, 70.0f, 80.0f, 90.0f};
-    mh->AddMixingVariable(VarManager::kCentVZERO, fCentLimsHashing.size(), fCentLimsHashing);
+    mh->AddMixingVariable(VarManager::kCentVZERO, fCentLimsHashing);
   }
   if (!nameStr.compare("CentralityFT0C1")) {
     std::vector<float> fCentFT0CLimsHashing = {0.0f, 20.0f, 40.0f, 60.0f, 90.0f};
-    mh->AddMixingVariable(VarManager::kCentFT0C, fCentFT0CLimsHashing.size(), fCentFT0CLimsHashing);
+    mh->AddMixingVariable(VarManager::kCentFT0C, fCentFT0CLimsHashing);
   }
   if (!nameStr.compare("CentralityFT0C2")) {
     std::vector<float> fCentFT0CLimsHashing = {0.0f, 10.0f, 20.0f, 40.0f, 60.0f, 90.0f};
-    mh->AddMixingVariable(VarManager::kCentFT0C, fCentFT0CLimsHashing.size(), fCentFT0CLimsHashing);
+    mh->AddMixingVariable(VarManager::kCentFT0C, fCentFT0CLimsHashing);
   }
   if (!nameStr.compare("CentralityFT0C3")) {
     std::vector<float> fCentFT0CLimsHashing = {0.0f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 70.0f, 90.0f};
-    mh->AddMixingVariable(VarManager::kCentFT0C, fCentFT0CLimsHashing.size(), fCentFT0CLimsHashing);
+    mh->AddMixingVariable(VarManager::kCentFT0C, fCentFT0CLimsHashing);
   }
   if (!nameStr.compare("CentralityFT0C4")) {
     std::vector<float> fCentFT0CLimsHashing = {0.0f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f, 70.0f, 80.0f, 90.0f};
-    mh->AddMixingVariable(VarManager::kCentFT0C, fCentFT0CLimsHashing.size(), fCentFT0CLimsHashing);
+    mh->AddMixingVariable(VarManager::kCentFT0C, fCentFT0CLimsHashing);
   }
   if (!nameStr.compare("CentralityFT0C5")) {
     std::vector<float> fCentFT0CLimsHashing = {0.0f, 5.0f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f, 70.0f, 80.0f, 90.0f};
-    mh->AddMixingVariable(VarManager::kCentFT0C, fCentFT0CLimsHashing.size(), fCentFT0CLimsHashing);
+    mh->AddMixingVariable(VarManager::kCentFT0C, fCentFT0CLimsHashing);
   }
   if (!nameStr.compare("CentralityFT0C6")) {
     std::vector<float> fCentFT0CLimsHashing = {0.0f, 2.5f, 5.0f, 7.5f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f, 70.0f, 80.0f, 90.0f};
-    mh->AddMixingVariable(VarManager::kCentFT0C, fCentFT0CLimsHashing.size(), fCentFT0CLimsHashing);
+    mh->AddMixingVariable(VarManager::kCentFT0C, fCentFT0CLimsHashing);
   }
   if (!nameStr.compare("Mult1")) {
     std::vector<float> fMultLimsHashing = {0.0f, 10.0f, 20.0f, 40.0f, 60.0f, 80.0f, 100.0f, 120.0f, 160.0f, 350.0f};
-    mh->AddMixingVariable(VarManager::kVtxNcontrib, fMultLimsHashing.size(), fMultLimsHashing);
+    mh->AddMixingVariable(VarManager::kVtxNcontrib, fMultLimsHashing);
   }
   if (!nameStr.compare("Mult2")) {
     std::vector<float> fMultLimsHashing = {0.0f, 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f, 70.0f, 80.0f, 90.0f, 100.0f, 120.0f, 140.0f, 180.0f, 350.0f};
-    mh->AddMixingVariable(VarManager::kVtxNcontrib, fMultLimsHashing.size(), fMultLimsHashing);
+    mh->AddMixingVariable(VarManager::kVtxNcontrib, fMultLimsHashing);
   }
   if (!nameStr.compare("Mult3")) {
     std::vector<float> fMultLimsHashing = {0.0f, 5.0f, 10.0f, 15.0f, 20.0f, 25.0f, 30.0f, 35.0f, 40.0f, 45.0f, 50.0f, 55.0f, 60.0f, 65.0f, 70.0f, 75.0f, 80.0f, 85.0f, 90.0f, 100.0f, 120.0f, 140.0f, 165.0f, 200.0f, 350.0f};
-    mh->AddMixingVariable(VarManager::kVtxNcontrib, fMultLimsHashing.size(), fMultLimsHashing);
+    mh->AddMixingVariable(VarManager::kVtxNcontrib, fMultLimsHashing);
   }
   if (!nameStr.compare("Vtx1")) {
     std::vector<float> fZLimsHashing = {-10.0f, 0.0f, 10.0f};
-    mh->AddMixingVariable(VarManager::kVtxZ, fZLimsHashing.size(), fZLimsHashing);
+    mh->AddMixingVariable(VarManager::kVtxZ, fZLimsHashing);
   }
   if (!nameStr.compare("Vtx2")) {
     std::vector<float> fZLimsHashing = {-10.0f, -5.0f, 0.0f, 5.0f, 10.0f};
-    mh->AddMixingVariable(VarManager::kVtxZ, fZLimsHashing.size(), fZLimsHashing);
+    mh->AddMixingVariable(VarManager::kVtxZ, fZLimsHashing);
   }
   if (!nameStr.compare("Vtx3")) {
     std::vector<float> fZLimsHashing = {-10.0f, -7.5f, -5.0f, -2.5f, 0.0f, 2.5f, 5.0f, 7.5f, 10.0f};
-    mh->AddMixingVariable(VarManager::kVtxZ, fZLimsHashing.size(), fZLimsHashing);
+    mh->AddMixingVariable(VarManager::kVtxZ, fZLimsHashing);
   }
   if (!nameStr.compare("Vtx4")) {
     std::vector<float> fZLimsHashing = {-10.0f, -8.0f, -6.0f, -4.0f, -2.0f, 0.0f, 2.0f, 4.0f, 6.0f, 8.0f, 10.0f};
-    mh->AddMixingVariable(VarManager::kVtxZ, fZLimsHashing.size(), fZLimsHashing);
+    mh->AddMixingVariable(VarManager::kVtxZ, fZLimsHashing);
   }
   if (!nameStr.compare("Vtx5")) {
     std::vector<float> fZLimsHashing = {-10.0f, -9.0f, -8.0f, -7.0f, -6.0f, -5.0f, -4.0f, -3.0f, -2.0f, -1.0f, 0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f};
-    mh->AddMixingVariable(VarManager::kVtxZ, fZLimsHashing.size(), fZLimsHashing);
+    mh->AddMixingVariable(VarManager::kVtxZ, fZLimsHashing);
   }
   if (!nameStr.compare("Occupancy1")) {
     std::vector<float> fOccLimsHashing = {0.0f, 500.0f, 1000.0f, 2000.0f, 3000.0f, 6000.0f, 50000.0f};
-    mh->AddMixingVariable(VarManager::kTrackOccupancyInTimeRange, fOccLimsHashing.size(), fOccLimsHashing);
+    mh->AddMixingVariable(VarManager::kTrackOccupancyInTimeRange, fOccLimsHashing);
   }
   if (!nameStr.compare("Occupancy2")) {
     std::vector<float> fOccLimsHashing = {0.0f, 250.0f, 500.0f, 750.0f, 1000.0f, 1500.0f, 2000.0f, 3000.0f, 6000.0f, 50000.0f};
-    mh->AddMixingVariable(VarManager::kTrackOccupancyInTimeRange, fOccLimsHashing.size(), fOccLimsHashing);
+    mh->AddMixingVariable(VarManager::kTrackOccupancyInTimeRange, fOccLimsHashing);
   }
   if (!nameStr.compare("Occupancy3")) {
     std::vector<float> fOccLimsHashing = {0.0f, 250.0f, 500.0f, 750.0f, 1000.0f, 1500.0f, 2000.0f, 3000.0f, 4500.0f, 6000.0f, 8000.0f, 10000.0f, 50000.0f};
-    mh->AddMixingVariable(VarManager::kTrackOccupancyInTimeRange, fOccLimsHashing.size(), fOccLimsHashing);
+    mh->AddMixingVariable(VarManager::kTrackOccupancyInTimeRange, fOccLimsHashing);
   }
   if (!nameStr.compare("Psi2A1")) {
     std::vector<float> fPsi2A = {-TMath::Pi() / 2., 0.0f, TMath::Pi() / 2.};
-    mh->AddMixingVariable(VarManager::kPsi2A, fPsi2A.size(), fPsi2A);
+    mh->AddMixingVariable(VarManager::kPsi2A, fPsi2A);
   }
   if (!nameStr.compare("Psi2A2")) {
     std::vector<float> fPsi2A = {-TMath::Pi() / 2., -TMath::Pi() / 4., 0.0f, TMath::Pi() / 4., TMath::Pi() / 2.};
-    mh->AddMixingVariable(VarManager::kPsi2A, fPsi2A.size(), fPsi2A);
+    mh->AddMixingVariable(VarManager::kPsi2A, fPsi2A);
   }
   if (!nameStr.compare("Psi2A3")) {
     std::vector<float> fPsi2A = {-4 * TMath::Pi() / 8., -3 * TMath::Pi() / 8., -2 * TMath::Pi() / 8., -TMath::Pi() / 8., 0.0f, TMath::Pi() / 8., 2 * TMath::Pi() / 8., 3 * TMath::Pi() / 8., 4 * TMath::Pi() / 8.};
-    mh->AddMixingVariable(VarManager::kPsi2A, fPsi2A.size(), fPsi2A);
+    mh->AddMixingVariable(VarManager::kPsi2A, fPsi2A);
   }
   if (!nameStr.compare("Psi2A4")) {
     std::vector<float> fPsi2A = {-8 * TMath::Pi() / 16., -7 * TMath::Pi() / 16., -6 * TMath::Pi() / 16., -5 * TMath::Pi() / 16., -4 * TMath::Pi() / 16., -3 * TMath::Pi() / 16., -2 * TMath::Pi() / 16., -TMath::Pi() / 16., 0.0f, TMath::Pi() / 16., 2 * TMath::Pi() / 16., 3 * TMath::Pi() / 16., 4 * TMath::Pi() / 16., 5 * TMath::Pi() / 16., 6 * TMath::Pi() / 16., 7 * TMath::Pi() / 16., 8 * TMath::Pi() / 16.};
-    mh->AddMixingVariable(VarManager::kPsi2A, fPsi2A.size(), fPsi2A);
+    mh->AddMixingVariable(VarManager::kPsi2A, fPsi2A);
   }
   if (!nameStr.compare("Psi2A5")) {
     std::vector<float> fPsi2A = {-12 * TMath::Pi() / 24., -11 * TMath::Pi() / 24., -10 * TMath::Pi() / 24., -9 * TMath::Pi() / 24., -8 * TMath::Pi() / 24., -7 * TMath::Pi() / 24., -6 * TMath::Pi() / 24., -5 * TMath::Pi() / 24., -4 * TMath::Pi() / 24., -3 * TMath::Pi() / 24., -2 * TMath::Pi() / 24., -TMath::Pi() / 24., 0.0f, TMath::Pi() / 24., 2 * TMath::Pi() / 24., 3 * TMath::Pi() / 24., 4 * TMath::Pi() / 24., 5 * TMath::Pi() / 24., 6 * TMath::Pi() / 24., 7 * TMath::Pi() / 24., 8 * TMath::Pi() / 24., 9 * TMath::Pi() / 24., 10 * TMath::Pi() / 24., 11 * TMath::Pi() / 24., 12 * TMath::Pi() / 24.};
-    mh->AddMixingVariable(VarManager::kPsi2A, fPsi2A.size(), fPsi2A);
+    mh->AddMixingVariable(VarManager::kPsi2A, fPsi2A);
   }
   if (!nameStr.compare("Psi2B1")) {
     std::vector<float> fPsi2B = {-TMath::Pi() / 2., 0.0f, TMath::Pi() / 2.};
-    mh->AddMixingVariable(VarManager::kPsi2B, fPsi2B.size(), fPsi2B);
+    mh->AddMixingVariable(VarManager::kPsi2B, fPsi2B);
   }
   if (!nameStr.compare("Psi2B2")) {
     std::vector<float> fPsi2B = {-TMath::Pi() / 2., -TMath::Pi() / 4., 0.0f, TMath::Pi() / 4., TMath::Pi() / 2.};
-    mh->AddMixingVariable(VarManager::kPsi2B, fPsi2B.size(), fPsi2B);
+    mh->AddMixingVariable(VarManager::kPsi2B, fPsi2B);
   }
   if (!nameStr.compare("Psi2B3")) {
     std::vector<float> fPsi2B = {-4 * TMath::Pi() / 8., -3 * TMath::Pi() / 8., -2 * TMath::Pi() / 8., -TMath::Pi() / 8., 0.0f, TMath::Pi() / 8., 2 * TMath::Pi() / 8., 3 * TMath::Pi() / 8., 4 * TMath::Pi() / 8.};
-    mh->AddMixingVariable(VarManager::kPsi2B, fPsi2B.size(), fPsi2B);
+    mh->AddMixingVariable(VarManager::kPsi2B, fPsi2B);
   }
   if (!nameStr.compare("Psi2B4")) {
     std::vector<float> fPsi2B = {-8 * TMath::Pi() / 16., -7 * TMath::Pi() / 16., -6 * TMath::Pi() / 16., -5 * TMath::Pi() / 16., -4 * TMath::Pi() / 16., -3 * TMath::Pi() / 16., -2 * TMath::Pi() / 16., -TMath::Pi() / 16., 0.0f, TMath::Pi() / 16., 2 * TMath::Pi() / 16., 3 * TMath::Pi() / 16., 4 * TMath::Pi() / 16., 5 * TMath::Pi() / 16., 6 * TMath::Pi() / 16., 7 * TMath::Pi() / 16., 8 * TMath::Pi() / 16.};
-    mh->AddMixingVariable(VarManager::kPsi2B, fPsi2B.size(), fPsi2B);
+    mh->AddMixingVariable(VarManager::kPsi2B, fPsi2B);
   }
   if (!nameStr.compare("Psi2B5")) {
     std::vector<float> fPsi2B = {-12 * TMath::Pi() / 24., -11 * TMath::Pi() / 24., -10 * TMath::Pi() / 24., -9 * TMath::Pi() / 24., -8 * TMath::Pi() / 24., -7 * TMath::Pi() / 24., -6 * TMath::Pi() / 24., -5 * TMath::Pi() / 24., -4 * TMath::Pi() / 24., -3 * TMath::Pi() / 24., -2 * TMath::Pi() / 24., -TMath::Pi() / 24., 0.0f, TMath::Pi() / 24., 2 * TMath::Pi() / 24., 3 * TMath::Pi() / 24., 4 * TMath::Pi() / 24., 5 * TMath::Pi() / 24., 6 * TMath::Pi() / 24., 7 * TMath::Pi() / 24., 8 * TMath::Pi() / 24., 9 * TMath::Pi() / 24., 10 * TMath::Pi() / 24., 11 * TMath::Pi() / 24., 12 * TMath::Pi() / 24.};
-    mh->AddMixingVariable(VarManager::kPsi2B, fPsi2B.size(), fPsi2B);
+    mh->AddMixingVariable(VarManager::kPsi2B, fPsi2B);
   }
   if (!nameStr.compare("Psi2C1")) {
     std::vector<float> fPsi2C = {-TMath::Pi() / 2., 0.0f, TMath::Pi() / 2.};
-    mh->AddMixingVariable(VarManager::kPsi2C, fPsi2C.size(), fPsi2C);
+    mh->AddMixingVariable(VarManager::kPsi2C, fPsi2C);
   }
   if (!nameStr.compare("Psi2C2")) {
     std::vector<float> fPsi2C = {-TMath::Pi() / 2., -TMath::Pi() / 4., 0.0f, TMath::Pi() / 4., TMath::Pi() / 2.};
-    mh->AddMixingVariable(VarManager::kPsi2C, fPsi2C.size(), fPsi2C);
+    mh->AddMixingVariable(VarManager::kPsi2C, fPsi2C);
   }
   if (!nameStr.compare("Psi2C3")) {
     std::vector<float> fPsi2C = {-4 * TMath::Pi() / 8., -3 * TMath::Pi() / 8., -2 * TMath::Pi() / 8., -TMath::Pi() / 8., 0.0f, TMath::Pi() / 8., 2 * TMath::Pi() / 8., 3 * TMath::Pi() / 8., 4 * TMath::Pi() / 8.};
-    mh->AddMixingVariable(VarManager::kPsi2C, fPsi2C.size(), fPsi2C);
+    mh->AddMixingVariable(VarManager::kPsi2C, fPsi2C);
   }
   if (!nameStr.compare("Psi2C4")) {
     std::vector<float> fPsi2C = {-8 * TMath::Pi() / 16., -7 * TMath::Pi() / 16., -6 * TMath::Pi() / 16., -5 * TMath::Pi() / 16., -4 * TMath::Pi() / 16., -3 * TMath::Pi() / 16., -2 * TMath::Pi() / 16., -TMath::Pi() / 16., 0.0f, TMath::Pi() / 16., 2 * TMath::Pi() / 16., 3 * TMath::Pi() / 16., 4 * TMath::Pi() / 16., 5 * TMath::Pi() / 16., 6 * TMath::Pi() / 16., 7 * TMath::Pi() / 16., 8 * TMath::Pi() / 16.};
-    mh->AddMixingVariable(VarManager::kPsi2C, fPsi2C.size(), fPsi2C);
+    mh->AddMixingVariable(VarManager::kPsi2C, fPsi2C);
   }
   if (!nameStr.compare("Psi2C5")) {
     std::vector<float> fPsi2C = {-12 * TMath::Pi() / 24., -11 * TMath::Pi() / 24., -10 * TMath::Pi() / 24., -9 * TMath::Pi() / 24., -8 * TMath::Pi() / 24., -7 * TMath::Pi() / 24., -6 * TMath::Pi() / 24., -5 * TMath::Pi() / 24., -4 * TMath::Pi() / 24., -3 * TMath::Pi() / 24., -2 * TMath::Pi() / 24., -TMath::Pi() / 24., 0.0f, TMath::Pi() / 24., 2 * TMath::Pi() / 24., 3 * TMath::Pi() / 24., 4 * TMath::Pi() / 24., 5 * TMath::Pi() / 24., 6 * TMath::Pi() / 24., 7 * TMath::Pi() / 24., 8 * TMath::Pi() / 24., 9 * TMath::Pi() / 24., 10 * TMath::Pi() / 24., 11 * TMath::Pi() / 24., 12 * TMath::Pi() / 24.};
-    mh->AddMixingVariable(VarManager::kPsi2C, fPsi2C.size(), fPsi2C);
+    mh->AddMixingVariable(VarManager::kPsi2C, fPsi2C);
   }
   if (!nameStr.compare("MedianTimeA1")) {
     std::vector<float> fMTLimsHashing = {-100.0f, -40.0f, -20.0f, 20.0f, 40.0f, 100.0f};
-    mh->AddMixingVariable(VarManager::kNTPCmedianTimeLongA, fMTLimsHashing.size(), fMTLimsHashing);
+    mh->AddMixingVariable(VarManager::kNTPCmedianTimeLongA, fMTLimsHashing);
   }
   if (!nameStr.compare("MedianTimeA2")) {
     std::vector<float> fMTLimsHashing = {-100.0f, -80.0f, -60.0f, -40.0f, -20.0f, 0.0f, 20.0f, 40.0f, 60.0f, 80.0f, 100.0f};
-    mh->AddMixingVariable(VarManager::kNTPCmedianTimeLongA, fMTLimsHashing.size(), fMTLimsHashing);
+    mh->AddMixingVariable(VarManager::kNTPCmedianTimeLongA, fMTLimsHashing);
   }
   if (!nameStr.compare("MedianTimeA3")) {
     std::vector<float> fMTLimsHashing = {-100.0f, -80.0f, -60.0f, -40.0f, -30.0f, -20.0f, -10.0f, 0.0f, 10.0f, 20.0f, 30.0f, 40.0f, 60.0f, 80.0f, 100.0f};
-    mh->AddMixingVariable(VarManager::kNTPCmedianTimeLongA, fMTLimsHashing.size(), fMTLimsHashing);
+    mh->AddMixingVariable(VarManager::kNTPCmedianTimeLongA, fMTLimsHashing);
   }
   if (!nameStr.compare("PileUpA1")) {
     std::vector<float> fPileUpLimsHashing = {0.0f, 1000.0f, 2000.0f, 6000.0f, 10000.0f, 20000.0f};
-    mh->AddMixingVariable(VarManager::kNTPCcontribLongA, fPileUpLimsHashing.size(), fPileUpLimsHashing);
+    mh->AddMixingVariable(VarManager::kNTPCcontribLongA, fPileUpLimsHashing);
   }
   if (!nameStr.compare("PileUpA2")) {
     std::vector<float> fPileUpLimsHashing = {0.0f, 1000.0f, 2000.0f, 4000.0f, 6000.0f, 8000.0f, 10000.0f, 20000.0f};
-    mh->AddMixingVariable(VarManager::kNTPCcontribLongA, fPileUpLimsHashing.size(), fPileUpLimsHashing);
+    mh->AddMixingVariable(VarManager::kNTPCcontribLongA, fPileUpLimsHashing);
   }
   if (!nameStr.compare("PileUpA3")) {
     std::vector<float> fPileUpLimsHashing = {0.0f, 1000.0f, 2000.0f, 3000.0f, 4000.0f, 5000.0f, 6000.0f, 8000.0f, 10000.0f, 20000.0f};
-    mh->AddMixingVariable(VarManager::kNTPCcontribLongA, fPileUpLimsHashing.size(), fPileUpLimsHashing);
+    mh->AddMixingVariable(VarManager::kNTPCcontribLongA, fPileUpLimsHashing);
   }
   if (!nameStr.compare("PileUpA4")) {
     std::vector<float> fPileUpLimsHashing = {0.0f, 500.0f, 1000.0f, 1500.0f, 2000.0f, 2500.0f, 3000.0f, 3500.0f, 4000.0f, 4500.0f, 5000.0f, 5500.0f, 6000.0f, 8000.0f, 10000.0f, 20000.0f};
-    mh->AddMixingVariable(VarManager::kNTPCcontribLongA, fPileUpLimsHashing.size(), fPileUpLimsHashing);
+    mh->AddMixingVariable(VarManager::kNTPCcontribLongA, fPileUpLimsHashing);
   }
 }
 
@@ -250,6 +250,6 @@ void o2::aod::dqmixing::SetUpMixingFromJSON(MixingHandler* mh, const char* json)
     }
 
     // set up mixing variable
-    mh->AddMixingVariable(VarManager::fgVarNamesMap[varStr], limits.size(), limits);
+    mh->AddMixingVariable(VarManager::fgVarNamesMap[varStr], limits);
   }
 }

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -1396,6 +1396,8 @@ class VarManager : public TObject
   static void FillTriple(T1 const& t1, T2 const& t2, T3 const& t3, float* values = nullptr, PairCandidateType pairType = kTripleCandidateToEEPhoton);
   template <uint32_t fillMap, int pairType, typename T1, typename T2>
   static void FillPairME(T1 const& t1, T2 const& t2, float* values = nullptr);
+  template <typename T>
+  static void FillPairMEAcrossTFs(T const& t1, T const& t2, float* values = nullptr);
   template <int pairType, typename T1, typename T2>
   static void FillPairMC(T1 const& t1, T2 const& t2, float* values = nullptr);
   template <int candidateType, typename T1, typename T2, typename T3>
@@ -4212,6 +4214,24 @@ void VarManager::FillPairME(T1 const& t1, T2 const& t2, float* values)
   if (fgUsedVars[kPairPhiv]) {
     values[kPairPhiv] = calculatePhiV<pairType>(t1, t2);
   }
+}
+
+template <typename T>
+void VarManager::FillPairMEAcrossTFs(T const& t1, T const& t2, float* values)
+{
+  if (!values) {
+    values = fgValues;
+  }
+
+  float m1 = o2::constants::physics::MassElectron;
+  ROOT::Math::PtEtaPhiMVector v1(t1.pt, t1.eta, t1.phi, m1);
+  ROOT::Math::PtEtaPhiMVector v2(t2.pt, t2.eta, t2.phi, m1);
+  ROOT::Math::PtEtaPhiMVector v12 = v1 + v2;
+  values[kMass] = v12.M();
+  values[kPt] = v12.Pt();
+  values[kEta] = v12.Eta();
+  values[kPhi] = v12.Phi() > 0 ? v12.Phi() : v12.Phi() + 2. * M_PI;
+  values[kRap] = -v12.Rapidity();
 }
 
 template <int pairType, typename T1, typename T2>

--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -1630,7 +1630,7 @@ struct AnalysisSameEventPairing {
       TString mixVarsJsonString = fConfigMixingVariablesJson.value;
       std::unique_ptr<TObjArray> objArray(mixVarsString.Tokenize(","));
       if (objArray->GetEntries() > 0 || mixVarsJsonString != "") {
-        //fMixingHandler = new MixingHandler("mixingHandler", "mixing handler");
+        // fMixingHandler = new MixingHandler("mixingHandler", "mixing handler");
         if (objArray->GetEntries() > 0) {
           for (int iVar = 0; iVar < objArray->GetEntries(); ++iVar) {
             dqmixing::SetUpMixing(&fMixingHandler, objArray->At(iVar)->GetName());
@@ -1643,7 +1643,6 @@ struct AnalysisSameEventPairing {
       fMixingHandler.SetPoolDepth(fConfigMixingDepth);
       fMixingHandler.Init();
     }
-  
 
     fCurrentRun = 0;
 
@@ -2294,7 +2293,7 @@ struct AnalysisSameEventPairing {
         }
         // 3) add the current event to the pool
         pool.UpdatePool(mixingEvent, fMixingHandler.GetPoolDepth());
-        //pool.Print();
+        // pool.Print();
       }
     } // end loop over events
   }

--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -2294,7 +2294,7 @@ struct AnalysisSameEventPairing {
         }
         // 3) add the current event to the pool
         pool.UpdatePool(mixingEvent, fMixingHandler.GetPoolDepth());
-        pool.Print();
+        //pool.Print();
       }
     } // end loop over events
   }

--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -1306,6 +1306,9 @@ struct AnalysisSameEventPairing {
   } fConfigCuts;
 
   Configurable<int> fConfigMixingDepth{"cfgMixingDepth", 100, "Number of Events stored for event mixing"};
+  Configurable<std::string> fConfigMixingVariables{"cfgMixingVars", "", "Mixing configs separated by a comma, default no mixing"};
+  Configurable<std::string> fConfigMixingVariablesJson{"cfgMixingVarsJSON", "", "Mixing configs in JSON format"};
+  Configurable<bool> fConfigRunMixingAcrossTFs{"cfgRunMixingAcrossTFs", false, "If true, run event mixing using the MixingHandler which accumulates events across multiple TFs"};
   // Configurable<std::string> fConfigAddEventMixingHistogram{"cfgAddEventMixingHistogram", "", "Comma separated list of histograms"};
   Configurable<std::string> fConfigAddSEPHistogram{"cfgAddSEPHistogram", "", "Comma separated list of histograms"};
   Configurable<std::string> fConfigAddJSONHistograms{"cfgAddJSONHistograms", "", "Histograms in JSON format"};
@@ -1353,6 +1356,7 @@ struct AnalysisSameEventPairing {
   Filter filterEventSelected = aod::dqanalysisflags::isEventSelected > static_cast<uint8_t>(0);
 
   HistogramManager* fHistMan;
+  MixingHandler fMixingHandler;
 
   o2::analysis::DQMlResponse<float> fDQMlResponse;
   std::vector<float> fOutputMlPsi2ee = {}; // TODO: check this is needed or not
@@ -1390,6 +1394,7 @@ struct AnalysisSameEventPairing {
   {
     fEnableBarrelHistos = context.mOptions.get<bool>("processAllSkimmed") || context.mOptions.get<bool>("processBarrelOnlySkimmed") || context.mOptions.get<bool>("processBarrelOnlyWithCollSkimmed") || context.mOptions.get<bool>("processBarrelOnlySkimmedNoCov") || context.mOptions.get<bool>("processBarrelOnlySkimmedNoCovWithMultExtra") || context.mOptions.get<bool>("processBarrelOnlyWithQvectorCentrSkimmedNoCov");
     fEnableBarrelMixingHistos = context.mOptions.get<bool>("processMixingAllSkimmed") || context.mOptions.get<bool>("processMixingBarrelSkimmed") || context.mOptions.get<bool>("processMixingBarrelSkimmedFlow") || context.mOptions.get<bool>("processMixingBarrelWithQvectorCentrSkimmedNoCov");
+    fEnableBarrelMixingHistos |= fConfigRunMixingAcrossTFs;
     fEnableMuonHistos = context.mOptions.get<bool>("processAllSkimmed") || context.mOptions.get<bool>("processMuonOnlySkimmed") || context.mOptions.get<bool>("processMuonOnlySkimmedMultExtra") || context.mOptions.get<bool>("processMuonOnlySkimmedFlow");
     fEnableMuonMixingHistos = context.mOptions.get<bool>("processMixingAllSkimmed") || context.mOptions.get<bool>("processMixingMuonSkimmed") || context.mOptions.get<bool>("processMixingMuonSkimmedFlow");
     fEnableBarrelMuonHistos = context.mOptions.get<bool>("processElectronMuonSkimmed");
@@ -1619,6 +1624,26 @@ struct AnalysisSameEventPairing {
         }
       }
     }
+
+    if (fConfigRunMixingAcrossTFs) {
+      TString mixVarsString = fConfigMixingVariables.value;
+      TString mixVarsJsonString = fConfigMixingVariablesJson.value;
+      std::unique_ptr<TObjArray> objArray(mixVarsString.Tokenize(","));
+      if (objArray->GetEntries() > 0 || mixVarsJsonString != "") {
+        //fMixingHandler = new MixingHandler("mixingHandler", "mixing handler");
+        if (objArray->GetEntries() > 0) {
+          for (int iVar = 0; iVar < objArray->GetEntries(); ++iVar) {
+            dqmixing::SetUpMixing(&fMixingHandler, objArray->At(iVar)->GetName());
+          }
+        }
+      }
+      if (mixVarsJsonString != "") {
+        dqmixing::SetUpMixingFromJSON(&fMixingHandler, mixVarsJsonString.Data());
+      }
+      fMixingHandler.SetPoolDepth(fConfigMixingDepth);
+      fMixingHandler.Init();
+    }
+  
 
     fCurrentRun = 0;
 
@@ -2181,6 +2206,95 @@ struct AnalysisSameEventPairing {
       VarManager::fgValues[VarManager::kNPairsPerEvent] = fNPairPerEvent;
       if (fEnableBarrelHistos && fConfigQA) {
         fHistMan->FillHistClass("PairingSEQA", VarManager::fgValues);
+      }
+
+      if (fConfigRunMixingAcrossTFs) {
+        // run event mixing across TFs
+        // 1) create a MixingEvent and fill it with the relevant tracks
+        MixingHandler::MixingEvent mixingEvent;
+        uint32_t trackFilterForMixing = 0;
+        for (auto& assoc : groupedAssocs) {
+          if constexpr (TPairType == VarManager::kDecayToEE) {
+            trackFilterForMixing = assoc.isBarrelSelected_raw() & assoc.isBarrelSelectedPrefilter_raw() & fTrackFilterMask;
+            if (!trackFilterForMixing) {
+              continue;
+            }
+            auto t1 = assoc.template reducedtrack_as<TTracks>();
+            MixingHandler::MixingTrack mixingTrack(t1.pt(), t1.eta(), t1.phi(), trackFilterForMixing);
+            if (t1.sign() > 0) {
+              mixingEvent.AddTrack1(mixingTrack);
+            } else {
+              mixingEvent.AddTrack2(mixingTrack);
+            }
+          }
+        }
+        // 2) run the mixing with the events in the pool corresponding to this event
+        auto& pool = fMixingHandler.GetPool(fMixingHandler.FindEventCategory(VarManager::fgValues));
+        for (auto& poolEvent : pool.GetEvents()) {
+          for (auto& t1 : mixingEvent.tracks1) {
+            // run +- pairing
+            for (auto& t2 : poolEvent.tracks2) {
+              // check the two-track filter for the mixed pair
+              uint32_t mixedTwoTrackFilter = t1.filteringFlags & t2.filteringFlags;
+              if (!mixedTwoTrackFilter) {
+                continue;
+              }
+              VarManager::FillPairMEAcrossTFs(t1, t2);
+              for (int icut = 0; icut < ncuts; icut++) {
+                if (mixedTwoTrackFilter & (static_cast<uint32_t>(1) << icut)) {
+                  fHistMan->FillHistClass(Form("PairsBarrelMEPM_%s", fTrackCuts[icut].Data()), VarManager::fgValues);
+                }
+              }
+            }
+            // run ++ pairing
+            for (auto& t2 : poolEvent.tracks1) {
+              // check the two-track filter for the mixed pair
+              uint32_t mixedTwoTrackFilter = t1.filteringFlags & t2.filteringFlags;
+              if (!mixedTwoTrackFilter) {
+                continue;
+              }
+              VarManager::FillPairMEAcrossTFs(t1, t2);
+              for (int icut = 0; icut < ncuts; icut++) {
+                if (mixedTwoTrackFilter & (static_cast<uint32_t>(1) << icut)) {
+                  fHistMan->FillHistClass(Form("PairsBarrelMEPP_%s", fTrackCuts[icut].Data()), VarManager::fgValues);
+                }
+              }
+            }
+          }
+          for (auto& t1 : mixingEvent.tracks2) {
+            // run -+ pairing
+            for (auto& t2 : poolEvent.tracks1) {
+              // check the two-track filter for the mixed pair
+              uint32_t mixedTwoTrackFilter = t1.filteringFlags & t2.filteringFlags;
+              if (!mixedTwoTrackFilter) {
+                continue;
+              }
+              VarManager::FillPairMEAcrossTFs(t1, t2);
+              for (int icut = 0; icut < ncuts; icut++) {
+                if (mixedTwoTrackFilter & (static_cast<uint32_t>(1) << icut)) {
+                  fHistMan->FillHistClass(Form("PairsBarrelMEPM_%s", fTrackCuts[icut].Data()), VarManager::fgValues);
+                }
+              }
+            }
+            // run -- pairing
+            for (auto& t2 : poolEvent.tracks2) {
+              // check the two-track filter for the mixed pair
+              uint32_t mixedTwoTrackFilter = t1.filteringFlags & t2.filteringFlags;
+              if (!mixedTwoTrackFilter) {
+                continue;
+              }
+              VarManager::FillPairMEAcrossTFs(t1, t2);
+              for (int icut = 0; icut < ncuts; icut++) {
+                if (mixedTwoTrackFilter & (static_cast<uint32_t>(1) << icut)) {
+                  fHistMan->FillHistClass(Form("PairsBarrelMEMM_%s", fTrackCuts[icut].Data()), VarManager::fgValues);
+                }
+              }
+            }
+          }
+        }
+        // 3) add the current event to the pool
+        pool.UpdatePool(mixingEvent, fMixingHandler.GetPoolDepth());
+        pool.Print();
       }
     } // end loop over events
   }


### PR DESCRIPTION
This is implemented so far just for the dielectron channel, in the table-reader-with-assoc. The event mixing categories are created in the same way as for the usual mixing (within a single TF), but they are configured directly in the same-event-pairing task.
In this mixing, the candidate electrons are temporarily stored in event pools which are permanent (data members of the task) and included in the mixing using a rolling buffer of configurable depth. The important aspect is that in the case when mixing is done with very many categories or the signal is very rare, and the pools cannot be filled during a single TF, this method will allow using all the TFs in the job, so all pools can get enough events. 