### PR TITLE
[Tools] MlResponse: bugfix assure equality of number of checked features to that in the .onnx file

### DIFF
--- a/Tools/ML/MlResponse.h
+++ b/Tools/ML/MlResponse.h
@@ -151,14 +151,8 @@ class MlResponse
   void init(bool enableOptimizations = false, int threads = 0)
   {
     uint8_t counterModel{0};
-    const int numCachedIndices = static_cast<int>(mCachedIndices.size());
     for (const auto& path : mPaths) {
       mModels[counterModel].initModel(path, enableOptimizations, threads);
-      const int numInputNodes = mModels[counterModel].getNumInputNodes();
-      if (numInputNodes != numCachedIndices) {
-        LOG(fatal) << "Number of input nodes in the model " << path << " is different from the number of input features indices (" << numInputNodes << " vs " << numCachedIndices << ")";
-        return;
-      }
       ++counterModel;
     }
   }
@@ -186,6 +180,13 @@ class MlResponse
   {
     if (nModel < 0 || static_cast<std::size_t>(nModel) >= mModels.size()) {
       LOG(fatal) << "Model index " << nModel << " is out of range! The number of initialised models is " << mModels.size() << ". Please check your configurables.";
+    }
+
+    const int numInputNodes = mModels[nModel].getNumInputNodes();
+    const int numInputFeatures = static_cast<int>(input.size());
+
+    if (numInputNodes != numInputFeatures) {
+      LOG(fatal) << "Number of input nodes in the model " << mPaths[nModel] << " is different from the number of input features to be tested (" << numInputNodes << " vs " << numInputFeatures << ")";
     }
 
     TypeOutputScore* outputPtr = mModels[nModel].template evalModel<TypeOutputScore>(input);


### PR DESCRIPTION
The check introduced by PR https://github.com/AliceO2Group/O2Physics/pull/16424 did not take into account the case when input features are not configured via json file, but are fixed (as in [PWGHF/TableProducer/trackIndexSkimCreator.cxx](https://github.com/AliceO2Group/O2Physics/blob/c6c269385db71de6ff292627a386b637df7e67b8/PWGHF/TableProducer/trackIndexSkimCreator.cxx#L2546-L2547)), and thus `mCachedIndices.size() == 0`.
This PR fixes this error by moving the check from `init()` to `getModelOutput()` and checking `getNumInputNodes()` against the size of the input features vector.
Tagging @fgrosa 