### PR TITLE
[PWGLF] strangeness in pp: refine gen. sels; fix labels

### DIFF
--- a/PWGLF/TableProducer/Strangeness/cascqaanalysis.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascqaanalysis.cxx
@@ -51,7 +51,6 @@
 #include <TString.h>
 
 #include <algorithm>
-#include <array>
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
@@ -85,12 +84,6 @@ struct Cascqaanalysis {
     kNEventTypeBins
   };
 
-  static constexpr std::array<std::pair<EventTypeBin, const char*>, kNEventTypeBins> EventTypeBinLabels{{
-    {kINEL, "INEL"},
-    {kINELgt0, "INEL>0"},
-    {kINELgt1, "INEL>1"},
-  }};
-
   // Axes
   ConfigurableAxis ptAxis{"ptAxis", {200, 0.0f, 10.0f}, "#it{p}_{T} (GeV/#it{c})"};
   ConfigurableAxis rapidityAxis{"rapidityAxis", {200, -2.0f, 2.0f}, "y"};
@@ -112,6 +105,7 @@ struct Cascqaanalysis {
 
   // Event selection criteria
   Configurable<float> cutzvertex{"cutzvertex", 10.0f, "Accepted z-vertex range (cm)"};
+  Configurable<float> cutzvertexGen{"cutzvertexGen", -1.0f, "Accepted generated z-vertex range (cm); negative disables the cut"};
   Configurable<bool> isVertexITSTPC{"isVertexITSTPC", 0, "Select collisions with at least one ITS-TPC track"};
   Configurable<bool> isNoSameBunchPileup{"isNoSameBunchPileup", 0, "Same found-by-T0 bunch crossing rejection"};
   Configurable<bool> isGoodZvtxFT0vsPV{"isGoodZvtxFT0vsPV", 0, "z of PV by tracks and z of PV from FT0 A-C time difference cut"};
@@ -213,14 +207,6 @@ struct Cascqaanalysis {
             o2::constants::physics::MassOmegaMinus * decayLength * invMomentum};
   }
 
-  template <typename TAxisType>
-  static void setEventTypeAxisLabels(TAxisType* axis)
-  {
-    for (const auto& [bin, label] : EventTypeBinLabels) {
-      axis->SetBinLabel(static_cast<int>(bin) + 1, label);
-    }
-  }
-
   void init(InitContext const&)
   {
     TString hCandidateCounterLabels[4] = {"All candidates", "passed topo cuts", "has associated MC particle", "associated with Xi(Omega)"};
@@ -255,17 +241,9 @@ struct Cascqaanalysis {
       registry.add("hNchFT0MGenEvType", "hNchFT0MGenEvType", {HistType::kTH2D, {nChargedFT0MGenAxis, eventTypeAxis}});
       registry.add("hNchFV0AGenEvType", "hNchFV0AGenEvType", {HistType::kTH2D, {nChargedFV0AGenAxis, eventTypeAxis}});
       registry.add("hCentFT0M_genMC", "hCentFT0M_genMC", {HistType::kTH2D, {centFT0MAxis, eventTypeAxis}});
-      setEventTypeAxisLabels(registry.get<TH2>(HIST("hEventTypeRecVsGen"))->GetXaxis());
-      setEventTypeAxisLabels(registry.get<TH2>(HIST("hEventTypeRecVsGen"))->GetYaxis());
-      setEventTypeAxisLabels(registry.get<TH3>(HIST("hNchFT0MNAssocMCCollisions"))->GetZaxis());
-      setEventTypeAxisLabels(registry.get<TH3>(HIST("hNchFT0MNAssocMCCollisionsSameType"))->GetZaxis());
-      setEventTypeAxisLabels(registry.get<TH2>(HIST("hNchFT0MGenEvType"))->GetYaxis());
-      setEventTypeAxisLabels(registry.get<TH2>(HIST("hNchFV0AGenEvType"))->GetYaxis());
-      setEventTypeAxisLabels(registry.get<TH2>(HIST("hCentFT0M_genMC"))->GetYaxis());
     }
 
     registry.add("hCentFT0M_rec", "hCentFT0M_rec", {HistType::kTH2D, {centFT0MAxis, eventTypeAxis}});
-    setEventTypeAxisLabels(registry.get<TH2>(HIST("hCentFT0M_rec"))->GetYaxis());
 
     if (candidateQA) {
       registry.add("hNcandidates", "hNcandidates", {HistType::kTH3D, {nCandidates, centFT0MAxis, {2, -0.5f, 1.5f}}});
@@ -279,9 +257,6 @@ struct Cascqaanalysis {
         registry.add("hNchFT0Mglobal", "hNchFT0Mglobal", {HistType::kTH3D, {nChargedFT0MGenAxis, multNTracksAxis, eventTypeAxis}});
         registry.add("hNchFT0MPVContr", "hNchFT0MPVContr", {HistType::kTH3D, {nChargedFT0MGenAxis, multNTracksAxis, eventTypeAxis}});
         registry.add("hNchFV0APVContr", "hNchFV0APVContr", {HistType::kTH3D, {nChargedFV0AGenAxis, multNTracksAxis, eventTypeAxis}});
-        setEventTypeAxisLabels(registry.get<TH3>(HIST("hNchFT0Mglobal"))->GetZaxis());
-        setEventTypeAxisLabels(registry.get<TH3>(HIST("hNchFT0MPVContr"))->GetZaxis());
-        setEventTypeAxisLabels(registry.get<TH3>(HIST("hNchFV0APVContr"))->GetZaxis());
       }
       registry.add("hFT0MpvContr", "hFT0MpvContr", {HistType::kTH3D, {centFT0MAxis, multNTracksAxis, eventTypeAxis}});
       registry.add("hFV0ApvContr", "hFV0ApvContr", {HistType::kTH3D, {centFV0AAxis, multNTracksAxis, eventTypeAxis}});
@@ -289,11 +264,6 @@ struct Cascqaanalysis {
       registry.add("hFV0AFT0M", "hFV0AFT0M", {HistType::kTH3D, {centFV0AAxis, centFT0MAxis, eventTypeAxis}});
       registry.add("hFT0MFV0Asignal", "hFT0MFV0Asignal", {HistType::kTH2D, {signalFT0MAxis, signalFV0AAxis}});
       registry.add("hFT0MsignalPVContr", "hFT0MsignalPVContr", {HistType::kTH3D, {signalFT0MAxis, multNTracksAxis, eventTypeAxis}});
-      setEventTypeAxisLabels(registry.get<TH3>(HIST("hFT0MpvContr"))->GetZaxis());
-      setEventTypeAxisLabels(registry.get<TH3>(HIST("hFV0ApvContr"))->GetZaxis());
-      setEventTypeAxisLabels(registry.get<TH3>(HIST("hFT0Mglobal"))->GetZaxis());
-      setEventTypeAxisLabels(registry.get<TH3>(HIST("hFV0AFT0M"))->GetZaxis());
-      setEventTypeAxisLabels(registry.get<TH3>(HIST("hFT0MsignalPVContr"))->GetZaxis());
     }
 
     rctChecker.init(cfgEvtRCTFlagCheckerLabel, cfgEvtRCTFlagCheckerZDCCheck, cfgEvtRCTFlagCheckerLimitAcceptAsBad, requireRCTFlagChecker || applyRCTOnGen);
@@ -711,8 +681,8 @@ struct Cascqaanalysis {
     // All generated collisions
     registry.fill(HIST("hNEventsMC"), 0.5);
 
-    // Generated with accepted z vertex
-    if (std::fabs(mcCollision.posZ()) > cutzvertex) {
+    // Generated after optional z-vertex selection
+    if (cutzvertexGen >= 0.f && std::fabs(mcCollision.posZ()) > cutzvertexGen) {
       return;
     }
     registry.fill(HIST("hNEventsMC"), 1.5);

--- a/PWGLF/TableProducer/Strangeness/cascqaanalysis.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascqaanalysis.cxx
@@ -681,7 +681,7 @@ struct Cascqaanalysis {
     // All generated collisions
     registry.fill(HIST("hNEventsMC"), 0.5);
 
-    // Generated after optional z-vertex selection
+    // Generated z-vertex selection
     if (cutzvertexGen >= 0.f && std::fabs(mcCollision.posZ()) > cutzvertexGen) {
       return;
     }

--- a/PWGLF/TableProducer/Strangeness/cascqaanalysis.cxx
+++ b/PWGLF/TableProducer/Strangeness/cascqaanalysis.cxx
@@ -434,7 +434,7 @@ struct Cascqaanalysis {
       registry.fill(HIST("hNEvents"), 8.5);
     }
 
-    // Z vertex selection
+    // z-vertex selection
     if (std::fabs(collision.posZ()) > cutzvertex) {
       return false;
     }

--- a/PWGLF/TableProducer/Strangeness/v0qaanalysis.cxx
+++ b/PWGLF/TableProducer/Strangeness/v0qaanalysis.cxx
@@ -20,6 +20,7 @@
 #include "PWGLF/Utils/inelGt.h"
 
 #include "Common/CCDB/EventSelectionParams.h"
+#include "Common/CCDB/RCTSelectionFlags.h"
 #include "Common/DataModel/Centrality.h"
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/Multiplicity.h"
@@ -43,12 +44,14 @@
 
 #include <TH1.h>
 
+#include <string>
 #include <utility>
 #include <vector>
 
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
+using namespace o2::aod::rctsel;
 
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
@@ -61,6 +64,7 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 using DauTracks = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::pidTPCPi, aod::pidTPCKa, aod::pidTPCPr, aod::pidTOFPi, aod::pidTOFPr>;
 using DauTracksMC = soa::Join<DauTracks, aod::McTrackLabels>;
 using V0Collisions = soa::Join<aod::Collisions, aod::EvSels, aod::PVMults, aod::CentFT0Ms, aod::CentNGlobals>;
+using BCsWithBcSels = soa::Join<aod::BCsWithTimestamps, aod::BcSels>;
 
 struct LfV0qaanalysis {
 
@@ -106,10 +110,12 @@ struct LfV0qaanalysis {
       registry.add("hCentFT0M_GenRecoColl_MC_INELgt0", "hCentFT0M_GenRecoColl_MC_INELgt0", {HistType::kTH1F, {{1000, 0.f, 100.f}}});
       registry.add("hCentFT0M_GenColl_MC", "hCentFT0M_GenColl_MC", {HistType::kTH1F, {{1000, 0.f, 100.f}}});
       registry.add("hCentFT0M_GenColl_MC_INELgt0", "hCentFT0M_GenColl_MC_INELgt0", {HistType::kTH1F, {{1000, 0.f, 100.f}}});
-      registry.add("hNEventsMCGen", "hNEventsMCGen", {HistType::kTH1D, {{4, 0.f, 4.f}}});
+      registry.add("hNEventsMCGen", "hNEventsMCGen", {HistType::kTH1D, {{5, 0.f, 5.f}}});
       registry.get<TH1>(HIST("hNEventsMCGen"))->GetXaxis()->SetBinLabel(1, "all");
       registry.get<TH1>(HIST("hNEventsMCGen"))->GetXaxis()->SetBinLabel(2, "zvertex_true");
-      registry.get<TH1>(HIST("hNEventsMCGen"))->GetXaxis()->SetBinLabel(3, "INELgt0_true");
+      registry.get<TH1>(HIST("hNEventsMCGen"))->GetXaxis()->SetBinLabel(3, "BC TF/ITS ROF border");
+      registry.get<TH1>(HIST("hNEventsMCGen"))->GetXaxis()->SetBinLabel(4, "RCTFlagsChecker");
+      registry.get<TH1>(HIST("hNEventsMCGen"))->GetXaxis()->SetBinLabel(5, "INELgt0_true");
       registry.add("hNEventsMCGenReco", "hNEventsMCGenReco", {HistType::kTH1D, {{2, 0.f, 2.f}}});
       registry.get<TH1>(HIST("hNEventsMCGenReco"))->GetXaxis()->SetBinLabel(1, "INEL");
       registry.get<TH1>(HIST("hNEventsMCGenReco"))->GetXaxis()->SetBinLabel(2, "INELgt0");
@@ -153,6 +159,7 @@ struct LfV0qaanalysis {
       registry.add("Generated_MCGenColl_INELgt0_Lambda", "Generated_MCGenColl_INELgt0_Lambda", {HistType::kTH2F, {{250, 0.f, 25.f}, {1000, 0.f, 100.f}}});
       registry.add("Generated_MCGenColl_INELgt0_AntiLambda", "Generated_MCGenColl_INELgt0_AntiLambda", {HistType::kTH2F, {{250, 0.f, 25.f}, {1000, 0.f, 100.f}}});
     }
+    rctChecker.init(cfgEvtRCTFlagCheckerLabel, cfgEvtRCTFlagCheckerZDCCheck, cfgEvtRCTFlagCheckerLimitAcceptAsBad, applyRCTOnGen);
     registry.print();
   }
 
@@ -164,10 +171,17 @@ struct LfV0qaanalysis {
   Configurable<bool> isTriggerTVX{"isTriggerTVX", 1, "Is Trigger TVX"};
   Configurable<bool> isNoTimeFrameBorder{"isNoTimeFrameBorder", 1, "Is No Time Frame Border"};
   Configurable<bool> isNoITSROFrameBorder{"isNoITSROFrameBorder", 1, "Is No ITS Readout Frame Border"};
+  Configurable<bool> applyBcBorderCutsOnGen{"applyBcBorderCutsOnGen", false, "Apply enabled BC-level TF and ITS ROF border cuts on generated-level MC collisions"};
+  Configurable<bool> applyRCTOnGen{"applyRCTOnGen", false, "Apply enabled BC-level RCT run-condition selection on generated-level MC collisions"};
   Configurable<bool> isVertexTOFmatched{"isVertexTOFmatched", 0, "Is Vertex TOF matched"};
   Configurable<bool> isNoSameBunchPileup{"isNoSameBunchPileup", 0, "isNoSameBunchPileup"};
+  Configurable<std::string> cfgEvtRCTFlagCheckerLabel{"cfgEvtRCTFlagCheckerLabel", "CBT_hadronPID", "Evt sel: RCT flag checker label"};
+  Configurable<bool> cfgEvtRCTFlagCheckerZDCCheck{"cfgEvtRCTFlagCheckerZDCCheck", false, "Evt sel: RCT flag checker ZDC check"};
+  Configurable<bool> cfgEvtRCTFlagCheckerLimitAcceptAsBad{"cfgEvtRCTFlagCheckerLimitAcceptAsBad", false, "Evt sel: RCT flag checker treat Limited Acceptance As Bad"};
   Configurable<int> v0TypeSelection{"v0TypeSelection", 1, "select on a certain V0 type (leave negative if no selection desired)"};
   Configurable<bool> NotITSAfterburner{"NotITSAfterburner", 0, "NotITSAfterburner"};
+
+  RCTFlagsChecker rctChecker;
 
   // V0 selection criteria
   Configurable<double> v0cospa{"v0cospa", 0.97, "V0 CosPA"};
@@ -212,6 +226,27 @@ struct LfV0qaanalysis {
     registry.fill(HIST("hNEvents"), 7.5);
 
     return true;
+  }
+
+  template <typename TBC>
+  bool acceptGeneratedEventBcBorderCuts(TBC const& bc)
+  {
+    if (!applyBcBorderCutsOnGen) {
+      return true;
+    }
+    if (isNoTimeFrameBorder && !bc.selection_bit(aod::evsel::kNoTimeFrameBorder)) {
+      return false;
+    }
+    if (isNoITSROFrameBorder && !bc.selection_bit(aod::evsel::kNoITSROFrameBorder)) {
+      return false;
+    }
+    return true;
+  }
+
+  template <typename TBC>
+  bool acceptGeneratedEventRCT(TBC const& bc)
+  {
+    return !applyRCTOnGen || rctChecker(bc);
   }
 
   Filter preFilterV0 = nabs(aod::v0data::dcapostopv) > dcapostopv&&
@@ -469,7 +504,8 @@ struct LfV0qaanalysis {
 
   void processMCGen(soa::Join<aod::McCollisions, aod::McCentFT0Ms>::iterator const& mcCollision,
                     aod::McParticles const& mcParticles,
-                    soa::SmallGroups<soa::Join<aod::Collisions, aod::EvSels, aod::McCollisionLabels, aod::PVMults>> const& collisions)
+                    soa::SmallGroups<soa::Join<aod::Collisions, aod::EvSels, aod::McCollisionLabels, aod::PVMults>> const& collisions,
+                    BCsWithBcSels const&)
   {
     //====================================
     //===== Event Loss Denominator =======
@@ -481,13 +517,22 @@ struct LfV0qaanalysis {
       return;
     }
     registry.fill(HIST("hNEventsMCGen"), 1.5);
+    const auto bc = mcCollision.bc_as<BCsWithBcSels>();
+    if (!acceptGeneratedEventBcBorderCuts(bc)) {
+      return;
+    }
+    registry.fill(HIST("hNEventsMCGen"), 2.5);
+    if (!acceptGeneratedEventRCT(bc)) {
+      return;
+    }
+    registry.fill(HIST("hNEventsMCGen"), 3.5);
     registry.fill(HIST("hCentFT0M_GenColl_MC"), mcCollision.centFT0M());
 
     bool isINELgt0true = false;
 
     if (pwglf::isINELgtNmc(mcParticles, 0, pdgDB)) {
       isINELgt0true = true;
-      registry.fill(HIST("hNEventsMCGen"), 2.5);
+      registry.fill(HIST("hNEventsMCGen"), 4.5);
       registry.fill(HIST("hCentFT0M_GenColl_MC_INELgt0"), mcCollision.centFT0M());
     }
 

--- a/PWGLF/TableProducer/Strangeness/v0qaanalysis.cxx
+++ b/PWGLF/TableProducer/Strangeness/v0qaanalysis.cxx
@@ -265,7 +265,7 @@ struct LfV0qaanalysis {
     registry.fill(HIST("hCentFT0M"), collision.centFT0M());
     registry.fill(HIST("hCentNGlobals"), collision.centNGlobal());
 
-    for (auto& v0 : V0s) { // loop over V0s
+    for (const auto& v0 : V0s) { // loop over V0s
 
       if (v0.v0Type() != v0TypeSelection) {
         continue;
@@ -358,7 +358,7 @@ struct LfV0qaanalysis {
       }
 
       auto v0sThisCollision = V0s.sliceBy(perCol, collision.globalIndex());
-      for (auto& v0 : v0sThisCollision) { // loop over V0s
+      for (const auto& v0 : v0sThisCollision) { // loop over V0s
 
         if (!v0.has_mcParticle()) {
           continue;
@@ -406,8 +406,8 @@ struct LfV0qaanalysis {
           lPDG = v0mcparticle.pdgCode();
           isprimary = v0mcparticle.isPhysicalPrimary();
         }
-        for (auto& mcparticleDaughter0 : v0mcparticle.daughters_as<aod::McParticles>()) {
-          for (auto& mcparticleDaughter1 : v0mcparticle.daughters_as<aod::McParticles>()) {
+        for (const auto& mcparticleDaughter0 : v0mcparticle.daughters_as<aod::McParticles>()) {
+          for (const auto& mcparticleDaughter1 : v0mcparticle.daughters_as<aod::McParticles>()) {
             if (mcparticleDaughter0.pdgCode() == 211 && mcparticleDaughter1.pdgCode() == -211) {
               isDauK0Short = true;
             }
@@ -424,7 +424,7 @@ struct LfV0qaanalysis {
         float pdgMother = 0.;
 
         if (std::abs(v0mcparticle.pdgCode()) == 3122 && v0mcparticle.has_mothers()) {
-          for (auto& mcparticleMother0 : v0mcparticle.mothers_as<aod::McParticles>()) {
+          for (const auto& mcparticleMother0 : v0mcparticle.mothers_as<aod::McParticles>()) {
             if (std::abs(mcparticleMother0.pdgCode()) == 3312 || std::abs(mcparticleMother0.pdgCode()) == 3322) {
               ptMotherMC = mcparticleMother0.pt();
               pdgMother = mcparticleMother0.pdgCode();
@@ -470,7 +470,7 @@ struct LfV0qaanalysis {
       // Generated particles
       const auto particlesInCollision = mcParticles.sliceByCached(aod::mcparticle::mcCollisionId, mcCollision.globalIndex(), cache1);
 
-      for (auto& mcParticle : particlesInCollision) {
+      for (const auto& mcParticle : particlesInCollision) {
         if (!mcParticle.isPhysicalPrimary()) {
           continue;
         }
@@ -540,7 +540,7 @@ struct LfV0qaanalysis {
     //===== Signal Loss Denominator =======
     //=====================================
 
-    for (auto& mcParticle : mcParticles) {
+    for (const auto& mcParticle : mcParticles) {
 
       if (!mcParticle.isPhysicalPrimary()) {
         continue;
@@ -571,7 +571,7 @@ struct LfV0qaanalysis {
 
     int recoCollIndex_INEL = 0;
     int recoCollIndex_INELgt0 = 0;
-    for (auto& collision : collisions) { // loop on reconstructed collisions
+    for (const auto& collision : collisions) { // loop on reconstructed collisions
 
       //=====================================
       //====== Event Split Numerator ========
@@ -598,7 +598,7 @@ struct LfV0qaanalysis {
       //======== Sgn Split Numerator ========
       //=====================================
 
-      for (auto& mcParticle : mcParticles) {
+      for (const auto& mcParticle : mcParticles) {
 
         if (!mcParticle.isPhysicalPrimary()) {
           continue;
@@ -650,7 +650,7 @@ struct LfV0qaanalysis {
     //===== Signal Loss Numerator =========
     //=====================================
 
-    for (auto& mcParticle : mcParticles) {
+    for (const auto& mcParticle : mcParticles) {
 
       if (!mcParticle.isPhysicalPrimary()) {
         continue;
@@ -727,7 +727,7 @@ struct LfMyV0s {
 
   void process(aod::MyV0Candidates const& myv0s)
   {
-    for (auto& candidate : myv0s) {
+    for (const auto& candidate : myv0s) {
 
       registry.fill(HIST("hMassLambda"), candidate.masslambda());
       registry.fill(HIST("hPt"), candidate.v0pt());

--- a/PWGLF/Tasks/Strangeness/cascpostprocessing.cxx
+++ b/PWGLF/Tasks/Strangeness/cascpostprocessing.cxx
@@ -26,7 +26,9 @@
 #include <Framework/InitContext.h>
 #include <Framework/runDataProcessing.h>
 
+#include <TAxis.h>
 #include <TH1.h>
+#include <TH2.h>
 #include <TMathBase.h>
 #include <TPDGCode.h>
 #include <TString.h>
@@ -44,7 +46,51 @@ using namespace o2::framework;
 using namespace o2::framework::expressions;
 
 struct LfCascpostprocessing {
-  static constexpr int OobRejTofOnly = 2;
+  static constexpr int TrackQualityTofHighPt = 2;
+  static constexpr int TrackQualityMinITS = 3;
+
+  enum MisidentifiedParticleBin {
+    kMisIdUnknown = 0,
+    kMisIdElectron,
+    kMisIdMuon,
+    kMisIdPion,
+    kMisIdKaon,
+    kMisIdProton,
+    kMisIdK0Short,
+    kMisIdLambda,
+    kMisIdXi,
+    kMisIdOmega,
+    kMisIdOther,
+    kNMisidentifiedParticleBins
+  };
+
+  static int getMisidentifiedParticleBin(int pdgCode)
+  {
+    switch (TMath::Abs(pdgCode)) {
+      case 0:
+        return kMisIdUnknown;
+      case PDG_t::kElectron:
+        return kMisIdElectron;
+      case PDG_t::kMuonMinus:
+        return kMisIdMuon;
+      case PDG_t::kPiPlus:
+        return kMisIdPion;
+      case PDG_t::kKPlus:
+        return kMisIdKaon;
+      case PDG_t::kProton:
+        return kMisIdProton;
+      case PDG_t::kK0Short:
+        return kMisIdK0Short;
+      case PDG_t::kLambda0:
+        return kMisIdLambda;
+      case PDG_t::kXiMinus:
+        return kMisIdXi;
+      case PDG_t::kOmegaMinus:
+        return kMisIdOmega;
+      default:
+        return kMisIdOther;
+    }
+  }
 
   // Xi or Omega
   Configurable<bool> isXi{"isXi", 1, "Apply cuts for Xi identification"};
@@ -79,7 +125,8 @@ struct LfCascpostprocessing {
   Configurable<float> nsigmatofPr{"nsigmatofPr", 6, "N sigma TOF Proton"};
   Configurable<float> nsigmatofKa{"nsigmatofKa", 6, "N sigma TOF Kaon"};
   Configurable<int> mintpccrrows{"mintpccrrows", 50, "min N TPC crossed rows"};
-  Configurable<int> dooobrej{"dooobrej", 0, "OOB rejection: 0 no selection, 1 = ITS||TOF, 2 = TOF only for pT > ptthrtof"};
+  Configurable<int> dooobrej{"dooobrej", 0, "Track association requirement: 0 no selection, 1 = ITS||TOF, 2 = TOF only for pT > ptthrtof, 3 = ITS hits >= trackQualityMinITS"};
+  Configurable<int> trackQualityMinITS{"trackQualityMinITS", 2, "Minimum ITS hits for dooobrej=3 track-quality variation"};
 
   Configurable<bool> isSelectBachBaryon{"isSelectBachBaryon", 0, "Bachelor-baryon cascade selection"};
   Configurable<float> bachBaryonCosPA{"bachBaryonCosPA", 0.9999, "Bachelor baryon CosPA"};
@@ -107,6 +154,13 @@ struct LfCascpostprocessing {
     AxisSpec ptAxisPID = {50, 0.0f, 10.0f, "#it{p}_{T} (GeV/#it{c})"};
     ConfigurableAxis etaAxis{"etaAxis", {40, -2.0f, 2.0f}, "#eta"};
     AxisSpec pdgCodeAxis = {10001, -5000.5f, 5000.5f, "MC PDG code (0 = no MC assoc.)"};
+    AxisSpec misidentifiedParticleAxis = {kNMisidentifiedParticleBins, -0.5f, static_cast<float>(kNMisidentifiedParticleBins) - 0.5f, "Associated MC particle"};
+    auto setMisidentifiedParticleLabels = [](TAxis* axis) {
+      TString misidentifiedParticleLabels[kNMisidentifiedParticleBins] = {"Unknown/no assoc.", "e", "#mu", "#pi", "K", "p", "K^{0}_{S}", "#Lambda", "#Xi", "#Omega", "Other"};
+      for (int n = 1; n <= kNMisidentifiedParticleBins; n++) {
+        axis->SetBinLabel(n, misidentifiedParticleLabels[n - 1]);
+      }
+    };
 
     ConfigurableAxis centFT0MAxis{"centFT0MAxis",
                                   {VARIABLE_WIDTH, 0., 0.01, 0.05, 0.1, 0.5, 1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, 101, 105.5},
@@ -119,8 +173,8 @@ struct LfCascpostprocessing {
 
     AxisSpec rapidityAxis = {200, -2.0f, 2.0f, "y"};
 
-    TString CutLabel[26] = {"All", "MassWin", "y", "EtaDau", "DCADauToPV", "CascCosPA", "V0CosPA", "DCACascDau", "DCAV0Dau", "rCasc", "rCascMax", "rV0", "rV0Max", "DCAV0ToPV", "LambdaMass", "TPCPr", "TPCPi", "TOFPr", "TOFPi", "TPCBach", "TOFBach", "ctau", "CompDecayMass", "Bach-baryon", "NTPCrows", "OOBRej"};
-    TString CutLabelSummary[29] = {"MassWin", "y", "EtaDau", "dcapostopv", "dcanegtopv", "dcabachtopv", "CascCosPA", "V0CosPA", "DCACascDau", "DCAV0Dau", "rCasc", "rV0", "DCAV0ToPV", "LambdaMass", "TPCPr", "TPCPi", "TOFPr", "TOFPi", "TPCBach", "TOFBach", "proplifetime", "rejcomp", "ptthrtof", "bachBaryonCosPA", "bachBaryonDCAxyToPV", "NTPCrows", "OOBRej", "rCascMax", "rV0Max"};
+    TString CutLabel[26] = {"All", "MassWin", "y", "EtaDau", "DCADauToPV", "CascCosPA", "V0CosPA", "DCACascDau", "DCAV0Dau", "rCasc", "rCascMax", "rV0", "rV0Max", "DCAV0ToPV", "LambdaMass", "TPCPr", "TPCPi", "TOFPr", "TOFPi", "TPCBach", "TOFBach", "ctau", "CompDecayMass", "Bach-baryon", "NTPCrows", "TrackQuality"};
+    TString CutLabelSummary[29] = {"MassWin", "y", "EtaDau", "dcapostopv", "dcanegtopv", "dcabachtopv", "CascCosPA", "V0CosPA", "DCACascDau", "DCAV0Dau", "rCasc", "rV0", "DCAV0ToPV", "LambdaMass", "TPCPr", "TPCPi", "TOFPr", "TOFPi", "TPCBach", "TOFBach", "proplifetime", "rejcomp", "ptthrtof", "bachBaryonCosPA", "bachBaryonDCAxyToPV", "NTPCrows", "TrackQuality", "rCascMax", "rV0Max"};
 
     registry.add("hCandidate", "hCandidate", HistType::kTH1F, {{26, -0.5, 25.5}});
     for (Int_t n = 1; n <= registry.get<TH1>(HIST("hCandidate"))->GetNbinsX(); n++) {
@@ -242,6 +296,14 @@ struct LfCascpostprocessing {
       registry.add("hMisidentifiedCascPdgCode", "hMisidentifiedCascPdgCode", {HistType::kTH1F, {pdgCodeAxis}});
       registry.add("hMisidentifiedCascMinusPdgCode", "hMisidentifiedCascMinusPdgCode", {HistType::kTH1F, {pdgCodeAxis}});
       registry.add("hMisidentifiedCascPlusPdgCode", "hMisidentifiedCascPlusPdgCode", {HistType::kTH1F, {pdgCodeAxis}});
+      registry.add("hMisidentifiedCascParticle", "hMisidentifiedCascParticle", {HistType::kTH1F, {misidentifiedParticleAxis}});
+      registry.add("hMisidentifiedCascMinusParticle", "hMisidentifiedCascMinusParticle", {HistType::kTH1F, {misidentifiedParticleAxis}});
+      registry.add("hMisidentifiedCascPlusParticle", "hMisidentifiedCascPlusParticle", {HistType::kTH1F, {misidentifiedParticleAxis}});
+      registry.add("hMisidentifiedCascParticleVsPt", "hMisidentifiedCascParticleVsPt", {HistType::kTH2F, {ptAxis, misidentifiedParticleAxis}});
+      setMisidentifiedParticleLabels(registry.get<TH1>(HIST("hMisidentifiedCascParticle"))->GetXaxis());
+      setMisidentifiedParticleLabels(registry.get<TH1>(HIST("hMisidentifiedCascMinusParticle"))->GetXaxis());
+      setMisidentifiedParticleLabels(registry.get<TH1>(HIST("hMisidentifiedCascPlusParticle"))->GetXaxis());
+      setMisidentifiedParticleLabels(registry.get<TH2>(HIST("hMisidentifiedCascParticleVsPt"))->GetYaxis());
       registry.add("hPtXiPlusTrue", "hPtXiPlusTrue", {HistType::kTH3F, {ptAxis, rapidityAxis, centFT0MAxis}});
       registry.add("hPtXiMinusTrue", "hPtXiMinusTrue", {HistType::kTH3F, {ptAxis, rapidityAxis, centFT0MAxis}});
       registry.add("hPtOmegaPlusTrue", "hPtOmegaPlusTrue", {HistType::kTH3F, {ptAxis, rapidityAxis, centFT0MAxis}});
@@ -433,12 +495,17 @@ struct LfCascpostprocessing {
       registry.fill(HIST("hCandidate"), ++counter);
       bool kHasTOF = (candidate.poshastof() || candidate.neghastof() || candidate.bachhastof());
       bool kHasITS = ((candidate.positshits() > 1) || (candidate.negitshits() > 1) || (candidate.bachitshits() > 1));
+      bool kPassMinITS = ((candidate.positshits() >= trackQualityMinITS) || (candidate.negitshits() >= trackQualityMinITS) || (candidate.bachitshits() >= trackQualityMinITS));
       if (dooobrej == 1) {
         if (!kHasTOF && !kHasITS)
           continue;
         registry.fill(HIST("hCandidate"), ++counter);
-      } else if (dooobrej == OobRejTofOnly) {
+      } else if (dooobrej == TrackQualityTofHighPt) {
         if (!kHasTOF && (candidate.pt() > ptthrtof))
+          continue;
+        registry.fill(HIST("hCandidate"), ++counter);
+      } else if (dooobrej == TrackQualityMinITS) {
+        if (!kPassMinITS)
           continue;
         registry.fill(HIST("hCandidate"), ++counter);
       } else {
@@ -519,11 +586,16 @@ struct LfCascpostprocessing {
       // registry.fill(HIST("hBachITSHits"), candidate.bachitshits());
 
       if (isMC && !isCorrectlyRec) {
+        const int misidentifiedParticleBin = getMisidentifiedParticleBin(candidate.mcPdgCode());
         registry.fill(HIST("hMisidentifiedCascPdgCode"), candidate.mcPdgCode());
+        registry.fill(HIST("hMisidentifiedCascParticle"), misidentifiedParticleBin);
+        registry.fill(HIST("hMisidentifiedCascParticleVsPt"), candidate.pt(), misidentifiedParticleBin);
         if (candidate.sign() < 0) {
           registry.fill(HIST("hMisidentifiedCascMinusPdgCode"), candidate.mcPdgCode());
+          registry.fill(HIST("hMisidentifiedCascMinusParticle"), misidentifiedParticleBin);
         } else if (candidate.sign() > 0) {
           registry.fill(HIST("hMisidentifiedCascPlusPdgCode"), candidate.mcPdgCode());
+          registry.fill(HIST("hMisidentifiedCascPlusParticle"), misidentifiedParticleBin);
         }
       }
 


### PR DESCRIPTION
1. separates generated-level z-vertex handling for cascades
2. adds generated-level BC border and RCT selections for v0s
3. extends cascade postprocessing with a track-quality variation plus misidentification QA histograms