### PR TITLE
[PWGLF] Fix strangenesstofpid converter

### DIFF
--- a/PWGLF/TableProducer/Strangeness/Converters/stradautrackstofpidconverter3.cxx
+++ b/PWGLF/TableProducer/Strangeness/Converters/stradautrackstofpidconverter3.cxx
@@ -36,13 +36,13 @@ struct stradautrackstofpidconverter3 {
     dautracktofpids.reserve(dauTracks.size());
     for (const auto& dauTrack : dauTracks) {
       dautracktofpids(
-        -1,
-        -1,
+        dauTrack.straCollisionId(),
+        dauTrack.dauTrackExtraId(),
         dauTrack.tofSignal(),
         dauTrack.tofEvTime(),
         999.0f, /*dummy event time error for TOF*/
         dauTrack.length(),
-        0.0f);
+        dauTrack.tofExpMom());
     }
     straEvTimes.reserve(straEvTimes_000.size());
     for (const auto& value : straEvTimes_000) {

--- a/PWGLF/TableProducer/Strangeness/Converters/stradautrackstofpidconverter3.cxx
+++ b/PWGLF/TableProducer/Strangeness/Converters/stradautrackstofpidconverter3.cxx
@@ -18,9 +18,9 @@
 #include "PWGLF/DataModel/LFStrangenessPIDTables.h"
 #include "PWGLF/DataModel/LFStrangenessTables.h"
 
-#include "Framework/AnalysisDataModel.h"
-#include "Framework/AnalysisTask.h"
-#include "Framework/runDataProcessing.h"
+#include <Framework/AnalysisDataModel.h>
+#include <Framework/AnalysisTask.h>
+#include <Framework/runDataProcessing.h>
 
 using namespace o2;
 using namespace o2::framework;

--- a/PWGLF/TableProducer/Strangeness/strangenesstofpid.cxx
+++ b/PWGLF/TableProducer/Strangeness/strangenesstofpid.cxx
@@ -1967,7 +1967,11 @@ struct strangenesstofpid {
     if (isNewTOFFormat) {
       // re-index
       for (const auto& dauTrackTOFPID : dauTrackTOFPIDs) {
-        tofIndices[dauTrackTOFPID.dauTrackExtraId()] = dauTrackTOFPID.globalIndex();
+        if (dauTrackTOFPID.dauTrackExtraId() >= 0) {
+          tofIndices[dauTrackTOFPID.dauTrackExtraId()] = dauTrackTOFPID.globalIndex();
+        } else {
+          LOGF(warning, "dauTrackTOFPID points to no entry in the DauTrackExtras table (dauTrackExtraId = %i)! This could be intentional (for example, using converters) but please be careful.", dauTrackTOFPID.dauTrackExtraId());
+        }
       }
     } else {
       // they are actually joinable


### PR DESCRIPTION
- fill `DauTrackTOFPIDs_002` table with available columns in `DauTrackTOFPIDs_001`
- add safety in the `strangenesstofpid` to prevent heap corruption and warn the user (even though it could intentional in case using specific converters)