### PR TITLE
[Common] Add light ion centrality tables with anchoring at 90%

### DIFF
--- a/Common/DataModel/Centrality.h
+++ b/Common/DataModel/Centrality.h
@@ -64,7 +64,7 @@ DECLARE_SOA_TABLE(CentMFTs, "AOD", "CENTMFT", cent::CentMFT);             //! Ru
 DECLARE_SOA_TABLE(CentFT0CVariant1s, "AOD", "CENTFT0Cvar1", cent::CentFT0CVariant1);                    //! Run 3 FT0C variant 1
 DECLARE_SOA_TABLE(CentFT0CVariant2s, "AOD", "CENTFT0Cvar2", cent::CentFT0CVariant2);                    //! Run 3 FT0C variant 1 - uses truncated Nancestors in glauber fit. Not recommended! for cross-checks only
 DECLARE_SOA_TABLE(CentFT0MLightIonAnchorCols, "AOD", "CENTFT0MLICOL", cent::CentFT0MLightIonAnchorCol); //! Run 3 Light ions FT0M - Traditional anchor at 90% with Glauber. Colliison based calibration. Not recommended! for cross-checks only
-DECLARE_SOA_TABLE(CentFT0MLightIonAnchorBCs, "AOD", "CENTFT0MLIbc", cent::CentFT0MLightIonAnchorBC);    //! Run 3 Light ions FT0M - Traditional anchor at 90% with Glauber. Bunch crossing based calibration. Not recommended! for cross-checks only
+DECLARE_SOA_TABLE(CentFT0MLightIonAnchorBCs, "AOD", "CENTFT0MLIBC", cent::CentFT0MLightIonAnchorBC);    //! Run 3 Light ions FT0M - Traditional anchor at 90% with Glauber. Bunch crossing based calibration. Not recommended! for cross-checks only
 
 // Run 3 centrality per BC (joinable with BC)
 DECLARE_SOA_TABLE(BCCentFT0Ms, "AOD", "BCCENTFT0M", cent::CentFT0M, o2::soa::Marker<1>); //! Run 3 FT0M BC centrality table

--- a/Common/DataModel/Centrality.h
+++ b/Common/DataModel/Centrality.h
@@ -26,16 +26,18 @@ DECLARE_SOA_COLUMN(CentRun2CL1, centRun2CL1, float);                   //! Run 2
 DECLARE_SOA_COLUMN(CentRun2RefMult5, centRun2RefMult5, float);         //! Run 2 cent. from ref. mult. estimator, eta 0.5
 DECLARE_SOA_COLUMN(CentRun2RefMult8, centRun2RefMult8, float);         //! Run 2 cent. from  ref. mult. estimator, eta 0.8
 
-DECLARE_SOA_COLUMN(CentFV0A, centFV0A, float);                 //! Run 3 cent. from FV0A multiplicities
-DECLARE_SOA_COLUMN(CentFT0M, centFT0M, float);                 //! Run 3 cent. from FT0A+FT0C multiplicities
-DECLARE_SOA_COLUMN(CentFT0A, centFT0A, float);                 //! Run 3 cent. from FT0A multiplicity
-DECLARE_SOA_COLUMN(CentFT0C, centFT0C, float);                 //! Run 3 cent. from FT0C multiplicity
-DECLARE_SOA_COLUMN(CentFT0CVariant1, centFT0CVariant1, float); //! Run 3 cent. from FT0C multiplicity
-DECLARE_SOA_COLUMN(CentFT0CVariant2, centFT0CVariant2, float); //! Run 3 cent. from FT0C multiplicity, uses classical truncated Nancestors (NOT recommended, cross-check only!)
-DECLARE_SOA_COLUMN(CentFDDM, centFDDM, float);                 //! Run 3 cent. from FDDA+FDDC multiplicity
-DECLARE_SOA_COLUMN(CentNTPV, centNTPV, float);                 //! Run 3 cent. from the number of tracks contributing to the PV
-DECLARE_SOA_COLUMN(CentNGlobal, centNGlobal, float);           //! Run 3 cent. from the number of global tracks
-DECLARE_SOA_COLUMN(CentMFT, centMFT, float);                   //! Run 3 cent. from the number of tracks in the MFT
+DECLARE_SOA_COLUMN(CentFV0A, centFV0A, float);                                   //! Run 3 cent. from FV0A multiplicities
+DECLARE_SOA_COLUMN(CentFT0M, centFT0M, float);                                   //! Run 3 cent. from FT0A+FT0C multiplicities
+DECLARE_SOA_COLUMN(CentFT0MLightIonAnchorCol, centFT0MLightIonAnchorCol, float); //! Run 3 cent. from FT0A+FT0C multiplicities - light ion only - 90% anchor - collision based (NOT recommended, cross-check only!)
+DECLARE_SOA_COLUMN(CentFT0MLightIonAnchorBC, centFT0MLightIonAnchorBC, float);   //! Run 3 cent. from FT0A+FT0C multiplicities - light ion only - 90% anchor - bunch crossing based (NOT recommended, cross-check only!)
+DECLARE_SOA_COLUMN(CentFT0A, centFT0A, float);                                   //! Run 3 cent. from FT0A multiplicity
+DECLARE_SOA_COLUMN(CentFT0C, centFT0C, float);                                   //! Run 3 cent. from FT0C multiplicity
+DECLARE_SOA_COLUMN(CentFT0CVariant1, centFT0CVariant1, float);                   //! Run 3 cent. from FT0C multiplicity
+DECLARE_SOA_COLUMN(CentFT0CVariant2, centFT0CVariant2, float);                   //! Run 3 cent. from FT0C multiplicity, uses classical truncated Nancestors (NOT recommended, cross-check only!)
+DECLARE_SOA_COLUMN(CentFDDM, centFDDM, float);                                   //! Run 3 cent. from FDDA+FDDC multiplicity
+DECLARE_SOA_COLUMN(CentNTPV, centNTPV, float);                                   //! Run 3 cent. from the number of tracks contributing to the PV
+DECLARE_SOA_COLUMN(CentNGlobal, centNGlobal, float);                             //! Run 3 cent. from the number of global tracks
+DECLARE_SOA_COLUMN(CentMFT, centMFT, float);                                     //! Run 3 cent. from the number of tracks in the MFT
 } // namespace cent
 
 // Run 2 tables
@@ -59,8 +61,10 @@ DECLARE_SOA_TABLE(CentNGlobals, "AOD", "CENTNGLOBAL", cent::CentNGlobal); //! Ru
 DECLARE_SOA_TABLE(CentMFTs, "AOD", "CENTMFT", cent::CentMFT);             //! Run 3 MFT tracks centrality table
 
 // Run 3 variant tables
-DECLARE_SOA_TABLE(CentFT0CVariant1s, "AOD", "CENTFT0Cvar1", cent::CentFT0CVariant1); //! Run 3 FT0C variant 1
-DECLARE_SOA_TABLE(CentFT0CVariant2s, "AOD", "CENTFT0Cvar2", cent::CentFT0CVariant2); //! Run 3 FT0C variant 1 - uses truncated Nancestors in glauber fit. Not recommended! for cross-checks only
+DECLARE_SOA_TABLE(CentFT0CVariant1s, "AOD", "CENTFT0Cvar1", cent::CentFT0CVariant1);                    //! Run 3 FT0C variant 1
+DECLARE_SOA_TABLE(CentFT0CVariant2s, "AOD", "CENTFT0Cvar2", cent::CentFT0CVariant2);                    //! Run 3 FT0C variant 1 - uses truncated Nancestors in glauber fit. Not recommended! for cross-checks only
+DECLARE_SOA_TABLE(CentFT0MLightIonAnchorCols, "AOD", "CENTFT0MLICOL", cent::CentFT0MLightIonAnchorCol); //! Run 3 Light ions FT0M - Traditional anchor at 90% with Glauber. Colliison based calibration. Not recommended! for cross-checks only
+DECLARE_SOA_TABLE(CentFT0MLightIonAnchorBCs, "AOD", "CENTFT0MLIbc", cent::CentFT0MLightIonAnchorBC);    //! Run 3 Light ions FT0M - Traditional anchor at 90% with Glauber. Bunch crossing based calibration. Not recommended! for cross-checks only
 
 // Run 3 centrality per BC (joinable with BC)
 DECLARE_SOA_TABLE(BCCentFT0Ms, "AOD", "BCCENTFT0M", cent::CentFT0M, o2::soa::Marker<1>); //! Run 3 FT0M BC centrality table

--- a/Common/Tasks/centralityQa.cxx
+++ b/Common/Tasks/centralityQa.cxx
@@ -155,6 +155,8 @@ struct CentralityQa {
       histos.add("hCentNTPV", ";NTPV centrality (%)", kTH1D, {{nBins, 0, 105.}});
       histos.add("hCentNGlobal", ";NGlobal centrality (%)", kTH1D, {{nBins, 0, 105.}});
       histos.add("hCentMFT", ";MFT centrality (%)", kTH1D, {{nBins, 0, 105.}});
+      histos.add("hCentFT0MLightIonAnchorCols", ";FT0MLightIonAnchorCols centrality (%)", kTH1D, {{nBins, 0, 105.}});
+      histos.add("hCentFT0MLightIonAnchorBCs", ";FT0MLightIonAnchorBCs centrality (%)", kTH1D, {{nBins, 0, 105.}});
 
       // profiles of midrapidity multiplicity density
       histos.add("hCentProfileFV0A", ";FV0A centrality (%)", kTProfile, {{nBins, 0, 105.}});
@@ -167,6 +169,8 @@ struct CentralityQa {
       histos.add("hCentProfileNTPV", ";NTPV centrality (%)", kTProfile, {{nBins, 0, 105.}});
       histos.add("hCentProfileNGlobal", ";NGlobal centrality (%)", kTProfile, {{nBins, 0, 105.}});
       histos.add("hCentProfileMFT", ";MFT centrality (%)", kTProfile, {{nBins, 0, 105.}});
+      histos.add("hCentProfileFT0MLightIonAnchorCols", ";FT0MLightIonAnchorCols centrality (%)", kTProfile, {{nBins, 0, 105.}});
+      histos.add("hCentProfileFT0MLightIonAnchorBCs", ";FT0MLightIonAnchorBCs centrality (%)", kTProfile, {{nBins, 0, 105.}});
 
       histos.add("hMultEta05VsCentFV0A", ";FV0A centrality (%); Multiplicity PV contributors (|#it{#eta}| < 0.5)", kTH2D, {{nBins, 0, 105.}, axisMultiplicityPV});
       histos.add("hMultEta05VsCentFT0M", ";FT0M centrality (%); Multiplicity PV contributors (|#it{#eta}| < 0.5)", kTH2D, {{nBins, 0, 105.}, axisMultiplicityPV});
@@ -178,6 +182,8 @@ struct CentralityQa {
       histos.add("hMultEta05VsCentNTPV", ";NTPV centrality (%); Multiplicity PV contributors (|#it{#eta}| < 0.5)", kTH2D, {{nBins, 0, 105.}, axisMultiplicityPV});
       histos.add("hMultEta05VsCentNGlobal", ";NGlobal centrality (%); Multiplicity PV contributors (|#it{#eta}| < 0.5)", kTH2D, {{nBins, 0, 105.}, axisMultiplicityPV});
       histos.add("hMultEta05VsCentMFT", ";MFT centrality (%); Multiplicity PV contributors (|#it{#eta}| < 0.5)", kTH2D, {{nBins, 0, 105.}, axisMultiplicityPV});
+      histos.add("hMultEta05VsCentFT0MLightIonAnchorCols", ";FT0MLightIonAnchorCols centrality (%); Multiplicity PV contributors (|#it{#eta}| < 0.5)", kTH2D, {{nBins, 0, 105.}, axisMultiplicityPV});
+      histos.add("hMultEta05VsCentFT0MLightIonAnchorBCs", ";FT0MLightIonAnchorBCs centrality (%); Multiplicity PV contributors (|#it{#eta}| < 0.5)", kTH2D, {{nBins, 0, 105.}, axisMultiplicityPV});
 
       if (isMC) {
         histos.add("hMultEta05VsGenMultFV0A", ";Multiplicity FV0A; Multiplicity PV contributors (|#it{#eta}| < 0.5)", kTH2D, {axisMultiplicity, axisMultiplicityPV});
@@ -655,6 +661,28 @@ struct CentralityQa {
     histos.fill(HIST("hMultEta05VsCentMFT"), col.centMFT(), col.multNTracksPVetaHalf());
   }
   PROCESS_SWITCH(CentralityQa, processRun3_MFT, "Process with Run 3 MFT estimator", false);
+
+  void processRun3_FT0MLightIonAnchorCol(soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0MLightIonAnchorCols>::iterator const& col)
+  {
+    if (!isCollisionAccepted(col)) {
+      return;
+    }
+    histos.fill(HIST("hCentFT0MLightIonAnchorCols"), col.centFT0MLightIonAnchorCol());
+    histos.fill(HIST("hCentProfileFT0MLightIonAnchorCols"), col.centFT0MLightIonAnchorCol(), col.multNTracksPVetaHalf());
+    histos.fill(HIST("hMultEta05VsCentFT0MLightIonAnchorCols"), col.centFT0MLightIonAnchorCol(), col.multNTracksPVetaHalf());
+  }
+  PROCESS_SWITCH(CentralityQa, processRun3_FT0MLightIonAnchorCol, "Process with Run 3 FT0MLightIonAnchorCol estimator", false);
+
+  void processRun3_FT0MLightIonAnchorBC(soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0MLightIonAnchorBCs>::iterator const& col)
+  {
+    if (!isCollisionAccepted(col)) {
+      return;
+    }
+    histos.fill(HIST("hCentFT0MLightIonAnchorBCs"), col.centFT0MLightIonAnchorBC());
+    histos.fill(HIST("hCentProfileFT0MLightIonAnchorBCs"), col.centFT0MLightIonAnchorBC(), col.multNTracksPVetaHalf());
+    histos.fill(HIST("hMultEta05VsCentFT0MLightIonAnchorBCs"), col.centFT0MLightIonAnchorBC(), col.multNTracksPVetaHalf());
+  }
+  PROCESS_SWITCH(CentralityQa, processRun3_FT0MLightIonAnchorBC, "Process with Run 3 FT0MLightIonAnchorBC estimator", false);
 
   void processMonteCarloRun3_FV0A(soa::Join<aod::Collisions, aod::McCollisionLabels, aod::EvSels, aod::Mults, aod::CentFV0As>::iterator const& col,
                                   soa::Join<aod::McCollisions, aod::MultMCExtras> const& /*mcCollisions*/,

--- a/Common/Tools/Multiplicity/MultModule.h
+++ b/Common/Tools/Multiplicity/MultModule.h
@@ -58,7 +58,7 @@ static constexpr int nParameters = 1;
 static const std::vector<std::string> tableNames{
   // multiplicity subcomponent
   "FV0Mults",
-  "FV0AOuterMults",
+  "FITExtraMults",
   "FT0Mults",
   "FDDMults",
   "ZDCMults",
@@ -97,12 +97,16 @@ static const std::vector<std::string> tableNames{
   "CentMFTs",
   "BCCentFT0Ms",
   "BCCentFT0As",
-  "BCCentFT0Cs"};
+  "BCCentFT0Cs",
+  "CentFT0MLightIonAnchorCols",
+  "CentFT0MLightIonAnchorBCs"};
 
-static constexpr int nTablesConst = 39;
+static constexpr int nTablesConst = 41;
 
 static const std::vector<std::string> parameterNames{"enable"};
 static const int defaultParameters[nTablesConst][nParameters]{
+  {-1},
+  {-1},
   {-1},
   {-1},
   {-1},
@@ -166,25 +170,27 @@ enum tableIndex { kFV0Mults,       // standard
                   kMultsGlobal,    // requires track selection task
 
                   // centrality subcomponent
-                  kCentRun2V0Ms,      // Run 2
-                  kCentRun2V0As,      // Run 2
-                  kCentRun2SPDTrks,   // Run 2
-                  kCentRun2SPDClss,   // Run 2
-                  kCentRun2CL0s,      // Run 2
-                  kCentRun2CL1s,      // Run 2
-                  kCentFV0As,         // standard Run 3
-                  kCentFT0Ms,         // standard Run 3
-                  kCentFT0As,         // standard Run 3
-                  kCentFT0Cs,         // standard Run 3
-                  kCentFT0CVariant1s, // standard Run 3
-                  kCentFT0CVariant2s, // standard Run 3
-                  kCentFDDMs,         // standard Run 3
-                  kCentNTPVs,         // standard Run 3
-                  kCentNGlobals,      // requires track selection task
-                  kCentMFTs,          // requires MFT task
-                  kBCCentFT0Ms,       // bc centrality
-                  kBCCentFT0As,       // bc centrality
-                  kBCCentFT0Cs,       // bc centrality
+                  kCentRun2V0Ms,               // Run 2
+                  kCentRun2V0As,               // Run 2
+                  kCentRun2SPDTrks,            // Run 2
+                  kCentRun2SPDClss,            // Run 2
+                  kCentRun2CL0s,               // Run 2
+                  kCentRun2CL1s,               // Run 2
+                  kCentFV0As,                  // standard Run 3
+                  kCentFT0Ms,                  // standard Run 3
+                  kCentFT0As,                  // standard Run 3
+                  kCentFT0Cs,                  // standard Run 3
+                  kCentFT0CVariant1s,          // standard Run 3
+                  kCentFT0CVariant2s,          // standard Run 3
+                  kCentFDDMs,                  // standard Run 3
+                  kCentNTPVs,                  // standard Run 3
+                  kCentNGlobals,               // requires track selection task
+                  kCentMFTs,                   // requires MFT task
+                  kBCCentFT0Ms,                // bc centrality
+                  kBCCentFT0As,                // bc centrality
+                  kBCCentFT0Cs,                // bc centrality
+                  kCentFT0MLightIonAnchorCols, // light ion specific
+                  kCentFT0MLightIonAnchorBCs,  // light ion specific
                   kNTables };
 
 struct products : o2::framework::ProducesGroup {
@@ -233,6 +239,8 @@ struct products : o2::framework::ProducesGroup {
   o2::framework::Produces<aod::BCCentFT0As> bcCentFT0A;
   o2::framework::Produces<aod::BCCentFT0Cs> bcCentFT0C;
   o2::framework::Produces<aod::BCCentFT0Ms> bcCentFT0M;
+  o2::framework::Produces<aod::CentFT0MLightIonAnchorCols> centFT0MLightIonAnchorCol;
+  o2::framework::Produces<aod::CentFT0MLightIonAnchorBCs> centFT0MLightIonAnchorBC;
 
   //__________________________________________________
   // centrality tables per BC
@@ -443,6 +451,8 @@ class MultModule
 
   CalibrationInfo fv0aInfo = CalibrationInfo("FV0");
   CalibrationInfo ft0mInfo = CalibrationInfo("FT0");
+  CalibrationInfo ft0mColInfo = CalibrationInfo("FT0LightIonAncCol");
+  CalibrationInfo ft0mBcInfo = CalibrationInfo("FT0LightIonAncBc");
   CalibrationInfo ft0aInfo = CalibrationInfo("FT0A");
   CalibrationInfo ft0cInfo = CalibrationInfo("FT0C");
   CalibrationInfo ft0cVariant1Info = CalibrationInfo("FT0Cvar1");
@@ -1212,6 +1222,8 @@ class MultModule
 
       fv0aInfo.mCalibrationStored = false;
       ft0mInfo.mCalibrationStored = false;
+      ft0mColInfo.mCalibrationStored = false;
+      ft0mBcInfo.mCalibrationStored = false;
       ft0aInfo.mCalibrationStored = false;
       ft0cInfo.mCalibrationStored = false;
       ft0cVariant1Info.mCalibrationStored = false;
@@ -1249,6 +1261,10 @@ class MultModule
           getccdb(fv0aInfo, internalOpts.generatorName);
         if (internalOpts.mEnabledTables[kCentFT0Ms] || internalOpts.mEnabledTables[kBCCentFT0Ms])
           getccdb(ft0mInfo, internalOpts.generatorName);
+        if (internalOpts.mEnabledTables[kCentFT0MLightIonAnchorCols])
+          getccdb(ft0mColInfo, internalOpts.generatorName);
+        if (internalOpts.mEnabledTables[kCentFT0MLightIonAnchorBCs])
+          getccdb(ft0mBcInfo, internalOpts.generatorName);
         if (internalOpts.mEnabledTables[kCentFT0As] || internalOpts.mEnabledTables[kBCCentFT0As])
           getccdb(ft0aInfo, internalOpts.generatorName);
         if (internalOpts.mEnabledTables[kCentFT0Cs] || internalOpts.mEnabledTables[kBCCentFT0Cs])
@@ -1286,7 +1302,8 @@ class MultModule
       internalOpts.mEnabledTables[kCentFDDMs] ||
       internalOpts.mEnabledTables[kCentNTPVs] || internalOpts.mEnabledTables[kCentNGlobals] ||
       internalOpts.mEnabledTables[kCentMFTs] || internalOpts.mEnabledTables[kBCCentFT0Ms] ||
-      internalOpts.mEnabledTables[kBCCentFT0As] || internalOpts.mEnabledTables[kBCCentFT0Cs]) {
+      internalOpts.mEnabledTables[kBCCentFT0As] || internalOpts.mEnabledTables[kBCCentFT0Cs] ||
+      internalOpts.mEnabledTables[kCentFT0MLightIonAnchorCols] || internalOpts.mEnabledTables[kCentFT0MLightIonAnchorBCs]) {
       // check and update centrality calibration objects for Run 3
       const auto& firstbc = bcs.begin();
       ConfigureCentralityRun3(ccdb, metadataInfo, firstbc);
@@ -1332,6 +1349,10 @@ class MultModule
           populateTable(cursors.centFV0A, fv0aInfo, mults[iEv].multFV0AZeq, isInelGt0);
         if (internalOpts.mEnabledTables[kCentFT0Ms])
           populateTable(cursors.centFT0M, ft0mInfo, mults[iEv].multFT0AZeq + mults[iEv].multFT0CZeq, isInelGt0);
+        if (internalOpts.mEnabledTables[kCentFT0Ms])
+          populateTable(cursors.centFT0MLightIonAnchorCol, ft0mColInfo, mults[iEv].multFT0AZeq + mults[iEv].multFT0CZeq, isInelGt0);
+        if (internalOpts.mEnabledTables[kCentFT0Ms])
+          populateTable(cursors.centFT0MLightIonAnchorBC, ft0mBcInfo, mults[iEv].multFT0AZeq + mults[iEv].multFT0CZeq, isInelGt0);
         if (internalOpts.mEnabledTables[kCentFT0As])
           populateTable(cursors.centFT0A, ft0aInfo, mults[iEv].multFT0AZeq, isInelGt0);
         if (internalOpts.mEnabledTables[kCentFT0Cs])


### PR DESCRIPTION
This PR adds two new centrality tables, specifically meant for cross checks for light ions.
The approach here is the same approach as in Pb--Pb, where we fit with Glauber+NBD, anchor at 90%, use data for 0-90% and Glauber+NBD for 90-100%. One table is added for a collision based calibration and one table for a bc based calibration. 

Tagging @ddobrigk