### PR TITLE
[PWGLF] Update KF cascade building in strangenessBuilderHelper

### DIFF
--- a/PWGLF/Utils/strangenessBuilderHelper.h
+++ b/PWGLF/Utils/strangenessBuilderHelper.h
@@ -1059,6 +1059,11 @@ class strangenessBuilderHelper
       return false;
     }
 
+    // Calculate V0 mass before mass constraint
+    float MLambda, SigmaLambda;
+    KFV0.GetMass(MLambda, SigmaLambda);
+    cascade.kfMLambda = MLambda;
+
     if (kfUseV0MassConstraint) {
       KFV0.SetNonlinearMassConstraint(o2::constants::physics::MassLambda);
     }
@@ -1117,9 +1122,20 @@ class strangenessBuilderHelper
       cascade = {};
       return false;
     }
+
+    // Calculate masses a priori before potentially applying mass constraint
+    // --> this is the invariant mass of the decay products, not the mass-constrained value
+    float MXi, SigmaXi, MOmega, SigmaOmega;
+    KFXi.GetMass(MXi, SigmaXi);
+    KFOmega.GetMass(MOmega, SigmaOmega);
+    cascade.massXi = MXi;
+    cascade.massOmega = MOmega;
+
     if (kfUseCascadeMassConstraint) {
       // set mass constraint if requested
       // WARNING: this is only adequate for decay chains, i.e. XiC -> Xi or OmegaC -> Omega
+      // WARNING: be aware of the fact that if enabled, the stored particle momentum and covariance matrix will be mass-constrained
+      // while the stored mass will be the invariant mass of the decay products (i.e. not mass-constrained)
       KFXi.SetNonlinearMassConstraint(o2::constants::physics::MassXiMinus);
       KFOmega.SetNonlinearMassConstraint(o2::constants::physics::MassOmegaMinus);
     }
@@ -1214,15 +1230,6 @@ class strangenessBuilderHelper
       return false;
     }
     cascade.pointingAngle = TMath::ACos(cosPA);
-
-    // Calculate masses a priori
-    float MLambda, SigmaLambda, MXi, SigmaXi, MOmega, SigmaOmega;
-    KFV0.GetMass(MLambda, SigmaLambda);
-    KFXi.GetMass(MXi, SigmaXi);
-    KFOmega.GetMass(MOmega, SigmaOmega);
-    cascade.kfMLambda = MLambda;
-    cascade.massXi = MXi;
-    cascade.massOmega = MOmega;
 
     // KF Cascade covariance matrix
     std::array<float, 21> covCascKF;


### PR DESCRIPTION
Update LF strangenessbuilderHelper KF cascade building: 
- store unconstrained V0 and cascade masses in StoredKFCascCores table in all cases

Hi @ddobrigk and @romainschotter :) 
I noticed that in the KF cascade building I had implemented the computation of the V0 and cascade masses in a way that the constrained masses (PDG masses) are stored in the StoredKFCascCores table in case the mass constraints are enabled. On the one hand this makes sense from the point of view of storing consistently the constrained particle parameters (mom, E, mass) and covariance matrix. But on the other hand it is essential to store the unconstrained invariant mass to for example apply selections on it. In our case of the Xic to Xipipi analysis of triggered data with the KF we indeed need the unconstrained V0 and cascade masses while using the constrained parameters.
I therefore updated the strangenessBuilderHelper accordingly in this PR. I would be happy to have your thoughts on this, maybe there is a better way to do it. :)
I am not aware of any other analysis using the KF cascade building. Do you know of anyone whom we should include in this discussion/update?