### PR TITLE
[PWGLF] Compile headers

### DIFF
--- a/PWGLF/Utils/CMakeLists.txt
+++ b/PWGLF/Utils/CMakeLists.txt
@@ -24,3 +24,15 @@ o2physics_add_library(collisionCutsGroup
 o2physics_target_root_dictionary(collisionCutsGroup
     HEADERS collisionCutsGroup.h
     LINKDEF collisionCutsGroupLinkDef.h)
+
+o2physics_add_library(LfDecay3bodyBuilderHelper
+    SOURCES decay3bodyBuilderHelper.cxx
+    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore KFParticle::KFParticle)
+
+o2physics_add_library(LfStrangenessBuilderHelper
+    SOURCES strangenessBuilderHelper.cxx
+    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore KFParticle::KFParticle)
+
+o2physics_add_library(LfStrangenessBuilderModule
+    SOURCES strangenessBuilderModule.cxx
+    PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore KFParticle::KFParticle)

--- a/PWGLF/Utils/decay3bodyBuilderHelper.cxx
+++ b/PWGLF/Utils/decay3bodyBuilderHelper.cxx
@@ -14,4 +14,5 @@
 ///
 /// \author Vít Kučera <vit.kucera@cern.ch>, Inha University
 
+// o2-linter: disable=name/workflow-file (not a workflow file)
 #include "decay3bodyBuilderHelper.h" // IWYU pragma: keep

--- a/PWGLF/Utils/decay3bodyBuilderHelper.cxx
+++ b/PWGLF/Utils/decay3bodyBuilderHelper.cxx
@@ -1,0 +1,17 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file decay3bodyBuilderHelper.cxx
+/// \brief Helper file to provide compilation command for headers.
+///
+/// \author Vít Kučera <vit.kucera@cern.ch>, Inha University
+
+#include "decay3bodyBuilderHelper.h" // IWYU pragma: keep

--- a/PWGLF/Utils/strangenessBuilderHelper.cxx
+++ b/PWGLF/Utils/strangenessBuilderHelper.cxx
@@ -14,4 +14,5 @@
 ///
 /// \author Vít Kučera <vit.kucera@cern.ch>, Inha University
 
+// o2-linter: disable=name/workflow-file (not a workflow file)
 #include "strangenessBuilderHelper.h" // IWYU pragma: keep

--- a/PWGLF/Utils/strangenessBuilderHelper.cxx
+++ b/PWGLF/Utils/strangenessBuilderHelper.cxx
@@ -1,0 +1,17 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file strangenessBuilderHelper.cxx
+/// \brief Helper file to provide compilation command for headers.
+///
+/// \author Vít Kučera <vit.kucera@cern.ch>, Inha University
+
+#include "strangenessBuilderHelper.h" // IWYU pragma: keep

--- a/PWGLF/Utils/strangenessBuilderModule.cxx
+++ b/PWGLF/Utils/strangenessBuilderModule.cxx
@@ -1,0 +1,17 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file strangenessBuilderModule.cxx
+/// \brief Helper file to provide compilation command for headers.
+///
+/// \author Vít Kučera <vit.kucera@cern.ch>, Inha University
+
+#include "strangenessBuilderModule.h" // IWYU pragma: keep

--- a/PWGLF/Utils/strangenessBuilderModule.cxx
+++ b/PWGLF/Utils/strangenessBuilderModule.cxx
@@ -14,4 +14,5 @@
 ///
 /// \author Vít Kučera <vit.kucera@cern.ch>, Inha University
 
+// o2-linter: disable=name/workflow-file (not a workflow file)
 #include "strangenessBuilderModule.h" // IWYU pragma: keep


### PR DESCRIPTION
Provides missing compile commands needed by Clang-Tidy.