### PR TITLE
[PWGHF] trackIndexSkimCreator: Avoid slicing inside the inner loop

### DIFF
--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -3938,10 +3938,6 @@ struct HfTrackIndexSkimCreatorLfCascades {
       // cascade loop
       const auto thisCollId = collision.globalIndex();
       const auto groupedCascades = cascades.sliceBy(cascadesPerCollision, thisCollId);
-      // The bachelor track indices depend only on the collision, not on the
-      // cascade, so slice them once per collision. Each sliceBy on this Filtered
-      // join does a full arrow Table::Slice (per-column allocation) plus a
-      // selection-vector slice, so rebuilding it for every cascade is pure waste.
       const auto groupedBachTrackIndices = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
 
       for (const auto& casc : groupedCascades) {

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -3938,6 +3938,11 @@ struct HfTrackIndexSkimCreatorLfCascades {
       // cascade loop
       const auto thisCollId = collision.globalIndex();
       const auto groupedCascades = cascades.sliceBy(cascadesPerCollision, thisCollId);
+      // The bachelor track indices depend only on the collision, not on the
+      // cascade, so slice them once per collision. Each sliceBy on this Filtered
+      // join does a full arrow Table::Slice (per-column allocation) plus a
+      // selection-vector slice, so rebuilding it for every cascade is pure waste.
+      const auto groupedBachTrackIndices = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
 
       for (const auto& casc : groupedCascades) {
 
@@ -3995,7 +4000,6 @@ struct HfTrackIndexSkimCreatorLfCascades {
         trackParCovCascOmega.setPID(o2::track::PID::OmegaMinus);
 
         //--------------combining cascade and pion tracks--------------
-        const auto groupedBachTrackIndices = trackIndices.sliceBy(trackIndicesPerCollision, thisCollId);
         for (auto trackIdCharmBachelor1 = groupedBachTrackIndices.begin(); trackIdCharmBachelor1 != groupedBachTrackIndices.end(); ++trackIdCharmBachelor1) {
 
           hfFlag = 0;


### PR DESCRIPTION
The bachelor track indices depend only on the collision, not on the
cascade, so slice them once per collision. Each sliceBy on this Filtered
join does a full arrow Table::Slice (per-column allocation) plus a
selection-vector slice, so rebuilding it for every cascade is pure waste.