### PR TITLE
[PWGUD] Fix wrong offset

### DIFF
--- a/PWGUD/Core/UDHelpers.h
+++ b/PWGUD/Core/UDHelpers.h
@@ -164,7 +164,7 @@ T compatibleBCs(B const& bc, uint64_t const& meanBC, int const& deltaBC, T const
   }
 
   // create bc slice
-  auto bcslice = bcs.rawSlice(minBCId, maxBCId - minBCId + 1);
+  auto bcslice = bcs.rawSlice(minBCId, maxBCId);
   bcs.copyIndexBindings(bcslice);
   LOGF(debug, "  size of slice %d", bcslice.size());
   return bcslice;


### PR DESCRIPTION
@rolavick @amatyja @siragoni 
It appears that I indeed made a mistake in #16790 - `rawSlice()` requires start and end, rather than start and size. Could you please verify this change in analysis and confirm that it is enough?