### PR TITLE
[PWGDQ] fix track selection for MCH realignment

### DIFF
--- a/PWGDQ/Tasks/global-muon-matcher.cxx
+++ b/PWGDQ/Tasks/global-muon-matcher.cxx
@@ -1258,7 +1258,7 @@ struct GlobalMuonMatching {
     for (auto const& muon : muons) {
       int mchIndex = muon.globalIndex();
       // skip global forward matches
-      if (muon.trackType() > GlobalTrackTypeMax) {
+      if (muon.trackType() <= GlobalTrackTypeMax) {
         continue;
       }
 


### PR DESCRIPTION
The MCH realignment was applied to global muon tracks instead of MCH(-MID) tracks.