### PR TITLE
[PWGDQ] add rematching task

### DIFF
--- a/PWGDQ/Tasks/CMakeLists.txt
+++ b/PWGDQ/Tasks/CMakeLists.txt
@@ -163,3 +163,8 @@ o2physics_add_dpl_workflow(muon-global-alignment
                     SOURCES muonGlobalAlignment.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::PWGDQCore O2::MCHGeometryTransformer
                     COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(global-muon-matcher
+                    SOURCES global-muon-matcher.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::PWGDQCore O2::MCHGeometryTransformer
+                    COMPONENT_NAME Analysis)

--- a/PWGDQ/Tasks/global-muon-matcher.cxx
+++ b/PWGDQ/Tasks/global-muon-matcher.cxx
@@ -1,0 +1,1701 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+/// \file globalMuonMatching.cxx
+/// \brief Global muon matching
+//
+#include "PWGDQ/Core/MuonMatchingMlResponse.h"
+#include "PWGDQ/Core/VarManager.h"
+
+#include "Common/Core/fwdtrackUtilities.h"
+#include "Common/DataModel/Centrality.h"
+#include "Common/DataModel/CollisionAssociationTables.h"
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/FwdTrackReAlignTables.h"
+#include "Common/DataModel/Multiplicity.h"
+#include "Common/DataModel/TrackSelectionTables.h"
+#include "Tools/ML/MlResponse.h"
+
+#include <CCDB/BasicCCDBManager.h>
+#include <CCDB/CcdbApi.h>
+#include <CommonConstants/LHCConstants.h>
+#include <CommonConstants/MathConstants.h>
+#include <CommonConstants/PhysicsConstants.h>
+#include <DataFormatsParameters/GRPMagField.h>
+#include <DetectorsBase/GeometryManager.h>
+#include <DetectorsBase/Propagator.h>
+#include <Field/MagneticField.h>
+#include <Framework/ASoA.h>
+#include <Framework/AnalysisDataModel.h>
+#include <Framework/AnalysisTask.h>
+#include <Framework/Configurable.h>
+#include <Framework/DataTypes.h>
+#include <Framework/InitContext.h>
+#include <Framework/runDataProcessing.h>
+#include <MCHBase/TrackerParam.h>
+#include <MCHGeometryTransformer/Transformations.h>
+#include <MCHTracking/Track.h>
+#include <MCHTracking/TrackExtrap.h>
+#include <MCHTracking/TrackFitter.h>
+#include <MCHTracking/TrackParam.h>
+#include <MFTTracking/Constants.h>
+#include <ReconstructionDataFormats/TrackFwd.h>
+
+#include <Math/MatrixFunctions.h>
+#include <Math/MatrixRepresentationsStatic.h>
+#include <Math/ProbFuncMathCore.h>
+#include <Math/SMatrix.h>
+#include <Math/SVector.h>
+#include <TGeoGlobalMagField.h>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::aod;
+
+namespace o2::aod::globalmuonmatching
+{
+DECLARE_SOA_COLUMN(MchTrackId, mchTrackId, int64_t);
+DECLARE_SOA_COLUMN(MftTrackId, mftTrackId, int64_t);
+DECLARE_SOA_COLUMN(MatchChi2, matchChi2, float);
+DECLARE_SOA_COLUMN(MatchScore, matchScore, float);
+DECLARE_SOA_COLUMN(MatchRanking, matchRanking, int32_t);
+DECLARE_SOA_COLUMN(IsTagged, isTagged, bool);
+} // namespace o2::aod::globalmuonmatching
+
+namespace o2::aod
+{
+DECLARE_SOA_TABLE(GlobalMuonMatchCandidates, "AOD", "GMCAND",
+                  o2::soa::Index<>,
+                  globalmuonmatching::MchTrackId,
+                  globalmuonmatching::MftTrackId,
+                  globalmuonmatching::MatchChi2, globalmuonmatching::MatchScore, globalmuonmatching::MatchRanking,
+                  globalmuonmatching::IsTagged);
+
+namespace globalmuonmatching
+{
+DECLARE_SOA_ARRAY_INDEX_COLUMN(GlobalMuonMatchCandidate, globalMuonMatchCandidate);         //! Array of GlobalMuonMatchCandidates indices
+DECLARE_SOA_INDEX_COLUMN_FULL(FwdTrackRealign, fwdTrackRealign, int, FwdTracksReAlign, ""); //! Index of ambiguous FwdTracksReAlign entry
+DECLARE_SOA_SLICE_INDEX_COLUMN(BC, bc);                                                     //! BC index slice compatible with the track time window
+} // namespace globalmuonmatching
+
+DECLARE_SOA_TABLE(FwdTrkMatchCands, "AOD", "FWDTRKMATCHCAND", //! Vectors of match-candidate indices stored per fwdtrack
+                  globalmuonmatching::GlobalMuonMatchCandidateIds, o2::soa::Marker<3>);
+
+DECLARE_SOA_TABLE(AmbiguousFwdTracksReAlign, "AOD", "AMBIGFWDREALIGN", //! FwdTracksReAlign entries without a unique collision association
+                  o2::soa::Index<>, globalmuonmatching::FwdTrackRealignId, globalmuonmatching::BCIdSlice);
+} // namespace o2::aod
+
+using MyEvents = soa::Join<aod::Collisions, aod::EvSels>;
+using MyMuons = soa::Join<aod::FwdTracks, aod::FwdTracksCov>;
+using MyMFTs = aod::MFTTracks;
+using MyMFTCovariances = aod::MFTTracksCov;
+
+using SMatrix55Sym = o2::track::SMatrix55Sym;
+using SMatrix55Std = o2::track::SMatrix55Std;
+using SMatrix5 = o2::track::SMatrix5;
+
+const int fgNDetElemCh[10] = {4, 4, 4, 4, 18, 18, 26, 26, 26, 26};
+const int fgSNDetElemCh[11] = {0, 4, 8, 12, 16, 34, 52, 78, 104, 130, 156};
+
+struct GlobalMuonMatching {
+
+  static constexpr int GlobalTrackTypeMax = 2;
+  static constexpr int MchMidTrackType = 3;
+  static constexpr int NMchChambers = 10;
+  static constexpr int MchDetElemNumberingBase = 100;
+  static constexpr int NMchDetElems = 156;
+  static constexpr int MinRemovableTrackClusters = 10;
+  static constexpr double DefaultChamberResolution = 0.04;
+  static constexpr int ThetaAbsBoundaryDeg = 3;
+  static constexpr double SlopeResolutionZ = 535.;
+  static constexpr int MatchingDegreesOfFreedom = 5;
+  static constexpr float MatchingScoreChi2Max = 50.f;
+  static constexpr float MatchingPlaneDefaultZ = -77.5;
+
+  struct MatchingCandidate {
+    int64_t muonTrackId{-1};
+    int64_t mftTrackId{-1};
+    double matchScore{-1};
+    double matchChi2{-1};
+    int matchRanking{-1};
+  };
+
+  ////   Variables for selecting tagged muons
+  struct : ConfigurableGroup {
+    Configurable<int> cfgMuonTaggingNCrossedMftPlanesLow{"cfgMuonTaggingNCrossedMftPlanesLow", 5, ""};
+    Configurable<float> cfgMuonTaggingTrackChi2MchUp{"cfgMuonTaggingTrackChi2MchUp", 5.f, ""};
+    Configurable<float> cfgMuonTaggingPMchLow{"cfgMuonTaggingPMchLow", 0.0f, ""};
+    Configurable<float> cfgMuonTaggingPtMchLow{"cfgMuonTaggingPtMchLow", 0.7f, ""};
+    Configurable<float> cfgMuonTaggingEtaMchLow{"cfgMuonTaggingEtaMchLow", -3.6f, ""};
+    Configurable<float> cfgMuonTaggingEtaMchUp{"cfgMuonTaggingEtaMchUp", -2.5f, ""};
+    Configurable<float> cfgMuonTaggingRabsLow{"cfgMuonTaggingRabsLow", 17.6f, ""};
+    Configurable<float> cfgMuonTaggingRabsUp{"cfgMuonTaggingRabsUp", 89.5f, ""};
+    Configurable<float> cfgMuonTaggingPdcaUp{"cfgMuonTaggingPdcaUp", 4.f, ""};
+    Configurable<float> cfgMuonTaggingRadiusAtMftFrontLow{"cfgMuonTaggingRadiusAtMftFrontLow", 3.f, ""};
+    Configurable<float> cfgMuonTaggingRadiusAtMftFrontUp{"cfgMuonTaggingRadiusAtMftFrontUp", 9.f, ""};
+    Configurable<float> cfgMuonTaggingRadiusAtMftBackLow{"cfgMuonTaggingRadiusAtMftBackLow", 5.f, ""};
+    Configurable<float> cfgMuonTaggingRadiusAtMftBackUp{"cfgMuonTaggingRadiusAtMftBackUp", 12.f, ""};
+  } configMuonTagging;
+
+  ////   Variables for MCH realignment
+  struct : ConfigurableGroup {
+    Configurable<bool> cfgEnableMCHRealign{"cfgEnableMCHRealign", true, "Enable re-alignment of MCH clusters and tracks"};
+    Configurable<std::string> cfgGeoRefPath{"cfgGeoRefPath", "GLO/Config/GeometryAligned", "Path of the reference geometry file"};
+    Configurable<std::string> cfgGeoNewPath{"cfgGeoNewPath", "GLO/Config/GeometryAligned", "Path of the new geometry file"};
+    Configurable<int64_t> cfgCcdbNoLaterThanRef{"cfgCcdbNoLaterThanRef", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(), "latest acceptable timestamp of creation for the object of reference basis"};
+    Configurable<int64_t> cfgCcdbNoLaterThanNew{"cfgCcdbNoLaterThanNew", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(), "latest acceptable timestamp of creation for the object of new basis"};
+    Configurable<double> cfgChamberResolutionX{"cfgChamberResolutionX", 0.04, "Chamber resolution along X configuration for refit"}; // 0.4cm pp, 0.2cm PbPb
+    Configurable<double> cfgChamberResolutionY{"cfgChamberResolutionY", 0.04, "Chamber resolution along Y configuration for refit"}; // 0.4cm pp, 0.2cm PbPb
+    Configurable<double> cfgSigmaCutImprove{"cfgSigmaCutImprove", 6., "Sigma cut for track improvement"};                            // 6 for pp, 4 for PbPb
+  } configMchRealign;
+
+  ////   Variables for MFT alignment corrections
+  struct : ConfigurableGroup {
+    Configurable<bool> cfgEnableMftAlignmentCorrections{"cfgEnableMftAlignmentCorrections", true, "Enable alignment corrections for the MFT tracks"};
+    // slope corrections
+    // Configurable<float> cfgMFTAlignmentCorrXSlopeTop{"cfgMFTAlignmentCorrXSlopeTop", (-0.0006696 - 0.0005621) / 2.f, "MFT X slope correction - top half"};
+    // Configurable<float> cfgMFTAlignmentCorrXSlopeBottom{"cfgMFTAlignmentCorrXSlopeBottom", (0.00105 + 0.001007) / 2.f, "MFT X slope correction - bottom half"};
+    // Configurable<float> cfgMFTAlignmentCorrYSlopeTop{"cfgMFTAlignmentCorrYSlopeTop", (-0.002299 - 0.002442) / 2.f, "MFT Y slope correction - top half"};
+    // Configurable<float> cfgMFTAlignmentCorrYSlopeBottom{"cfgMFTAlignmentCorrYSlopeBottom", (-0.0005339 - 0.0006921) / 2.f, "MFT Y slope correction - bottom half"};
+    Configurable<float> cfgMFTAlignmentCorrXSlopeTop{"cfgMFTAlignmentCorrXSlopeTop", 0.f, "MFT X slope correction - top half"};
+    Configurable<float> cfgMFTAlignmentCorrXSlopeBottom{"cfgMFTAlignmentCorrXSlopeBottom", 0.f, "MFT X slope correction - bottom half"};
+    Configurable<float> cfgMFTAlignmentCorrYSlopeTop{"cfgMFTAlignmentCorrYSlopeTop", 0.f, "MFT Y slope correction - top half"};
+    Configurable<float> cfgMFTAlignmentCorrYSlopeBottom{"cfgMFTAlignmentCorrYSlopeBottom", 0.f, "MFT Y slope correction - bottom half"};
+    // offset corrections
+    Configurable<float> cfgMFTAlignmentCorrXOffsetTop{"cfgMFTAlignmentCorrXOffsetTop", 0.f, "MFT X offset correction - top half"};
+    Configurable<float> cfgMFTAlignmentCorrXOffsetBottom{"cfgMFTAlignmentCorrXOffsetBottom", 0.f, "MFT X offset correction - bottom half"};
+    Configurable<float> cfgMFTAlignmentCorrYOffsetTop{"cfgMFTAlignmentCorrYOffsetTop", 0.f, "MFT Y offset correction - top half"};
+    Configurable<float> cfgMFTAlignmentCorrYOffsetBottom{"cfgMFTAlignmentCorrYOffsetBottom", 0.f, "MFT Y offset correction - bottom half"};
+  } configMftAlignmentCorrections;
+
+  // Variables for CCDB objects access and retrieval
+  struct : ConfigurableGroup {
+    Configurable<std::string> cfgCcdbUrl{"cfgCcdbUrl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+    Configurable<int64_t> cfgCcdbNoLaterThan{"cfgCcdbNoLaterThan", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(), "latest acceptable timestamp of creation for the object"};
+    Configurable<std::string> cfgGrpPath{"cfgGrpPath", "GLO/GRP/GRP", "Path of the grp file"};
+    Configurable<std::string> cfgGeoPath{"cfgGeoPath", "GLO/Config/GeometryAligned", "Path of the geometry file"};
+    Configurable<std::string> cfgGrpMagPath{"cfgGrpMagPath", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
+  } configCcdb;
+
+  // Matching strategy for the *custom* matches (production baseline is always computed).
+  // 0 = chi2 (runChi2Matching), 1 = ML (runMlMatching)
+  struct : ConfigurableGroup {
+    Configurable<int> cfgCustomMatchingStrategy{"cfgCustomMatchingStrategy", 0, "0=chi2, 1=ML for custom matches"};
+    Configurable<bool> cfgIncludeGlobalMuonsInFwdTracks{"cfgIncludeGlobalMuonsInFwdTracks", false, "Include MFT-MCH-MID global muons in GMMCANDTRK table"};
+    Configurable<int> cfgMaxCandidatesPerMchTrack{"cfgMaxCandidatesPerMchTrack", -1, "Maximum number of match candidates stored per MCH track (-1: no limit)"};
+    Configurable<bool> cfgMatchAllTracks{"cfgMatchAllTracks", false, "If true the matching is performed considering all the MFT tracks for which the covariances are available; if false the matching is performed considering only the global forward tracks stored at production"};
+  } configMatching;
+
+  double mBzAtMftCenter{0};
+
+  using MatchingFunc = std::function<std::tuple<double, int>(const o2::track::TrackParCovFwd& mchtrack, const o2::track::TrackParCovFwd& mfttrack)>;
+  std::map<std::string, MatchingFunc> mMatchingFunctionMap; ///< MFT-MCH Matching function
+
+  // Chi2 matching interface (single configurable method)
+  struct : ConfigurableGroup {
+    Configurable<std::string> cfgChi2FunctionLabel{"cfgChi2FunctionLabel", std::string{"ProdAll"}, "Text label identifying the chi2 matching method"};
+    Configurable<std::string> cfgChi2FunctionName{"cfgChi2FunctionName", std::string{"prod"}, "Name of the chi2 matching function"};
+    Configurable<float> cfgChi2FunctionMatchingPlaneZ{"cfgChi2FunctionMatchingPlaneZ", static_cast<float>(o2::mft::constants::mft::LayerZCoordinate()[9]), "Z position of the matching plane"};
+  } configChi2MatchingOptions;
+
+  // ML interface (single configurable model)
+  struct : ConfigurableGroup {
+    Configurable<std::string> cfgMlModelLabel{"cfgMlModelLabel", std::string{""}, "Text label identifying this ML model"};
+    Configurable<std::string> cfgMlModelPathCcdb{"cfgMlModelPathCcdb", "Users/m/mcoquet/MLTest", "Path of model on CCDB"};
+    Configurable<std::string> cfgMlModelName{"cfgMlModelName", "model.onnx", "ONNX file name (if not from CCDB full path)"};
+    Configurable<std::vector<std::string>> cfgMlInputFeatures{"cfgMlInputFeatures", std::vector<std::string>{"chi2MCHMFT"}, "Names of ML model input features"};
+    Configurable<float> cfgMlModelMatchingPlaneZ{"cfgMlModelMatchingPlaneZ", static_cast<float>(o2::mft::constants::mft::LayerZCoordinate()[9]), "Z position of the matching plane"};
+  } configMlOptions;
+
+  std::vector<double> binsPtMl;
+  std::array<double, 1> cutValues;
+  std::vector<int> cutDirMl;
+  bool hasActiveChi2Matching{false};
+  std::string activeChi2FunctionName;
+  double activeChi2MatchingPlaneZ{0.};
+
+  bool hasActiveMlMatching{false};
+  o2::analysis::MlResponseMFTMuonMatch<float> activeMlResponse;
+  double activeMlMatchingPlaneZ{0.};
+
+  int mRunNumber{0}; // needed to detect if the run changed and trigger update of magnetic field
+
+  Service<o2::ccdb::BasicCCDBManager> ccdbManager;
+  o2::ccdb::CcdbApi fCCDBApi;
+
+  // vector of all MFT-MCH(-MID) matching candidates associated to the same MCH(-MID) track,
+  // to be sorted in descending order with respect to the matching score
+  // the map key is the MCH(-MID) track global index
+  using MatchingCandidates = std::map<int64_t, std::vector<MatchingCandidate>>;
+  std::map<int64_t, std::vector<MatchingCandidate>> mMatchingCandidates;
+
+  class TrackParExt : public o2::track::TrackParCovFwd
+  {
+   public:
+    TrackParExt() = default;
+    TrackParExt(const TrackParExt& t) = default;
+    explicit TrackParExt(o2::track::TrackParCovFwd const& t, int nc = -1, bool r = false)
+      : TrackParCovFwd(t), nClusters(nc), removable(r) {}
+    ~TrackParExt() = default;
+
+    TrackParExt& operator=(const TrackParCovFwd& tpf)
+    {
+      o2::track::TrackParCovFwd::operator=(tpf);
+      return *this;
+    }
+    TrackParExt& operator=(const TrackParExt& tpe)
+    {
+      o2::track::TrackParCovFwd::operator=(tpe);
+      nClusters = tpe.getNClusters();
+      removable = tpe.isRemovable();
+      return *this;
+    }
+
+    void setNClusters(int n) { nClusters = n; }
+    int getNClusters() const { return nClusters; }
+
+    void setRemovable() { removable = true; }
+    bool isRemovable() const { return removable; }
+
+   private:
+    int nClusters{-1};
+    bool removable{false};
+  };
+
+  std::unordered_map<int64_t, TrackParExt> mMchTrackPars;
+  std::unordered_map<int64_t, TrackParExt> mMftTrackPars;
+
+  std::unordered_map<int64_t, int32_t> mftTrackCovs;
+
+  Produces<o2::aod::GlobalMuonMatchCandidates> globalMuonMatchCandidates;
+  Produces<o2::aod::FwdTrkMatchCands> fwdTrkMatchCands;
+  Produces<o2::aod::StoredFwdTracksReAlign> gmCandidateFwdTracks;
+  Produces<o2::aod::StoredFwdTrksCovReAlign> gmCandidateFwdTracksCov;
+  Produces<o2::aod::AmbiguousFwdTracksReAlign> gmAmbiguousFwdTracksReAlign;
+
+  int32_t mGmmCandFwdTrackRowIndex{0};
+  std::unordered_map<int64_t, std::array<int32_t, 2>> mAmbBcSliceByFwdTrackId;
+  bool mHasLastMchAmbiguousBcSlice{false};
+  std::array<int32_t, 2> mLastMchAmbiguousBcSlice{};
+
+  int32_t mMatchCandidateCounter{0};
+  std::unordered_map<int64_t, std::vector<int32_t>> mMchTrackToCandidateIndices;
+  std::unordered_map<int64_t, std::vector<MatchingCandidate>> mMchTrackMatchingCandidates;
+  std::unordered_map<int64_t, int32_t> mFwdTrackToGmmCandTrkIndex;
+
+  mch::TrackFitter trackFitter; // Track fitter from MCH tracking library
+  mch::geo::TransformationCreator transformation;
+  std::map<int, math_utils::Transform3D> transformRef; // reference geometry w.r.t track data
+  std::map<int, math_utils::Transform3D> transformNew; // new geometry
+  double mImproveCutChi2;                              // Chi2 cut for track improvement.
+  TGeoManager* geoNew = nullptr;
+  TGeoManager* geoRef = nullptr;
+  globaltracking::MatchGlobalFwd mMatching;
+
+  Preslice<aod::FwdTrkCls> perMuon = aod::fwdtrkcl::fwdtrackId;
+
+  template <class T>
+  o2::mch::TrackParam FwdtoMCH(const T& fwdtrack)
+  {
+    // Convert Forward Track parameters and covariances matrix to the
+    // MCH track format.
+
+    // Parameter conversion
+    double alpha1, alpha3, alpha4, x2, x3, x4;
+
+    x2 = fwdtrack.getPhi();
+    x3 = fwdtrack.getTanl();
+    x4 = fwdtrack.getInvQPt();
+
+    auto sinx2 = TMath::Sin(x2);
+    auto cosx2 = TMath::Cos(x2);
+
+    alpha1 = cosx2 / x3;
+    alpha3 = sinx2 / x3;
+    alpha4 = x4 / TMath::Sqrt(x3 * x3 + sinx2 * sinx2);
+
+    auto K = TMath::Sqrt(x3 * x3 + sinx2 * sinx2);
+    auto K3 = K * K * K;
+
+    // Covariances matrix conversion
+    SMatrix55Std jacobian;
+    SMatrix55Sym covariances;
+
+    covariances(0, 0) = fwdtrack.getCovariances()(0, 0);
+    covariances(0, 1) = fwdtrack.getCovariances()(0, 1);
+    covariances(0, 2) = fwdtrack.getCovariances()(0, 2);
+    covariances(0, 3) = fwdtrack.getCovariances()(0, 3);
+    covariances(0, 4) = fwdtrack.getCovariances()(0, 4);
+
+    covariances(1, 1) = fwdtrack.getCovariances()(1, 1);
+    covariances(1, 2) = fwdtrack.getCovariances()(1, 2);
+    covariances(1, 3) = fwdtrack.getCovariances()(1, 3);
+    covariances(1, 4) = fwdtrack.getCovariances()(1, 4);
+
+    covariances(2, 2) = fwdtrack.getCovariances()(2, 2);
+    covariances(2, 3) = fwdtrack.getCovariances()(2, 3);
+    covariances(2, 4) = fwdtrack.getCovariances()(2, 4);
+
+    covariances(3, 3) = fwdtrack.getCovariances()(3, 3);
+    covariances(3, 4) = fwdtrack.getCovariances()(3, 4);
+
+    covariances(4, 4) = fwdtrack.getCovariances()(4, 4);
+
+    jacobian(0, 0) = 1;
+
+    jacobian(1, 2) = -sinx2 / x3;
+    jacobian(1, 3) = -cosx2 / (x3 * x3);
+
+    jacobian(2, 1) = 1;
+
+    jacobian(3, 2) = cosx2 / x3;
+    jacobian(3, 3) = -sinx2 / (x3 * x3);
+
+    jacobian(4, 2) = -x4 * sinx2 * cosx2 / K3;
+    jacobian(4, 3) = -x3 * x4 / K3;
+    jacobian(4, 4) = 1 / K;
+    // jacobian*covariances*jacobian^T
+    covariances = ROOT::Math::Similarity(jacobian, covariances);
+
+    double cov[] = {covariances(0, 0), covariances(1, 0), covariances(1, 1), covariances(2, 0), covariances(2, 1), covariances(2, 2), covariances(3, 0), covariances(3, 1), covariances(3, 2), covariances(3, 3), covariances(4, 0), covariances(4, 1), covariances(4, 2), covariances(4, 3), covariances(4, 4)};
+    double param[] = {fwdtrack.getX(), alpha1, fwdtrack.getY(), alpha3, alpha4};
+
+    o2::mch::TrackParam convertedTrack(fwdtrack.getZ(), param, cov);
+    return o2::mch::TrackParam(convertedTrack);
+  }
+
+  o2::track::TrackParCovFwd MCHtoFwd(const o2::mch::TrackParam& mchParam)
+  {
+    // Convert a MCH Track parameters and covariances matrix to the
+    // Forward track format. Must be called after propagation though the absorber
+
+    o2::track::TrackParCovFwd convertedTrack;
+
+    // Parameter conversion
+    double alpha1, alpha3, alpha4, x2, x3, x4;
+
+    alpha1 = mchParam.getNonBendingSlope();
+    alpha3 = mchParam.getBendingSlope();
+    alpha4 = mchParam.getInverseBendingMomentum();
+
+    x2 = TMath::ATan2(-alpha3, -alpha1);
+    x3 = -1. / TMath::Sqrt(alpha3 * alpha3 + alpha1 * alpha1);
+    x4 = alpha4 * -x3 * TMath::Sqrt(1 + alpha3 * alpha3);
+
+    auto K = alpha1 * alpha1 + alpha3 * alpha3;
+    auto K32 = K * TMath::Sqrt(K);
+    auto L = TMath::Sqrt(alpha3 * alpha3 + 1);
+
+    // Covariances matrix conversion
+    SMatrix55Std jacobian;
+    SMatrix55Sym covariances;
+
+    covariances(0, 0) = mchParam.getCovariances()(0, 0);
+    covariances(0, 1) = mchParam.getCovariances()(0, 1);
+    covariances(0, 2) = mchParam.getCovariances()(0, 2);
+    covariances(0, 3) = mchParam.getCovariances()(0, 3);
+    covariances(0, 4) = mchParam.getCovariances()(0, 4);
+
+    covariances(1, 1) = mchParam.getCovariances()(1, 1);
+    covariances(1, 2) = mchParam.getCovariances()(1, 2);
+    covariances(1, 3) = mchParam.getCovariances()(1, 3);
+    covariances(1, 4) = mchParam.getCovariances()(1, 4);
+
+    covariances(2, 2) = mchParam.getCovariances()(2, 2);
+    covariances(2, 3) = mchParam.getCovariances()(2, 3);
+    covariances(2, 4) = mchParam.getCovariances()(2, 4);
+
+    covariances(3, 3) = mchParam.getCovariances()(3, 3);
+    covariances(3, 4) = mchParam.getCovariances()(3, 4);
+
+    covariances(4, 4) = mchParam.getCovariances()(4, 4);
+
+    jacobian(0, 0) = 1;
+
+    jacobian(1, 2) = 1;
+
+    jacobian(2, 1) = -alpha3 / K;
+    jacobian(2, 3) = alpha1 / K;
+
+    jacobian(3, 1) = alpha1 / K32;
+    jacobian(3, 3) = alpha3 / K32;
+
+    jacobian(4, 1) = -alpha1 * alpha4 * L / K32;
+    jacobian(4, 3) = alpha3 * alpha4 * (1 / (TMath::Sqrt(K) * L) - L / K32);
+    jacobian(4, 4) = L / TMath::Sqrt(K);
+
+    // jacobian*covariances*jacobian^T
+    covariances = ROOT::Math::Similarity(jacobian, covariances);
+
+    // Set output
+    convertedTrack.setX(mchParam.getNonBendingCoor());
+    convertedTrack.setY(mchParam.getBendingCoor());
+    convertedTrack.setZ(mchParam.getZ());
+    convertedTrack.setPhi(x2);
+    convertedTrack.setTanl(x3);
+    convertedTrack.setInvQPt(x4);
+    convertedTrack.setCharge(mchParam.getCharge());
+    convertedTrack.setCovariances(covariances);
+
+    return convertedTrack;
+  }
+
+  int GetDetElemId(int iDetElemNumber)
+  {
+    // make sure detector number is valid
+    if (!(iDetElemNumber >= fgSNDetElemCh[0] &&
+          iDetElemNumber < fgSNDetElemCh[NMchChambers])) {
+      LOGF(fatal, "Invalid detector element number: %d", iDetElemNumber);
+    }
+    /// get det element number from ID
+    // get chamber and element number in chamber
+    int iCh = 0;
+    int iDet = 0;
+    for (int i = 1; i <= NMchChambers; i++) {
+      if (iDetElemNumber < fgSNDetElemCh[i]) {
+        iCh = i;
+        iDet = iDetElemNumber - fgSNDetElemCh[i - 1];
+        break;
+      }
+    }
+
+    // make sure detector index is valid
+    if (!(iCh > 0 && iCh <= NMchChambers && iDet < fgNDetElemCh[iCh - 1])) {
+      LOGF(fatal, "Invalid detector element id: %d", MchDetElemNumberingBase * iCh + iDet);
+    }
+
+    // add number of detectors up to this chamber
+    return MchDetElemNumberingBase * iCh + iDet;
+  }
+
+  bool RemoveTrack(mch::Track& track)
+  {
+    // Refit track with re-aligned clusters
+    bool removeTrack = false;
+    try {
+      trackFitter.fit(track, false);
+    } catch (std::exception const& e) {
+      removeTrack = true;
+      return removeTrack;
+    }
+
+    auto itStartingParam = std::prev(track.rend());
+
+    while (true) {
+
+      try {
+        trackFitter.fit(track, true, false, (itStartingParam == track.rbegin()) ? nullptr : &itStartingParam);
+      } catch (std::exception const&) {
+        removeTrack = true;
+        break;
+      }
+
+      double worstLocalChi2 = -1.0;
+
+      track.tagRemovableClusters(0x1F, false);
+
+      auto itWorstParam = track.end();
+
+      for (auto itParam = track.begin(); itParam != track.end(); ++itParam) {
+        if (itParam->getLocalChi2() > worstLocalChi2) {
+          worstLocalChi2 = itParam->getLocalChi2();
+          itWorstParam = itParam;
+        }
+      }
+
+      if (worstLocalChi2 < mImproveCutChi2) {
+        break;
+      }
+
+      if (!itWorstParam->isRemovable()) {
+        removeTrack = true;
+        track.removable();
+        break;
+      }
+
+      auto itNextParam = track.removeParamAtCluster(itWorstParam);
+      auto itNextToNextParam = (itNextParam == track.end()) ? itNextParam : std::next(itNextParam);
+      itStartingParam = track.rbegin();
+
+      if (track.getNClusters() < MinRemovableTrackClusters) {
+        removeTrack = true;
+        break;
+      } else {
+        while (itNextToNextParam != track.end()) {
+          if (itNextToNextParam->getClusterPtr()->getChamberId() != itNextParam->getClusterPtr()->getChamberId()) {
+            itStartingParam = std::make_reverse_iterator(++itNextParam);
+            break;
+          }
+          ++itNextToNextParam;
+        }
+      }
+    }
+
+    if (!removeTrack) {
+      for (auto& param : track) { // o2-linter: disable=const-ref-in-for-loop (object is modified in loop)
+        param.setParameters(param.getSmoothParameters());
+        param.setCovariances(param.getSmoothCovariances());
+      }
+    }
+
+    return removeTrack;
+  }
+
+  template <typename BC>
+  void initCcdb(BC const& bc)
+  {
+    if (mRunNumber == bc.runNumber())
+      return;
+
+    mRunNumber = bc.runNumber();
+    std::map<std::string, std::string> metadata;
+    auto soreor = o2::ccdb::BasicCCDBManager::getRunDuration(fCCDBApi, mRunNumber);
+    auto ts = soreor.first;
+    auto grpmag = fCCDBApi.retrieveFromTFileAny<o2::parameters::GRPMagField>(configCcdb.cfgGrpMagPath, metadata, ts);
+    o2::base::Propagator::initFieldFromGRP(grpmag);
+    LOGF(info, "Set field for muons");
+    VarManager::SetupMuonMagField();
+    if (!o2::base::GeometryManager::isGeometryLoaded()) {
+      ccdbManager->get<TGeoManager>(configCcdb.cfgGeoPath);
+    }
+    mch::TrackExtrap::setField();
+    mch::TrackExtrap::useExtrapV2();
+
+    // Load geometry information from CCDB/local
+    LOGF(info, "Loading reference aligned geometry from CCDB no later than %d", configMchRealign.cfgCcdbNoLaterThanRef.value);
+    ccdbManager->setCreatedNotAfter(configMchRealign.cfgCcdbNoLaterThanRef.value); // this timestamp has to be consistent with what has been used in reco
+    geoRef = ccdbManager->getForTimeStamp<TGeoManager>(configMchRealign.cfgGeoRefPath, bc.timestamp());
+    ccdbManager->clearCache(configMchRealign.cfgGeoRefPath);
+    if (geoRef != nullptr) {
+      transformation = mch::geo::transformationFromTGeoManager(*geoRef);
+    } else {
+      LOGF(fatal, "Reference aligned geometry object is not available in CCDB at timestamp=%llu", bc.timestamp());
+    }
+    for (int i = 0; i < NMchDetElems; i++) {
+      int iDEN = GetDetElemId(i);
+      transformRef[iDEN] = transformation(iDEN);
+    }
+
+    LOGF(info, "Loading new aligned geometry from CCDB no later than %d", configMchRealign.cfgCcdbNoLaterThanNew.value);
+    ccdbManager->setCreatedNotAfter(configMchRealign.cfgCcdbNoLaterThanNew.value); // make sure this timestamp can be resolved regarding the reference one
+    geoNew = ccdbManager->getForTimeStamp<TGeoManager>(configMchRealign.cfgGeoNewPath, bc.timestamp());
+    ccdbManager->clearCache(configMchRealign.cfgGeoNewPath);
+    if (geoNew != nullptr) {
+      transformation = mch::geo::transformationFromTGeoManager(*geoNew);
+    } else {
+      LOGF(fatal, "New aligned geometry object is not available in CCDB at timestamp=%llu", bc.timestamp());
+    }
+    for (int i = 0; i < NMchDetElems; i++) {
+      int iDEN = GetDetElemId(i);
+      transformNew[iDEN] = transformation(iDEN);
+    }
+
+    // Init magnetic field for MFT track extrapolation
+    auto* fieldB = static_cast<o2::field::MagneticField*>(TGeoGlobalMagField::Instance()->GetField());
+    if (fieldB) {
+      double centerMft[3] = {0, 0, -61.4}; // Field at center of MFT
+      mBzAtMftCenter = fieldB->getBz(centerMft);
+      // std::cout << "fieldB: " << (void*)fieldB << std::endl;
+    }
+  }
+
+  void initMatchingFunctions()
+  {
+    using SVector2 = ROOT::Math::SVector<double, 2>;
+    using SVector4 = ROOT::Math::SVector<double, 4>;
+    using SVector5 = ROOT::Math::SVector<double, 5>;
+
+    using SMatrix44 = ROOT::Math::SMatrix<double, 4>;
+    using SMatrix45 = ROOT::Math::SMatrix<double, 4, 5>;
+    using SMatrix22 = ROOT::Math::SMatrix<double, 2>;
+    using SMatrix25 = ROOT::Math::SMatrix<double, 2, 5>;
+
+    // Define built-in matching functions
+    //________________________________________________________________________________
+    mMatchingFunctionMap["matchALL"] = [](const o2::track::TrackParCovFwd& mchTrack, const o2::track::TrackParCovFwd& mftTrack) -> std::tuple<double, int> {
+      // Match two tracks evaluating all parameters: X,Y, phi, tanl & q/pt
+
+      SMatrix55Sym hK, vK;
+      SVector5 mK(mftTrack.getX(), mftTrack.getY(), mftTrack.getPhi(),
+                  mftTrack.getTanl(), mftTrack.getInvQPt()),
+        rKKminus1;
+      SVector5 globalMuonTrackParameters = mchTrack.getParameters();
+      SMatrix55Sym globalMuonTrackCovariances = mchTrack.getCovariances();
+      vK(0, 0) = mftTrack.getCovariances()(0, 0);
+      vK(1, 1) = mftTrack.getCovariances()(1, 1);
+      vK(2, 2) = mftTrack.getCovariances()(2, 2);
+      vK(3, 3) = mftTrack.getCovariances()(3, 3);
+      vK(4, 4) = mftTrack.getCovariances()(4, 4);
+      hK(0, 0) = 1.0;
+      hK(1, 1) = 1.0;
+      hK(2, 2) = 1.0;
+      hK(3, 3) = 1.0;
+      hK(4, 4) = 1.0;
+
+      // Covariance of residuals
+      SMatrix55Std invResCov = (vK + ROOT::Math::Similarity(hK, globalMuonTrackCovariances));
+      invResCov.Invert();
+
+      // Update Parameters
+      rKKminus1 = mK - hK * globalMuonTrackParameters; // Residuals of prediction
+
+      auto matchChi2Track = ROOT::Math::Similarity(rKKminus1, invResCov);
+
+      // return chi2 and NDF
+      return {matchChi2Track, 5};
+    };
+
+    //________________________________________________________________________________
+    mMatchingFunctionMap["matchXYPhiTanl"] = [](const o2::track::TrackParCovFwd& mchTrack, const o2::track::TrackParCovFwd& mftTrack) -> std::tuple<double, int> {
+      // Match two tracks evaluating positions & angles
+
+      SMatrix45 hK;
+      SMatrix44 vK;
+      SVector4 mK(mftTrack.getX(), mftTrack.getY(), mftTrack.getPhi(),
+                  mftTrack.getTanl()),
+        rKKminus1;
+      SVector5 globalMuonTrackParameters = mchTrack.getParameters();
+      SMatrix55Sym globalMuonTrackCovariances = mchTrack.getCovariances();
+      vK(0, 0) = mftTrack.getCovariances()(0, 0);
+      vK(1, 1) = mftTrack.getCovariances()(1, 1);
+      vK(2, 2) = mftTrack.getCovariances()(2, 2);
+      vK(3, 3) = mftTrack.getCovariances()(3, 3);
+      hK(0, 0) = 1.0;
+      hK(1, 1) = 1.0;
+      hK(2, 2) = 1.0;
+      hK(3, 3) = 1.0;
+
+      // Covariance of residuals
+      SMatrix44 invResCov = (vK + ROOT::Math::Similarity(hK, globalMuonTrackCovariances));
+      invResCov.Invert();
+
+      // Residuals of prediction
+      rKKminus1 = mK - hK * globalMuonTrackParameters;
+
+      auto matchChi2Track = ROOT::Math::Similarity(rKKminus1, invResCov);
+
+      // return chi2 and NDF
+      return {matchChi2Track, 4};
+    };
+
+    //________________________________________________________________________________
+    mMatchingFunctionMap["matchXY"] = [](const o2::track::TrackParCovFwd& mchTrack, const o2::track::TrackParCovFwd& mftTrack) -> std::tuple<double, int> {
+      // Calculate Matching Chi2 - X and Y positions
+
+      SMatrix25 hK;
+      SMatrix22 vK;
+      SVector2 mK(mftTrack.getX(), mftTrack.getY()), rKKminus1;
+      SVector5 globalMuonTrackParameters = mchTrack.getParameters();
+      SMatrix55Sym globalMuonTrackCovariances = mchTrack.getCovariances();
+      vK(0, 0) = mftTrack.getCovariances()(0, 0);
+      vK(1, 1) = mftTrack.getCovariances()(1, 1);
+      hK(0, 0) = 1.0;
+      hK(1, 1) = 1.0;
+
+      // Covariance of residuals
+      SMatrix22 invResCov = (vK + ROOT::Math::Similarity(hK, globalMuonTrackCovariances));
+      invResCov.Invert();
+
+      // Residuals of prediction
+      rKKminus1 = mK - hK * globalMuonTrackParameters;
+      auto matchChi2Track = ROOT::Math::Similarity(rKKminus1, invResCov);
+
+      // return reduced chi2
+      return {matchChi2Track, 2};
+    };
+  }
+
+  void init(o2::framework::InitContext&)
+  {
+    // Load geometry
+    ccdbManager->setURL(configCcdb.cfgCcdbUrl);
+    ccdbManager->setCaching(true);
+    ccdbManager->setLocalObjectValidityChecking();
+    fCCDBApi.init(configCcdb.cfgCcdbUrl);
+    mRunNumber = 0;
+
+    // Configuration for track fitter
+    const auto& trackerParam = mch::TrackerParam::Instance();
+    trackFitter.setBendingVertexDispersion(trackerParam.bendingVertexDispersion);
+    trackFitter.setChamberResolution(configMchRealign.cfgChamberResolutionX.value, configMchRealign.cfgChamberResolutionY.value);
+    trackFitter.smoothTracks(true);
+    trackFitter.useChamberResolution();
+    mImproveCutChi2 = 2. * configMchRealign.cfgSigmaCutImprove.value * configMchRealign.cfgSigmaCutImprove.value;
+
+    // Reset matching configuration, then populate only what we need.
+    hasActiveChi2Matching = false;
+    activeChi2FunctionName.clear();
+    activeChi2MatchingPlaneZ = 0.;
+
+    hasActiveMlMatching = false;
+    activeMlMatchingPlaneZ = 0.;
+
+    if (configMatching.cfgCustomMatchingStrategy.value == 0) {
+      // Matching functions (custom chi2)
+      initMatchingFunctions();
+      auto label = configChi2MatchingOptions.cfgChi2FunctionLabel.value;
+      auto funcName = configChi2MatchingOptions.cfgChi2FunctionName.value;
+      auto matchingPlaneZ = configChi2MatchingOptions.cfgChi2FunctionMatchingPlaneZ.value;
+
+      if (label != "" && funcName != "") {
+        hasActiveChi2Matching = true;
+        activeChi2FunctionName = funcName;
+        activeChi2MatchingPlaneZ = matchingPlaneZ;
+      }
+    } else {
+      // Matching ML models (custom ML)
+      // TODO : for now we use hard coded values since the current models use 1 pT bin
+      binsPtMl = {-1e-6, 1000.0};
+      cutValues = {0.0};
+      cutDirMl = {cuts_ml::CutNot};
+      o2::framework::LabeledArray<double> mycutsMl(cutValues.data(), 1, 1, std::vector<std::string>{"pT bin 0"}, std::vector<std::string>{"score"});
+
+      auto label = configMlOptions.cfgMlModelLabel.value;
+      auto modelPath = configMlOptions.cfgMlModelPathCcdb.value;
+      auto inputFeatures = configMlOptions.cfgMlInputFeatures.value;
+      auto modelName = configMlOptions.cfgMlModelName.value;
+      auto matchingPlaneZ = configMlOptions.cfgMlModelMatchingPlaneZ.value;
+
+      if (label != "" && modelPath != "" && !inputFeatures.empty() && modelName != "") {
+        activeMlResponse.configure(binsPtMl, mycutsMl, cutDirMl, 1);
+        activeMlResponse.setModelPathsCCDB(std::vector<std::string>{modelName}, fCCDBApi, std::vector<std::string>{modelPath}, configCcdb.cfgCcdbNoLaterThan.value);
+        activeMlResponse.cacheInputFeaturesIndices(inputFeatures);
+        activeMlResponse.init();
+
+        hasActiveMlMatching = true;
+        activeMlMatchingPlaneZ = matchingPlaneZ;
+      }
+    }
+  }
+
+  template <class T, class C>
+  bool pDcaCut(const T& mchTrack, const C& collision, double nSigmaPDCA)
+  {
+    static const double sigmaPDCA23 = 80.;
+    static const double sigmaPDCA310 = 54.;
+    static const double relPRes = 0.0004;
+    static const double slopeRes = 0.0005;
+
+    constexpr double AbsorberEndZ = 505.;
+    constexpr double RadToDeg = 180. / o2::constants::math::PI;
+    double thetaAbs = std::atan(mchTrack.rAtAbsorberEnd() / AbsorberEndZ) * RadToDeg;
+
+    // propagate muon track to vertex
+    auto mchTrackAtVertex = VarManager::PropagateMuon(mchTrack, collision, VarManager::kToVertex);
+
+    // double pUncorr = mchTrack.p();
+    double p = mchTrackAtVertex.getP();
+
+    double pDCA = mchTrack.pDca();
+    double sigmaPDCA = (thetaAbs < ThetaAbsBoundaryDeg) ? sigmaPDCA23 : sigmaPDCA310;
+    double nrp = nSigmaPDCA * relPRes * p;
+    double pResEffect = sigmaPDCA / (1. - nrp / (1. + nrp));
+    double slopeResEffect = SlopeResolutionZ * slopeRes * p;
+    double sigmaPDCAWithRes = std::sqrt(pResEffect * pResEffect + slopeResEffect * slopeResEffect);
+    if (pDCA > nSigmaPDCA * sigmaPDCAWithRes) {
+      return false;
+    }
+
+    return true;
+  }
+
+  template <class T, class C>
+  bool isGoodMuon(const T& mchTrack, const C& collision,
+                  double chi2Cut,
+                  double pCut,
+                  double pTCut,
+                  std::array<double, 2> etaCut,
+                  std::array<double, 2> rAbsCut,
+                  double nSigmaPdcaCut)
+  {
+    // chi2 cut
+    if (mchTrack.chi2() > chi2Cut)
+      return false;
+
+    // momentum cut
+    if (mchTrack.p() < pCut) {
+      return false; // skip low-momentum tracks
+    }
+
+    // transverse momentum cut
+    if (mchTrack.pt() < pTCut) {
+      return false; // skip low-momentum tracks
+    }
+
+    // Eta cut
+    double eta = mchTrack.eta();
+    if ((eta < etaCut[0] || eta > etaCut[1])) {
+      return false;
+    }
+
+    // RAbs cut
+    double rAbs = mchTrack.rAtAbsorberEnd();
+    if ((rAbs < rAbsCut[0] || rAbs > rAbsCut[1])) {
+      return false;
+    }
+
+    // pDCA cut
+    if (!pDcaCut(mchTrack, collision, nSigmaPdcaCut)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  void storeFwdTrackCovariance(const SMatrix55Sym& cov)
+  {
+    const float sigX = std::sqrt(cov(0, 0));
+    const float sigY = std::sqrt(cov(1, 1));
+    const float sigPhi = std::sqrt(cov(2, 2));
+    const float sigTgl = std::sqrt(cov(3, 3));
+    const float sig1Pt = std::sqrt(cov(4, 4));
+    const auto rhoXY = static_cast<int8_t>(128.f * cov(0, 1) / (sigX * sigY));
+    const auto rhoPhiX = static_cast<int8_t>(128.f * cov(0, 2) / (sigPhi * sigX));
+    const auto rhoPhiY = static_cast<int8_t>(128.f * cov(1, 2) / (sigPhi * sigY));
+    const auto rhoTglX = static_cast<int8_t>(128.f * cov(0, 3) / (sigTgl * sigX));
+    const auto rhoTglY = static_cast<int8_t>(128.f * cov(1, 3) / (sigTgl * sigY));
+    const auto rhoTglPhi = static_cast<int8_t>(128.f * cov(2, 3) / (sigTgl * sigPhi));
+    const auto rho1PtX = static_cast<int8_t>(128.f * cov(0, 4) / (sig1Pt * sigX));
+    const auto rho1PtY = static_cast<int8_t>(128.f * cov(1, 4) / (sig1Pt * sigY));
+    const auto rho1PtPhi = static_cast<int8_t>(128.f * cov(2, 4) / (sig1Pt * sigPhi));
+    const auto rho1PtTgl = static_cast<int8_t>(128.f * cov(3, 4) / (sig1Pt * sigTgl));
+    gmCandidateFwdTracksCov(sigX, sigY, sigPhi, sigTgl, sig1Pt,
+                            rhoXY, rhoPhiY, rhoPhiX, rhoTglX, rhoTglY, rhoTglPhi, rho1PtX, rho1PtY, rho1PtPhi, rho1PtTgl);
+  }
+
+  template <class TMCH>
+  void fillBaseGmmCandFwdTrack(TMCH const& track,
+                               TrackParExt const& trackPar,
+                               int32_t gmmMchTrackId,
+                               float chi2MatchMCHMFT,
+                               float matchScoreMCHMFT)
+  {
+    const auto collisionId = track.collisionId();
+    bool hasBcSlice = false;
+    std::array<int32_t, 2> bcSlice{};
+    if (collisionId < 0) {
+      const auto ambIt = mAmbBcSliceByFwdTrackId.find(track.globalIndex());
+      if (ambIt != mAmbBcSliceByFwdTrackId.end()) {
+        bcSlice = ambIt->second;
+        hasBcSlice = true;
+      }
+    }
+
+    gmCandidateFwdTracks(
+      collisionId,
+      track.trackType(),
+      trackPar.getX(),
+      trackPar.getY(),
+      trackPar.getZ(),
+      trackPar.getPhi(),
+      trackPar.getTgl(),
+      trackPar.getInvQPt(),
+      trackPar.getNClusters(),
+      track.pDca(),
+      track.rAtAbsorberEnd(),
+      trackPar.isRemovable(),
+      trackPar.getTrackChi2(),
+      track.chi2MatchMCHMID(),
+      chi2MatchMCHMFT,
+      matchScoreMCHMFT,
+      track.matchMFTTrackId(),
+      gmmMchTrackId,
+      track.mchBitMap(),
+      track.midBitMap(),
+      track.midBoards(),
+      track.trackTime(),
+      track.trackTimeRes());
+
+    storeFwdTrackCovariance(trackPar.getCovariances());
+    if (hasBcSlice) {
+      int32_t bcSliceArray[2] = {bcSlice[0], bcSlice[1]};
+      gmAmbiguousFwdTracksReAlign(mGmmCandFwdTrackRowIndex, bcSliceArray);
+    }
+    mGmmCandFwdTrackRowIndex += 1;
+
+    mHasLastMchAmbiguousBcSlice = hasBcSlice;
+    if (hasBcSlice) {
+      mLastMchAmbiguousBcSlice = bcSlice;
+    }
+  }
+
+  template <class TMCH, class TMFT>
+  void fillCandidateFwdTrack(TMCH const& mchTrack,
+                             TrackParExt const& mchPar,
+                             int32_t gmmMchTrackId,
+                             TMFT const& mftTrack,
+                             TrackParExt const& mftPar,
+                             const MatchingCandidate& candidate)
+  {
+    using o2::aod::fwdtrack::ForwardTrackTypeEnum;
+    using o2::aod::fwdtrackutils::propagationPoint;
+
+    constexpr uint8_t candidateTrackType = static_cast<uint8_t>(ForwardTrackTypeEnum::GlobalForwardTrack);
+
+    auto propmuonAtMft = FwdtoMCH(mchPar);
+    o2::mch::TrackExtrap::extrapToVertex(propmuonAtMft,
+                                         mftPar.getX(),
+                                         mftPar.getY(),
+                                         mftPar.getZ(),
+                                         mftPar.getSigma2X(),
+                                         mftPar.getSigma2Y());
+
+    const auto globalMuonRefit = o2::aod::fwdtrackutils::refitGlobalMuonCov(MCHtoFwd(propmuonAtMft), mftPar);
+
+    int8_t nClusters = static_cast<int8_t>(std::min(127, static_cast<int>(mchPar.getNClusters()) + static_cast<int>(mftPar.getNClusters())));
+
+    const float chi2 = static_cast<float>(mchTrack.chi2());
+    const int32_t collisionId = mchTrack.has_collision() ? mchTrack.collisionId() : -1;
+    bool hasBcSlice = false;
+    std::array<int32_t, 2> bcSlice{};
+    if (collisionId < 0) {
+      if (mHasLastMchAmbiguousBcSlice) {
+        bcSlice = mLastMchAmbiguousBcSlice;
+        hasBcSlice = true;
+      } else {
+        const auto ambIt = mAmbBcSliceByFwdTrackId.find(mchTrack.globalIndex());
+        if (ambIt != mAmbBcSliceByFwdTrackId.end()) {
+          bcSlice = ambIt->second;
+          hasBcSlice = true;
+        }
+      }
+    }
+
+    bool isRemovable = mchPar.isRemovable();
+
+    gmCandidateFwdTracks(
+      collisionId,
+      candidateTrackType,
+      globalMuonRefit.getX(),
+      globalMuonRefit.getY(),
+      globalMuonRefit.getZ(),
+      globalMuonRefit.getPhi(),
+      globalMuonRefit.getTgl(),
+      globalMuonRefit.getInvQPt(),
+      nClusters,
+      mchTrack.pDca(),
+      mchTrack.rAtAbsorberEnd(),
+      isRemovable,
+      chi2,
+      mchTrack.chi2MatchMCHMID(),
+      static_cast<float>(candidate.matchChi2),
+      static_cast<float>(candidate.matchScore),
+      static_cast<int>(mftTrack.globalIndex()),
+      gmmMchTrackId,
+      mchTrack.mchBitMap(),
+      mchTrack.midBitMap(),
+      mchTrack.midBoards(),
+      mchTrack.trackTime(),
+      mchTrack.trackTimeRes());
+
+    storeFwdTrackCovariance(globalMuonRefit.getCovariances());
+    if (hasBcSlice) {
+      int32_t bcSliceArray[2] = {bcSlice[0], bcSlice[1]};
+      gmAmbiguousFwdTracksReAlign(mGmmCandFwdTrackRowIndex, bcSliceArray);
+    }
+    mGmmCandFwdTrackRowIndex += 1;
+  }
+
+  o2::track::TrackParCovFwd propagateToZMch(const o2::track::TrackParCovFwd& muon, const double z)
+  {
+    auto mchTrack = FwdtoMCH(muon);
+
+    float absFront = -90.f;
+    float absBack = -505.f;
+
+    if (muon.getZ() < absBack && z > absFront) {
+      // extrapolation through the absorber in the upstream direction
+      o2::mch::TrackExtrap::extrapToVertexWithoutBranson(mchTrack, z);
+    } else {
+      // all other cases
+      o2::mch::TrackExtrap::extrapToZCov(mchTrack, z);
+    }
+
+    return MCHtoFwd(mchTrack);
+  }
+
+  o2::track::TrackParCovFwd propagateToZMft(const o2::track::TrackParCovFwd& mftTrack, const double z)
+  {
+    o2::track::TrackParCovFwd trackExtrap{mftTrack};
+    trackExtrap.propagateToZ(z, mBzAtMftCenter);
+    return trackExtrap;
+  }
+
+  template <class TMCH, class C>
+  o2::track::TrackParCovFwd propagateToVertexMch(const TMCH& muon,
+                                                 const C& collision)
+  {
+    auto mchTrack = FwdtoMCH(fwdtrackutils::getTrackParCovFwd(muon, muon));
+    o2::mch::TrackExtrap::extrapToVertex(mchTrack,
+                                         collision.posX(),
+                                         collision.posY(),
+                                         collision.posZ(),
+                                         collision.covXX(),
+                                         collision.covYY());
+    return MCHtoFwd(mchTrack);
+  }
+
+  // tag muons based on the track quality and the track position at the front and back MFT planes
+  template <class TMUON, class C>
+  void getTaggedMuons(C const& collisions,
+                      TMUON const& muonTracks,
+                      std::vector<int64_t>& taggedMuons)
+  {
+    taggedMuons.clear();
+    for (const auto& muonTrack : muonTracks) {
+
+      // only consider MCH-MID matches
+      if (static_cast<int>(muonTrack.trackType()) != MchMidTrackType) {
+        continue;
+      }
+
+      // only select MCH-MID tracks associated to a collision
+      if (!muonTrack.has_collision())
+        continue;
+
+      const auto& collision = collisions.rawIteratorAt(muonTrack.collisionId());
+
+      // select MCH tracks with strict quality cuts
+      if (!isGoodMuon(muonTrack, collision,
+                      configMuonTagging.cfgMuonTaggingTrackChi2MchUp,
+                      configMuonTagging.cfgMuonTaggingPMchLow,
+                      configMuonTagging.cfgMuonTaggingPtMchLow,
+                      {configMuonTagging.cfgMuonTaggingEtaMchLow, configMuonTagging.cfgMuonTaggingEtaMchUp},
+                      {configMuonTagging.cfgMuonTaggingRabsLow, configMuonTagging.cfgMuonTaggingRabsUp},
+                      configMuonTagging.cfgMuonTaggingPdcaUp)) {
+        continue;
+      }
+
+      // propagate MCH track to the vertex
+      auto mchTrackAtVertex = propagateToVertexMch(muonTrack, collision);
+
+      // propagate the track from the vertex to the first MFT plane
+      const auto& extrapToMFTfirst = propagateToZMch(mchTrackAtVertex, o2::mft::constants::mft::LayerZCoordinate()[0]);
+      double rFront = std::sqrt(extrapToMFTfirst.getX() * extrapToMFTfirst.getX() + extrapToMFTfirst.getY() * extrapToMFTfirst.getY());
+      if (rFront < configMuonTagging.cfgMuonTaggingRadiusAtMftFrontLow.value || rFront > configMuonTagging.cfgMuonTaggingRadiusAtMftFrontUp.value)
+        continue;
+
+      // propagate the track from the vertex to the last MFT plane
+      const auto& extrapToMFTlast = propagateToZMch(mchTrackAtVertex, o2::mft::constants::mft::LayerZCoordinate()[9]);
+      double rBack = std::sqrt(extrapToMFTlast.getX() * extrapToMFTlast.getX() + extrapToMFTlast.getY() * extrapToMFTlast.getY());
+      if (rBack < configMuonTagging.cfgMuonTaggingRadiusAtMftBackLow.value || rBack > configMuonTagging.cfgMuonTaggingRadiusAtMftBackUp.value)
+        continue;
+
+      int64_t muonTrackIndex = muonTrack.globalIndex();
+      taggedMuons.emplace_back(muonTrackIndex);
+    }
+  }
+
+  template <class EVT, class BC, class TMUON, class TMFT>
+  bool isMftMchTimeCompatible(EVT const& collisions,
+                              BC const& bcs,
+                              TMUON const& mchTrack,
+                              TMFT const& mftTrack)
+  {
+    if (!mchTrack.has_collision() || !mftTrack.has_collision()) {
+      return false;
+    }
+
+    const auto& collMch = collisions.rawIteratorAt(mchTrack.collisionId());
+    const auto& bcMch = bcs.rawIteratorAt(collMch.bcId());
+    const auto& collMft = collisions.rawIteratorAt(mftTrack.collisionId());
+    const auto& bcMft = bcs.rawIteratorAt(collMft.bcId());
+
+    int64_t deltaBc = static_cast<int64_t>(bcMft.globalBC()) - static_cast<int64_t>(bcMch.globalBC());
+    double deltaBcNS = o2::constants::lhc::LHCBunchSpacingNS * deltaBc;
+    double deltaTrackTime = mftTrack.trackTime() - mchTrack.trackTime() + deltaBcNS;
+    double trackTimeResTot = mftTrack.trackTimeRes() + mchTrack.trackTimeRes();
+
+    return std::fabs(deltaTrackTime) <= trackTimeResTot;
+  }
+
+  template <class EVT, class BC, class TMUON, class TMFT>
+  void prepareMatchingCandidates(EVT const& collisions,
+                                 BC const& bcs,
+                                 TMUON const& muonTracks,
+                                 TMFT const& mftTracks,
+                                 MyMFTCovariances const& mftCovs)
+  {
+    mMftTrackPars.clear();
+    mMchTrackPars.clear();
+    mMatchingCandidates.clear();
+
+    LOGF(info, "Filling matching candidate tables");
+
+    for (const auto& muonTrack : muonTracks) {
+      if (static_cast<int>(muonTrack.trackType()) <= GlobalTrackTypeMax) {
+        continue;
+      }
+      auto mchTrackIndex = muonTrack.globalIndex();
+
+      // initialize the MCH track parameters, which will be updated by the realignment if enabled
+      if (mMchTrackPars.count(mchTrackIndex) == 0) {
+        mMchTrackPars.emplace(mchTrackIndex, TrackParExt(fwdtrackutils::getTrackParCovFwd(muonTrack, muonTrack), muonTrack.nClusters()));
+      }
+    }
+
+    for (const auto& mftTrack : mftTracks) {
+      auto mftTrackIndex = mftTrack.globalIndex();
+
+      // initialize the MFT track parameters, which will be updated by the alignment corrections if enabled
+      if (mftTrackCovs.count(mftTrackIndex) > 0 && mMftTrackPars.count(mftTrackIndex) == 0) {
+        auto const& mftTrackCov = mftCovs.rawIteratorAt(mftTrackCovs[mftTrackIndex]);
+        mMftTrackPars.emplace(mftTrackIndex, TrackParExt(fwdtrackutils::getTrackParCovFwd(mftTrack, mftTrackCov), mftTrack.nClusters()));
+      }
+    }
+
+    // fill matching candidates table
+    if (!configMatching.cfgMatchAllTracks.value) {
+      // collect global MFT-MCH or MFT-MCH-MID tracks and associate them to the corresponding MCH(-MID) track
+      for (const auto& muonTrack : muonTracks) {
+        // skip MCH or MCH-MID tracks
+        if (static_cast<int>(muonTrack.trackType()) > GlobalTrackTypeMax) {
+          continue;
+        }
+
+        auto const& mchTrack = muonTrack.template matchMCHTrack_as<TMUON>();
+        int64_t mchTrackIndex = mchTrack.globalIndex();
+        auto const& mftTrack = muonTrack.template matchMFTTrack_as<TMFT>();
+        int64_t mftTrackIndex = mftTrack.globalIndex();
+
+        if (mftTrackCovs.count(mftTrackIndex) < 1) {
+          continue;
+        }
+
+        mMatchingCandidates[mchTrackIndex].emplace_back(MatchingCandidate{
+          muonTrack.globalIndex(),
+          mftTrackIndex,
+          muonTrack.matchScoreMCHMFT(),
+          muonTrack.chi2MatchMCHMFT()});
+      }
+    } else {
+      // build matching candidates from all time-compatible MFT-MCH pairs
+      for (const auto& muonTrack : muonTracks) {
+        if (static_cast<int>(muonTrack.trackType()) <= GlobalTrackTypeMax) {
+          continue;
+        }
+        auto mchTrackIndex = muonTrack.globalIndex();
+        for (const auto& mftTrack : mftTracks) {
+          if (!isMftMchTimeCompatible(collisions, bcs, muonTrack, mftTrack)) {
+            continue;
+          }
+          if (mftTrackCovs.count(mftTrack.globalIndex()) < 1) {
+            continue;
+          }
+
+          mMatchingCandidates[mchTrackIndex].emplace_back(MatchingCandidate{
+            -1,
+            mftTrack.globalIndex()});
+        }
+      }
+    }
+
+    // sort the vectors of matching candidates in ascending order based on the matching chi2 value
+    auto compareMatchingChi2 = [](const MatchingCandidate& track1, const MatchingCandidate& track2) -> bool {
+      return (track1.matchChi2 < track2.matchChi2);
+    };
+
+    for (auto& [mchIndex, candidatesVector] : mMatchingCandidates) { // o2-linter: disable=const-ref-in-for-loop (object is modified in loop)
+      std::sort(candidatesVector.begin(), candidatesVector.end(), compareMatchingChi2);
+    }
+  }
+
+  template <typename TMFT, typename TMFTCOV>
+  o2::track::TrackParCovFwd TransformMFT(TMFT& mftTrack, TMFTCOV const& mftTrackCov)
+  {
+    auto track = FwdtoMCH(fwdtrackutils::getTrackParCovFwd(mftTrack, mftTrackCov));
+
+    double z = track.getZ();
+    // double dZ = zMCH - z;
+    double x = track.getNonBendingCoor();
+    double y = track.getBendingCoor();
+    double xSlope = track.getNonBendingSlope();
+    double ySlope = track.getBendingSlope();
+
+    double xSlopeCorrection = (y > 0) ? configMftAlignmentCorrections.cfgMFTAlignmentCorrXSlopeTop : configMftAlignmentCorrections.cfgMFTAlignmentCorrXSlopeBottom;
+    double xCorrection = xSlopeCorrection * z +
+                         ((y > 0) ? configMftAlignmentCorrections.cfgMFTAlignmentCorrXOffsetTop : configMftAlignmentCorrections.cfgMFTAlignmentCorrXOffsetBottom);
+    double xNew = x + xCorrection;
+    double xSlopeNew = xSlope + xSlopeCorrection;
+
+    track.setNonBendingCoor(xNew);
+    track.setNonBendingSlope(xSlopeNew);
+
+    double ySlopeCorrection = (y > 0) ? configMftAlignmentCorrections.cfgMFTAlignmentCorrYSlopeTop : configMftAlignmentCorrections.cfgMFTAlignmentCorrYSlopeBottom;
+    double yCorrection = ySlopeCorrection * z +
+                         ((y > 0) ? configMftAlignmentCorrections.cfgMFTAlignmentCorrYOffsetTop : configMftAlignmentCorrections.cfgMFTAlignmentCorrYOffsetBottom);
+    track.setBendingCoor(y + yCorrection);
+    track.setBendingSlope(ySlope + ySlopeCorrection);
+
+    return MCHtoFwd(track);
+  }
+
+  template <typename TMFTs, typename TMFTCOVs>
+  void runMftRealignment(TMFTs const& mftTracks, TMFTCOVs const& mftCovs)
+  {
+    for (const auto& mftTrack : mftTracks) {
+      auto mftTrackIndex = mftTrack.globalIndex();
+      if (mftTrackCovs.count(mftTrackIndex) < 0) {
+        continue;
+      }
+
+      auto const& mftTrackCov = mftCovs.rawIteratorAt(mftTrackCovs[mftTrackIndex]);
+      mMftTrackPars[mftTrackIndex] = TransformMFT(mftTrack, mftTrackCov);
+    }
+  }
+
+  template <typename TMuons, typename TMuonCls>
+  void runMuonRealignment(TMuons const& muons, TMuonCls const& clusters)
+  {
+    // Loop over forward tracks
+    for (auto const& muon : muons) {
+      int mchIndex = muon.globalIndex();
+      // skip global forward matches
+      if (muon.trackType() > GlobalTrackTypeMax) {
+        continue;
+      }
+
+      // continue;
+
+      auto mchTrackParIt = mMchTrackPars.find(mchIndex);
+      if (mchTrackParIt == mMchTrackPars.end()) {
+        continue;
+      }
+
+      auto clustersSliced = clusters.sliceBy(perMuon, muon.globalIndex()); // Slice clusters by muon id
+      mch::Track convertedTrack = mch::Track();                            // Temporary variable to store re-aligned clusters
+
+      int clIndex = -1;
+      // Get re-aligned clusters associated to current track
+      for (auto const& cluster : clustersSliced) {
+        clIndex += 1;
+
+        mch::Cluster* clusterMCH = new mch::Cluster();
+
+        math_utils::Point3D<double> local;
+        math_utils::Point3D<double> master;
+        master.SetXYZ(cluster.x(), cluster.y(), cluster.z());
+
+        // Transformation from reference geometry frame to new geometry frame
+        transformRef[cluster.deId()].MasterToLocal(master, local);
+        transformNew[cluster.deId()].LocalToMaster(local, master);
+
+        clusterMCH->x = master.x();
+        clusterMCH->y = master.y();
+        clusterMCH->z = master.z();
+
+        uint32_t ClUId = mch::Cluster::buildUniqueId(static_cast<int>(cluster.deId() / 100) - 1, cluster.deId(), clIndex);
+        clusterMCH->uid = ClUId;
+        clusterMCH->ex = cluster.isGoodX() ? 0.2 : 10.0;
+        clusterMCH->ey = cluster.isGoodY() ? 0.2 : 10.0;
+
+        // Add transformed cluster into temporary variable
+        convertedTrack.createParamAtCluster(*clusterMCH);
+        // LOGF(debug, "Track %d, cluster DE%d:  x:%g  y:%g  z:%g", muon.globalIndex(), cluster.deId(), cluster.x(), cluster.y(), cluster.z());
+        // LOGF(debug, "Track %d, re-aligned cluster DE%d:  x:%g  y:%g  z:%g", muonRealignId, cluster.deId(), clusterMCH->getX(), clusterMCH->getY(), clusterMCH->getZ());
+      }
+
+      // Refit the re-aligned track
+      int removable = 0;
+      if (convertedTrack.getNClusters() != 0) {
+        removable = RemoveTrack(convertedTrack);
+      } else {
+        LOGF(fatal, "Muon track %d has no associated clusters.", muon.globalIndex());
+      }
+
+      // Get the re-aligned track parameter: track param at the first cluster
+      mch::TrackParam trackParam = mch::TrackParam(convertedTrack.first());
+
+      // Convert MCH track to FWD track and store new parameters after realignment
+      mchTrackParIt->second = MCHtoFwd(mch::TrackParam(convertedTrack.first()));
+      mchTrackParIt->second.setTrackChi2(trackParam.getTrackChi2() / convertedTrack.getNDF());
+      mchTrackParIt->second.setNClusters(convertedTrack.getNClusters());
+      if (removable) {
+        mchTrackParIt->second.setRemovable();
+      }
+    }
+  }
+
+  void runChi2Matching(std::string funcName,
+                       float matchingPlaneZ,
+                       const MatchingCandidates& matchingCandidates,
+                       MatchingCandidates& newMatchingCandidates)
+  {
+    newMatchingCandidates.clear();
+
+    std::string funcNameEffective = funcName;
+    float matchingPlaneZEffective = matchingPlaneZ;
+    if (funcName == "prod") {
+      funcNameEffective = "matchALL";
+      matchingPlaneZEffective = MatchingPlaneDefaultZ;
+    }
+
+    if (mMatchingFunctionMap.count(funcNameEffective) < 1) {
+      return;
+    }
+    auto matchingFunc = mMatchingFunctionMap.at(funcNameEffective);
+
+    for (const auto& [mchIndex, candidatesVector] : matchingCandidates) {
+
+      // get the tracks parameters, which have been updated by the realignment if enabled
+      const auto mchTrackParIt = mMchTrackPars.find(mchIndex);
+      if (mchTrackParIt == mMchTrackPars.end()) {
+        continue;
+      }
+
+      for (const auto& candidate : candidatesVector) {
+        auto mftTrackParIt = mMftTrackPars.find(candidate.mftTrackId);
+        if (mftTrackParIt == mMftTrackPars.end()) {
+          continue;
+        }
+
+        o2::track::TrackParCovFwd mftTrackProp = mftTrackParIt->second;
+        o2::track::TrackParCovFwd mchTrackProp = mchTrackParIt->second;
+
+        if (matchingPlaneZEffective < 0.) {
+          mftTrackProp = propagateToZMft(mftTrackProp, matchingPlaneZ);
+          mchTrackProp = propagateToZMch(mchTrackProp, matchingPlaneZ);
+        }
+
+        auto matchResult = matchingFunc(mchTrackProp, mftTrackProp);
+        float matchChi2 = std::get<0>(matchResult);
+
+        newMatchingCandidates[mchIndex].emplace_back(MatchingCandidate{
+          candidate.muonTrackId,
+          candidate.mftTrackId,
+          -1,
+          matchChi2});
+      }
+    }
+
+    auto compareMatchingChi2 = [](const MatchingCandidate& track1, const MatchingCandidate& track2) -> bool {
+      return (track1.matchChi2 < track2.matchChi2);
+    };
+
+    for (auto& [mchIndex, globalTracksVector] : newMatchingCandidates) { // o2-linter: disable=const-ref-in-for-loop (object is modified in loop)
+      std::sort(globalTracksVector.begin(), globalTracksVector.end(), compareMatchingChi2);
+
+      int ranking = 1;
+      for (auto& candidate : globalTracksVector) { // o2-linter: disable=const-ref-in-for-loop (object is modified in loop)
+        candidate.matchRanking = ranking;
+        ranking += 1;
+      }
+    }
+  }
+
+  template <class C, class TMUON, class TMFT>
+  void runMlMatching(C const& collisions,
+                     TMUON const& muonTracks,
+                     TMFT const& mftTracks,
+                     o2::analysis::MlResponseMFTMuonMatch<float>& mlResponse,
+                     float matchingPlaneZ,
+                     const MatchingCandidates& matchingCandidates,
+                     MatchingCandidates& newMatchingCandidates)
+  {
+    newMatchingCandidates.clear();
+    for (const auto& [mchIndex, candidatesVector] : matchingCandidates) {
+      auto const& mchTrack = muonTracks.rawIteratorAt(mchIndex);
+      if (!mchTrack.has_collision()) {
+        continue;
+      }
+
+      auto collision = collisions.rawIteratorAt(mchTrack.collisionId());
+
+      // get the tracks parameters, which have been updated by the realignment if enabled
+      auto mchTrackParIt = mMchTrackPars.find(mchIndex);
+      if (mchTrackParIt == mMchTrackPars.end()) {
+        continue;
+      }
+
+      for (const auto& candidate : candidatesVector) {
+        auto const& muonTrack = (candidate.muonTrackId >= 0) ? muonTracks.rawIteratorAt(candidate.muonTrackId) : mchTrack;
+        auto const& mftTrack = mftTracks.rawIteratorAt(candidate.mftTrackId);
+        auto mftTrackParIt = mMftTrackPars.find(candidate.mftTrackId);
+        if (mftTrackParIt == mMftTrackPars.end()) {
+          continue;
+        }
+
+        o2::track::TrackParCovFwd mftTrackProp = mftTrackParIt->second;
+        o2::track::TrackParCovFwd mchTrackProp = mchTrackParIt->second;
+
+        if (matchingPlaneZ < 0.) {
+          mftTrackProp = propagateToZMft(mftTrackProp, matchingPlaneZ);
+          mchTrackProp = propagateToZMch(mchTrackProp, matchingPlaneZ);
+        }
+
+        std::vector<float> output;
+        std::vector<float> inputML = mlResponse.getInputFeatures(muonTrack, mftTrack, mchTrack, mftTrackProp, mchTrackProp, collision);
+        mlResponse.isSelectedMl(inputML, 0, output);
+        float matchScore = output[0];
+
+        newMatchingCandidates[mchIndex].emplace_back(MatchingCandidate{
+          candidate.muonTrackId,
+          candidate.mftTrackId,
+          matchScore,
+          -1});
+      }
+    }
+
+    auto compareMatchingScore = [](const MatchingCandidate& track1, const MatchingCandidate& track2) -> bool {
+      return (track1.matchScore > track2.matchScore);
+    };
+
+    for (auto& [mchIndex, globalTracksVector] : newMatchingCandidates) { // o2-linter: disable=const-ref-in-for-loop (object is modified in loop)
+      std::sort(globalTracksVector.begin(), globalTracksVector.end(), compareMatchingScore);
+
+      int ranking = 1;
+      for (auto& candidate : globalTracksVector) { // o2-linter: disable=const-ref-in-for-loop (object is modified in loop)
+        candidate.matchRanking = ranking;
+        ranking += 1;
+      }
+    }
+  }
+
+  template <class C, class TMUON, class TMFT, class CMFT>
+  void processMatchingCandidates(C const& collisions,
+                                 TMUON const& muonTracks,
+                                 TMFT const& mftTracks,
+                                 CMFT const& mftCovs,
+                                 aod::FwdTrkCls const& clusters)
+  {
+    if (configMchRealign.cfgEnableMCHRealign.value) {
+      runMuonRealignment(muonTracks, clusters);
+    }
+
+    if (configMftAlignmentCorrections.cfgEnableMftAlignmentCorrections) {
+      runMftRealignment(mftTracks, mftCovs);
+    }
+
+    std::vector<int64_t> taggedMuons;
+    getTaggedMuons(collisions, muonTracks, taggedMuons);
+
+    if (configMatching.cfgCustomMatchingStrategy.value == 0) {
+      if (hasActiveChi2Matching) {
+        MatchingCandidates newMatchingCandidates;
+        runChi2Matching(activeChi2FunctionName, activeChi2MatchingPlaneZ, mMatchingCandidates, newMatchingCandidates);
+        fillMatchingCandidates(newMatchingCandidates, taggedMuons);
+      }
+    } else {
+      if (hasActiveMlMatching) {
+        MatchingCandidates newMatchingCandidates;
+        runMlMatching(collisions, muonTracks, mftTracks, activeMlResponse, activeMlMatchingPlaneZ, mMatchingCandidates, newMatchingCandidates);
+        fillMatchingCandidates(newMatchingCandidates, taggedMuons);
+      }
+    }
+  }
+
+  void fillMatchingCandidates(const MatchingCandidates& matchingCandidates,
+                              const std::vector<int64_t>& taggedMuons)
+  {
+    for (const auto& [mchIndex, candidates] : matchingCandidates) {
+      if (candidates.empty()) {
+        continue;
+      }
+
+      bool isTagged = std::find(taggedMuons.begin(), taggedMuons.end(), mchIndex) != taggedMuons.end();
+
+      std::vector<MatchingCandidate> storedCandidates;
+      int nStored = 0;
+      for (const auto& candidate : candidates) {
+        if (configMatching.cfgMaxCandidatesPerMchTrack.value >= 0 && nStored >= configMatching.cfgMaxCandidatesPerMchTrack.value) {
+          break;
+        }
+
+        int32_t candidateIndex = mMatchCandidateCounter;
+        globalMuonMatchCandidates(
+          mchIndex,
+          candidate.mftTrackId,
+          static_cast<float>(candidate.matchChi2),
+          static_cast<float>(candidate.matchScore),
+          static_cast<int32_t>(candidate.matchRanking),
+          isTagged);
+        mMatchCandidateCounter += 1;
+
+        mMchTrackToCandidateIndices[mchIndex].push_back(candidateIndex);
+        storedCandidates.push_back(candidate);
+        nStored += 1;
+      }
+
+      if (!storedCandidates.empty()) {
+        mMchTrackMatchingCandidates[mchIndex] = std::move(storedCandidates);
+      }
+    }
+  }
+
+  int32_t countStoredCandidatesForMchTrack(int64_t mchTrackIndex) const
+  {
+    const auto candidateIterator = mMchTrackMatchingCandidates.find(mchTrackIndex);
+    if (candidateIterator == mMchTrackMatchingCandidates.end()) {
+      return 0;
+    }
+    return static_cast<int32_t>(candidateIterator->second.size());
+  }
+
+  template <class TMUON, class TMFT>
+  void fillGmmCandidateFwdTracks(TMUON const& muonTracks,
+                                 TMFT const& mftTracks,
+                                 aod::AmbiguousFwdTracks const& ambFwdTracks)
+  {
+    mFwdTrackToGmmCandTrkIndex.clear();
+    mGmmCandFwdTrackRowIndex = 0;
+    mHasLastMchAmbiguousBcSlice = false;
+    mAmbBcSliceByFwdTrackId.clear();
+    for (const auto& ambFwdTrack : ambFwdTracks) {
+      const auto bcIds = ambFwdTrack.bcIds();
+      mAmbBcSliceByFwdTrackId[ambFwdTrack.fwdtrackId()] = {bcIds[0], bcIds[1]};
+    }
+
+    // First pass: assign GMMCANDTRK row indices for MCH/MCH-MID base entries so that
+    // MCHTrackId can be remapped consistently even when global muons appear first in FwdTracks.
+    int32_t nextGmmCandTrkIndex = 0;
+    for (const auto& track : muonTracks) {
+      const int trackType = static_cast<int>(track.trackType());
+      if (trackType > GlobalTrackTypeMax) {
+        mFwdTrackToGmmCandTrkIndex[track.globalIndex()] = nextGmmCandTrkIndex;
+        nextGmmCandTrkIndex += 1 + countStoredCandidatesForMchTrack(track.globalIndex());
+      } else if (configMatching.cfgIncludeGlobalMuonsInFwdTracks.value && trackType <= GlobalTrackTypeMax) {
+        nextGmmCandTrkIndex += 1;
+      }
+    }
+
+    // Second pass: fill GMMCANDTRK/GMMCANDTRKCOV in FwdTracks order.
+    for (const auto& track : muonTracks) {
+      const int trackType = static_cast<int>(track.trackType());
+
+      if (trackType > GlobalTrackTypeMax) {
+        mHasLastMchAmbiguousBcSlice = false;
+        const int64_t mchTrackIndex = track.globalIndex();
+        const int32_t gmmMchTrackId = mFwdTrackToGmmCandTrkIndex.at(mchTrackIndex);
+
+        const auto candidateIterator = mMchTrackMatchingCandidates.find(mchTrackIndex);
+        auto mchTrackParIt = mMchTrackPars.find(mchTrackIndex);
+        if (mchTrackParIt == mMchTrackPars.end()) {
+          // fill muon tracks table with original parameters
+          const TrackParExt trackPar{fwdtrackutils::getTrackParCovFwd(track, track)};
+          fillBaseGmmCandFwdTrack(track, trackPar, gmmMchTrackId, -1.f, -1.f);
+        } else {
+          // fill muon tracks table with realignment parameters
+          fillBaseGmmCandFwdTrack(track, mchTrackParIt->second, gmmMchTrackId, -1.f, -1.f);
+        }
+
+        if (candidateIterator != mMchTrackMatchingCandidates.end()) {
+          for (const auto& candidate : candidateIterator->second) {
+            auto mftTrackParIt = mMftTrackPars.find(candidate.mftTrackId);
+            if (mftTrackParIt != mMftTrackPars.end()) {
+              const auto& mftTrack = mftTracks.rawIteratorAt(candidate.mftTrackId);
+              fillCandidateFwdTrack(track, mchTrackParIt->second, gmmMchTrackId, mftTrack, mftTrackParIt->second, candidate);
+            }
+          }
+        }
+      }
+
+      if (configMatching.cfgIncludeGlobalMuonsInFwdTracks.value && trackType <= GlobalTrackTypeMax) {
+        int32_t gmmMchTrackId = -1;
+        const auto mchIterator = mFwdTrackToGmmCandTrkIndex.find(track.matchMCHTrackId());
+        if (mchIterator != mFwdTrackToGmmCandTrkIndex.end()) {
+          gmmMchTrackId = mchIterator->second;
+        }
+        TrackParExt parExt(fwdtrackutils::getTrackParCovFwd(track, track));
+        fillBaseGmmCandFwdTrack(track,
+                                parExt,
+                                gmmMchTrackId,
+                                track.chi2MatchMCHMFT(),
+                                track.matchScoreMCHMFT());
+      }
+    }
+  }
+
+  template <class TMUON>
+  void fillFwdTrkMatchCands(TMUON const& muonTracks)
+  {
+    std::vector<int32_t> empty{};
+    for (const auto& muonTrack : muonTracks) {
+      if (static_cast<int>(muonTrack.trackType()) <= GlobalTrackTypeMax) {
+        fwdTrkMatchCands(empty);
+        continue;
+      }
+
+      const int64_t mchTrackIndex = muonTrack.globalIndex();
+      const auto matchIterator = mMchTrackToCandidateIndices.find(mchTrackIndex);
+      if (matchIterator == mMchTrackToCandidateIndices.end() || matchIterator->second.empty()) {
+        fwdTrkMatchCands(empty);
+      } else {
+        fwdTrkMatchCands(matchIterator->second);
+      }
+    }
+  }
+
+  void processData(MyEvents const& collisions,
+                   aod::BCsWithTimestamps const& bcs,
+                   MyMuons const& muonTracks,
+                   MyMFTs const& mftTracks,
+                   MyMFTCovariances const& mftCovs,
+                   aod::FwdTrkCls const& clusters,
+                   aod::AmbiguousFwdTracks const& ambFwdTracks)
+  {
+    auto bc = bcs.begin();
+    initCcdb(bc);
+
+    LOGF(info, "Filling MFT cov");
+    mftTrackCovs.clear();
+    for (const auto& mftTrackCov : mftCovs) {
+      mftTrackCovs[mftTrackCov.matchMFTTrackId()] = mftTrackCov.globalIndex();
+    }
+
+    mMatchCandidateCounter = 0;
+    mMchTrackToCandidateIndices.clear();
+    mMchTrackMatchingCandidates.clear();
+    mFwdTrackToGmmCandTrkIndex.clear();
+
+    LOGF(info, "Preparing candidates");
+    prepareMatchingCandidates(collisions, bcs, muonTracks, mftTracks, mftCovs);
+
+    LOGF(info, "Processing candidates");
+    processMatchingCandidates(collisions, muonTracks, mftTracks, mftCovs, clusters);
+
+    LOGF(info, "Filling tables");
+    // fill table with track/candidates index mapping
+    fillFwdTrkMatchCands(muonTracks);
+    // fill track tables
+    fillGmmCandidateFwdTracks(muonTracks, mftTracks, ambFwdTracks);
+  }
+
+  PROCESS_SWITCH(GlobalMuonMatching, processData, "processData", true);
+};
+
+// Extends the fwdtracksrealign table with expression columns
+struct GlobalMuonMatchingSpawner {
+  Spawns<aod::FwdTrksCovReAlign> realignFwdTrksCov;
+  Spawns<aod::FwdTracksReAlign> realignFwdTrks;
+  void init(InitContext const&) {}
+};
+
+WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
+{
+  return WorkflowSpec{
+    adaptAnalysisTask<GlobalMuonMatching>(cfgc),
+    adaptAnalysisTask<GlobalMuonMatchingSpawner>(cfgc)};
+};


### PR DESCRIPTION
Add task to perform the following steps:
* refit the MCH tracks with a custom alignment (optional)
* apply alignment corrections to the MFT tracks (optional, no track refitting applied)
* run a user-selected matching algorithm, based on chi2 or ML models
* output the refitted and rematched tracks as `FwdTracksReAlign`and `FwdTrksCovReAlign` tables