### PR TITLE
[PWGCF] fix labeled array configurable in twoParticleCorrelationsMPI.cxx

### DIFF
--- a/PWGCF/GenericFramework/Tasks/flowGenericFramework.cxx
+++ b/PWGCF/GenericFramework/Tasks/flowGenericFramework.cxx
@@ -715,7 +715,7 @@ struct FlowGenericFramework {
           registryQA.add("K0/PiMinusTOF_K0", "", {HistType::kTH2D, {{ptAxis, axisNsigmaTOF}}});
           registryQA.add("K0/hK0Phi", "", {HistType::kTH1D, {phiAxis}});
           registryQA.add("K0/hK0Eta", "", {HistType::kTH1D, {etaAxis}});
-          registryQA.add("K0/hK0AP", "", {HistType::kTH2D, {{100, -1, 1}, {100, 0, 5.}}});
+          registryQA.add("K0/hK0AP", "", {HistType::kTH2D, {{100, -1, 1}, {500, 0, 1.}}});
           registryQA.add("K0/hK0Mass_sparse", "", {HistType::kTHnSparseF, {{axisK0Mass, ptAxis, nchAxis}}});
           registryQA.add("K0/hK0s", "", {HistType::kTH1D, {singleCount}});
           registryQA.add("K0/hK0s_corrected", "", {HistType::kTH1D, {singleCount}});
@@ -2916,20 +2916,6 @@ struct FlowGenericFramework {
     return track.eta() > cfgKinematics.cfgEta->first && track.eta() < cfgKinematics.cfgEta->second;
   }
 
-  template <typename TParticle>
-  bool areGeneratedDaughtersWithinEfficiencyEtaAcceptance(const TParticle& particle)
-  {
-    if (!particle.has_daughters()) {
-      return false;
-    }
-    for (const auto& daughter : particle.template daughters_as<aod::McParticles>()) {
-      if (daughter.eta() <= cfgKinematics.cfgEta->first || daughter.eta() >= cfgKinematics.cfgEta->second) {
-        return false;
-      }
-    }
-    return true;
-  }
-
   void fillV0EfficiencyRecoDebug(float pt, float centrality, int particleIndex, int stage)
   {
     registry.fill(HIST("Efficiency/v0RecoDebug"), pt, centrality, particleIndex, stage);
@@ -3010,7 +2996,7 @@ struct FlowGenericFramework {
             return;
           }
           fillV0EfficiencyRecoDebug(posMother.pt(), centrality, EfficiencyK0, V0EfficiencySelection);
-          if (!areGeneratedDaughtersWithinEfficiencyEtaAcceptance(posMother)) {
+          if (!isWithinEfficiencyEtaAcceptance(posMcParticle) || !isWithinEfficiencyEtaAcceptance(negMcParticle)) {
             return;
           }
           fillV0EfficiencyRecoDebug(posMother.pt(), centrality, EfficiencyK0, V0EfficiencyGeneratedDaughterEta);
@@ -3035,7 +3021,7 @@ struct FlowGenericFramework {
             return;
           }
           fillV0EfficiencyRecoDebug(posMother.pt(), centrality, EfficiencyLambda, V0EfficiencySelection);
-          if (!areGeneratedDaughtersWithinEfficiencyEtaAcceptance(posMother)) {
+          if (!isWithinEfficiencyEtaAcceptance(posMcParticle) || !isWithinEfficiencyEtaAcceptance(negMcParticle)) {
             return;
           }
           fillV0EfficiencyRecoDebug(posMother.pt(), centrality, EfficiencyLambda, V0EfficiencyGeneratedDaughterEta);

--- a/PWGCF/GenericFramework/Tasks/flowGfwNonflow.cxx
+++ b/PWGCF/GenericFramework/Tasks/flowGfwNonflow.cxx
@@ -243,11 +243,11 @@ struct FlowGfwNonflow {
 
   // Generic Framework
   GFW* fGFW = new GFW();
-  std::vector<GFW::CorrConfig> corrconfigs{};
+  std::vector<GFW::CorrConfig> corrconfigs;
   TRandom3* fRndm = new TRandom3(0);
   TAxis* fPtAxis = nullptr;
   int lastRun = -1;
-  std::vector<std::string> multipletKeys{};
+  std::vector<std::string> multipletKeys;
 
   // Track selection - DCA functions
   TF1* fPtDepDCAxy = nullptr;
@@ -420,7 +420,7 @@ struct FlowGfwNonflow {
     delete oba;
 
     // Identify unique multiplet setups and populate with identifying keys
-    identifyUniqueMultipletKeys(multipletKeys, corrconfigs, centAxis); // For now keep centrality axis hardcoded
+    identifyUniqueMultipletKeys(multipletKeys, corrconfigs, multAxis);
     LOGF(info, "Unique multiplet keys for current configuration setup");
     for (const auto& key : multipletKeys) {
       LOGF(info, key);
@@ -524,7 +524,7 @@ struct FlowGfwNonflow {
     }
   }
 
-  void identifyUniqueMultipletKeys(std::vector<std::string>& keys, const std::vector<GFW::CorrConfig>& configs, AxisSpec xAxis)
+  void identifyUniqueMultipletKeys(std::vector<std::string>& keys, const std::vector<GFW::CorrConfig>& configs, const AxisSpec& xAxis)
   {
     std::set<std::string> uniqueKeys(keys.begin(), keys.end());
     const auto& regionNames = gfwMemberCache.regions.GetNames();
@@ -584,7 +584,7 @@ struct FlowGfwNonflow {
 
       if (uniqueKeys.insert(key).second) {
         keys.push_back(std::move(key));
-        MultipletConfig currentMultipletConfig{configIndex, totalOrder, registry.add<TProfile>(Form("%s", keys.back().c_str()), Form("; centrality ; N_{%d}", totalOrder), {HistType::kTProfile, {xAxis}})};
+        MultipletConfig currentMultipletConfig{.representativeConfigIndex = configIndex, .order = totalOrder, .profile = registry.add<TProfile>(Form("%s", keys.back().c_str()), Form("; centrality ; N_{%d}", totalOrder), {HistType::kTProfile, {xAxis}})};
         effectiveMultiplets[keys.back()] = currentMultipletConfig;
       }
     }

--- a/PWGCF/TwoParticleCorrelations/Tasks/twoParticleCorrelationsMpi.cxx
+++ b/PWGCF/TwoParticleCorrelations/Tasks/twoParticleCorrelationsMpi.cxx
@@ -99,7 +99,7 @@ struct TwoParticleCorrelationsMpi {
   Configurable<std::string> cfgMultCutFormula{"cfgMultCutFormula", "", "Multiplicity correlations cut formula. A result greater than zero results in accepted event. Parameters: [cFT0C] FT0C centrality, [mFV0A] V0A multiplicity, [mGlob] global track multiplicity, [mPV] PV track multiplicity, [cFT0M] FT0M centrality"};
 
   // Suggested values: Photon: 0.004; K0 and Lambda: 0.005
-  Configurable<LabeledArray<float>> cfgPairCut{"cfgPairCut", {CfgPairCutDefaults.front().data(), 5, 1, {"Photon", "K0", "Lambda", "Phi", "Rho"}}, "Pair cuts on various particles"};
+  Configurable<LabeledArray<float>> cfgPairCut{"cfgPairCut", {CfgPairCutDefaults.front().data(), 5, {"Photon", "K0", "Lambda", "Phi", "Rho"}}, "Pair cuts on various particles"};
 
   Configurable<std::string> cfgEfficiencyTrigger{"cfgEfficiencyTrigger", "", "CCDB path to efficiency object for trigger particles"};
   Configurable<std::string> cfgEfficiencyAssociated{"cfgEfficiencyAssociated", "", "CCDB path to efficiency object for associated particles"};


### PR DESCRIPTION
Fix labeled array configurable in twoParticleCorrelationsMPI.cxx
Add nch/cent axis support in flowGfwNonflow.cxx
Use MCLabels of reconstructed particles for rejection of generated daughter eta range in flowGenericFramework.cx