### PR TITLE
[PWGDQ] adds single muon pTcut 1p5 1p7 and 2 GeV/c with MCH-MID matching

### DIFF
--- a/PWGDQ/Core/CutsLibrary.cxx
+++ b/PWGDQ/Core/CutsLibrary.cxx
@@ -3042,7 +3042,25 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     cut->AddCut(GetAnalysisCut("MCHMID"));
     return cut;
   }
-
+ 
+  if (!nameStr.compare("muonLowPt1p5_MchMidmatching")) {
+    cut->AddCut(GetAnalysisCut("muonLowPt1p5"));
+    cut->AddCut(GetAnalysisCut("matchedMchMid"));
+    return cut;
+  }
+  
+  if (!nameStr.compare("muonLowPt1p7_MchMidmatching")) {
+    cut->AddCut(GetAnalysisCut("muonLowPt1p7"));
+    cut->AddCut(GetAnalysisCut("matchedMchMid"));
+    return cut;
+  }
+ 
+  if (!nameStr.compare("muonLowPt6_MchMidmatching")) {
+    cut->AddCut(GetAnalysisCut("muonLowPt6"));
+    cut->AddCut(GetAnalysisCut("matchedMchMid"));
+    return cut;
+  }
+  
   if (!nameStr.compare("muonLowPt10SigmaPDCA")) {
     cut->AddCut(GetAnalysisCut("muonLowPt"));
     cut->AddCut(GetAnalysisCut("muonQualityCuts10SigmaPDCA"));
@@ -3103,6 +3121,18 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
 
   if (!nameStr.compare("muonLowPt6")) {
     cut->AddCut(GetAnalysisCut("muonLowPt6"));
+    cut->AddCut(GetAnalysisCut("muonQualityCuts"));
+    return cut;
+  }
+ 
+  if (!nameStr.compare("muonLowPt1p5")) {
+    cut->AddCut(GetAnalysisCut("muonLowPt1p5"));
+    cut->AddCut(GetAnalysisCut("muonQualityCuts"));
+    return cut;
+  }
+ 
+  if (!nameStr.compare("muonLowPt1p7")) {
+    cut->AddCut(GetAnalysisCut("muonLowPt1p7"));
     cut->AddCut(GetAnalysisCut("muonQualityCuts"));
     return cut;
   }
@@ -6544,7 +6574,17 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     cut->AddCut(VarManager::kPt, 2.0, 1000.0);
     return cut;
   }
+ 
+  if (!nameStr.compare("muonLowPt1p5")) {
+    cut->AddCut(VarManager::kPt, 1.5, 1000.0);
+    return cut;
+  }
 
+  if (!nameStr.compare("muonLowPt1p7")) {
+    cut->AddCut(VarManager::kPt, 1.7, 1000.0);
+    return cut;
+  }
+    
   if (!nameStr.compare("muonHighPt")) {
     cut->AddCut(VarManager::kPt, 3.0, 1000.0);
     return cut;
@@ -6574,7 +6614,7 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     cut->AddCut(VarManager::kPt, 20.0, 1000.0);
     return cut;
   }
-
+  
   if (!nameStr.compare("muonTightQualityCutsForTests")) {
     cut->AddCut(VarManager::kEta, -4.0, -2.5);
     cut->AddCut(VarManager::kMuonRAtAbsorberEnd, 20.0, 60.0);

--- a/PWGDQ/Core/CutsLibrary.cxx
+++ b/PWGDQ/Core/CutsLibrary.cxx
@@ -3042,25 +3042,25 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     cut->AddCut(GetAnalysisCut("MCHMID"));
     return cut;
   }
- 
+
   if (!nameStr.compare("muonLowPt1p5_MchMidmatching")) {
     cut->AddCut(GetAnalysisCut("muonLowPt1p5"));
     cut->AddCut(GetAnalysisCut("matchedMchMid"));
     return cut;
   }
-  
+
   if (!nameStr.compare("muonLowPt1p7_MchMidmatching")) {
     cut->AddCut(GetAnalysisCut("muonLowPt1p7"));
     cut->AddCut(GetAnalysisCut("matchedMchMid"));
     return cut;
   }
- 
+
   if (!nameStr.compare("muonLowPt6_MchMidmatching")) {
     cut->AddCut(GetAnalysisCut("muonLowPt6"));
     cut->AddCut(GetAnalysisCut("matchedMchMid"));
     return cut;
   }
-  
+
   if (!nameStr.compare("muonLowPt10SigmaPDCA")) {
     cut->AddCut(GetAnalysisCut("muonLowPt"));
     cut->AddCut(GetAnalysisCut("muonQualityCuts10SigmaPDCA"));
@@ -3124,13 +3124,13 @@ AnalysisCompositeCut* o2::aod::dqcuts::GetCompositeCut(const char* cutName)
     cut->AddCut(GetAnalysisCut("muonQualityCuts"));
     return cut;
   }
- 
+
   if (!nameStr.compare("muonLowPt1p5")) {
     cut->AddCut(GetAnalysisCut("muonLowPt1p5"));
     cut->AddCut(GetAnalysisCut("muonQualityCuts"));
     return cut;
   }
- 
+
   if (!nameStr.compare("muonLowPt1p7")) {
     cut->AddCut(GetAnalysisCut("muonLowPt1p7"));
     cut->AddCut(GetAnalysisCut("muonQualityCuts"));
@@ -6574,7 +6574,7 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     cut->AddCut(VarManager::kPt, 2.0, 1000.0);
     return cut;
   }
- 
+
   if (!nameStr.compare("muonLowPt1p5")) {
     cut->AddCut(VarManager::kPt, 1.5, 1000.0);
     return cut;
@@ -6584,7 +6584,7 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     cut->AddCut(VarManager::kPt, 1.7, 1000.0);
     return cut;
   }
-    
+
   if (!nameStr.compare("muonHighPt")) {
     cut->AddCut(VarManager::kPt, 3.0, 1000.0);
     return cut;
@@ -6614,7 +6614,7 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     cut->AddCut(VarManager::kPt, 20.0, 1000.0);
     return cut;
   }
-  
+
   if (!nameStr.compare("muonTightQualityCutsForTests")) {
     cut->AddCut(VarManager::kEta, -4.0, -2.5);
     cut->AddCut(VarManager::kMuonRAtAbsorberEnd, 20.0, 60.0);


### PR DESCRIPTION
This PR adds new predefined single-muon cuts in CutsLibrary.cxx.

Added:

muonLowPt1p5
muonLowPt1p7
muonLowPt1p5_MchMidmatching
muonLowPt1p7_MchMidmatching
muonLowPt6_MchMidmatching

These cuts provide additional pT thresholds combined with MCH-MID matching for PWGDQ analyses and Hyperloop workflows.