### PR TITLE
[PWGHF] Fix missing McCollisions and refactor MC histograms into subdirectories in taskLcToK0sP.cxx

### DIFF
--- a/PWGHF/D2H/Tasks/taskLcToK0sP.cxx
+++ b/PWGHF/D2H/Tasks/taskLcToK0sP.cxx
@@ -65,6 +65,7 @@ struct HfTaskLcToK0sP {
   using FilteredCandLcToPK0SWSelFlagAndMl = soa::Filtered<soa::Join<aod::HfCandCascade, aod::HfSelLcToK0sP, aod::HfMlLcToK0sP>>;
   using FilteredCandLcToPK0SWSelFlagAndMc = soa::Filtered<soa::Join<aod::HfCandCascade, aod::HfSelLcToK0sP, aod::HfCandCascadeMcRec>>;
   using FilteredCandLcToPK0SWSelFlagAndMcAndMl = soa::Filtered<soa::Join<aod::HfCandCascade, aod::HfSelLcToK0sP, aod::HfCandCascadeMcRec, aod::HfMlLcToK0sP>>;
+  using McParticlesCascadeMatched = soa::Join<aod::McParticles, aod::HfCandCascadeMcGen>;
 
   using TracksWPid = soa::Join<aod::TracksWExtra, aod::TracksPidPr>;
 
@@ -87,7 +88,7 @@ struct HfTaskLcToK0sP {
   ConfigurableAxis thnConfigAxisBdtScorePrompt{"thnConfigAxisBdtScorePrompt", {100, 0., 1.}, ""};
   ConfigurableAxis thnConfigAxisBdtScoreNonPrompt{"thnConfigAxisBdtScoreNonPrompt", {100, 0., 1.}, ""};
   ConfigurableAxis thnConfigAxisPtB{"thnConfigAxisPtB", {3000, 0., 300.}, ""};
-  ConfigurableAxis thnConfigAxisOrigin{"thnConfigAxisOrigin", {2, -0.5, 1.5}, ""};
+  ConfigurableAxis thnConfigAxisOrigin{"thnConfigAxisOrigin", {3, -0.5, 2.5}, ""};
   ConfigurableAxis thnConfigAxisCentrality{"thnConfigAxisCentrality", {100, 0., 100.}, ""};
   ConfigurableAxis thnConfigAxisNumPvContr{"thnConfigAxisNumPvContr", {200, -0.5, 199.5}, "Number of PV contributors"};
   ConfigurableAxis thnConfigAxisY{"thnConfigAxisY", {20, -1., 1.}, "candidate rapidity"};
@@ -103,6 +104,16 @@ struct HfTaskLcToK0sP {
   };
 
   static constexpr int KDecayChannelLcToK0sP = 1;
+
+  // Names of folders and suffixes for MC signal histograms
+  constexpr static std::string_view SignalFolders[] = {"signal", "prompt", "nonprompt"};
+  constexpr static std::string_view SignalSuffixes[] = {"", "Prompt", "NonPrompt"};
+
+  enum SignalClass : int {
+    Signal = 0,
+    Prompt,
+    NonPrompt
+  };
 
   void init(InitContext&)
   {
@@ -130,7 +141,7 @@ struct HfTaskLcToK0sP {
     AxisSpec const axisMassK0Short = {500, 0.4f, 0.6f, "#it{m}(K_{S}^{0}) (GeV/#it{c}^{2})"};
     AxisSpec const axisMassLambda = {500, 1.0f, 1.2f, "#it{m}(#Lambda) (GeV/#it{c}^{2})"};
     AxisSpec const axisMassGamma = {500, 0.0f, 0.4f, "#it{m}(#gamma) (GeV/#it{c}^{2})"};
-    AxisSpec const axisCPACand = {110, -1.1f, 1.1f, "candiate cos pointing angle"};
+    AxisSpec const axisCPACand = {110, -1.1f, 1.1f, "candidate cos pointing angle"};
     AxisSpec const axisDecLength = {200, 0.f, 2.0f, "decay length (cm)"};
     AxisSpec const axisProperLifetime = {100, 0.f, 0.2f, "#it{c#tau} (cm)"};
     AxisSpec const axisProperLifetimeV0 = {1000, 0.f, 80.f, "#it{c#tau} (cm)"};
@@ -179,23 +190,33 @@ struct HfTaskLcToK0sP {
     bool const isMc = doprocessMcStd || doprocessMcStdWithFT0C || doprocessMcStdWithFT0M ||
                       doprocessMcWithMl || doprocessMcWithMlWithFT0C || doprocessMcWithMlWithFT0M;
     if (isMc) {
-      // MC helper lambdas
+      // MC Rec helper: signal/prompt/nonprompt + background
       auto addHistosMcRec = [&](const std::string& name, const std::string& title, const AxisSpec& axis) {
-        registry.add(("MC/Rec/h" + name + "RecSig").c_str(), ("cascade candidates;" + title + ";entries").c_str(), {HistType::kTH1F, {axis}});
-        registry.add(("MC/Rec/h" + name + "VsPtCandRecSig").c_str(), ("cascade candidates;" + title + ";p_{T}").c_str(), {HistType::kTH2F, {axis, axisBinsPt}});
-        registry.add(("MC/Rec/h" + name + "RecBg").c_str(), ("cascade candidates;" + title + ";entries").c_str(), {HistType::kTH1F, {axis}});
-        registry.add(("MC/Rec/h" + name + "VsPtCandRecBg").c_str(), ("cascade candidates;" + title + ";p_{T}").c_str(), {HistType::kTH2F, {axis, axisBinsPt}});
-      };
-      auto addHistosMcGen = [&](const std::string& name, const std::string& title, const AxisSpec& axis) {
-        registry.add(("MC/Gen/h" + name + "Gen").c_str(), ("cascade candidates;" + title + ";entries").c_str(), {HistType::kTH1F, {axis}});
-        registry.add(("MC/Gen/h" + name + "VsPtCandGen").c_str(), ("cascade candidates;" + title + ";p_{T}").c_str(), {HistType::kTH2F, {axis, axisBinsPt}});
+        registry.add(("MC/Rec/signal/h" + name + "RecSig").c_str(), ("cascade candidates (matched);" + title + ";entries").c_str(), {HistType::kTH1F, {axis}});
+        registry.add(("MC/Rec/signal/h" + name + "VsPtCandRecSig").c_str(), ("cascade candidates (matched);" + title + ";p_{T}").c_str(), {HistType::kTH2F, {axis, axisBinsPt}});
+        registry.add(("MC/Rec/prompt/h" + name + "RecSigPrompt").c_str(), ("cascade candidates (matched, prompt);" + title + ";entries").c_str(), {HistType::kTH1F, {axis}});
+        registry.add(("MC/Rec/prompt/h" + name + "VsPtCandRecSigPrompt").c_str(), ("cascade candidates (matched, prompt);" + title + ";p_{T}").c_str(), {HistType::kTH2F, {axis, axisBinsPt}});
+        registry.add(("MC/Rec/nonprompt/h" + name + "RecSigNonPrompt").c_str(), ("cascade candidates (matched, non-prompt);" + title + ";entries").c_str(), {HistType::kTH1F, {axis}});
+        registry.add(("MC/Rec/nonprompt/h" + name + "VsPtCandRecSigNonPrompt").c_str(), ("cascade candidates (matched, non-prompt);" + title + ";p_{T}").c_str(), {HistType::kTH2F, {axis, axisBinsPt}});
+        registry.add(("MC/Rec/background/h" + name + "RecBg").c_str(), ("cascade candidates (unmatched);" + title + ";entries").c_str(), {HistType::kTH1F, {axis}});
+        registry.add(("MC/Rec/background/h" + name + "VsPtCandRecBg").c_str(), ("cascade candidates (unmatched);" + title + ";p_{T}").c_str(), {HistType::kTH2F, {axis, axisBinsPt}});
       };
 
-      // MC Rec: PtCand has extra Prompt/NonPrompt variants
-      registry.add("MC/Rec/hPtCandRecSig", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-      registry.add("MC/Rec/hPtCandRecSigPrompt", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-      registry.add("MC/Rec/hPtCandRecSigNonPrompt", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-      registry.add("MC/Rec/hPtCandRecBg", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
+      // MC Gen helper: signal/prompt/nonprompt
+      auto addHistosMcGen = [&](const std::string& name, const std::string& title, const AxisSpec& axis) {
+        registry.add(("MC/Gen/signal/h" + name + "Gen").c_str(), ("MC particles (matched);" + title + ";entries").c_str(), {HistType::kTH1F, {axis}});
+        registry.add(("MC/Gen/signal/h" + name + "VsPtCandGen").c_str(), ("MC particles (matched);" + title + ";p_{T}").c_str(), {HistType::kTH2F, {axis, axisBinsPt}});
+        registry.add(("MC/Gen/prompt/h" + name + "GenPrompt").c_str(), ("MC particles (matched, prompt);" + title + ";entries").c_str(), {HistType::kTH1F, {axis}});
+        registry.add(("MC/Gen/prompt/h" + name + "VsPtCandGenPrompt").c_str(), ("MC particles (matched, prompt);" + title + ";p_{T}").c_str(), {HistType::kTH2F, {axis, axisBinsPt}});
+        registry.add(("MC/Gen/nonprompt/h" + name + "GenNonPrompt").c_str(), ("MC particles (matched, non-prompt);" + title + ";entries").c_str(), {HistType::kTH1F, {axis}});
+        registry.add(("MC/Gen/nonprompt/h" + name + "VsPtCandGenNonPrompt").c_str(), ("MC particles (matched, non-prompt);" + title + ";p_{T}").c_str(), {HistType::kTH2F, {axis, axisBinsPt}});
+      };
+
+      // MC Rec: PtCand has extra signal/prompt/nonprompt + background variants
+      registry.add("MC/Rec/signal/hPtCandRecSig", "cascade candidates (matched);candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
+      registry.add("MC/Rec/prompt/hPtCandRecSigPrompt", "cascade candidates (matched, prompt);candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
+      registry.add("MC/Rec/nonprompt/hPtCandRecSigNonPrompt", "cascade candidates (matched, non-prompt);candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
+      registry.add("MC/Rec/background/hPtCandRecBg", "cascade candidates (unmatched);candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
 
       addHistosMcRec("EtaCand", "candidate #it{#eta}", axisEta);
       addHistosMcRec("PhiCand", "candidate #it{#phi}", axisPhi);
@@ -224,19 +245,27 @@ struct HfTaskLcToK0sP {
       addHistosMcRec("CtCand", "proper lifetime (#Lambda_{c}) * #it{c} (cm)", axisProperLifetime);
 
       // MC Rec PID
-      registry.add("MC/Rec/hTPCNSigmaPrBachRecSig", "cascade candidates;n#it{#sigma}_{p} TPC;entries", {HistType::kTH1F, {axisNSigma}});
-      registry.add("MC/Rec/hPBachVsTPCNSigmaPrBachRecSig", "cascade candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TPC", {HistType::kTH2F, {axisPidP, axisNSigma}});
-      registry.add("MC/Rec/hTPCNSigmaPrBachRecBg", "cascade candidates;n#it{#sigma}_{p} TPC;entries", {HistType::kTH1F, {axisNSigma}});
-      registry.add("MC/Rec/hPBachVsTPCNSigmaPrBachRecBg", "cascade candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TPC", {HistType::kTH2F, {axisPidP, axisNSigma}});
-      registry.add("MC/Rec/hTOFNSigmaPrBachRecSig", "cascade candidates;n#it{#sigma}_{p} TOF;entries", {HistType::kTH1F, {axisNSigma}});
-      registry.add("MC/Rec/hPBachVsTOFNSigmaPrBachRecSig", "cascade candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TOF", {HistType::kTH2F, {axisPidP, axisNSigma}});
-      registry.add("MC/Rec/hTOFNSigmaPrBachRecBg", "cascade candidates;n#it{#sigma}_{p} TOF;entries", {HistType::kTH1F, {axisNSigma}});
-      registry.add("MC/Rec/hPBachVsTOFNSigmaPrBachRecBg", "cascade candidates;#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TOF", {HistType::kTH2F, {axisPidP, axisNSigma}});
+      registry.add("MC/Rec/signal/hTPCNSigmaPrBachRecSig", "cascade candidates (matched);n#it{#sigma}_{p} TPC;entries", {HistType::kTH1F, {axisNSigma}});
+      registry.add("MC/Rec/signal/hPBachVsTPCNSigmaPrBachRecSig", "cascade candidates (matched);#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TPC", {HistType::kTH2F, {axisPidP, axisNSigma}});
+      registry.add("MC/Rec/signal/hTOFNSigmaPrBachRecSig", "cascade candidates (matched);n#it{#sigma}_{p} TOF;entries", {HistType::kTH1F, {axisNSigma}});
+      registry.add("MC/Rec/signal/hPBachVsTOFNSigmaPrBachRecSig", "cascade candidates (matched);#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TOF", {HistType::kTH2F, {axisPidP, axisNSigma}});
+      registry.add("MC/Rec/prompt/hTPCNSigmaPrBachRecSigPrompt", "cascade candidates (matched, prompt);n#it{#sigma}_{p} TPC;entries", {HistType::kTH1F, {axisNSigma}});
+      registry.add("MC/Rec/prompt/hPBachVsTPCNSigmaPrBachRecSigPrompt", "cascade candidates (matched, prompt);#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TPC", {HistType::kTH2F, {axisPidP, axisNSigma}});
+      registry.add("MC/Rec/prompt/hTOFNSigmaPrBachRecSigPrompt", "cascade candidates (matched, prompt);n#it{#sigma}_{p} TOF;entries", {HistType::kTH1F, {axisNSigma}});
+      registry.add("MC/Rec/prompt/hPBachVsTOFNSigmaPrBachRecSigPrompt", "cascade candidates (matched, prompt);#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TOF", {HistType::kTH2F, {axisPidP, axisNSigma}});
+      registry.add("MC/Rec/nonprompt/hTPCNSigmaPrBachRecSigNonPrompt", "cascade candidates (matched, non-prompt);n#it{#sigma}_{p} TPC;entries", {HistType::kTH1F, {axisNSigma}});
+      registry.add("MC/Rec/nonprompt/hPBachVsTPCNSigmaPrBachRecSigNonPrompt", "cascade candidates (matched, non-prompt);#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TPC", {HistType::kTH2F, {axisPidP, axisNSigma}});
+      registry.add("MC/Rec/nonprompt/hTOFNSigmaPrBachRecSigNonPrompt", "cascade candidates (matched, non-prompt);n#it{#sigma}_{p} TOF;entries", {HistType::kTH1F, {axisNSigma}});
+      registry.add("MC/Rec/nonprompt/hPBachVsTOFNSigmaPrBachRecSigNonPrompt", "cascade candidates (matched, non-prompt);#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TOF", {HistType::kTH2F, {axisPidP, axisNSigma}});
+      registry.add("MC/Rec/background/hTPCNSigmaPrBachRecBg", "cascade candidates (unmatched);n#it{#sigma}_{p} TPC;entries", {HistType::kTH1F, {axisNSigma}});
+      registry.add("MC/Rec/background/hPBachVsTPCNSigmaPrBachRecBg", "cascade candidates (unmatched);#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TPC", {HistType::kTH2F, {axisPidP, axisNSigma}});
+      registry.add("MC/Rec/background/hTOFNSigmaPrBachRecBg", "cascade candidates (unmatched);n#it{#sigma}_{p} TOF;entries", {HistType::kTH1F, {axisNSigma}});
+      registry.add("MC/Rec/background/hPBachVsTOFNSigmaPrBachRecBg", "cascade candidates (unmatched);#it{p} bachelor (GeV/#it{c}) ;n#it{#sigma}_{p} TOF", {HistType::kTH2F, {axisPidP, axisNSigma}});
 
-      // MC Gen
-      registry.add("MC/Gen/hPtCandGen", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-      registry.add("MC/Gen/hPtCandGenPrompt", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
-      registry.add("MC/Gen/hPtCandGenNonPrompt", "cascade candidates;candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
+      // MC Gen: PtCand with signal/prompt/nonprompt variants
+      registry.add("MC/Gen/signal/hPtCandGen", "MC particles (matched);candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
+      registry.add("MC/Gen/prompt/hPtCandGenPrompt", "MC particles (matched, prompt);candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
+      registry.add("MC/Gen/nonprompt/hPtCandGenNonPrompt", "MC particles (matched, non-prompt);candidate #it{p}_{T} (GeV/#it{c});entries", {HistType::kTH1F, {axisPt}});
 
       addHistosMcGen("EtaCand", "candidate #it{#eta}", axisEta);
       addHistosMcGen("PhiCand", "candidate #it{#phi}", axisPhi);
@@ -249,7 +278,15 @@ struct HfTaskLcToK0sP {
       const AxisSpec thnAxisBdtScoreBkg{thnConfigAxisBdtScoreBkg, "BDT bkg score"};
       const AxisSpec thnAxisBdtScorePrompt{thnConfigAxisBdtScorePrompt, "BDT prompt score"};
       const AxisSpec thnAxisBdtScoreNonPrompt{thnConfigAxisBdtScoreNonPrompt, "BDT non-prompt score"};
-      const AxisSpec thnAxisCentrality{thnConfigAxisCentrality, "centrality (FT0C)"};
+      bool const isFT0C = doprocessDataStdWithFT0C || doprocessDataWithMlWithFT0C || doprocessMcStdWithFT0C || doprocessMcWithMlWithFT0C;
+      bool const isFT0M = doprocessDataStdWithFT0M || doprocessDataWithMlWithFT0M || doprocessMcStdWithFT0M || doprocessMcWithMlWithFT0M;
+      std::string centLabel = "centrality";
+      if (isFT0C) {
+        centLabel = "centrality (FT0C)";
+      } else if (isFT0M) {
+        centLabel = "centrality (FT0M)";
+      }
+      const AxisSpec thnAxisCentrality{thnConfigAxisCentrality, centLabel};
       const AxisSpec thnAxisNumPvContr{thnConfigAxisNumPvContr, "Number of PV contributors"};
       const AxisSpec thnAxisPtB{thnConfigAxisPtB, "#it{p}_{T}^{B} (GeV/#it{c})"};
       const AxisSpec thnAxisOrigin{thnConfigAxisOrigin, "origin"};
@@ -268,7 +305,7 @@ struct HfTaskLcToK0sP {
       }
 
       // MC Gen: {pt, centrality, rapidity, numPvContr, ptB, origin}
-      if (doprocessMcWithMl || doprocessMcWithMlWithFT0C || doprocessMcWithMlWithFT0M) {
+      if (isMc) {
         registry.add("hnLcK0sPGenMc", "THn for Lc->K0sP MC gen", HistType::kTHnSparseF,
                      {thnAxisPt, thnAxisCentrality, thnAxisY, thnAxisNumPvContr, thnAxisPtB, thnAxisOrigin});
       }
@@ -284,89 +321,109 @@ struct HfTaskLcToK0sP {
     return o2::hf_centrality::getCentralityColl<Coll>(collision);
   }
 
+  /// Bundled candidate variables with conversion constructor
+  struct HfCandVars {
+    double ptCand{}, eta{}, phi{}, invMassLcToK0sP{};
+    double ptProng0{}, ptProng1{};
+    double impactParameter0{}, impactParameter1{};
+    double dcaPosToPV{}, dcaNegToPV{};
+    double ptV0Pos{}, ptV0Neg{};
+    double v0CosPA{}, v0Radius{}, dcaV0Daughters{};
+    double mK0Short{}, mLambda{}, mAntiLambda{}, mGamma{};
+    double ctV0K0Short{}, ctV0Lambda{};
+    double cpa{}, cpaXY{};
+    double decayLength{}, decayLengthXY{}, ctLc{};
+
+    template <typename CandType>
+    explicit HfCandVars(CandType const& candidate)
+      : ptCand(candidate.pt()),
+        eta(candidate.eta()),
+        phi(candidate.phi()),
+        invMassLcToK0sP(HfHelper::invMassLcToK0sP(candidate)),
+        ptProng0(candidate.ptProng0()),
+        ptProng1(candidate.ptProng1()),
+        impactParameter0(candidate.impactParameter0()),
+        impactParameter1(candidate.impactParameter1()),
+        dcaPosToPV(candidate.dcapostopv()),
+        dcaNegToPV(candidate.dcanegtopv()),
+        ptV0Pos(candidate.ptV0Pos()),
+        ptV0Neg(candidate.ptV0Neg()),
+        v0CosPA(candidate.v0cosPA()),
+        v0Radius(candidate.v0radius()),
+        dcaV0Daughters(candidate.dcaV0daughters()),
+        mK0Short(candidate.mK0Short()),
+        mLambda(candidate.mLambda()),
+        mAntiLambda(candidate.mAntiLambda()),
+        mGamma(candidate.mGamma()),
+        ctV0K0Short(HfHelper::ctV0K0s(candidate)),
+        ctV0Lambda(HfHelper::ctV0Lambda(candidate)),
+        cpa(candidate.cpa()),
+        cpaXY(candidate.cpaXY()),
+        decayLength(candidate.decayLength()),
+        decayLengthXY(candidate.decayLengthXY()),
+        ctLc(HfHelper::ctLc(candidate))
+    {
+    }
+  };
+
   /// Helper function to fill candidate histograms
   /// \param candidate is the candidate
   template <typename CandType>
   void fillCandHistograms(CandType const& candidate)
   {
-    auto ptCand = candidate.pt();
-    auto eta = candidate.eta();
-    auto phi = candidate.phi();
-    auto invMassLcToK0sP = HfHelper::invMassLcToK0sP(candidate);
-    auto ptProng0 = candidate.ptProng0();
-    auto ptProng1 = candidate.ptProng1();
-    auto impactParameter0 = candidate.impactParameter0();
-    auto impactParameter1 = candidate.impactParameter1();
-    auto dcaPosToPV = candidate.dcapostopv();
-    auto dcaNegToPV = candidate.dcanegtopv();
-    auto ptV0Pos = candidate.ptV0Pos();
-    auto ptV0Neg = candidate.ptV0Neg();
-    auto v0CosPA = candidate.v0cosPA();
-    auto v0Radius = candidate.v0radius();
-    auto dcaV0Daughters = candidate.dcaV0daughters();
-    auto mK0Short = candidate.mK0Short();
-    auto mLambda = candidate.mLambda();
-    auto mAntiLambda = candidate.mAntiLambda();
-    auto mGamma = candidate.mGamma();
-    auto ctV0K0Short = HfHelper::ctV0K0s(candidate);
-    auto ctV0Lambda = HfHelper::ctV0Lambda(candidate);
-    auto cpa = candidate.cpa();
-    auto cpaXY = candidate.cpaXY();
-    auto decayLength = candidate.decayLength();
-    auto decayLengthXY = candidate.decayLengthXY();
-    auto ctLc = HfHelper::ctLc(candidate);
+    HfCandVars cand(candidate);
 
-    registry.fill(HIST("Data/hPtCand"), ptCand);
-    registry.fill(HIST("Data/hEtaCand"), eta);
-    registry.fill(HIST("Data/hEtaCandVsPtCand"), eta, ptCand);
-    registry.fill(HIST("Data/hPhiCand"), phi);
-    registry.fill(HIST("Data/hPhiCandVsPtCand"), phi, ptCand);
-    registry.fill(HIST("Data/hMass"), invMassLcToK0sP);
-    registry.fill(HIST("Data/hMassVsPtCand"), invMassLcToK0sP, ptCand);
-    registry.fill(HIST("Data/hPtBach"), ptProng0);
-    registry.fill(HIST("Data/hPtBachVsPtCand"), ptProng0, ptCand);
-    registry.fill(HIST("Data/hPtV0"), ptProng1);
-    registry.fill(HIST("Data/hPtV0VsPtCand"), ptProng1, ptCand);
-    registry.fill(HIST("Data/hd0Bach"), impactParameter0);
-    registry.fill(HIST("Data/hd0BachVsPtCand"), impactParameter0, ptCand);
-    registry.fill(HIST("Data/hd0V0"), impactParameter1);
-    registry.fill(HIST("Data/hd0V0VsPtCand"), impactParameter1, ptCand);
-    registry.fill(HIST("Data/hd0V0pos"), dcaPosToPV);
-    registry.fill(HIST("Data/hd0V0posVsPtCand"), dcaPosToPV, ptCand);
-    registry.fill(HIST("Data/hd0V0neg"), dcaNegToPV);
-    registry.fill(HIST("Data/hd0V0negVsPtCand"), dcaNegToPV, ptCand);
-    registry.fill(HIST("Data/hPtV0pos"), ptV0Pos);
-    registry.fill(HIST("Data/hPtV0posVsPtCand"), ptV0Pos, ptCand);
-    registry.fill(HIST("Data/hPtV0neg"), ptV0Neg);
-    registry.fill(HIST("Data/hPtV0negVsPtCand"), ptV0Neg, ptCand);
-    registry.fill(HIST("Data/hV0CPA"), v0CosPA);
-    registry.fill(HIST("Data/hV0CPAVsPtCand"), v0CosPA, ptCand);
-    registry.fill(HIST("Data/hV0Radius"), v0Radius);
-    registry.fill(HIST("Data/hV0RadiusVsPtCand"), v0Radius, ptCand);
-    registry.fill(HIST("Data/hV0DCADaughters"), dcaV0Daughters);
-    registry.fill(HIST("Data/hV0DCADaughtersVsPtCand"), dcaV0Daughters, ptCand);
-    registry.fill(HIST("Data/hV0MK0Short"), mK0Short);
-    registry.fill(HIST("Data/hV0MK0ShortVsPtCand"), mK0Short, ptCand);
-    registry.fill(HIST("Data/hV0MLambda"), mLambda);
-    registry.fill(HIST("Data/hV0MLambdaVsPtCand"), mLambda, ptCand);
-    registry.fill(HIST("Data/hV0MAntiLambda"), mAntiLambda);
-    registry.fill(HIST("Data/hV0MAntiLambdaVsPtCand"), mAntiLambda, ptCand);
-    registry.fill(HIST("Data/hV0MGamma"), mGamma);
-    registry.fill(HIST("Data/hV0MGammaVsPtCand"), mGamma, ptCand);
-    registry.fill(HIST("Data/hCtV0K0Short"), ctV0K0Short);
-    registry.fill(HIST("Data/hCtV0K0ShortVsPtCand"), ctV0K0Short, ptCand);
-    registry.fill(HIST("Data/hCtV0Lambda"), ctV0Lambda);
-    registry.fill(HIST("Data/hCtV0LambdaVsPtCand"), ctV0Lambda, ptCand);
-    registry.fill(HIST("Data/hCPACand"), cpa);
-    registry.fill(HIST("Data/hCPACandVsPtCand"), cpa, ptCand);
-    registry.fill(HIST("Data/hCPAxyCand"), cpaXY);
-    registry.fill(HIST("Data/hCPAxyCandVsPtCand"), cpaXY, ptCand);
-    registry.fill(HIST("Data/hDecLengthCand"), decayLength);
-    registry.fill(HIST("Data/hDecLengthCandVsPtCand"), decayLength, ptCand);
-    registry.fill(HIST("Data/hDecLengthXYCand"), decayLengthXY);
-    registry.fill(HIST("Data/hDecLengthXYCandVsPtCand"), decayLengthXY, ptCand);
-    registry.fill(HIST("Data/hCtCand"), ctLc);
-    registry.fill(HIST("Data/hCtCandVsPtCand"), ctLc, ptCand);
+    registry.fill(HIST("Data/hPtCand"), cand.ptCand);
+    registry.fill(HIST("Data/hEtaCand"), cand.eta);
+    registry.fill(HIST("Data/hEtaCandVsPtCand"), cand.eta, cand.ptCand);
+    registry.fill(HIST("Data/hPhiCand"), cand.phi);
+    registry.fill(HIST("Data/hPhiCandVsPtCand"), cand.phi, cand.ptCand);
+    registry.fill(HIST("Data/hMass"), cand.invMassLcToK0sP);
+    registry.fill(HIST("Data/hMassVsPtCand"), cand.invMassLcToK0sP, cand.ptCand);
+    registry.fill(HIST("Data/hPtBach"), cand.ptProng0);
+    registry.fill(HIST("Data/hPtBachVsPtCand"), cand.ptProng0, cand.ptCand);
+    registry.fill(HIST("Data/hPtV0"), cand.ptProng1);
+    registry.fill(HIST("Data/hPtV0VsPtCand"), cand.ptProng1, cand.ptCand);
+    registry.fill(HIST("Data/hd0Bach"), cand.impactParameter0);
+    registry.fill(HIST("Data/hd0BachVsPtCand"), cand.impactParameter0, cand.ptCand);
+    registry.fill(HIST("Data/hd0V0"), cand.impactParameter1);
+    registry.fill(HIST("Data/hd0V0VsPtCand"), cand.impactParameter1, cand.ptCand);
+    registry.fill(HIST("Data/hd0V0pos"), cand.dcaPosToPV);
+    registry.fill(HIST("Data/hd0V0posVsPtCand"), cand.dcaPosToPV, cand.ptCand);
+    registry.fill(HIST("Data/hd0V0neg"), cand.dcaNegToPV);
+    registry.fill(HIST("Data/hd0V0negVsPtCand"), cand.dcaNegToPV, cand.ptCand);
+    registry.fill(HIST("Data/hPtV0pos"), cand.ptV0Pos);
+    registry.fill(HIST("Data/hPtV0posVsPtCand"), cand.ptV0Pos, cand.ptCand);
+    registry.fill(HIST("Data/hPtV0neg"), cand.ptV0Neg);
+    registry.fill(HIST("Data/hPtV0negVsPtCand"), cand.ptV0Neg, cand.ptCand);
+    registry.fill(HIST("Data/hV0CPA"), cand.v0CosPA);
+    registry.fill(HIST("Data/hV0CPAVsPtCand"), cand.v0CosPA, cand.ptCand);
+    registry.fill(HIST("Data/hV0Radius"), cand.v0Radius);
+    registry.fill(HIST("Data/hV0RadiusVsPtCand"), cand.v0Radius, cand.ptCand);
+    registry.fill(HIST("Data/hV0DCADaughters"), cand.dcaV0Daughters);
+    registry.fill(HIST("Data/hV0DCADaughtersVsPtCand"), cand.dcaV0Daughters, cand.ptCand);
+    registry.fill(HIST("Data/hV0MK0Short"), cand.mK0Short);
+    registry.fill(HIST("Data/hV0MK0ShortVsPtCand"), cand.mK0Short, cand.ptCand);
+    registry.fill(HIST("Data/hV0MLambda"), cand.mLambda);
+    registry.fill(HIST("Data/hV0MLambdaVsPtCand"), cand.mLambda, cand.ptCand);
+    registry.fill(HIST("Data/hV0MAntiLambda"), cand.mAntiLambda);
+    registry.fill(HIST("Data/hV0MAntiLambdaVsPtCand"), cand.mAntiLambda, cand.ptCand);
+    registry.fill(HIST("Data/hV0MGamma"), cand.mGamma);
+    registry.fill(HIST("Data/hV0MGammaVsPtCand"), cand.mGamma, cand.ptCand);
+    registry.fill(HIST("Data/hCtV0K0Short"), cand.ctV0K0Short);
+    registry.fill(HIST("Data/hCtV0K0ShortVsPtCand"), cand.ctV0K0Short, cand.ptCand);
+    registry.fill(HIST("Data/hCtV0Lambda"), cand.ctV0Lambda);
+    registry.fill(HIST("Data/hCtV0LambdaVsPtCand"), cand.ctV0Lambda, cand.ptCand);
+    registry.fill(HIST("Data/hCPACand"), cand.cpa);
+    registry.fill(HIST("Data/hCPACandVsPtCand"), cand.cpa, cand.ptCand);
+    registry.fill(HIST("Data/hCPAxyCand"), cand.cpaXY);
+    registry.fill(HIST("Data/hCPAxyCandVsPtCand"), cand.cpaXY, cand.ptCand);
+    registry.fill(HIST("Data/hDecLengthCand"), cand.decayLength);
+    registry.fill(HIST("Data/hDecLengthCandVsPtCand"), cand.decayLength, cand.ptCand);
+    registry.fill(HIST("Data/hDecLengthXYCand"), cand.decayLengthXY);
+    registry.fill(HIST("Data/hDecLengthXYCandVsPtCand"), cand.decayLengthXY, cand.ptCand);
+    registry.fill(HIST("Data/hCtCand"), cand.ctLc);
+    registry.fill(HIST("Data/hCtCandVsPtCand"), cand.ctLc, cand.ptCand);
   }
 
   /// Data processing template
@@ -428,6 +485,77 @@ struct HfTaskLcToK0sP {
     }
   }
 
+  /// Fill MC reconstructed signal histograms
+  /// \tparam SignalType signal class (Signal, Prompt, NonPrompt)
+  template <int SignalType, typename CandidateType>
+  void fillHistogramsRecSig(CandidateType const& candidate)
+  {
+    HfCandVars cand(candidate);
+
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hEtaCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.eta);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hEtaCandVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.eta, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hPhiCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.phi);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hPhiCandVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.phi, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hMassRecSig") + HIST(SignalSuffixes[SignalType]), cand.invMassLcToK0sP);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hMassVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.invMassLcToK0sP, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hPtBachRecSig") + HIST(SignalSuffixes[SignalType]), cand.ptProng0);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hPtBachVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.ptProng0, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hPtV0RecSig") + HIST(SignalSuffixes[SignalType]), cand.ptProng1);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hPtV0VsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.ptProng1, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hd0BachRecSig") + HIST(SignalSuffixes[SignalType]), cand.impactParameter0);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hd0BachVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.impactParameter0, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hd0V0RecSig") + HIST(SignalSuffixes[SignalType]), cand.impactParameter1);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hd0V0VsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.impactParameter1, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hd0V0posRecSig") + HIST(SignalSuffixes[SignalType]), cand.dcaPosToPV);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hd0V0posVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.dcaPosToPV, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hd0V0negRecSig") + HIST(SignalSuffixes[SignalType]), cand.dcaNegToPV);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hd0V0negVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.dcaNegToPV, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hPtV0posRecSig") + HIST(SignalSuffixes[SignalType]), cand.ptV0Pos);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hPtV0posVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.ptV0Pos, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hPtV0negRecSig") + HIST(SignalSuffixes[SignalType]), cand.ptV0Neg);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hPtV0negVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.ptV0Neg, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hV0CPARecSig") + HIST(SignalSuffixes[SignalType]), cand.v0CosPA);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hV0CPAVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.v0CosPA, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hV0RadiusRecSig") + HIST(SignalSuffixes[SignalType]), cand.v0Radius);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hV0RadiusVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.v0Radius, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hV0DCADaughtersRecSig") + HIST(SignalSuffixes[SignalType]), cand.dcaV0Daughters);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hV0DCADaughtersVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.dcaV0Daughters, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hV0MK0ShortRecSig") + HIST(SignalSuffixes[SignalType]), cand.mK0Short);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hV0MK0ShortVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.mK0Short, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hV0MLambdaRecSig") + HIST(SignalSuffixes[SignalType]), cand.mLambda);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hV0MLambdaVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.mLambda, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hV0MAntiLambdaRecSig") + HIST(SignalSuffixes[SignalType]), cand.mAntiLambda);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hV0MAntiLambdaVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.mAntiLambda, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hV0MGammaRecSig") + HIST(SignalSuffixes[SignalType]), cand.mGamma);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hV0MGammaVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.mGamma, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hCtV0K0ShortRecSig") + HIST(SignalSuffixes[SignalType]), cand.ctV0K0Short);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hCtV0K0ShortVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.ctV0K0Short, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hCtV0LambdaRecSig") + HIST(SignalSuffixes[SignalType]), cand.ctV0Lambda);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hCtV0LambdaVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.ctV0Lambda, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hCPACandRecSig") + HIST(SignalSuffixes[SignalType]), cand.cpa);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hCPACandVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.cpa, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hCPAxyCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.cpaXY);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hCPAxyCandVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.cpaXY, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hDecLengthCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.decayLength);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hDecLengthCandVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.decayLength, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hDecLengthXYCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.decayLengthXY);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hDecLengthXYCandVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.decayLengthXY, cand.ptCand);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hCtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.ctLc);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hCtCandVsPtCandRecSig") + HIST(SignalSuffixes[SignalType]), cand.ctLc, cand.ptCand);
+
+    // PID
+    const auto& bach = candidate.template prong0_as<TracksWPid>();
+    auto tpcNSigmaPr = bach.tpcNSigmaPr();
+    auto pBach = bach.p();
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hTPCNSigmaPrBachRecSig") + HIST(SignalSuffixes[SignalType]), tpcNSigmaPr);
+    registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hPBachVsTPCNSigmaPrBachRecSig") + HIST(SignalSuffixes[SignalType]), pBach, tpcNSigmaPr);
+    if (bach.hasTOF()) {
+      registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hTOFNSigmaPrBachRecSig") + HIST(SignalSuffixes[SignalType]), bach.tofNSigmaPr());
+      registry.fill(HIST("MC/Rec/") + HIST(SignalFolders[SignalType]) + HIST("/hPBachVsTOFNSigmaPrBachRecSig") + HIST(SignalSuffixes[SignalType]), pBach, bach.tofNSigmaPr());
+    }
+  }
+
   /// MC processing template
   /// \tparam FillMl switch to fill ML histograms
   template <bool FillMl, typename CollType, typename CandType, typename CandMcGen>
@@ -460,6 +588,16 @@ struct HfTaskLcToK0sP {
       if (std::abs(candidate.flagMcMatchRec()) == KDecayChannelLcToK0sP) {
         fillCandHistograms(candidate);
 
+        // MC reconstructed signal
+        fillHistogramsRecSig<Signal>(candidate);
+
+        // reconstructed signal prompt / nonprompt
+        if (candidate.originMcRec() == RecoDecay::OriginType::Prompt) {
+          fillHistogramsRecSig<Prompt>(candidate);
+        } else if (candidate.originMcRec() == RecoDecay::OriginType::NonPrompt) {
+          fillHistogramsRecSig<NonPrompt>(candidate);
+        }
+
         if (fillTHn && FillMl) {
           float mass = HfHelper::invMassLcToK0sP(candidate);
           float pt = candidate.pt();
@@ -476,8 +614,84 @@ struct HfTaskLcToK0sP {
           int8_t origin = candidate.originMcRec();
           registry.get<THnSparse>(HIST("hnLcK0sPRecMcWithBdt"))->Fill(mass, pt, cent, mlScores[0], mlScores[1], mlScores[2], static_cast<double>(numPvContr), origin);
         }
+      } else {
+        // MC reconstructed background
+        HfCandVars cand(candidate);
+
+        registry.fill(HIST("MC/Rec/background/hPtCandRecBg"), cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hEtaCandRecBg"), cand.eta);
+        registry.fill(HIST("MC/Rec/background/hEtaCandVsPtCandRecBg"), cand.eta, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hPhiCandRecBg"), cand.phi);
+        registry.fill(HIST("MC/Rec/background/hPhiCandVsPtCandRecBg"), cand.phi, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hMassRecBg"), cand.invMassLcToK0sP);
+        registry.fill(HIST("MC/Rec/background/hMassVsPtCandRecBg"), cand.invMassLcToK0sP, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hPtBachRecBg"), cand.ptProng0);
+        registry.fill(HIST("MC/Rec/background/hPtBachVsPtCandRecBg"), cand.ptProng0, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hPtV0RecBg"), cand.ptProng1);
+        registry.fill(HIST("MC/Rec/background/hPtV0VsPtCandRecBg"), cand.ptProng1, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hd0BachRecBg"), cand.impactParameter0);
+        registry.fill(HIST("MC/Rec/background/hd0BachVsPtCandRecBg"), cand.impactParameter0, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hd0V0RecBg"), cand.impactParameter1);
+        registry.fill(HIST("MC/Rec/background/hd0V0VsPtCandRecBg"), cand.impactParameter1, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hd0V0posRecBg"), cand.dcaPosToPV);
+        registry.fill(HIST("MC/Rec/background/hd0V0posVsPtCandRecBg"), cand.dcaPosToPV, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hd0V0negRecBg"), cand.dcaNegToPV);
+        registry.fill(HIST("MC/Rec/background/hd0V0negVsPtCandRecBg"), cand.dcaNegToPV, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hPtV0posRecBg"), cand.ptV0Pos);
+        registry.fill(HIST("MC/Rec/background/hPtV0posVsPtCandRecBg"), cand.ptV0Pos, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hPtV0negRecBg"), cand.ptV0Neg);
+        registry.fill(HIST("MC/Rec/background/hPtV0negVsPtCandRecBg"), cand.ptV0Neg, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hV0CPARecBg"), cand.v0CosPA);
+        registry.fill(HIST("MC/Rec/background/hV0CPAVsPtCandRecBg"), cand.v0CosPA, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hV0RadiusRecBg"), cand.v0Radius);
+        registry.fill(HIST("MC/Rec/background/hV0RadiusVsPtCandRecBg"), cand.v0Radius, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hV0DCADaughtersRecBg"), cand.dcaV0Daughters);
+        registry.fill(HIST("MC/Rec/background/hV0DCADaughtersVsPtCandRecBg"), cand.dcaV0Daughters, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hV0MK0ShortRecBg"), cand.mK0Short);
+        registry.fill(HIST("MC/Rec/background/hV0MK0ShortVsPtCandRecBg"), cand.mK0Short, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hV0MLambdaRecBg"), cand.mLambda);
+        registry.fill(HIST("MC/Rec/background/hV0MLambdaVsPtCandRecBg"), cand.mLambda, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hV0MAntiLambdaRecBg"), cand.mAntiLambda);
+        registry.fill(HIST("MC/Rec/background/hV0MAntiLambdaVsPtCandRecBg"), cand.mAntiLambda, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hV0MGammaRecBg"), cand.mGamma);
+        registry.fill(HIST("MC/Rec/background/hV0MGammaVsPtCandRecBg"), cand.mGamma, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hCtV0K0ShortRecBg"), cand.ctV0K0Short);
+        registry.fill(HIST("MC/Rec/background/hCtV0K0ShortVsPtCandRecBg"), cand.ctV0K0Short, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hCtV0LambdaRecBg"), cand.ctV0Lambda);
+        registry.fill(HIST("MC/Rec/background/hCtV0LambdaVsPtCandRecBg"), cand.ctV0Lambda, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hCPACandRecBg"), cand.cpa);
+        registry.fill(HIST("MC/Rec/background/hCPACandVsPtCandRecBg"), cand.cpa, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hCPAxyCandRecBg"), cand.cpaXY);
+        registry.fill(HIST("MC/Rec/background/hCPAxyCandVsPtCandRecBg"), cand.cpaXY, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hDecLengthCandRecBg"), cand.decayLength);
+        registry.fill(HIST("MC/Rec/background/hDecLengthCandVsPtCandRecBg"), cand.decayLength, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hDecLengthXYCandRecBg"), cand.decayLengthXY);
+        registry.fill(HIST("MC/Rec/background/hDecLengthXYCandVsPtCandRecBg"), cand.decayLengthXY, cand.ptCand);
+        registry.fill(HIST("MC/Rec/background/hCtCandRecBg"), cand.ctLc);
+        registry.fill(HIST("MC/Rec/background/hCtCandVsPtCandRecBg"), cand.ctLc, cand.ptCand);
+
+        // PID background
+        const auto& bach = candidate.template prong0_as<TracksWPid>();
+        auto tpcNSigmaPr = bach.tpcNSigmaPr();
+        auto pBach = bach.p();
+        registry.fill(HIST("MC/Rec/background/hTPCNSigmaPrBachRecBg"), tpcNSigmaPr);
+        registry.fill(HIST("MC/Rec/background/hPBachVsTPCNSigmaPrBachRecBg"), pBach, tpcNSigmaPr);
+        if (bach.hasTOF()) {
+          registry.fill(HIST("MC/Rec/background/hTOFNSigmaPrBachRecBg"), bach.tofNSigmaPr());
+          registry.fill(HIST("MC/Rec/background/hPBachVsTOFNSigmaPrBachRecBg"), pBach, bach.tofNSigmaPr());
+        }
       }
     }
+  }
+
+  /// Fill MC generated signal histograms
+  /// \tparam SignalType signal class (Signal, Prompt, NonPrompt)
+  template <int SignalType, typename ParticleType>
+  void fillHistogramsGenSig(ParticleType const& particle)
+  {
+    registry.fill(HIST("MC/Gen/") + HIST(SignalFolders[SignalType]) + HIST("/hPtCandGen") + HIST(SignalSuffixes[SignalType]), particle.pt());
+    registry.fill(HIST("MC/Gen/") + HIST(SignalFolders[SignalType]) + HIST("/hEtaCandGen") + HIST(SignalSuffixes[SignalType]), particle.eta());
+    registry.fill(HIST("MC/Gen/") + HIST(SignalFolders[SignalType]) + HIST("/hPhiCandGen") + HIST(SignalSuffixes[SignalType]), particle.phi());
   }
 
   /// Helper function to fill MC generated histograms
@@ -485,21 +699,16 @@ struct HfTaskLcToK0sP {
   void fillHistosMcGen(CandMcGen const& mcParticles, Coll const& recoCollisions)
   {
     for (const auto& particle : mcParticles) {
-      // if (etaCandMax >= 0. && std::abs(particle.eta()) > etaCandMax) {
-      //   continue;
-      // }
       if (std::abs(particle.flagMcMatchGen()) == KDecayChannelLcToK0sP) {
         auto yGen = RecoDecay::y(particle.pVector(), o2::constants::physics::MassLambdaCPlus);
         if (yCandGenMax >= 0. && std::abs(yGen) > yCandGenMax) {
           continue;
         }
-        registry.fill(HIST("MC/Gen/hPtCandGen"), particle.pt());
-        registry.fill(HIST("MC/Gen/hEtaCandGen"), particle.eta());
-        registry.fill(HIST("MC/Gen/hPhiCandGen"), particle.phi());
+        fillHistogramsGenSig<Signal>(particle);
         if (particle.originMcGen() == RecoDecay::OriginType::Prompt) {
-          registry.fill(HIST("MC/Gen/hPtCandGenPrompt"), particle.pt());
+          fillHistogramsGenSig<Prompt>(particle);
         } else if (particle.originMcGen() == RecoDecay::OriginType::NonPrompt) {
-          registry.fill(HIST("MC/Gen/hPtCandGenNonPrompt"), particle.pt());
+          fillHistogramsGenSig<NonPrompt>(particle);
         }
 
         if (fillTHn) {
@@ -527,8 +736,9 @@ struct HfTaskLcToK0sP {
 
   void processMcStd(CollisionsMc const& collisions,
                     FilteredCandLcToPK0SWSelFlagAndMc const& candidates,
-                    soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& mcParticles,
+                    McParticlesCascadeMatched const& mcParticles,
                     aod::TracksWMc const&,
+                    aod::McCollisions const&,
                     TracksWPid const&)
   {
     runAnalysisPerCollisionMc<false>(collisions, candidates, mcParticles);
@@ -547,8 +757,9 @@ struct HfTaskLcToK0sP {
   // MC Rec and Gen with ML
   void processMcWithMl(CollisionsMc const& collisions,
                        FilteredCandLcToPK0SWSelFlagAndMcAndMl const& candidates,
-                       soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& mcParticles,
+                       McParticlesCascadeMatched const& mcParticles,
                        aod::TracksWMc const&,
+                       aod::McCollisions const&,
                        TracksWPid const&)
   {
     runAnalysisPerCollisionMc<true>(collisions, candidates, mcParticles);
@@ -594,8 +805,9 @@ struct HfTaskLcToK0sP {
   // MC Std with FT0C centrality
   void processMcStdWithFT0C(CollisionsMcWithFT0C const& collisions,
                             FilteredCandLcToPK0SWSelFlagAndMc const& candidates,
-                            soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& mcParticles,
+                            McParticlesCascadeMatched const& mcParticles,
                             aod::TracksWMc const&,
+                            aod::McCollisions const&,
                             TracksWPid const&)
   {
     runAnalysisPerCollisionMc<false>(collisions, candidates, mcParticles);
@@ -605,8 +817,9 @@ struct HfTaskLcToK0sP {
   // MC Std with FT0M centrality
   void processMcStdWithFT0M(CollisionsMcWithFT0M const& collisions,
                             FilteredCandLcToPK0SWSelFlagAndMc const& candidates,
-                            soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& mcParticles,
+                            McParticlesCascadeMatched const& mcParticles,
                             aod::TracksWMc const&,
+                            aod::McCollisions const&,
                             TracksWPid const&)
   {
     runAnalysisPerCollisionMc<false>(collisions, candidates, mcParticles);
@@ -616,8 +829,9 @@ struct HfTaskLcToK0sP {
   // MC with ML + FT0C centrality
   void processMcWithMlWithFT0C(CollisionsMcWithFT0C const& collisions,
                                FilteredCandLcToPK0SWSelFlagAndMcAndMl const& candidates,
-                               soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& mcParticles,
+                               McParticlesCascadeMatched const& mcParticles,
                                aod::TracksWMc const&,
+                               aod::McCollisions const&,
                                TracksWPid const&)
   {
     runAnalysisPerCollisionMc<true>(collisions, candidates, mcParticles);
@@ -627,8 +841,9 @@ struct HfTaskLcToK0sP {
   // MC with ML + FT0M centrality
   void processMcWithMlWithFT0M(CollisionsMcWithFT0M const& collisions,
                                FilteredCandLcToPK0SWSelFlagAndMcAndMl const& candidates,
-                               soa::Join<aod::McParticles, aod::HfCandCascadeMcGen> const& mcParticles,
+                               McParticlesCascadeMatched const& mcParticles,
                                aod::TracksWMc const&,
+                               aod::McCollisions const&,
                                TracksWPid const&)
   {
     runAnalysisPerCollisionMc<true>(collisions, candidates, mcParticles);

--- a/PWGHF/D2H/Tasks/taskLcToK0sP.cxx
+++ b/PWGHF/D2H/Tasks/taskLcToK0sP.cxx
@@ -107,7 +107,7 @@ struct HfTaskLcToK0sP {
     NumberOfMlClasses
   };
 
-  static constexpr int KDecayChannelLcToK0sP = 1;
+  static constexpr int DecayChannelLcToK0sP = 1;
 
   // Names of folders and suffixes for MC signal histograms
   constexpr static std::string_view SignalFolders[] = {"signal", "prompt", "nonprompt"};
@@ -589,7 +589,7 @@ struct HfTaskLcToK0sP {
         continue;
       }
 
-      if (std::abs(candidate.flagMcMatchRec()) == KDecayChannelLcToK0sP) {
+      if (std::abs(candidate.flagMcMatchRec()) == DecayChannelLcToK0sP) {
         fillCandHistograms(candidate);
 
         // MC reconstructed signal
@@ -703,7 +703,7 @@ struct HfTaskLcToK0sP {
   void fillHistosMcGen(CandMcGen const& mcParticles, Coll const& recoCollisions)
   {
     for (const auto& particle : mcParticles) {
-      if (std::abs(particle.flagMcMatchGen()) == KDecayChannelLcToK0sP) {
+      if (std::abs(particle.flagMcMatchGen()) == DecayChannelLcToK0sP) {
         auto yGen = RecoDecay::y(particle.pVector(), o2::constants::physics::MassLambdaCPlus);
         if (yCandGenMax >= 0. && std::abs(yGen) > yCandGenMax) {
           continue;

--- a/PWGHF/D2H/Tasks/taskLcToK0sP.cxx
+++ b/PWGHF/D2H/Tasks/taskLcToK0sP.cxx
@@ -26,6 +26,8 @@
 #include "PWGHF/DataModel/CandidateSelectionTables.h"
 
 #include "Common/Core/RecoDecay.h"
+#include "Common/DataModel/Centrality.h"
+#include "Common/DataModel/EventSelection.h"
 
 #include <CommonConstants/PhysicsConstants.h>
 #include <Framework/ASoA.h>
@@ -39,6 +41,7 @@
 
 #include <THnSparse.h>
 
+#include <cstdint>
 #include <cstdlib>
 #include <numeric>
 #include <string>

--- a/PWGHF/D2H/Tasks/taskLcToK0sP.cxx
+++ b/PWGHF/D2H/Tasks/taskLcToK0sP.cxx
@@ -45,6 +45,7 @@
 #include <cstdlib>
 #include <numeric>
 #include <string>
+#include <string_view>
 #include <vector>
 
 using namespace o2;


### PR DESCRIPTION
taskLcToK0sP.cxx was Updated in this PR
- Add missing McCollisions to fix bug
- Reorganise MC/Rec and MC/Gen histograms into signal/prompt/nonprompt/background subdirectories
- Code clean up