### PR TITLE
[PWGHF] Refactor mixed event handling for track selection in Charm Track femto task

### DIFF
--- a/PWGHF/HFC/Tasks/taskCharmHadronsTrackFemtoDream.cxx
+++ b/PWGHF/HFC/Tasks/taskCharmHadronsTrackFemtoDream.cxx
@@ -920,15 +920,19 @@ struct HfTaskCharmHadronsTrackFemtoDream {
       }
     }
     if (mixSetting.doMixEvent) {
+      auto* partitionTrk1Selected = &partitionTrk1;
+      if (trackSel.pdgCodeTrack1.value == kKPlus) {
+        partitionTrk1Selected = &partitionTrk1Ka;
+      }
       switch (mixSetting.mixingBinPolicy) {
         case femtodreamcollision::kMult:
-          doMixedEvent<false, DecayChannel::LcToPKPi, FilteredCollisions>(cols, partitionCharmHadron3Prong, partitionTrk1, parts, colBinningMult);
+          doMixedEvent<false, DecayChannel::LcToPKPi, FilteredCollisions>(cols, partitionCharmHadron3Prong, *partitionTrk1Selected, parts, colBinningMult);
           break;
         case femtodreamcollision::kMultPercentile:
-          doMixedEvent<false, DecayChannel::LcToPKPi, FilteredCollisions>(cols, partitionCharmHadron3Prong, partitionTrk1, parts, colBinningMultPercentile);
+          doMixedEvent<false, DecayChannel::LcToPKPi, FilteredCollisions>(cols, partitionCharmHadron3Prong, *partitionTrk1Selected, parts, colBinningMultPercentile);
           break;
         case femtodreamcollision::kMultMultPercentile:
-          doMixedEvent<false, DecayChannel::LcToPKPi, FilteredCollisions>(cols, partitionCharmHadron3Prong, partitionTrk1, parts, colBinningMultMultPercentile);
+          doMixedEvent<false, DecayChannel::LcToPKPi, FilteredCollisions>(cols, partitionCharmHadron3Prong, *partitionTrk1Selected, parts, colBinningMultMultPercentile);
           break;
         default:
           LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -962,15 +966,19 @@ struct HfTaskCharmHadronsTrackFemtoDream {
       }
     }
     if (mixSetting.doMixEvent) {
+      auto* partitionTrk1Selected = &partitionTrk1;
+      if (trackSel.pdgCodeTrack1.value == kKPlus) {
+        partitionTrk1Selected = &partitionTrk1Ka;
+      }
       switch (mixSetting.mixingBinPolicy) {
         case femtodreamcollision::kMult:
-          doMixedEvent<false, DecayChannel::DplusToPiKPi, FilteredCollisions>(cols, partitionCharmHadron3Prong, partitionTrk1, parts, colBinningMult);
+          doMixedEvent<false, DecayChannel::DplusToPiKPi, FilteredCollisions>(cols, partitionCharmHadron3Prong, *partitionTrk1Selected, parts, colBinningMult);
           break;
         case femtodreamcollision::kMultPercentile:
-          doMixedEvent<false, DecayChannel::DplusToPiKPi, FilteredCollisions>(cols, partitionCharmHadron3Prong, partitionTrk1, parts, colBinningMultPercentile);
+          doMixedEvent<false, DecayChannel::DplusToPiKPi, FilteredCollisions>(cols, partitionCharmHadron3Prong, *partitionTrk1Selected, parts, colBinningMultPercentile);
           break;
         case femtodreamcollision::kMultMultPercentile:
-          doMixedEvent<false, DecayChannel::DplusToPiKPi, FilteredCollisions>(cols, partitionCharmHadron3Prong, partitionTrk1, parts, colBinningMultMultPercentile);
+          doMixedEvent<false, DecayChannel::DplusToPiKPi, FilteredCollisions>(cols, partitionCharmHadron3Prong, *partitionTrk1Selected, parts, colBinningMultMultPercentile);
           break;
         default:
           LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -1003,15 +1011,19 @@ struct HfTaskCharmHadronsTrackFemtoDream {
       }
     }
     if (mixSetting.doMixEvent) {
+      auto* partitionTrk1Selected = &partitionTrk1;
+      if (trackSel.pdgCodeTrack1.value == kKPlus) {
+        partitionTrk1Selected = &partitionTrk1Ka;
+      }
       switch (mixSetting.mixingBinPolicy) {
         case femtodreamcollision::kMult:
-          doMixedEvent<false, DecayChannel::D0ToPiK, FilteredCollisions>(cols, partitionCharmHadron2Prong, partitionTrk1, parts, colBinningMult);
+          doMixedEvent<false, DecayChannel::D0ToPiK, FilteredCollisions>(cols, partitionCharmHadron2Prong, *partitionTrk1Selected, parts, colBinningMult);
           break;
         case femtodreamcollision::kMultPercentile:
-          doMixedEvent<false, DecayChannel::D0ToPiK, FilteredCollisions>(cols, partitionCharmHadron2Prong, partitionTrk1, parts, colBinningMultPercentile);
+          doMixedEvent<false, DecayChannel::D0ToPiK, FilteredCollisions>(cols, partitionCharmHadron2Prong, *partitionTrk1Selected, parts, colBinningMultPercentile);
           break;
         case femtodreamcollision::kMultMultPercentile:
-          doMixedEvent<false, DecayChannel::D0ToPiK, FilteredCollisions>(cols, partitionCharmHadron2Prong, partitionTrk1, parts, colBinningMultMultPercentile);
+          doMixedEvent<false, DecayChannel::D0ToPiK, FilteredCollisions>(cols, partitionCharmHadron2Prong, *partitionTrk1Selected, parts, colBinningMultMultPercentile);
           break;
         default:
           LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -1044,15 +1056,19 @@ struct HfTaskCharmHadronsTrackFemtoDream {
       }
     }
     if (mixSetting.doMixEvent) {
+      auto* partitionTrk1Selected = &partitionTrk1;
+      if (trackSel.pdgCodeTrack1.value == kKPlus) {
+        partitionTrk1Selected = &partitionTrk1Ka;
+      }
       switch (mixSetting.mixingBinPolicy) {
         case femtodreamcollision::kMult:
-          doMixedEvent<false, DecayChannel::DstarToD0Pi, FilteredCollisions>(cols, partitionCharmHadronDstar, partitionTrk1, parts, colBinningMult);
+          doMixedEvent<false, DecayChannel::DstarToD0Pi, FilteredCollisions>(cols, partitionCharmHadronDstar, *partitionTrk1Selected, parts, colBinningMult);
           break;
         case femtodreamcollision::kMultPercentile:
-          doMixedEvent<false, DecayChannel::DstarToD0Pi, FilteredCollisions>(cols, partitionCharmHadronDstar, partitionTrk1, parts, colBinningMultPercentile);
+          doMixedEvent<false, DecayChannel::DstarToD0Pi, FilteredCollisions>(cols, partitionCharmHadronDstar, *partitionTrk1Selected, parts, colBinningMultPercentile);
           break;
         case femtodreamcollision::kMultMultPercentile:
-          doMixedEvent<false, DecayChannel::DstarToD0Pi, FilteredCollisions>(cols, partitionCharmHadronDstar, partitionTrk1, parts, colBinningMultMultPercentile);
+          doMixedEvent<false, DecayChannel::DstarToD0Pi, FilteredCollisions>(cols, partitionCharmHadronDstar, *partitionTrk1Selected, parts, colBinningMultMultPercentile);
           break;
         default:
           LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -1123,18 +1139,24 @@ struct HfTaskCharmHadronsTrackFemtoDream {
       }
       doSameEvent<true, DecayChannel::LcToPKPi, FilteredCharmMcCand3Prongs>(sliceMcCharmHad, sliceMcTrk1, parts, col);
     }
-    switch (mixSetting.mixingBinPolicy) {
-      case femtodreamcollision::kMult:
-        doMixedEvent<true, DecayChannel::LcToPKPi, FilteredMcColisions>(cols, partitionMcCharmHadron3Prong, partitionMcTrk1, parts, colBinningMult);
-        break;
-      case femtodreamcollision::kMultPercentile:
-        doMixedEvent<true, DecayChannel::LcToPKPi, FilteredMcColisions>(cols, partitionMcCharmHadron3Prong, partitionMcTrk1, parts, colBinningMultPercentile);
-        break;
-      case femtodreamcollision::kMultMultPercentile:
-        doMixedEvent<true, DecayChannel::LcToPKPi, FilteredMcColisions>(cols, partitionMcCharmHadron3Prong, partitionMcTrk1, parts, colBinningMultMultPercentile);
-        break;
-      default:
-        LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
+    if (mixSetting.doMixEvent) {
+      auto* partitionTrk1Selected = &partitionMcTrk1;
+      if (trackSel.pdgCodeTrack1.value == kKPlus) {
+        partitionTrk1Selected = &partitionMcTrk1Ka;
+      }
+      switch (mixSetting.mixingBinPolicy) {
+        case femtodreamcollision::kMult:
+          doMixedEvent<true, DecayChannel::LcToPKPi, FilteredMcColisions>(cols, partitionMcCharmHadron3Prong, *partitionTrk1Selected, parts, colBinningMult);
+          break;
+        case femtodreamcollision::kMultPercentile:
+          doMixedEvent<true, DecayChannel::LcToPKPi, FilteredMcColisions>(cols, partitionMcCharmHadron3Prong, *partitionTrk1Selected, parts, colBinningMultPercentile);
+          break;
+        case femtodreamcollision::kMultMultPercentile:
+          doMixedEvent<true, DecayChannel::LcToPKPi, FilteredMcColisions>(cols, partitionMcCharmHadron3Prong, *partitionTrk1Selected, parts, colBinningMultMultPercentile);
+          break;
+        default:
+          LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
+      }
     }
   }
   PROCESS_SWITCH(HfTaskCharmHadronsTrackFemtoDream, processMcLcTrk, "Enable processing LcToPKPi and Tracks correlation for Monte Carlo", false);
@@ -1158,18 +1180,24 @@ struct HfTaskCharmHadronsTrackFemtoDream {
       }
       doSameEvent<true, DecayChannel::DplusToPiKPi, FilteredCharmMcCand3Prongs>(sliceMcCharmHad, sliceMcTrk1, parts, col);
     }
-    switch (mixSetting.mixingBinPolicy) {
-      case femtodreamcollision::kMult:
-        doMixedEvent<true, DecayChannel::DplusToPiKPi, FilteredMcColisions>(cols, partitionMcCharmHadron3Prong, partitionMcTrk1, parts, colBinningMult);
-        break;
-      case femtodreamcollision::kMultPercentile:
-        doMixedEvent<true, DecayChannel::DplusToPiKPi, FilteredMcColisions>(cols, partitionMcCharmHadron3Prong, partitionMcTrk1, parts, colBinningMultPercentile);
-        break;
-      case femtodreamcollision::kMultMultPercentile:
-        doMixedEvent<true, DecayChannel::DplusToPiKPi, FilteredMcColisions>(cols, partitionMcCharmHadron3Prong, partitionMcTrk1, parts, colBinningMultMultPercentile);
-        break;
-      default:
-        LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
+    if (mixSetting.doMixEvent) {
+      auto* partitionTrk1Selected = &partitionMcTrk1;
+      if (trackSel.pdgCodeTrack1.value == kKPlus) {
+        partitionTrk1Selected = &partitionMcTrk1Ka;
+      }
+      switch (mixSetting.mixingBinPolicy) {
+        case femtodreamcollision::kMult:
+          doMixedEvent<true, DecayChannel::DplusToPiKPi, FilteredMcColisions>(cols, partitionMcCharmHadron3Prong, *partitionTrk1Selected, parts, colBinningMult);
+          break;
+        case femtodreamcollision::kMultPercentile:
+          doMixedEvent<true, DecayChannel::DplusToPiKPi, FilteredMcColisions>(cols, partitionMcCharmHadron3Prong, *partitionTrk1Selected, parts, colBinningMultPercentile);
+          break;
+        case femtodreamcollision::kMultMultPercentile:
+          doMixedEvent<true, DecayChannel::DplusToPiKPi, FilteredMcColisions>(cols, partitionMcCharmHadron3Prong, *partitionTrk1Selected, parts, colBinningMultMultPercentile);
+          break;
+        default:
+          LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
+      }
     }
   }
   PROCESS_SWITCH(HfTaskCharmHadronsTrackFemtoDream, processMcDplusTrk, "Enable processing DplusToPiKPi and Tracks correlation for Monte Carlo", false);
@@ -1193,18 +1221,24 @@ struct HfTaskCharmHadronsTrackFemtoDream {
       }
       doSameEvent<true, DecayChannel::D0ToPiK, FilteredCharmMcCand2Prongs>(sliceMcCharmHad, sliceMcTrk1, parts, col);
     }
-    switch (mixSetting.mixingBinPolicy) {
-      case femtodreamcollision::kMult:
-        doMixedEvent<true, DecayChannel::D0ToPiK, FilteredMcColisions>(cols, partitionMcCharmHadron2Prong, partitionMcTrk1, parts, colBinningMult);
-        break;
-      case femtodreamcollision::kMultPercentile:
-        doMixedEvent<true, DecayChannel::D0ToPiK, FilteredMcColisions>(cols, partitionMcCharmHadron2Prong, partitionMcTrk1, parts, colBinningMultPercentile);
-        break;
-      case femtodreamcollision::kMultMultPercentile:
-        doMixedEvent<true, DecayChannel::D0ToPiK, FilteredMcColisions>(cols, partitionMcCharmHadron2Prong, partitionMcTrk1, parts, colBinningMultMultPercentile);
-        break;
-      default:
-        LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
+    if (mixSetting.doMixEvent) {
+      auto* partitionTrk1Selected = &partitionMcTrk1;
+      if (trackSel.pdgCodeTrack1.value == kKPlus) {
+        partitionTrk1Selected = &partitionMcTrk1Ka;
+      }
+      switch (mixSetting.mixingBinPolicy) {
+        case femtodreamcollision::kMult:
+          doMixedEvent<true, DecayChannel::D0ToPiK, FilteredMcColisions>(cols, partitionMcCharmHadron2Prong, *partitionTrk1Selected, parts, colBinningMult);
+          break;
+        case femtodreamcollision::kMultPercentile:
+          doMixedEvent<true, DecayChannel::D0ToPiK, FilteredMcColisions>(cols, partitionMcCharmHadron2Prong, *partitionTrk1Selected, parts, colBinningMultPercentile);
+          break;
+        case femtodreamcollision::kMultMultPercentile:
+          doMixedEvent<true, DecayChannel::D0ToPiK, FilteredMcColisions>(cols, partitionMcCharmHadron2Prong, *partitionTrk1Selected, parts, colBinningMultMultPercentile);
+          break;
+        default:
+          LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
+      }
     }
   }
   PROCESS_SWITCH(HfTaskCharmHadronsTrackFemtoDream, processMcD0Trk, "Enable processing D0ToPiK and Tracks correlation for Monte Carlo", false);
@@ -1228,18 +1262,24 @@ struct HfTaskCharmHadronsTrackFemtoDream {
       }
       doSameEvent<true, DecayChannel::DstarToD0Pi, FilteredCharmMcCandDstars>(sliceMcCharmHad, sliceMcTrk1, parts, col);
     }
-    switch (mixSetting.mixingBinPolicy) {
-      case femtodreamcollision::kMult:
-        doMixedEvent<true, DecayChannel::DstarToD0Pi, FilteredMcColisions>(cols, partitionMcCharmHadronDstar, partitionMcTrk1, parts, colBinningMult);
-        break;
-      case femtodreamcollision::kMultPercentile:
-        doMixedEvent<true, DecayChannel::DstarToD0Pi, FilteredMcColisions>(cols, partitionMcCharmHadronDstar, partitionMcTrk1, parts, colBinningMultPercentile);
-        break;
-      case femtodreamcollision::kMultMultPercentile:
-        doMixedEvent<true, DecayChannel::DstarToD0Pi, FilteredMcColisions>(cols, partitionMcCharmHadronDstar, partitionMcTrk1, parts, colBinningMultMultPercentile);
-        break;
-      default:
-        LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
+    if (mixSetting.doMixEvent) {
+      auto* partitionTrk1Selected = &partitionMcTrk1;
+      if (trackSel.pdgCodeTrack1.value == kKPlus) {
+        partitionTrk1Selected = &partitionMcTrk1Ka;
+      }
+      switch (mixSetting.mixingBinPolicy) {
+        case femtodreamcollision::kMult:
+          doMixedEvent<true, DecayChannel::DstarToD0Pi, FilteredMcColisions>(cols, partitionMcCharmHadronDstar, *partitionTrk1Selected, parts, colBinningMult);
+          break;
+        case femtodreamcollision::kMultPercentile:
+          doMixedEvent<true, DecayChannel::DstarToD0Pi, FilteredMcColisions>(cols, partitionMcCharmHadronDstar, *partitionTrk1Selected, parts, colBinningMultPercentile);
+          break;
+        case femtodreamcollision::kMultMultPercentile:
+          doMixedEvent<true, DecayChannel::DstarToD0Pi, FilteredMcColisions>(cols, partitionMcCharmHadronDstar, *partitionTrk1Selected, parts, colBinningMultMultPercentile);
+          break;
+        default:
+          LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
+      }
     }
   }
   PROCESS_SWITCH(HfTaskCharmHadronsTrackFemtoDream, processMcDstarTrk, "Enable processing DstarToD0Pi and Tracks correlation for Monte Carlo", false);

--- a/PWGHF/HFC/Tasks/taskCharmHadronsTrackFemtoDream.cxx
+++ b/PWGHF/HFC/Tasks/taskCharmHadronsTrackFemtoDream.cxx
@@ -382,10 +382,9 @@ struct HfTaskCharmHadronsTrackFemtoDream {
       if (cand.candidateSelFlag() == 1) {
         invMass = cand.m(std::array{MassPiPlus, MassKPlus});
         return invMass;
-      } else {
-        invMass = cand.m(std::array{MassKPlus, MassPiPlus});
-        return invMass;
       }
+      invMass = cand.m(std::array{MassKPlus, MassPiPlus});
+      return invMass;
     } else if constexpr (Channel == DecayChannel::DstarToD0Pi) { // D* → D0π (PDG: 413)
       float mDstar = 0.f;
       float mD0 = 0.f;
@@ -398,9 +397,8 @@ struct HfTaskCharmHadronsTrackFemtoDream {
       }
       if (ReturnDaughMass) {
         return mD0;
-      } else {
-        return mDstar - mD0;
       }
+      return mDstar - mD0;
     } else if constexpr (Channel == DecayChannel::XicToXiPiPi) {
       invMass = cand.m(std::array{MassXiMinus, MassPiPlus, MassPiPlus});
       return invMass;
@@ -621,7 +619,7 @@ struct HfTaskCharmHadronsTrackFemtoDream {
   }
 
   template <bool IsMc, DecayChannel Channel, typename CollisionType, typename PartitionType1, typename PartitionType2, typename TableTracks, typename BinningType>
-  void doMixedEvent(CollisionType const& cols, PartitionType1& charms, PartitionType2& trks, TableTracks const& parts, BinningType policy)
+  void doMixedEvent(CollisionType const& cols, PartitionType1& charms, PartitionType2& trks, TableTracks const& parts, BinningType const& policy)
   {
     processType = 2; // for mixed event
     // Mixed events that contain the pair of interest
@@ -912,9 +910,8 @@ struct HfTaskCharmHadronsTrackFemtoDream {
       auto sliceCharmHad = partitionCharmHadron3Prong->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
       if (fillTableWithCharm.value && sliceCharmHad.size() == 0) {
         continue;
-      } else {
-        fillTables<false, DecayChannel::LcToPKPi>(col, sliceTrk1, sliceCharmHad);
       }
+      fillTables<false, DecayChannel::LcToPKPi>(col, sliceTrk1, sliceCharmHad);
       if (sliceCharmHad.size() > 0 && sliceTrk1.size() > 0) {
         doSameEvent<false, DecayChannel::LcToPKPi, FilteredCharmCand3Prongs>(sliceCharmHad, sliceTrk1, parts, col);
       }
@@ -958,9 +955,8 @@ struct HfTaskCharmHadronsTrackFemtoDream {
 
       if (fillTableWithCharm.value && sliceCharmHad.size() == 0) {
         continue;
-      } else {
-        fillTables<false, DecayChannel::DplusToPiKPi>(col, sliceTrk1, sliceCharmHad);
       }
+      fillTables<false, DecayChannel::DplusToPiKPi>(col, sliceTrk1, sliceCharmHad);
       if (sliceCharmHad.size() > 0 && sliceTrk1.size() > 0) {
         doSameEvent<false, DecayChannel::DplusToPiKPi, FilteredCharmCand3Prongs>(sliceCharmHad, sliceTrk1, parts, col);
       }
@@ -1003,9 +999,8 @@ struct HfTaskCharmHadronsTrackFemtoDream {
       auto sliceCharmHad = partitionCharmHadron2Prong->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
       if (fillTableWithCharm.value && sliceCharmHad.size() == 0) {
         continue;
-      } else {
-        fillTables<false, DecayChannel::D0ToPiK>(col, sliceTrk1, sliceCharmHad);
       }
+      fillTables<false, DecayChannel::D0ToPiK>(col, sliceTrk1, sliceCharmHad);
       if (sliceCharmHad.size() > 0 && sliceTrk1.size() > 0) {
         doSameEvent<false, DecayChannel::D0ToPiK, FilteredCharmCand2Prongs>(sliceCharmHad, sliceTrk1, parts, col);
       }
@@ -1048,9 +1043,8 @@ struct HfTaskCharmHadronsTrackFemtoDream {
       auto sliceCharmHad = partitionCharmHadronDstar->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
       if (fillTableWithCharm.value && sliceCharmHad.size() == 0) {
         continue;
-      } else {
-        fillTables<false, DecayChannel::DstarToD0Pi>(col, sliceTrk1, sliceCharmHad);
       }
+      fillTables<false, DecayChannel::DstarToD0Pi>(col, sliceTrk1, sliceCharmHad);
       if (sliceCharmHad.size() > 0 && sliceTrk1.size() > 0) {
         doSameEvent<false, DecayChannel::DstarToD0Pi, FilteredCharmCandDstars>(sliceCharmHad, sliceTrk1, parts, col);
       }
@@ -1091,9 +1085,8 @@ struct HfTaskCharmHadronsTrackFemtoDream {
       auto sliceCharmHad = partitionCharmHadron3ProngXic->sliceByCached(aod::femtodreamparticle::fdCollisionId, col.globalIndex(), cache);
       if (fillTableWithCharm.value && sliceCharmHad.size() == 0) {
         continue;
-      } else {
-        fillTables<false, DecayChannel::XicToXiPiPi>(col, sliceTrk1, sliceCharmHad);
       }
+      fillTables<false, DecayChannel::XicToXiPiPi>(col, sliceTrk1, sliceCharmHad);
       if (sliceCharmHad.size() > 0 && sliceTrk1.size() > 0) {
         doSameEvent<false, DecayChannel::XicToXiPiPi, FilteredCharmCand3ProngsXic>(sliceCharmHad, sliceTrk1, parts, col);
       }


### PR DESCRIPTION
Updated mixed event handling to use selected partition for track 1 based on PDG code. This change applies to multiple decay channels and ensures correct partitioning for mixed events. The effect only for the MC mixed-event