### PR TITLE
[PWGCF] FemtoUniverse: Add more track cuts to task, add optional rectangular cut on Nsigma

### DIFF
--- a/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackMultKtExtended.cxx
+++ b/PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackMultKtExtended.cxx
@@ -28,6 +28,8 @@
 #include "PWGCF/FemtoUniverse/Core/FemtoUniverseTrackSelection.h"
 #include "PWGCF/FemtoUniverse/DataModel/FemtoDerived.h"
 
+#include "Common/DataModel/TrackSelectionTables.h"
+
 #include <Framework/ASoA.h>
 #include <Framework/ASoAHelpers.h>
 #include <Framework/AnalysisDataModel.h>
@@ -71,6 +73,7 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
   /// Table for both particles
   struct : o2::framework::ConfigurableGroup {
     Configurable<bool> isKaonNsigma{"isKaonNsigma", false, "Enable a strict cut selection for K+ and K-"};
+    Configurable<bool> isNsigmaRectangular{"isNsigmaRectangular", false, "Apply rectangular TPC and TOF nSigma cut, instead of a combined one (TPC<confNsigmaTPC, TOF<confNsigmaCombined)"};
     Configurable<float> confNsigmaCombined{"confNsigmaCombined", 3.0f, "TPC and TOF Pion Sigma (combined) for momentum > confTOFpMin"};
     Configurable<float> confNsigmaTPC{"confNsigmaTPC", 3.0f, "TPC Pion Sigma for momentum < confTOFpMin"};
     Configurable<float> confTOFpMin{"confTOFpMin", 0.5f, "Min. momentum for which TOF is required for PID."};
@@ -82,6 +85,13 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
     Configurable<bool> confOnlyPrimaryMCPair{"confOnlyPrimaryMCPair", false, "Fill MC pair histograms only with primary particles"};
 
   } twotracksconfigs;
+
+  struct : o2::framework::ConfigurableGroup {
+    Configurable<int> confTrkTPCnclsMin{"confTrkTPCnclsMin", 0, "Track selection: "};
+    Configurable<int> confTrkTPCcRowsMin{"confTrkTPCcRowsMin", 0, "Track selection: "};
+    Configurable<float> confDcaXYCustom1FilterCut{"confDcaXYCustom1FilterCut", 10, "Value for [1] custom DCAxy cut -> |DCAxy| < [1] + [2]/pT"};
+    Configurable<float> confDcaXYCustom2FilterCut{"confDcaXYCustom2FilterCut", 0, "Value for [2] custom DCAxy cut -> |DCAxy| < [1] + [2]/pT"};
+  } additionalcuts;
 
   using FemtoFullParticles = soa::Join<aod::FDParticles, aod::FDExtParticles>;
   using FemtoFullSigmaParticles = soa::Join<aod::FDParticles, aod::FDExtParticles, aod::FDSigmaParticles>;
@@ -110,7 +120,7 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
   } trackonefilter;
 
   /// Partition for particle 1
-  Partition<FilteredFemtoFullParticles> partsOne = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack)) && aod::femtouniverseparticle::sign == as<int8_t>(trackonefilter.confChargePart1) && aod::femtouniverseparticle::pt < trackonefilter.confPtHighPart1 && aod::femtouniverseparticle::pt > trackonefilter.confpLowPart1;
+  Partition<FilteredFemtoFullParticles> partsOne = (nabs(aod::track::dcaXY) < (additionalcuts.confDcaXYCustom1FilterCut + additionalcuts.confDcaXYCustom2FilterCut / aod::femtouniverseparticle::pt)) && (aod::femtouniverseparticle::tpcNClsFound) > as<uint8_t>(additionalcuts.confTrkTPCnclsMin) && (aod::femtouniverseparticle::tpcNClsCrossedRows) > as<uint8_t>(additionalcuts.confTrkTPCcRowsMin) && (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack)) && aod::femtouniverseparticle::sign == as<int8_t>(trackonefilter.confChargePart1) && aod::femtouniverseparticle::pt<trackonefilter.confPtHighPart1 && aod::femtouniverseparticle::pt> trackonefilter.confpLowPart1;
 
   Partition<FilteredFemtoFullSigmaParticles> partsOneSigma = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack)) && aod::femtouniverseparticle::sign == as<int8_t>(trackonefilter.confChargePart1) && aod::femtouniverseparticle::pt < trackonefilter.confPtHighPart1 && aod::femtouniverseparticle::pt > trackonefilter.confpLowPart1;
 
@@ -124,14 +134,13 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
   /// Particle 2
   struct : o2::framework::ConfigurableGroup {
     Configurable<int> confPDGCodePartTwo{"confPDGCodePartTwo", 211, "Particle 2 -- PDG code"};
-    // Configurable<uint32_t> confCutPartTwo{"confCutPartTwo", 5542474, "Particle 2 -- Selection bit"};
     Configurable<float> confpLowPart2{"confpLowPart2", 0.14, "Lower limit for Pt for the second particle"};
     Configurable<float> confPtHighPart2{"confPtHighPart2", 1.5, "Higher limit for Pt for the second particle"};
     Configurable<int> confChargePart2{"confChargePart2", -1, "Particle 2 sign"};
   } tracktwofilter;
 
   /// Partition for particle 2
-  Partition<FilteredFemtoFullParticles> partsTwo = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack)) && (aod::femtouniverseparticle::sign == as<int8_t>(tracktwofilter.confChargePart2)) && aod::femtouniverseparticle::pt < tracktwofilter.confPtHighPart2 && aod::femtouniverseparticle::pt > tracktwofilter.confpLowPart2;
+  Partition<FilteredFemtoFullParticles> partsTwo = (nabs(aod::track::dcaXY) < (additionalcuts.confDcaXYCustom1FilterCut + additionalcuts.confDcaXYCustom2FilterCut / aod::femtouniverseparticle::pt)) && (aod::femtouniverseparticle::tpcNClsFound > as<uint8_t>(additionalcuts.confTrkTPCnclsMin)) && aod::femtouniverseparticle::tpcNClsCrossedRows > as<uint8_t>(additionalcuts.confTrkTPCcRowsMin) && (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack)) && aod::femtouniverseparticle::sign == as<int8_t>(tracktwofilter.confChargePart2) && aod::femtouniverseparticle::pt<tracktwofilter.confPtHighPart2 && aod::femtouniverseparticle::pt> tracktwofilter.confpLowPart2;
 
   Partition<FilteredFemtoFullSigmaParticles> partsTwoSigma = (aod::femtouniverseparticle::partType == uint8_t(aod::femtouniverseparticle::ParticleType::kTrack)) && (aod::femtouniverseparticle::sign == as<int8_t>(tracktwofilter.confChargePart2)) && aod::femtouniverseparticle::pt < tracktwofilter.confPtHighPart2 && aod::femtouniverseparticle::pt > tracktwofilter.confpLowPart2;
 
@@ -258,6 +267,12 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
     // confTOFpMin -- momentum value when we start using TOF; set to 1000 if TOF not needed
     // confNsigmaTPC -> TPC Sigma for momentum < confTOFpMin
     // confNsigmaCombined -> TPC and TOF Sigma (combined) for momentum > confTOFpMin
+    if (twotracksconfigs.isNsigmaRectangular) {
+      if (mom < twotracksconfigs.confTOFpMin) {
+        return std::abs(nsigmaTPC) < twotracksconfigs.confNsigmaTPC;
+      }
+      return (std::abs(nsigmaTPC) < twotracksconfigs.confNsigmaTPC && std::abs(nsigmaTOF) < twotracksconfigs.confNsigmaCombined);
+    }
 
     if (mom < twotracksconfigs.confTOFpMin) {
       return std::abs(nsigmaTPC) < twotracksconfigs.confNsigmaTPC;
@@ -469,7 +484,6 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
   template <bool isMC, typename PartitionType, typename PartType>
   void doSameEvent(PartitionType const& groupPartsOne, PartitionType const& groupPartsTwo, PartType const& parts, float magFieldTesla, float multCol, int pairType, bool fillQA)
   {
-
     enum PairTypes { type1 = 1,
                      type2 = 2,
                      type3 = 3 };
@@ -649,6 +663,7 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
       if (!isParticleNSigma((int8_t)1, part.p(), part.tpcFullNSigmaPr(), part.tofFullNSigmaPr(), part.tpcFullNSigmaPi(), part.tofFullNSigmaPi(), part.tpcFullNSigmaKa(), part.tofFullNSigmaKa())) {
         continue;
       }
+
       trackHistoPartOne.fillQA<false, true>(part);
       qaRegistry.fill(HIST("Tracks_one/nSigmaTOF"), part.pt(), whichTOFNSigma(trackonefilter.confPDGCodePartOne, part), multCol);
     }
@@ -736,7 +751,6 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
   template <bool isMC, typename PartitionType, typename PartType>
   void doMixedEvent(PartitionType const& groupPartsOne, PartitionType const& groupPartsTwo, PartType const& parts, float magFieldTesla, float multCol, int pairType)
   {
-
     for (const auto& [p1, p2] : combinations(CombinationsFullIndexPolicy(groupPartsOne, groupPartsTwo))) {
 
       if (!isParticleNSigma((int8_t)2, p1.p(), trackCuts.getNsigmaTPC(p1, o2::track::PID::Proton), trackCuts.getNsigmaTOF(p1, o2::track::PID::Proton), trackCuts.getNsigmaTPC(p1, o2::track::PID::Pion), trackCuts.getNsigmaTOF(p1, o2::track::PID::Pion), trackCuts.getNsigmaTPC(p1, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(p1, o2::track::PID::Kaon))) {
@@ -921,7 +935,6 @@ struct FemtoUniversePairTaskTrackTrackMultKtExtended {
                         FemtoRecoParticles const& parts,
                         o2::aod::FdMCParticles const& mparts)
   {
-
     auto doFractions = [&](auto& p1, auto& p2, auto& magFieldTesla, int partType) -> void {
       if (!isParticleNSigma((int8_t)2, p1.p(), trackCuts.getNsigmaTPC(p1, o2::track::PID::Proton), trackCuts.getNsigmaTOF(p1, o2::track::PID::Proton), trackCuts.getNsigmaTPC(p1, o2::track::PID::Pion), trackCuts.getNsigmaTOF(p1, o2::track::PID::Pion), trackCuts.getNsigmaTPC(p1, o2::track::PID::Kaon), trackCuts.getNsigmaTOF(p1, o2::track::PID::Kaon))) {
         return;


### PR DESCRIPTION
`PWGCF/FemtoUniverse/Tasks/femtoUniversePairTaskTrackTrackMultKtExtended.cxx`:
- add option to perform a rectangilar cut on TPC and TOF nSigma, instead of classic combined one. This option is set with configurable _isNsigmaRectangular_ (default to false),
- add track cuts on TPC clusters, TPC rows and DCAxy (so that they can be set looser in the producer.