### PR TITLE
[PWGDQ] Add a ppbar pair type in tableReaderwithAssoc

### DIFF
--- a/PWGDQ/Core/CutsLibrary.cxx
+++ b/PWGDQ/Core/CutsLibrary.cxx
@@ -7173,6 +7173,11 @@ AnalysisCut* o2::aod::dqcuts::GetAnalysisCut(const char* cutName)
     return cut;
   }
 
+  if (nameStr == "pairIsPr") {
+    cut->AddCut(VarManager::kIsPrPair, 0.5, 1.5);
+    return cut;
+  }
+
   // -------------------------------------------------------------------------------------------------
   //
   // Below are a list of single electron single muon and pair selection in order or optimize the trigger

--- a/PWGDQ/Core/HistogramsLibrary.cxx
+++ b/PWGDQ/Core/HistogramsLibrary.cxx
@@ -1584,6 +1584,12 @@ void o2::aod::dqhistograms::DefineHistograms(HistogramManager* hm, const char* h
         hm->AddHistogram(histClass, "Mass_cos2DeltaPhi", "cos 2(#varphi-#Psi_{2}^{A}) vs m", true, 125, 0.0, 5.0, VarManager::kMass, 100, -1.0, 1.0, VarManager::kCos2DeltaPhi);
         hm->AddHistogram(histClass, "Mass_cos3DeltaPhi", "cos 3(#varphi-#Psi_{3}^{A}) vs m", true, 125, 0.0, 5.0, VarManager::kMass, 100, -1.0, 1.0, VarManager::kCos3DeltaPhi);
       }
+
+      if (subGroupStr.Contains("prpairpid")) {
+        hm->AddHistogram(histClass, "nSigmaPr1_nSigmaPr2", "", false, 100, -8.0, 8.0, VarManager::kTPCorTOFnSigmaPr1, 100, -8.0, 8.0, VarManager::kTPCorTOFnSigmaPr2);
+        hm->AddHistogram(histClass, "t1Pt", "", false, 2000, 0.0, 20.0, VarManager::kPt1);
+        hm->AddHistogram(histClass, "t2Pt", "", false, 2000, 0.0, 20.0, VarManager::kPt2);
+      }
     } else if (subGroupStr.Contains("dimuon")) {
       hm->AddHistogram(histClass, "Mass_Pt", "", false, 750, 0.0, 15.0, VarManager::kMass, 120, 0.0, 30.0, VarManager::kPt);
       hm->AddHistogram(histClass, "Mass_Rapidity", "", false, 750, 0.0, 15.0, VarManager::kMass, 150, 2.5, 4.0, VarManager::kRap);

--- a/PWGDQ/Core/VarManager.cxx
+++ b/PWGDQ/Core/VarManager.cxx
@@ -2237,6 +2237,8 @@ void VarManager::SetDefaultVarNames()
   fgVarNamesMap["kDCAz2"] = kDCAz2;
   fgVarNamesMap["kITSclusterMap2"] = kITSclusterMap2;
   fgVarNamesMap["kTPCnSigmaEl2"] = kTPCnSigmaEl2;
+  fgVarNamesMap["kTPCorTOFnSigmaPr1"] = kTPCorTOFnSigmaPr1;
+  fgVarNamesMap["kTPCorTOFnSigmaPr2"] = kTPCorTOFnSigmaPr2;
   fgVarNamesMap["kPin"] = kPin;
   fgVarNamesMap["kSignedPin"] = kSignedPin;
   fgVarNamesMap["kTOFExpMom"] = kTOFExpMom;
@@ -2315,6 +2317,7 @@ void VarManager::SetDefaultVarNames()
   fgVarNamesMap["kIsLegFromOmega"] = kIsLegFromOmega;
   fgVarNamesMap["kIsProtonFromLambdaAndAntiLambda"] = kIsProtonFromLambdaAndAntiLambda;
   fgVarNamesMap["kIsDalitzLeg"] = kIsDalitzLeg;
+  fgVarNamesMap["kIsPrPair"] = kIsPrPair;
   fgVarNamesMap["kBarrelNAssocsInBunch"] = kBarrelNAssocsInBunch;
   fgVarNamesMap["kBarrelNAssocsOutOfBunch"] = kBarrelNAssocsOutOfBunch;
   fgVarNamesMap["kNBarrelTrackVariables"] = kNBarrelTrackVariables;

--- a/PWGDQ/Core/VarManager.h
+++ b/PWGDQ/Core/VarManager.h
@@ -158,6 +158,7 @@ class VarManager : public TObject
     kDecayToEE = 0, // e.g. J/psi        -> e+ e-
     kDecayToMuMu,   // e.g. J/psi        -> mu+ mu-
     kDecayToPiPi,
+    kDecayToPrPr,
     kElectronMuon,              // e.g. Electron - muon correlations
     kBcToThreeMuons,            // e.g. Bc           -> mu+ mu- mu+
     kBtoJpsiEEK,                // e.g. B+           -> e+ e- K+
@@ -986,6 +987,9 @@ class VarManager : public TObject
     kPairEfficiency,
     kPairWeight,
     kNPairVariables,
+    kTPCorTOFnSigmaPr1,
+    kTPCorTOFnSigmaPr2,
+    kIsPrPair,
 
     // Candidate-track correlation variables
     kPairMass,
@@ -3686,6 +3690,11 @@ void VarManager::FillPair(T1 const& t1, T2 const& t2, float* values)
     values[kTPCnSigmaKa_leg1] = t1.tpcNSigmaKa();
   }
 
+  if constexpr (pairType == kDecayToPrPr) {
+    m1 = o2::constants::physics::MassProton;
+    m2 = o2::constants::physics::MassProtonBar;
+  }
+
   if constexpr (pairType == kElectronMuon) {
     m2 = o2::constants::physics::MassMuon;
   }
@@ -3741,6 +3750,36 @@ void VarManager::FillPair(T1 const& t1, T2 const& t2, float* values)
         arg = -1;
       }
       values[kOpeningAngle] = TMath::ACos(arg);
+    }
+  }
+
+  if constexpr (pairType == kDecayToPrPr && (fillMap & ReducedTrackBarrelPID) > 0 && (fillMap & ReducedTrackBarrel) > 0) {
+
+    if (t1.hasTOF()) {
+      values[kTPCorTOFnSigmaPr1] = t1.tofNSigmaPr();
+    } else if (t1.hasTPC()) {
+      values[kTPCorTOFnSigmaPr1] = t1.tpcNSigmaPr();
+    } else {
+      values[kTPCorTOFnSigmaPr1] = -999.f;
+    }
+
+    if (t2.hasTOF()) {
+      values[kTPCorTOFnSigmaPr2] = t2.tofNSigmaPr();
+    } else if (t2.hasTPC()) {
+      values[kTPCorTOFnSigmaPr2] = t2.tpcNSigmaPr();
+    } else {
+      values[kTPCorTOFnSigmaPr2] = -999.f;
+    }
+
+    bool tof1 = t1.hasTOF(), tpc1 = t1.hasTPC();
+    bool tof2 = t2.hasTOF(), tpc2 = t2.hasTPC();
+    bool hasTOForgood = (tof1 && tpc2) || (tpc1 && tof2) || (tof1 && tof2);
+    if (hasTOForgood) {
+      float nsigma1 = values[kTPCorTOFnSigmaPr1];
+      float nsigma2 = values[kTPCorTOFnSigmaPr2];
+      values[kIsPrPair] = (std::abs(nsigma1) < 4.f && std::abs(nsigma2) < 4.f && std::pow(nsigma1, 2.0) + std::pow(nsigma2, 2.0) < 16.f) ? 1 : 0;
+    } else {
+      values[kIsPrPair] = 0;
     }
   }
 

--- a/PWGDQ/Tasks/tableReader_withAssoc.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc.cxx
@@ -3814,6 +3814,13 @@ struct AnalysisAsymmetricPairing {
     runAsymmetricPairing<true, VarManager::kDecayToKPi, gkEventFillMapWithCovZdcFitMultExtra, gkTrackFillMapWithCov>(events, trackAssocsPerCollision, barrelAssocs, barrelTracks);
   }
 
+  void processProtonPairSkimmed(MyEventsVtxCovZdcFitSelected const& events,
+                                soa::Join<aod::ReducedTracksAssoc, aod::BarrelTrackCuts> const& barrelAssocs,
+                                MyBarrelTracksWithCovWithAmbiguities const& barrelTracks)
+  {
+    runAsymmetricPairing<false, VarManager::kDecayToPrPr, gkEventFillMapWithCovZdcFit, gkTrackFillMapWithCov>(events, trackAssocsPerCollision, barrelAssocs, barrelTracks);
+  }
+
   void processKaonPionPionSkimmed(MyEventsVtxCovZdcFitSelected const& events,
                                   soa::Join<aod::ReducedTracksAssoc, aod::BarrelTrackCuts> const& barrelAssocs,
                                   MyBarrelTracksWithCovWithAmbiguities const& barrelTracks)
@@ -3841,6 +3848,7 @@ struct AnalysisAsymmetricPairing {
   }
 
   PROCESS_SWITCH(AnalysisAsymmetricPairing, processKaonPionSkimmed, "Run kaon pion pairing, with skimmed tracks", false);
+  PROCESS_SWITCH(AnalysisAsymmetricPairing, processProtonPairSkimmed, "Run proton anti-proton pairing, with skimmed tracks", false);
   PROCESS_SWITCH(AnalysisAsymmetricPairing, processKaonPionPionSkimmed, "Run kaon pion pion triplets, with skimmed tracks", false);
   PROCESS_SWITCH(AnalysisAsymmetricPairing, processKaonPionSkimmedMultExtra, "Run kaon pion pairing, with skimmed tracks", false);
   PROCESS_SWITCH(AnalysisAsymmetricPairing, processKaonPionPionSkimmedMultExtra, "Run kaon pion pion triplets, with skimmed tracks", false);


### PR DESCRIPTION
Add a pair type to process ppbar pairing in tableReader_withAssoc

The motivation is to analyse Jpsi->ppbar and gamma gamma->ppbar in DQ framework. Since same event pairing in table reader is designed to analyse leptons, asymmetric pairing is suitable for proton pairing.

- Modification in VarManager::FillPair is necessary for complex proton PID
- The results of pairing have been proved to be good