### PR TITLE
[PWGHF] Add centrality to Ds-hadron correlation tables

### DIFF
--- a/PWGHF/HFC/DataModel/CorrelationTables.h
+++ b/PWGHF/HFC/DataModel/CorrelationTables.h
@@ -315,6 +315,7 @@ DECLARE_SOA_TABLE(CandCharge, "AOD", "CANDCHARGE",
 // definition of columns and tables for Ds-Hadron correlation pairs
 namespace hf_correlation_ds_hadron
 {
+DECLARE_SOA_COLUMN(Centrality, centrality, float);                         //! Centrality of Collision
 DECLARE_SOA_COLUMN(DeltaPhi, deltaPhi, float);                             //! DeltaPhi between Ds and Hadrons
 DECLARE_SOA_COLUMN(DeltaEta, deltaEta, float);                             //! DeltaEta between Ds and Hadrons
 DECLARE_SOA_COLUMN(SignedPtD, signedPtD, float);                           //! Transverse momentum of Ds
@@ -340,7 +341,8 @@ DECLARE_SOA_TABLE(DsHadronPair, "AOD", "DSHPAIR", //! Ds-Hadrons pairs Informati
                   aod::hf_correlation_ds_hadron::SignedPtD,
                   aod::hf_correlation_ds_hadron::SignedPtHadron,
                   aod::hf_correlation_ds_hadron::PoolBin,
-                  aod::hf_correlation_ds_hadron::NumPvContrib);
+                  aod::hf_correlation_ds_hadron::NumPvContrib,
+                  aod::hf_correlation_ds_hadron::Centrality);
 
 DECLARE_SOA_TABLE(DsHadronRecoInfo, "AOD", "DSHRECOINFO", //! Ds-Hadrons pairs Reconstructed Information
                   aod::hf_correlation_ds_hadron::MD,
@@ -361,7 +363,8 @@ DECLARE_SOA_TABLE(DsCandRecoInfo, "AOD", "DSCANDRECOINFO", //! Ds candidates Rec
                   aod::hf_correlation_ds_hadron::SignedPtD,
                   aod::hf_correlation_ds_hadron::MlScorePrompt,
                   aod::hf_correlation_ds_hadron::MlScoreBkg,
-                  aod::hf_correlation_ds_hadron::NumPvContrib);
+                  aod::hf_correlation_ds_hadron::NumPvContrib,
+                  aod::hf_correlation_ds_hadron::Centrality);
 
 DECLARE_SOA_TABLE(DsCandGenInfo, "AOD", "DSCANDGENOINFO", //! Ds candidates Generated Information
                   aod::hf_correlation_ds_hadron::IsPrompt);

--- a/PWGHF/HFC/DataModel/DerivedDataCorrelationTables.h
+++ b/PWGHF/HFC/DataModel/DerivedDataCorrelationTables.h
@@ -32,6 +32,7 @@ DECLARE_SOA_COLUMN(PosZ, posZ, float);                 //! Primary vertex z posi
 DECLARE_SOA_TABLE(HfcRedCollisions, "AOD", "HFCREDCOLLISION", //! Table with collision info
                   soa::Index<>,
                   aod::hf_collisions_reduced::Multiplicity,
+                  aod::hf_collisions_reduced::Centrality,
                   aod::hf_collisions_reduced::NumPvContrib,
                   aod::hf_collisions_reduced::PosZ);
 

--- a/PWGHF/HFC/TableProducer/correlatorDplusHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDplusHadrons.cxx
@@ -576,7 +576,7 @@ struct HfCorrelatorDplusHadrons {
         assocTrackSelInfo(indexHfcReducedCollision, track.tpcNClsCrossedRows(), track.itsClusterMap(), track.itsNCls(), track.dcaXY(), track.dcaZ());
       }
 
-      collReduced(collision.multFT0M(), collision.numContrib(), collision.posZ());
+      collReduced(collision.multFT0M(), 0.f, collision.numContrib(), collision.posZ());
     }
   }
   PROCESS_SWITCH(HfCorrelatorDplusHadrons, processDerivedDataDplus, "Process derived data D+", false);

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -30,6 +30,7 @@
 #include "Common/Core/RecoDecay.h"
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/Multiplicity.h"
+#include "Common/DataModel/Centrality.h"
 #include "Common/DataModel/PIDResponseTOF.h"
 #include "Common/DataModel/PIDResponseTPC.h"
 #include "Common/DataModel/TrackSelectionTables.h"
@@ -216,7 +217,7 @@ struct HfCorrelatorDsHadrons {
 
   SliceCache cache;
 
-  using SelCollisionsWithDs = soa::Filtered<soa::Join<aod::Collisions, aod::Mults, aod::EvSels, aod::DmesonSelection>>; // collisionFilter applied
+  using SelCollisionsWithDs = soa::Filtered<soa::Join<aod::Collisions, aod::Mults, aod::CentFT0Ms, aod::EvSels, aod::DmesonSelection>>; // collisionFilter applied
   // using SelCollisionsWithDsWithMc = soa::Filtered<soa::Join<aod::Collisions, aod::Mults, aod::EvSels, aod::DmesonSelection, aod::McCollisionLabels>>; // collisionFilter applied
   using SelCollisionsMc = soa::Join<aod::McCollisions, aod::MultsExtraMC>;
   using CandDsData = soa::Filtered<soa::Join<aod::HfCand3Prong, aod::HfSelDsToKKPi, aod::HfMlDsToKKPi>>;                                                                                                                                           // flagDsFilter applied
@@ -468,13 +469,13 @@ struct HfCorrelatorDsHadrons {
         for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
           outputMl[iclass] = candidate.mlProbDsToKKPi()[classMl->at(iclass)];
         }
-        entryDsCandRecoInfo(HfHelper::invMassDsToKKPi(candidate), candidate.pt() * chargeDs, outputMl[0], outputMl[2], collision.numContrib());
+        entryDsCandRecoInfo(HfHelper::invMassDsToKKPi(candidate), candidate.pt() * chargeDs, outputMl[0], outputMl[2], collision.numContrib(), collision.centFT0M());
       } else if (candidate.isSelDsToPiKK() >= selectionFlagDs) {
         fillHistoPiKK(candidate, efficiencyWeightD);
         for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
           outputMl[iclass] = candidate.mlProbDsToPiKK()[classMl->at(iclass)];
         }
-        entryDsCandRecoInfo(HfHelper::invMassDsToPiKK(candidate), candidate.pt() * chargeDs, outputMl[0], outputMl[2], collision.numContrib());
+        entryDsCandRecoInfo(HfHelper::invMassDsToPiKK(candidate), candidate.pt() * chargeDs, outputMl[0], outputMl[2], collision.numContrib(), collision.centFT0M());
       }
       if (candidate.isSelDsToKKPi() >= selectionFlagDs && candidate.isSelDsToPiKK() >= selectionFlagDs) {
         registry.fill(HIST("hCountSelectionStatusDsToKKPiAndToPiKK"), 0.);
@@ -498,7 +499,8 @@ struct HfCorrelatorDsHadrons {
                             candidate.pt() * chargeDs,
                             track.pt() * track.sign(),
                             poolBin,
-                            collision.numContrib());
+                            collision.numContrib(),
+                            collision.centFT0M());
           entryDsHadronRecoInfo(HfHelper::invMassDsToKKPi(candidate), false, false);
           // entryDsHadronGenInfo(false, false, 0);
           entryDsHadronMlInfo(outputMl[0], outputMl[2]);
@@ -509,7 +511,8 @@ struct HfCorrelatorDsHadrons {
                             candidate.pt() * chargeDs,
                             track.pt() * track.sign(),
                             poolBin,
-                            collision.numContrib());
+                            collision.numContrib(),
+                            collision.centFT0M());
           entryDsHadronRecoInfo(HfHelper::invMassDsToPiKK(candidate), false, false);
           // entryDsHadronGenInfo(false, false, 0);
           entryDsHadronMlInfo(outputMl[0], outputMl[2]);
@@ -569,7 +572,7 @@ struct HfCorrelatorDsHadrons {
           registry.fill(HIST("hMassDsMcRecSig"), HfHelper::invMassDsToKKPi(candidate), candidate.pt(), efficiencyWeightD);
           registry.fill(HIST("hMassDsVsPtMcRec"), HfHelper::invMassDsToKKPi(candidate), candidate.pt(), efficiencyWeightD);
           registry.fill(HIST("hSelectionStatusDsToKKPiMcRec"), candidate.isSelDsToKKPi());
-          entryDsCandRecoInfo(HfHelper::invMassDsToKKPi(candidate), candidate.pt() * chargeDs, outputMl[0], outputMl[2], collision.numContrib());
+          entryDsCandRecoInfo(HfHelper::invMassDsToKKPi(candidate), candidate.pt() * chargeDs, outputMl[0], outputMl[2], collision.numContrib(), collision.centFT0M());
           entryDsCandGenInfo(isDsPrompt);
         } else if (candidate.isSelDsToPiKK() >= selectionFlagDs) {
           for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
@@ -579,7 +582,7 @@ struct HfCorrelatorDsHadrons {
           registry.fill(HIST("hMassDsMcRecSig"), HfHelper::invMassDsToPiKK(candidate), candidate.pt(), efficiencyWeightD);
           registry.fill(HIST("hMassDsVsPtMcRec"), HfHelper::invMassDsToPiKK(candidate), candidate.pt(), efficiencyWeightD);
           registry.fill(HIST("hSelectionStatusDsToPiKKMcRec"), candidate.isSelDsToPiKK());
-          entryDsCandRecoInfo(HfHelper::invMassDsToPiKK(candidate), candidate.pt() * chargeDs, outputMl[0], outputMl[2], collision.numContrib());
+          entryDsCandRecoInfo(HfHelper::invMassDsToPiKK(candidate), candidate.pt() * chargeDs, outputMl[0], outputMl[2], collision.numContrib(), collision.centFT0M());
           entryDsCandGenInfo(isDsPrompt);
         }
       } else {
@@ -653,7 +656,8 @@ struct HfCorrelatorDsHadrons {
                             candidate.pt() * chargeDs,
                             track.pt() * track.sign(),
                             poolBin,
-                            collision.numContrib());
+                            collision.numContrib(),
+                            collision.centFT0M());
           entryDsHadronRecoInfo(HfHelper::invMassDsToKKPi(candidate), isDsSignal, isDecayChan);
           entryDsHadronMlInfo(outputMl[0], outputMl[2]);
           isPhysicalPrimary = mcParticle.isPhysicalPrimary();
@@ -675,7 +679,8 @@ struct HfCorrelatorDsHadrons {
                             candidate.pt() * chargeDs,
                             track.pt() * track.sign(),
                             poolBin,
-                            collision.numContrib());
+                            collision.numContrib(),
+                            collision.centFT0M());
           entryDsHadronRecoInfo(HfHelper::invMassDsToPiKK(candidate), isDsSignal, isDecayChan);
           entryDsHadronMlInfo(outputMl[0], outputMl[2]);
           isPhysicalPrimary = mcParticle.isPhysicalPrimary();
@@ -819,7 +824,8 @@ struct HfCorrelatorDsHadrons {
                                 particle.pt() * chargeDs,
                                 particleAssoc.pt() * chargeParticle,
                                 poolBin,
-                                0);
+                                0,
+                                0.f); // no multiplicity and centrality info at gen level
               entryDsHadronRecoInfo(MassDS, true, isDecayChan);
               entryDsHadronGenInfo(isDsPrompt, particleAssoc.isPhysicalPrimary(), trackOrigin);
             } // end loop generated particles
@@ -902,7 +908,7 @@ struct HfCorrelatorDsHadrons {
         }
       }
 
-      collReduced(collision.multFT0M(), collision.numContrib(), collision.posZ());
+      collReduced(collision.multFT0M(), collision.centFT0M(), collision.numContrib(), collision.posZ());
     }
   }
   PROCESS_SWITCH(HfCorrelatorDsHadrons, processDerivedDataDs, "Process derived data Ds", false);
@@ -952,7 +958,8 @@ struct HfCorrelatorDsHadrons {
                             cand.pt() * chargeDs,
                             pAssoc.pt() * pAssoc.sign(),
                             poolBin,
-                            c1.numContrib());
+                            c1.numContrib(),
+                            c1.centFT0M());
           entryDsHadronRecoInfo(HfHelper::invMassDsToKKPi(cand), false, false);
           // entryDsHadronGenInfo(false, false, 0);
           for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
@@ -967,7 +974,8 @@ struct HfCorrelatorDsHadrons {
                             cand.pt() * chargeDs,
                             pAssoc.pt() * pAssoc.sign(),
                             poolBin,
-                            c1.numContrib());
+                            c1.numContrib(),
+                            c1.centFT0M());
           entryDsHadronRecoInfo(HfHelper::invMassDsToPiKK(cand), false, false);
           // entryDsHadronGenInfo(false, false, 0);
           for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
@@ -1044,7 +1052,8 @@ struct HfCorrelatorDsHadrons {
                             candidate.pt() * chargeDs,
                             pAssoc.pt() * pAssoc.sign(),
                             poolBin,
-                            c1.numContrib());
+                            c1.numContrib(),
+                            c1.centFT0M());
           entryDsHadronRecoInfo(HfHelper::invMassDsToKKPi(candidate), isDsSignal, isDecayChan);
           entryDsHadronGenInfo(isDsPrompt, isPhysicalPrimary, trackOrigin);
           for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
@@ -1058,7 +1067,8 @@ struct HfCorrelatorDsHadrons {
                             candidate.pt() * chargeDs,
                             pAssoc.pt() * pAssoc.sign(),
                             poolBin,
-                            c1.numContrib());
+                            c1.numContrib(),
+                            c1.centFT0M());
           entryDsHadronRecoInfo(HfHelper::invMassDsToPiKK(candidate), isDsSignal, isDecayChan);
           entryDsHadronGenInfo(isDsPrompt, isPhysicalPrimary, trackOrigin);
           for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
@@ -1128,7 +1138,8 @@ struct HfCorrelatorDsHadrons {
                             candidate.pt() * chargeDs,
                             particleAssoc.pt() * chargeParticle,
                             poolBin,
-                            0);
+                            0,
+                            0.f); // no multiplicity and centrality info at gen level
           entryDsHadronRecoInfo(MassDS, true, true);
           entryDsHadronGenInfo(isDsPrompt, particleAssoc.isPhysicalPrimary(), trackOrigin);
         }

--- a/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadrons.cxx
@@ -28,9 +28,9 @@
 
 #include "Common/CCDB/EventSelectionParams.h"
 #include "Common/Core/RecoDecay.h"
+#include "Common/DataModel/Centrality.h"
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/Multiplicity.h"
-#include "Common/DataModel/Centrality.h"
 #include "Common/DataModel/PIDResponseTOF.h"
 #include "Common/DataModel/PIDResponseTPC.h"
 #include "Common/DataModel/TrackSelectionTables.h"

--- a/PWGHF/HFC/TableProducer/correlatorDsHadronsReduced.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorDsHadronsReduced.cxx
@@ -126,7 +126,7 @@ struct HfCorrelatorDsHadronsReduced {
         registry.fill(HIST("hDsPoolBin"), poolBin);
         registry.fill(HIST("hPhiVsPtCand"), RecoDecay::constrainAngle(candidate.phiCand(), -PIHalf), candidate.ptCand());
         registry.fill(HIST("hEtaVsPtCand"), candidate.etaCand(), candidate.ptCand());
-        entryDsCandRecoInfo(candidate.invMass(), candidate.ptCand(), candidate.bdtScorePrompt(), candidate.bdtScoreBkg(), collision.numPvContrib());
+        entryDsCandRecoInfo(candidate.invMass(), candidate.ptCand(), candidate.bdtScorePrompt(), candidate.bdtScoreBkg(), collision.numPvContrib(), collision.centrality());
         for (const auto& track : tracksThisColl) {
           // Removing Ds daughters by checking track indices
           if ((candidate.prong0Id() == track.originTrackId()) || (candidate.prong1Id() == track.originTrackId()) || (candidate.prong2Id() == track.originTrackId())) {
@@ -141,7 +141,8 @@ struct HfCorrelatorDsHadronsReduced {
                             candidate.ptCand(),
                             track.ptAssocTrack(),
                             poolBin,
-                            collision.numPvContrib());
+                            collision.numPvContrib(),
+                            collision.centrality());
           entryDsHadronRecoInfo(candidate.invMass(), false, false);
           entryDsHadronMlInfo(candidate.bdtScorePrompt(), candidate.bdtScoreBkg());
           entryTrackRecoInfo(track.dcaXY(), track.dcaZ(), track.nTpcCrossedRows());
@@ -204,7 +205,8 @@ struct HfCorrelatorDsHadronsReduced {
                           cand.ptCand(),
                           pAssoc.ptAssocTrack(),
                           poolBin,
-                          c1.numPvContrib());
+                          c1.numPvContrib(),
+                          c1.centrality());
         entryDsHadronRecoInfo(cand.invMass(), false, false);
         // entryDsHadronGenInfo(false, false, 0);
       }

--- a/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
+++ b/PWGHF/HFC/Tasks/taskCorrelationDsHadrons.cxx
@@ -128,6 +128,7 @@ struct HfTaskCorrelationDsHadrons {
   Configurable<std::vector<float>> pidTOFMax{"pidTOFMax", std::vector<float>{3., 0., 0.}, "maximum nSigma TOF"};
   Configurable<std::vector<double>> binsPtD{"binsPtD", std::vector<double>{o2::analysis::hf_cuts_ds_to_k_k_pi::vecBinsPt}, "pT bin limits for candidate mass plots and efficiency"};
   Configurable<std::vector<double>> binsPtHadron{"binsPtHadron", std::vector<double>{0.3, 2., 4., 8., 12., 50.}, "pT bin limits for assoc particle efficiency"};
+  Configurable<std::vector<double>> binsCentrality{"binsCentrality", std::vector<double>{0., 10., 30., 100.}, "Centrality bin limits"};
   Configurable<std::vector<double>> mlOutputPromptMin{"mlOutputPromptMin", {0.5, 0.5, 0.5, 0.5}, "Machine learning scores for prompt"};
   Configurable<std::vector<double>> mlOutputPromptMax{"mlOutputPromptMax", {1.0, 1.0, 1.0, 1.0}, "Machine learning scores for prompt"};
   Configurable<std::vector<double>> mlOutputBkg{"mlOutputBkg", {0.5, 0.5, 0.5, 0.5}, "Machine learning scores for bkg"};
@@ -196,6 +197,7 @@ struct HfTaskCorrelationDsHadrons {
     AxisSpec axisEta = {binsEta, "#it{#eta}"};
     AxisSpec axisDetlaPhi = {binsPhi, "#it{#varphi}^{Hadron}-#it{#varphi}^{D} (rad)"};
     AxisSpec axisPtD = {(std::vector<double>)binsPtD, "#it{p}_{T}^{D} (GeV/#it{c})"};
+    AxisSpec axisCentrality = {(std::vector<double>)binsCentrality, "centrality FT0M (%)"};
     AxisSpec axisPtHadron = {(std::vector<double>)binsPtHadron, "#it{p}_{T}^{Hadron} (GeV/#it{c})"};
     AxisSpec axisPoolBin = {binsPoolBin, "poolBin"};
     AxisSpec const axisBdtScore = {binsBdtScore, "Bdt score"};
@@ -207,7 +209,7 @@ struct HfTaskCorrelationDsHadrons {
     // Histograms for data analysis
     registry.add("hBdtScorePrompt", "Ds BDT prompt score", {HistType::kTH1F, {axisBdtScore}});
     registry.add("hBdtScoreBkg", "Ds BDT bkg score", {HistType::kTH1F, {axisBdtScore}});
-    registry.add("hMassDsVsPt", "Ds candidates massVsPt", {HistType::kTH2F, {{axisMassD}, {axisPtD}}});
+    registry.add("hMassDsVsPt", "Ds candidates massVsPt", {HistType::kTH3F, {{axisMassD}, {axisPtD}, {axisCentrality}}});
     if (doLSpair) {
       registry.add("hCorrel2DVsPtSignalRegionLS", "Ds-h correlations signal region - LS pairs", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}});
       registry.add("hCorrel2DVsPtSidebandLeftLS", "Ds-h correlations sideband left region - LS pairs", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}});
@@ -229,13 +231,13 @@ struct HfTaskCorrelationDsHadrons {
     if (fillHistoData) {
       registry.add("hDeltaEtaPtIntSignalRegion", "Ds-h deltaEta signal region", {HistType::kTH1F, {axisDetlaEta}});
       registry.add("hDeltaPhiPtIntSignalRegion", "Ds-h deltaPhi signal region", {HistType::kTH1F, {axisDetlaPhi}});
-      registry.add("hCorrel2DVsPtSignalRegion", "Ds-h correlations signal region", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}});
+      registry.add("hCorrel2DVsPtSignalRegion", "Ds-h correlations signal region", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}, {axisCentrality}}});
       registry.add("hDeltaEtaPtIntSidebandLeft", "Ds-h deltaEta sideband left region", {HistType::kTH1F, {axisDetlaEta}});
       registry.add("hDeltaPhiPtIntSidebandLeft", "Ds-h deltaPhi sideband left region", {HistType::kTH1F, {axisDetlaPhi}});
       registry.add("hDeltaEtaPtIntSidebandRight", "Ds-h deltaEta sideband right region", {HistType::kTH1F, {axisDetlaEta}});
       registry.add("hDeltaPhiPtIntSidebandRight", "Ds-h deltaPhi sideband right region", {HistType::kTH1F, {axisDetlaPhi}});
-      registry.add("hCorrel2DVsPtSidebandLeft", "Ds-h correlations sideband left region", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}});
-      registry.add("hCorrel2DVsPtSidebandRight", "Ds-h correlations sideband right region", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}}});
+      registry.add("hCorrel2DVsPtSidebandLeft", "Ds-h correlations sideband left region", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}, {axisCentrality}}});
+      registry.add("hCorrel2DVsPtSidebandRight", "Ds-h correlations sideband right region", {HistType::kTHnSparseD, {{axisDetlaPhi}, {axisDetlaEta}, {axisPtD}, {axisPtHadron}, {axisPoolBin}, {axisCentrality}}});
 
       registry.get<THnSparse>(HIST("hCorrel2DVsPtSignalRegion"))->Sumw2();
       registry.get<THnSparse>(HIST("hCorrel2DVsPtSidebandLeft"))->Sumw2();
@@ -487,6 +489,7 @@ struct HfTaskCorrelationDsHadrons {
                    aod::DsCandRecoInfo const& candidates)
   {
     for (const auto& candidate : candidates) {
+      float const centrality = candidate.centrality();
       float const massD = candidate.mD();
       float const ptD = candidate.signedPtD();
       float const bdtScorePrompt = candidate.mlScorePrompt();
@@ -505,13 +508,14 @@ struct HfTaskCorrelationDsHadrons {
         efficiencyWeightD = getEfficiencyWeight(std::abs(ptD));
       }
 
-      registry.fill(HIST("hMassDsVsPt"), massD, std::abs(ptD), efficiencyWeightD);
+      registry.fill(HIST("hMassDsVsPt"), massD, std::abs(ptD), centrality, efficiencyWeightD);
       registry.fill(HIST("hBdtScorePrompt"), bdtScorePrompt);
       registry.fill(HIST("hBdtScoreBkg"), bdtScoreBkg);
     }
 
     for (const auto& pairEntry : pairEntries) {
       // define variables for widely used quantities
+      float const centrality = pairEntry.centrality();
       float deltaPhi = pairEntry.deltaPhi();
       float const deltaEta = pairEntry.deltaEta();
       float const ptD = pairEntry.signedPtD();
@@ -549,7 +553,7 @@ struct HfTaskCorrelationDsHadrons {
         } else if (doULSpair && !haveSameSign) { // unlike-sign pairs
           registry.fill(HIST("hCorrel2DVsPtSignalRegionULS"), deltaPhi, deltaEta, std::abs(ptD), std::abs(ptHadron), poolBin, efficiencyWeight);
         } else if (fillHistoData) { // default case
-          registry.fill(HIST("hCorrel2DVsPtSignalRegion"), deltaPhi, deltaEta, std::abs(ptD), std::abs(ptHadron), poolBin, efficiencyWeight);
+          registry.fill(HIST("hCorrel2DVsPtSignalRegion"), deltaPhi, deltaEta, std::abs(ptD), std::abs(ptHadron), poolBin, centrality, efficiencyWeight);
           registry.fill(HIST("hDeltaEtaPtIntSignalRegion"), deltaEta, efficiencyWeight);
           registry.fill(HIST("hDeltaPhiPtIntSignalRegion"), deltaPhi, efficiencyWeight);
         }
@@ -561,7 +565,7 @@ struct HfTaskCorrelationDsHadrons {
         } else if (doULSpair && !haveSameSign) { // unlike-sign pairs
           registry.fill(HIST("hCorrel2DVsPtSidebandLeftULS"), deltaPhi, deltaEta, std::abs(ptD), std::abs(ptHadron), poolBin, efficiencyWeight);
         } else if (fillHistoData) { // default case
-          registry.fill(HIST("hCorrel2DVsPtSidebandLeft"), deltaPhi, deltaEta, std::abs(ptD), std::abs(ptHadron), poolBin, efficiencyWeight);
+          registry.fill(HIST("hCorrel2DVsPtSidebandLeft"), deltaPhi, deltaEta, std::abs(ptD), std::abs(ptHadron), poolBin, centrality, efficiencyWeight);
           registry.fill(HIST("hDeltaEtaPtIntSidebandLeft"), deltaEta, efficiencyWeight);
           registry.fill(HIST("hDeltaPhiPtIntSidebandLeft"), deltaPhi, efficiencyWeight);
         }
@@ -573,7 +577,7 @@ struct HfTaskCorrelationDsHadrons {
         } else if (doULSpair && !haveSameSign) { // unlike-sign pairs
           registry.fill(HIST("hCorrel2DVsPtSidebandRightULS"), deltaPhi, deltaEta, std::abs(ptD), std::abs(ptHadron), poolBin, efficiencyWeight);
         } else if (fillHistoData) { // default case
-          registry.fill(HIST("hCorrel2DVsPtSidebandRight"), deltaPhi, deltaEta, std::abs(ptD), std::abs(ptHadron), poolBin, efficiencyWeight);
+          registry.fill(HIST("hCorrel2DVsPtSidebandRight"), deltaPhi, deltaEta, std::abs(ptD), std::abs(ptHadron), poolBin, centrality, efficiencyWeight);
           registry.fill(HIST("hDeltaEtaPtIntSidebandRight"), deltaEta, efficiencyWeight);
           registry.fill(HIST("hDeltaPhiPtIntSidebandRight"), deltaPhi, efficiencyWeight);
         }


### PR DESCRIPTION
This PR adds centrality information to the Ds-hadron correlation workflow. The changes include:
- adding the centrality column to the relevant Ds-hadron pair and candidate tables
- adding centrality to the reduced HF collision table
- filling the new centrality information in the Ds-hadron table producers
- updating the Dplus-hadron table producer to consistently fill the modified reduced collision table
- propagating the centrality information to the final Ds-hadron correlation task.