### PR TITLE
[PWGLF] Updated the Table producer and Task for uncertainty analysis

### DIFF
--- a/PWGLF/DataModel/LFSpincorrelationTables.h
+++ b/PWGLF/DataModel/LFSpincorrelationTables.h
@@ -52,6 +52,8 @@ DECLARE_SOA_COLUMN(ProtonEta, protonEta, float);                   //! Proton Et
 DECLARE_SOA_COLUMN(ProtonPhi, protonPhi, float);                   //! Proton Phi
 DECLARE_SOA_COLUMN(ProtonIndex, protonIndex, int);                 //! Proton index
 DECLARE_SOA_COLUMN(PionIndex, pionIndex, int);                     //! Pion index
+DECLARE_SOA_COLUMN(DcaV0ToPV, dcaV0ToPV, float);                   //! DCA of V0 to primary vertex
+
 } // namespace lambdapair
 DECLARE_SOA_TABLE(LambdaPairs, "AOD", "LAMBDAPAIR",
                   o2::soa::Index<>,
@@ -71,7 +73,8 @@ DECLARE_SOA_TABLE(LambdaPairs, "AOD", "LAMBDAPAIR",
                   lambdapair::ProtonEta,
                   lambdapair::ProtonPhi,
                   lambdapair::ProtonIndex,
-                  lambdapair::PionIndex);
+                  lambdapair::PionIndex,
+                  lambdapair::DcaV0ToPV);
 
 using LambdaPair = LambdaPairs::iterator;
 
@@ -105,6 +108,7 @@ DECLARE_SOA_COLUMN(ProtonEtamc, protonEtamc, float);                   //! Proto
 DECLARE_SOA_COLUMN(ProtonPhimc, protonPhimc, float);                   //! Proton Phi in montecarlo
 DECLARE_SOA_COLUMN(ProtonIndexmc, protonIndexmc, int);                 //! Proton index in montecarlo
 DECLARE_SOA_COLUMN(PionIndexmc, pionIndexmc, int);                     //! Pion index in montecarlo
+DECLARE_SOA_COLUMN(DcaV0ToPVmc, dcaV0ToPVmc, float);                   //! DCA of V0 to primary vertex
 } // namespace lambdapairmc
 DECLARE_SOA_TABLE(LambdaPairmcs, "AOD", "LAMBDAPAIRMC",
                   o2::soa::Index<>,
@@ -124,7 +128,8 @@ DECLARE_SOA_TABLE(LambdaPairmcs, "AOD", "LAMBDAPAIRMC",
                   lambdapairmc::ProtonEtamc,
                   lambdapairmc::ProtonPhimc,
                   lambdapairmc::ProtonIndexmc,
-                  lambdapairmc::PionIndexmc);
+                  lambdapairmc::PionIndexmc,
+                  lambdapairmc::DcaV0ToPVmc);
 
 using LambdaPairmc = LambdaPairmcs::iterator;
 

--- a/PWGLF/TableProducer/Strangeness/lambdaspincorrelation.cxx
+++ b/PWGLF/TableProducer/Strangeness/lambdaspincorrelation.cxx
@@ -298,6 +298,7 @@ struct lambdaspincorrelation {
     std::vector<int> positiveIndex = {};
     std::vector<int> negativeIndex = {};
     std::vector<float> dcaBetweenDaughter = {};
+    std::vector<float> dcaV0ToPV = {};
     int numbV0 = 0;
     // LOGF(info, "event collisions: (%d)", collision.index());
     auto centrality = collision.centFT0C();
@@ -355,6 +356,7 @@ struct lambdaspincorrelation {
           positiveIndex.push_back(postrack1.globalIndex());
           negativeIndex.push_back(negtrack1.globalIndex());
           v0Cospa.push_back(v0.v0cosPA());
+          dcaV0ToPV.push_back(std::abs(v0.dcav0topv()));
           v0Radius.push_back(v0.v0radius());
           dcaPositive.push_back(std::abs(v0.dcapostopv()));
           dcaNegative.push_back(std::abs(v0.dcanegtopv()));
@@ -391,7 +393,7 @@ struct lambdaspincorrelation {
           lambdaDummy = lambdaMother.at(i5);
           protonDummy = protonDaughter.at(i5);
           pionDummy = pionDaughter.at(i5);
-          lambdaPair(indexEvent, v0Status.at(i5), doubleStatus.at(i5), v0Cospa.at(i5), v0Radius.at(i5), dcaPositive.at(i5), dcaNegative.at(i5), dcaBetweenDaughter.at(i5), lambdaDummy.Pt(), lambdaDummy.Eta(), lambdaDummy.Phi(), lambdaDummy.M(), protonDummy.Pt(), protonDummy.Eta(), protonDummy.Phi(), positiveIndex.at(i5), negativeIndex.at(i5));
+          lambdaPair(indexEvent, v0Status.at(i5), doubleStatus.at(i5), v0Cospa.at(i5), v0Radius.at(i5), dcaPositive.at(i5), dcaNegative.at(i5), dcaBetweenDaughter.at(i5), lambdaDummy.Pt(), lambdaDummy.Eta(), lambdaDummy.Phi(), lambdaDummy.M(), protonDummy.Pt(), protonDummy.Eta(), protonDummy.Phi(), positiveIndex.at(i5), negativeIndex.at(i5), dcaV0ToPV.at(i5));
         }
       }
     }
@@ -410,6 +412,7 @@ struct lambdaspincorrelation {
     std::vector<int> positiveIndex = {};
     std::vector<int> negativeIndex = {};
     std::vector<float> dcaBetweenDaughter = {};
+    std::vector<float> dcaV0ToPV = {};
     int numbV0 = 0;
     // LOGF(info, "event collisions: (%d)", collision.index());
     auto centrality = collision.centFT0C();
@@ -470,6 +473,7 @@ struct lambdaspincorrelation {
           dcaPositive.push_back(std::abs(v0.dcapostopv()));
           dcaNegative.push_back(std::abs(v0.dcanegtopv()));
           dcaBetweenDaughter.push_back(std::abs(v0.dcaV0daughters()));
+          dcaV0ToPV.push_back(std::abs(v0.dcav0topv()));
           if (lambdaTag) {
             v0Status.push_back(0);
             proton = ROOT::Math::PxPyPzMVector(v0.pxpos(), v0.pypos(), v0.pzpos(), o2::constants::physics::MassProton);
@@ -502,7 +506,7 @@ struct lambdaspincorrelation {
           lambdaDummy = lambdaMother.at(i5);
           protonDummy = protonDaughter.at(i5);
           pionDummy = pionDaughter.at(i5);
-          lambdaPairmc(indexEvent, v0Status.at(i5), doubleStatus.at(i5), v0Cospa.at(i5), v0Radius.at(i5), dcaPositive.at(i5), dcaNegative.at(i5), dcaBetweenDaughter.at(i5), lambdaDummy.Pt(), lambdaDummy.Eta(), lambdaDummy.Phi(), lambdaDummy.M(), protonDummy.Pt(), protonDummy.Eta(), protonDummy.Phi(), positiveIndex.at(i5), negativeIndex.at(i5));
+          lambdaPairmc(indexEvent, v0Status.at(i5), doubleStatus.at(i5), v0Cospa.at(i5), v0Radius.at(i5), dcaPositive.at(i5), dcaNegative.at(i5), dcaBetweenDaughter.at(i5), lambdaDummy.Pt(), lambdaDummy.Eta(), lambdaDummy.Phi(), lambdaDummy.M(), protonDummy.Pt(), protonDummy.Eta(), protonDummy.Phi(), positiveIndex.at(i5), negativeIndex.at(i5), dcaV0ToPV.at(i5));
         }
       }
     }
@@ -530,6 +534,7 @@ struct lambdaspincorrelation {
         std::vector<int> positiveIndex = {};
         std::vector<int> negativeIndex = {};
         std::vector<float> dcaBetweenDaughter = {};
+        std::vector<float> dcaV0ToPV = {};
         int numbV0 = 0;
 
         auto centrality = collision.centFT0C();
@@ -610,6 +615,7 @@ struct lambdaspincorrelation {
               negativeIndex.push_back(negtrack1.globalIndex());
 
               v0Cospa.push_back(v0.v0cosPA());
+              dcaV0ToPV.push_back(std::abs(v0.dcav0topv()));
               v0Radius.push_back(v0.v0radius());
               dcaPositive.push_back(std::abs(v0.dcapostopv()));
               dcaNegative.push_back(std::abs(v0.dcanegtopv()));
@@ -695,7 +701,8 @@ struct lambdaspincorrelation {
                            protonDummy.Eta(),
                            protonDummy.Phi(),
                            positiveIndex.at(i5),
-                           negativeIndex.at(i5));
+                           negativeIndex.at(i5),
+                           dcaV0ToPV.at(i5));
             }
           }
         }

--- a/PWGLF/Tasks/Strangeness/lambdaspincorrderived.cxx
+++ b/PWGLF/Tasks/Strangeness/lambdaspincorrderived.cxx
@@ -168,6 +168,13 @@ static inline int piIdx(const T& t)
 {
   return t.pionIndexmc();
 }
+
+template <typename T>
+static inline float dcaV0ToPVMC(const T& t)
+{
+  return t.dcaV0ToPVmc();
+}
+
 } // namespace mcacc
 
 // Optional fixed-leg correction pointers kept outside the task struct.
@@ -261,21 +268,27 @@ struct lambdaspincorrderived {
   Configurable<bool> fillWeightQAHistos{"fillWeightQAHistos", false, "Fill weighted/final-weighted REP/FIX QA maps"};
   Configurable<bool> fillAnalysisSparses{"fillAnalysisSparses", false, "Fill extra deltaR/deltaRap/deltaPhi Analysis THnSparse objects"};
   Configurable<bool> fillAdditionalSparses{"fillAdditionalSparses", false, "Fill extra rapidity/dphi/pair-mass THnSparse objects"};
-
   Configurable<bool> checkDoubleStatus{"checkDoubleStatus", 0, "Check Double status"};
-  Configurable<float> cosPA{"cosPA", 0.995, "Cosine Pointing Angle"};
-  Configurable<float> radiusMin{"radiusMin", 3, "Minimum V0 radius"};
-  Configurable<float> radiusMax{"radiusMax", 30, "Maximum V0 radius"};
-  Configurable<float> dcaProton{"dcaProton", 0.1, "DCA Proton"};
-  Configurable<float> dcaPion{"dcaPion", 0.2, "DCA Pion"};
-  Configurable<float> dcaDaughters{"dcaDaughters", 1.0, "DCA between daughters"};
+
   Configurable<float> ptMin{"ptMin", 0.5, "V0 Pt minimum"};
   Configurable<float> ptMax{"ptMax", 3.0, "V0 Pt maximum"};
   Configurable<float> MassMin{"MassMin", 1.09, "V0 Mass minimum"};
   Configurable<float> MassMax{"MassMax", 1.14, "V0 Mass maximum"};
-  Configurable<float> rapidity{"rapidity", 0.5, "Rapidity cut on lambda"};
   Configurable<float> v0etaMixBuffer{"v0etaMixBuffer", 0.8, "Eta cut on mix event buffer"};
+  Configurable<float> rapidity{"rapidity", 0.5, "Rapidity cut on lambda"};
   Configurable<float> v0eta{"v0eta", 0.8, "Eta cut on lambda"};
+
+  struct : ConfigurableGroup {
+    std::string prefix = "v0Configuration";
+    Configurable<float> cosPA{"cosPA", 0.995, "Cosine Pointing Angle"};
+    Configurable<float> radiusMin{"radiusMin", 3, "Minimum V0 radius"};
+    Configurable<float> radiusMax{"radiusMax", 30, "Maximum V0 radius"};
+    Configurable<float> dcaProton{"dcaProton", 0.1, "DCA Proton"};
+    Configurable<float> dcaPion{"dcaPion", 0.2, "DCA Pion"};
+    Configurable<float> dcaDaughters{"dcaDaughters", 1.0, "DCA between daughters"};
+    Configurable<float> dcaV0ToPV{"dcaV0ToPV", 1.2, "DCA V0 to PV cut on lambda"};
+
+  } v0Configurations;
 
   // Event Mixing
   Configurable<int> cosDef{"cosDef", 1, "Defination of cos"};
@@ -573,25 +586,30 @@ struct lambdaspincorrderived {
     if (candidate.lambdaMass() < MassMin || candidate.lambdaMass() > MassMax) {
       return false;
     }
-    if (candidate.v0Cospa() < cosPA) {
+    if (candidate.v0Cospa() < v0Configurations.cosPA) {
       return false;
     }
     if (checkDoubleStatus && candidate.doubleStatus()) {
       return false;
     }
-    if (candidate.v0Radius() > radiusMax) {
+    if (candidate.v0Radius() > v0Configurations.radiusMax) {
       return false;
     }
-    if (candidate.v0Radius() < radiusMin) {
+    if (candidate.v0Radius() < v0Configurations.radiusMin) {
       return false;
     }
-    if (candidate.dcaBetweenDaughter() > dcaDaughters) {
+    if (candidate.dcaBetweenDaughter() > v0Configurations.dcaDaughters) {
       return false;
     }
-    if (candidate.v0Status() == 0 && (std::abs(candidate.dcaPositive()) < dcaProton || std::abs(candidate.dcaNegative()) < dcaPion)) {
+
+    if (candidate.dcaV0ToPV() > v0Configurations.dcaV0ToPV) {
       return false;
     }
-    if (candidate.v0Status() == 1 && (std::abs(candidate.dcaPositive()) < dcaPion || std::abs(candidate.dcaNegative()) < dcaProton)) {
+
+    if (candidate.v0Status() == 0 && (std::abs(candidate.dcaPositive()) < v0Configurations.dcaProton || std::abs(candidate.dcaNegative()) < v0Configurations.dcaPion)) {
+      return false;
+    }
+    if (candidate.v0Status() == 1 && (std::abs(candidate.dcaPositive()) < v0Configurations.dcaPion || std::abs(candidate.dcaNegative()) < v0Configurations.dcaProton)) {
       return false;
     }
     if (candidate.lambdaPt() < ptMin) {
@@ -1836,25 +1854,30 @@ struct lambdaspincorrderived {
     if (mcacc::lamMass(candidate) < MassMin || mcacc::lamMass(candidate) > MassMax) {
       return false;
     }
-    if (mcacc::v0CosPA(candidate) < cosPA) {
+    if (mcacc::v0CosPA(candidate) < v0Configurations.cosPA) {
       return false;
     }
     if (checkDoubleStatus && mcacc::doubleStatus(candidate)) {
       return false;
     }
-    if (mcacc::v0Radius(candidate) > radiusMax) {
+    if (mcacc::v0Radius(candidate) > v0Configurations.radiusMax) {
       return false;
     }
-    if (mcacc::v0Radius(candidate) < radiusMin) {
+    if (mcacc::v0Radius(candidate) < v0Configurations.radiusMin) {
       return false;
     }
-    if (mcacc::dcaDau(candidate) > dcaDaughters) {
+    if (mcacc::dcaDau(candidate) > v0Configurations.dcaDaughters) {
       return false;
     }
-    if (mcacc::v0Status(candidate) == 0 && (std::abs(mcacc::dcaPos(candidate)) < dcaProton || std::abs(mcacc::dcaNeg(candidate)) < dcaPion)) {
+
+    if (mcacc::dcaV0ToPVMC(candidate) > v0Configurations.dcaV0ToPV) {
       return false;
     }
-    if (mcacc::v0Status(candidate) == 1 && (std::abs(mcacc::dcaPos(candidate)) < dcaPion || std::abs(mcacc::dcaNeg(candidate)) < dcaProton)) {
+
+    if (mcacc::v0Status(candidate) == 0 && (std::abs(mcacc::dcaPos(candidate)) < v0Configurations.dcaProton || std::abs(mcacc::dcaNeg(candidate)) < v0Configurations.dcaPion)) {
+      return false;
+    }
+    if (mcacc::v0Status(candidate) == 1 && (std::abs(mcacc::dcaPos(candidate)) < v0Configurations.dcaPion || std::abs(mcacc::dcaNeg(candidate)) < v0Configurations.dcaProton)) {
       return false;
     }
     if (mcacc::lamPt(candidate) < ptMin) {


### PR DESCRIPTION
Dear Experts:
The recent code is mainly used to calculate Lambda spin correlation
I have two .cxx files and one header file to complete my analysis.These codes have been updated.

DataModel : LFSpincorrelationTables.h : Add a column to story the dca V0 to primary vertex for data and MC

TableProducer : lambdaspincorrelation.cxx : Story the messages of dca V0 to primary vertex for data and MC

Tasks ：lambdaspincorrderived.cxx : The messages of dca V0 to primary vertex are used

I am preparing to further run the analysis on Hyperloop and hope that the experts can approve my pull request.
Best wishes,
Youpeng Su
Jul 27, 2026