### PR TITLE
[PWGEM] Compile headers

### DIFF
--- a/PWGEM/Dilepton/Utils/CMakeLists.txt
+++ b/PWGEM/Dilepton/Utils/CMakeLists.txt
@@ -9,8 +9,6 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-add_subdirectory(Core)
-# add_subdirectory(DataModel)
-add_subdirectory(Tasks)
-add_subdirectory(TableProducer)
-add_subdirectory(Utils)
+o2physics_add_library(EmDileptonMlCore
+  SOURCES EmDileptonMlResponse.cxx
+  PUBLIC_LINK_LIBRARIES O2Physics::MLCore)

--- a/PWGEM/Dilepton/Utils/EmDileptonMlResponse.cxx
+++ b/PWGEM/Dilepton/Utils/EmDileptonMlResponse.cxx
@@ -1,0 +1,22 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file EmDileptonMlResponse.cxx
+/// \brief Helper file to provide compilation command for headers.
+///
+/// \author Vít Kučera <vit.kucera@cern.ch>, Inha University
+
+#include "ElectronModule.h"                  // IWYU pragma: keep
+#include "MlResponseDielectronSingleTrack.h" // IWYU pragma: keep
+#include "MlResponseFwdTrack.h"              // IWYU pragma: keep
+#include "MlResponseO2Track.h"               // IWYU pragma: keep
+#include "MlResponsePID.h"                   // IWYU pragma: keep
+#include "MlResponseSCT.h"                   // IWYU pragma: keep


### PR DESCRIPTION
Provides missing compile commands needed by Clang-Tidy.