### PR TITLE
[PWGLF] added configurable to save the like-sign pairs

### DIFF
--- a/PWGLF/TableProducer/Nuspex/hyperRecoTask.cxx
+++ b/PWGLF/TableProducer/Nuspex/hyperRecoTask.cxx
@@ -213,6 +213,7 @@ struct hyperRecoTask {
   Configurable<float> nTPCCrossedRowsMinHe{"nTPCCrossedRowsMinHe", 70, "helium minimum crossed rows"};
   Configurable<float> nTPCCrossedRowsMinPi{"nTPCCrossedRowsMinPi", -1., "pion minimum crossed rows"};
   Configurable<bool> mcSignalOnly{"mcSignalOnly", true, "If true, save only signal in MC"};
+  Configurable<bool> useLikeSignPairs{"useLikeSignPairs", false, "If true, reconstruct like-sign pairs for background estimation. Does not work with processDataTracked"};
   Configurable<bool> cfgSkimmedProcessing{"cfgSkimmedProcessing", false, "Skimmed dataset processing"};
   Configurable<bool> isEventUsedForEPCalibration{"isEventUsedForEPCalibration", 1, "Event is used for EP calibration"};
 
@@ -768,7 +769,7 @@ struct hyperRecoTask {
 
       svCreator.appendTrackCand(track, collisions, pdgHypo, ambiguousTracks, bcs);
     }
-    auto& svPool = svCreator.getSVCandPool(collisions);
+    auto& svPool = svCreator.getSVCandPool(collisions, useLikeSignPairs);
     LOG(debug) << "SV pool size: " << svPool.size();
 
     for (const auto& svCand : svPool) {


### PR DESCRIPTION
For background modelling.
Tested locally with mc (using mcSignalOnly == false)

<img width="1140" height="925" alt="Screenshot 2026-06-08 at 19 06 31" src="https://github.com/user-attachments/assets/ac75e394-baae-4524-95a3-fa1635109ce9" />
hypertriton invariant mass with useLikeSignPairs == false (default)

<img width="1189" height="902" alt="Screenshot 2026-06-08 at 19 07 12" src="https://github.com/user-attachments/assets/a0be0fb9-a049-4418-9858-e61acab73f0c" />
hypertriton invariant mass with useLikeSignPairs == true