### PR TITLE
[ALICE3] Compile headers

### DIFF
--- a/ALICE3/ML/CMakeLists.txt
+++ b/ALICE3/ML/CMakeLists.txt
@@ -9,10 +9,6 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-
-add_subdirectory(Core)
-# add_subdirectory(DataModel)
-add_subdirectory(ML)
-add_subdirectory(Tasks)
-add_subdirectory(TableProducer)
-add_subdirectory(Macros)
+o2physics_add_library(A3HfMlCore
+  SOURCES HfMlResponse3Prong.cxx
+  PUBLIC_LINK_LIBRARIES O2Physics::MLCore)

--- a/ALICE3/ML/HfMlResponse3Prong.cxx
+++ b/ALICE3/ML/HfMlResponse3Prong.cxx
@@ -1,0 +1,17 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file HfMlResponse3Prong.cxx
+/// \brief Helper file to provide compilation command for headers.
+///
+/// \author Vít Kučera <vit.kucera@cern.ch>, Inha University
+
+#include "HfMlResponse3Prong.h" // IWYU pragma: keep


### PR DESCRIPTION
Provides missing compile commands needed by Clang-Tidy.