### PR TITLE
[PWGDQ] Fix table reservation problem

### DIFF
--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -3485,8 +3485,23 @@ struct AnalysisAsymmetricPairing {
 
     int sign1 = 0;
     int sign2 = 0;
-    ditrackList.reserve(assocs.size());
-    ditrackExtraList.reserve(assocs.size());
+
+    //Reserve capacity for the output tables
+    int64_t reserveSize = 0;
+    for (auto const& event : events) {
+      if (!event.isEventSelected_bit(0)) {
+        continue;
+      }
+      if (fConfigRemoveCollSplittingCandidates.value && event.isEventSelected_bit(2)) {
+        continue; 
+      }
+      auto groupedLegAAssocs = legACandidateAssocs.sliceBy(preslice, event.globalIndex());
+      auto groupedLegBAssocs = legBCandidateAssocs.sliceBy(preslice, event.globalIndex());
+      reserveSize += static_cast<int64_t>(groupedLegAAssocs.size()) *
+                    static_cast<int64_t>(groupedLegBAssocs.size());
+    }
+    ditrackList.reserve(reserveSize);
+    ditrackExtraList.reserve(reserveSize);
 
     constexpr bool trackHasCov = ((TTrackFillMap & VarManager::ObjTypes::TrackCov) > 0 || (TTrackFillMap & VarManager::ObjTypes::ReducedTrackBarrelCov) > 0);
 

--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -3472,7 +3472,7 @@ struct AnalysisAsymmetricPairing {
 
   // Template function to run same event pairing with asymmetric pairs (e.g. kaon-pion)
   template <bool TTwoProngFitter, int TPairType, uint32_t TEventFillMap, uint32_t TTrackFillMap, typename TEvents, typename TTrackAssocs, typename TTracks>
-  void runAsymmetricPairing(TEvents const& events, Preslice<TTrackAssocs>& preslice, TTrackAssocs const& assocs, TTracks const& /*tracks*/)
+  void runAsymmetricPairing(TEvents const& events, Preslice<TTrackAssocs>& preslice, TTrackAssocs const& /*assocs*/, TTracks const& /*tracks*/)
   {
     fPairCount.clear();
 
@@ -3486,19 +3486,19 @@ struct AnalysisAsymmetricPairing {
     int sign1 = 0;
     int sign2 = 0;
 
-    //Reserve capacity for the output tables
+    // Reserve capacity for the output tables
     int64_t reserveSize = 0;
     for (auto const& event : events) {
       if (!event.isEventSelected_bit(0)) {
         continue;
       }
       if (fConfigRemoveCollSplittingCandidates.value && event.isEventSelected_bit(2)) {
-        continue; 
+        continue;
       }
       auto groupedLegAAssocs = legACandidateAssocs.sliceBy(preslice, event.globalIndex());
       auto groupedLegBAssocs = legBCandidateAssocs.sliceBy(preslice, event.globalIndex());
       reserveSize += static_cast<int64_t>(groupedLegAAssocs.size()) *
-                    static_cast<int64_t>(groupedLegBAssocs.size());
+                     static_cast<int64_t>(groupedLegBAssocs.size());
     }
     ditrackList.reserve(reserveSize);
     ditrackExtraList.reserve(reserveSize);


### PR DESCRIPTION
Fix the reserve size problem in asymmetric pairing of tableReader_withAssoc

In the original code, ditrack table reserves based on the number of tracks rather than on the number of pairs, which may cause the crash of the program.

Adapt the similar strategy as what has been done in same event pairing to fix the problem.