### PR TITLE
[PWGCF] Rework interface for MC processing in femto framework

### DIFF
--- a/PWGCF/Femto/Core/cascadeHistManager.h
+++ b/PWGCF/Femto/Core/cascadeHistManager.h
@@ -618,16 +618,16 @@ class CascadeHistManager
     mHistogramRegistry->fill(HIST(cascadePrefix) + HIST(McDir) + HIST(getHistName(kPdg, HistTable)), mcParticle.pdgCode());
 
     // get mother
-    if (cascadeCandidate.has_fMcMother()) {
-      auto mother = cascadeCandidate.template fMcMother_as<T3>();
+    if (mcParticle.has_fMcMother()) {
+      auto mother = mcParticle.template fMcMother_as<T3>();
       mHistogramRegistry->fill(HIST(cascadePrefix) + HIST(McDir) + HIST(getHistName(kPdgMother, HistTable)), mother.pdgCode());
     } else {
       mHistogramRegistry->fill(HIST(cascadePrefix) + HIST(McDir) + HIST(getHistName(kPdgMother, HistTable)), 0);
     }
 
     // get partonic mother
-    if (cascadeCandidate.has_fMcPartMoth()) {
-      auto partonicMother = cascadeCandidate.template fMcPartMoth_as<T4>();
+    if (mcParticle.has_fMcPartMoth()) {
+      auto partonicMother = mcParticle.template fMcPartMoth_as<T4>();
       mHistogramRegistry->fill(HIST(cascadePrefix) + HIST(McDir) + HIST(getHistName(kPdgPartonicMother, HistTable)), partonicMother.pdgCode());
     } else {
       mHistogramRegistry->fill(HIST(cascadePrefix) + HIST(McDir) + HIST(getHistName(kPdgPartonicMother, HistTable)), 0);
@@ -652,8 +652,8 @@ class CascadeHistManager
               mHistogramRegistry->fill(HIST(cascadePrefix) + HIST(McDir) + HIST(getHistName(kFromMaterial, HistTable)), cascadeCandidate.pt(), cascadeCandidate.cascadeCosPa());
               break;
             case modes::McOrigin::kFromSecondaryDecay:
-              if (cascadeCandidate.has_fMcMother()) {
-                auto mother = cascadeCandidate.template fMcMother_as<T3>();
+              if (mcParticle.has_fMcMother()) {
+                auto mother = mcParticle.template fMcMother_as<T3>();
                 int motherPdgCode = std::abs(mother.pdgCode());
                 // Switch on PDG of the mother
                 if (mPlotNSecondaries >= histmanager::kSecondaryPlotLevel1 && motherPdgCode == mPdgCodesSecondaryMother[0]) {

--- a/PWGCF/Femto/Core/collisionBuilder.h
+++ b/PWGCF/Femto/Core/collisionBuilder.h
@@ -62,7 +62,6 @@ struct ConfCollisionFilters : o2::framework::ConfigurableGroup {
   o2::framework::Configurable<int> subGeneratorId{"subGeneratorId", 0, "MC ONLY: If positive, keep 0 = MB, <0 triggered on something"};
 };
 
-
 struct ConfCollisionBits : o2::framework::ConfigurableGroup {
   std::string prefix = std::string("CollisionBits");
   o2::framework::Configurable<bool> passThrough{"passThrough", false, "If true, all tracks are passed through. Bits for all selections are stored."};

--- a/PWGCF/Femto/Core/collisionBuilder.h
+++ b/PWGCF/Femto/Core/collisionBuilder.h
@@ -62,6 +62,7 @@ struct ConfCollisionFilters : o2::framework::ConfigurableGroup {
   o2::framework::Configurable<int> subGeneratorId{"subGeneratorId", 0, "MC ONLY: If positive, keep 0 = MB, <0 triggered on something"};
 };
 
+
 struct ConfCollisionBits : o2::framework::ConfigurableGroup {
   std::string prefix = std::string("CollisionBits");
   o2::framework::Configurable<bool> passThrough{"passThrough", false, "If true, all tracks are passed through. Bits for all selections are stored."};

--- a/PWGCF/Femto/Core/collisionHistManager.h
+++ b/PWGCF/Femto/Core/collisionHistManager.h
@@ -52,6 +52,7 @@ enum ColHist {
   kCentVsSphericity,
   kMultVsSphericity,
   // mc
+  kTruePosZVsPosZ,
   kTrueCentVsCent,
   kTrueMultVsMult,
   kColHistLast
@@ -80,6 +81,7 @@ constexpr std::array<histmanager::HistInfo<ColHist>, kColHistLast> HistTable = {
     {kMultVsSphericity, o2::framework::HistType::kTH2F, "hMultVsSphericity", "Multiplicity vs Sphericity; Multiplicity; Sphericity"},
     {kCentVsSphericity, o2::framework::HistType::kTH2F, "hCentVsSphericity", "Centrality vs Sphericity; Centrality (%); Sphericity"},
     // mc
+    {kTruePosZVsPosZ, o2::framework::HistType::kTH2F, "hTruePosZVsPosZ", "True Vertex Z vs Vertex Z; V_{Z,True} (cm); V_{Z} (cm)"},
     {kTrueCentVsCent, o2::framework::HistType::kTH2F, "hTrueCentVsCent", "True centrality vs centrality; Centrality_{True} (%); Centrality (%)"},
     {kTrueMultVsMult, o2::framework::HistType::kTH2F, "hTrueMultVsMult", "True multiplicity vs multiplicity; Multiplicity_{True}; Multiplicity"},
   }};
@@ -102,9 +104,10 @@ constexpr std::array<histmanager::HistInfo<ColHist>, kColHistLast> HistTable = {
     {kMultVsSphericity, {confAnalysis.mult, confQa.sphericity}}, \
     {kCentVsSphericity, {confBinningAnalysis.cent, confQa.sphericity}},
 
-#define COL_HIST_MC_MAP(conf)                \
-  {kTrueMultVsMult, {conf.mult, conf.mult}}, \
-    {kTrueCentVsCent, {conf.cent, conf.cent}},
+#define COL_HIST_MC_MAP(conf)                  \
+  {kTruePosZVsPosZ, {conf.vtxZ, conf.vtxZ}},   \
+    {kTrueCentVsCent, {conf.cent, conf.cent}}, \
+    {kTrueMultVsMult, {conf.mult, conf.mult}},
 
 template <typename T>
 auto makeColHistSpecMap(const T& confBinningAnalysis)
@@ -253,8 +256,9 @@ class CollisionHistManager
   void initMc(std::map<ColHist, std::vector<o2::framework::AxisSpec>> const& Specs)
   {
     std::string mcDir = std::string(McDir);
-    mHistogramRegistry->add(mcDir + getHistNameV2(kTrueMultVsMult, HistTable), getHistDesc(kTrueMultVsMult, HistTable), getHistType(kTrueMultVsMult, HistTable), {Specs.at(kTrueMultVsMult)});
+    mHistogramRegistry->add(mcDir + getHistNameV2(kTruePosZVsPosZ, HistTable), getHistDesc(kTruePosZVsPosZ, HistTable), getHistType(kTruePosZVsPosZ, HistTable), {Specs.at(kTruePosZVsPosZ)});
     mHistogramRegistry->add(mcDir + getHistNameV2(kTrueCentVsCent, HistTable), getHistDesc(kTrueCentVsCent, HistTable), getHistType(kTrueCentVsCent, HistTable), {Specs.at(kTrueCentVsCent)});
+    mHistogramRegistry->add(mcDir + getHistNameV2(kTrueMultVsMult, HistTable), getHistDesc(kTrueMultVsMult, HistTable), getHistType(kTrueMultVsMult, HistTable), {Specs.at(kTrueMultVsMult)});
   }
 
   template <typename T>
@@ -290,8 +294,9 @@ class CollisionHistManager
       return;
     }
     auto mcCol = col.template fMcCol_as<T2>();
-    mHistogramRegistry->fill(HIST(McDir) + HIST(getHistName(kTrueMultVsMult, HistTable)), mcCol.mult(), col.mult());
+    mHistogramRegistry->fill(HIST(McDir) + HIST(getHistName(kTruePosZVsPosZ, HistTable)), mcCol.posZ(), col.posZ());
     mHistogramRegistry->fill(HIST(McDir) + HIST(getHistName(kTrueCentVsCent, HistTable)), mcCol.cent(), col.cent());
+    mHistogramRegistry->fill(HIST(McDir) + HIST(getHistName(kTrueMultVsMult, HistTable)), mcCol.mult(), col.mult());
   }
 
   o2::framework::HistogramRegistry* mHistogramRegistry = nullptr;

--- a/PWGCF/Femto/Core/kinkHistManager.h
+++ b/PWGCF/Femto/Core/kinkHistManager.h
@@ -559,16 +559,16 @@ class KinkHistManager
     mHistogramRegistry->fill(HIST(kinkPrefix) + HIST(McDir) + HIST(getHistName(kPdg, HistTable)), mcParticle.pdgCode());
 
     // get mother
-    if (kinkCandidate.has_fMcMother()) {
-      auto mother = kinkCandidate.template fMcMother_as<T3>();
+    if (mcParticle.has_fMcMother()) {
+      auto mother = mcParticle.template fMcMother_as<T3>();
       mHistogramRegistry->fill(HIST(kinkPrefix) + HIST(McDir) + HIST(getHistName(kPdgMother, HistTable)), mother.pdgCode());
     } else {
       mHistogramRegistry->fill(HIST(kinkPrefix) + HIST(McDir) + HIST(getHistName(kPdgMother, HistTable)), 0);
     }
 
     // get partonic mother
-    if (kinkCandidate.has_fMcPartMoth()) {
-      auto partonicMother = kinkCandidate.template fMcPartMoth_as<T4>();
+    if (mcParticle.has_fMcPartMoth()) {
+      auto partonicMother = mcParticle.template fMcPartMoth_as<T4>();
       mHistogramRegistry->fill(HIST(kinkPrefix) + HIST(McDir) + HIST(getHistName(kPdgPartonicMother, HistTable)), partonicMother.pdgCode());
     } else {
       mHistogramRegistry->fill(HIST(kinkPrefix) + HIST(McDir) + HIST(getHistName(kPdgPartonicMother, HistTable)), 0);
@@ -593,8 +593,8 @@ class KinkHistManager
               mHistogramRegistry->fill(HIST(kinkPrefix) + HIST(McDir) + HIST(getHistName(kFromMaterial, HistTable)), kinkCandidate.pt(), kinkCandidate.kinkAngle());
               break;
             case modes::McOrigin::kFromSecondaryDecay:
-              if (kinkCandidate.has_fMcMother()) {
-                auto mother = kinkCandidate.template fMcMother_as<T3>();
+              if (mcParticle.has_fMcMother()) {
+                auto mother = mcParticle.template fMcMother_as<T3>();
                 int motherPdgCode = std::abs(mother.pdgCode());
                 // Switch on PDG of the mother
                 if (mPlotNSecondaries >= histmanager::kSecondaryPlotLevel1 && motherPdgCode == mPdgCodesSecondaryMother[0]) {

--- a/PWGCF/Femto/Core/mcBuilder.h
+++ b/PWGCF/Femto/Core/mcBuilder.h
@@ -27,6 +27,8 @@
 
 #include <TPDGCode.h>
 
+#include <Rtypes.h>
+
 #include <cmath>
 #include <cstdint>
 #include <string>
@@ -49,6 +51,7 @@ struct McBuilderProducts : o2::framework::ProducesGroup {
   o2::framework::Produces<o2::aod::FMcParticles> producedMcParticles;
   o2::framework::Produces<o2::aod::FMcMothers> producedMothers;
   o2::framework::Produces<o2::aod::FMcPartMoths> producedPartonicMothers;
+  o2::framework::Produces<o2::aod::FMcMotherLabels> producedMcMotherLabels;
 
   o2::framework::Produces<o2::aod::FColLabels> producedCollisionLabels;
   o2::framework::Produces<o2::aod::FTrackLabels> producedTrackLabels;
@@ -66,8 +69,9 @@ struct ConfMcTables : o2::framework::ConfigurableGroup {
   o2::framework::Configurable<int> produceMcParticles{"produceMcParticles", -1, "Produce MC particles (-1: auto; 0 off; 1 on)"};
   o2::framework::Configurable<int> produceMcMothers{"produceMcMothers", -1, "Produce MC mother particles (-1: auto; 0 off; 1 on)"};
   o2::framework::Configurable<int> produceMcPartonicMothers{"produceMcPartonicMothers", -1, "Produce MC partonic mother particles (-1: auto; 0 off; 1 on)"};
+  o2::framework::Configurable<int> producedMcMotherLabels{"producedMcMotherLabels", -1, "Produce mother/partonic-mother labels (-1: auto; 0 off; 1 on)"};
 
-  o2::framework::Configurable<int> producedCollisionLabels{"producedCollisionLabels", -1, "Produce MC partonic mother particles (-1: auto; 0 off; 1 on)"};
+  o2::framework::Configurable<int> producedCollisionLabels{"producedCollisionLabels", -1, "Produce MC collision labels (-1: auto; 0 off; 1 on)"};
   o2::framework::Configurable<int> producedTrackLabels{"producedTrackLabels", -1, "Produce track labels (-1: auto; 0 off; 1 on)"};
   o2::framework::Configurable<int> producedLambdaLabels{"producedLambdaLabels", -1, "Produce lambda labels (-1: auto; 0 off; 1 on)"};
   o2::framework::Configurable<int> producedK0shortLabels{"producedK0shortLabels", -1, "Produce k0short labels (-1: auto; 0 off; 1 on)"};
@@ -76,6 +80,38 @@ struct ConfMcTables : o2::framework::ConfigurableGroup {
   o2::framework::Configurable<int> producedXiLabels{"producedXiLabels", -1, "Produce xi labels (-1: auto; 0 off; 1 on)"};
   o2::framework::Configurable<int> producedOmegaLabels{"producedOmegaLabels", -1, "Produce omega labels (-1: auto; 0 off; 1 on)"};
 };
+
+// filter/selections for mc collision and mc particles
+
+struct ConfMcCollisionFilters : o2::framework::ConfigurableGroup {
+  std::string prefix = std::string("McCollisionFilter");
+  o2::framework::Configurable<float> vtxZMin{"vtxZMin", -10.f, "Minimum vertex Z position (cm)"};
+  o2::framework::Configurable<float> vtxZMax{"vtxZMax", 10.f, "Maximum vertex Z position (cm)"};
+  o2::framework::Configurable<float> multMin{"multMin", 0.f, "Minimum multiplicity"};
+  o2::framework::Configurable<float> multMax{"multMax", 5000.f, "Maximum multiplicity"};
+  o2::framework::Configurable<float> centMin{"centMin", 0.f, "Minimum centrality (multiplicity percentile)"};
+  o2::framework::Configurable<float> centMax{"centMax", 100.f, "Maximum centrality (multiplicity percentile)"};
+};
+
+template <const char* Prefix>
+struct ConfMcParticleSelection : o2::framework::ConfigurableGroup {
+  std::string prefix = std::string(Prefix);
+  // kinematic cuts for filtering tracks
+  o2::framework::Configurable<float> ptMin{"ptMin", 0.2f, "Minimum pT"};
+  o2::framework::Configurable<float> ptMax{"ptMax", 6.f, "Maximum pT"};
+  o2::framework::Configurable<float> etaMin{"etaMin", -0.9f, "Minimum eta"};
+  o2::framework::Configurable<float> etaMax{"etaMax", 0.9f, "Maximum eta"};
+  o2::framework::Configurable<float> phiMin{"phiMin", 0.f, "Minimum phi"};
+  o2::framework::Configurable<float> phiMax{"phiMax", 1.f * o2::constants::math::TwoPI, "Maximum phi"};
+  o2::framework::Configurable<int> pdgCodeAbs{"pdgCodeAbs", 2212, "Absolute value of PDG code. Set sign of charge to -1 for antiparticle."};
+  o2::framework::Configurable<int> chargeSign{"chargeSign", 1, "Particle charge sign: +1 for positive, -1 for negative, 0 for both"};
+};
+
+constexpr const char PrefixMcParticleSelection1[] = "McParticleSelection1";
+constexpr const char PrefixMcParticleSelection2[] = "McParticleSelection2";
+
+using ConfMcParticleSelection1 = ConfMcParticleSelection<PrefixMcParticleSelection1>;
+using ConfMcParticleSelection2 = ConfMcParticleSelection<PrefixMcParticleSelection2>;
 
 class McBuilder
 {
@@ -92,6 +128,7 @@ class McBuilder
     mProduceMcParticles = utils::enableTable("FMcParticles_001", table.produceMcParticles.value, initContext);
     mProduceMcMothers = utils::enableTable("FMcMothers_001", table.produceMcMothers.value, initContext);
     mProduceMcPartonicMothers = utils::enableTable("FMcPartMoths_001", table.produceMcPartonicMothers.value, initContext);
+    mProduceMcMotherLabels = utils::enableTable("FMcMotherLabels", table.producedMcMotherLabels.value, initContext);
 
     mProduceCollisionLabels = utils::enableTable("FColLabels", table.producedCollisionLabels.value, initContext);
     mProduceTrackLabels = utils::enableTable("FTrackLabels", table.producedTrackLabels.value, initContext);
@@ -104,6 +141,7 @@ class McBuilder
 
     if (mProduceMcCollisions || mProduceCollisionLabels ||
         mProduceMcParticles || mProduceMcMothers || mProduceMcPartonicMothers ||
+        mProduceMcMotherLabels ||
         mProduceTrackLabels ||
         mProduceLambdaLabels || mProduceK0shortLabels ||
         mProduceSigmaLabels || mProduceSigmaPlusLabels ||
@@ -143,34 +181,58 @@ class McBuilder
     }
   }
 
+  template <modes::System system, typename T1, typename T2>
+  void fillMcCollision(T1 const& mcCol, T2& mcProducts)
+  {
+    float centrality = -1;
+    if constexpr (modes::isFlagSet(system, modes::System::kPP)) {
+      centrality = mcCol.centFT0M();
+    }
+    if constexpr (modes::isFlagSet(system, modes::System::kPbPb)) {
+      centrality = mcCol.centFT0C();
+    }
+
+    mcProducts.producedMcCollisions(
+      mcCol.posZ(),
+      mcCol.multMCNParticlesEta08(),
+      centrality);
+    mCollisionMap.emplace(mcCol.globalIndex(), mcProducts.producedMcCollisions.lastIndex());
+  }
+
+  template <modes::System system, typename T1, typename T2, typename T3, typename T4>
+  void fillMcParticle(T1 const& mcParticle, T2 const& mcParticles, T3 const& mcCol, T4& mcProducts)
+  {
+    this->getOrCreateMcParticleRow<system>(mcParticle, mcParticles, mcCol, mcProducts);
+  }
+
   template <modes::System system, typename T1, typename T2, typename T3, typename T4, typename T5>
   void fillMcTrackWithLabel(T1 const& col, T2 const& mcCols, T3 const& track, T4 const& mcParticles, T5& mcProducts)
   {
     if (!mProduceTrackLabels) {
-      mcProducts.producedTrackLabels(-1, -1, -1);
+      mcProducts.producedTrackLabels(-1);
       return;
     }
-    fillMcLabelGeneric<system>(col, mcCols, track, mcParticles, mcProducts, [](auto& prod, int64_t p, int64_t m, int64_t pm) { prod.producedTrackLabels(p, m, pm); });
+    fillMcLabelGeneric<system>(col, mcCols, track, mcParticles, mcProducts, [](auto& prod, int64_t p) { prod.producedTrackLabels(p); });
   }
 
   template <modes::System system, typename T1, typename T2, typename T3, typename T4, typename T5>
   void fillMcLambdaWithLabel(T1 const& col, T2 const& mcCols, T3 const& lambda, T4 const& mcParticles, T5& mcProducts)
   {
     if (!mProduceLambdaLabels) {
-      mcProducts.producedLambdaLabels(-1, -1, -1);
+      mcProducts.producedLambdaLabels(-1);
       return;
     }
-    fillMcLabelGeneric<system>(col, mcCols, lambda, mcParticles, mcProducts, [](auto& prod, int64_t p, int64_t m, int64_t pm) { prod.producedLambdaLabels(p, m, pm); });
+    fillMcLabelGeneric<system>(col, mcCols, lambda, mcParticles, mcProducts, [](auto& prod, int64_t p) { prod.producedLambdaLabels(p); });
   }
 
   template <modes::System system, typename T1, typename T2, typename T3, typename T4, typename T5>
   void fillMcK0shortWithLabel(T1 const& col, T2 const& mcCols, T3 const& k0short, T4 const& mcParticles, T5& mcProducts)
   {
     if (!mProduceK0shortLabels) {
-      mcProducts.producedK0shortLabels(-1, -1, -1);
+      mcProducts.producedK0shortLabels(-1);
       return;
     }
-    fillMcLabelGeneric<system>(col, mcCols, k0short, mcParticles, mcProducts, [](auto& prod, int64_t p, int64_t m, int64_t pm) { prod.producedK0shortLabels(p, m, pm); });
+    fillMcLabelGeneric<system>(col, mcCols, k0short, mcParticles, mcProducts, [](auto& prod, int64_t p) { prod.producedK0shortLabels(p); });
   }
 
   template <modes::System system, typename T1, typename T2, typename T3, typename T4, typename T5>
@@ -179,7 +241,7 @@ class McBuilder
     if (!mProduceSigmaLabels) {
       return;
     }
-    fillMcLabelGeneric<system>(col, mcCols, sigmaDaughter, mcParticles, mcProducts, [](auto& prod, int64_t p, int64_t m, int64_t pm) { prod.producedSigmaLabels(p, m, pm); }, true);
+    fillMcLabelGeneric<system>(col, mcCols, sigmaDaughter, mcParticles, mcProducts, [](auto& prod, int64_t p) { prod.producedSigmaLabels(p); }, true);
   }
 
   template <modes::System system, typename T1, typename T2, typename T3, typename T4, typename T5>
@@ -188,27 +250,27 @@ class McBuilder
     if (!mProduceSigmaPlusLabels) {
       return;
     }
-    fillMcLabelGeneric<system>(col, mcCols, sigmaPlusDaughter, mcParticles, mcProducts, [](auto& prod, int64_t p, int64_t m, int64_t pm) { prod.producedSigmaPlusLabels(p, m, pm); }, true);
+    fillMcLabelGeneric<system>(col, mcCols, sigmaPlusDaughter, mcParticles, mcProducts, [](auto& prod, int64_t p) { prod.producedSigmaPlusLabels(p); }, true);
   }
 
   template <modes::System system, typename T1, typename T2, typename T3, typename T4, typename T5>
   void fillMcXiWithLabel(T1 const& col, T2 const& mcCols, T3 const& xi, T4 const& mcParticles, T5& mcProducts)
   {
     if (!mProduceXiLabels) {
-      mcProducts.producedXiLabels(-1, -1, -1);
+      mcProducts.producedXiLabels(-1);
       return;
     }
-    fillMcLabelGeneric<system>(col, mcCols, xi, mcParticles, mcProducts, [](auto& prod, int64_t p, int64_t m, int64_t pm) { prod.producedXiLabels(p, m, pm); });
+    fillMcLabelGeneric<system>(col, mcCols, xi, mcParticles, mcProducts, [](auto& prod, int64_t p) { prod.producedXiLabels(p); });
   }
 
   template <modes::System system, typename T1, typename T2, typename T3, typename T4, typename T5>
   void fillMcOmegaWithLabel(T1 const& col, T2 const& mcCols, T3 const& omega, T4 const& mcParticles, T5& mcProducts)
   {
     if (!mProduceOmegaLabels) {
-      mcProducts.producedOmegaLabels(-1, -1, -1);
+      mcProducts.producedOmegaLabels(-1);
       return;
     }
-    fillMcLabelGeneric<system>(col, mcCols, omega, mcParticles, mcProducts, [](auto& prod, int64_t p, int64_t m, int64_t pm) { prod.producedOmegaLabels(p, m, pm); });
+    fillMcLabelGeneric<system>(col, mcCols, omega, mcParticles, mcProducts, [](auto& prod, int64_t p) { prod.producedOmegaLabels(p); });
   }
 
   bool fillAnyTable() const { return mFillAnyTable; }
@@ -226,25 +288,25 @@ class McBuilder
     mMcPartonicMotherMap.reserve(mcParticles.size());
   }
 
- private:
-  template <modes::System system, typename T1, typename T2>
-  void fillMcCollision(T1 const& mcCol, T2& mcProducts)
+  // mc only, then there is only 1 mc collision
+  template <typename T>
+  void reset(T const& mcParticles)
   {
-    float centrality = -1;
-    if constexpr (modes::isFlagSet(system, modes::System::kPP)) {
-      centrality = mcCol.centFT0M();
-    }
-    if constexpr (modes::isFlagSet(system, modes::System::kPbPb)) {
-      centrality = mcCol.centFT0C();
-    }
-
-    mcProducts.producedMcCollisions(mcCol.multMCNParticlesEta08(), centrality);
-    mCollisionMap.emplace(mcCol.globalIndex(), mcProducts.producedMcCollisions.lastIndex());
+    mCollisionMap.clear();
+    mMcParticleMap.clear();
+    mMcParticleMap.reserve(mcParticles.size());
+    mMcMotherMap.clear();
+    mMcMotherMap.reserve(mcParticles.size());
+    mMcPartonicMotherMap.clear();
+    mMcPartonicMotherMap.reserve(mcParticles.size());
   }
 
+ private:
   template <typename T1, typename T2, typename T3>
   modes::McOrigin getOrigin(T1 const& col, T2 const& /*mcCols*/, T3 const& mcParticle)
   {
+    // whether a particle is misidentified or not can only be checked by qa/pair task later so it is not set here
+
     // constants
     const int producedByDecay = 4;
     // check if reconstructed collision has a generated collision
@@ -265,6 +327,19 @@ class McBuilder
     return modes::McOrigin::kFromWrongCollision;
   }
 
+  template <typename T1>
+  modes::McOrigin getOrigin(T1 const& mcParticle)
+  {
+    const int producedByDecay = 4;
+    if (mcParticle.isPhysicalPrimary()) {
+      return modes::McOrigin::kPhysicalPrimary;
+    }
+    if (mcParticle.has_mothers() && mcParticle.getProcess() == producedByDecay) {
+      return modes::McOrigin::kFromSecondaryDecay;
+    }
+    return modes::McOrigin::kFromMaterial;
+  }
+
   template <modes::System system, typename T1, typename T2>
   int64_t getMcColId(T1 const& mcCol, T2& mcProducts)
   {
@@ -279,81 +354,79 @@ class McBuilder
     return it->second;
   }
 
-  template <modes::System system, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
-  void fillMcLabelGeneric(T1 const& col,
-                          T2 const& mcCols,
-                          T3 const& particle,
-                          T4 const& mcParticles,
-                          T5& mcProducts,
-                          T6 writeLabels,
-                          bool startFromMotherParticle = false)
+  /// Mc-only entry point: no reconstructed collision to match against, so origin
+  /// is derived purely from the mc particle itself.
+  template <modes::System system, typename T1, typename T2, typename T3, typename T4>
+  int64_t getOrCreateMcParticleRow(T1 const& mcParticle, T2 const& mcParticles, T3 const& mcCol, T4& mcProducts)
   {
-    if (!particle.has_mcParticle()) {
-      writeLabels(mcProducts, -1, -1, -1);
-      return;
-    }
+    auto origin = this->getOrigin(mcParticle);
+    return this->buildMcParticleRow<system>(mcParticle, mcParticles, mcCol, origin, mcProducts);
+  }
 
-    auto mcParticle = particle.template mcParticle_as<T4>();
-    auto mcCol = mcParticle.template mcCollision_as<T2>();
+  /// Reco-matched entry point: origin is derived by comparing the reconstructed
+  /// collision against the mc collision.
+  template <modes::System system, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
+  int64_t getOrCreateMcParticleRow(T1 const& col, T2 const& mcCols, T3 const& mcParticle, T4 const& mcParticles, T5 const& mcCol, T6& mcProducts)
+  {
+    auto origin = this->getOrigin(col, mcCols, mcParticle);
+    return this->buildMcParticleRow<system>(mcParticle, mcParticles, mcCol, origin, mcProducts);
+  }
 
-    if (startFromMotherParticle) {
-      // in case of e.g. sigmas we do not reconstruct the mother but the daughter, so here we want to start from the mother particle
-      auto mcDaughterParticle = particle.template mcParticle_as<T4>();
-      if (!mcDaughterParticle.has_mothers()) {
-        writeLabels(mcProducts, -1, -1, -1);
-        return;
-      }
-      auto mothersOfDaughter = mcDaughterParticle.template mothers_as<T4>();
-      mcParticle = mothersOfDaughter.front();
-    }
-
+  /// Find-or-create the FMcParticles row for mcParticle. On first creation, also
+  /// resolves the mother / partonic mother (with kinematics) and writes the single
+  /// corresponding FMcMotherLabels row, so it always stays in lockstep, one row
+  /// per FMcParticles row.
+  template <modes::System system, typename T1, typename T2, typename T3, typename T4>
+  int64_t buildMcParticleRow(T1 const& mcParticle, T2 const& mcParticles, T3 const& mcCol, modes::McOrigin origin, T4& mcProducts)
+  {
     int64_t mcParticleIndex = mcParticle.globalIndex();
-    int64_t mcParticleRow = -1;
 
-    // MC particle
     auto itP = mMcParticleMap.find(mcParticleIndex);
     if (itP != mMcParticleMap.end()) {
-      mcParticleRow = itP->second;
-    } else {
-      auto origin = this->getOrigin(col, mcCols, mcParticle);
-      int64_t mcColId = this->getMcColId<system>(mcCol, mcProducts);
-
-      mcProducts.producedMcParticles(
-        mcColId,
-        static_cast<aod::femtodatatypes::McOriginType>(origin),
-        mcParticle.pdgCode(),
-        mcParticle.pt() * utils::signum(mcParticle.pdgCode()),
-        mcParticle.eta(),
-        mcParticle.phi());
-
-      mcParticleRow = mcProducts.producedMcParticles.lastIndex();
-      mMcParticleMap[mcParticleIndex] = mcParticleRow;
+      return itP->second;
     }
 
-    // MC mother
+    int64_t mcColId = this->getMcColId<system>(mcCol, mcProducts);
+
+    mcProducts.producedMcParticles(
+      mcColId,
+      static_cast<aod::femtodatatypes::McOriginType>(origin),
+      mcParticle.pdgCode(),
+      mcParticle.pt() * utils::signum(mcParticle.pdgCode()),
+      mcParticle.eta(),
+      mcParticle.phi());
+
+    int64_t mcParticleRow = mcProducts.producedMcParticles.lastIndex();
+    mMcParticleMap[mcParticleIndex] = mcParticleRow;
+
+    // --- mother ---
     int64_t mcMotherRow = -1;
     if (mcParticle.has_mothers()) {
-      auto mothers = mcParticle.template mothers_as<T4>();
-      auto mcMotherIndex = mothers.front().globalIndex();
+      auto mothers = mcParticle.template mothers_as<T2>();
+      auto motherParticle = mothers.front();
+      auto mcMotherIndex = motherParticle.globalIndex();
 
       auto itM = mMcMotherMap.find(mcMotherIndex);
       if (itM != mMcMotherMap.end()) {
         mcMotherRow = itM->second;
       } else {
-        mcProducts.producedMothers(mothers.front().pdgCode());
+        auto motherOrigin = this->getOrigin(motherParticle);
+        mcProducts.producedMothers(
+          static_cast<aod::femtodatatypes::McOriginType>(motherOrigin),
+          motherParticle.pdgCode(),
+          motherParticle.pt() * utils::signum(motherParticle.pdgCode()),
+          motherParticle.eta(),
+          motherParticle.phi());
         mcMotherRow = mcProducts.producedMothers.lastIndex();
         mMcMotherMap[mcMotherIndex] = mcMotherRow;
       }
     }
 
-    // Partonic mother
+    // --- partonic mother ---
     int64_t mcPartonicMotherRow = -1;
-    int64_t mcPartonicMotherIndex = -1;
-    if (mFindLastPartonicMother) {
-      mcPartonicMotherIndex = this->findLastPartonicMother(mcParticle, mcParticles);
-    } else {
-      mcPartonicMotherIndex = this->findFirstPartonicMother(mcParticle, mcParticles);
-    }
+    int64_t mcPartonicMotherIndex = mFindLastPartonicMother
+                                      ? this->findLastPartonicMother(mcParticle, mcParticles)
+                                      : this->findFirstPartonicMother(mcParticle, mcParticles);
     if (mcPartonicMotherIndex >= 0) {
       auto itPM = mMcPartonicMotherMap.find(mcPartonicMotherIndex);
       if (itPM != mMcPartonicMotherMap.end()) {
@@ -366,7 +439,45 @@ class McBuilder
       }
     }
 
-    writeLabels(mcProducts, mcParticleRow, mcMotherRow, mcPartonicMotherRow);
+    // exactly one FMcMotherLabels row per FMcParticles row, written here and only here
+    if (mProduceMcMotherLabels) {
+      mcProducts.producedMcMotherLabels(mcMotherRow, mcPartonicMotherRow);
+    }
+
+    return mcParticleRow;
+  }
+
+  template <modes::System system, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
+  void fillMcLabelGeneric(T1 const& col,
+                          T2 const& mcCols,
+                          T3 const& particle,
+                          T4 const& mcParticles,
+                          T5& mcProducts,
+                          T6 writeLabels,
+                          bool startFromMotherParticle = false)
+  {
+    if (!particle.has_mcParticle()) {
+      writeLabels(mcProducts, -1);
+      return;
+    }
+
+    auto mcParticle = particle.template mcParticle_as<T4>();
+    auto mcCol = mcParticle.template mcCollision_as<T2>();
+
+    if (startFromMotherParticle) {
+      // in case of e.g. sigmas we do not reconstruct the mother but the daughter, so here we want to start from the mother particle
+      auto mcDaughterParticle = particle.template mcParticle_as<T4>();
+      if (!mcDaughterParticle.has_mothers()) {
+        writeLabels(mcProducts, -1);
+        return;
+      }
+      auto mothersOfDaughter = mcDaughterParticle.template mothers_as<T4>();
+      mcParticle = mothersOfDaughter.front();
+    }
+
+    int64_t mcParticleRow = this->getOrCreateMcParticleRow<system>(col, mcCols, mcParticle, mcParticles, mcCol, mcProducts);
+
+    writeLabels(mcProducts, mcParticleRow);
   }
 
   template <typename T1, typename T2>
@@ -467,6 +578,7 @@ class McBuilder
   bool mProduceSigmaPlusLabels = false;
   bool mProduceXiLabels = false;
   bool mProduceOmegaLabels = false;
+  bool mProduceMcMotherLabels = false;
 
   std::unordered_map<int64_t, int64_t> mCollisionMap;
 

--- a/PWGCF/Femto/Core/mcCollisionHistManager.h
+++ b/PWGCF/Femto/Core/mcCollisionHistManager.h
@@ -1,0 +1,129 @@
+// Copyright 2019-2025 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file mcCollisionHistManager.h
+/// \brief histogram manager for mc particle histograms
+/// \author Anton Riedel, TU München, anton.riedel@cern.ch
+
+#ifndef PWGCF_FEMTO_CORE_MCCOLLISIONHISTMANAGER_H_
+#define PWGCF_FEMTO_CORE_MCCOLLISIONHISTMANAGER_H_
+
+#include "PWGCF/Femto/Core/histManager.h"
+#include "PWGCF/Femto/Core/modes.h"
+
+#include <CommonConstants/MathConstants.h>
+#include <Framework/Configurable.h>
+#include <Framework/HistogramRegistry.h>
+#include <Framework/HistogramSpec.h>
+#include <Framework/Logger.h>
+
+#include <TH1.h>
+
+#include <array>
+#include <map>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace o2::analysis::femto
+{
+namespace mccollisionhistmanager
+{
+
+// enum for mc particle histograms
+enum McCollisionHist {
+  kPosZ,
+  kMult,
+  kCent,
+  kPoszVsMult,
+  kPoszVsCent,
+  kCentVsMult,
+  kMcCollisionHistLast
+};
+
+struct ConfMcCollisionBinning : o2::framework::ConfigurableGroup {
+  std::string prefix = std::string("McCollisionBinning");
+  o2::framework::ConfigurableAxis vtxZ{"vtxZ", {200, -10, 10}, "Vertex Z binning"};
+  o2::framework::ConfigurableAxis mult{"mult", {200, 0, 200}, "Multiplicity binning"};
+  o2::framework::ConfigurableAxis cent{"cent", {100, 0.0f, 100.0f}, "Centrality (multiplicity percentile) binning"};
+};
+
+// the enum gives the correct index in the array
+constexpr std::array<histmanager::HistInfo<McCollisionHist>, kMcCollisionHistLast>
+  HistTable = {
+    {
+      {kPosZ, o2::framework::HistType::kTH1F, "hPosZ", "Vertex Z; V_{Z} (cm); Entries"},
+      {kMult, o2::framework::HistType::kTH1F, "hMult", "Multiplicity; Multiplicity; Entries"},
+      {kCent, o2::framework::HistType::kTH1F, "hCent", "Centrality; Centrality (%); Entries"},
+      {kPoszVsMult, o2::framework::HistType::kTH2F, "hPoszVsMult", "Vertex Z vs Multiplicity; V_{Z} (cm); Multiplicity"},
+      {kPoszVsCent, o2::framework::HistType::kTH2F, "hPoszVsCent", "Vertex Z vs Centrality; V_{Z} (cm); Centrality (%)"},
+      {kCentVsMult, o2::framework::HistType::kTH2F, "hCentVsMult", "Centrality vs Multiplicity; Centrality (%); Multiplicity"},
+    }};
+
+template <typename T>
+auto makeMcCollisionHistSpecMap(const T& confBinning)
+{
+  return std::map<McCollisionHist, std::vector<o2::framework::AxisSpec>>{
+    {kPosZ, {confBinning.vtxZ}},
+    {kMult, {confBinning.mult}},
+    {kCent, {confBinning.cent}},
+    {kPoszVsCent, {confBinning.vtxZ, confBinning.cent}},
+    {kPoszVsMult, {confBinning.vtxZ, confBinning.mult}},
+    {kCentVsMult, {confBinning.cent, confBinning.mult}},
+  };
+}
+
+constexpr char PrefixMcCollsion[] = "McCollision/";
+
+constexpr std::string_view McDir = "MC/";
+
+template <const char* prefix>
+class McCollisionHistManager
+{
+ public:
+  McCollisionHistManager() = default;
+  ~McCollisionHistManager() = default;
+
+  // init for analysis and mc
+  void init(o2::framework::HistogramRegistry* registry,
+            std::map<McCollisionHist, std::vector<o2::framework::AxisSpec>> const& Specs)
+
+  {
+    mHistogramRegistry = registry;
+
+    std::string mcDir = std::string(prefix) + std::string(McDir);
+    mHistogramRegistry->add(mcDir + getHistNameV2(kPosZ, HistTable), getHistDesc(kPosZ, HistTable), getHistType(kPosZ, HistTable), {Specs.at(kPosZ)});
+    mHistogramRegistry->add(mcDir + getHistNameV2(kMult, HistTable), getHistDesc(kMult, HistTable), getHistType(kMult, HistTable), {Specs.at(kMult)});
+    mHistogramRegistry->add(mcDir + getHistNameV2(kCent, HistTable), getHistDesc(kCent, HistTable), getHistType(kCent, HistTable), {Specs.at(kCent)});
+
+    mHistogramRegistry->add(mcDir + getHistNameV2(kPoszVsMult, HistTable), getHistDesc(kPoszVsMult, HistTable), getHistType(kPoszVsMult, HistTable), {Specs.at(kPoszVsMult)});
+    mHistogramRegistry->add(mcDir + getHistNameV2(kPoszVsCent, HistTable), getHistDesc(kPoszVsCent, HistTable), getHistType(kPoszVsCent, HistTable), {Specs.at(kPoszVsCent)});
+    mHistogramRegistry->add(mcDir + getHistNameV2(kCentVsMult, HistTable), getHistDesc(kCentVsMult, HistTable), getHistType(kCentVsMult, HistTable), {Specs.at(kCentVsMult)});
+  }
+
+  template <typename T1>
+  void fill(T1 const& col)
+  {
+    mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kPosZ, HistTable)), col.posZ());
+    mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kMult, HistTable)), col.mult());
+    mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kCent, HistTable)), col.cent());
+
+    mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kPoszVsMult, HistTable)), col.posZ(), col.mult());
+    mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kPoszVsCent, HistTable)), col.posZ(), col.cent());
+    mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kCentVsMult, HistTable)), col.cent(), col.mult());
+  }
+
+ private:
+  o2::framework::HistogramRegistry* mHistogramRegistry = nullptr;
+};
+}; // namespace mccollisionhistmanager
+}; // namespace o2::analysis::femto
+#endif // PWGCF_FEMTO_CORE_MCCOLLISIONHISTMANAGER_H_

--- a/PWGCF/Femto/Core/mcParticleHistManager.h
+++ b/PWGCF/Femto/Core/mcParticleHistManager.h
@@ -1,0 +1,183 @@
+// Copyright 2019-2025 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file mcParticleHistManager.h
+/// \brief histogram manager for mc particle histograms
+/// \author Anton Riedel, TU München, anton.riedel@cern.ch
+
+#ifndef PWGCF_FEMTO_CORE_MCPARTICLEHISTMANAGER_H_
+#define PWGCF_FEMTO_CORE_MCPARTICLEHISTMANAGER_H_
+
+#include "PWGCF/Femto/Core/histManager.h"
+#include "PWGCF/Femto/Core/modes.h"
+
+#include <CommonConstants/MathConstants.h>
+#include <Framework/Configurable.h>
+#include <Framework/HistogramRegistry.h>
+#include <Framework/HistogramSpec.h>
+#include <Framework/Logger.h>
+
+#include <TH1.h>
+
+#include <array>
+#include <cstddef>
+#include <map>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace o2::analysis::femto
+{
+namespace mcparticlehistmanager
+{
+
+// enum for mc particle histograms
+enum McParticleHist {
+  // kinemtics
+  kPt,
+  kEta,
+  kPhi,
+  kSign,
+  // pdg codes
+  kPdg,
+  kPdgMother,
+  kPdgPartonicMother,
+  // mother kinematics
+  kMotherPt,
+  kMotherEta,
+  kMotherPhi,
+  kMotherSign,
+
+  kMcParticleHistLast
+};
+
+constexpr std::size_t MaxSecondary = 3;
+
+template <const char* Prefix>
+struct ConfMcParticleBinning : o2::framework::ConfigurableGroup {
+  std::string prefix = Prefix;
+  o2::framework::ConfigurableAxis pt{"pt", {{600, 0, 6}}, "Pt"};
+  o2::framework::ConfigurableAxis eta{"eta", {{300, -1.5, 1.5}}, "Eta"};
+  o2::framework::ConfigurableAxis phi{"phi", {{720, 0, 1.f * o2::constants::math::TwoPI}}, "Phi"};
+  o2::framework::ConfigurableAxis sign{"sign", {{3, -1.5, 1.5}}, "Sign"};
+  o2::framework::ConfigurableAxis pdgCodes{"pdgCodes", {{8001, -4000.5, 4000.5}}, "PDG codes of selected particles"};
+};
+
+constexpr const char PrefixMcParticleBinning1[] = "McParticleBinning1";
+constexpr const char PrefixMcParticleBinning2[] = "McParticleBinning2";
+
+using ConfMcParticleBinning1 = ConfMcParticleBinning<PrefixMcParticleBinning1>;
+using ConfMcParticleBinning2 = ConfMcParticleBinning<PrefixMcParticleBinning2>;
+
+// the enum gives the correct index in the array
+constexpr std::array<histmanager::HistInfo<McParticleHist>, kMcParticleHistLast>
+  HistTable = {
+    {
+      {kPt, o2::framework::HistType::kTH1F, "hPt", "Transverse Momentum; p_{T} (GeV/#it{c}); Entries"},
+      {kEta, o2::framework::HistType::kTH1F, "hEta", "Pseudorapidity; #eta; Entries"},
+      {kPhi, o2::framework::HistType::kTH1F, "hPhi", "Azimuthal angle; #varphi; Entries"},
+      {kSign, o2::framework::HistType::kTH1F, "hSign", "Sign of charge; Sign; Entries"},
+      {kPdg, o2::framework::HistType::kTH1F, "hPdg", "PDG code of the particle; PDG Code; Entries"},
+      {kPdgMother, o2::framework::HistType::kTH1F, "hPdgMother", "PDG code of the mother; PDG Code; Entries"},
+      {kPdgPartonicMother, o2::framework::HistType::kTH1F, "hPdgPartonicMother", "PDG code of the partonic mother; PDG Code; Entries"},
+      {kMotherPt, o2::framework::HistType::kTH1F, "hMotherPt", "Mother transverse momentum; p_{T} (GeV/#it{c}); Entries"},
+      {kMotherEta, o2::framework::HistType::kTH1F, "hMotherEta", "Mother pseudorapidity; #eta; Entries"},
+      {kMotherPhi, o2::framework::HistType::kTH1F, "hMotherPhi", "Mother azimuthal angle; #varphi; Entries"},
+      {kMotherSign, o2::framework::HistType::kTH1F, "hMotherSign", "Sign of mother charge; Sign; Entries"},
+    }};
+
+template <typename T>
+auto makeMcParticleHistSpecMap(const T& confBinning)
+{
+  return std::map<McParticleHist, std::vector<o2::framework::AxisSpec>>{
+    {kPt, {confBinning.pt}},
+    {kEta, {confBinning.eta}},
+    {kPhi, {confBinning.phi}},
+    {kSign, {confBinning.sign}},
+    {kPdg, {confBinning.pdgCodes}},
+    {kPdgMother, {confBinning.pdgCodes}},
+    {kPdgPartonicMother, {confBinning.pdgCodes}},
+    {kMotherPt, {confBinning.pt}},
+    {kMotherEta, {confBinning.eta}},
+    {kMotherPhi, {confBinning.phi}},
+    {kMotherSign, {confBinning.sign}},
+  };
+}
+
+constexpr char PrefixMcParticle1[] = "McParticle1/";
+constexpr char PrefixMcParticle2[] = "McParticle2/";
+
+constexpr std::string_view McDir = "MC/";
+
+template <const char* prefix>
+class McParticleHistManager
+{
+ public:
+  McParticleHistManager() = default;
+  ~McParticleHistManager() = default;
+
+  void init(o2::framework::HistogramRegistry* registry,
+            std::map<McParticleHist, std::vector<o2::framework::AxisSpec>> const& Specs)
+  {
+    mHistogramRegistry = registry;
+
+    std::string mcDir = std::string(prefix) + std::string(McDir);
+    mHistogramRegistry->add(mcDir + getHistNameV2(kPt, HistTable), getHistDesc(kPt, HistTable), getHistType(kPt, HistTable), {Specs.at(kPt)});
+    mHistogramRegistry->add(mcDir + getHistNameV2(kEta, HistTable), getHistDesc(kEta, HistTable), getHistType(kEta, HistTable), {Specs.at(kEta)});
+    mHistogramRegistry->add(mcDir + getHistNameV2(kPhi, HistTable), getHistDesc(kPhi, HistTable), getHistType(kPhi, HistTable), {Specs.at(kPhi)});
+    mHistogramRegistry->add(mcDir + getHistNameV2(kSign, HistTable), getHistDesc(kSign, HistTable), getHistType(kSign, HistTable), {Specs.at(kSign)});
+    mHistogramRegistry->add(mcDir + getHistNameV2(kPdg, HistTable), getHistDesc(kPdg, HistTable), getHistType(kPdg, HistTable), {Specs.at(kPdg)});
+    mHistogramRegistry->add(mcDir + getHistNameV2(kPdgMother, HistTable), getHistDesc(kPdgMother, HistTable), getHistType(kPdgMother, HistTable), {Specs.at(kPdgMother)});
+    mHistogramRegistry->add(mcDir + getHistNameV2(kPdgPartonicMother, HistTable), getHistDesc(kPdgPartonicMother, HistTable), getHistType(kPdgPartonicMother, HistTable), {Specs.at(kPdgPartonicMother)});
+    mHistogramRegistry->add(mcDir + getHistNameV2(kMotherPt, HistTable), getHistDesc(kMotherPt, HistTable), getHistType(kMotherPt, HistTable), {Specs.at(kMotherPt)});
+    mHistogramRegistry->add(mcDir + getHistNameV2(kMotherEta, HistTable), getHistDesc(kMotherEta, HistTable), getHistType(kMotherEta, HistTable), {Specs.at(kMotherEta)});
+    mHistogramRegistry->add(mcDir + getHistNameV2(kMotherPhi, HistTable), getHistDesc(kMotherPhi, HistTable), getHistType(kMotherPhi, HistTable), {Specs.at(kMotherPhi)});
+    mHistogramRegistry->add(mcDir + getHistNameV2(kMotherSign, HistTable), getHistDesc(kMotherSign, HistTable), getHistType(kMotherSign, HistTable), {Specs.at(kMotherSign)});
+  }
+
+  /// T1 = mc particle row — must carry FMcMotherId/FMcPartMothId, i.e. this should be
+  ///      a row from o2::soa::Join<FMcParticles, FMcMotherLabels>, not bare FMcParticles
+  /// T2 = FMcMothers (now with kinematics: Origin, PdgCode, SignedPt, Eta, Phi)
+  /// T3 = FMcPartMoths
+  template <typename T1, typename T2, typename T3>
+  void fill(T1 const& mcParticle, T2 const& /*mcMothers*/, T3 const& /*mcPartonicMothers*/)
+  {
+    mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kPt, HistTable)), mcParticle.pt());
+    mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kEta, HistTable)), mcParticle.eta());
+    mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kPhi, HistTable)), mcParticle.phi());
+    mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kSign, HistTable)), mcParticle.sign());
+    mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kPdg, HistTable)), mcParticle.pdgCode());
+
+    if (mcParticle.has_fMcMother()) {
+      auto mother = mcParticle.template fMcMother_as<T2>();
+      mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kPdgMother, HistTable)), mother.pdgCode());
+      mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kMotherPt, HistTable)), mother.pt());
+      mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kMotherEta, HistTable)), mother.eta());
+      mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kMotherPhi, HistTable)), mother.phi());
+      mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kMotherSign, HistTable)), mother.sign());
+    } else {
+      mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kPdgMother, HistTable)), 0);
+    }
+
+    if (mcParticle.has_fMcPartMoth()) {
+      auto partonicMother = mcParticle.template fMcPartMoth_as<T3>();
+      mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kPdgPartonicMother, HistTable)), partonicMother.pdgCode());
+    } else {
+      mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kPdgPartonicMother, HistTable)), 0);
+    }
+  }
+
+ private:
+  o2::framework::HistogramRegistry* mHistogramRegistry = nullptr;
+};
+}; // namespace mcparticlehistmanager
+}; // namespace o2::analysis::femto
+#endif // PWGCF_FEMTO_CORE_MCPARTICLEHISTMANAGER_H_

--- a/PWGCF/Femto/Core/pairCleaner.h
+++ b/PWGCF/Femto/Core/pairCleaner.h
@@ -50,31 +50,51 @@ class BasePairCleaner
     return track1.globalIndex() != track2.globalIndex();
   };
 
-  template <typename T1, typename T2, typename T3>
-  bool pairHasCommonAncestor(T1 const& particle1, T2 const& particle2, T3 const& /*partonicMothers*/) const
+  template <typename T1, typename T2, typename T3, typename T4>
+  bool pairHasCommonAncestor(T1 const& particle1, T2 const& particle2, T3 const& /*mcparticles*/, T4 const& /*partonicMothers*/) const
   {
-    // if one of the two particles has no associated partonic mother, we cannot know if they have a common anchestor, so we break out with false
-    if (!particle1.has_fMcPartMoth() || !particle2.has_fMcPartMoth()) {
+    // if one of the two particles has no associated mc particle, we cannot know if they have a common anchestor, so we break out with false
+    if (!particle1.has_fMcParticle() || !particle2.has_fMcParticle()) {
       return false;
     }
+
     // get mc particles
-    auto partonicMother1 = particle1.template fMcPartMoth_as<T3>();
-    auto partonicMother2 = particle2.template fMcPartMoth_as<T3>();
+    auto mcParticle1 = particle1.template fMcParticle_as<T3>();
+    auto mcParticle2 = particle2.template fMcParticle_as<T3>();
+
+    // if one of the two particles has no associated partonic mother, we cannot know if they have a common anchestor, so we break out with false
+    if (!mcParticle1.has_fMcPartMoth() || !mcParticle2.has_fMcPartMoth()) {
+      return false;
+    }
+
     // get partonic mothers
+    auto partonicMother1 = mcParticle1.template fMcPartMoth_as<T3>();
+    auto partonicMother2 = mcParticle2.template fMcPartMoth_as<T3>();
+
     return partonicMother1.globalIndex() == partonicMother2.globalIndex();
   };
 
-  template <typename T1, typename T2, typename T3>
-  bool pairHasNonCommonAncestor(T1 const& particle1, T2 const& particle2, T3 const& /*partonicMothers*/) const
+  template <typename T1, typename T2, typename T3, typename T4>
+  bool pairHasNonCommonAncestor(T1 const& particle1, T2 const& particle2, T3 const& /*mcparticles*/, T4 const& /*partonicMothers*/) const
   {
-    // if one of the two particles has no associated partonic mother, we cannot now if they have a non-common anchestor, so we break out with false
-    if (!particle1.has_fMcPartMoth() || !particle2.has_fMcPartMoth()) {
+    // if one of the two particles has no associated mc particle, we cannot know if they have a common anchestor, so we break out with false
+    if (!particle1.has_fMcParticle() || !particle2.has_fMcParticle()) {
       return false;
     }
+
     // get mc particles
-    auto partonicMother1 = particle1.template fMcPartMoth_as<T3>();
-    auto partonicMother2 = particle2.template fMcPartMoth_as<T3>();
+    auto mcParticle1 = particle1.template fMcParticle_as<T3>();
+    auto mcParticle2 = particle2.template fMcParticle_as<T3>();
+
+    // if one of the two particles has no associated partonic mother, we cannot know if they have a common anchestor, so we break out with false
+    if (!mcParticle1.has_fMcPartMoth() || !mcParticle2.has_fMcPartMoth()) {
+      return false;
+    }
+
     // get partonic mothers
+    auto partonicMother1 = mcParticle1.template fMcPartMoth_as<T3>();
+    auto partonicMother2 = mcParticle2.template fMcPartMoth_as<T3>();
+
     return partonicMother1.globalIndex() != partonicMother2.globalIndex();
   };
 
@@ -93,8 +113,8 @@ class TrackTrackPairCleaner : public BasePairCleaner
     return this->isCleanTrackPair(track1, track2);
   }
 
-  template <typename T1, typename T2, typename T3, typename T4>
-  bool isCleanPair(T1 const& track1, T2 const& track2, T3 const& trackTable, T4 const& partonicMothers) const
+  template <typename T1, typename T2, typename T3, typename T4, typename T5>
+  bool isCleanPair(T1 const& track1, T2 const& track2, T3 const& trackTable, T4 const& mcParticles, T5 const& partonicMothers) const
   {
     if (!this->isCleanPair(track1, track2, trackTable)) {
       return false;
@@ -102,10 +122,10 @@ class TrackTrackPairCleaner : public BasePairCleaner
     // pair is clean
     // no check if we require common or non-common ancestry
     if (mMixPairsWithCommonAncestor) {
-      return this->pairHasCommonAncestor(track1, track2, partonicMothers);
+      return this->pairHasCommonAncestor(track1, track2, mcParticles, partonicMothers);
     }
     if (mMixPairsWithNonCommonAncestor) {
-      return this->pairHasNonCommonAncestor(track1, track2, partonicMothers);
+      return this->pairHasNonCommonAncestor(track1, track2, mcParticles, partonicMothers);
     }
     return true;
   }
@@ -127,8 +147,8 @@ class V0V0PairCleaner : public BasePairCleaner // also works for particles decay
            this->isCleanTrackPair(posDaughter1, negDaughter2) && this->isCleanTrackPair(negDaughter1, posDaughter2);
   }
 
-  template <typename T1, typename T2, typename T3, typename T4>
-  bool isCleanPair(T1 const& v01, T2 const& v02, T3 const& trackTable, T4 const& partonicMothers) const
+  template <typename T1, typename T2, typename T3, typename T4, typename T5>
+  bool isCleanPair(T1 const& v01, T2 const& v02, T3 const& trackTable, T4 const& mcParticles, T5 const& partonicMothers) const
   {
     if (!this->isCleanPair(v01, v02, trackTable)) {
       return false;
@@ -136,10 +156,10 @@ class V0V0PairCleaner : public BasePairCleaner // also works for particles decay
     // pair is clean
     // no check if we require common or non-common ancestry
     if (mMixPairsWithCommonAncestor) {
-      return this->pairHasCommonAncestor(v01, v02, partonicMothers);
+      return this->pairHasCommonAncestor(v01, v02, mcParticles, partonicMothers);
     }
     if (mMixPairsWithNonCommonAncestor) {
-      return this->pairHasNonCommonAncestor(v01, v02, partonicMothers);
+      return this->pairHasNonCommonAncestor(v01, v02, mcParticles, partonicMothers);
     }
     return true;
   }
@@ -157,8 +177,8 @@ class TrackV0PairCleaner : public BasePairCleaner // also works for particles de
     return (this->isCleanTrackPair(posDaughter, track) && this->isCleanTrackPair(negDaughter, track));
   }
 
-  template <typename T1, typename T2, typename T3, typename T4>
-  bool isCleanPair(T1 const& track1, T2 const& v0, T3 const& trackTable, T4 const& partonicMothers) const
+  template <typename T1, typename T2, typename T3, typename T4, typename T5>
+  bool isCleanPair(T1 const& track1, T2 const& v0, T3 const& trackTable, T4 const& mcParticles, T5 const& partonicMothers) const
   {
     if (!this->isCleanPair(track1, v0, trackTable)) {
       return false;
@@ -166,10 +186,10 @@ class TrackV0PairCleaner : public BasePairCleaner // also works for particles de
     // pair is clean
     // now check if we require common or non-common ancestry
     if (mMixPairsWithCommonAncestor) {
-      return this->pairHasCommonAncestor(track1, v0, partonicMothers);
+      return this->pairHasCommonAncestor(track1, v0, mcParticles, partonicMothers);
     }
     if (mMixPairsWithNonCommonAncestor) {
-      return this->pairHasNonCommonAncestor(track1, v0, partonicMothers);
+      return this->pairHasNonCommonAncestor(track1, v0, mcParticles, partonicMothers);
     }
     return true;
   }
@@ -186,8 +206,8 @@ class TrackKinkPairCleaner : public BasePairCleaner
     return this->isCleanTrackPair(chaDaughter, track);
   }
 
-  template <typename T1, typename T2, typename T3, typename T4>
-  bool isCleanPair(T1 const& track1, T2 const& kink, T3 const& trackTable, T4 const& partonicMothers) const
+  template <typename T1, typename T2, typename T3, typename T4, typename T5>
+  bool isCleanPair(T1 const& track1, T2 const& kink, T3 const& trackTable, T4 const& mcParticles, T5 const& partonicMothers) const
   {
     if (!this->isCleanPair(track1, kink, trackTable)) {
       return false;
@@ -195,10 +215,10 @@ class TrackKinkPairCleaner : public BasePairCleaner
     // pair is clean
     // now check if we require common or non-common ancestry
     if (mMixPairsWithCommonAncestor) {
-      return this->pairHasCommonAncestor(track1, kink, partonicMothers);
+      return this->pairHasCommonAncestor(track1, kink, mcParticles, partonicMothers);
     }
     if (mMixPairsWithNonCommonAncestor) {
-      return this->pairHasNonCommonAncestor(track1, kink, partonicMothers);
+      return this->pairHasNonCommonAncestor(track1, kink, mcParticles, partonicMothers);
     }
     return true;
   }
@@ -217,8 +237,8 @@ class TrackCascadePairCleaner : public BasePairCleaner
     return (this->isCleanTrackPair(bachelor, track) && this->isCleanTrackPair(posDaughter, track) && this->isCleanTrackPair(negDaughter, track));
   }
 
-  template <typename T1, typename T2, typename T3, typename T4>
-  bool isCleanPair(T1 const& track1, T2 const& cascade, T3 const& trackTable, T4 const& partonicMothers) const
+  template <typename T1, typename T2, typename T3, typename T4, typename T5>
+  bool isCleanPair(T1 const& track1, T2 const& cascade, T3 const& trackTable, T4 const& mcParticles, T5 const& partonicMothers) const
   {
     if (!this->isCleanPair(track1, cascade, trackTable)) {
       return false;
@@ -226,10 +246,10 @@ class TrackCascadePairCleaner : public BasePairCleaner
     // pair is clean
     // now check if we require common or non-common ancestry
     if (mMixPairsWithCommonAncestor) {
-      return this->pairHasCommonAncestor(track1, cascade, partonicMothers);
+      return this->pairHasCommonAncestor(track1, cascade, mcParticles, partonicMothers);
     }
     if (mMixPairsWithNonCommonAncestor) {
-      return this->pairHasNonCommonAncestor(track1, cascade, partonicMothers);
+      return this->pairHasNonCommonAncestor(track1, cascade, mcParticles, partonicMothers);
     }
     return true;
   }

--- a/PWGCF/Femto/Core/pairProcessHelpers.h
+++ b/PWGCF/Femto/Core/pairProcessHelpers.h
@@ -131,7 +131,7 @@ void processSameEvent(T1 const& SliceParticle,
       continue;
     }
     // check if pair is clean
-    if (!PcManager.isCleanPair(p1, p2, TrackTable, mcPartonicMothers)) {
+    if (!PcManager.isCleanPair(p1, p2, TrackTable, mcParticles, mcPartonicMothers)) {
       continue;
     }
     // check if pair is close
@@ -264,7 +264,7 @@ void processSameEvent(T1 const& SliceParticle1,
       continue;
     }
     // pair cleaning
-    if (!PcManager.isCleanPair(p1, p2, TrackTable, mcPartonicMothers)) {
+    if (!PcManager.isCleanPair(p1, p2, TrackTable, mcParticles, mcPartonicMothers)) {
       continue;
     }
     // Close pair rejection

--- a/PWGCF/Femto/Core/particleCleaner.h
+++ b/PWGCF/Femto/Core/particleCleaner.h
@@ -78,6 +78,11 @@ constexpr const char PrefixOmegaCleaner2[] = "OmegaCleaner2";
 using ConfOmegaCleaner1 = ConfParticleCleaner<PrefixOmegaCleaner1>;
 using ConfOmegaCleaner2 = ConfParticleCleaner<PrefixOmegaCleaner2>;
 
+constexpr const char PrefixMcParticleCleaner1[] = "McParticleCleaner1";
+constexpr const char PrefixMcParticleCleaner2[] = "McParticleCleaner2";
+using ConfMcParticleCleaner1 = ConfParticleCleaner<PrefixMcParticleCleaner1>;
+using ConfMcParticleCleaner2 = ConfParticleCleaner<PrefixMcParticleCleaner2>;
+
 class ParticleCleaner
 {
  public:
@@ -103,11 +108,37 @@ class ParticleCleaner
     mRejectedPartonicMotherPdgCodes = confMpc.rejectPartonicMotherPdgCodes.value;
   }
 
+  /// mc + reco
   template <typename T1, typename T2, typename T3, typename T4>
   bool isClean(T1 const& particle,
                T2 const& /*mcParticles*/,
-               T3 const& /*mcMothers*/,
-               T4 const& /*mcPartonicMothers*/)
+               T3 const& mcMothers,
+               T4 const& mcPartonicMothers)
+  {
+    if (!mActivate) {
+      return true;
+    }
+
+    // No MC particle at all → no mother/partonic-mother info is reachable either,
+    // since that lookup now goes through the mc particle row.
+    if (!particle.has_fMcParticle()) {
+      if (mRejectParticleWithoutMcParticle || !mRequiredPdgCodes.empty() ||
+          mRejectParticleWithoutMcMother || !mRequiredMotherPdgCodes.empty() ||
+          mRejectParticleWithoutMcPartonicMother || !mRequiredPartonicMotherPdgCodes.empty()) {
+        return false;
+      }
+      return true;
+    }
+
+    auto mcParticle = particle.template fMcParticle_as<T2>();
+    return this->isClean(mcParticle, mcMothers, mcPartonicMothers);
+  }
+
+  // mc only
+  template <typename T1, typename T2, typename T3>
+  bool isClean(T1 const& mcParticle,
+               T2 const& /*mcMothers*/,
+               T3 const& /*mcPartonicMothers*/)
   {
     if (!mActivate) {
       return true;
@@ -123,40 +154,32 @@ class ParticleCleaner
     bool hasPartonicMotherWithRejectedPdgCode = false;
 
     // MC particle
-    if (!particle.has_fMcParticle()) {
-      if (mRejectParticleWithoutMcParticle || !mRequiredPdgCodes.empty()) {
-        return false;
-      }
-    } else {
-      auto mcParticle = particle.template fMcParticle_as<T2>();
-
-      if (!mRequiredPdgCodes.empty()) {
-        hasRequiredPdgCode = false;
-        for (int const& pdgCode : mRequiredPdgCodes) {
-          if (pdgCode == mcParticle.pdgCode()) {
-            hasRequiredPdgCode = true;
-            break;
-          }
-        }
-      }
-
-      if (!mRejectedPdgCodes.empty()) {
-        for (int const& pdgCode : mRejectedPdgCodes) {
-          if (pdgCode == mcParticle.pdgCode()) {
-            hasRejectedPdgCode = true;
-            break;
-          }
+    if (!mRequiredPdgCodes.empty()) {
+      hasRequiredPdgCode = false;
+      for (int const& pdgCode : mRequiredPdgCodes) {
+        if (pdgCode == mcParticle.pdgCode()) {
+          hasRequiredPdgCode = true;
+          break;
         }
       }
     }
 
-    // MC mother
-    if (!particle.has_fMcMother()) {
+    if (!mRejectedPdgCodes.empty()) {
+      for (int const& pdgCode : mRejectedPdgCodes) {
+        if (pdgCode == mcParticle.pdgCode()) {
+          hasRejectedPdgCode = true;
+          break;
+        }
+      }
+    }
+
+    // MC mother — looked up via mcParticle (T2 must be Join<FMcParticles, FMcMotherLabels>)
+    if (!mcParticle.has_fMcMother()) {
       if (mRejectParticleWithoutMcMother || !mRequiredMotherPdgCodes.empty()) {
         return false;
       }
     } else {
-      auto mother = particle.template fMcMother_as<T3>();
+      auto mother = mcParticle.template fMcMother_as<T2>();
 
       if (!mRequiredMotherPdgCodes.empty()) {
         hasMotherWithRequiredPdgCode = false;
@@ -178,14 +201,14 @@ class ParticleCleaner
       }
     }
 
-    // MC partonic mother
-    if (!particle.has_fMcPartMoth()) {
+    // MC partonic mother — same idea, via mcParticle
+    if (!mcParticle.has_fMcPartMoth()) {
       if (mRejectParticleWithoutMcPartonicMother ||
           !mRequiredPartonicMotherPdgCodes.empty()) {
         return false;
       }
     } else {
-      auto partonicMother = particle.template fMcPartMoth_as<T4>();
+      auto partonicMother = mcParticle.template fMcPartMoth_as<T3>();
 
       if (!mRequiredPartonicMotherPdgCodes.empty()) {
         hasPartonicMotherWithRequiredPdgCode = false;

--- a/PWGCF/Femto/Core/partitions.h
+++ b/PWGCF/Femto/Core/partitions.h
@@ -152,4 +152,22 @@
     (o2::aod::femtobase::stored::mass < selection.massMax) &&                                                                                \
     ncheckbit(o2::aod::femtokinks::mask, selection.mask)
 
+// macros for mc collisions (mc only)
+#define MAKE_MC_COLLISION_FILTER(selection)                                                                         \
+  (o2::aod::femtocollisions::posZ >= selection.vtxZMin && o2::aod::femtocollisions::posZ <= selection.vtxZMax) &&   \
+    (o2::aod::femtocollisions::mult >= selection.multMin && o2::aod::femtocollisions::mult <= selection.multMax) && \
+    (o2::aod::femtocollisions::cent >= selection.centMin && o2::aod::femtocollisions::cent <= selection.centMax)
+
+// macros for mc particle (mc only)
+#define MAKE_MC_PARTICLE_PARTITION(selection)                                                                                                                                          \
+  ifnode(selection.pdgCodeAbs.node() == 0, true, selection.pdgCodeAbs == nabs(o2::aod::femtomcparticle::pdgCode)) &&                                                                   \
+    ifnode(selection.chargeSign.node() != 0, ifnode(selection.chargeSign.node() > 0, o2::aod::femtobase::stored::signedPt > 0.f, o2::aod::femtobase::stored::signedPt < 0.f), true) && \
+    (nabs(o2::aod::femtobase::stored::signedPt) > selection.ptMin) &&                                                                                                                  \
+    (nabs(o2::aod::femtobase::stored::signedPt) < selection.ptMax) &&                                                                                                                  \
+    (o2::aod::femtobase::stored::eta > selection.etaMin) &&                                                                                                                            \
+    (o2::aod::femtobase::stored::eta < selection.etaMax) &&                                                                                                                            \
+    (o2::aod::femtobase::stored::phi > selection.phiMin) &&                                                                                                                            \
+    (o2::aod::femtobase::stored::phi < selection.phiMax)
+
 #endif // PWGCF_FEMTO_CORE_PARTITIONS_H_
+//

--- a/PWGCF/Femto/Core/trackBuilder.h
+++ b/PWGCF/Femto/Core/trackBuilder.h
@@ -145,7 +145,7 @@ struct ConfTrackSelection : public o2::framework::ConfigurableGroup {
   o2::framework::Configurable<float> phiMin{"phiMin", 0.f, "Minimum phi"};
   o2::framework::Configurable<float> phiMax{"phiMax", 1.f * o2::constants::math::TwoPI, "Maximum phi"};
   o2::framework::Configurable<float> massMin{"massMin", 0.f, "Minimum TOF mass (only used if enabled)"};
-  o2::framework::Configurable<float> massMax{"massMax", 2.f, "Maximum TOF mass (only used if enabled)"};
+  o2::framework::Configurable<float> massMax{"massMax", 99.f, "Maximum TOF mass (only used if enabled)"};
   // track selection masks
   o2::framework::Configurable<o2::aod::femtodatatypes::TrackMaskType> maskLowMomentum{"maskLowMomentum", 1ul, "Bitmask for selections below momentum threshold"};
   o2::framework::Configurable<o2::aod::femtodatatypes::TrackMaskType> maskHighMomentum{"maskHighMomentum", 2ul, "Bitmask for selections above momentum threshold"};

--- a/PWGCF/Femto/Core/trackHistManager.h
+++ b/PWGCF/Femto/Core/trackHistManager.h
@@ -354,7 +354,7 @@ constexpr std::array<histmanager::HistInfo<TrackHist>, kTrackHistLast>
       {kPdg, o2::framework::HistType::kTH1F, "hPdg", "PDG Codes of selected tracks; PDG Code; Entries"},
       {kPdgMother, o2::framework::HistType::kTH1F, "hPdgMother", "PDG Codes of mother of selected tracks; PDG Code; Entries"},
       {kPdgPartonicMother, o2::framework::HistType::kTH1F, "hPdgPartonicMother", "PDG Codes of partonic mother selected tracks; PDG Code; Entries"},
-      {kTruePtVsPt, o2::framework::HistType::kTH2F, "hTruePtVsPt", "True transverse momentum vs transverse momentum; p_{T,True} (GeV/#it{c}); p_{T,True} (GeV/#it{c})"},
+      {kTruePtVsPt, o2::framework::HistType::kTH2F, "hTruePtVsPt", "True transverse momentum vs transverse momentum; p_{T,True} (GeV/#it{c}); p_{T} (GeV/#it{c})"},
       {kTrueEtaVsEta, o2::framework::HistType::kTH2F, "hTrueEtaVsEta", "True pseudorapdity vs pseudorapdity; #eta_{True}; #eta"},
       {kTruePhiVsPhi, o2::framework::HistType::kTH2F, "hTruePhiVsPhi", "True azimuthal angle vs azimuthal angle; #varphi_{True}; #varphi"},
       {kNoMcParticle, o2::framework::HistType::kTHnSparseF, "hNoMcParticle", "Wrongly reconstructed particles; p_{T} (GeV/#it{c}); DCA_{xy} (cm); DCA_{z} (cm);"},
@@ -963,16 +963,16 @@ class TrackHistManager
     mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kPdg, HistTable)), mcParticle.pdgCode());
 
     // get mother
-    if (track.has_fMcMother()) {
-      auto mother = track.template fMcMother_as<T3>();
+    if (mcParticle.has_fMcMother()) {
+      auto mother = mcParticle.template fMcMother_as<T3>();
       mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kPdgMother, HistTable)), mother.pdgCode());
     } else {
       mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kPdgMother, HistTable)), 0);
     }
 
     // get partonic mother
-    if (track.has_fMcPartMoth()) {
-      auto partonicMother = track.template fMcPartMoth_as<T4>();
+    if (mcParticle.has_fMcPartMoth()) {
+      auto partonicMother = mcParticle.template fMcPartMoth_as<T4>();
       mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kPdgPartonicMother, HistTable)), partonicMother.pdgCode());
     } else {
       mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kPdgPartonicMother, HistTable)), 0);
@@ -997,8 +997,8 @@ class TrackHistManager
               mHistogramRegistry->fill(HIST(prefix) + HIST(McDir) + HIST(getHistName(kFromMaterial, HistTable)), track.pt(), track.dcaXY(), track.dcaZ());
               break;
             case modes::McOrigin::kFromSecondaryDecay:
-              if (track.has_fMcMother()) {
-                auto mother = track.template fMcMother_as<T3>();
+              if (mcParticle.has_fMcMother()) {
+                auto mother = mcParticle.template fMcMother_as<T3>();
                 int motherPdgCode = std::abs(mother.pdgCode());
                 // Switch on PDG of the mother
                 if (mPlotNSecondaries >= histmanager::kSecondaryPlotLevel1 && motherPdgCode == mPdgCodesSecondaryMother[0]) {

--- a/PWGCF/Femto/Core/tripletCleaner.h
+++ b/PWGCF/Femto/Core/tripletCleaner.h
@@ -37,8 +37,8 @@ class TrackTrackTrackTripletCleaner : public paircleaner::BasePairCleaner
            this->isCleanTrackPair(track1, track3);
   }
 
-  template <typename T1, typename T2, typename T3, typename T4, typename T5>
-  bool isCleanTriplet(T1 const& track1, T2 const& track2, T3 const& track3, T4 const& trackTable, T5 const& partonicMothers) const
+  template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
+  bool isCleanTriplet(T1 const& track1, T2 const& track2, T3 const& track3, T4 const& trackTable, T5 const& mcParticles, T6 const& partonicMothers) const
   {
     if (!this->isCleanTriplet(track1, track2, track3, trackTable)) {
       return false;
@@ -46,14 +46,14 @@ class TrackTrackTrackTripletCleaner : public paircleaner::BasePairCleaner
     // pair is clean
     // no check if we require common or non-common ancestry
     if (mMixPairsWithCommonAncestor) {
-      return this->pairHasCommonAncestor(track1, track2, partonicMothers) &&
-             this->pairHasCommonAncestor(track2, track3, partonicMothers) &&
-             this->pairHasCommonAncestor(track1, track3, partonicMothers);
+      return this->pairHasCommonAncestor(track1, track2, mcParticles, partonicMothers) &&
+             this->pairHasCommonAncestor(track2, track3, mcParticles, partonicMothers) &&
+             this->pairHasCommonAncestor(track1, track3, mcParticles, partonicMothers);
     }
     if (mMixPairsWithNonCommonAncestor) {
-      return this->pairHasNonCommonAncestor(track1, track2, partonicMothers) &&
-             this->pairHasNonCommonAncestor(track2, track3, partonicMothers) &&
-             this->pairHasNonCommonAncestor(track1, track3, partonicMothers);
+      return this->pairHasNonCommonAncestor(track1, track2, mcParticles, partonicMothers) &&
+             this->pairHasNonCommonAncestor(track2, track3, mcParticles, partonicMothers) &&
+             this->pairHasNonCommonAncestor(track1, track3, mcParticles, partonicMothers);
     }
     return true;
   }
@@ -77,8 +77,8 @@ class TrackTrackV0TripletCleaner : public paircleaner::BasePairCleaner
            this->isCleanTrackPair(track2, negDaughter);
   }
 
-  template <typename T1, typename T2, typename T3, typename T4, typename T5>
-  bool isCleanTriplet(T1 const& track1, T2 const& track2, T3 const& v0, T4 const& trackTable, T5 const& partonicMothers) const
+  template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
+  bool isCleanTriplet(T1 const& track1, T2 const& track2, T3 const& v0, T4 const& trackTable, T5 const& mcParticles, T6 const& partonicMothers) const
   {
     if (!this->isCleanTriplet(track1, track2, v0, trackTable)) {
       return false;
@@ -86,14 +86,14 @@ class TrackTrackV0TripletCleaner : public paircleaner::BasePairCleaner
     // pair is clean
     // no check if we require common or non-common ancestry
     if (mMixPairsWithCommonAncestor) {
-      return this->pairHasCommonAncestor(track1, track2, partonicMothers) &&
-             this->pairHasCommonAncestor(track1, v0, partonicMothers) &&
-             this->pairHasCommonAncestor(track2, v0, partonicMothers);
+      return this->pairHasCommonAncestor(track1, track2, mcParticles, partonicMothers) &&
+             this->pairHasCommonAncestor(track1, v0, mcParticles, partonicMothers) &&
+             this->pairHasCommonAncestor(track2, v0, mcParticles, partonicMothers);
     }
     if (mMixPairsWithNonCommonAncestor) {
-      return this->pairHasNonCommonAncestor(track1, track2, partonicMothers) &&
-             this->pairHasNonCommonAncestor(track1, v0, partonicMothers) &&
-             this->pairHasNonCommonAncestor(track2, v0, partonicMothers);
+      return this->pairHasNonCommonAncestor(track1, track2, mcParticles, partonicMothers) &&
+             this->pairHasNonCommonAncestor(track1, v0, mcParticles, partonicMothers) &&
+             this->pairHasNonCommonAncestor(track2, v0, mcParticles, partonicMothers);
     }
     return true;
   }
@@ -120,8 +120,8 @@ class TrackTrackCascadeTripletCleaner : public paircleaner::BasePairCleaner
            this->isCleanTrackPair(track2, bachelor);
   }
 
-  template <typename T1, typename T2, typename T3, typename T4, typename T5>
-  bool isCleanTriplet(T1 const& track1, T2 const& track2, T3 const& cascade, T4 const& trackTable, T5 const& partonicMothers) const
+  template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
+  bool isCleanTriplet(T1 const& track1, T2 const& track2, T3 const& cascade, T4 const& trackTable, T5 const& mcParticles, T6 const& partonicMothers) const
   {
     if (!this->isCleanTriplet(track1, track2, cascade, trackTable)) {
       return false;
@@ -129,14 +129,14 @@ class TrackTrackCascadeTripletCleaner : public paircleaner::BasePairCleaner
     // pair is clean
     // no check if we require common or non-common ancestry
     if (mMixPairsWithCommonAncestor) {
-      return this->pairHasCommonAncestor(track1, track2, partonicMothers) &&
-             this->pairHasCommonAncestor(track1, cascade, partonicMothers) &&
-             this->pairHasCommonAncestor(track2, cascade, partonicMothers);
+      return this->pairHasCommonAncestor(track1, track2, mcParticles, partonicMothers) &&
+             this->pairHasCommonAncestor(track1, cascade, mcParticles, partonicMothers) &&
+             this->pairHasCommonAncestor(track2, cascade, mcParticles, partonicMothers);
     }
     if (mMixPairsWithNonCommonAncestor) {
-      return this->pairHasNonCommonAncestor(track1, track2, partonicMothers) &&
-             this->pairHasNonCommonAncestor(track1, cascade, partonicMothers) &&
-             this->pairHasNonCommonAncestor(track2, cascade, partonicMothers);
+      return this->pairHasNonCommonAncestor(track1, track2, mcParticles, partonicMothers) &&
+             this->pairHasNonCommonAncestor(track1, cascade, mcParticles, partonicMothers) &&
+             this->pairHasNonCommonAncestor(track2, cascade, mcParticles, partonicMothers);
     }
     return true;
   }

--- a/PWGCF/Femto/Core/tripletProcessHelpers.h
+++ b/PWGCF/Femto/Core/tripletProcessHelpers.h
@@ -268,7 +268,7 @@ void processSameEvent(T1 const& SliceParticle,
 
   for (auto const& [p1, p2, p3] : o2::soa::combinations(o2::soa::CombinationsStrictlyUpperIndexPolicy(SliceParticle, SliceParticle, SliceParticle))) {
     // check if triplet is clean
-    if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable, mcPartonicMothers)) {
+    if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable, mcParticles, mcPartonicMothers)) {
       continue;
     }
     // check if triplet is close
@@ -337,7 +337,7 @@ void processSameEvent(T1 const& SliceParticle1,
   for (auto const& p3 : SliceParticle3) {
     for (auto const& [p1, p2] : o2::soa::combinations(o2::soa::CombinationsStrictlyUpperIndexPolicy(SliceParticle1, SliceParticle1))) {
       // check if triplet is clean
-      if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable, mcPartonicMothers)) {
+      if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable, mcParticles, mcPartonicMothers)) {
         continue;
       }
       // check if triplet is close
@@ -416,7 +416,7 @@ void processSameEvent(T1 const& SliceParticle1,
 
   for (auto const& [p1, p2, p3] : o2::soa::combinations(o2::soa::CombinationsFullIndexPolicy(SliceParticle1, SliceParticle2, SliceParticle3))) {
     // check if triplet is clean
-    if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable, mcPartonicMothers)) {
+    if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable, mcParticles, mcPartonicMothers)) {
       continue;
     }
     // check if triplet is close

--- a/PWGCF/Femto/Core/v0HistManager.h
+++ b/PWGCF/Femto/Core/v0HistManager.h
@@ -629,16 +629,16 @@ class V0HistManager
     mHistogramRegistry->fill(HIST(v0Prefix) + HIST(McDir) + HIST(getHistName(kPdg, HistTable)), mcParticle.pdgCode());
 
     // get mother
-    if (v0Candidate.has_fMcMother()) {
-      auto mother = v0Candidate.template fMcMother_as<T3>();
+    if (mcParticle.has_fMcMother()) {
+      auto mother = mcParticle.template fMcMother_as<T3>();
       mHistogramRegistry->fill(HIST(v0Prefix) + HIST(McDir) + HIST(getHistName(kPdgMother, HistTable)), mother.pdgCode());
     } else {
       mHistogramRegistry->fill(HIST(v0Prefix) + HIST(McDir) + HIST(getHistName(kPdgMother, HistTable)), 0);
     }
 
     // get partonic mother
-    if (v0Candidate.has_fMcPartMoth()) {
-      auto partonicMother = v0Candidate.template fMcPartMoth_as<T4>();
+    if (mcParticle.has_fMcPartMoth()) {
+      auto partonicMother = mcParticle.template fMcPartMoth_as<T4>();
       mHistogramRegistry->fill(HIST(v0Prefix) + HIST(McDir) + HIST(getHistName(kPdgPartonicMother, HistTable)), partonicMother.pdgCode());
     } else {
       mHistogramRegistry->fill(HIST(v0Prefix) + HIST(McDir) + HIST(getHistName(kPdgPartonicMother, HistTable)), 0);
@@ -663,8 +663,8 @@ class V0HistManager
               mHistogramRegistry->fill(HIST(v0Prefix) + HIST(McDir) + HIST(getHistName(kFromMaterial, HistTable)), v0Candidate.pt(), v0Candidate.cosPa());
               break;
             case modes::McOrigin::kFromSecondaryDecay:
-              if (v0Candidate.has_fMcMother()) {
-                auto mother = v0Candidate.template fMcMother_as<T3>();
+              if (mcParticle.has_fMcMother()) {
+                auto mother = mcParticle.template fMcMother_as<T3>();
                 int motherPdgCode = std::abs(mother.pdgCode());
                 // Switch on PDG of the mother
                 if (mPlotNSecondaries >= histmanager::kSecondaryPlotLevel1 && motherPdgCode == mPdgCodesSecondaryMother[0]) {

--- a/PWGCF/Femto/DataModel/FemtoTables.h
+++ b/PWGCF/Femto/DataModel/FemtoTables.h
@@ -707,15 +707,16 @@ using FOmegaExtras = FOmegaExtras_001;
 
 namespace femtomccollisions
 {
-DECLARE_SOA_COLUMN(Mult, mult, int);   //! Multiplicity of the event as given by the generator in |eta|<0.8
-DECLARE_SOA_COLUMN(Cent, cent, float); //! Multiplicity of the event as given by the generator in |eta|<0.8
-                                       //
+// DECLARE_SOA_COLUMN(Mult, mult, int);   //! Multiplicity of the event as given by the generator in |eta|<0.8
+// DECLARE_SOA_COLUMN(Cent, cent, float);
+//
 } // namespace femtomccollisions
 
 DECLARE_SOA_TABLE_STAGED_VERSIONED(FMcCols_001, "FMCCOL", 1, //! femto mc collisions
                                    o2::soa::Index<>,
-                                   femtomccollisions::Mult,
-                                   femtomccollisions::Cent);
+                                   femtocollisions::PosZ, //! Multiplicity of the event as given by the generator in |eta|<0.8
+                                   femtocollisions::Mult,
+                                   femtocollisions::Cent);
 using FMcCols = FMcCols_001;
 using FMcCol = FMcCols_001::iterator;
 
@@ -746,8 +747,20 @@ using FMcParticles = FMcParticles_001;
 using FMcParticle = FMcParticles::iterator;
 
 DECLARE_SOA_TABLE_STAGED_VERSIONED(FMcMothers_001, "FMCMOTHER", 1, //! first direct mother of the monte carlo particle
-                                   o2::soa::Index<>,
-                                   femtomcparticle::PdgCode);
+                                   o2::soa::Index<>, // no collision index needed since the mother is retrieved from the daughter mc particle
+                                   femtomcparticle::Origin,
+                                   femtomcparticle::PdgCode,
+                                   femtobase::stored::SignedPt,
+                                   femtobase::stored::Eta,
+                                   femtobase::stored::Phi,
+                                   femtobase::dynamic::Sign<femtobase::stored::SignedPt>,
+                                   femtobase::dynamic::Pt<femtobase::stored::SignedPt>,
+                                   femtobase::dynamic::P<femtobase::stored::SignedPt, femtobase::stored::Eta>,
+                                   femtobase::dynamic::Px<femtobase::stored::SignedPt, femtobase::stored::Phi>,
+                                   femtobase::dynamic::Py<femtobase::stored::SignedPt, femtobase::stored::Phi>,
+                                   femtobase::dynamic::Pz<femtobase::stored::SignedPt, femtobase::stored::Eta>,
+                                   femtobase::dynamic::Theta<femtobase::stored::Eta>);
+
 using FMcMothers = FMcMothers_001;
 using FMcMother = FMcMothers::iterator;
 
@@ -766,41 +779,24 @@ DECLARE_SOA_INDEX_COLUMN(FMcMother, fMcMother);     //!
 DECLARE_SOA_INDEX_COLUMN(FMcPartMoth, fMcPartMoth); //!
 } // namespace femtolabels
 
-DECLARE_SOA_TABLE(FColLabels, "AOD", "FCOLMCLABEL",
-                  femtolabels::FMcColId);
+DECLARE_SOA_TABLE(FColLabels, "AOD", "FCOLMCLABEL", femtolabels::FMcColId);
 
-DECLARE_SOA_TABLE(FTrackLabels, "AOD", "FTRACKLABEL",
-                  femtolabels::FMcParticleId,
-                  femtolabels::FMcMotherId,
-                  femtolabels::FMcPartMothId);
+DECLARE_SOA_TABLE(FTrackLabels, "AOD", "FTRACKLABEL", femtolabels::FMcParticleId);
 
-DECLARE_SOA_TABLE(FLambdaLabels, "AOD", "FLAMBDALABEL",
-                  femtolabels::FMcParticleId,
-                  femtolabels::FMcMotherId,
-                  femtolabels::FMcPartMothId);
+DECLARE_SOA_TABLE(FLambdaLabels, "AOD", "FLAMBDALABEL", femtolabels::FMcParticleId);
 
-DECLARE_SOA_TABLE(FK0shortLabels, "AOD", "FK0SHORTLABEL",
-                  femtolabels::FMcParticleId,
-                  femtolabels::FMcMotherId,
-                  femtolabels::FMcPartMothId);
+DECLARE_SOA_TABLE(FK0shortLabels, "AOD", "FK0SHORTLABEL", femtolabels::FMcParticleId);
 
-DECLARE_SOA_TABLE(FSigmaLabels, "AOD", "FSIGMALABEL",
-                  femtolabels::FMcParticleId,
-                  femtolabels::FMcMotherId,
-                  femtolabels::FMcPartMothId);
+DECLARE_SOA_TABLE(FSigmaLabels, "AOD", "FSIGMALABEL", femtolabels::FMcParticleId);
 
-DECLARE_SOA_TABLE(FSigmaPlusLabels, "AOD", "FSIGMAPLUSLABEL",
-                  femtolabels::FMcParticleId,
-                  femtolabels::FMcMotherId,
-                  femtolabels::FMcPartMothId);
+DECLARE_SOA_TABLE(FSigmaPlusLabels, "AOD", "FSIGMAPLUSLABEL", femtolabels::FMcParticleId);
 
-DECLARE_SOA_TABLE(FXiLabels, "AOD", "FXILABEL",
-                  femtolabels::FMcParticleId,
-                  femtolabels::FMcMotherId,
-                  femtolabels::FMcPartMothId);
+DECLARE_SOA_TABLE(FXiLabels, "AOD", "FXILABEL", femtolabels::FMcParticleId);
 
-DECLARE_SOA_TABLE(FOmegaLabels, "AOD", "FOMEGALABEL",
-                  femtolabels::FMcParticleId,
+DECLARE_SOA_TABLE(FOmegaLabels, "AOD", "FOMEGALABEL", femtolabels::FMcParticleId);
+
+// for mc only processing, we also need Labels pointing from mc particles to mothers and partonic mothers
+DECLARE_SOA_TABLE(FMcMotherLabels, "AOD", "FMCMOTHERLABEL",
                   femtolabels::FMcMotherId,
                   femtolabels::FMcPartMothId);
 

--- a/PWGCF/Femto/DataModel/FemtoTables.h
+++ b/PWGCF/Femto/DataModel/FemtoTables.h
@@ -747,7 +747,7 @@ using FMcParticles = FMcParticles_001;
 using FMcParticle = FMcParticles::iterator;
 
 DECLARE_SOA_TABLE_STAGED_VERSIONED(FMcMothers_001, "FMCMOTHER", 1, //! first direct mother of the monte carlo particle
-                                   o2::soa::Index<>, // no collision index needed since the mother is retrieved from the daughter mc particle
+                                   o2::soa::Index<>,               // no collision index needed since the mother is retrieved from the daughter mc particle
                                    femtomcparticle::Origin,
                                    femtomcparticle::PdgCode,
                                    femtobase::stored::SignedPt,

--- a/PWGCF/Femto/TableProducer/femtoProducer.cxx
+++ b/PWGCF/Femto/TableProducer/femtoProducer.cxx
@@ -33,6 +33,7 @@
 #include "Common/DataModel/TrackSelectionTables.h"
 
 #include <CCDB/BasicCCDBManager.h>
+#include <Framework/ASoA.h>
 #include <Framework/AnalysisDataModel.h>
 #include <Framework/AnalysisHelpers.h>
 #include <Framework/AnalysisTask.h>
@@ -82,6 +83,8 @@ using Run3McGenParticles = o2::aod::McParticles;
 } // namespace o2::analysis::femto
 
 struct FemtoProducer {
+
+  o2::framework::Preslice<consumeddata::Run3McGenParticles> perMcCollision = o2::aod::mcparticle::mcCollisionId;
 
   // ccdb
   collisionbuilder::ConfCcdb confCcdb;
@@ -144,16 +147,26 @@ struct FemtoProducer {
 
   void init(o2::framework::InitContext& context)
   {
-    if ((xiBuilder.fillAnyTable() || omegaBuilder.fillAnyTable()) && (!doprocessTracksV0sCascadesRun3pp && !doprocessTracksV0sCascadesKinksRun3pp)) {
+    if ((xiBuilder.fillAnyTable() || omegaBuilder.fillAnyTable()) &&
+        (!doprocessTracksV0sCascadesRun3pp && !doprocessTracksV0sCascadesKinksRun3pp && !doprocessTracksV0sCascadesRun3ppMc)) {
       LOG(fatal) << "At least one cascade table is enabled, but wrong process function is enabled. Breaking...";
     }
-    if ((lambdaBuilder.fillAnyTable() || antilambdaBuilder.fillAnyTable() || k0shortBuilder.fillAnyTable()) && (!doprocessTracksV0sCascadesRun3pp && !doprocessTracksV0sRun3pp && !doprocessTracksV0sCascadesKinksRun3pp && !doprocessTracksV0sRun3ppMc)) {
+    if ((lambdaBuilder.fillAnyTable() || antilambdaBuilder.fillAnyTable() || k0shortBuilder.fillAnyTable()) &&
+        (!doprocessTracksV0sCascadesRun3pp && !doprocessTracksV0sRun3pp && !doprocessTracksV0sCascadesKinksRun3pp &&
+         !doprocessTracksV0sRun3ppMc && !doprocessTracksV0sRun3PbPb && !doprocessTracksV0sRun3PbPbMc &&
+         !doprocessTracksV0sCascadesRun3ppMc && !doprocessTracksV0sKinksRun3ppMc)) {
       LOG(fatal) << "At least one v0 table is enabled, but wrong process function is enabled. Breaking...";
     }
-    if ((sigmaBuilder.fillAnyTable() || sigmaPlusBuilder.fillAnyTable()) && (!doprocessTracksKinksRun3pp && !doprocessTracksV0sCascadesKinksRun3pp && !doprocessTracksKinksRun3ppMc)) {
+    if ((sigmaBuilder.fillAnyTable() || sigmaPlusBuilder.fillAnyTable()) &&
+        (!doprocessTracksKinksRun3pp && !doprocessTracksV0sCascadesKinksRun3pp &&
+         !doprocessTracksKinksRun3ppMc && !doprocessTracksV0sKinksRun3ppMc)) {
       LOG(fatal) << "At least one kink table is enabled, but wrong process function is enabled. Breaking...";
     }
-    if (mcBuilder.fillAnyTable() && (!doprocessTracksV0sRun3ppMc && !doprocessTracksKinksRun3ppMc)) {
+    if (mcBuilder.fillAnyTable() &&
+        (!doprocessTracksV0sRun3ppMc && !doprocessTracksKinksRun3ppMc &&
+         !doprocessTracksV0sCascadesRun3ppMc && !doprocessTracksV0sKinksRun3ppMc &&
+         !doprocessTracksRun3ppMc && !doprocessTracksRun3PbPbMc && !doprocessTracksV0sRun3PbPbMc &&
+         !doprocessRun3ppMcOnly)) {
       LOG(fatal) << "At least one mc table is enabled, but wrong process function is enabled. Breaking...";
     }
 
@@ -188,6 +201,7 @@ struct FemtoProducer {
     mcBuilder.init(confMc, confMcTables, context);
 
     hRegistry.print();
+    LOG(warn) << __LINE__;
   }
 
   // processing collisions
@@ -514,6 +528,21 @@ struct FemtoProducer {
     processMcCascades<modes::System::kPP_Run3_MC>(col, mcCols, tracks, cascades, mcParticles);
   }
   PROCESS_SWITCH(FemtoProducer, processTracksV0sCascadesRun3ppMc, "Provide reconstructed and generated tracks and v0s", false);
+
+  // process generator level only input (for MCGEN datasets)
+  // do not preslice mcParticles tables for each collision, otherwise the finding of the partonic mother can fail
+  void processRun3ppMcOnly(consumeddata::Run3PpMcGenCollisions const& mcCols, consumeddata::Run3McGenParticles const& mcParticles)
+  {
+    mcBuilder.reset(mcParticles);
+    for (const auto& mcCol : mcCols) {
+      mcBuilder.fillMcCollision<modes::System::kPP_Run3_MC>(mcCol, mcProducts);
+      auto particlesThisCollision = mcParticles.sliceBy(perMcCollision, mcCol.globalIndex());
+      for (const auto& mcParticle : particlesThisCollision) {
+        mcBuilder.fillMcParticle<modes::System::kPP_Run3_MC>(mcParticle, mcParticles, mcCol, mcProducts);
+      }
+    }
+  }
+  PROCESS_SWITCH(FemtoProducer, processRun3ppMcOnly, "Provide generated particles", false);
 };
 
 o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)

--- a/PWGCF/Femto/Tasks/CMakeLists.txt
+++ b/PWGCF/Femto/Tasks/CMakeLists.txt
@@ -34,6 +34,11 @@ o2physics_add_dpl_workflow(femto-cascade-qa
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
           COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(femto-mc-particle-qa
+          SOURCES femtoMcParticleQa.cxx
+          PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+          COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(femto-pair-track-track
 	  SOURCES femtoPairTrackTrack.cxx
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore

--- a/PWGCF/Femto/Tasks/femtoCascadeQa.cxx
+++ b/PWGCF/Femto/Tasks/femtoCascadeQa.cxx
@@ -57,6 +57,8 @@ struct FemtoCascadeQa {
   using FemtoOmegasWithLabel = o2::soa::Join<FemtoOmegas, o2::aod::FOmegaLabels>;
   using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, o2::aod::FTrackLabels>;
 
+  using FemtoMcParticlesWithLabel = o2::soa::Join<o2::aod::FMcParticles, o2::aod::FMcMotherLabels>;
+
   o2::framework::SliceCache cache;
 
   // setup collisions
@@ -182,7 +184,7 @@ struct FemtoCascadeQa {
   }
   PROCESS_SWITCH(FemtoCascadeQa, processXi, "Process Xis", true);
 
-  void processXiMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& /*xis*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processXiMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& /*xis*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     auto xiSlice = xiWithLabelPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
     if (xiSlice.size() == 0) {
@@ -211,7 +213,7 @@ struct FemtoCascadeQa {
   }
   PROCESS_SWITCH(FemtoCascadeQa, processOmega, "Process Omegas", false);
 
-  void processOmegaMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoOmegasWithLabel const& /*omegas*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processOmegaMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoOmegasWithLabel const& /*omegas*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     auto omegaSlice = omegaWithLabelPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
     if (omegaSlice.size() == 0) {

--- a/PWGCF/Femto/Tasks/femtoKinkQa.cxx
+++ b/PWGCF/Femto/Tasks/femtoKinkQa.cxx
@@ -60,6 +60,8 @@ struct FemtoKinkQa {
   using FemtoSigmaPlusWithLabel = o2::soa::Join<FemtoSigmaPlus, o2::aod::FSigmaPlusLabels>;
   using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, o2::aod::FTrackLabels>;
 
+  using FemtoMcParticlesWithLabel = o2::soa::Join<o2::aod::FMcParticles, o2::aod::FMcMotherLabels>;
+
   o2::framework::SliceCache cache;
 
   // setup for collisions
@@ -173,7 +175,7 @@ struct FemtoKinkQa {
   }
   PROCESS_SWITCH(FemtoKinkQa, processSigma, "Process sigmas", true);
 
-  void processSigmaMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmasWithLabel const& /*sigmas*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processSigmaMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmasWithLabel const& /*sigmas*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     auto sigmaSlice = sigmaWithLabelPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
     if (sigmaSlice.size() == 0) {
@@ -202,7 +204,7 @@ struct FemtoKinkQa {
   }
   PROCESS_SWITCH(FemtoKinkQa, processSigmaPlus, "Process sigma plus", false);
 
-  void processSigmaPlusMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmaPlusWithLabel const& /*sigmaPlus*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processSigmaPlusMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmaPlusWithLabel const& /*sigmaPlus*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     auto sigmaPlusSlice = sigmaPlusWithLabelPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
     if (sigmaPlusSlice.size() == 0) {

--- a/PWGCF/Femto/Tasks/femtoMcParticleQa.cxx
+++ b/PWGCF/Femto/Tasks/femtoMcParticleQa.cxx
@@ -1,0 +1,107 @@
+// Copyright 2019-2025 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file femtoMcParticleQa.cxx
+/// \brief QA task for tracks
+/// \author Anton Riedel, TU München, anton.riedel@cern.ch
+
+#include "PWGCF/Femto/Core/mcBuilder.h"
+#include "PWGCF/Femto/Core/mcCollisionHistManager.h"
+#include "PWGCF/Femto/Core/mcParticleHistManager.h"
+#include "PWGCF/Femto/Core/particleCleaner.h"
+#include "PWGCF/Femto/Core/partitions.h"
+#include "PWGCF/Femto/DataModel/FemtoTables.h"
+
+#include <Framework/ASoA.h>
+#include <Framework/AnalysisHelpers.h>
+#include <Framework/AnalysisTask.h>
+#include <Framework/Configurable.h>
+#include <Framework/Expressions.h>
+#include <Framework/HistogramRegistry.h>
+#include <Framework/HistogramSpec.h>
+#include <Framework/InitContext.h>
+#include <Framework/OutputObjHeader.h>
+#include <Framework/runDataProcessing.h>
+
+#include <map>
+#include <vector>
+
+using namespace o2::analysis::femto;
+
+struct FemtoMcParticleQa {
+
+  // setup tables
+  using FemtoMcCollisions = o2::aod::FMcCols;
+  using FilteredFemtoMcCollisions = o2::soa::Filtered<FemtoMcCollisions>;
+  using FilteredFemtoMcCollision = FilteredFemtoMcCollisions::iterator;
+
+  using FemtoMcParticles = o2::soa::Join<o2::aod::FMcParticles, o2::aod::FMcMotherLabels>;
+
+  o2::framework::SliceCache cache;
+
+  // setup collisions
+  mcbuilder::ConfMcCollisionFilters collisionSelection;
+  o2::framework::expressions::Filter collisionFilter = MAKE_MC_COLLISION_FILTER(collisionSelection);
+  mccollisionhistmanager::ConfMcCollisionBinning confCollisionBinning;
+  mccollisionhistmanager::McCollisionHistManager<mccollisionhistmanager::PrefixMcCollsion> colHistManager;
+
+  // setup mc particles
+  mcbuilder::ConfMcParticleSelection1 confMcParticleSelection1;
+  mcparticlehistmanager::ConfMcParticleBinning1 confMcParticleBinning1;
+  mcparticlehistmanager::McParticleHistManager<mcparticlehistmanager::PrefixMcParticle1> mcParticleHistManager1;
+
+  o2::framework::Partition<FemtoMcParticles> mcParticlesPartition1 = MAKE_MC_PARTICLE_PARTITION(confMcParticleSelection1);
+  o2::framework::Preslice<FemtoMcParticles> perColReco = o2::aod::femtomcparticle::fMcColId;
+
+  particlecleaner::ConfMcParticleCleaner1 confMcParticleCleaner1;
+  particlecleaner::ParticleCleaner mcParticleCleaner;
+
+  o2::framework::HistogramRegistry hRegistry{"FemtoMcParticleQA", {}, o2::framework::OutputObjHandlingPolicy::AnalysisObject};
+
+  void init(o2::framework::InitContext&)
+  {
+    mcParticleCleaner.init(confMcParticleCleaner1);
+
+    std::map<mccollisionhistmanager::McCollisionHist, std::vector<o2::framework::AxisSpec>> colHistSpec;
+    std::map<mcparticlehistmanager::McParticleHist, std::vector<o2::framework::AxisSpec>> mcParticleHistSpec;
+
+    colHistSpec = mccollisionhistmanager::makeMcCollisionHistSpecMap(confCollisionBinning);
+    colHistManager.init(&hRegistry, colHistSpec);
+    mcParticleHistSpec = mcparticlehistmanager::makeMcParticleHistSpecMap(confMcParticleBinning1);
+    mcParticleHistManager1.init(&hRegistry, mcParticleHistSpec);
+
+    hRegistry.print();
+  };
+
+  void process(FilteredFemtoMcCollision const& col, FemtoMcParticles const& /*mcParticles*/, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  {
+    auto mcParticleSlice = mcParticlesPartition1->sliceByCached(o2::aod::femtomcparticle::fMcColId, col.globalIndex(), cache);
+    if (mcParticleSlice.size() == 0) {
+      return;
+    }
+    colHistManager.fill(col);
+    for (auto const& mcParticle : mcParticleSlice) {
+      if (!mcParticleCleaner.isClean(mcParticle, mcMothers, mcPartonicMothers)) {
+        continue;
+      }
+      mcParticleHistManager1.fill(mcParticle, mcMothers, mcPartonicMothers);
+    }
+  }
+};
+
+o2::framework::WorkflowSpec
+  defineDataProcessing(o2::framework::ConfigContext const& cfgc)
+{
+  o2::framework::WorkflowSpec workflow{
+    adaptAnalysisTask<FemtoMcParticleQa>(cfgc),
+  };
+  return workflow;
+}

--- a/PWGCF/Femto/Tasks/femtoPairTrackCascade.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackCascade.cxx
@@ -63,6 +63,8 @@ struct FemtoPairTrackCascade {
   using FemtoXisWithLabel = o2::soa::Join<FemtoXis, o2::aod::FLambdaLabels>;
   using FemtoOmegasWithLabel = o2::soa::Join<FemtoOmegas, o2::aod::FK0shortLabels>;
 
+  using FemtoMcParticlesWithLabel = o2::soa::Join<o2::aod::FMcParticles, o2::aod::FMcMotherLabels>;
+
   o2::framework::SliceCache cache;
 
   // setup collisions
@@ -229,7 +231,7 @@ struct FemtoPairTrackCascade {
   }
   PROCESS_SWITCH(FemtoPairTrackCascade, processXiSameEvent, "Enable processing same event processing for tracks and xis", true);
 
-  void processXiSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& xis, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processXiSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& xis, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackXiBuilder.processSameEvent<modes::Mode::kSe_Analysis_Mc>(col, mcCols, tracks, trackWithLabelPartition, xis, xiWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -241,7 +243,7 @@ struct FemtoPairTrackCascade {
   }
   PROCESS_SWITCH(FemtoPairTrackCascade, processXiMixedEvent, "Enable processing mixed event processing for tracks and xis", true);
 
-  void processXiMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& /*xis*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processXiMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& /*xis*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackXiBuilder.processMixedEvent<modes::Mode::kMe_Analysis_Mc>(cols, mcCols, tracks, trackWithLabelPartition, xiWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }
@@ -253,7 +255,7 @@ struct FemtoPairTrackCascade {
   }
   PROCESS_SWITCH(FemtoPairTrackCascade, processOmegaSameEvent, "Enable processing same event processing for tracks and omegas", false);
 
-  void processOmegaSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoOmegasWithLabel const& omegas, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processOmegaSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoOmegasWithLabel const& omegas, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackOmegaBuilder.processSameEvent<modes::Mode::kSe_Analysis_Mc>(col, mcCols, tracks, trackWithLabelPartition, omegas, omegaWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -265,7 +267,7 @@ struct FemtoPairTrackCascade {
   }
   PROCESS_SWITCH(FemtoPairTrackCascade, processOmegaMixedEvent, "Enable processing mixed event processing for tracks and omegas", false);
 
-  void processOmegaMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& /*xis*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processOmegaMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& /*xis*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackOmegaBuilder.processMixedEvent<modes::Mode::kMe_Analysis_Mc>(cols, mcCols, tracks, trackWithLabelPartition, omegaWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }

--- a/PWGCF/Femto/Tasks/femtoPairTrackKink.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackKink.cxx
@@ -64,6 +64,8 @@ struct FemtoPairTrackKink {
   using FemtoSigmasWithLabel = o2::soa::Join<FemtoSigmas, o2::aod::FSigmaLabels>;
   using FemtoSigmaPlusWithLabel = o2::soa::Join<FemtoSigmaPlus, o2::aod::FSigmaPlusLabels>;
 
+  using FemtoMcParticlesWithLabel = o2::soa::Join<o2::aod::FMcParticles, o2::aod::FMcMotherLabels>;
+
   o2::framework::SliceCache cache;
 
   // setup collisions
@@ -211,7 +213,7 @@ struct FemtoPairTrackKink {
   }
   PROCESS_SWITCH(FemtoPairTrackKink, processSigmaSameEvent, "Enable processing same event processing for tracks and sigmas", true);
 
-  void processSigmaSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmasWithLabel const& sigmas, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processSigmaSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmasWithLabel const& sigmas, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackSigmaBuilder.processSameEvent<modes::Mode::kSe_Analysis_Mc>(col, mcCols, tracks, trackWithLabelPartition, sigmas, sigmaWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -223,7 +225,7 @@ struct FemtoPairTrackKink {
   }
   PROCESS_SWITCH(FemtoPairTrackKink, processSigmaMixedEvent, "Enable processing mixed event processing for tracks and sigmas", true);
 
-  void processSigmaMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmasWithLabel const& /*sigmas*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processSigmaMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmasWithLabel const& /*sigmas*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackSigmaBuilder.processMixedEvent<modes::Mode::kMe_Analysis_Mc>(cols, mcCols, tracks, trackWithLabelPartition, sigmaWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }
@@ -235,7 +237,7 @@ struct FemtoPairTrackKink {
   }
   PROCESS_SWITCH(FemtoPairTrackKink, processSigmaPlusSameEvent, "Enable processing same event processing for tracks and sigma plus", false);
 
-  void processSigmaPlusSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmaPlusWithLabel const& sigmaplus, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processSigmaPlusSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmaPlusWithLabel const& sigmaplus, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackSigmaPlusBuilder.processSameEvent<modes::Mode::kSe_Analysis_Mc>(col, mcCols, tracks, trackWithLabelPartition, sigmaplus, sigmaPlusWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -247,7 +249,7 @@ struct FemtoPairTrackKink {
   }
   PROCESS_SWITCH(FemtoPairTrackKink, processSigmaPlusMixedEvent, "Enable processing mixed event processing for tracks and sigma plus", false);
 
-  void processSigmaPlusMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmaPlusWithLabel const& /*sigmaplus*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processSigmaPlusMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoSigmaPlusWithLabel const& /*sigmaplus*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackSigmaPlusBuilder.processMixedEvent<modes::Mode::kMe_Analysis_Mc>(cols, mcCols, tracks, trackWithLabelPartition, sigmaPlusWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }

--- a/PWGCF/Femto/Tasks/femtoPairTrackTrack.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackTrack.cxx
@@ -60,6 +60,8 @@ struct FemtoPairTrackTrack {
 
   using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, o2::aod::FTrackLabels>;
 
+  using FemtoMcParticlesWithLabel = o2::soa::Join<o2::aod::FMcParticles, o2::aod::FMcMotherLabels>;
+
   o2::framework::SliceCache cache;
 
   // setup collisions
@@ -166,7 +168,7 @@ struct FemtoPairTrackTrack {
   }
   PROCESS_SWITCH(FemtoPairTrackTrack, processSameEventWithMass, "Enable processing same event processing (with track masses)", false);
 
-  void processSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackTrackBuilder.processSameEvent<modes::Mode::kSe_Analysis_Mc>(col, mcCols, tracks, trackWithLabelPartition1, trackWithLabelPartition2, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -184,7 +186,7 @@ struct FemtoPairTrackTrack {
   }
   PROCESS_SWITCH(FemtoPairTrackTrack, processMixedEventWithMass, "Enable processing mixed event processing (with track masses)", false);
 
-  void processMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackTrackBuilder.processMixedEvent<modes::Mode::kMe_Analysis_Mc>(cols, mcCols, tracks, trackWithLabelPartition1, trackWithLabelPartition2, mcParticles, mcMothers, mcPartonicMothers, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }

--- a/PWGCF/Femto/Tasks/femtoPairTrackV0.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackV0.cxx
@@ -63,6 +63,8 @@ struct FemtoPairTrackV0 {
   using FemtoLambdasWithLabel = o2::soa::Join<FemtoLambdas, o2::aod::FLambdaLabels>;
   using FemtoK0shortsWithLabel = o2::soa::Join<FemtoK0shorts, o2::aod::FK0shortLabels>;
 
+  using FemtoMcParticlesWithLabel = o2::soa::Join<o2::aod::FMcParticles, o2::aod::FMcMotherLabels>;
+
   o2::framework::SliceCache cache;
 
   // setup collisions
@@ -216,7 +218,7 @@ struct FemtoPairTrackV0 {
   }
   PROCESS_SWITCH(FemtoPairTrackV0, processLambdaSameEvent, "Enable processing same event processing for tracks and lambdas", true);
 
-  void processLambdaSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& lambdas, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processLambdaSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& lambdas, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackLambdaBuilder.processSameEvent<modes::Mode::kSe_Analysis_Mc>(col, mcCols, tracks, trackWithLabelPartition, lambdas, lambdaWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -228,7 +230,7 @@ struct FemtoPairTrackV0 {
   }
   PROCESS_SWITCH(FemtoPairTrackV0, processLambdaMixedEvent, "Enable processing mixed event processing for tracks and lambdas", true);
 
-  void processLambdaMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& /*lambas*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processLambdaMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& /*lambas*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackLambdaBuilder.processMixedEvent<modes::Mode::kMe_Analysis_Mc>(cols, mcCols, tracks, trackWithLabelPartition, lambdaWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }
@@ -240,7 +242,7 @@ struct FemtoPairTrackV0 {
   }
   PROCESS_SWITCH(FemtoPairTrackV0, processK0shortSameEvent, "Enable processing same event processing for tracks and k0shorts", false);
 
-  void processK0shortSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& k0shorts, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processK0shortSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& k0shorts, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackK0shortBuilder.processSameEvent<modes::Mode::kSe_Analysis_Mc>(col, mcCols, tracks, trackWithLabelPartition, k0shorts, k0shortWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -252,7 +254,7 @@ struct FemtoPairTrackV0 {
   }
   PROCESS_SWITCH(FemtoPairTrackV0, processK0shortMixedEvent, "Enable processing mixed event processing for tracks and k0shorts", false);
 
-  void processK0shortMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& /*k0shorts*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processK0shortMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& /*k0shorts*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackK0shortBuilder.processMixedEvent<modes::Mode::kMe_Analysis_Mc>(cols, mcCols, tracks, trackWithLabelPartition, k0shortWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }

--- a/PWGCF/Femto/Tasks/femtoPairV0V0.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairV0V0.cxx
@@ -61,7 +61,9 @@ struct FemtoPairV0V0 {
   using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, o2::aod::FTrackLabels>;
   using FemtoLambdasWithLabel = o2::soa::Join<FemtoLambdas, o2::aod::FLambdaLabels>;
   using FemtoK0shortsWithLabel = o2::soa::Join<FemtoK0shorts, o2::aod::FK0shortLabels>;
-  //
+
+  using FemtoMcParticlesWithLabel = o2::soa::Join<o2::aod::FMcParticles, o2::aod::FMcMotherLabels>;
+
   o2::framework::SliceCache cache;
 
   // setup collisions
@@ -222,7 +224,7 @@ struct FemtoPairV0V0 {
   }
   PROCESS_SWITCH(FemtoPairV0V0, processLambdaLambdaSameEvent, "Enable processing same event processing for lambda-lambda", true);
 
-  void processLambdaLambdaSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& lambdas, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processLambdaLambdaSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& lambdas, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairLambdaLambdaBuilder.processSameEvent<modes::Mode::kSe_Analysis_Mc>(col, mcCols, tracks, lambdas, lambdaWithLabelPartition, lambdaWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -234,7 +236,7 @@ struct FemtoPairV0V0 {
   }
   PROCESS_SWITCH(FemtoPairV0V0, processLambdaLambdaMixedEvent, "Enable processing mixed event processing for lambda-lambda", true);
 
-  void processLambdaLambdaMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& /*lambdas*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processLambdaLambdaMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& /*lambdas*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairLambdaLambdaBuilder.processMixedEvent<modes::Mode::kMe_Analysis_Mc>(cols, mcCols, tracks, lambdaWithLabelPartition, lambdaWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }
@@ -246,7 +248,7 @@ struct FemtoPairV0V0 {
   }
   PROCESS_SWITCH(FemtoPairV0V0, processK0shortK0shortSameEvent, "Enable processing same event processing for k0short-k0short", false);
 
-  void processK0shortK0shortSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& k0shorts, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processK0shortK0shortSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& k0shorts, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairK0shortK0shortBuilder.processSameEvent<modes::Mode::kSe_Analysis_Mc>(col, mcCols, tracks, k0shorts, k0shortWithLabelPartition, k0shortWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -258,7 +260,7 @@ struct FemtoPairV0V0 {
   }
   PROCESS_SWITCH(FemtoPairV0V0, processK0shortK0shortMixedEvent, "Enable processing mixed event processing for k0short-k0short", false);
 
-  void processK0shortK0shortMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& /*k0shorts*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processK0shortK0shortMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& /*k0shorts*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairK0shortK0shortBuilder.processMixedEvent<modes::Mode::kMe_Analysis>(cols, mcCols, tracks, k0shortWithLabelPartition, k0shortWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }

--- a/PWGCF/Femto/Tasks/femtoTrackQa.cxx
+++ b/PWGCF/Femto/Tasks/femtoTrackQa.cxx
@@ -53,6 +53,8 @@ struct FemtoTrackQa {
 
   using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, o2::aod::FTrackLabels>;
 
+  using FemtoMcParticlesWithLabel = o2::soa::Join<o2::aod::FMcParticles, o2::aod::FMcMotherLabels>;
+
   o2::framework::SliceCache cache;
 
   // setup collisions
@@ -117,7 +119,7 @@ struct FemtoTrackQa {
   };
   PROCESS_SWITCH(FemtoTrackQa, processData, "Track QA in Data", true);
 
-  void processMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     auto trackSlice = trackWithLabelPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
     if (trackSlice.size() == 0) {

--- a/PWGCF/Femto/Tasks/femtoTripletTrackTrackCascade.cxx
+++ b/PWGCF/Femto/Tasks/femtoTripletTrackTrackCascade.cxx
@@ -63,6 +63,8 @@ struct FemtoTripletTrackTrackCascade {
   using FemtoXisWithLabel = o2::soa::Join<FemtoXis, o2::aod::FLambdaLabels>;
   using FemtoOmegasWithLabel = o2::soa::Join<FemtoOmegas, o2::aod::FK0shortLabels>;
 
+  using FemtoMcParticlesWithLabel = o2::soa::Join<o2::aod::FMcParticles, o2::aod::FMcMotherLabels>;
+
   o2::framework::SliceCache cache;
   // setup collisions
   collisionbuilder::ConfCollisionSelection collisionSelection;
@@ -257,7 +259,7 @@ struct FemtoTripletTrackTrackCascade {
   }
   PROCESS_SWITCH(FemtoTripletTrackTrackCascade, processXiSameEvent, "Enable processing same event processing for tracks and xis", true);
 
-  void processXiSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& /*xis*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processXiSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& /*xis*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     tripletTrackTrackXiBuilder.processSameEvent<modes::Mode::kSe_Analysis_Mc>(col, mcCols, tracks, trackWithLabelPartition1, trackWithLabelPartition2, xiWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -269,7 +271,7 @@ struct FemtoTripletTrackTrackCascade {
   }
   PROCESS_SWITCH(FemtoTripletTrackTrackCascade, processXiMixedEvent, "Enable processing mixed event processing for tracks and xis", true);
 
-  void processXiMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& /*xis*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& /*mcMothers*/, o2::aod::FMcPartMoths const& /*mcPartonicMothers*/)
+  void processXiMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& /*xis*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& /*mcMothers*/, o2::aod::FMcPartMoths const& /*mcPartonicMothers*/)
   {
     tripletTrackTrackXiBuilder.processMixedEvent<modes::Mode::kMe_Analysis_Mc>(cols, mcCols, tracks, trackWithLabelPartition1, trackWithLabelPartition2, xiWithLabelPartition, mcParticles, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }
@@ -281,7 +283,7 @@ struct FemtoTripletTrackTrackCascade {
   }
   PROCESS_SWITCH(FemtoTripletTrackTrackCascade, processOmegaSameEvent, "Enable processing same event processing for tracks and omegas", false);
 
-  void processOmegaSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoOmegasWithLabel const& /*omegas*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processOmegaSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoOmegasWithLabel const& /*omegas*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     tripletTrackTrackOmegaBuilder.processSameEvent<modes::Mode::kSe_Analysis_Mc>(col, mcCols, tracks, trackWithLabelPartition1, trackWithLabelPartition2, omegaWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -293,7 +295,7 @@ struct FemtoTripletTrackTrackCascade {
   }
   PROCESS_SWITCH(FemtoTripletTrackTrackCascade, processOmegaMixedEvent, "Enable processing mixed event processing for tracks and omegas", false);
 
-  void processOmegaMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& /*xis*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& /*mcMothers*/, o2::aod::FMcPartMoths const& /*mcPartonicMothers*/)
+  void processOmegaMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& /*xis*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& /*mcMothers*/, o2::aod::FMcPartMoths const& /*mcPartonicMothers*/)
   {
     tripletTrackTrackOmegaBuilder.processMixedEvent<modes::Mode::kMe_Analysis_Mc>(cols, mcCols, tracks, trackWithLabelPartition1, trackWithLabelPartition2, omegaWithLabelPartition, mcParticles, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }

--- a/PWGCF/Femto/Tasks/femtoTripletTrackTrackTrack.cxx
+++ b/PWGCF/Femto/Tasks/femtoTripletTrackTrackTrack.cxx
@@ -57,6 +57,8 @@ struct FemtoTripletTrackTrackTrack {
 
   using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, o2::aod::FTrackLabels>;
 
+  using FemtoMcParticlesWithLabel = o2::soa::Join<o2::aod::FMcParticles, o2::aod::FMcMotherLabels>;
+
   o2::framework::SliceCache cache;
 
   // setup collisions
@@ -163,7 +165,7 @@ struct FemtoTripletTrackTrackTrack {
   }
   PROCESS_SWITCH(FemtoTripletTrackTrackTrack, processSameEvent, "Enable processing same event processing", true);
 
-  void processSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     tripletTrackTrackTrackBuilder.processSameEvent<modes::Mode::kSe_Analysis_Mc>(col, mcCols, tracks, trackWithLabelPartition1, trackWithLabelPartition2, trackWithLabelPartition3, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -175,7 +177,7 @@ struct FemtoTripletTrackTrackTrack {
   }
   PROCESS_SWITCH(FemtoTripletTrackTrackTrack, processMixedEvent, "Enable processing mixed event processing", true);
 
-  void processMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, o2::aod::FMcParticles const& mcParticles)
+  void processMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoMcParticlesWithLabel const& mcParticles)
   {
     tripletTrackTrackTrackBuilder.processMixedEvent<modes::Mode::kMe_Analysis_Mc>(cols, mcCols, tracks, trackWithLabelPartition1, trackWithLabelPartition2, trackWithLabelPartition3, mcParticles, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }

--- a/PWGCF/Femto/Tasks/femtoTripletTrackTrackV0.cxx
+++ b/PWGCF/Femto/Tasks/femtoTripletTrackTrackV0.cxx
@@ -64,6 +64,8 @@ struct FemtoTripletTrackTrackV0 {
   using FemtoLambdasWithLabel = o2::soa::Join<FemtoLambdas, o2::aod::FLambdaLabels>;
   // using FemtoK0shortsWithLabel = o2::soa::Join<FemtoK0shorts, o2::aod::FK0shortLabels>;
 
+  using FemtoMcParticlesWithLabel = o2::soa::Join<o2::aod::FMcParticles, o2::aod::FMcMotherLabels>;
+
   o2::framework::SliceCache cache;
 
   // setup collisions
@@ -189,7 +191,7 @@ struct FemtoTripletTrackTrackV0 {
   }
   PROCESS_SWITCH(FemtoTripletTrackTrackV0, processSameEvent, "Enable processing same event processing", true);
 
-  void processSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& /*lambdas*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& /*lambdas*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     tripletTrackTrackLambdaBuilder.processSameEvent<modes::Mode::kSe_Analysis_Mc>(col, mcCols, tracks, trackWithLabelPartition1, trackWithLabelPartition2, lambdaWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -201,7 +203,7 @@ struct FemtoTripletTrackTrackV0 {
   }
   PROCESS_SWITCH(FemtoTripletTrackTrackV0, processMixedEvent, "Enable processing mixed event processing", true);
 
-  void processMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& /*lambdas*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& /*mcMothers*/, o2::aod::FMcPartMoths const& /*mcPartonicMothers*/)
+  void processMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& /*lambdas*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& /*mcMothers*/, o2::aod::FMcPartMoths const& /*mcPartonicMothers*/)
   {
     tripletTrackTrackLambdaBuilder.processMixedEvent<modes::Mode::kMe_Analysis_Mc>(cols, mcCols, tracks, trackWithLabelPartition1, trackWithLabelPartition2, lambdaWithLabelPartition, mcParticles, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }

--- a/PWGCF/Femto/Tasks/femtoV0Qa.cxx
+++ b/PWGCF/Femto/Tasks/femtoV0Qa.cxx
@@ -58,6 +58,8 @@ struct FemtoV0Qa {
   using FemtoK0shortsWithLabel = o2::soa::Join<FemtoK0shorts, o2::aod::FK0shortLabels>;
   using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, o2::aod::FTrackLabels>;
 
+  using FemtoMcParticlesWithLabel = o2::soa::Join<o2::aod::FMcParticles, o2::aod::FMcMotherLabels>;
+
   o2::framework::SliceCache cache;
 
   // setup for collisions
@@ -177,7 +179,7 @@ struct FemtoV0Qa {
   }
   PROCESS_SWITCH(FemtoV0Qa, processK0short, "Process k0shorts", false);
 
-  void processK0shortMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& /*k0shorts*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processK0shortMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& /*k0shorts*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     auto k0shortSlice = k0shortWithLabelPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
     if (k0shortSlice.size() == 0) {
@@ -206,7 +208,7 @@ struct FemtoV0Qa {
   }
   PROCESS_SWITCH(FemtoV0Qa, processLambda, "Process lambdas", true);
 
-  void processLambdaMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& /*lambdas*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processLambdaMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& /*lambdas*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     auto lambdaSlice = lambdaWithLabelPartition->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
     if (lambdaSlice.size() == 0) {

--- a/PWGCF/FemtoWorld/Tasks/femtoPairLambdaAntilambda.cxx
+++ b/PWGCF/FemtoWorld/Tasks/femtoPairLambdaAntilambda.cxx
@@ -63,6 +63,8 @@ struct FemtoPairLambdaAntilambda {
   using FemtoLambdasWithLabel = o2::soa::Join<FemtoLambdas, o2::aod::FLambdaLabels>;
   using FemtoK0shortsWithLabel = o2::soa::Join<FemtoK0shorts, o2::aod::FK0shortLabels>;
 
+  using FemtoMcParticlesWithLabel = o2::soa::Join<o2::aod::FMcParticles, o2::aod::FMcMotherLabels>;
+
   o2::framework::SliceCache cache;
 
   // setup collisions
@@ -228,7 +230,7 @@ struct FemtoPairLambdaAntilambda {
   }
   PROCESS_SWITCH(FemtoPairLambdaAntilambda, processLambdaLambdaSameEvent, "Enable processing same event processing for lambda-lambda", true);
 
-  void processLambdaLambdaSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& lambdas, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processLambdaLambdaSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& lambdas, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairLambdaLambdaBuilder.processSameEvent<modes::Mode::kSe_Analysis_Mc>(col, mcCols, tracks, lambdas, lambdaWithLabelPartition, lambdaWithLabelPartition2, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -240,7 +242,7 @@ struct FemtoPairLambdaAntilambda {
   }
   PROCESS_SWITCH(FemtoPairLambdaAntilambda, processLambdaLambdaMixedEvent, "Enable processing mixed event processing for lambda-lambda", true);
 
-  void processLambdaLambdaMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& /*lambdas*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processLambdaLambdaMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoLambdasWithLabel const& /*lambdas*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairLambdaLambdaBuilder.processMixedEvent<modes::Mode::kMe_Analysis_Mc>(cols, mcCols, tracks, lambdaWithLabelPartition, lambdaWithLabelPartition2, mcParticles, mcMothers, mcPartonicMothers, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }
@@ -252,7 +254,7 @@ struct FemtoPairLambdaAntilambda {
   }
   PROCESS_SWITCH(FemtoPairLambdaAntilambda, processK0shortK0shortSameEvent, "Enable processing same event processing for k0short-k0short", false);
 
-  void processK0shortK0shortSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& k0shorts, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processK0shortK0shortSameEventMc(FilteredFemtoCollisionWithLabel const& col, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& k0shorts, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairK0shortK0shortBuilder.processSameEvent<modes::Mode::kSe_Analysis_Mc>(col, mcCols, tracks, k0shorts, k0shortWithLabelPartition, k0shortWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache);
   }
@@ -264,7 +266,7 @@ struct FemtoPairLambdaAntilambda {
   }
   PROCESS_SWITCH(FemtoPairLambdaAntilambda, processK0shortK0shortMixedEvent, "Enable processing mixed event processing for k0short-k0short", false);
 
-  void processK0shortK0shortMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& /*k0shorts*/, o2::aod::FMcParticles const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processK0shortK0shortMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoK0shortsWithLabel const& /*k0shorts*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairK0shortK0shortBuilder.processMixedEvent<modes::Mode::kMe_Analysis>(cols, mcCols, tracks, k0shortWithLabelPartition, k0shortWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }


### PR DESCRIPTION
With this PR we want to add MC only processing into the femto framework. In particular
- The labels linking a particle to its mother particles are now consolidated in the FMcMotherLabel table, which is joined to the FMcParticle table
- As a consequence of the above, the data subscription had to be changed in most processing tasks
- A mc-only processing option has been added to the producer task
- A mc-particle-qa task has been added (the mc-particle-pair task is still WIP)