### PR TITLE
[ALICE3] Fix JSON cut usage

### DIFF
--- a/ALICE3/Tasks/alice3-dq-efficiency.cxx
+++ b/ALICE3/Tasks/alice3-dq-efficiency.cxx
@@ -331,7 +331,7 @@ struct AnalysisTrackSelection {
     if (addTrackCutsStr != "") {
       std::vector<AnalysisCut*> addTrackCuts = dqcuts::GetCutsFromJSON(addTrackCutsStr.Data());
       for (const auto& t : addTrackCuts) {
-        fTrackCuts.push_back(dynamic_cast<AnalysisCompositeCut*>(t));
+        fTrackCuts.push_back(static_cast<AnalysisCompositeCut*>(t));
       }
     }
     VarManager::SetUseVars(AnalysisCut::fgUsedVars); // provide the list of required variables so that VarManager knows what to fill
@@ -1610,7 +1610,7 @@ struct AnalysisAsymmetricPairing {
     if (addPairCutsStr != "") {
       std::vector<AnalysisCut*> addPairCuts = dqcuts::GetCutsFromJSON(addPairCutsStr.Data());
       for (const auto& t : addPairCuts) {
-        fPairCuts.push_back(dynamic_cast<AnalysisCompositeCut*>(t));
+        fPairCuts.push_back(static_cast<AnalysisCompositeCut*>(t));
         cutNamesStr += Form(",%s", t->GetName());
       }
     }


### PR DESCRIPTION
Revert use of dynamic_cast to static_cast. JSON cuts are not cast correctly and lead to a segmentation fault