### PR TITLE
[DPG] tpcSkimsTableCreator: bugfix reserve tables size

### DIFF
--- a/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
+++ b/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
@@ -422,6 +422,9 @@ struct TreeWriterTpcV0 {
                                               aod::pidits::ITSNSigmaEl, aod::pidits::ITSNSigmaPi,
                                               aod::pidits::ITSNSigmaKa, aod::pidits::ITSNSigmaPr>(myTracks);
 
+    int nV0Entries{0};
+    int nCascEntries{0};
+
     for (const auto& collision : collisions) {
       if (!isEventSelected(collision, applyEvSel)) {
         continue;
@@ -481,7 +484,9 @@ struct TreeWriterTpcV0 {
             evaluateOccupancyVariables(dauTrack, occValues);
           }
           fillSkimmedV0Table<IsCorrectedDeDx, ModeId>(mother, dauTrack, trackQAInstance, existTrkQA, collision, daughter.tpcNSigma, daughter.tofNSigma, daughter.itsNSigma, daughter.tpcExpSignal, daughter.id, runnumber, daughter.dwnSmplFactor, hadronicRate, bcGlobalIndex, bcTimeFrameId, bcBcInTimeFrame, occValues, isGoodRctEvent);
+          return true;
         }
+        return false;
       };
 
       /// Loop over v0 candidates
@@ -493,8 +498,12 @@ struct TreeWriterTpcV0 {
         const auto posTrack = v0.posTrack_as<TrksType>();
         const auto negTrack = v0.negTrack_as<TrksType>();
 
-        fillDaughterTrack(v0, posTrack, v0, true);
-        fillDaughterTrack(v0, negTrack, v0, false);
+        if (fillDaughterTrack(v0, posTrack, v0, true)) {
+          ++nV0Entries;
+        }
+        if (fillDaughterTrack(v0, negTrack, v0, false)) {
+          ++nV0Entries;
+        }
       }
 
       /// Loop over cascade candidates
@@ -506,9 +515,18 @@ struct TreeWriterTpcV0 {
         const auto bachTrack = casc.bachelor_as<TrksType>();
         // Omega and antiomega
         const auto isDaughterPositive = cascId == MotherAntiOmega ? true : false;
-        fillDaughterTrack(casc, bachTrack, casc, isDaughterPositive);
+        if (fillDaughterTrack(casc, bachTrack, casc, isDaughterPositive)) {
+          ++nCascEntries;
+        }
       }
     }
+    LOG(info) << "runV0() summary:";
+    LOG(info) << "V0 table size = " << myV0s.size();
+    LOG(info) << "Cascade table size = " << myCascs.size();
+    LOG(info) << "nV0Entries = " << nV0Entries;
+    LOG(info) << "nCascEntries = " << nCascEntries;
+    LOG(info) << "nV0Entries / V0 table size = " << static_cast<double>(nV0Entries) / myV0s.size();
+    LOG(info) << "nCascEntries / Cascade table size = " << static_cast<double>(nCascEntries) / myCascs.size();
   } /// runV0
 
   void processStandard(Colls const& collisions,
@@ -875,6 +893,10 @@ struct TreeWriterTpcTof {
         }
       } /// Loop tracks
     }
+    LOG(info) << "runTof() summary:";
+    LOG(info) << "Track table size = " << myTracks.size();
+    LOG(info) << "nTrackEntries = " << rowTPCTOFTree.lastIndex() + 1;
+    LOG(info) << "nTrackEntries / Track table size = " << static_cast<double>((rowTPCTOFTree.lastIndex() + 1)) / myTracks.size();
   } /// runTof
 
   void processStandard(Colls const& collisions,

--- a/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
+++ b/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
@@ -103,6 +103,9 @@ struct TreeWriterTpcV0 {
   Configurable<float> maxPt4dwnsmplTsalisProtons{"maxPt4dwnsmplTsalisProtons", 100., "Maximum Pt for applying downsampling factor of protons"};
   Configurable<float> maxPt4dwnsmplTsalisElectrons{"maxPt4dwnsmplTsalisElectrons", 100., "Maximum Pt for applying  downsampling factor of electrons"};
   Configurable<float> maxPt4dwnsmplTsalisKaons{"maxPt4dwnsmplTsalisKaons", 100., "Maximum Pt for applying  downsampling factor of kaons"};
+  // Configurables for output tables reservation size
+  Configurable<float> reserveV0Ratio{"reserveV0Ratio", 0.06, "Ratio of how many tracks from V0s are expected in the output table to the input V0 table size"};
+  Configurable<float> reserveCascRatio{"reserveCascRatio", 0.003, "Ratio of how many tracks from cascades are expected in the output table to the input Cascade table size"};
   // Configurables for run condtion table
   Configurable<std::string> rctLabel{"rctLabel", "CBT_hadronPID", "select 1 [CBT, CBT_hadronPID, CBT_muon_glo] see O2Physics/Common/CCDB/RCTSelectionFlags.h"};
   Configurable<bool> checkZdc{"checkZdc", false, "set ZDC flag for PbPb"};
@@ -425,6 +428,13 @@ struct TreeWriterTpcV0 {
     int nV0Entries{0};
     int nCascEntries{0};
 
+    const int64_t expectedOutputTableSize = static_cast<int64_t>(reserveV0Ratio * myV0s.size() + reserveCascRatio * myCascs.size());
+    if constexpr (ModeId == ModeWithdEdxTrkQA || ModeId == ModeStandard) {
+      rowTPCTree.reserve(expectedOutputTableSize);
+    } else {
+      rowTPCTreeWithTrkQA.reserve(expectedOutputTableSize);
+    }
+
     for (const auto& collision : collisions) {
       if (!isEventSelected(collision, applyEvSel)) {
         continue;
@@ -444,11 +454,9 @@ struct TreeWriterTpcV0 {
       if constexpr (ModeId == ModeWithdEdxTrkQA || ModeId == ModeStandard) {
         bcTimeFrameId = UndefValueInt;
         bcBcInTimeFrame = UndefValueInt;
-        rowTPCTree.reserve(2 * v0s.size() + cascs.size());
       } else if constexpr (ModeId == ModeWithTrkQA) {
         bcTimeFrameId = bc.tfId();
         bcBcInTimeFrame = bc.bcInTF();
-        rowTPCTreeWithTrkQA.reserve(2 * v0s.size() + cascs.size());
       }
 
       auto getTrackQA = [&](const TrksType::iterator& track) {
@@ -650,6 +658,8 @@ struct TreeWriterTpcTof {
   Configurable<float> downsamplingTsalisProtons{"downsamplingTsalisProtons", -1., "Downsampling factor to reduce the number of protons"};
   Configurable<float> downsamplingTsalisKaons{"downsamplingTsalisKaons", -1., "Downsampling factor to reduce the number of kaons"};
   Configurable<float> downsamplingTsalisPions{"downsamplingTsalisPions", -1., "Downsampling factor to reduce the number of pions"};
+  // Configurable for output table reservation size
+  Configurable<float> reserveTrackRatio{"reserveTrackRatio", 0.005, "Ratio of how many tracks are expected in the output table to the input Tracks table size"};
   // Configurables for run condtion table
   Configurable<std::string> rctLabel{"rctLabel", "CBT_hadronPID", "select 1 [CBT, CBT_hadronPID, CBT_muon_glo] see O2Physics/Common/CCDB/RCTSelectionFlags.h"};
   Configurable<bool> checkZdc{"checkZdc", false, "set ZDC flag for PbPb"};
@@ -821,6 +831,14 @@ struct TreeWriterTpcTof {
         labelTrack2TrackQA.at(trackId) = trackQA.globalIndex();
       }
     }
+
+    const int64_t expectedOutputTableSize = static_cast<int64_t>(reserveTrackRatio * myTracks.size());
+    if constexpr (ModeId == ModeWithdEdxTrkQA || ModeId == ModeStandard) {
+      rowTPCTOFTree.reserve(expectedOutputTableSize);
+    } else {
+      rowTPCTOFTreeWithTrkQA.reserve(expectedOutputTableSize);
+    }
+
     for (const auto& collision : collisions) {
       const auto tracks = myTracks.sliceBy(perCollisionTracksType, collision.globalIndex());
       if (!isEventSelected(collision, applyEvSel)) {
@@ -847,11 +865,9 @@ struct TreeWriterTpcTof {
       if constexpr (ModeId == ModeStandard || ModeId == ModeWithdEdxTrkQA) {
         bcTimeFrameId = UndefValueInt;
         bcBcInTimeFrame = UndefValueInt;
-        rowTPCTOFTree.reserve(tracks.size());
       } else {
         bcTimeFrameId = bc.tfId();
         bcBcInTimeFrame = bc.bcInTF();
-        rowTPCTOFTreeWithTrkQA.reserve(tracks.size());
       }
       for (auto const& trk : tracksWithITSPid) {
         if (!isTrackSelected(trk, trackSelection)) {

--- a/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
+++ b/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
@@ -42,6 +42,8 @@
 #include <Framework/AnalysisHelpers.h>
 #include <Framework/AnalysisTask.h>
 #include <Framework/Configurable.h>
+#include <Framework/HistogramRegistry.h>
+#include <Framework/HistogramSpec.h>
 #include <Framework/InitContext.h>
 #include <Framework/runDataProcessing.h>
 #include <ReconstructionDataFormats/PID.h>
@@ -106,11 +108,14 @@ struct TreeWriterTpcV0 {
   // Configurables for output tables reservation size
   Configurable<float> reserveV0Ratio{"reserveV0Ratio", 0.06, "Ratio of how many tracks from V0s are expected in the output table to the input V0 table size"};
   Configurable<float> reserveCascRatio{"reserveCascRatio", 0.003, "Ratio of how many tracks from cascades are expected in the output table to the input Cascade table size"};
+  Configurable<bool> saveReserveQaHisto{"saveReserveQaHisto", true, "Flag to save the DF-wise ratio of output table size to that of input table"};
   // Configurables for run condtion table
   Configurable<std::string> rctLabel{"rctLabel", "CBT_hadronPID", "select 1 [CBT, CBT_hadronPID, CBT_muon_glo] see O2Physics/Common/CCDB/RCTSelectionFlags.h"};
   Configurable<bool> checkZdc{"checkZdc", false, "set ZDC flag for PbPb"};
   Configurable<bool> treatLimitedAcceptanceAsBad{"treatLimitedAcceptanceAsBad", false, "reject all events where the detectors relevant for the specified Runlist are flagged as LimitedAcceptance"};
   Configurable<bool> requireGoodRct{"requireGoodRct", false, "require good detector flag in run condtion table"};
+
+  HistogramRegistry registry{"registry", {}};
 
   // an arbitrary value of N sigma TOF assigned by TOF task to tracks which are not matched to TOF hits
   constexpr static float NSigmaTofUnmatched{o2::aod::v0data::kNoTOFValue};
@@ -185,6 +190,11 @@ struct TreeWriterTpcV0 {
     ccdb->setFatalWhenNull(false);
 
     rctChecker.init(rctLabel, checkZdc, treatLimitedAcceptanceAsBad);
+
+    if (saveReserveQaHisto) {
+      registry.add("hV0OutputRatio", "V0 out/in ratio;V0 out/in ratio;Entries", {HistType::kTH1F, {{100, 0, reserveV0Ratio}}});
+      registry.add("hCascOutputRatio", "Casc out/in ratio;Casc out/in ratio;Entries", {HistType::kTH1F, {{100, 0, reserveCascRatio}}});
+    }
   }
 
   template <bool IsCorrectedDeDx, typename V0Casc, typename T>
@@ -535,6 +545,11 @@ struct TreeWriterTpcV0 {
     LOG(info) << "nCascEntries = " << nCascEntries;
     LOG(info) << "nV0Entries / V0 table size = " << static_cast<double>(nV0Entries) / myV0s.size();
     LOG(info) << "nCascEntries / Cascade table size = " << static_cast<double>(nCascEntries) / myCascs.size();
+
+    if (saveReserveQaHisto) {
+      registry.fill(HIST("hV0OutputRatio"), static_cast<double>(nV0Entries) / myV0s.size());
+      registry.fill(HIST("hCascOutputRatio"), static_cast<double>(nCascEntries) / myCascs.size());
+    }
   } /// runV0
 
   void processStandard(Colls const& collisions,
@@ -660,11 +675,14 @@ struct TreeWriterTpcTof {
   Configurable<float> downsamplingTsalisPions{"downsamplingTsalisPions", -1., "Downsampling factor to reduce the number of pions"};
   // Configurable for output table reservation size
   Configurable<float> reserveTrackRatio{"reserveTrackRatio", 0.005, "Ratio of how many tracks are expected in the output table to the input Tracks table size"};
+  Configurable<bool> saveReserveQaHisto{"saveReserveQaHisto", true, "Flag to save the DF-wise ratio of output table size to that of input table"};
   // Configurables for run condtion table
   Configurable<std::string> rctLabel{"rctLabel", "CBT_hadronPID", "select 1 [CBT, CBT_hadronPID, CBT_muon_glo] see O2Physics/Common/CCDB/RCTSelectionFlags.h"};
   Configurable<bool> checkZdc{"checkZdc", false, "set ZDC flag for PbPb"};
   Configurable<bool> treatLimitedAcceptanceAsBad{"treatLimitedAcceptanceAsBad", false, "reject all events where the detectors relevant for the specified Runlist are flagged as LimitedAcceptance"};
   Configurable<bool> requireGoodRct{"requireGoodRct", false, "require good detector flag in run condtion table"};
+
+  HistogramRegistry registry{"registry", {}};
 
   struct TofTrack {
     bool isApplyHardCutOnly;
@@ -720,6 +738,10 @@ struct TreeWriterTpcTof {
     ccdb->setFatalWhenNull(false);
 
     rctChecker.init(rctLabel, checkZdc, treatLimitedAcceptanceAsBad);
+
+    if (saveReserveQaHisto) {
+      registry.add("hTrackOutputRatio", "Track out/in ratio;Track out/in ratio;Entries", {HistType::kTH1F, {{100, 0, reserveTrackRatio}}});
+    }
   }
 
   template <bool DoCorrectDeDx, int ModeId, typename T, typename C>
@@ -913,6 +935,10 @@ struct TreeWriterTpcTof {
     LOG(info) << "Track table size = " << myTracks.size();
     LOG(info) << "nTrackEntries = " << rowTPCTOFTree.lastIndex() + 1;
     LOG(info) << "nTrackEntries / Track table size = " << static_cast<double>((rowTPCTOFTree.lastIndex() + 1)) / myTracks.size();
+
+    if (saveReserveQaHisto) {
+      registry.fill(HIST("hTrackOutputRatio"), static_cast<double>((rowTPCTOFTree.lastIndex() + 1)) / myTracks.size());
+    }
   } /// runTof
 
   void processStandard(Colls const& collisions,

--- a/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
+++ b/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
@@ -106,8 +106,8 @@ struct TreeWriterTpcV0 {
   Configurable<float> maxPt4dwnsmplTsalisElectrons{"maxPt4dwnsmplTsalisElectrons", 100., "Maximum Pt for applying  downsampling factor of electrons"};
   Configurable<float> maxPt4dwnsmplTsalisKaons{"maxPt4dwnsmplTsalisKaons", 100., "Maximum Pt for applying  downsampling factor of kaons"};
   // Configurables for output tables reservation size
-  Configurable<float> reserveV0Ratio{"reserveV0Ratio", 0.06, "Ratio of how many tracks from V0s are expected in the output table to the input V0 table size"};
-  Configurable<float> reserveCascRatio{"reserveCascRatio", 0.003, "Ratio of how many tracks from cascades are expected in the output table to the input Cascade table size"};
+  Configurable<float> reserveV0Ratio{"reserveV0Ratio", 0.05, "Ratio of how many tracks from V0s are expected in the output table to the input V0 table size"};
+  Configurable<float> reserveCascRatio{"reserveCascRatio", 0.0025, "Ratio of how many tracks from cascades are expected in the output table to the input Cascade table size"};
   Configurable<bool> saveReserveQaHisto{"saveReserveQaHisto", true, "Flag to save the DF-wise ratio of output table size to that of input table"};
   // Configurables for run condtion table
   Configurable<std::string> rctLabel{"rctLabel", "CBT_hadronPID", "select 1 [CBT, CBT_hadronPID, CBT_muon_glo] see O2Physics/Common/CCDB/RCTSelectionFlags.h"};
@@ -674,7 +674,7 @@ struct TreeWriterTpcTof {
   Configurable<float> downsamplingTsalisKaons{"downsamplingTsalisKaons", -1., "Downsampling factor to reduce the number of kaons"};
   Configurable<float> downsamplingTsalisPions{"downsamplingTsalisPions", -1., "Downsampling factor to reduce the number of pions"};
   // Configurable for output table reservation size
-  Configurable<float> reserveTrackRatio{"reserveTrackRatio", 0.005, "Ratio of how many tracks are expected in the output table to the input Tracks table size"};
+  Configurable<float> reserveTrackRatio{"reserveTrackRatio", 0.003, "Ratio of how many tracks are expected in the output table to the input Tracks table size"};
   Configurable<bool> saveReserveQaHisto{"saveReserveQaHisto", true, "Flag to save the DF-wise ratio of output table size to that of input table"};
   // Configurables for run condtion table
   Configurable<std::string> rctLabel{"rctLabel", "CBT_hadronPID", "select 1 [CBT, CBT_hadronPID, CBT_muon_glo] see O2Physics/Common/CCDB/RCTSelectionFlags.h"};


### PR DESCRIPTION
* In the `tpcSkimsTableCreator` there are two nested loops: collisions and tracks (V0s, cascades). Currently the reservation of the output table size is done inside the collision loop, while it should be done once per dataframe. It brings to underreservation of the size, which had no fatal effect before (although performance could worsen), but after these PRs, https://github.com/AliceO2Group/AliceO2/pull/15450 and https://github.com/AliceO2Group/AliceO2/pull/15512 it brings to a fatal error. This PR fixes this logical error by bringing table reservation outside the collision loop;
* Currently the size to be reserved was equal to the number of input tracks (or $2N_{\mathrm{V0}} + N_{\mathrm{casc}}$), which is extremely conservative, since only small part of the input is propagated to the output. This PR introduces configurables, which define the ratio of the expected output table size to that of the input table. The default values are chosen to be by factor of ~5 larger than the "usual" ratio with "common" selection configuration;
* Added QA histograms, where the dataframe-wise distribution of the output/input table size ratios are stored, so one can tune the mentioned configurables if they are too conservative (if they are too aggressive the code will crash).

Tagging @amaringarcia 