### PR TITLE
[ALICE3] Fix ALICE 3 DQ datamodel naming

### DIFF
--- a/ALICE3/DataModel/ReducedTablesAlice3.h
+++ b/ALICE3/DataModel/ReducedTablesAlice3.h
@@ -1,0 +1,335 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+/// \file ReducedTablesAlice3.h
+///
+/// \brief Reduced DQ table definitions for ALICE 3
+///
+/// \author Alexander Tiekoetter (atiekoet@cern.ch) University of Muenster
+
+#ifndef ALICE3_DATAMODEL_REDUCEDTABLESALICE3_H_
+#define ALICE3_DATAMODEL_REDUCEDTABLESALICE3_H_
+
+#include "PWGDQ/DataModel/ReducedInfoTables.h"
+
+#include "ALICE3/DataModel/OTFPIDTrk.h"
+#include "ALICE3/DataModel/OTFRICH.h"
+#include "ALICE3/DataModel/OTFTOF.h"
+
+#include <Framework/ASoA.h>
+#include <Framework/AnalysisDataModel.h>
+#include <Framework/DataTypes.h>
+
+#include <cmath>
+#include <cstdint>
+
+namespace o2::aod
+{
+namespace reducedeventalice3
+{
+DECLARE_SOA_COLUMN(MultDensity, multDensity, float);
+DECLARE_SOA_COLUMN(MCPosX, mcPosX, float); //!  MC event position X
+DECLARE_SOA_COLUMN(MCPosY, mcPosY, float); //!  MC event position Y
+DECLARE_SOA_COLUMN(MCPosZ, mcPosZ, float); //!  MC event position Z
+} // namespace reducedeventalice3
+
+namespace reducedeventmcalice3
+{
+DECLARE_SOA_COLUMN(MultMCNParticlesEta05, multMCNParticlesEta05, float);
+DECLARE_SOA_COLUMN(MultMCNParticlesEta08, multMCNParticlesEta08, float);
+DECLARE_SOA_COLUMN(MultMCNParticlesEta10, multMCNParticlesEta10, float);
+DECLARE_SOA_COLUMN(MultMCNParticlesEta20, multMCNParticlesEta20, float);
+DECLARE_SOA_COLUMN(MultMCNParticlesEta40, multMCNParticlesEta40, float);
+} // namespace reducedeventmcalice3
+
+DECLARE_SOA_TABLE_STAGED(ReA3Events, "REA3EVENT", //!   Main event information table
+                         o2::soa::Index<>,
+                         collision::PosX, collision::PosY, collision::PosZ, collision::NumContrib,
+                         collision::CollisionTime, collision::CollisionTimeRes, reducedeventalice3::MultDensity);
+
+DECLARE_SOA_TABLE(ReducedA3EventsVtxCov, "AOD", "REA3VTXCOV", //!    Event vertex covariance matrix
+                  collision::CovXX, collision::CovXY, collision::CovXZ,
+                  collision::CovYY, collision::CovYZ, collision::CovZZ, collision::Chi2);
+
+DECLARE_SOA_TABLE(ReducedA3EventsInfo, "AOD", "REA3EVENTINFO", //!   Main event index table
+                  reducedevent::CollisionId);
+
+DECLARE_SOA_TABLE(ReA3MCEvents, "AOD", "REA3MCEVENT", //!   Event level MC truth information
+                  o2::soa::Index<>,
+                  mccollision::GeneratorsID, reducedeventalice3::MCPosX, reducedeventalice3::MCPosY, reducedeventalice3::MCPosZ,
+                  mccollision::T, mccollision::Weight, mccollision::ImpactParameter);
+
+using ReducedA3MCEvent = ReA3MCEvents::iterator;
+using ReA3Event = ReA3Events::iterator;
+
+namespace reducedtrackalice3
+{
+// basic track information
+DECLARE_SOA_INDEX_COLUMN(ReA3Event, rea3event); //!
+DECLARE_SOA_INDEX_COLUMN(Track, track);         //!
+// ----  flags reserved for storing various information during filtering
+DECLARE_SOA_BITMAP_COLUMN(FilteringFlags, filteringFlags, 64); //!
+// -----------------------------------------------------
+
+DECLARE_SOA_COLUMN(IsReconstructed, isReconstructed, bool);
+DECLARE_SOA_COLUMN(NSiliconHits, nSiliconHits, int);
+DECLARE_SOA_COLUMN(NTPCHits, nTPCHits, int);
+
+DECLARE_SOA_COLUMN(Pt, pt, float);                     //!
+DECLARE_SOA_COLUMN(Eta, eta, float);                   //!
+DECLARE_SOA_COLUMN(Phi, phi, float);                   //!
+DECLARE_SOA_COLUMN(Sign, sign, int);                   //!
+DECLARE_SOA_COLUMN(IsAmbiguous, isAmbiguous, int);     //!
+DECLARE_SOA_COLUMN(DcaXY, dcaXY, float);               //!
+DECLARE_SOA_COLUMN(DcaZ, dcaZ, float);                 //!
+DECLARE_SOA_COLUMN(DetectorMap, detectorMap, uint8_t); //! Detector map: see enum DetectorMapEnum
+DECLARE_SOA_INDEX_COLUMN(Collision, collision);        //!
+DECLARE_SOA_DYNAMIC_COLUMN(HasITS, hasITS,             //! Flag to check if track has a ITS match
+                           [](uint8_t detectorMap) -> bool { return detectorMap & o2::aod::track::ITS; });
+DECLARE_SOA_DYNAMIC_COLUMN(HasTPC, hasTPC, //! Flag to check if track has a TPC match
+                           [](uint8_t detectorMap) -> bool { return detectorMap & o2::aod::track::TPC; });
+DECLARE_SOA_DYNAMIC_COLUMN(HasTRD, hasTRD, //! Flag to check if track has a TRD match
+                           [](uint8_t detectorMap) -> bool { return detectorMap & o2::aod::track::TRD; });
+DECLARE_SOA_DYNAMIC_COLUMN(HasTOF, hasTOF, //! Flag to check if track has a TOF measurement
+                           [](uint8_t detectorMap) -> bool { return detectorMap & o2::aod::track::TOF; });
+DECLARE_SOA_DYNAMIC_COLUMN(Px, px, //!
+                           [](float pt, float phi) -> float { return pt * std::cos(phi); });
+DECLARE_SOA_DYNAMIC_COLUMN(Py, py, //!
+                           [](float pt, float phi) -> float { return pt * std::sin(phi); });
+DECLARE_SOA_DYNAMIC_COLUMN(Pz, pz, //!
+                           [](float pt, float eta) -> float { return pt * std::sinh(eta); });
+DECLARE_SOA_DYNAMIC_COLUMN(P, p, //!
+                           [](float pt, float eta) -> float { return pt * std::cosh(eta); });
+} // namespace reducedtrackalice3
+
+// basic track information
+DECLARE_SOA_TABLE(ReA3Tracks, "AOD", "REA3TRACK", //!
+                  o2::soa::Index<>, reducedtrackalice3::ReA3EventId, reducedtrackalice3::FilteringFlags,
+                  reducedtrackalice3::Pt, reducedtrackalice3::Eta, reducedtrackalice3::Phi, reducedtrackalice3::Sign, reducedtrackalice3::IsAmbiguous,
+                  reducedtrackalice3::Px<reducedtrackalice3::Pt, reducedtrackalice3::Phi>,
+                  reducedtrackalice3::Py<reducedtrackalice3::Pt, reducedtrackalice3::Phi>,
+                  reducedtrackalice3::Pz<reducedtrackalice3::Pt, reducedtrackalice3::Eta>,
+                  reducedtrackalice3::P<reducedtrackalice3::Pt, reducedtrackalice3::Eta>);
+
+DECLARE_SOA_TABLE(ReducedA3TracksBarrelCov, "AOD", "REA3BARRELCOV", //!
+                  track::CYY, track::CZY, track::CZZ, track::CSnpY, track::CSnpZ,
+                  track::CSnpSnp, track::CTglY, track::CTglZ, track::CTglSnp, track::CTglTgl,
+                  track::C1PtY, track::C1PtZ, track::C1PtSnp, track::C1PtTgl, track::C1Pt21Pt2);
+
+namespace reducedA3trackMC
+{
+DECLARE_SOA_INDEX_COLUMN(ReA3MCEvent, reA3MCEvent);                                      //!
+DECLARE_SOA_COLUMN(McReducedFlags, mcReducedFlags, uint16_t);                            //! Flags to hold compressed MC selection information
+DECLARE_SOA_SELF_INDEX_COLUMN_FULL(Mother0, mother0, int, "ReA3MCTracks_Mother0");       //! Track index of the first mother
+DECLARE_SOA_SELF_INDEX_COLUMN_FULL(Mother1, mother1, int, "ReA3MCTracks_Mother1");       //! Track index of the last mother
+DECLARE_SOA_SELF_INDEX_COLUMN_FULL(Daughter0, daughter0, int, "ReA3MCTracks_Daughter0"); //! Track index of the first daughter
+DECLARE_SOA_SELF_INDEX_COLUMN_FULL(Daughter1, daughter1, int, "ReA3MCTracks_Daughter1"); //! Track index of the last daughter
+DECLARE_SOA_SELF_ARRAY_INDEX_COLUMN(Mothers, mothers);                                   //! Mother tracks (possible empty) array. Iterate over mcParticle.mothers_as<aod::McParticles>())
+DECLARE_SOA_SELF_SLICE_INDEX_COLUMN(Daughters, daughters);                               //! Daughter tracks (possibly empty) slice. Check for non-zero with mcParticle.has_daughters(). Iterate over mcParticle.daughters_as<aod::McParticles>())
+DECLARE_SOA_COLUMN(Pt, pt, float);                                                       //!
+DECLARE_SOA_COLUMN(Eta, eta, float);                                                     //!
+DECLARE_SOA_COLUMN(Phi, phi, float);                                                     //!
+DECLARE_SOA_COLUMN(E, e, float);                                                         //!
+DECLARE_SOA_DYNAMIC_COLUMN(Px, px,                                                       //!
+                           [](float pt, float phi) -> float { return pt * std::cos(phi); });
+DECLARE_SOA_DYNAMIC_COLUMN(Py, py, //!
+                           [](float pt, float phi) -> float { return pt * std::sin(phi); });
+DECLARE_SOA_DYNAMIC_COLUMN(Pz, pz, //!
+                           [](float pt, float eta) -> float { return pt * std::sinh(eta); });
+DECLARE_SOA_DYNAMIC_COLUMN(P, p, //!
+                           [](float pt, float eta) -> float { return pt * std::cosh(eta); });
+DECLARE_SOA_DYNAMIC_COLUMN(Y, y, //! Particle rapidity
+                           [](float pt, float eta, float e) -> float {
+                             float pz = pt * std::sinh(eta);
+                             if ((e - pz) > static_cast<float>(1e-7)) {
+                               return 0.5f * std::log((e + pz) / (e - pz));
+                             } else {
+                               return -999.0f;
+                             }
+                           });
+} // namespace reducedA3trackMC
+
+// NOTE: This table is nearly identical to the one from Framework (except that it points to the event ID, not the BC id)
+//       This table contains all MC truth tracks (both barrel and muon)
+DECLARE_SOA_TABLE(ReA3MCTracks, "AOD", "REA3MCTRACK", //!  MC track information (on disk)
+                  o2::soa::Index<>, reducedA3trackMC::ReA3MCEventId,
+                  mcparticle::PdgCode, mcparticle::StatusCode, mcparticle::Flags,
+                  reducedA3trackMC::MothersIds, reducedA3trackMC::DaughtersIdSlice,
+                  mcparticle::Weight,
+                  reducedA3trackMC::Pt, reducedA3trackMC::Eta, reducedA3trackMC::Phi, reducedA3trackMC::E,
+                  mcparticle::Vx, mcparticle::Vy, mcparticle::Vz, mcparticle::Vt,
+                  reducedA3trackMC::McReducedFlags,
+                  reducedA3trackMC::Px<reducedA3trackMC::Pt, reducedA3trackMC::Phi>,
+                  reducedA3trackMC::Py<reducedA3trackMC::Pt, reducedA3trackMC::Phi>,
+                  reducedA3trackMC::Pz<reducedA3trackMC::Pt, reducedA3trackMC::Eta>,
+                  reducedA3trackMC::P<reducedA3trackMC::Pt, reducedA3trackMC::Eta>,
+                  reducedA3trackMC::Y<reducedA3trackMC::Pt, reducedA3trackMC::Eta, reducedA3trackMC::E>,
+                  mcparticle::ProducedByGenerator<mcparticle::Flags>,
+                  mcparticle::FromBackgroundEvent<mcparticle::Flags>,
+                  mcparticle::GetGenStatusCode<mcparticle::Flags, mcparticle::StatusCode>,
+                  mcparticle::GetProcess<mcparticle::Flags, mcparticle::StatusCode>,
+                  mcparticle::GetHepMCStatusCode<mcparticle::Flags, mcparticle::StatusCode>,
+                  mcparticle::IsPhysicalPrimary<mcparticle::Flags>);
+
+using ReA3MCTrack = ReA3MCTracks::iterator;
+
+namespace reduceda3barreltracklabel
+{
+DECLARE_SOA_INDEX_COLUMN(ReA3MCTrack, reA3MCTrack); //!
+DECLARE_SOA_COLUMN(McMask, mcMask, uint16_t);
+} // namespace reduceda3barreltracklabel
+
+// NOTE: MC labels. This table has one entry for each reconstructed track (joinable with the track tables)
+//          The McParticleId points to the position of the MC truth track from the ReducedTracksMC table
+DECLARE_SOA_TABLE(ReducedA3TracksBarrelLabels, "AOD", "REA3BARLA", //!
+                  reduceda3barreltracklabel::ReA3MCTrackId, reduceda3barreltracklabel::McMask, reducedA3trackMC::McReducedFlags);
+
+using ReducedA3TrackBarrelLabel = ReducedA3TracksBarrelLabels::iterator;
+
+DECLARE_SOA_TABLE(ReducedA3TracksBarrel, "AOD", "REA3BARREL",
+                  track::X, track::Alpha, track::IsWithinBeamPipe<track::X>,
+                  track::Y, track::Z, track::Snp, track::Tgl, track::Signed1Pt,
+                  track::Flags, track::ITSClusterMap, track::ITSChi2NCl,
+                  reducedtrackalice3::IsReconstructed, reducedtrackalice3::NSiliconHits,
+                  reducedtrackalice3::NTPCHits, track::Length, reducedtrack::DcaXY, reducedtrack::DcaZ,
+                  track::IsPVContributor<track::Flags>);
+
+// barrel collision information (joined with ReducedTracks) allowing to connect different tables (cross PWGs)
+DECLARE_SOA_TABLE(ReducedA3TracksBarrelInfo, "AOD", "REA3BARRELINFO",
+                  reducedtrackalice3::CollisionId, collision::PosX, collision::PosY, collision::PosZ, reducedtrackalice3::TrackId);
+
+using ReducedA3Track = ReA3Tracks::iterator;
+using ReducedA3TrackBarrel = ReducedA3TracksBarrel::iterator;
+using ReducedA3TrackBarrelCov = ReducedA3TracksBarrelCov::iterator;
+using ReducedA3TrackBarrelInfo = ReducedA3TracksBarrelInfo::iterator;
+
+namespace reducedeventlabela3
+{
+DECLARE_SOA_INDEX_COLUMN(ReA3MCEvent, reA3MCEvent); //! MC collision
+DECLARE_SOA_COLUMN(McMask, mcMask, uint16_t);       //! Bit mask to indicate collision mismatches (bit ON means mismatch). Bit 15: indicates negative label
+} // namespace reducedeventlabela3
+
+DECLARE_SOA_TABLE(ReducedA3MCEventLabels, "AOD", "REA3MCCOLLBL", //! Table joined to the ReducedEvents table containing the MC index
+                  reducedeventlabela3::ReA3MCEventId, reducedeventlabela3::McMask);
+
+using ReducedA3MCEventLabel = ReducedA3MCEventLabels::iterator;
+
+namespace reducedA3track_association
+{
+DECLARE_SOA_INDEX_COLUMN(ReA3Event, reA3event); //! ReducedEvent index
+DECLARE_SOA_INDEX_COLUMN(ReA3Track, reA3track); //! ReducedTrack index
+} // namespace reducedA3track_association
+
+DECLARE_SOA_TABLE(ReducedA3TracksAssoc, "AOD", "REA3ASSOC", //! Table for reducedtrack-to-reducedcollision association
+                  reducedA3track_association::ReA3EventId,
+                  reducedA3track_association::ReA3TrackId);
+
+DECLARE_SOA_TABLE(ReducedA3PIDTOF, "AOD", "REA3PIDTOF",
+                  upgrade_tof::TOFEventTime,
+                  upgrade_tof::TOFEventTimeErr,
+                  upgrade_tof::NSigmaElectronInnerTOF,
+                  upgrade_tof::NSigmaMuonInnerTOF,
+                  upgrade_tof::NSigmaPionInnerTOF,
+                  upgrade_tof::NSigmaKaonInnerTOF,
+                  upgrade_tof::NSigmaProtonInnerTOF,
+                  upgrade_tof::NSigmaDeuteronInnerTOF,
+                  upgrade_tof::NSigmaTritonInnerTOF,
+                  upgrade_tof::NSigmaHelium3InnerTOF,
+                  upgrade_tof::NSigmaAlphaInnerTOF,
+                  upgrade_tof::InnerTOFTrackTimeReco,
+                  upgrade_tof::InnerTOFTrackLengthReco,
+                  upgrade_tof::NSigmaElectronOuterTOF,
+                  upgrade_tof::NSigmaMuonOuterTOF,
+                  upgrade_tof::NSigmaPionOuterTOF,
+                  upgrade_tof::NSigmaKaonOuterTOF,
+                  upgrade_tof::NSigmaProtonOuterTOF,
+                  upgrade_tof::NSigmaDeuteronOuterTOF,
+                  upgrade_tof::NSigmaTritonOuterTOF,
+                  upgrade_tof::NSigmaHelium3OuterTOF,
+                  upgrade_tof::NSigmaAlphaOuterTOF,
+                  upgrade_tof::OuterTOFTrackTimeReco,
+                  upgrade_tof::OuterTOFTrackLengthReco,
+                  upgrade_tof::NSigmaInnerTOF<upgrade_tof::NSigmaElectronInnerTOF,
+                                              upgrade_tof::NSigmaMuonInnerTOF,
+                                              upgrade_tof::NSigmaPionInnerTOF,
+                                              upgrade_tof::NSigmaKaonInnerTOF,
+                                              upgrade_tof::NSigmaProtonInnerTOF,
+                                              upgrade_tof::NSigmaDeuteronInnerTOF,
+                                              upgrade_tof::NSigmaTritonInnerTOF,
+                                              upgrade_tof::NSigmaHelium3InnerTOF,
+                                              upgrade_tof::NSigmaAlphaInnerTOF>,
+                  upgrade_tof::NSigmaOuterTOF<upgrade_tof::NSigmaElectronOuterTOF,
+                                              upgrade_tof::NSigmaMuonOuterTOF,
+                                              upgrade_tof::NSigmaPionOuterTOF,
+                                              upgrade_tof::NSigmaKaonOuterTOF,
+                                              upgrade_tof::NSigmaProtonOuterTOF,
+                                              upgrade_tof::NSigmaDeuteronOuterTOF,
+                                              upgrade_tof::NSigmaTritonOuterTOF,
+                                              upgrade_tof::NSigmaHelium3OuterTOF,
+                                              upgrade_tof::NSigmaAlphaOuterTOF>);
+
+DECLARE_SOA_TABLE(ReducedA3PIDRich, "AOD", "REA3PIDRICH",
+                  upgrade_rich::NSigmaElectronRich,
+                  upgrade_rich::NSigmaMuonRich,
+                  upgrade_rich::NSigmaPionRich,
+                  upgrade_rich::NSigmaKaonRich,
+                  upgrade_rich::NSigmaProtonRich,
+                  upgrade_rich::NSigmaDeuteronRich,
+                  upgrade_rich::NSigmaTritonRich,
+                  upgrade_rich::NSigmaHelium3Rich,
+                  upgrade_rich::NSigmaAlphaRich,
+                  upgrade_rich::NSigmaRich<upgrade_rich::NSigmaElectronRich,
+                                           upgrade_rich::NSigmaMuonRich,
+                                           upgrade_rich::NSigmaPionRich,
+                                           upgrade_rich::NSigmaKaonRich,
+                                           upgrade_rich::NSigmaProtonRich,
+                                           upgrade_rich::NSigmaDeuteronRich,
+                                           upgrade_rich::NSigmaTritonRich,
+                                           upgrade_rich::NSigmaHelium3Rich,
+                                           upgrade_rich::NSigmaAlphaRich>);
+
+DECLARE_SOA_TABLE(ReducedA3PIDRichSignals, "AOD", "REA3PIDRICHSIG",
+                  upgrade_rich::HasSig,
+                  upgrade_rich::HasSigInGas,
+                  upgrade_rich::HasSigEl,
+                  upgrade_rich::HasSigMu,
+                  upgrade_rich::HasSigPi,
+                  upgrade_rich::HasSigKa,
+                  upgrade_rich::HasSigPr,
+                  upgrade_rich::HasSigDe,
+                  upgrade_rich::HasSigTr,
+                  upgrade_rich::HasSigHe3,
+                  upgrade_rich::HasSigAl);
+
+DECLARE_SOA_TABLE(ReducedA3PIDOT, "AOD", "REA3PIDOT",
+                  upgrade::trk::TimeOverThresholdBarrel,
+                  upgrade::trk::NSigmaTrkEl,
+                  upgrade::trk::NSigmaTrkMu,
+                  upgrade::trk::NSigmaTrkPi,
+                  upgrade::trk::NSigmaTrkKa,
+                  upgrade::trk::NSigmaTrkPr,
+                  upgrade::trk::NSigmaTrkDe,
+                  upgrade::trk::NSigmaTrkTr,
+                  upgrade::trk::NSigmaTrkHe,
+                  upgrade::trk::NSigmaTrkAl,
+                  upgrade::trk::NSigmaTrk<upgrade::trk::NSigmaTrkEl,
+                                          upgrade::trk::NSigmaTrkMu,
+                                          upgrade::trk::NSigmaTrkPi,
+                                          upgrade::trk::NSigmaTrkKa,
+                                          upgrade::trk::NSigmaTrkPr,
+                                          upgrade::trk::NSigmaTrkDe,
+                                          upgrade::trk::NSigmaTrkTr,
+                                          upgrade::trk::NSigmaTrkHe,
+                                          upgrade::trk::NSigmaTrkAl>);
+
+} // namespace o2::aod
+
+#endif // ALICE3_DATAMODEL_REDUCEDTABLESALICE3_H_

--- a/ALICE3/TableProducer/alice3-dq-table-maker.cxx
+++ b/ALICE3/TableProducer/alice3-dq-table-maker.cxx
@@ -22,10 +22,10 @@
 #include "PWGDQ/Core/MCSignal.h"
 #include "PWGDQ/Core/MCSignalLibrary.h"
 #include "PWGDQ/Core/VarManager.h"
-#include "PWGDQ/DataModel/ReducedTablesAlice3.h"
 
 #include "ALICE3/DataModel/OTFRICH.h"
 #include "ALICE3/DataModel/OTFTOF.h"
+#include "ALICE3/DataModel/ReducedTablesAlice3.h"
 #include "ALICE3/DataModel/collisionAlice3.h"
 #include "ALICE3/DataModel/tracksAlice3.h"
 #include "Common/CCDB/EventSelectionParams.h"
@@ -74,16 +74,14 @@ constexpr static uint32_t gkTrackFillMapWithCov = VarManager::ObjTypes::Track | 
 
 struct Alice3DQTableMaker {
 
-  Produces<ReducedA3MCEvents> eventMC;
-  Produces<ReducedA3MCTracks> trackMC;
+  Produces<ReA3MCEvents> eventMC;
+  Produces<ReA3MCTracks> trackMC;
 
-  Produces<ReducedA3Events> event;
+  Produces<ReA3Events> event;
   Produces<ReducedA3EventsVtxCov> eventVtxCov;
-  Produces<ReducedA3EventsInfo> eventInfo;
   Produces<ReducedA3MCEventLabels> eventMClabels;
 
-  Produces<ReducedA3TracksBarrelInfo> trackBarrelInfo;
-  Produces<ReducedA3Tracks> trackBasic;
+  Produces<ReA3Tracks> trackBasic;
   Produces<ReducedA3TracksBarrel> trackBarrel;
   Produces<ReducedA3TracksBarrelCov> trackBarrelCov;
   Produces<ReducedA3TracksAssoc> trackBarrelAssoc;
@@ -444,7 +442,6 @@ struct Alice3DQTableMaker {
 
       eventVtxCov(collision.covXX(), collision.covXY(), collision.covXZ(), collision.covYY(), collision.covYZ(), collision.covZZ(), collision.chi2());
       eventMClabels(collision.mcCollisionId(), collision.mcMask());
-      eventInfo(collision.globalIndex());
 
       // add an element for this collision into the map
       fCollIndexMap[collision.globalIndex()] = event.lastIndex();
@@ -512,9 +509,6 @@ struct Alice3DQTableMaker {
       //      In the case of Run2-like analysis, there will be no associations, so this ID will be the one originally assigned in the AO2Ds (updated for the skims)
       uint32_t reducedEventIdx = fCollIndexMap[track.collisionId()];
 
-      // NOTE: trackBarrelInfo stores the index of the collision as in AO2D (for use in some cases where the analysis on skims is done
-      //   in workflows where the original AO2Ds are also present)
-      // trackBarrelInfo(track.collisionId(), collision.posX(), collision.posY(), collision.posZ(), track.globalIndex());
       trackBasic(reducedEventIdx, trackFilteringTag, track.pt(), track.eta(), track.phi(), track.sign(), 0);
 
       trackBarrel(track.x(), track.alpha(), track.y(), track.z(), track.snp(), track.tgl(), track.signed1Pt(),
@@ -612,7 +606,6 @@ struct Alice3DQTableMaker {
     event.reserve(collisions.size());
     eventVtxCov.reserve(collisions.size());
     eventMClabels.reserve(collisions.size());
-    eventInfo.reserve(collisions.size());
 
     skimCollisions(collisions);
 

--- a/ALICE3/TableProducer/alice3-dq-table-maker.cxx
+++ b/ALICE3/TableProducer/alice3-dq-table-maker.cxx
@@ -94,7 +94,7 @@ struct Alice3DQTableMaker {
   OutputObj<THashList> fOutputList{"output"};
   OutputObj<TList> fStatsList{"Statistics"}; //! skimming statistics
 
-  HistogramManager* fHistMan;
+  HistogramManager* fHistMan = nullptr;
 
   // Event and track AnalysisCut configurables
   struct : ConfigurableGroup {
@@ -118,9 +118,8 @@ struct Alice3DQTableMaker {
     Configurable<std::string> fConfigAddJSONHistograms{"cfgAddJSONHistograms", "", "Histograms in JSON format"};
   } fConfigHistOutput;
 
-  AnalysisCompositeCut* fEventCut;               //! Event selection cut
+  AnalysisCompositeCut* fEventCut = nullptr;     //! Event selection cut
   std::vector<AnalysisCompositeCut*> fTrackCuts; //! Barrel track cuts
-  std::vector<AnalysisCompositeCut*> fMuonCuts;  //! Muon track cuts
 
   bool fDoDetailedQA = false;
 
@@ -288,38 +287,38 @@ struct Alice3DQTableMaker {
       }
     }
 
-    // create statistics histograms (event, tracks, muons, MCsignals)
+    // create statistics histograms (event, tracks, MCsignals)
     fStatsList.setObject(new TList());
     fStatsList->SetOwner(true);
     std::vector<TString> eventLabels{"Collisions before filtering", "Before cuts", "After cuts"};
     TH2I* histEvents = new TH2I("EventStats", "Event statistics", eventLabels.size(), -0.5, eventLabels.size() - 0.5, o2::aod::evsel::kNsel + 1, -0.5, (float)o2::aod::evsel::kNsel + 0.5);
-    int ib = 1;
-    for (auto label = eventLabels.begin(); label != eventLabels.end(); label++, ib++) {
-      histEvents->GetXaxis()->SetBinLabel(ib, (*label).Data());
+    int ibX = 1;
+    for (auto label = eventLabels.begin(); label != eventLabels.end(); label++, ibX++) {
+      histEvents->GetXaxis()->SetBinLabel(ibX, (*label).Data());
     }
-    for (int ib = 1; ib <= o2::aod::evsel::kNsel; ib++) {
-      histEvents->GetYaxis()->SetBinLabel(ib, o2::aod::evsel::selectionLabels[ib - 1]);
+    for (int ibY = 1; ibY <= o2::aod::evsel::kNsel; ibY++) {
+      histEvents->GetYaxis()->SetBinLabel(ibY, o2::aod::evsel::selectionLabels[ibY - 1]);
     }
     histEvents->GetYaxis()->SetBinLabel(o2::aod::evsel::kNsel + 1, "Total");
     fStatsList->Add(histEvents);
 
     // Track statistics: one bin for each track selection and 5 bins for V0 tags (gamma, K0s, Lambda, anti-Lambda, Omega)
     TH1I* histTracks = new TH1I("TrackStats", "Track statistics", fTrackCuts.size() + 5.0, -0.5, fTrackCuts.size() - 0.5 + 5.0);
-    ib = 1;
-    for (auto cut = fTrackCuts.begin(); cut != fTrackCuts.end(); cut++, ib++) {
-      histTracks->GetXaxis()->SetBinLabel(ib, (*cut)->GetName());
+    ibX = 1;
+    for (auto cut = fTrackCuts.begin(); cut != fTrackCuts.end(); cut++, ibX++) {
+      histTracks->GetXaxis()->SetBinLabel(ibX, (*cut)->GetName());
     }
     constexpr int nV0Tags = 5;
     const char* v0TagNames[nV0Tags] = {"Photon conversion", "K^{0}_{s}", "#Lambda", "#bar{#Lambda}", "#Omega"};
-    for (int ib = 0; ib < nV0Tags; ib++) {
-      histTracks->GetXaxis()->SetBinLabel(fTrackCuts.size() + 1 + ib, v0TagNames[ib]);
+    for (int ibY = 0; ibY < nV0Tags; ibY++) {
+      histTracks->GetXaxis()->SetBinLabel(fTrackCuts.size() + 1 + ibY, v0TagNames[ibY]);
     }
     fStatsList->Add(histTracks);
 
     TH1I* histMCsignals = new TH1I("MCsignals", "MC signals", fMCSignals.size() + 1, -0.5, fMCSignals.size() - 0.5 + 1.0);
-    ib = 1;
-    for (auto signal = fMCSignals.begin(); signal != fMCSignals.end(); signal++, ib++) {
-      histMCsignals->GetXaxis()->SetBinLabel(ib, (*signal)->GetName());
+    ibX = 1;
+    for (auto signal = fMCSignals.begin(); signal != fMCSignals.end(); signal++, ibX++) {
+      histMCsignals->GetXaxis()->SetBinLabel(ibX, (*signal)->GetName());
     }
     histMCsignals->GetXaxis()->SetBinLabel(fMCSignals.size() + 1, "Others (matched to reco tracks)");
     fStatsList->Add(histMCsignals);
@@ -481,14 +480,14 @@ struct Alice3DQTableMaker {
         fHistMan->FillHistClass("TrackBarrel_BeforeCuts", VarManager::fgValues);
       }
 
-      int i = 0;
-      for (auto cut = fTrackCuts.begin(); cut != fTrackCuts.end(); cut++, i++) {
+      int n = 0;
+      for (auto cut = fTrackCuts.begin(); cut != fTrackCuts.end(); cut++, n++) {
         if ((*cut)->IsSelected(VarManager::fgValues)) {
-          trackTempFilterMap |= (static_cast<uint32_t>(1) << i);
+          trackTempFilterMap |= (static_cast<uint32_t>(1) << n);
           if (fConfigHistOutput.fConfigQA) {
             fHistMan->FillHistClass(Form("TrackBarrel_%s", (*cut)->GetName()), VarManager::fgValues);
           }
-          (reinterpret_cast<TH1I*>(fStatsList->At(1)))->Fill(static_cast<float>(i));
+          (reinterpret_cast<TH1I*>(fStatsList->At(1)))->Fill(static_cast<float>(n));
         }
       }
       if (!trackTempFilterMap) {

--- a/ALICE3/TableProducer/alice3-dq-table-maker.cxx
+++ b/ALICE3/TableProducer/alice3-dq-table-maker.cxx
@@ -381,19 +381,22 @@ struct Alice3DQTableMaker {
       }
 
       // If this MC track was not already added to the map, add it now
-      if (fLabelsMap.find(mctrack.globalIndex()) == fLabelsMap.end()) {
-        fLabelsMap[mctrack.globalIndex()] = trackCounter;
-        fLabelsMapReversed[trackCounter] = mctrack.globalIndex();
-        fMCFlags[mctrack.globalIndex()] = mcflags;
-        trackCounter++;
+      const auto mcTrackIndex = mctrack.globalIndex();
+      const bool inserted = fLabelsMap.try_emplace(mcTrackIndex, trackCounter).second;
+
+      if (inserted) {
+        fLabelsMapReversed.try_emplace(trackCounter, mcTrackIndex);
+        fMCFlags.try_emplace(mcTrackIndex, mcflags);
+        ++trackCounter;
 
         // fill histograms for each of the signals, if found
         if (fConfigHistOutput.fConfigQA) {
           VarManager::FillTrackMC(mcTracks, mctrack);
           auto mcCollision = mctrack.template mcCollision_as<MyEventsMC>();
           VarManager::FillEvent<gkEventMcFillMap>(mcCollision);
+
           int j = 0;
-          for (auto signal = fMCSignals.begin(); signal != fMCSignals.end(); signal++, j++) {
+          for (auto signal = fMCSignals.begin(); signal != fMCSignals.end(); ++signal, ++j) {
             if (mcflags & (static_cast<uint16_t>(1) << j)) {
               fHistMan->FillHistClass(Form("MCTruth_%s", (*signal)->GetName()), VarManager::fgValues);
             }

--- a/ALICE3/Tasks/alice3-dq-efficiency.cxx
+++ b/ALICE3/Tasks/alice3-dq-efficiency.cxx
@@ -909,9 +909,9 @@ struct AnalysisSameEventPairing {
             // if there are pair cuts specified, assign hist directories for each barrel cut - pair cut combination
             // NOTE: This could possibly lead to large histogram outputs. It is strongly advised to use pair cuts only
             //   if you know what you are doing.
-            TString pairCutNamesStr = fConfigCuts.pair.value;
-            if (!pairCutNamesStr.IsNull()) { // if pair cuts
-              std::unique_ptr<TObjArray> objArrayPair(pairCutNamesStr.Tokenize(","));
+            TString pairCutHistNamesStr = fConfigCuts.pair.value;
+            if (!pairCutHistNamesStr.IsNull()) { // if pair cuts
+              std::unique_ptr<TObjArray> objArrayPair(pairCutHistNamesStr.Tokenize(","));
               fNPairCuts = objArrayPair->GetEntries();
               for (int iPairCut = 0; iPairCut < fNPairCuts; ++iPairCut) { // loop over pair cuts
                 names = {
@@ -1757,9 +1757,9 @@ struct AnalysisAsymmetricPairing {
           DefineHistograms(fHistMan, Form("TripletsBarrelSE_%s_%s", legsStr.Data(), objArrayCommon->At(iCommonCut)->GetName()), fConfigHistogramSubgroups.value.data());
         }
 
-        TString pairCutNamesStr = fConfigPairCuts.value;
-        if (!pairCutNamesStr.IsNull()) { // if pair cuts
-          std::unique_ptr<TObjArray> objArrayPair(pairCutNamesStr.Tokenize(","));
+        TString pairCutHistNamesStr = fConfigPairCuts.value;
+        if (!pairCutHistNamesStr.IsNull()) { // if pair cuts
+          std::unique_ptr<TObjArray> objArrayPair(pairCutHistNamesStr.Tokenize(","));
           fNPairCuts = objArrayPair->GetEntries();
           for (int iPairCut = 0; iPairCut < fNPairCuts; ++iPairCut) { // loop over pair cuts
             DefineHistograms(fHistMan, Form("TripletsBarrelSE_%s_%s", legsStr.Data(), objArrayPair->At(iPairCut)->GetName()), fConfigHistogramSubgroups.value.data());

--- a/ALICE3/Tasks/alice3-dq-efficiency.cxx
+++ b/ALICE3/Tasks/alice3-dq-efficiency.cxx
@@ -24,8 +24,8 @@
 #include "PWGDQ/Core/MixingLibrary.h"
 #include "PWGDQ/Core/VarManager.h"
 #include "PWGDQ/DataModel/ReducedInfoTables.h"
-#include "PWGDQ/DataModel/ReducedTablesAlice3.h"
 
+#include "ALICE3/DataModel/ReducedTablesAlice3.h"
 #include "Common/Core/TableHelper.h"
 
 #include <DetectorsBase/MatLayerCylSet.h>
@@ -111,23 +111,23 @@ DECLARE_SOA_TABLE(OniaMCTruth, "AOD", "MCTRUTHONIA", dqanalysisflags::OniaPt, dq
 
 // TODO: USE PROPER TABLES
 
-using MyEvents = soa::Join<aod::ReducedA3Events, aod::ReducedA3MCEventLabels>;
-using MyEventsSelected = soa::Join<aod::ReducedA3Events, aod::EventCuts, aod::ReducedA3MCEventLabels>;
-using MyEventsVtxCov = soa::Join<aod::ReducedA3Events, aod::ReducedA3EventsVtxCov, aod::ReducedA3MCEventLabels>;
-using MyEventsVtxCovSelected = soa::Join<aod::ReducedA3Events, aod::ReducedA3EventsVtxCov, aod::EventCuts, aod::ReducedA3MCEventLabels>;
+using MyEvents = soa::Join<aod::ReA3Events, aod::ReducedA3MCEventLabels>;
+using MyEventsSelected = soa::Join<aod::ReA3Events, aod::EventCuts, aod::ReducedA3MCEventLabels>;
+using MyEventsVtxCov = soa::Join<aod::ReA3Events, aod::ReducedA3EventsVtxCov, aod::ReducedA3MCEventLabels>;
+using MyEventsVtxCovSelected = soa::Join<aod::ReA3Events, aod::ReducedA3EventsVtxCov, aod::EventCuts, aod::ReducedA3MCEventLabels>;
 
 using MyBarrelAssocs = soa::Join<aod::ReducedA3TracksAssoc, aod::BarrelTrackCuts>;
 using MyBarrelAssocsPrefilter = soa::Join<aod::ReducedA3TracksAssoc, aod::BarrelTrackCuts, aod::Prefilter>;
 
-using MyBarrelTracks = soa::Join<aod::ReducedA3Tracks, aod::ReducedA3TracksBarrel,
+using MyBarrelTracks = soa::Join<aod::ReA3Tracks, aod::ReducedA3TracksBarrel,
                                  aod::ReducedA3PIDTOF, aod::ReducedA3PIDRich, aod::ReducedA3PIDRichSignals,
                                  aod::ReducedA3TracksBarrelLabels>;
 
-using MyBarrelTracksWithCov = soa::Join<aod::ReducedA3Tracks, aod::ReducedA3TracksBarrel, aod::ReducedA3TracksBarrelCov,
+using MyBarrelTracksWithCov = soa::Join<aod::ReA3Tracks, aod::ReducedA3TracksBarrel, aod::ReducedA3TracksBarrelCov,
                                         aod::ReducedA3PIDTOF, aod::ReducedA3PIDRich, aod::ReducedA3PIDRichSignals,
                                         aod::ReducedA3TracksBarrelLabels>;
 
-using MyBarrelTracksWithCovWithAmbiguities = soa::Join<aod::ReducedA3Tracks, aod::ReducedA3TracksBarrel, aod::ReducedA3TracksBarrelCov,
+using MyBarrelTracksWithCovWithAmbiguities = soa::Join<aod::ReA3Tracks, aod::ReducedA3TracksBarrel, aod::ReducedA3TracksBarrelCov,
                                                        aod::ReducedA3PIDTOF, aod::ReducedA3PIDRich, aod::ReducedA3PIDRichSignals,
                                                        aod::BarrelAmbiguities, aod::ReducedA3TracksBarrelLabels>;
 
@@ -218,7 +218,7 @@ struct AnalysisEventSelection {
     }
   }
 
-  void runEventSelection(MyEventsVtxCov const& events, ReducedA3MCEvents const& mcEvents)
+  void runEventSelection(MyEventsVtxCov const& events, ReA3MCEvents const& mcEvents)
   {
     fSelMap.clear();
 
@@ -226,8 +226,8 @@ struct AnalysisEventSelection {
       // Reset the fValues array and fill event observables
       VarManager::ResetValues(0, VarManager::kNEventWiseVariables);
       VarManager::FillEventAlice3<gkEventFillMap>(event);
-      if (event.has_reducedA3MCEvent()) {
-        VarManager::FillEventAlice3<VarManager::ObjTypes::ReducedEventMC>(event.reducedA3MCEvent());
+      if (event.has_reA3MCEvent()) {
+        VarManager::FillEventAlice3<VarManager::ObjTypes::ReducedEventMC>(event.reA3MCEvent());
       }
 
       bool decision = false;
@@ -271,7 +271,7 @@ struct AnalysisEventSelection {
     }
   }
 
-  void processSkimmed(MyEventsVtxCov const& events, aod::ReducedA3MCEvents const& mcEvents)
+  void processSkimmed(MyEventsVtxCov const& events, aod::ReA3MCEvents const& mcEvents)
   {
     runEventSelection(events, mcEvents);
     publishSelections(events);
@@ -392,7 +392,7 @@ struct AnalysisTrackSelection {
     }
   }
 
-  void runTrackSelection(ReducedA3TracksAssoc const& assocs, MyEventsVtxCovSelected const& /*events*/, MyBarrelTracksWithCov const& tracks, ReducedA3MCEvents const& /*eventsMC*/, ReducedA3MCTracks const& tracksMC)
+  void runTrackSelection(ReducedA3TracksAssoc const& assocs, MyEventsVtxCovSelected const& /*events*/, MyBarrelTracksWithCov const& tracks, ReA3MCEvents const& /*eventsMC*/, ReA3MCTracks const& tracksMC)
   {
     fNAssocsInBunch.clear();
     fNAssocsOutOfBunch.clear();
@@ -402,7 +402,7 @@ struct AnalysisTrackSelection {
 
     // Loop over associations
     for (const auto& assoc : assocs) {
-      auto event = assoc.template reducedA3event_as<MyEventsVtxCovSelected>();
+      auto event = assoc.template reA3event_as<MyEventsVtxCovSelected>();
       if (!event.isEventSelected_bit(0)) {
         trackSel(0);
         continue;
@@ -411,21 +411,21 @@ struct AnalysisTrackSelection {
       VarManager::ResetValues(0, VarManager::kNBarrelTrackVariables);
       // fill event information which might be needed in histograms/cuts that combine track and event properties
       VarManager::FillEventAlice3<gkEventFillMapWithCov>(event);
-      if (event.has_reducedA3MCEvent()) {
-        VarManager::FillEventAlice3<VarManager::ObjTypes::ReducedEventMC>(event.reducedA3MCEvent());
+      if (event.has_reA3MCEvent()) {
+        VarManager::FillEventAlice3<VarManager::ObjTypes::ReducedEventMC>(event.reA3MCEvent());
       }
 
-      auto track = assoc.template reducedA3track_as<MyBarrelTracksWithCov>();
+      auto track = assoc.template reA3track_as<MyBarrelTracksWithCov>();
       VarManager::FillTrackAlice3<gkTrackFillMapWithCov>(track);
       // compute quantities which depend on the associated collision, such as DCA
       VarManager::FillTrackCollision<gkTrackFillMapWithCov>(track, event);
 
       bool isCorrectAssoc = false;
-      if (track.has_reducedA3MCTrack()) {
-        auto trackMC = track.reducedA3MCTrack();
-        auto eventMCfromTrack = trackMC.reducedA3MCEvent();
-        if (event.has_reducedA3MCEvent()) {
-          isCorrectAssoc = (eventMCfromTrack.globalIndex() == event.reducedA3MCEvent().globalIndex());
+      if (track.has_reA3MCTrack()) {
+        auto trackMC = track.reA3MCTrack();
+        auto eventMCfromTrack = trackMC.reA3MCEvent();
+        if (event.has_reA3MCEvent()) {
+          isCorrectAssoc = (eventMCfromTrack.globalIndex() == event.reA3MCEvent().globalIndex());
         }
         VarManager::FillTrackMC(tracksMC, trackMC);
         VarManager::FillResolutions(trackMC, track);
@@ -449,11 +449,11 @@ struct AnalysisTrackSelection {
 
       // compute MC matching decisions and fill histograms for matched associations
       int isig = 0;
-      if (filterMap > 0 && track.has_reducedA3MCTrack()) {
+      if (filterMap > 0 && track.has_reA3MCTrack()) {
         // loop over all MC signals
         for (auto sig = fMCSignals.begin(); sig != fMCSignals.end(); sig++, isig++) {
           // check if this MC signal is matched
-          if ((*sig)->CheckSignal(true, track.reducedA3MCTrack())) {
+          if ((*sig)->CheckSignal(true, track.reA3MCTrack())) {
             // mcDecision |= (static_cast<uint32_t>(1) << isig);
             //  loop over cuts and fill histograms for the cuts that are fulfilled
             for (unsigned int icut = 0; icut < fTrackCuts.size(); icut++) {
@@ -535,7 +535,7 @@ struct AnalysisTrackSelection {
     }
   } // end runTrackSelection()
 
-  void processSkimmedWithCov(ReducedA3TracksAssoc const& assocs, MyEventsVtxCovSelected const& events, MyBarrelTracksWithCov const& tracks, ReducedA3MCEvents const& eventsMC, ReducedA3MCTracks const& tracksMC)
+  void processSkimmedWithCov(ReducedA3TracksAssoc const& assocs, MyEventsVtxCovSelected const& events, MyBarrelTracksWithCov const& tracks, ReA3MCEvents const& eventsMC, ReA3MCTracks const& tracksMC)
   {
     runTrackSelection(assocs, events, tracks, eventsMC, tracksMC);
   }
@@ -564,7 +564,7 @@ struct AnalysisPrefilterSelection {
   uint32_t fPrefilterMask = 0;
   int fPrefilterCutBit = -1;
 
-  PresliceUnsorted<aod::ReducedA3TracksAssoc> trackAssocsPerCollision = aod::reducedA3track_association::reducedA3eventId;
+  PresliceUnsorted<aod::ReducedA3TracksAssoc> trackAssocsPerCollision = aod::reducedA3track_association::reA3eventId;
 
   void init(o2::framework::InitContext& context)
   {
@@ -651,8 +651,8 @@ struct AnalysisPrefilterSelection {
     }
 
     for (const auto& [assoc1, assoc2] : o2::soa::combinations(assocs, assocs)) {
-      auto track1 = assoc1.template reducedA3track_as<MyBarrelTracks>();
-      auto track2 = assoc2.template reducedA3track_as<MyBarrelTracks>();
+      auto track1 = assoc1.template reA3track_as<MyBarrelTracks>();
+      auto track2 = assoc2.template reA3track_as<MyBarrelTracks>();
 
       // NOTE: here we restrict to just pairs of opposite sign (conversions), but in principle this can be made
       // a configurable and check also same-sign pairs (track splitting)
@@ -708,7 +708,7 @@ struct AnalysisPrefilterSelection {
     } else {
       for (const auto& assoc : assocs) {
         // TODO: just use the index from the assoc (no need to cast the whole track)
-        auto track = assoc.template reducedA3track_as<MyBarrelTracks>();
+        auto track = assoc.template reA3track_as<MyBarrelTracks>();
         mymap = -1;
         if (!fPrefilterMap.contains(track.globalIndex())) {
           // NOTE: publish the bitwise negated bits (~), so there will be zeroes for cuts that failed the prefiltering and 1 everywhere else
@@ -795,7 +795,7 @@ struct AnalysisSameEventPairing {
 
   bool fEnableBarrelHistos = false;
 
-  PresliceUnsorted<MyBarrelAssocsPrefilter> trackAssocsPerCollision = aod::reducedA3track_association::reducedA3eventId;
+  PresliceUnsorted<MyBarrelAssocsPrefilter> trackAssocsPerCollision = aod::reducedA3track_association::reA3eventId;
 
   void init(o2::framework::InitContext& context)
   {
@@ -1002,7 +1002,7 @@ struct AnalysisSameEventPairing {
   }
 
   // Template function to run same event pairing (barrel-barrel)
-  void runSameEventPairing(MyEventsVtxCovSelected const& events, PresliceUnsorted<MyBarrelAssocsPrefilter>& preslice, MyBarrelAssocsPrefilter const& assocs, MyBarrelTracksWithCovWithAmbiguities const& /*tracks*/, ReducedA3MCEvents const& /*mcEvents*/, ReducedA3MCTracks const& /*mcTracks*/)
+  void runSameEventPairing(MyEventsVtxCovSelected const& events, PresliceUnsorted<MyBarrelAssocsPrefilter>& preslice, MyBarrelAssocsPrefilter const& assocs, MyBarrelTracksWithCovWithAmbiguities const& /*tracks*/, ReA3MCEvents const& /*mcEvents*/, ReA3MCTracks const& /*mcTracks*/)
   {
     if (events.size() == 0) {
       LOG(warning) << "No events in this TF, going to the next one ...";
@@ -1049,7 +1049,7 @@ struct AnalysisSameEventPairing {
       // Reset the fValues array
       VarManager::ResetValues(0, VarManager::kNVars);
       VarManager::FillEventAlice3<gkEventFillMap>(event, dqefficiency_helpers::varValues());
-      VarManager::FillEventAlice3<VarManager::ObjTypes::ReducedEventMC>(event.reducedA3MCEvent(), dqefficiency_helpers::varValues());
+      VarManager::FillEventAlice3<VarManager::ObjTypes::ReducedEventMC>(event.reA3MCEvent(), dqefficiency_helpers::varValues());
 
       auto groupedAssocs = assocs.sliceBy(preslice, event.globalIndex());
       if (groupedAssocs.size() == 0) {
@@ -1064,8 +1064,8 @@ struct AnalysisSameEventPairing {
           continue;
         }
 
-        auto t1 = a1.template reducedA3track_as<MyBarrelTracksWithCovWithAmbiguities>();
-        auto t2 = a2.template reducedA3track_as<MyBarrelTracksWithCovWithAmbiguities>();
+        auto t1 = a1.template reA3track_as<MyBarrelTracksWithCovWithAmbiguities>();
+        auto t2 = a2.template reA3track_as<MyBarrelTracksWithCovWithAmbiguities>();
         sign1 = t1.sign();
         sign2 = t2.sign();
         // store the ambiguity number of the two dilepton legs in the last 4 digits of the two-track filter
@@ -1086,15 +1086,15 @@ struct AnalysisSameEventPairing {
         int iSigMc = 0;
         mcDecision = 0;
         for (auto sig = fRecMCSignals.begin(); sig != fRecMCSignals.end(); sig++, iSigMc++) {
-          if (t1.has_reducedA3MCTrack() && t2.has_reducedA3MCTrack()) {
-            if ((*sig)->CheckSignal(true, t1.reducedA3MCTrack(), t2.reducedA3MCTrack())) {
+          if (t1.has_reA3MCTrack() && t2.has_reA3MCTrack()) {
+            if ((*sig)->CheckSignal(true, t1.reA3MCTrack(), t2.reA3MCTrack())) {
               mcDecision |= (static_cast<uint32_t>(1) << iSigMc);
             }
           }
         } // end loop over MC signals
-        if (t1.has_reducedA3MCTrack() && t2.has_reducedA3MCTrack()) {
-          isCorrectAssoc_leg1 = (t1.reducedA3MCTrack().reducedA3MCEvent() == event.reducedA3MCEvent());
-          isCorrectAssoc_leg2 = (t2.reducedA3MCTrack().reducedA3MCEvent() == event.reducedA3MCEvent());
+        if (t1.has_reA3MCTrack() && t2.has_reA3MCTrack()) {
+          isCorrectAssoc_leg1 = (t1.reA3MCTrack().reA3MCEvent() == event.reA3MCEvent());
+          isCorrectAssoc_leg2 = (t2.reA3MCTrack().reA3MCEvent() == event.reA3MCEvent());
         }
 
         VarManager::FillPairAlice3<VarManager::kDecayToEE, gkTrackFillMap>(t1, t2);
@@ -1209,9 +1209,9 @@ struct AnalysisSameEventPairing {
     } // end loop over events
   }
 
-  PresliceUnsorted<ReducedA3MCTracks> perReducedMcEvent = aod::reducedA3trackMC::reducedA3MCEventId;
+  PresliceUnsorted<ReA3MCTracks> perReducedMcEvent = aod::reducedA3trackMC::reA3MCEventId;
 
-  void runMCGenWithGrouping(MyEventsVtxCovSelected const& events, ReducedA3MCEvents const& /*mcEvents*/, ReducedA3MCTracks const& mcTracks)
+  void runMCGenWithGrouping(MyEventsVtxCovSelected const& events, ReA3MCEvents const& /*mcEvents*/, ReA3MCTracks const& mcTracks)
   {
     for (const auto& mctrack : mcTracks) {
       VarManager::FillTrackMC(mcTracks, mctrack);
@@ -1235,12 +1235,12 @@ struct AnalysisSameEventPairing {
       if (!event.isEventSelected_bit(0)) {
         continue;
       }
-      if (!event.has_reducedA3MCEvent()) {
+      if (!event.has_reA3MCEvent()) {
         continue;
       }
 
       for (const auto& track : mcTracks) {
-        if (track.reducedA3MCEventId() != event.reducedA3MCEventId()) {
+        if (track.reA3MCEventId() != event.reA3MCEventId()) {
           continue;
         }
         VarManager::FillTrackMC(mcTracks, track);
@@ -1264,7 +1264,7 @@ struct AnalysisSameEventPairing {
       for (const auto& [t1, t2] : combinations(mcTracks, mcTracks)) {
         auto t1_raw = mcTracks.rawIteratorAt(t1.globalIndex());
         auto t2_raw = mcTracks.rawIteratorAt(t2.globalIndex());
-        if (t1_raw.reducedA3MCEventId() == t2_raw.reducedA3MCEventId()) {
+        if (t1_raw.reA3MCEventId() == t2_raw.reA3MCEventId()) {
           for (const auto& sig : fGenMCSignals) {
             if (sig->GetNProngs() != TWO_PRONG) { // NOTE: 2-prong signals required here
               continue;
@@ -1286,17 +1286,17 @@ struct AnalysisSameEventPairing {
       if (!event.isEventSelected_bit(0)) {
         continue;
       }
-      if (!event.has_reducedA3MCEvent()) {
+      if (!event.has_reA3MCEvent()) {
         continue;
       }
       // CURRENTLY ONLY FOR 1-GENERATION 2-PRONG SIGNALS
       if (fHasTwoProngGenMCsignals) {
-        auto groupedMCTracks = mcTracks.sliceBy(perReducedMcEvent, event.reducedA3MCEventId());
+        auto groupedMCTracks = mcTracks.sliceBy(perReducedMcEvent, event.reA3MCEventId());
         groupedMCTracks.bindInternalIndicesTo(&mcTracks);
         for (const auto& [t1, t2] : combinations(groupedMCTracks, groupedMCTracks)) {
           auto t1_raw = mcTracks.rawIteratorAt(t1.globalIndex());
           auto t2_raw = mcTracks.rawIteratorAt(t2.globalIndex());
-          if (t1_raw.reducedA3MCEventId() == t2_raw.reducedA3MCEventId()) {
+          if (t1_raw.reA3MCEventId() == t2_raw.reA3MCEventId()) {
             for (const auto& sig : fGenMCSignals) {
               if (sig->GetNProngs() != TWO_PRONG) { // NOTE: 2-prong signals required here
                 continue;
@@ -1319,15 +1319,15 @@ struct AnalysisSameEventPairing {
 
   void processBarrelOnlySkimmed(MyEventsVtxCovSelected const& events,
                                 MyBarrelAssocsPrefilter const& barrelAssocs,
-                                MyBarrelTracksWithCovWithAmbiguities const& barrelTracks, ReducedA3MCEvents const& mcEvents, ReducedA3MCTracks const& mcTracks)
+                                MyBarrelTracksWithCovWithAmbiguities const& barrelTracks, ReA3MCEvents const& mcEvents, ReA3MCTracks const& mcTracks)
   {
     runSameEventPairing(events, trackAssocsPerCollision, barrelAssocs, barrelTracks, mcEvents, mcTracks);
     runMCGenWithGrouping(events, mcEvents, mcTracks);
   }
 
-  PresliceUnsorted<ReducedA3MCTracks> perReducedMcGenEvent = aod::reducedA3trackMC::reducedA3MCEventId;
+  PresliceUnsorted<ReA3MCTracks> perReducedMcGenEvent = aod::reducedA3trackMC::reA3MCEventId;
 
-  void processMCGen(soa::Filtered<MyEventsVtxCovSelected> const& events, ReducedA3MCEvents const& /*mcEvents*/, ReducedA3MCTracks const& mcTracks)
+  void processMCGen(soa::Filtered<MyEventsVtxCovSelected> const& events, ReA3MCEvents const& /*mcEvents*/, ReA3MCTracks const& mcTracks)
   {
     for (const auto& mctrack : mcTracks) {
       VarManager::FillTrackMC(mcTracks, mctrack);
@@ -1346,14 +1346,14 @@ struct AnalysisSameEventPairing {
       if (!event.isEventSelected_bit(0)) {
         continue;
       }
-      if (!event.has_reducedA3MCEvent()) {
+      if (!event.has_reA3MCEvent()) {
         continue;
       }
       VarManager::FillEventAlice3<gkEventFillMap>(event, dqefficiency_helpers::varValues());
-      VarManager::FillEventAlice3<VarManager::ObjTypes::ReducedEventMC>(event.reducedA3MCEvent(), dqefficiency_helpers::varValues());
+      VarManager::FillEventAlice3<VarManager::ObjTypes::ReducedEventMC>(event.reA3MCEvent(), dqefficiency_helpers::varValues());
 
       for (const auto& track : mcTracks) {
-        if (track.reducedA3MCEventId() != event.reducedA3MCEventId()) {
+        if (track.reA3MCEventId() != event.reA3MCEventId()) {
           continue;
         }
         VarManager::FillTrackMC(mcTracks, track);
@@ -1370,7 +1370,7 @@ struct AnalysisSameEventPairing {
       for (const auto& [t1, t2] : combinations(mcTracks, mcTracks)) {
         auto t1_raw = mcTracks.rawIteratorAt(t1.globalIndex());
         auto t2_raw = mcTracks.rawIteratorAt(t2.globalIndex());
-        if (t1_raw.reducedA3MCEventId() == t2_raw.reducedA3MCEventId()) {
+        if (t1_raw.reA3MCEventId() == t2_raw.reA3MCEventId()) {
           for (const auto& sig : fGenMCSignals) {
             if (sig->GetNProngs() != TWO_PRONG) { // NOTE: 2-prong signals required here
               continue;
@@ -1387,21 +1387,21 @@ struct AnalysisSameEventPairing {
       if (!event.isEventSelected_bit(0)) {
         continue;
       }
-      if (!event.has_reducedA3MCEvent()) {
+      if (!event.has_reA3MCEvent()) {
         continue;
       }
 
       if (fHasTwoProngGenMCsignals) {
         for (const auto& [t1, t2] : combinations(mcTracks, mcTracks)) {
-          if (t1.reducedA3MCEventId() != event.reducedA3MCEventId()) {
+          if (t1.reA3MCEventId() != event.reA3MCEventId()) {
             continue;
           }
-          if (t2.reducedA3MCEventId() != event.reducedA3MCEventId()) {
+          if (t2.reA3MCEventId() != event.reA3MCEventId()) {
             continue;
           }
           auto t1_raw = mcTracks.rawIteratorAt(t1.globalIndex());
           auto t2_raw = mcTracks.rawIteratorAt(t2.globalIndex());
-          if (t1_raw.reducedA3MCEventId() == t2_raw.reducedA3MCEventId()) {
+          if (t1_raw.reA3MCEventId() == t2_raw.reA3MCEventId()) {
             for (const auto& sig : fGenMCSignals) {
               if (sig->GetNProngs() != TWO_PRONG) { // NOTE: 2-prong signals required here
                 continue;
@@ -1416,7 +1416,7 @@ struct AnalysisSameEventPairing {
     } // end loop over reconstructed events
   }
 
-  void processMCGenWithGrouping(soa::Filtered<MyEventsVtxCovSelected> const& events, ReducedA3MCEvents const& /*mcEvents*/, ReducedA3MCTracks const& mcTracks)
+  void processMCGenWithGrouping(soa::Filtered<MyEventsVtxCovSelected> const& events, ReA3MCEvents const& /*mcEvents*/, ReA3MCTracks const& mcTracks)
   {
     for (const auto& mctrack : mcTracks) {
       VarManager::FillTrackMC(mcTracks, mctrack);
@@ -1434,12 +1434,12 @@ struct AnalysisSameEventPairing {
       if (!event.isEventSelected_bit(0)) {
         continue;
       }
-      if (!event.has_reducedA3MCEvent()) {
+      if (!event.has_reA3MCEvent()) {
         continue;
       }
 
       for (const auto& track : mcTracks) {
-        if (track.reducedA3MCEventId() != event.reducedA3MCEventId()) {
+        if (track.reA3MCEventId() != event.reA3MCEventId()) {
           continue;
         }
         VarManager::FillTrackMC(mcTracks, track);
@@ -1456,7 +1456,7 @@ struct AnalysisSameEventPairing {
       for (const auto& [t1, t2] : combinations(mcTracks, mcTracks)) {
         auto t1_raw = mcTracks.rawIteratorAt(t1.globalIndex());
         auto t2_raw = mcTracks.rawIteratorAt(t2.globalIndex());
-        if (t1_raw.reducedA3MCEventId() == t2_raw.reducedA3MCEventId()) {
+        if (t1_raw.reA3MCEventId() == t2_raw.reA3MCEventId()) {
           for (const auto& sig : fGenMCSignals) {
             if (sig->GetNProngs() != TWO_PRONG) { // NOTE: 2-prong signals required here
               continue;
@@ -1472,17 +1472,17 @@ struct AnalysisSameEventPairing {
       if (!event.isEventSelected_bit(0)) {
         continue;
       }
-      if (!event.has_reducedA3MCEvent()) {
+      if (!event.has_reA3MCEvent()) {
         continue;
       }
       // CURRENTLY ONLY FOR 1-GENERATION 2-PRONG SIGNALS
       if (fHasTwoProngGenMCsignals) {
-        auto groupedMCTracks = mcTracks.sliceBy(perReducedMcEvent, event.reducedA3MCEventId());
+        auto groupedMCTracks = mcTracks.sliceBy(perReducedMcEvent, event.reA3MCEventId());
         groupedMCTracks.bindInternalIndicesTo(&mcTracks);
         for (const auto& [t1, t2] : combinations(groupedMCTracks, groupedMCTracks)) {
           auto t1_raw = groupedMCTracks.rawIteratorAt(t1.globalIndex());
           auto t2_raw = groupedMCTracks.rawIteratorAt(t2.globalIndex());
-          if (t1_raw.reducedA3MCEventId() == t2_raw.reducedA3MCEventId()) {
+          if (t1_raw.reA3MCEventId() == t2_raw.reA3MCEventId()) {
             for (const auto& sig : fGenMCSignals) {
               if (sig->GetNProngs() != TWO_PRONG) { // NOTE: 2-prong signals required here
                 continue;
@@ -1569,8 +1569,8 @@ struct AnalysisAsymmetricPairing {
 
   Filter eventFilter = aod::dqanalysisflags::isEventSelected > static_cast<uint32_t>(0);
 
-  PresliceUnsorted<MyBarrelAssocs> trackAssocsPerCollision = aod::reducedA3track_association::reducedA3eventId;
-  // PresliceUnsorted<aod::ReducedA3TracksAssoc> trackAssocsPerCollision = aod::reducedA3track_association::reducedA3eventId;
+  PresliceUnsorted<MyBarrelAssocs> trackAssocsPerCollision = aod::reducedA3track_association::reA3eventId;
+  // PresliceUnsorted<aod::ReducedA3TracksAssoc> trackAssocsPerCollision = aod::reducedA3track_association::reA3eventId;
 
   // Partitions for triplets and asymmetric pairs
   Partition<MyBarrelAssocs> legACandidateAssocs = (o2::aod::dqanalysisflags::isBarrelSelected & fConfigLegAFilterMask) > static_cast<uint32_t>(0);
@@ -1921,7 +1921,7 @@ struct AnalysisAsymmetricPairing {
   }
 
   // Function to run same event pairing with asymmetric pairs (e.g. kaon-pion)
-  void runAsymmetricPairing(MyEventsVtxCovSelected const& events, PresliceUnsorted<MyBarrelAssocs>& preslice, MyBarrelAssocs const& /*assocs*/, MyBarrelTracksWithCovWithAmbiguities const& /*tracks*/, ReducedA3MCEvents const& /*mcEvents*/, ReducedA3MCTracks const& /*mcTracks*/)
+  void runAsymmetricPairing(MyEventsVtxCovSelected const& events, PresliceUnsorted<MyBarrelAssocs>& preslice, MyBarrelAssocs const& /*assocs*/, MyBarrelTracksWithCovWithAmbiguities const& /*tracks*/, ReA3MCEvents const& /*mcEvents*/, ReA3MCTracks const& /*mcTracks*/)
   {
     fPairCount.clear();
 
@@ -1973,8 +1973,8 @@ struct AnalysisAsymmetricPairing {
         // Find common track cuts both candidates pass
         twoTrackCommonFilter |= a1.isBarrelSelected_raw() & a2.isBarrelSelected_raw() & fCommonTrackCutMask;
 
-        auto t1 = a1.template reducedA3track_as<MyBarrelTracksWithCovWithAmbiguities>();
-        auto t2 = a2.template reducedA3track_as<MyBarrelTracksWithCovWithAmbiguities>();
+        auto t1 = a1.template reA3track_as<MyBarrelTracksWithCovWithAmbiguities>();
+        auto t2 = a2.template reA3track_as<MyBarrelTracksWithCovWithAmbiguities>();
 
         // Avoid self-pairs
         if (t1.globalIndex() == t2.globalIndex()) {
@@ -2007,9 +2007,9 @@ struct AnalysisAsymmetricPairing {
         int iSigMc = 0;
         mcDecision = 0;
         for (auto sig = fRecMCSignals.begin(); sig != fRecMCSignals.end(); sig++, iSigMc++) {
-          if (t1.has_reducedA3MCTrack() && t2.has_reducedA3MCTrack()) {
-            VarManager::FillPairMC<VarManager::kDecayToKPi>(t1.reducedA3MCTrack(), t2.reducedA3MCTrack());
-            if ((*sig)->CheckSignal(true, t1.reducedA3MCTrack(), t2.reducedA3MCTrack())) {
+          if (t1.has_reA3MCTrack() && t2.has_reA3MCTrack()) {
+            VarManager::FillPairMC<VarManager::kDecayToKPi>(t1.reA3MCTrack(), t2.reA3MCTrack());
+            if ((*sig)->CheckSignal(true, t1.reA3MCTrack(), t2.reA3MCTrack())) {
               mcDecision |= static_cast<uint32_t>(1) << iSigMc;
             }
           }
@@ -2166,7 +2166,7 @@ struct AnalysisAsymmetricPairing {
 
   // Function to run same event triplets (e.g. D+->K-pi+pi+)
   template <bool TThreeProngFitter, typename TEvents, typename TTrackAssocs, typename TTracks>
-  void runThreeProng(TEvents const& events, PresliceUnsorted<TTrackAssocs>& preslice, TTrackAssocs const& /*assocs*/, TTracks const& tracks, ReducedA3MCEvents const& /*mcEvents*/, ReducedA3MCTracks const& /*mcTracks*/, VarManager::PairCandidateType tripletType)
+  void runThreeProng(TEvents const& events, PresliceUnsorted<TTrackAssocs>& preslice, TTrackAssocs const& /*assocs*/, TTracks const& tracks, ReA3MCEvents const& /*mcEvents*/, ReA3MCTracks const& /*mcTracks*/, VarManager::PairCandidateType tripletType)
   {
     for (const auto& event : events) {
       if (!event.isEventSelected_bit(0)) {
@@ -2242,9 +2242,9 @@ struct AnalysisAsymmetricPairing {
     // Find common track cuts all candidates pass
     threeTrackCommonFilter |= a1.isBarrelSelected_raw() & a2.isBarrelSelected_raw() & a3.isBarrelSelected_raw() & fCommonTrackCutMask;
 
-    auto t1 = a1.template reducedA3track_as<TTracks>();
-    auto t2 = a2.template reducedA3track_as<TTracks>();
-    auto t3 = a3.template reducedA3track_as<TTracks>();
+    auto t1 = a1.template reA3track_as<TTracks>();
+    auto t2 = a2.template reA3track_as<TTracks>();
+    auto t3 = a3.template reA3track_as<TTracks>();
 
     // Avoid self-pairs
     if (t1 == t2 || t1 == t3 || t2 == t3) {
@@ -2277,8 +2277,8 @@ struct AnalysisAsymmetricPairing {
     int iSigMc = 0;
     mcDecision = 0;
     for (auto sig = fRecMCSignals.begin(); sig != fRecMCSignals.end(); sig++, iSigMc++) {
-      if (t1.has_reducedA3MCTrack() && t2.has_reducedA3MCTrack() && t3.has_reducedA3MCTrack()) {
-        if ((*sig)->CheckSignal(true, t1.reducedA3MCTrack(), t2.reducedA3MCTrack(), t3.reducedA3MCTrack())) {
+      if (t1.has_reA3MCTrack() && t2.has_reA3MCTrack() && t3.has_reA3MCTrack()) {
+        if ((*sig)->CheckSignal(true, t1.reA3MCTrack(), t2.reA3MCTrack(), t3.reA3MCTrack())) {
           mcDecision |= (static_cast<uint32_t>(1) << iSigMc);
         }
       }
@@ -2344,7 +2344,7 @@ struct AnalysisAsymmetricPairing {
   void processKaonPionSkimmed(MyEventsVtxCovSelected const& events,
                               MyBarrelAssocs const& barrelAssocs,
                               MyBarrelTracksWithCovWithAmbiguities const& barrelTracks,
-                              ReducedA3MCEvents const& mcEvents, ReducedA3MCTracks const& mcTracks)
+                              ReA3MCEvents const& mcEvents, ReA3MCTracks const& mcTracks)
   {
     runAsymmetricPairing(events, trackAssocsPerCollision, barrelAssocs, barrelTracks, mcEvents, mcTracks);
   }
@@ -2352,7 +2352,7 @@ struct AnalysisAsymmetricPairing {
   void processKaonPionPionSkimmed(MyEventsVtxCovSelected const& events,
                                   MyBarrelAssocs const& barrelAssocs,
                                   MyBarrelTracksWithCovWithAmbiguities const& barrelTracks,
-                                  ReducedA3MCEvents const& mcEvents, ReducedA3MCTracks const& mcTracks)
+                                  ReA3MCEvents const& mcEvents, ReA3MCTracks const& mcTracks)
   {
     runThreeProng<true>(events, trackAssocsPerCollision, barrelAssocs, barrelTracks, mcEvents, mcTracks, VarManager::kTripleCandidateToKPiPi);
   }
@@ -2360,16 +2360,16 @@ struct AnalysisAsymmetricPairing {
   void processProtonKaonPionSkimmed(MyEventsVtxCovSelected const& events,
                                     MyBarrelAssocs const& barrelAssocs,
                                     MyBarrelTracksWithCovWithAmbiguities const& barrelTracks,
-                                    ReducedA3MCEvents const& mcEvents, ReducedA3MCTracks const& mcTracks)
+                                    ReA3MCEvents const& mcEvents, ReA3MCTracks const& mcTracks)
   {
     runThreeProng<true>(events, trackAssocsPerCollision, barrelAssocs, barrelTracks, mcEvents, mcTracks, VarManager::kTripleCandidateToPKPi);
   }
 
-  void processMCGen(ReducedA3MCTracks const& mcTracks)
+  void processMCGen(ReA3MCTracks const& mcTracks)
   {
     // loop over mc stack and fill histograms for pure MC truth signals
     // group all the MC tracks which belong to the MC event corresponding to the current reconstructed event
-    // auto groupedMCTracks = tracksMC.sliceBy(aod::reducedA3trackMC::reducedA3MCEventId, event.reducedMCevent().globalIndex());
+    // auto groupedMCTracks = tracksMC.sliceBy(aod::reducedA3trackMC::reA3MCEventId, event.reducedMCevent().globalIndex());
     for (const auto& mctrack : mcTracks) {
 
       VarManager::FillTrackMC(mcTracks, mctrack);
@@ -2384,20 +2384,20 @@ struct AnalysisAsymmetricPairing {
     }
   }
 
-  PresliceUnsorted<ReducedA3MCTracks> perReducedMcEvent = aod::reducedA3trackMC::reducedA3MCEventId;
+  PresliceUnsorted<ReA3MCTracks> perReducedMcEvent = aod::reducedA3trackMC::reA3MCEventId;
 
   void processMCGenWithEventSelection(soa::Filtered<MyEventsVtxCovSelected> const& events,
-                                      ReducedA3MCEvents const& /*mcEvents*/, ReducedA3MCTracks const& mcTracks)
+                                      ReA3MCEvents const& /*mcEvents*/, ReA3MCTracks const& mcTracks)
   {
     for (const auto& event : events) {
       if (!event.isEventSelected_bit(0)) {
         continue;
       }
-      if (!event.has_reducedA3MCEvent()) {
+      if (!event.has_reA3MCEvent()) {
         continue;
       }
 
-      auto groupedMCTracks = mcTracks.sliceBy(perReducedMcEvent, event.reducedA3MCEventId());
+      auto groupedMCTracks = mcTracks.sliceBy(perReducedMcEvent, event.reA3MCEventId());
       groupedMCTracks.bindInternalIndicesTo(&mcTracks);
       for (const auto& track : groupedMCTracks) {
 

--- a/ALICE3/Tasks/alice3-dq-efficiency.cxx
+++ b/ALICE3/Tasks/alice3-dq-efficiency.cxx
@@ -809,9 +809,9 @@ struct AnalysisSameEventPairing {
 
     // Keep track of all the histogram class names to avoid composing strings in the pairing loop
     TString histNames = "";
-    TString cutNamesStr = fConfigCuts.pair.value;
-    if (!cutNamesStr.IsNull()) {
-      std::unique_ptr<TObjArray> objArray(cutNamesStr.Tokenize(","));
+    TString pairCutNamesStr = fConfigCuts.pair.value;
+    if (!pairCutNamesStr.IsNull()) {
+      std::unique_ptr<TObjArray> objArray(pairCutNamesStr.Tokenize(","));
       for (int icut = 0; icut < objArray->GetEntries(); ++icut) {
         fPairCuts.push_back(*dqcuts::GetCompositeCut(objArray->At(icut)->GetName()));
       }
@@ -1598,9 +1598,9 @@ struct AnalysisAsymmetricPairing {
     fLegCFilterMask = fConfigLegCFilterMask.value;
 
     // Get the pair cuts
-    TString cutNamesStr = fConfigPairCuts.value;
-    if (!cutNamesStr.IsNull()) {
-      std::unique_ptr<TObjArray> objArray(cutNamesStr.Tokenize(","));
+    TString pairCutNamesStr = fConfigPairCuts.value;
+    if (!pairCutNamesStr.IsNull()) {
+      std::unique_ptr<TObjArray> objArray(pairCutNamesStr.Tokenize(","));
       for (int icut = 0; icut < objArray->GetEntries(); ++icut) {
         fPairCuts.push_back(dqcuts::GetCompositeCut(objArray->At(icut)->GetName()));
       }
@@ -1611,10 +1611,10 @@ struct AnalysisAsymmetricPairing {
       std::vector<AnalysisCut*> addPairCuts = dqcuts::GetCutsFromJSON(addPairCutsStr.Data());
       for (const auto& t : addPairCuts) {
         fPairCuts.push_back(static_cast<AnalysisCompositeCut*>(t));
-        cutNamesStr += Form(",%s", t->GetName());
+        pairCutNamesStr += Form(",%s", t->GetName());
       }
     }
-    std::unique_ptr<TObjArray> objArrayPairCuts(cutNamesStr.Tokenize(","));
+    std::unique_ptr<TObjArray> objArrayPairCuts(pairCutNamesStr.Tokenize(","));
     fNPairCuts = objArrayPairCuts->GetEntries();
     for (int j = 0; j < fNPairCuts; j++) {
       fPairCutNames.push_back(objArrayPairCuts->At(j)->GetName());
@@ -1757,9 +1757,9 @@ struct AnalysisAsymmetricPairing {
           DefineHistograms(fHistMan, Form("TripletsBarrelSE_%s_%s", legsStr.Data(), objArrayCommon->At(iCommonCut)->GetName()), fConfigHistogramSubgroups.value.data());
         }
 
-        TString cutNamesStr = fConfigPairCuts.value;
-        if (!cutNamesStr.IsNull()) { // if pair cuts
-          std::unique_ptr<TObjArray> objArrayPair(cutNamesStr.Tokenize(","));
+        TString pairCutNamesStr = fConfigPairCuts.value;
+        if (!pairCutNamesStr.IsNull()) { // if pair cuts
+          std::unique_ptr<TObjArray> objArrayPair(pairCutNamesStr.Tokenize(","));
           fNPairCuts = objArrayPair->GetEntries();
           for (int iPairCut = 0; iPairCut < fNPairCuts; ++iPairCut) { // loop over pair cuts
             DefineHistograms(fHistMan, Form("TripletsBarrelSE_%s_%s", legsStr.Data(), objArrayPair->At(iPairCut)->GetName()), fConfigHistogramSubgroups.value.data());
@@ -1779,8 +1779,8 @@ struct AnalysisAsymmetricPairing {
               DefineHistograms(fHistMan, Form("TripletsBarrelSE_%s_%s_%s", legsStr.Data(), objArrayCommon->At(iCommonCut)->GetName(), sig->GetName()), fConfigHistogramSubgroups.value.data());
             }
 
-            if (!cutNamesStr.IsNull()) { // if pair cuts
-              std::unique_ptr<TObjArray> objArrayPair(cutNamesStr.Tokenize(","));
+            if (!pairCutNamesStr.IsNull()) { // if pair cuts
+              std::unique_ptr<TObjArray> objArrayPair(pairCutNamesStr.Tokenize(","));
               for (int iPairCut = 0; iPairCut < fNPairCuts; ++iPairCut) { // loop over pair cuts
                 DefineHistograms(fHistMan, Form("TripletsBarrelSE_%s_%s_%s", legsStr.Data(), objArrayPair->At(iPairCut)->GetName(), sig->GetName()), fConfigHistogramSubgroups.value.data());
                 for (int iCommonCut = 0; iCommonCut < fNCommonTrackCuts; ++iCommonCut) {
@@ -1819,8 +1819,8 @@ struct AnalysisAsymmetricPairing {
           }
         }
 
-        if (!cutNamesStr.IsNull()) { // if pair cuts
-          std::unique_ptr<TObjArray> objArrayPair(cutNamesStr.Tokenize(","));
+        if (!pairCutNamesStr.IsNull()) { // if pair cuts
+          std::unique_ptr<TObjArray> objArrayPair(pairCutNamesStr.Tokenize(","));
           fNPairCuts = objArrayPair->GetEntries();
           for (int iPairCut = 0; iPairCut < fNPairCuts; ++iPairCut) { // loop over pair cuts
             for (int iPrefix = 0; iPrefix < fNPairHistPrefixes; ++iPrefix) {
@@ -1853,8 +1853,8 @@ struct AnalysisAsymmetricPairing {
               }
             }
 
-            if (!cutNamesStr.IsNull()) { // if pair cuts
-              std::unique_ptr<TObjArray> objArrayPair(cutNamesStr.Tokenize(","));
+            if (!pairCutNamesStr.IsNull()) { // if pair cuts
+              std::unique_ptr<TObjArray> objArrayPair(pairCutNamesStr.Tokenize(","));
               for (int iPairCut = 0; iPairCut < fNPairCuts; ++iPairCut) { // loop over pair cuts
                 for (int iPrefix = 0; iPrefix < fNPairHistPrefixes; ++iPrefix) {
                   DefineHistograms(fHistMan, Form("%s_%s_%s_%s", pairHistPrefixes[iPrefix].Data(), legsStr.Data(), objArrayPair->At(iPairCut)->GetName(), sig->GetName()), fConfigHistogramSubgroups.value.data());


### PR DESCRIPTION
1. Move datamodel definition to ALICE3 folder
2. Rename tables to fix merger error