### PR TITLE
[PWGDQ] fix computation of match attempts in QA task

### DIFF
--- a/PWGDQ/Tasks/qaMatching.cxx
+++ b/PWGDQ/Tasks/qaMatching.cxx
@@ -2120,10 +2120,10 @@ struct QaMatching {
           int64_t mchTrackIndex = muonTrack.globalIndex();
           auto& mchTrackInfo = collisionInfo.mchTracks[mchTrackIndex];
           mchTrackInfo.index = mchTrackIndex;
-          getMftMchMatchAttempts(mchTrackInfo, collisionInfo.mftTimeInfos);
           mchTrackInfo.bc = bc.globalBC();
           mchTrackInfo.time = muonTrack.trackTime();
           mchTrackInfo.timeRes = muonTrack.trackTimeRes();
+          getMftMchMatchAttempts(mchTrackInfo, collisionInfo.mftTimeInfos);
 
           collisionInfo.reducedMchTrackIds[mchTrackIndex] = reducedMchTrackId;
           reducedMchTrackId += 1;


### PR DESCRIPTION
The function to compute the number of match attempts was colled before setting the time and BC of the MCH track, resulting in no attepts found.