### PR TITLE
[PWGHF] CharmbaryonCorrelator: add column for reflected mass of lambda0 and modified efficiency block

### DIFF
--- a/PWGHF/HFC/DataModel/CorrelationTables.h
+++ b/PWGHF/HFC/DataModel/CorrelationTables.h
@@ -227,7 +227,7 @@ DECLARE_SOA_COLUMN(PiNsigmTOF, piNsigmTOF, float);                         //! A
 DECLARE_SOA_COLUMN(MCandHadron, mCandHadron, float);                       //! Invariant mass of Lc/Sc+Hadron combined system
 DECLARE_SOA_COLUMN(PtCombined, ptCombined, float);                         //! Transverse momentum of combined Lc+Hadron system
 DECLARE_SOA_COLUMN(MV0, mV0, float);                                       //! Invariant mass of V0
-DECLARE_SOA_COLUMN(MRefV0, mRefV0, float);                                       //! Invariant mass of reflected V0
+DECLARE_SOA_COLUMN(MRefV0, mRefV0, float);                                 //! Invariant mass of reflected V0
 } // namespace hf_correlation_lc_hadron
 
 DECLARE_SOA_TABLE(PtLcFromScHPair, "AOD", "PTLCSCHPAIR", //! Sc-->Lc pT for paired Sc-proton

--- a/PWGHF/HFC/DataModel/CorrelationTables.h
+++ b/PWGHF/HFC/DataModel/CorrelationTables.h
@@ -227,6 +227,7 @@ DECLARE_SOA_COLUMN(PiNsigmTOF, piNsigmTOF, float);                         //! A
 DECLARE_SOA_COLUMN(MCandHadron, mCandHadron, float);                       //! Invariant mass of Lc/Sc+Hadron combined system
 DECLARE_SOA_COLUMN(PtCombined, ptCombined, float);                         //! Transverse momentum of combined Lc+Hadron system
 DECLARE_SOA_COLUMN(MV0, mV0, float);                                       //! Invariant mass of V0
+DECLARE_SOA_COLUMN(MRefV0, mRefV0, float);                                       //! Invariant mass of reflected V0
 } // namespace hf_correlation_lc_hadron
 
 DECLARE_SOA_TABLE(PtLcFromScHPair, "AOD", "PTLCSCHPAIR", //! Sc-->Lc pT for paired Sc-proton
@@ -259,9 +260,9 @@ DECLARE_SOA_TABLE(CandHadronInvMass, "AOD", "CANDHIMASS", //! Lc-Hadron mass
                   aod::hf_correlation_lc_hadron::MCandHadron,
                   aod::hf_correlation_lc_hadron::PtCombined);
 DECLARE_SOA_TABLE(PairedV0InvMass, "AOD", "PAIRV0IMASS", //! invarient mass of v0 which paired with  charm candidates
-                  aod::hf_correlation_lc_hadron::MV0);
+                  aod::hf_correlation_lc_hadron::MV0, aod::hf_correlation_lc_hadron::MRefV0);
 DECLARE_SOA_TABLE(V0InvMass, "AOD", "V0IMASS", //! invarient mass of v0
-                  aod::hf_correlation_lc_hadron::MV0);
+                  aod::hf_correlation_lc_hadron::MV0, aod::hf_correlation_lc_hadron::MRefV0);
 
 DECLARE_SOA_TABLE(LcHadronRecoInfo, "AOD", "LCHRECOINFO", //! Lc-Hadrons pairs Reconstructed Informations
                   aod::hf_correlation_lc_hadron::MLc,

--- a/PWGHF/HFC/DataModel/CorrelationTables.h
+++ b/PWGHF/HFC/DataModel/CorrelationTables.h
@@ -227,7 +227,7 @@ DECLARE_SOA_COLUMN(PiNsigmTOF, piNsigmTOF, float);                         //! A
 DECLARE_SOA_COLUMN(MCandHadron, mCandHadron, float);                       //! Invariant mass of Lc/Sc+Hadron combined system
 DECLARE_SOA_COLUMN(PtCombined, ptCombined, float);                         //! Transverse momentum of combined Lc+Hadron system
 DECLARE_SOA_COLUMN(MV0, mV0, float);                                       //! Invariant mass of V0
-DECLARE_SOA_COLUMN(MV0Ref, mV0Ref, float);                                       //! Invariant mass of reflected V0
+DECLARE_SOA_COLUMN(MV0Ref, mV0Ref, float);                                 //! Invariant mass of reflected V0
 } // namespace hf_correlation_lc_hadron
 
 DECLARE_SOA_TABLE(PtLcFromScHPair, "AOD", "PTLCSCHPAIR", //! Sc-->Lc pT for paired Sc-proton

--- a/PWGHF/HFC/DataModel/CorrelationTables.h
+++ b/PWGHF/HFC/DataModel/CorrelationTables.h
@@ -227,7 +227,7 @@ DECLARE_SOA_COLUMN(PiNsigmTOF, piNsigmTOF, float);                         //! A
 DECLARE_SOA_COLUMN(MCandHadron, mCandHadron, float);                       //! Invariant mass of Lc/Sc+Hadron combined system
 DECLARE_SOA_COLUMN(PtCombined, ptCombined, float);                         //! Transverse momentum of combined Lc+Hadron system
 DECLARE_SOA_COLUMN(MV0, mV0, float);                                       //! Invariant mass of V0
-DECLARE_SOA_COLUMN(MRefV0, mRefV0, float);                                 //! Invariant mass of reflected V0
+DECLARE_SOA_COLUMN(MV0Ref, mV0Ref, float);                                       //! Invariant mass of reflected V0
 } // namespace hf_correlation_lc_hadron
 
 DECLARE_SOA_TABLE(PtLcFromScHPair, "AOD", "PTLCSCHPAIR", //! Sc-->Lc pT for paired Sc-proton
@@ -260,9 +260,9 @@ DECLARE_SOA_TABLE(CandHadronInvMass, "AOD", "CANDHIMASS", //! Lc-Hadron mass
                   aod::hf_correlation_lc_hadron::MCandHadron,
                   aod::hf_correlation_lc_hadron::PtCombined);
 DECLARE_SOA_TABLE(PairedV0InvMass, "AOD", "PAIRV0IMASS", //! invarient mass of v0 which paired with  charm candidates
-                  aod::hf_correlation_lc_hadron::MV0, aod::hf_correlation_lc_hadron::MRefV0);
+                  aod::hf_correlation_lc_hadron::MV0, aod::hf_correlation_lc_hadron::MV0Ref);
 DECLARE_SOA_TABLE(V0InvMass, "AOD", "V0IMASS", //! invarient mass of v0
-                  aod::hf_correlation_lc_hadron::MV0, aod::hf_correlation_lc_hadron::MRefV0);
+                  aod::hf_correlation_lc_hadron::MV0, aod::hf_correlation_lc_hadron::MV0Ref);
 
 DECLARE_SOA_TABLE(LcHadronRecoInfo, "AOD", "LCHRECOINFO", //! Lc-Hadrons pairs Reconstructed Informations
                   aod::hf_correlation_lc_hadron::MLc,

--- a/PWGHF/HFC/TableProducer/correlatorLcScHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorLcScHadrons.cxx
@@ -389,7 +389,7 @@ struct HfCorrelatorLcScHadrons {
     Configurable<bool> calEffV0{"calEffV0", false, "calculate lambda0 efficiency"};
   } cfgV0;
 
-    // Event Mixing for the Data Mode
+  // Event Mixing for the Data Mode
   // using SelCollisionsWithSc = soa::Join<aod::Collisions, aod::Mults, aod::EvSels>;
   using SelCollisions = soa::Filtered<soa::Join<aod::Collisions, aod::Mults, aod::EvSels, aod::LcSelection>>;
   using SelCollisionsMc = soa::Filtered<soa::Join<aod::McCollisions, aod::LcSelection, aod::MultsExtraMC>>; // collisionFilter applied

--- a/PWGHF/HFC/TableProducer/correlatorLcScHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorLcScHadrons.cxx
@@ -580,72 +580,71 @@ struct HfCorrelatorLcScHadrons {
     return y;
   }
 
-
-template <class T>
-using hasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
+  template <class T>
+  using hasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
 
   template <typename Tracktype, typename V0Type>
   bool isSelectedV0Daughter(Tracktype const& track, V0Type v0, int pid)
-{
-  if (std::abs(track.eta()) > cfgCharmCand.etaTrackMax) {
-    return false;
-  }
-  // ---------------------------------------------------------
-  // 1. Proton PID Selection
-  // ---------------------------------------------------------
-  if (std::abs(pid) == kProton) {
-    bool passTOF = false;
-    
-    if (track.pt() > cfgV0.cfgDaughPrPtMax || track.pt() < cfgV0.cfgDaughPrPtMin) {
+  {
+    if (std::abs(track.eta()) > cfgCharmCand.etaTrackMax) {
       return false;
     }
-    if (track.hasTOF()) {
-      if constexpr (std::experimental::is_detected<hasStrangeTOFinV0, V0Type>::value) {
-        // pid > 0: Proton from Lambda (LaPr)
-        // pid < 0: Antiproton from Anti-Lambda (ALaPr)
-        double strangeTOF = (pid > 0) ? v0.tofNSigmaLaPr() : v0.tofNSigmaALaPr();
-        passTOF = std::abs(strangeTOF) > cfgV0.cfgDaughPIDCutsTOFPr;
-      } else {
-        // if strange TOF is unavailable
-        passTOF = std::abs(track.tofNSigmaPr()) > cfgV0.cfgDaughPIDCutsTOFPr;
+    // ---------------------------------------------------------
+    // 1. Proton PID Selection
+    // ---------------------------------------------------------
+    if (std::abs(pid) == kProton) {
+      bool passTOF = false;
+
+      if (track.pt() > cfgV0.cfgDaughPrPtMax || track.pt() < cfgV0.cfgDaughPrPtMin) {
+        return false;
+      }
+      if (track.hasTOF()) {
+        if constexpr (std::experimental::is_detected<hasStrangeTOFinV0, V0Type>::value) {
+          // pid > 0: Proton from Lambda (LaPr)
+          // pid < 0: Antiproton from Anti-Lambda (ALaPr)
+          double strangeTOF = (pid > 0) ? v0.tofNSigmaLaPr() : v0.tofNSigmaALaPr();
+          passTOF = std::abs(strangeTOF) > cfgV0.cfgDaughPIDCutsTOFPr;
+        } else {
+          // if strange TOF is unavailable
+          passTOF = std::abs(track.tofNSigmaPr()) > cfgV0.cfgDaughPIDCutsTOFPr;
+        }
+      }
+
+      if ((std::abs(track.tpcNSigmaPr()) > cfgV0.cfgDaughPIDCutsTPCPr) || passTOF) {
+        return false;
       }
     }
 
-    if ((std::abs(track.tpcNSigmaPr()) > cfgV0.cfgDaughPIDCutsTPCPr) || passTOF) {
-      return false;
-    }
-  }
+    // ---------------------------------------------------------
+    // 2. Pion PID Selection
+    // ---------------------------------------------------------
+    if (std::abs(pid) == kPiPlus) {
+      bool passTOF = false;
 
-  // ---------------------------------------------------------
-  // 2. Pion PID Selection
-  // ---------------------------------------------------------
-  if (std::abs(pid) == kPiPlus) {
-    bool passTOF = false;
+      if (track.pt() > cfgV0.cfgDaughPiPtMax || track.pt() < cfgV0.cfgDaughPiPtMin) {
+        return false;
+      }
 
-     if (track.pt() > cfgV0.cfgDaughPiPtMax || track.pt() < cfgV0.cfgDaughPiPtMin) {
-      return false;
-    }
-    
-    if (track.hasTOF()) {
-      if constexpr (std::experimental::is_detected<hasStrangeTOFinV0, V0Type>::value) {
-        // A pion can belong to either a Lambda/Anti-Lambda decay or a K0s decay.
-        // We evaluate both applicable hypotheses based on charge sign and pick the best match.
-        double tofLa = (pid > 0) ? v0.tofNSigmaALaPi() : v0.tofNSigmaLaPi();
-        
-        passTOF = tofLa > cfgV0.cfgDaughPIDCutsTOFPi;
-      } else {
-        // Fallback to standard track TOF
-        passTOF = std::abs(track.tofNSigmaPi()) > cfgV0.cfgDaughPIDCutsTOFPi;
+      if (track.hasTOF()) {
+        if constexpr (std::experimental::is_detected<hasStrangeTOFinV0, V0Type>::value) {
+          // A pion can belong to either a Lambda/Anti-Lambda decay or a K0s decay.
+          // We evaluate both applicable hypotheses based on charge sign and pick the best match.
+          double tofLa = (pid > 0) ? v0.tofNSigmaALaPi() : v0.tofNSigmaLaPi();
+
+          passTOF = tofLa > cfgV0.cfgDaughPIDCutsTOFPi;
+        } else {
+          // Fallback to standard track TOF
+          passTOF = std::abs(track.tofNSigmaPi()) > cfgV0.cfgDaughPIDCutsTOFPi;
+        }
+      }
+
+      if ((std::abs(track.tpcNSigmaPi()) > cfgV0.cfgDaughPIDCutsTPCPi) || passTOF) {
+        return false;
       }
     }
 
-    if ((std::abs(track.tpcNSigmaPi()) > cfgV0.cfgDaughPIDCutsTPCPi) || passTOF) {
-      return false;
-    }
+    return true;
   }
-
-  return true;
-}
 
   template <typename T1, typename T2>
   float calculateInvMass(T1 const& particle1, T2 const& particle2, float mass1, float mass2)
@@ -919,8 +918,8 @@ using hasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
     }
   }
 
-    // ========================================
-  // Efficiency calculation block 
+  // ========================================
+  // Efficiency calculation block
   // ========================================
   template <bool IsMc, typename V0, typename TrackType>
   void fillEffV0(V0 const& v0s,
@@ -928,155 +927,149 @@ using hasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
                  aod::McParticles const& mcParticles)
   {
     // Data-driven efficiency calculation for protons using Lambda
-      for (const auto& v0 : v0s) {
-        auto const& trackV0Pos = v0.template posTrack_as<TrackType>();
-        auto const& trackV0Neg = v0.template negTrack_as<TrackType>();
-        if (cfgV0.cfgIsCorrCollMatchV0 && ((v0.collisionId() != trackV0Pos.collisionId()) || (v0.collisionId() != trackV0Neg.collisionId()))) {
-          continue;
-        }
-
-        // Process Lambda (proton + pion)
-        if (std::abs(o2::constants::physics::MassLambda - v0.mLambda()) < cfgV0.cfgHypMassWindow) {
-          entryHadron(v0.mLambda(), trackV0Pos.eta(), trackV0Pos.pt() * trackV0Pos.sign(), 0, 0, v0.pt());
-          entryTrkPID(trackV0Pos.tpcNSigmaPr(), trackV0Pos.tpcNSigmaKa(), trackV0Pos.tpcNSigmaPi(), trackV0Pos.tofNSigmaPr(), trackV0Pos.tofNSigmaKa(), trackV0Pos.tofNSigmaPi());
-
-          if (isSelectedV0Daughter(trackV0Pos, v0, kProton) && isSelectedV0Daughter(trackV0Neg, v0, kPiMinus)) {
-            registry.fill(HIST("hV0Lambda"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
-            registry.fill(HIST("hV0LambdaRefl"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
-            registry.fill(HIST("hTPCnSigmaPr"), trackV0Pos.pt(), trackV0Pos.tpcNSigmaPr());
-
-            if (trackV0Pos.hasTOF()) {
-              registry.fill(HIST("hTOFnSigmaPr"), trackV0Pos.pt(), trackV0Pos.tofNSigmaPr());
-            }
-
-            if (passPIDSelection(trackV0Pos, cfgCharmCand.trkPIDspecies, cfgCharmCand.pidTPCMax, cfgCharmCand.pidTOFMax, cfgCharmCand.tofPIDThreshold, cfgCharmCand.forceTOF)) {
-              registry.fill(HIST("hV0LambdaPiKRej"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
-              registry.fill(HIST("hV0LambdaReflPiKRej"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
-              registry.fill(HIST("hTPCnSigmaPrPiKRej"), trackV0Pos.pt(), trackV0Pos.tpcNSigmaPr());
-              if (trackV0Pos.hasTOF()) {
-                registry.fill(HIST("hTOFnSigmaPrPiKRej"), trackV0Pos.pt(), trackV0Pos.tofNSigmaPr());
-              }
-            }
-          }
-        }
-
-        if (std::abs(o2::constants::physics::MassLambda - v0.mAntiLambda()) < cfgV0.cfgHypMassWindow) {
-          entryHadron(v0.mAntiLambda(), trackV0Neg.eta(), trackV0Neg.pt() * trackV0Neg.sign(), 0, 0, v0.pt());
-          entryTrkPID(trackV0Neg.tpcNSigmaPr(), trackV0Neg.tpcNSigmaKa(), trackV0Neg.tpcNSigmaPi(), trackV0Neg.tofNSigmaPr(), trackV0Neg.tofNSigmaKa(), trackV0Neg.tofNSigmaPi());
-
-          if (isSelectedV0Daughter(trackV0Neg, v0, kProtonBar) && isSelectedV0Daughter(trackV0Pos, v0, kPiPlus)) {
-            registry.fill(HIST("hV0Lambda"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
-            registry.fill(HIST("hV0LambdaRefl"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
-            registry.fill(HIST("hTPCnSigmaPr"), trackV0Neg.pt(), trackV0Neg.tpcNSigmaPr());
-
-            if (trackV0Neg.hasTOF()) {
-              registry.fill(HIST("hTOFnSigmaPr"), trackV0Neg.pt(), trackV0Neg.tofNSigmaPr());
-            }
-
-            if (passPIDSelection(trackV0Neg, cfgCharmCand.trkPIDspecies, cfgCharmCand.pidTPCMax, cfgCharmCand.pidTOFMax, cfgCharmCand.tofPIDThreshold, cfgCharmCand.forceTOF)) {
-              registry.fill(HIST("hV0LambdaPiKRej"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
-              registry.fill(HIST("hV0LambdaReflPiKRej"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
-              registry.fill(HIST("hTPCnSigmaPrPiKRej"), trackV0Neg.pt(), trackV0Neg.tpcNSigmaPr());
-              if (trackV0Neg.hasTOF()) {
-                registry.fill(HIST("hTOFnSigmaPrPiKRej"), trackV0Neg.pt(), trackV0Neg.tofNSigmaPr());
-              }
-            }
-          }
-        }
-
-        // MC-Reco specific V0 matching
-        if constexpr (IsMc) {
-          if (!v0.has_mcParticle() || !trackV0Pos.has_mcParticle() || !trackV0Neg.has_mcParticle()) {
-            continue;
-          }
-          auto const& v0Mc = v0.mcParticle();
-          auto const& partV0Pos = trackV0Pos.mcParticle();
-          auto const& partV0Neg = trackV0Neg.mcParticle();
-
-            if (v0Mc.pdgCode() == kLambda0) {
-              registry.fill(HIST("hV0LambdaMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
-              registry.fill(HIST("hV0LambdaReflMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
-              if (cfgV0.calEffV0 && v0Mc.isPhysicalPrimary() && v0Mc.producedByGenerator()) {
-              registry.fill(HIST("hV0PrimLambdaMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
-              registry.fill(HIST("hV0PrimLambdaReflMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
-              }
-
-              if (passPIDSelection(trackV0Pos, cfgCharmCand.trkPIDspecies, cfgCharmCand.pidTPCMax, cfgCharmCand.pidTOFMax, cfgCharmCand.tofPIDThreshold, cfgCharmCand.forceTOF)) {
-                registry.fill(HIST("hV0LambdaPiKRejMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
-                registry.fill(HIST("hV0LambdaReflPiKRejMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
-              }
-            }
-            if (v0Mc.pdgCode() == kLambda0Bar) {
-              registry.fill(HIST("hV0LambdaMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
-              registry.fill(HIST("hV0LambdaReflMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
-
-              if (cfgV0.calEffV0 && v0Mc.isPhysicalPrimary() && v0Mc.producedByGenerator()) {
-              registry.fill(HIST("hV0PrimLambdaMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
-              registry.fill(HIST("hV0PrimLambdaReflMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
-              }
-              if (passPIDSelection(trackV0Neg, cfgCharmCand.trkPIDspecies, cfgCharmCand.pidTPCMax, cfgCharmCand.pidTOFMax, cfgCharmCand.tofPIDThreshold, cfgCharmCand.forceTOF)) {
-                registry.fill(HIST("hV0LambdaPiKRejMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
-                registry.fill(HIST("hV0LambdaReflPiKRejMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
-              }
-            }
-
-          }
+    for (const auto& v0 : v0s) {
+      auto const& trackV0Pos = v0.template posTrack_as<TrackType>();
+      auto const& trackV0Neg = v0.template negTrack_as<TrackType>();
+      if (cfgV0.cfgIsCorrCollMatchV0 && ((v0.collisionId() != trackV0Pos.collisionId()) || (v0.collisionId() != trackV0Neg.collisionId()))) {
+        continue;
       }
 
-              if constexpr (IsMc) {
-                if (cfgV0.calEffV0){
+      // Process Lambda (proton + pion)
+      if (std::abs(o2::constants::physics::MassLambda - v0.mLambda()) < cfgV0.cfgHypMassWindow) {
+        entryHadron(v0.mLambda(), trackV0Pos.eta(), trackV0Pos.pt() * trackV0Pos.sign(), 0, 0, v0.pt());
+        entryTrkPID(trackV0Pos.tpcNSigmaPr(), trackV0Pos.tpcNSigmaKa(), trackV0Pos.tpcNSigmaPi(), trackV0Pos.tofNSigmaPr(), trackV0Pos.tofNSigmaKa(), trackV0Pos.tofNSigmaPi());
 
-                for (const auto& particle : mcParticles) {
+        if (isSelectedV0Daughter(trackV0Pos, v0, kProton) && isSelectedV0Daughter(trackV0Neg, v0, kPiMinus)) {
+          registry.fill(HIST("hV0Lambda"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
+          registry.fill(HIST("hV0LambdaRefl"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
+          registry.fill(HIST("hTPCnSigmaPr"), trackV0Pos.pt(), trackV0Pos.tpcNSigmaPr());
 
-        if (std::abs(particle.pdgCode()) != kLambda0) {
+          if (trackV0Pos.hasTOF()) {
+            registry.fill(HIST("hTOFnSigmaPr"), trackV0Pos.pt(), trackV0Pos.tofNSigmaPr());
+          }
+
+          if (passPIDSelection(trackV0Pos, cfgCharmCand.trkPIDspecies, cfgCharmCand.pidTPCMax, cfgCharmCand.pidTOFMax, cfgCharmCand.tofPIDThreshold, cfgCharmCand.forceTOF)) {
+            registry.fill(HIST("hV0LambdaPiKRej"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
+            registry.fill(HIST("hV0LambdaReflPiKRej"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
+            registry.fill(HIST("hTPCnSigmaPrPiKRej"), trackV0Pos.pt(), trackV0Pos.tpcNSigmaPr());
+            if (trackV0Pos.hasTOF()) {
+              registry.fill(HIST("hTOFnSigmaPrPiKRej"), trackV0Pos.pt(), trackV0Pos.tofNSigmaPr());
+            }
+          }
+        }
+      }
+
+      if (std::abs(o2::constants::physics::MassLambda - v0.mAntiLambda()) < cfgV0.cfgHypMassWindow) {
+        entryHadron(v0.mAntiLambda(), trackV0Neg.eta(), trackV0Neg.pt() * trackV0Neg.sign(), 0, 0, v0.pt());
+        entryTrkPID(trackV0Neg.tpcNSigmaPr(), trackV0Neg.tpcNSigmaKa(), trackV0Neg.tpcNSigmaPi(), trackV0Neg.tofNSigmaPr(), trackV0Neg.tofNSigmaKa(), trackV0Neg.tofNSigmaPi());
+
+        if (isSelectedV0Daughter(trackV0Neg, v0, kProtonBar) && isSelectedV0Daughter(trackV0Pos, v0, kPiPlus)) {
+          registry.fill(HIST("hV0Lambda"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
+          registry.fill(HIST("hV0LambdaRefl"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
+          registry.fill(HIST("hTPCnSigmaPr"), trackV0Neg.pt(), trackV0Neg.tpcNSigmaPr());
+
+          if (trackV0Neg.hasTOF()) {
+            registry.fill(HIST("hTOFnSigmaPr"), trackV0Neg.pt(), trackV0Neg.tofNSigmaPr());
+          }
+
+          if (passPIDSelection(trackV0Neg, cfgCharmCand.trkPIDspecies, cfgCharmCand.pidTPCMax, cfgCharmCand.pidTOFMax, cfgCharmCand.tofPIDThreshold, cfgCharmCand.forceTOF)) {
+            registry.fill(HIST("hV0LambdaPiKRej"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
+            registry.fill(HIST("hV0LambdaReflPiKRej"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
+            registry.fill(HIST("hTPCnSigmaPrPiKRej"), trackV0Neg.pt(), trackV0Neg.tpcNSigmaPr());
+            if (trackV0Neg.hasTOF()) {
+              registry.fill(HIST("hTOFnSigmaPrPiKRej"), trackV0Neg.pt(), trackV0Neg.tofNSigmaPr());
+            }
+          }
+        }
+      }
+
+      // MC-Reco specific V0 matching
+      if constexpr (IsMc) {
+        if (!v0.has_mcParticle() || !trackV0Pos.has_mcParticle() || !trackV0Neg.has_mcParticle()) {
           continue;
         }
+        auto const& v0Mc = v0.mcParticle();
+        auto const& partV0Pos = trackV0Pos.mcParticle();
+        auto const& partV0Neg = trackV0Neg.mcParticle();
 
-        if (std::abs(particle.y()) > cfgCharmCand.yCandMax) {
-          continue;
+        if (v0Mc.pdgCode() == kLambda0) {
+          registry.fill(HIST("hV0LambdaMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+          registry.fill(HIST("hV0LambdaReflMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+          if (cfgV0.calEffV0 && v0Mc.isPhysicalPrimary() && v0Mc.producedByGenerator()) {
+            registry.fill(HIST("hV0PrimLambdaMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+            registry.fill(HIST("hV0PrimLambdaReflMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+          }
+
+          if (passPIDSelection(trackV0Pos, cfgCharmCand.trkPIDspecies, cfgCharmCand.pidTPCMax, cfgCharmCand.pidTOFMax, cfgCharmCand.tofPIDThreshold, cfgCharmCand.forceTOF)) {
+            registry.fill(HIST("hV0LambdaPiKRejMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+            registry.fill(HIST("hV0LambdaReflPiKRejMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+          }
         }
-        if (!particle.isPhysicalPrimary() || !particle.producedByGenerator()) {
-          continue;
+        if (v0Mc.pdgCode() == kLambda0Bar) {
+          registry.fill(HIST("hV0LambdaMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+          registry.fill(HIST("hV0LambdaReflMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+
+          if (cfgV0.calEffV0 && v0Mc.isPhysicalPrimary() && v0Mc.producedByGenerator()) {
+            registry.fill(HIST("hV0PrimLambdaMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+            registry.fill(HIST("hV0PrimLambdaReflMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+          }
+          if (passPIDSelection(trackV0Neg, cfgCharmCand.trkPIDspecies, cfgCharmCand.pidTPCMax, cfgCharmCand.pidTOFMax, cfgCharmCand.tofPIDThreshold, cfgCharmCand.forceTOF)) {
+            registry.fill(HIST("hV0LambdaPiKRejMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+            registry.fill(HIST("hV0LambdaReflPiKRejMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+          }
         }
+      }
+    }
 
+    if constexpr (IsMc) {
+      if (cfgV0.calEffV0) {
 
-    auto daughterParts = particle.daughters_as<aod::McParticles>();
-    const int8_t NdaughtersV0 = 2;
+        for (const auto& particle : mcParticles) {
 
-    if (daughterParts.size() != NdaughtersV0) {
-          continue;
-        }
-
-        for (const auto& currentDaughter : daughterParts) {
-
-          if (std::abs(currentDaughter.eta()) > cfgCharmCand.etaTrackMax) {
+          if (std::abs(particle.pdgCode()) != kLambda0) {
             continue;
           }
 
-          if (std::abs(currentDaughter.pdgCode()) == kProton ){
+          if (std::abs(particle.y()) > cfgCharmCand.yCandMax) {
+            continue;
+          }
+          if (!particle.isPhysicalPrimary() || !particle.producedByGenerator()) {
+            continue;
+          }
 
-            if (currentDaughter.pt() > cfgV0.cfgDaughPrPtMax || currentDaughter.pt() < cfgV0.cfgDaughPrPtMin) {
-             continue;
-                      }
+          auto daughterParts = particle.daughters_as<aod::McParticles>();
+          const int8_t NdaughtersV0 = 2;
 
-          } else if (std::abs(currentDaughter.pdgCode()) == kPiPlus ){
-                    if (currentDaughter.pt() > cfgV0.cfgDaughPiPtMax || currentDaughter.pt() < cfgV0.cfgDaughPiPtMin) {
-                     continue;
+          if (daughterParts.size() != NdaughtersV0) {
+            continue;
+          }
+
+          for (const auto& currentDaughter : daughterParts) {
+
+            if (std::abs(currentDaughter.eta()) > cfgCharmCand.etaTrackMax) {
+              continue;
             }
 
-          } else {
-            continue;
-          }
-          
+            if (std::abs(currentDaughter.pdgCode()) == kProton) {
+
+              if (currentDaughter.pt() > cfgV0.cfgDaughPrPtMax || currentDaughter.pt() < cfgV0.cfgDaughPrPtMin) {
+                continue;
+              }
+
+            } else if (std::abs(currentDaughter.pdgCode()) == kPiPlus) {
+              if (currentDaughter.pt() > cfgV0.cfgDaughPiPtMax || currentDaughter.pt() < cfgV0.cfgDaughPiPtMin) {
+                continue;
+              }
+
+            } else {
+              continue;
+            }
           }
           registry.fill(HIST("hV0PtPrimLambdaMcGen"), particle.pt());
-    
-          }
         }
       }
-
+    }
   }
-
 
   template <bool IsMcRec, int LambdaPart, typename AssocType, typename CandType, typename McPart>
   void fillCorrelationTable(bool trkPidFill, AssocType const& assoc, CandType const& candidate,
@@ -1874,16 +1867,14 @@ using hasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
   }
   PROCESS_SWITCH(HfCorrelatorLcScHadrons, processMcLambdaV0, "Mc process for v0 lambda with Lc", false);
 
-
   void processLambda0EffCal(SelCollisions::iterator const&,
-                         TracksWithMc const& tracks,
-                         soa::Join<aod::V0Datas, aod::V0TOFNSigmas, aod::McV0Labels> const& v0s,
-                         aod::McParticles const& mcParticles)
+                            TracksWithMc const& tracks,
+                            soa::Join<aod::V0Datas, aod::V0TOFNSigmas, aod::McV0Labels> const& v0s,
+                            aod::McParticles const& mcParticles)
   {
     fillEffV0<true>(v0s, tracks, mcParticles);
   }
   PROCESS_SWITCH(HfCorrelatorLcScHadrons, processLambda0EffCal, "Mc process for lambda0", false);
-
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGHF/HFC/TableProducer/correlatorLcScHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorLcScHadrons.cxx
@@ -337,6 +337,8 @@ struct HfCorrelatorLcScHadrons {
   Produces<aod::PairedV0InvMass> entryPairedV0InvMass;
   Produces<aod::V0InvMass> entryV0InvMass;
 
+  Service<o2::framework::O2DatabasePDG> pdg{};
+
   struct : ConfigurableGroup {
     Configurable<int> selectionFlagLc{"selectionFlagLc", 1, "Selection Flag for Lc"};
     Configurable<int> numberEventsMixed{"numberEventsMixed", 5, "number of events mixed in ME process"};
@@ -387,27 +389,7 @@ struct HfCorrelatorLcScHadrons {
     Configurable<bool> calEffV0{"calEffV0", false, "calculate lambda0 efficiency"};
   } cfgV0;
 
-  SliceCache cache;
-  Service<o2::framework::O2DatabasePDG> pdg{};
-  int8_t chargeCand = 3;
-  int8_t signSoftPion = 0;
-  int leadingIndex = 0;
-  int poolBin = 0;
-  int poolBinLc = 0;
-  bool correlationStatus = false;
-  bool isPrompt = false;
-  bool isNonPrompt = false;
-  bool isSignal = false;
-  static constexpr int8_t ChargeScPlusPlus{2};
-  static constexpr int8_t ChargeZero{0};
-  static constexpr int8_t AssignedChargeSc0{1}; // to distinguish sc0 from anti-sc0, charge set to +1 and -1
-
-  TRandom3* rnd = new TRandom3(0);
-  // std::vector<float> outputMl = {-1., -1., -1.};
-  std::vector<float> outputMlPKPi = {-1., -1., -1.};
-  std::vector<float> outputMlPiKP = {-1., -1., -1.};
-
-  // Event Mixing for the Data Mode
+    // Event Mixing for the Data Mode
   // using SelCollisionsWithSc = soa::Join<aod::Collisions, aod::Mults, aod::EvSels>;
   using SelCollisions = soa::Filtered<soa::Join<aod::Collisions, aod::Mults, aod::EvSels, aod::LcSelection>>;
   using SelCollisionsMc = soa::Filtered<soa::Join<aod::McCollisions, aod::LcSelection, aod::MultsExtraMC>>; // collisionFilter applied
@@ -427,6 +409,9 @@ struct HfCorrelatorLcScHadrons {
   // Tracks used in Data and MC
   using TracksData = soa::Filtered<soa::Join<aod::TracksWDca, aod::TrackSelection, aod::TracksExtra, aod::pidTPCFullPi, aod::pidTPCFullKa, aod::pidTPCFullPr, aod::pidTOFFullPi, aod::pidTOFFullKa, aod::pidTOFFullPr>>;                           // trackFilter applied
   using TracksWithMc = soa::Filtered<soa::Join<aod::TracksWDca, aod::TrackSelection, aod::TracksExtra, o2::aod::McTrackLabels, aod::pidTPCFullPi, aod::pidTPCFullKa, aod::pidTPCFullPr, aod::pidTOFFullPi, aod::pidTOFFullKa, aod::pidTOFFullPr>>; // trackFilter applied
+
+  template <class T>
+  using hasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
 
   // Filters for ME
   Filter collisionFilter = aod::hf_selection_lc_collision::lcSel == true;
@@ -451,8 +436,25 @@ struct HfCorrelatorLcScHadrons {
   ConfigurableAxis binsNSigmas{"binsNSigmas", {4000, -500., 500.}, "n#sigma"};
 
   BinningType corrBinning{{binsZVtx, binsMultiplicity}, true};
-
   HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject};
+
+  SliceCache cache;
+  int8_t chargeCand = 3;
+  int8_t signSoftPion = 0;
+  int leadingIndex = 0;
+  int poolBin = 0;
+  int poolBinLc = 0;
+  bool correlationStatus = false;
+  bool isPrompt = false;
+  bool isNonPrompt = false;
+  bool isSignal = false;
+  static constexpr int8_t ChargeScPlusPlus{2};
+  static constexpr int8_t ChargeZero{0};
+  static constexpr int8_t AssignedChargeSc0{1}; // to distinguish sc0 from anti-sc0, charge set to +1 and -1
+  TRandom3 rnd{0};
+  std::vector<float> outputMlPKPi = {-1., -1., -1.};
+  std::vector<float> outputMlPiKP = {-1., -1., -1.};
+
   void init(InitContext&)
   {
     AxisSpec axisCandMass = {binsCandMass, "inv. mass (p K #pi) (GeV/#it{c}^{2})"};
@@ -580,9 +582,6 @@ struct HfCorrelatorLcScHadrons {
     return y;
   }
 
-  template <class T>
-  using hasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
-
   template <typename Tracktype, typename V0Type>
   bool isSelectedV0Daughter(Tracktype const& track, V0Type v0, int pid)
   {
@@ -680,7 +679,7 @@ struct HfCorrelatorLcScHadrons {
     }
 
     if (cfgCharmCand.eventFractionToAnalyze > 0) {
-      if (rnd->Uniform(0, 1) > cfgCharmCand.eventFractionToAnalyze) {
+      if (rnd.Uniform(0, 1) > cfgCharmCand.eventFractionToAnalyze) {
         skipMixedEventTableFilling = true;
       }
     }
@@ -1162,7 +1161,7 @@ struct HfCorrelatorLcScHadrons {
     }
 
     if (cfgCharmCand.eventFractionToAnalyze > 0) {
-      if (rnd->Uniform(0, 1) > cfgCharmCand.eventFractionToAnalyze) {
+      if (rnd.Uniform(0, 1) > cfgCharmCand.eventFractionToAnalyze) {
         skipMixedEventTableFilling = true;
       }
     }

--- a/PWGHF/HFC/TableProducer/correlatorLcScHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorLcScHadrons.cxx
@@ -26,6 +26,7 @@
 #include "PWGHF/HFC/DataModel/CorrelationTables.h"
 #include "PWGHF/HFC/Utils/utilsCorrelations.h"
 #include "PWGHF/Utils/utilsAnalysis.h"
+#include "PWGLF/DataModel/LFStrangenessPIDTables.h"
 #include "PWGLF/DataModel/LFStrangenessTables.h"
 
 #include "Common/CCDB/EventSelectionParams.h"
@@ -63,6 +64,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <experimental/type_traits>
 #include <vector>
 
 using namespace o2;
@@ -375,12 +377,14 @@ struct HfCorrelatorLcScHadrons {
     Configurable<float> cfgDaughPrPtMin{"cfgDaughPrPtMin", 0.3, "min. pT Daughter Proton"};
     Configurable<float> cfgDaughPiPtMax{"cfgDaughPiPtMax", 10., "max. pT Daughter Pion"};
     Configurable<float> cfgDaughPiPtMin{"cfgDaughPiPtMin", 0.3, "min. pT Daughter Pion"};
-    Configurable<float> cfgDaughPIDCutsTPCPr{"cfgDaughPIDCutsTPCPr", 3., "max. TPCnSigma Proton"};
-    Configurable<float> cfgDaughPIDCutsTPCPi{"cfgDaughPIDCutsTPCPi", 2., "max. TPCnSigma Pion"};
-    Configurable<float> cfgDaughPIDCutsTOFPi{"cfgDaughPIDCutsTOFPi", 2., "max. TOFnSigma Pion"};
+    Configurable<float> cfgDaughPIDCutsTPCPr{"cfgDaughPIDCutsTPCPr", 2.5, "max. TPCnSigma Proton"};
+    Configurable<float> cfgDaughPIDCutsTPCPi{"cfgDaughPIDCutsTPCPi", 2.5, "max. TPCnSigma Pion"};
+    Configurable<float> cfgDaughPIDCutsTOFPi{"cfgDaughPIDCutsTOFPi", 2.5, "max. TOFnSigma Pion"};
+    Configurable<float> cfgDaughPIDCutsTOFPr{"cfgDaughPIDCutsTOFPr", 2.5, "max. TOFnSigma Pion"};
     Configurable<float> cfgHypMassWindow{"cfgHypMassWindow", 0.1, "single lambda mass selection"};
     Configurable<bool> cfgIsCorrCollMatchV0{"cfgIsCorrCollMatchV0", true, "check if daughter and mother collision are same"};
     Configurable<bool> cfgCalDataDrivenEffPr{"cfgCalDataDrivenEffPr", false, "calculate data driven efficiency of proton using Lambda"};
+    Configurable<bool> calEffV0{"calEffV0", false, "calculate lambda0 efficiency"};
   } cfgV0;
 
   SliceCache cache;
@@ -576,35 +580,72 @@ struct HfCorrelatorLcScHadrons {
     return y;
   }
 
-  template <typename T>
-  bool isSelectedV0Daughter(T const& track, int pid)
-  {
-    // if (!track.isGlobalTrackWoDCA())
-    //   return false;
-    if (std::abs(pid) == kProton && std::abs(track.tpcNSigmaPr()) > cfgV0.cfgDaughPIDCutsTPCPr) {
+
+template <class T>
+using hasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
+
+  template <typename Tracktype, typename V0Type>
+  bool isSelectedV0Daughter(Tracktype const& track, V0Type v0, int pid)
+{
+  if (std::abs(track.eta()) > cfgCharmCand.etaTrackMax) {
+    return false;
+  }
+  // ---------------------------------------------------------
+  // 1. Proton PID Selection
+  // ---------------------------------------------------------
+  if (std::abs(pid) == kProton) {
+    bool passTOF = false;
+    
+    if (track.pt() > cfgV0.cfgDaughPrPtMax || track.pt() < cfgV0.cfgDaughPrPtMin) {
       return false;
     }
-    if (std::abs(pid) == kPiPlus && (std::abs(track.tpcNSigmaPi()) > cfgV0.cfgDaughPIDCutsTPCPi || std::abs(track.tofNSigmaPi()) > cfgV0.cfgDaughPIDCutsTOFPi)) {
-      return false;
-    }
-    if (std::abs(track.eta()) > cfgCharmCand.etaTrackMax) {
-      return false;
-    }
-    if (std::abs(pid) == kProton && track.pt() > cfgV0.cfgDaughPrPtMax) {
-      return false;
-    }
-    if (std::abs(pid) == kProton && track.pt() < cfgV0.cfgDaughPrPtMin) {
-      return false;
-    }
-    if (std::abs(pid) == kPiPlus && track.pt() > cfgV0.cfgDaughPiPtMax) {
-      return false;
-    }
-    if (std::abs(pid) == kPiPlus && track.pt() < cfgV0.cfgDaughPiPtMin) {
-      return false;
+    if (track.hasTOF()) {
+      if constexpr (std::experimental::is_detected<hasStrangeTOFinV0, V0Type>::value) {
+        // pid > 0: Proton from Lambda (LaPr)
+        // pid < 0: Antiproton from Anti-Lambda (ALaPr)
+        double strangeTOF = (pid > 0) ? v0.tofNSigmaLaPr() : v0.tofNSigmaALaPr();
+        passTOF = std::abs(strangeTOF) > cfgV0.cfgDaughPIDCutsTOFPr;
+      } else {
+        // if strange TOF is unavailable
+        passTOF = std::abs(track.tofNSigmaPr()) > cfgV0.cfgDaughPIDCutsTOFPr;
+      }
     }
 
-    return true;
+    if ((std::abs(track.tpcNSigmaPr()) > cfgV0.cfgDaughPIDCutsTPCPr) || passTOF) {
+      return false;
+    }
   }
+
+  // ---------------------------------------------------------
+  // 2. Pion PID Selection
+  // ---------------------------------------------------------
+  if (std::abs(pid) == kPiPlus) {
+    bool passTOF = false;
+
+     if (track.pt() > cfgV0.cfgDaughPiPtMax || track.pt() < cfgV0.cfgDaughPiPtMin) {
+      return false;
+    }
+    
+    if (track.hasTOF()) {
+      if constexpr (std::experimental::is_detected<hasStrangeTOFinV0, V0Type>::value) {
+        // A pion can belong to either a Lambda/Anti-Lambda decay or a K0s decay.
+        // We evaluate both applicable hypotheses based on charge sign and pick the best match.
+        double tofLa = (pid > 0) ? v0.tofNSigmaALaPi() : v0.tofNSigmaLaPi();
+        
+        passTOF = tofLa > cfgV0.cfgDaughPIDCutsTOFPi;
+      } else {
+        // Fallback to standard track TOF
+        passTOF = std::abs(track.tofNSigmaPi()) > cfgV0.cfgDaughPIDCutsTOFPi;
+      }
+    }
+
+    if ((std::abs(track.tpcNSigmaPi()) > cfgV0.cfgDaughPIDCutsTPCPi) || passTOF) {
+      return false;
+    }
+  }
+
+  return true;
+}
 
   template <typename T1, typename T2>
   float calculateInvMass(T1 const& particle1, T2 const& particle2, float mass1, float mass2)
@@ -628,92 +669,6 @@ struct HfCorrelatorLcScHadrons {
   template <bool IsMcRec = false, typename CollisionType, typename V0, typename TrackType, typename CandsLcType>
   void fillV0HistogramsWithLc(CollisionType const& collision, V0 const& v0s, TrackType const& tracks, CandsLcType const& candidates, aod::McParticles const* mcParticles = nullptr)
   {
-    if (cfgV0.cfgCalDataDrivenEffPr) {
-      for (const auto& v0 : v0s) {
-        auto posTrackV0 = v0.template posTrack_as<TrackType>();
-        auto negTrackV0 = v0.template negTrack_as<TrackType>();
-        if (cfgV0.cfgIsCorrCollMatchV0 && ((v0.collisionId() != posTrackV0.collisionId()) || (v0.collisionId() != negTrackV0.collisionId()))) {
-          continue;
-        }
-
-        if (std::abs(o2::constants::physics::MassLambda - v0.mLambda()) < cfgV0.cfgHypMassWindow) {
-          entryHadron(v0.mLambda(), posTrackV0.eta(), posTrackV0.pt() * posTrackV0.sign(), 0, 0, v0.pt());
-          entryTrkPID(posTrackV0.tpcNSigmaPr(), posTrackV0.tpcNSigmaKa(), posTrackV0.tpcNSigmaPi(), posTrackV0.tofNSigmaPr(), posTrackV0.tofNSigmaKa(), posTrackV0.tofNSigmaPi());
-
-          if (isSelectedV0Daughter(posTrackV0, kProton) && isSelectedV0Daughter(negTrackV0, kPiPlus)) {
-            registry.fill(HIST("hV0Lambda"), v0.mLambda(), v0.pt(), posTrackV0.pt());
-            registry.fill(HIST("hV0LambdaRefl"), v0.mAntiLambda(), v0.pt(), negTrackV0.pt());
-
-            registry.fill(HIST("hTPCnSigmaPr"), posTrackV0.pt(), posTrackV0.tpcNSigmaPr());
-            if (posTrackV0.hasTOF()) {
-              registry.fill(HIST("hTOFnSigmaPr"), posTrackV0.pt(), posTrackV0.tofNSigmaPr());
-            }
-
-            if (passPIDSelection(posTrackV0, cfgCharmCand.trkPIDspecies, cfgCharmCand.pidTPCMax, cfgCharmCand.pidTOFMax, cfgCharmCand.tofPIDThreshold, cfgCharmCand.forceTOF)) {
-              registry.fill(HIST("hV0LambdaPiKRej"), v0.mLambda(), v0.pt(), posTrackV0.pt());
-              registry.fill(HIST("hV0LambdaReflPiKRej"), v0.mAntiLambda(), v0.pt(), negTrackV0.pt());
-
-              registry.fill(HIST("hTPCnSigmaPrPiKRej"), posTrackV0.pt(), posTrackV0.tpcNSigmaPr());
-              if (posTrackV0.hasTOF()) {
-                registry.fill(HIST("hTOFnSigmaPrPiKRej"), posTrackV0.pt(), posTrackV0.tofNSigmaPr());
-              }
-            }
-          }
-        }
-        if (std::abs(o2::constants::physics::MassLambda - v0.mAntiLambda()) < cfgV0.cfgHypMassWindow) {
-          entryHadron(v0.mAntiLambda(), negTrackV0.eta(), negTrackV0.pt() * negTrackV0.sign(), 0, 0, v0.pt());
-          entryTrkPID(negTrackV0.tpcNSigmaPr(), negTrackV0.tpcNSigmaKa(), negTrackV0.tpcNSigmaPi(), negTrackV0.tofNSigmaPr(), negTrackV0.tofNSigmaKa(), negTrackV0.tofNSigmaPi());
-
-          if (isSelectedV0Daughter(negTrackV0, kProton) && isSelectedV0Daughter(posTrackV0, kPiPlus)) {
-            registry.fill(HIST("hV0Lambda"), v0.mAntiLambda(), v0.pt(), negTrackV0.pt());
-            registry.fill(HIST("hV0LambdaRefl"), v0.mLambda(), v0.pt(), posTrackV0.pt());
-
-            registry.fill(HIST("hTPCnSigmaPr"), negTrackV0.pt(), negTrackV0.tpcNSigmaPr());
-            if (negTrackV0.hasTOF()) {
-              registry.fill(HIST("hTOFnSigmaPr"), negTrackV0.pt(), negTrackV0.tofNSigmaPr());
-            }
-            if (passPIDSelection(negTrackV0, cfgCharmCand.trkPIDspecies, cfgCharmCand.pidTPCMax, cfgCharmCand.pidTOFMax, cfgCharmCand.tofPIDThreshold, cfgCharmCand.forceTOF)) {
-              registry.fill(HIST("hV0LambdaPiKRej"), v0.mAntiLambda(), v0.pt(), negTrackV0.pt());
-              registry.fill(HIST("hV0LambdaReflPiKRej"), v0.mLambda(), v0.pt(), posTrackV0.pt());
-
-              registry.fill(HIST("hTPCnSigmaPrPiKRej"), negTrackV0.pt(), negTrackV0.tpcNSigmaPr());
-              if (negTrackV0.hasTOF()) {
-                registry.fill(HIST("hTOFnSigmaPrPiKRej"), negTrackV0.pt(), negTrackV0.tofNSigmaPr());
-              }
-            }
-          }
-        }
-        if constexpr (IsMcRec) {
-          if (!v0.has_mcParticle() || !posTrackV0.has_mcParticle() || !negTrackV0.has_mcParticle()) {
-            continue;
-          }
-          auto v0Mc = v0.mcParticle();
-          auto posTrack = posTrackV0.mcParticle();
-          auto negTrack = negTrackV0.mcParticle();
-
-          if (std::abs(v0Mc.pdgCode()) == kLambda0) {
-            if (std::abs(posTrack.pdgCode()) == kProton) {
-              registry.fill(HIST("hV0LambdaMcRec"), v0.mLambda(), v0.pt(), posTrackV0.pt());
-              registry.fill(HIST("hV0LambdaReflMcRec"), v0.mAntiLambda(), v0.pt(), negTrackV0.pt());
-
-              if (passPIDSelection(posTrackV0, cfgCharmCand.trkPIDspecies, cfgCharmCand.pidTPCMax, cfgCharmCand.pidTOFMax, cfgCharmCand.tofPIDThreshold, cfgCharmCand.forceTOF)) {
-                registry.fill(HIST("hV0LambdaPiKRejMcRec"), v0.mLambda(), v0.pt(), posTrackV0.pt());
-                registry.fill(HIST("hV0LambdaReflPiKRejMcRec"), v0.mAntiLambda(), v0.pt(), negTrackV0.pt());
-              }
-            }
-            if (std::abs(negTrack.pdgCode()) == kProton) {
-              registry.fill(HIST("hV0LambdaMcRec"), v0.mAntiLambda(), v0.pt(), negTrackV0.pt());
-              registry.fill(HIST("hV0LambdaReflMcRec"), v0.mLambda(), v0.pt(), posTrackV0.pt());
-
-              if (passPIDSelection(negTrackV0, cfgCharmCand.trkPIDspecies, cfgCharmCand.pidTPCMax, cfgCharmCand.pidTOFMax, cfgCharmCand.tofPIDThreshold, cfgCharmCand.forceTOF)) {
-                registry.fill(HIST("hV0LambdaPiKRejMcRec"), v0.mAntiLambda(), v0.pt(), negTrackV0.pt());
-                registry.fill(HIST("hV0LambdaReflPiKRejMcRec"), v0.mLambda(), v0.pt(), posTrackV0.pt());
-              }
-            }
-          }
-        }
-      }
-    }
 
     int nTracks = 0;
     float efficiencyWeightCand = 1.;
@@ -878,7 +833,7 @@ struct HfCorrelatorLcScHadrons {
 
         // Process Lambda (proton-pion)
         if (std::abs(o2::constants::physics::MassLambda - v0.mLambda()) < cfgV0.cfgHypMassWindow) {
-          if (isSelectedV0Daughter(posTrackV0, kProton) && isSelectedV0Daughter(negTrackV0, kPiPlus)) {
+          if (isSelectedV0Daughter(posTrackV0, v0, kProton) && isSelectedV0Daughter(negTrackV0, v0, kPiMinus)) {
 
             if (selLcPKPi) {
               fillCorrelationTable<IsMcRec, v0Lambda>(cfgCharmCand.fillTrkPID, v0, candidate, outputMlPKPi, poolBin, correlationStatus, yCand, chargeCand, 0, massCandPKPi, *mcParticles);
@@ -890,7 +845,7 @@ struct HfCorrelatorLcScHadrons {
             if (countCand == 1) {
               if (!skipMixedEventTableFilling) {
                 entryHadron(v0.phi(), v0.eta(), v0.pt() * v0Lambda, poolBin, gCollisionId, timeStamp);
-                entryV0InvMass(v0.mLambda());
+                entryV0InvMass(v0.mLambda(), v0.mAntiLambda());
                 registry.fill(HIST("hTracksBin"), poolBin);
               }
             }
@@ -899,7 +854,7 @@ struct HfCorrelatorLcScHadrons {
 
         // Process anti-Lambda (anti-proton-pion)
         if (std::abs(o2::constants::physics::MassLambda - v0.mAntiLambda()) < cfgV0.cfgHypMassWindow) {
-          if (isSelectedV0Daughter(negTrackV0, kProton) && isSelectedV0Daughter(posTrackV0, kPiPlus)) {
+          if (isSelectedV0Daughter(negTrackV0, v0, kProtonBar) && isSelectedV0Daughter(posTrackV0, v0, kPiPlus)) {
 
             if (selLcPKPi) {
               fillCorrelationTable<IsMcRec, v0AntiLambda>(cfgCharmCand.fillTrkPID, v0, candidate, outputMlPKPi, poolBin, correlationStatus, yCand, chargeCand, 0, massCandPKPi, *mcParticles);
@@ -910,7 +865,7 @@ struct HfCorrelatorLcScHadrons {
             if (countCand == 1) {
               if (!skipMixedEventTableFilling) {
                 entryHadron(v0.phi(), v0.eta(), v0.pt() * v0AntiLambda, poolBin, gCollisionId, timeStamp);
-                entryV0InvMass(v0.mAntiLambda());
+                entryV0InvMass(v0.mAntiLambda(), v0.mLambda());
                 registry.fill(HIST("hTracksBin"), poolBin);
               }
             }
@@ -963,6 +918,166 @@ struct HfCorrelatorLcScHadrons {
       registry.fill(HIST("hPtTracksVsSignGen"), track.pt(), chargeTrack / (std::abs(chargeTrack)));
     }
   }
+
+    // ========================================
+  // Efficiency calculation block 
+  // ========================================
+  template <bool IsMc, typename V0, typename TrackType>
+  void fillEffV0(V0 const& v0s,
+                 TrackType const&,
+                 aod::McParticles const& mcParticles)
+  {
+    // Data-driven efficiency calculation for protons using Lambda
+      for (const auto& v0 : v0s) {
+        auto const& trackV0Pos = v0.template posTrack_as<TrackType>();
+        auto const& trackV0Neg = v0.template negTrack_as<TrackType>();
+        if (cfgV0.cfgIsCorrCollMatchV0 && ((v0.collisionId() != trackV0Pos.collisionId()) || (v0.collisionId() != trackV0Neg.collisionId()))) {
+          continue;
+        }
+
+        // Process Lambda (proton + pion)
+        if (std::abs(o2::constants::physics::MassLambda - v0.mLambda()) < cfgV0.cfgHypMassWindow) {
+          entryHadron(v0.mLambda(), trackV0Pos.eta(), trackV0Pos.pt() * trackV0Pos.sign(), 0, 0, v0.pt());
+          entryTrkPID(trackV0Pos.tpcNSigmaPr(), trackV0Pos.tpcNSigmaKa(), trackV0Pos.tpcNSigmaPi(), trackV0Pos.tofNSigmaPr(), trackV0Pos.tofNSigmaKa(), trackV0Pos.tofNSigmaPi());
+
+          if (isSelectedV0Daughter(trackV0Pos, v0, kProton) && isSelectedV0Daughter(trackV0Neg, v0, kPiMinus)) {
+            registry.fill(HIST("hV0Lambda"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
+            registry.fill(HIST("hV0LambdaRefl"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
+            registry.fill(HIST("hTPCnSigmaPr"), trackV0Pos.pt(), trackV0Pos.tpcNSigmaPr());
+
+            if (trackV0Pos.hasTOF()) {
+              registry.fill(HIST("hTOFnSigmaPr"), trackV0Pos.pt(), trackV0Pos.tofNSigmaPr());
+            }
+
+            if (passPIDSelection(trackV0Pos, cfgCharmCand.trkPIDspecies, cfgCharmCand.pidTPCMax, cfgCharmCand.pidTOFMax, cfgCharmCand.tofPIDThreshold, cfgCharmCand.forceTOF)) {
+              registry.fill(HIST("hV0LambdaPiKRej"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
+              registry.fill(HIST("hV0LambdaReflPiKRej"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
+              registry.fill(HIST("hTPCnSigmaPrPiKRej"), trackV0Pos.pt(), trackV0Pos.tpcNSigmaPr());
+              if (trackV0Pos.hasTOF()) {
+                registry.fill(HIST("hTOFnSigmaPrPiKRej"), trackV0Pos.pt(), trackV0Pos.tofNSigmaPr());
+              }
+            }
+          }
+        }
+
+        if (std::abs(o2::constants::physics::MassLambda - v0.mAntiLambda()) < cfgV0.cfgHypMassWindow) {
+          entryHadron(v0.mAntiLambda(), trackV0Neg.eta(), trackV0Neg.pt() * trackV0Neg.sign(), 0, 0, v0.pt());
+          entryTrkPID(trackV0Neg.tpcNSigmaPr(), trackV0Neg.tpcNSigmaKa(), trackV0Neg.tpcNSigmaPi(), trackV0Neg.tofNSigmaPr(), trackV0Neg.tofNSigmaKa(), trackV0Neg.tofNSigmaPi());
+
+          if (isSelectedV0Daughter(trackV0Neg, v0, kProtonBar) && isSelectedV0Daughter(trackV0Pos, v0, kPiPlus)) {
+            registry.fill(HIST("hV0Lambda"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
+            registry.fill(HIST("hV0LambdaRefl"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
+            registry.fill(HIST("hTPCnSigmaPr"), trackV0Neg.pt(), trackV0Neg.tpcNSigmaPr());
+
+            if (trackV0Neg.hasTOF()) {
+              registry.fill(HIST("hTOFnSigmaPr"), trackV0Neg.pt(), trackV0Neg.tofNSigmaPr());
+            }
+
+            if (passPIDSelection(trackV0Neg, cfgCharmCand.trkPIDspecies, cfgCharmCand.pidTPCMax, cfgCharmCand.pidTOFMax, cfgCharmCand.tofPIDThreshold, cfgCharmCand.forceTOF)) {
+              registry.fill(HIST("hV0LambdaPiKRej"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
+              registry.fill(HIST("hV0LambdaReflPiKRej"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
+              registry.fill(HIST("hTPCnSigmaPrPiKRej"), trackV0Neg.pt(), trackV0Neg.tpcNSigmaPr());
+              if (trackV0Neg.hasTOF()) {
+                registry.fill(HIST("hTOFnSigmaPrPiKRej"), trackV0Neg.pt(), trackV0Neg.tofNSigmaPr());
+              }
+            }
+          }
+        }
+
+        // MC-Reco specific V0 matching
+        if constexpr (IsMc) {
+          if (!v0.has_mcParticle() || !trackV0Pos.has_mcParticle() || !trackV0Neg.has_mcParticle()) {
+            continue;
+          }
+          auto const& v0Mc = v0.mcParticle();
+          auto const& partV0Pos = trackV0Pos.mcParticle();
+          auto const& partV0Neg = trackV0Neg.mcParticle();
+
+            if (v0Mc.pdgCode() == kLambda0) {
+              registry.fill(HIST("hV0LambdaMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+              registry.fill(HIST("hV0LambdaReflMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+              if (cfgV0.calEffV0 && v0Mc.isPhysicalPrimary() && v0Mc.producedByGenerator()) {
+              registry.fill(HIST("hV0PrimLambdaMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+              registry.fill(HIST("hV0PrimLambdaReflMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+              }
+
+              if (passPIDSelection(trackV0Pos, cfgCharmCand.trkPIDspecies, cfgCharmCand.pidTPCMax, cfgCharmCand.pidTOFMax, cfgCharmCand.tofPIDThreshold, cfgCharmCand.forceTOF)) {
+                registry.fill(HIST("hV0LambdaPiKRejMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+                registry.fill(HIST("hV0LambdaReflPiKRejMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+              }
+            }
+            if (v0Mc.pdgCode() == kLambda0Bar) {
+              registry.fill(HIST("hV0LambdaMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+              registry.fill(HIST("hV0LambdaReflMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+
+              if (cfgV0.calEffV0 && v0Mc.isPhysicalPrimary() && v0Mc.producedByGenerator()) {
+              registry.fill(HIST("hV0PrimLambdaMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+              registry.fill(HIST("hV0PrimLambdaReflMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+              }
+              if (passPIDSelection(trackV0Neg, cfgCharmCand.trkPIDspecies, cfgCharmCand.pidTPCMax, cfgCharmCand.pidTOFMax, cfgCharmCand.tofPIDThreshold, cfgCharmCand.forceTOF)) {
+                registry.fill(HIST("hV0LambdaPiKRejMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+                registry.fill(HIST("hV0LambdaReflPiKRejMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+              }
+            }
+
+          }
+      }
+
+              if constexpr (IsMc) {
+                if (cfgV0.calEffV0){
+
+                for (const auto& particle : mcParticles) {
+
+        if (std::abs(particle.pdgCode()) != kLambda0) {
+          continue;
+        }
+
+        if (std::abs(particle.y()) > cfgCharmCand.yCandMax) {
+          continue;
+        }
+        if (!particle.isPhysicalPrimary() || !particle.producedByGenerator()) {
+          continue;
+        }
+
+
+    auto daughterParts = particle.daughters_as<aod::McParticles>();
+    const int8_t NdaughtersV0 = 2;
+
+    if (daughterParts.size() != NdaughtersV0) {
+          continue;
+        }
+
+        for (const auto& currentDaughter : daughterParts) {
+
+          if (std::abs(currentDaughter.eta()) > cfgCharmCand.etaTrackMax) {
+            continue;
+          }
+
+          if (std::abs(currentDaughter.pdgCode()) == kProton ){
+
+            if (currentDaughter.pt() > cfgV0.cfgDaughPrPtMax || currentDaughter.pt() < cfgV0.cfgDaughPrPtMin) {
+             continue;
+                      }
+
+          } else if (std::abs(currentDaughter.pdgCode()) == kPiPlus ){
+                    if (currentDaughter.pt() > cfgV0.cfgDaughPiPtMax || currentDaughter.pt() < cfgV0.cfgDaughPiPtMin) {
+                     continue;
+            }
+
+          } else {
+            continue;
+          }
+          
+          }
+          registry.fill(HIST("hV0PtPrimLambdaMcGen"), particle.pt());
+    
+          }
+        }
+      }
+
+  }
+
+
   template <bool IsMcRec, int LambdaPart, typename AssocType, typename CandType, typename McPart>
   void fillCorrelationTable(bool trkPidFill, AssocType const& assoc, CandType const& candidate,
                             const std::vector<float>& outMl, int binPool, int8_t correlStatus,
@@ -978,12 +1093,12 @@ struct HfCorrelatorLcScHadrons {
 
     if constexpr (LambdaPart == 1) {
       massCandHadron = calculateInvMass(candidate, assoc, massCand, assoc.mLambda());
-      entryPairedV0InvMass(assoc.mLambda());
+      entryPairedV0InvMass(assoc.mLambda(), assoc.mAntiLambda());
       signAssoc = 1;
       yAssoc = assoc.yLambda();
     } else if constexpr (LambdaPart == -1) {
       massCandHadron = calculateInvMass(candidate, assoc, massCand, assoc.mAntiLambda());
-      entryPairedV0InvMass(assoc.mAntiLambda());
+      entryPairedV0InvMass(assoc.mAntiLambda(), assoc.mLambda());
       signAssoc = -1; // Note: Ensure signAssoc vs assoc.signAssoc is consistent
       yAssoc = assoc.yLambda();
     } else {
@@ -1741,7 +1856,7 @@ struct HfCorrelatorLcScHadrons {
   // Updated processDataLambdaV0 to include Lc candidates
   void processDataLambdaV0(SelCollisions::iterator const& collision,
                            TracksData const& tracks,
-                           aod::V0Datas const& v0s,
+                           soa::Join<aod::V0Datas, aod::V0TOFNSigmas> const& v0s,
                            CandsLcDataFiltered const& candidates,
                            aod::BCsWithTimestamps const&)
   {
@@ -1751,13 +1866,24 @@ struct HfCorrelatorLcScHadrons {
 
   void processMcLambdaV0(SelCollisions::iterator const& collision,
                          TracksWithMc const& tracks,
-                         soa::Join<aod::V0Datas, aod::McV0Labels> const& v0s,
+                         soa::Join<aod::V0Datas, aod::V0TOFNSigmas, aod::McV0Labels> const& v0s,
                          CandsLcMcRecFiltered const& candidates,
                          aod::McParticles const& mcParticles)
   {
     fillV0HistogramsWithLc<true>(collision, v0s, tracks, candidates, &mcParticles);
   }
   PROCESS_SWITCH(HfCorrelatorLcScHadrons, processMcLambdaV0, "Mc process for v0 lambda with Lc", false);
+
+
+  void processLambda0EffCal(SelCollisions::iterator const&,
+                         TracksWithMc const& tracks,
+                         soa::Join<aod::V0Datas, aod::V0TOFNSigmas, aod::McV0Labels> const& v0s,
+                         aod::McParticles const& mcParticles)
+  {
+    fillEffV0<true>(v0s, tracks, mcParticles);
+  }
+  PROCESS_SWITCH(HfCorrelatorLcScHadrons, processLambda0EffCal, "Mc process for lambda0", false);
+
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)

--- a/PWGHF/HFC/TableProducer/correlatorLcScHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorLcScHadrons.cxx
@@ -337,6 +337,7 @@ struct HfCorrelatorLcScHadrons {
   Produces<aod::PairedV0InvMass> entryPairedV0InvMass;
   Produces<aod::V0InvMass> entryV0InvMass;
 
+  SliceCache cache;
   Service<o2::framework::O2DatabasePDG> pdg{};
 
   struct : ConfigurableGroup {
@@ -389,7 +390,7 @@ struct HfCorrelatorLcScHadrons {
     Configurable<bool> calEffV0{"calEffV0", false, "calculate lambda0 efficiency"};
   } cfgV0;
 
-  // Event Mixing for the Data Mode
+    // Event Mixing for the Data Mode
   // using SelCollisionsWithSc = soa::Join<aod::Collisions, aod::Mults, aod::EvSels>;
   using SelCollisions = soa::Filtered<soa::Join<aod::Collisions, aod::Mults, aod::EvSels, aod::LcSelection>>;
   using SelCollisionsMc = soa::Filtered<soa::Join<aod::McCollisions, aod::LcSelection, aod::MultsExtraMC>>; // collisionFilter applied
@@ -411,7 +412,7 @@ struct HfCorrelatorLcScHadrons {
   using TracksWithMc = soa::Filtered<soa::Join<aod::TracksWDca, aod::TrackSelection, aod::TracksExtra, o2::aod::McTrackLabels, aod::pidTPCFullPi, aod::pidTPCFullKa, aod::pidTPCFullPr, aod::pidTOFFullPi, aod::pidTOFFullKa, aod::pidTOFFullPr>>; // trackFilter applied
 
   template <class T>
-  using hasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
+  using HasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
 
   // Filters for ME
   Filter collisionFilter = aod::hf_selection_lc_collision::lcSel == true;
@@ -438,7 +439,6 @@ struct HfCorrelatorLcScHadrons {
   BinningType corrBinning{{binsZVtx, binsMultiplicity}, true};
   HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject};
 
-  SliceCache cache;
   int8_t chargeCand = 3;
   int8_t signSoftPion = 0;
   int leadingIndex = 0;
@@ -598,7 +598,7 @@ struct HfCorrelatorLcScHadrons {
         return false;
       }
       if (track.hasTOF()) {
-        if constexpr (std::experimental::is_detected<hasStrangeTOFinV0, V0Type>::value) {
+        if constexpr (std::experimental::is_detected<HasStrangeTOFinV0, V0Type>::value) {
           // pid > 0: Proton from Lambda (LaPr)
           // pid < 0: Antiproton from Anti-Lambda (ALaPr)
           double strangeTOF = (pid > 0) ? v0.tofNSigmaLaPr() : v0.tofNSigmaALaPr();
@@ -625,7 +625,7 @@ struct HfCorrelatorLcScHadrons {
       }
 
       if (track.hasTOF()) {
-        if constexpr (std::experimental::is_detected<hasStrangeTOFinV0, V0Type>::value) {
+        if constexpr (std::experimental::is_detected<HasStrangeTOFinV0, V0Type>::value) {
           // A pion can belong to either a Lambda/Anti-Lambda decay or a K0s decay.
           // We evaluate both applicable hypotheses based on charge sign and pick the best match.
           double tofLa = (pid > 0) ? v0.tofNSigmaALaPi() : v0.tofNSigmaLaPi();
@@ -1037,9 +1037,9 @@ struct HfCorrelatorLcScHadrons {
           }
 
           auto daughterParts = particle.daughters_as<aod::McParticles>();
-          const int8_t NdaughtersV0 = 2;
+          const int8_t nDaughtersV0 = 2;
 
-          if (daughterParts.size() != NdaughtersV0) {
+          if (daughterParts.size() != nDaughtersV0) {
             continue;
           }
 

--- a/PWGHF/HFC/TableProducer/correlatorLcScHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorLcScHadrons.cxx
@@ -390,7 +390,7 @@ struct HfCorrelatorLcScHadrons {
     Configurable<bool> calEffV0{"calEffV0", false, "calculate lambda0 efficiency"};
   } cfgV0;
 
-    // Event Mixing for the Data Mode
+  // Event Mixing for the Data Mode
   // using SelCollisionsWithSc = soa::Join<aod::Collisions, aod::Mults, aod::EvSels>;
   using SelCollisions = soa::Filtered<soa::Join<aod::Collisions, aod::Mults, aod::EvSels, aod::LcSelection>>;
   using SelCollisionsMc = soa::Filtered<soa::Join<aod::McCollisions, aod::LcSelection, aod::MultsExtraMC>>; // collisionFilter applied

--- a/PWGHF/HFC/TableProducer/correlatorXicHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorXicHadrons.cxx
@@ -366,8 +366,6 @@ struct HfCorrelatorXicHadrons {
   Produces<aod::PairedV0InvMass> entryPairedV0InvMass;
   Produces<aod::V0InvMass> entryV0InvMass;
 
-  Service<o2::framework::O2DatabasePDG> pdg{};
-
   struct : ConfigurableGroup {
     Configurable<int> selectionFlagXic{"selectionFlagXic", 1, "Selection flag for Xic"};
     Configurable<int> numberEventsMixed{"numberEventsMixed", 5, "number of events mixed in ME process"};
@@ -420,6 +418,9 @@ struct HfCorrelatorXicHadrons {
     Configurable<bool> calEffV0{"calEffV0", false, "calculate lambda0 efficiency"};
   } cfgV0;
 
+  SliceCache cache;
+  Service<o2::framework::O2DatabasePDG> pdg{};
+
   // Event Mixing for the Data Mode
   using SelCollisions = soa::Filtered<soa::Join<aod::Collisions, aod::Mults, aod::EvSels, aod::LcSelection>>;
   using SelCollisionsMc = soa::Filtered<soa::Join<aod::McCollisions, aod::LcSelection, aod::MultsExtraMC>>;
@@ -448,7 +449,7 @@ struct HfCorrelatorXicHadrons {
   using TracksWithMc = soa::Filtered<soa::Join<aod::TracksWDca, aod::TrackSelection, aod::TracksExtra, o2::aod::McTrackLabels, aod::pidTPCFullPi, aod::pidTPCFullKa, aod::pidTPCFullPr, aod::pidTOFFullPi, aod::pidTOFFullKa, aod::pidTOFFullPr>>;
 
   template <class T>
-  using hasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
+  using HasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
 
   Filter collisionFilter = aod::hf_selection_lc_collision::lcSel == true;
   Filter trackFilter = (nabs(aod::track::eta) < cfgXicCand.etaTrackMax) && (nabs(aod::track::pt) > cfgXicCand.ptTrackMin) && (nabs(aod::track::dcaXY) < cfgXicCand.dcaXYTrackMax) && (nabs(aod::track::dcaZ) < cfgXicCand.dcaZTrackMax);
@@ -476,7 +477,6 @@ struct HfCorrelatorXicHadrons {
   BinningType corrBinning{{binsZVtx, binsMultiplicity}, true};
   HistogramRegistry registry{"registry"};
 
-  SliceCache cache;
   int8_t chargeCand = 3;
   int leadingIndex = 0;
   int poolBin = 0;
@@ -648,7 +648,7 @@ struct HfCorrelatorXicHadrons {
         return false;
       }
       if (track.hasTOF()) {
-        if constexpr (std::experimental::is_detected<hasStrangeTOFinV0, V0Type>::value) {
+        if constexpr (std::experimental::is_detected<HasStrangeTOFinV0, V0Type>::value) {
           // pid > 0: Proton from Lambda (LaPr)
           // pid < 0: Antiproton from Anti-Lambda (ALaPr)
           double strangeTOF = (pid > 0) ? v0.tofNSigmaLaPr() : v0.tofNSigmaALaPr();
@@ -675,7 +675,7 @@ struct HfCorrelatorXicHadrons {
       }
 
       if (track.hasTOF()) {
-        if constexpr (std::experimental::is_detected<hasStrangeTOFinV0, V0Type>::value) {
+        if constexpr (std::experimental::is_detected<HasStrangeTOFinV0, V0Type>::value) {
           // A pion can belong to either a Lambda/Anti-Lambda decay or a K0s decay.
           // We evaluate both applicable hypotheses based on charge sign and pick the best match.
           double tofLa = (pid > 0) ? v0.tofNSigmaALaPi() : v0.tofNSigmaLaPi();
@@ -815,9 +815,9 @@ struct HfCorrelatorXicHadrons {
           }
 
           auto daughterParts = particle.daughters_as<aod::McParticles>();
-          const int8_t NdaughtersV0 = 2;
+          const int8_t nDaughtersV0 = 2;
 
-          if (daughterParts.size() != NdaughtersV0) {
+          if (daughterParts.size() != nDaughtersV0) {
             continue;
           }
 

--- a/PWGHF/HFC/TableProducer/correlatorXicHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorXicHadrons.cxx
@@ -92,6 +92,7 @@ enum XicDecayDaughtersCount : size_t {
   XicPlusDaughtersCount = 5u
 };
 
+
 namespace corr_particle_type
 {
 enum Type : int8_t {
@@ -408,12 +409,14 @@ struct HfCorrelatorXicHadrons {
     Configurable<float> cfgDaughPrPtMin{"cfgDaughPrPtMin", 0.3f, "min. pT daughter proton"};
     Configurable<float> cfgDaughPiPtMax{"cfgDaughPiPtMax", 10.f, "max. pT daughter pion"};
     Configurable<float> cfgDaughPiPtMin{"cfgDaughPiPtMin", 0.3f, "min. pT daughter pion"};
-    Configurable<float> cfgDaughPIDCutsTPCPr{"cfgDaughPIDCutsTPCPr", 3.f, "max. TPC nSigma proton"};
-    Configurable<float> cfgDaughPIDCutsTPCPi{"cfgDaughPIDCutsTPCPi", 2.f, "max. TPC nSigma pion"};
-    Configurable<float> cfgDaughPIDCutsTOFPi{"cfgDaughPIDCutsTOFPi", 2.f, "max. TOF nSigma pion"};
+    Configurable<float> cfgDaughPIDCutsTPCPr{"cfgDaughPIDCutsTPCPr", 2.5f, "max. TPC nSigma proton"};
+    Configurable<float> cfgDaughPIDCutsTPCPi{"cfgDaughPIDCutsTPCPi", 2.5f, "max. TPC nSigma pion"};
+    Configurable<float> cfgDaughPIDCutsTOFPi{"cfgDaughPIDCutsTOFPi", 2.5f, "max. TOF nSigma pion"};
+    Configurable<float> cfgDaughPIDCutsTOFPr{"cfgDaughPIDCutsTOFPr", 2.5f, "max. TOF nSigma pion"};
     Configurable<float> cfgHypMassWindow{"cfgHypMassWindow", 0.1f, "single lambda mass selection"};
     Configurable<bool> cfgIsCorrCollMatchV0{"cfgIsCorrCollMatchV0", true, "check if daughter and mother collision are same"};
     Configurable<bool> cfgCalDataDrivenEffPr{"cfgCalDataDrivenEffPr", false, "calculate data driven efficiency of proton using Lambda"};
+    Configurable<bool> calEffV0{"calEffV0", false, "calculate lambda0 efficiency"};
   } cfgV0;
 
   SliceCache cache;
@@ -588,8 +591,11 @@ struct HfCorrelatorXicHadrons {
     registry.add("hV0LambdaReflPiKRej", "V0 Lambda reflected candidates with #pi K rejection;inv. mass (p #pi) (GeV/#it{c}^{2});GeV/#it{c};GeV/#it{c}", {HistType::kTH3F, {{axisMassV0}, {axisPtV0}, {axisPtHadron}}});
     registry.add("hV0LambdaMcRec", "McRec V0 Lambda candidates;inv. mass (p #pi) (GeV/#it{c}^{2});GeV/#it{c};GeV/#it{c}", {HistType::kTH3F, {{axisMassV0}, {axisPtV0}, {axisPtHadron}}});
     registry.add("hV0LambdaReflMcRec", "McRec V0 Lambda reflected candidates;inv. mass (p #pi) (GeV/#it{c}^{2});GeV/#it{c};GeV/#it{c}", {HistType::kTH3F, {{axisMassV0}, {axisPtV0}, {axisPtHadron}}});
+    registry.add("hV0PrimLambdaMcRec", "McRec V0 Lambda candidates;inv. mass (p #pi) (GeV/#it{c}^{2});GeV/#it{c};GeV/#it{c}", {HistType::kTH3F, {{axisMassV0}, {axisPtV0}, {axisPtHadron}}});
+    registry.add("hV0PrimLambdaReflMcRec", "McRec V0 Lambda reflected candidates;inv. mass (p #pi) (GeV/#it{c}^{2});GeV/#it{c};GeV/#it{c}", {HistType::kTH3F, {{axisMassV0}, {axisPtV0}, {axisPtHadron}}});
     registry.add("hV0LambdaPiKRejMcRec", "McRec V0 Lambda candidates with #pi K rejection;inv. mass (p #pi) (GeV/#it{c}^{2});GeV/#it{c};GeV/#it{c}", {HistType::kTH3F, {{axisMassV0}, {axisPtV0}, {axisPtHadron}}});
     registry.add("hV0LambdaReflPiKRejMcRec", "McRec V0 Lambda reflected candidates with #pi K rejection;inv. mass (p #pi) (GeV/#it{c}^{2});GeV/#it{c};GeV/#it{c}", {HistType::kTH3F, {{axisMassV0}, {axisPtV0}, {axisPtHadron}}});
+    registry.add("hV0PtPrimLambdaMcGen", "Mcgen V0 Lambda candidates;GeV/#it{c}", {HistType::kTH1F, {{axisPtV0}}});
 
     corrBinning = {{binsZVtx, binsMultiplicity}, true};
   }
@@ -624,47 +630,82 @@ struct HfCorrelatorXicHadrons {
     }
   }
 
-  template <typename T>
-  bool isSelectedV0Daughter(T const& track, int pid)
-  {
-    if (std::abs(pid) == kProton && std::abs(track.tpcNSigmaPr()) > cfgV0.cfgDaughPIDCutsTPCPr) {
+template <class T>
+using hasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
+
+  template <typename Tracktype, typename V0Type>
+  bool isSelectedV0Daughter(Tracktype const& track, V0Type v0, int pid)
+{
+  if (std::abs(track.eta()) > cfgXicCand.etaTrackMax) {
+    return false;
+  }
+  // ---------------------------------------------------------
+  // 1. Proton PID Selection
+  // ---------------------------------------------------------
+  if (std::abs(pid) == kProton) {
+    bool passTOF = false;
+    
+    if (track.pt() > cfgV0.cfgDaughPrPtMax || track.pt() < cfgV0.cfgDaughPrPtMin) {
       return false;
     }
-    if (std::abs(pid) == kPiPlus && (std::abs(track.tpcNSigmaPi()) > cfgV0.cfgDaughPIDCutsTPCPi || std::abs(track.tofNSigmaPi()) > cfgV0.cfgDaughPIDCutsTOFPi)) {
-      return false;
-    }
-    if (std::abs(track.eta()) > cfgXicCand.etaTrackMax) {
-      return false;
-    }
-    if (std::abs(pid) == kProton && track.pt() > cfgV0.cfgDaughPrPtMax) {
-      return false;
-    }
-    if (std::abs(pid) == kProton && track.pt() < cfgV0.cfgDaughPrPtMin) {
-      return false;
-    }
-    if (std::abs(pid) == kPiPlus && track.pt() > cfgV0.cfgDaughPiPtMax) {
-      return false;
-    }
-    if (std::abs(pid) == kPiPlus && track.pt() < cfgV0.cfgDaughPiPtMin) {
-      return false;
+    if (track.hasTOF()) {
+      if constexpr (std::experimental::is_detected<hasStrangeTOFinV0, V0Type>::value) {
+        // pid > 0: Proton from Lambda (LaPr)
+        // pid < 0: Antiproton from Anti-Lambda (ALaPr)
+        double strangeTOF = (pid > 0) ? v0.tofNSigmaLaPr() : v0.tofNSigmaALaPr();
+        passTOF = std::abs(strangeTOF) > cfgV0.cfgDaughPIDCutsTOFPr;
+      } else {
+        // if strange TOF is unavailable
+        passTOF = std::abs(track.tofNSigmaPr()) > cfgV0.cfgDaughPIDCutsTOFPr;
+      }
     }
 
-    return true;
+    if ((std::abs(track.tpcNSigmaPr()) > cfgV0.cfgDaughPIDCutsTPCPr) || passTOF) {
+      return false;
+    }
   }
 
-  // ============================================================================
-  // SAME EVENT WITH V0 LAMBDA PROCESSING
-  // ============================================================================
+  // ---------------------------------------------------------
+  // 2. Pion PID Selection
+  // ---------------------------------------------------------
+  if (std::abs(pid) == kPiPlus) {
+    bool passTOF = false;
 
-  template <bool IsMcRec, bool IsXicPlus, typename CollisionType, typename V0, typename TrackType, typename CandsXics>
-  void doSameEventWithV0(CollisionType const& collision,
+     if (track.pt() > cfgV0.cfgDaughPiPtMax || track.pt() < cfgV0.cfgDaughPiPtMin) {
+      return false;
+    }
+    
+    if (track.hasTOF()) {
+      if constexpr (std::experimental::is_detected<hasStrangeTOFinV0, V0Type>::value) {
+        // A pion can belong to either a Lambda/Anti-Lambda decay or a K0s decay.
+        // We evaluate both applicable hypotheses based on charge sign and pick the best match.
+        double tofLa = (pid > 0) ? v0.tofNSigmaALaPi() : v0.tofNSigmaLaPi();
+        
+        passTOF = tofLa > cfgV0.cfgDaughPIDCutsTOFPi;
+      } else {
+        // Fallback to standard track TOF
+        passTOF = std::abs(track.tofNSigmaPi()) > cfgV0.cfgDaughPIDCutsTOFPi;
+      }
+    }
+
+    if ((std::abs(track.tpcNSigmaPi()) > cfgV0.cfgDaughPIDCutsTPCPi) || passTOF) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+  // ========================================
+  // Efficiency calculation block 
+  // ========================================
+  template <bool IsMc, typename CollisionType, typename V0, typename TrackType>
+  void fillEffV0(CollisionType const& collision,
                          V0 const& v0s,
-                         TrackType const& tracks,
-                         CandsXics const& candidates,
-                         aod::McParticles const* mcParticles = nullptr)
+                         TrackType const&,
+                         aod::McParticles const& mcParticles)
   {
     // Data-driven efficiency calculation for protons using Lambda
-    if (cfgV0.cfgCalDataDrivenEffPr) {
       for (const auto& v0 : v0s) {
         auto const& trackV0Pos = v0.template posTrack_as<TrackType>();
         auto const& trackV0Neg = v0.template negTrack_as<TrackType>();
@@ -677,7 +718,7 @@ struct HfCorrelatorXicHadrons {
           entryHadron(v0.mLambda(), trackV0Pos.eta(), trackV0Pos.pt() * trackV0Pos.sign(), 0, 0, v0.pt());
           entryTrkPID(trackV0Pos.tpcNSigmaPr(), trackV0Pos.tpcNSigmaKa(), trackV0Pos.tpcNSigmaPi(), trackV0Pos.tofNSigmaPr(), trackV0Pos.tofNSigmaKa(), trackV0Pos.tofNSigmaPi());
 
-          if (isSelectedV0Daughter(trackV0Pos, kProton) && isSelectedV0Daughter(trackV0Neg, kPiPlus)) {
+          if (isSelectedV0Daughter(trackV0Pos, v0, kProton) && isSelectedV0Daughter(trackV0Neg, v0, kPiMinus)) {
             registry.fill(HIST("hV0Lambda"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
             registry.fill(HIST("hV0LambdaRefl"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
             registry.fill(HIST("hTPCnSigmaPr"), trackV0Pos.pt(), trackV0Pos.tpcNSigmaPr());
@@ -701,7 +742,7 @@ struct HfCorrelatorXicHadrons {
           entryHadron(v0.mAntiLambda(), trackV0Neg.eta(), trackV0Neg.pt() * trackV0Neg.sign(), 0, 0, v0.pt());
           entryTrkPID(trackV0Neg.tpcNSigmaPr(), trackV0Neg.tpcNSigmaKa(), trackV0Neg.tpcNSigmaPi(), trackV0Neg.tofNSigmaPr(), trackV0Neg.tofNSigmaKa(), trackV0Neg.tofNSigmaPi());
 
-          if (isSelectedV0Daughter(trackV0Neg, kProton) && isSelectedV0Daughter(trackV0Neg, kPiPlus)) {
+          if (isSelectedV0Daughter(trackV0Neg, v0, kProtonBar) && isSelectedV0Daughter(trackV0Pos, v0, kPiPlus)) {
             registry.fill(HIST("hV0Lambda"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
             registry.fill(HIST("hV0LambdaRefl"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
             registry.fill(HIST("hTPCnSigmaPr"), trackV0Neg.pt(), trackV0Neg.tpcNSigmaPr());
@@ -722,7 +763,7 @@ struct HfCorrelatorXicHadrons {
         }
 
         // MC-Reco specific V0 matching
-        if constexpr (IsMcRec) {
+        if constexpr (IsMc) {
           if (!v0.has_mcParticle() || !trackV0Pos.has_mcParticle() || !trackV0Neg.has_mcParticle()) {
             continue;
           }
@@ -730,29 +771,101 @@ struct HfCorrelatorXicHadrons {
           auto const& partV0Pos = trackV0Pos.mcParticle();
           auto const& partV0Neg = trackV0Neg.mcParticle();
 
-          if (std::abs(v0Mc.pdgCode()) == kLambda0) {
-            if (std::abs(partV0Pos.pdgCode()) == kProton) {
-              registry.fill(HIST("hV0LambdaMcRec"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
-              registry.fill(HIST("hV0LambdaReflMcRec"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
+            if (v0Mc.pdgCode() == kLambda0) {
+              registry.fill(HIST("hV0LambdaMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+              registry.fill(HIST("hV0LambdaReflMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+              if (cfgV0.calEffV0 && v0Mc.isPhysicalPrimary() && v0Mc.producedByGenerator()) {
+              registry.fill(HIST("hV0PrimLambdaMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+              registry.fill(HIST("hV0PrimLambdaReflMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+              }
 
               if (passPIDSelection(trackV0Pos, cfgXicCand.trkPIDspecies, cfgXicCand.pidTPCMax, cfgXicCand.pidTOFMax, cfgXicCand.tofPIDThreshold, cfgXicCand.forceTOF)) {
-                registry.fill(HIST("hV0LambdaPiKRejMcRec"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
-                registry.fill(HIST("hV0LambdaReflPiKRejMcRec"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
+                registry.fill(HIST("hV0LambdaPiKRejMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+                registry.fill(HIST("hV0LambdaReflPiKRejMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
               }
             }
-            if (std::abs(partV0Neg.pdgCode()) == kProton) {
-              registry.fill(HIST("hV0LambdaMcRec"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
-              registry.fill(HIST("hV0LambdaReflMcRec"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
+            if (v0Mc.pdgCode() == kLambda0Bar) {
+              registry.fill(HIST("hV0LambdaMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+              registry.fill(HIST("hV0LambdaReflMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
 
+              if (cfgV0.calEffV0 && v0Mc.isPhysicalPrimary() && v0Mc.producedByGenerator()) {
+              registry.fill(HIST("hV0PrimLambdaMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+              registry.fill(HIST("hV0PrimLambdaReflMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+              }
               if (passPIDSelection(trackV0Neg, cfgXicCand.trkPIDspecies, cfgXicCand.pidTPCMax, cfgXicCand.pidTOFMax, cfgXicCand.tofPIDThreshold, cfgXicCand.forceTOF)) {
-                registry.fill(HIST("hV0LambdaPiKRejMcRec"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
-                registry.fill(HIST("hV0LambdaReflPiKRejMcRec"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
+                registry.fill(HIST("hV0LambdaPiKRejMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+                registry.fill(HIST("hV0LambdaReflPiKRejMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
               }
             }
+
+          }
+      }
+
+              if constexpr (IsMc) {
+                if (cfgV0.calEffV0){
+
+                for (const auto& particle : mcParticles) {
+
+        if (std::abs(particle.pdgCode()) != kLambda0) {
+          continue;
+        }
+
+        if (std::abs(particle.y()) > cfgXicCand.yCandMax) {
+          continue;
+        }
+        if (!particle.isPhysicalPrimary() || !particle.producedByGenerator()) {
+          continue;
+        }
+
+
+    auto daughterParts = particle.daughters_as<aod::McParticles>();
+    const int8_t NdaughtersV0 = 2;
+
+    if (daughterParts.size() != NdaughtersV0) {
+          continue;
+        }
+
+        for (const auto& currentDaughter : daughterParts) {
+
+          if (std::abs(currentDaughter.eta()) > cfgXicCand.etaTrackMax) {
+            continue;
+          }
+
+          if (std::abs(currentDaughter.pdgCode()) == kProton ){
+
+            if (currentDaughter.pt() > cfgV0.cfgDaughPrPtMax || currentDaughter.pt() < cfgV0.cfgDaughPrPtMin) {
+             continue;
+                      }
+
+          } else if (std::abs(currentDaughter.pdgCode()) == kPiPlus ){
+                    if (currentDaughter.pt() > cfgV0.cfgDaughPiPtMax || currentDaughter.pt() < cfgV0.cfgDaughPiPtMin) {
+                     continue;
+            }
+
+          } else {
+            continue;
+          }
+          
+          }
+          registry.fill(HIST("hV0PtPrimLambdaMcGen"), particle.pt());
+    
           }
         }
       }
-    }
+
+  }
+
+  // ============================================================================
+  // SAME EVENT WITH V0 LAMBDA PROCESSING
+  // ============================================================================
+
+  template <bool IsMcRec, bool IsXicPlus, typename CollisionType, typename V0, typename TrackType, typename CandsXics>
+  void doSameEventWithV0(CollisionType const& collision,
+                         V0 const& v0s,
+                         TrackType const& tracks,
+                         CandsXics const& candidates,
+                         aod::McParticles const* mcParticles = nullptr)
+  {
 
     // Main Xic-Lambda correlation loop
     int nTracks = 0;
@@ -899,7 +1012,7 @@ struct HfCorrelatorXicHadrons {
 
         // Process Lambda (proton-pion)
         if (std::abs(o2::constants::physics::MassLambda - v0.mLambda()) < cfgV0.cfgHypMassWindow) {
-          if (isSelectedV0Daughter(trackV0Pos, kProton) && isSelectedV0Daughter(trackV0Neg, kPiPlus)) {
+          if (isSelectedV0Daughter(trackV0Pos, v0, kProton) && isSelectedV0Daughter(trackV0Neg, v0, kPiMinus)) {
 
             if (selXicCand) {
               fillCorrelationTable<IsMcRec, V0LambdaType::Lambda>(cfgXicCand.fillTrkPID, v0, ptCand, etaCand, phiCand, outputMlXic, poolBin, correlationStatus, yCand, massCand, *mcParticles);
@@ -908,7 +1021,7 @@ struct HfCorrelatorXicHadrons {
             if (countCand == 1) {
               if (!skipMixedEventTableFilling) {
                 entryHadron(v0.phi(), v0.eta(), v0.pt() * static_cast<int>(V0LambdaType::Lambda), poolBin, gCollisionId, timeStamp);
-                entryV0InvMass(v0.mLambda());
+                entryV0InvMass(v0.mLambda(), v0.mAntiLambda());
                 registry.fill(HIST("hTracksBin"), poolBin);
               }
             }
@@ -917,7 +1030,7 @@ struct HfCorrelatorXicHadrons {
 
         // Process anti-Lambda (anti-proton-pion)
         if (std::abs(o2::constants::physics::MassLambda - v0.mAntiLambda()) < cfgV0.cfgHypMassWindow) {
-          if (isSelectedV0Daughter(trackV0Neg, kProton) && isSelectedV0Daughter(trackV0Pos, kPiPlus)) {
+          if (isSelectedV0Daughter(trackV0Neg, v0, kProtonBar) && isSelectedV0Daughter(trackV0Pos, v0, kPiPlus)) {
 
             if (selXicCand) {
               fillCorrelationTable<IsMcRec, V0LambdaType::AntiLambda>(cfgXicCand.fillTrkPID, v0, ptCand, etaCand, phiCand, outputMlXic, poolBin, correlationStatus, yCand, massCand, *mcParticles);
@@ -926,7 +1039,7 @@ struct HfCorrelatorXicHadrons {
             if (countCand == 1) {
               if (!skipMixedEventTableFilling) {
                 entryHadron(v0.phi(), v0.eta(), v0.pt() * static_cast<int>(V0LambdaType::AntiLambda), poolBin, gCollisionId, timeStamp);
-                entryV0InvMass(v0.mAntiLambda());
+                entryV0InvMass(v0.mAntiLambda(), v0.mLambda());
                 registry.fill(HIST("hTracksBin"), poolBin);
               }
             }
@@ -997,14 +1110,14 @@ struct HfCorrelatorXicHadrons {
 
     if constexpr (LambdaType == V0LambdaType::Lambda) { // Lambda
       massPart2 = assoc.mLambda();
-      entryPairedV0InvMass(assoc.mLambda());
+      entryPairedV0InvMass(assoc.mLambda(), assoc.mAntiLambda());
       signAssoc = V0LambdaType::Lambda;
       yAssoc = assoc.yLambda();
     } else if constexpr (LambdaType == V0LambdaType::AntiLambda) { // AntiLambda
       massPart2 = assoc.mAntiLambda();
       signAssoc = V0LambdaType::AntiLambda;
       yAssoc = assoc.yLambda();
-      entryPairedV0InvMass(assoc.mLambda());
+      entryPairedV0InvMass(assoc.mAntiLambda(), assoc.mLambda());
     } else { // Regular track
       massPart2 = getMassFromPdg(cfgXicCand.particlePdg);
       signAssoc = assoc.sign();
@@ -1347,18 +1460,18 @@ struct HfCorrelatorXicHadrons {
           }
         } else {
 
-          auto const& trackV0Pos = assocParticle.template posTrack_as<TrackType>();
-          auto const& trackV0Neg = assocParticle.template negTrack_as<TrackType>();
+          auto const&  trackV0Pos = assocParticle.template posTrack_as<TrackType>();
+          auto const&  trackV0Neg = assocParticle.template negTrack_as<TrackType>();
 
           if (std::abs(o2::constants::physics::MassLambda - assocParticle.mLambda()) < cfgV0.cfgHypMassWindow) {
-            if (isSelectedV0Daughter(trackV0Pos, kProton) && isSelectedV0Daughter(trackV0Neg, kPiPlus)) {
+            if (isSelectedV0Daughter(trackV0Pos, assocParticle, kProton) && isSelectedV0Daughter(trackV0Neg, assocParticle, kPiPlus)) {
 
               fillCorrelationTable<IsMcRec, V0LambdaType::Lambda>(cfgXicCand.fillTrkPID, assocParticle, ptCand, etaCand, phiCand, outputMlXic, poolBin, correlationStatus, yCand, massCand, *mcParticles);
             }
           }
 
           if (std::abs(o2::constants::physics::MassLambda - assocParticle.mAntiLambda()) < cfgV0.cfgHypMassWindow) {
-            if (isSelectedV0Daughter(trackV0Neg, kProton) && isSelectedV0Daughter(trackV0Pos, kPiPlus)) {
+            if (isSelectedV0Daughter(trackV0Neg, assocParticle, -kProton) && isSelectedV0Daughter(trackV0Pos, assocParticle, -kPiPlus)) {
               fillCorrelationTable<IsMcRec, V0LambdaType::AntiLambda>(cfgXicCand.fillTrkPID, assocParticle, ptCand, etaCand, phiCand, outputMlXic, poolBin, correlationStatus, yCand, massCand, *mcParticles);
             }
           }
@@ -1418,6 +1531,7 @@ struct HfCorrelatorXicHadrons {
       registry.fill(HIST("hEtaMcGen"), particle.eta());
       registry.fill(HIST("hPhiMcGen"), RecoDecay::constrainAngle(particle.phi(), -PIHalf));
       registry.fill(HIST("hYMcGen"), yCand);
+
 
       isPrompt = particle.originMcGen() == RecoDecay::OriginType::Prompt;
       isNonPrompt = particle.originMcGen() == RecoDecay::OriginType::NonPrompt;
@@ -1588,6 +1702,16 @@ struct HfCorrelatorXicHadrons {
     doSameEventWithV0<true, false>(collision, v0s, tracks, candidates, &mcParticles);
   }
   PROCESS_SWITCH(HfCorrelatorXicHadrons, processMcRecXic0V0, "Mc process for v0 lambda with Xic0", false);
+
+    /// MC Reco processing: Xic0 with V0 Lambda
+  void processV0McRec(SelCollisions::iterator const& collision,
+                          TracksWithMc const& tracks,
+                          soa::Join<aod::V0Datas, aod::McV0Labels> const& v0s,
+                          aod::McParticles const& mcParticles)
+  {
+    fillEffV0<true>(collision, v0s, tracks, mcParticles);
+  }
+  PROCESS_SWITCH(HfCorrelatorXicHadrons, processV0McRec, "Mc process for v0 lambda", false);
 
   // ============================================================================
   // MIXED EVENT PROCESS FUNCTIONS

--- a/PWGHF/HFC/TableProducer/correlatorXicHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorXicHadrons.cxx
@@ -366,6 +366,8 @@ struct HfCorrelatorXicHadrons {
   Produces<aod::PairedV0InvMass> entryPairedV0InvMass;
   Produces<aod::V0InvMass> entryV0InvMass;
 
+  Service<o2::framework::O2DatabasePDG> pdg{};
+
   struct : ConfigurableGroup {
     Configurable<int> selectionFlagXic{"selectionFlagXic", 1, "Selection flag for Xic"};
     Configurable<int> numberEventsMixed{"numberEventsMixed", 5, "number of events mixed in ME process"};
@@ -418,22 +420,9 @@ struct HfCorrelatorXicHadrons {
     Configurable<bool> calEffV0{"calEffV0", false, "calculate lambda0 efficiency"};
   } cfgV0;
 
-  SliceCache cache;
-  Service<o2::framework::O2DatabasePDG> pdg{};
-  int8_t chargeCand = 3;
-  int leadingIndex = 0;
-  int poolBin = 0;
-  int poolBinXic = 0;
-  bool correlationStatus = false;
-  bool isPrompt = false;
-  bool isNonPrompt = false;
-  bool isSignal = false;
-  TRandom3 rnd{0};
-  std::vector<float> outputMlXic = {-1., -1., -1.};
-
   // Event Mixing for the Data Mode
   using SelCollisions = soa::Filtered<soa::Join<aod::Collisions, aod::Mults, aod::EvSels, aod::LcSelection>>;
-  using SelCollisionsMc = soa::Filtered<soa::Join<aod::McCollisions, aod::LcSelection, aod::MultsExtraMC>>; // collisionFilter applied
+  using SelCollisionsMc = soa::Filtered<soa::Join<aod::McCollisions, aod::LcSelection, aod::MultsExtraMC>>;
 
   // XicPlus data
   using CandsXicPlusData = soa::Join<aod::HfCandXic, aod::HfSelXicToXiPiPi, aod::HfMlXicToXiPiPi>;
@@ -454,9 +443,12 @@ struct HfCorrelatorXicHadrons {
   using McCollisionsSel = soa::Filtered<soa::Join<aod::McCollisions, aod::LcSelection>>;
   using McParticlesSel = soa::Filtered<aod::McParticles>;
 
-  // Tracks used in Data and MC
+  // Tracks
   using TracksData = soa::Filtered<soa::Join<aod::TracksWDca, aod::TrackSelection, aod::TracksExtra, aod::pidTPCFullPi, aod::pidTPCFullKa, aod::pidTPCFullPr, aod::pidTOFFullPi, aod::pidTOFFullKa, aod::pidTOFFullPr>>;
   using TracksWithMc = soa::Filtered<soa::Join<aod::TracksWDca, aod::TrackSelection, aod::TracksExtra, o2::aod::McTrackLabels, aod::pidTPCFullPi, aod::pidTPCFullKa, aod::pidTPCFullPr, aod::pidTOFFullPi, aod::pidTOFFullKa, aod::pidTOFFullPr>>;
+
+  template <class T>
+  using hasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
 
   Filter collisionFilter = aod::hf_selection_lc_collision::lcSel == true;
   Filter trackFilter = (nabs(aod::track::eta) < cfgXicCand.etaTrackMax) && (nabs(aod::track::pt) > cfgXicCand.ptTrackMin) && (nabs(aod::track::dcaXY) < cfgXicCand.dcaXYTrackMax) && (nabs(aod::track::dcaZ) < cfgXicCand.dcaZTrackMax);
@@ -482,8 +474,19 @@ struct HfCorrelatorXicHadrons {
   ConfigurableAxis binsNSigmas{"binsNSigmas", {4000, -500., 500.}, "n#sigma"};
 
   BinningType corrBinning{{binsZVtx, binsMultiplicity}, true};
-
   HistogramRegistry registry{"registry"};
+
+  SliceCache cache;
+  int8_t chargeCand = 3;
+  int leadingIndex = 0;
+  int poolBin = 0;
+  int poolBinXic = 0;
+  bool correlationStatus = false;
+  bool isPrompt = false;
+  bool isNonPrompt = false;
+  bool isSignal = false;
+  TRandom3 rnd{0};
+  std::vector<float> outputMlXic = {-1., -1., -1.};
 
   void init(InitContext&)
   {
@@ -629,9 +632,6 @@ struct HfCorrelatorXicHadrons {
     }
   }
 
-  template <class T>
-  using hasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
-
   template <typename Tracktype, typename V0Type>
   bool isSelectedV0Daughter(Tracktype const& track, V0Type v0, int pid)
   {
@@ -698,9 +698,8 @@ struct HfCorrelatorXicHadrons {
   // ========================================
   // Efficiency calculation block
   // ========================================
-  template <bool IsMc, typename CollisionType, typename V0, typename TrackType>
-  void fillEffV0(CollisionType const& collision,
-                 V0 const& v0s,
+  template <bool IsMc, typename V0, typename TrackType>
+  void fillEffV0(V0 const& v0s,
                  TrackType const&,
                  aod::McParticles const& mcParticles)
   {
@@ -1697,12 +1696,12 @@ struct HfCorrelatorXicHadrons {
   PROCESS_SWITCH(HfCorrelatorXicHadrons, processMcRecXic0V0, "Mc process for v0 lambda with Xic0", false);
 
   /// MC Reco processing: Xic0 with V0 Lambda
-  void processV0McRec(SelCollisions::iterator const& collision,
+  void processV0McRec(SelCollisions::iterator const&,
                       TracksWithMc const& tracks,
                       soa::Join<aod::V0Datas, aod::McV0Labels> const& v0s,
                       aod::McParticles const& mcParticles)
   {
-    fillEffV0<true>(collision, v0s, tracks, mcParticles);
+    fillEffV0<true>(v0s, tracks, mcParticles);
   }
   PROCESS_SWITCH(HfCorrelatorXicHadrons, processV0McRec, "Mc process for v0 lambda", false);
 

--- a/PWGHF/HFC/TableProducer/correlatorXicHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorXicHadrons.cxx
@@ -92,7 +92,6 @@ enum XicDecayDaughtersCount : size_t {
   XicPlusDaughtersCount = 5u
 };
 
-
 namespace corr_particle_type
 {
 enum Type : int8_t {
@@ -630,229 +629,224 @@ struct HfCorrelatorXicHadrons {
     }
   }
 
-template <class T>
-using hasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
+  template <class T>
+  using hasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
 
   template <typename Tracktype, typename V0Type>
   bool isSelectedV0Daughter(Tracktype const& track, V0Type v0, int pid)
-{
-  if (std::abs(track.eta()) > cfgXicCand.etaTrackMax) {
-    return false;
-  }
-  // ---------------------------------------------------------
-  // 1. Proton PID Selection
-  // ---------------------------------------------------------
-  if (std::abs(pid) == kProton) {
-    bool passTOF = false;
-    
-    if (track.pt() > cfgV0.cfgDaughPrPtMax || track.pt() < cfgV0.cfgDaughPrPtMin) {
+  {
+    if (std::abs(track.eta()) > cfgXicCand.etaTrackMax) {
       return false;
     }
-    if (track.hasTOF()) {
-      if constexpr (std::experimental::is_detected<hasStrangeTOFinV0, V0Type>::value) {
-        // pid > 0: Proton from Lambda (LaPr)
-        // pid < 0: Antiproton from Anti-Lambda (ALaPr)
-        double strangeTOF = (pid > 0) ? v0.tofNSigmaLaPr() : v0.tofNSigmaALaPr();
-        passTOF = std::abs(strangeTOF) > cfgV0.cfgDaughPIDCutsTOFPr;
-      } else {
-        // if strange TOF is unavailable
-        passTOF = std::abs(track.tofNSigmaPr()) > cfgV0.cfgDaughPIDCutsTOFPr;
+    // ---------------------------------------------------------
+    // 1. Proton PID Selection
+    // ---------------------------------------------------------
+    if (std::abs(pid) == kProton) {
+      bool passTOF = false;
+
+      if (track.pt() > cfgV0.cfgDaughPrPtMax || track.pt() < cfgV0.cfgDaughPrPtMin) {
+        return false;
+      }
+      if (track.hasTOF()) {
+        if constexpr (std::experimental::is_detected<hasStrangeTOFinV0, V0Type>::value) {
+          // pid > 0: Proton from Lambda (LaPr)
+          // pid < 0: Antiproton from Anti-Lambda (ALaPr)
+          double strangeTOF = (pid > 0) ? v0.tofNSigmaLaPr() : v0.tofNSigmaALaPr();
+          passTOF = std::abs(strangeTOF) > cfgV0.cfgDaughPIDCutsTOFPr;
+        } else {
+          // if strange TOF is unavailable
+          passTOF = std::abs(track.tofNSigmaPr()) > cfgV0.cfgDaughPIDCutsTOFPr;
+        }
+      }
+
+      if ((std::abs(track.tpcNSigmaPr()) > cfgV0.cfgDaughPIDCutsTPCPr) || passTOF) {
+        return false;
       }
     }
 
-    if ((std::abs(track.tpcNSigmaPr()) > cfgV0.cfgDaughPIDCutsTPCPr) || passTOF) {
-      return false;
-    }
-  }
+    // ---------------------------------------------------------
+    // 2. Pion PID Selection
+    // ---------------------------------------------------------
+    if (std::abs(pid) == kPiPlus) {
+      bool passTOF = false;
 
-  // ---------------------------------------------------------
-  // 2. Pion PID Selection
-  // ---------------------------------------------------------
-  if (std::abs(pid) == kPiPlus) {
-    bool passTOF = false;
+      if (track.pt() > cfgV0.cfgDaughPiPtMax || track.pt() < cfgV0.cfgDaughPiPtMin) {
+        return false;
+      }
 
-     if (track.pt() > cfgV0.cfgDaughPiPtMax || track.pt() < cfgV0.cfgDaughPiPtMin) {
-      return false;
-    }
-    
-    if (track.hasTOF()) {
-      if constexpr (std::experimental::is_detected<hasStrangeTOFinV0, V0Type>::value) {
-        // A pion can belong to either a Lambda/Anti-Lambda decay or a K0s decay.
-        // We evaluate both applicable hypotheses based on charge sign and pick the best match.
-        double tofLa = (pid > 0) ? v0.tofNSigmaALaPi() : v0.tofNSigmaLaPi();
-        
-        passTOF = tofLa > cfgV0.cfgDaughPIDCutsTOFPi;
-      } else {
-        // Fallback to standard track TOF
-        passTOF = std::abs(track.tofNSigmaPi()) > cfgV0.cfgDaughPIDCutsTOFPi;
+      if (track.hasTOF()) {
+        if constexpr (std::experimental::is_detected<hasStrangeTOFinV0, V0Type>::value) {
+          // A pion can belong to either a Lambda/Anti-Lambda decay or a K0s decay.
+          // We evaluate both applicable hypotheses based on charge sign and pick the best match.
+          double tofLa = (pid > 0) ? v0.tofNSigmaALaPi() : v0.tofNSigmaLaPi();
+
+          passTOF = tofLa > cfgV0.cfgDaughPIDCutsTOFPi;
+        } else {
+          // Fallback to standard track TOF
+          passTOF = std::abs(track.tofNSigmaPi()) > cfgV0.cfgDaughPIDCutsTOFPi;
+        }
+      }
+
+      if ((std::abs(track.tpcNSigmaPi()) > cfgV0.cfgDaughPIDCutsTPCPi) || passTOF) {
+        return false;
       }
     }
 
-    if ((std::abs(track.tpcNSigmaPi()) > cfgV0.cfgDaughPIDCutsTPCPi) || passTOF) {
-      return false;
-    }
+    return true;
   }
-
-  return true;
-}
 
   // ========================================
-  // Efficiency calculation block 
+  // Efficiency calculation block
   // ========================================
   template <bool IsMc, typename CollisionType, typename V0, typename TrackType>
   void fillEffV0(CollisionType const& collision,
-                         V0 const& v0s,
-                         TrackType const&,
-                         aod::McParticles const& mcParticles)
+                 V0 const& v0s,
+                 TrackType const&,
+                 aod::McParticles const& mcParticles)
   {
     // Data-driven efficiency calculation for protons using Lambda
-      for (const auto& v0 : v0s) {
-        auto const& trackV0Pos = v0.template posTrack_as<TrackType>();
-        auto const& trackV0Neg = v0.template negTrack_as<TrackType>();
-        if (cfgV0.cfgIsCorrCollMatchV0 && ((v0.collisionId() != trackV0Pos.collisionId()) || (v0.collisionId() != trackV0Neg.collisionId()))) {
-          continue;
-        }
-
-        // Process Lambda (proton + pion)
-        if (std::abs(o2::constants::physics::MassLambda - v0.mLambda()) < cfgV0.cfgHypMassWindow) {
-          entryHadron(v0.mLambda(), trackV0Pos.eta(), trackV0Pos.pt() * trackV0Pos.sign(), 0, 0, v0.pt());
-          entryTrkPID(trackV0Pos.tpcNSigmaPr(), trackV0Pos.tpcNSigmaKa(), trackV0Pos.tpcNSigmaPi(), trackV0Pos.tofNSigmaPr(), trackV0Pos.tofNSigmaKa(), trackV0Pos.tofNSigmaPi());
-
-          if (isSelectedV0Daughter(trackV0Pos, v0, kProton) && isSelectedV0Daughter(trackV0Neg, v0, kPiMinus)) {
-            registry.fill(HIST("hV0Lambda"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
-            registry.fill(HIST("hV0LambdaRefl"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
-            registry.fill(HIST("hTPCnSigmaPr"), trackV0Pos.pt(), trackV0Pos.tpcNSigmaPr());
-
-            if (trackV0Pos.hasTOF()) {
-              registry.fill(HIST("hTOFnSigmaPr"), trackV0Pos.pt(), trackV0Pos.tofNSigmaPr());
-            }
-
-            if (passPIDSelection(trackV0Pos, cfgXicCand.trkPIDspecies, cfgXicCand.pidTPCMax, cfgXicCand.pidTOFMax, cfgXicCand.tofPIDThreshold, cfgXicCand.forceTOF)) {
-              registry.fill(HIST("hV0LambdaPiKRej"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
-              registry.fill(HIST("hV0LambdaReflPiKRej"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
-              registry.fill(HIST("hTPCnSigmaPrPiKRej"), trackV0Pos.pt(), trackV0Pos.tpcNSigmaPr());
-              if (trackV0Pos.hasTOF()) {
-                registry.fill(HIST("hTOFnSigmaPrPiKRej"), trackV0Pos.pt(), trackV0Pos.tofNSigmaPr());
-              }
-            }
-          }
-        }
-
-        if (std::abs(o2::constants::physics::MassLambda - v0.mAntiLambda()) < cfgV0.cfgHypMassWindow) {
-          entryHadron(v0.mAntiLambda(), trackV0Neg.eta(), trackV0Neg.pt() * trackV0Neg.sign(), 0, 0, v0.pt());
-          entryTrkPID(trackV0Neg.tpcNSigmaPr(), trackV0Neg.tpcNSigmaKa(), trackV0Neg.tpcNSigmaPi(), trackV0Neg.tofNSigmaPr(), trackV0Neg.tofNSigmaKa(), trackV0Neg.tofNSigmaPi());
-
-          if (isSelectedV0Daughter(trackV0Neg, v0, kProtonBar) && isSelectedV0Daughter(trackV0Pos, v0, kPiPlus)) {
-            registry.fill(HIST("hV0Lambda"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
-            registry.fill(HIST("hV0LambdaRefl"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
-            registry.fill(HIST("hTPCnSigmaPr"), trackV0Neg.pt(), trackV0Neg.tpcNSigmaPr());
-
-            if (trackV0Neg.hasTOF()) {
-              registry.fill(HIST("hTOFnSigmaPr"), trackV0Neg.pt(), trackV0Neg.tofNSigmaPr());
-            }
-
-            if (passPIDSelection(trackV0Neg, cfgXicCand.trkPIDspecies, cfgXicCand.pidTPCMax, cfgXicCand.pidTOFMax, cfgXicCand.tofPIDThreshold, cfgXicCand.forceTOF)) {
-              registry.fill(HIST("hV0LambdaPiKRej"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
-              registry.fill(HIST("hV0LambdaReflPiKRej"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
-              registry.fill(HIST("hTPCnSigmaPrPiKRej"), trackV0Neg.pt(), trackV0Neg.tpcNSigmaPr());
-              if (trackV0Neg.hasTOF()) {
-                registry.fill(HIST("hTOFnSigmaPrPiKRej"), trackV0Neg.pt(), trackV0Neg.tofNSigmaPr());
-              }
-            }
-          }
-        }
-
-        // MC-Reco specific V0 matching
-        if constexpr (IsMc) {
-          if (!v0.has_mcParticle() || !trackV0Pos.has_mcParticle() || !trackV0Neg.has_mcParticle()) {
-            continue;
-          }
-          auto const& v0Mc = v0.mcParticle();
-          auto const& partV0Pos = trackV0Pos.mcParticle();
-          auto const& partV0Neg = trackV0Neg.mcParticle();
-
-            if (v0Mc.pdgCode() == kLambda0) {
-              registry.fill(HIST("hV0LambdaMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
-              registry.fill(HIST("hV0LambdaReflMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
-              if (cfgV0.calEffV0 && v0Mc.isPhysicalPrimary() && v0Mc.producedByGenerator()) {
-              registry.fill(HIST("hV0PrimLambdaMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
-              registry.fill(HIST("hV0PrimLambdaReflMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
-              }
-
-              if (passPIDSelection(trackV0Pos, cfgXicCand.trkPIDspecies, cfgXicCand.pidTPCMax, cfgXicCand.pidTOFMax, cfgXicCand.tofPIDThreshold, cfgXicCand.forceTOF)) {
-                registry.fill(HIST("hV0LambdaPiKRejMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
-                registry.fill(HIST("hV0LambdaReflPiKRejMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
-              }
-            }
-            if (v0Mc.pdgCode() == kLambda0Bar) {
-              registry.fill(HIST("hV0LambdaMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
-              registry.fill(HIST("hV0LambdaReflMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
-
-              if (cfgV0.calEffV0 && v0Mc.isPhysicalPrimary() && v0Mc.producedByGenerator()) {
-              registry.fill(HIST("hV0PrimLambdaMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
-              registry.fill(HIST("hV0PrimLambdaReflMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
-              }
-              if (passPIDSelection(trackV0Neg, cfgXicCand.trkPIDspecies, cfgXicCand.pidTPCMax, cfgXicCand.pidTOFMax, cfgXicCand.tofPIDThreshold, cfgXicCand.forceTOF)) {
-                registry.fill(HIST("hV0LambdaPiKRejMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
-                registry.fill(HIST("hV0LambdaReflPiKRejMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
-              }
-            }
-
-          }
+    for (const auto& v0 : v0s) {
+      auto const& trackV0Pos = v0.template posTrack_as<TrackType>();
+      auto const& trackV0Neg = v0.template negTrack_as<TrackType>();
+      if (cfgV0.cfgIsCorrCollMatchV0 && ((v0.collisionId() != trackV0Pos.collisionId()) || (v0.collisionId() != trackV0Neg.collisionId()))) {
+        continue;
       }
 
-              if constexpr (IsMc) {
-                if (cfgV0.calEffV0){
+      // Process Lambda (proton + pion)
+      if (std::abs(o2::constants::physics::MassLambda - v0.mLambda()) < cfgV0.cfgHypMassWindow) {
+        entryHadron(v0.mLambda(), trackV0Pos.eta(), trackV0Pos.pt() * trackV0Pos.sign(), 0, 0, v0.pt());
+        entryTrkPID(trackV0Pos.tpcNSigmaPr(), trackV0Pos.tpcNSigmaKa(), trackV0Pos.tpcNSigmaPi(), trackV0Pos.tofNSigmaPr(), trackV0Pos.tofNSigmaKa(), trackV0Pos.tofNSigmaPi());
 
-                for (const auto& particle : mcParticles) {
+        if (isSelectedV0Daughter(trackV0Pos, v0, kProton) && isSelectedV0Daughter(trackV0Neg, v0, kPiMinus)) {
+          registry.fill(HIST("hV0Lambda"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
+          registry.fill(HIST("hV0LambdaRefl"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
+          registry.fill(HIST("hTPCnSigmaPr"), trackV0Pos.pt(), trackV0Pos.tpcNSigmaPr());
 
-        if (std::abs(particle.pdgCode()) != kLambda0) {
+          if (trackV0Pos.hasTOF()) {
+            registry.fill(HIST("hTOFnSigmaPr"), trackV0Pos.pt(), trackV0Pos.tofNSigmaPr());
+          }
+
+          if (passPIDSelection(trackV0Pos, cfgXicCand.trkPIDspecies, cfgXicCand.pidTPCMax, cfgXicCand.pidTOFMax, cfgXicCand.tofPIDThreshold, cfgXicCand.forceTOF)) {
+            registry.fill(HIST("hV0LambdaPiKRej"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
+            registry.fill(HIST("hV0LambdaReflPiKRej"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
+            registry.fill(HIST("hTPCnSigmaPrPiKRej"), trackV0Pos.pt(), trackV0Pos.tpcNSigmaPr());
+            if (trackV0Pos.hasTOF()) {
+              registry.fill(HIST("hTOFnSigmaPrPiKRej"), trackV0Pos.pt(), trackV0Pos.tofNSigmaPr());
+            }
+          }
+        }
+      }
+
+      if (std::abs(o2::constants::physics::MassLambda - v0.mAntiLambda()) < cfgV0.cfgHypMassWindow) {
+        entryHadron(v0.mAntiLambda(), trackV0Neg.eta(), trackV0Neg.pt() * trackV0Neg.sign(), 0, 0, v0.pt());
+        entryTrkPID(trackV0Neg.tpcNSigmaPr(), trackV0Neg.tpcNSigmaKa(), trackV0Neg.tpcNSigmaPi(), trackV0Neg.tofNSigmaPr(), trackV0Neg.tofNSigmaKa(), trackV0Neg.tofNSigmaPi());
+
+        if (isSelectedV0Daughter(trackV0Neg, v0, kProtonBar) && isSelectedV0Daughter(trackV0Pos, v0, kPiPlus)) {
+          registry.fill(HIST("hV0Lambda"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
+          registry.fill(HIST("hV0LambdaRefl"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
+          registry.fill(HIST("hTPCnSigmaPr"), trackV0Neg.pt(), trackV0Neg.tpcNSigmaPr());
+
+          if (trackV0Neg.hasTOF()) {
+            registry.fill(HIST("hTOFnSigmaPr"), trackV0Neg.pt(), trackV0Neg.tofNSigmaPr());
+          }
+
+          if (passPIDSelection(trackV0Neg, cfgXicCand.trkPIDspecies, cfgXicCand.pidTPCMax, cfgXicCand.pidTOFMax, cfgXicCand.tofPIDThreshold, cfgXicCand.forceTOF)) {
+            registry.fill(HIST("hV0LambdaPiKRej"), v0.mAntiLambda(), v0.pt(), trackV0Neg.pt());
+            registry.fill(HIST("hV0LambdaReflPiKRej"), v0.mLambda(), v0.pt(), trackV0Pos.pt());
+            registry.fill(HIST("hTPCnSigmaPrPiKRej"), trackV0Neg.pt(), trackV0Neg.tpcNSigmaPr());
+            if (trackV0Neg.hasTOF()) {
+              registry.fill(HIST("hTOFnSigmaPrPiKRej"), trackV0Neg.pt(), trackV0Neg.tofNSigmaPr());
+            }
+          }
+        }
+      }
+
+      // MC-Reco specific V0 matching
+      if constexpr (IsMc) {
+        if (!v0.has_mcParticle() || !trackV0Pos.has_mcParticle() || !trackV0Neg.has_mcParticle()) {
           continue;
         }
+        auto const& v0Mc = v0.mcParticle();
+        auto const& partV0Pos = trackV0Pos.mcParticle();
+        auto const& partV0Neg = trackV0Neg.mcParticle();
 
-        if (std::abs(particle.y()) > cfgXicCand.yCandMax) {
-          continue;
+        if (v0Mc.pdgCode() == kLambda0) {
+          registry.fill(HIST("hV0LambdaMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+          registry.fill(HIST("hV0LambdaReflMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+          if (cfgV0.calEffV0 && v0Mc.isPhysicalPrimary() && v0Mc.producedByGenerator()) {
+            registry.fill(HIST("hV0PrimLambdaMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+            registry.fill(HIST("hV0PrimLambdaReflMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+          }
+
+          if (passPIDSelection(trackV0Pos, cfgXicCand.trkPIDspecies, cfgXicCand.pidTPCMax, cfgXicCand.pidTOFMax, cfgXicCand.tofPIDThreshold, cfgXicCand.forceTOF)) {
+            registry.fill(HIST("hV0LambdaPiKRejMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+            registry.fill(HIST("hV0LambdaReflPiKRejMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+          }
         }
-        if (!particle.isPhysicalPrimary() || !particle.producedByGenerator()) {
-          continue;
+        if (v0Mc.pdgCode() == kLambda0Bar) {
+          registry.fill(HIST("hV0LambdaMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+          registry.fill(HIST("hV0LambdaReflMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+
+          if (cfgV0.calEffV0 && v0Mc.isPhysicalPrimary() && v0Mc.producedByGenerator()) {
+            registry.fill(HIST("hV0PrimLambdaMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+            registry.fill(HIST("hV0PrimLambdaReflMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+          }
+          if (passPIDSelection(trackV0Neg, cfgXicCand.trkPIDspecies, cfgXicCand.pidTPCMax, cfgXicCand.pidTOFMax, cfgXicCand.tofPIDThreshold, cfgXicCand.forceTOF)) {
+            registry.fill(HIST("hV0LambdaPiKRejMcRec"), v0.mAntiLambda(), v0.pt(), partV0Neg.pt());
+            registry.fill(HIST("hV0LambdaReflPiKRejMcRec"), v0.mLambda(), v0.pt(), partV0Pos.pt());
+          }
         }
+      }
+    }
 
+    if constexpr (IsMc) {
+      if (cfgV0.calEffV0) {
 
-    auto daughterParts = particle.daughters_as<aod::McParticles>();
-    const int8_t NdaughtersV0 = 2;
+        for (const auto& particle : mcParticles) {
 
-    if (daughterParts.size() != NdaughtersV0) {
-          continue;
-        }
-
-        for (const auto& currentDaughter : daughterParts) {
-
-          if (std::abs(currentDaughter.eta()) > cfgXicCand.etaTrackMax) {
+          if (std::abs(particle.pdgCode()) != kLambda0) {
             continue;
           }
 
-          if (std::abs(currentDaughter.pdgCode()) == kProton ){
+          if (std::abs(particle.y()) > cfgXicCand.yCandMax) {
+            continue;
+          }
+          if (!particle.isPhysicalPrimary() || !particle.producedByGenerator()) {
+            continue;
+          }
 
-            if (currentDaughter.pt() > cfgV0.cfgDaughPrPtMax || currentDaughter.pt() < cfgV0.cfgDaughPrPtMin) {
-             continue;
-                      }
+          auto daughterParts = particle.daughters_as<aod::McParticles>();
+          const int8_t NdaughtersV0 = 2;
 
-          } else if (std::abs(currentDaughter.pdgCode()) == kPiPlus ){
-                    if (currentDaughter.pt() > cfgV0.cfgDaughPiPtMax || currentDaughter.pt() < cfgV0.cfgDaughPiPtMin) {
-                     continue;
+          if (daughterParts.size() != NdaughtersV0) {
+            continue;
+          }
+
+          for (const auto& currentDaughter : daughterParts) {
+
+            if (std::abs(currentDaughter.eta()) > cfgXicCand.etaTrackMax) {
+              continue;
             }
 
-          } else {
-            continue;
-          }
-          
+            if (std::abs(currentDaughter.pdgCode()) == kProton) {
+
+              if (currentDaughter.pt() > cfgV0.cfgDaughPrPtMax || currentDaughter.pt() < cfgV0.cfgDaughPrPtMin) {
+                continue;
+              }
+
+            } else if (std::abs(currentDaughter.pdgCode()) == kPiPlus) {
+              if (currentDaughter.pt() > cfgV0.cfgDaughPiPtMax || currentDaughter.pt() < cfgV0.cfgDaughPiPtMin) {
+                continue;
+              }
+
+            } else {
+              continue;
+            }
           }
           registry.fill(HIST("hV0PtPrimLambdaMcGen"), particle.pt());
-    
-          }
         }
       }
-
+    }
   }
 
   // ============================================================================
@@ -1460,8 +1454,8 @@ using hasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
           }
         } else {
 
-          auto const&  trackV0Pos = assocParticle.template posTrack_as<TrackType>();
-          auto const&  trackV0Neg = assocParticle.template negTrack_as<TrackType>();
+          auto const& trackV0Pos = assocParticle.template posTrack_as<TrackType>();
+          auto const& trackV0Neg = assocParticle.template negTrack_as<TrackType>();
 
           if (std::abs(o2::constants::physics::MassLambda - assocParticle.mLambda()) < cfgV0.cfgHypMassWindow) {
             if (isSelectedV0Daughter(trackV0Pos, assocParticle, kProton) && isSelectedV0Daughter(trackV0Neg, assocParticle, kPiPlus)) {
@@ -1531,7 +1525,6 @@ using hasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
       registry.fill(HIST("hEtaMcGen"), particle.eta());
       registry.fill(HIST("hPhiMcGen"), RecoDecay::constrainAngle(particle.phi(), -PIHalf));
       registry.fill(HIST("hYMcGen"), yCand);
-
 
       isPrompt = particle.originMcGen() == RecoDecay::OriginType::Prompt;
       isNonPrompt = particle.originMcGen() == RecoDecay::OriginType::NonPrompt;
@@ -1703,11 +1696,11 @@ using hasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
   }
   PROCESS_SWITCH(HfCorrelatorXicHadrons, processMcRecXic0V0, "Mc process for v0 lambda with Xic0", false);
 
-    /// MC Reco processing: Xic0 with V0 Lambda
+  /// MC Reco processing: Xic0 with V0 Lambda
   void processV0McRec(SelCollisions::iterator const& collision,
-                          TracksWithMc const& tracks,
-                          soa::Join<aod::V0Datas, aod::McV0Labels> const& v0s,
-                          aod::McParticles const& mcParticles)
+                      TracksWithMc const& tracks,
+                      soa::Join<aod::V0Datas, aod::McV0Labels> const& v0s,
+                      aod::McParticles const& mcParticles)
   {
     fillEffV0<true>(collision, v0s, tracks, mcParticles);
   }

--- a/PWGHF/HFC/Utils/utilsCorrelations.h
+++ b/PWGHF/HFC/Utils/utilsCorrelations.h
@@ -96,7 +96,7 @@ bool passPIDSelection(Atrack const& track, SpeciesContainer const mPIDspecies,
     auto const& pid = mPIDspecies->at(speciesIndex);
     auto nSigmaTPC = o2::aod::pidutils::tpcNSigma(pid, track);
 
-    if ((track.pt() > ptThreshold) && !track.hasTOF()) {
+    if (tofForced && !track.hasTOF()) {
       return false;
     }
 

--- a/PWGHF/HFC/Utils/utilsCorrelations.h
+++ b/PWGHF/HFC/Utils/utilsCorrelations.h
@@ -96,7 +96,7 @@ bool passPIDSelection(Atrack const& track, SpeciesContainer const mPIDspecies,
     auto const& pid = mPIDspecies->at(speciesIndex);
     auto nSigmaTPC = o2::aod::pidutils::tpcNSigma(pid, track);
 
-    if (tofForced && !track.hasTOF()) {
+    if ((track.pt() > ptThreshold) && !track.hasTOF()) {
       return false;
     }
 


### PR DESCRIPTION
- Add column and table for reflected V0 mass
- efficiency block initially was the part of same event correlation block, now separated out
- added strange TOF information for lambda0 daughters