### PR TITLE
[Common] Compile headers

### DIFF
--- a/Common/Tools/PID/CMakeLists.txt
+++ b/Common/Tools/PID/CMakeLists.txt
@@ -16,3 +16,7 @@ o2physics_add_executable(pidparam-tpc-response
 o2physics_add_executable(check-pid-packing
     SOURCES checkPidPacking.cxx
     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore)
+
+o2physics_add_library(pidTPCModule
+  SOURCES pidTPCModule.cxx
+  PUBLIC_LINK_LIBRARIES O2Physics::MLCore)

--- a/Common/Tools/PID/pidTPCModule.cxx
+++ b/Common/Tools/PID/pidTPCModule.cxx
@@ -1,0 +1,17 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file pidTPCModule.cxx
+/// \brief Helper file to provide compilation command for headers.
+///
+/// \author Vít Kučera <vit.kucera@cern.ch>, Inha University
+
+#include "pidTPCModule.h" // IWYU pragma: keep

--- a/Common/Tools/PID/pidTPCModule.h
+++ b/Common/Tools/PID/pidTPCModule.h
@@ -35,7 +35,6 @@
 #include <Framework/Configurable.h>
 #include <Framework/DeviceSpec.h>
 #include <Framework/RunningWorkflowInfo.h>
-#include <Framework/runDataProcessing.h>
 #include <ReconstructionDataFormats/PID.h>
 
 #include <TFile.h>


### PR DESCRIPTION
Provides missing compile commands needed by Clang-Tidy.