### PR TITLE
[PWGHF] Add possibility to reapply trigger selections in Xic+ candidate creator

### DIFF
--- a/PWGHF/TableProducer/candidateCreatorXicToXiPiPi.cxx
+++ b/PWGHF/TableProducer/candidateCreatorXicToXiPiPi.cxx
@@ -111,12 +111,21 @@ struct HfCandidateCreatorXicToXiPiPi {
   Configurable<bool> constrainXicPlusToPv{"constrainXicPlusToPv", false, "Constrain XicPlus to PV"};
   Configurable<int> kfConstructMethod{"kfConstructMethod", 2, "Construct method of XicPlus: 0 fast mathematics without constraint of fixed daughter particle masses, 2 daughter particle masses stay fixed in construction process"};
   Configurable<bool> rejDiffCollTrack{"rejDiffCollTrack", true, "Reject tracks coming from different collisions (effective only for KFParticle w/o derived data)"};
+  // configurables for software trigger selections
+  struct : ConfigurableGroup {
+    std::string prefix = "softtrig";
+    Configurable<bool> applySoftwareTrigSelections{"applySoftwareTrigSelections", false, "Enable application of software trigger selections"};
+    Configurable<float> minDecayLength{"minDecayLength", 0.015, "Minimum decay length (computed with DCAFitter)"};
+    Configurable<float> minCosPA{"minCosPA", 0.9, "Minimum coine of pointing angle (computed with DCAFitter)"};
+    Configurable<float> maxChi2Pca{"maxChi2Pca", 3., "Maximum chi2 PCA (computed with DCAFitter)"};
+  } softTrigCuts;
 
   Service<o2::ccdb::BasicCCDBManager> ccdb{};
   o2::base::MatLayerCylSet* lut{};
   o2::base::Propagator::MatCorrType matCorr = o2::base::Propagator::MatCorrType::USEMatCorrLUT;
 
   o2::vertexing::DCAFitterN<3> df;
+  o2::vertexing::DCAFitterN<2> df2Prong;
 
   HfEventSelection hfEvSel;
 
@@ -196,6 +205,66 @@ struct HfCandidateCreatorXicToXiPiPi {
     df.setMinRelChi2Change(minRelChi2Change);
     df.setUseAbsDCA(useAbsDCA);
     df.setWeightedFinalPCA(useWeightedFinalPCA);
+
+    if (softTrigCuts.applySoftwareTrigSelections) {
+      float maxRadSoftTrig = 200.;
+      float maxDZIniSoftTrig = 1.e9;
+      float maxDXYIniSoftTrig = 4.;
+      float minParamChangeSoftTrig = 1.e-3;
+      float maxChi2SoftTrig = 0.9;
+      float minRelChi2ChangeSoftTrig = 0.9;
+      df2Prong.setPropagateToPCA(true);
+      df2Prong.setMaxR(maxRadSoftTrig);
+      df2Prong.setMaxDZIni(maxDZIniSoftTrig);
+      df2Prong.setMaxDXYIni(maxDXYIniSoftTrig);
+      df2Prong.setMinParamChange(minParamChangeSoftTrig);
+      df2Prong.setMinRelChi2Change(minRelChi2ChangeSoftTrig);
+      df2Prong.setMaxChi2(maxChi2SoftTrig);
+      df2Prong.setUseAbsDCA(false);
+      df2Prong.setWeightedFinalPCA(false);
+    }
+  }
+
+  /// Method that reapplies the selections applied in the software trigger
+  /// \param pVecCascade is the cascade momentum vector
+  /// \param trackParBachelor is the array with two bachelor track parametrisations
+  /// \param collision is the collision containing the candidate
+  template <typename TTrackParCov, typename Coll>
+  bool isSelectedXicSoftwareTriggers(std::array<float, 3> const& pVecCascade, std::array<TTrackParCov, 2> const& trackParBachelor, Coll const& collision)
+  {
+    int nCand{0};
+    try {
+      nCand = df2Prong.process(trackParBachelor[0], trackParBachelor[1]);
+    } catch (...) {
+      LOG(error) << "Exception caught in DCA fitter process call for bachelor + bachelor in software trigger selection function!";
+      return false;
+    }
+    if (nCand == 0) {
+      return false;
+    }
+
+    const auto& vtx = df2Prong.getPCACandidate();
+    if (df2Prong.getChi2AtPCACandidate() > softTrigCuts.maxChi2Pca) {
+      return false;
+    }
+
+    std::array<float, 3> pVecBachFirst{}, pVecBachSecond{};
+    const auto& trackBachFirstProp = df2Prong.getTrack(0);
+    const auto& trackBachSecondProp = df2Prong.getTrack(1);
+    trackBachFirstProp.getPxPyPzGlo(pVecBachFirst);
+    trackBachSecondProp.getPxPyPzGlo(pVecBachSecond);
+    auto momXiBachBach = RecoDecay::pVec(pVecCascade, pVecBachFirst, pVecBachSecond);
+
+    std::array<float, 3> primVtx = {collision.posX(), collision.posY(), collision.posZ()};
+    if (RecoDecay::cpa(primVtx, std::array{vtx[0], vtx[1], vtx[2]}, momXiBachBach) < softTrigCuts.minCosPA) {
+      return false;
+    }
+
+    if (RecoDecay::distance(primVtx, vtx) < softTrigCuts.minDecayLength) {
+      return false;
+    }
+
+    return true;
   }
 
   template <o2::hf_centrality::CentralityEstimator CentEstimator, typename Collision>
@@ -281,6 +350,13 @@ struct HfCandidateCreatorXicToXiPiPi {
       //----------------------------fit SV and create XicPlus track------------------
       auto trackParCovCharmBachelor0 = getTrackParCov(trackCharmBachelor0);
       auto trackParCovCharmBachelor1 = getTrackParCov(trackCharmBachelor1);
+
+      // if enabled, apply selections of software trigger
+      if (softTrigCuts.applySoftwareTrigSelections) {
+        if (!isSelectedXicSoftwareTriggers(pVecCasc, std::array{trackParCovCharmBachelor0, trackParCovCharmBachelor1}, collision)) {
+          continue;
+        }
+      }
 
       // reconstruct the 3-prong secondary vertex
       try {
@@ -459,8 +535,19 @@ struct HfCandidateCreatorXicToXiPiPi {
         continue;
       }
       auto casc = cascAodElement.kfCascData_as<KFCascFull>();
+
       auto trackCharmBachelor0 = rowTrackIndexXicPlus.prong0_as<TracksWCovExtraPidPrPi>();
       auto trackCharmBachelor1 = rowTrackIndexXicPlus.prong1_as<TracksWCovExtraPidPrPi>();
+
+      // if enabled, apply selections of software trigger
+      if (softTrigCuts.applySoftwareTrigSelections) {
+        auto trackParCovCharmBachelor0 = getTrackParCov(trackCharmBachelor0);
+        auto trackParCovCharmBachelor1 = getTrackParCov(trackCharmBachelor1);
+        std::array<float, 3> const pVecCasc = {casc.px(), casc.py(), casc.pz()};
+        if (!isSelectedXicSoftwareTriggers(pVecCasc, std::array{trackParCovCharmBachelor0, trackParCovCharmBachelor1}, collision)) {
+          continue;
+        }
+      }
 
       //-------------------preselect cascade candidates--------------------------------------
       if (doCascadePreselection) {


### PR DESCRIPTION
This PR implements the possibility to reapply the selections applied in the software triggers, since the topological variables in the software trigger are computed using the DCAFitter and only the two pion tracks. This is in particular important for the MC, since software triggers are not simulated.
@fchinu for info