### PR TITLE
[PWGJE] Adding centrality dependency for recoil jets

### DIFF
--- a/PWGJE/Tasks/recoilJets.cxx
+++ b/PWGJE/Tasks/recoilJets.cxx
@@ -198,6 +198,8 @@ struct RecoilJets {
 
     ConfigurableAxis multFT0MThresh{"multFT0MThresh", {VARIABLE_WIDTH, 0.0, 0.167, 0.267, 0.4, 0.567, 0.8, 1.067, 1.4, 1.833, 2.433, 3.667, 5.1, 6.433, 20.}, "Percentiles of scaled FT0M: 100%, 90%, 80%, 70%, 60%, 50%, 40%, 30%, 20%, 10%, 1%, 0.1%, 0.01%"}; // default values for raw data
     ConfigurableAxis multFT0MThreshPartLevel{"multFT0MThreshPartLevel", {VARIABLE_WIDTH, 0.0, 0.167, 0.267, 0.4, 0.567, 0.8, 1.067, 1.4, 1.833, 2.433, 3.667, 5.1, 6.433, 20.}, "Percentiles of scaled FT0M: 100%, 90%, 80%, 70%, 60%, 50%, 40%, 30%, 20%, 10%, 1%, 0.1%, 0.01%"};
+
+    ConfigurableAxis axisPtTrackEff{"axisPtTrackEff", {VARIABLE_WIDTH, 0.15, 0.2, 0.25, 0.3, 0.4, 0.5, 0.6, 0.8, 1.0, 1.2, 1.5, 2.0, 2.5, 3.0, 4.0, 5.0, 6.0, 8.0, 10.0, 12.0, 15.0, 20.0, 25.0, 30.0, 40.0, 50.0, 70.0, 100.0}, "#it{p}_{T} (GeV/#it{c})"};
   } hist;
 
   // Auxiliary variables
@@ -223,7 +225,8 @@ struct RecoilJets {
   std::vector<int> triggerMaskBits;
 
   Service<o2::framework::O2DatabasePDG> pdg;
-  Preslice<MatchedJetsPartToDetTbl> partJetsPerMcCollision = aod::jet::mcCollisionId;
+  Preslice<MatchedJetsPartToDetTbl> partJetsByMcCollision = aod::jet::mcCollisionId;
+  Preslice<aod::JetParticles> particlesByMcCollision = aod::jet::mcCollisionId;
 
   template <typename AxisObject>
   struct AxisDesc {
@@ -284,10 +287,10 @@ struct RecoilJets {
                                                                 {"FT0C", unscaledFT0C},
                                                                 {"FT0M", unscaledFT0M}}};
 
-    std::array<AxisDesc<ConfigurableAxis>, 2> arrConfigurableAxis = {{{"FT0C", hist.multFT0CThresh, nameFT0Caxis},
+    std::array<AxisDesc<ConfigurableAxis>, 2> arrConfigurableAxisEA = {{{"FT0C", hist.multFT0CThresh, nameFT0Caxis},
                                                                       {"FT0M", hist.multFT0MThresh, nameFT0Maxis}}};
 
-    std::array<AxisDesc<ConfigurableAxis>, 2> arrConfigurableAxisPartLevel = {{{"FT0C", hist.multFT0CThreshPartLevel, nameFT0Caxis},
+    std::array<AxisDesc<ConfigurableAxis>, 2> arrConfigurableAxisEAPartLevel = {{{"FT0C", hist.multFT0CThreshPartLevel, nameFT0Caxis},
                                                                                {"FT0M", hist.multFT0MThreshPartLevel, nameFT0Maxis}}};
 
     // Zero-degree calorimeter
@@ -329,7 +332,7 @@ struct RecoilJets {
       spectra.add("hJetArea_JetPt_Rho_TTRef", "Events w. TT_{Ref}: A_{jet} & jet pT & #rho", kTH3F, {jetArea, pT, rho}, hist.sumw2);
       spectra.add("hJetArea_JetPt_Rho_TTSig", "Events w. TT_{Sig}: A_{jet} & jet pT & #rho", kTH3F, {jetArea, pT, rho}, hist.sumw2);
 
-      for (const auto& eaAxis : arrConfigurableAxis) {
+      for (const auto& eaAxis : arrConfigurableAxisEA) {
         spectra.add(Form("hScaled%s_vertexZ", eaAxis.label),
                     "Z vertex of collisions",
                     kTH2F, {{eaAxis.axis, eaAxis.axisName}, {60, -12., 12., "#it{z}_{vertex}"}}, hist.sumw2);
@@ -430,7 +433,7 @@ struct RecoilJets {
       spectra.add("hJetArea_JetPt_Rho_TTRef_Part", "Events w. TT_{Ref}: A_{jet} & jet pT & #rho", kTH3F, {jetArea, pT, rho}, hist.sumw2);
       spectra.add("hJetArea_JetPt_Rho_TTSig_Part", "Events w. TT_{Sig}: A_{jet} & jet pT & #rho", kTH3F, {jetArea, pT, rho}, hist.sumw2);
 
-      for (const auto& eaAxis : arrConfigurableAxisPartLevel) {
+      for (const auto& eaAxis : arrConfigurableAxisEAPartLevel) {
         spectra.add(Form("hScaled%s_vertexZMC", eaAxis.label),
                     "Z vertex of MC collision",
                     kTH2F, {{eaAxis.axis, eaAxis.axisName}, {60, -12., 12., "#it{z}_{vertex}"}}, hist.sumw2);
@@ -665,9 +668,9 @@ struct RecoilJets {
                     kTH1F, {eaAxis.axis}, hist.sumw2);
       }
 
-      spectra.add("hScaleMultFT0A", "Scaled FTOA signal", kTH1F, {scaledFT0A}, hist.sumw2);
+      spectra.add("hScaledMultFT0A", "Scaled FTOA signal", kTH1F, {scaledFT0A}, hist.sumw2);
       for (const auto& eaAxis : arrAxisSpecScaledEA) {
-        spectra.add(Form("hScaleMult%s", eaAxis.label),
+        spectra.add(Form("hScaledMult%s", eaAxis.label),
                     Form("Scaled %s signal", eaAxis.label),
                     kTH1F, {eaAxis.axis}, hist.sumw2);
       }
@@ -697,24 +700,24 @@ struct RecoilJets {
                     kTH2F, {{arrAxisSpecUnscaledEA[i].axis}, {arrAxisSpecZDCNeutron[i].axis}}, hist.sumw2);
 
         if (i != 0) {
-          spectra.add(Form("hScaleMult%s_vs_%s", arrAxisSpecScaledEA[i - 1].label, arrAxisSpecZDCNeutron[i].label),
+          spectra.add(Form("hScaledMult%s_vs_%s", arrAxisSpecScaledEA[i - 1].label, arrAxisSpecZDCNeutron[i].label),
                       Form("Correlation of signals scaled %s vs %s", arrAxisSpecScaledEA[i - 1].label, arrAxisSpecZDCNeutron[i].label),
                       kTH2F, {{arrAxisSpecScaledEA[i - 1].axis}, {arrAxisSpecZDCNeutron[i].axis}}, hist.sumw2);
 
-          spectra.add(Form("hScaleMult%s_vs_%s", arrAxisSpecScaledEA[i - 1].label, arrAxisSpecZDCProton[i].label),
+          spectra.add(Form("hScaledMult%s_vs_%s", arrAxisSpecScaledEA[i - 1].label, arrAxisSpecZDCProton[i].label),
                       Form("Correlation of signals scaled %s vs %s", arrAxisSpecScaledEA[i - 1].label, arrAxisSpecZDCProton[i].label),
                       kTH2F, {{arrAxisSpecScaledEA[i - 1].axis}, {arrAxisSpecZDCProton[i].axis}}, hist.sumw2);
         } else {
-          spectra.add("hScaleMultFT0A_vs_ZNA", "Correlation of signals scaled FT0A vs ZNA", kTH2F, {{scaledFT0A}, {arrAxisSpecZDCNeutron[i].axis}}, hist.sumw2);
-          spectra.add("hScaleMultFT0A_vs_ZPA", "Correlation of signals scaled FT0A vs ZPA", kTH2F, {{scaledFT0A}, {arrAxisSpecZDCProton[i].axis}}, hist.sumw2);
+          spectra.add("hScaledMultFT0A_vs_ZNA", "Correlation of signals scaled FT0A vs ZNA", kTH2F, {{scaledFT0A}, {arrAxisSpecZDCNeutron[i].axis}}, hist.sumw2);
+          spectra.add("hScaledMultFT0A_vs_ZPA", "Correlation of signals scaled FT0A vs ZPA", kTH2F, {{scaledFT0A}, {arrAxisSpecZDCProton[i].axis}}, hist.sumw2);
         }
       }
 
-      spectra.add("hScaleMultFT0M_vs_ZNA_vs_ZNC",
+      spectra.add("hScaledMultFT0M_vs_ZNA_vs_ZNC",
                   "Correlation of signals FT0M^{*} vs ZNA vs ZNC",
                   kTH3F, {{scaledFT0M}, {600, 0.0, 3000., "ZNA"}, {600, 0.0, 3000., "ZNC"}}, hist.sumw2);
 
-      spectra.add("hScaleMultFT0M_vs_ZPA_vs_ZPC",
+      spectra.add("hScaledMultFT0M_vs_ZPA_vs_ZPC",
                   "Correlation of signals FT0M^{*} vs ZPA vs ZPC",
                   kTH3F, {{scaledFT0M}, {600, 0.0, 3000., "ZPA"}, {600, 0.0, 3000., "ZPC"}}, hist.sumw2);
     }
@@ -725,9 +728,9 @@ struct RecoilJets {
       spectra.add("hMultFT0CPartLevel", "# of primary particles within FTOC acceptance", kTH1F, {{2000, 0.0, 1000., "FT0C"}}, hist.sumw2);
       spectra.add("hMultFT0MPartLevel", "Total # of primary particles from FT0A & FTOC", kTH1F, {{4000, 0.0, 2000., "FT0M"}}, hist.sumw2);
 
-      spectra.add("hScaleMultFT0APartLevel", "Scaled # of primary particles within FTOA acceptance", kTH1F, {{scaledFT0A}}, hist.sumw2);
+      spectra.add("hScaledMultFT0APartLevel", "Scaled # of primary particles within FTOA acceptance", kTH1F, {{scaledFT0A}}, hist.sumw2);
       for (const auto& eaAxis : arrAxisSpecScaledEA) {
-        spectra.add(Form("hScaleMult%sPartLevel", eaAxis.label),
+        spectra.add(Form("hScaledMult%sPartLevel", eaAxis.label),
                     Form("Scaled # of primary particles within %s acceptance", eaAxis.label),
                     kTH1F, {{eaAxis.axis}}, hist.sumw2);
       }
@@ -914,15 +917,15 @@ struct RecoilJets {
       //====================================================================================
       // Signal TT
       for (const auto& eaAxis : arrAxisSpecScaledEA) {
-        spectra.add(Form("hScaleMult%s_PtSmearingTTSig", eaAxis.label),
+        spectra.add(Form("hScaledMult%s_PtSmearingTTSig", eaAxis.label),
                     Form("#it{p}_{T} smearing of TT_{Sig} vs %s", eaAxis.label),
                     kTH3F, {{eaAxis.axis}, {relPtSmearTT}, {partPtTTSig}}, hist.sumw2);
 
-        spectra.add(Form("hScaleMult%s_PhiSmearingTTSig", eaAxis.label),
+        spectra.add(Form("hScaledMult%s_PhiSmearingTTSig", eaAxis.label),
                     Form("#it{#varphi} smearing of TT_{Sig} vs %s", eaAxis.label),
                     kTH3F, {{eaAxis.axis}, {smearPhi}, {partPtTTSig}}, hist.sumw2);
 
-        spectra.add(Form("hScaleMult%s_EtaSmearingTTSig", eaAxis.label),
+        spectra.add(Form("hScaledMult%s_EtaSmearingTTSig", eaAxis.label),
                     Form("#it{#eta} smearing of TT_{Sig} vs %s", eaAxis.label),
                     kTH3F, {{eaAxis.axis}, {smearEta}, {partPtTTSig}}, hist.sumw2);
 
@@ -937,17 +940,62 @@ struct RecoilJets {
 
       // Reference TT
       for (const auto& eaAxis : arrAxisSpecScaledEA) {
-        spectra.add(Form("hScaleMult%s_PtSmearingTTRef", eaAxis.label),
+        spectra.add(Form("hScaledMult%s_PtSmearingTTRef", eaAxis.label),
                     Form("#it{p}_{T} smearing of TT_{Ref} vs %s", eaAxis.label),
                     kTH3F, {{eaAxis.axis}, {relPtSmearTT}, {partPtTTRef}}, hist.sumw2);
 
-        spectra.add(Form("hScaleMult%s_PhiSmearingTTRef", eaAxis.label),
+        spectra.add(Form("hScaledMult%s_PhiSmearingTTRef", eaAxis.label),
                     Form("#it{#varphi} smearing of TT_{Ref} vs %s", eaAxis.label),
                     kTH3F, {{eaAxis.axis}, {smearPhi}, {partPtTTRef}}, hist.sumw2);
 
-        spectra.add(Form("hScaleMult%s_EtaSmearingTTRef", eaAxis.label),
+        spectra.add(Form("hScaledMult%s_EtaSmearingTTRef", eaAxis.label),
                     Form("#it{#eta} smearing of TT_{Ref} vs %s", eaAxis.label),
                     kTH3F, {{eaAxis.axis}, {smearEta}, {partPtTTRef}}, hist.sumw2);
+      }
+    }
+
+    // Tracking efficiency as a function of EA / Centrality
+    if(doprocessTrackingEfficiency || doprocessTrackingEfficiencyWeighted)
+    {
+      for (const auto& eaAxis : arrConfigurableAxisEA)
+      {
+        // ------------------------------------------------------------------
+        // Denominator: all generated particles passing phase-space cuts
+        // ------------------------------------------------------------------
+        spectra.add(Form("hScaledMult%s_AllGeneratedParticlesPt", eaAxis.label),
+                    Form("Generated & selected particles; %s ; #it{p}_{T}^{part} (GeV/#it{c})", eaAxis.label),
+                    kTH2F, {{eaAxis.axis, eaAxis.axisName}, {hist.axisPtTrackEff, "#it{p}_{T}^{part}"}}, hist.sumw2);
+
+
+        // ------------------------------------------------------------------
+        // Track has an associated MC particle,
+        // the particle belongs to the same MC collision,
+        // and the particle passes the generated-particle selection.
+        // ------------------------------------------------------------------
+        spectra.add(Form("hScaledMult%s_ResponseMatrixTrackEff", eaAxis.label),
+                    Form("Track eff.; %s; #it{p}_{T}^{rec}; #it{p}_{T}^{part}", eaAxis.label),
+                    kTH3F, {{eaAxis.axis, eaAxis.axisName}, {hist.axisPtTrackEff, "#it{p}_{T}^{rec}"}, {hist.axisPtTrackEff, "#it{p}_{T}^{part}"}}, hist.sumw2);
+
+
+        // ------------------------------------------------------------------
+        // Fake reconstructed tracks
+
+        // Case 1: no associated MC particle
+        spectra.add(Form("hScaledMult%s_NoMcParticle", eaAxis.label),
+                    Form("Tracks without associated MC particle; %s; #it{p}_{T}^{rec} (GeV/#it{c})", eaAxis.label),
+                    kTH2F, {{eaAxis.axis, eaAxis.axisName}, {hist.axisPtTrackEff, "#it{p}_{T}^{rec}"}}, hist.sumw2);
+
+
+        // Case 2: MC particle exists, but belongs to another MC collision
+        spectra.add(Form("hScaledMult%s_MismatchedMcCollisionTracks", eaAxis.label),
+                    Form("Tracks matched to particle from different MC collision; %s; #it{p}_{T}^{rec} (GeV/#it{c})", eaAxis.label),
+                    kTH2F, {{eaAxis.axis, eaAxis.axisName}, {hist.axisPtTrackEff, "#it{p}_{T}^{rec}"}}, hist.sumw2);
+
+
+        // Case 3: same MC collision, but particle fails phase-space cuts
+        spectra.add(Form("hScaledMult%s_MatchedToRejectedTracks", eaAxis.label),
+                    Form("Tracks matched to rejected particle; %s; #it{p}_{T}^{rec} (GeV/#it{c})", eaAxis.label),
+                    kTH2F, {{eaAxis.axis, eaAxis.axisName}, {hist.axisPtTrackEff, "#it{p}_{T}^{rec} (GeV/#it{c})"}}, hist.sumw2);
       }
     }
   }
@@ -1523,9 +1571,9 @@ struct RecoilJets {
     spectra.fill(HIST("hMultFT0C"), multFT0C, weight);
     spectra.fill(HIST("hMultFT0M"), multFT0M, weight);
 
-    spectra.fill(HIST("hScaleMultFT0A"), scaledFT0A, weight);
-    spectra.fill(HIST("hScaleMultFT0C"), scaledFT0C, weight);
-    spectra.fill(HIST("hScaleMultFT0M"), scaledFT0M, weight);
+    spectra.fill(HIST("hScaledMultFT0A"), scaledFT0A, weight);
+    spectra.fill(HIST("hScaledMultFT0C"), scaledFT0C, weight);
+    spectra.fill(HIST("hScaledMultFT0M"), scaledFT0M, weight);
 
     spectra.fill(HIST("hMultZNA"), multZNA, weight);
     spectra.fill(HIST("hMultZNC"), multZNC, weight);
@@ -1543,16 +1591,16 @@ struct RecoilJets {
     spectra.fill(HIST("hMultFT0C_vs_ZNC"), multFT0C, multZNC, weight);
     spectra.fill(HIST("hMultFT0M_vs_ZNM"), multFT0M, multZNM, weight);
 
-    spectra.fill(HIST("hScaleMultFT0A_vs_ZNA"), scaledFT0A, multZNA, weight);
-    spectra.fill(HIST("hScaleMultFT0C_vs_ZNC"), scaledFT0C, multZNC, weight);
-    spectra.fill(HIST("hScaleMultFT0M_vs_ZNM"), scaledFT0M, multZNM, weight);
+    spectra.fill(HIST("hScaledMultFT0A_vs_ZNA"), scaledFT0A, multZNA, weight);
+    spectra.fill(HIST("hScaledMultFT0C_vs_ZNC"), scaledFT0C, multZNC, weight);
+    spectra.fill(HIST("hScaledMultFT0M_vs_ZNM"), scaledFT0M, multZNM, weight);
 
-    spectra.fill(HIST("hScaleMultFT0A_vs_ZPA"), scaledFT0A, multZPA, weight);
-    spectra.fill(HIST("hScaleMultFT0C_vs_ZPC"), scaledFT0C, multZPC, weight);
-    spectra.fill(HIST("hScaleMultFT0M_vs_ZPM"), scaledFT0M, multZPM, weight);
+    spectra.fill(HIST("hScaledMultFT0A_vs_ZPA"), scaledFT0A, multZPA, weight);
+    spectra.fill(HIST("hScaledMultFT0C_vs_ZPC"), scaledFT0C, multZPC, weight);
+    spectra.fill(HIST("hScaledMultFT0M_vs_ZPM"), scaledFT0M, multZPM, weight);
 
-    spectra.fill(HIST("hScaleMultFT0M_vs_ZNA_vs_ZNC"), scaledFT0M, multZNA, multZNC, weight);
-    spectra.fill(HIST("hScaleMultFT0M_vs_ZPA_vs_ZPC"), scaledFT0M, multZPA, multZPC, weight);
+    spectra.fill(HIST("hScaledMultFT0M_vs_ZNA_vs_ZNC"), scaledFT0M, multZNA, multZNC, weight);
+    spectra.fill(HIST("hScaledMultFT0M_vs_ZPA_vs_ZPC"), scaledFT0M, multZPA, multZPC, weight);
   }
 
   template <typename JCollisionMC>
@@ -1564,9 +1612,9 @@ struct RecoilJets {
     spectra.fill(HIST("hMultFT0CPartLevel"), ft0Metrics.multFT0C, weight);
     spectra.fill(HIST("hMultFT0MPartLevel"), ft0Metrics.multFT0M, weight);
 
-    spectra.fill(HIST("hScaleMultFT0APartLevel"), ft0Metrics.scaledFT0A, weight);
-    spectra.fill(HIST("hScaleMultFT0CPartLevel"), ft0Metrics.scaledFT0C, weight);
-    spectra.fill(HIST("hScaleMultFT0MPartLevel"), ft0Metrics.scaledFT0M, weight);
+    spectra.fill(HIST("hScaledMultFT0APartLevel"), ft0Metrics.scaledFT0A, weight);
+    spectra.fill(HIST("hScaledMultFT0CPartLevel"), ft0Metrics.scaledFT0C, weight);
+    spectra.fill(HIST("hScaledMultFT0MPartLevel"), ft0Metrics.scaledFT0M, weight);
   }
 
   //=============================================================================
@@ -2214,7 +2262,7 @@ struct RecoilJets {
       return;
 
     // No filter on Particles, it can be outside of |eta| acceptance
-    auto particle = tracks.iteratorAt(chosenTTPos).mcParticle_as<JParticles>();
+    auto particle = tracks.iteratorAt(chosenTTPos).template mcParticle_as<JParticles>();
     float particleEta = particle.eta();
     bool bPartWithinEta = std::fabs(particleEta) < trk.etaCut;
 
@@ -2255,23 +2303,102 @@ struct RecoilJets {
     float etaSmearing = particleEta - tracks.iteratorAt(chosenTTPos).eta();
 
     if (bSigEv) {
-      spectra.fill(HIST("hScaleMultFT0C_PtSmearingTTSig"), scaledFT0C, relPtSmearing, particlePt, weight);
-      spectra.fill(HIST("hScaleMultFT0M_PtSmearingTTSig"), scaledFT0M, relPtSmearing, particlePt, weight);
+      spectra.fill(HIST("hScaledMultFT0C_PtSmearingTTSig"), scaledFT0C, relPtSmearing, particlePt, weight);
+      spectra.fill(HIST("hScaledMultFT0M_PtSmearingTTSig"), scaledFT0M, relPtSmearing, particlePt, weight);
 
-      spectra.fill(HIST("hScaleMultFT0C_PhiSmearingTTSig"), scaledFT0C, phiSmearing, particlePt, weight);
-      spectra.fill(HIST("hScaleMultFT0M_PhiSmearingTTSig"), scaledFT0M, phiSmearing, particlePt, weight);
+      spectra.fill(HIST("hScaledMultFT0C_PhiSmearingTTSig"), scaledFT0C, phiSmearing, particlePt, weight);
+      spectra.fill(HIST("hScaledMultFT0M_PhiSmearingTTSig"), scaledFT0M, phiSmearing, particlePt, weight);
 
-      spectra.fill(HIST("hScaleMultFT0C_EtaSmearingTTSig"), scaledFT0C, etaSmearing, particlePt, weight);
-      spectra.fill(HIST("hScaleMultFT0M_EtaSmearingTTSig"), scaledFT0M, etaSmearing, particlePt, weight);
+      spectra.fill(HIST("hScaledMultFT0C_EtaSmearingTTSig"), scaledFT0C, etaSmearing, particlePt, weight);
+      spectra.fill(HIST("hScaledMultFT0M_EtaSmearingTTSig"), scaledFT0M, etaSmearing, particlePt, weight);
     } else {
-      spectra.fill(HIST("hScaleMultFT0C_PtSmearingTTRef"), scaledFT0C, relPtSmearing, particlePt, weight);
-      spectra.fill(HIST("hScaleMultFT0M_PtSmearingTTRef"), scaledFT0M, relPtSmearing, particlePt, weight);
+      spectra.fill(HIST("hScaledMultFT0C_PtSmearingTTRef"), scaledFT0C, relPtSmearing, particlePt, weight);
+      spectra.fill(HIST("hScaledMultFT0M_PtSmearingTTRef"), scaledFT0M, relPtSmearing, particlePt, weight);
 
-      spectra.fill(HIST("hScaleMultFT0C_PhiSmearingTTRef"), scaledFT0C, phiSmearing, particlePt, weight);
-      spectra.fill(HIST("hScaleMultFT0M_PhiSmearingTTRef"), scaledFT0M, phiSmearing, particlePt, weight);
+      spectra.fill(HIST("hScaledMultFT0C_PhiSmearingTTRef"), scaledFT0C, phiSmearing, particlePt, weight);
+      spectra.fill(HIST("hScaledMultFT0M_PhiSmearingTTRef"), scaledFT0M, phiSmearing, particlePt, weight);
 
-      spectra.fill(HIST("hScaleMultFT0C_EtaSmearingTTRef"), scaledFT0C, etaSmearing, particlePt, weight);
-      spectra.fill(HIST("hScaleMultFT0M_EtaSmearingTTRef"), scaledFT0M, etaSmearing, particlePt, weight);
+      spectra.fill(HIST("hScaledMultFT0C_EtaSmearingTTRef"), scaledFT0C, etaSmearing, particlePt, weight);
+      spectra.fill(HIST("hScaledMultFT0M_EtaSmearingTTRef"), scaledFT0M, etaSmearing, particlePt, weight);
+    }
+  }
+
+  //=============================================================================
+  // Track reconstruction efficiency as a function of EA / Centrality
+  //=============================================================================
+  template <typename JMcColl, typename JParticles, typename JColl, typename JTracks>
+  void fillTrackRecoEff(JColl const& collision,
+                        JTracks const& tracks,
+                        JParticles const& particles,
+                        float weight = 1.)
+  {
+    const auto ft0Metrics = getFT0Metrics(collision, ft0a.mean, ft0c.mean);
+    const auto scaledFT0C = ft0Metrics.scaledFT0C;
+    const auto scaledFT0M = ft0Metrics.scaledFT0M;
+    const auto mcCollisionId = collision.mcCollisionId();
+
+    // Numerator candidates: reconstructed tracks in this detector collision
+    for(const auto& trackPerColl : tracks)
+    {
+      if (skipTrack(trackPerColl))
+        continue;
+
+      auto trackPt = trackPerColl.pt();
+
+      // Case 1: no associated MC particle
+      if(!trackPerColl.has_mcParticle())
+      { 
+        spectra.fill(HIST("hScaledMultFT0C_NoMcParticle"), scaledFT0C, trackPt, weight);
+        spectra.fill(HIST("hScaledMultFT0M_NoMcParticle"), scaledFT0M, trackPt, weight);
+        continue;
+      }
+
+
+      // Case 2: MC particle exists, but belongs to another MC collision
+      auto particle = trackPerColl.mcParticle();
+      if(particle.mcCollisionId() != mcCollisionId)
+      {
+        spectra.fill(HIST("hScaledMultFT0C_MismatchedMcCollisionTracks"), scaledFT0C, trackPt, weight);
+        spectra.fill(HIST("hScaledMultFT0M_MismatchedMcCollisionTracks"), scaledFT0M, trackPt, weight);
+        continue;
+      }
+
+      
+      // Case 3: same MC collision, but particle fails phase-space cuts
+      float particleEta = particle.eta();
+      bool bKeepParticle = std::fabs(particleEta) < trk.etaCut && !skipParticle(particle);
+
+      if(!bKeepParticle)
+      {
+        spectra.fill(HIST("hScaledMultFT0C_MatchedToRejectedTracks"), scaledFT0C, trackPt, weight);
+        spectra.fill(HIST("hScaledMultFT0M_MatchedToRejectedTracks"), scaledFT0M, trackPt, weight);
+        continue;
+      }
+
+
+      // Track has an associated MC particle,
+      // the particle belongs to the same MC collision,
+      // and the particle passes the generated-particle selection.
+      float particlePt = particle.pt();
+      spectra.fill(HIST("hScaledMultFT0C_ResponseMatrixTrackEff"), scaledFT0C, trackPt, particlePt, weight);
+      spectra.fill(HIST("hScaledMultFT0M_ResponseMatrixTrackEff"), scaledFT0M, trackPt, particlePt, weight);
+    }
+     
+
+    // Denominator: generated selected particles from the same MC collision
+    auto particlesInMcCollision = particles.sliceBy(particlesByMcCollision, mcCollisionId);
+
+    for(const auto& particleInMcCollision : particlesInMcCollision)
+    {
+      float particleEta = particleInMcCollision.eta();
+      float particlePt = particleInMcCollision.pt();
+      bool bKeepParticle = std::fabs(particleEta) < trk.etaCut && !skipParticle(particleInMcCollision);
+
+      if(!bKeepParticle)
+        continue;
+      
+      spectra.fill(HIST("hScaledMultFT0C_AllGeneratedParticlesPt"), scaledFT0C, particlePt, weight);
+      spectra.fill(HIST("hScaledMultFT0M_AllGeneratedParticlesPt"), scaledFT0M, particlePt, weight);
     }
   }
 
@@ -2404,7 +2531,7 @@ struct RecoilJets {
 
     // Slice for mc part level jets associated to a given mcCollisionId
     auto mcCollisionId = collision.mcCollisionId();
-    auto mcPartJetsPerMcCollision = mcPartJets.sliceBy(partJetsPerMcCollision, mcCollisionId); // signature: (__column to slice___, __index__)
+    auto mcPartJetsPerMcCollision = mcPartJets.sliceBy(partJetsByMcCollision, mcCollisionId); // signature: (__column to slice___, __index__)
 
     fillMatchedGeoHistograms(mcPartJetsPerMcCollision, mcDetJetsPerColl, tracksPerColl, partLevelCollRho, detLevelCollRho);
   }
@@ -2430,7 +2557,7 @@ struct RecoilJets {
 
     // Slice for mc part level jets associated to a given mcCollisionId
     auto mcCollisionId = collision.mcCollisionId();
-    auto mcPartJetsPerMcCollision = mcPartJets.sliceBy(partJetsPerMcCollision, mcCollisionId); // signature: (__column to slice___, __index__)
+    auto mcPartJetsPerMcCollision = mcPartJets.sliceBy(partJetsByMcCollision, mcCollisionId); // signature: (__column to slice___, __index__)
 
     fillMatchedGeoPtHistograms(mcPartJetsPerMcCollision, mcDetJetsPerColl, tracksPerColl, partLevelCollRho, detLevelCollRho);
   }
@@ -2457,7 +2584,7 @@ struct RecoilJets {
 
     // Slice for mc part level jets associated to a given mcCollisionId
     auto mcCollisionId = collision.mcCollisionId();
-    auto mcPartJetsPerMcCollision = mcPartJets.sliceBy(partJetsPerMcCollision, mcCollisionId); // signature: (__column to slice___, __index__)
+    auto mcPartJetsPerMcCollision = mcPartJets.sliceBy(partJetsByMcCollision, mcCollisionId); // signature: (__column to slice___, __index__)
 
     fillMatchedGeoHistograms(mcPartJetsPerMcCollision, mcDetJetsPerColl, tracksPerColl, partLevelCollRho, detLevelCollRho, weight);
   }
@@ -2484,7 +2611,7 @@ struct RecoilJets {
 
     // Slice for mc part level jets associated to a given mcCollisionId
     auto mcCollisionId = collision.mcCollisionId();
-    auto mcPartJetsPerMcCollision = mcPartJets.sliceBy(partJetsPerMcCollision, mcCollisionId); // signature: (__column to slice___, __index__)
+    auto mcPartJetsPerMcCollision = mcPartJets.sliceBy(partJetsByMcCollision, mcCollisionId); // signature: (__column to slice___, __index__)
 
     fillMatchedGeoPtHistograms(mcPartJetsPerMcCollision, mcDetJetsPerColl, tracksPerColl, partLevelCollRho, detLevelCollRho, weight);
   }
@@ -2660,6 +2787,35 @@ struct RecoilJets {
     fillTTSmearingPtPhi<aod::JetParticles>(collision, tracksPerColl, weight);
   }
   PROCESS_SWITCH(RecoilJets, processTTSmearingPtPhiWeighted, "process MC data (weighted JJ) to estimate pT and phi smearing of TT", false);
+
+  //_________________________________
+  void processTrackingEfficiency(CollDetIt const& collision,
+                                 aod::JetMcCollisions const&,
+                                 TrackMCLbsTbl const& tracksPerColl,
+                                 aod::JetParticles const& particles)
+  {
+    // Skip detector level collision
+    if (skipEvent(collision) || !collision.has_mcCollision())
+      return;
+
+    fillTrackRecoEff<aod::JetMcCollisions>(collision, tracksPerColl, particles);
+  }
+  PROCESS_SWITCH(RecoilJets, processTrackingEfficiency, "process MC data (no weight; MB events) to estimate track reco eff", false);
+
+  //_________________________________
+  void processTrackingEfficiencyWeighted(CollOutlierDetIt const& collision,
+                                         aod::JetMcCollisions const&,
+                                         TrackMCLbsTbl const& tracksPerColl,
+                                         aod::JetParticles const& particles)
+  {
+    // Skip detector level collision
+    if (skipEvent(collision) || !collision.has_mcCollision() || collision.isOutlier())
+      return;
+
+    const auto weight = collision.mcCollision().weight();
+    fillTrackRecoEff<aod::JetMcCollisions>(collision, tracksPerColl, particles, weight);
+  }
+  PROCESS_SWITCH(RecoilJets, processTrackingEfficiencyWeighted, "process MC data (weighted JJ) to estimate track reco eff", false);
 
   //------------------------------------------------------------------------------
   // Auxiliary functions

--- a/PWGJE/Tasks/recoilJets.cxx
+++ b/PWGJE/Tasks/recoilJets.cxx
@@ -1572,10 +1572,8 @@ struct RecoilJets {
   //=============================================================================
   // Event Activity QA analysis in raw OO data
   //=============================================================================
-  template <typename BC, typename Collision, typename ZDC>
+  template <typename BC, typename ZDC, typename Collision>
   void fillEventActivitySelectionQAHistograms(Collision const& collision,
-                                              BC const&,
-                                              ZDC const&,
                                               float weight = 1.)
   {
     int runNumber = collision.multRunNumber();
@@ -2159,10 +2157,9 @@ struct RecoilJets {
   //=============================================================================
   // Pt and Phi smearing of TT
   //=============================================================================
-  template <typename JColl, typename JTracks, typename JParticles>
+  template <typename JParticles, typename JColl, typename JTracks>
   void fillTTSmearingPtPhi(JColl const& collision,
                            JTracks const& tracks,
-                           JParticles const&,
                            float weight = 1.)
   {
     const auto ft0Metrics = getFT0Metrics(collision, ft0a.mean, ft0c.mean);
@@ -2217,7 +2214,7 @@ struct RecoilJets {
       return;
 
     // No filter on Particles, it can be outside of |eta| acceptance
-    auto particle = tracks.iteratorAt(chosenTTPos).mcParticle();
+    auto particle = tracks.iteratorAt(chosenTTPos).mcParticle_as<JParticles>();
     float particleEta = particle.eta();
     bool bPartWithinEta = std::fabs(particleEta) < trk.etaCut;
 
@@ -2544,14 +2541,14 @@ struct RecoilJets {
   // Event Activity QA analysis in raw OO
   //=============================================================================
   void processEventActivitySelectionQA(CollEvSelExtendedIt const& collision,
-                                       BCsRun3Tbl const& BCs,
-                                       aod::Zdcs const& ZDCs)
+                                       BCsRun3Tbl const&,
+                                       aod::Zdcs const&)
   {
     // Base flag for event selection
     if (!collision.sel8())
       return;
 
-    fillEventActivitySelectionQAHistograms(collision, BCs, ZDCs);
+    fillEventActivitySelectionQAHistograms<BCsRun3Tbl, aod::Zdcs>(collision);
   }
   PROCESS_SWITCH(RecoilJets, processEventActivitySelectionQA, "process function for EA QA purposes in raw OO collisions", false);
 
@@ -2637,14 +2634,14 @@ struct RecoilJets {
   //=============================================================================
   void processTTSmearingPtPhi(CollDetIt const& collision,
                               TrackMCLbsTbl const& tracksPerColl,
-                              aod::JetParticles const& particles)
+                              aod::JetParticles const&)
   {
 
     // Skip detector level collisions
     if (skipEvent(collision))
       return;
 
-    fillTTSmearingPtPhi(collision, tracksPerColl, particles);
+    fillTTSmearingPtPhi<aod::JetParticles>(collision, tracksPerColl);
   }
   PROCESS_SWITCH(RecoilJets, processTTSmearingPtPhi, "process MC data (no weight; MB events) to estimate pT and phi smearing of TT", false);
 
@@ -2652,7 +2649,7 @@ struct RecoilJets {
   void processTTSmearingPtPhiWeighted(CollOutlierDetIt const& collision,
                                       aod::JetMcCollisions const&,
                                       TrackMCLbsTbl const& tracksPerColl,
-                                      aod::JetParticles const& particles)
+                                      aod::JetParticles const&)
   {
 
     // Skip detector level collisions
@@ -2660,7 +2657,7 @@ struct RecoilJets {
       return;
 
     auto weight = collision.mcCollision().weight();
-    fillTTSmearingPtPhi(collision, tracksPerColl, particles, weight);
+    fillTTSmearingPtPhi<aod::JetParticles>(collision, tracksPerColl, weight);
   }
   PROCESS_SWITCH(RecoilJets, processTTSmearingPtPhiWeighted, "process MC data (weighted JJ) to estimate pT and phi smearing of TT", false);
 

--- a/PWGJE/Tasks/recoilJets.cxx
+++ b/PWGJE/Tasks/recoilJets.cxx
@@ -106,11 +106,10 @@ struct RecoilJets {
       triggerMasks{"triggerMasks", "", "Relevant trigger masks: fTrackLowPt,fTrackHighPt"};
 
     Configurable<float> vertexZCut{"vertexZCut", 10., "Accepted z-vertex range"};
-    Configurable<bool> isMCJJProd{"isMCJJProd", false, "Flag to select MC production: MB (false) or JJ(true)"},
-      skipMBGapEvents{"skipMBGapEvents", false,
-                      "Flag to choose to reject min. bias gap events; jet-level rejection "
-                      "applied at the jet finder level, here rejection is applied for "
-                      "collision and track process functions"};
+    Configurable<bool> skipMBGapEvents{"skipMBGapEvents", false,
+                       "Flag to choose to reject min. bias gap events; jet-level rejection "
+                       "applied at the jet finder level, here rejection is applied for "
+                       "collision and track process functions"};
   } ev;
 
   // ---------- RCT / flag-based selections ----------
@@ -200,6 +199,8 @@ struct RecoilJets {
     ConfigurableAxis multFT0MThreshPartLevel{"multFT0MThreshPartLevel", {VARIABLE_WIDTH, 0.0, 0.167, 0.267, 0.4, 0.567, 0.8, 1.067, 1.4, 1.833, 2.433, 3.667, 5.1, 6.433, 20.}, "Percentiles of scaled FT0M: 100%, 90%, 80%, 70%, 60%, 50%, 40%, 30%, 20%, 10%, 1%, 0.1%, 0.01%"};
 
     ConfigurableAxis axisPtTrackEff{"axisPtTrackEff", {VARIABLE_WIDTH, 0.15, 0.2, 0.25, 0.3, 0.4, 0.5, 0.6, 0.8, 1.0, 1.2, 1.5, 2.0, 2.5, 3.0, 4.0, 5.0, 6.0, 8.0, 10.0, 12.0, 15.0, 20.0, 25.0, 30.0, 40.0, 50.0, 70.0, 100.0}, "#it{p}_{T} (GeV/#it{c})"};
+
+    ConfigurableAxis axisCentrality{"axisCentrality", {VARIABLE_WIDTH, -5.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 35.0, 40.0, 45.0, 50.0, 55.0, 60.0, 65.0, 70.0, 75.0, 80.0, 85.0, 90.0, 95.0, 100.0, 105.0}, "Centrality (%)"};
   } hist;
 
   // Auxiliary variables
@@ -279,7 +280,9 @@ struct RecoilJets {
 
     std::string nameFT0Caxis = "FT0C / #LT FT0C #GT";
     std::string nameFT0Maxis = "FT0M^{*}";
+    std::string nameCentralityAxis = "Centrality (%)";
 
+    // FIT detector
     std::array<AxisDesc<AxisSpec>, 2> arrAxisSpecScaledEA = {{{"FT0C", scaledFT0C},
                                                               {"FT0M", scaledFT0M}}};
 
@@ -292,6 +295,11 @@ struct RecoilJets {
 
     std::array<AxisDesc<ConfigurableAxis>, 2> arrConfigurableAxisEAPartLevel = {{{"FT0C", hist.multFT0CThreshPartLevel, nameFT0Caxis},
                                                                                {"FT0M", hist.multFT0MThreshPartLevel, nameFT0Maxis}}};
+
+    std::array<AxisDesc<ConfigurableAxis>, 4> arrConfigurableAxisCentrality = {{{"CentFT0A", hist.axisCentrality, nameCentralityAxis},
+                                                                                {"CentFT0C", hist.axisCentrality, nameCentralityAxis},
+                                                                                {"CentFT0M", hist.axisCentrality, nameCentralityAxis},
+                                                                                {"CentFT0CVar1", hist.axisCentrality, nameCentralityAxis}}};
 
     // Zero-degree calorimeter
     std::array<AxisDesc<AxisSpec>, 3> arrAxisSpecZDCNeutron = {{{"ZNA", zdcNeutronA},
@@ -416,6 +424,71 @@ struct RecoilJets {
         spectra.add(Form("hScaled%s_TTSig", eaAxis.label),
                     Form("Events w. TT_{Sig}: scaled %s", eaAxis.label),
                     kTH1F, {eaAxis.axis});
+      }
+
+      // Centrality dependence
+      for (const auto& centAxis : arrConfigurableAxisCentrality) {
+
+        // Vertex Z position
+        spectra.add(Form("h%s_vertexZ", centAxis.label),
+                    "Centrality vs Z vertex of collisions",
+                    kTH2F, {{centAxis.axis, centAxis.axisName}, {60, -12., 12., "#it{z}_{vertex}"}}, hist.sumw2);
+
+        // Distributions of centrality in events w/o and w. TT
+        spectra.add(Form("h%s", centAxis.label),
+                    "",
+                    kTH1F, {{centAxis.axis, centAxis.axisName}});
+
+        spectra.add(Form("h%s_TTRef", centAxis.label),
+                    Form("%s in events w. TT_{Ref}", centAxis.label),
+                    kTH1F, {{centAxis.axis, centAxis.axisName}});
+
+        spectra.add(Form("h%s_TTSig", centAxis.label),
+                    Form("%s in events w. TT_{Sig}", centAxis.label),
+                    kTH1F, {{centAxis.axis}});
+
+        // Distribution of tracks
+        spectra.add(Form("h%sTrackPtEtaPhi", centAxis.label),
+                    "Charact. of tracks",
+                    kTHnSparseF, {{centAxis.axis, centAxis.axisName}, pT, pseudorap, phiAngle}, hist.sumw2);
+
+
+        // Rho vs centrality
+        spectra.add(Form("h%s_Rho", centAxis.label),
+                    Form("Scaled %s & #rho", centAxis.label),
+                    kTH2F, {{centAxis.axis, centAxis.axisName}, rho}, hist.sumw2);
+
+        spectra.add(Form("h%s_Rho_TTRef", centAxis.label),
+                    Form("Events w. TT_{Ref}: %s & #rho", centAxis.label),
+                    kTH2F, {{centAxis.axis, centAxis.axisName}, rho}, hist.sumw2);
+
+        spectra.add(Form("h%s_Rho_TTSig", centAxis.label),
+                    Form("Events w. TT_{Sig}: %s & #rho", centAxis.label),
+                    kTH2F, {{centAxis.axis, centAxis.axisName}, rho}, hist.sumw2);
+
+
+        // Recoil jets vs centrality
+        auto tmpHistPointer = spectra.add<TH2>(Form("h%s_Ntrig", centAxis.label),
+                                        Form("Total number of selected triggers per class vs %s", centAxis.label),
+                                        kTH2F, {{centAxis.axis, centAxis.axisName}, {2, 0.0, 2.}});
+        tmpHistPointer->GetYaxis()->SetBinLabel(1, "TT_{Ref}");
+        tmpHistPointer->GetYaxis()->SetBinLabel(2, "TT_{Sig}");
+
+        spectra.add(Form("h%s_DPhi_JetPt_Corr_TTRef", centAxis.label),
+                    Form("Events w. TT_{Ref}: %s & #Delta#varphi & #it{p}_{T, jet}^{ch}", centAxis.label),
+                    kTH3F, {{centAxis.axis, centAxis.axisName}, deltaPhiAngle, jetPTcorr}, hist.sumw2);
+
+        spectra.add(Form("h%s_DPhi_JetPt_Corr_TTSig", centAxis.label),
+                    Form("Events w. TT_{Sig}: %s & #Delta#varphi & #it{p}_{T, jet}^{ch}", centAxis.label),
+                    kTH3F, {{centAxis.axis, centAxis.axisName}, deltaPhiAngle, jetPTcorr}, hist.sumw2);
+
+        spectra.add(Form("h%s_Recoil_JetPt_Corr_TTRef", centAxis.label),
+                    Form("Events w. TT_{Ref}: %s & #it{p}_{T} of recoil jets", centAxis.label),
+                    kTH2F, {{centAxis.axis, centAxis.axisName}, jetPTcorr}, hist.sumw2);
+
+        spectra.add(Form("h%s_Recoil_JetPt_Corr_TTSig", centAxis.label),
+                    Form("Events w. TT_{Sig}: %s & #it{p}_{T} of recoil jets", centAxis.label),
+                    kTH2F, {{centAxis.axis, centAxis.axisName}, jetPTcorr}, hist.sumw2);
       }
     }
 
@@ -1015,20 +1088,50 @@ struct RecoilJets {
     std::vector<double> vPhiOfTT;
     double phiTT = 0.;
     int nTT = 0;
-    float rho = collision.rho();
+    const float addCountToTTRef = 0.5;
+    const float addCountToTTSig = 1.5;
+
+    const auto vertexZ = collision.posZ();
+    const auto rho = collision.rho();
+
     const auto ft0Metrics = getFT0Metrics(collision, ft0a.mean, ft0c.mean);
     const auto scaledFT0C = ft0Metrics.scaledFT0C;
     const auto scaledFT0M = ft0Metrics.scaledFT0M;
 
-    auto dice = randGen->Rndm();
+    const auto centFT0A = collision.centFT0A();
+    const auto centFT0C = collision.centFT0C();
+    const auto centFT0M = collision.centFT0M();
+    const auto centFT0CVar1 = collision.centFT0CVariant1();
+
+    const auto dice = randGen->Rndm();
     if (dice < tt.fracSig)
       bSigEv = true;
 
-    spectra.fill(HIST("hScaledFT0C_vertexZ"), scaledFT0C, collision.posZ(), weight);
-    spectra.fill(HIST("hScaledFT0M_vertexZ"), scaledFT0M, collision.posZ(), weight);
+    // Centrality distribution
+    spectra.fill(HIST("hCentFT0A"), centFT0A, weight);
+    spectra.fill(HIST("hCentFT0C"), centFT0C, weight);
+    spectra.fill(HIST("hCentFT0M"), centFT0M, weight);
+    spectra.fill(HIST("hCentFT0CVar1"), centFT0CVar1, weight);
 
+
+    // Z vertex position vs EA / centrality
+    spectra.fill(HIST("hScaledFT0C_vertexZ"), scaledFT0C, vertexZ, weight);
+    spectra.fill(HIST("hScaledFT0M_vertexZ"), scaledFT0M, vertexZ, weight);
+
+    spectra.fill(HIST("hCentFT0A_vertexZ"), centFT0A, vertexZ, weight);
+    spectra.fill(HIST("hCentFT0C_vertexZ"), centFT0C, vertexZ, weight);
+    spectra.fill(HIST("hCentFT0M_vertexZ"), centFT0M, vertexZ, weight);
+    spectra.fill(HIST("hCentFT0CVar1_vertexZ"), centFT0CVar1, vertexZ, weight);
+
+
+    // Rho vs EA / centrality
     spectra.fill(HIST("hScaledFT0C_Rho"), scaledFT0C, rho, weight);
     spectra.fill(HIST("hScaledFT0M_Rho"), scaledFT0M, rho, weight);
+
+    spectra.fill(HIST("hCentFT0A_Rho"), centFT0A, rho, weight);
+    spectra.fill(HIST("hCentFT0C_Rho"), centFT0C, rho, weight);
+    spectra.fill(HIST("hCentFT0M_Rho"), centFT0M, rho, weight);
+    spectra.fill(HIST("hCentFT0CVar1_Rho"), centFT0CVar1, rho, weight);
 
     for (const auto& track : tracks) {
       spectra.fill(HIST("hTrackSelectionCount"), 0.5);
@@ -1036,12 +1139,18 @@ struct RecoilJets {
       if (skipTrack(track))
         continue;
 
-      float trackPt = track.pt();
-      float trackPhi = track.phi();
+      const float trackPt = track.pt();
+      const float trackPhi = track.phi();
+      const float trackEta = track.eta();
 
       spectra.fill(HIST("hTrackSelectionCount"), 1.5);
-      spectra.fill(HIST("hScaledFT0CTrackPtEtaPhi"), scaledFT0C, trackPt, track.eta(), trackPhi, weight);
-      spectra.fill(HIST("hScaledFT0MTrackPtEtaPhi"), scaledFT0M, trackPt, track.eta(), trackPhi, weight);
+      spectra.fill(HIST("hScaledFT0CTrackPtEtaPhi"), scaledFT0C, trackPt, trackEta, trackPhi, weight);
+      spectra.fill(HIST("hScaledFT0MTrackPtEtaPhi"), scaledFT0M, trackPt, trackEta, trackPhi, weight);
+
+      spectra.fill(HIST("hCentFT0ATrackPtEtaPhi"), centFT0A, trackPt, trackEta, trackPhi, weight);
+      spectra.fill(HIST("hCentFT0CTrackPtEtaPhi"), centFT0C, trackPt, trackEta, trackPhi, weight);
+      spectra.fill(HIST("hCentFT0MTrackPtEtaPhi"), centFT0M, trackPt, trackEta, trackPhi, weight);
+      spectra.fill(HIST("hCentFT0CVar1TrackPtEtaPhi"), centFT0CVar1, trackPt, trackEta, trackPhi, weight);
 
       // Search for TT candidate
       const auto ptTTsigMin = tt.sigPtRange->at(0);
@@ -1065,8 +1174,10 @@ struct RecoilJets {
       phiTT = getPhiTT(vPhiOfTT);
 
       if (bSigEv) {
-        spectra.fill(HIST("hScaledFT0C_Ntrig"), scaledFT0C, 1.5, weight);
-        spectra.fill(HIST("hScaledFT0M_Ntrig"), scaledFT0M, 1.5, weight);
+        // EA
+        spectra.fill(HIST("hScaledFT0C_Ntrig"), scaledFT0C, addCountToTTSig, weight);
+        spectra.fill(HIST("hScaledFT0M_Ntrig"), scaledFT0M, addCountToTTSig, weight);
+
         spectra.fill(HIST("hScaledFT0C_TTSig_per_event"), scaledFT0C, nTT, weight);
         spectra.fill(HIST("hScaledFT0M_TTSig_per_event"), scaledFT0M, nTT, weight);
 
@@ -1075,9 +1186,28 @@ struct RecoilJets {
 
         spectra.fill(HIST("hScaledFT0C_Rho_TTSig"), scaledFT0C, rho, weight);
         spectra.fill(HIST("hScaledFT0M_Rho_TTSig"), scaledFT0M, rho, weight);
+
+        //_____________________________________________________
+        // Centrality
+        spectra.fill(HIST("hCentFT0A_Ntrig"), centFT0A, addCountToTTSig, weight);
+        spectra.fill(HIST("hCentFT0C_Ntrig"), centFT0C, addCountToTTSig, weight);
+        spectra.fill(HIST("hCentFT0M_Ntrig"), centFT0M, addCountToTTSig, weight);
+        spectra.fill(HIST("hCentFT0CVar1_Ntrig"), centFT0CVar1, addCountToTTSig, weight);
+
+        spectra.fill(HIST("hCentFT0A_TTSig"), centFT0A, weight);
+        spectra.fill(HIST("hCentFT0C_TTSig"), centFT0C, weight);
+        spectra.fill(HIST("hCentFT0M_TTSig"), centFT0M, weight);
+        spectra.fill(HIST("hCentFT0CVar1_TTSig"), centFT0CVar1, weight);
+
+        spectra.fill(HIST("hCentFT0A_Rho_TTSig"), centFT0A, rho, weight);
+        spectra.fill(HIST("hCentFT0C_Rho_TTSig"), centFT0C, rho, weight);
+        spectra.fill(HIST("hCentFT0M_Rho_TTSig"), centFT0M, rho, weight);
+        spectra.fill(HIST("hCentFT0CVar1_Rho_TTSig"), centFT0CVar1, rho, weight);
+
       } else {
-        spectra.fill(HIST("hScaledFT0C_Ntrig"), scaledFT0C, 0.5, weight);
-        spectra.fill(HIST("hScaledFT0M_Ntrig"), scaledFT0M, 0.5, weight);
+        spectra.fill(HIST("hScaledFT0C_Ntrig"), scaledFT0C, addCountToTTRef, weight);
+        spectra.fill(HIST("hScaledFT0M_Ntrig"), scaledFT0M, addCountToTTRef, weight);
+
         spectra.fill(HIST("hScaledFT0C_TTRef_per_event"), scaledFT0C, nTT, weight);
         spectra.fill(HIST("hScaledFT0M_TTRef_per_event"), scaledFT0M, nTT, weight);
 
@@ -1086,6 +1216,23 @@ struct RecoilJets {
 
         spectra.fill(HIST("hScaledFT0C_Rho_TTRef"), scaledFT0C, rho, weight);
         spectra.fill(HIST("hScaledFT0M_Rho_TTRef"), scaledFT0M, rho, weight);
+
+        //_____________________________________________________
+        // Centrality
+        spectra.fill(HIST("hCentFT0A_Ntrig"), centFT0A, addCountToTTRef, weight);
+        spectra.fill(HIST("hCentFT0C_Ntrig"), centFT0C, addCountToTTRef, weight);
+        spectra.fill(HIST("hCentFT0M_Ntrig"), centFT0M, addCountToTTRef, weight);
+        spectra.fill(HIST("hCentFT0CVar1_Ntrig"), centFT0CVar1, addCountToTTRef, weight);
+
+        spectra.fill(HIST("hCentFT0A_TTRef"), centFT0A, weight);
+        spectra.fill(HIST("hCentFT0C_TTRef"), centFT0C, weight);
+        spectra.fill(HIST("hCentFT0M_TTRef"), centFT0M, weight);
+        spectra.fill(HIST("hCentFT0CVar1_TTRef"), centFT0CVar1, weight);
+
+        spectra.fill(HIST("hCentFT0A_Rho_TTRef"), centFT0A, rho, weight);
+        spectra.fill(HIST("hCentFT0C_Rho_TTRef"), centFT0C, rho, weight);
+        spectra.fill(HIST("hCentFT0M_Rho_TTRef"), centFT0M, rho, weight);
+        spectra.fill(HIST("hCentFT0CVar1_Rho_TTRef"), centFT0CVar1, rho, weight);
       }
     }
 
@@ -1110,6 +1257,11 @@ struct RecoilJets {
           spectra.fill(HIST("hScaledFT0C_DPhi_JetPt_Corr_TTSig"), scaledFT0C, dphi, jetPtCorr, weight);
           spectra.fill(HIST("hScaledFT0M_DPhi_JetPt_Corr_TTSig"), scaledFT0M, dphi, jetPtCorr, weight);
 
+          spectra.fill(HIST("hCentFT0A_DPhi_JetPt_Corr_TTSig"), centFT0A, dphi, jetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0C_DPhi_JetPt_Corr_TTSig"), centFT0C, dphi, jetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0M_DPhi_JetPt_Corr_TTSig"), centFT0M, dphi, jetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0CVar1_DPhi_JetPt_Corr_TTSig"), centFT0CVar1, dphi, jetPtCorr, weight);
+
           spectra.fill(HIST("hScaledFT0C_DPhi_JetPt_TTSig"), scaledFT0C, dphi, jetPt, weight);
           spectra.fill(HIST("hScaledFT0M_DPhi_JetPt_TTSig"), scaledFT0M, dphi, jetPt, weight);
           spectra.fill(HIST("hJetArea_JetPt_Rho_TTSig"), jetArea, jetPt, rho, weight);
@@ -1123,12 +1275,22 @@ struct RecoilJets {
             spectra.fill(HIST("hScaledFT0C_Recoil_JetPt_Corr_TTSig"), scaledFT0C, jetPtCorr, weight);
             spectra.fill(HIST("hScaledFT0M_Recoil_JetPt_Corr_TTSig"), scaledFT0M, jetPtCorr, weight);
 
+            spectra.fill(HIST("hCentFT0A_Recoil_JetPt_Corr_TTSig"), centFT0A, jetPtCorr, weight);
+            spectra.fill(HIST("hCentFT0C_Recoil_JetPt_Corr_TTSig"), centFT0C, jetPtCorr, weight);
+            spectra.fill(HIST("hCentFT0M_Recoil_JetPt_Corr_TTSig"), centFT0M, jetPtCorr, weight);
+            spectra.fill(HIST("hCentFT0CVar1_Recoil_JetPt_Corr_TTSig"), centFT0CVar1, jetPtCorr, weight);
+
             spectra.fill(HIST("hScaledFT0C_Recoil_JetPt_TTSig"), scaledFT0C, jetPt, weight);
             spectra.fill(HIST("hScaledFT0M_Recoil_JetPt_TTSig"), scaledFT0M, jetPt, weight);
           }
         } else {
           spectra.fill(HIST("hScaledFT0C_DPhi_JetPt_Corr_TTRef"), scaledFT0C, dphi, jetPtCorr, weight);
           spectra.fill(HIST("hScaledFT0M_DPhi_JetPt_Corr_TTRef"), scaledFT0M, dphi, jetPtCorr, weight);
+
+          spectra.fill(HIST("hCentFT0A_DPhi_JetPt_Corr_TTRef"), centFT0A, dphi, jetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0C_DPhi_JetPt_Corr_TTRef"), centFT0C, dphi, jetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0M_DPhi_JetPt_Corr_TTRef"), centFT0M, dphi, jetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0CVar1_DPhi_JetPt_Corr_TTRef"), centFT0CVar1, dphi, jetPtCorr, weight);
 
           spectra.fill(HIST("hScaledFT0C_DPhi_JetPt_TTRef"), scaledFT0C, dphi, jetPt, weight);
           spectra.fill(HIST("hScaledFT0M_DPhi_JetPt_TTRef"), scaledFT0M, dphi, jetPt, weight);
@@ -1142,6 +1304,11 @@ struct RecoilJets {
           if (bRecoilJet) {
             spectra.fill(HIST("hScaledFT0C_Recoil_JetPt_Corr_TTRef"), scaledFT0C, jetPtCorr, weight);
             spectra.fill(HIST("hScaledFT0M_Recoil_JetPt_Corr_TTRef"), scaledFT0M, jetPtCorr, weight);
+
+            spectra.fill(HIST("hCentFT0A_Recoil_JetPt_Corr_TTRef"), centFT0A, jetPtCorr, weight);
+            spectra.fill(HIST("hCentFT0C_Recoil_JetPt_Corr_TTRef"), centFT0C, jetPtCorr, weight);
+            spectra.fill(HIST("hCentFT0M_Recoil_JetPt_Corr_TTRef"), centFT0M, jetPtCorr, weight);
+            spectra.fill(HIST("hCentFT0CVar1_Recoil_JetPt_Corr_TTRef"), centFT0CVar1, jetPtCorr, weight);
 
             spectra.fill(HIST("hScaledFT0C_Recoil_JetPt_TTRef"), scaledFT0C, jetPt, weight);
             spectra.fill(HIST("hScaledFT0M_Recoil_JetPt_TTRef"), scaledFT0M, jetPt, weight);
@@ -2797,7 +2964,7 @@ struct RecoilJets {
     // Skip detector level collision
     if (skipEvent(collision) || !collision.has_mcCollision())
       return;
-
+    
     fillTrackRecoEff<aod::JetMcCollisions>(collision, tracksPerColl, particles);
   }
   PROCESS_SWITCH(RecoilJets, processTrackingEfficiency, "process MC data (no weight; MB events) to estimate track reco eff", false);

--- a/PWGJE/Tasks/recoilJets.cxx
+++ b/PWGJE/Tasks/recoilJets.cxx
@@ -607,7 +607,8 @@ struct RecoilJets {
       uint8_t iCent = 0;
       for (const auto& centAxis : arrConfigurableAxisCentrality) {
 
-        if (iCent == 3) { // case of "CentFT0CVar1"
+        int positionCentFT0CVar1 = 3;
+        if (iCent == positionCentFT0CVar1) { // case of "CentFT0CVar1"
           ++iCent;
           continue;
         }
@@ -750,7 +751,9 @@ struct RecoilJets {
       uint8_t iCent = 0;
       for (const auto& centAxis : arrConfigurableAxisCentrality) {
 
-        if (iCent == 0 || iCent == 3) { // case of "CentFT0A" & "CentFT0CVar1"
+        int positionCentFT0A = 0;
+        int positionCentFT0CVar1 = 3;
+        if (iCent == positionCentFT0A || iCent == positionCentFT0CVar1) { // case of "CentFT0A" & "CentFT0CVar1"
           ++iCent;
           continue;
         }

--- a/PWGJE/Tasks/recoilJets.cxx
+++ b/PWGJE/Tasks/recoilJets.cxx
@@ -17,11 +17,13 @@
 #include "PWGJE/DataModel/Jet.h"
 #include "PWGJE/DataModel/JetReducedData.h"
 #include "PWGJE/DataModel/JetSubtraction.h"
+#include "PWGLF/DataModel/mcCentrality.h"
 
 #include "Common/CCDB/EventSelectionParams.h"
 #include "Common/Core/RecoDecay.h"
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/Multiplicity.h"
+#include "Common/DataModel/Centrality.h"
 
 #include <CommonConstants/MathConstants.h>
 #include <Framework/ASoA.h>
@@ -69,7 +71,9 @@ using CollRhoDetIt = soa::Filtered<soa::Join<aod::JetCollisionsMCD, aod::BkgChar
 using CollPartIt = soa::Filtered<aod::JetMcCollisions>::iterator;
 using CollRhoPartTbl = soa::Join<aod::JetMcCollisions, aod::BkgChargedMcRhos>;
 using CollRhoPartIt = soa::Filtered<soa::Join<aod::JetMcCollisions, aod::BkgChargedMcRhos>>::iterator;
+using CollCentRhoPartIt = soa::Filtered<soa::Join<aod::JetMcCollisions, aod::McCentFT0As, aod::McCentFT0Cs, aod::BkgChargedMcRhos>>::iterator;
 using CollRhoOutlierPartIt = soa::Filtered<soa::Join<aod::JetMcCollisions, aod::BkgChargedMcRhos, aod::JMcCollisionOutliers>>::iterator;
+using CollCentRhoOutlierPartIt = soa::Filtered<soa::Join<aod::JetMcCollisions, aod::McCentFT0As, aod::McCentFT0Cs, aod::BkgChargedMcRhos, aod::JMcCollisionOutliers>>::iterator;
 using CollRhoOutlierPartTbl = soa::Join<aod::JetMcCollisions, aod::BkgChargedMcRhos, aod::JMcCollisionOutliers>;
 
 // --- Event multiplicity (+ ZDC etc.)
@@ -323,18 +327,18 @@ struct RecoilJets {
 
     // List of raw and MC det. distributions
     if (doprocessData || doprocessMCDetLevel || doprocessMCDetLevelWeighted) {
-      spectra.add("hEventSelectionCountReco", "Count # of events in the analysis", kTH1F, {{5, 0.0, 5.}});
+      spectra.add("hEventSelectionCountReco", "Count # of events", kTH1F, {{5, 0.0, 5.}});
       spectra.get<TH1>(HIST("hEventSelectionCountReco"))->GetXaxis()->SetBinLabel(1, "Total # of events");
       spectra.get<TH1>(HIST("hEventSelectionCountReco"))->GetXaxis()->SetBinLabel(2, Form("# of events after sel. %s", evSelToString.data()));
       spectra.get<TH1>(HIST("hEventSelectionCountReco"))->GetXaxis()->SetBinLabel(3, "# of events w. outlier");
       spectra.get<TH1>(HIST("hEventSelectionCountReco"))->GetXaxis()->SetBinLabel(4, "# of events w/o assoc MC.");
       spectra.get<TH1>(HIST("hEventSelectionCountReco"))->GetXaxis()->SetBinLabel(5, "# of selected events");
 
-      spectra.add("hTrackSelectionCount", "Count # of tracks in the analysis", kTH1F, {{2, 0.0, 2.}});
+      spectra.add("hTrackSelectionCount", "Count # of tracks", kTH1F, {{2, 0.0, 2.}});
       spectra.get<TH1>(HIST("hTrackSelectionCount"))->GetXaxis()->SetBinLabel(1, "Total # of tracks");
       spectra.get<TH1>(HIST("hTrackSelectionCount"))->GetXaxis()->SetBinLabel(2, Form("# of tracks after sel. %s", trkSelToString.data()));
 
-      spectra.add("hTTSig_pT", "pT spectrum of all found TT_{Sig} cand.", kTH1F, {{40, 10., 50.}}); // needed to distinguish merged data from diff. wagons
+      spectra.add("hTTSig_pT", "#it{p}_{T} spectrum of all found TT_{Sig}", kTH1F, {{40, 10., 50.}}); // needed to distinguish merged data from diff. wagons
 
       spectra.add("hJetPtEtaPhiRhoArea", "Charact. of inclusive jets", kTHnSparseF, {pT, pseudorapJets, phiAngle, rho, jetArea}, hist.sumw2);
       spectra.add("hJetArea_JetPt_Rho_TTRef", "Events w. TT_{Ref}: A_{jet} & jet pT & #rho", kTH3F, {jetArea, pT, rho}, hist.sumw2);
@@ -342,7 +346,7 @@ struct RecoilJets {
 
       for (const auto& eaAxis : arrConfigurableAxisEA) {
         spectra.add(Form("hScaled%s_vertexZ", eaAxis.label),
-                    "Z vertex of collisions",
+                    Form("Scaled %s vs. Z vertex of collisions", eaAxis.label),
                     kTH2F, {{eaAxis.axis, eaAxis.axisName}, {60, -12., 12., "#it{z}_{vertex}"}}, hist.sumw2);
 
         spectra.add(Form("hScaled%sTrackPtEtaPhi", eaAxis.label),
@@ -350,17 +354,17 @@ struct RecoilJets {
                     kTHnSparseF, {{eaAxis.axis, eaAxis.axisName}, pT, pseudorap, phiAngle}, hist.sumw2);
 
         auto tmpHistPointer = spectra.add<TH2>(Form("hScaled%s_Ntrig", eaAxis.label),
-                                               Form("Total number of selected triggers per class vs scaled %s", eaAxis.label),
+                                               Form("Scaled %s vs Total number of selected triggers per class", eaAxis.label),
                                                kTH2F, {{eaAxis.axis, eaAxis.axisName}, {2, 0.0, 2.}});
         tmpHistPointer->GetYaxis()->SetBinLabel(1, "TT_{Ref}");
         tmpHistPointer->GetYaxis()->SetBinLabel(2, "TT_{Sig}");
 
         spectra.add(Form("hScaled%s_TTRef_per_event", eaAxis.label),
-                    Form("Number of TT_{Ref} per event vs scaled %s", eaAxis.label),
+                    Form("Scaled %s vs Number of TT_{Ref} per event", eaAxis.label),
                     kTH2F, {{eaAxis.axis, eaAxis.axisName}, {15, 0.5, 15.5, "# of TT_{Ref}"}});
 
         spectra.add(Form("hScaled%s_TTSig_per_event", eaAxis.label),
-                    Form("Number of TT_{Sig} per event vs scaled %s", eaAxis.label),
+                    Form("Scaled %s vs Number of TT_{Sig} per event", eaAxis.label),
                     kTH2F, {{eaAxis.axis, eaAxis.axisName}, {10, 0.5, 10.5, "# of TT_{Sig}"}});
 
         spectra.add(Form("hScaled%s_DPhi_JetPt_Corr_TTRef", eaAxis.label),
@@ -417,6 +421,10 @@ struct RecoilJets {
       }
 
       for (const auto& eaAxis : arrAxisSpecScaledEA) {
+        spectra.add(Form("hScaled%s", eaAxis.label),
+                    Form("Scaled %s", eaAxis.label),
+                    kTH1F, {eaAxis.axis});
+
         spectra.add(Form("hScaled%s_TTRef", eaAxis.label),
                     Form("Events w. TT_{Ref}: scaled %s", eaAxis.label),
                     kTH1F, {eaAxis.axis});
@@ -431,12 +439,12 @@ struct RecoilJets {
 
         // Vertex Z position
         spectra.add(Form("h%s_vertexZ", centAxis.label),
-                    "Centrality vs Z vertex of collisions",
+                    Form("%s vs Z vertex of collisions", centAxis.label),
                     kTH2F, {{centAxis.axis, centAxis.axisName}, {60, -12., 12., "#it{z}_{vertex}"}}, hist.sumw2);
 
         // Distributions of centrality in events w/o and w. TT
         spectra.add(Form("h%s", centAxis.label),
-                    "",
+                    Form("%s", centAxis.label),
                     kTH1F, {{centAxis.axis, centAxis.axisName}});
 
         spectra.add(Form("h%s_TTRef", centAxis.label),
@@ -452,10 +460,9 @@ struct RecoilJets {
                     "Charact. of tracks",
                     kTHnSparseF, {{centAxis.axis, centAxis.axisName}, pT, pseudorap, phiAngle}, hist.sumw2);
 
-
         // Rho vs centrality
         spectra.add(Form("h%s_Rho", centAxis.label),
-                    Form("Scaled %s & #rho", centAxis.label),
+                    Form("%s & #rho", centAxis.label),
                     kTH2F, {{centAxis.axis, centAxis.axisName}, rho}, hist.sumw2);
 
         spectra.add(Form("h%s_Rho_TTRef", centAxis.label),
@@ -469,7 +476,7 @@ struct RecoilJets {
 
         // Recoil jets vs centrality
         auto tmpHistPointer = spectra.add<TH2>(Form("h%s_Ntrig", centAxis.label),
-                                        Form("Total number of selected triggers per class vs %s", centAxis.label),
+                                        Form("%s vs Total number of selected triggers per class", centAxis.label),
                                         kTH2F, {{centAxis.axis, centAxis.axisName}, {2, 0.0, 2.}});
         tmpHistPointer->GetYaxis()->SetBinLabel(1, "TT_{Ref}");
         tmpHistPointer->GetYaxis()->SetBinLabel(2, "TT_{Sig}");
@@ -507,90 +514,165 @@ struct RecoilJets {
       spectra.add("hJetArea_JetPt_Rho_TTSig_Part", "Events w. TT_{Sig}: A_{jet} & jet pT & #rho", kTH3F, {jetArea, pT, rho}, hist.sumw2);
 
       for (const auto& eaAxis : arrConfigurableAxisEAPartLevel) {
-        spectra.add(Form("hScaled%s_vertexZMC", eaAxis.label),
+        spectra.add(Form("hScaled%s_vertexZ_Part", eaAxis.label),
                     "Z vertex of MC collision",
                     kTH2F, {{eaAxis.axis, eaAxis.axisName}, {60, -12., 12., "#it{z}_{vertex}"}}, hist.sumw2);
 
         auto tmpHistPointer = spectra.add<TH2>(Form("hScaled%s_Ntrig_Part", eaAxis.label),
-                                               Form("Total number of selected triggers per class vs scaled %s", eaAxis.label),
+                                               Form("Scaled %s vs Total number of selected triggers per class", eaAxis.label),
                                                kTH2F, {{eaAxis.axis, eaAxis.axisName}, {2, 0.0, 2.}});
         tmpHistPointer->GetYaxis()->SetBinLabel(1, "TT_{Ref}");
         tmpHistPointer->GetYaxis()->SetBinLabel(2, "TT_{Sig}");
 
-        spectra.add(Form("hScaled%sPartPtEtaPhi", eaAxis.label),
-                    "Charact. of particles",
+        spectra.add(Form("hScaled%sTrackPtEtaPhi_Part", eaAxis.label),
+                    "Charact. of MC generated particles",
                     kTHnSparseF, {{eaAxis.axis, eaAxis.axisName}, pT, pseudorap, phiAngle}, hist.sumw2);
 
         spectra.add(Form("hScaled%s_TTRef_per_event_Part", eaAxis.label),
-                    Form("Number of TT_{Ref} per event vs scaled %s", eaAxis.label),
+                    Form("Scaled %s vs Number of MC TT_{Ref} per event", eaAxis.label),
                     kTH2F, {{eaAxis.axis, eaAxis.axisName}, {15, 0.5, 15.5, "# of TT_{Ref}"}});
 
         spectra.add(Form("hScaled%s_TTSig_per_event_Part", eaAxis.label),
-                    Form("Number of TT_{Sig} per event vs scaled %s", eaAxis.label),
+                    Form("Scaled %s vs Number of MC TT_{Sig} per event", eaAxis.label),
                     kTH2F, {{eaAxis.axis, eaAxis.axisName}, {10, 0.5, 10.5, "# of TT_{Sig}"}});
 
         spectra.add(Form("hScaled%s_DPhi_JetPt_Corr_TTRef_Part", eaAxis.label),
-                    Form("Events w. TT_{Ref}: scaled %s & #Delta#varphi & #it{p}_{T, jet}^{ch}", eaAxis.label),
+                    Form("MC events w. TT_{Ref}: scaled %s & #Delta#varphi & #it{p}_{T, jet}^{ch}", eaAxis.label),
                     kTH3F, {{eaAxis.axis, eaAxis.axisName}, deltaPhiAngle, jetPTcorr}, hist.sumw2);
 
         spectra.add(Form("hScaled%s_DPhi_JetPt_Corr_TTSig_Part", eaAxis.label),
-                    Form("Events w. TT_{Sig}: scaled %s & #Delta#varphi & #it{p}_{T, jet}^{ch}", eaAxis.label),
+                    Form("MC events w. TT_{Sig}: scaled %s & #Delta#varphi & #it{p}_{T, jet}^{ch}", eaAxis.label),
                     kTH3F, {{eaAxis.axis, eaAxis.axisName}, deltaPhiAngle, jetPTcorr}, hist.sumw2);
 
         spectra.add(Form("hScaled%s_DPhi_JetPt_TTRef_Part", eaAxis.label),
-                    Form("Events w. TT_{Ref}: scaled %s & #Delta#varphi & #it{p}_{T, jet}^{ch}", eaAxis.label),
+                    Form("MC events w. TT_{Ref}: scaled %s & #Delta#varphi & #it{p}_{T, jet}^{ch}", eaAxis.label),
                     kTH3F, {{eaAxis.axis, eaAxis.axisName}, deltaPhiAngle, pT}, hist.sumw2);
 
         spectra.add(Form("hScaled%s_DPhi_JetPt_TTSig_Part", eaAxis.label),
-                    Form("Events w. TT_{Sig}: scaled %s & #Delta#varphi & #it{p}_{T, jet}^{ch}", eaAxis.label),
+                    Form("MC events w. TT_{Sig}: scaled %s & #Delta#varphi & #it{p}_{T, jet}^{ch}", eaAxis.label),
                     kTH3F, {{eaAxis.axis, eaAxis.axisName}, deltaPhiAngle, pT}, hist.sumw2);
 
         spectra.add(Form("hScaled%s_Recoil_JetPt_Corr_TTRef_Part", eaAxis.label),
-                    Form("Events w. TT_{Ref}: scaled %s & #it{p}_{T} of recoil jets", eaAxis.label),
+                    Form("MC events w. TT_{Ref}: scaled %s & #it{p}_{T} of recoil jets", eaAxis.label),
                     kTH2F, {{eaAxis.axis, eaAxis.axisName}, jetPTcorr}, hist.sumw2);
 
         spectra.add(Form("hScaled%s_Recoil_JetPt_Corr_TTSig_Part", eaAxis.label),
-                    Form("Events w. TT_{Sig}: scaled %s & #it{p}_{T} of recoil jets", eaAxis.label),
+                    Form("MC events w. TT_{Sig}: scaled %s & #it{p}_{T} of recoil jets", eaAxis.label),
                     kTH2F, {{eaAxis.axis, eaAxis.axisName}, jetPTcorr}, hist.sumw2);
 
         spectra.add(Form("hScaled%s_Recoil_JetPt_TTRef_Part", eaAxis.label),
-                    Form("Events w. TT_{Ref}: scaled %s & #it{p}_{T} of recoil jets", eaAxis.label),
+                    Form("MC events w. TT_{Ref}: scaled %s & #it{p}_{T} of recoil jets", eaAxis.label),
                     kTH2F, {{eaAxis.axis, eaAxis.axisName}, pT}, hist.sumw2);
 
         spectra.add(Form("hScaled%s_Recoil_JetPt_TTSig_Part", eaAxis.label),
-                    Form("Events w. TT_{Sig}: scaled %s & #it{p}_{T} of recoil jets", eaAxis.label),
+                    Form("MC events w. TT_{Sig}: scaled %s & #it{p}_{T} of recoil jets", eaAxis.label),
                     kTH2F, {{eaAxis.axis, eaAxis.axisName}, pT}, hist.sumw2);
 
         spectra.add(Form("hScaled%s_Rho_Part", eaAxis.label),
-                    Form("Scaled %s & #rho", eaAxis.label),
+                    Form("MC events %s & #rho", eaAxis.label),
                     kTH2F, {{eaAxis.axis, eaAxis.axisName}, rho}, hist.sumw2);
 
         spectra.add(Form("hScaled%s_Rho_TTRef_Part", eaAxis.label),
-                    Form("Events w. TT_{Ref}: scaled %s & #rho", eaAxis.label),
+                    Form("MC events w. TT_{Ref}: scaled %s & #rho", eaAxis.label),
                     kTH2F, {{eaAxis.axis, eaAxis.axisName}, rho}, hist.sumw2);
 
         spectra.add(Form("hScaled%s_Rho_TTSig_Part", eaAxis.label),
-                    Form("Events w. TT_{Sig}: scaled %s & #rho", eaAxis.label),
+                    Form("MC events w. TT_{Sig}: scaled %s & #rho", eaAxis.label),
                     kTH2F, {{eaAxis.axis, eaAxis.axisName}, rho}, hist.sumw2);
 
         // Rectricted phi range for TT selection
         spectra.add(Form("hScaled%s_DPhi_JetPt_Corr_TTRef_RestrictedPhi_Part", eaAxis.label),
-                    Form("Events w. TT_{Ref} #in #varphi (%.2f, %.2f): scaled %s & #Delta#varphi & #it{p}_{T, jet}^{ch}", phiMin, phiMax, eaAxis.label),
+                    Form("MC events w. TT_{Ref} #in #varphi (%.2f, %.2f): scaled %s & #Delta#varphi & #it{p}_{T, jet}^{ch}", phiMin, phiMax, eaAxis.label),
                     kTH3F, {{eaAxis.axis, eaAxis.axisName}, deltaPhiAngle, jetPTcorr}, hist.sumw2);
 
         spectra.add(Form("hScaled%s_DPhi_JetPt_Corr_TTSig_RestrictedPhi_Part", eaAxis.label),
-                    Form("Events w. TT_{Sig} #in #varphi (%.2f, %.2f): scaled %s & #Delta#varphi & #it{p}_{T, jet}^{ch}", phiMin, phiMax, eaAxis.label),
+                    Form("MC events w. TT_{Sig} #in #varphi (%.2f, %.2f): scaled %s & #Delta#varphi & #it{p}_{T, jet}^{ch}", phiMin, phiMax, eaAxis.label),
                     kTH3F, {{eaAxis.axis, eaAxis.axisName}, deltaPhiAngle, jetPTcorr}, hist.sumw2);
       }
 
       for (const auto& eaAxis : arrAxisSpecScaledEA) {
+        spectra.add(Form("hScaled%s_Part", eaAxis.label),
+                    "Scaled EA in MC collisions",
+                    kTH1F, {eaAxis.axis});
+
         spectra.add(Form("hScaled%s_TTRef_Part", eaAxis.label),
-                    Form("Events w. TT_{Ref}: scaled %s", eaAxis.label),
+                    Form("MC events w. TT_{Ref}: scaled %s", eaAxis.label),
                     kTH1F, {eaAxis.axis});
 
         spectra.add(Form("hScaled%s_TTSig_Part", eaAxis.label),
-                    Form("Events w. TT_{Sig}: scaled %s", eaAxis.label),
+                    Form("MC events w. TT_{Sig}: scaled %s", eaAxis.label),
                     kTH1F, {eaAxis.axis});
+      }
+
+      // Centrality dependence
+      uint8_t iCent = 0;
+      for (const auto& centAxis : arrConfigurableAxisCentrality) {
+        
+        if (iCent == 3) // case of "CentFT0CVar1"
+          continue;
+
+        // Vertex Z position
+        spectra.add(Form("h%s_vertexZ_Part", centAxis.label),
+                    "Centrality vs Z vertex of MC collisions",
+                    kTH2F, {{centAxis.axis, centAxis.axisName}, {60, -12., 12., "#it{z}_{vertex}"}}, hist.sumw2);
+
+        // Distributions of centrality in events w/o and w. TT
+        spectra.add(Form("h%s_Part", centAxis.label),
+                    "Centrality in MC collisions",
+                    kTH1F, {{centAxis.axis, centAxis.axisName}});
+
+        spectra.add(Form("h%s_TTRef_Part", centAxis.label),
+                    Form("%s in MC events w. TT_{Ref}", centAxis.label),
+                    kTH1F, {{centAxis.axis, centAxis.axisName}});
+
+        spectra.add(Form("h%s_TTSig_Part", centAxis.label),
+                    Form("%s in MC events w. TT_{Sig}", centAxis.label),
+                    kTH1F, {{centAxis.axis}});
+
+        // Distribution of tracks
+        spectra.add(Form("h%sTrackPtEtaPhi_Part", centAxis.label),
+                    "Charact. of MC generated particles",
+                    kTHnSparseF, {{centAxis.axis, centAxis.axisName}, pT, pseudorap, phiAngle}, hist.sumw2);
+
+
+        // Rho vs centrality
+        spectra.add(Form("h%s_Rho_Part", centAxis.label),
+                    Form("MC events %s & #rho", centAxis.label),
+                    kTH2F, {{centAxis.axis, centAxis.axisName}, rho}, hist.sumw2);
+
+        spectra.add(Form("h%s_Rho_TTRef_Part", centAxis.label),
+                    Form("MC events w. TT_{Ref}: %s & #rho", centAxis.label),
+                    kTH2F, {{centAxis.axis, centAxis.axisName}, rho}, hist.sumw2);
+
+        spectra.add(Form("h%s_Rho_TTSig_Part", centAxis.label),
+                    Form("MC events w. TT_{Sig}: %s & #rho", centAxis.label),
+                    kTH2F, {{centAxis.axis, centAxis.axisName}, rho}, hist.sumw2);
+
+
+        // Recoil jets vs centrality
+        auto tmpHistPointer = spectra.add<TH2>(Form("h%s_Ntrig_Part", centAxis.label),
+                                        Form("%s vs Total number of selected MC triggers per class", centAxis.label),
+                                        kTH2F, {{centAxis.axis, centAxis.axisName}, {2, 0.0, 2.}});
+        tmpHistPointer->GetYaxis()->SetBinLabel(1, "TT_{Ref}");
+        tmpHistPointer->GetYaxis()->SetBinLabel(2, "TT_{Sig}");
+
+        spectra.add(Form("h%s_DPhi_JetPt_Corr_TTRef_Part", centAxis.label),
+                    Form("MC events w. TT_{Ref}: %s & #Delta#varphi & #it{p}_{T, jet}^{ch}", centAxis.label),
+                    kTH3F, {{centAxis.axis, centAxis.axisName}, deltaPhiAngle, jetPTcorr}, hist.sumw2);
+
+        spectra.add(Form("h%s_DPhi_JetPt_Corr_TTSig_Part", centAxis.label),
+                    Form("MC events w. TT_{Sig}: %s & #Delta#varphi & #it{p}_{T, jet}^{ch}", centAxis.label),
+                    kTH3F, {{centAxis.axis, centAxis.axisName}, deltaPhiAngle, jetPTcorr}, hist.sumw2);
+
+        spectra.add(Form("h%s_Recoil_JetPt_Corr_TTRef_Part", centAxis.label),
+                    Form("MC events w. TT_{Ref}: %s & #it{p}_{T} of recoil jets", centAxis.label),
+                    kTH2F, {{centAxis.axis, centAxis.axisName}, jetPTcorr}, hist.sumw2);
+
+        spectra.add(Form("h%s_Recoil_JetPt_Corr_TTSig_Part", centAxis.label),
+                    Form("MC events w. TT_{Sig}: %s & #it{p}_{T} of recoil jets", centAxis.label),
+                    kTH2F, {{centAxis.axis, centAxis.axisName}, jetPTcorr}, hist.sumw2);
+          
+        ++iCent;
       }
     }
 
@@ -1107,6 +1189,10 @@ struct RecoilJets {
     if (dice < tt.fracSig)
       bSigEv = true;
 
+    // EA distributions
+    spectra.fill(HIST("hScaledFT0C"), scaledFT0C, weight);
+    spectra.fill(HIST("hScaledFT0M"), scaledFT0M, weight);
+
     // Centrality distribution
     spectra.fill(HIST("hCentFT0A"), centFT0A, weight);
     spectra.fill(HIST("hCentFT0C"), centFT0C, weight);
@@ -1241,9 +1327,9 @@ struct RecoilJets {
       if (isJetWithHighPtConstituent<JTracks>(jet))
         continue;
 
-      float jetPt = jet.pt();
-      float jetArea = jet.area();
-      float jetPtCorr = jetPt - rho * jetArea;
+      const auto jetPt = jet.pt();
+      const auto jetArea = jet.area();
+      const auto jetPtCorr = jetPt - rho * jetArea;
 
       spectra.fill(HIST("hJetPtEtaPhiRhoArea"), jetPt, jet.eta(), jet.phi(), rho, jetArea, weight);
 
@@ -1254,64 +1340,74 @@ struct RecoilJets {
         auto [dphi, bRecoilJet] = isRecoilJet(jet, phiTT);
 
         if (bSigEv) {
+
+          spectra.fill(HIST("hJetArea_JetPt_Rho_TTSig"), jetArea, jetPt, rho, weight);
+
+          // EA dependence
           spectra.fill(HIST("hScaledFT0C_DPhi_JetPt_Corr_TTSig"), scaledFT0C, dphi, jetPtCorr, weight);
           spectra.fill(HIST("hScaledFT0M_DPhi_JetPt_Corr_TTSig"), scaledFT0M, dphi, jetPtCorr, weight);
-
-          spectra.fill(HIST("hCentFT0A_DPhi_JetPt_Corr_TTSig"), centFT0A, dphi, jetPtCorr, weight);
-          spectra.fill(HIST("hCentFT0C_DPhi_JetPt_Corr_TTSig"), centFT0C, dphi, jetPtCorr, weight);
-          spectra.fill(HIST("hCentFT0M_DPhi_JetPt_Corr_TTSig"), centFT0M, dphi, jetPtCorr, weight);
-          spectra.fill(HIST("hCentFT0CVar1_DPhi_JetPt_Corr_TTSig"), centFT0CVar1, dphi, jetPtCorr, weight);
-
           spectra.fill(HIST("hScaledFT0C_DPhi_JetPt_TTSig"), scaledFT0C, dphi, jetPt, weight);
           spectra.fill(HIST("hScaledFT0M_DPhi_JetPt_TTSig"), scaledFT0M, dphi, jetPt, weight);
-          spectra.fill(HIST("hJetArea_JetPt_Rho_TTSig"), jetArea, jetPt, rho, weight);
 
           if (phiTT > phiMin && phiTT < phiMax) {
             spectra.fill(HIST("hScaledFT0C_DPhi_JetPt_Corr_TTSig_RestrictedPhi"), scaledFT0C, dphi, jetPtCorr, weight);
             spectra.fill(HIST("hScaledFT0M_DPhi_JetPt_Corr_TTSig_RestrictedPhi"), scaledFT0M, dphi, jetPtCorr, weight);
           }
 
+          // Centrality dependence
+          spectra.fill(HIST("hCentFT0A_DPhi_JetPt_Corr_TTSig"), centFT0A, dphi, jetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0C_DPhi_JetPt_Corr_TTSig"), centFT0C, dphi, jetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0M_DPhi_JetPt_Corr_TTSig"), centFT0M, dphi, jetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0CVar1_DPhi_JetPt_Corr_TTSig"), centFT0CVar1, dphi, jetPtCorr, weight);
+
           if (bRecoilJet) {
+
+            // EA dependence
             spectra.fill(HIST("hScaledFT0C_Recoil_JetPt_Corr_TTSig"), scaledFT0C, jetPtCorr, weight);
             spectra.fill(HIST("hScaledFT0M_Recoil_JetPt_Corr_TTSig"), scaledFT0M, jetPtCorr, weight);
+            spectra.fill(HIST("hScaledFT0C_Recoil_JetPt_TTSig"), scaledFT0C, jetPt, weight);
+            spectra.fill(HIST("hScaledFT0M_Recoil_JetPt_TTSig"), scaledFT0M, jetPt, weight);
 
+            // Centrality dependence
             spectra.fill(HIST("hCentFT0A_Recoil_JetPt_Corr_TTSig"), centFT0A, jetPtCorr, weight);
             spectra.fill(HIST("hCentFT0C_Recoil_JetPt_Corr_TTSig"), centFT0C, jetPtCorr, weight);
             spectra.fill(HIST("hCentFT0M_Recoil_JetPt_Corr_TTSig"), centFT0M, jetPtCorr, weight);
             spectra.fill(HIST("hCentFT0CVar1_Recoil_JetPt_Corr_TTSig"), centFT0CVar1, jetPtCorr, weight);
-
-            spectra.fill(HIST("hScaledFT0C_Recoil_JetPt_TTSig"), scaledFT0C, jetPt, weight);
-            spectra.fill(HIST("hScaledFT0M_Recoil_JetPt_TTSig"), scaledFT0M, jetPt, weight);
           }
         } else {
+
+          spectra.fill(HIST("hJetArea_JetPt_Rho_TTRef"), jetArea, jetPt, rho, weight);
+
+          // EA dependence
           spectra.fill(HIST("hScaledFT0C_DPhi_JetPt_Corr_TTRef"), scaledFT0C, dphi, jetPtCorr, weight);
           spectra.fill(HIST("hScaledFT0M_DPhi_JetPt_Corr_TTRef"), scaledFT0M, dphi, jetPtCorr, weight);
-
-          spectra.fill(HIST("hCentFT0A_DPhi_JetPt_Corr_TTRef"), centFT0A, dphi, jetPtCorr, weight);
-          spectra.fill(HIST("hCentFT0C_DPhi_JetPt_Corr_TTRef"), centFT0C, dphi, jetPtCorr, weight);
-          spectra.fill(HIST("hCentFT0M_DPhi_JetPt_Corr_TTRef"), centFT0M, dphi, jetPtCorr, weight);
-          spectra.fill(HIST("hCentFT0CVar1_DPhi_JetPt_Corr_TTRef"), centFT0CVar1, dphi, jetPtCorr, weight);
-
           spectra.fill(HIST("hScaledFT0C_DPhi_JetPt_TTRef"), scaledFT0C, dphi, jetPt, weight);
           spectra.fill(HIST("hScaledFT0M_DPhi_JetPt_TTRef"), scaledFT0M, dphi, jetPt, weight);
-          spectra.fill(HIST("hJetArea_JetPt_Rho_TTRef"), jetArea, jetPt, rho, weight);
 
           if (phiTT > phiMin && phiTT < phiMax) {
             spectra.fill(HIST("hScaledFT0C_DPhi_JetPt_Corr_TTRef_RestrictedPhi"), scaledFT0C, dphi, jetPtCorr, weight);
             spectra.fill(HIST("hScaledFT0M_DPhi_JetPt_Corr_TTRef_RestrictedPhi"), scaledFT0M, dphi, jetPtCorr, weight);
           }
 
+          // Centrality dependence
+          spectra.fill(HIST("hCentFT0A_DPhi_JetPt_Corr_TTRef"), centFT0A, dphi, jetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0C_DPhi_JetPt_Corr_TTRef"), centFT0C, dphi, jetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0M_DPhi_JetPt_Corr_TTRef"), centFT0M, dphi, jetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0CVar1_DPhi_JetPt_Corr_TTRef"), centFT0CVar1, dphi, jetPtCorr, weight);
+
           if (bRecoilJet) {
+
+            // EA dependence
             spectra.fill(HIST("hScaledFT0C_Recoil_JetPt_Corr_TTRef"), scaledFT0C, jetPtCorr, weight);
             spectra.fill(HIST("hScaledFT0M_Recoil_JetPt_Corr_TTRef"), scaledFT0M, jetPtCorr, weight);
+            spectra.fill(HIST("hScaledFT0C_Recoil_JetPt_TTRef"), scaledFT0C, jetPt, weight);
+            spectra.fill(HIST("hScaledFT0M_Recoil_JetPt_TTRef"), scaledFT0M, jetPt, weight);
 
+            // Centrality dependence
             spectra.fill(HIST("hCentFT0A_Recoil_JetPt_Corr_TTRef"), centFT0A, jetPtCorr, weight);
             spectra.fill(HIST("hCentFT0C_Recoil_JetPt_Corr_TTRef"), centFT0C, jetPtCorr, weight);
             spectra.fill(HIST("hCentFT0M_Recoil_JetPt_Corr_TTRef"), centFT0M, jetPtCorr, weight);
             spectra.fill(HIST("hCentFT0CVar1_Recoil_JetPt_Corr_TTRef"), centFT0CVar1, jetPtCorr, weight);
-
-            spectra.fill(HIST("hScaledFT0C_Recoil_JetPt_TTRef"), scaledFT0C, jetPt, weight);
-            spectra.fill(HIST("hScaledFT0M_Recoil_JetPt_TTRef"), scaledFT0M, jetPt, weight);
           }
         }
       }
@@ -1327,19 +1423,46 @@ struct RecoilJets {
     bool bSigEv = false;
     std::vector<double> vPhiOfTT;
     double phiTT = 0.;
-    int nTT = 0;
-    float rho = collision.rho();
+    int nTT = 0;    
+    const float addCountToTTRef = 0.5;
+    const float addCountToTTSig = 1.5;
+
+    const auto vertexZ = collision.posZ();
+    const auto rho = collision.rho();
+
     const auto ft0Metrics = getFT0Metrics(collision, ft0a.meanPartLevel, ft0c.meanPartLevel);
     const auto scaledFT0C = ft0Metrics.scaledFT0C;
     const auto scaledFT0M = ft0Metrics.scaledFT0M;
 
-    auto dice = randGen->Rndm();
+    const auto centFT0A = collision.centFT0A();
+    const auto centFT0C = collision.centFT0C();
+    const auto centFT0M = collision.centFT0M();
+
+    const auto dice = randGen->Rndm();
     if (dice < tt.fracSig)
       bSigEv = true;
 
-    spectra.fill(HIST("hScaledFT0C_vertexZMC"), scaledFT0C, collision.posZ(), weight);
-    spectra.fill(HIST("hScaledFT0M_vertexZMC"), scaledFT0M, collision.posZ(), weight);
+    // EA distributions
+    spectra.fill(HIST("hScaledFT0C_Part"), scaledFT0C, weight);
+    spectra.fill(HIST("hScaledFT0M_Part"), scaledFT0M, weight);
 
+
+    // Centrality distribution
+    spectra.fill(HIST("hCentFT0A_Part"), centFT0A, weight);
+    spectra.fill(HIST("hCentFT0C_Part"), centFT0C, weight);
+    spectra.fill(HIST("hCentFT0M_Part"), centFT0M, weight);
+
+
+    // Z vertex position vs EA / centrality
+    spectra.fill(HIST("hScaledFT0C_vertexZ_Part"), scaledFT0C, vertexZ, weight);
+    spectra.fill(HIST("hScaledFT0M_vertexZ_Part"), scaledFT0M, vertexZ, weight);
+
+    spectra.fill(HIST("hCentFT0A_vertexZ_Part"), centFT0A, vertexZ, weight);
+    spectra.fill(HIST("hCentFT0C_vertexZ_Part"), centFT0C, vertexZ, weight);
+    spectra.fill(HIST("hCentFT0M_vertexZ_Part"), centFT0M, vertexZ, weight);
+
+
+    // Rho vs EA / centrality
     spectra.fill(HIST("hScaledFT0C_Rho_Part"), scaledFT0C, rho, weight);
     spectra.fill(HIST("hScaledFT0M_Rho_Part"), scaledFT0M, rho, weight);
 
@@ -1347,11 +1470,16 @@ struct RecoilJets {
       if (skipParticle(particle))
         continue;
 
-      float particlePt = particle.pt();
-      float particlePhi = particle.phi();
+      const auto particlePt = particle.pt();
+      const auto particlePhi = particle.phi();
+      const auto particleEta = particle.eta();
 
-      spectra.fill(HIST("hScaledFT0CPartPtEtaPhi"), scaledFT0C, particlePt, particle.eta(), particlePhi, weight);
-      spectra.fill(HIST("hScaledFT0MPartPtEtaPhi"), scaledFT0M, particlePt, particle.eta(), particlePhi, weight);
+      spectra.fill(HIST("hScaledFT0CTrackPtEtaPhi_Part"), scaledFT0C, particlePt, particleEta, particlePhi, weight);
+      spectra.fill(HIST("hScaledFT0MTrackPtEtaPhi_Part"), scaledFT0M, particlePt, particleEta, particlePhi, weight);
+
+      spectra.fill(HIST("hCentFT0ATrackPtEtaPhi_Part"), centFT0A, particlePt, particleEta, particlePhi, weight);
+      spectra.fill(HIST("hCentFT0CTrackPtEtaPhi_Part"), centFT0C, particlePt, particleEta, particlePhi, weight);
+      spectra.fill(HIST("hCentFT0MTrackPtEtaPhi_Part"), centFT0M, particlePt, particleEta, particlePhi, weight);
 
       // Search for TT candidate
       const auto ptTTsigMin = tt.sigPtRange->at(0);
@@ -1374,8 +1502,11 @@ struct RecoilJets {
       phiTT = getPhiTT(vPhiOfTT);
 
       if (bSigEv) {
-        spectra.fill(HIST("hScaledFT0C_Ntrig_Part"), scaledFT0C, 1.5, weight);
-        spectra.fill(HIST("hScaledFT0M_Ntrig_Part"), scaledFT0M, 1.5, weight);
+
+        // EA
+        spectra.fill(HIST("hScaledFT0C_Ntrig_Part"), scaledFT0C, addCountToTTSig, weight);
+        spectra.fill(HIST("hScaledFT0M_Ntrig_Part"), scaledFT0M, addCountToTTSig, weight);
+
         spectra.fill(HIST("hScaledFT0C_TTSig_per_event_Part"), scaledFT0C, nTT, weight);
         spectra.fill(HIST("hScaledFT0M_TTSig_per_event_Part"), scaledFT0M, nTT, weight);
 
@@ -1384,9 +1515,25 @@ struct RecoilJets {
 
         spectra.fill(HIST("hScaledFT0C_Rho_TTSig_Part"), scaledFT0C, rho, weight);
         spectra.fill(HIST("hScaledFT0M_Rho_TTSig_Part"), scaledFT0M, rho, weight);
+
+        //_____________________________________________________
+        // Centrality
+        spectra.fill(HIST("hCentFT0A_Ntrig_Part"), centFT0A, addCountToTTSig, weight);
+        spectra.fill(HIST("hCentFT0C_Ntrig_Part"), centFT0C, addCountToTTSig, weight);
+        spectra.fill(HIST("hCentFT0M_Ntrig_Part"), centFT0M, addCountToTTSig, weight);
+
+        spectra.fill(HIST("hCentFT0A_TTSig_Part"), centFT0A, weight);
+        spectra.fill(HIST("hCentFT0C_TTSig_Part"), centFT0C, weight);
+        spectra.fill(HIST("hCentFT0M_TTSig_Part"), centFT0M, weight);
+
+        spectra.fill(HIST("hCentFT0A_Rho_TTSig_Part"), centFT0A, rho, weight);
+        spectra.fill(HIST("hCentFT0C_Rho_TTSig_Part"), centFT0C, rho, weight);
+        spectra.fill(HIST("hCentFT0M_Rho_TTSig_Part"), centFT0M, rho, weight);
+
       } else {
-        spectra.fill(HIST("hScaledFT0C_Ntrig_Part"), scaledFT0C, 0.5, weight);
-        spectra.fill(HIST("hScaledFT0M_Ntrig_Part"), scaledFT0M, 0.5, weight);
+        spectra.fill(HIST("hScaledFT0C_Ntrig_Part"), scaledFT0C, addCountToTTRef, weight);
+        spectra.fill(HIST("hScaledFT0M_Ntrig_Part"), scaledFT0M, addCountToTTRef, weight);
+
         spectra.fill(HIST("hScaledFT0C_TTRef_per_event_Part"), scaledFT0C, nTT, weight);
         spectra.fill(HIST("hScaledFT0M_TTRef_per_event_Part"), scaledFT0M, nTT, weight);
 
@@ -1395,13 +1542,27 @@ struct RecoilJets {
 
         spectra.fill(HIST("hScaledFT0C_Rho_TTRef_Part"), scaledFT0C, rho, weight);
         spectra.fill(HIST("hScaledFT0M_Rho_TTRef_Part"), scaledFT0M, rho, weight);
+
+        //_____________________________________________________
+        // Centrality
+        spectra.fill(HIST("hCentFT0A_Ntrig_Part"), centFT0A, addCountToTTRef, weight);
+        spectra.fill(HIST("hCentFT0C_Ntrig_Part"), centFT0C, addCountToTTRef, weight);
+        spectra.fill(HIST("hCentFT0M_Ntrig_Part"), centFT0M, addCountToTTRef, weight);
+
+        spectra.fill(HIST("hCentFT0A_TTRef_Part"), centFT0A, weight);
+        spectra.fill(HIST("hCentFT0C_TTRef_Part"), centFT0C, weight);
+        spectra.fill(HIST("hCentFT0M_TTRef_Part"), centFT0M, weight);
+
+        spectra.fill(HIST("hCentFT0A_Rho_TTRef_Part"), centFT0A, rho, weight);
+        spectra.fill(HIST("hCentFT0C_Rho_TTRef_Part"), centFT0C, rho, weight);
+        spectra.fill(HIST("hCentFT0M_Rho_TTRef_Part"), centFT0M, rho, weight);
       }
     }
 
     for (const auto& jet : jets) {
-      float jetPt = jet.pt();
-      float jetArea = jet.area();
-      float jetPtCorr = jetPt - rho * jetArea;
+      const auto jetPt = jet.pt();
+      const auto jetArea = jet.area();
+      const auto jetPtCorr = jetPt - rho * jetArea;
 
       spectra.fill(HIST("hJetPtEtaPhiRhoArea_Part"), jetPt, jet.eta(), jet.phi(), rho, jetArea, weight);
 
@@ -1412,48 +1573,70 @@ struct RecoilJets {
         auto [dphi, bRecoilJet] = isRecoilJet(jet, phiTT);
 
         if (bSigEv) {
-          spectra.fill(HIST("hScaledFT0C_DPhi_JetPt_Corr_TTSig_Part"), scaledFT0C, dphi, jetPtCorr, weight);
-          spectra.fill(HIST("hScaledFT0M_DPhi_JetPt_Corr_TTSig_Part"), scaledFT0M, dphi, jetPtCorr, weight);
-
-          spectra.fill(HIST("hScaledFT0C_DPhi_JetPt_TTSig_Part"), scaledFT0C, dphi, jetPt, weight);
-          spectra.fill(HIST("hScaledFT0M_DPhi_JetPt_TTSig_Part"), scaledFT0M, dphi, jetPt, weight);
 
           spectra.fill(HIST("hJetArea_JetPt_Rho_TTSig_Part"), jetArea, jetPt, rho, weight);
+
+          // EA dependence
+          spectra.fill(HIST("hScaledFT0C_DPhi_JetPt_Corr_TTSig_Part"), scaledFT0C, dphi, jetPtCorr, weight);
+          spectra.fill(HIST("hScaledFT0M_DPhi_JetPt_Corr_TTSig_Part"), scaledFT0M, dphi, jetPtCorr, weight);
+          spectra.fill(HIST("hScaledFT0C_DPhi_JetPt_TTSig_Part"), scaledFT0C, dphi, jetPt, weight);
+          spectra.fill(HIST("hScaledFT0M_DPhi_JetPt_TTSig_Part"), scaledFT0M, dphi, jetPt, weight);
 
           if (phiTT > phiMin && phiTT < phiMax) {
             spectra.fill(HIST("hScaledFT0C_DPhi_JetPt_Corr_TTSig_RestrictedPhi_Part"), scaledFT0C, dphi, jetPtCorr, weight);
             spectra.fill(HIST("hScaledFT0M_DPhi_JetPt_Corr_TTSig_RestrictedPhi_Part"), scaledFT0M, dphi, jetPtCorr, weight);
           }
 
+          // Centrality dependence
+          spectra.fill(HIST("hCentFT0A_DPhi_JetPt_Corr_TTSig_Part"), centFT0A, dphi, jetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0C_DPhi_JetPt_Corr_TTSig_Part"), centFT0C, dphi, jetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0M_DPhi_JetPt_Corr_TTSig_Part"), centFT0M, dphi, jetPtCorr, weight);
+
           if (bRecoilJet) {
+
+            // EA dependence
             spectra.fill(HIST("hScaledFT0C_Recoil_JetPt_Corr_TTSig_Part"), scaledFT0C, jetPtCorr, weight);
             spectra.fill(HIST("hScaledFT0M_Recoil_JetPt_Corr_TTSig_Part"), scaledFT0M, jetPtCorr, weight);
-
             spectra.fill(HIST("hScaledFT0C_Recoil_JetPt_TTSig_Part"), scaledFT0C, jetPt, weight);
             spectra.fill(HIST("hScaledFT0M_Recoil_JetPt_TTSig_Part"), scaledFT0M, jetPt, weight);
-          }
 
+            // Centrality dependence
+            spectra.fill(HIST("hCentFT0A_Recoil_JetPt_Corr_TTSig_Part"), centFT0A, jetPtCorr, weight);
+            spectra.fill(HIST("hCentFT0C_Recoil_JetPt_Corr_TTSig_Part"), centFT0C, jetPtCorr, weight);
+            spectra.fill(HIST("hCentFT0M_Recoil_JetPt_Corr_TTSig_Part"), centFT0M, jetPtCorr, weight);
+          }
         } else {
 
+          spectra.fill(HIST("hJetArea_JetPt_Rho_TTRef_Part"), jetArea, jetPt, rho, weight);
+
+          // EA dependence
           spectra.fill(HIST("hScaledFT0C_DPhi_JetPt_Corr_TTRef_Part"), scaledFT0C, dphi, jetPtCorr, weight);
           spectra.fill(HIST("hScaledFT0M_DPhi_JetPt_Corr_TTRef_Part"), scaledFT0M, dphi, jetPtCorr, weight);
-
           spectra.fill(HIST("hScaledFT0C_DPhi_JetPt_TTRef_Part"), scaledFT0C, dphi, jetPt, weight);
           spectra.fill(HIST("hScaledFT0M_DPhi_JetPt_TTRef_Part"), scaledFT0M, dphi, jetPt, weight);
-
-          spectra.fill(HIST("hJetArea_JetPt_Rho_TTRef_Part"), jetArea, jetPt, rho, weight);
 
           if (phiTT > phiMin && phiTT < phiMax) {
             spectra.fill(HIST("hScaledFT0C_DPhi_JetPt_Corr_TTRef_RestrictedPhi_Part"), scaledFT0C, dphi, jetPtCorr, weight);
             spectra.fill(HIST("hScaledFT0M_DPhi_JetPt_Corr_TTRef_RestrictedPhi_Part"), scaledFT0M, dphi, jetPtCorr, weight);
           }
 
+          // Centrality dependence
+          spectra.fill(HIST("hCentFT0A_DPhi_JetPt_Corr_TTRef_Part"), centFT0A, dphi, jetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0C_DPhi_JetPt_Corr_TTRef_Part"), centFT0C, dphi, jetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0M_DPhi_JetPt_Corr_TTRef_Part"), centFT0M, dphi, jetPtCorr, weight);
+
           if (bRecoilJet) {
+
+            // EA dependence
             spectra.fill(HIST("hScaledFT0C_Recoil_JetPt_Corr_TTRef_Part"), scaledFT0C, jetPtCorr, weight);
             spectra.fill(HIST("hScaledFT0M_Recoil_JetPt_Corr_TTRef_Part"), scaledFT0M, jetPtCorr, weight);
-
             spectra.fill(HIST("hScaledFT0C_Recoil_JetPt_TTRef_Part"), scaledFT0C, jetPt, weight);
             spectra.fill(HIST("hScaledFT0M_Recoil_JetPt_TTRef_Part"), scaledFT0M, jetPt, weight);
+
+            // Centrality dependence
+            spectra.fill(HIST("hCentFT0A_Recoil_JetPt_Corr_TTRef_Part"), centFT0A, jetPtCorr, weight);
+            spectra.fill(HIST("hCentFT0C_Recoil_JetPt_Corr_TTRef_Part"), centFT0C, jetPtCorr, weight);
+            spectra.fill(HIST("hCentFT0M_Recoil_JetPt_Corr_TTRef_Part"), centFT0M, jetPtCorr, weight);
           }
         }
       }
@@ -1471,21 +1654,20 @@ struct RecoilJets {
                                 float detLevelCollRho,
                                 float weight = 1.)
   {
-    /// TODO: consider TT cand. on both MC levels simultaneously
 
     // Utilities for recoil jets; TTsis at det. level MC
     std::vector<double> vPhiOfTT = getPhiOfAllTTsigCandidates(tracks);
     double phiTTSig = 0.0;
-    bool bIsThereTTSig = vPhiOfTT.size() > 0;
+    const bool bIsThereTTSig = vPhiOfTT.size() > 0;
 
     if (bIsThereTTSig)
       phiTTSig = getPhiTT(vPhiOfTT);
 
     for (const auto& jetPart : jetsPart) {
-      auto partJetPt = jetPart.pt();
-      auto partJetPtCorr = partJetPt - partLevelCollRho * jetPart.area();
+      const auto partJetPt = jetPart.pt();
+      const auto partJetPtCorr = partJetPt - partLevelCollRho * jetPart.area();
 
-      bool bIsPartJetRecoil =
+      const bool bIsPartJetRecoil =
         get<1>(isRecoilJet(jetPart, phiTTSig)) && bIsThereTTSig;
 
       // Distribution of all part. level jets
@@ -1515,8 +1697,8 @@ struct RecoilJets {
             }
 
           } else {
-            auto detJetPt = jetDetMatched.pt();
-            auto detJetPtCorr = detJetPt - detLevelCollRho * jetDetMatched.area();
+            const auto detJetPt = jetDetMatched.pt();
+            const auto detJetPtCorr = detJetPt - detLevelCollRho * jetDetMatched.area();
 
             spectra.fill(HIST("hNumberMatchedInclusiveDetJetsPerOnePartJet"), jetsDetMatched.size(), detJetPt, partJetPt, weight);
 
@@ -1558,10 +1740,10 @@ struct RecoilJets {
       if (isJetWithHighPtConstituent<JTracks>(jetDet))
         continue;
 
-      auto detJetPt = jetDet.pt();
-      auto detJetPtCorr = detJetPt - detLevelCollRho * jetDet.area();
+      const auto detJetPt = jetDet.pt();
+      const auto detJetPtCorr = detJetPt - detLevelCollRho * jetDet.area();
 
-      bool bIsJetRecoil =
+      const bool bIsJetRecoil =
         get<1>(isRecoilJet(jetDet, phiTTSig)) && bIsThereTTSig;
 
       // Distribution of all det. level jets
@@ -1597,16 +1779,16 @@ struct RecoilJets {
     // Utilities for recoil jets; TTsis at det. level MC
     std::vector<double> vPhiOfTT = getPhiOfAllTTsigCandidates(tracks);
     double phiTTSig = 0.0;
-    bool bIsThereTTSig = vPhiOfTT.size() > 0;
+    const bool bIsThereTTSig = vPhiOfTT.size() > 0;
 
     if (bIsThereTTSig)
       phiTTSig = getPhiTT(vPhiOfTT);
 
     for (const auto& jetPart : jetsPart) {
-      auto partJetPt = jetPart.pt();
-      auto partJetPtCorr = partJetPt - partLevelCollRho * jetPart.area();
+      const auto partJetPt = jetPart.pt();
+      const auto partJetPtCorr = partJetPt - partLevelCollRho * jetPart.area();
 
-      bool bIsPartJetRecoil =
+      const bool bIsPartJetRecoil =
         get<1>(isRecoilJet(jetPart, phiTTSig)) && bIsThereTTSig;
 
       // Distribution of all part. level jets
@@ -1640,8 +1822,8 @@ struct RecoilJets {
               spectra.fill(HIST("hMissedRecoilJetsPtCorr"), partJetPtCorr, weight);
             }
           } else {
-            auto detJetPt = jetDetMatched.pt();
-            auto detJetPtCorr = detJetPt - detLevelCollRho * jetDetMatched.area();
+            const auto detJetPt = jetDetMatched.pt();
+            const auto detJetPtCorr = detJetPt - detLevelCollRho * jetDetMatched.area();
 
             spectra.fill(HIST("hNumberMatchedInclusiveDetJetsPerOnePartJet"), jetsDetMatched.size(), detJetPt, partJetPt, weight);
 
@@ -1683,10 +1865,10 @@ struct RecoilJets {
       if (isJetWithHighPtConstituent<JTracks>(jetDet))
         continue;
 
-      auto detJetPt = jetDet.pt();
-      auto detJetPtCorr = detJetPt - detLevelCollRho * jetDet.area();
+      const auto detJetPt = jetDet.pt();
+      const auto detJetPtCorr = detJetPt - detLevelCollRho * jetDet.area();
 
-      bool bIsJetRecoil =
+      const bool bIsJetRecoil =
         get<1>(isRecoilJet(jetDet, phiTTSig)) && bIsThereTTSig;
 
       // Distribution of all det. level jets
@@ -2635,7 +2817,7 @@ struct RecoilJets {
   PROCESS_SWITCH(RecoilJets, processMCDetLevelWeighted, "process MC det. level data (weighted JJ)", false);
 
   //_____________________
-  void processMCPartLevel(CollRhoPartIt const& collision,
+  void processMCPartLevel(CollCentRhoPartIt const& collision,
                           PartTbl const& particlesPerColl,
                           JetsPartTbl const& jetsPerColl)
   {
@@ -2652,7 +2834,7 @@ struct RecoilJets {
   PROCESS_SWITCH(RecoilJets, processMCPartLevel, "process MC part. level data (no weight; MB events)", false);
 
   //_____________________________
-  void processMCPartLevelWeighted(CollRhoOutlierPartIt const& collision,
+  void processMCPartLevelWeighted(CollCentRhoOutlierPartIt const& collision,
                                   PartTbl const& particlesPerColl,
                                   JetsPartTbl const& jetsPerColl)
   {

--- a/PWGJE/Tasks/recoilJets.cxx
+++ b/PWGJE/Tasks/recoilJets.cxx
@@ -900,6 +900,7 @@ struct RecoilJets {
       }
     }
 
+    // Smearing of trigger-track parameters
     if (doprocessTTSmearingPtPhi || doprocessTTSmearingPtPhiWeighted) {
       AxisSpec relPtSmearTT{120, -5., 1., "(#it{p}_{T, part} - #it{p}_{T, det}) / #it{p}_{T, part}"};
       AxisSpec smearPhi{80, -0.2, 0.2, "#it{#varphi}_{part} - #it{#varphi}_{det}"};
@@ -2397,13 +2398,15 @@ struct RecoilJets {
     if (skipEvent(collision) || !collision.has_mcCollision())
       return;
 
-    auto mcCollisionId = collision.mcCollisionId();
-    auto detLevelCollRho = collision.rho();
-
     auto mcColl = collision.mcCollision_as<CollRhoPartTbl>();
+    if(std::fabs(mcColl.posZ()) > ev.vertexZCut)
+      return;
+
+    auto detLevelCollRho = collision.rho();
     auto partLevelCollRho = mcColl.rho();
 
     // Slice for mc part level jets associated to a given mcCollisionId
+    auto mcCollisionId = collision.mcCollisionId();
     auto mcPartJetsPerMcCollision = mcPartJets.sliceBy(partJetsPerMcCollision, mcCollisionId); // signature: (__column to slice___, __index__)
 
     fillMatchedGeoHistograms(mcPartJetsPerMcCollision, mcDetJetsPerColl, tracksPerColl, partLevelCollRho, detLevelCollRho);
@@ -2421,13 +2424,15 @@ struct RecoilJets {
     if (skipEvent(collision) || !collision.has_mcCollision())
       return;
 
-    auto mcCollisionId = collision.mcCollisionId();
-    auto detLevelCollRho = collision.rho();
-
     auto mcColl = collision.mcCollision_as<CollRhoPartTbl>();
+    if(std::fabs(mcColl.posZ()) > ev.vertexZCut)
+      return;
+
+    auto detLevelCollRho = collision.rho();
     auto partLevelCollRho = mcColl.rho();
 
     // Slice for mc part level jets associated to a given mcCollisionId
+    auto mcCollisionId = collision.mcCollisionId();
     auto mcPartJetsPerMcCollision = mcPartJets.sliceBy(partJetsPerMcCollision, mcCollisionId); // signature: (__column to slice___, __index__)
 
     fillMatchedGeoPtHistograms(mcPartJetsPerMcCollision, mcDetJetsPerColl, tracksPerColl, partLevelCollRho, detLevelCollRho);
@@ -2445,14 +2450,16 @@ struct RecoilJets {
     if (skipEvent(collision) || collision.isOutlier() || !collision.has_mcCollision())
       return;
 
-    auto mcCollisionId = collision.mcCollisionId();
-    auto detLevelCollRho = collision.rho();
-
     auto mcColl = collision.mcCollision_as<CollRhoOutlierPartTbl>();
+    if(std::fabs(mcColl.posZ()) > ev.vertexZCut)
+      return;
+
+    auto detLevelCollRho = collision.rho();
     auto partLevelCollRho = mcColl.rho();
     auto weight = mcColl.weight();
 
     // Slice for mc part level jets associated to a given mcCollisionId
+    auto mcCollisionId = collision.mcCollisionId();
     auto mcPartJetsPerMcCollision = mcPartJets.sliceBy(partJetsPerMcCollision, mcCollisionId); // signature: (__column to slice___, __index__)
 
     fillMatchedGeoHistograms(mcPartJetsPerMcCollision, mcDetJetsPerColl, tracksPerColl, partLevelCollRho, detLevelCollRho, weight);
@@ -2470,14 +2477,16 @@ struct RecoilJets {
     if (skipEvent(collision) || collision.isOutlier() || !collision.has_mcCollision())
       return;
 
-    auto mcCollisionId = collision.mcCollisionId();
-    auto detLevelCollRho = collision.rho();
-
     auto mcColl = collision.mcCollision_as<CollRhoOutlierPartTbl>();
+    if(std::fabs(mcColl.posZ()) > ev.vertexZCut)
+      return;
+
+    auto detLevelCollRho = collision.rho();
     auto partLevelCollRho = mcColl.rho();
     auto weight = mcColl.weight();
 
     // Slice for mc part level jets associated to a given mcCollisionId
+    auto mcCollisionId = collision.mcCollisionId();
     auto mcPartJetsPerMcCollision = mcPartJets.sliceBy(partJetsPerMcCollision, mcCollisionId); // signature: (__column to slice___, __index__)
 
     fillMatchedGeoPtHistograms(mcPartJetsPerMcCollision, mcDetJetsPerColl, tracksPerColl, partLevelCollRho, detLevelCollRho, weight);
@@ -2632,7 +2641,7 @@ struct RecoilJets {
   {
 
     // Skip detector level collisions
-    if (skipEvent(collision) || !collision.has_mcCollision())
+    if (skipEvent(collision))
       return;
 
     fillTTSmearingPtPhi(collision, tracksPerColl, particles);

--- a/PWGJE/Tasks/recoilJets.cxx
+++ b/PWGJE/Tasks/recoilJets.cxx
@@ -2627,7 +2627,6 @@ struct RecoilJets {
   // Pt and Phi smearing of TT
   //=============================================================================
   void processTTSmearingPtPhi(CollDetIt const& collision,
-                              aod::JetMcCollisions const&,
                               TrackMCLbsTbl const& tracksPerColl,
                               aod::JetParticles const& particles)
   {

--- a/PWGJE/Tasks/recoilJets.cxx
+++ b/PWGJE/Tasks/recoilJets.cxx
@@ -295,10 +295,10 @@ struct RecoilJets {
                                                                 {"FT0M", unscaledFT0M}}};
 
     std::array<AxisDesc<ConfigurableAxis>, 2> arrConfigurableAxisEA = {{{"FT0C", hist.multFT0CThresh, nameFT0Caxis},
-                                                                      {"FT0M", hist.multFT0MThresh, nameFT0Maxis}}};
+                                                                        {"FT0M", hist.multFT0MThresh, nameFT0Maxis}}};
 
     std::array<AxisDesc<ConfigurableAxis>, 2> arrConfigurableAxisEAPartLevel = {{{"FT0C", hist.multFT0CThreshPartLevel, nameFT0Caxis},
-                                                                               {"FT0M", hist.multFT0MThreshPartLevel, nameFT0Maxis}}};
+                                                                                 {"FT0M", hist.multFT0MThreshPartLevel, nameFT0Maxis}}};
 
     std::array<AxisDesc<ConfigurableAxis>, 4> arrConfigurableAxisCentrality = {{{"CentFT0A", hist.axisCentrality, nameCentralityAxis},
                                                                                 {"CentFT0C", hist.axisCentrality, nameCentralityAxis},
@@ -608,8 +608,10 @@ struct RecoilJets {
       uint8_t iCent = 0;
       for (const auto& centAxis : arrConfigurableAxisCentrality) {
         
-        if (iCent == 3) // case of "CentFT0CVar1"
+        if (iCent == 3){ // case of "CentFT0CVar1"
+          ++iCent;
           continue;
+        }
 
         // Vertex Z position
         spectra.add(Form("h%s_vertexZ_Part", centAxis.label),
@@ -676,7 +678,7 @@ struct RecoilJets {
       }
     }
 
-    // Jet matching
+    // Jet matching analysis
     if (doprocessJetsGeoMatching || doprocessJetsGeoMatchingWeighted || doprocessJetsGeoPtMatchingWeighted || doprocessJetsGeoPtMatching) {
       AxisSpec detJetPt{200, 0.0, 200., "#it{p}_{T, det} (GeV/#it{c})"};
       AxisSpec detJetPtCorr{220, -20.0, 200., "#it{p}_{T, det}^{corr.} (GeV/#it{c})"};
@@ -685,6 +687,9 @@ struct RecoilJets {
       AxisSpec partJetPtCorr{220, -20.0, 200., "#it{p}_{T, part}^{corr.} (GeV/#it{c})"};
 
       AxisSpec relJetSmearPt{100, -5., 1., "(#it{p}_{T, part} - #it{p}_{T, det}) / #it{p}_{T, part}"};
+      AxisSpec jetSmearPhi{100, -0.5, 0.5, "#it{#varphi}_{part} - #it{#varphi}_{det}"};
+
+      AxisSpec numberMatchedDetJets{4, 0.5, 4.5, "# of matched det. level jets"};
 
       //====================================================================================
       // Part. level jets
@@ -692,33 +697,17 @@ struct RecoilJets {
                   "All part. level inclusive jets",
                   kTH1F, {partJetPt}, hist.sumw2);
 
-      spectra.add("hPartLevelInclusiveJetsPtCorr",
-                  "All part. level inclusive jets",
-                  kTH1F, {partJetPtCorr}, hist.sumw2);
-
       spectra.add("hPartLevelRecoilJetsPt",
                   "All part. level recoil jets",
                   kTH1F, {partJetPt}, hist.sumw2);
-
-      spectra.add("hPartLevelRecoilJetsPtCorr",
-                  "All part. level recoil jets",
-                  kTH1F, {partJetPtCorr}, hist.sumw2);
 
       spectra.add("hMissedInclusiveJetsPt",
                   "Part. level inclusive jets w/o matched pair",
                   kTH1F, {partJetPt}, hist.sumw2);
 
-      spectra.add("hMissedInclusiveJetsPtCorr",
-                  "Part. level inclusive jets w/o matched pair",
-                  kTH1F, {partJetPtCorr}, hist.sumw2);
-
       spectra.add("hMissedRecoilJetsPt",
                   "Part. level recoil jets w/o matched pair",
                   kTH1F, {partJetPt}, hist.sumw2);
-
-      spectra.add("hMissedRecoilJetsPtCorr",
-                  "Part. level recoil jets w/o matched pair",
-                  kTH1F, {partJetPtCorr}, hist.sumw2);
 
       //====================================================================================
       // Det. level jets
@@ -726,90 +715,177 @@ struct RecoilJets {
                   "All reconstructed inclusive jets",
                   kTH1F, {detJetPt}, hist.sumw2);
 
-      spectra.add("hDetLevelInclusiveJetsPtCorr",
-                  "All reconstructed inclusive jets",
-                  kTH1F, {detJetPtCorr}, hist.sumw2);
-
       spectra.add("hDetLevelRecoilJetsPt",
                   "All reconstructed recoil jets",
                   kTH1F, {detJetPt}, hist.sumw2);
-
-      spectra.add("hDetLevelRecoilJetsPtCorr",
-                  "All reconstructed recoil jets",
-                  kTH1F, {detJetPtCorr}, hist.sumw2);
 
       spectra.add("hFakeInclusiveJetsPt",
                   "Det. level inclusive jets w/o matched pair",
                   kTH1F, {detJetPt}, hist.sumw2);
 
-      spectra.add("hFakeInclusiveJetsPtCorr",
-                  "Det. level inclusive jets w/o matched pair",
-                  kTH1F, {detJetPtCorr}, hist.sumw2);
-
       spectra.add("hFakeRecoilJetsPt",
                   "Det. level recoil jets w/o matched pair",
                   kTH1F, {detJetPt}, hist.sumw2);
 
-      spectra.add("hFakeRecoilJetsPtCorr",
-                  "Det. level recoil jets w/o matched pair",
-                  kTH1F, {detJetPtCorr}, hist.sumw2);
-
       //====================================================================================
-      // Response matices with inclusive jets
+      // Response matrices with inclusive jets
       spectra.add("hResponseMatrixInclusiveJetsPt",
                   "Correlation inclusive #it{p}_{T, det.} vs. #it{p}_{T, part}",
                   kTH2F, {detJetPt, partJetPt}, hist.sumw2);
 
-      spectra.add("hResponseMatrixInclusiveJetsPtCorr",
-                  "Correlation inclusive #it{p}_{T, det.} vs. #it{p}_{T, part}",
-                  kTH2F, {detJetPtCorr, partJetPtCorr}, hist.sumw2);
-
-      //====================================================================================
-      // Response matices with recoil jets
+      // Response matrices with recoil jets
       spectra.add("hResponseMatrixRecoilJetsPt",
                   "Correlation recoil #it{p}_{T, det.} vs. #it{p}_{T, part}",
                   kTH2F, {detJetPt, partJetPt}, hist.sumw2);
 
-      spectra.add("hResponseMatrixRecoilJetsPtCorr",
-                  "Correlation recoil #it{p}_{T, det.} vs. #it{p}_{T, part}",
-                  kTH2F, {detJetPtCorr, partJetPtCorr}, hist.sumw2);
-
       //====================================================================================
-      // Jet energy scale and resolution: pT and phi
-      spectra.add("hInclusiveJESPt",
-                  "ES of inclusive jets vs. #it{p}_{T, part}",
-                  kTH2F, {relJetSmearPt, partJetPt}, hist.sumw2);
-
+      // Jet energy scale and resolution
       spectra.add("hInclusiveJESPtCorr",
-                  "ES of inclusive jets vs. #it{p}_{T, part}",
+                  "ES of inclusive jets vs. #it{p}_{T, part}^{corr.}",
                   kTH2F, {relJetSmearPt, partJetPtCorr}, hist.sumw2);
-
-      spectra.add("hRecoilJESPt",
-                  "ES of recoil jets vs. #it{p}_{T, part}",
-                  kTH2F, {relJetSmearPt, partJetPt}, hist.sumw2);
 
       spectra.add("hRecoilJESPtCorr",
-                  "ES of recoil jets vs. #it{p}_{T, part}",
+                  "ES of recoil jets vs. #it{p}_{T, part}^{corr.}",
                   kTH2F, {relJetSmearPt, partJetPtCorr}, hist.sumw2);
 
-      AxisSpec jetSmearPhi{100, -0.5, 0.5, "#it{#varphi}_{part} - #it{#varphi}_{det}"};
-      spectra.add("hInclusiveJESPhi",
-                  "#varphi resolution as a func. of jet #it{p}_{T, part}",
-                  kTH2F, {jetSmearPhi, partJetPt}, hist.sumw2);
+      //====================================================================================
+      // Centrality-differential corrected spectra and response QA
+      uint8_t iCent = 0;
+      for (const auto& centAxis : arrConfigurableAxisCentrality) {
+        
+        if (iCent == 0 || iCent == 3) { // case of "CentFT0A" & "CentFT0CVar1"
+          ++iCent;
+          continue;
+        }
+        
+        spectra.add(Form("h%s_ResponseMatrixInclusiveJetsPtCorr", centAxis.label),
+                    Form("%s: correlation inclusive #it{p}_{T, det.}^{corr.} vs. #it{p}_{T, part}^{corr.}", centAxis.label),
+                    kTH3F, {{centAxis.axis, centAxis.axisName}, detJetPtCorr, partJetPtCorr}, hist.sumw2);
 
-      spectra.add("hRecoilJESPhi",
-                  "#varphi resolution as a func. of jet #it{p}_{T, part}",
-                  kTH2F, {jetSmearPhi, partJetPt}, hist.sumw2);
+        spectra.add(Form("h%s_ResponseMatrixRecoilJetsPtCorr", centAxis.label),
+                    Form("%s: correlation recoil #it{p}_{T, det.}^{corr.} vs. #it{p}_{T, part}^{corr.}", centAxis.label),
+                    kTH3F, {{centAxis.axis, centAxis.axisName}, detJetPtCorr, partJetPtCorr}, hist.sumw2);
+
+        spectra.add(Form("h%s_InclusiveJESPt", centAxis.label),
+                    Form("%s: ES of inclusive jets vs. #it{p}_{T, part}", centAxis.label),
+                    kTH3F, {{centAxis.axis, centAxis.axisName}, relJetSmearPt, partJetPt}, hist.sumw2);
+
+        spectra.add(Form("h%s_RecoilJESPt", centAxis.label),
+                    Form("%s: ES of recoil jets vs. #it{p}_{T, part}", centAxis.label),
+                    kTH3F, {{centAxis.axis, centAxis.axisName}, relJetSmearPt, partJetPt}, hist.sumw2);
+
+        spectra.add(Form("h%s_InclusiveJESPhi", centAxis.label),
+                    Form("%s: #varphi resolution as a func. of jet #it{p}_{T, part}", centAxis.label),
+                    kTH3F, {{centAxis.axis, centAxis.axisName}, jetSmearPhi, partJetPt}, hist.sumw2);
+
+        spectra.add(Form("h%s_RecoilJESPhi", centAxis.label),
+                    Form("%s: #varphi resolution as a func. of jet #it{p}_{T, part}", centAxis.label),
+                    kTH3F, {{centAxis.axis, centAxis.axisName}, jetSmearPhi, partJetPt}, hist.sumw2);
+
+        spectra.add(Form("h%s_FakeInclusiveJetsPtCorr", centAxis.label),
+                    Form("%s: det. level inclusive jets w/o matched pair", centAxis.label),
+                    kTH2F, {{centAxis.axis, centAxis.axisName}, detJetPtCorr}, hist.sumw2);
+
+        spectra.add(Form("h%s_FakeRecoilJetsPtCorr", centAxis.label),
+                    Form("%s: det. level recoil jets w/o matched pair", centAxis.label), kTH2F,
+                    {{centAxis.axis, centAxis.axisName}, detJetPtCorr}, hist.sumw2);
+
+        spectra.add(Form("h%s_DetLevelInclusiveJetsPtCorr", centAxis.label),
+                    Form("%s: all reconstructed inclusive jets", centAxis.label),
+                    kTH2F, {{centAxis.axis, centAxis.axisName}, detJetPtCorr}, hist.sumw2);
+
+        spectra.add(Form("h%s_DetLevelRecoilJetsPtCorr", centAxis.label),
+                    Form("%s: all reconstructed recoil jets", centAxis.label),
+                    kTH2F, {{centAxis.axis, centAxis.axisName}, detJetPtCorr}, hist.sumw2);
+
+        spectra.add(Form("h%s_PartLevelInclusiveJetsPtCorr", centAxis.label),
+                    Form("%s: all part. level inclusive jets", centAxis.label),
+                    kTH2F, {{centAxis.axis, centAxis.axisName}, partJetPtCorr}, hist.sumw2);
+
+        spectra.add(Form("h%s_PartLevelRecoilJetsPtCorr", centAxis.label),
+                    Form("%s: all part. level recoil jets", centAxis.label),
+                    kTH2F, {{centAxis.axis, centAxis.axisName}, partJetPtCorr}, hist.sumw2);
+
+        spectra.add(Form("h%s_MissedInclusiveJetsPtCorr", centAxis.label),
+                    Form("%s: part. level inclusive jets w/o matched pair", centAxis.label),
+                    kTH2F, {{centAxis.axis, centAxis.axisName}, partJetPtCorr}, hist.sumw2);
+
+        spectra.add(Form("h%s_MissedRecoilJetsPtCorr", centAxis.label),
+                    Form("%s: part. level recoil jets w/o matched pair", centAxis.label),
+                    kTH2F, {{centAxis.axis, centAxis.axisName}, partJetPtCorr}, hist.sumw2);
+
+        ++iCent;
+      }
+
+      //====================================================================================
+      // EA-differential corrected spectra and response QA
+      for (const auto& eaAxis : arrConfigurableAxisEA) {
+        spectra.add(Form("hScaled%s_ResponseMatrixInclusiveJetsPtCorr", eaAxis.label),
+                    Form("Scaled %s: correlation inclusive #it{p}_{T, det.}^{corr.} vs. #it{p}_{T, part}^{corr.}", eaAxis.label),
+                    kTH3F, {{eaAxis.axis, eaAxis.axisName}, detJetPtCorr, partJetPtCorr}, hist.sumw2);
+
+        spectra.add(Form("hScaled%s_ResponseMatrixRecoilJetsPtCorr", eaAxis.label),
+                    Form("Scaled %s: correlation recoil #it{p}_{T, det.}^{corr.} vs. #it{p}_{T, part}^{corr.}", eaAxis.label),
+                    kTH3F, {{eaAxis.axis, eaAxis.axisName}, detJetPtCorr, partJetPtCorr}, hist.sumw2);
+
+        spectra.add(Form("hScaled%s_InclusiveJESPt", eaAxis.label),
+                    Form("Scaled %s: ES of inclusive jets vs. #it{p}_{T, part}", eaAxis.label),
+                    kTH3F, {{eaAxis.axis, eaAxis.axisName}, relJetSmearPt, partJetPt}, hist.sumw2);
+
+        spectra.add(Form("hScaled%s_RecoilJESPt", eaAxis.label),
+                    Form("Scaled %s: ES of recoil jets vs. #it{p}_{T, part}", eaAxis.label),
+                    kTH3F, {{eaAxis.axis, eaAxis.axisName}, relJetSmearPt, partJetPt}, hist.sumw2);
+
+        spectra.add(Form("hScaled%s_InclusiveJESPhi", eaAxis.label),
+                    Form("Scaled %s: #varphi resolution as a func. of jet #it{p}_{T, part}", eaAxis.label),
+                    kTH3F, {{eaAxis.axis, eaAxis.axisName}, jetSmearPhi, partJetPt}, hist.sumw2);
+
+        spectra.add(Form("hScaled%s_RecoilJESPhi", eaAxis.label),
+                    Form("Scaled %s: #varphi resolution as a func. of jet #it{p}_{T, part}", eaAxis.label),
+                    kTH3F, {{eaAxis.axis, eaAxis.axisName}, jetSmearPhi, partJetPt}, hist.sumw2);
+
+        spectra.add(Form("hScaled%s_FakeInclusiveJetsPtCorr", eaAxis.label),
+                    Form("Scaled %s: det. level inclusive jets w/o matched pair", eaAxis.label),
+                    kTH2F, {{eaAxis.axis, eaAxis.axisName}, detJetPtCorr}, hist.sumw2);
+
+        spectra.add(Form("hScaled%s_FakeRecoilJetsPtCorr", eaAxis.label),
+                    Form("Scaled %s: det. level recoil jets w/o matched pair", eaAxis.label),
+                    kTH2F, {{eaAxis.axis, eaAxis.axisName}, detJetPtCorr}, hist.sumw2);
+
+        spectra.add(Form("hScaled%s_DetLevelInclusiveJetsPtCorr", eaAxis.label),
+                    Form("Scaled %s: all reconstructed inclusive jets", eaAxis.label),
+                    kTH2F, {{eaAxis.axis, eaAxis.axisName}, detJetPtCorr}, hist.sumw2);
+
+        spectra.add(Form("hScaled%s_DetLevelRecoilJetsPtCorr", eaAxis.label),
+                    Form("Scaled %s: all reconstructed recoil jets", eaAxis.label),
+                    kTH2F, {{eaAxis.axis, eaAxis.axisName}, detJetPtCorr}, hist.sumw2);
+
+        spectra.add(Form("hScaled%s_PartLevelInclusiveJetsPtCorr", eaAxis.label),
+                    Form("Scaled %s: all part. level inclusive jets", eaAxis.label),
+                    kTH2F, {{eaAxis.axis, eaAxis.axisName}, partJetPtCorr}, hist.sumw2);
+
+        spectra.add(Form("hScaled%s_PartLevelRecoilJetsPtCorr", eaAxis.label),
+                    Form("Scaled %s: all part. level recoil jets", eaAxis.label),
+                    kTH2F, {{eaAxis.axis, eaAxis.axisName}, partJetPtCorr}, hist.sumw2);
+
+        spectra.add(Form("hScaled%s_MissedInclusiveJetsPtCorr", eaAxis.label),
+                    Form("Scaled %s: part. level inclusive jets w/o matched pair", eaAxis.label),
+                    kTH2F, {{eaAxis.axis, eaAxis.axisName}, partJetPtCorr}, hist.sumw2);
+
+        spectra.add(Form("hScaled%s_MissedRecoilJetsPtCorr", eaAxis.label),
+                    Form("Scaled %s: part. level recoil jets w/o matched pair", eaAxis.label),
+                    kTH2F, {{eaAxis.axis, eaAxis.axisName}, partJetPtCorr}, hist.sumw2);
+      }
 
       //====================================================================================
       // Utility histograms
       spectra.add("hNumberMatchedInclusiveDetJetsPerOnePartJet",
                   "# of det. level inclusive jets per 1 part. level jet vs. #it{p}_{T, det.} vs. #it{p}_{T, part.}",
-                  kTH3F, {{6, 0.5, 6.5, "# of matched det. level jets"}, {200, 0.0, 200., "#it{p}_{T, det.}"}, {200, 0.0, 200., "#it{p}_{T, part.}"}}, hist.sumw2);
+                  kTH3F, {{numberMatchedDetJets}, {detJetPt}, {partJetPt}}, hist.sumw2);
 
       spectra.add("hNumberMatchedRecoilDetJetsPerOnePartJet",
                   "# of det. level recoil jets per 1 part. level jet vs. #it{p}_{T, det.} vs. #it{p}_{T, part.}",
-                  kTH3F, {{6, 0.5, 6.5, "# of matched det. level jets"}, {200, 0.0, 200., "#it{p}_{T, det.}"}, {200, 0.0, 200., "#it{p}_{T, part.}"}}, hist.sumw2);
+                  kTH3F, {{numberMatchedDetJets}, {detJetPt}, {partJetPt}}, hist.sumw2);
     }
 
     // Multiplicity for raw data and detector level MC
@@ -940,7 +1016,7 @@ struct RecoilJets {
 
       //====================================================================================
       // Run-by-run study of EA
-      std::vector<const char*> runNumbersOO = {
+      const std::vector<const char*> runNumbersOO = {
         "564356", "564359", "564373", "564374", "564387", "564400", "564414", "564430", "564445"};
       const int nRunsOO = runNumbersOO.size();
 
@@ -1646,247 +1722,398 @@ struct RecoilJets {
   //=============================================================================
   // Construction of response matrix
   //=============================================================================
-  template <typename JTracks, typename JetsPart, typename JetsDet>
-  void fillMatchedGeoHistograms(JetsPart const& jetsPart,
+  template <typename JCollision, typename JTracks, typename JetsPart, typename JetsDet>
+  void fillMatchedGeoHistograms(JCollision const& collision,
+                                JetsPart const& jetsPart,
                                 JetsDet const& jetsDet,
                                 JTracks const& tracks,
-                                float partLevelCollRho,
-                                float detLevelCollRho,
+                                const float partLevelCollRho,
                                 float weight = 1.)
-  {
+  { 
 
-    // Utilities for recoil jets; TTsis at det. level MC
+    //====================================================================================
+    // Event properties
+    const auto ft0Metrics = getFT0Metrics(collision, ft0a.mean, ft0c.mean);
+    const auto scaledFT0C = ft0Metrics.scaledFT0C;
+    const auto scaledFT0M = ft0Metrics.scaledFT0M;
+
+    const auto centFT0C = collision.centFT0C();
+    const auto centFT0M = collision.centFT0M();
+
+    const auto detLevelCollRho = collision.rho();
+
+    //====================================================================================
+    // Trigger-track information
     std::vector<double> vPhiOfTT = getPhiOfAllTTsigCandidates(tracks);
     double phiTTSig = 0.0;
-    const bool bIsThereTTSig = vPhiOfTT.size() > 0;
+    const bool bIsThereTTSig = !vPhiOfTT.empty();
 
-    if (bIsThereTTSig)
+    if (bIsThereTTSig) {
       phiTTSig = getPhiTT(vPhiOfTT);
+    }
 
+    //====================================================================================
+    // Particle-level jets
     for (const auto& jetPart : jetsPart) {
       const auto partJetPt = jetPart.pt();
       const auto partJetPtCorr = partJetPt - partLevelCollRho * jetPart.area();
+      const bool bIsPartJetRecoil = bIsThereTTSig && get<1>(isRecoilJet(jetPart, phiTTSig));
 
-      const bool bIsPartJetRecoil =
-        get<1>(isRecoilJet(jetPart, phiTTSig)) && bIsThereTTSig;
-
-      // Distribution of all part. level jets
+      //==================================================================================
+      // All particle-level inclusive jets
       spectra.fill(HIST("hPartLevelInclusiveJetsPt"), partJetPt, weight);
-      spectra.fill(HIST("hPartLevelInclusiveJetsPtCorr"), partJetPtCorr, weight);
+      spectra.fill(HIST("hScaledFT0C_PartLevelInclusiveJetsPtCorr"), scaledFT0C, partJetPtCorr, weight);
+      spectra.fill(HIST("hScaledFT0M_PartLevelInclusiveJetsPtCorr"), scaledFT0M, partJetPtCorr, weight);
+      spectra.fill(HIST("hCentFT0C_PartLevelInclusiveJetsPtCorr"), centFT0C, partJetPtCorr, weight);
+      spectra.fill(HIST("hCentFT0M_PartLevelInclusiveJetsPtCorr"), centFT0M, partJetPtCorr, weight);
 
+      //==================================================================================
+      // All particle-level recoil jets
       if (bIsPartJetRecoil) {
         spectra.fill(HIST("hPartLevelRecoilJetsPt"), partJetPt, weight);
-        spectra.fill(HIST("hPartLevelRecoilJetsPtCorr"), partJetPtCorr, weight);
+        spectra.fill(HIST("hScaledFT0C_PartLevelRecoilJetsPtCorr"), scaledFT0C, partJetPtCorr, weight);
+        spectra.fill(HIST("hScaledFT0M_PartLevelRecoilJetsPtCorr"), scaledFT0M, partJetPtCorr, weight);
+        spectra.fill(HIST("hCentFT0C_PartLevelRecoilJetsPtCorr"), centFT0C, partJetPtCorr, weight);
+        spectra.fill(HIST("hCentFT0M_PartLevelRecoilJetsPtCorr"), centFT0M, partJetPtCorr, weight);
       }
 
+      bool hasAcceptedDetMatch = false;
+
+      //==================================================================================
+      // Matched detector-level jets
       if (jetPart.has_matchedJetGeo()) {
         const auto& jetsDetMatched = jetPart.template matchedJetGeo_as<JetsDet>();
 
         for (const auto& jetDetMatched : jetsDetMatched) {
-          // Skip matches where detector level jets have a constituent with pT above specified cut
-          const bool skipMatchedDetJet = isJetWithHighPtConstituent<JTracks>(jetDetMatched);
+          if (isJetWithHighPtConstituent<JTracks>(jetDetMatched)) {
+            continue;
+          }
 
-          if (skipMatchedDetJet) {
-            // Miss jets
-            spectra.fill(HIST("hMissedInclusiveJetsPt"), partJetPt, weight);
-            spectra.fill(HIST("hMissedInclusiveJetsPtCorr"), partJetPtCorr, weight);
+          const auto detJetPt = jetDetMatched.pt();
+          const auto detJetPtCorr = detJetPt - detLevelCollRho * jetDetMatched.area();
+          const auto relJetSmearPt = (partJetPt - detJetPt) / partJetPt;
+          const auto relJetSmearPtCorr = (partJetPtCorr - detJetPtCorr) / partJetPtCorr;
+          const auto deltaPhi = RecoDecay::constrainAngle(jetPart.phi() - jetDetMatched.phi(), -constants::math::PI);
+          hasAcceptedDetMatch = true;
 
-            if (bIsPartJetRecoil) {
-              spectra.fill(HIST("hMissedRecoilJetsPt"), partJetPt, weight);
-              spectra.fill(HIST("hMissedRecoilJetsPtCorr"), partJetPtCorr, weight);
-            }
+          //================================================================================
+          // QA data
+          spectra.fill(HIST("hNumberMatchedInclusiveDetJetsPerOnePartJet"), jetsDetMatched.size(), detJetPt, partJetPt, weight);
 
-          } else {
-            const auto detJetPt = jetDetMatched.pt();
-            const auto detJetPtCorr = detJetPt - detLevelCollRho * jetDetMatched.area();
+          //================================================================================
+          // Inclusive response matrix
+          spectra.fill(HIST("hResponseMatrixInclusiveJetsPt"), detJetPt, partJetPt, weight);
+          spectra.fill(HIST("hScaledFT0C_ResponseMatrixInclusiveJetsPtCorr"), scaledFT0C, detJetPtCorr, partJetPtCorr, weight);
+          spectra.fill(HIST("hScaledFT0M_ResponseMatrixInclusiveJetsPtCorr"), scaledFT0M, detJetPtCorr, partJetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0C_ResponseMatrixInclusiveJetsPtCorr"), centFT0C, detJetPtCorr, partJetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0M_ResponseMatrixInclusiveJetsPtCorr"), centFT0M, detJetPtCorr, partJetPtCorr, weight);
 
-            spectra.fill(HIST("hNumberMatchedInclusiveDetJetsPerOnePartJet"), jetsDetMatched.size(), detJetPt, partJetPt, weight);
+          //================================================================================
+          // Inclusive JES and phi resolution
+          spectra.fill(HIST("hInclusiveJESPtCorr"), relJetSmearPtCorr, partJetPtCorr, weight);
+          spectra.fill(HIST("hScaledFT0C_InclusiveJESPt"), scaledFT0C, relJetSmearPt, partJetPt, weight);
+          spectra.fill(HIST("hScaledFT0M_InclusiveJESPt"), scaledFT0M, relJetSmearPt, partJetPt, weight);
+          spectra.fill(HIST("hCentFT0C_InclusiveJESPt"), centFT0C, relJetSmearPt, partJetPt, weight);
+          spectra.fill(HIST("hCentFT0M_InclusiveJESPt"), centFT0M, relJetSmearPt, partJetPt, weight);
 
-            spectra.fill(HIST("hResponseMatrixInclusiveJetsPt"), detJetPt, partJetPt, weight);
-            spectra.fill(HIST("hResponseMatrixInclusiveJetsPtCorr"), detJetPtCorr, partJetPtCorr, weight);
+          spectra.fill(HIST("hScaledFT0C_InclusiveJESPhi"), scaledFT0C, deltaPhi, partJetPt, weight);
+          spectra.fill(HIST("hScaledFT0M_InclusiveJESPhi"), scaledFT0M, deltaPhi, partJetPt, weight);
+          spectra.fill(HIST("hCentFT0C_InclusiveJESPhi"), centFT0C, deltaPhi, partJetPt, weight);
+          spectra.fill(HIST("hCentFT0M_InclusiveJESPhi"), centFT0M, deltaPhi, partJetPt, weight);
 
-            spectra.fill(HIST("hInclusiveJESPt"), (partJetPt - detJetPt) / partJetPt, partJetPt, weight);
-            spectra.fill(HIST("hInclusiveJESPtCorr"), (partJetPtCorr - detJetPtCorr) / partJetPtCorr, partJetPtCorr, weight);
+          //================================================================================
+          // Recoil response, JES, phi resolution and QA data
+          if (bIsPartJetRecoil) {
+            spectra.fill(HIST("hResponseMatrixRecoilJetsPt"), detJetPt, partJetPt, weight);
+            spectra.fill(HIST("hScaledFT0C_ResponseMatrixRecoilJetsPtCorr"), scaledFT0C, detJetPtCorr, partJetPtCorr, weight);
+            spectra.fill(HIST("hScaledFT0M_ResponseMatrixRecoilJetsPtCorr"), scaledFT0M, detJetPtCorr, partJetPtCorr, weight);
+            spectra.fill(HIST("hCentFT0C_ResponseMatrixRecoilJetsPtCorr"), centFT0C, detJetPtCorr, partJetPtCorr, weight);
+            spectra.fill(HIST("hCentFT0M_ResponseMatrixRecoilJetsPtCorr"), centFT0M, detJetPtCorr, partJetPtCorr, weight);
 
-            spectra.fill(HIST("hInclusiveJESPhi"), jetPart.phi() - jetDetMatched.phi(), partJetPt, weight);
+            spectra.fill(HIST("hRecoilJESPtCorr"), relJetSmearPtCorr, partJetPtCorr, weight);
+            spectra.fill(HIST("hScaledFT0C_RecoilJESPt"), scaledFT0C, relJetSmearPt, partJetPt, weight);
+            spectra.fill(HIST("hScaledFT0M_RecoilJESPt"), scaledFT0M, relJetSmearPt, partJetPt, weight);
+            spectra.fill(HIST("hCentFT0C_RecoilJESPt"), centFT0C, relJetSmearPt, partJetPt, weight);
+            spectra.fill(HIST("hCentFT0M_RecoilJESPt"), centFT0M, relJetSmearPt, partJetPt, weight);
 
-            if (bIsPartJetRecoil) {
-              spectra.fill(HIST("hNumberMatchedRecoilDetJetsPerOnePartJet"), jetsDetMatched.size(), detJetPt, partJetPt, weight);
+            spectra.fill(HIST("hScaledFT0C_RecoilJESPhi"), scaledFT0C, deltaPhi, partJetPt, weight);
+            spectra.fill(HIST("hScaledFT0M_RecoilJESPhi"), scaledFT0M, deltaPhi, partJetPt, weight);
+            spectra.fill(HIST("hCentFT0C_RecoilJESPhi"), centFT0C, deltaPhi, partJetPt, weight);
+            spectra.fill(HIST("hCentFT0M_RecoilJESPhi"), centFT0M, deltaPhi, partJetPt, weight);
 
-              spectra.fill(HIST("hResponseMatrixRecoilJetsPt"), detJetPt, partJetPt, weight);
-              spectra.fill(HIST("hResponseMatrixRecoilJetsPtCorr"), detJetPtCorr, partJetPtCorr, weight);
-
-              spectra.fill(HIST("hRecoilJESPt"), (partJetPt - detJetPt) / partJetPt, partJetPt, weight);
-              spectra.fill(HIST("hRecoilJESPtCorr"), (partJetPtCorr - detJetPtCorr) / partJetPtCorr, partJetPtCorr, weight);
-
-              spectra.fill(HIST("hRecoilJESPhi"), jetPart.phi() - jetDetMatched.phi(), partJetPt, weight);
-            }
+            spectra.fill(HIST("hNumberMatchedRecoilDetJetsPerOnePartJet"), jetsDetMatched.size(), detJetPt, partJetPt, weight);
           }
         }
-      } else {
-        // Miss jets
+      }
+
+      //==================================================================================
+      // Missed particle-level jets: no matched detector level jet
+      if (!hasAcceptedDetMatch) {
         spectra.fill(HIST("hMissedInclusiveJetsPt"), partJetPt, weight);
-        spectra.fill(HIST("hMissedInclusiveJetsPtCorr"), partJetPtCorr, weight);
+        spectra.fill(HIST("hScaledFT0C_MissedInclusiveJetsPtCorr"), scaledFT0C, partJetPtCorr, weight);
+        spectra.fill(HIST("hScaledFT0M_MissedInclusiveJetsPtCorr"), scaledFT0M, partJetPtCorr, weight);
+        spectra.fill(HIST("hCentFT0C_MissedInclusiveJetsPtCorr"), centFT0C, partJetPtCorr, weight);
+        spectra.fill(HIST("hCentFT0M_MissedInclusiveJetsPtCorr"), centFT0M, partJetPtCorr, weight);
 
         if (bIsPartJetRecoil) {
           spectra.fill(HIST("hMissedRecoilJetsPt"), partJetPt, weight);
-          spectra.fill(HIST("hMissedRecoilJetsPtCorr"), partJetPtCorr, weight);
+          spectra.fill(HIST("hScaledFT0C_MissedRecoilJetsPtCorr"), scaledFT0C, partJetPtCorr, weight);
+          spectra.fill(HIST("hScaledFT0M_MissedRecoilJetsPtCorr"), scaledFT0M, partJetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0C_MissedRecoilJetsPtCorr"), centFT0C, partJetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0M_MissedRecoilJetsPtCorr"), centFT0M, partJetPtCorr, weight);
         }
       }
     }
 
-    // Reconstructed jets
+    //====================================================================================
+    // Detector-level jets    
     for (const auto& jetDet : jetsDet) {
-      if (isJetWithHighPtConstituent<JTracks>(jetDet))
+      if (isJetWithHighPtConstituent<JTracks>(jetDet)) {
         continue;
+      }
 
       const auto detJetPt = jetDet.pt();
       const auto detJetPtCorr = detJetPt - detLevelCollRho * jetDet.area();
 
-      const bool bIsJetRecoil =
-        get<1>(isRecoilJet(jetDet, phiTTSig)) && bIsThereTTSig;
+      const bool bIsJetRecoil = bIsThereTTSig && get<1>(isRecoilJet(jetDet, phiTTSig));
 
-      // Distribution of all det. level jets
+      //==================================================================================    
+      // All detector-level inclusive jets
       spectra.fill(HIST("hDetLevelInclusiveJetsPt"), detJetPt, weight);
-      spectra.fill(HIST("hDetLevelInclusiveJetsPtCorr"), detJetPtCorr, weight);
+      spectra.fill(HIST("hScaledFT0C_DetLevelInclusiveJetsPtCorr"), scaledFT0C, detJetPtCorr, weight);
+      spectra.fill(HIST("hScaledFT0M_DetLevelInclusiveJetsPtCorr"), scaledFT0M, detJetPtCorr, weight);
+      spectra.fill(HIST("hCentFT0C_DetLevelInclusiveJetsPtCorr"), centFT0C, detJetPtCorr, weight);
+      spectra.fill(HIST("hCentFT0M_DetLevelInclusiveJetsPtCorr"), centFT0M, detJetPtCorr, weight);
 
+      //==================================================================================
+      // All detector-level recoil jets
       if (bIsJetRecoil) {
         spectra.fill(HIST("hDetLevelRecoilJetsPt"), detJetPt, weight);
-        spectra.fill(HIST("hDetLevelRecoilJetsPtCorr"), detJetPtCorr, weight);
+        spectra.fill(HIST("hScaledFT0C_DetLevelRecoilJetsPtCorr"), scaledFT0C, detJetPtCorr, weight);
+        spectra.fill(HIST("hScaledFT0M_DetLevelRecoilJetsPtCorr"), scaledFT0M, detJetPtCorr, weight);
+        spectra.fill(HIST("hCentFT0C_DetLevelRecoilJetsPtCorr"), centFT0C, detJetPtCorr, weight);
+        spectra.fill(HIST("hCentFT0M_DetLevelRecoilJetsPtCorr"), centFT0M, detJetPtCorr, weight);
       }
 
+      //==================================================================================
+      // Fake detector-level jets: no matched particle level jet
       if (!jetDet.has_matchedJetGeo()) {
         spectra.fill(HIST("hFakeInclusiveJetsPt"), detJetPt, weight);
-        spectra.fill(HIST("hFakeInclusiveJetsPtCorr"), detJetPtCorr, weight);
+        spectra.fill(HIST("hScaledFT0C_FakeInclusiveJetsPtCorr"), scaledFT0C, detJetPtCorr, weight);
+        spectra.fill(HIST("hScaledFT0M_FakeInclusiveJetsPtCorr"), scaledFT0M, detJetPtCorr, weight);
+        spectra.fill(HIST("hCentFT0C_FakeInclusiveJetsPtCorr"), centFT0C, detJetPtCorr, weight);
+        spectra.fill(HIST("hCentFT0M_FakeInclusiveJetsPtCorr"), centFT0M, detJetPtCorr, weight);
 
         if (bIsJetRecoil) {
           spectra.fill(HIST("hFakeRecoilJetsPt"), detJetPt, weight);
-          spectra.fill(HIST("hFakeRecoilJetsPtCorr"), detJetPtCorr, weight);
+          spectra.fill(HIST("hScaledFT0C_FakeRecoilJetsPtCorr"), scaledFT0C, detJetPtCorr, weight);
+          spectra.fill(HIST("hScaledFT0M_FakeRecoilJetsPtCorr"), scaledFT0M, detJetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0C_FakeRecoilJetsPtCorr"), centFT0C, detJetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0M_FakeRecoilJetsPtCorr"), centFT0M, detJetPtCorr, weight);
         }
       }
     }
   }
 
-  /// TODO: think how to implement matching matching geo/geo+pT in one function
-  template <typename JTracks, typename JetsPart, typename JetsDet>
-  void fillMatchedGeoPtHistograms(JetsPart const& jetsPart,
+  template <typename JCollision, typename JTracks, typename JetsPart, typename JetsDet>
+  void fillMatchedGeoPtHistograms(JCollision const& collision,
+                                  JetsPart const& jetsPart,
                                   JetsDet const& jetsDet,
                                   JTracks const& tracks,
-                                  float partLevelCollRho,
-                                  float detLevelCollRho,
+                                  const float partLevelCollRho,
                                   float weight = 1.)
   {
-    // Utilities for recoil jets; TTsis at det. level MC
+    //====================================================================================
+    // Event properties
+    const auto ft0Metrics = getFT0Metrics(collision, ft0a.mean, ft0c.mean);
+    const auto scaledFT0C = ft0Metrics.scaledFT0C;
+    const auto scaledFT0M = ft0Metrics.scaledFT0M;
+
+    const auto centFT0C = collision.centFT0C();
+    const auto centFT0M = collision.centFT0M();
+
+    const auto detLevelCollRho = collision.rho();
+
+    //====================================================================================
+    // Trigger-track information
     std::vector<double> vPhiOfTT = getPhiOfAllTTsigCandidates(tracks);
     double phiTTSig = 0.0;
-    const bool bIsThereTTSig = vPhiOfTT.size() > 0;
+    const bool bIsThereTTSig = !vPhiOfTT.empty();
 
-    if (bIsThereTTSig)
+    if (bIsThereTTSig) {
       phiTTSig = getPhiTT(vPhiOfTT);
+    }
 
+    //====================================================================================
+    // Particle-level jets
     for (const auto& jetPart : jetsPart) {
       const auto partJetPt = jetPart.pt();
       const auto partJetPtCorr = partJetPt - partLevelCollRho * jetPart.area();
+      const bool bIsPartJetRecoil = bIsThereTTSig && get<1>(isRecoilJet(jetPart, phiTTSig));
 
-      const bool bIsPartJetRecoil =
-        get<1>(isRecoilJet(jetPart, phiTTSig)) && bIsThereTTSig;
-
-      // Distribution of all part. level jets
+      //==================================================================================
+      // All particle-level inclusive jets
       spectra.fill(HIST("hPartLevelInclusiveJetsPt"), partJetPt, weight);
-      spectra.fill(HIST("hPartLevelInclusiveJetsPtCorr"), partJetPtCorr, weight);
+      spectra.fill(HIST("hScaledFT0C_PartLevelInclusiveJetsPtCorr"), scaledFT0C, partJetPtCorr, weight);
+      spectra.fill(HIST("hScaledFT0M_PartLevelInclusiveJetsPtCorr"), scaledFT0M, partJetPtCorr, weight);
+      spectra.fill(HIST("hCentFT0C_PartLevelInclusiveJetsPtCorr"), centFT0C, partJetPtCorr, weight);
+      spectra.fill(HIST("hCentFT0M_PartLevelInclusiveJetsPtCorr"), centFT0M, partJetPtCorr, weight);
 
+      //==================================================================================
+      // All particle-level recoil jets
       if (bIsPartJetRecoil) {
         spectra.fill(HIST("hPartLevelRecoilJetsPt"), partJetPt, weight);
-        spectra.fill(HIST("hPartLevelRecoilJetsPtCorr"), partJetPtCorr, weight);
+        spectra.fill(HIST("hScaledFT0C_PartLevelRecoilJetsPtCorr"), scaledFT0C, partJetPtCorr, weight);
+        spectra.fill(HIST("hScaledFT0M_PartLevelRecoilJetsPtCorr"), scaledFT0M, partJetPtCorr, weight);
+        spectra.fill(HIST("hCentFT0C_PartLevelRecoilJetsPtCorr"), centFT0C, partJetPtCorr, weight);
+        spectra.fill(HIST("hCentFT0M_PartLevelRecoilJetsPtCorr"), centFT0M, partJetPtCorr, weight);
       }
 
-      // Geo + pT matching
+      bool hasAcceptedDetMatch = false;
+
+      //==================================================================================
+      // Matched detector-level jets: geo + pT matching
       if (jetPart.has_matchedJetGeo() && jetPart.has_matchedJetPt()) {
         const auto& jetsDetMatched = jetPart.template matchedJetGeo_as<JetsDet>();
-        auto both = intersectMatchIds(jetPart.matchedJetGeoIds(), jetPart.matchedJetPtIds());
+        const auto both = intersectMatchIds(jetPart.matchedJetGeoIds(), jetPart.matchedJetPtIds());
 
         for (const auto& jetDetMatched : jetsDetMatched) {
-          // Skip matches where detector level jets have a constituent with pT above specified cut
-          const bool skipMatchedDetJet = isJetWithHighPtConstituent<JTracks>(jetDetMatched);
+          if (!both.contains(jetDetMatched.globalIndex())) {
+            continue;
+          }
 
-          // If indecies for geo and pT matching do not coinside, reject detector level jet
-          const bool skipNotBothId = !both.contains(jetDetMatched.globalIndex());
+          if (isJetWithHighPtConstituent<JTracks>(jetDetMatched)) {
+            continue;
+          }
 
-          if (skipMatchedDetJet || skipNotBothId) {
-            // Miss jets
-            spectra.fill(HIST("hMissedInclusiveJetsPt"), partJetPt, weight);
-            spectra.fill(HIST("hMissedInclusiveJetsPtCorr"), partJetPtCorr, weight);
+          const auto detJetPt = jetDetMatched.pt();
+          const auto detJetPtCorr = detJetPt - detLevelCollRho * jetDetMatched.area();
+          const auto relJetSmearPt = (partJetPt - detJetPt) / partJetPt;
+          const auto relJetSmearPtCorr = (partJetPtCorr - detJetPtCorr) / partJetPtCorr;
+          const auto deltaPhi = RecoDecay::constrainAngle(jetPart.phi() - jetDetMatched.phi(), -constants::math::PI);
+          hasAcceptedDetMatch = true;
 
-            if (bIsPartJetRecoil) {
-              spectra.fill(HIST("hMissedRecoilJetsPt"), partJetPt, weight);
-              spectra.fill(HIST("hMissedRecoilJetsPtCorr"), partJetPtCorr, weight);
-            }
-          } else {
-            const auto detJetPt = jetDetMatched.pt();
-            const auto detJetPtCorr = detJetPt - detLevelCollRho * jetDetMatched.area();
+          //================================================================================
+          // QA data
+          spectra.fill(HIST("hNumberMatchedInclusiveDetJetsPerOnePartJet"), jetsDetMatched.size(), detJetPt, partJetPt, weight);
 
-            spectra.fill(HIST("hNumberMatchedInclusiveDetJetsPerOnePartJet"), jetsDetMatched.size(), detJetPt, partJetPt, weight);
+          //================================================================================
+          // Inclusive response matrix
+          spectra.fill(HIST("hResponseMatrixInclusiveJetsPt"), detJetPt, partJetPt, weight);
+          spectra.fill(HIST("hScaledFT0C_ResponseMatrixInclusiveJetsPtCorr"), scaledFT0C, detJetPtCorr, partJetPtCorr, weight);
+          spectra.fill(HIST("hScaledFT0M_ResponseMatrixInclusiveJetsPtCorr"), scaledFT0M, detJetPtCorr, partJetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0C_ResponseMatrixInclusiveJetsPtCorr"), centFT0C, detJetPtCorr, partJetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0M_ResponseMatrixInclusiveJetsPtCorr"), centFT0M, detJetPtCorr, partJetPtCorr, weight);
 
-            spectra.fill(HIST("hResponseMatrixInclusiveJetsPt"), detJetPt, partJetPt, weight);
-            spectra.fill(HIST("hResponseMatrixInclusiveJetsPtCorr"), detJetPtCorr, partJetPtCorr, weight);
+          //================================================================================
+          // Inclusive JES and phi resolution
+          spectra.fill(HIST("hInclusiveJESPtCorr"), relJetSmearPtCorr, partJetPtCorr, weight);
+          spectra.fill(HIST("hScaledFT0C_InclusiveJESPt"), scaledFT0C, relJetSmearPt, partJetPt, weight);
+          spectra.fill(HIST("hScaledFT0M_InclusiveJESPt"), scaledFT0M, relJetSmearPt, partJetPt, weight);
+          spectra.fill(HIST("hCentFT0C_InclusiveJESPt"), centFT0C, relJetSmearPt, partJetPt, weight);
+          spectra.fill(HIST("hCentFT0M_InclusiveJESPt"), centFT0M, relJetSmearPt, partJetPt, weight);
 
-            spectra.fill(HIST("hInclusiveJESPt"), (partJetPt - detJetPt) / partJetPt, partJetPt, weight);
-            spectra.fill(HIST("hInclusiveJESPtCorr"), (partJetPtCorr - detJetPtCorr) / partJetPtCorr, partJetPtCorr, weight);
+          spectra.fill(HIST("hScaledFT0C_InclusiveJESPhi"), scaledFT0C, deltaPhi, partJetPt, weight);
+          spectra.fill(HIST("hScaledFT0M_InclusiveJESPhi"), scaledFT0M, deltaPhi, partJetPt, weight);
+          spectra.fill(HIST("hCentFT0C_InclusiveJESPhi"), centFT0C, deltaPhi, partJetPt, weight);
+          spectra.fill(HIST("hCentFT0M_InclusiveJESPhi"), centFT0M, deltaPhi, partJetPt, weight);
 
-            spectra.fill(HIST("hInclusiveJESPhi"), jetPart.phi() - jetDetMatched.phi(), partJetPt, weight);
+          //================================================================================
+          // Recoil response, JES, phi resolution and QA data
+          if (bIsPartJetRecoil) {
+            spectra.fill(HIST("hResponseMatrixRecoilJetsPt"), detJetPt, partJetPt, weight);
+            spectra.fill(HIST("hScaledFT0C_ResponseMatrixRecoilJetsPtCorr"), scaledFT0C, detJetPtCorr, partJetPtCorr, weight);
+            spectra.fill(HIST("hScaledFT0M_ResponseMatrixRecoilJetsPtCorr"), scaledFT0M, detJetPtCorr, partJetPtCorr, weight);
+            spectra.fill(HIST("hCentFT0C_ResponseMatrixRecoilJetsPtCorr"), centFT0C, detJetPtCorr, partJetPtCorr, weight);
+            spectra.fill(HIST("hCentFT0M_ResponseMatrixRecoilJetsPtCorr"), centFT0M, detJetPtCorr, partJetPtCorr, weight);
 
-            if (bIsPartJetRecoil) {
-              spectra.fill(HIST("hNumberMatchedRecoilDetJetsPerOnePartJet"), jetsDetMatched.size(), detJetPt, partJetPt, weight);
+            spectra.fill(HIST("hRecoilJESPtCorr"), relJetSmearPtCorr, partJetPtCorr, weight);
+            spectra.fill(HIST("hScaledFT0C_RecoilJESPt"), scaledFT0C, relJetSmearPt, partJetPt, weight);
+            spectra.fill(HIST("hScaledFT0M_RecoilJESPt"), scaledFT0M, relJetSmearPt, partJetPt, weight);
+            spectra.fill(HIST("hCentFT0C_RecoilJESPt"), centFT0C, relJetSmearPt, partJetPt, weight);
+            spectra.fill(HIST("hCentFT0M_RecoilJESPt"), centFT0M, relJetSmearPt, partJetPt, weight);
 
-              spectra.fill(HIST("hResponseMatrixRecoilJetsPt"), detJetPt, partJetPt, weight);
-              spectra.fill(HIST("hResponseMatrixRecoilJetsPtCorr"), detJetPtCorr, partJetPtCorr, weight);
+            spectra.fill(HIST("hScaledFT0C_RecoilJESPhi"), scaledFT0C, deltaPhi, partJetPt, weight);
+            spectra.fill(HIST("hScaledFT0M_RecoilJESPhi"), scaledFT0M, deltaPhi, partJetPt, weight);
+            spectra.fill(HIST("hCentFT0C_RecoilJESPhi"), centFT0C, deltaPhi, partJetPt, weight);
+            spectra.fill(HIST("hCentFT0M_RecoilJESPhi"), centFT0M, deltaPhi, partJetPt, weight);
 
-              spectra.fill(HIST("hRecoilJESPt"), (partJetPt - detJetPt) / partJetPt, partJetPt, weight);
-              spectra.fill(HIST("hRecoilJESPtCorr"), (partJetPtCorr - detJetPtCorr) / partJetPtCorr, partJetPtCorr, weight);
-
-              spectra.fill(HIST("hRecoilJESPhi"), jetPart.phi() - jetDetMatched.phi(), partJetPt, weight);
-            }
+            spectra.fill(HIST("hNumberMatchedRecoilDetJetsPerOnePartJet"), jetsDetMatched.size(), detJetPt, partJetPt, weight);
           }
         }
-      } else {
-        // Miss jets
+      }
+
+      //==================================================================================
+      // Missed particle-level jets: no detector-level jet accepted by both geo and pT matching
+      if (!hasAcceptedDetMatch) {
         spectra.fill(HIST("hMissedInclusiveJetsPt"), partJetPt, weight);
-        spectra.fill(HIST("hMissedInclusiveJetsPtCorr"), partJetPtCorr, weight);
+        spectra.fill(HIST("hScaledFT0C_MissedInclusiveJetsPtCorr"), scaledFT0C, partJetPtCorr, weight);
+        spectra.fill(HIST("hScaledFT0M_MissedInclusiveJetsPtCorr"), scaledFT0M, partJetPtCorr, weight);
+        spectra.fill(HIST("hCentFT0C_MissedInclusiveJetsPtCorr"), centFT0C, partJetPtCorr, weight);
+        spectra.fill(HIST("hCentFT0M_MissedInclusiveJetsPtCorr"), centFT0M, partJetPtCorr, weight);
 
         if (bIsPartJetRecoil) {
           spectra.fill(HIST("hMissedRecoilJetsPt"), partJetPt, weight);
-          spectra.fill(HIST("hMissedRecoilJetsPtCorr"), partJetPtCorr, weight);
+          spectra.fill(HIST("hScaledFT0C_MissedRecoilJetsPtCorr"), scaledFT0C, partJetPtCorr, weight);
+          spectra.fill(HIST("hScaledFT0M_MissedRecoilJetsPtCorr"), scaledFT0M, partJetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0C_MissedRecoilJetsPtCorr"), centFT0C, partJetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0M_MissedRecoilJetsPtCorr"), centFT0M, partJetPtCorr, weight);
         }
       }
     }
 
-    // Reconstructed jets
+    //====================================================================================
+    // Detector-level jets
     for (const auto& jetDet : jetsDet) {
-      if (isJetWithHighPtConstituent<JTracks>(jetDet))
+      if (isJetWithHighPtConstituent<JTracks>(jetDet)) {
         continue;
+      }
 
       const auto detJetPt = jetDet.pt();
       const auto detJetPtCorr = detJetPt - detLevelCollRho * jetDet.area();
 
-      const bool bIsJetRecoil =
-        get<1>(isRecoilJet(jetDet, phiTTSig)) && bIsThereTTSig;
+      const bool bIsJetRecoil = bIsThereTTSig && get<1>(isRecoilJet(jetDet, phiTTSig));
 
-      // Distribution of all det. level jets
+      //==================================================================================
+      // All detector-level inclusive jets
       spectra.fill(HIST("hDetLevelInclusiveJetsPt"), detJetPt, weight);
-      spectra.fill(HIST("hDetLevelInclusiveJetsPtCorr"), detJetPtCorr, weight);
+      spectra.fill(HIST("hScaledFT0C_DetLevelInclusiveJetsPtCorr"), scaledFT0C, detJetPtCorr, weight);
+      spectra.fill(HIST("hScaledFT0M_DetLevelInclusiveJetsPtCorr"), scaledFT0M, detJetPtCorr, weight);
+      spectra.fill(HIST("hCentFT0C_DetLevelInclusiveJetsPtCorr"), centFT0C, detJetPtCorr, weight);
+      spectra.fill(HIST("hCentFT0M_DetLevelInclusiveJetsPtCorr"), centFT0M, detJetPtCorr, weight);
 
+      //==================================================================================
+      // All detector-level recoil jets
       if (bIsJetRecoil) {
         spectra.fill(HIST("hDetLevelRecoilJetsPt"), detJetPt, weight);
-        spectra.fill(HIST("hDetLevelRecoilJetsPtCorr"), detJetPtCorr, weight);
+        spectra.fill(HIST("hScaledFT0C_DetLevelRecoilJetsPtCorr"), scaledFT0C, detJetPtCorr, weight);
+        spectra.fill(HIST("hScaledFT0M_DetLevelRecoilJetsPtCorr"), scaledFT0M, detJetPtCorr, weight);
+        spectra.fill(HIST("hCentFT0C_DetLevelRecoilJetsPtCorr"), centFT0C, detJetPtCorr, weight);
+        spectra.fill(HIST("hCentFT0M_DetLevelRecoilJetsPtCorr"), centFT0M, detJetPtCorr, weight);
       }
 
-      if (!jetDet.has_matchedJetGeo()) {
+      //==================================================================================
+      // Fake detector-level jets: no matched particle-level jet accepted by both geo and pT matching
+      bool hasAcceptedPartMatch = false;
+
+      if (jetDet.has_matchedJetGeo() && jetDet.has_matchedJetPt()) {
+        const auto both = intersectMatchIds(jetDet.matchedJetGeoIds(), jetDet.matchedJetPtIds());
+        hasAcceptedPartMatch = !both.empty();
+      }
+
+      if (!hasAcceptedPartMatch) {
         spectra.fill(HIST("hFakeInclusiveJetsPt"), detJetPt, weight);
-        spectra.fill(HIST("hFakeInclusiveJetsPtCorr"), detJetPtCorr, weight);
+        spectra.fill(HIST("hScaledFT0C_FakeInclusiveJetsPtCorr"), scaledFT0C, detJetPtCorr, weight);
+        spectra.fill(HIST("hScaledFT0M_FakeInclusiveJetsPtCorr"), scaledFT0M, detJetPtCorr, weight);
+        spectra.fill(HIST("hCentFT0C_FakeInclusiveJetsPtCorr"), centFT0C, detJetPtCorr, weight);
+        spectra.fill(HIST("hCentFT0M_FakeInclusiveJetsPtCorr"), centFT0M, detJetPtCorr, weight);
 
         if (bIsJetRecoil) {
           spectra.fill(HIST("hFakeRecoilJetsPt"), detJetPt, weight);
-          spectra.fill(HIST("hFakeRecoilJetsPtCorr"), detJetPtCorr, weight);
+          spectra.fill(HIST("hScaledFT0C_FakeRecoilJetsPtCorr"), scaledFT0C, detJetPtCorr, weight);
+          spectra.fill(HIST("hScaledFT0M_FakeRecoilJetsPtCorr"), scaledFT0M, detJetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0C_FakeRecoilJetsPtCorr"), centFT0C, detJetPtCorr, weight);
+          spectra.fill(HIST("hCentFT0M_FakeRecoilJetsPtCorr"), centFT0M, detJetPtCorr, weight);
         }
       }
     }
@@ -1907,13 +2134,13 @@ struct RecoilJets {
     const auto scaledFT0C = ft0Metrics.scaledFT0C;
     const auto scaledFT0M = ft0Metrics.scaledFT0M;
 
-    float multZNA = collision.multZNA();
-    float multZNC = collision.multZNC();
-    float multZNM = multZNA + multZNC;
+    const auto multZNA = collision.multZNA();
+    const auto multZNC = collision.multZNC();
+    const auto multZNM = multZNA + multZNC;
 
-    float multZPA = collision.multZPA();
-    float multZPC = collision.multZPC();
-    float multZPM = multZPA + multZPC;
+    const auto multZPA = collision.multZPA();
+    const auto multZPC = collision.multZPC();
+    const auto multZPM = multZPA + multZPC;
 
     // Individual distributions
     spectra.fill(HIST("hMultFT0A"), multFT0A, weight);
@@ -1973,7 +2200,7 @@ struct RecoilJets {
   void fillEventActivitySelectionQAHistograms(Collision const& collision,
                                               float weight = 1.)
   {
-    int runNumber = collision.multRunNumber();
+    const auto runNumber = collision.multRunNumber();
     int fillNumber = getBinNumberOnYaxisForGivenRun(spectra.get<TH3>(HIST("hScaledFT0CPerRunPerSetOfFlags")), runNumber) - 0.5; // Same for FT0M distrib.
 
     // FT0 Signal
@@ -1996,7 +2223,7 @@ struct RecoilJets {
 
     spectra.fill(HIST("hEventSelectionCountQA"), 0.5);
 
-    bool isGoodZvtxFT0vsPV = collision.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV);
+    const auto isGoodZvtxFT0vsPV = collision.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV);
     if (isGoodZvtxFT0vsPV) {
       spectra.fill(HIST("hFT0APerRunPerSetOfFlags"), multFT0A, fillNumber, 1.5, weight);
       spectra.fill(HIST("hFT0CPerRunPerSetOfFlags"), multFT0C, fillNumber, 1.5, weight);
@@ -2009,7 +2236,7 @@ struct RecoilJets {
       spectra.fill(HIST("hEventSelectionCountQA"), 1.5);
     }
 
-    bool isNoSameBunchPileup = collision.selection_bit(aod::evsel::kNoSameBunchPileup);
+    const auto isNoSameBunchPileup = collision.selection_bit(aod::evsel::kNoSameBunchPileup);
     if (isNoSameBunchPileup) {
       spectra.fill(HIST("hFT0APerRunPerSetOfFlags"), multFT0A, fillNumber, 2.5, weight);
       spectra.fill(HIST("hFT0CPerRunPerSetOfFlags"), multFT0C, fillNumber, 2.5, weight);
@@ -2022,7 +2249,7 @@ struct RecoilJets {
       spectra.fill(HIST("hEventSelectionCountQA"), 2.5);
     }
 
-    bool isNoCollInTimeRangeStandard = collision.selection_bit(aod::evsel::kNoCollInTimeRangeStandard);
+    const auto isNoCollInTimeRangeStandard = collision.selection_bit(aod::evsel::kNoCollInTimeRangeStandard);
     if (isNoCollInTimeRangeStandard) {
 
       spectra.fill(HIST("hFT0APerRunPerSetOfFlags"), multFT0A, fillNumber, 3.5, weight);
@@ -2080,13 +2307,13 @@ struct RecoilJets {
     spectra.fill(HIST("hTimeZnaVsZncVsFT0M"), timeZNA, timeZNC, scaledFT0M, weight);
 
     // ITS only tracks
-    int nITSonly = collision.multNTracksITSOnly();
+    const auto nITSonly = collision.multNTracksITSOnly();
 
     spectra.fill(HIST("hScaledFT0C_ITStracks"), scaledFT0C, nITSonly, weight);
     spectra.fill(HIST("hScaledFT0M_ITStracks"), scaledFT0M, nITSonly, weight);
 
     // Global tracks from PV within |eta| < 0.8
-    int multNContribs = collision.multNTracksPV();
+    const auto multNContribs = collision.multNTracksPV();
 
     spectra.fill(HIST("hScaledFT0C_TracksPV"), scaledFT0C, multNContribs, weight);
     spectra.fill(HIST("hScaledFT0M_TracksPV"), scaledFT0M, multNContribs, weight);
@@ -2126,7 +2353,7 @@ struct RecoilJets {
       if (skipTrack(track))
         continue;
 
-      float trackPt = track.pt();
+      const auto trackPt = track.pt();
 
       if (trackPt > twoPartCorrel.leadPtRange->at(0) && trackPt < twoPartCorrel.leadPtRange->at(1)) {
         vPhiOfLeadingTracks.push_back(track.phi());
@@ -2139,8 +2366,8 @@ struct RecoilJets {
     if (nLeadingTracks > 0) {
       auto indexLeadTrack = randGen->Integer(nLeadingTracks);
 
-      double phiLeadingTrack = vPhiOfLeadingTracks[indexLeadTrack];
-      double pTLeadingTrack = vPtOfLeadingTracks[indexLeadTrack];
+      const auto phiLeadingTrack = vPhiOfLeadingTracks[indexLeadTrack];
+      const auto pTLeadingTrack = vPtOfLeadingTracks[indexLeadTrack];
 
       spectra.fill(HIST("hScaledFT0C_NleadTracks"), scaledFT0C, 0.5, weight);
       spectra.fill(HIST("hScaledFT0M_NleadTracks"), scaledFT0M, 0.5, weight);
@@ -2149,12 +2376,12 @@ struct RecoilJets {
         if (skipTrack(track))
           continue;
 
-        float trackPt = track.pt();
-        float trackPhi = track.phi();
+        const auto trackPt = track.pt();
+        const auto trackPhi = track.phi();
 
         // Search for associated tracks
         if (trackPt > twoPartCorrel.associatTrackPtMin && trackPt < pTLeadingTrack) {
-          double dphi = RecoDecay::constrainAngle(phiLeadingTrack - trackPhi, -1.3);
+          const auto dphi = RecoDecay::constrainAngle(phiLeadingTrack - trackPhi, -1.3);
           spectra.fill(HIST("hScaledFT0C_Correlation_LeadTrack_AssociatTracks"), scaledFT0C, dphi, weight);
           spectra.fill(HIST("hScaledFT0M_Correlation_LeadTrack_AssociatTracks"), scaledFT0M, dphi, weight);
         }
@@ -2174,7 +2401,7 @@ struct RecoilJets {
                             float weight = 1.)
   {
     //----------------------------------------------------------
-    float rho = collision.rho();
+    const auto rho = collision.rho();
     const auto ft0Metrics = getFT0Metrics(collision, ft0a.mean, ft0c.mean);
     const auto scaledFT0C = ft0Metrics.scaledFT0C;
     const auto scaledFT0M = ft0Metrics.scaledFT0M;
@@ -2867,22 +3094,21 @@ struct RecoilJets {
                               MatchedJetsDetToPartTbl const& mcDetJetsPerColl,
                               MatchedJetsPartToDetTbl const& mcPartJets)
   {
-    // Skip detector level collisions
     if (skipEvent(collision) || !collision.has_mcCollision())
       return;
 
-    auto mcColl = collision.mcCollision_as<CollRhoPartTbl>();
-    if(std::fabs(mcColl.posZ()) > ev.vertexZCut)
+    const auto mcColl = collision.mcCollision_as<CollRhoPartTbl>();
+
+    if (std::fabs(mcColl.posZ()) > ev.vertexZCut)
       return;
 
-    auto detLevelCollRho = collision.rho();
-    auto partLevelCollRho = mcColl.rho();
+    const auto partLevelCollRho = mcColl.rho();
 
     // Slice for mc part level jets associated to a given mcCollisionId
-    auto mcCollisionId = collision.mcCollisionId();
-    auto mcPartJetsPerMcCollision = mcPartJets.sliceBy(partJetsByMcCollision, mcCollisionId); // signature: (__column to slice___, __index__)
+    const auto mcCollisionId = collision.mcCollisionId();
+    const auto mcPartJetsPerMcCollision = mcPartJets.sliceBy(partJetsByMcCollision, mcCollisionId); // signature: (__column to slice___, __index__)
 
-    fillMatchedGeoHistograms(mcPartJetsPerMcCollision, mcDetJetsPerColl, tracksPerColl, partLevelCollRho, detLevelCollRho);
+    fillMatchedGeoHistograms(collision, mcPartJetsPerMcCollision, mcDetJetsPerColl, tracksPerColl, partLevelCollRho);
   }
   PROCESS_SWITCH(RecoilJets, processJetsGeoMatching, "process matching of MC jets using Geo criterion (no weight; MB events)", false);
 
@@ -2897,18 +3123,17 @@ struct RecoilJets {
     if (skipEvent(collision) || !collision.has_mcCollision())
       return;
 
-    auto mcColl = collision.mcCollision_as<CollRhoPartTbl>();
+    const auto mcColl = collision.mcCollision_as<CollRhoPartTbl>();
     if(std::fabs(mcColl.posZ()) > ev.vertexZCut)
       return;
 
-    auto detLevelCollRho = collision.rho();
-    auto partLevelCollRho = mcColl.rho();
+    const auto partLevelCollRho = mcColl.rho();
 
     // Slice for mc part level jets associated to a given mcCollisionId
-    auto mcCollisionId = collision.mcCollisionId();
-    auto mcPartJetsPerMcCollision = mcPartJets.sliceBy(partJetsByMcCollision, mcCollisionId); // signature: (__column to slice___, __index__)
+    const auto mcCollisionId = collision.mcCollisionId();
+    const auto mcPartJetsPerMcCollision = mcPartJets.sliceBy(partJetsByMcCollision, mcCollisionId); // signature: (__column to slice___, __index__)
 
-    fillMatchedGeoPtHistograms(mcPartJetsPerMcCollision, mcDetJetsPerColl, tracksPerColl, partLevelCollRho, detLevelCollRho);
+    fillMatchedGeoPtHistograms(collision, mcPartJetsPerMcCollision, mcDetJetsPerColl, tracksPerColl, partLevelCollRho);
   }
   PROCESS_SWITCH(RecoilJets, processJetsGeoPtMatching, "process matching of MC jets using Geo+Pt criteria (no weight; MB events)", false);
 
@@ -2923,19 +3148,18 @@ struct RecoilJets {
     if (skipEvent(collision) || collision.isOutlier() || !collision.has_mcCollision())
       return;
 
-    auto mcColl = collision.mcCollision_as<CollRhoOutlierPartTbl>();
+    const auto mcColl = collision.mcCollision_as<CollRhoOutlierPartTbl>();
     if(std::fabs(mcColl.posZ()) > ev.vertexZCut)
       return;
 
-    auto detLevelCollRho = collision.rho();
-    auto partLevelCollRho = mcColl.rho();
-    auto weight = mcColl.weight();
+    const auto partLevelCollRho = mcColl.rho();
+    const auto weight = mcColl.weight();
 
     // Slice for mc part level jets associated to a given mcCollisionId
-    auto mcCollisionId = collision.mcCollisionId();
-    auto mcPartJetsPerMcCollision = mcPartJets.sliceBy(partJetsByMcCollision, mcCollisionId); // signature: (__column to slice___, __index__)
+    const auto mcCollisionId = collision.mcCollisionId();
+    const auto mcPartJetsPerMcCollision = mcPartJets.sliceBy(partJetsByMcCollision, mcCollisionId); // signature: (__column to slice___, __index__)
 
-    fillMatchedGeoHistograms(mcPartJetsPerMcCollision, mcDetJetsPerColl, tracksPerColl, partLevelCollRho, detLevelCollRho, weight);
+    fillMatchedGeoHistograms(collision, mcPartJetsPerMcCollision, mcDetJetsPerColl, tracksPerColl, partLevelCollRho, weight);
   }
   PROCESS_SWITCH(RecoilJets, processJetsGeoMatchingWeighted, "process matching of MC jets using Geo criterion (weighted JJ)", false);
 
@@ -2954,7 +3178,6 @@ struct RecoilJets {
     if(std::fabs(mcColl.posZ()) > ev.vertexZCut)
       return;
 
-    auto detLevelCollRho = collision.rho();
     auto partLevelCollRho = mcColl.rho();
     auto weight = mcColl.weight();
 
@@ -2962,7 +3185,7 @@ struct RecoilJets {
     auto mcCollisionId = collision.mcCollisionId();
     auto mcPartJetsPerMcCollision = mcPartJets.sliceBy(partJetsByMcCollision, mcCollisionId); // signature: (__column to slice___, __index__)
 
-    fillMatchedGeoPtHistograms(mcPartJetsPerMcCollision, mcDetJetsPerColl, tracksPerColl, partLevelCollRho, detLevelCollRho, weight);
+    fillMatchedGeoPtHistograms(collision, mcPartJetsPerMcCollision, mcDetJetsPerColl, tracksPerColl, partLevelCollRho, weight);
   }
   PROCESS_SWITCH(RecoilJets, processJetsGeoPtMatchingWeighted, "process matching of MC jets using Geo+Pt criteria (weighted JJ)", false);
 

--- a/PWGJE/Tasks/recoilJets.cxx
+++ b/PWGJE/Tasks/recoilJets.cxx
@@ -21,9 +21,9 @@
 
 #include "Common/CCDB/EventSelectionParams.h"
 #include "Common/Core/RecoDecay.h"
+#include "Common/DataModel/Centrality.h"
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/Multiplicity.h"
-#include "Common/DataModel/Centrality.h"
 
 #include <CommonConstants/MathConstants.h>
 #include <Framework/ASoA.h>
@@ -111,9 +111,9 @@ struct RecoilJets {
 
     Configurable<float> vertexZCut{"vertexZCut", 10., "Accepted z-vertex range"};
     Configurable<bool> skipMBGapEvents{"skipMBGapEvents", false,
-                       "Flag to choose to reject min. bias gap events; jet-level rejection "
-                       "applied at the jet finder level, here rejection is applied for "
-                       "collision and track process functions"};
+                                       "Flag to choose to reject min. bias gap events; jet-level rejection "
+                                       "applied at the jet finder level, here rejection is applied for "
+                                       "collision and track process functions"};
   } ev;
 
   // ---------- RCT / flag-based selections ----------
@@ -473,11 +473,10 @@ struct RecoilJets {
                     Form("Events w. TT_{Sig}: %s & #rho", centAxis.label),
                     kTH2F, {{centAxis.axis, centAxis.axisName}, rho}, hist.sumw2);
 
-
         // Recoil jets vs centrality
         auto tmpHistPointer = spectra.add<TH2>(Form("h%s_Ntrig", centAxis.label),
-                                        Form("%s vs Total number of selected triggers per class", centAxis.label),
-                                        kTH2F, {{centAxis.axis, centAxis.axisName}, {2, 0.0, 2.}});
+                                               Form("%s vs Total number of selected triggers per class", centAxis.label),
+                                               kTH2F, {{centAxis.axis, centAxis.axisName}, {2, 0.0, 2.}});
         tmpHistPointer->GetYaxis()->SetBinLabel(1, "TT_{Ref}");
         tmpHistPointer->GetYaxis()->SetBinLabel(2, "TT_{Sig}");
 
@@ -607,8 +606,8 @@ struct RecoilJets {
       // Centrality dependence
       uint8_t iCent = 0;
       for (const auto& centAxis : arrConfigurableAxisCentrality) {
-        
-        if (iCent == 3){ // case of "CentFT0CVar1"
+
+        if (iCent == 3) { // case of "CentFT0CVar1"
           ++iCent;
           continue;
         }
@@ -636,7 +635,6 @@ struct RecoilJets {
                     "Charact. of MC generated particles",
                     kTHnSparseF, {{centAxis.axis, centAxis.axisName}, pT, pseudorap, phiAngle}, hist.sumw2);
 
-
         // Rho vs centrality
         spectra.add(Form("h%s_Rho_Part", centAxis.label),
                     Form("MC events %s & #rho", centAxis.label),
@@ -650,11 +648,10 @@ struct RecoilJets {
                     Form("MC events w. TT_{Sig}: %s & #rho", centAxis.label),
                     kTH2F, {{centAxis.axis, centAxis.axisName}, rho}, hist.sumw2);
 
-
         // Recoil jets vs centrality
         auto tmpHistPointer = spectra.add<TH2>(Form("h%s_Ntrig_Part", centAxis.label),
-                                        Form("%s vs Total number of selected MC triggers per class", centAxis.label),
-                                        kTH2F, {{centAxis.axis, centAxis.axisName}, {2, 0.0, 2.}});
+                                               Form("%s vs Total number of selected MC triggers per class", centAxis.label),
+                                               kTH2F, {{centAxis.axis, centAxis.axisName}, {2, 0.0, 2.}});
         tmpHistPointer->GetYaxis()->SetBinLabel(1, "TT_{Ref}");
         tmpHistPointer->GetYaxis()->SetBinLabel(2, "TT_{Sig}");
 
@@ -673,7 +670,7 @@ struct RecoilJets {
         spectra.add(Form("h%s_Recoil_JetPt_Corr_TTSig_Part", centAxis.label),
                     Form("MC events w. TT_{Sig}: %s & #it{p}_{T} of recoil jets", centAxis.label),
                     kTH2F, {{centAxis.axis, centAxis.axisName}, jetPTcorr}, hist.sumw2);
-          
+
         ++iCent;
       }
     }
@@ -752,12 +749,12 @@ struct RecoilJets {
       // Centrality-differential corrected spectra and response QA
       uint8_t iCent = 0;
       for (const auto& centAxis : arrConfigurableAxisCentrality) {
-        
+
         if (iCent == 0 || iCent == 3) { // case of "CentFT0A" & "CentFT0CVar1"
           ++iCent;
           continue;
         }
-        
+
         spectra.add(Form("h%s_ResponseMatrixInclusiveJetsPtCorr", centAxis.label),
                     Form("%s: correlation inclusive #it{p}_{T, det.}^{corr.} vs. #it{p}_{T, part}^{corr.}", centAxis.label),
                     kTH3F, {{centAxis.axis, centAxis.axisName}, detJetPtCorr, partJetPtCorr}, hist.sumw2);
@@ -1186,17 +1183,14 @@ struct RecoilJets {
     }
 
     // Tracking efficiency as a function of EA / Centrality
-    if(doprocessTrackingEfficiency || doprocessTrackingEfficiencyWeighted)
-    {
-      for (const auto& eaAxis : arrConfigurableAxisEA)
-      {
+    if (doprocessTrackingEfficiency || doprocessTrackingEfficiencyWeighted) {
+      for (const auto& eaAxis : arrConfigurableAxisEA) {
         // ------------------------------------------------------------------
         // Denominator: all generated particles passing phase-space cuts
         // ------------------------------------------------------------------
         spectra.add(Form("hScaledMult%s_AllGeneratedParticlesPt", eaAxis.label),
                     Form("Generated & selected particles; %s ; #it{p}_{T}^{part} (GeV/#it{c})", eaAxis.label),
                     kTH2F, {{eaAxis.axis, eaAxis.axisName}, {hist.axisPtTrackEff, "#it{p}_{T}^{part}"}}, hist.sumw2);
-
 
         // ------------------------------------------------------------------
         // Track has an associated MC particle,
@@ -1207,7 +1201,6 @@ struct RecoilJets {
                     Form("Track eff.; %s; #it{p}_{T}^{rec}; #it{p}_{T}^{part}", eaAxis.label),
                     kTH3F, {{eaAxis.axis, eaAxis.axisName}, {hist.axisPtTrackEff, "#it{p}_{T}^{rec}"}, {hist.axisPtTrackEff, "#it{p}_{T}^{part}"}}, hist.sumw2);
 
-
         // ------------------------------------------------------------------
         // Fake reconstructed tracks
 
@@ -1216,12 +1209,10 @@ struct RecoilJets {
                     Form("Tracks without associated MC particle; %s; #it{p}_{T}^{rec} (GeV/#it{c})", eaAxis.label),
                     kTH2F, {{eaAxis.axis, eaAxis.axisName}, {hist.axisPtTrackEff, "#it{p}_{T}^{rec}"}}, hist.sumw2);
 
-
         // Case 2: MC particle exists, but belongs to another MC collision
         spectra.add(Form("hScaledMult%s_MismatchedMcCollisionTracks", eaAxis.label),
                     Form("Tracks matched to particle from different MC collision; %s; #it{p}_{T}^{rec} (GeV/#it{c})", eaAxis.label),
                     kTH2F, {{eaAxis.axis, eaAxis.axisName}, {hist.axisPtTrackEff, "#it{p}_{T}^{rec}"}}, hist.sumw2);
-
 
         // Case 3: same MC collision, but particle fails phase-space cuts
         spectra.add(Form("hScaledMult%s_MatchedToRejectedTracks", eaAxis.label),
@@ -1275,7 +1266,6 @@ struct RecoilJets {
     spectra.fill(HIST("hCentFT0M"), centFT0M, weight);
     spectra.fill(HIST("hCentFT0CVar1"), centFT0CVar1, weight);
 
-
     // Z vertex position vs EA / centrality
     spectra.fill(HIST("hScaledFT0C_vertexZ"), scaledFT0C, vertexZ, weight);
     spectra.fill(HIST("hScaledFT0M_vertexZ"), scaledFT0M, vertexZ, weight);
@@ -1284,7 +1274,6 @@ struct RecoilJets {
     spectra.fill(HIST("hCentFT0C_vertexZ"), centFT0C, vertexZ, weight);
     spectra.fill(HIST("hCentFT0M_vertexZ"), centFT0M, vertexZ, weight);
     spectra.fill(HIST("hCentFT0CVar1_vertexZ"), centFT0CVar1, vertexZ, weight);
-
 
     // Rho vs EA / centrality
     spectra.fill(HIST("hScaledFT0C_Rho"), scaledFT0C, rho, weight);
@@ -1499,7 +1488,7 @@ struct RecoilJets {
     bool bSigEv = false;
     std::vector<double> vPhiOfTT;
     double phiTT = 0.;
-    int nTT = 0;    
+    int nTT = 0;
     const float addCountToTTRef = 0.5;
     const float addCountToTTSig = 1.5;
 
@@ -1522,12 +1511,10 @@ struct RecoilJets {
     spectra.fill(HIST("hScaledFT0C_Part"), scaledFT0C, weight);
     spectra.fill(HIST("hScaledFT0M_Part"), scaledFT0M, weight);
 
-
     // Centrality distribution
     spectra.fill(HIST("hCentFT0A_Part"), centFT0A, weight);
     spectra.fill(HIST("hCentFT0C_Part"), centFT0C, weight);
     spectra.fill(HIST("hCentFT0M_Part"), centFT0M, weight);
-
 
     // Z vertex position vs EA / centrality
     spectra.fill(HIST("hScaledFT0C_vertexZ_Part"), scaledFT0C, vertexZ, weight);
@@ -1536,7 +1523,6 @@ struct RecoilJets {
     spectra.fill(HIST("hCentFT0A_vertexZ_Part"), centFT0A, vertexZ, weight);
     spectra.fill(HIST("hCentFT0C_vertexZ_Part"), centFT0C, vertexZ, weight);
     spectra.fill(HIST("hCentFT0M_vertexZ_Part"), centFT0M, vertexZ, weight);
-
 
     // Rho vs EA / centrality
     spectra.fill(HIST("hScaledFT0C_Rho_Part"), scaledFT0C, rho, weight);
@@ -1729,7 +1715,7 @@ struct RecoilJets {
                                 JTracks const& tracks,
                                 const float partLevelCollRho,
                                 float weight = 1.)
-  { 
+  {
 
     //====================================================================================
     // Event properties
@@ -1866,7 +1852,7 @@ struct RecoilJets {
     }
 
     //====================================================================================
-    // Detector-level jets    
+    // Detector-level jets
     for (const auto& jetDet : jetsDet) {
       if (isJetWithHighPtConstituent<JTracks>(jetDet)) {
         continue;
@@ -1877,7 +1863,7 @@ struct RecoilJets {
 
       const bool bIsJetRecoil = bIsThereTTSig && get<1>(isRecoilJet(jetDet, phiTTSig));
 
-      //==================================================================================    
+      //==================================================================================
       // All detector-level inclusive jets
       spectra.fill(HIST("hDetLevelInclusiveJetsPt"), detJetPt, weight);
       spectra.fill(HIST("hScaledFT0C_DetLevelInclusiveJetsPtCorr"), scaledFT0C, detJetPtCorr, weight);
@@ -2914,43 +2900,36 @@ struct RecoilJets {
     const auto mcCollisionId = collision.mcCollisionId();
 
     // Numerator candidates: reconstructed tracks in this detector collision
-    for(const auto& trackPerColl : tracks)
-    {
+    for (const auto& trackPerColl : tracks) {
       if (skipTrack(trackPerColl))
         continue;
 
       auto trackPt = trackPerColl.pt();
 
       // Case 1: no associated MC particle
-      if(!trackPerColl.has_mcParticle())
-      { 
+      if (!trackPerColl.has_mcParticle()) {
         spectra.fill(HIST("hScaledMultFT0C_NoMcParticle"), scaledFT0C, trackPt, weight);
         spectra.fill(HIST("hScaledMultFT0M_NoMcParticle"), scaledFT0M, trackPt, weight);
         continue;
       }
 
-
       // Case 2: MC particle exists, but belongs to another MC collision
       auto particle = trackPerColl.mcParticle();
-      if(particle.mcCollisionId() != mcCollisionId)
-      {
+      if (particle.mcCollisionId() != mcCollisionId) {
         spectra.fill(HIST("hScaledMultFT0C_MismatchedMcCollisionTracks"), scaledFT0C, trackPt, weight);
         spectra.fill(HIST("hScaledMultFT0M_MismatchedMcCollisionTracks"), scaledFT0M, trackPt, weight);
         continue;
       }
 
-      
       // Case 3: same MC collision, but particle fails phase-space cuts
       float particleEta = particle.eta();
       bool bKeepParticle = std::fabs(particleEta) < trk.etaCut && !skipParticle(particle);
 
-      if(!bKeepParticle)
-      {
+      if (!bKeepParticle) {
         spectra.fill(HIST("hScaledMultFT0C_MatchedToRejectedTracks"), scaledFT0C, trackPt, weight);
         spectra.fill(HIST("hScaledMultFT0M_MatchedToRejectedTracks"), scaledFT0M, trackPt, weight);
         continue;
       }
-
 
       // Track has an associated MC particle,
       // the particle belongs to the same MC collision,
@@ -2959,20 +2938,18 @@ struct RecoilJets {
       spectra.fill(HIST("hScaledMultFT0C_ResponseMatrixTrackEff"), scaledFT0C, trackPt, particlePt, weight);
       spectra.fill(HIST("hScaledMultFT0M_ResponseMatrixTrackEff"), scaledFT0M, trackPt, particlePt, weight);
     }
-     
 
     // Denominator: generated selected particles from the same MC collision
     auto particlesInMcCollision = particles.sliceBy(particlesByMcCollision, mcCollisionId);
 
-    for(const auto& particleInMcCollision : particlesInMcCollision)
-    {
+    for (const auto& particleInMcCollision : particlesInMcCollision) {
       float particleEta = particleInMcCollision.eta();
       float particlePt = particleInMcCollision.pt();
       bool bKeepParticle = std::fabs(particleEta) < trk.etaCut && !skipParticle(particleInMcCollision);
 
-      if(!bKeepParticle)
+      if (!bKeepParticle)
         continue;
-      
+
       spectra.fill(HIST("hScaledMultFT0C_AllGeneratedParticlesPt"), scaledFT0C, particlePt, weight);
       spectra.fill(HIST("hScaledMultFT0M_AllGeneratedParticlesPt"), scaledFT0M, particlePt, weight);
     }
@@ -3124,7 +3101,7 @@ struct RecoilJets {
       return;
 
     const auto mcColl = collision.mcCollision_as<CollRhoPartTbl>();
-    if(std::fabs(mcColl.posZ()) > ev.vertexZCut)
+    if (std::fabs(mcColl.posZ()) > ev.vertexZCut)
       return;
 
     const auto partLevelCollRho = mcColl.rho();
@@ -3149,7 +3126,7 @@ struct RecoilJets {
       return;
 
     const auto mcColl = collision.mcCollision_as<CollRhoOutlierPartTbl>();
-    if(std::fabs(mcColl.posZ()) > ev.vertexZCut)
+    if (std::fabs(mcColl.posZ()) > ev.vertexZCut)
       return;
 
     const auto partLevelCollRho = mcColl.rho();
@@ -3175,7 +3152,7 @@ struct RecoilJets {
       return;
 
     auto mcColl = collision.mcCollision_as<CollRhoOutlierPartTbl>();
-    if(std::fabs(mcColl.posZ()) > ev.vertexZCut)
+    if (std::fabs(mcColl.posZ()) > ev.vertexZCut)
       return;
 
     auto partLevelCollRho = mcColl.rho();
@@ -3369,7 +3346,7 @@ struct RecoilJets {
     // Skip detector level collision
     if (skipEvent(collision) || !collision.has_mcCollision())
       return;
-    
+
     fillTrackRecoEff<aod::JetMcCollisions>(collision, tracksPerColl, particles);
   }
   PROCESS_SWITCH(RecoilJets, processTrackingEfficiency, "process MC data (no weight; MB events) to estimate track reco eff", false);


### PR DESCRIPTION
Main update:
 - add dependency on centrality for recoil jet analysis
 - use 4 definitions of centrality: FT0A, FT0C, FT0M, and CentFT0CVar1
 - centrality FT0C and FT0M are main, the rest will be used only for QA studies
 - new process function to analyse the tracking efficiency as a function of EA and Centrality

Other updates:
 - fixed the issues when the same particle level jet could be filled in the "Miss" histogram several times