### PR TITLE
[PWGHF] Compile headers

### DIFF
--- a/PWGHF/CMakeLists.txt
+++ b/PWGHF/CMakeLists.txt
@@ -9,7 +9,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-# add_subdirectory(Core)
+add_subdirectory(Core)
 # add_subdirectory(DataModel)
 add_subdirectory(TableProducer)
 add_subdirectory(Tasks)

--- a/PWGHF/Core/CMakeLists.txt
+++ b/PWGHF/Core/CMakeLists.txt
@@ -9,6 +9,6 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-add_subdirectory(Core)
-add_subdirectory(TableProducer)
-add_subdirectory(Tasks)
+o2physics_add_library(HfMlCore
+  SOURCES HfMlResponse.cxx
+  PUBLIC_LINK_LIBRARIES O2Physics::MLCore)

--- a/PWGHF/Core/HfMlResponse.cxx
+++ b/PWGHF/Core/HfMlResponse.cxx
@@ -1,0 +1,17 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file HfMlResponse.cxx
+/// \brief Helper file to provide compilation command for headers.
+///
+/// \author Vít Kučera <vit.kucera@cern.ch>, Inha University
+
+#include "HfMlResponse.h" // IWYU pragma: keep

--- a/PWGHF/D2H/Core/CMakeLists.txt
+++ b/PWGHF/D2H/Core/CMakeLists.txt
@@ -9,6 +9,6 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-add_subdirectory(Core)
-add_subdirectory(TableProducer)
-add_subdirectory(Tasks)
+o2physics_add_library(HfDataCreationCharmReso
+  SOURCES DataCreationCharmReso.cxx
+  PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore KFParticle::KFParticle)

--- a/PWGHF/D2H/Core/DataCreationCharmReso.cxx
+++ b/PWGHF/D2H/Core/DataCreationCharmReso.cxx
@@ -1,0 +1,17 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file DataCreationCharmReso.cxx
+/// \brief Helper file to provide compilation command for headers.
+///
+/// \author Vít Kučera <vit.kucera@cern.ch>, Inha University
+
+#include "DataCreationCharmReso.h" // IWYU pragma: keep


### PR DESCRIPTION
Provides missing compile commands needed by Clang-Tidy.