### PR TITLE
[PWGEM] Fix clang-tidy warnings and errors in EMCal cuts related files

### DIFF
--- a/PWGEM/PhotonMeson/Core/EMBitFlags.cxx
+++ b/PWGEM/PhotonMeson/Core/EMBitFlags.cxx
@@ -33,7 +33,7 @@ std::size_t EMBitFlags::size() const
 bool EMBitFlags::test(std::size_t i) const
 {
   assert(i < mSize);
-  return mBits[word(i)] & mask(i);
+  return static_cast<bool>(mBits[word(i)] & mask(i));
 }
 
 void EMBitFlags::set(std::size_t i)

--- a/PWGEM/PhotonMeson/Core/EMBitFlags.h
+++ b/PWGEM/PhotonMeson/Core/EMBitFlags.h
@@ -33,11 +33,11 @@ class EMBitFlags
   explicit EMBitFlags(std::size_t nBits = 0);
 
   /// \brief get number of stored bits
-  std::size_t size() const;
+  [[nodiscard]] std::size_t size() const;
 
   /// \brief check bit i
   /// \param i index of bit that should be checked
-  bool test(std::size_t i) const;
+  [[nodiscard]] bool test(std::size_t i) const;
 
   /// \brief set bit i
   /// \param i index of bit which value should be set

--- a/PWGEM/PhotonMeson/Core/EMCPhotonCut.cxx
+++ b/PWGEM/PhotonMeson/Core/EMCPhotonCut.cxx
@@ -19,15 +19,11 @@
 
 #include <Framework/Logger.h>
 
-#include <Rtypes.h>
-
 #include <string>
 
-ClassImp(EMCPhotonCut);
+std::array<std::string, static_cast<std::size_t>(EMCPhotonCut::EMCPhotonCuts::kNCuts)> EMCPhotonCut::mCutNames = {"Definition", "Energy", "NCell", "M02", "Timing", "TrackMatching", "SecTrackMatching", "Exotic"};
 
-const char* EMCPhotonCut::mCutNames[static_cast<int>(EMCPhotonCut::EMCPhotonCuts::kNCuts)] = {"Definition", "Energy", "NCell", "M02", "Timing", "TrackMatching", "SecTrackMatching", "Exotic"};
-
-void EMCPhotonCut::SetClusterizer(std::string clusterDefinitionString)
+void EMCPhotonCut::SetClusterizer(const std::string& clusterDefinitionString)
 {
   mDefinition = static_cast<int>(o2::aod::emcalcluster::getClusterDefinitionFromString(clusterDefinitionString));
   LOG(info) << "EMCal Photon Cut, set cluster definition to: " << mDefinition << " (" << clusterDefinitionString << ")";

--- a/PWGEM/PhotonMeson/Core/EMCPhotonCut.h
+++ b/PWGEM/PhotonMeson/Core/EMCPhotonCut.h
@@ -130,10 +130,10 @@ class EMCPhotonCut
     kSecondary,
   };
 
-  const std::string getName() const { return name; }
-  const std::string getTitle() const { return title; }
+  std::string getName() const { return name; }
+  std::string getTitle() const { return title; }
 
-  static const char* mCutNames[static_cast<int>(EMCPhotonCuts::kNCuts)];
+  static std::array<std::string, static_cast<std::size_t>(EMCPhotonCut::EMCPhotonCuts::kNCuts)> mCutNames;
 
   static constexpr auto getClusterId(o2::soa::is_iterator auto const& t)
   {
@@ -253,7 +253,7 @@ class EMCPhotonCut
   void fillBeforeClusterHistogram(o2::soa::is_iterator auto const& cluster, o2::framework::HistogramRegistry* fRegistry = nullptr) const
   {
 
-    if (mDoQA == false || fRegistry == nullptr) {
+    if (!mDoQA || fRegistry == nullptr) {
       return;
     }
 
@@ -269,7 +269,7 @@ class EMCPhotonCut
   void fillAfterClusterHistogram(o2::soa::is_iterator auto const& cluster, o2::framework::HistogramRegistry* fRegistry = nullptr) const
   {
 
-    if (mDoQA == false || fRegistry == nullptr) {
+    if (!mDoQA || fRegistry == nullptr) {
       return;
     }
 
@@ -421,8 +421,6 @@ class EMCPhotonCut
         return mMinTime <= cluster.time() && cluster.time() <= mMaxTime;
 
       case EMCPhotonCuts::kTM:
-        return false;
-
       case EMCPhotonCuts::kSecondaryTM:
         return false;
 
@@ -593,7 +591,7 @@ class EMCPhotonCut
   // Setters
   /// \brief Set clusterizer
   /// \param clusterDefinitionString name of the clusterizer
-  void SetClusterizer(std::string clusterDefinitionString = "kV3Default");
+  void SetClusterizer(const std::string& clusterDefinitionString = "kV3Default");
 
   /// \brief Set minimum cluster energy
   /// \param min minimum cluster energy
@@ -639,7 +637,7 @@ class EMCPhotonCut
   /// \param c c in a + (pT + b)^c
   void SetTrackMatchingEtaParams(float a, float b, float c)
   {
-    mTrackMatchingEtaParams = {a, b, c};
+    mTrackMatchingEtaParams = {.a = a, .b = b, .c = c};
   }
 
   /// \brief Set parameters for track matching delta phi = a + (pT + b)^c
@@ -648,7 +646,7 @@ class EMCPhotonCut
   /// \param c c in a + (pT + b)^c
   void SetTrackMatchingPhiParams(float a, float b, float c)
   {
-    mTrackMatchingPhiParams = {a, b, c};
+    mTrackMatchingPhiParams = {.a = a, .b = b, .c = c};
   }
 
   /// \brief Set parameters for secondary track matching delta eta = a + (pT + b)^c
@@ -657,7 +655,7 @@ class EMCPhotonCut
   /// \param c c in a + (pT + b)^c
   void SetSecTrackMatchingEtaParams(float a, float b, float c)
   {
-    mSecTrackMatchingEtaParams = {a, b, c};
+    mSecTrackMatchingEtaParams = {.a = a, .b = b, .c = c};
   }
 
   /// \brief Set parameters for secondary track matching delta phi = a + (pT + b)^c
@@ -666,7 +664,7 @@ class EMCPhotonCut
   /// \param c c in a + (pT + b)^c
   void SetSecTrackMatchingPhiParams(float a, float b, float c)
   {
-    mSecTrackMatchingPhiParams = {a, b, c};
+    mSecTrackMatchingPhiParams = {.a = a, .b = b, .c = c};
   }
 
   /// \brief calculate delta eta for track matching at given track pT
@@ -721,10 +719,10 @@ class EMCPhotonCut
   mutable uint nAccClusterPerColl{0}; ///< running number of accepted cluster per collision used for QA
   mutable int currentCollID{-1};      ///< running collision ID of clusters used for QA
 
-  TrackMatchingParams mTrackMatchingEtaParams = {-1.f, 0.f, 0.f};
-  TrackMatchingParams mTrackMatchingPhiParams = {-1.f, 0.f, 0.f};
-  TrackMatchingParams mSecTrackMatchingEtaParams = {-1.f, 0.f, 0.f};
-  TrackMatchingParams mSecTrackMatchingPhiParams = {-1.f, 0.f, 0.f};
+  TrackMatchingParams mTrackMatchingEtaParams = {.a = -1.f, .b = 0.f, .c = 0.f};
+  TrackMatchingParams mTrackMatchingPhiParams = {.a = -1.f, .b = 0.f, .c = 0.f};
+  TrackMatchingParams mSecTrackMatchingEtaParams = {.a = -1.f, .b = 0.f, .c = 0.f};
+  TrackMatchingParams mSecTrackMatchingPhiParams = {.a = -1.f, .b = 0.f, .c = 0.f};
 };
 
 #endif // PWGEM_PHOTONMESON_CORE_EMCPHOTONCUT_H_

--- a/PWGEM/PhotonMeson/Core/EMCPhotonCut.h
+++ b/PWGEM/PhotonMeson/Core/EMCPhotonCut.h
@@ -130,8 +130,8 @@ class EMCPhotonCut
     kSecondary,
   };
 
-  std::string getName() const { return name; }
-  std::string getTitle() const { return title; }
+  const std::string& getName() const { return name; }
+  const std::string& getTitle() const { return title; }
 
   static std::array<std::string, static_cast<std::size_t>(EMCPhotonCut::EMCPhotonCuts::kNCuts)> mCutNames;
 

--- a/PWGEM/PhotonMeson/Tasks/emcalQC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/emcalQC.cxx
@@ -99,7 +99,8 @@ struct EmcalQC {
 
   struct : ConfigurableGroup {
     std::string prefix = "axis_group";
-    ConfigurableAxis thnConfigAxisE{"thnConfigAxisE", {100, 0., 20.}, "pT axis for photon candidates"};
+    ConfigurableAxis thnConfigAxisE{"thnConfigAxisE", {100, 0., 20.}, "energy axis for photon candidates"};
+    ConfigurableAxis thnConfigAxisPt{"thnConfigAxisPt", {100, 0., 20.}, "pT axis for matched tracks"};
   } axisGroup;
 
   void defineEMEventCut()
@@ -151,7 +152,8 @@ struct EmcalQC {
     defineEMCCut();
     defineEMEventCut();
 
-    const AxisSpec thnAxisE{axisGroup.thnConfigAxisE, "#it{p}_{T} (GeV/#it{c})"};
+    const AxisSpec thnAxisE{axisGroup.thnConfigAxisE, "#it{E}} (GeV)"};
+    const AxisSpec thnAxisPt{axisGroup.thnConfigAxisPt, "#it{p}_{T} (GeV/#it{c})"};
     const AxisSpec thAxisdEta{200, -0.06, 0.06, "#Delta#eta"};
     const AxisSpec thAxisdPhi{200, -0.06, 0.06, "#Delta#varphi (rad)"};
 
@@ -171,6 +173,11 @@ struct EmcalQC {
       fRegistry.add("Cluster/hDeltaEtaPhiClosestPrimTracks", "#Delta#eta #Delta#varphi distribution of the Closest matched prim. track", HistType::kTH3D, {thAxisdEta, thAxisdPhi, thnAxisE}, false);
       fRegistry.add("Cluster/hDeltaEtaPhiAllSecTracks", "#Delta#eta #Delta#varphi distribution of all matched sec. tracks", HistType::kTH3D, {thAxisdEta, thAxisdPhi, thnAxisE}, false);
       fRegistry.add("Cluster/hDeltaEtaPhiClosestSecTracks", "#Delta#eta #Delta#varphi distribution of the Closest matched sec. track", HistType::kTH3D, {thAxisdEta, thAxisdPhi, thnAxisE}, false);
+
+      fRegistry.add("Cluster/hDeltaEtaPhiAllPrimTracksTrackPt", "#Delta#eta #Delta#varphi distribution of all matched prim. tracks", HistType::kTH3D, {thAxisdEta, thAxisdPhi, thnAxisPt}, false);
+      fRegistry.add("Cluster/hDeltaEtaPhiClosestPrimTracksTrackPt", "#Delta#eta #Delta#varphi distribution of the Closest matched prim. track", HistType::kTH3D, {thAxisdEta, thAxisdPhi, thnAxisPt}, false);
+      fRegistry.add("Cluster/hDeltaEtaPhiAllSecTracksTrackPt", "#Delta#eta #Delta#varphi distribution of all matched sec. tracks", HistType::kTH3D, {thAxisdEta, thAxisdPhi, thnAxisPt}, false);
+      fRegistry.add("Cluster/hDeltaEtaPhiClosestSecTracksTrackPt", "#Delta#eta #Delta#varphi distribution of the Closest matched sec. track", HistType::kTH3D, {thAxisdEta, thAxisdPhi, thnAxisPt}, false);
     }
   }
 
@@ -294,16 +301,20 @@ struct EmcalQC {
       if (primTracksPerCluster.size() > 0) {
         const auto closestPrimTrack = primTracksPerCluster.begin();
         fRegistry.fill(HIST("Cluster/hDeltaEtaPhiClosestPrimTracks"), closestPrimTrack.deltaEta(), closestPrimTrack.deltaPhi(), cluster.e());
+        fRegistry.fill(HIST("Cluster/hDeltaEtaPhiClosestPrimTracksTrackPt"), closestPrimTrack.deltaEta(), closestPrimTrack.deltaPhi(), closestPrimTrack.trackPt());
       }
       for (const auto& matchedPrimTrack : primTracksPerCluster) {
         fRegistry.fill(HIST("Cluster/hDeltaEtaPhiAllPrimTracks"), matchedPrimTrack.deltaEta(), matchedPrimTrack.deltaPhi(), cluster.e());
+        fRegistry.fill(HIST("Cluster/hDeltaEtaPhiAllPrimTracksTrackPt"), matchedPrimTrack.deltaEta(), matchedPrimTrack.deltaPhi(), matchedPrimTrack.trackPt());
       }
       if (secTracksPerCluster.size() > 0) {
         const auto closestSecTrack = secTracksPerCluster.begin();
         fRegistry.fill(HIST("Cluster/hDeltaEtaPhiClosestSecTracks"), closestSecTrack.deltaEta(), closestSecTrack.deltaPhi(), cluster.e());
+        fRegistry.fill(HIST("Cluster/hDeltaEtaPhiClosestSecTracksTrackPt"), closestSecTrack.deltaEta(), closestSecTrack.deltaPhi(), closestSecTrack.trackPt());
       }
       for (const auto& matchedSecTrack : secTracksPerCluster) {
         fRegistry.fill(HIST("Cluster/hDeltaEtaPhiAllSecTracks"), matchedSecTrack.deltaEta(), matchedSecTrack.deltaPhi(), cluster.e());
+        fRegistry.fill(HIST("Cluster/hDeltaEtaPhiAllSecTracksTrackPt"), matchedSecTrack.deltaEta(), matchedSecTrack.deltaPhi(), matchedSecTrack.trackPt());
       }
 
       if (!fEMCCut.IsSelectedEMCal(EMCPhotonCut::EMCPhotonCuts::kTM, cluster, primTracksPerCluster)) { // Check whether cluster passes this cluster requirement, if not, fill why in the next row


### PR DESCRIPTION
- Fix clang-tidy warnings and errors in EMCal cuts related files.
- Add emcal qc histogram to have cluster track matching as function of track pT