### PR TITLE
[PWGCF] Add MC gen process

### DIFF
--- a/PWGCF/Flow/Tasks/flowFlucGfwPp.cxx
+++ b/PWGCF/Flow/Tasks/flowFlucGfwPp.cxx
@@ -336,7 +336,8 @@ struct FlowFlucGfwPp {
 
   o2::framework::expressions::Filter collisionFilter = nabs(aod::collision::posZ) < cfgVtxZ;
   o2::framework::expressions::Filter trackFilter = nabs(aod::track::eta) < cfgEta && aod::track::pt > cfgPtmin&& aod::track::pt < cfgPtmax && (aod::track::itsChi2NCl < cfgChi2PrITSCls) && (aod::track::tpcChi2NCl < cfgChi2PrTPCCls) && nabs(aod::track::dcaZ) < cfgDCAz;
-
+  
+  Preslice<aod::Tracks> perCollision = aod::track::collisionId;
   o2::framework::expressions::Filter mcCollFilter = nabs(aod::mccollision::posZ) < cfgVtxZ;
   o2::framework::expressions::Filter mcParticlesFilter = (aod::mcparticle::eta > o2::analysis::gfwflowflucpp::etalow && aod::mcparticle::eta < o2::analysis::gfwflowflucpp::etaup && aod::mcparticle::pt > o2::analysis::gfwflowflucpp::ptlow && aod::mcparticle::pt < o2::analysis::gfwflowflucpp::ptup);
 

--- a/PWGCF/Flow/flowFlucGfwPp.cxx
+++ b/PWGCF/Flow/flowFlucGfwPp.cxx
@@ -121,7 +121,7 @@ struct FlowFlucGfwPp {
 
   O2_DEFINE_CONFIGURABLE(cfgNbootstrap, int, 10, "Number of subsamples")
   O2_DEFINE_CONFIGURABLE(cfgIsMC, bool, false, "Is MC event")
-  O2_DEFINE_CONFIGURABLE(cfgCentEstimator, int, 0, "0:FT0C; 1:FT0CVariant1; 2:FT0M; 3:FV0A, 4:NTPV, 5:NGlobals")
+  O2_DEFINE_CONFIGURABLE(cfgCentEstimator, int, 0, "0:FT0C; 1:FT0CVariant1; 2:FT0M; 3:FV0A, 4:NTPV, 5:NGlobals, 6:MFT")
   O2_DEFINE_CONFIGURABLE(cfgUseNch, bool, false, "Do correlations as function of Nch")
   O2_DEFINE_CONFIGURABLE(cfgQvecQA, bool, false, "Enable filling QA for q-Vec of TPC")
   O2_DEFINE_CONFIGURABLE(cfgFillWeights, bool, false, "Fill NUA weights")
@@ -278,7 +278,8 @@ struct FlowFlucGfwPp {
     kCentFT0M,
     kCentFV0A,
     kCentNTPV,
-    kCentNGlobal
+    kCentNGlobal,
+    kCentMFT
   };
   enum EventSelFlags {
     kFilteredEvent = 1,
@@ -337,6 +338,7 @@ struct FlowFlucGfwPp {
   o2::framework::expressions::Filter collisionFilter = nabs(aod::collision::posZ) < cfgVtxZ;
   o2::framework::expressions::Filter trackFilter = nabs(aod::track::eta) < cfgEta && aod::track::pt > cfgPtmin&& aod::track::pt < cfgPtmax && (aod::track::itsChi2NCl < cfgChi2PrITSCls) && (aod::track::tpcChi2NCl < cfgChi2PrTPCCls) && nabs(aod::track::dcaZ) < cfgDCAz;
 
+  Preslice<aod::Tracks> perCollision = aod::track::collisionId;
   o2::framework::expressions::Filter mcCollFilter = nabs(aod::mccollision::posZ) < cfgVtxZ;
   o2::framework::expressions::Filter mcParticlesFilter = (aod::mcparticle::eta > o2::analysis::gfwflowflucpp::etalow && aod::mcparticle::eta < o2::analysis::gfwflowflucpp::etaup && aod::mcparticle::pt > o2::analysis::gfwflowflucpp::ptlow && aod::mcparticle::pt < o2::analysis::gfwflowflucpp::ptup);
 
@@ -415,7 +417,8 @@ struct FlowFlucGfwPp {
       {kCentFT0M, "FT0M"},
       {kCentFV0A, "FV0A"},
       {kCentNTPV, "NTPV"},
-      {kCentNGlobal, "NGlobals"}};
+      {kCentNGlobal, "NGlobals"},
+      {kCentMFT, "MFT"}};
     sCentralityEstimator = centEstimatorMap.at(cfgCentEstimator);
     sCentralityEstimator += " centrality (%)";
     AxisSpec centAxis = {o2::analysis::gfwflowflucpp::centbinning, sCentralityEstimator.c_str()};
@@ -538,6 +541,8 @@ struct FlowFlucGfwPp {
       registry.add("eventQA/before/centV0A_centT0C", "", {HistType::kTH2D, {centAxis, centAxis}});
       registry.add("eventQA/before/centGlobal_centT0C", "", {HistType::kTH2D, {centAxis, centAxis}});
       registry.add("eventQA/before/centNTPV_centT0C", "", {HistType::kTH2D, {centAxis, centAxis}});
+      registry.add("eventQA/before/centMFT_centT0C", "", {HistType::kTH2D, {centAxis, centAxis}});
+
       if (cfgIsMC || doprocessMC) {
         registry.add("MCGen/trackQA/phi_eta_vtxZ", "", {HistType::kTH3D, {phiAxis, etaAxis, vtxAxis}});
         registry.add("MCGen/trackQA/nch_pt", "#it{p}_{T} vs multiplicity; N_{ch}; #it{p}_{T}", {HistType::kTH2D, {nchAxis, ptAxis}});
@@ -893,7 +898,6 @@ struct FlowFlucGfwPp {
         std::string name = Form("%s_%d_%s", shapeSel.c_str(), jese, it->Head.c_str());
         std::string title = it->Head + std::string("_ese");
         oba->Add(new TNamed(name.c_str(), title.c_str()));
-
       }
     }
   }
@@ -1372,6 +1376,8 @@ struct FlowFlucGfwPp {
         return collision.centNTPV();
       case kCentNGlobal:
         return collision.centNGlobal();
+      case kCentMFT:
+        return collision.centMFT();
       default:
         return collision.centFT0C();
     }
@@ -1388,6 +1394,7 @@ struct FlowFlucGfwPp {
       registry.fill(HIST("eventQA/") + HIST(FillTimeName[ft]) + HIST("centV0A_centT0C"), collision.centFT0C(), collision.centFV0A());
       registry.fill(HIST("eventQA/") + HIST(FillTimeName[ft]) + HIST("centGlobal_centT0C"), collision.centFT0C(), collision.centNGlobal());
       registry.fill(HIST("eventQA/") + HIST(FillTimeName[ft]) + HIST("centNTPV_centT0C"), collision.centFT0C(), collision.centNTPV());
+      registry.fill(HIST("eventQA/") + HIST(FillTimeName[ft]) + HIST("centMFT_centT0C"), collision.centFT0C(), collision.centMFT());
     }
     registry.fill(HIST("eventQA/") + HIST(FillTimeName[ft]) + HIST("globalTracks_PVTracks"), collision.multNTracksPV(), xaxis.multiplicity);
     registry.fill(HIST("eventQA/") + HIST(FillTimeName[ft]) + HIST("globalTracks_multT0A"), collision.multFT0A(), xaxis.multiplicity);
@@ -1441,7 +1448,8 @@ struct FlowFlucGfwPp {
 
   void processData(soa::Filtered<soa::Join<aod::Collisions, aod::EvSels, aod::Mults,
                                            aod::CentFT0Cs, aod::CentFT0CVariant1s, aod::CentFT0Ms,
-                                           aod::CentFV0As, aod::CentNTPVs, aod::CentNGlobals>>::iterator const& collision,
+                                           aod::CentFV0As, aod::CentNTPVs, aod::CentNGlobals,
+                                           aod::CentMFTs>>::iterator const& collision,
                    aod::BCsWithTimestamps const&, GFWTracks const& tracks)
   {
     auto bc = collision.bc_as<aod::BCsWithTimestamps>();
@@ -1521,7 +1529,7 @@ struct FlowFlucGfwPp {
   }
   PROCESS_SWITCH(FlowFlucGfwPp, processData, "Process analysis for non-derived data", false);
 
-  void processq2(soa::Filtered<soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Cs, aod::CentFT0CVariant1s, aod::CentFT0Ms, aod::CentFV0As, aod::CentNTPVs, aod::CentNGlobals>>::iterator const& collision, aod::BCsWithTimestamps const&, GFWTracks const& tracks)
+  void processq2(soa::Filtered<soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0Cs, aod::CentFT0CVariant1s, aod::CentFT0Ms, aod::CentFV0As, aod::CentNTPVs, aod::CentNGlobals, aod::CentMFTs>>::iterator const& collision, aod::BCsWithTimestamps const&, GFWTracks const& tracks)
   {
     float count{0.5};
     fillQnEventCounter(count++);
@@ -1559,7 +1567,7 @@ struct FlowFlucGfwPp {
   void processMC(soa::Filtered<soa::Join<aod::Collisions, aod::EvSels, aod::Mults,
                                            aod::CentFT0Cs, aod::CentFT0CVariant1s, aod::CentFT0Ms,
                                            aod::CentFV0As, aod::CentNTPVs, aod::CentNGlobals,
-                                           aod::McCollisionLabels>>::iterator const& collision,
+                                           aod::CentMFTs, aod::McCollisionLabels>>::iterator const& collision,
                    aod::BCsWithTimestamps const&, GFWTracksMC const& tracks, aod::McCollisions const&, aod::McParticles const& mcParticles)
   {
     auto bc = collision.bc_as<aod::BCsWithTimestamps>();


### PR DESCRIPTION
Update information:

- Remove the MFT centrality estimator, which is useless in 24 pp collision data
- Add a cutoff of the eta range for the calculation of the q-vector
- Add MC gen process for efficiency weight and MC closure