### PR TITLE
[PWGCF] FU: TOF match. eff. update and D0 task update (BDT vs pT plots)

### DIFF
--- a/PWGCF/FemtoUniverse/Tasks/femtoUniverseEfficiencyBase.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniverseEfficiencyBase.cxx
@@ -206,8 +206,11 @@ struct FemtoUniverseEfficiencyBase {
     trackHistoPartOneRec.init(&qaRegistry, confTempFitVarpTBins, confTempFitVarDCABins, confIsMCReco, confPDGCodePartOne, confIsDebug);
     registryMCOrigin.add("part1/hRecoPt", " ;#it{p}_{T} (GeV/c); Entries", {HistType::kTH1F, {{confTempFitVarpTBins}}});
     registryMCOrigin.add("part1/hTruthPt", " ;#it{p}_{T} (GeV/c); Entries", {HistType::kTH1F, {{confTempFitVarpTBins}}});
-    registryTOFMatch.add("part1/hTofMatchPtBeforePID", " ;#it{p}_{T} (GeV/c); Entries", {HistType::kTH1F, {{confTempFitVarpTBins}}});
-    registryTOFMatch.add("part1/hTofMatchPtAfterPID", " ;#it{p}_{T} (GeV/c); Entries", {HistType::kTH1F, {{confTempFitVarpTBins}}});
+    registryTOFMatch.add("part1/hTofMatchPtBeforePIDAllPart", " ;#it{p}_{T} (GeV/c); Entries", {HistType::kTH1F, {{confTempFitVarpTBins}}});
+    registryTOFMatch.add("part1/hTofMatchPtBeforePIDPartWithTof", " ;#it{p}_{T} (GeV/c); Entries", {HistType::kTH1F, {{confTempFitVarpTBins}}});
+    registryTOFMatch.add("part1/hTofMatchPtAfterPIDAllPart", " ;#it{p}_{T} (GeV/c); Entries", {HistType::kTH1F, {{confTempFitVarpTBins}}});
+    registryTOFMatch.add("part1/hTofMatchPtAfterPIDPartWithTof", " ;#it{p}_{T} (GeV/c); Entries", {HistType::kTH1F, {{confTempFitVarpTBins}}});
+    registryTOFMatch.add("part1/hTofMatchPtAfterPIDPrimaryWithTof", " ;#it{p}_{T} (GeV/c); Entries", {HistType::kTH1F, {{confTempFitVarpTBins}}});
     registryTOFMatch.add("part1/hTpcPt", " ;#it{p}_{T} (GeV/c); Entries", {HistType::kTH1F, {{confTempFitVarpTBins}}});
     registryPDG.add("part1/PDGvspT", "PDG;#it{p}_{T} (GeV/c); PDG", {HistType::kTH2F, {{confTempFitVarpTBins}, {16001, -8000.5, 8000.5}}});
     registryPDG.add("part1/PDGvspTall", "PDG;#it{p}_{T} (GeV/c); PDG", {HistType::kTH2F, {{confTempFitVarpTBins}, {16001, -8000.5, 8000.5}}});
@@ -234,8 +237,11 @@ struct FemtoUniverseEfficiencyBase {
       trackHistoPartTwoRec.init(&qaRegistry, confTempFitVarpTBins, confTempFitVarDCABins, confIsMCReco, confPDGCodePartTwo, confIsDebug);
       registryMCOrigin.add("part2/hRecoPt", " ;#it{p}_{T} (GeV/c); Entries", {HistType::kTH1F, {{confTempFitVarpTBins}}});
       registryMCOrigin.add("part2/hTruthPt", " ;#it{p}_{T} (GeV/c); Entries", {HistType::kTH1F, {{confTempFitVarpTBins}}});
-      registryTOFMatch.add("part2/hTofMatchPtBeforePID", " ;#it{p}_{T} (GeV/c); Entries", {HistType::kTH1F, {{confTempFitVarpTBins}}});
-      registryTOFMatch.add("part2/hTofMatchPtAfterPID", " ;#it{p}_{T} (GeV/c); Entries", {HistType::kTH1F, {{confTempFitVarpTBins}}});
+      registryTOFMatch.add("part2/hTofMatchPtBeforePIDAllPart", " ;#it{p}_{T} (GeV/c); Entries", {HistType::kTH1F, {{confTempFitVarpTBins}}});
+      registryTOFMatch.add("part2/hTofMatchPtBeforePIDPartWithTof", " ;#it{p}_{T} (GeV/c); Entries", {HistType::kTH1F, {{confTempFitVarpTBins}}});
+      registryTOFMatch.add("part2/hTofMatchPtAfterPIDAllPart", " ;#it{p}_{T} (GeV/c); Entries", {HistType::kTH1F, {{confTempFitVarpTBins}}});
+      registryTOFMatch.add("part2/hTofMatchPtAfterPIDPartWithTof", " ;#it{p}_{T} (GeV/c); Entries", {HistType::kTH1F, {{confTempFitVarpTBins}}});
+      registryTOFMatch.add("part2/hTofMatchPtAfterPIDPrimaryWithTof", " ;#it{p}_{T} (GeV/c); Entries", {HistType::kTH1F, {{confTempFitVarpTBins}}});
       registryTOFMatch.add("part2/hTpcPt", " ;#it{p}_{T} (GeV/c); Entries", {HistType::kTH1F, {{confTempFitVarpTBins}}});
       registryPDG.add("part2/PDGvspT", "PDG;#it{p}_{T} (GeV/c); PDG", {HistType::kTH2F, {{confTempFitVarpTBins}, {16001, -8000.5, 8000.5}}});
       registryPDG.add("part2/PDGvspTall", "PDG;#it{p}_{T} (GeV/c); PDG", {HistType::kTH2F, {{confTempFitVarpTBins}, {16001, -8000.5, 8000.5}}});
@@ -644,7 +650,11 @@ struct FemtoUniverseEfficiencyBase {
         continue;
       }
       registryCuts.fill(HIST("part1/cutsVspT"), part.pt(), 3);
-      registryTOFMatch.fill(HIST("part1/hTofMatchPtBeforePID"), part.pt());
+      // TOF Matching efficiency before PID
+      registryTOFMatch.fill(HIST("part1/hTofMatchPtBeforePIDAllPart"), part.pt());
+      if (part.mLambda() == 1) {
+        registryTOFMatch.fill(HIST("part1/hTofMatchPtBeforePIDPartWithTof"), part.pt());
+      }
 
       if (!ConfTracksPid.trkUsePassPIDSelection) {
         if (!isParticleNSigma(confPDGCodePartOne, static_cast<bool>(part.mLambda()), part.p(), trackCuts.getNsigmaTPC(part, o2::track::PID::Proton), trackCuts.getNsigmaTOF(part, o2::track::PID::Proton), trackCuts.getNsigmaTPC(part, o2::track::PID::Pion), trackCuts.getNsigmaTOF(part, o2::track::PID::Pion), trackCuts.getNsigmaTPC(part, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(part, o2::track::PID::Kaon), trackCuts.getNsigmaTPC(part, o2::track::PID::Deuteron), trackCuts.getNsigmaTOF(part, o2::track::PID::Deuteron))) {
@@ -660,9 +670,10 @@ struct FemtoUniverseEfficiencyBase {
       }
       registryCuts.fill(HIST("part1/cutsVspT"), part.pt(), 4);
 
-      // TOF Matching efficiency
+      // TOF Matching efficiency after PID
+      registryTOFMatch.fill(HIST("part1/hTofMatchPtAfterPIDAllPart"), part.pt());
       if (part.mLambda() == 1) {
-        registryTOFMatch.fill(HIST("part1/hTofMatchPtAfterPID"), part.pt());
+        registryTOFMatch.fill(HIST("part1/hTofMatchPtAfterPIDPartWithTof"), part.pt());
       } else {
         registryTOFMatch.fill(HIST("part1/hTpcPt"), part.pt());
       }
@@ -671,6 +682,11 @@ struct FemtoUniverseEfficiencyBase {
       const auto mcParticle = part.fdMCParticle();
 
       registryPDG.fill(HIST("part1/PDGvspTall"), part.pt(), mcParticle.pdgMCTruth());
+
+      // Primary particles which have TOF after PID
+      if (part.mLambda() == 1 && mcParticle.partOriginMCTruth() == aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kPrimary) {
+        registryTOFMatch.fill(HIST("part1/hTofMatchPtAfterPIDPrimaryWithTof"), part.pt());
+      }
 
       if (fillSecTrkContHistos) {
         if (mcParticle.partOriginMCTruth() == aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kPrimary) {
@@ -723,7 +739,11 @@ struct FemtoUniverseEfficiencyBase {
           continue;
         }
         registryCuts.fill(HIST("part2/cutsVspT"), part.pt(), 3);
-        registryTOFMatch.fill(HIST("part2/hTofMatchPtBeforePID"), part.pt());
+        // TOF Matching efficiency before PID
+        registryTOFMatch.fill(HIST("part2/hTofMatchPtBeforePIDAllPart"), part.pt());
+        if (part.mLambda() == 1) {
+          registryTOFMatch.fill(HIST("part2/hTofMatchPtBeforePIDPartWithTof"), part.pt());
+        }
 
         if (!ConfTracksPid.trkUsePassPIDSelection) {
           if (!isParticleNSigma(confPDGCodePartTwo, static_cast<bool>(part.mLambda()), part.p(), trackCuts.getNsigmaTPC(part, o2::track::PID::Proton), trackCuts.getNsigmaTOF(part, o2::track::PID::Proton), trackCuts.getNsigmaTPC(part, o2::track::PID::Pion), trackCuts.getNsigmaTOF(part, o2::track::PID::Pion), trackCuts.getNsigmaTPC(part, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(part, o2::track::PID::Kaon), trackCuts.getNsigmaTPC(part, o2::track::PID::Deuteron), trackCuts.getNsigmaTOF(part, o2::track::PID::Deuteron))) {
@@ -739,9 +759,10 @@ struct FemtoUniverseEfficiencyBase {
         }
         registryCuts.fill(HIST("part2/cutsVspT"), part.pt(), 4);
 
-        // TOF Matching efficiency
+        // TOF Matching efficiency after PID
+        registryTOFMatch.fill(HIST("part2/hTofMatchPtAfterPIDAllPart"), part.pt());
         if (part.mLambda() == 1) {
-          registryTOFMatch.fill(HIST("part2/hTofMatchPtAfterPID"), part.pt());
+          registryTOFMatch.fill(HIST("part2/hTofMatchPtAfterPIDPartWithTof"), part.pt());
         } else {
           registryTOFMatch.fill(HIST("part2/hTpcPt"), part.pt());
         }
@@ -750,6 +771,11 @@ struct FemtoUniverseEfficiencyBase {
         const auto mcParticle = part.fdMCParticle();
 
         registryPDG.fill(HIST("part2/PDGvspTall"), part.pt(), mcParticle.pdgMCTruth());
+
+        // Primary particles which have TOF after PID
+        if (part.mLambda() == 1 && mcParticle.partOriginMCTruth() == aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kPrimary) {
+          registryTOFMatch.fill(HIST("part2/hTofMatchPtAfterPIDPrimaryWithTof"), part.pt());
+        }
 
         if (fillSecTrkContHistos) {
           if (mcParticle.partOriginMCTruth() == aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kPrimary) {

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackD0.cxx
@@ -175,7 +175,7 @@ struct FemtoUniversePairTaskTrackD0 {
   // Correlated background for D0/D0bar candidates
   Configurable<bool> fillCorrBkgs{"fillCorrBkgs", false, "Fill histograms with correlated background candidates"};
   // Configurable to enable BDT vs pT histograms for D0/D0bar at MC Reco level
-  Configurable<bool> fillBDTvsPt{"fillBDTvsPt", false, "Fill BDT vs pT histograms for D0/D0bar candidates"};
+  Configurable<bool> fillBDTvsPt{"fillBDTvsPt", true, "Fill BDT vs pT histograms for D0/D0bar candidates"};
 
   // Efficiency
   Configurable<bool> doEfficiencyCorr{"doEfficiencyCorr", false, "Apply efficiency corrections"};
@@ -534,12 +534,10 @@ struct FemtoUniversePairTaskTrackD0 {
       registry.add("DebugBdtMcReco/hBdtScore1VsPt", ";BDT score;#it{p}_{T} (GeV/#it{c})", {HistType::kTH2F, {axisBdtScore, {vbins}}});
       registry.add("DebugBdtMcReco/hBdtScore2VsPt", ";BDT score;#it{p}_{T} (GeV/#it{c})", {HistType::kTH2F, {axisBdtScore, {vbins}}});
       registry.add("DebugBdtMcReco/hBdtScore3VsPt", ";BDT score;#it{p}_{T} (GeV/#it{c})", {HistType::kTH2F, {axisBdtScore, {vbins}}});
-      registry.add("DebugBdtMcReco/hBdtScore1VsPtD0", ";BDT score;#it{p}_{T} (GeV/#it{c})", {HistType::kTH2F, {axisBdtScore, {vbins}}});
-      registry.add("DebugBdtMcReco/hBdtScore2VsPtD0", ";BDT score;#it{p}_{T} (GeV/#it{c})", {HistType::kTH2F, {axisBdtScore, {vbins}}});
-      registry.add("DebugBdtMcReco/hBdtScore3VsPtD0", ";BDT score;#it{p}_{T} (GeV/#it{c})", {HistType::kTH2F, {axisBdtScore, {vbins}}});
-      registry.add("DebugBdtMcReco/hBdtScore1VsPtD0bar", ";BDT score;#it{p}_{T} (GeV/#it{c})", {HistType::kTH2F, {axisBdtScore, {vbins}}});
-      registry.add("DebugBdtMcReco/hBdtScore2VsPtD0bar", ";BDT score;#it{p}_{T} (GeV/#it{c})", {HistType::kTH2F, {axisBdtScore, {vbins}}});
-      registry.add("DebugBdtMcReco/hBdtScore3VsPtD0bar", ";BDT score;#it{p}_{T} (GeV/#it{c})", {HistType::kTH2F, {axisBdtScore, {vbins}}});
+      registry.add("DebugBdtMcReco/hBdtScore3VsPtVsMassPromptD0", ";BDT score;#it{p}_{T} (GeV/#it{c});M(K#pi) (GeV/#it{c}^{2})", {HistType::kTH3F, {axisBdtScore, {vbins}, confInvMassBins}});
+      registry.add("DebugBdtMcReco/hBdtScore3VsPtVsMassNonPromptD0", ";BDT score;#it{p}_{T} (GeV/#it{c});M(K#pi) (GeV/#it{c}^{2})", {HistType::kTH3F, {axisBdtScore, {vbins}, confInvMassBins}});
+      registry.add("DebugBdtMcReco/hBdtScore3VsPtVsMassPromptD0bar", ";BDT score;#it{p}_{T} (GeV/#it{c});M(K#pi) (GeV/#it{c}^{2})", {HistType::kTH3F, {axisBdtScore, {vbins}, confInvMassBins}});
+      registry.add("DebugBdtMcReco/hBdtScore3VsPtVsMassNonPromptD0bar", ";BDT score;#it{p}_{T} (GeV/#it{c});M(K#pi) (GeV/#it{c}^{2})", {HistType::kTH3F, {axisBdtScore, {vbins}, confInvMassBins}});
     }
     if (applyMLOpt) {
       registry.add("D0D0bar_MLSel/hMassVsPt1", "2-prong candidates;inv. mass (#pi K) (GeV/#it{c}^{2});entries", {HistType::kTH2F, {confInvMassBins, {vbins, "#it{p}_{T} (GeV/#it{c})"}}});
@@ -1480,41 +1478,42 @@ struct FemtoUniversePairTaskTrackD0 {
           mcRecoRegistry.fill(HIST("hMcRecD0"), part.pt(), part.eta());
           mcRecoRegistry.fill(HIST("hMcRecD0Pt"), part.pt());
           mcRecoRegistry.fill(HIST("hMcRecD0Phi"), part.phi());
-          if (fillBDTvsPt) {
-            registry.fill(HIST("DebugBdtMcReco/hBdtScore1VsPtD0"), part.decayVtxX(), part.pt());
-            registry.fill(HIST("DebugBdtMcReco/hBdtScore2VsPtD0"), part.decayVtxY(), part.pt());
-            registry.fill(HIST("DebugBdtMcReco/hBdtScore3VsPtD0"), part.decayVtxZ(), part.pt());
-          }
+
           if (part.tpcNClsFound() == 0) { // prompt candidates
             mcRecoRegistry.fill(HIST("hMcRecD0Prompt"), part.pt(), part.eta());
             mcRecoRegistry.fill(HIST("hMcRecD0PromptPt"), part.pt());
             mcRecoRegistry.fill(HIST("hMcRecD0PromptPhi"), part.phi());
+            if (fillBDTvsPt) {
+              registry.fill(HIST("DebugBdtMcReco/hBdtScore3VsPtVsMassPromptD0"), part.decayVtxZ(), part.pt(), part.mLambda());
+            }
           } else if (part.tpcNClsFound() == 1) { // non-prompt candidates
             mcRecoRegistry.fill(HIST("hMcRecD0NonPrompt"), part.pt(), part.eta());
             mcRecoRegistry.fill(HIST("hMcRecD0NonPromptPt"), part.pt());
             mcRecoRegistry.fill(HIST("hMcRecD0NonPromptPhi"), part.phi());
+            if (fillBDTvsPt) {
+              registry.fill(HIST("DebugBdtMcReco/hBdtScore3VsPtVsMassNonPromptD0"), part.decayVtxZ(), part.pt(), part.mAntiLambda());
+            }
           }
         } else if (mcpart.pdgMCTruth() == ConfDmesons.confPDGCodeD0bar) {
           mcRecoRegistry.fill(HIST("hMcRecD0bar"), part.pt(), part.eta());
           mcRecoRegistry.fill(HIST("hMcRecD0barPt"), part.pt());
           mcRecoRegistry.fill(HIST("hMcRecD0barPhi"), part.phi());
-          if (fillBDTvsPt) {
-            registry.fill(HIST("DebugBdtMcReco/hBdtScore1VsPtD0bar"), part.decayVtxX(), part.pt());
-            registry.fill(HIST("DebugBdtMcReco/hBdtScore2VsPtD0bar"), part.decayVtxY(), part.pt());
-            registry.fill(HIST("DebugBdtMcReco/hBdtScore3VsPtD0bar"), part.decayVtxZ(), part.pt());
-          }
+
           if (part.tpcNClsFound() == 0) { // prompt candidates
             mcRecoRegistry.fill(HIST("hMcRecD0barPrompt"), part.pt(), part.eta());
             mcRecoRegistry.fill(HIST("hMcRecD0barPromptPt"), part.pt());
+            if (fillBDTvsPt) {
+              registry.fill(HIST("DebugBdtMcReco/hBdtScore3VsPtVsMassPromptD0bar"), part.decayVtxZ(), part.pt(), part.mLambda());
+            }
           } else if (part.tpcNClsFound() == 1) { // non-prompt candidates
             mcRecoRegistry.fill(HIST("hMcRecD0barNonPrompt"), part.pt(), part.eta());
             mcRecoRegistry.fill(HIST("hMcRecD0barNonPromptPt"), part.pt());
+            if (fillBDTvsPt) {
+              registry.fill(HIST("DebugBdtMcReco/hBdtScore3VsPtVsMassNonPromptD0bar"), part.decayVtxZ(), part.pt(), part.mAntiLambda());
+            }
           }
         }
       }
-      // if (isParticleNSigma(part.p(), trackCuts.getNsigmaTPC(part, o2::track::PID::Proton), trackCuts.getNsigmaTOF(part, o2::track::PID::Proton), trackCuts.getNsigmaTPC(part, o2::track::PID::Pion), trackCuts.getNsigmaTOF(part, o2::track::PID::Pion), trackCuts.getNsigmaTPC(part, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(part, o2::track::PID::Kaon))) {
-      // hTrackDCA.fillQA<true, true>(part);
-      //} This part required change
     }
   }
   PROCESS_SWITCH(FemtoUniversePairTaskTrackD0, processMcReco, "Process MC reco data", false);


### PR DESCRIPTION
`femtoUniverseEfficiencyBase.cxx`:
- corrections to the TOF matching efficiency (histogram adjustments)
- new feature: the possibility to check the TOF matching efficiency for primary particles

`femtoUniversePairTaskTrackD0.cxx`:
- correction to the plots with BDT score classes vs pT for D0 mesons (plots needed for prompt fraction estimation)