### PR TITLE
[PWGDQ] Fix e-mu mixed-event histograms

### DIFF
--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -1739,7 +1739,6 @@ struct AnalysisSameEventPairing {
             Form("PairsEleMuSEMM_%s_%s", trackCutName.Data(), muonCutName.Data())};
           histNames += Form("%s;%s;%s;", names[0].Data(), names[1].Data(), names[2].Data());
           int index = iTrack * fNCutsMuon + iMuon;
-          fTrackMuonHistNames[index] = names;
 
           if (fEnableBarrelMuonMixingHistos) {
             names.push_back(Form("PairsEleMuMEPM_%s_%s", trackCutName.Data(), muonCutName.Data()));
@@ -1747,6 +1746,7 @@ struct AnalysisSameEventPairing {
             names.push_back(Form("PairsEleMuMEMM_%s_%s", trackCutName.Data(), muonCutName.Data()));
             histNames += Form("%s;%s;%s;", names[3].Data(), names[4].Data(), names[5].Data());
           }
+          fTrackMuonHistNames[index] = names;
 
           if (!cutNamesStr.IsNull()) {
             std::unique_ptr<TObjArray> objArrayPair(cutNamesStr.Tokenize(","));


### PR DESCRIPTION
Fix e-mu mixed-event histograms being silently empty in tableReader_withAssoc fTrackMuonHistNames was stored before the mixing histogram names were appended, so PairsEleMuME* classes were never filled. Store the names after the ME block, matching the ordering already used in dqEfficiency_withAssoc.