### PR TITLE
[PWGLF,PWGMM] Update for the latest data model

### DIFF
--- a/PWGMM/Mult/Tasks/dndeta.cxx
+++ b/PWGMM/Mult/Tasks/dndeta.cxx
@@ -842,7 +842,10 @@ struct MultiplicityCounter {
   using LabeledTracksEx = soa::Join<LabeledTracks, aod::TracksExtra, aod::TrackSelection, aod::TracksDCA>;
   using FiLTracks = soa::Filtered<LabeledTracksEx>;
   using ParticlesI = soa::Filtered<soa::Join<aod::McParticles, aod::ParticlesToTracks>>;
-  expressions::Filter primaries = ncheckbit(aod::mcparticle::flags, (uint8_t)o2::aod::mcparticle::enums::PhysicalPrimary);
+  expressions::Filter primaries =
+    ifnode(nsqrt(aod::mcparticle::vx * aod::mcparticle::vx + aod::mcparticle::vy * aod::mcparticle::vy) > 5.f,
+           false,
+           ncheckbit(aod::mcparticle_v2::storedFlags, (uint8_t)o2::aod::mcparticle::enums::PhysicalPrimary));
 
   bool isChargedParticle(int code)
   {


### PR DESCRIPTION
The particle primary definition was changed, which breaks the filter. Since this wagon is used in nightly simulation tests, it has to be updated.