### PR TITLE
[PWGCF] FemtoUniverse: Add pair randomization, fix hardcoded pion mass

### DIFF
--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseContainer.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseContainer.h
@@ -28,6 +28,7 @@
 #include <Framework/HistogramSpec.h>
 
 #include <TDatabasePDG.h>
+#include <TRandom2.h>
 
 #include <string>
 #include <string_view>
@@ -229,36 +230,53 @@ class FemtoUniverseContainer
   /// \param part2 Particle two
   /// \param mult Multiplicity of the event
   template <bool isMC, typename T>
-  void setPair(T const& part1, T const& part2, const int mult, bool use3dplots, float weight = 1.0f, bool isiden = false)
+  void setPair(T const& part1, T const& part2, const int mult, bool use3dplots, float weight = 1.0f, bool isiden = false, bool randomizePair = false, double randValue = 0.5)
   {
     float femtoObs, femtoObsMC;
+
+    auto p1 = part1;
+    auto p2 = part2;
+    auto mass1 = mMassOne;
+    auto mass2 = mMassTwo;
+    if (randomizePair) {
+      TRandom2* randgen = new TRandom2(0);
+      double rand = randgen->Rndm();
+
+      if (rand > randValue) {
+        p1 = part2;
+        p2 = part1;
+        mass1 = mMassTwo;
+        mass2 = mMassOne;
+      }
+      delete randgen;
+    }
     // Calculate femto observable and the mT with reconstructed information
     if constexpr (FemtoObs == femto_universe_container::Observable::kstar) {
       if (!isiden) {
-        femtoObs = FemtoUniverseMath::getkstar(part1, mMassOne, part2, mMassTwo);
+        femtoObs = FemtoUniverseMath::getkstar(p1, mass1, p2, mass2);
       } else {
-        femtoObs = 2.0 * FemtoUniverseMath::getkstar(part1, mMassOne, part2, mMassTwo);
+        femtoObs = 2.0 * FemtoUniverseMath::getkstar(p1, mass1, p2, mass2);
       }
     }
-    const float mT = FemtoUniverseMath::getmT(part1, mMassOne, part2, mMassTwo);
+    const float mT = FemtoUniverseMath::getmT(p1, mass1, p2, mass2);
 
     if (mHistogramRegistry) {
-      setPairBase<o2::aod::femtouniverse_mc_particle::MCType::kRecon>(femtoObs, mT, part1, part2, mult, use3dplots, weight);
+      setPairBase<o2::aod::femtouniverse_mc_particle::MCType::kRecon>(femtoObs, mT, p1, p2, mult, use3dplots, weight);
 
       if constexpr (isMC) {
         if (part1.has_fdMCParticle() && part2.has_fdMCParticle()) {
           // calculate the femto observable and the mT with MC truth information
           if constexpr (FemtoObs == femto_universe_container::Observable::kstar) {
             if (!isiden) {
-              femtoObsMC = FemtoUniverseMath::getkstar(part1.fdMCParticle(), mMassOne, part2.fdMCParticle(), mMassTwo);
+              femtoObsMC = FemtoUniverseMath::getkstar(p1.fdMCParticle(), mass1, p2.fdMCParticle(), mass2);
             } else {
-              femtoObsMC = 2.0 * FemtoUniverseMath::getkstar(part1.fdMCParticle(), mMassOne, part2.fdMCParticle(), mMassTwo);
+              femtoObsMC = 2.0 * FemtoUniverseMath::getkstar(p1.fdMCParticle(), mass1, p2.fdMCParticle(), mass2);
             }
           }
-          const float mTMC = FemtoUniverseMath::getmT(part1.fdMCParticle(), mMassOne, part2.fdMCParticle(), mMassTwo);
+          const float mTMC = FemtoUniverseMath::getmT(part1.fdMCParticle(), mass1, part2.fdMCParticle(), mass2);
 
           if (std::abs(part1.fdMCParticle().pdgMCTruth()) == std::abs(mPDGOne) && std::abs(part2.fdMCParticle().pdgMCTruth()) == std::abs(mPDGTwo)) { // Note: all pair-histogramms are filled with MC truth information ONLY in case of non-fake candidates
-            setPairBase<o2::aod::femtouniverse_mc_particle::MCType::kTruth>(femtoObsMC, mTMC, part1.fdMCParticle(), part2.fdMCParticle(), mult, use3dplots, weight);
+            setPairBase<o2::aod::femtouniverse_mc_particle::MCType::kTruth>(femtoObsMC, mTMC, p1.fdMCParticle(), p2.fdMCParticle(), mult, use3dplots, weight);
             setPairMC(femtoObsMC, femtoObs, mT, mult);
           } else {
             mHistogramRegistry->fill(HIST(FolderSuffix[EventType]) + HIST(o2::aod::femtouniverse_mc_particle::MCTypeName[o2::aod::femtouniverse_mc_particle::MCType::kTruth]) + HIST("/hFakePairsCounter"), 0);

--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseFemtoContainer.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseFemtoContainer.h
@@ -243,7 +243,7 @@ class FemtoUniverseFemtoContainer
           const float mTMC = FemtoUniverseMath::getmT(p1.fdMCParticle(), mass1, p2.fdMCParticle(), mass2);
 
           if (std::abs(part1.fdMCParticle().pdgMCTruth()) == std::abs(kPDGOne) && std::abs(part2.fdMCParticle().pdgMCTruth()) == std::abs(kPDGTwo)) { // Note: all pair-histogramms are filled with MC truth information ONLY in case of non-fake candidates
-            if (!onlyPrimaryMC || part1.fdMCParticle().partOriginMCTruth() == o2::aod::femtouniverse_mc_particle::kPrimary && part2.fdMCParticle().partOriginMCTruth() == o2::aod::femtouniverse_mc_particle::kPrimary) {
+            if (!onlyPrimaryMC || (part1.fdMCParticle().partOriginMCTruth() == o2::aod::femtouniverse_mc_particle::kPrimary && part2.fdMCParticle().partOriginMCTruth() == o2::aod::femtouniverse_mc_particle::kPrimary)) {
               setPairBase<o2::aod::femtouniverse_mc_particle::MCType::kTruth>(femtoObsMC, mTMC, p1.fdMCParticle(), p1.fdMCParticle(), mult, use3dplots);
               setPairMC(femtoObsMC, femtoObs, mT, mult);
             }

--- a/PWGCF/FemtoUniverse/Core/FemtoUniverseFemtoContainer.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniverseFemtoContainer.h
@@ -27,6 +27,7 @@
 #include <Framework/HistogramSpec.h>
 
 #include <TDatabasePDG.h>
+#include <TRandom2.h>
 
 #include <string>
 #include <string_view>
@@ -205,29 +206,47 @@ class FemtoUniverseFemtoContainer
   /// \param part2 Particle two
   /// \param mult Multiplicity of the event
   template <bool isMC, typename T>
-  void setPair(T const& part1, T const& part2, const int mult, bool use3dplots)
+  void setPair(T const& part1, T const& part2, const int mult, bool use3dplots, bool onlyPrimaryMC = false, bool randomizePair = false, double randValue = 0.5)
   {
     float femtoObs, femtoObsMC;
+    auto p1 = part1;
+    auto p2 = part2;
+
+    auto mass1 = kMassOne;
+    auto mass2 = kMassTwo;
+    if (randomizePair) {
+      TRandom2* randgen = new TRandom2(0);
+      double rand = randgen->Rndm();
+      if (rand > randValue) {
+        p1 = part2;
+        p2 = part1;
+        mass1 = kMassTwo;
+        mass2 = kMassOne;
+      }
+      delete randgen;
+    }
     // Calculate femto observable and the mT with reconstructed information
     if constexpr (kFemtoObs == femto_universe_femto_container::Observable::kstar) {
-      femtoObs = FemtoUniverseMath::getkstar(part1, kMassOne, part2, kMassTwo);
+      femtoObs = FemtoUniverseMath::getkstar(p1, mass1, p2, mass2);
     }
-    const float mT = FemtoUniverseMath::getmT(part1, kMassOne, part2, kMassTwo);
+    const float mT = FemtoUniverseMath::getmT(p1, mass1, p2, mass2);
 
     if (kHistogramRegistry) {
-      setPairBase<o2::aod::femtouniverse_mc_particle::MCType::kRecon>(femtoObs, mT, part1, part2, mult, use3dplots);
+      setPairBase<o2::aod::femtouniverse_mc_particle::MCType::kRecon>(femtoObs, mT, p1, p2, mult, use3dplots);
 
       if constexpr (isMC) {
-        if (part1.has_fdMCParticle() && part2.has_fdMCParticle()) {
+        if (p1.has_fdMCParticle() && p1.has_fdMCParticle()) {
           // calculate the femto observable and the mT with MC truth information
           if constexpr (kFemtoObs == femto_universe_femto_container::Observable::kstar) {
-            femtoObsMC = FemtoUniverseMath::getkstar(part1.fdMCParticle(), kMassOne, part2.fdMCParticle(), kMassTwo);
+            femtoObsMC = FemtoUniverseMath::getkstar(p1.fdMCParticle(), mass1, p2.fdMCParticle(), mass2);
           }
-          const float mTMC = FemtoUniverseMath::getmT(part1.fdMCParticle(), kMassOne, part2.fdMCParticle(), kMassTwo);
+          const float mTMC = FemtoUniverseMath::getmT(p1.fdMCParticle(), mass1, p2.fdMCParticle(), mass2);
 
           if (std::abs(part1.fdMCParticle().pdgMCTruth()) == std::abs(kPDGOne) && std::abs(part2.fdMCParticle().pdgMCTruth()) == std::abs(kPDGTwo)) { // Note: all pair-histogramms are filled with MC truth information ONLY in case of non-fake candidates
-            setPairBase<o2::aod::femtouniverse_mc_particle::MCType::kTruth>(femtoObsMC, mTMC, part1.fdMCParticle(), part2.fdMCParticle(), mult, use3dplots);
-            setPairMC(femtoObsMC, femtoObs, mT, mult);
+            if (!onlyPrimaryMC || part1.fdMCParticle().partOriginMCTruth() == o2::aod::femtouniverse_mc_particle::kPrimary && part2.fdMCParticle().partOriginMCTruth() == o2::aod::femtouniverse_mc_particle::kPrimary) {
+              setPairBase<o2::aod::femtouniverse_mc_particle::MCType::kTruth>(femtoObsMC, mTMC, p1.fdMCParticle(), p1.fdMCParticle(), mult, use3dplots);
+              setPairMC(femtoObsMC, femtoObs, mT, mult);
+            }
           } else {
             kHistogramRegistry->fill(HIST(kFolderSuffix[kEventType]) + HIST(o2::aod::femtouniverse_mc_particle::MCTypeName[o2::aod::femtouniverse_mc_particle::MCType::kTruth]) + HIST("/hFakePairsCounter"), 0);
           }

--- a/PWGCF/FemtoUniverse/Core/FemtoUniversePairSHCentMultKt.h
+++ b/PWGCF/FemtoUniverse/Core/FemtoUniversePairSHCentMultKt.h
@@ -190,7 +190,7 @@ class PairSHCentMultKt
   /// \param ktval kT value
   template <typename T>
   void fillMultNumDen(T const& part1, T const& part2, uint8_t ChosenEventType,
-                      int maxl, int multval, float ktval, bool isIdenLCMS, bool isqinvfill, bool isWeight, bool isIdenPRF)
+                      int maxl, int multval, float ktval, bool isIdenLCMS, bool isqinvfill, bool isWeight, bool isIdenPRF, bool randomizePair = false, double randValue = 0.5)
   {
     int multbinval;
     int absmultval = multval;
@@ -207,7 +207,7 @@ class PairSHCentMultKt
       return;
     }
     // std::cout<<"multbinval "<<multbinval<<std::endl;
-    fillkTNumDen(part1, part2, ChosenEventType, maxl, multbinval, ktval, isIdenLCMS, isqinvfill, isWeight, isIdenPRF);
+    fillkTNumDen(part1, part2, ChosenEventType, maxl, multbinval, ktval, isIdenLCMS, isqinvfill, isWeight, isIdenPRF, randomizePair, randValue);
   }
 
   /// Templated function to access different kT directory and call addEventPair
@@ -219,7 +219,7 @@ class PairSHCentMultKt
   /// \param ktval kT value
   template <typename T>
   void fillkTNumDen(T const& part1, T const& part2, uint8_t ChosenEventType,
-                    int maxl, int multval, float ktval, bool isIdenLCMS, bool isqinvfill, bool isWeight, bool isIdenPRF)
+                    int maxl, int multval, float ktval, bool isIdenLCMS, bool isqinvfill, bool isWeight, bool isIdenPRF, bool randomizePair = false, double randValue = 0.5)
   {
     int ktbinval = -1;
     if (ktval >= ktBins[0] && ktval < ktBins[1]) {
@@ -239,16 +239,16 @@ class PairSHCentMultKt
     } else {
       return;
     }
-    addEventPair(part1, part2, ChosenEventType, maxl, multval, ktbinval, isIdenLCMS, isqinvfill, isWeight, isIdenPRF);
+    addEventPair(part1, part2, ChosenEventType, maxl, multval, ktbinval, isIdenLCMS, isqinvfill, isWeight, isIdenPRF, randomizePair, randValue);
   }
 
   /// Set the PDG codes of the two particles involved
   /// \param pdg1 PDG code of particle one
   /// \param pdg2 PDG code of particle two
-  void setPionPairMass()
+  void setPDGCodes(const int pdg1, const int pdg2)
   {
-    mMassOne = o2::constants::physics::MassPiPlus; // FIXME: Get from the PDG service of the common header
-    mMassTwo = o2::constants::physics::MassPiPlus; // FIXME: Get from the PDG service of the common header
+    mMassOne = TDatabasePDG::Instance()->GetParticle(pdg1)->Mass();
+    mMassTwo = TDatabasePDG::Instance()->GetParticle(pdg2)->Mass();
   }
 
   /// To compute the bin value for cavariance matrix
@@ -272,16 +272,31 @@ class PairSHCentMultKt
   /// \param ktval kT value
   template <typename T>
   void addEventPair(T const& part1, T const& part2, uint8_t ChosenEventType,
-                    int /*maxl*/, int multval, int ktval, bool isIdenLCMS, bool isqinvfill, bool isWeight, bool isIdenPRF)
+                    int /*maxl*/, int multval, int ktval, bool isIdenLCMS, bool isqinvfill, bool isWeight, bool isIdenPRF, bool randomizePair = false, double randValue = 0.5)
   {
     int fMultBin = multval;
     int fKtBin = ktval;
     std::vector<std::complex<double>> fYlmBuffer(kMaxJM);
     std::vector<double> f3d;
-    setPionPairMass();
 
-    f3d = FemtoUniverseMath::newpairfunc(part1, mMassOne, part2, mMassTwo,
-                                         isIdenLCMS, isWeight, isIdenPRF);
+    auto p1 = part1;
+    auto p2 = part2;
+    auto mass1 = mMassOne;
+    auto mass2 = mMassTwo;
+    if (randomizePair) {
+      TRandom2* randgen = new TRandom2(0);
+      double rand = randgen->Rndm();
+
+      if (rand > randValue) {
+        p1 = part2;
+        p2 = part1;
+        mass1 = mMassTwo;
+        mass2 = mMassOne;
+      }
+      delete randgen;
+    }
+
+    f3d = FemtoUniverseMath::newpairfunc(p1, mass1, p2, mass2, isIdenLCMS, isWeight, isIdenPRF);
     double varout = 0.0;
     double varside = 0.0;
     double varlong = 0.0;

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackMultKtExtended.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackMultKtExtended.cxx
@@ -88,6 +88,9 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
     Configurable<bool> confIsMC{"confIsMC", false, "Enable additional Histogramms in the case of a MonteCarlo Run"};
     Configurable<std::vector<float>> confTrkPIDnSigmaMax{"confTrkPIDnSigmaMax", std::vector<float>{4.f, 3.f, 2.f}, "This configurable needs to be the same as the one used in the producer task"};
     Configurable<bool> confUse3D{"confUse3D", false, "Enable three dimensional histogramms (to be used only for analysis with high statistics): k* vs mT vs multiplicity"};
+    Configurable<bool> confOnlyPrimaryMCPair{"confOnlyPrimaryMCPair", false, "Fill MC pair histograms only with primary particles"};
+    Configurable<bool> confRandomizePair{"confRandomizePair", true, "Randomize pair before filling pair histograms, like k*"};
+
   } twotracksconfigs;
 
   using FemtoFullParticles = soa::Join<aod::FDParticles, aod::FDExtParticles>;
@@ -536,7 +539,7 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
         float kstar = FemtoUniverseMath::getkstar(p1, mass1, p2, mass2);
         float kT = FemtoUniverseMath::getkT(p1, mass1, p2, mass2);
 
-        sameEventCont.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D);
+        sameEventCont.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D, twotracksconfigs.confOnlyPrimaryMCPair, twotracksconfigs.confRandomizePair);
         if (cfgProcessMultBins)
           sameEventMultCont.fill<float>(kstar, multCol, kT);
       }
@@ -583,14 +586,14 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
               float kstar = FemtoUniverseMath::getkstar(p1, mass1, p2, mass1);
               float kT = FemtoUniverseMath::getkT(p1, mass1, p2, mass1);
 
-              sameEventContPP.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D);
+              sameEventContPP.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D, twotracksconfigs.confOnlyPrimaryMCPair, twotracksconfigs.confRandomizePair);
               if (cfgProcessMultBins)
                 sameEventMultContPP.fill<float>(kstar, multCol, kT);
             } else {
               float kstar = FemtoUniverseMath::getkstar(p1, mass1, p2, mass2);
               float kT = FemtoUniverseMath::getkT(p1, mass1, p2, mass2);
 
-              sameEventContPP.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D);
+              sameEventContPP.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D, twotracksconfigs.confOnlyPrimaryMCPair, twotracksconfigs.confRandomizePair);
               if (cfgProcessMultBins)
                 sameEventMultContPP.fill<float>(kstar, multCol, kT);
             }
@@ -603,14 +606,14 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
               float kstar = FemtoUniverseMath::getkstar(p1, mass2, p2, mass2);
               float kT = FemtoUniverseMath::getkT(p1, mass2, p2, mass2);
 
-              sameEventContMM.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D);
+              sameEventContMM.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D, twotracksconfigs.confOnlyPrimaryMCPair, twotracksconfigs.confRandomizePair);
               if (cfgProcessMultBins)
                 sameEventMultContMM.fill<float>(kstar, multCol, kT);
             } else {
               float kstar = FemtoUniverseMath::getkstar(p1, mass1, p2, mass2);
               float kT = FemtoUniverseMath::getkT(p1, mass1, p2, mass2);
 
-              sameEventContMM.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D);
+              sameEventContMM.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D, twotracksconfigs.confOnlyPrimaryMCPair, twotracksconfigs.confRandomizePair);
               if (cfgProcessMultBins)
                 sameEventMultContMM.fill<float>(kstar, multCol, kT);
             }
@@ -730,7 +733,7 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
           float kstar = FemtoUniverseMath::getkstar(p1, mass1, p2, mass2);
           float kT = FemtoUniverseMath::getkT(p1, mass1, p2, mass2);
 
-          mixedEventCont.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D);
+          mixedEventCont.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D, twotracksconfigs.confOnlyPrimaryMCPair, twotracksconfigs.confRandomizePair);
           if (cfgProcessMultBins)
             mixedEventMultCont.fill<float>(kstar, multCol, kT);
 
@@ -741,14 +744,14 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
             float kstar = FemtoUniverseMath::getkstar(p1, mass1, p2, mass1);
             float kT = FemtoUniverseMath::getkT(p1, mass1, p2, mass1);
 
-            mixedEventContPP.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D);
+            mixedEventContPP.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D, twotracksconfigs.confOnlyPrimaryMCPair, twotracksconfigs.confRandomizePair);
             if (cfgProcessMultBins)
               mixedEventMultContPP.fill<float>(kstar, multCol, kT);
           } else {
             float kstar = FemtoUniverseMath::getkstar(p1, mass1, p2, mass2);
             float kT = FemtoUniverseMath::getkT(p1, mass1, p2, mass2);
 
-            mixedEventContPP.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D);
+            mixedEventContPP.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D, twotracksconfigs.confOnlyPrimaryMCPair, twotracksconfigs.confRandomizePair);
             if (cfgProcessMultBins)
               mixedEventMultContPP.fill<float>(kstar, multCol, kT);
           }
@@ -761,14 +764,14 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
             float kstar = FemtoUniverseMath::getkstar(p1, mass2, p2, mass2);
             float kT = FemtoUniverseMath::getkT(p1, mass2, p2, mass2);
 
-            mixedEventContMM.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D);
+            mixedEventContMM.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D, twotracksconfigs.confOnlyPrimaryMCPair, twotracksconfigs.confRandomizePair);
             if (cfgProcessMultBins)
               mixedEventMultContMM.fill<float>(kstar, multCol, kT);
           } else {
             float kstar = FemtoUniverseMath::getkstar(p1, mass1, p2, mass2);
             float kT = FemtoUniverseMath::getkT(p1, mass1, p2, mass2);
 
-            mixedEventContMM.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D);
+            mixedEventContMM.setPair<isMC>(p1, p2, multCol, twotracksconfigs.confUse3D, twotracksconfigs.confOnlyPrimaryMCPair, twotracksconfigs.confRandomizePair);
             if (cfgProcessMultBins)
               mixedEventMultContMM.fill<float>(kstar, multCol, kT);
           }

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackSpherHarMultKtExtended.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackSpherHarMultKtExtended.cxx
@@ -167,6 +167,7 @@ struct FemtoUniversePairTaskTrackTrackSpherHarMultKtExtended {
     ConfigurableAxis confDeltaEtaAxis{"confDeltaEtaAxis", {100, -0.15, 0.15}, "DeltaEta"};
     ConfigurableAxis confDeltaPhiStarAxis{"confDeltaPhiStarAxis", {100, -0.15, 0.15}, "DeltaPhiStar"};
     Configurable<bool> confIsDebug{"confIsDebug", true, "Fill additional histograms"};
+    Configurable<bool> confRandomizePair{"confRandomizePair", true, "Randomize pair before filling pair histograms, like k*"};
   } twotracksconfigs;
 
   using FemtoFullParticles = soa::Join<aod::FDParticles, aod::FDExtParticles>;
@@ -510,6 +511,8 @@ struct FemtoUniversePairTaskTrackTrackSpherHarMultKtExtended {
       } else {
         sameEventMultCont.init(&sameMultRegistryPM, confkstarBins, confMultKstarBins, confKtKstarBins, confLMax, twotracksconfigs.confIs1D);
         mixedEventMultCont.init(&mixedMultRegistryPM, confkstarBins, confMultKstarBins, confKtKstarBins, confLMax, twotracksconfigs.confIs1D);
+        sameEventMultCont.setPDGCodes(trackonefilter.confPDGCodePartOne, tracktwofilter.confPDGCodePartTwo);
+        mixedEventMultCont.setPDGCodes(trackonefilter.confPDGCodePartOne, tracktwofilter.confPDGCodePartTwo);
       }
     }
 
@@ -522,6 +525,8 @@ struct FemtoUniversePairTaskTrackTrackSpherHarMultKtExtended {
       } else {
         sameEventMultContPP.init(&sameMultRegistryPP, confkstarBins, confMultKstarBins, confKtKstarBins, confLMax, twotracksconfigs.confIs1D);
         mixedEventMultContPP.init(&mixedMultRegistryPP, confkstarBins, confMultKstarBins, confKtKstarBins, confLMax, twotracksconfigs.confIs1D);
+        sameEventMultContPP.setPDGCodes(trackonefilter.confPDGCodePartOne, tracktwofilter.confPDGCodePartTwo);
+        mixedEventMultContPP.setPDGCodes(trackonefilter.confPDGCodePartOne, tracktwofilter.confPDGCodePartTwo);
       }
       sameEventCont1dpp.init(&resultRegistry1D, confkstarBins, confMultBinsCent, confkTBins, confmTBins, confmultBins3D, confmTBins3D, twotracksconfigs.confEtaBins, twotracksconfigs.confPhiBins, twotracksconfigs.confIsMC, twotracksconfigs.confUse3D);
       sameEventCont1dpp.setPDGCodes(trackonefilter.confPDGCodePartOne, tracktwofilter.confPDGCodePartTwo);
@@ -538,6 +543,8 @@ struct FemtoUniversePairTaskTrackTrackSpherHarMultKtExtended {
       } else {
         sameEventMultContMM.init(&sameMultRegistryMM, confkstarBins, confMultKstarBins, confKtKstarBins, confLMax, twotracksconfigs.confIs1D);
         mixedEventMultContMM.init(&mixedMultRegistryMM, confkstarBins, confMultKstarBins, confKtKstarBins, confLMax, twotracksconfigs.confIs1D);
+        sameEventMultContMM.setPDGCodes(trackonefilter.confPDGCodePartOne, tracktwofilter.confPDGCodePartTwo);
+        mixedEventMultContMM.setPDGCodes(trackonefilter.confPDGCodePartOne, tracktwofilter.confPDGCodePartTwo);
       }
       sameEventCont1dmm.init(&resultRegistry1D, confkstarBins, confMultBinsCent, confkTBins, confmTBins, confmultBins3D, confmTBins3D, twotracksconfigs.confEtaBins, twotracksconfigs.confPhiBins, twotracksconfigs.confIsMC, twotracksconfigs.confUse3D);
       sameEventCont1dmm.setPDGCodes(trackonefilter.confPDGCodePartOne, tracktwofilter.confPDGCodePartTwo);
@@ -755,7 +762,7 @@ struct FemtoUniversePairTaskTrackTrackSpherHarMultKtExtended {
             }
             if (twotracksconfigs.confIsMC || twotracksconfigs.confUse3D) {
               float weight = 1.0f;
-              sameEventCont1dpp.setPair<isMC>(part1, part2, multCol, twotracksconfigs.confUse3D, weight, twotracksconfigs.confisIdenLCMS);
+              sameEventCont1dpp.setPair<isMC>(part1, part2, multCol, twotracksconfigs.confUse3D, weight, twotracksconfigs.confisIdenLCMS, twotracksconfigs.confRandomizePair, twotracksconfigs.confRandValue);
             }
             if (twotracksconfigs.confIsFillAngqLCMS) {
               kv = std::sqrt(f3d[1] * f3d[1] + f3d[2] * f3d[2] + f3d[3] * f3d[3]);
@@ -781,7 +788,7 @@ struct FemtoUniversePairTaskTrackTrackSpherHarMultKtExtended {
             }
             if (twotracksconfigs.confIsMC || twotracksconfigs.confUse3D) {
               float weight = 1.0f;
-              sameEventCont1dmm.setPair<isMC>(part1, part2, multCol, twotracksconfigs.confUse3D, weight, twotracksconfigs.confisIdenLCMS);
+              sameEventCont1dmm.setPair<isMC>(part1, part2, multCol, twotracksconfigs.confUse3D, weight, twotracksconfigs.confisIdenLCMS, false);
             }
             if (twotracksconfigs.confIsFillAngqLCMS) {
               kv = std::sqrt(f3d[1] * f3d[1] + f3d[2] * f3d[2] + f3d[3] * f3d[3]);
@@ -956,7 +963,7 @@ struct FemtoUniversePairTaskTrackTrackSpherHarMultKtExtended {
               if (twotracksconfigs.confIs1D) {
                 f3d = FemtoUniverseMath::newpairfunc(part1, mass1, part2, mass2, twotracksconfigs.confisIdenLCMS, twotracksconfigs.confIsWeight, twotracksconfigs.confisIdenPRF);
                 float weight = f3d[5];
-                sameEventCont1dpp.setPair<isMC>(part1, part2, multCol, twotracksconfigs.confUse3D, weight, twotracksconfigs.confisIdenLCMS);
+                sameEventCont1dpp.setPair<isMC>(part1, part2, multCol, twotracksconfigs.confUse3D, weight, twotracksconfigs.confisIdenLCMS, twotracksconfigs.confRandomizePair, twotracksconfigs.confRandValue);
               } else {
                 sameEventMultContPP.fillMultNumDen(part1, part2, femto_universe_sh_container::EventType::same, 2, multCol, kT, twotracksconfigs.confisIdenLCMS, twotracksconfigs.confIs1D, twotracksconfigs.confIsWeight, twotracksconfigs.confisIdenPRF);
               }
@@ -967,7 +974,7 @@ struct FemtoUniversePairTaskTrackTrackSpherHarMultKtExtended {
               if (twotracksconfigs.confIs1D) {
                 f3d = FemtoUniverseMath::newpairfunc(part1, mass1, part2, mass2, twotracksconfigs.confisIdenLCMS, twotracksconfigs.confIsWeight, twotracksconfigs.confisIdenPRF);
                 float weight = f3d[5];
-                sameEventCont1dmm.setPair<isMC>(part1, part2, multCol, twotracksconfigs.confUse3D, weight, twotracksconfigs.confisIdenLCMS);
+                sameEventCont1dmm.setPair<isMC>(part1, part2, multCol, twotracksconfigs.confUse3D, weight, twotracksconfigs.confisIdenLCMS, twotracksconfigs.confRandomizePair, twotracksconfigs.confRandValue);
               } else {
                 sameEventMultContMM.fillMultNumDen(part1, part2, femto_universe_sh_container::EventType::same, 2, multCol, kT, twotracksconfigs.confisIdenLCMS, twotracksconfigs.confIs1D, twotracksconfigs.confIsWeight, twotracksconfigs.confisIdenPRF);
               }
@@ -1130,7 +1137,7 @@ struct FemtoUniversePairTaskTrackTrackSpherHarMultKtExtended {
           }
           if (twotracksconfigs.confIsMC || twotracksconfigs.confUse3D) {
             float weight = 1.0f;
-            mixedEventCont1dpp.setPair<isMC>(part1, part2, multCol, twotracksconfigs.confUse3D, weight, twotracksconfigs.confisIdenLCMS);
+            mixedEventCont1dpp.setPair<isMC>(part1, part2, multCol, twotracksconfigs.confUse3D, weight, twotracksconfigs.confisIdenLCMS, twotracksconfigs.confRandomizePair, twotracksconfigs.confRandValue);
           }
 
           if (twotracksconfigs.confIsFillAngqLCMS) {
@@ -1157,7 +1164,7 @@ struct FemtoUniversePairTaskTrackTrackSpherHarMultKtExtended {
           }
           if (twotracksconfigs.confIsMC || twotracksconfigs.confUse3D) {
             float weight = 1.0f;
-            mixedEventCont1dmm.setPair<isMC>(part1, part2, multCol, twotracksconfigs.confUse3D, weight, twotracksconfigs.confisIdenLCMS);
+            mixedEventCont1dmm.setPair<isMC>(part1, part2, multCol, twotracksconfigs.confUse3D, weight, twotracksconfigs.confisIdenLCMS, twotracksconfigs.confRandomizePair, twotracksconfigs.confRandValue);
           }
           if (twotracksconfigs.confIsFillAngqLCMS) {
             kv = std::sqrt(f3d[1] * f3d[1] + f3d[2] * f3d[2] + f3d[3] * f3d[3]);
@@ -1416,7 +1423,7 @@ struct FemtoUniversePairTaskTrackTrackSpherHarMultKtExtended {
           case PairType::PlusPlus: {
             if (twotracksconfigs.confIs1D) {
               float weight = 1.0;
-              mixedEventCont1dpp.setPair<isMC>(part1, part2, multCol, twotracksconfigs.confUse3D, weight, twotracksconfigs.confisIdenLCMS);
+              mixedEventCont1dpp.setPair<isMC>(part1, part2, multCol, twotracksconfigs.confUse3D, weight, twotracksconfigs.confisIdenLCMS, twotracksconfigs.confRandomizePair, twotracksconfigs.confRandValue);
             } else {
               mixedEventMultContPP.fillMultNumDen(part1, part2, femto_universe_sh_container::EventType::mixed, 2, multCol, kT, twotracksconfigs.confisIdenLCMS, twotracksconfigs.confIs1D, twotracksconfigs.confIsWeight, twotracksconfigs.confisIdenPRF);
             }
@@ -1426,7 +1433,7 @@ struct FemtoUniversePairTaskTrackTrackSpherHarMultKtExtended {
           case PairType::MinusMinus: {
             if (twotracksconfigs.confIs1D) {
               float weight = 1.0;
-              mixedEventCont1dmm.setPair<isMC>(part1, part2, multCol, twotracksconfigs.confUse3D, weight, twotracksconfigs.confisIdenLCMS);
+              mixedEventCont1dmm.setPair<isMC>(part1, part2, multCol, twotracksconfigs.confUse3D, weight, twotracksconfigs.confisIdenLCMS, twotracksconfigs.confRandomizePair, twotracksconfigs.confRandValue);
             } else {
               mixedEventMultContMM.fillMultNumDen(part1, part2, femto_universe_sh_container::EventType::mixed, 2, multCol, kT, twotracksconfigs.confisIdenLCMS, twotracksconfigs.confIs1D, twotracksconfigs.confIsWeight, twotracksconfigs.confisIdenPRF);
             }


### PR DESCRIPTION
`PWGCF/FemtoUniverse/Core/FemtoUniverseContainer.h`, `FemtoUniverseFemtoContainer.h` and `FemtoUniversePairSHCentMultKt.h`:
add optional randomization of part1 and part2 before filling pair histograms

`PWGCF/FemtoUniverse/Core/FemtoUniverseFemtoContainer.h`:
add option to fill only primary MC pairs in MC histograms

`PWGCF/FemtoUniverse/Core/FemtoUniversePairSHCentMultKt.h`:
fix harcoded `setPionPairMass()` into `setPDGCodes` that sets masses according to configurable

`PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackMultKtExtended.cxx` and `femtoUniversePairTaskTrackTrackSpherHarMultKtExtended.cxx`:
apply changes from the core files