### PR TITLE
[PWGLF] Improvements to L1405 task

### DIFF
--- a/PWGLF/DataModel/LFLambda1405Table.h
+++ b/PWGLF/DataModel/LFLambda1405Table.h
@@ -50,7 +50,7 @@ DECLARE_SOA_COLUMN(NSigmaTOFPiDau, nSigmaTOFPiDau, float);   //! Number of sigma
 
 // Event properties
 DECLARE_SOA_COLUMN(Centrality, centrality, float); //! Centrality of the candidate
-DECLARE_SOA_COLUMN(Occupancy, occupancy, float); //! Occupancy of the candidate
+DECLARE_SOA_COLUMN(Occupancy, occupancy, float);   //! Occupancy of the candidate
 
 // Flow columns
 DECLARE_SOA_COLUMN(ScalarProd, scalarProd, float); //! Scalar product of the candidate

--- a/PWGLF/DataModel/LFLambda1405Table.h
+++ b/PWGLF/DataModel/LFLambda1405Table.h
@@ -48,9 +48,12 @@ DECLARE_SOA_COLUMN(DCAKinkDauToPV, dcaKinkDauToPV, float);   //! DCA of the kink
 DECLARE_SOA_COLUMN(NSigmaTPCPiDau, nSigmaTPCPiDau, float);   //! Number of sigmas for the lambda1405 pion daughter in TPC
 DECLARE_SOA_COLUMN(NSigmaTOFPiDau, nSigmaTOFPiDau, float);   //! Number of sigmas for the lambda1405 pion daughter in TOF
 
+// Event properties
+DECLARE_SOA_COLUMN(Centrality, centrality, float); //! Centrality of the candidate
+DECLARE_SOA_COLUMN(Occupancy, occupancy, float); //! Occupancy of the candidate
+
 // Flow columns
 DECLARE_SOA_COLUMN(ScalarProd, scalarProd, float); //! Scalar product of the candidate
-DECLARE_SOA_COLUMN(Centrality, centrality, float); //! Centrality of the candidate
 
 // MC Columns
 DECLARE_SOA_COLUMN(PtMC, ptMC, float);                   //! pT of the candidate in MC
@@ -70,7 +73,8 @@ DECLARE_SOA_TABLE(Lambda1405Cands, "AOD", "LAMBDA1405",
                   lambda1405::NSigmaTPCPiKink, lambda1405::NSigmaTOFPiKink,
                   lambda1405::NSigmaTPCPrKink, lambda1405::NSigmaTOFPrKink,
                   lambda1405::DCAKinkDauToPV,
-                  lambda1405::NSigmaTPCPiDau, lambda1405::NSigmaTOFPiDau);
+                  lambda1405::NSigmaTPCPiDau, lambda1405::NSigmaTOFPiDau,
+                  lambda1405::Centrality, lambda1405::Occupancy);
 
 DECLARE_SOA_TABLE(Lambda1405Flow, "AOD", "LAMBDA1405FLOW",
                   o2::soa::Index<>,
@@ -95,7 +99,8 @@ DECLARE_SOA_TABLE(Lambda1405CandsMC, "AOD", "MCLAMBDA1405",
                   lambda1405::NSigmaTPCPrKink, lambda1405::NSigmaTOFPrKink,
                   lambda1405::DCAKinkDauToPV,
                   lambda1405::NSigmaTPCPiDau, lambda1405::NSigmaTOFPiDau,
-                  lambda1405::PtMC, lambda1405::MassMC, lambda1405::SigmaPdgCode, lambda1405::KinkDauPdgCode);
+                  lambda1405::PtMC, lambda1405::MassMC, lambda1405::SigmaPdgCode, lambda1405::KinkDauPdgCode,
+                  lambda1405::Centrality, lambda1405::Occupancy);
 
 } // namespace o2::aod
 

--- a/PWGLF/Tasks/Resonances/lambda1405analysis.cxx
+++ b/PWGLF/Tasks/Resonances/lambda1405analysis.cxx
@@ -17,13 +17,13 @@
 #include "PWGLF/DataModel/LFLambda1405Table.h"
 
 #include "Common/Core/RecoDecay.h"
+#include "Common/Core/trackUtilities.h"
 #include "Common/DataModel/Centrality.h"
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/Multiplicity.h"
 #include "Common/DataModel/PIDResponseTOF.h"
 #include "Common/DataModel/PIDResponseTPC.h"
 #include "Common/DataModel/Qvectors.h"
-#include "Common/Core/trackUtilities.h"
 
 #include <CCDB/BasicCCDBManager.h>
 #include <CommonConstants/MathConstants.h>
@@ -103,9 +103,9 @@ struct lambda1405candidate {
   int sigmaId = 0;          // Id of the Sigma candidate in MC
   int bachPiId = 0;         // Id of the pion candidate in MC
 
-  float centMult = -1;    // Centrality of the collision
-  float pvContrib = -1;   // Number of contributors to the primary vertex
-  float occ = -1;         // Occupancy of the collision
+  float centMult = -1;  // Centrality of the collision
+  float pvContrib = -1; // Number of contributors to the primary vertex
+  float occ = -1;       // Occupancy of the collision
 
   float scalarProd = -1; // Scalar product for flow analysis
 };
@@ -862,8 +862,8 @@ struct lambda1405analysis {
         return;
       }
       if (success) {
-        float sigmaPOriginal = std::sqrt(sigmaCand.pxMoth() * sigmaCand.pxMoth() + 
-                                         sigmaCand.pyMoth() * sigmaCand.pyMoth() + 
+        float sigmaPOriginal = std::sqrt(sigmaCand.pxMoth() * sigmaCand.pxMoth() +
+                                         sigmaCand.pyMoth() * sigmaCand.pyMoth() +
                                          sigmaCand.pzMoth() * sigmaCand.pzMoth());
         if (sigmaPRecalc > 0.f && sigmaPOriginal > 0.f) {
           float scale = sigmaPRecalc / sigmaPOriginal;
@@ -980,8 +980,8 @@ struct lambda1405analysis {
 
     // Collision properties
     lambda1405Cand.pvContrib = collision.numContrib();
-    lambda1405Cand.centMult  = getCentMult(collision);
-    lambda1405Cand.occ       = collision.ft0cOccupancyInTimeRange();
+    lambda1405Cand.centMult = getCentMult(collision);
+    lambda1405Cand.occ = collision.ft0cOccupancyInTimeRange();
 
     fillHistosSigma(lambda1405Cand, sigmaCand, kinkDauTrack);
 
@@ -1133,15 +1133,15 @@ struct lambda1405analysis {
             }
           }
           if (fillOutputTree) {
-          outputDataTable(lambda1405Cand.px, lambda1405Cand.py, lambda1405Cand.pz,
-                          lambda1405Cand.massL1405, lambda1405Cand.massXi1530,
-                          lambda1405Cand.sigmaMinusMass, lambda1405Cand.sigmaPlusMass, lambda1405Cand.xiMinusMass,
-                          lambda1405Cand.sigmaPt, lambda1405Cand.sigmaAlphaAP, lambda1405Cand.sigmaQtAP, lambda1405Cand.sigmaRadius,
-                          lambda1405Cand.kinkPt,
-                          lambda1405Cand.kinkPiNSigTpc, lambda1405Cand.kinkPiNSigTof,
-                          lambda1405Cand.kinkPrNSigTpc, lambda1405Cand.kinkPrNSigTof,
-                          lambda1405Cand.kinkDcaDauToPv,
-                          lambda1405Cand.bachPiNSigTpc, lambda1405Cand.bachPiNSigTof);
+            outputDataTable(lambda1405Cand.px, lambda1405Cand.py, lambda1405Cand.pz,
+                            lambda1405Cand.massL1405, lambda1405Cand.massXi1530,
+                            lambda1405Cand.sigmaMinusMass, lambda1405Cand.sigmaPlusMass, lambda1405Cand.xiMinusMass,
+                            lambda1405Cand.sigmaPt, lambda1405Cand.sigmaAlphaAP, lambda1405Cand.sigmaQtAP, lambda1405Cand.sigmaRadius,
+                            lambda1405Cand.kinkPt,
+                            lambda1405Cand.kinkPiNSigTpc, lambda1405Cand.kinkPiNSigTof,
+                            lambda1405Cand.kinkPrNSigTpc, lambda1405Cand.kinkPrNSigTof,
+                            lambda1405Cand.kinkDcaDauToPv,
+                            lambda1405Cand.bachPiNSigTpc, lambda1405Cand.bachPiNSigTof);
           } else {
             outputDataFlowTable(ptCand, lambda1405Cand.massL1405,
                                 lambda1405Cand.sigmaPt,
@@ -1311,9 +1311,9 @@ struct lambda1405analysis {
         auto genSigma = labelSigma.template mcParticle_as<aod::McParticles>();
         auto genKinkDaug = labelKinkDaug.template mcParticle_as<aod::McParticles>();
 
-        bool isSigmaMinusKink    = checkSigmaKinkMC(genSigma, genKinkDaug, PDG_t::kSigmaMinus, PDG_t::kPiPlus, particlesMC);
-        bool isSigmaPlusToPiKink = checkSigmaKinkMC(genSigma, genKinkDaug, PDG_t::kSigmaPlus,  PDG_t::kPiPlus, particlesMC);
-        bool isSigmaPlusToPrKink = checkSigmaKinkMC(genSigma, genKinkDaug, PDG_t::kSigmaPlus,  PDG_t::kProton, particlesMC);
+        bool isSigmaMinusKink = checkSigmaKinkMC(genSigma, genKinkDaug, PDG_t::kSigmaMinus, PDG_t::kPiPlus, particlesMC);
+        bool isSigmaPlusToPiKink = checkSigmaKinkMC(genSigma, genKinkDaug, PDG_t::kSigmaPlus, PDG_t::kPiPlus, particlesMC);
+        bool isSigmaPlusToPrKink = checkSigmaKinkMC(genSigma, genKinkDaug, PDG_t::kSigmaPlus, PDG_t::kProton, particlesMC);
 
         if (!isSigmaMinusKink && !isSigmaPlusToPiKink && !isSigmaPlusToPrKink) {
           LOG(info) << "Candidate is not a valid Sigma kink decay, skipping ...";
@@ -1327,7 +1327,7 @@ struct lambda1405analysis {
           LOG(info) << "Filling h2DeltaGenRecoPtSigmaPlus with: " << sigmaCand.ptMoth() - genSigma.pt() << ", " << sigmaCand.ptMoth();
           rSigmaPlus.fill(HIST("h2DeltaGenRecoPtSigmaPlus"), sigmaCand.ptMoth() - genSigma.pt(), sigmaCand.ptMoth());
         }
-        
+
         std::vector<lambda1405candidate> selectedCandidates;
         LOG(info) << "Constructing Lambda(1405) candidates from Sigma candidate with global index: " << sigmaCand.globalIndex();
         constructCollCandidates(collision, sigmaCand, tracksPerCol, selectedCandidates);

--- a/PWGLF/Tasks/Resonances/lambda1405analysis.cxx
+++ b/PWGLF/Tasks/Resonances/lambda1405analysis.cxx
@@ -503,7 +503,7 @@ struct lambda1405analysis {
     if (isSigmaMinus) {
       rSelections.fill(HIST("hRecalcSigmaMinusMom"), 0); // All
     } else {
-      rSelections.fill(HIST("hRecalcSigmaMinusMom"), 0); // All
+      rSelections.fill(HIST("hRecalcSigmaPlusMom"), 0); // All
     }
     // Sigma- -> n + pi-  (charged daughter = pion, neutral daughter = neutron)
     // Sigma+ -> p + pi0  (charged daughter = proton, neutral daughter = pi0)
@@ -519,7 +519,7 @@ struct lambda1405analysis {
     if (isSigmaMinus) {
       rSelections.fill(HIST("hRecalcSigmaMinusMom"), 1); // Non-zero momentum
     } else {
-      rSelections.fill(HIST("hRecalcSigmaMinusMom"), 1); // Non-zero momentum
+      rSelections.fill(HIST("hRecalcSigmaPlusMom"), 1); // Non-zero momentum
     }
 
     double versorX = sigmaPx / pMother;
@@ -539,7 +539,7 @@ struct lambda1405analysis {
     if (isSigmaMinus) {
       rSelections.fill(HIST("hRecalcSigmaMinusMom"), 2); // Non-zero A
     } else {
-      rSelections.fill(HIST("hRecalcSigmaMinusMom"), 2); // Non-zero A
+      rSelections.fill(HIST("hRecalcSigmaPlusMom"), 2); // Non-zero A
     }
 
     double D = B * B - 4.0 * A * C;
@@ -550,7 +550,7 @@ struct lambda1405analysis {
     if (isSigmaMinus) {
       rSelections.fill(HIST("hRecalcSigmaMinusMom"), 3); // Positive D
     } else {
-      rSelections.fill(HIST("hRecalcSigmaMinusMom"), 3); // Positive D
+      rSelections.fill(HIST("hRecalcSigmaPlusMom"), 3); // Positive D
     }
 
     double sqrtD = std::sqrt(D);
@@ -563,7 +563,7 @@ struct lambda1405analysis {
     if (isSigmaMinus) {
       rSelections.fill(HIST("hRecalcSigmaMinusMom"), 4); // Real solutions
     } else {
-      rSelections.fill(HIST("hRecalcSigmaMinusMom"), 4); // Real solutions
+      rSelections.fill(HIST("hRecalcSigmaPlusMom"), 4); // Real solutions
     }
 
     success = true;
@@ -1056,11 +1056,6 @@ struct lambda1405analysis {
       }
       if (piTrack.pt() < funcMinBachPiPtVsL1405Pt.Eval(lambda1405Cand.pt()) ||
           piTrack.pt() > funcMaxBachPiPtVsL1405Pt.Eval(lambda1405Cand.pt())) {
-        continue;
-      }
-      rSelections.fill(HIST("hSelectionsL1405"), 4); // Pt correlations
-
-      if (lambda1405Cand.pt() < cutMinPtL1405) {
         continue;
       }
       rSelections.fill(HIST("hSelectionsL1405"), 4); // Pt correlations

--- a/PWGLF/Tasks/Resonances/lambda1405analysis.cxx
+++ b/PWGLF/Tasks/Resonances/lambda1405analysis.cxx
@@ -45,9 +45,9 @@
 #include <ReconstructionDataFormats/Vertex.h>
 
 #include <TF1.h>
-#include <THnSparse.h>
 #include <TH2.h>
 #include <TH3.h>
+#include <THnSparse.h>
 
 #include <array>
 #include <cmath>
@@ -106,9 +106,9 @@ struct lambda1405candidate {
   int sigmaId = 0;          // Id of the Sigma candidate in MC
   int bachPiId = 0;         // Id of the pion candidate in MC
 
-  float centMult = -1;    // Centrality of the collision
-  float pvContrib = -1;   // Number of contributors to the primary vertex
-  float occupancy = -1;   // Occupancy of the collision
+  float centMult = -1;  // Centrality of the collision
+  float pvContrib = -1; // Number of contributors to the primary vertex
+  float occupancy = -1; // Occupancy of the collision
 
   float scalarProd = -1; // Scalar product for flow analysis
 };

--- a/PWGLF/Tasks/Resonances/lambda1405analysis.cxx
+++ b/PWGLF/Tasks/Resonances/lambda1405analysis.cxx
@@ -45,6 +45,9 @@
 #include <ReconstructionDataFormats/Vertex.h>
 
 #include <TF1.h>
+#include <THnSparse.h>
+#include <TH2.h>
+#include <TH3.h>
 
 #include <array>
 #include <cmath>
@@ -103,9 +106,9 @@ struct lambda1405candidate {
   int sigmaId = 0;          // Id of the Sigma candidate in MC
   int bachPiId = 0;         // Id of the pion candidate in MC
 
-  float centMult = -1;  // Centrality of the collision
-  float pvContrib = -1; // Number of contributors to the primary vertex
-  float occ = -1;       // Occupancy of the collision
+  float centMult = -1;    // Centrality of the collision
+  float pvContrib = -1;   // Number of contributors to the primary vertex
+  float occupancy = -1;   // Occupancy of the collision
 
   float scalarProd = -1; // Scalar product for flow analysis
 };
@@ -165,7 +168,7 @@ struct lambda1405analysis {
 
   Configurable<bool> fillOutputTree{"fillOutputTree", true, "If true, fill the output tree with Lambda(1405) candidates"};
   Configurable<bool> doLikeSignBkg{"doLikeSignBkg", false, "Use like-sign background"};
-  Configurable<bool> useTof{"useTof", false, "Use Tof for PId for pion candidates"};
+  Configurable<bool> useTof{"useTof", false, "Use Tof for PID for pion candidates"};
   Configurable<bool> recomputeSigmaMom{"recomputeSigmaMom", true, "Recalculate sigma momentum from daughter kinematics"};
   Configurable<bool> skipSigmasFailedRecompMom{"skipSigmasFailedRecompMom", false, "Skip sigmas for which momentum recalculation fails"};
 
@@ -311,8 +314,8 @@ struct lambda1405analysis {
     rLambda1405.add("hPairedBachPiVsCent", "hPairedBachPiVsCent", {HistType::kTH2F, {centMultAxis, {1000, -0.5, 999.5}}});
     rLambda1405.add("h2BachPiPtNSigTof", "h2BachPiPtNSigTof", {HistType::kTH2F, {ptKinkDaugAxis, nSigmaAxis}});
     rLambda1405.add("h2BachPiPtNSigTpc", "h2BachPiPtNSigTpc", {HistType::kTH2F, {ptKinkDaugAxis, nSigmaAxis}});
-    rLambda1405.add("h2BachPiDcaXYVsPt", "h2BachPiDcaXYVsPt", {HistType::kTH2F, {ptKinkDaugAxis, dcaBachPiAxis}});
-    rLambda1405.add("h2BachPiDcaZVsPt", "h2BachPiDcaZVsPt", {HistType::kTH2F, {ptKinkDaugAxis, dcaBachPiAxis}});
+    rLambda1405.add("h3BachPiDcaXYVsPt", "h3BachPiDcaXYVsPt", {HistType::kTH3F, {ptKinkDaugAxis, dcaBachPiAxis, centMultAxis}});
+    rLambda1405.add("h3BachPiDcaZVsPt", "h3BachPiDcaZVsPt", {HistType::kTH3F, {ptKinkDaugAxis, dcaBachPiAxis, centMultAxis}});
     // Sparse histograms
     std::vector<AxisSpec> axesMass = {lambda1405MassAxis, ptAxis, sigmaMassAxis, dcaSigmaToPvAxis, dcaKinkToPvAxis};
     if (doprocessMc || doprocessMcWCentSel) {
@@ -579,7 +582,7 @@ struct lambda1405analysis {
   }
 
   template <typename TTrack>
-  bool selectPiBach(const TTrack& candidate, const o2::dataformats::VertexBase& vtx)
+  bool selectPiBach(const TTrack& candidate, const o2::dataformats::VertexBase& vtx, float centMult)
   {
     if (std::abs(candidate.tpcNSigmaPi()) > cutNSigTpc) {
       return false;
@@ -601,8 +604,8 @@ struct lambda1405analysis {
     o2::base::Propagator::Instance()->propagateToDCABxByBz({vtx.getX(), vtx.getY(), vtx.getZ()},
                                                            trackParCovTrack, 2.f, static_cast<o2::base::Propagator::MatCorrType>(cfgMaterialCorrection.value),
                                                            &dcaInfoMoth);
-    rLambda1405.fill(HIST("h2BachPiDcaXYVsPt"), candidate.pt(), dcaInfoMoth[0]);
-    rLambda1405.fill(HIST("h2BachPiDcaZVsPt"), candidate.pt(), dcaInfoMoth[1]);
+    rLambda1405.fill(HIST("h3BachPiDcaXYVsPt"), candidate.pt(), dcaInfoMoth[0], centMult);
+    rLambda1405.fill(HIST("h3BachPiDcaZVsPt"), candidate.pt(), dcaInfoMoth[1], centMult);
     if (std::abs(dcaInfoMoth[0]) > funcDcaXYPtCutBachPi.Eval(candidate.pt()) || std::abs(dcaInfoMoth[1]) > cutMaxDcaZBach) {
       return false;
     }
@@ -694,7 +697,7 @@ struct lambda1405analysis {
     if (lambda1405Cand.isSigmaPlus) {
       rSigmaPlus.fill(HIST("h2dPtMassSigmaPlus"), sigmaCand.ptMoth(), sigmaCand.mSigmaPlus());
       rSigmaPlus.fill(HIST("h2dPvContribMassSigmaPlus"), lambda1405Cand.pvContrib, sigmaCand.mSigmaPlus());
-      rSigmaPlus.fill(HIST("h2dOccMassSigmaPlus"), lambda1405Cand.occ, sigmaCand.mSigmaPlus());
+      rSigmaPlus.fill(HIST("h2dOccMassSigmaPlus"), lambda1405Cand.occupancy, sigmaCand.mSigmaPlus());
       rSigmaPlus.fill(HIST("h2dPvContribPtSigmaPlus"), lambda1405Cand.pvContrib, sigmaCand.ptMoth());
       rSigmaPlus.fill(HIST("hMassXiMinusSigmaPlus"), sigmaCand.mXiMinus(), sigmaCand.mSigmaPlus());
       rSigmaPlus.fill(HIST("hSigmaPlusArmPod"), lambda1405Cand.sigmaAlphaAP, lambda1405Cand.sigmaQtAP);
@@ -708,7 +711,7 @@ struct lambda1405analysis {
     } else {
       rSigmaMinus.fill(HIST("h2dPtMassSigmaMinus"), sigmaCand.ptMoth(), sigmaCand.mSigmaMinus());
       rSigmaMinus.fill(HIST("h2dPvContribMassSigmaMinus"), lambda1405Cand.pvContrib, sigmaCand.mSigmaMinus());
-      rSigmaMinus.fill(HIST("h2dOccMassSigmaMinus"), lambda1405Cand.occ, sigmaCand.mSigmaMinus());
+      rSigmaMinus.fill(HIST("h2dOccMassSigmaMinus"), lambda1405Cand.occupancy, sigmaCand.mSigmaMinus());
       rSigmaMinus.fill(HIST("h2dPvContribPtSigmaMinus"), lambda1405Cand.pvContrib, sigmaCand.ptMoth());
       rSigmaMinus.fill(HIST("hMassXiMinusSigmaMinus"), sigmaCand.mXiMinus(), sigmaCand.mSigmaMinus());
       rSigmaMinus.fill(HIST("hSigmaMinusArmPod"), lambda1405Cand.sigmaAlphaAP, lambda1405Cand.sigmaQtAP);
@@ -981,7 +984,7 @@ struct lambda1405analysis {
     // Collision properties
     lambda1405Cand.pvContrib = collision.numContrib();
     lambda1405Cand.centMult = getCentMult(collision);
-    lambda1405Cand.occ = collision.ft0cOccupancyInTimeRange();
+    lambda1405Cand.occupancy = collision.ft0cOccupancyInTimeRange();
 
     fillHistosSigma(lambda1405Cand, sigmaCand, kinkDauTrack);
 
@@ -1005,7 +1008,7 @@ struct lambda1405analysis {
       }
       rSelections.fill(HIST("hSelectionsBachPi"), 1);
 
-      if (!selectPiBach(piTrack, primaryVertex)) {
+      if (!selectPiBach(piTrack, primaryVertex, lambda1405Cand.centMult)) {
         continue;
       }
       rSelections.fill(HIST("hSelectionsL1405"), 2);  // Bach Pi selection
@@ -1113,7 +1116,7 @@ struct lambda1405analysis {
     for (const auto& sigmaCand : sigmaCands) {
       std::vector<lambda1405candidate> selectedCandidates;
       constructCollCandidates(collision, sigmaCand, tracks, selectedCandidates);
-      for (auto& lambda1405Cand : selectedCandidates) {
+      for (const auto& lambda1405Cand : selectedCandidates) {
         if (lambda1405Cand.isSigmaMinus) {
           rLambda1405.fill(HIST("h2SigmaMinusMassVsLambdaMass"), lambda1405Cand.massL1405, lambda1405Cand.sigmaMinusMass);
         } else {
@@ -1136,7 +1139,8 @@ struct lambda1405analysis {
                             lambda1405Cand.kinkPiNSigTpc, lambda1405Cand.kinkPiNSigTof,
                             lambda1405Cand.kinkPrNSigTpc, lambda1405Cand.kinkPrNSigTof,
                             lambda1405Cand.kinkDcaDauToPv,
-                            lambda1405Cand.bachPiNSigTpc, lambda1405Cand.bachPiNSigTof);
+                            lambda1405Cand.bachPiNSigTpc, lambda1405Cand.bachPiNSigTof,
+                            lambda1405Cand.centMult, lambda1405Cand.occupancy);
           } else {
             outputDataFlowTable(ptCand, lambda1405Cand.massL1405,
                                 lambda1405Cand.sigmaPt,
@@ -1326,7 +1330,7 @@ struct lambda1405analysis {
         std::vector<lambda1405candidate> selectedCandidates;
         LOG(info) << "Constructing Lambda(1405) candidates from Sigma candidate with global index: " << sigmaCand.globalIndex();
         constructCollCandidates(collision, sigmaCand, tracksPerCol, selectedCandidates);
-        for (auto& lambda1405Cand : selectedCandidates) {
+        for (const auto& lambda1405Cand : selectedCandidates) {
           rLambda1405.fill(HIST("hRecoL1405"), 0., lambda1405Cand.pt()); // All reconstructed
 
           // Do MC association
@@ -1385,7 +1389,8 @@ struct lambda1405analysis {
                               lambda1405Cand.kinkPrNSigTpc, lambda1405Cand.kinkPrNSigTof,
                               lambda1405Cand.kinkDcaDauToPv,
                               lambda1405Cand.bachPiNSigTpc, lambda1405Cand.bachPiNSigTof,
-                              lambda1405Mother.pt(), lambda1405Mass, genSigma.pdgCode(), genBachPi.pdgCode());
+                              lambda1405Mother.pt(), lambda1405Mass, genSigma.pdgCode(), genBachPi.pdgCode(),
+                              lambda1405Cand.centMult, lambda1405Cand.occupancy);
           }
           fillHistosLambda1405<true, false, false>(lambda1405Cand, tracksPerCol);
         }

--- a/PWGLF/Tasks/Resonances/lambda1405analysis.cxx
+++ b/PWGLF/Tasks/Resonances/lambda1405analysis.cxx
@@ -19,11 +19,18 @@
 #include "Common/Core/RecoDecay.h"
 #include "Common/DataModel/Centrality.h"
 #include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/Multiplicity.h"
 #include "Common/DataModel/PIDResponseTOF.h"
 #include "Common/DataModel/PIDResponseTPC.h"
 #include "Common/DataModel/Qvectors.h"
+#include "Common/Core/trackUtilities.h"
 
+#include <CCDB/BasicCCDBManager.h>
+#include <CommonConstants/MathConstants.h>
 #include <CommonConstants/PhysicsConstants.h>
+#include <DataFormatsParameters/GRPMagField.h>
+#include <DetectorsBase/MatLayerCylSet.h>
+#include <DetectorsBase/Propagator.h>
 #include <Framework/ASoA.h>
 #include <Framework/AnalysisDataModel.h>
 #include <Framework/AnalysisHelpers.h>
@@ -34,6 +41,8 @@
 #include <Framework/InitContext.h>
 #include <Framework/OutputObjHeader.h>
 #include <Framework/runDataProcessing.h>
+#include <ReconstructionDataFormats/Track.h>
+#include <ReconstructionDataFormats/Vertex.h>
 
 #include <TF1.h>
 
@@ -48,9 +57,9 @@ using namespace o2::framework;
 using namespace o2::framework::expressions;
 
 using TracksFull = soa::Join<aod::TracksIU, aod::TracksExtra, aod::TracksCovIU, aod::pidTPCFullPi, aod::pidTPCFullPr, aod::pidTOFFullPi, aod::pidTOFFullPr>;
-using CollisionsFull = soa::Join<aod::Collisions, aod::EvSel>;
+using CollisionsFull = soa::Join<aod::Collisions, aod::EvSel, aod::FT0Mults>;
 using CollisionsFullWCentQVecs = soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0Cs, aod::QvectorFT0Cs>;
-using CollisionsFullMc = soa::Join<aod::Collisions, aod::McCollisionLabels, aod::EvSels>;
+using CollisionsFullMc = soa::Join<aod::Collisions, aod::McCollisionLabels, aod::EvSels, aod::FT0Mults>;
 using CollisionsFullMcWCent = soa::Join<aod::Collisions, aod::McCollisionLabels, aod::EvSels, aod::CentFT0Cs>;
 
 enum L1405DecayType { kSigmaMinusPiToPiPiNeutron = 0,
@@ -67,6 +76,7 @@ struct lambda1405candidate {
   float pz = -1;                                            // Pz of the Lambda(1405) candidate
   float pt() const { return std::sqrt(px * px + py * py); } // pT of the Lambda(1405) candidate
   float phi = -1;                                           // Phi of the Lambda(1405) candidate
+  float eta = -1;                                           // Eta of the Lambda(1405) candidate
 
   bool isSigmaPlus = false;   // True if compatible with Sigma+
   bool isSigmaMinus = false;  // True if compatible with Sigma-
@@ -93,18 +103,21 @@ struct lambda1405candidate {
   int sigmaId = 0;          // Id of the Sigma candidate in MC
   int bachPiId = 0;         // Id of the pion candidate in MC
 
-  float cent = -1;      // Centrality of the collision
-  float pvContrib = -1; // Number of contributors to the primary vertex
+  float centMult = -1;    // Centrality of the collision
+  float pvContrib = -1;   // Number of contributors to the primary vertex
+  float occ = -1;         // Occupancy of the collision
 
   float scalarProd = -1; // Scalar product for flow analysis
 };
 
 struct lambda1405analysis {
   int lambda1405PdgCode = 102132;                     // PDG code for Lambda(1405)
-
   Produces<aod::Lambda1405Cands> outputDataTable;     // Output table for Lambda(1405) candidates
   Produces<aod::Lambda1405Flow> outputDataFlowTable;  // Output table for Lambda(1405) flow analysis
   Produces<aod::Lambda1405CandsMC> outputDataTableMC; // Output table for Lambda(1405) candidates in MC
+
+  Service<o2::ccdb::BasicCCDBManager> ccdb;
+
   // Histograms are defined with HistogramRegistry
   HistogramRegistry rEventSelection{"eventSelection", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
   HistogramRegistry rLambda1405{"lambda1405", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
@@ -114,17 +127,21 @@ struct lambda1405analysis {
   // Configurable for event selection
   Configurable<float> cutZVertex{"cutZVertex", 10.0f, "Accepted z-vertex range (cm)"};
   Configurable<float> cutEtaDaughter{"cutEtaDaughter", 0.8f, "Eta cut for daughter tracks"};
-  Configurable<float> cutDCAtoPvSigma{"cutDCAtoPvSigma", 0.1f, "Max DCA to primary vertex for Sigma candidates (cm)"};
-  Configurable<float> cutDCAtoPvPiFromSigma{"cutDCAtoPvPiFromSigma", 2., "Min DCA to primary vertex for pion from Sigma candidates (cm)"};
+  Configurable<float> cutDcaToPvSigma{"cutDcaToPvSigma", 0.1f, "Max DCA to primary vertex for Sigma candidates (cm)"};
+  Configurable<float> cutDcaToPvPiFromSigma{"cutDcaToPvPiFromSigma", 2., "Min DCA to primary vertex for pion from Sigma candidates (cm)"};
 
   Configurable<float> cutMinPtL1405{"cutMinPtL1405", 2.0f, "Minimum pT cut for Lambda(1405) candidates (GeV/c)"};
   Configurable<float> cutUpperMass{"cutUpperMass", 1.6f, "Upper mass cut for Lambda(1405) candidates (GeV/c^2)"};
   Configurable<float> cutSigmaRadius{"cutSigmaRadius", 20.f, "Minimum radius for Sigma candidates (cm)"};
   Configurable<float> cutSigmaMass{"cutSigmaMass", 0.1, "Sigma mass window (MeV/c^2)"};
-  Configurable<float> cutNITSClusKink{"cutNITSClusKink", 3, "Minimum number of ITS clusters for pion candidate"};
-  Configurable<float> cutNTpcClusPi{"cutNTpcClusPi", 90, "Minimum number of Tpc clusters for pion candidate"};
+  Configurable<float> cutItsNClusKinkMin{"cutItsNClusKinkMin", 1, "Minimum number of ITS clusters for kink daughter"};
+  Configurable<float> cutItsNClusKinkMax{"cutItsNClusKinkMax", 3, "Maximum number of ITS clusters for kink daughter"};
+  Configurable<float> cutNTpcClus{"cutNTpcClus", 90, "Minimum number of Tpc clusters for pion candidate"};
   Configurable<float> cutNSigTpc{"cutNSigTpc", 3, "NSigTpcPion"};
   Configurable<float> cutNSigTof{"cutNSigTof", 3, "NSigTofPion"};
+  Configurable<float> cutMaxDcaZBach{"cutMaxDcaZBach", 0.1, "Maximum DcaZ for bachelor pion (cm)"};
+  Configurable<float> dcaXYBachNSigmaMax{"dcaXYBachNSigmaMax", 7, "Cut on number of sigma deviations from expected DCA in the transverse direction"};
+  Configurable<std::string> dcaXYPtBachFunc{"dcaXYPtBachFunc", "(0.0026+0.005/(x^1.01))", "Functional form of pt-dependent DCAxy cut"};
   Configurable<std::string> cutSigmaQtAPMin{"cutSigmaQtAPMin", "0.17", "Functional form of minimum qT(alpha) selection"};
   Configurable<std::string> cutSigmaQtAPMax{"cutSigmaQtAPMax", "0.2", "Functional form of minimum qT(alpha) selection"};
   Configurable<std::string> cutMinBachPiPtVsL1405Pt{"cutMinBachPiPtVsL1405Pt", "0", "Functional form of minimum qT(alpha) selection"};
@@ -133,8 +150,13 @@ struct lambda1405analysis {
   Configurable<std::string> cutMaxSigmaPtVsL1405Pt{"cutMaxSigmaPtVsL1405Pt", "10", "Functional form of minimum qT(alpha) selection"};
 
   // Configurables for flow analysis
-  Configurable<float> centralityMin{"centralityMin", 0., "Minimum centrality accepted in SP/EP computation (not applied in resolution process)"};
-  Configurable<float> centralityMax{"centralityMax", 100., "Maximum centrality accepted in SP/EP computation (not applied in resolution process)"};
+  Configurable<float> centMultMin{"centMultMin", 0., "Minimum collision centrality/multiplicity accepted"};
+  Configurable<float> centMultMax{"centMultMax", 100., "Maximum collision centrality/multiplicity accepted"};
+  Configurable<float> occupancyMax{"occupancyMax", 3000000., "Maximum collision occupancy accepted"};
+  Configurable<float> minDEta{"minDEta", -1., "Minimum delta eta between L1405-track pairs"};
+  Configurable<float> assTrkMinPt{"assTrkMinPt", 0., "Minimum pT of associated track for 2PC"};
+  Configurable<float> assTrkMaxPt{"assTrkMaxPt", 10., "Maximum pT of associated track for 2PC"};
+  Configurable<bool> saveDEtaDPhi{"saveDEtaDPhi", false, "If true, save the dEta and dPhi distributions for Lambda(1405) candidates"};
   Configurable<bool> fillFlowTree{"fillFlowTree", false, "If true, fill the output tree with Lambda(1405) candidates"};
 
   // Downsample for table filling
@@ -144,35 +166,52 @@ struct lambda1405analysis {
   Configurable<bool> fillOutputTree{"fillOutputTree", true, "If true, fill the output tree with Lambda(1405) candidates"};
   Configurable<bool> doLikeSignBkg{"doLikeSignBkg", false, "Use like-sign background"};
   Configurable<bool> useTof{"useTof", false, "Use Tof for PId for pion candidates"};
+  Configurable<bool> recomputeSigmaMom{"recomputeSigmaMom", true, "Recalculate sigma momentum from daughter kinematics"};
+  Configurable<bool> skipSigmasFailedRecompMom{"skipSigmasFailedRecompMom", false, "Skip sigmas for which momentum recalculation fails"};
 
-  TF1 funcMinQtAlphaAP, funcMaxQtAlphaAP, funcMinBachPiPtVsL1405Pt, funcMaxBachPiPtVsL1405Pt, funcMinSigmaPtVsL1405Pt, funcMaxSigmaPtVsL1405Pt;
+  // CCDB options
+  Configurable<int> cfgMaterialCorrection{"cfgMaterialCorrection", static_cast<int>(o2::base::Propagator::MatCorrType::USEMatCorrNONE), "Type of material correction"};
+  Configurable<std::string> ccdbPath{"ccdbPath", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
+  Configurable<std::string> grpmagPath{"grpmagPath", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
+  Configurable<std::string> lutPath{"lutPath", "GLO/Param/MatLUT", "Path of the Lut parametrization"};
+
+  TF1 funcMinQtAlphaAP, funcMaxQtAlphaAP, funcMinBachPiPtVsL1405Pt, funcMaxBachPiPtVsL1405Pt, funcMinSigmaPtVsL1405Pt, funcMaxSigmaPtVsL1405Pt, funcDcaXYPtCutBachPi;
 
   using CollisionsCentSel = soa::Filtered<CollisionsFullWCentQVecs>;
   using McRecoCollisionsCentSel = soa::Filtered<CollisionsFullMcWCent>;
 
-  Filter filterCentrality = aod::cent::centFT0C >= centralityMin && aod::cent::centFT0C <= centralityMax;
+  Filter filterOccupancy = aod::evsel::ft0cOccupancyInTimeRange <= occupancyMax;
 
   PresliceUnsorted<aod::McCollisionLabels> colPerMcCollision = aod::mccollisionlabel::mcCollisionId;
+
+  // Needed for DCA propagation of bachelor tracks
+  int mRunNumber;
+  float mBz;
+  o2::base::MatLayerCylSet* lut = nullptr;
 
   // Configurable axes
   ConfigurableAxis axisPvContrib{"axisPvContrib", {5000, 0., 5000.}, ""};
   ConfigurableAxis axisCent{"axisCent", {100, 0., 100.}, ""};
+  ConfigurableAxis axisOccupancy{"axisOccupancy", {100, 0., 140000.}, ""};
   ConfigurableAxis axisPtL1405{"axisPtL1405", {100, 0., 10.}, ""};
   ConfigurableAxis axisPCompsL1405{"axisPCompsL1405", {100, -10., 10.}, ""};
   ConfigurableAxis axisPtKinkDaug{"axisPtKinkDaug", {100, 0., 10.}, ""};
   ConfigurableAxis axisPtResolution{"axisPtResolution", {100, -0.5, 0.5}, ""};
-  ConfigurableAxis axisMassL1405{"axisMassL1405", {100, 1.3, 1.8}, ""};
-  ConfigurableAxis axisXi1530Mass{"axisXi1530Mass", {100, 1.4, 1.6}, ""};
+  ConfigurableAxis axisMassL1405{"axisMassL1405", {500, 1.3, 1.8}, ""};
+  ConfigurableAxis axisXi1530Mass{"axisXi1530Mass", {500, 1.3, 1.8}, ""};
   ConfigurableAxis axisMassResolution{"axisMassResolution", {100, -0.1, 0.1}, ""};
   ConfigurableAxis axisNSig{"axisNSig", {100, -5., 5.}, ""};
-  ConfigurableAxis axisSigmaMass{"axisSigmaMass", {100, 1.1, 1.4}, ""};
-  ConfigurableAxis axisXiMass{"axisXiMass", {100, 1.2, 1.5}, ""};
+  ConfigurableAxis axisSigmaMass{"axisSigmaMass", {300, 1.1, 1.4}, ""};
+  ConfigurableAxis axisXiMass{"axisXiMass", {300, 1.2, 1.5}, ""};
   ConfigurableAxis axisVertexZ{"axisVertexZ", {100, -15., 15.}, ""};
   ConfigurableAxis axisQtAP{"axisQtAP", {100, 0., 0.3}, ""};
   ConfigurableAxis axisAlphaAP{"axisAlphaAP", {200, -1., 1.}, ""};
   ConfigurableAxis axisSigmaRadius{"axisSigmaRadius", {100, 0., 100.}, ""};
   ConfigurableAxis axisDcaSigmaToPv{"axisDcaSigmaToPv", {120, 0., 0.05}, ""};
   ConfigurableAxis axisDcaKinkToPv{"axisDcaKinkToPv", {200, 0., 20.}, ""};
+  ConfigurableAxis axisDcaBachPi{"axisDcaBachPi", {4000, -1., 1.}, ""};
+  ConfigurableAxis axisDeltaEta{"axisDeltaEta", {100, -2., 2.}, ""};
+  ConfigurableAxis axisDeltaPhi{"axisDeltaPhi", {64, -o2::constants::math::PIHalf, 3. * o2::constants::math::PIHalf}, ""};
   ConfigurableAxis axisScalarProd{"axisScalarProd", {200, -4., 4.}, ""};
 
   Preslice<aod::KinkCands> mKinkPerCol = aod::track::collisionId;
@@ -195,13 +234,20 @@ struct lambda1405analysis {
     const AxisSpec qtAxis{axisQtAP, "q_{T, AP}"};
     const AxisSpec alphaAxis{axisAlphaAP, "#alpha_{AP}"};
     const AxisSpec sigmaRadiusAxis{axisSigmaRadius, "Dec. radius #Sigma (cm)"};
-    const AxisSpec centAxis{axisCent, "Centrality (%)"};
+    const AxisSpec centMultAxis{axisCent, "Centrality (%)"};
+    const AxisSpec occAxis{axisOccupancy, "Occupancy FT0C"};
     const AxisSpec pvContribAxis{axisPvContrib, "PV Contributors"};
-    const AxisSpec dcaSigmaToPvBinsAxis{axisDcaSigmaToPv, "#Sigma DCA to PV (cm)"};
-    const AxisSpec dcaKinkToPvBinsAxis{axisDcaKinkToPv, "Kink daug. DCA to PV (cm)"};
+    const AxisSpec dcaSigmaToPvAxis{axisDcaSigmaToPv, "#Sigma DCA to PV (cm)"};
+    const AxisSpec dcaKinkToPvAxis{axisDcaKinkToPv, "Kink daug. DCA to PV (cm)"};
+    const AxisSpec dcaBachPiAxis{axisDcaBachPi, "Bach. #pi DCA to PV (cm)"};
+    const AxisSpec deltaEtaAxis{axisDeltaEta, "#Delta#it{#eta}"};
+    const AxisSpec deltaPhiAxis{axisDeltaPhi, "#Delta#it{#varphi}"};
     const AxisSpec scalarProdAxis{axisScalarProd, "SP"};
 
     rEventSelection.add("hVertexZRec", "hVertexZRec", {HistType::kTH1F, {vertexZAxis}});
+    rEventSelection.add("hCentMultVsPvContrib", "hCentMultVsPvContrib", {HistType::kTH2F, {centMultAxis, pvContribAxis}});
+    rEventSelection.add("hOccVsPvContrib", "hOccVsPvContrib", {HistType::kTH2F, {occAxis, pvContribAxis}});
+    rEventSelection.add("hCentVsOcc", "hCentVsOcc", {HistType::kTH2F, {centMultAxis, occAxis}});
 
     // Sigma- candidate properties
     rSigmaMinus.add("hMassXiMinusSigmaMinus", "hMassXiMinusSigmaMinus", {HistType::kTH2F, {xiMassAxis, sigmaMassAxis}});
@@ -209,29 +255,43 @@ struct lambda1405analysis {
     rSigmaMinus.add("h2PtPiKinkNSigBeforeCutsSigmaMinus", "h2PtPiKinkNSigBeforeCutsSigmaMinus", {HistType::kTH2F, {ptAxis, nSigmaAxis}});
     rSigmaMinus.add("h2dPtMassSigmaMinus", "h2dPtMassSigmaMinus", {HistType::kTH2F, {ptAxis, sigmaMassAxis}});
     rSigmaMinus.add("h2dPvContribMassSigmaMinus", "h2dPvContribMassSigmaMinus", {HistType::kTH2F, {pvContribAxis, sigmaMassAxis}});
+    rSigmaMinus.add("h2dOccMassSigmaMinus", "h2dOccMassSigmaMinus", {HistType::kTH2F, {occAxis, sigmaMassAxis}});
     rSigmaMinus.add("h2dPvContribPtSigmaMinus", "h2dPvContribPtSigmaMinus", {HistType::kTH2F, {pvContribAxis, ptAxis}});
     rSigmaMinus.add("h2KinkPiPtNSigTofSigmaMinus", "h2KinkPiPtNSigTofSigmaMinus", {HistType::kTH2F, {ptKinkDaugAxis, nSigmaAxis}});
     rSigmaMinus.add("hSigmaMinusArmPod", "hSigmaMinusArmPod", {HistType::kTH2D, {alphaAxis, qtAxis}});
     rSigmaMinus.add("hSigmaMinusRadius", "hSigmaMinusRadius", {HistType::kTH2F, {sigmaRadiusAxis, ptAxis}});
-    rSigmaMinus.add("hSigmaMinusDcaToPv", "hSigmaMinusDcaToPv", {HistType::kTH2F, {dcaSigmaToPvBinsAxis, ptAxis}});
+    rSigmaMinus.add("hSigmaMinusDcaToPv", "hSigmaMinusDcaToPv", {HistType::kTH2F, {dcaSigmaToPvAxis, ptAxis}});
     rSigmaMinus.add("hSigmaMinusKinkTpcNSigPi", "hSigmaMinusKinkTpcNSigPi", {HistType::kTH2F, {nSigmaAxis, ptKinkDaugAxis}});
     rSigmaMinus.add("hSigmaMinusKinkTofNSigPi", "hSigmaMinusKinkTofNSigPi", {HistType::kTH2F, {nSigmaAxis, ptKinkDaugAxis}});
-    rSigmaMinus.add("hSigmaMinusDcaKinkDauToPv", "hSigmaMinusDcaKinkDauToPv", {HistType::kTH2F, {dcaKinkToPvBinsAxis, ptAxis}});
+    rSigmaMinus.add("hSigmaMinusDcaKinkDauToPv", "hSigmaMinusDcaKinkDauToPv", {HistType::kTH2F, {dcaKinkToPvAxis, ptAxis}});
+    if (recomputeSigmaMom) {
+      rSigmaMinus.add("hDeltaPxRecalcSigmaMinus", "hDeltaPxRecalcSigmaMinus;#Delta #it{p}_{x}/p_{x};#it{p}_{x}", {HistType::kTH2F, {{800, -4, 4}, ptAxis}});
+      rSigmaMinus.add("hDeltaPyRecalcSigmaMinus", "hDeltaPyRecalcSigmaMinus;#Delta #it{p}_{y}/p_{y};#it{p}_{y}", {HistType::kTH2F, {{800, -4, 4}, ptAxis}});
+      rSigmaMinus.add("hDeltaPzRecalcSigmaMinus", "hDeltaPzRecalcSigmaMinus;#Delta #it{p}_{z}/p_{z};#it{p}_{z}", {HistType::kTH2F, {{800, -4, 4}, ptAxis}});
+      rSigmaMinus.add("hRecalcPtFactorSigmaMinus", "hRecalcPtFactorSigmaMinus;Rescale factor;|#it{p}|", {HistType::kTH2F, {{250, 0, 5}, ptAxis}});
+    }
 
     // Sigma+ candidate properties
     rSigmaPlus.add("h2PtMassSigmaPlusBeforeCuts", "h2PtMassSigmaPlusBeforeCuts", {HistType::kTH2F, {ptAxis, sigmaMassAxis}});
     rSigmaPlus.add("h2PtPrKinkNSigBeforeCuts", "h2PtPrKinkNSigBeforeCuts", {HistType::kTH2F, {ptAxis, nSigmaAxis}});
     rSigmaPlus.add("h2dPtMassSigmaPlus", "h2dPtMassSigmaPlus", {HistType::kTH2F, {ptAxis, sigmaMassAxis}});
     rSigmaPlus.add("h2dPvContribMassSigmaPlus", "h2dPvContribMassSigmaPlus", {HistType::kTH2F, {pvContribAxis, sigmaMassAxis}});
+    rSigmaPlus.add("h2dOccMassSigmaPlus", "h2dOccMassSigmaPlus", {HistType::kTH2F, {occAxis, sigmaMassAxis}});
     rSigmaPlus.add("h2dPvContribPtSigmaPlus", "h2dPvContribPtSigmaPlus", {HistType::kTH2F, {pvContribAxis, ptAxis}});
     rSigmaPlus.add("h2KinkPrPtNSigTofSigmaPlus", "h2KinkPrPtNSigTofSigmaPlus", {HistType::kTH2F, {ptKinkDaugAxis, nSigmaAxis}});
     rSigmaPlus.add("hSigmaPlusArmPod", "hSigmaPlusArmPod", {HistType::kTH2F, {alphaAxis, qtAxis}});
     rSigmaPlus.add("hSigmaPlusRadius", "hSigmaPlusRadius", {HistType::kTH2F, {sigmaRadiusAxis, ptAxis}});
-    rSigmaPlus.add("hSigmaPlusDcaToPv", "hSigmaPlusDcaToPv", {HistType::kTH2F, {dcaSigmaToPvBinsAxis, ptAxis}});
+    rSigmaPlus.add("hSigmaPlusDcaToPv", "hSigmaPlusDcaToPv", {HistType::kTH2F, {dcaSigmaToPvAxis, ptAxis}});
     rSigmaPlus.add("hSigmaPlusKinkTpcNSigPr", "hSigmaPlusKinkTpcNSigPr", {HistType::kTH2F, {nSigmaAxis, ptKinkDaugAxis}});
     rSigmaPlus.add("hSigmaPlusKinkTofNSigPr", "hSigmaPlusKinkTofNSigPr", {HistType::kTH2F, {nSigmaAxis, ptKinkDaugAxis}});
-    rSigmaPlus.add("hSigmaPlusDcaKinkDauToPv", "hSigmaPlusDcaKinkDauToPv", {HistType::kTH2F, {dcaKinkToPvBinsAxis, ptKinkDaugAxis}});
+    rSigmaPlus.add("hSigmaPlusDcaKinkDauToPv", "hSigmaPlusDcaKinkDauToPv", {HistType::kTH2F, {dcaKinkToPvAxis, ptKinkDaugAxis}});
     rSigmaPlus.add("hMassXiMinusSigmaPlus", "hMassXiMinusSigmaPlus", {HistType::kTH2F, {xiMassAxis, sigmaMassAxis}});
+    if (recomputeSigmaMom) {
+      rSigmaPlus.add("hDeltaPxRecalcSigmaPlus", "hDeltaPxRecalcSigmaPlus;#Delta #it{p}_{x}/p_{x};#it{p}_{x}", {HistType::kTH2F, {{800, -4, 4}, ptAxis}});
+      rSigmaPlus.add("hDeltaPyRecalcSigmaPlus", "hDeltaPyRecalcSigmaPlus;#Delta #it{p}_{y}/p_{y};#it{p}_{y}", {HistType::kTH2F, {{800, -4, 4}, ptAxis}});
+      rSigmaPlus.add("hDeltaPzRecalcSigmaPlus", "hDeltaPzRecalcSigmaPlus;#Delta #it{p}_{z}/p_{z};#it{p}_{z}", {HistType::kTH2F, {{800, -4, 4}, ptAxis}});
+      rSigmaPlus.add("hRecalcPtFactorSigmaPlus", "hRecalcPtFactorSigmaPlus;Rescale factor;|#it{p}|", {HistType::kTH2F, {{250, 0, 5}, ptAxis}});
+    }
 
     // Mass QA
     rLambda1405.add("h2SigmaMinusMassVsLambdaMass", "h2SigmaMinusMassVsLambdaMass", {HistType::kTH2F, {lambda1405MassAxis, sigmaMassAxis}});
@@ -239,82 +299,117 @@ struct lambda1405analysis {
     rLambda1405.add("hMassL1405", "hMassL1405", {HistType::kTH2F, {lambda1405MassAxis, ptAxis}});
     rLambda1405.add("hMassXi1530", "hMassXi1530", {HistType::kTH2F, {xi1530MassAxis, ptAxis}});
     // Kinematic distributions
-    rLambda1405.add("hPx", "hPx;#it{p}_x;Counts", {HistType::kTH1D, {pCompAxisL1405}});
-    rLambda1405.add("hPy", "hPy;#it{p}_y;Counts", {HistType::kTH1D, {pCompAxisL1405}});
-    rLambda1405.add("hPz", "hPz;#it{p}_z;Counts", {HistType::kTH1D, {pCompAxisL1405}});
+    rLambda1405.add("hPx", "hPx;#it{p}_{x};Counts", {HistType::kTH1D, {pCompAxisL1405}});
+    rLambda1405.add("hPy", "hPy;#it{p}_{y};Counts", {HistType::kTH1D, {pCompAxisL1405}});
+    rLambda1405.add("hPz", "hPz;#it{p}_{z};Counts", {HistType::kTH1D, {pCompAxisL1405}});
     rLambda1405.add("hPt", "hPt", {HistType::kTH1D, {ptAxis}});
     rLambda1405.add("hPhi", "hPhi", {HistType::kTH1D, {{128, -o2::constants::math::PI, o2::constants::math::PI}}});
+    // Correlation histograms
+    rLambda1405.add("hDeltaEta", "hDeltaEta", {HistType::kTH1D, {deltaEtaAxis}});
+    rLambda1405.add("hDeltaPhi", "hDeltaPhi", {HistType::kTH1D, {deltaPhiAxis}});
     // Pion daughter properties
+    rLambda1405.add("hPairedBachPiVsCent", "hPairedBachPiVsCent", {HistType::kTH2F, {centMultAxis, {1000, -0.5, 999.5}}});
     rLambda1405.add("h2BachPiPtNSigTof", "h2BachPiPtNSigTof", {HistType::kTH2F, {ptKinkDaugAxis, nSigmaAxis}});
     rLambda1405.add("h2BachPiPtNSigTpc", "h2BachPiPtNSigTpc", {HistType::kTH2F, {ptKinkDaugAxis, nSigmaAxis}});
-    // Sparse histogram
-    std::vector<AxisSpec> axes = {lambda1405MassAxis, ptAxis, sigmaMassAxis, alphaAxis, qtAxis, dcaSigmaToPvBinsAxis, dcaKinkToPvBinsAxis};
-    if (doprocessDataWCentQVecs) {
-      axes.push_back(centAxis);
-      axes.push_back(scalarProdAxis);
-    }
+    rLambda1405.add("h2BachPiDcaXYVsPt", "h2BachPiDcaXYVsPt", {HistType::kTH2F, {ptKinkDaugAxis, dcaBachPiAxis}});
+    rLambda1405.add("h2BachPiDcaZVsPt", "h2BachPiDcaZVsPt", {HistType::kTH2F, {ptKinkDaugAxis, dcaBachPiAxis}});
+    // Sparse histograms
+    std::vector<AxisSpec> axesMass = {lambda1405MassAxis, ptAxis, sigmaMassAxis, dcaSigmaToPvAxis, dcaKinkToPvAxis};
     if (doprocessMc || doprocessMcWCentSel) {
-      axes.push_back(pvContribAxis);
+      axesMass.push_back(pvContribAxis);
+    } else {
+      axesMass.push_back(centMultAxis);
     }
-    rLambda1405.add("hSparseL1405", "THn for SP", HistType::kTHnSparseF, axes);
+    rLambda1405.add("hSparseL1405", "THn for mass peak", HistType::kTHnSparseF, axesMass);
+    std::vector<AxisSpec> axesScalarProd = {lambda1405MassAxis, ptAxis, sigmaMassAxis, dcaSigmaToPvAxis, dcaKinkToPvAxis, centMultAxis, scalarProdAxis};
+    if (doprocessDataWCentQVecs) {
+      rLambda1405.add("hSparseL1405ScalProd", "THn for SP", HistType::kTHnSparseF, axesScalarProd);
+    }
+    std::vector<AxisSpec> axesCorrel = {lambda1405MassAxis, ptAxis, deltaEtaAxis, deltaPhiAxis};
+    if (saveDEtaDPhi) {
+      rLambda1405.add("hSparseL1405Correl", "THn for 2PC", HistType::kTHnSparseF, axesCorrel);
+    }
 
     // Selection QA
     rSelections.add("hSelectionsL1405", "hSelectionsL1405", {HistType::kTH1D, {{6, -0.f, 5.5f}}});
     rSelections.get<TH1>(HIST("hSelectionsL1405"))->GetXaxis()->SetBinLabel(1, "All");
-    rSelections.get<TH1>(HIST("hSelectionsL1405"))->GetXaxis()->SetBinLabel(2, "Passed Sigma sel");
-    rSelections.get<TH1>(HIST("hSelectionsL1405"))->GetXaxis()->SetBinLabel(3, "Passed Bach PID sel");
+    rSelections.get<TH1>(HIST("hSelectionsL1405"))->GetXaxis()->SetBinLabel(2, "Sigma sel");
+    rSelections.get<TH1>(HIST("hSelectionsL1405"))->GetXaxis()->SetBinLabel(3, "Bach PID sel");
     rSelections.get<TH1>(HIST("hSelectionsL1405"))->GetXaxis()->SetBinLabel(4, "Upper mass sel");
     rSelections.get<TH1>(HIST("hSelectionsL1405"))->GetXaxis()->SetBinLabel(5, "#it{p}_{T} Correl");
     rSelections.get<TH1>(HIST("hSelectionsL1405"))->GetXaxis()->SetBinLabel(6, "Accepted");
-    rSelections.add("hSelectionsSigmaPlus", "hSelectionsSigmaPlus", {HistType::kTH1D, {{7, -0.f, 6.5f}}});
+    rSelections.add("hSelectionsSigmaPlus", "hSelectionsSigmaPlus", {HistType::kTH1D, {{8, -0.f, 7.5f}}});
     rSelections.get<TH1>(HIST("hSelectionsSigmaPlus"))->GetXaxis()->SetBinLabel(1, "All");
-    rSelections.get<TH1>(HIST("hSelectionsSigmaPlus"))->GetXaxis()->SetBinLabel(2, "Passed kink sel");
-    rSelections.get<TH1>(HIST("hSelectionsSigmaPlus"))->GetXaxis()->SetBinLabel(3, "Passed mass sel");
-    rSelections.get<TH1>(HIST("hSelectionsSigmaPlus"))->GetXaxis()->SetBinLabel(4, "Passed cutDCAtoPvSigma");
-    rSelections.get<TH1>(HIST("hSelectionsSigmaPlus"))->GetXaxis()->SetBinLabel(5, "Passed cutDCAtoPvPiFromSigma");
-    rSelections.get<TH1>(HIST("hSelectionsSigmaPlus"))->GetXaxis()->SetBinLabel(6, "Passed cutSigmaRadius");
-    rSelections.get<TH1>(HIST("hSelectionsSigmaPlus"))->GetXaxis()->SetBinLabel(7, "Passed cutSigmaQtAP");
-    rSelections.add("hSelectionsSigmaMinus", "hSelectionsSigmaMinus", {HistType::kTH1D, {{7, -0.f, 6.5f}}});
+    rSelections.get<TH1>(HIST("hSelectionsSigmaPlus"))->GetXaxis()->SetBinLabel(2, "Kink");
+    rSelections.get<TH1>(HIST("hSelectionsSigmaPlus"))->GetXaxis()->SetBinLabel(3, "Mom recomp.");
+    rSelections.get<TH1>(HIST("hSelectionsSigmaPlus"))->GetXaxis()->SetBinLabel(4, "Mass");
+    rSelections.get<TH1>(HIST("hSelectionsSigmaPlus"))->GetXaxis()->SetBinLabel(5, "DCA PV #Sigma");
+    rSelections.get<TH1>(HIST("hSelectionsSigmaPlus"))->GetXaxis()->SetBinLabel(6, "DCA PV #pi #leftarrow #Sigma");
+    rSelections.get<TH1>(HIST("hSelectionsSigmaPlus"))->GetXaxis()->SetBinLabel(7, "#Sigma Radius");
+    rSelections.get<TH1>(HIST("hSelectionsSigmaPlus"))->GetXaxis()->SetBinLabel(8, "#Sigma Qt");
+    rSelections.add("hSelectionsSigmaMinus", "hSelectionsSigmaMinus", {HistType::kTH1D, {{8, -0.f, 7.5f}}});
     rSelections.get<TH1>(HIST("hSelectionsSigmaMinus"))->GetXaxis()->SetBinLabel(1, "All");
-    rSelections.get<TH1>(HIST("hSelectionsSigmaMinus"))->GetXaxis()->SetBinLabel(2, "Passed kink sel");
-    rSelections.get<TH1>(HIST("hSelectionsSigmaMinus"))->GetXaxis()->SetBinLabel(3, "Passed mass sel");
-    rSelections.get<TH1>(HIST("hSelectionsSigmaMinus"))->GetXaxis()->SetBinLabel(4, "Passed cutDCAtoPvSigma");
-    rSelections.get<TH1>(HIST("hSelectionsSigmaMinus"))->GetXaxis()->SetBinLabel(5, "Passed cutDCAtoPvPiFromSigma");
-    rSelections.get<TH1>(HIST("hSelectionsSigmaMinus"))->GetXaxis()->SetBinLabel(6, "Passed cutSigmaRadius");
-    rSelections.get<TH1>(HIST("hSelectionsSigmaMinus"))->GetXaxis()->SetBinLabel(7, "Passed cutSigmaQtAP");
+    rSelections.get<TH1>(HIST("hSelectionsSigmaMinus"))->GetXaxis()->SetBinLabel(2, "Kink");
+    rSelections.get<TH1>(HIST("hSelectionsSigmaMinus"))->GetXaxis()->SetBinLabel(3, "Mom recomp.");
+    rSelections.get<TH1>(HIST("hSelectionsSigmaMinus"))->GetXaxis()->SetBinLabel(4, "Mass");
+    rSelections.get<TH1>(HIST("hSelectionsSigmaMinus"))->GetXaxis()->SetBinLabel(5, "DCA PV #Sigma");
+    rSelections.get<TH1>(HIST("hSelectionsSigmaMinus"))->GetXaxis()->SetBinLabel(6, "DCA PV Pi #leftarrow #Sigma");
+    rSelections.get<TH1>(HIST("hSelectionsSigmaMinus"))->GetXaxis()->SetBinLabel(7, "#Sigma Radius");
+    rSelections.get<TH1>(HIST("hSelectionsSigmaMinus"))->GetXaxis()->SetBinLabel(8, "#Sigma Qt");
+    rSelections.add("hRecalcSigmaPlusMom", "hRecalcSigmaPlusMom", {HistType::kTH1D, {{5, -0.f, 4.5f}}});
+    rSelections.get<TH1>(HIST("hRecalcSigmaPlusMom"))->GetXaxis()->SetBinLabel(1, "All");
+    rSelections.get<TH1>(HIST("hRecalcSigmaPlusMom"))->GetXaxis()->SetBinLabel(2, "Non-null mom.");
+    rSelections.get<TH1>(HIST("hRecalcSigmaPlusMom"))->GetXaxis()->SetBinLabel(3, "Non-null A");
+    rSelections.get<TH1>(HIST("hRecalcSigmaPlusMom"))->GetXaxis()->SetBinLabel(4, "Positive D");
+    rSelections.get<TH1>(HIST("hRecalcSigmaPlusMom"))->GetXaxis()->SetBinLabel(5, "Real sol.");
+    rSelections.add("hRecalcSigmaMinusMom", "hRecalcSigmaMinusMom", {HistType::kTH1D, {{5, -0.f, 4.5f}}});
+    rSelections.get<TH1>(HIST("hRecalcSigmaMinusMom"))->GetXaxis()->SetBinLabel(1, "All");
+    rSelections.get<TH1>(HIST("hRecalcSigmaMinusMom"))->GetXaxis()->SetBinLabel(2, "Non-null mom.");
+    rSelections.get<TH1>(HIST("hRecalcSigmaMinusMom"))->GetXaxis()->SetBinLabel(3, "Non-null A");
+    rSelections.get<TH1>(HIST("hRecalcSigmaMinusMom"))->GetXaxis()->SetBinLabel(4, "Positive D");
+    rSelections.get<TH1>(HIST("hRecalcSigmaMinusMom"))->GetXaxis()->SetBinLabel(5, "Real sol.");
     rSelections.add("hSelectionsBachPi", "hSelectionsBachPi", {HistType::kTH1D, {{6, -0.f, 5.5f}}});
     rSelections.get<TH1>(HIST("hSelectionsBachPi"))->GetXaxis()->SetBinLabel(1, "All");
-    rSelections.get<TH1>(HIST("hSelectionsBachPi"))->GetXaxis()->SetBinLabel(2, "Sign sel");
-    rSelections.get<TH1>(HIST("hSelectionsBachPi"))->GetXaxis()->SetBinLabel(3, "Nsigma Tpc sel");
-    rSelections.get<TH1>(HIST("hSelectionsBachPi"))->GetXaxis()->SetBinLabel(4, "Tpc clusters sel");
-    rSelections.get<TH1>(HIST("hSelectionsBachPi"))->GetXaxis()->SetBinLabel(5, "#eta sel");
-    rSelections.get<TH1>(HIST("hSelectionsBachPi"))->GetXaxis()->SetBinLabel(6, "PID sel");
+    rSelections.get<TH1>(HIST("hSelectionsBachPi"))->GetXaxis()->SetBinLabel(2, "Sign");
+    rSelections.get<TH1>(HIST("hSelectionsBachPi"))->GetXaxis()->SetBinLabel(3, "Tpc N#sigma");
+    rSelections.get<TH1>(HIST("hSelectionsBachPi"))->GetXaxis()->SetBinLabel(4, "Tpc Ncls");
+    rSelections.get<TH1>(HIST("hSelectionsBachPi"))->GetXaxis()->SetBinLabel(5, "#eta");
+    rSelections.get<TH1>(HIST("hSelectionsBachPi"))->GetXaxis()->SetBinLabel(6, "DCA");
     rSelections.add("hSelectionsKinkPi", "hSelectionsKinkPi", {HistType::kTH1D, {{7, -0.f, 6.5f}}});
     rSelections.get<TH1>(HIST("hSelectionsKinkPi"))->GetXaxis()->SetBinLabel(1, "All");
-    rSelections.get<TH1>(HIST("hSelectionsKinkPi"))->GetXaxis()->SetBinLabel(2, "Tpc N#sigma PID sel");
-    rSelections.get<TH1>(HIST("hSelectionsKinkPi"))->GetXaxis()->SetBinLabel(3, "Tpc N clusters sel");
-    rSelections.get<TH1>(HIST("hSelectionsKinkPi"))->GetXaxis()->SetBinLabel(4, "#eta sel");
-    rSelections.get<TH1>(HIST("hSelectionsKinkPi"))->GetXaxis()->SetBinLabel(5, "ITS clusters sel");
-    rSelections.get<TH1>(HIST("hSelectionsKinkPi"))->GetXaxis()->SetBinLabel(6, "has Tof sel");
-    rSelections.get<TH1>(HIST("hSelectionsKinkPi"))->GetXaxis()->SetBinLabel(7, "N#sigma Tof sel");
+    rSelections.get<TH1>(HIST("hSelectionsKinkPi"))->GetXaxis()->SetBinLabel(2, "Tpc N#sigma");
+    rSelections.get<TH1>(HIST("hSelectionsKinkPi"))->GetXaxis()->SetBinLabel(3, "Tpc Ncls");
+    rSelections.get<TH1>(HIST("hSelectionsKinkPi"))->GetXaxis()->SetBinLabel(4, "#eta");
+    rSelections.get<TH1>(HIST("hSelectionsKinkPi"))->GetXaxis()->SetBinLabel(5, "ITS cls");
+    rSelections.get<TH1>(HIST("hSelectionsKinkPi"))->GetXaxis()->SetBinLabel(6, "has TOF");
+    rSelections.get<TH1>(HIST("hSelectionsKinkPi"))->GetXaxis()->SetBinLabel(7, "N#sigma TOF");
     rSelections.add("hSelectionsKinkPr", "hSelectionsKinkPr", {HistType::kTH1D, {{7, -0.f, 6.5f}}});
     rSelections.get<TH1>(HIST("hSelectionsKinkPr"))->GetXaxis()->SetBinLabel(1, "All");
-    rSelections.get<TH1>(HIST("hSelectionsKinkPr"))->GetXaxis()->SetBinLabel(2, "Tpc N#sigma PID sel");
-    rSelections.get<TH1>(HIST("hSelectionsKinkPr"))->GetXaxis()->SetBinLabel(3, "Tpc N clusters sel");
-    rSelections.get<TH1>(HIST("hSelectionsKinkPr"))->GetXaxis()->SetBinLabel(4, "#eta sel");
-    rSelections.get<TH1>(HIST("hSelectionsKinkPr"))->GetXaxis()->SetBinLabel(5, "ITS clusters sel");
-    rSelections.get<TH1>(HIST("hSelectionsKinkPr"))->GetXaxis()->SetBinLabel(6, "has Tof sel");
-    rSelections.get<TH1>(HIST("hSelectionsKinkPr"))->GetXaxis()->SetBinLabel(7, "N#sigma Tof sel");
+    rSelections.get<TH1>(HIST("hSelectionsKinkPr"))->GetXaxis()->SetBinLabel(2, "Tpc N#sigma");
+    rSelections.get<TH1>(HIST("hSelectionsKinkPr"))->GetXaxis()->SetBinLabel(3, "Tpc Ncls");
+    rSelections.get<TH1>(HIST("hSelectionsKinkPr"))->GetXaxis()->SetBinLabel(4, "#eta");
+    rSelections.get<TH1>(HIST("hSelectionsKinkPr"))->GetXaxis()->SetBinLabel(5, "ITS cls");
+    rSelections.get<TH1>(HIST("hSelectionsKinkPr"))->GetXaxis()->SetBinLabel(6, "has TOF");
+    rSelections.get<TH1>(HIST("hSelectionsKinkPr"))->GetXaxis()->SetBinLabel(7, "N#sigma TOF");
 
     if (doprocessDataWCentQVecs) {
       rLambda1405.add("hScalarProd", "hScalarProd", {HistType::kTH2F, {scalarProdAxis, ptAxis}});
-      std::vector<AxisSpec> axesFlow = {lambda1405MassAxis, ptAxis, centAxis, scalarProdAxis};
+      std::vector<AxisSpec> axesFlow = {lambda1405MassAxis, ptAxis, centMultAxis, scalarProdAxis};
       rLambda1405.add("hSparseFlowL1405", "THn for SP", HistType::kTHnSparseF, axesFlow);
     }
 
+    // Add MC histograms
     if (doprocessMc || doprocessMcWCentSel) {
-      // Add MC histograms
+
+      rSelections.add("hRecoNotMatchedCounter", "hRecoNotMatchedCounter", {HistType::kTH1D, {{4, -0.5, 3.5f}}});
+      rSelections.get<TH1>(HIST("hRecoNotMatchedCounter"))->GetXaxis()->SetBinLabel(1, "#Lambda(1405)");
+      rSelections.get<TH1>(HIST("hRecoNotMatchedCounter"))->GetXaxis()->SetBinLabel(2, "#Sigma");
+      rSelections.get<TH1>(HIST("hRecoNotMatchedCounter"))->GetXaxis()->SetBinLabel(3, "Kink daug");
+      rSelections.get<TH1>(HIST("hRecoNotMatchedCounter"))->GetXaxis()->SetBinLabel(4, "Bach #pi");
+
+      rSigmaPlus.add("h2DeltaGenRecoPtSigmaPlus", "h2DeltaGenRecoPtSigmaPlus", {HistType::kTH2F, {{600, -3, 3}, ptAxis}});
       rSigmaPlus.add("h2GenSigmaPlusPvContribPt", "h2GenSigmaPlusPvContribPt", {HistType::kTH2F, {pvContribAxis, ptAxis}});
+      rSigmaMinus.add("h2DeltaGenRecoPtSigmaMinus", "h2DeltaGenRecoPtSigmaMinus", {HistType::kTH2F, {{600, -3, 3}, ptAxis}});
       rSigmaMinus.add("h2GenSigmaMinusPvContribPt", "h2GenSigmaMinusPvContribPt", {HistType::kTH2F, {pvContribAxis, ptAxis}});
 
       rLambda1405.add("hRecoL1405", "hRecoL1405;;Counts", {HistType::kTH2F, {{4, -0.5, 3.5}, ptAxis}});
@@ -359,11 +454,31 @@ struct lambda1405analysis {
     LOGF(info, "funcMinSigmaPtVsL1405Pt: %s", Form("%s", cutMinSigmaPtVsL1405Pt.value.data()));
     funcMaxSigmaPtVsL1405Pt = TF1("funcMaxSigmaPtVsL1405Pt", Form("%s", cutMaxSigmaPtVsL1405Pt.value.data()), 0., 100);
     LOGF(info, "funcMaxSigmaPtVsL1405Pt: %s", Form("%s", cutMaxSigmaPtVsL1405Pt.value.data()));
+    funcDcaXYPtCutBachPi = TF1("funcDcaXYPtCutBachPi", Form("[0]*%s", dcaXYPtBachFunc.value.data()), 0.001, 100);
+    funcDcaXYPtCutBachPi.SetParameter(0, dcaXYBachNSigmaMax);
+    LOGF(info, "DCAxy pt-dependence function: %s", Form("[0]*%s", dcaXYPtBachFunc.value.data()));
 
     rSelections.print();
     rSigmaMinus.print();
     rSigmaPlus.print();
     rLambda1405.print();
+
+    // Info for DCA propagation of bachelor tracks
+    mRunNumber = 0;
+    mBz = 0;
+    ccdb->setURL(ccdbPath);
+    ccdb->setCaching(true);
+    ccdb->setLocalObjectValidityChecking();
+  }
+
+  template <typename TCollision>
+  float getCentMult(const TCollision& collision)
+  {
+    if constexpr (requires { collision.centFT0C(); }) {
+      return collision.centFT0C();
+    } else {
+      return collision.multFT0C();
+    }
   }
 
   float alphaAP(const std::array<float, 3>& momMother, const std::array<float, 3>& momKink)
@@ -382,15 +497,96 @@ struct lambda1405analysis {
     return std::sqrt(p2A - dp * dp / p2V0);
   }
 
+  float recalcSigmaMom(bool& success, bool isSigmaMinus, float sigmaPx, float sigmaPy, float sigmaPz, float sigmaDauPx, float sigmaDauPy, float sigmaDauPz)
+  {
+    success = false;
+    if (isSigmaMinus) {
+      rSelections.fill(HIST("hRecalcSigmaMinusMom"), 0); // All
+    } else {
+      rSelections.fill(HIST("hRecalcSigmaMinusMom"), 0); // All
+    }
+    // Sigma- -> n + pi-  (charged daughter = pion, neutral daughter = neutron)
+    // Sigma+ -> p + pi0  (charged daughter = proton, neutral daughter = pi0)
+    double massChargedDau = isSigmaMinus ? o2::constants::physics::MassPionCharged : o2::constants::physics::MassProton;
+    double massNeutralDau = isSigmaMinus ? o2::constants::physics::MassNeutron : o2::constants::physics::MassPionNeutral;
+    double massSigma = isSigmaMinus ? o2::constants::physics::MassSigmaMinus : o2::constants::physics::MassSigmaPlus;
+
+    double pMother = std::sqrt(sigmaPx * sigmaPx + sigmaPy * sigmaPy + sigmaPz * sigmaPz);
+    if (pMother < 1e-12f) {
+      LOG(info) << "Recalculation of Sigma momentum failed: mother momentum is zero " << sigmaPx << ", " << sigmaPy << ", " << sigmaPz;
+      return -999.f;
+    }
+    if (isSigmaMinus) {
+      rSelections.fill(HIST("hRecalcSigmaMinusMom"), 1); // Non-zero momentum
+    } else {
+      rSelections.fill(HIST("hRecalcSigmaMinusMom"), 1); // Non-zero momentum
+    }
+
+    double versorX = sigmaPx / pMother;
+    double versorY = sigmaPy / pMother;
+    double versorZ = sigmaPz / pMother;
+    double eChDau = std::sqrt(massChargedDau * massChargedDau + sigmaDauPx * sigmaDauPx + sigmaDauPy * sigmaDauPy + sigmaDauPz * sigmaDauPz);
+    double a = versorX * sigmaDauPx + versorY * sigmaDauPy + versorZ * sigmaDauPz;
+    double K = massSigma * massSigma + massChargedDau * massChargedDau - massNeutralDau * massNeutralDau;
+    double A = 4.0 * (eChDau * eChDau - a * a);
+    double B = -4.0 * a * K;
+    double C = 4.0 * eChDau * eChDau * massSigma * massSigma - K * K;
+
+    if (std::abs(A) < 1e-6f) {
+      LOG(info) << "Recalculation of Sigma momentum failed: A is zero " << sigmaPx << ", " << sigmaPy << ", " << sigmaPz << ", A = " << A << ", B = " << B << ", C = " << C;
+      return -999.f;
+    }
+    if (isSigmaMinus) {
+      rSelections.fill(HIST("hRecalcSigmaMinusMom"), 2); // Non-zero A
+    } else {
+      rSelections.fill(HIST("hRecalcSigmaMinusMom"), 2); // Non-zero A
+    }
+
+    double D = B * B - 4.0 * A * C;
+    if (D < 0.0) {
+      LOG(info) << "Recalculation of Sigma momentum failed: D is negative " << sigmaPx << ", " << sigmaPy << ", " << sigmaPz << ", A = " << A << ", B = " << B << ", C = " << C << ", D = " << D;
+      return -999.f;
+    }
+    if (isSigmaMinus) {
+      rSelections.fill(HIST("hRecalcSigmaMinusMom"), 3); // Positive D
+    } else {
+      rSelections.fill(HIST("hRecalcSigmaMinusMom"), 3); // Positive D
+    }
+
+    double sqrtD = std::sqrt(D);
+    double P1 = (-B + sqrtD) / (2.0 * A);
+    double P2 = (-B - sqrtD) / (2.0 * A);
+    if (P2 < 0.0 && P1 < 0.0) {
+      LOG(info) << "Recalculation of Sigma momentum failed: both solutions are negative " << sigmaPx << ", " << sigmaPy << ", " << sigmaPz << ", P1: " << P1 << ", P2: " << P2;
+      return -999.f;
+    }
+    if (isSigmaMinus) {
+      rSelections.fill(HIST("hRecalcSigmaMinusMom"), 4); // Real solutions
+    } else {
+      rSelections.fill(HIST("hRecalcSigmaMinusMom"), 4); // Real solutions
+    }
+
+    success = true;
+    if (P2 < 0.0) {
+      return static_cast<float>(P1);
+    }
+    if (P1 < 0.0) {
+      return static_cast<float>(P2);
+    }
+    double p1Diff = std::abs(P1 - pMother);
+    double p2Diff = std::abs(P2 - pMother);
+    return static_cast<float>((p1Diff < p2Diff) ? P1 : P2);
+  }
+
   template <typename TTrack>
-  bool selectPiBach(const TTrack& candidate)
+  bool selectPiBach(const TTrack& candidate, const o2::dataformats::VertexBase& vtx)
   {
     if (std::abs(candidate.tpcNSigmaPi()) > cutNSigTpc) {
       return false;
     }
     rSelections.fill(HIST("hSelectionsBachPi"), 2); // Nsigma Tpc
 
-    if (candidate.tpcNClsFound() < cutNTpcClusPi) {
+    if (candidate.tpcNClsFound() < cutNTpcClus) {
       return false;
     }
     rSelections.fill(HIST("hSelectionsBachPi"), 3); // Tpc clusters
@@ -399,6 +595,18 @@ struct lambda1405analysis {
       return false;
     }
     rSelections.fill(HIST("hSelectionsBachPi"), 4); // Eta selection
+
+    o2::track::TrackParCov trackParCovTrack = getTrackParCov(candidate);
+    std::array<float, 2> dcaInfoMoth;
+    o2::base::Propagator::Instance()->propagateToDCABxByBz({vtx.getX(), vtx.getY(), vtx.getZ()},
+                                                           trackParCovTrack, 2.f, static_cast<o2::base::Propagator::MatCorrType>(cfgMaterialCorrection.value),
+                                                           &dcaInfoMoth);
+    rLambda1405.fill(HIST("h2BachPiDcaXYVsPt"), candidate.pt(), dcaInfoMoth[0]);
+    rLambda1405.fill(HIST("h2BachPiDcaZVsPt"), candidate.pt(), dcaInfoMoth[1]);
+    if (std::abs(dcaInfoMoth[0]) > funcDcaXYPtCutBachPi.Eval(candidate.pt()) || std::abs(dcaInfoMoth[1]) > cutMaxDcaZBach) {
+      return false;
+    }
+    rSelections.fill(HIST("hSelectionsBachPi"), 5); // DCA selection
 
     return true;
   }
@@ -413,7 +621,7 @@ struct lambda1405analysis {
     }
     rSelections.fill(HIST("hSelectionsKinkPi"), 1); // Nsigma Tpc
 
-    if (candidate.tpcNClsFound() < cutNTpcClusPi) {
+    if (candidate.tpcNClsFound() < cutNTpcClus) {
       return false;
     }
     rSelections.fill(HIST("hSelectionsKinkPi"), 2); // Tpc clusters
@@ -423,7 +631,7 @@ struct lambda1405analysis {
     }
     rSelections.fill(HIST("hSelectionsKinkPi"), 3); // Eta selection
 
-    if (candidate.itsNCls() < cutNITSClusKink) {
+    if (candidate.itsNCls() < cutItsNClusKinkMin || candidate.itsNCls() > cutItsNClusKinkMax) {
       return false;
     }
     rSelections.fill(HIST("hSelectionsKinkPi"), 4); // ITS clusters
@@ -451,7 +659,7 @@ struct lambda1405analysis {
     }
     rSelections.fill(HIST("hSelectionsKinkPr"), 1); // Nsigma Tpc
 
-    if (candidate.tpcNClsFound() < cutNTpcClusPi) {
+    if (candidate.tpcNClsFound() < cutNTpcClus) {
       return false;
     }
     rSelections.fill(HIST("hSelectionsKinkPr"), 2); // Tpc clusters
@@ -461,7 +669,7 @@ struct lambda1405analysis {
     }
     rSelections.fill(HIST("hSelectionsKinkPr"), 3); // eta selection
 
-    if (candidate.itsNCls() < cutNITSClusKink) {
+    if (candidate.itsNCls() < cutItsNClusKinkMin || candidate.itsNCls() > cutItsNClusKinkMax) {
       return false;
     }
     rSelections.fill(HIST("hSelectionsKinkPr"), 4); // ITS clusters
@@ -486,6 +694,7 @@ struct lambda1405analysis {
     if (lambda1405Cand.isSigmaPlus) {
       rSigmaPlus.fill(HIST("h2dPtMassSigmaPlus"), sigmaCand.ptMoth(), sigmaCand.mSigmaPlus());
       rSigmaPlus.fill(HIST("h2dPvContribMassSigmaPlus"), lambda1405Cand.pvContrib, sigmaCand.mSigmaPlus());
+      rSigmaPlus.fill(HIST("h2dOccMassSigmaPlus"), lambda1405Cand.occ, sigmaCand.mSigmaPlus());
       rSigmaPlus.fill(HIST("h2dPvContribPtSigmaPlus"), lambda1405Cand.pvContrib, sigmaCand.ptMoth());
       rSigmaPlus.fill(HIST("hMassXiMinusSigmaPlus"), sigmaCand.mXiMinus(), sigmaCand.mSigmaPlus());
       rSigmaPlus.fill(HIST("hSigmaPlusArmPod"), lambda1405Cand.sigmaAlphaAP, lambda1405Cand.sigmaQtAP);
@@ -499,6 +708,7 @@ struct lambda1405analysis {
     } else {
       rSigmaMinus.fill(HIST("h2dPtMassSigmaMinus"), sigmaCand.ptMoth(), sigmaCand.mSigmaMinus());
       rSigmaMinus.fill(HIST("h2dPvContribMassSigmaMinus"), lambda1405Cand.pvContrib, sigmaCand.mSigmaMinus());
+      rSigmaMinus.fill(HIST("h2dOccMassSigmaMinus"), lambda1405Cand.occ, sigmaCand.mSigmaMinus());
       rSigmaMinus.fill(HIST("h2dPvContribPtSigmaMinus"), lambda1405Cand.pvContrib, sigmaCand.ptMoth());
       rSigmaMinus.fill(HIST("hMassXiMinusSigmaMinus"), sigmaCand.mXiMinus(), sigmaCand.mSigmaMinus());
       rSigmaMinus.fill(HIST("hSigmaMinusArmPod"), lambda1405Cand.sigmaAlphaAP, lambda1405Cand.sigmaQtAP);
@@ -512,8 +722,8 @@ struct lambda1405analysis {
     }
   }
 
-  template <bool IsMC>
-  void fillHistosLambda1405(const lambda1405candidate& cand)
+  template <bool IsMC, bool FillQVectors, bool FillCorrelations, typename TTrack>
+  void fillHistosLambda1405(const lambda1405candidate& cand, const TTrack& trks)
   {
 
     // Fill QA histos for Lambda(1405) candidate
@@ -529,22 +739,94 @@ struct lambda1405analysis {
     rLambda1405.fill(HIST("h2BachPiPtNSigTpc"), cand.bachPiPt, cand.bachPiNSigTpc);
     rLambda1405.fill(HIST("h2BachPiPtNSigTof"), cand.bachPiPt, cand.bachPiNSigTof);
 
-    // Fill sparse histo
-    std::vector<double> sparseEntry = {cand.massL1405, cand.pt(), cand.sigmaMinusMass, cand.sigmaAlphaAP, cand.sigmaQtAP, cand.dcaSigmaToPv, cand.kinkDcaDauToPv};
+    // std::vector<AxisSpec> axesMass = {lambda1405MassAxis, ptAxis, sigmaMassAxis, dcaSigmaToPvAxis, dcaKinkToPvAxis};
+    // if (doprocessMc || doprocessMcWCentSel) {
+    //   axesMass.push_back(pvContribAxis);
+    // } else {
+    //   axesMass.push_back(centMultAxis);
+    // }
+    // rLambda1405.add("hSparseL1405", "THn for mass peak", HistType::kTHnSparseF, axes);
+    // std::vector<AxisSpec> axesScalarProd = {lambda1405MassAxis, ptAxis, sigmaMassAxis, dcaSigmaToPvAxis, dcaKinkToPvAxis, centMultAxis, scalarProdAxis};
+    // if (doprocessDataWCentQVecs) {
+    //   rLambda1405.add("hSparseL1405ScalProd", "THn for SP", HistType::kTHnSparseF, axesScalarProd);
+    // }
+    // std::vector<AxisSpec> axesCorrel = {lambda1405MassAxis, ptAxis, deltaEtaAxis, deltaPhiAxis};
+    // if (saveDEtaDPhi) {
+    //   rLambda1405.add("hSparseL1405Correl", "THn for 2PC", HistType::kTHnSparseF, axesCorrel);
+    // }
+
+    auto hSparseMass = rLambda1405.get<THnSparse>(HIST("hSparseL1405"));
+    std::vector<double> sparseMassEntry = {cand.massL1405, cand.pt(), cand.sigmaMinusMass, cand.dcaSigmaToPv, cand.kinkDcaDauToPv};
     if constexpr (IsMC) {
-      sparseEntry.push_back(cand.pvContrib);
+      sparseMassEntry.push_back(cand.pvContrib);
+    } else {
+      sparseMassEntry.push_back(cand.centMult);
     }
-    if (doprocessDataWCentQVecs) {
-      sparseEntry.push_back(cand.cent);
-      sparseEntry.push_back(cand.scalarProd);
+    hSparseMass->Fill(sparseMassEntry.data());
+    if constexpr (FillQVectors) {
+      std::vector<double> sparseScalProdEntry = {cand.massL1405, cand.pt(), cand.sigmaMinusMass, cand.dcaSigmaToPv, cand.kinkDcaDauToPv};
+      sparseScalProdEntry.push_back(cand.centMult);
+      sparseScalProdEntry.push_back(cand.scalarProd);
+      auto hSparseScalProd = rLambda1405.get<THnSparse>(HIST("hSparseL1405ScalProd"));
+      hSparseScalProd->Fill(sparseScalProdEntry.data());
     }
-    auto hSparse = rLambda1405.get<THnSparse>(HIST("hSparseL1405"));
-    hSparse->Fill(sparseEntry.data());
+    if constexpr (FillCorrelations) {
+      std::vector<double> sparseCorrelEntry = {cand.massL1405, cand.pt(), cand.sigmaMinusMass, cand.dcaSigmaToPv, cand.kinkDcaDauToPv};
+      auto hSparseCorrel = rLambda1405.get<THnSparse>(HIST("hSparseL1405Correl"));
+      sparseCorrelEntry.push_back(0.0); // Δη
+      sparseCorrelEntry.push_back(0.0); // Δφ
+      const auto deltaEtaIdx = sparseCorrelEntry.size() - 2;
+      const auto deltaPhiIdx = sparseCorrelEntry.size() - 1;
+
+      for (const auto& trk : trks) {
+        if (trk.globalIndex() == cand.bachPiId || trk.globalIndex() == cand.kinkDauId) {
+          continue; // Skip the bachelor pi and kink daughter
+        }
+        if (trk.pt() < assTrkMinPt || trk.pt() > assTrkMaxPt) {
+          continue; // Skip tracks outside the pT range
+        }
+        double deltaPhi = RecoDecay::constrainAngle(trk.phi() - cand.phi, -o2::constants::math::PIHalf);
+        double deltaEta = trk.eta() - cand.eta;
+        if (std::abs(deltaEta) < minDEta) {
+          continue;
+        }
+        sparseCorrelEntry[deltaEtaIdx] = deltaEta;
+        sparseCorrelEntry[deltaPhiIdx] = deltaPhi;
+        rLambda1405.fill(HIST("hDeltaEta"), deltaEta);
+        rLambda1405.fill(HIST("hDeltaPhi"), deltaPhi);
+        hSparseCorrel->Fill(sparseCorrelEntry.data());
+      }
+    }
+  }
+
+  void initCCDB(aod::BCs::iterator const& bc)
+  {
+    if (mRunNumber == bc.runNumber()) {
+      return;
+    }
+    mRunNumber = bc.runNumber();
+    LOG(info) << "Initializing CCDB for run " << mRunNumber;
+    o2::parameters::GRPMagField* grpmag = ccdb->getForRun<o2::parameters::GRPMagField>(grpmagPath, mRunNumber);
+    o2::base::Propagator::initFieldFromGRP(grpmag);
+    mBz = grpmag->getNominalL3Field();
+
+    if (!lut) {
+      lut = o2::base::MatLayerCylSet::rectifyPtrFromFile(ccdb->get<o2::base::MatLayerCylSet>(lutPath));
+    }
+    o2::base::Propagator::Instance()->setMatLUT(lut);
+    LOG(info) << "Task initialized for run " << mRunNumber << " with magnetic field " << mBz << " kZG";
   }
 
   template <typename TColl>
   void constructCollCandidates(const TColl& collision, aod::KinkCands::iterator const& sigmaCand, TracksFull const& tracks, std::vector<lambda1405candidate>& selectedCandidates)
   {
+
+    // Retrieve primary vertex, once for all candidates in the collision
+    auto const& bc = collision.template bc_as<aod::BCs>();
+    initCCDB(bc);
+    o2::dataformats::VertexBase primaryVertex;
+    primaryVertex.setPos({collision.posX(), collision.posY(), collision.posZ()});
+    primaryVertex.setCov(collision.covXX(), collision.covXY(), collision.covYY(), collision.covXZ(), collision.covYZ(), collision.covZZ());
 
     lambda1405candidate lambda1405Cand{};
 
@@ -569,13 +851,54 @@ struct lambda1405analysis {
       rSelections.fill(HIST("hSelectionsSigmaPlus"), 1); // Passed kink sel
     }
 
+    auto sigmaMom = std::array{sigmaCand.pxMoth(), sigmaCand.pyMoth(), sigmaCand.pzMoth()};
+    auto sigmaPt = std::sqrt(sigmaMom[0] * sigmaMom[0] + sigmaMom[1] * sigmaMom[1]);
+    if (recomputeSigmaMom) {
+      bool success{false};
+      float sigmaPRecalc = recalcSigmaMom(success, lambda1405Cand.isSigmaMinus,
+                                          sigmaCand.pxMoth(), sigmaCand.pyMoth(), sigmaCand.pzMoth(),
+                                          sigmaCand.pxDaug(), sigmaCand.pyDaug(), sigmaCand.pzDaug());
+      if (!success && skipSigmasFailedRecompMom) {
+        return;
+      }
+      if (success) {
+        float sigmaPOriginal = std::sqrt(sigmaCand.pxMoth() * sigmaCand.pxMoth() + 
+                                         sigmaCand.pyMoth() * sigmaCand.pyMoth() + 
+                                         sigmaCand.pzMoth() * sigmaCand.pzMoth());
+        if (sigmaPRecalc > 0.f && sigmaPOriginal > 0.f) {
+          float scale = sigmaPRecalc / sigmaPOriginal;
+          sigmaMom[0] *= scale;
+          sigmaMom[1] *= scale;
+          sigmaMom[2] *= scale;
+
+          sigmaPt = std::sqrt(sigmaMom[0] * sigmaMom[0] + sigmaMom[1] * sigmaMom[1]);
+          if (lambda1405Cand.isSigmaMinus) {
+            rSigmaMinus.fill(HIST("hDeltaPxRecalcSigmaMinus"), sigmaMom[0] - sigmaCand.pxMoth(), sigmaCand.pxMoth());
+            rSigmaMinus.fill(HIST("hDeltaPyRecalcSigmaMinus"), sigmaMom[1] - sigmaCand.pyMoth(), sigmaCand.pyMoth());
+            rSigmaMinus.fill(HIST("hDeltaPzRecalcSigmaMinus"), sigmaMom[2] - sigmaCand.pzMoth(), sigmaCand.pzMoth());
+            rSigmaMinus.fill(HIST("hRecalcPtFactorSigmaMinus"), scale, sigmaPOriginal);
+          } else {
+            rSigmaPlus.fill(HIST("hDeltaPxRecalcSigmaPlus"), sigmaMom[0] - sigmaCand.pxMoth(), sigmaCand.pxMoth());
+            rSigmaPlus.fill(HIST("hDeltaPyRecalcSigmaPlus"), sigmaMom[1] - sigmaCand.pyMoth(), sigmaCand.pyMoth());
+            rSigmaPlus.fill(HIST("hDeltaPzRecalcSigmaPlus"), sigmaMom[2] - sigmaCand.pzMoth(), sigmaCand.pzMoth());
+            rSigmaPlus.fill(HIST("hRecalcPtFactorSigmaPlus"), scale, sigmaPOriginal);
+          }
+        }
+      }
+    }
+    if (lambda1405Cand.isSigmaMinus) {
+      rSelections.fill(HIST("hSelectionsSigmaMinus"), 2); // Passed mass sel
+    } else {
+      rSelections.fill(HIST("hSelectionsSigmaPlus"), 2); // Passed mass sel
+    }
+
     // Sigma- or AntiSigma+ candidates
     if (lambda1405Cand.isSigmaMinus) {
-      rSigmaMinus.fill(HIST("h2PtMassSigmaMinusBeforeCuts"), sigmaCand.ptMoth(), sigmaCand.mSigmaMinus());
+      rSigmaMinus.fill(HIST("h2PtMassSigmaMinusBeforeCuts"), sigmaPt, sigmaCand.mSigmaMinus());
       rSigmaMinus.fill(HIST("h2PtPiKinkNSigBeforeCutsSigmaMinus"), kinkDauTrack.pt(), kinkDauTrack.tpcNSigmaPi());
     }
     if (lambda1405Cand.isSigmaPlus) {
-      rSigmaPlus.fill(HIST("h2PtMassSigmaPlusBeforeCuts"), sigmaCand.ptMoth(), sigmaCand.mSigmaPlus());
+      rSigmaPlus.fill(HIST("h2PtMassSigmaPlusBeforeCuts"), sigmaPt, sigmaCand.mSigmaPlus());
       rSigmaPlus.fill(HIST("h2PtPrKinkNSigBeforeCuts"), kinkDauTrack.pt(), kinkDauTrack.tpcNSigmaPr());
     }
 
@@ -588,27 +911,27 @@ struct lambda1405analysis {
       return;
     }
     if (lambda1405Cand.isSigmaMinus) {
-      rSelections.fill(HIST("hSelectionsSigmaMinus"), 2); // Passed mass sel
+      rSelections.fill(HIST("hSelectionsSigmaMinus"), 3); // Passed mass sel
     } else {
-      rSelections.fill(HIST("hSelectionsSigmaPlus"), 2); // Passed mass sel
+      rSelections.fill(HIST("hSelectionsSigmaPlus"), 3); // Passed mass sel
     }
 
-    if (std::abs(sigmaCand.dcaMothPv()) > cutDCAtoPvSigma) {
+    if (std::abs(sigmaCand.dcaMothPv()) > cutDcaToPvSigma) {
       return;
     }
     if (lambda1405Cand.isSigmaMinus) {
-      rSelections.fill(HIST("hSelectionsSigmaMinus"), 3); // Passed cutDCAtoPvSigma
+      rSelections.fill(HIST("hSelectionsSigmaMinus"), 4); // Passed cutDcaToPvSigma
     } else {
-      rSelections.fill(HIST("hSelectionsSigmaPlus"), 3); // Passed cutDCAtoPvSigma
+      rSelections.fill(HIST("hSelectionsSigmaPlus"), 4); // Passed cutDcaToPvSigma
     }
 
-    if (std::abs(sigmaCand.dcaDaugPv()) < cutDCAtoPvPiFromSigma) {
+    if (std::abs(sigmaCand.dcaDaugPv()) < cutDcaToPvPiFromSigma) {
       return;
     }
     if (lambda1405Cand.isSigmaMinus) {
-      rSelections.fill(HIST("hSelectionsSigmaMinus"), 4); // cutDCAtoPvPiFromSigma
+      rSelections.fill(HIST("hSelectionsSigmaMinus"), 5); // cutDcaToPvPiFromSigma
     } else {
-      rSelections.fill(HIST("hSelectionsSigmaPlus"), 4); // cutDCAtoPvPiFromSigma
+      rSelections.fill(HIST("hSelectionsSigmaPlus"), 5); // cutDcaToPvPiFromSigma
     }
 
     float sigmaRad = std::hypot(sigmaCand.xDecVtx(), sigmaCand.yDecVtx());
@@ -616,13 +939,12 @@ struct lambda1405analysis {
       return;
     }
     if (lambda1405Cand.isSigmaMinus) {
-      rSelections.fill(HIST("hSelectionsSigmaMinus"), 5); // Passed radius sel
+      rSelections.fill(HIST("hSelectionsSigmaMinus"), 6); // Passed radius sel
     } else {
-      rSelections.fill(HIST("hSelectionsSigmaPlus"), 5); // Passed radius sel
+      rSelections.fill(HIST("hSelectionsSigmaPlus"), 6); // Passed radius sel
     }
 
     auto kinkDauMom = std::array{sigmaCand.pxDaug(), sigmaCand.pyDaug(), sigmaCand.pzDaug()};
-    auto sigmaMom = std::array{sigmaCand.pxMoth(), sigmaCand.pyMoth(), sigmaCand.pzMoth()};
     // Sigma properties
     lambda1405Cand.sigmaId = sigmaCand.globalIndex();
     lambda1405Cand.sigmaMinusMass = sigmaCand.mSigmaMinus();
@@ -631,7 +953,7 @@ struct lambda1405analysis {
     lambda1405Cand.sigmaSign = sigmaCand.mothSign();
     lambda1405Cand.sigmaAlphaAP = alphaAP(sigmaMom, kinkDauMom);
     lambda1405Cand.sigmaQtAP = qtAP(sigmaMom, kinkDauMom);
-    lambda1405Cand.sigmaPt = sigmaCand.ptMoth();
+    lambda1405Cand.sigmaPt = sigmaPt;
     lambda1405Cand.sigmaRadius = sigmaRad;
     lambda1405Cand.dcaSigmaToPv = sigmaCand.dcaMothPv();
 
@@ -640,9 +962,9 @@ struct lambda1405analysis {
       return;
     }
     if (lambda1405Cand.isSigmaMinus) {
-      rSelections.fill(HIST("hSelectionsSigmaMinus"), 6); // Passed AP sel
+      rSelections.fill(HIST("hSelectionsSigmaMinus"), 7); // Passed AP sel
     } else {
-      rSelections.fill(HIST("hSelectionsSigmaPlus"), 6); // Passed AP sel
+      rSelections.fill(HIST("hSelectionsSigmaPlus"), 7); // Passed AP sel
     }
 
     // Kink daughter properties
@@ -658,14 +980,12 @@ struct lambda1405analysis {
 
     // Collision properties
     lambda1405Cand.pvContrib = collision.numContrib();
-    if constexpr (requires { collision.centFT0C(); }) {
-      lambda1405Cand.cent = collision.centFT0C();
-    } else {
-      lambda1405Cand.cent = -1; // Not available
-    }
+    lambda1405Cand.centMult  = getCentMult(collision);
+    lambda1405Cand.occ       = collision.ft0cOccupancyInTimeRange();
 
     fillHistosSigma(lambda1405Cand, sigmaCand, kinkDauTrack);
 
+    int countPairedBachPi{0};
     for (const auto& piTrack : tracks) {
       rSelections.fill(HIST("hSelectionsBachPi"), 0); // All bachelors
 
@@ -685,10 +1005,9 @@ struct lambda1405analysis {
       }
       rSelections.fill(HIST("hSelectionsBachPi"), 1);
 
-      if (!selectPiBach(piTrack)) {
+      if (!selectPiBach(piTrack, primaryVertex)) {
         continue;
       }
-      rSelections.fill(HIST("hSelectionsBachPi"), 5); // PID sel
       rSelections.fill(HIST("hSelectionsL1405"), 2);  // Bach Pi selection
 
       auto piMom = std::array{piTrack.px(), piTrack.py(), piTrack.pz()};
@@ -719,8 +1038,8 @@ struct lambda1405analysis {
       lambda1405Cand.px = sigmaMom[0] + piMom[0];
       lambda1405Cand.py = sigmaMom[1] + piMom[1];
       lambda1405Cand.pz = sigmaMom[2] + piMom[2];
-
       lambda1405Cand.phi = std::atan2(lambda1405Cand.py, lambda1405Cand.px);
+      lambda1405Cand.eta = -std::log(std::tan(0.5 * std::atan2(std::hypot(lambda1405Cand.px, lambda1405Cand.py), lambda1405Cand.pz)));
       lambda1405Cand.scalarProd = -1;
       if constexpr (requires { collision.qvecFT0CRe(); }) {
         float const xQVec = collision.qvecFT0CRe();
@@ -735,9 +1054,13 @@ struct lambda1405analysis {
           std::hypot(sigmaCand.pxMoth(), sigmaCand.pyMoth()) > funcMaxSigmaPtVsL1405Pt.Eval(lambda1405Cand.pt())) {
         continue;
       }
-
       if (piTrack.pt() < funcMinBachPiPtVsL1405Pt.Eval(lambda1405Cand.pt()) ||
           piTrack.pt() > funcMaxBachPiPtVsL1405Pt.Eval(lambda1405Cand.pt())) {
+        continue;
+      }
+      rSelections.fill(HIST("hSelectionsL1405"), 4); // Pt correlations
+
+      if (lambda1405Cand.pt() < cutMinPtL1405) {
         continue;
       }
       rSelections.fill(HIST("hSelectionsL1405"), 4); // Pt correlations
@@ -748,22 +1071,28 @@ struct lambda1405analysis {
       rSelections.fill(HIST("hSelectionsL1405"), 5); // Accepted
 
       selectedCandidates.push_back(lambda1405Cand);
+      countPairedBachPi++;
     }
+    rLambda1405.fill(HIST("hPairedBachPiVsCent"), lambda1405Cand.centMult, countPairedBachPi);
   }
 
   template <typename mcTrack>
   bool checkSigmaKinkMC(const mcTrack& mcTrackSigma, const mcTrack& mcTrackKinkDau, float sigmaAbsPDG, float kinkAbsPDG, aod::McParticles const&)
   {
+    LOG(info) << "Checking Sigma kink decay for MC tracks: Sigma PDG = " << mcTrackSigma.pdgCode() << ", Kink daughter PDG = " << mcTrackKinkDau.pdgCode();
     if (std::abs(mcTrackSigma.pdgCode()) != sigmaAbsPDG || std::abs(mcTrackKinkDau.pdgCode()) != kinkAbsPDG) {
+      LOG(info) << "PDG codes do not match expected values: Sigma PDG = " << sigmaAbsPDG << ", Kink daughter PDG = " << kinkAbsPDG;
       return false; // Not a valid Sigma kink decay
     }
     if (!mcTrackKinkDau.has_mothers()) {
+      LOG(info) << "Kink daughter has no mothers";
       return false; // No mothers found
     }
     // Check if the kink comes from the Sigma
     bool isKinkFromSigma = false;
     for (const auto& mcMother : mcTrackKinkDau.template mothers_as<aod::McParticles>()) {
       if (mcMother.globalIndex() == mcTrackSigma.globalIndex()) {
+        LOG(info) << "Kink daughter comes from the Sigma";
         isKinkFromSigma = true;
         break;
       }
@@ -774,15 +1103,18 @@ struct lambda1405analysis {
   template <typename TCollision, typename TCand, typename TTrack>
   void fillOutputData(const TCollision& collision, const TCand& sigmaCands, const TTrack& tracks)
   {
-    if constexpr (requires { collision.centFT0C(); }) {
-      if (collision.centFT0C() < centralityMin || collision.centFT0C() > centralityMax) {
-        return;
-      }
-    }
     if (std::abs(collision.posZ()) > cutZVertex || !collision.sel8()) {
       return;
     }
     rEventSelection.fill(HIST("hVertexZRec"), collision.posZ());
+    float centMult = getCentMult(collision);
+    if (centMult < centMultMin || centMult > centMultMax) {
+      return;
+    }
+    rEventSelection.fill(HIST("hCentMultVsPvContrib"), centMult, collision.numContrib());
+    rEventSelection.fill(HIST("hOccVsPvContrib"), collision.ft0cOccupancyInTimeRange(), collision.numContrib());
+    rEventSelection.fill(HIST("hCentVsOcc"), centMult, collision.ft0cOccupancyInTimeRange());
+
     for (const auto& sigmaCand : sigmaCands) {
       std::vector<lambda1405candidate> selectedCandidates;
       constructCollCandidates(collision, sigmaCand, tracks, selectedCandidates);
@@ -792,7 +1124,7 @@ struct lambda1405analysis {
         } else {
           rLambda1405.fill(HIST("h2SigmaPlusMassVsLambdaMass"), lambda1405Cand.massL1405, lambda1405Cand.sigmaPlusMass);
         }
-        if (fillOutputTree) {
+        if (fillOutputTree || fillFlowTree) {
           float const ptCand = lambda1405Cand.pt();
           if (downSampleFactor < 1.) {
             float const pseudoRndm = ptCand * 1000. - static_cast<int64_t>(ptCand * 1000);
@@ -800,6 +1132,7 @@ struct lambda1405analysis {
               continue;
             }
           }
+          if (fillOutputTree) {
           outputDataTable(lambda1405Cand.px, lambda1405Cand.py, lambda1405Cand.pz,
                           lambda1405Cand.massL1405, lambda1405Cand.massXi1530,
                           lambda1405Cand.sigmaMinusMass, lambda1405Cand.sigmaPlusMass, lambda1405Cand.xiMinusMass,
@@ -809,22 +1142,7 @@ struct lambda1405analysis {
                           lambda1405Cand.kinkPrNSigTpc, lambda1405Cand.kinkPrNSigTof,
                           lambda1405Cand.kinkDcaDauToPv,
                           lambda1405Cand.bachPiNSigTpc, lambda1405Cand.bachPiNSigTof);
-        }
-        if constexpr (requires { collision.qvecFT0CRe(); }) {
-          float const xQVec = collision.qvecFT0CRe();
-          float const yQVec = collision.qvecFT0CIm();
-          float const cos2Phi = std::cos(2 * lambda1405Cand.phi);
-          float const sin2Phi = std::sin(2 * lambda1405Cand.phi);
-          lambda1405Cand.scalarProd = cos2Phi * xQVec + sin2Phi * yQVec;
-          float const ptCand = lambda1405Cand.pt();
-          rLambda1405.fill(HIST("hScalarProd"), lambda1405Cand.scalarProd, ptCand);
-          if (fillFlowTree) {
-            if (downSampleFactor < 1.) {
-              float const pseudoRndm = ptCand * 1000. - static_cast<int64_t>(ptCand * 1000);
-              if (ptCand < ptDownSampleMax && pseudoRndm >= downSampleFactor) {
-                continue;
-              }
-            }
+          } else {
             outputDataFlowTable(ptCand, lambda1405Cand.massL1405,
                                 lambda1405Cand.sigmaPt,
                                 lambda1405Cand.sigmaMinusMass, lambda1405Cand.sigmaPlusMass,
@@ -833,17 +1151,32 @@ struct lambda1405analysis {
                                 lambda1405Cand.kinkPrNSigTpc, lambda1405Cand.kinkPrNSigTof,
                                 lambda1405Cand.kinkDcaDauToPv,
                                 lambda1405Cand.bachPiNSigTpc, lambda1405Cand.bachPiNSigTof,
-                                lambda1405Cand.scalarProd, collision.centFT0C());
+                                lambda1405Cand.scalarProd, lambda1405Cand.centMult);
           }
         }
-        fillHistosLambda1405<false>(lambda1405Cand);
+
+        // Fill histograms
+        if constexpr (requires { collision.qvecFT0CRe(); }) {
+          if (saveDEtaDPhi) {
+            fillHistosLambda1405<false, true, true>(lambda1405Cand, tracks);
+          } else {
+            fillHistosLambda1405<false, true, false>(lambda1405Cand, tracks);
+          }
+        } else {
+          if (saveDEtaDPhi) {
+            fillHistosLambda1405<false, false, true>(lambda1405Cand, tracks);
+          } else {
+            fillHistosLambda1405<false, false, false>(lambda1405Cand, tracks);
+          }
+        }
       }
     }
   }
 
   void processData(CollisionsFull::iterator const& collision,
                    aod::KinkCands const& kinkCands,
-                   TracksFull const& tracks)
+                   TracksFull const& tracks,
+                   const aod::BCs&)
   {
     fillOutputData(collision, kinkCands, tracks);
   }
@@ -851,7 +1184,8 @@ struct lambda1405analysis {
 
   void processDataWCentQVecs(CollisionsCentSel::iterator const& collision,
                              aod::KinkCands const& kinkCands,
-                             TracksFull const& tracks)
+                             TracksFull const& tracks,
+                             const aod::BCs&)
   {
     fillOutputData(collision, kinkCands, tracks);
   }
@@ -936,40 +1270,66 @@ struct lambda1405analysis {
                     const TTrack& tracks,
                     const aod::McParticles& particlesMC)
   {
+    LOG(info) << "Filling output MC for " << recoCollisions.size() << " collisions, " << sigmaCands.size() << " Sigma candidates, and " << tracks.size() << " tracks";
     for (const auto& collision : recoCollisions) {
-      if constexpr (requires { collision.centFT0C(); }) {
-        auto cent = collision.centFT0C();
-        if (cent < centralityMin || cent > centralityMax) {
-          return;
-        }
-      }
+      LOG(info) << "\n\nProcessing collision with global index: " << collision.globalIndex() << " and " << sigmaCands.size() << " Sigma candidates, and " << tracks.size() << " tracks";
       if (std::abs(collision.posZ()) > cutZVertex) { // || !collision.sel8()) {
+        LOG(info) << "Collision failed Z vertex cut: " << collision.posZ();
         continue;
       }
+      LOG(info) << "Collision passed Z vertex cut: " << collision.posZ();
       rEventSelection.fill(HIST("hVertexZRec"), collision.posZ());
+      float centMult = getCentMult(collision);
+      LOG(info) << "Collision centrality: " << centMult;
+      if (centMult < centMultMin || centMult > centMultMax) {
+        LOG(info) << "Collision failed centrality cut: " << centMult;
+        continue;
+      }
+      LOG(info) << "Collision passed centrality cut: " << centMult;
+      rEventSelection.fill(HIST("hCentMultVsPvContrib"), centMult, collision.numContrib());
+      rEventSelection.fill(HIST("hOccVsPvContrib"), collision.ft0cOccupancyInTimeRange(), collision.numContrib());
+      rEventSelection.fill(HIST("hCentVsOcc"), centMult, collision.ft0cOccupancyInTimeRange());
+
       auto sigmaCandsPerCol = sigmaCands.sliceBy(mKinkPerCol, collision.globalIndex());
       auto tracksPerCol = tracks.sliceBy(mPerColTracks, collision.globalIndex());
+      LOG(info) << "Start loop on " << sigmaCandsPerCol.size() << " Sigma candidates ... ";
       for (const auto& sigmaCand : sigmaCandsPerCol) {
+        LOG(info) << "Processing Sigma candidate with global index: " << sigmaCand.globalIndex();
 
         // Perform the sigma matching here, so sigma histograms
         // can be used for efficiency studies on the sigma
         auto labelSigma = trackLabelsMC.rawIteratorAt(sigmaCand.trackMothId());
         auto labelKinkDaug = trackLabelsMC.rawIteratorAt(sigmaCand.trackDaugId());
-        if (!labelSigma.has_mcParticle() || !labelKinkDaug.has_mcParticle()) {
-          continue; // Skip if no valid MC association
+        if (!labelSigma.has_mcParticle()) {
+          LOG(info) << "Sigma candidate with global index: " << sigmaCand.globalIndex() << " is not matched to MC particle";
+          rSelections.fill(HIST("hRecoNotMatchedCounter"), 1); // Sigma not matched
+        }
+        if (!labelKinkDaug.has_mcParticle()) {
+          LOG(info) << "Kink daughter candidate with global index: " << sigmaCand.globalIndex() << " is not matched to MC particle";
+          rSelections.fill(HIST("hRecoNotMatchedCounter"), 2); // Kink daughter not matched
         }
         auto genSigma = labelSigma.template mcParticle_as<aod::McParticles>();
         auto genKinkDaug = labelKinkDaug.template mcParticle_as<aod::McParticles>();
 
-        bool isSigmaMinusKink = checkSigmaKinkMC(genSigma, genKinkDaug, PDG_t::kSigmaMinus, PDG_t::kPiPlus, particlesMC);
-        bool isSigmaPlusToPiKink = checkSigmaKinkMC(genSigma, genKinkDaug, PDG_t::kSigmaPlus, PDG_t::kPiPlus, particlesMC);
-        bool isSigmaPlusToPrKink = checkSigmaKinkMC(genSigma, genKinkDaug, PDG_t::kSigmaPlus, PDG_t::kProton, particlesMC);
+        bool isSigmaMinusKink    = checkSigmaKinkMC(genSigma, genKinkDaug, PDG_t::kSigmaMinus, PDG_t::kPiPlus, particlesMC);
+        bool isSigmaPlusToPiKink = checkSigmaKinkMC(genSigma, genKinkDaug, PDG_t::kSigmaPlus,  PDG_t::kPiPlus, particlesMC);
+        bool isSigmaPlusToPrKink = checkSigmaKinkMC(genSigma, genKinkDaug, PDG_t::kSigmaPlus,  PDG_t::kProton, particlesMC);
 
         if (!isSigmaMinusKink && !isSigmaPlusToPiKink && !isSigmaPlusToPrKink) {
+          LOG(info) << "Candidate is not a valid Sigma kink decay, skipping ...";
           continue; // Skip if not a valid Sigma kink decay
         }
-
+        if (isSigmaMinusKink) {
+          LOG(info) << "Filling h2DeltaGenRecoPtSigmaMinus with: " << sigmaCand.ptMoth() - genSigma.pt() << ", " << sigmaCand.ptMoth();
+          rSigmaMinus.fill(HIST("h2DeltaGenRecoPtSigmaMinus"), sigmaCand.ptMoth() - genSigma.pt(), sigmaCand.ptMoth());
+        }
+        if (isSigmaPlusToPiKink || isSigmaPlusToPrKink) {
+          LOG(info) << "Filling h2DeltaGenRecoPtSigmaPlus with: " << sigmaCand.ptMoth() - genSigma.pt() << ", " << sigmaCand.ptMoth();
+          rSigmaPlus.fill(HIST("h2DeltaGenRecoPtSigmaPlus"), sigmaCand.ptMoth() - genSigma.pt(), sigmaCand.ptMoth());
+        }
+        
         std::vector<lambda1405candidate> selectedCandidates;
+        LOG(info) << "Constructing Lambda(1405) candidates from Sigma candidate with global index: " << sigmaCand.globalIndex();
         constructCollCandidates(collision, sigmaCand, tracksPerCol, selectedCandidates);
         for (auto& lambda1405Cand : selectedCandidates) {
           rLambda1405.fill(HIST("hRecoL1405"), 0., lambda1405Cand.pt()); // All reconstructed
@@ -977,6 +1337,7 @@ struct lambda1405analysis {
           // Do MC association
           auto labelBachPi = trackLabelsMC.rawIteratorAt(lambda1405Cand.bachPiId);
           if (!labelBachPi.has_mcParticle()) {
+            rSelections.fill(HIST("hRecoNotMatchedCounter"), 3); // Bach pion not matched
             continue; // Skip if no valid MC association
           }
 
@@ -1031,7 +1392,7 @@ struct lambda1405analysis {
                               lambda1405Cand.bachPiNSigTpc, lambda1405Cand.bachPiNSigTof,
                               lambda1405Mother.pt(), lambda1405Mass, genSigma.pdgCode(), genBachPi.pdgCode());
           }
-          fillHistosLambda1405<true>(lambda1405Cand);
+          fillHistosLambda1405<true, false, false>(lambda1405Cand, tracksPerCol);
         }
       }
     }
@@ -1106,6 +1467,7 @@ struct lambda1405analysis {
                  aod::McTrackLabels const& trackLabelsMC,
                  aod::McParticles const& particlesMC,
                  TracksFull const& tracks,
+                 const aod::BCs&,
                  aod::McCollisions const&)
   {
     fillOutputMc(recoCollisions, kinkCands, trackLabelsMC, tracks, particlesMC);
@@ -1116,7 +1478,8 @@ struct lambda1405analysis {
                          aod::KinkCands const& kinkCands,
                          aod::McTrackLabels const& trackLabelsMC,
                          aod::McParticles const& particlesMC,
-                         TracksFull const& tracks)
+                         TracksFull const& tracks,
+                         const aod::BCs&)
   {
     fillOutputMc(recoCollisions, kinkCands, trackLabelsMC, tracks, particlesMC);
   }


### PR DESCRIPTION
Adds:
- pt-differential DCA selection for bachelor pions
- Recomputation of Sigma candidate momentum as in `sigmaHadCorr.cxx`
- Sparse for two-particle correlation

Tagging @fmazzasc @stefanopolitano 