### PR TITLE
[PWGHF] Fix D0 ML prompt and non-prompt score ordering

### DIFF
--- a/PWGHF/Core/HfMlResponseD0ToKPi.h
+++ b/PWGHF/Core/HfMlResponseD0ToKPi.h
@@ -225,8 +225,8 @@ class HfMlResponseD0ToKPi : public HfMlResponse<TypeOutputScore>
         CHECK_AND_FILL_VEC_D0_SIGNED(candidate, nSigTpcTofKaExpKa, tpcTofNSigmaKa1, tpcTofNSigmaKa0);
 
         CHECK_AND_FILL_VEC_D0_ML(candidate, bdtOutputBkg, mlProbD0, mlProbD0bar, 0);
-        CHECK_AND_FILL_VEC_D0_ML(candidate, bdtOutputNonPrompt, mlProbD0, mlProbD0bar, 1);
-        CHECK_AND_FILL_VEC_D0_ML(candidate, bdtOutputPrompt, mlProbD0, mlProbD0bar, 2);
+        CHECK_AND_FILL_VEC_D0_ML(candidate, bdtOutputPrompt, mlProbD0, mlProbD0bar, 1);
+        CHECK_AND_FILL_VEC_D0_ML(candidate, bdtOutputNonPrompt, mlProbD0, mlProbD0bar, 2);
 
         CHECK_AND_FILL_VEC_D0(maxNormalisedDeltaIP);
         CHECK_AND_FILL_VEC_D0_FULL(candidate, impactParameterProduct, impactParameterProduct);

--- a/PWGHF/D2H/Tasks/taskD0.cxx
+++ b/PWGHF/D2H/Tasks/taskD0.cxx
@@ -366,8 +366,8 @@ struct HfTaskD0 {
 
       // Insert ML scores after pt (position 2) to match taskDplus structure: [mass, pt, mlScores, ...]
       if (doprocessDataWithDCAFitterNMlWithUpc) {
-        axes.insert(axes.begin() + 2, thnAxisPromptScore);
         axes.insert(axes.begin() + 2, thnAxisNonPromptScore);
+        axes.insert(axes.begin() + 2, thnAxisPromptScore);
         axes.insert(axes.begin() + 2, thnAxisBkgScore);
       } else {
         axes.insert(axes.begin(), thnAxisPromptScore);


### PR DESCRIPTION
I received several reports from different analysers about the D0 BDT score ordering, which has caused some confusion.

This PR fixes the D0 ML score class ordering used in the D0 task and ML response helper.

The D0 ML output vector follows the common charm-hadron convention:
- index 0: background
- index 1: prompt
- index 2: non-prompt

The previous code interpreted indices 1 and 2 as non-prompt and prompt in some places. This update aligns the D0 ML feature mapping and THnSparse axis ordering with the model output convention and with the convention used by other charm-hadron tasks.

The ML selection cut directions are unchanged. For `o2-analysis-hf-candidate-selector-d0`, `cutDirMl` should remain:
- 0 for the background score
- 1 for the prompt score
- 1 for the non-prompt score

i.e. `cutDirMl = 0,1,1`.

Tagging D0 task users: @Mingyu3360715 @wuctlby @xinyepeng @kgwizdzi @atavirag  

Please let me know if you have any comments on this! Thanks a lot!