### PR TITLE
[PWGJE] jet-spectra-charged: weighted-bind fix + add gen-only spectra task

### DIFF
--- a/PWGJE/Tasks/CMakeLists.txt
+++ b/PWGJE/Tasks/CMakeLists.txt
@@ -277,6 +277,10 @@ if(FastJet_FOUND)
                         SOURCES jetSpectraCharged.cxx
                         PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::PWGJECore O2Physics::AnalysisCore
                         COMPONENT_NAME Analysis)
+    o2physics_add_dpl_workflow(jet-spectra-charged-gen
+                        SOURCES jetSpectraChargedGen.cxx
+                        PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::PWGJECore O2Physics::AnalysisCore
+                        COMPONENT_NAME Analysis)
     o2physics_add_dpl_workflow(charged-jet-hadron
                         SOURCES chargedJetHadron.cxx
                         PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::PWGJECore O2Physics::AnalysisCore

--- a/PWGJE/Tasks/jetSpectraCharged.cxx
+++ b/PWGJE/Tasks/jetSpectraCharged.cxx
@@ -95,6 +95,7 @@ struct JetSpectraCharged {
   float configSwitchHigh = 9998.0;
 
   float ptHardCalcMethodSwitch = 999.0;
+  static constexpr float kBrokenPtHardSentinel = 1.0f;
 
   enum AcceptSplitCollisionsOptions {
     NonSplitOnly = 0,
@@ -921,7 +922,7 @@ struct JetSpectraCharged {
   void processSpectraMCDWeighted(soa::Filtered<aod::JetCollisionsMCD>::iterator const& collision,
                                  soa::Join<aod::ChargedMCDetectorLevelJets, aod::ChargedMCDetectorLevelJetConstituents> const& jets,
                                  aod::JetTracks const&,
-                                 aod::JetMcCollisions const&)
+                                 aod::JetMcCollisions const& mccollisions)
   {
     bool fillHistograms = false;
     bool isWeighted = true;
@@ -929,7 +930,16 @@ struct JetSpectraCharged {
     if (!applyCollisionCuts(collision, fillHistograms, isWeighted, eventWeight)) {
       return;
     }
-    float pTHat = collision.has_mcCollision() && collision.mcCollision().ptHard() < ptHardCalcMethodSwitch ? collision.mcCollision().ptHard() : simPtRef / (std::pow(eventWeight, 1.0 / pTHatExponent));
+    // collision.mcCollision() auto-resolves to the wrong JMcCollisions binding here; bind via rawIteratorAt.
+    float ptHardFromMc = ptHardCalcMethodSwitch;
+    if (collision.mcCollisionId() >= 0) {
+      float storedPtHard = mccollisions.rawIteratorAt(collision.mcCollisionId()).ptHard();
+      // LHC26b5 ships placeholder ptHard=1.0; fall back to weight-derived.
+      if (storedPtHard > kBrokenPtHardSentinel && storedPtHard < ptHardCalcMethodSwitch) {
+        ptHardFromMc = storedPtHard;
+      }
+    }
+    float pTHat = ptHardFromMc < ptHardCalcMethodSwitch ? ptHardFromMc : simPtRef / (std::pow(eventWeight, 1.0 / pTHatExponent));
     float centrality = -1.0;
     checkCentFT0M ? centrality = collision.centFT0M() : (centrality = (useFT0CVariant ? collision.centFT0CVariant1() : collision.centFT0C()));
 
@@ -948,7 +958,7 @@ struct JetSpectraCharged {
   void processSpectraAreaSubMCDWeighted(soa::Filtered<soa::Join<aod::JetCollisionsMCD, aod::BkgChargedRhos>>::iterator const& collision,
                                         soa::Join<aod::ChargedMCDetectorLevelJets, aod::ChargedMCDetectorLevelJetConstituents> const& jets,
                                         aod::JetTracks const&,
-                                        aod::JetMcCollisions const&)
+                                        aod::JetMcCollisions const& mccollisions)
   {
     bool fillHistograms = false;
     bool isWeighted = true;
@@ -956,7 +966,16 @@ struct JetSpectraCharged {
     if (!applyCollisionCuts(collision, fillHistograms, isWeighted, eventWeight)) {
       return;
     }
-    float pTHat = collision.has_mcCollision() && collision.mcCollision().ptHard() < ptHardCalcMethodSwitch ? collision.mcCollision().ptHard() : simPtRef / (std::pow(eventWeight, 1.0 / pTHatExponent));
+    // See note in processSpectraMCDWeighted: avoid the wrong-type bind by
+    // looking the MC collision up explicitly via the named subscribed table.
+    float ptHardFromMc = ptHardCalcMethodSwitch;
+    if (collision.mcCollisionId() >= 0) {
+      float storedPtHard = mccollisions.rawIteratorAt(collision.mcCollisionId()).ptHard();
+      if (storedPtHard > kBrokenPtHardSentinel && storedPtHard < ptHardCalcMethodSwitch) {
+        ptHardFromMc = storedPtHard;
+      }
+    }
+    float pTHat = ptHardFromMc < ptHardCalcMethodSwitch ? ptHardFromMc : simPtRef / (std::pow(eventWeight, 1.0 / pTHatExponent));
     float centrality = -1.0;
     checkCentFT0M ? centrality = collision.centFT0M() : (centrality = (useFT0CVariant ? collision.centFT0CVariant1() : collision.centFT0C()));
 
@@ -1199,7 +1218,8 @@ struct JetSpectraCharged {
     if (!applyMCCollisionCuts(mccollision, collisions, fillHistograms, isWeighted, eventWeight)) {
       return;
     }
-    float pTHat = mccollision.ptHard() < ptHardCalcMethodSwitch ? mccollision.ptHard() : simPtRef / (std::pow(eventWeight, 1.0 / pTHatExponent));
+    // LHC26b5 ships placeholder ptHard=1.0; fall back to weight-derived.
+    float pTHat = (mccollision.ptHard() > kBrokenPtHardSentinel && mccollision.ptHard() < ptHardCalcMethodSwitch) ? mccollision.ptHard() : simPtRef / (std::pow(eventWeight, 1.0 / pTHatExponent));
     for (auto const& jet : jets) {
       if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
         continue;
@@ -1231,7 +1251,9 @@ struct JetSpectraCharged {
     if (!applyMCCollisionCuts(mccollision, collisions, fillHistograms, isWeighted, eventWeight)) {
       return;
     }
-    float pTHat = mccollision.ptHard() < ptHardCalcMethodSwitch ? mccollision.ptHard() : simPtRef / (std::pow(eventWeight, 1.0 / pTHatExponent));
+    // See note in processSpectraMCPWeighted re: ptHard=1.0 placeholder in
+    // current LHC26b5-class MC.
+    float pTHat = (mccollision.ptHard() > kBrokenPtHardSentinel && mccollision.ptHard() < ptHardCalcMethodSwitch) ? mccollision.ptHard() : simPtRef / (std::pow(eventWeight, 1.0 / pTHatExponent));
     registry.fill(HIST("h_mccollisions_rho"), mccollision.rho(), eventWeight);
 
     for (auto const& jet : jets) {
@@ -1314,7 +1336,7 @@ struct JetSpectraCharged {
                                   ChargedMCDMatchedJets const& mcdjets,
                                   ChargedMCPMatchedJets const&,
                                   aod::JetTracks const&, aod::JetParticles const&,
-                                  aod::JetMcCollisions const&)
+                                  aod::JetMcCollisions const& mccollisions)
   {
     bool fillHistograms = false;
     bool isWeighted = true;
@@ -1322,7 +1344,16 @@ struct JetSpectraCharged {
     if (!applyCollisionCuts(collision, fillHistograms, isWeighted, eventWeight)) {
       return;
     }
-    float pTHat = collision.has_mcCollision() && collision.mcCollision().ptHard() < ptHardCalcMethodSwitch ? collision.mcCollision().ptHard() : simPtRef / (std::pow(eventWeight, 1.0 / pTHatExponent));
+    // See note in processSpectraMCDWeighted: avoid the wrong-type bind by
+    // looking the MC collision up explicitly via the named subscribed table.
+    float ptHardFromMc = ptHardCalcMethodSwitch;
+    if (collision.mcCollisionId() >= 0) {
+      float storedPtHard = mccollisions.rawIteratorAt(collision.mcCollisionId()).ptHard();
+      if (storedPtHard > kBrokenPtHardSentinel && storedPtHard < ptHardCalcMethodSwitch) {
+        ptHardFromMc = storedPtHard;
+      }
+    }
+    float pTHat = ptHardFromMc < ptHardCalcMethodSwitch ? ptHardFromMc : simPtRef / (std::pow(eventWeight, 1.0 / pTHatExponent));
     for (const auto& mcdjet : mcdjets) {
       if (!isAcceptedJet<aod::JetTracks>(mcdjet)) {
         continue;
@@ -1365,9 +1396,21 @@ struct JetSpectraCharged {
     if (!applyCollisionCuts(collision, fillHistograms, isWeighted, eventWeight)) {
       return;
     }
-    float pTHat = collision.has_mcCollision() && collision.mcCollision().ptHard() < ptHardCalcMethodSwitch ? collision.mcCollision().ptHard() : simPtRef / (std::pow(eventWeight, 1.0 / pTHatExponent));
+    // Here we already have JetBkgRhoMcCollisions explicitly subscribed; use the
+    // mcCollision_as<JetBkgRhoMcCollisions>() cast to dodge the wrong-type bind
+    // (same root cause as processSpectraMCDWeighted) and also guard against the
+    // ptHard=1.0 placeholder seen in current LHC26b5-class MC.
+    bool hasMc = collision.has_mcCollision();
+    float ptHardFromMc = ptHardCalcMethodSwitch;
+    if (hasMc) {
+      float storedPtHard = collision.mcCollision_as<JetBkgRhoMcCollisions>().ptHard();
+      if (storedPtHard > kBrokenPtHardSentinel && storedPtHard < ptHardCalcMethodSwitch) {
+        ptHardFromMc = storedPtHard;
+      }
+    }
+    float pTHat = ptHardFromMc < ptHardCalcMethodSwitch ? ptHardFromMc : simPtRef / (std::pow(eventWeight, 1.0 / pTHatExponent));
 
-    double mcrho = collision.has_mcCollision() ? collision.mcCollision_as<JetBkgRhoMcCollisions>().rho() : -1;
+    double mcrho = hasMc ? collision.mcCollision_as<JetBkgRhoMcCollisions>().rho() : -1;
 
     for (const auto& mcdjet : mcdjets) {
       if (!isAcceptedJet<aod::JetTracks>(mcdjet)) {

--- a/PWGJE/Tasks/jetSpectraChargedGen.cxx
+++ b/PWGJE/Tasks/jetSpectraChargedGen.cxx
@@ -1,0 +1,285 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file jetSpectraChargedGen.cxx
+/// \brief Charged-particle jet spectra at MC-particle level for generator-only
+///        AODs (no reconstruction tables required). Companion to
+///        jetSpectraCharged.cxx for productions such as EPOS 4 on-the-fly
+///        where only mc-particle and mc-collision tables exist.
+/// \author Joonsuk Bae <joonsuk.bae@cern.ch>
+
+#include "PWGJE/Core/JetFindingUtilities.h"
+#include "PWGJE/Core/JetUtilities.h"
+#include "PWGJE/DataModel/Jet.h"
+#include "PWGJE/DataModel/JetSubtraction.h"
+
+#include <CommonConstants/MathConstants.h>
+#include <Framework/ASoA.h>
+#include <Framework/AnalysisTask.h>
+#include <Framework/Configurable.h>
+#include <Framework/HistogramRegistry.h>
+#include <Framework/HistogramSpec.h>
+#include <Framework/InitContext.h>
+#include <Framework/runDataProcessing.h>
+
+#include <cmath>
+#include <string>
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+
+struct JetSpectraChargedGen {
+
+  using JetBkgRhoMcCollisions = soa::Join<aod::JetMcCollisions, aod::BkgChargedMcRhos>;
+
+  HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject};
+
+  Configurable<float> selectedJetsRadius{"selectedJetsRadius", 0.2, "resolution parameter for histograms without radius"};
+  Configurable<float> jetEtaMin{"jetEtaMin", -0.7, "minimum jet pseudorapidity"};
+  Configurable<float> jetEtaMax{"jetEtaMax", 0.7, "maximum jet pseudorapidity"};
+  Configurable<float> trackEtaMin{"trackEtaMin", -0.9, "minimum particle pseudorapidity"};
+  Configurable<float> trackEtaMax{"trackEtaMax", 0.9, "maximum particle pseudorapidity"};
+  Configurable<float> jetAreaFractionMin{"jetAreaFractionMin", -99.0, "minimum area fraction relative to pi R^2"};
+  Configurable<float> leadingConstituentPtMin{"leadingConstituentPtMin", -99.0, "minimum pT of the leading constituent"};
+  Configurable<float> leadingConstituentPtMax{"leadingConstituentPtMax", 9999.0, "maximum pT of the leading constituent"};
+  Configurable<float> pTHatMaxMCP{"pTHatMaxMCP", 999.0, "maximum jet pT in units of pTHat (outlier rejection)"};
+  Configurable<float> pTHatAbsoluteMin{"pTHatAbsoluteMin", -99.0, "minimum pTHat"};
+  Configurable<float> pTHatExponent{"pTHatExponent", 6.0, "exponent of the event weight for the back-calculation of pTHat"};
+  Configurable<float> simPtRef{"simPtRef", 10.0, "reference pT for the back-calculation of pTHat from the event weight"};
+  Configurable<float> vertexZCut{"vertexZCut", 10.0, "truth vertex-z cut; <=0 disables"};
+  Configurable<float> kappa{"kappa", 1.0, "angularity kappa"};
+  Configurable<float> alpha{"alpha", 1.0, "angularity alpha"};
+  Configurable<double> jetPtMax{"jetPtMax", 200.0, "max of the jet pT axis"};
+
+  static constexpr float kConfigSwitchLow = -98.0f;
+  static constexpr float kConfigSwitchHigh = 9998.0f;
+
+  void init(InitContext const&)
+  {
+    AxisSpec jetPtAxis = {static_cast<int>(jetPtMax), 0.0, jetPtMax, "#it{p}_{T,jet} (GeV/#it{c})"};
+    AxisSpec etaAxis = {100, -1.0, 1.0, "#eta_{jet}"};
+    AxisSpec phiAxis = {160, -1.0, 7.0, "#varphi_{jet}"};
+    AxisSpec rhoAxis = {200, 0.0, 200.0, "#rho (GeV/#it{c})"};
+
+    registry.add("h_mccollisions", "MC collisions counter;;entries", {HistType::kTH1F, {{1, 0.0, 1.0}}});
+    registry.add("h_mccollisions_rho", "#rho distribution;#rho (GeV/#it{c});entries", {HistType::kTH1F, {rhoAxis}});
+    registry.add("p_xSection", ";;<#sigma_{gen}> from HepMC (pb)", {HistType::kTProfile, {{1, 0.0, 1.0}}});
+
+    registry.add("h_jet_pt_part", ";#it{p}_{T,jet}^{part} (GeV/#it{c});entries", {HistType::kTH1F, {jetPtAxis}});
+    registry.add("h_jet_eta_part", ";#eta_{jet}^{part};entries", {HistType::kTH1F, {etaAxis}});
+    registry.add("h_jet_phi_part", ";#varphi_{jet}^{part};entries", {HistType::kTH1F, {phiAxis}});
+    registry.add("h3_jet_pt_jet_eta_jet_phi_part", ";#it{p}_{T,jet}^{part};#eta_{jet}^{part};#varphi_{jet}^{part}",
+                 {HistType::kTH3F, {jetPtAxis, etaAxis, phiAxis}});
+    registry.add("h2_jet_pt_part_jet_area_part", ";#it{p}_{T,jet}^{part};jet area",
+                 {HistType::kTH2F, {jetPtAxis, {200, 0.0, 4.0}}});
+    registry.add("h2_jet_pt_part_jet_ntracks_part", ";#it{p}_{T,jet}^{part};#it{N}_{tracks}",
+                 {HistType::kTH2F, {jetPtAxis, {100, 0.0, 100.0}}});
+    registry.add("h2_jet_pt_part_track_pt_part", ";#it{p}_{T,jet}^{part};#it{p}_{T,track}^{part}",
+                 {HistType::kTH2F, {jetPtAxis, jetPtAxis}});
+    registry.add("h2_jet_pt_jet_angularity_part", ";#it{p}_{T,jet}^{part};angularity",
+                 {HistType::kTH2F, {jetPtAxis, {200, 0.0, 4.0}}});
+
+    registry.add("h_jet_pt_part_rhoareasubtracted", ";#it{p}_{T,jet}^{part,sub} (GeV/#it{c});entries",
+                 {HistType::kTH1F, {{static_cast<int>(2 * jetPtMax), -jetPtMax, jetPtMax}}});
+    registry.add("h_jet_eta_part_rhoareasubtracted", ";#eta_{jet}^{part};entries", {HistType::kTH1F, {etaAxis}});
+    registry.add("h_jet_phi_part_rhoareasubtracted", ";#varphi_{jet}^{part};entries", {HistType::kTH1F, {phiAxis}});
+    registry.add("h3_jet_pt_jet_eta_jet_phi_part_rhoareasubtracted",
+                 ";#it{p}_{T,jet}^{part,sub};#eta_{jet}^{part};#varphi_{jet}^{part}",
+                 {HistType::kTH3F, {{static_cast<int>(2 * jetPtMax), -jetPtMax, jetPtMax}, etaAxis, phiAxis}});
+    registry.add("h2_jet_pt_part_jet_area_part_rhoareasubtracted", ";#it{p}_{T,jet}^{part,sub};jet area",
+                 {HistType::kTH2F, {{static_cast<int>(2 * jetPtMax), -jetPtMax, jetPtMax}, {200, 0.0, 4.0}}});
+    registry.add("h2_jet_pt_part_jet_ntracks_part_rhoareasubtracted", ";#it{p}_{T,jet}^{part,sub};#it{N}_{tracks}",
+                 {HistType::kTH2F, {{static_cast<int>(2 * jetPtMax), -jetPtMax, jetPtMax}, {100, 0.0, 100.0}}});
+  }
+
+  // Truth-only zvtx cut: returns true if accepted.
+  template <typename TMcColl>
+  bool passVertexZ(TMcColl const& mccollision)
+  {
+    if (vertexZCut <= 0.0f) {
+      return true;
+    }
+    return std::abs(mccollision.posZ()) < vertexZCut;
+  }
+
+  template <typename TJet>
+  bool isAcceptedJet(TJet const& jet)
+  {
+    if (jetAreaFractionMin > kConfigSwitchLow) {
+      if (jet.area() < jetAreaFractionMin * o2::constants::math::PI * (jet.r() / 100.0) * (jet.r() / 100.0)) {
+        return false;
+      }
+    }
+    bool checkMin = (leadingConstituentPtMin > kConfigSwitchLow);
+    bool checkMax = (leadingConstituentPtMax < kConfigSwitchHigh);
+    if (!checkMin && !checkMax) {
+      return true;
+    }
+    bool passMin = !checkMin;
+    bool passMax = checkMax;
+    for (const auto& constituent : jet.template tracks_as<aod::JetParticles>()) {
+      double pt = constituent.pt();
+      if (checkMin && pt >= leadingConstituentPtMin) {
+        passMin = true;
+      }
+      if (checkMax && pt > leadingConstituentPtMax) {
+        passMax = false;
+      }
+    }
+    return passMin && passMax;
+  }
+
+  template <typename TJet>
+  void fillRawHistograms(TJet const& jet, float weight, float pTHat)
+  {
+    if (jet.pt() > pTHatMaxMCP * pTHat || pTHat < pTHatAbsoluteMin) {
+      return;
+    }
+    if (jet.r() == std::round(selectedJetsRadius * 100.0f)) {
+      registry.fill(HIST("h_jet_pt_part"), jet.pt(), weight);
+      registry.fill(HIST("h_jet_eta_part"), jet.eta(), weight);
+      registry.fill(HIST("h_jet_phi_part"), jet.phi(), weight);
+      registry.fill(HIST("h3_jet_pt_jet_eta_jet_phi_part"), jet.pt(), jet.eta(), jet.phi(), weight);
+      registry.fill(HIST("h2_jet_pt_part_jet_area_part"), jet.pt(), jet.area(), weight);
+      registry.fill(HIST("h2_jet_pt_part_jet_ntracks_part"), jet.pt(), jet.tracksIds().size(), weight);
+    }
+    float angularity = 0.0f;
+    for (const auto& constituent : jet.template tracks_as<aod::JetParticles>()) {
+      registry.fill(HIST("h2_jet_pt_part_track_pt_part"), jet.pt(), constituent.pt(), weight);
+      angularity += std::pow(constituent.pt(), kappa) * std::pow(jetutilities::deltaR(jet, constituent), alpha);
+    }
+    angularity /= (jet.pt() * (jet.r() / 100.0f));
+    registry.fill(HIST("h2_jet_pt_jet_angularity_part"), jet.pt(), angularity, weight);
+  }
+
+  template <typename TJet>
+  void fillAreaSubHistograms(TJet const& jet, float rho, float weight, float pTHat)
+  {
+    if (jet.pt() > pTHatMaxMCP * pTHat || pTHat < pTHatAbsoluteMin) {
+      return;
+    }
+    if (jet.r() != std::round(selectedJetsRadius * 100.0f)) {
+      return;
+    }
+    double ptSub = jet.pt() - (rho * jet.area());
+    registry.fill(HIST("h_jet_pt_part_rhoareasubtracted"), ptSub, weight);
+    registry.fill(HIST("h3_jet_pt_jet_eta_jet_phi_part_rhoareasubtracted"), ptSub, jet.eta(), jet.phi(), weight);
+    if (ptSub > 0.0) {
+      registry.fill(HIST("h_jet_eta_part_rhoareasubtracted"), jet.eta(), weight);
+      registry.fill(HIST("h_jet_phi_part_rhoareasubtracted"), jet.phi(), weight);
+      registry.fill(HIST("h2_jet_pt_part_jet_area_part_rhoareasubtracted"), ptSub, jet.area(), weight);
+      registry.fill(HIST("h2_jet_pt_part_jet_ntracks_part_rhoareasubtracted"), ptSub, jet.tracksIds().size(), weight);
+    }
+  }
+
+  void processDummy(aod::JDummys const&) {}
+  PROCESS_SWITCH(JetSpectraChargedGen, processDummy, "dummy process", true);
+
+  void processChargedGen(aod::JetMcCollisions::iterator const& mccollision,
+                         soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents> const& jets,
+                         aod::JetParticles const&)
+  {
+    if (!passVertexZ(mccollision)) {
+      return;
+    }
+    registry.fill(HIST("h_mccollisions"), 0.5);
+    registry.fill(HIST("p_xSection"), 0.5, mccollision.xsectGen());
+    for (auto const& jet : jets) {
+      if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
+        continue;
+      }
+      if (!isAcceptedJet(jet)) {
+        continue;
+      }
+      fillRawHistograms(jet, /*weight*/ 1.0f, /*pTHat*/ 999.0f);
+    }
+  }
+  PROCESS_SWITCH(JetSpectraChargedGen, processChargedGen,
+                 "charged-jet spectra at MC particle level (generator-only AOD)", false);
+
+  void processChargedGenWeighted(aod::JetMcCollisions::iterator const& mccollision,
+                                 soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents> const& jets,
+                                 aod::JetParticles const&)
+  {
+    if (!passVertexZ(mccollision)) {
+      return;
+    }
+    float weight = mccollision.weight();
+    float pTHat = simPtRef / std::pow(weight, 1.0f / pTHatExponent);
+    registry.fill(HIST("h_mccollisions"), 0.5, weight);
+    registry.fill(HIST("p_xSection"), 0.5, mccollision.xsectGen(), weight);
+    for (auto const& jet : jets) {
+      if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
+        continue;
+      }
+      if (!isAcceptedJet(jet)) {
+        continue;
+      }
+      fillRawHistograms(jet, weight, pTHat);
+    }
+  }
+  PROCESS_SWITCH(JetSpectraChargedGen, processChargedGenWeighted,
+                 "charged-jet spectra at MC particle level, weighted (generator-only AOD)", false);
+
+  void processChargedAreaSubGen(JetBkgRhoMcCollisions::iterator const& mccollision,
+                                soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents> const& jets,
+                                aod::JetParticles const&)
+  {
+    if (!passVertexZ(mccollision)) {
+      return;
+    }
+    registry.fill(HIST("h_mccollisions"), 0.5);
+    registry.fill(HIST("p_xSection"), 0.5, mccollision.xsectGen());
+    registry.fill(HIST("h_mccollisions_rho"), mccollision.rho());
+    for (auto const& jet : jets) {
+      if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
+        continue;
+      }
+      if (!isAcceptedJet(jet)) {
+        continue;
+      }
+      fillAreaSubHistograms(jet, mccollision.rho(), /*weight*/ 1.0f, /*pTHat*/ 999.0f);
+    }
+  }
+  PROCESS_SWITCH(JetSpectraChargedGen, processChargedAreaSubGen,
+                 "charged-jet area-subtracted spectra at MC particle level (generator-only AOD)", false);
+
+  void processChargedAreaSubGenWeighted(JetBkgRhoMcCollisions::iterator const& mccollision,
+                                        soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents> const& jets,
+                                        aod::JetParticles const&)
+  {
+    if (!passVertexZ(mccollision)) {
+      return;
+    }
+    float weight = mccollision.weight();
+    float pTHat = simPtRef / std::pow(weight, 1.0f / pTHatExponent);
+    registry.fill(HIST("h_mccollisions"), 0.5, weight);
+    registry.fill(HIST("p_xSection"), 0.5, mccollision.xsectGen(), weight);
+    registry.fill(HIST("h_mccollisions_rho"), mccollision.rho(), weight);
+    for (auto const& jet : jets) {
+      if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
+        continue;
+      }
+      if (!isAcceptedJet(jet)) {
+        continue;
+      }
+      fillAreaSubHistograms(jet, mccollision.rho(), weight, pTHat);
+    }
+  }
+  PROCESS_SWITCH(JetSpectraChargedGen, processChargedAreaSubGenWeighted,
+                 "charged-jet area-subtracted spectra at MC particle level, weighted (generator-only AOD)", false);
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{adaptAnalysisTask<JetSpectraChargedGen>(cfgc)};
+}


### PR DESCRIPTION
- jetSpectraCharged.cxx: bind aod::JetMcCollisions explicitly in the four
  Weighted process functions to avoid an auto-resolved wrong-table iterator
  on JJ-MC AODs that triggered a runtime FATAL in multi-R pipelines.

- pTHat reads go through rawIteratorAt(mcCollisionId) and fall back to the
  weight-derived value when the stored ptHard is the placeholder sentinel
  (named kBrokenPtHardSentinel = 1.0f).

- jetSpectraChargedGen.cxx (new): MCP-only charged-jet spectra task for
  generator-only AODs; 4 process functions covering unweighted/weighted ×
  inclusive/area-sub; xsectGen() filled into p_xSection TProfile (HepMC
  convention, pb).

- CMakeLists.txt: register o2-analysis-je-jet-spectra-charged-gen.