### PR TITLE
[Infrastructure] Update checkout configuration

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -32,6 +32,7 @@ jobs:
           fetch-depth: 0
           # So we can use secrets.ALIBUILD_GITHUB_TOKEN to push later.
           persist-credentials: false
+          allow-unsafe-pr-checkout: true # needed for pull_request_target
 
       # MegaLinter
       - name: MegaLinter

--- a/.github/workflows/o2-linter.yml
+++ b/.github/workflows/o2-linter.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           ref: ${{ env.BRANCH_HEAD }}
           fetch-depth: 0 # needed to get the full history
+          allow-unsafe-pr-checkout: true # needed for pull_request_target
       - name: Run tests
         id: linter
         run: |


### PR DESCRIPTION
checkout@v7 forbids checking out fork pull request code on `pull_request_target` by default.