### PR TITLE
[PWGHF] Reserve memory before filling charm femto tables

### DIFF
--- a/PWGHF/HFC/TableProducer/producerCharmHadronsTrackFemtoDream.cxx
+++ b/PWGHF/HFC/TableProducer/producerCharmHadronsTrackFemtoDream.cxx
@@ -622,11 +622,11 @@ struct HfProducerCharmHadronsTrackFemtoDream {
     bool isSelectedMlDstarToD0Pi = true;
 
     if constexpr (Channel == DecayChannel::DplusToPiKPi || Channel == DecayChannel::LcToPKPi) {
-      rowCandCharm3Prong.reserve(candidates.size());
+      rowCandCharm3Prong.reserve(rowCandCharm3Prong.lastIndex() + sizeCand + 1);
     } else if constexpr (Channel == DecayChannel::D0ToPiK) {
-      rowCandCharm2Prong.reserve(candidates.size());
+      rowCandCharm2Prong.reserve(rowCandCharm2Prong.lastIndex() + sizeCand + 1);
     } else if constexpr (Channel == DecayChannel::DstarToD0Pi) {
-      rowCandCharmDstar.reserve(candidates.size());
+      rowCandCharmDstar.reserve(rowCandCharmDstar.lastIndex() + sizeCand + 1);
     }
 
     for (const auto& candidate : candidates) {

--- a/PWGHF/HFC/TableProducer/producerCharmHadronsTrackFemtoDream.cxx
+++ b/PWGHF/HFC/TableProducer/producerCharmHadronsTrackFemtoDream.cxx
@@ -628,11 +628,7 @@ struct HfProducerCharmHadronsTrackFemtoDream {
     } else if constexpr (Channel == DecayChannel::DstarToD0Pi) {
       rowCandCharmDstar.reserve(rowCandCharmDstar.lastIndex() + sizeCand + 1);
     }
-    if (sizeCand > 0) {
-      LOGP(info, "Last index {} candidate size {}, reserved memory {}", rowCandCharm3Prong.lastIndex(), sizeCand, rowCandCharm3Prong.lastIndex() + sizeCand + 1);
-    }
 
-    int iCand{0};
     for (const auto& candidate : candidates) {
       outputMlD0 = {-1.0f, -1.0f, -1.0f};
       outputMlD0bar = {-1.0f, -1.0f, -1.0f};
@@ -642,7 +638,6 @@ struct HfProducerCharmHadronsTrackFemtoDream {
       outputMlPiKP = {-1.0f, -1.0f, -1.0f};
       auto trackPos1 = candidate.template prong0_as<TrackType>(); // positive daughter (negative for the antiparticles)
       auto trackNeg = candidate.template prong1_as<TrackType>();  // negative daughter (positive for the antiparticles)
-      LOGP(info, "Filling candidate number {}", iCand);
 
       auto bc = col.template bc_as<aod::BCsWithTimestamps>();
       int64_t timeStamp = bc.timestamp();
@@ -863,7 +858,6 @@ struct HfProducerCharmHadronsTrackFemtoDream {
         }
         fillTable(2, candidate.isSelDstarToD0Pi(), outputMlDstar.at(0), outputMlDstar.at(1), outputMlDstar.at(2));
       }
-      iCand++;
     }
     isTrackFilled = fillTracksForCharmHadron<IsMc>(col, tracks);
 

--- a/PWGHF/HFC/TableProducer/producerCharmHadronsTrackFemtoDream.cxx
+++ b/PWGHF/HFC/TableProducer/producerCharmHadronsTrackFemtoDream.cxx
@@ -621,6 +621,14 @@ struct HfProducerCharmHadronsTrackFemtoDream {
     bool isSelectedMlD0barToKPi = true;
     bool isSelectedMlDstarToD0Pi = true;
 
+    if constexpr (Channel == DecayChannel::DplusToPiKPi || Channel == DecayChannel::LcToPKPi) {
+      rowCandCharm3Prong.reserve(candidates.size());
+    } else if constexpr (Channel == DecayChannel::D0ToPiK) {
+      rowCandCharm2Prong.reserve(candidates.size());
+    } else if constexpr (Channel == DecayChannel::DstarToD0Pi) {
+      rowCandCharmDstar.reserve(candidates.size());
+    }
+
     for (const auto& candidate : candidates) {
       outputMlD0 = {-1.0f, -1.0f, -1.0f};
       outputMlD0bar = {-1.0f, -1.0f, -1.0f};

--- a/PWGHF/HFC/TableProducer/producerCharmHadronsTrackFemtoDream.cxx
+++ b/PWGHF/HFC/TableProducer/producerCharmHadronsTrackFemtoDream.cxx
@@ -622,13 +622,17 @@ struct HfProducerCharmHadronsTrackFemtoDream {
     bool isSelectedMlDstarToD0Pi = true;
 
     if constexpr (Channel == DecayChannel::DplusToPiKPi || Channel == DecayChannel::LcToPKPi) {
-      rowCandCharm3Prong.reserve(rowCandCharm3Prong.lastIndex() + sizeCand + 1);
+      rowCandCharm3Prong.reserve(rowCandCharm3Prong.lastIndex() + sizeCand * 2 + 1);
     } else if constexpr (Channel == DecayChannel::D0ToPiK) {
-      rowCandCharm2Prong.reserve(rowCandCharm2Prong.lastIndex() + sizeCand + 1);
+      rowCandCharm2Prong.reserve(rowCandCharm2Prong.lastIndex() + sizeCand * 2 + 1);
     } else if constexpr (Channel == DecayChannel::DstarToD0Pi) {
       rowCandCharmDstar.reserve(rowCandCharmDstar.lastIndex() + sizeCand + 1);
     }
+    if (sizeCand > 0) {
+      LOGP(info, "Last index {} candidate size {}, reserved memory {}", rowCandCharm3Prong.lastIndex(), sizeCand, rowCandCharm3Prong.lastIndex() + sizeCand + 1);
+    }
 
+    int iCand{0};
     for (const auto& candidate : candidates) {
       outputMlD0 = {-1.0f, -1.0f, -1.0f};
       outputMlD0bar = {-1.0f, -1.0f, -1.0f};
@@ -638,6 +642,7 @@ struct HfProducerCharmHadronsTrackFemtoDream {
       outputMlPiKP = {-1.0f, -1.0f, -1.0f};
       auto trackPos1 = candidate.template prong0_as<TrackType>(); // positive daughter (negative for the antiparticles)
       auto trackNeg = candidate.template prong1_as<TrackType>();  // negative daughter (positive for the antiparticles)
+      LOGP(info, "Filling candidate number {}", iCand);
 
       auto bc = col.template bc_as<aod::BCsWithTimestamps>();
       int64_t timeStamp = bc.timestamp();
@@ -858,6 +863,7 @@ struct HfProducerCharmHadronsTrackFemtoDream {
         }
         fillTable(2, candidate.isSelDstarToD0Pi(), outputMlDstar.at(0), outputMlDstar.at(1), outputMlDstar.at(2));
       }
+      iCand++;
     }
     isTrackFilled = fillTracksForCharmHadron<IsMc>(col, tracks);
 
@@ -902,7 +908,7 @@ struct HfProducerCharmHadronsTrackFemtoDream {
   void fillCharmHadMcGen(ParticleType particles)
   {
     // Filling particle properties
-    rowCandCharmHadGen.reserve(particles.size());
+    rowCandCharmHadGen.reserve(particles.size() + 1);
     if constexpr (Channel == DecayChannel::DplusToPiKPi) {
       for (const auto& particle : particles) {
         if (std::abs(particle.flagMcMatchGen()) == hf_decay::hf_cand_3prong::DecayChannelMain::DplusToPiKPi) {

--- a/PWGHF/HFC/TableProducer/producerCharmHadronsV0FemtoDream.cxx
+++ b/PWGHF/HFC/TableProducer/producerCharmHadronsV0FemtoDream.cxx
@@ -722,6 +722,14 @@ struct HfProducerCharmHadronsV0FemtoDream {
       return;
     }
 
+    if constexpr (Channel == DecayChannel::DplusToPiKPi || Channel == DecayChannel::LcToPKPi) {
+      rowCandCharm3Prong.reserve(rowCandCharm3Prong.lastIndex() + sizeCand * 2 + 1);
+    } else if constexpr (Channel == DecayChannel::D0ToPiK) {
+      rowCandCharm2Prong.reserve(rowCandCharm2Prong.lastIndex() + sizeCand * 2 + 1);
+    } else if constexpr (Channel == DecayChannel::DstarToD0Pi) {
+      rowCandCharmDstar.reserve(rowCandCharmDstar.lastIndex() + sizeCand + 1);
+    }
+
     outputCollision(vtxZ, mult, multNtr, spher, magField);
     if constexpr (IsMc) {
       fillMcCollision(col);
@@ -1124,7 +1132,7 @@ struct HfProducerCharmHadronsV0FemtoDream {
   void fillCharmHadMcGen(ParticleType particles)
   {
     // Filling particle properties
-    rowCandCharmHadGen.reserve(rowCandCharmHadGen.lastIndex() + particles.size() + 1);
+    rowCandCharmHadGen.reserve(particles.size() + 1);
     if constexpr (Channel == DecayChannel::DplusToPiKPi) {
       for (const auto& particle : particles) {
         if (std::abs(particle.flagMcMatchGen()) == hf_decay::hf_cand_3prong::DecayChannelMain::DplusToPiKPi) {

--- a/PWGHF/HFC/TableProducer/producerCharmHadronsV0FemtoDream.cxx
+++ b/PWGHF/HFC/TableProducer/producerCharmHadronsV0FemtoDream.cxx
@@ -1124,7 +1124,7 @@ struct HfProducerCharmHadronsV0FemtoDream {
   void fillCharmHadMcGen(ParticleType particles)
   {
     // Filling particle properties
-    rowCandCharmHadGen.reserve(particles.size());
+    rowCandCharmHadGen.reserve(rowCandCharmHadGen.lastIndex() + particles.size() + 1);
     if constexpr (Channel == DecayChannel::DplusToPiKPi) {
       for (const auto& particle : particles) {
         if (std::abs(particle.flagMcMatchGen()) == hf_decay::hf_cand_3prong::DecayChannelMain::DplusToPiKPi) {

--- a/PWGHF/HFC/Tasks/taskCharmHadronsV0FemtoDream.cxx
+++ b/PWGHF/HFC/Tasks/taskCharmHadronsV0FemtoDream.cxx
@@ -755,7 +755,7 @@ struct HfTaskCharmHadronsV0FemtoDream {
                        FilteredCharmCand3Prongs const& candidates)
   {
 
-    rowFemtoResultCharm3Prong.reserve(rowFemtoResultCharm3Prong.lastIndex() + candidates.size() + 1);
+    rowFemtoResultCharm3Prong.reserve(candidates.size() + 1);
 
     for (const auto& col : cols) {
       eventHisto.fillQA(col);
@@ -789,7 +789,7 @@ struct HfTaskCharmHadronsV0FemtoDream {
                           FDV0Particles const& parts,
                           FilteredCharmCand3Prongs const& candidates)
   {
-    rowFemtoResultCharm3Prong.reserve(rowFemtoResultCharm3Prong.lastIndex() + candidates.size() + 1);
+    rowFemtoResultCharm3Prong.reserve(candidates.size() + 1);
 
     for (const auto& col : cols) {
       eventHisto.fillQA(col);
@@ -823,7 +823,7 @@ struct HfTaskCharmHadronsV0FemtoDream {
                        FDV0Particles const& parts,
                        FilteredCharmCand2Prongs const& candidates)
   {
-    rowFemtoResultCharm2Prong.reserve(rowFemtoResultCharm2Prong.lastIndex() + candidates.size() + 1);
+    rowFemtoResultCharm2Prong.reserve(candidates.size() + 1);
 
     for (const auto& col : cols) {
       eventHisto.fillQA(col);
@@ -858,7 +858,7 @@ struct HfTaskCharmHadronsV0FemtoDream {
                           FilteredCharmCandDstars const& candidates)
   {
 
-    rowFemtoResultCharmDstar.reserve(rowFemtoResultCharmDstar.lastIndex() + candidates.size() + 1);
+    rowFemtoResultCharmDstar.reserve(candidates.size() + 1);
 
     for (const auto& col : cols) {
       eventHisto.fillQA(col);

--- a/PWGHF/HFC/Tasks/taskCharmHadronsV0FemtoDream.cxx
+++ b/PWGHF/HFC/Tasks/taskCharmHadronsV0FemtoDream.cxx
@@ -755,7 +755,7 @@ struct HfTaskCharmHadronsV0FemtoDream {
                        FilteredCharmCand3Prongs const& candidates)
   {
 
-    rowFemtoResultCharm3Prong.reserve(candidates.size());
+    rowFemtoResultCharm3Prong.reserve(rowFemtoResultCharm3Prong.lastIndex() + candidates.size() + 1);
 
     for (const auto& col : cols) {
       eventHisto.fillQA(col);
@@ -789,7 +789,7 @@ struct HfTaskCharmHadronsV0FemtoDream {
                           FDV0Particles const& parts,
                           FilteredCharmCand3Prongs const& candidates)
   {
-    rowFemtoResultCharm3Prong.reserve(candidates.size());
+    rowFemtoResultCharm3Prong.reserve(rowFemtoResultCharm3Prong.lastIndex() + candidates.size() + 1);
 
     for (const auto& col : cols) {
       eventHisto.fillQA(col);
@@ -823,7 +823,7 @@ struct HfTaskCharmHadronsV0FemtoDream {
                        FDV0Particles const& parts,
                        FilteredCharmCand2Prongs const& candidates)
   {
-    rowFemtoResultCharm2Prong.reserve(candidates.size());
+    rowFemtoResultCharm2Prong.reserve(rowFemtoResultCharm2Prong.lastIndex() + candidates.size() + 1);
 
     for (const auto& col : cols) {
       eventHisto.fillQA(col);
@@ -858,7 +858,7 @@ struct HfTaskCharmHadronsV0FemtoDream {
                           FilteredCharmCandDstars const& candidates)
   {
 
-    rowFemtoResultCharmDstar.reserve(candidates.size());
+    rowFemtoResultCharmDstar.reserve(rowFemtoResultCharmDstar.lastIndex() + candidates.size() + 1);
 
     for (const auto& col : cols) {
       eventHisto.fillQA(col);

--- a/PWGHF/HFC/Tasks/taskCharmHadronsV0FemtoDream.cxx
+++ b/PWGHF/HFC/Tasks/taskCharmHadronsV0FemtoDream.cxx
@@ -752,8 +752,11 @@ struct HfTaskCharmHadronsV0FemtoDream {
 
   void processDataLcV0(FilteredCollisions const& cols,
                        FDV0Particles const& parts,
-                       FilteredCharmCand3Prongs const&)
+                       FilteredCharmCand3Prongs const& candidates)
   {
+
+    rowFemtoResultCharm3Prong.reserve(candidates.size());
+
     for (const auto& col : cols) {
       eventHisto.fillQA(col);
       auto sliceCharmHad = partitionCharmHadron3Prong->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
@@ -784,8 +787,10 @@ struct HfTaskCharmHadronsV0FemtoDream {
 
   void processDataDplusV0(FilteredCollisions const& cols,
                           FDV0Particles const& parts,
-                          FilteredCharmCand3Prongs const&)
+                          FilteredCharmCand3Prongs const& candidates)
   {
+    rowFemtoResultCharm3Prong.reserve(candidates.size());
+
     for (const auto& col : cols) {
       eventHisto.fillQA(col);
       auto sliceCharmHad = partitionCharmHadron3Prong->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
@@ -816,8 +821,10 @@ struct HfTaskCharmHadronsV0FemtoDream {
 
   void processDataD0V0(FilteredCollisions const& cols,
                        FDV0Particles const& parts,
-                       FilteredCharmCand2Prongs const&)
+                       FilteredCharmCand2Prongs const& candidates)
   {
+    rowFemtoResultCharm2Prong.reserve(candidates.size());
+
     for (const auto& col : cols) {
       eventHisto.fillQA(col);
       auto sliceCharmHad = partitionCharmHadron2Prong->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
@@ -848,8 +855,11 @@ struct HfTaskCharmHadronsV0FemtoDream {
 
   void processDataDstarV0(FilteredCollisions const& cols,
                           FDV0Particles const& parts,
-                          FilteredCharmCandDstars const&)
+                          FilteredCharmCandDstars const& candidates)
   {
+
+    rowFemtoResultCharmDstar.reserve(candidates.size());
+
     for (const auto& col : cols) {
       eventHisto.fillQA(col);
       auto sliceCharmHad = partitionCharmHadronDstar->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);


### PR DESCRIPTION
@zhangbiao-phy this PR adds the reservation of the memory before filling the tables, to prevent the following error:
```
[2492830:hf-producer-charm-hadrons-track-femto-dream]: [18:40:17][FATAL] Table 'FDHfCand3Prong': filled 37 rows after reserve(0). UnsafeAppend overran the reserved buffer â€” reserve() must request at least as many rows as are filled.
```
To to the change to the unsafe cursor introduced in https://github.com/AliceO2Group/AliceO2/commit/6a773bee8bfde7f2803d1ea21638cb0372d50758