### PR TITLE
[Common] Protect TOF PID tasks against empty collision tables

### DIFF
--- a/Common/TableProducer/PID/pidTOFBase.cxx
+++ b/Common/TableProducer/PID/pidTOFBase.cxx
@@ -358,7 +358,7 @@ struct tofEventTime {
   using ResponseImplementationEvTime = o2::pid::tof::ExpTimes<TrksEvTime::iterator, pid>;
   using EvTimeCollisions = soa::Join<aod::Collisions, aod::EvSels>;
   void processNoFT0(TrksEvTime const& tracks,
-                    EvTimeCollisions const&)
+                    EvTimeCollisions const& collisions)
   {
     if (!enableTable) {
       return;
@@ -372,7 +372,7 @@ struct tofEventTime {
 
     int lastCollisionId = -1;                                                                                    // Last collision ID analysed
     for (auto const& t : tracks) {                                                                               // Loop on collisions
-      if (!t.has_collision() || ((sel8TOFEvTime.value == true) && !t.collision_as<EvTimeCollisions>().sel8())) { // Track was not assigned, cannot compute event time or event did not pass the event selection
+      if (!t.has_collision() || collisions.size() == 0 || ((sel8TOFEvTime.value == true) && !t.collision_as<EvTimeCollisions>().sel8())) { // Track was not assigned, cannot compute event time or event did not pass the event selection
         tableFlags(0);
         tableEvTime(0.f, 999.f);
         if (enableTableTOFOnly) {
@@ -420,7 +420,7 @@ struct tofEventTime {
   using EvTimeCollisionsFT0 = soa::Join<EvTimeCollisions, aod::FT0sCorrected>;
   void processFT0(TrksEvTime const& tracks,
                   aod::FT0s const&,
-                  EvTimeCollisionsFT0 const&)
+                  EvTimeCollisionsFT0 const& collisions)
   {
     if (!enableTable) {
       return;
@@ -434,7 +434,7 @@ struct tofEventTime {
 
     int lastCollisionId = -1;                                                                                       // Last collision ID analysed
     for (auto const& t : tracks) {                                                                                  // Loop on collisions
-      if (!t.has_collision() || ((sel8TOFEvTime.value == true) && !t.collision_as<EvTimeCollisionsFT0>().sel8())) { // Track was not assigned, cannot compute event time or event did not pass the event selection
+      if (!t.has_collision() || collisions.size() == 0 || ((sel8TOFEvTime.value == true) && !t.collision_as<EvTimeCollisionsFT0>().sel8())) { // Track was not assigned, cannot compute event time or event did not pass the event selection
         tableFlags(0);
         tableEvTime(0.f, 999.f);
         if (enableTableTOFOnly) {
@@ -515,7 +515,7 @@ struct tofEventTime {
   /// Process function to prepare the event for each track on Run 3 data with only the FT0
   void processOnlyFT0(TrksEvTime const& tracks,
                       aod::FT0s const&,
-                      EvTimeCollisionsFT0 const&)
+                      EvTimeCollisionsFT0 const& collisions)
   {
     if (!enableTable) {
       return;
@@ -531,7 +531,7 @@ struct tofEventTime {
       if (enableTableTOFOnly) {
         tableEvTimeTOFOnly((uint8_t)0, 0.f, 0.f, -1);
       }
-      if (!t.has_collision()) { // Track was not assigned, cannot compute event time
+      if (!t.has_collision() || collisions.size() == 0) { // Track was not assigned, cannot compute event time
         tableFlags(0);
         tableEvTime(0.f, 999.f);
         continue;

--- a/Common/TableProducer/PID/pidTOFFull.cxx
+++ b/Common/TableProducer/PID/pidTOFFull.cxx
@@ -286,7 +286,7 @@ struct tofPidFull {
   Preslice<Trks> perCollision = aod::track::collisionId;
   template <o2::track::PID::ID pid>
   using ResponseImplementation = o2::pid::tof::ExpTimes<Trks::iterator, pid>;
-  void processWSlice(Trks const& tracks, aod::Collisions const&, aod::BCsWithTimestamps const&)
+  void processWSlice(Trks const& tracks, aod::Collisions const& collisions, aod::BCsWithTimestamps const&)
   {
     constexpr auto responseEl = ResponseImplementation<PID::Electron>();
     constexpr auto responseMu = ResponseImplementation<PID::Muon>();
@@ -305,7 +305,7 @@ struct tofPidFull {
     int lastCollisionId = -1;          // Last collision ID analysed
     float resolution = 1.f;            // Last resolution assigned
     for (auto const& track : tracks) { // Loop on all tracks
-      if (!track.has_collision()) {    // Track was not assigned, cannot compute NSigma (no event time) -> filling with empty table
+      if (!track.has_collision() || collisions.size() == 0) { // Track was not assigned, cannot compute NSigma (no event time) -> filling with empty table
         for (auto const& pidId : mEnabledParticles) {
           makeTableEmpty(pidId);
         }
@@ -392,7 +392,7 @@ struct tofPidFull {
   using TrksIU = soa::Join<aod::TracksIU, aod::TracksExtra, aod::TOFSignal, aod::TOFEvTime, aod::pidEvTimeFlags>;
   template <o2::track::PID::ID pid>
   using ResponseImplementationIU = o2::pid::tof::ExpTimes<TrksIU::iterator, pid>;
-  void processWoSlice(TrksIU const& tracks, aod::Collisions const&, aod::BCsWithTimestamps const&)
+  void processWoSlice(TrksIU const& tracks, aod::Collisions const& collisions, aod::BCsWithTimestamps const&)
   {
     constexpr auto responseEl = ResponseImplementationIU<PID::Electron>();
     constexpr auto responseMu = ResponseImplementationIU<PID::Muon>();
@@ -409,7 +409,7 @@ struct tofPidFull {
     }
     float resolution = 1.f;            // Last resolution assigned
     for (auto const& track : tracks) { // Loop on all tracks
-      if (!track.has_collision()) {    // Track was not assigned, cannot compute NSigma (no event time) -> filling with empty table
+      if (!track.has_collision() || collisions.size() == 0) { // Track was not assigned, cannot compute NSigma (no event time) -> filling with empty table
         for (auto const& pidId : mEnabledParticles) {
           makeTableEmpty(pidId);
         }

--- a/Common/TableProducer/PID/pidTOFMerge.cxx
+++ b/Common/TableProducer/PID/pidTOFMerge.cxx
@@ -334,7 +334,7 @@ struct tofEventTime {
   ///
   /// Process function to prepare the event for each track on Run 2 data
   void processRun2(aod::Tracks const& tracks,
-                   aod::Collisions const&,
+                   aod::Collisions const& collisions,
                    aod::BCsWithTimestamps const& bcs)
   {
     if (!enableTableTOFEvTime) {
@@ -346,7 +346,7 @@ struct tofEventTime {
     tableFlags.reserve(tracks.size());
 
     for (auto const& t : tracks) { // Loop on collisions
-      if (!t.has_collision()) {    // Track was not assigned, cannot compute event time
+      if (!t.has_collision() || collisions.size() == 0) { // Track was not assigned, cannot compute event time
         tableFlags(0);
         tableEvTime(0.f, 999.f);
         continue;
@@ -365,7 +365,7 @@ struct tofEventTime {
   using ResponseImplementationEvTime = o2::pid::tof::ExpTimes<Run3TrksWtof::iterator, pid>;
   void processRun3(Run3TrksWtof const& tracks,
                    aod::FT0s const&,
-                   EvTimeCollisionsFT0 const&,
+                   EvTimeCollisionsFT0 const& collisions,
                    aod::BCsWithTimestamps const& bcs)
   {
     if (!enableTableTOFEvTime) {
@@ -401,7 +401,7 @@ struct tofEventTime {
     if (mComputeEvTimeWithTOF == 1 && mComputeEvTimeWithFT0 == 1) {
       int lastCollisionId = -1;                                                                                       // Last collision ID analysed
       for (auto const& t : tracks) {                                                                                  // Loop on collisions
-        if (!t.has_collision() || ((sel8TOFEvTime.value == true) && !t.collision_as<EvTimeCollisionsFT0>().sel8())) { // Track was not assigned, cannot compute event time or event did not pass the event selection
+        if (!t.has_collision() || collisions.size() == 0 || ((sel8TOFEvTime.value == true) && !t.collision_as<EvTimeCollisionsFT0>().sel8())) { // Track was not assigned, cannot compute event time or event did not pass the event selection
           tableFlags(0);
           tableEvTime(0.f, 999.f);
           if (enableTableEvTimeTOFOnly) {
@@ -477,7 +477,7 @@ struct tofEventTime {
     } else if (mComputeEvTimeWithTOF == 1 && mComputeEvTimeWithFT0 == 0) {
       int lastCollisionId = -1;                                                                                    // Last collision ID analysed
       for (auto const& t : tracks) {                                                                               // Loop on collisions
-        if (!t.has_collision() || ((sel8TOFEvTime.value == true) && !t.collision_as<EvTimeCollisions>().sel8())) { // Track was not assigned, cannot compute event time or event did not pass the event selection
+        if (!t.has_collision() || collisions.size() == 0 || ((sel8TOFEvTime.value == true) && !t.collision_as<EvTimeCollisions>().sel8())) { // Track was not assigned, cannot compute event time or event did not pass the event selection
           tableFlags(0);
           tableEvTime(0.f, 999.f);
           if (enableTableEvTimeTOFOnly) {
@@ -522,7 +522,7 @@ struct tofEventTime {
         if (enableTableEvTimeTOFOnly) {
           tableEvTimeTOFOnly((uint8_t)0, 0.f, 0.f, -1);
         }
-        if (!t.has_collision()) { // Track was not assigned, cannot compute event time
+        if (!t.has_collision() || collisions.size() == 0) { // Track was not assigned, cannot compute event time
           tableFlags(0);
           tableEvTime(0.f, 999.f);
           continue;
@@ -881,7 +881,7 @@ struct tofPidMerge {
   template <o2::track::PID::ID pid>
   using ResponseImplementation = o2::pid::tof::ExpTimes<Run3TrksWtofWevTime::iterator, pid>;
   void processRun3(Run3TrksWtofWevTime const& tracks,
-                   aod::Collisions const&,
+                   aod::Collisions const& collisions,
                    aod::BCsWithTimestamps const& bcs)
   {
     constexpr auto responseEl = ResponseImplementation<PID::Electron>();
@@ -907,7 +907,7 @@ struct tofPidMerge {
     float resolution = 1.f; // Last resolution assigned
     float nsigma = 0;
     for (auto const& trk : tracks) { // Loop on all tracks
-      if (!trk.has_collision()) {    // Track was not assigned, cannot compute NSigma (no event time) -> filling with empty table
+      if (!trk.has_collision() || collisions.size() == 0) { // Track was not assigned, cannot compute NSigma (no event time) -> filling with empty table
         for (auto const& pidId : mEnabledParticles) {
           makeTableEmpty(pidId, false);
         }
@@ -1043,7 +1043,7 @@ struct tofPidMerge {
   template <o2::track::PID::ID pid>
   using ResponseImplementationRun2 = o2::pid::tof::ExpTimes<Run2TrksWtofWevTime::iterator, pid>;
   void processRun2(Run2TrksWtofWevTime const& tracks,
-                   aod::Collisions const&,
+                   aod::Collisions const& collisions,
                    aod::BCsWithTimestamps const& bcs)
   {
     constexpr auto responseEl = ResponseImplementationRun2<PID::Electron>();
@@ -1069,7 +1069,7 @@ struct tofPidMerge {
     float resolution = 1.f; // Last resolution assigned
     float nsigma = 0;
     for (auto const& trk : tracks) { // Loop on all tracks
-      if (!trk.has_collision()) {    // Track was not assigned, cannot compute NSigma (no event time) -> filling with empty table
+      if (!trk.has_collision() || collisions.size() == 0) { // Track was not assigned, cannot compute NSigma (no event time) -> filling with empty table
         for (auto const& pidId : mEnabledParticles) {
           makeTableEmpty(pidId, false);
         }


### PR DESCRIPTION
This PR adds the same protection as [#16935](https://github.com/AliceO2Group/O2Physics/pull/16935,) for the TOF PID tasks.

It covers very rare AO2Ds from MC productions that do not contain any reconstructed collision. In these cases, all tracks have `collisionId = 0`, while the collision table is empty. The current code can therefore crash when trying to access the 0-th collision entry, which is not allocated.

The affected TOF PID paths now check that the collision table is non-empty before dereferencing the collision associated to a track.

Tagging @fgrosa for info! 