### PR TITLE
[PWGDQ] fix time difference computation for match attempts in QA task

### DIFF
--- a/PWGDQ/Tasks/qaMatching.cxx
+++ b/PWGDQ/Tasks/qaMatching.cxx
@@ -2014,8 +2014,8 @@ struct QaMatching {
 
       int64_t deltaBc = bcMft - bcMch;
       double deltaBcNS = o2::constants::lhc::LHCBunchSpacingNS * deltaBc;
-      double deltaTrackTime = mftTrackInfo.time - mftTrackInfo.time + deltaBcNS;
-      double trackTimeResTot = mftTrackInfo.timeRes + mftTrackInfo.timeRes;
+      double deltaTrackTime = mftTrackInfo.time - mchTrackInfo.time + deltaBcNS;
+      double trackTimeResTot = mftTrackInfo.timeRes + mchTrackInfo.timeRes;
 
       if (std::fabs(deltaTrackTime) > trackTimeResTot) {
         continue;


### PR DESCRIPTION
The MFT track time was subtracted from itself instead from the MCH time.