### PR TITLE
[Common] TrackTuner: fix mean shift.

### DIFF
--- a/Common/Tools/TrackTuner.h
+++ b/Common/Tools/TrackTuner.h
@@ -940,7 +940,7 @@ struct TrackTuner : o2::framework::ConfigurableGroup {
 
       // double dd0mrpn=std::abs(sd0mrpn)-std::abs(sd0mrpo);
       // double deltaDcaXYmean = std::abs(dcaXYMeanData) - std::abs(dcaXYMeanMC) ;
-      double deltaDcaXYmean = dcaXYMeanData - dcaXYMeanMC;
+      double deltaDcaXYmean = dcaXYMeanData; // - dcaXYMeanMC; // Remove the shift of the mean, already introduced in deltaDcaXYTuned
 
       // double d0rpn =d0rpmc+dd0rpn-dd0mrpn;
       double trackParDcaXYTuned = trackParDcaXYMC + deltaDcaXYTuned + deltaDcaXYmean;


### PR DESCRIPTION
This PR fixes a conceptual mistake in the dca mean shift applied with the TrackTuner (with no impact for current analyses, see later).
From the PR https://github.com/AliceO2Group/O2Physics/pull/7009 the dca correction is the following:

<img width="771" height="173" alt="Schermata del 2026-07-16 14-05-31" src="https://github.com/user-attachments/assets/b16cbd1c-75e3-40aa-8454-88eaf7960068" />

In particular, that PR introduced the subtraction of the dcaMC mean from the reco dca in MC, in order to center it at 0 when computing the residual to the generated y parameter, i.e. in the calculation of the dca resolution term. This operation already centers the reconstructed dca in MC to 0, i.e. the `-<dcaXYMC_reco>` term in the 3rd row is a leftover. In this PR we remove this term, ending up with the following formula:

<img width="771" height="180" alt="Schermata del 2026-07-16 14-09-17" src="https://github.com/user-attachments/assets/7de2d451-9f94-4f78-961b-e697448b50e0" />

In particular, this formula now provides a robust correction, which in the ideal case of MC perfectly matching the data returns exactly the reconstructed dca in MC as it is.

The discussed issue is fixed with this PR. However, this should be totally transparent in analysis given that the dca mean in MC looks always at 0. Below some plots with some tests done on the pp reference HF MC `LHC25b4a6`, showing the performance of the mean and sigma w/o the usage of the TrackTuner (black), with the usage of the TrackTuner as in O2Physics up to now (violet) and with the usage of the TrackTuner as fixed in this PR (green). As expected, the TrackTuner changes the mean and resolution of the DCA, but the fix in the TrackTuner mean shift of this PR does not have a big impact given that `<dca_MC>=0` (in other words: the violet and the green points coincide, even if the green are conceptually more correct).

Mean:

<img width="598" height="576" alt="can_meanUpgrDcaXY" src="https://github.com/user-attachments/assets/2d669c0f-8590-4221-b596-0c4ddddb8fd9" />
<img width="598" height="576" alt="can_meanUpgrDcaZ" src="https://github.com/user-attachments/assets/240fdbde-49bd-410e-8de0-f99a05203ed6" />
<img width="598" height="576" alt="can_withPvRefit_meanUpgrDcaXY" src="https://github.com/user-attachments/assets/481bc9bc-e253-4cd1-8ba6-d0f62b6c6f2f" />
<img width="598" height="576" alt="can_withPvRefit_meanUpgrDcaZ" src="https://github.com/user-attachments/assets/fb24c2f7-b455-44f9-90e7-0bb5bc52145c" />




Resolution:
<img width="598" height="576" alt="can_resUpgrDcaXY" src="https://github.com/user-attachments/assets/394511d7-37ad-4310-a206-718456cc7f4d" />
<img width="598" height="576" alt="can_resDcUpgraZ" src="https://github.com/user-attachments/assets/104105d6-0ce6-42a8-a117-f45d7c77455a" />
<img width="598" height="576" alt="can_withPvRefit_resUpgrDcaXY" src="https://github.com/user-attachments/assets/4ab719db-ad95-45a8-8a95-27c4d5ada067" />
<img width="598" height="576" alt="can_withPvRefit_resUpgrDcaZ" src="https://github.com/user-attachments/assets/ad4e1f69-f2ab-4d42-b6ab-247062524ac3" />

Thanks @fchinu for spotting it.
Tagging also @arossi81 and @phymanshu for info

