### PR TITLE
[DPG] tpcSkimsTableCreator: read IR source and sqrtSNN from CCDB; fix nclPID definition

### DIFF
--- a/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
+++ b/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
@@ -107,6 +107,7 @@ struct TreeWriterTpcV0 {
   Configurable<bool> checkZdc{"checkZdc", false, "set ZDC flag for PbPb"};
   Configurable<bool> treatLimitedAcceptanceAsBad{"treatLimitedAcceptanceAsBad", false, "reject all events where the detectors relevant for the specified Runlist are flagged as LimitedAcceptance"};
   Configurable<bool> requireGoodRct{"requireGoodRct", false, "require good detector flag in run condtion table"};
+  // Configurable for the path of CCDB General Run Parameters LHC Interface information
   Configurable<std::string> ccdbPathGrpLhcIf{"ccdbPathGrpLhcIf", "GLO/Config/GRPLHCIF", "Path on the CCDB for the GRPLHCIF object"};
 
   // an arbitrary value of N sigma TOF assigned by TOF task to tracks which are not matched to TOF hits
@@ -422,6 +423,8 @@ struct TreeWriterTpcV0 {
                                               aod::pidits::ITSNSigmaEl, aod::pidits::ITSNSigmaPi,
                                               aod::pidits::ITSNSigmaKa, aod::pidits::ITSNSigmaPr>(myTracks);
 
+    std::string irSource{};
+    bool isFirstCollision{true};
     for (const auto& collision : collisions) {
       if (!isEventSelected(collision, applyEvSel)) {
         continue;
@@ -434,7 +437,10 @@ struct TreeWriterTpcV0 {
       const auto v0s = myV0s.sliceBy(perCollisionV0s, static_cast<int>(collision.globalIndex()));
       const auto cascs = myCascs.sliceBy(perCollisionCascs, static_cast<int>(collision.globalIndex()));
       const auto bc = collision.bc_as<BCType>();
-      const std::string irSource = evaluateIrSource(ccdb, ccdbPathGrpLhcIf, bc.timestamp());
+      if (isFirstCollision) {
+        irSource = evaluateIrSource(ccdb, ccdbPathGrpLhcIf, bc.timestamp());
+      }
+      isFirstCollision = false;
       const int runnumber = bc.runNumber();
       const auto hadronicRate = !irSource.empty() ? mRateFetcher.fetch(ccdb.service, bc.timestamp(), runnumber, irSource) * OneToKilo : 0.;
       const int bcGlobalIndex = bc.globalIndex();
@@ -637,6 +643,7 @@ struct TreeWriterTpcTof {
   Configurable<bool> checkZdc{"checkZdc", false, "set ZDC flag for PbPb"};
   Configurable<bool> treatLimitedAcceptanceAsBad{"treatLimitedAcceptanceAsBad", false, "reject all events where the detectors relevant for the specified Runlist are flagged as LimitedAcceptance"};
   Configurable<bool> requireGoodRct{"requireGoodRct", false, "require good detector flag in run condtion table"};
+  // Configurable for the path of CCDB General Run Parameters LHC Interface information
   Configurable<std::string> ccdbPathGrpLhcIf{"ccdbPathGrpLhcIf", "GLO/Config/GRPLHCIF", "Path on the CCDB for the GRPLHCIF object"};
 
   struct TofTrack {
@@ -804,6 +811,8 @@ struct TreeWriterTpcTof {
         labelTrack2TrackQA.at(trackId) = trackQA.globalIndex();
       }
     }
+    std::string irSource{};
+    bool isFirstCollision{true};
     for (const auto& collision : collisions) {
       const auto tracks = myTracks.sliceBy(perCollisionTracksType, collision.globalIndex());
       if (!isEventSelected(collision, applyEvSel)) {
@@ -823,7 +832,10 @@ struct TreeWriterTpcTof {
       }
 
       const auto bc = collision.bc_as<BCType>();
-      const std::string irSource = evaluateIrSource(ccdb, ccdbPathGrpLhcIf, bc.timestamp());
+      if (isFirstCollision) {
+        irSource = evaluateIrSource(ccdb, ccdbPathGrpLhcIf, bc.timestamp());
+      }
+      isFirstCollision = false;
       const int runnumber = bc.runNumber();
       const auto hadronicRate = !irSource.empty() ? mRateFetcher.fetch(ccdb.service, bc.timestamp(), runnumber, irSource) * OneToKilo : 0.;
       const int bcGlobalIndex = bc.globalIndex();

--- a/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
+++ b/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
@@ -88,7 +88,6 @@ struct TreeWriterTpcV0 {
   Configurable<float> nClNorm{"nClNorm", 152., "Number of cluster normalization. Run 2: 159, Run 3 152"};
   Configurable<int> applyEvSel{"applyEvSel", 2, "Flag to apply rapidity cut: 0 -> no event selection, 1 -> Run 2 event selection, 2 -> Run 3 event selection"};
   Configurable<int> trackSelection{"trackSelection", 0, "Track selection: 0 -> No Cut, 1 -> kGlobalTrack, 2 -> kGlobalTrackWoPtEta, 3 -> kGlobalTrackWoDCA, 4 -> kQualityTracks, 5 -> kInAcceptanceTracks"};
-  Configurable<std::string> irSource{"irSource", "T0VTX", "Estimator of the interaction rate (Recommended: pp --> T0VTX, Pb-Pb --> ZNC hadronic)"};
   /// Configurables downsampling
   Configurable<double> dwnSmplFactorPi{"dwnSmplFactorPi", 1., "downsampling factor for pions, default fraction to keep is 1."};
   Configurable<double> dwnSmplFactorPr{"dwnSmplFactorPr", 1., "downsampling factor for protons, default fraction to keep is 1."};
@@ -108,6 +107,7 @@ struct TreeWriterTpcV0 {
   Configurable<bool> checkZdc{"checkZdc", false, "set ZDC flag for PbPb"};
   Configurable<bool> treatLimitedAcceptanceAsBad{"treatLimitedAcceptanceAsBad", false, "reject all events where the detectors relevant for the specified Runlist are flagged as LimitedAcceptance"};
   Configurable<bool> requireGoodRct{"requireGoodRct", false, "require good detector flag in run condtion table"};
+  Configurable<std::string> ccdbPathGrpLhcIf{"ccdbPathGrpLhcIf", "GLO/Config/GRPLHCIF", "Path on the CCDB for the GRPLHCIF object"};
 
   // an arbitrary value of N sigma TOF assigned by TOF task to tracks which are not matched to TOF hits
   constexpr static float NSigmaTofUnmatched{o2::aod::v0data::kNoTOFValue};
@@ -434,8 +434,9 @@ struct TreeWriterTpcV0 {
       const auto v0s = myV0s.sliceBy(perCollisionV0s, static_cast<int>(collision.globalIndex()));
       const auto cascs = myCascs.sliceBy(perCollisionCascs, static_cast<int>(collision.globalIndex()));
       const auto bc = collision.bc_as<BCType>();
+      const std::string irSource = evaluateIrSource(ccdb, ccdbPathGrpLhcIf, bc.timestamp());
       const int runnumber = bc.runNumber();
-      const auto hadronicRate = mRateFetcher.fetch(ccdb.service, bc.timestamp(), runnumber, irSource) * OneToKilo;
+      const auto hadronicRate = !irSource.empty() ? mRateFetcher.fetch(ccdb.service, bc.timestamp(), runnumber, irSource) * OneToKilo : 0.;
       const int bcGlobalIndex = bc.globalIndex();
       int bcTimeFrameId{}, bcBcInTimeFrame{};
       if constexpr (ModeId == ModeWithdEdxTrkQA || ModeId == ModeStandard) {
@@ -591,7 +592,6 @@ struct TreeWriterTpcTof {
   Configurable<float> nClNorm{"nClNorm", 152., "Number of cluster normalization. Run 2: 159, Run 3 152"};
   Configurable<int> applyEvSel{"applyEvSel", 2, "Flag to apply rapidity cut: 0 -> no event selection, 1 -> Run 2 event selection, 2 -> Run 3 event selection"};
   Configurable<int> trackSelection{"trackSelection", 1, "Track selection: 0 -> No Cut, 1 -> kGlobalTrack, 2 -> kGlobalTrackWoPtEta, 3 -> kGlobalTrackWoDCA, 4 -> kQualityTracks, 5 -> kInAcceptanceTracks"};
-  Configurable<std::string> irSource{"irSource", "T0VTX", "Estimator of the interaction rate (Recommended: pp --> T0VTX, Pb-Pb --> ZNC hadronic)"};
   /// Triton
   Configurable<float> maxMomTPCOnlyTr{"maxMomTPCOnlyTr", 1.5, "Maximum momentum for TPC only cut triton"};
   Configurable<float> maxMomHardCutOnlyTr{"maxMomHardCutOnlyTr", 50, "Maximum TPC inner momentum for triton"};
@@ -637,6 +637,7 @@ struct TreeWriterTpcTof {
   Configurable<bool> checkZdc{"checkZdc", false, "set ZDC flag for PbPb"};
   Configurable<bool> treatLimitedAcceptanceAsBad{"treatLimitedAcceptanceAsBad", false, "reject all events where the detectors relevant for the specified Runlist are flagged as LimitedAcceptance"};
   Configurable<bool> requireGoodRct{"requireGoodRct", false, "require good detector flag in run condtion table"};
+  Configurable<std::string> ccdbPathGrpLhcIf{"ccdbPathGrpLhcIf", "GLO/Config/GRPLHCIF", "Path on the CCDB for the GRPLHCIF object"};
 
   struct TofTrack {
     bool isApplyHardCutOnly;
@@ -822,8 +823,9 @@ struct TreeWriterTpcTof {
       }
 
       const auto bc = collision.bc_as<BCType>();
+      const std::string irSource = evaluateIrSource(ccdb, ccdbPathGrpLhcIf, bc.timestamp());
       const int runnumber = bc.runNumber();
-      const auto hadronicRate = mRateFetcher.fetch(ccdb.service, bc.timestamp(), runnumber, irSource) * OneToKilo;
+      const auto hadronicRate = !irSource.empty() ? mRateFetcher.fetch(ccdb.service, bc.timestamp(), runnumber, irSource) * OneToKilo : 0.;
       const int bcGlobalIndex = bc.globalIndex();
       int bcTimeFrameId{}, bcBcInTimeFrame{};
       if constexpr (ModeId == ModeStandard || ModeId == ModeWithdEdxTrkQA) {

--- a/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
+++ b/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
@@ -264,7 +264,7 @@ struct TreeWriterTpcV0 {
   void fillSkimmedV0Table(V0Casc const& v0casc, T const& track, aod::TracksQA const& trackQA, const bool existTrkQA, C const& collision, const float nSigmaTPC, const float nSigmaTOF, const float nSigmaITS, const float dEdxExp, const o2::track::PID::ID id, const int runnumber, const double dwnSmplFactor, const float hadronicRate, const int bcGlobalIndex, const int bcTimeFrameId, const int bcBcInTimeFrame, const OccupancyValues& occValues, const bool isGoodRctEvent)
   {
     const double ncl = track.tpcNClsFound();
-    const double nclPID = track.tpcNClsFindableMinusPID();
+    const double nclPID = track.tpcNClsPID();
     const double p = track.tpcInnerParam();
     const double mass = o2::track::pid_constants::sMasses[id];
     const double bg = p / mass;
@@ -706,7 +706,7 @@ struct TreeWriterTpcTof {
   void fillSkimmedTpcTofTable(T const& track, aod::TracksQA const& trackQA, const bool existTrkQA, C const& collision, const float nSigmaTPC, const float nSigmaTOF, const float nSigmaITS, const float dEdxExp, const o2::track::PID::ID id, const int runnumber, const double dwnSmplFactor, const double hadronicRate, const int bcGlobalIndex, const int bcTimeFrameId, const int bcBcInTimeFrame, const OccupancyValues& occValues, const bool isGoodRctEvent)
   {
     const double ncl = track.tpcNClsFound();
-    const double nclPID = track.tpcNClsFindableMinusPID();
+    const double nclPID = track.tpcNClsPID();
     const double p = track.tpcInnerParam();
     const double mass = o2::track::pid_constants::sMasses[id];
     const double bg = p / mass;

--- a/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
+++ b/DPG/Tasks/TPC/tpcSkimsTableCreator.cxx
@@ -93,7 +93,6 @@ struct TreeWriterTpcV0 {
   Configurable<double> dwnSmplFactorPr{"dwnSmplFactorPr", 1., "downsampling factor for protons, default fraction to keep is 1."};
   Configurable<double> dwnSmplFactorEl{"dwnSmplFactorEl", 1., "downsampling factor for electrons, default fraction to keep is 1."};
   Configurable<double> dwnSmplFactorKa{"dwnSmplFactorKa", 1., "downsampling factor for kaons, default fraction to keep is 1."};
-  Configurable<float> sqrtSNN{"sqrtSNN", 5360., "sqrt(s_NN), used for downsampling with the Tsallis distribution"};
   Configurable<float> downsamplingTsalisPions{"downsamplingTsalisPions", -1., "Downsampling factor to reduce the number of pions"};
   Configurable<float> downsamplingTsalisProtons{"downsamplingTsalisProtons", -1., "Downsampling factor to reduce the number of protons"};
   Configurable<float> downsamplingTsalisElectrons{"downsamplingTsalisElectrons", -1., "Downsampling factor to reduce the number of electrons"};
@@ -424,6 +423,7 @@ struct TreeWriterTpcV0 {
                                               aod::pidits::ITSNSigmaKa, aod::pidits::ITSNSigmaPr>(myTracks);
 
     std::string irSource{};
+    float sqrtSNN{};
     bool isFirstCollision{true};
     for (const auto& collision : collisions) {
       if (!isEventSelected(collision, applyEvSel)) {
@@ -438,7 +438,7 @@ struct TreeWriterTpcV0 {
       const auto cascs = myCascs.sliceBy(perCollisionCascs, static_cast<int>(collision.globalIndex()));
       const auto bc = collision.bc_as<BCType>();
       if (isFirstCollision) {
-        irSource = evaluateIrSource(ccdb, ccdbPathGrpLhcIf, bc.timestamp());
+        evaluateIrSourceAndSqrtSnn(ccdb, ccdbPathGrpLhcIf, bc.timestamp(), irSource, sqrtSNN);
       }
       isFirstCollision = false;
       const int runnumber = bc.runNumber();
@@ -632,7 +632,6 @@ struct TreeWriterTpcTof {
   Configurable<float> nSigmaTofTpctofPi{"nSigmaTofTpctofPi", 4., "number of sigma for TOF cut for TPC and TOF combined pion"};
   Configurable<double> dwnSmplFactorPi{"dwnSmplFactorPi", 1., "downsampling factor for pions, default fraction to keep is 1."};
   /// pT dependent downsampling
-  Configurable<float> sqrtSNN{"sqrtSNN", 5360., "sqrt(s_NN), used for downsampling with the Tsallis distribution"};
   Configurable<float> downsamplingTsalisTritons{"downsamplingTsalisTritons", -1., "Downsampling factor to reduce the number of tritons"};
   Configurable<float> downsamplingTsalisDeuterons{"downsamplingTsalisDeuterons", -1., "Downsampling factor to reduce the number of deuterons"};
   Configurable<float> downsamplingTsalisProtons{"downsamplingTsalisProtons", -1., "Downsampling factor to reduce the number of protons"};
@@ -812,6 +811,7 @@ struct TreeWriterTpcTof {
       }
     }
     std::string irSource{};
+    float sqrtSNN{};
     bool isFirstCollision{true};
     for (const auto& collision : collisions) {
       const auto tracks = myTracks.sliceBy(perCollisionTracksType, collision.globalIndex());
@@ -833,7 +833,7 @@ struct TreeWriterTpcTof {
 
       const auto bc = collision.bc_as<BCType>();
       if (isFirstCollision) {
-        irSource = evaluateIrSource(ccdb, ccdbPathGrpLhcIf, bc.timestamp());
+        evaluateIrSourceAndSqrtSnn(ccdb, ccdbPathGrpLhcIf, bc.timestamp(), irSource, sqrtSNN);
       }
       isFirstCollision = false;
       const int runnumber = bc.runNumber();

--- a/DPG/Tasks/TPC/utilsTpcSkimsTableCreator.h
+++ b/DPG/Tasks/TPC/utilsTpcSkimsTableCreator.h
@@ -22,13 +22,19 @@
 
 #include "tpcSkimsTableCreator.h"
 
+#include "Common/Core/CollisionTypeHelper.h"
 #include "Common/DataModel/OccupancyTables.h"
 
+#include <CCDB/BasicCCDBManager.h>
+#include <DataFormatsParameters/GRPLHCIFData.h>
 #include <Framework/ASoA.h>
+#include <Framework/AnalysisHelpers.h>
+#include <Framework/Logger.h>
 
 #include <TRandom3.h>
 
 #include <cmath>
+#include <string>
 
 namespace o2::dpg_tpcskimstablecreator
 {
@@ -110,6 +116,26 @@ double tpcSignalGeneric(const TrkType& track)
   } else {
     return track.tpcSignal();
   }
+}
+
+/// Determine inteaction rate source from CCDB
+std::string evaluateIrSource(const o2::framework::Service<o2::ccdb::BasicCCDBManager>& ccdb, const std::string& ccdbPathGrpLhcIf, const uint64_t timestamp)
+{
+  std::string irSource{};
+  o2::parameters::GRPLHCIFData* genRunParams = ccdb->template getForTimeStamp<o2::parameters::GRPLHCIFData>(ccdbPathGrpLhcIf, timestamp);
+  if (genRunParams != nullptr) {
+    o2::common::core::CollisionSystemType::collType collSys = CollisionSystemType::getCollisionTypeFromGrp(genRunParams);
+    if (collSys == CollisionSystemType::kCollSyspp) {
+      irSource = "T0VTX";
+    } else {
+      irSource = "ZNC hadronic";
+    }
+    LOG(info) << "irSource determined from General Run Parameters: " << irSource;
+  } else {
+    LOG(info) << "No General Run Parameters object found. irSource will remain undefined";
+  }
+
+  return irSource;
 }
 
 struct OccupancyValues {

--- a/DPG/Tasks/TPC/utilsTpcSkimsTableCreator.h
+++ b/DPG/Tasks/TPC/utilsTpcSkimsTableCreator.h
@@ -118,24 +118,25 @@ double tpcSignalGeneric(const TrkType& track)
   }
 }
 
-/// Determine inteaction rate source from CCDB
-std::string evaluateIrSource(const o2::framework::Service<o2::ccdb::BasicCCDBManager>& ccdb, const std::string& ccdbPathGrpLhcIf, const uint64_t timestamp)
+/// Determine interaction rate source and sqrtSNN from CCDB
+void evaluateIrSourceAndSqrtSnn(const o2::framework::Service<o2::ccdb::BasicCCDBManager>& ccdb, const std::string& ccdbPathGrpLhcIf, const uint64_t timestamp, std::string& irSource, float& sqrtSNN)
 {
-  std::string irSource{};
   o2::parameters::GRPLHCIFData* genRunParams = ccdb->template getForTimeStamp<o2::parameters::GRPLHCIFData>(ccdbPathGrpLhcIf, timestamp);
   if (genRunParams != nullptr) {
-    o2::common::core::CollisionSystemType::collType collSys = CollisionSystemType::getCollisionTypeFromGrp(genRunParams);
+    const auto collSys = CollisionSystemType::getCollisionTypeFromGrp(genRunParams);
     if (collSys == CollisionSystemType::kCollSyspp) {
       irSource = "T0VTX";
     } else {
       irSource = "ZNC hadronic";
     }
+    sqrtSNN = genRunParams->getSqrtS();
     LOG(info) << "irSource determined from General Run Parameters: " << irSource;
+    LOG(info) << "sqrtSNN determined from General Run Parameters: " << sqrtSNN << " GeV";
   } else {
-    LOG(info) << "No General Run Parameters object found. irSource will remain undefined";
+    irSource = "";
+    sqrtSNN = 5360.f;
+    LOG(warning) << "No General Run Parameters object found. irSource will remain undefined, sqrtSNN defaulted to 5360 GeV";
   }
-
-  return irSource;
 }
 
 struct OccupancyValues {


### PR DESCRIPTION
1. IR source is read from CCDB automatically in runtime (using timestamp of the first BC), so there is no need to provide `irSource` configurable anymore;
2. Fixed `nclPID` definition

Tagging @amaringarcia 

_UPD:_
3. sqrtSNN is read from CCDB automatically.
If the Genreal Run Parameters pointer is not available, the irSource is defaulted to empty string (and hadronic rate will be filled with zeros), and sqrtSNN to 5360 GeV.