### PR TITLE
[PWGLF] Fix primary particle selection for predictions

### DIFF
--- a/PWGLF/Tasks/QC/mcParticlePrediction.cxx
+++ b/PWGLF/Tasks/QC/mcParticlePrediction.cxx
@@ -496,41 +496,7 @@ struct McParticlePrediction {
         continue;
       }
 
-      // if (!particle.isPhysicalPrimary()) {
-      //   continue;
-      // }
-
-      TParticlePDG* p = pdgDB->GetParticle(particle.pdgCode());
-      if (p) {
-        if (std::abs(p->Charge()) > chargetolerance) {
-          histos.fill(HIST("particles/eta/charged"), particle.eta());
-        } else {
-          histos.fill(HIST("particles/eta/neutral"), particle.eta());
-        }
-      }
-
-      if (std::abs(particle.y()) >= rapidityCut) {
-        continue;
-      }
-
-      // Check if particle has daughters (not a final state particle)
-      auto daughters = particle.daughters_as<aod::McParticles>();
-      bool isValid = false;
-
-      if (daughters.size() > 0) {
-        isValid = true;
-        for (const auto& daughter : daughters) {
-          if (!daughter.isPhysicalPrimary()) {
-            isValid = false;
-            break;
-          }
-        }
-      } else {
-        // Final state particle - check if particle itself is physical primary
-        isValid = particle.isPhysicalPrimary();
-      }
-
-      if (!isValid) {
+      if (!particle.isPhysicalPrimary()) {
         continue;
       }
 

--- a/PWGLF/Tasks/QC/mcParticlePrediction.cxx
+++ b/PWGLF/Tasks/QC/mcParticlePrediction.cxx
@@ -500,6 +500,19 @@ struct McParticlePrediction {
         continue;
       }
 
+      TParticlePDG* p = pdgDB->GetParticle(particle.pdgCode());
+      if (p) {
+        if (std::abs(p->Charge()) > chargetolerance) {
+          histos.fill(HIST("particles/eta/charged"), particle.eta());
+        } else {
+          histos.fill(HIST("particles/eta/neutral"), particle.eta());
+        }
+      }
+
+      if (std::abs(particle.y()) >= rapidityCut) {
+        continue;
+      }
+
       histos.fill(HIST("particles/vtx/x"), particle.vx());
       histos.fill(HIST("particles/vtx/y"), particle.vy());
       histos.fill(HIST("particles/vtx/z"), particle.vz() - mcCollision.posZ());


### PR DESCRIPTION
Removed checks for particle charge and validity, retaining only the physical primary check.