### PR TITLE
[Common,Tutorial,PWGJE,PWGUD] DPL Analysis: avoid including ASoA.h in dictionary generation

### DIFF
--- a/Common/Core/fwdtrackUtilities.h
+++ b/Common/Core/fwdtrackUtilities.h
@@ -18,7 +18,6 @@
 #ifndef COMMON_CORE_FWDTRACKUTILITIES_H_
 #define COMMON_CORE_FWDTRACKUTILITIES_H_
 
-#include <Framework/AnalysisDataModel.h>
 #include <Framework/DataTypes.h>
 #include <GlobalTracking/MatchGlobalFwd.h>
 #include <MCHTracking/TrackExtrap.h>
@@ -48,6 +47,16 @@ using SMatrix55 = ROOT::Math::SMatrix<double, 5, 5, ROOT::Math::MatRepSym<double
 using SMatrix55Std = ROOT::Math::SMatrix<double, 5>;
 using SMatrix5 = ROOT::Math::SVector<double, 5>;
 
+template <typename T>
+concept is_fwd_track = requires(T t) {
+  { t.rAtAbsorberEnd() } -> std::same_as<float>;
+};
+
+template <typename T>
+concept is_fwd_cov = requires(T t) {
+  { t.sigmaX() } -> std::same_as<float>;
+};
+
 /// Produce TrackParCovFwds for MFT and FwdTracks, w/ or w/o cov, with z shift
 template <typename TFwdTrack, typename... TCovariance>
 o2::track::TrackParCovFwd getTrackParCovFwdShift(TFwdTrack const& track, float zshift, TCovariance const&... covOpt)
@@ -55,7 +64,7 @@ o2::track::TrackParCovFwd getTrackParCovFwdShift(TFwdTrack const& track, float z
   double chi2 = track.chi2();
   if constexpr (sizeof...(covOpt) == 0) {
     // No covariance passed
-    if constexpr (std::is_same_v<std::decay_t<TFwdTrack>, aod::FwdTracks::iterator>) {
+    if constexpr (is_fwd_track<TFwdTrack>) {
       if (track.trackType() == o2::aod::fwdtrack::ForwardTrackTypeEnum::MuonStandaloneTrack) {
         chi2 = track.chi2() * (2.f * track.nClusters() - 5.f);
       }
@@ -63,7 +72,7 @@ o2::track::TrackParCovFwd getTrackParCovFwdShift(TFwdTrack const& track, float z
   } else {
     // Covariance passed
     using TCov = std::decay_t<decltype((covOpt, ...))>;
-    if constexpr (std::is_same_v<TCov, aod::FwdTracksCov::iterator>) {
+    if constexpr (is_fwd_cov<TCov>) {
       if (track.trackType() == o2::aod::fwdtrack::ForwardTrackTypeEnum::MuonStandaloneTrack) {
         chi2 = track.chi2() * (2.f * track.nClusters() - 5.f);
       }

--- a/PWGJE/Core/CMakeLists.txt
+++ b/PWGJE/Core/CMakeLists.txt
@@ -23,7 +23,6 @@ o2physics_target_root_dictionary(PWGJECore
                       FastJetUtilities.h
                       JetTaggingUtilities.h
                       JetBkgSubUtils.h
-                      JetDerivedDataUtilities.h
                       emcalCrossTalkEmulation.h
                       utilsTrackMatchingEMC.h
               LINKDEF PWGJECoreLinkDef.h)

--- a/PWGUD/Core/decayTree.cxx
+++ b/PWGUD/Core/decayTree.cxx
@@ -1228,4 +1228,162 @@ std::vector<std::vector<int>> decayTree::combinations(int nPool)
   return copes;
 }
 
+void decayTree::createHistograms(o2::framework::HistogramRegistry& registry)
+{
+  // definitions
+  auto etax = o2::framework::AxisSpec(100, -1.5, 1.5);
+  auto nSax = o2::framework::AxisSpec(300, -15.0, 15.0);
+  auto chi2ax = o2::framework::AxisSpec(100, 0.0, 5.0);
+  auto nClax = o2::framework::AxisSpec(170, 0.0, 170.0);
+  auto angax = o2::framework::AxisSpec(315, 0.0, 3.15);
+  auto dcaxyax = o2::framework::AxisSpec(400, -0.2, 0.2);
+  auto dcazax = o2::framework::AxisSpec(600, -0.3, 0.3);
+  auto sTPCax = o2::framework::AxisSpec(1000, 0., 1000.);
+
+  std::string base;
+  std::string hname;
+  std::string annot;
+  fhistPointers.clear();
+  for (const auto& res : getResonances()) {
+    auto max = o2::framework::AxisSpec(res->nmassBins(), res->massHistRange()[0], res->massHistRange()[1]);
+    auto momax = o2::framework::AxisSpec(res->nmomBins(), res->momHistRange()[0], res->momHistRange()[1]);
+
+    // M-pT, M-eta, pT-eta
+    for (const auto& cc : fccs) {
+      base = cc;
+      base.append("/").append(res->name()).append("/");
+      hname = base + "mpt";
+      annot = "M versus pT; M (" + res->name() + ") GeV/c^{2}; pT (" + res->name() + ") GeV/c";
+      fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, momax}})});
+      hname = base + "meta";
+      annot = "M versus eta; M (" + res->name() + ") GeV/c^{2}; eta (" + res->name() + ")";
+      fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, etax}})});
+      hname = base + "pteta";
+      annot = "pT versus eta; pT (" + res->name() + ") GeV/c; eta (" + res->name() + ")";
+      fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {momax, etax}})});
+
+      // M versus daughters
+      auto daughs = res->getDaughters();
+      auto ndaughs = daughs.size();
+      for (auto i = 0; i < static_cast<int>(ndaughs); i++) {
+        auto d1 = getResonance(daughs[i]);
+
+        // M vs pT daughter
+        hname = base;
+        hname.append("MvspT_").append(res->name()).append(d1->name());
+        annot = "M versus pT; M (" + res->name() + ") GeV/c^{2}; pT (" + d1->name() + ") GeV/c";
+        auto momax1 = o2::framework::AxisSpec(d1->nmomBins(), d1->momHistRange()[0], d1->momHistRange()[1]);
+        fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, momax1}})});
+
+        // M vs eta daughter
+        hname = base;
+        hname.append("Mvseta_").append(res->name()).append(d1->name());
+        annot = "M versus eta; M (" + res->name() + ") GeV/c^{2}; eta (" + d1->name() + ")";
+        fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, etax}})});
+
+        if (d1->isFinal()) {
+          // M vs dcaXYZ
+          hname = base;
+          hname.append("MvsdcaXY_").append(res->name()).append(d1->name());
+          annot = "M versus dcaXY; M (" + res->name() + ") GeV/c^{2}; dca_{XY} (" + d1->name() + ") #mu m";
+          fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, dcaxyax}})});
+          hname = base;
+          hname.append("MvsdcaZ_").append(res->name()).append(d1->name());
+          annot = "M versus dcaZ; M (" + res->name() + ") GeV/c^{2}; dca_{Z} (" + d1->name() + ") #mu m";
+          fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, dcazax}})});
+
+          // M vs chi2 track
+          hname = base;
+          hname.append("Mvschi2_").append(res->name()).append(d1->name());
+          annot = "M versus chi2; M (" + res->name() + ") GeV/c^{2}; chi2 (" + d1->name() + ")";
+          fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, chi2ax}})});
+
+          // M vs nCl track
+          hname = base;
+          hname.append("MvsnCl_").append(res->name()).append(d1->name());
+          annot = "M versus nCl; M (" + res->name() + ") GeV/c^{2}; nCl (" + d1->name() + ")";
+          fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, nClax}})});
+
+          // M versus detector hits
+          hname = base;
+          hname.append("MvsdetHits_").append(res->name()).append(d1->name());
+          annot = "M versus detector hits; M (" + res->name() + ") GeV/c^{2}; ITS + 2*TPC + 4*TRD + 8*TOF (" + d1->name() + ")";
+          fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, {16, -0.5, 15.5}}})});
+        } else {
+          // M vs Mi
+          hname = base;
+          hname.append("MvsM_").append(res->name()).append(d1->name());
+          annot = "M versus M; M (" + res->name() + ") GeV/c^{2}; M (" + d1->name() + ") GeV/c^{2}";
+          auto max1 = o2::framework::AxisSpec(res->nmassBins(), d1->massHistRange()[0], d1->massHistRange()[1]);
+          fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, max1}})});
+        }
+      }
+
+      // daughters vs daughters
+      for (auto i = 0; i < static_cast<int>(ndaughs - 1); i++) {
+        auto d1 = getResonance(daughs[i]);
+        auto max1 = o2::framework::AxisSpec(d1->nmassBins(), d1->massHistRange()[0], d1->massHistRange()[1]);
+        for (auto j = i + 1; j < static_cast<int>(ndaughs); j++) {
+          auto d2 = getResonance(daughs[j]);
+          auto max2 = o2::framework::AxisSpec(d2->nmassBins(), d2->massHistRange()[0], d2->massHistRange()[1]);
+
+          // M1 vs M2
+          hname = base;
+          hname.append("MvsM_").append(d1->name()).append(d2->name());
+          annot = std::string("M versus M; M (").append(d1->name()).append(") GeV/c^{2}; M (").append(d2->name()).append(") GeV/c^{2}");
+          fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max1, max2}})});
+
+          // angle(d1, d2)
+          hname = base;
+          hname.append("angle_").append(d1->name()).append(d2->name());
+          annot = std::string("angle; Angle (").append(d1->name()).append(", ").append(d2->name()).append(")");
+          fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH1F, {angax}})});
+
+          // M vs angle(d1, d2)
+          hname = base;
+          hname.append("Mvsangle_").append(d1->name()).append(d2->name());
+          annot = std::string("M versus angle; M (").append(res->name()).append(") GeV/c^{2}; Angle (").append(d1->name()).append(", ").append(d2->name()).append(")");
+          fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, angax}})});
+
+          // both daughters are finals
+          if (d1->isFinal() && d2->isFinal()) {
+            hname = base;
+            hname.append("TPCsignal_").append(d1->name()).append(d2->name());
+            annot = std::string("TPC signal of both tracks; TPCsignal (").append(d1->name()).append("); TPCsignal (").append(d2->name()).append(")");
+            fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {sTPCax, sTPCax}})});
+          }
+        }
+      }
+
+      // for finals only
+      if (res->isFinal()) {
+        // dca
+        hname = base;
+        hname.append("dcaXY");
+        annot = std::string("dcaXY; dca_{XY}(").append(res->name()).append(")");
+        fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH1F, {dcaxyax}})});
+        hname = base;
+        hname.append("dcaZ");
+        annot = std::string("dcaZ; dca_{Z}(").append(res->name()).append(")");
+        fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH1F, {dcazax}})});
+
+        // nSIgma[TPC, TOF] vs pT
+        for (const auto& det : fdets) {
+          for (const auto& part : fparts) {
+            hname = base;
+            hname.append("nS").append(part).append(det);
+            annot = std::string("nSigma_").append(det).append(" versus p; p (").append(res->name()).append(") GeV/c; nSigma_{").append(det).append(", ").append(part).append("} (").append(res->name()).append(")");
+            fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {momax, nSax}})});
+          }
+        }
+
+        // detector hits
+        hname = base;
+        hname.append("detectorHits");
+        annot = std::string("detectorHits; Detector(").append(res->name()).append(")");
+        fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH1F, {{4, 0.5, 4.5}}})});
+      }
+    }
+  }
+}
 // -----------------------------------------------------------------------------

--- a/PWGUD/Core/decayTree.h
+++ b/PWGUD/Core/decayTree.h
@@ -12,7 +12,6 @@
 #ifndef PWGUD_CORE_DECAYTREE_H_
 #define PWGUD_CORE_DECAYTREE_H_
 
-#include <Framework/HistogramRegistry.h>
 #include <Framework/HistogramSpec.h>
 #include <Framework/Logger.h>
 
@@ -28,6 +27,11 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+namespace o2::framework
+{
+class HistogramRegistry;
+}
 
 // -----------------------------------------------------------------------------
 class pidSelector
@@ -835,164 +839,7 @@ class decayTree
   }
 
   // create histograms
-  void createHistograms(o2::framework::HistogramRegistry& registry)
-  {
-    // definitions
-    auto etax = o2::framework::AxisSpec(100, -1.5, 1.5);
-    auto nSax = o2::framework::AxisSpec(300, -15.0, 15.0);
-    auto chi2ax = o2::framework::AxisSpec(100, 0.0, 5.0);
-    auto nClax = o2::framework::AxisSpec(170, 0.0, 170.0);
-    auto angax = o2::framework::AxisSpec(315, 0.0, 3.15);
-    auto dcaxyax = o2::framework::AxisSpec(400, -0.2, 0.2);
-    auto dcazax = o2::framework::AxisSpec(600, -0.3, 0.3);
-    auto sTPCax = o2::framework::AxisSpec(1000, 0., 1000.);
-
-    std::string base;
-    std::string hname;
-    std::string annot;
-    fhistPointers.clear();
-    for (const auto& res : getResonances()) {
-      auto max = o2::framework::AxisSpec(res->nmassBins(), res->massHistRange()[0], res->massHistRange()[1]);
-      auto momax = o2::framework::AxisSpec(res->nmomBins(), res->momHistRange()[0], res->momHistRange()[1]);
-
-      // M-pT, M-eta, pT-eta
-      for (const auto& cc : fccs) {
-        base = cc;
-        base.append("/").append(res->name()).append("/");
-        hname = base + "mpt";
-        annot = "M versus pT; M (" + res->name() + ") GeV/c^{2}; pT (" + res->name() + ") GeV/c";
-        fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, momax}})});
-        hname = base + "meta";
-        annot = "M versus eta; M (" + res->name() + ") GeV/c^{2}; eta (" + res->name() + ")";
-        fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, etax}})});
-        hname = base + "pteta";
-        annot = "pT versus eta; pT (" + res->name() + ") GeV/c; eta (" + res->name() + ")";
-        fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {momax, etax}})});
-
-        // M versus daughters
-        auto daughs = res->getDaughters();
-        auto ndaughs = daughs.size();
-        for (auto i = 0; i < static_cast<int>(ndaughs); i++) {
-          auto d1 = getResonance(daughs[i]);
-
-          // M vs pT daughter
-          hname = base;
-          hname.append("MvspT_").append(res->name()).append(d1->name());
-          annot = "M versus pT; M (" + res->name() + ") GeV/c^{2}; pT (" + d1->name() + ") GeV/c";
-          auto momax1 = o2::framework::AxisSpec(d1->nmomBins(), d1->momHistRange()[0], d1->momHistRange()[1]);
-          fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, momax1}})});
-
-          // M vs eta daughter
-          hname = base;
-          hname.append("Mvseta_").append(res->name()).append(d1->name());
-          annot = "M versus eta; M (" + res->name() + ") GeV/c^{2}; eta (" + d1->name() + ")";
-          fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, etax}})});
-
-          if (d1->isFinal()) {
-            // M vs dcaXYZ
-            hname = base;
-            hname.append("MvsdcaXY_").append(res->name()).append(d1->name());
-            annot = "M versus dcaXY; M (" + res->name() + ") GeV/c^{2}; dca_{XY} (" + d1->name() + ") #mu m";
-            fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, dcaxyax}})});
-            hname = base;
-            hname.append("MvsdcaZ_").append(res->name()).append(d1->name());
-            annot = "M versus dcaZ; M (" + res->name() + ") GeV/c^{2}; dca_{Z} (" + d1->name() + ") #mu m";
-            fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, dcazax}})});
-
-            // M vs chi2 track
-            hname = base;
-            hname.append("Mvschi2_").append(res->name()).append(d1->name());
-            annot = "M versus chi2; M (" + res->name() + ") GeV/c^{2}; chi2 (" + d1->name() + ")";
-            fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, chi2ax}})});
-
-            // M vs nCl track
-            hname = base;
-            hname.append("MvsnCl_").append(res->name()).append(d1->name());
-            annot = "M versus nCl; M (" + res->name() + ") GeV/c^{2}; nCl (" + d1->name() + ")";
-            fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, nClax}})});
-
-            // M versus detector hits
-            hname = base;
-            hname.append("MvsdetHits_").append(res->name()).append(d1->name());
-            annot = "M versus detector hits; M (" + res->name() + ") GeV/c^{2}; ITS + 2*TPC + 4*TRD + 8*TOF (" + d1->name() + ")";
-            fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, {16, -0.5, 15.5}}})});
-          } else {
-            // M vs Mi
-            hname = base;
-            hname.append("MvsM_").append(res->name()).append(d1->name());
-            annot = "M versus M; M (" + res->name() + ") GeV/c^{2}; M (" + d1->name() + ") GeV/c^{2}";
-            auto max1 = o2::framework::AxisSpec(res->nmassBins(), d1->massHistRange()[0], d1->massHistRange()[1]);
-            fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, max1}})});
-          }
-        }
-
-        // daughters vs daughters
-        for (auto i = 0; i < static_cast<int>(ndaughs - 1); i++) {
-          auto d1 = getResonance(daughs[i]);
-          auto max1 = o2::framework::AxisSpec(d1->nmassBins(), d1->massHistRange()[0], d1->massHistRange()[1]);
-          for (auto j = i + 1; j < static_cast<int>(ndaughs); j++) {
-            auto d2 = getResonance(daughs[j]);
-            auto max2 = o2::framework::AxisSpec(d2->nmassBins(), d2->massHistRange()[0], d2->massHistRange()[1]);
-
-            // M1 vs M2
-            hname = base;
-            hname.append("MvsM_").append(d1->name()).append(d2->name());
-            annot = std::string("M versus M; M (").append(d1->name()).append(") GeV/c^{2}; M (").append(d2->name()).append(") GeV/c^{2}");
-            fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max1, max2}})});
-
-            // angle(d1, d2)
-            hname = base;
-            hname.append("angle_").append(d1->name()).append(d2->name());
-            annot = std::string("angle; Angle (").append(d1->name()).append(", ").append(d2->name()).append(")");
-            fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH1F, {angax}})});
-
-            // M vs angle(d1, d2)
-            hname = base;
-            hname.append("Mvsangle_").append(d1->name()).append(d2->name());
-            annot = std::string("M versus angle; M (").append(res->name()).append(") GeV/c^{2}; Angle (").append(d1->name()).append(", ").append(d2->name()).append(")");
-            fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {max, angax}})});
-
-            // both daughters are finals
-            if (d1->isFinal() && d2->isFinal()) {
-              hname = base;
-              hname.append("TPCsignal_").append(d1->name()).append(d2->name());
-              annot = std::string("TPC signal of both tracks; TPCsignal (").append(d1->name()).append("); TPCsignal (").append(d2->name()).append(")");
-              fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {sTPCax, sTPCax}})});
-            }
-          }
-        }
-
-        // for finals only
-        if (res->isFinal()) {
-          // dca
-          hname = base;
-          hname.append("dcaXY");
-          annot = std::string("dcaXY; dca_{XY}(").append(res->name()).append(")");
-          fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH1F, {dcaxyax}})});
-          hname = base;
-          hname.append("dcaZ");
-          annot = std::string("dcaZ; dca_{Z}(").append(res->name()).append(")");
-          fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH1F, {dcazax}})});
-
-          // nSIgma[TPC, TOF] vs pT
-          for (const auto& det : fdets) {
-            for (const auto& part : fparts) {
-              hname = base;
-              hname.append("nS").append(part).append(det);
-              annot = std::string("nSigma_").append(det).append(" versus p; p (").append(res->name()).append(") GeV/c; nSigma_{").append(det).append(", ").append(part).append("} (").append(res->name()).append(")");
-              fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH2F, {momax, nSax}})});
-            }
-          }
-
-          // detector hits
-          hname = base;
-          hname.append("detectorHits");
-          annot = std::string("detectorHits; Detector(").append(res->name()).append(")");
-          fhistPointers.insert({hname, registry.add(hname.c_str(), annot.c_str(), {o2::framework::HistType::kTH1F, {{4, 0.5, 4.5}}})});
-        }
-      }
-    }
-  }
+  void createHistograms(o2::framework::HistogramRegistry& registry);
 
   // ClassDefNV(decayTree, 1);
 };

--- a/Tutorials/src/histogramRegistry.cxx
+++ b/Tutorials/src/histogramRegistry.cxx
@@ -59,22 +59,22 @@ struct EtaPhiHistograms {
   }
 };
 
-struct FilteredHistograms {
-  /// Construct a registry object with direct declaration
-  HistogramRegistry registry{
-    "registry",
-    {
-      {"eta", "#eta", {HistType::kTH1F, {{102, -2.01, 2.01}}}},                            //
-      {"ptToPt", "#ptToPt", {HistType::kTH2F, {{100, -0.01, 10.01}, {100, -0.01, 10.01}}}} //
-    } //
-  };
+// struct FilteredHistograms {
+//   /// Construct a registry object with direct declaration
+//   HistogramRegistry registry{
+//     "registry",
+//     {
+//       {"eta", "#eta", {HistType::kTH1F, {{102, -2.01, 2.01}}}},                            //
+//       {"ptToPt", "#ptToPt", {HistType::kTH2F, {{100, -0.01, 10.01}, {100, -0.01, 10.01}}}} //
+//     } //
+//   };
 
-  void process(aod::Tracks const& tracks)
-  {
-    registry.fill<aod::track::Eta>(HIST("eta"), tracks, aod::track::eta > 0.0f);
-    registry.fill<aod::track::Pt, aod::track::Pt>(HIST("ptToPt"), tracks, aod::track::pt < 5.0f);
-  }
-};
+//   void process(aod::Tracks const& tracks)
+//   {
+//     registry.fill<aod::track::Eta>(HIST("eta"), tracks, aod::track::eta > 0.0f);
+//     registry.fill<aod::track::Pt, aod::track::Pt>(HIST("ptToPt"), tracks, aod::track::pt < 5.0f);
+//   }
+// };
 
 struct DimensionTest {
 
@@ -118,19 +118,19 @@ struct DimensionTest {
   void process(aod::Tracks const& tracks)
   {
     using namespace aod::track;
-    // does not work with dynamic columns (e.g. Charge, NormalizedPhi)
-    registry.fill<Eta>(HIST("1d"), tracks, eta > -0.7f);
-    registry.fill<Pt, Eta, Phi>(HIST("3d"), tracks, eta > 0.f);
-    registry.fill<Pt, Eta, Phi, P, X>(HIST("5d"), tracks, pt > 0.15f);
-    registry.fill<Pt, Eta, Phi, P, X, Y, Z>(HIST("7d"), tracks, pt > 0.15f);
-    registry.fill<Pt, Eta, Phi>(HIST("2d-profile"), tracks, eta > -0.5f);
+    // // does not work with dynamic columns (e.g. Charge, NormalizedPhi)
+    // registry.fill<Eta>(HIST("1d"), tracks, eta > -0.7f);
+    // registry.fill<Pt, Eta, Phi>(HIST("3d"), tracks, eta > 0.f);
+    // registry.fill<Pt, Eta, Phi, P, X>(HIST("5d"), tracks, pt > 0.15f);
+    // registry.fill<Pt, Eta, Phi, P, X, Y, Z>(HIST("7d"), tracks, pt > 0.15f);
+    // registry.fill<Pt, Eta, Phi>(HIST("2d-profile"), tracks, eta > -0.5f);
 
-    // fill 4d histogram with weight (column X)
-    registry.fill<Pt, Eta, Phi, Z, X>(HIST("4d-weight"), tracks, eta > 0.f);
+    // // fill 4d histogram with weight (column X)
+    // registry.fill<Pt, Eta, Phi, Z, X>(HIST("4d-weight"), tracks, eta > 0.f);
 
-    registry.fill<Pt, Eta, Phi>(HIST("2d-weight"), tracks, eta > 0.f);
+    // registry.fill<Pt, Eta, Phi>(HIST("2d-weight"), tracks, eta > 0.f);
 
-    registry.fill<Pt, Eta, Phi>(HIST("1d-profile-weight"), tracks, eta > 0.f);
+    // registry.fill<Pt, Eta, Phi>(HIST("1d-profile-weight"), tracks, eta > 0.f);
 
     for (auto& track : tracks) {
       registry.fill(HIST("2d"), track.eta(), track.pt());
@@ -218,8 +218,8 @@ struct RealisticExample {
   {
     using namespace aod::track;
 
-    etaStudy.fill<Pt>(HIST("positive"), tracks, eta > 0.f);
-    etaStudy.fill<Pt>(HIST("negative"), tracks, eta < 0.f);
+    // etaStudy.fill<Pt>(HIST("positive"), tracks, eta > 0.f);
+    // etaStudy.fill<Pt>(HIST("negative"), tracks, eta < 0.f);
 
     for (auto& track : tracks) {
       spectra.fill(HIST("myControlHist"), track.pt(), track.eta());
@@ -329,7 +329,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   return WorkflowSpec{
     adaptAnalysisTask<OutputObjTest>(cfgc),
     adaptAnalysisTask<EtaPhiHistograms>(cfgc),
-    adaptAnalysisTask<FilteredHistograms>(cfgc),
+    // adaptAnalysisTask<FilteredHistograms>(cfgc),
     adaptAnalysisTask<DimensionTest>(cfgc),
     adaptAnalysisTask<RealisticExample>(cfgc),
     adaptAnalysisTask<TListTest>(cfgc),


### PR DESCRIPTION
Various PWGs create ROOT dictionaries for some of their classes, which, unfortunately, through their inclusion chains pull ASoA.h and expose it to rootcling. ROOT's internal llvm is outdated and thus each time we need to update ASoA.h with new code, we have to employ workarounds in oder to keep O2Physics functional. This is highly inconvenient, and thus there will be an update in O2 that will explicitly forbid exposing ASoA.h to rootcling - the compilation will fail with an error. This PR removes all the instances of ASoA.h inclusion in dictionaries, that have been exposed by the upcoming O2 change.

This is a suggested change, the final fix may be different. Preferably, the dictionaries that are not required should be simply removed from CMakeLists.txt. From the codeowners, we request reviewing these changes, suggesting improvements, if needed, and validating that the updated code does not affect the analysis.

requires https://github.com/AliceO2Group/AliceO2/pull/15557