### PR TITLE
[Tools] Modified MlResponse numInputNodes check: usage of dynamic input

### DIFF
--- a/Tools/ML/MlResponse.h
+++ b/Tools/ML/MlResponse.h
@@ -185,7 +185,8 @@ class MlResponse
     const int numInputNodes = mModels[nModel].getNumInputNodes();
     const int numInputFeatures = static_cast<int>(input.size());
 
-    if (numInputNodes != numInputFeatures) {
+    // Check that the number of input nodes in the model is equal to the number of input features, except for the case where the model input is dynamic (numInputNodes == -1)
+    if (numInputNodes != numInputFeatures && numInputNodes >= 0) {
       LOG(fatal) << "Number of input nodes in the model " << mPaths[nModel] << " is different from the number of input features to be tested (" << numInputNodes << " vs " << numInputFeatures << ")";
     }
 


### PR DESCRIPTION
Tools/ML/MlResponse.h
- Code lines added by lubynet at June 18th disabled the usage of inputs with dynamic sizes, which correspond to numInputNodes == -1. This must be allowed to use models with dynamic inputs, such as the GNN-based b-jet tagger.

Please consider applying this change. Thank you in advance.