### PR TITLE
[PWGCF] FemtoUniverse: Add tables for full TOF and TPC nSigma, fix linter and code check issues

### DIFF
--- a/PWGCF/FemtoUniverse/DataModel/FemtoDerived.h
+++ b/PWGCF/FemtoUniverse/DataModel/FemtoDerived.h
@@ -24,6 +24,7 @@
 #include <Framework/AnalysisDataModel.h>
 #include <Framework/Expressions.h>
 
+#include <array>
 #include <cmath>
 #include <cstdint>
 #include <string_view>
@@ -75,8 +76,8 @@ enum ParticleType {
   kNParticleTypes   //! Number of particle types
 };
 
-static constexpr std::string_view ParticleTypeName[kNParticleTypes] = {"Tracks", "MCTruthTracks", "V0", "V0Child", "Cascade", "CascadeV0Child", "CascadeBachelor", "Phi", "PhiChild", "D0", "D0Child"}; //! Naming of the different particle types
-static constexpr std::string_view TempFitVarName[kNParticleTypes] = {"/hDCAxy", "/hPDGvspT", "/hCPA", "/hDCAxy", "/hCPA", "/hDCAxy", "/hInvMass", "/hDCAxy", "/hInvMass", "/hDCAxy"};
+static constexpr std::array<std::string_view, kNParticleTypes> ParticleTypeName = {"Tracks", "MCTruthTracks", "V0", "V0Child", "Cascade", "CascadeV0Child", "CascadeBachelor", "Phi", "PhiChild", "D0", "D0Child"}; //! Naming of the different particle types
+static constexpr std::array<std::string_view, kNParticleTypes> TempFitVarName = {"/hDCAxy", "/hPDGvspT", "/hCPA", "/hDCAxy", "/hCPA", "/hDCAxy", "/hInvMass", "/hDCAxy", "/hInvMass", "/hDCAxy"};
 
 using CutContainerType = uint32_t; //! Definition of the data type for the bit-wise container for the different selection criteria
 
@@ -88,7 +89,7 @@ enum TrackType {
   kNTrackTypes //! Number of child types
 };
 
-static constexpr std::string_view TrackTypeName[kNTrackTypes] = {"Trk", "Pos", "Neg", "Bach"}; //! Naming of the different particle types
+static constexpr std::array<std::string_view, kNTrackTypes> TrackTypeName = {"Trk", "Pos", "Neg", "Bach"}; //! Naming of the different particle types
 
 DECLARE_SOA_INDEX_COLUMN(FdCollision, fdCollision);
 DECLARE_SOA_COLUMN(Pt, pt, float);                       //! p_T (GeV/c)
@@ -123,13 +124,25 @@ DECLARE_SOA_DYNAMIC_COLUMN(P, p, //! Compute the overall momentum in GeV/c
                              return pt * std::cosh(eta);
                            });
 
-DECLARE_SOA_COLUMN(ITSNSigmaEl, itsNSigmaEl, float); //! Nsigma separation with the Its detector for electron
-DECLARE_SOA_COLUMN(ITSNSigmaPi, itsNSigmaPi, float); //! Nsigma separation with the Its detector for pion
-DECLARE_SOA_COLUMN(ITSNSigmaKa, itsNSigmaKa, float); //! Nsigma separation with the Its detector for kaon
-DECLARE_SOA_COLUMN(ITSNSigmaPr, itsNSigmaPr, float); //! Nsigma separation with the Its detector for proton
-DECLARE_SOA_COLUMN(ITSNSigmaDe, itsNSigmaDe, float); //! Nsigma separation with the Its detector for deuteron
-DECLARE_SOA_COLUMN(ITSNSigmaTr, itsNSigmaTr, float); //! Nsigma separation with the Its detector for triton
-DECLARE_SOA_COLUMN(ITSNSigmaHe, itsNSigmaHe, float); //! Nsigma separation with the Its detector for helium3
+DECLARE_SOA_COLUMN(TofFullNSigmaEl, tofFullNSigmaEl, float); //! Nsigma separation with the TOF detector for electron
+DECLARE_SOA_COLUMN(TofFullNSigmaPi, tofFullNSigmaPi, float); //! Nsigma separation with the TOF detector for pion
+DECLARE_SOA_COLUMN(TofFullNSigmaKa, tofFullNSigmaKa, float); //! Nsigma separation with the TOF detector for kaon
+DECLARE_SOA_COLUMN(TofFullNSigmaPr, tofFullNSigmaPr, float); //! Nsigma separation with the TOF detector for proton
+DECLARE_SOA_COLUMN(TofFullNSigmaDe, tofFullNSigmaDe, float); //! Nsigma separation with the TOF detector for deuteron
+
+DECLARE_SOA_COLUMN(TpcFullNSigmaEl, tpcFullNSigmaEl, float); //! Nsigma separation with the TPC detector for electron
+DECLARE_SOA_COLUMN(TpcFullNSigmaPi, tpcFullNSigmaPi, float); //! Nsigma separation with the TPC detector for pion
+DECLARE_SOA_COLUMN(TpcFullNSigmaKa, tpcFullNSigmaKa, float); //! Nsigma separation with the TPC detector for kaon
+DECLARE_SOA_COLUMN(TpcFullNSigmaPr, tpcFullNSigmaPr, float); //! Nsigma separation with the TPC detector for proton
+DECLARE_SOA_COLUMN(TpcFullNSigmaDe, tpcFullNSigmaDe, float); //! Nsigma separation with the TPC detector for deuteron
+
+DECLARE_SOA_COLUMN(ItsNSigmaEl, itsNSigmaEl, float); //! Nsigma separation with the Its detector for electron
+DECLARE_SOA_COLUMN(ItsNSigmaPi, itsNSigmaPi, float); //! Nsigma separation with the Its detector for pion
+DECLARE_SOA_COLUMN(ItsNSigmaKa, itsNSigmaKa, float); //! Nsigma separation with the Its detector for kaon
+DECLARE_SOA_COLUMN(ItsNSigmaPr, itsNSigmaPr, float); //! Nsigma separation with the Its detector for proton
+DECLARE_SOA_COLUMN(ItsNSigmaDe, itsNSigmaDe, float); //! Nsigma separation with the Its detector for deuteron
+DECLARE_SOA_COLUMN(ItsNSigmaTr, itsNSigmaTr, float); //! Nsigma separation with the Its detector for triton
+DECLARE_SOA_COLUMN(ItsNSigmaHe, itsNSigmaHe, float); //! Nsigma separation with the Its detector for helium3
 
 // debug variables
 DECLARE_SOA_COLUMN(Sign, sign, int8_t);                                                  //! Sign of the track charge
@@ -174,7 +187,7 @@ using FDParticle = FDParticles::iterator;
 /// FemtoUniverseCascadeTrack
 namespace femtouniversecascparticle
 {
-DECLARE_SOA_INDEX_COLUMN(FDParticle, fdParticle);
+DECLARE_SOA_INDEX_COLUMN(FDParticle, fdParticle);              // o2-linter: disable=name/o2-column
 DECLARE_SOA_COLUMN(DcaV0daughters, dcaV0daughters, float);     //! DCA between V0 daughters
 DECLARE_SOA_COLUMN(Cpav0, cpav0, float);                       //! V0 cos of pointing angle
 DECLARE_SOA_COLUMN(V0radius, v0radius, float);                 //! V0 transverse radius
@@ -230,12 +243,25 @@ DECLARE_SOA_TABLE(FDExtParticles, "AOD", "FDEXTPARTICLE",
                   pidtof_tiny::TOFNSigmaDe<pidtof_tiny::TOFNSigmaStoreDe>);
 using FDFullParticle = FDExtParticles::iterator;
 
+DECLARE_SOA_TABLE(FDSigmaParticles, "AOD", "FDSIGMAPARTICLE",
+                  femtouniverseparticle::TofFullNSigmaEl,
+                  femtouniverseparticle::TofFullNSigmaPi,
+                  femtouniverseparticle::TofFullNSigmaKa,
+                  femtouniverseparticle::TofFullNSigmaPr,
+                  femtouniverseparticle::TofFullNSigmaDe,
+                  femtouniverseparticle::TpcFullNSigmaEl,
+                  femtouniverseparticle::TpcFullNSigmaPi,
+                  femtouniverseparticle::TpcFullNSigmaKa,
+                  femtouniverseparticle::TpcFullNSigmaPr,
+                  femtouniverseparticle::TpcFullNSigmaDe);
+using FDSigmaParticle = FDSigmaParticles::iterator;
+
 DECLARE_SOA_TABLE(FDItsParticles, "AOD", "FDITSPARTICLE",
-                  femtouniverseparticle::ITSNSigmaEl,
-                  femtouniverseparticle::ITSNSigmaPi,
-                  femtouniverseparticle::ITSNSigmaKa,
-                  femtouniverseparticle::ITSNSigmaPr,
-                  femtouniverseparticle::ITSNSigmaDe);
+                  femtouniverseparticle::ItsNSigmaEl,
+                  femtouniverseparticle::ItsNSigmaPi,
+                  femtouniverseparticle::ItsNSigmaKa,
+                  femtouniverseparticle::ItsNSigmaPr,
+                  femtouniverseparticle::ItsNSigmaDe);
 using FDItsParticle = FDItsParticles::iterator;
 
 DECLARE_SOA_TABLE(FDCascParticles, "AOD", "FDCASCPARTICLE",
@@ -279,7 +305,7 @@ enum ParticleOriginMCTruth {
 };
 
 //! Naming of the different OriginMCTruth types
-static constexpr std::string_view ParticleOriginMCTruthName[kNOriginMCTruthTypes] = {
+static constexpr std::array<std::string_view, kNOriginMCTruthTypes> ParticleOriginMCTruthName = {
   "_Primary",
   "_Daughter",
   "_Material",
@@ -297,7 +323,7 @@ enum MCType {
   kNMCTypes
 };
 
-static constexpr std::string_view MCTypeName[kNMCTypes] = {"", "_MC"};
+static constexpr std::array<std::string_view, kNMCTypes> MCTypeName = {"", "_MC"};
 
 DECLARE_SOA_COLUMN(PartOriginMCTruth, partOriginMCTruth, uint8_t); //! Origin of the particle, according to femtouniverseparticle::ParticleOriginMCTruth
 DECLARE_SOA_COLUMN(PdgMCTruth, pdgMCTruth, int);                   //! Particle PDG

--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -2361,7 +2361,6 @@ struct FemtoUniverseProducerTask {
   void fillMCTruthParticlesD0(TrackType const& mcParts)
   {
     std::vector<int> childIDs = {0, 0}; // these IDs are necessary to keep track of the children
-    std::vector<int> tmpIDtrack;
 
     for (const auto& particle : mcParts) {
 

--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -63,10 +63,9 @@
 #include <Framework/runDataProcessing.h>
 #include <ReconstructionDataFormats/PID.h>
 
-#include <TLorentzVector.h>
+#include <Math/GenVector/LorentzVector.h>
+#include <Math/GenVector/PtEtaPhiM4D.h>
 #include <TPDGCode.h>
-
-#include <RtypesCore.h>
 
 #include <algorithm>
 #include <array>
@@ -102,6 +101,7 @@ using FemtoFullCollisionCentRun3MC = soa::Join<aod::Collisions, aod::EvSels, aod
 using FemtoFullTracks = soa::Join<aod::FullTracks, aod::TracksDCA, aod::TOFSignal, aod::TrackSelection,
                                   aod::pidTPCEl, aod::pidTPCMu, aod::pidTPCPi, aod::pidTPCKa, aod::pidTPCPr, aod::pidTPCDe,
                                   aod::pidTOFEl, aod::pidTOFMu, aod::pidTOFPi, aod::pidTOFKa, aod::pidTOFPr, aod::pidTOFDe>;
+using FemtoFullNSigmaTracks = soa::Join<aod::FullTracks, aod::TracksDCA, aod::TOFSignal, aod::TrackSelection>;
 
 // using FilteredFullV0s = soa::Filtered<aod::V0Datas>; /// predefined Join
 // table for o2::aod::V0s = soa::Join<o2::aod::TransientV0s, o2::aod::StoredV0s>
@@ -135,6 +135,7 @@ struct FemtoUniverseProducerTask {
   Produces<aod::FdMCParticles> outputPartsMC;
   Produces<aod::FDExtParticles> outputDebugParts;
   Produces<aod::FDItsParticles> outputDebugITSParts;
+  Produces<aod::FDSigmaParticles> outputDebugSigmaParts;
   Produces<aod::FDMCLabels> outputPartsMCLabels;
   Produces<aod::FDExtMCParticles> outputDebugPartsMC;
   Produces<aod::FDCascParticles> outputCascParts;
@@ -384,65 +385,36 @@ struct FemtoUniverseProducerTask {
   HfHelper hfHelper;
   bool isKaonNSigma(float mom, float nsigmaTPCK, float nsigmaTOFK)
   {
-
     if (mom < ConfPhiSelection.confMomKaon03) { // 0.0-0.3
-      if (std::abs(nsigmaTPCK) < ConfPhiSelection.confPhiKaonNsigmaTPCfrom00to03) {
-        return true;
-      } else {
-        return false;
-      }
-    } else if (mom < ConfPhiSelection.confMomKaon045) { // 0.30 - 0.45
-      if (std::abs(nsigmaTPCK) < ConfPhiSelection.confPhiKaonNsigmaTPCfrom03to045) {
-        return true;
-      } else {
-        return false;
-      }
-    } else if (mom < ConfPhiSelection.confMomKaon055) { // 0.45-0.55
-      if (std::abs(nsigmaTPCK) < ConfPhiSelection.confPhiKaonNsigmaTPCfrom045to055) {
-        return true;
-      } else {
-        return false;
-      }
-    } else if (mom < ConfPhiSelection.confMomKaon15) { // 0.55-1.5 (now we use TPC and TOF)
-      if ((std::abs(nsigmaTOFK) < ConfPhiSelection.confPhiKaonNsigmaTOFfrom055to15) && (std::abs(nsigmaTPCK) < ConfPhiSelection.confPhiKaonNsigmaTPCfrom055to15)) {
-        {
-          return true;
-        }
-      } else {
-        return false;
-      }
-    } else if (mom > ConfPhiSelection.confMomKaon15) { // 1.5 -
-      if ((std::abs(nsigmaTOFK) < ConfPhiSelection.confPhiKaonNsigmaTOFfrom15) && (std::abs(nsigmaTPCK) < ConfPhiSelection.confPhiKaonNsigmaTPCfrom15)) {
-        return true;
-      } else {
-        return false;
-      }
-    } else {
-      return false;
+      return (std::abs(nsigmaTPCK) < ConfPhiSelection.confPhiKaonNsigmaTPCfrom00to03);
     }
+    if (mom < ConfPhiSelection.confMomKaon045) { // 0.30 - 0.45
+      return (std::abs(nsigmaTPCK) < ConfPhiSelection.confPhiKaonNsigmaTPCfrom03to045);
+    }
+    if (mom < ConfPhiSelection.confMomKaon055) { // 0.45-0.55
+      return (std::abs(nsigmaTPCK) < ConfPhiSelection.confPhiKaonNsigmaTPCfrom045to055);
+    }
+    if (mom < ConfPhiSelection.confMomKaon15) { // 0.55-1.5 (now we use TPC and TOF)
+      return ((std::abs(nsigmaTOFK) < ConfPhiSelection.confPhiKaonNsigmaTOFfrom055to15) && (std::abs(nsigmaTPCK) < ConfPhiSelection.confPhiKaonNsigmaTPCfrom055to15));
+    }
+    if (mom > ConfPhiSelection.confMomKaon15) { // 1.5 -
+      return ((std::abs(nsigmaTOFK) < ConfPhiSelection.confPhiKaonNsigmaTOFfrom15) && (std::abs(nsigmaTPCK) < ConfPhiSelection.confPhiKaonNsigmaTPCfrom15));
+    }
+    return false;
   }
 
   bool isKaonNSigmaLF(float mom, float nsigmaTPCK, float nsigmaTOFK, bool hasTOF)
   {
     if (mom < ConfPhiSelection.confMomKaonLF) {
-      if (std::abs(nsigmaTPCK) < ConfPhiSelection.confNSigmaTPCKaonLF) {
-        return true;
-      } else {
-        return false;
-      }
-    } else if (mom >= ConfPhiSelection.confMomKaonLF) { // 0.5-1.5 (now we use TPC and TOF)
+      return (std::abs(nsigmaTPCK) < ConfPhiSelection.confNSigmaTPCKaonLF);
+    }
+    if (mom >= ConfPhiSelection.confMomKaonLF) { // 0.5-1.5 (now we use TPC and TOF)
       if (!hasTOF) {
         return false;
-      } else {
-        if (std::sqrt(nsigmaTPCK * nsigmaTPCK + nsigmaTOFK * nsigmaTOFK) < ConfPhiSelection.confNSigmaCombKaonLF) {
-          return true;
-        } else {
-          return false;
-        }
       }
-    } else {
-      return false;
+      return (std::sqrt(nsigmaTPCK * nsigmaTPCK + nsigmaTOFK * nsigmaTOFK) < ConfPhiSelection.confNSigmaCombKaonLF);
     }
+    return false;
   }
 
   bool isKaonRejected(float mom, float nsigmaTPCPr, float nsigmaTOFPr, float nsigmaTPCPi, float nsigmaTOFPi)
@@ -450,21 +422,20 @@ struct FemtoUniverseProducerTask {
     if (mom < ConfPhiSelection.confMomKaonRejected) {
       if (std::abs(nsigmaTPCPi) < ConfPhiSelection.confPhiKaonRejectPionNsigma.value) {
         return true;
-      } else if (std::abs(nsigmaTPCPr) < ConfPhiSelection.confPhiKaonRejectProtonNsigma.value) {
+      }
+      if (std::abs(nsigmaTPCPr) < ConfPhiSelection.confPhiKaonRejectProtonNsigma.value) {
         return true;
       }
     }
     if (mom > ConfPhiSelection.confMomKaonRejected) {
       if (std::hypot(nsigmaTOFPi, nsigmaTPCPi) < ConfPhiSelection.confPhiKaonRejectPionNsigma.value) {
         return true;
-      } else if (std::hypot(nsigmaTOFPr, nsigmaTPCPr) < ConfPhiSelection.confPhiKaonRejectProtonNsigma.value) {
-        return true;
-      } else {
-        return false;
       }
-    } else {
-      return false;
+      if (std::hypot(nsigmaTOFPr, nsigmaTPCPr) < ConfPhiSelection.confPhiKaonRejectProtonNsigma.value) {
+        return true;
+      }
     }
+    return false;
   }
 
   bool isNSigmaTPC(float nsigmaTPCParticle)
@@ -477,84 +448,99 @@ struct FemtoUniverseProducerTask {
     // Cut only on daughter and bachelor tracks, that have TOF signal
     if (mom > ConfPIDBitmask.confMinMomTOF && hasTOF) {
       return (std::abs(nsigmaTOFParticle) < ConfPIDBitmask.confNsigmaTOFParticleChild);
-    } else {
-      return true;
     }
+    return true;
   }
 
   bool isNSigmaCombined(float mom, float nsigmaTPCParticle, float nsigmaTOFParticle)
   {
     if (mom <= ConfPIDBitmask.confMinMomTOF) {
       return (std::abs(nsigmaTPCParticle) < ConfPIDBitmask.confNsigmaTPCParticle);
-    } else {
-      return (std::hypot(nsigmaTOFParticle, nsigmaTPCParticle) < ConfPIDBitmask.confNsigmaCombinedParticle);
     }
+    return (std::hypot(nsigmaTOFParticle, nsigmaTPCParticle) < ConfPIDBitmask.confNsigmaCombinedParticle);
   }
 
   template <typename TrackType>
-  aod::femtouniverseparticle::CutContainerType PIDBitmask(const TrackType& track)
+  aod::femtouniverseparticle::CutContainerType pidBitmask(const TrackType& track)
   {
-    static const o2::track::PID pids[] = {o2::track::PID::Proton, o2::track::PID::Pion, o2::track::PID::Kaon};
+    static const std::array<o2::track::PID, 3> pids = {o2::track::PID::Proton, o2::track::PID::Pion, o2::track::PID::Kaon};
     aod::femtouniverseparticle::CutContainerType mask = 0u;
-    for (UInt_t i = 0; i < 3; ++i) {
-      if (isNSigmaTPC(trackCuts.getNsigmaTPC(track, pids[i])))
+    int size = 3;
+    for (int i = 0; i < size; ++i) {
+      if (isNSigmaTPC(trackCuts.getNsigmaTPC(track, pids[i]))) {
         mask |= (1u << i);
-      if (isNSigmaTOF(track.p(), trackCuts.getNsigmaTOF(track, pids[i]), track.hasTOF()))
+      }
+      if (isNSigmaTOF(track.p(), trackCuts.getNsigmaTOF(track, pids[i]), track.hasTOF())) {
         mask |= (8u << i);
-      if (isNSigmaCombined(track.p(), trackCuts.getNsigmaTPC(track, pids[i]), trackCuts.getNsigmaTOF(track, pids[i])))
+      }
+      if (isNSigmaCombined(track.p(), trackCuts.getNsigmaTPC(track, pids[i]), trackCuts.getNsigmaTOF(track, pids[i]))) {
         mask |= (64u << i);
+      }
     }
-    if (track.hasTOF())
+    if (track.hasTOF()) {
       mask |= (512u);
+    }
     return mask;
   }
 
   template <class T>
-  using hasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
+  using HasStrangeTOFinV0 = decltype(std::declval<T&>().tofNSigmaLaPr());
 
   /// bitmask to save strangeness TOF for V0 analysis
   template <typename V0Type>
-  aod::femtouniverseparticle::CutContainerType PIDStrangeTOFBitmaskV0(const V0Type& v0)
+  aod::femtouniverseparticle::CutContainerType pidStrangeTOFBitmaskV0(const V0Type& v0)
   {
     aod::femtouniverseparticle::CutContainerType mask = 0u;
-    if constexpr (std::experimental::is_detected<hasStrangeTOFinV0, V0Type>::value) {
-      if (v0.tofNSigmaLaPr() < ConfPIDBitmask.confNsigmaTOFParticleChild)
+    if constexpr (std::experimental::is_detected<HasStrangeTOFinV0, V0Type>::value) {
+      if (v0.tofNSigmaLaPr() < ConfPIDBitmask.confNsigmaTOFParticleChild) {
         mask |= (1u);
-      if (v0.tofNSigmaLaPi() < ConfPIDBitmask.confNsigmaTOFParticleChild)
+      }
+      if (v0.tofNSigmaLaPi() < ConfPIDBitmask.confNsigmaTOFParticleChild) {
         mask |= (2u);
-      if (v0.tofNSigmaALaPr() < ConfPIDBitmask.confNsigmaTOFParticleChild)
+      }
+      if (v0.tofNSigmaALaPr() < ConfPIDBitmask.confNsigmaTOFParticleChild) {
         mask |= (4u);
-      if (v0.tofNSigmaALaPi() < ConfPIDBitmask.confNsigmaTOFParticleChild)
+      }
+      if (v0.tofNSigmaALaPi() < ConfPIDBitmask.confNsigmaTOFParticleChild) {
         mask |= (8u);
-      if (v0.tofNSigmaK0PiPlus() < ConfPIDBitmask.confNsigmaTOFParticleChild)
+      }
+      if (v0.tofNSigmaK0PiPlus() < ConfPIDBitmask.confNsigmaTOFParticleChild) {
         mask |= (16u);
-      if (v0.tofNSigmaK0PiMinus() < ConfPIDBitmask.confNsigmaTOFParticleChild)
+      }
+      if (v0.tofNSigmaK0PiMinus() < ConfPIDBitmask.confNsigmaTOFParticleChild) {
         mask |= (32u);
+      }
     }
     return mask;
   }
 
   template <class T>
-  using hasStrangeTOFinCasc = decltype(std::declval<T&>().tofNSigmaXiLaPi());
+  using HasStrangeTOFinCasc = decltype(std::declval<T&>().tofNSigmaXiLaPi());
 
   /// bitmask to save strangeness TOF for cascade analysis
   template <typename CascType>
-  aod::femtouniverseparticle::CutContainerType PIDStrangeTOFBitmaskCasc(const CascType& casc)
+  aod::femtouniverseparticle::CutContainerType pidStrangeTOFBitmaskCasc(const CascType& casc)
   {
     aod::femtouniverseparticle::CutContainerType mask = 0u;
-    if constexpr (std::experimental::is_detected<hasStrangeTOFinCasc, CascType>::value) {
-      if (casc.tofNSigmaXiLaPi() < ConfPIDBitmask.confNsigmaTOFParticleChild)
+    if constexpr (std::experimental::is_detected<HasStrangeTOFinCasc, CascType>::value) {
+      if (casc.tofNSigmaXiLaPi() < ConfPIDBitmask.confNsigmaTOFParticleChild) {
         mask |= (1u);
-      if (casc.tofNSigmaXiLaPr() < ConfPIDBitmask.confNsigmaTOFParticleChild)
+      }
+      if (casc.tofNSigmaXiLaPr() < ConfPIDBitmask.confNsigmaTOFParticleChild) {
         mask |= (2u);
-      if (casc.tofNSigmaXiPi() < ConfPIDBitmask.confNsigmaTOFParticleChild)
+      }
+      if (casc.tofNSigmaXiPi() < ConfPIDBitmask.confNsigmaTOFParticleChild) {
         mask |= (4u);
-      if (casc.tofNSigmaOmLaPi() < ConfPIDBitmask.confNsigmaTOFParticleChild)
+      }
+      if (casc.tofNSigmaOmLaPi() < ConfPIDBitmask.confNsigmaTOFParticleChild) {
         mask |= (8u);
-      if (casc.tofNSigmaOmLaPr() < ConfPIDBitmask.confNsigmaTOFParticleChild)
+      }
+      if (casc.tofNSigmaOmLaPr() < ConfPIDBitmask.confNsigmaTOFParticleChild) {
         mask |= (16u);
-      if (casc.tofNSigmaOmKa() < ConfPIDBitmask.confNsigmaTOFParticleChild)
+      }
+      if (casc.tofNSigmaOmKa() < ConfPIDBitmask.confNsigmaTOFParticleChild) {
         mask |= (32u);
+      }
     }
     return mask;
   }
@@ -568,9 +554,9 @@ struct FemtoUniverseProducerTask {
 
   void initZorro(aod::BCsWithTimestamps::iterator const& bc)
   {
-    if (mRunNumberZorro == bc.runNumber())
+    if (mRunNumberZorro == bc.runNumber()) {
       return;
-
+    }
     zorro.initCCDB(ccdb.service, bc.runNumber(), bc.timestamp(), zorroMask.value);
     zorro.populateHistRegistry(qaRegistry, bc.runNumber());
     mRunNumberZorro = bc.runNumber();
@@ -584,16 +570,16 @@ struct FemtoUniverseProducerTask {
   // for now do not know why
 
   int mRunNumber = 0;
-  float mMagField;
-  Service<o2::ccdb::BasicCCDBManager> ccdb; /// Accessing the CCDB
-  ctpRateFetcher mRateFetcher;              // inspired by zdcSP.cxx in PWGLF
+  float mMagField = 0;
+  Service<o2::ccdb::BasicCCDBManager> ccdb{}; /// Accessing the CCDB
+  ctpRateFetcher mRateFetcher;                // inspired by zdcSP.cxx in PWGLF
 
   void init(InitContext&)
   {
-    if ((doprocessFullData || doprocessTrackPhiData || doprocessTrackData || doprocessTrackV0 || doprocessTrackCascadeData || doprocessTrackV0Cascade || doprocessTrackD0mesonData || doprocessTrackD0DataML || doprocessTrackCentRun2Data || doprocessTrackV0CentRun2Data || doprocessTrackCentRun3Data || doprocessV0CentRun3Data || doprocessCascadeCentRun3Data || doprocessTrackDataCentPP) == false && (doprocessFullMC || doprocessTrackMC || doprocessTrackMCTruth || doprocessTrackMCGen || doprocessTruthAndFullMCV0 || doprocessTrackD0MC || doprocessTruthAndFullMCCasc || doprocessFullMCCent || doprocessTrackCentRun3DataMC || doprocessTruthAndFullMCCentRun3 || doprocessTruthAndFullMCCentRun3V0 || doprocessTruthAndFullMCCentRun3Casc) == false) {
+    if (!(doprocessFullData || doprocessTrackPhiData || doprocessTrackData || doprocessTrackV0 || doprocessTrackCascadeData || doprocessTrackV0Cascade || doprocessTrackD0mesonData || doprocessTrackD0DataML || doprocessTrackCentRun2Data || doprocessTrackV0CentRun2Data || doprocessTrackCentRun3Data || doprocessTrackCentRun3DataFullNSigma || doprocessV0CentRun3Data || doprocessCascadeCentRun3Data || doprocessTrackDataCentPP) && !(doprocessFullMC || doprocessTrackMC || doprocessTrackMCTruth || doprocessTrackMCGen || doprocessTruthAndFullMCV0 || doprocessTrackD0MC || doprocessTruthAndFullMCCasc || doprocessFullMCCent || doprocessTrackCentRun3DataMC || doprocessTruthAndFullMCCentRun3 || doprocessTruthAndFullMCCentRun3V0 || doprocessTruthAndFullMCCentRun3Casc)) {
       LOGF(fatal, "Neither processFullData nor processFullMC enabled. Please choose one.");
     }
-    if ((doprocessFullData || doprocessTrackPhiData || doprocessTrackData || doprocessTrackV0 || doprocessTrackCascadeData || doprocessTrackV0Cascade || doprocessTrackD0mesonData || doprocessTrackD0DataML || doprocessTrackCentRun2Data || doprocessTrackV0CentRun2Data || doprocessTrackCentRun3Data || doprocessV0CentRun3Data || doprocessCascadeCentRun3Data || doprocessTrackDataCentPP) == true && (doprocessFullMC || doprocessTrackMC || doprocessTrackMCTruth || doprocessTrackMCGen || doprocessTruthAndFullMCV0 || doprocessTrackD0MC || doprocessTruthAndFullMCCasc || doprocessFullMCCent || doprocessTrackCentRun3DataMC || doprocessTruthAndFullMCCentRun3 || doprocessTruthAndFullMCCentRun3V0 || doprocessTruthAndFullMCCentRun3Casc) == true) {
+    if ((doprocessFullData || doprocessTrackPhiData || doprocessTrackData || doprocessTrackV0 || doprocessTrackCascadeData || doprocessTrackV0Cascade || doprocessTrackD0mesonData || doprocessTrackD0DataML || doprocessTrackCentRun2Data || doprocessTrackV0CentRun2Data || doprocessTrackCentRun3Data || doprocessTrackCentRun3DataFullNSigma || doprocessV0CentRun3Data || doprocessCascadeCentRun3Data || doprocessTrackDataCentPP) && (doprocessFullMC || doprocessTrackMC || doprocessTrackMCTruth || doprocessTrackMCGen || doprocessTruthAndFullMCV0 || doprocessTrackD0MC || doprocessTruthAndFullMCCasc || doprocessFullMCCent || doprocessTrackCentRun3DataMC || doprocessTruthAndFullMCCentRun3 || doprocessTruthAndFullMCCentRun3V0 || doprocessTruthAndFullMCCentRun3Casc)) {
       LOGF(fatal,
            "Cannot enable process Data and process MC at the same time. "
            "Please choose one.");
@@ -736,12 +722,13 @@ struct FemtoUniverseProducerTask {
   }
 
   /// Function to retrieve the nominal magnetic field in kG (0.1T) and convert it directly to T
-  void getMagneticFieldTesla(aod::BCsWithTimestamps::iterator bc)
+  void getMagneticFieldTesla(aod::BCsWithTimestamps::iterator const& bc)
   {
     // TODO done only once (and not per run). Will be replaced by CCDBConfigurable
     // get magnetic field for run
-    if (mRunNumber == bc.runNumber())
+    if (mRunNumber == bc.runNumber()) {
       return;
+    }
     auto timestamp = bc.timestamp();
     float output = -999;
 
@@ -775,7 +762,7 @@ struct FemtoUniverseProducerTask {
   void fillDebugParticle(ParticleType const& particle)
   {
     if constexpr (isTrackOrV0) {
-      if constexpr (std::experimental::is_detected<hasStrangeTOFinV0, ParticleType>::value) {
+      if constexpr (std::experimental::is_detected<HasStrangeTOFinV0, ParticleType>::value) {
         outputDebugParts(particle.sign(), (uint8_t)particle.tpcNClsFound(),
                          particle.tpcNClsFindable(),
                          (uint8_t)particle.tpcNClsCrossedRows(),
@@ -811,7 +798,7 @@ struct FemtoUniverseProducerTask {
                        -999., -999., -999.,
                        -999.); // QA for phi or D0/D0bar children
     } else if constexpr (isCasc) {
-      if constexpr (std::experimental::is_detected<hasStrangeTOFinCasc, ParticleType>::value) {
+      if constexpr (std::experimental::is_detected<HasStrangeTOFinCasc, ParticleType>::value) {
         outputDebugParts(-999., -999., -999., -999., -999., -999., -999., -999., -999.,
                          -999., -999., -999., -999., -999., -999., -999., particle.tofNSigmaXiLaPi(),
                          particle.tofNSigmaXiLaPr(), particle.tofNSigmaXiPi(), particle.tofNSigmaOmLaPi(),
@@ -908,20 +895,22 @@ struct FemtoUniverseProducerTask {
   }
 
   template <typename ParticleType>
-  int32_t getMotherPDG(ParticleType particle)
+  int32_t getMotherPDG(ParticleType const& particle)
   {
     if (particle.isPhysicalPrimary()) {
       return 0;
-    } else if (particle.has_mothers()) {
-      if (particle.getProcess() == 20 || particle.getProcess() == 23) { // treat particles from hadronic scattering (20, 23) as primary
+    }
+    if (particle.has_mothers()) {
+      int hadronElasticStatter = 20;
+      int hadronInelasticStatter = 20;
+      if (particle.getProcess() == hadronElasticStatter || particle.getProcess() == hadronInelasticStatter) { // treat particles from hadronic scattering (20, 23) as primary
         return 0;
       }
       auto motherparticlesMC = particle.template mothers_as<aod::McParticles>();
-      auto motherparticleMC = motherparticlesMC.front();
+      auto const& motherparticleMC = motherparticlesMC.front();
       return motherparticleMC.pdgCode();
-    } else {
-      return 999;
     }
+    return 999;
   }
 
   template <typename ParticleType>
@@ -944,7 +933,7 @@ struct FemtoUniverseProducerTask {
         if (particleMC.isPhysicalPrimary()) {
           particleOrigin = aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kPrimary;
         } else if (!motherparticlesMC.empty()) {
-          auto motherparticleMC = motherparticlesMC.front();
+          auto const& motherparticleMC = motherparticlesMC.front();
           if (motherparticleMC.producedByGenerator()) {
             particleOrigin = checkDaughterType(fdparttype, motherparticleMC.pdgCode());
           } else {
@@ -977,7 +966,7 @@ struct FemtoUniverseProducerTask {
       } else {
         auto mothers = mcparticle.template mothers_as<aod::McParticles>();
         if (!mothers.empty()) {
-          auto mother = mothers.front();
+          auto const& mother = mothers.front();
           if (mother.producedByGenerator()) {
             particleOrigin = checkDaughterType(fdparttype, mother.pdgCode());
           } else {
@@ -1033,16 +1022,13 @@ struct FemtoUniverseProducerTask {
         phiOrigin = aod::femtouniverse_mc_particle::ParticleOriginMCTruth::kFake;
       }
 
-      TLorentzVector part1Vec;
-      TLorentzVector part2Vec;
-
       const auto mMassOne = o2::constants::physics::MassKPlus;  // FIXME: Get from the PDG service of the common header
       const auto mMassTwo = o2::constants::physics::MassKMinus; // FIXME: Get from the PDG service of the common header
 
-      part1Vec.SetPtEtaPhiM(kaon1MC.pt(), kaon1MC.eta(), kaon1MC.phi(), mMassOne);
-      part2Vec.SetPtEtaPhiM(kaon2MC.pt(), kaon2MC.eta(), kaon2MC.phi(), mMassTwo);
+      ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> part1Vec(kaon1MC.pt(), kaon1MC.eta(), kaon1MC.phi(), mMassOne);
+      ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> part2Vec(kaon2MC.pt(), kaon2MC.eta(), kaon2MC.phi(), mMassTwo);
 
-      TLorentzVector sumVec(part1Vec);
+      ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> sumVec(part1Vec);
       sumVec += part2Vec;
 
       float phiEta = sumVec.Eta();
@@ -1086,24 +1072,20 @@ struct FemtoUniverseProducerTask {
       return false;
     }
 
-    if (zorroMask.value != "") {
+    if (!zorroMask.value.empty()) {
       auto bc = col.template bc_as<aod::BCsWithTimestamps>();
       initZorro(bc);
-      if (!zorro.isSelected(col.template bc_as<aod::BCsWithTimestamps>().globalBC()))
+      if (!zorro.isSelected(col.template bc_as<aod::BCsWithTimestamps>().globalBC())) {
         return false;
+      }
     }
 
-    if (!ConfGeneral.confIsUsePileUp) {
+    if (!ConfGeneral.confIsUsePileUp || ((!ConfGeneral.confEvNoSameBunchPileup || col.selection_bit(aod::evsel::kNoSameBunchPileup)) && (!ConfGeneral.confEvIsGoodZvtxFT0vsPV || col.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV)) && (!ConfGeneral.confEvIsVertexITSTPC || col.selection_bit(aod::evsel::kIsVertexITSTPC)))) {
       outputCollision(vtxZ, mult, multNtr, confDoSpher ? colCuts.computeSphericity(col, tracks) : 2, mMagField);
       colCuts.fillQA(col);
       return true;
-    } else if ((!ConfGeneral.confEvNoSameBunchPileup || col.selection_bit(aod::evsel::kNoSameBunchPileup)) && (!ConfGeneral.confEvIsGoodZvtxFT0vsPV || col.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV)) && (!ConfGeneral.confEvIsVertexITSTPC || col.selection_bit(aod::evsel::kIsVertexITSTPC))) {
-      outputCollision(vtxZ, mult, multNtr, confDoSpher ? colCuts.computeSphericity(col, tracks) : 2, mMagField);
-      colCuts.fillQA(col);
-      return true;
-    } else {
-      return false;
     }
+    return false;
   }
 
   template <bool isMC, typename CollisionType, typename TrackType>
@@ -1132,17 +1114,12 @@ struct FemtoUniverseProducerTask {
     if (!colCuts.isSelected(col)) {
       return false;
     }
-    if (!ConfGeneral.confIsUsePileUp) {
+    if (!ConfGeneral.confIsUsePileUp || ((!ConfGeneral.confEvNoSameBunchPileup || col.selection_bit(aod::evsel::kNoSameBunchPileup)) && (!ConfGeneral.confEvIsGoodZvtxFT0vsPV || col.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV)) && (!ConfGeneral.confEvIsVertexITSTPC || col.selection_bit(aod::evsel::kIsVertexITSTPC)))) {
       outputCollision(vtxZ, mult, multNtr, confDoSpher ? colCuts.computeSphericity(col, tracks) : 2, mMagField);
       colCuts.fillQA(col);
       return true;
-    } else if ((!ConfGeneral.confEvNoSameBunchPileup || col.selection_bit(aod::evsel::kNoSameBunchPileup)) && (!ConfGeneral.confEvIsGoodZvtxFT0vsPV || col.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV)) && (!ConfGeneral.confEvIsVertexITSTPC || col.selection_bit(aod::evsel::kIsVertexITSTPC))) {
-      outputCollision(vtxZ, mult, multNtr, confDoSpher ? colCuts.computeSphericity(col, tracks) : 2, mMagField);
-      colCuts.fillQA(col);
-      return true;
-    } else {
-      return false;
     }
+    return false;
   }
 
   template <typename CollisionType, typename TrackType>
@@ -1179,10 +1156,9 @@ struct FemtoUniverseProducerTask {
     // particle candidates for such collisions
     if (!colCuts.isSelected(col)) {
       return false;
-    } else {
-      outputCollision(vtxZ, cent, multNtr, 2, mMagField);
-      return true;
     }
+    outputCollision(vtxZ, cent, multNtr, 2, mMagField);
+    return true;
   }
 
   template <bool isMC, typename CollisionType>
@@ -1201,22 +1177,20 @@ struct FemtoUniverseProducerTask {
 
     if (!colCuts.isSelectedRun3(col) || (occupancy < ConfGeneral.confTPCOccupancyMin || occupancy > ConfGeneral.confTPCOccupancyMax)) {
       return false;
-    } else {
-      if ((!ConfGeneral.confEvNoSameBunchPileup || col.selection_bit(aod::evsel::kNoSameBunchPileup)) &&
-          (!ConfGeneral.confEvIsGoodZvtxFT0vsPV || col.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV)) &&
-          (!ConfGeneral.confIsGoodITSLayersAll || col.selection_bit(aod::evsel::kIsGoodITSLayersAll)) &&
-          (!ConfGeneral.confNoCollInRofStandard || col.selection_bit(aod::evsel::kNoCollInRofStandard)) &&
-          (!ConfGeneral.confNoHighMultCollInPrevRof || col.selection_bit(aod::evsel::kNoHighMultCollInPrevRof)) &&
-          (!ConfGeneral.confEvIsVertexITSTPC || col.selection_bit(aod::evsel::kIsVertexITSTPC)) &&
-          (!ConfGeneral.confNoCollInTimeRangeStandard || col.selection_bit(aod::evsel::kNoCollInTimeRangeStandard)) &&
-          (!ConfGeneral.confNoITSROFrameBorder || col.selection_bit(aod::evsel::kNoITSROFrameBorder)) &&
-          (!ConfGeneral.confNoTimeFrameBorder || col.selection_bit(aod::evsel::kNoTimeFrameBorder))) {
-        outputCollision(vtxZ, cent, multNtr, 2, mMagField);
-        return true;
-      } else {
-        return false;
-      }
     }
+    if ((!ConfGeneral.confEvNoSameBunchPileup || col.selection_bit(aod::evsel::kNoSameBunchPileup)) &&
+        (!ConfGeneral.confEvIsGoodZvtxFT0vsPV || col.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV)) &&
+        (!ConfGeneral.confIsGoodITSLayersAll || col.selection_bit(aod::evsel::kIsGoodITSLayersAll)) &&
+        (!ConfGeneral.confNoCollInRofStandard || col.selection_bit(aod::evsel::kNoCollInRofStandard)) &&
+        (!ConfGeneral.confNoHighMultCollInPrevRof || col.selection_bit(aod::evsel::kNoHighMultCollInPrevRof)) &&
+        (!ConfGeneral.confEvIsVertexITSTPC || col.selection_bit(aod::evsel::kIsVertexITSTPC)) &&
+        (!ConfGeneral.confNoCollInTimeRangeStandard || col.selection_bit(aod::evsel::kNoCollInTimeRangeStandard)) &&
+        (!ConfGeneral.confNoITSROFrameBorder || col.selection_bit(aod::evsel::kNoITSROFrameBorder)) &&
+        (!ConfGeneral.confNoTimeFrameBorder || col.selection_bit(aod::evsel::kNoTimeFrameBorder))) {
+      outputCollision(vtxZ, cent, multNtr, 2, mMagField);
+      return true;
+    }
+    return false;
   }
 
   template <typename CollisionType>
@@ -1226,10 +1200,9 @@ struct FemtoUniverseProducerTask {
 
     if (std::abs(vtxZ) > ConfGeneral.confEvtZvtx) {
       return false;
-    } else {
-      outputCollision(vtxZ, 0, 0, 2, mMagField);
-      return true;
     }
+    outputCollision(vtxZ, 0, 0, 2, mMagField);
+    return true;
   }
 
   template <bool isMC, typename CollisionType>
@@ -1277,7 +1250,7 @@ struct FemtoUniverseProducerTask {
                     femto_universe_track_selection::TrackContainerPosition::kCuts),
                   confIsUseCutculator ? cutContainer.at(
                                           femto_universe_track_selection::TrackContainerPosition::kPID)
-                                      : PIDBitmask(track),
+                                      : pidBitmask(track),
                   track.dcaXY(), childIDs,
                   track.hasTOF(), // hasTOF getter is mLambda()
                   track.sign());  // sign getter is mAntiLambda()
@@ -1286,10 +1259,67 @@ struct FemtoUniverseProducerTask {
       if (confIsDebug) {
         fillDebugParticle<true, false, false>(track);
       }
-
       if constexpr (isMC) {
         fillMCParticle(track, o2::aod::femtouniverseparticle::ParticleType::kTrack);
       }
+    }
+  }
+
+  template <bool isMC, typename TrackType>
+  void fillTracksFullNsigma(TrackType const& tracks)
+  {
+    std::vector<int> childIDs = {0, 0};
+    std::vector<int> tmpIDtrack;
+
+    for (const auto& track : tracks) {
+      if (!trackCuts.isSelectedMinimal(track)) {
+        continue;
+      }
+      if (track.tpcChi2NCl() < ConfTrkSelection.confTrkMinChi2PerClusterTPC || track.tpcChi2NCl() > ConfTrkSelection.confTrkMaxChi2PerClusterTPC) {
+        continue;
+      }
+      if (ConfTrkSelection.confTrkTPCRefit && !track.hasTPC()) {
+        continue;
+      }
+      if (track.pt() > confTOFpTmin) {
+        if (!track.hasTOF()) {
+          continue;
+        }
+      }
+
+      trackCuts.fillQA<aod::femtouniverseparticle::ParticleType::kTrack,
+                       aod::femtouniverseparticle::TrackType::kNoChild>(track);
+      // the bit-wise container of the systematic variations is obtained
+      auto cutContainer = trackCuts.getCutContainer<aod::femtouniverseparticle::CutContainerType>(track);
+
+      // now the table is filled
+      outputParts(outputCollision.lastIndex(), track.pt(), track.eta(),
+                  track.phi(), aod::femtouniverseparticle::ParticleType::kTrack,
+                  cutContainer.at(
+                    femto_universe_track_selection::TrackContainerPosition::kCuts),
+                  confIsUseCutculator ? cutContainer.at(
+                                          femto_universe_track_selection::TrackContainerPosition::kPID)
+                                      : pidBitmask(track),
+                  track.dcaXY(), childIDs,
+                  track.hasTOF(), // hasTOF getter is mLambda()
+                  track.sign());  // sign getter is mAntiLambda()
+
+      tmpIDtrack.push_back(track.globalIndex());
+
+      outputDebugParts(track.sign(), (uint8_t)track.tpcNClsFound(),
+                       track.tpcNClsFindable(),
+                       (uint8_t)track.tpcNClsCrossedRows(),
+                       track.tpcNClsShared(), track.tpcFractionSharedCls(), track.tpcInnerParam(),
+                       track.itsNCls(), track.itsNClsInnerBarrel(),
+                       track.dcaXY(), track.dcaZ(), track.tpcSignal(),
+                       -999., -999., -999., -999., -999., -999., -999., -999.,
+                       -999., -999., -999., -999., -999., -999., -999., -999.);
+
+      outputDebugSigmaParts(track.tofNSigmaEl(), track.tofNSigmaPi(),
+                            track.tofNSigmaKa(), track.tofNSigmaPr(),
+                            track.tofNSigmaDe(), track.tpcNSigmaEl(), track.tpcNSigmaPi(),
+                            track.tpcNSigmaKa(), track.tpcNSigmaPr(),
+                            track.tpcNSigmaDe());
     }
   }
 
@@ -1390,7 +1420,7 @@ struct FemtoUniverseProducerTask {
                   v0.positiveeta(), v0.positivephi(),
                   aod::femtouniverseparticle::ParticleType::kV0Child,
                   cutContainerV0.at(femto_universe_v0_selection::V0ContainerPosition::kPosCuts),
-                  confIsUseCutculator ? cutContainerV0.at(femto_universe_v0_selection::V0ContainerPosition::kPosPID) : PIDBitmask(postrack),
+                  confIsUseCutculator ? cutContainerV0.at(femto_universe_v0_selection::V0ContainerPosition::kPosPID) : pidBitmask(postrack),
                   0.,
                   childIDs,
                   0,
@@ -1410,7 +1440,7 @@ struct FemtoUniverseProducerTask {
                   v0.negativephi(),
                   aod::femtouniverseparticle::ParticleType::kV0Child,
                   cutContainerV0.at(femto_universe_v0_selection::V0ContainerPosition::kNegCuts),
-                  confIsUseCutculator ? cutContainerV0.at(femto_universe_v0_selection::V0ContainerPosition::kNegPID) : PIDBitmask(negtrack),
+                  confIsUseCutculator ? cutContainerV0.at(femto_universe_v0_selection::V0ContainerPosition::kNegPID) : pidBitmask(negtrack),
                   0.,
                   childIDs,
                   0,
@@ -1426,7 +1456,7 @@ struct FemtoUniverseProducerTask {
                   v0.phi(),
                   aod::femtouniverseparticle::ParticleType::kV0,
                   cutContainerV0.at(femto_universe_v0_selection::V0ContainerPosition::kV0),
-                  PIDStrangeTOFBitmaskV0(v0),
+                  pidStrangeTOFBitmaskV0(v0),
                   v0.v0cosPA(),
                   indexChildID,
                   v0.mLambda(),
@@ -1446,8 +1476,9 @@ struct FemtoUniverseProducerTask {
   void fillV0MCTruth(MCParticlesType const& mcParticles)
   {
     for (const auto& mc : mcParticles) { // Loop over all MC Truth particles
-      if (mc.pdgCode() != ConfV0Selection.confV0PDGMCTruth.value[2])
+      if (mc.pdgCode() != ConfV0Selection.confV0PDGMCTruth.value[2]) {
         continue; // Artificially single out V0s
+      }
 
       auto daughters = mc.template daughters_as<aod::McParticles>(); // Access daughters (no differentiation of signs, it needs to be checked separately)
 
@@ -1493,8 +1524,9 @@ struct FemtoUniverseProducerTask {
         }
       }
 
-      if (!foundPos || !foundNeg)
+      if (!foundPos || !foundNeg) {
         continue;
+      }
 
       childIDs[0] = rowPos;
       childIDs[1] = rowNeg;
@@ -1576,7 +1608,7 @@ struct FemtoUniverseProducerTask {
                   casc.positivephi(),
                   aod::femtouniverseparticle::ParticleType::kV0Child,
                   0,
-                  PIDBitmask(posTrackCasc),
+                  pidBitmask(posTrackCasc),
                   hasTOF,
                   childIDs,
                   0,
@@ -1598,7 +1630,7 @@ struct FemtoUniverseProducerTask {
                   casc.negativephi(),
                   aod::femtouniverseparticle::ParticleType::kV0Child,
                   0,
-                  PIDBitmask(negTrackCasc),
+                  pidBitmask(negTrackCasc),
                   hasTOF,
                   childIDs,
                   0,
@@ -1621,7 +1653,7 @@ struct FemtoUniverseProducerTask {
                   casc.bachelorphi(),
                   aod::femtouniverseparticle::ParticleType::kCascadeBachelor,
                   0,
-                  PIDBitmask(bachTrackCasc),
+                  pidBitmask(bachTrackCasc),
                   hasTOF,
                   childIDs,
                   0,
@@ -1638,7 +1670,7 @@ struct FemtoUniverseProducerTask {
                   casc.phi(),
                   aod::femtouniverseparticle::ParticleType::kCascade,
                   0,
-                  PIDStrangeTOFBitmaskCasc(casc),
+                  pidStrangeTOFBitmaskCasc(casc),
                   0,
                   indexCascChildID,
                   casc.mXi(),
@@ -2078,7 +2110,7 @@ struct FemtoUniverseProducerTask {
       }
       // implementing PID cuts for phi children
       if (ConfPhiSelection.confPhiDoLFPID4Kaons) {
-        if ((p1.isGlobalTrackWoDCA() == false) || (p2.isGlobalTrackWoDCA() == false) || (p1.isPVContributor() == false) || (p2.isPVContributor() == false)) {
+        if (!p1.isGlobalTrackWoDCA() || !p2.isGlobalTrackWoDCA() || !p1.isPVContributor() || p2.isPVContributor()) {
           continue;
         }
         if (!(isKaonNSigmaLF(p1.pt(), trackCuts.getNsigmaTPC(p1, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(p1, o2::track::PID::Kaon), p1.hasTOF()))) {
@@ -2102,16 +2134,13 @@ struct FemtoUniverseProducerTask {
         continue;
       }
 
-      TLorentzVector part1Vec;
-      TLorentzVector part2Vec;
-
       const auto mMassOne = o2::constants::physics::MassKPlus;  // FIXME: Get from the PDG service of the common header
       const auto mMassTwo = o2::constants::physics::MassKMinus; // FIXME: Get from the PDG service of the common header
 
-      part1Vec.SetPtEtaPhiM(p1.pt(), p1.eta(), p1.phi(), mMassOne);
-      part2Vec.SetPtEtaPhiM(p2.pt(), p2.eta(), p2.phi(), mMassTwo);
+      ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> part1Vec(p1.pt(), p1.eta(), p1.phi(), mMassOne);
+      ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> part2Vec(p2.pt(), p2.eta(), p2.phi(), mMassTwo);
 
-      TLorentzVector sumVec(part1Vec);
+      ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> sumVec(part1Vec);
       sumVec += part2Vec;
 
       float phiEta = sumVec.Eta();
@@ -2127,8 +2156,9 @@ struct FemtoUniverseProducerTask {
       float phiPhi = RecoDecay::constrainAngle(sumVec.Phi(), 0);
       float phiM = sumVec.M();
 
-      if ((phiM < ConfPhiSelection.confPhiInvMassLowLimit) || (phiM > ConfPhiSelection.confPhiInvMassUpLimit))
+      if ((phiM < ConfPhiSelection.confPhiInvMassLowLimit) || (phiM > ConfPhiSelection.confPhiInvMassUpLimit)) {
         continue;
+      }
 
       phiCuts.fillQA<aod::femtouniverseparticle::ParticleType::kPhi, aod::femtouniverseparticle::ParticleType::kPhiChild>(col, p1, p1, p2, 321, -321); ///\todo fill QA also for daughters
 
@@ -2206,30 +2236,32 @@ struct FemtoUniverseProducerTask {
       /// if the most open selection criteria are not fulfilled there is no
       /// point looking further at the track
 
-      if (particle.eta() < -ConfFilterCuts.confEtaFilterCut || particle.eta() > ConfFilterCuts.confEtaFilterCut)
+      if (particle.eta() < -ConfFilterCuts.confEtaFilterCut || particle.eta() > ConfFilterCuts.confEtaFilterCut) {
         continue;
-      if (particle.pt() < ConfFilterCuts.confPtLowFilterCut || particle.pt() > ConfFilterCuts.confPtHighFilterCut)
+      }
+      if (particle.pt() < ConfFilterCuts.confPtLowFilterCut || particle.pt() > ConfFilterCuts.confPtHighFilterCut) {
         continue;
+      }
 
-      uint32_t pdgCode = static_cast<uint32_t>(particle.pdgCode());
+      auto pdgCode = static_cast<uint32_t>(particle.pdgCode());
 
       if (ConfGeneral.confMCTruthAnalysisWithPID) {
         bool pass = false;
         std::vector<int> tmpPDGCodes = ConfGeneral.confMCTruthPDGCodes; // necessary due to some features of the Configurable
         for (auto const& pdg : tmpPDGCodes) {
           if (static_cast<int>(pdg) == static_cast<int>(pdgCode)) {
-            if (pdgCode == Pdg::kPhi) { // && (recoMcIds && recoMcIds->get().contains(particle.globalIndex()))) { // ATTENTION: all Phi mesons are NOT primary particles
-              pass = true;
-            } else if (pdgCode == Pdg::kD0) {
+            if (pdgCode == Pdg::kPhi || pdgCode == Pdg::kD0) { // && (recoMcIds && recoMcIds->get().contains(particle.globalIndex()))) { // ATTENTION: all Phi mesons are NOT primary particles
               pass = true;
             } else {
-              if (confStoreMCmothers || particle.isPhysicalPrimary() || (ConfGeneral.confActivateSecondaries && recoMcIds && recoMcIds->get().contains(particle.globalIndex())))
+              if (confStoreMCmothers || particle.isPhysicalPrimary() || (ConfGeneral.confActivateSecondaries && recoMcIds && recoMcIds->get().contains(particle.globalIndex()))) {
                 pass = true;
+              }
             }
           }
         }
-        if (!pass)
+        if (!pass) {
           continue;
+        }
       }
 
       // we cannot use isSelectedMinimal since it takes Ncls
@@ -2252,8 +2284,9 @@ struct FemtoUniverseProducerTask {
         continue;
       }
 
-      if (ConfGeneral.confIsActivateCascade)
+      if (ConfGeneral.confIsActivateCascade) {
         childIDs.push_back(0);
+      }
       outputParts(outputCollision.lastIndex(),
                   particle.pt(),
                   particle.eta(),
@@ -2334,8 +2367,9 @@ struct FemtoUniverseProducerTask {
 
     for (const auto& particle : mcParts) {
 
-      if (particle.pt() < ConfD0Selection.trackD0pTGenMin || particle.pt() > ConfD0Selection.trackD0pTGenMax)
+      if (particle.pt() < ConfD0Selection.trackD0pTGenMin || particle.pt() > ConfD0Selection.trackD0pTGenMax) {
         continue;
+      }
 
       int pdgCode = particle.pdgCode();
 
@@ -2343,19 +2377,19 @@ struct FemtoUniverseProducerTask {
         bool pass = false;
         std::vector<int> tmpPDGCodes = ConfGeneral.confMCTruthPDGCodes; // necessary due to some features of the Configurable
         for (auto const& pdg : tmpPDGCodes) {
-          if (static_cast<int>(pdg) == static_cast<int>(pdgCode)) {
-            if (pdgCode == Pdg::kPhi) {
-              pass = true;
-            } else if (std::abs(pdgCode) == Pdg::kD0) {
+          if (static_cast<int>(pdg) == pdgCode) {
+            if (pdgCode == Pdg::kPhi || std::abs(pdgCode) == Pdg::kD0) {
               pass = true;
             } else {
-              if (particle.isPhysicalPrimary())
+              if (particle.isPhysicalPrimary()) {
                 pass = true;
+              }
             }
           }
         }
-        if (!pass)
+        if (!pass) {
           continue;
+        }
       }
 
       /// check if we end-up with the correct final state using MC info
@@ -2370,10 +2404,9 @@ struct FemtoUniverseProducerTask {
       if (std::abs(particle.pdgCode()) == Pdg::kD0) {
         if (std::abs(particle.y()) > ConfD0Selection.yD0CandGenMax) {
           continue;
-        } else {
-          origin = RecoDecay::getCharmHadronOrigin(mcParts, particle);
-          mcGenFlag = particle.flagMcMatchGen();
         }
+        origin = RecoDecay::getCharmHadronOrigin(mcParts, particle);
+        mcGenFlag = particle.flagMcMatchGen();
       } else {
         if (std::abs(particle.eta()) > ConfD0Selection.trackD0CandEtaMax) {
           continue;
@@ -2695,8 +2728,9 @@ struct FemtoUniverseProducerTask {
         }
       }
       for (const auto& track : groupedTracks) {
-        if (trackCuts.isSelectedMinimal(track))
+        if (trackCuts.isSelectedMinimal(track)) {
           recoMcIds.insert(track.mcParticleId());
+        }
       }
     }
 
@@ -2741,8 +2775,9 @@ struct FemtoUniverseProducerTask {
         fillTracks<true>(groupedTracks);
       }
       for (const auto& track : groupedTracks) {
-        if (trackCuts.isSelectedMinimal(track))
+        if (trackCuts.isSelectedMinimal(track)) {
           recoMcIds.insert(track.mcParticleId());
+        }
       }
     }
 
@@ -2820,8 +2855,9 @@ struct FemtoUniverseProducerTask {
         fillCascade<true>(col, groupedCascParts, groupedTracks);
       }
       for (const auto& track : groupedTracks) {
-        if (trackCuts.isSelectedMinimal(track))
+        if (trackCuts.isSelectedMinimal(track)) {
           recoMcIds.insert(track.mcParticleId());
+        }
       }
     }
 
@@ -2958,6 +2994,18 @@ struct FemtoUniverseProducerTask {
   }
   PROCESS_SWITCH(FemtoUniverseProducerTask, processTrackCentRun3Data, "Provide experimental data for Run 3 with centrality for track track", false);
 
+  void processTrackCentRun3DataFullNSigma(aod::FemtoFullCollisionCentRun3 const& col,
+                                          soa::Filtered<soa::Join<aod::FemtoFullNSigmaTracks, aod::pidTPCFullEl, aod::pidTPCFullMu, aod::pidTPCFullPi, aod::pidTPCFullKa, aod::pidTPCFullPr, aod::pidTPCFullDe,
+                                                                  aod::pidTOFFullEl, aod::pidTOFFullMu, aod::pidTOFFullPi, aod::pidTOFFullKa, aod::pidTOFFullPr, aod::pidTOFFullDe>> const& tracksNsigma)
+  {
+    // fill the tables
+    const auto colcheck = fillCollisionsCentRun3<false>(col);
+    if (colcheck) {
+      fillTracksFullNsigma<false>(tracksNsigma);
+    }
+  }
+  PROCESS_SWITCH(FemtoUniverseProducerTask, processTrackCentRun3DataFullNSigma, "Provide experimental data for Run 3 with centrality for track track with full NSigma information", false);
+
   void processTrackCentRun3DataMC(aod::FemtoFullCollisionCentRun3MC const& col,
                                   aod::BCsWithTimestamps const&,
                                   soa::Join<aod::FemtoFullTracks, aod::McTrackLabels> const& tracks,
@@ -3021,8 +3069,9 @@ struct FemtoUniverseProducerTask {
         fillV0<true>(col, groupedV0Parts, groupedTracks);
       }
       for (const auto& track : groupedTracks) {
-        if (trackCuts.isSelectedMinimal(track))
+        if (trackCuts.isSelectedMinimal(track)) {
           recoMcIds.insert(track.mcParticleId());
+        }
       }
     }
 

--- a/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
+++ b/PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx
@@ -408,13 +408,11 @@ struct FemtoUniverseProducerTask {
     if (mom < ConfPhiSelection.confMomKaonLF) {
       return (std::abs(nsigmaTPCK) < ConfPhiSelection.confNSigmaTPCKaonLF);
     }
-    if (mom >= ConfPhiSelection.confMomKaonLF) { // 0.5-1.5 (now we use TPC and TOF)
-      if (!hasTOF) {
-        return false;
-      }
-      return (std::sqrt(nsigmaTPCK * nsigmaTPCK + nsigmaTOFK * nsigmaTOFK) < ConfPhiSelection.confNSigmaCombKaonLF);
+    // mom >= ConfPhiSelection.confMomKaonLF 0.5-1.5 (now we use TPC and TOF)
+    if (!hasTOF) {
+      return false;
     }
-    return false;
+    return (std::sqrt(nsigmaTPCK * nsigmaTPCK + nsigmaTOFK * nsigmaTOFK) < ConfPhiSelection.confNSigmaCombKaonLF);
   }
 
   bool isKaonRejected(float mom, float nsigmaTPCPr, float nsigmaTOFPr, float nsigmaTPCPi, float nsigmaTOFPi)
@@ -902,7 +900,7 @@ struct FemtoUniverseProducerTask {
     }
     if (particle.has_mothers()) {
       int hadronElasticStatter = 20;
-      int hadronInelasticStatter = 20;
+      int hadronInelasticStatter = 23;
       if (particle.getProcess() == hadronElasticStatter || particle.getProcess() == hadronInelasticStatter) { // treat particles from hadronic scattering (20, 23) as primary
         return 0;
       }

--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackMultKtExtended.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackMultKtExtended.cxx
@@ -84,13 +84,16 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
   } twotracksconfigs;
 
   using FemtoFullParticles = soa::Join<aod::FDParticles, aod::FDExtParticles>;
+  using FemtoFullSigmaParticles = soa::Join<aod::FDParticles, aod::FDExtParticles, aod::FDSigmaParticles>;
   // Filters for selecting particles (both p1 and p2)
   Filter trackAdditionalfilter = (nabs(aod::femtouniverseparticle::eta) < twotracksconfigs.confEtaMax); // example filtering on configurable
   using FilteredFemtoFullParticles = soa::Filtered<FemtoFullParticles>;
+  using FilteredFemtoFullSigmaParticles = soa::Filtered<FemtoFullSigmaParticles>;
   // using FilteredFemtoFullParticles = FemtoFullParticles; //if no filtering is applied uncomment this option
 
   SliceCache cache;
   Preslice<FilteredFemtoFullParticles> perCol = aod::femtouniverseparticle::fdCollisionId;
+  Preslice<FilteredFemtoFullSigmaParticles> perColSigma = aod::femtouniverseparticle::fdCollisionId;
 
   using FemtoTruthParticles = soa::Filtered<soa::Join<aod::FDParticles, aod::FDExtParticles, aod::FDMCLabels>>;
   Preslice<FemtoTruthParticles> perColMCTruth = aod::femtouniverseparticle::fdCollisionId;
@@ -109,10 +112,11 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
   /// Partition for particle 1
   Partition<FilteredFemtoFullParticles> partsOne = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack)) && aod::femtouniverseparticle::sign == as<int8_t>(trackonefilter.confChargePart1) && aod::femtouniverseparticle::pt < trackonefilter.confPtHighPart1 && aod::femtouniverseparticle::pt > trackonefilter.confpLowPart1;
 
+  Partition<FilteredFemtoFullSigmaParticles> partsOneSigma = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack)) && aod::femtouniverseparticle::sign == as<int8_t>(trackonefilter.confChargePart1) && aod::femtouniverseparticle::pt < trackonefilter.confPtHighPart1 && aod::femtouniverseparticle::pt > trackonefilter.confpLowPart1;
+
   Partition<FemtoRecoParticles> partsOneMC = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack)) && aod::femtouniverseparticle::sign == as<int8_t>(trackonefilter.confChargePart1) && aod::femtouniverseparticle::pt < trackonefilter.confPtHighPart1 && aod::femtouniverseparticle::pt > trackonefilter.confpLowPart1;
 
   Partition<FemtoTruthParticles> partsOneMCTruth = aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kMCTruthTrack) && aod::femtouniverseparticle::pt < trackonefilter.confPtHighPart1 && aod::femtouniverseparticle::pt > trackonefilter.confpLowPart1;
-  ;
 
   /// Histogramming for particle 1
   FemtoUniverseParticleHisto<aod::femtouniverseparticle::ParticleType::kTrack, 1> trackHistoPartOne;
@@ -128,6 +132,8 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
 
   /// Partition for particle 2
   Partition<FilteredFemtoFullParticles> partsTwo = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack)) && (aod::femtouniverseparticle::sign == as<int8_t>(tracktwofilter.confChargePart2)) && aod::femtouniverseparticle::pt < tracktwofilter.confPtHighPart2 && aod::femtouniverseparticle::pt > tracktwofilter.confpLowPart2;
+
+  Partition<FilteredFemtoFullSigmaParticles> partsTwoSigma = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack)) && (aod::femtouniverseparticle::sign == as<int8_t>(tracktwofilter.confChargePart2)) && aod::femtouniverseparticle::pt < tracktwofilter.confPtHighPart2 && aod::femtouniverseparticle::pt > tracktwofilter.confpLowPart2;
 
   Partition<FemtoRecoParticles> partsTwoMC = aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack) && (aod::femtouniverseparticle::sign == as<int8_t>(tracktwofilter.confChargePart2)) && aod::femtouniverseparticle::pt < tracktwofilter.confPtHighPart2 && aod::femtouniverseparticle::pt > tracktwofilter.confpLowPart2;
 
@@ -336,16 +342,16 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
     switch (PDGcode) {
       case kProton:
       case kProtonBar:
-        return trackCuts.getNsigmaTOF(part, o2::track::PID::Proton);
+        return part.tofFullNSigmaPr();
       case kPiPlus:
       case kPiMinus:
       case kPi0:
-        return trackCuts.getNsigmaTOF(part, o2::track::PID::Pion);
+        return part.tofFullNSigmaPi();
       case kKPlus:
       case kKMinus:
       case kK0Long:
       case kK0Short:
-        return trackCuts.getNsigmaTOF(part, o2::track::PID::Kaon);
+        return part.tofFullNSigmaKa();
       default:
         return 0;
     }
@@ -474,7 +480,6 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
           continue;
         }
         trackHistoPartOne.fillQA<isMC, true>(part);
-        qaRegistry.fill(HIST("Tracks_one/nSigmaTOF"), part.pt(), whichTOFNSigma(trackonefilter.confPDGCodePartOne, part), multCol);
       }
     }
 
@@ -484,7 +489,6 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
           continue;
         }
         trackHistoPartTwo.fillQA<isMC, true>(part);
-        qaRegistry.fill(HIST("Tracks_two/nSigmaTOF"), part.pt(), whichTOFNSigma(tracktwofilter.confPDGCodePartTwo, part), multCol);
       }
     }
 
@@ -625,6 +629,42 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
       }
     }
   }
+
+  /// \param col subscribe to the collision table (Data)
+  /// \param parts subscribe to the femtoUniverseParticleTable
+  void processPurityQA(soa::Filtered<o2::aod::FdCollisions>::iterator const& col,
+                       FilteredFemtoFullSigmaParticles const&)
+  {
+    fillCollision(col);
+    if (confFillDebug) {
+      sphericityRegistry.fill(HIST("sphericity"), col.sphericity());
+    }
+
+    auto thegroupPartsOne = partsOneSigma->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
+    auto thegroupPartsTwo = partsTwoSigma->sliceByCached(aod::femtouniverseparticle::fdCollisionId, col.globalIndex(), cache);
+
+    float const multCol = col.multV0M();
+
+    for (const auto& part : thegroupPartsOne) {
+      if (!isParticleNSigma((int8_t)1, part.p(), part.tpcFullNSigmaPr(), part.tofFullNSigmaPr(), part.tpcFullNSigmaPi(), part.tofFullNSigmaPi(), part.tpcFullNSigmaKa(), part.tofFullNSigmaKa())) {
+        continue;
+      }
+      trackHistoPartOne.fillQA<false, true>(part);
+      qaRegistry.fill(HIST("Tracks_one/nSigmaTOF"), part.pt(), whichTOFNSigma(trackonefilter.confPDGCodePartOne, part), multCol);
+    }
+
+    if (!isPairIdentical) {
+      // fill second
+      for (const auto& part : thegroupPartsTwo) {
+        if (!isParticleNSigma((int8_t)2, part.p(), part.tpcFullNSigmaPr(), part.tofFullNSigmaPr(), part.tpcFullNSigmaPi(), part.tofFullNSigmaPi(), part.tpcFullNSigmaKa(), part.tofFullNSigmaKa())) {
+          continue;
+        }
+        trackHistoPartTwo.fillQA<false, true>(part);
+        qaRegistry.fill(HIST("Tracks_two/nSigmaTOF"), part.pt(), whichTOFNSigma(tracktwofilter.confPDGCodePartTwo, part), multCol);
+      }
+    }
+  }
+  PROCESS_SWITCH(FemtoUniversePairTaskTrackTrackMultKtExtended, processPurityQA, "Enable processing QA for purity estimation", false);
 
   /// process function for to call doSameEvent with Data
   /// \param col subscribe to the collision table (Data)


### PR DESCRIPTION
`PWGCF/FemtoUniverse/DataModel/FemtoDerived.h`:
- add table for full TOF and TPC nSigma,
- fix linter and code check.

`PWGCF/FemtoUniverse/TableProducer/femtoUniverseProducerTask.cxx`:
- add process function that fills full TOF and TPC nSigma,
- fix linter and code check.

`PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackMultKtExtended.cxx`:
- add process function to fill histogram of full TOF nSigma in dependence of centrality and pT. 