### PR TITLE
[PWGDQ] Add SS/OS functionality to J/Psi-muon correlations task + fixes

### DIFF
--- a/PWGDQ/Tasks/jPsiMuonCorrelations.cxx
+++ b/PWGDQ/Tasks/jPsiMuonCorrelations.cxx
@@ -110,7 +110,8 @@ struct DqJPsiMuonCorrelations {
   Filter eventFilter = aod::dqanalysisflags::isEventSelected == 1;
 
   // Define the filter for the dileptons
-  Filter dileptonFilter = aod::reducedpair::sign == 0;
+  Filter dileptonFilter = aod::reducedpair::pt > fConfigDileptonPtMin && aod::reducedpair::pt < fConfigDileptonPtMax &&
+                          aod::reducedpair::eta > fConfigDileptonEtaMin && aod::reducedpair::eta < fConfigDileptonEtaMax;
 
   constexpr static uint32_t FgDimuonsFillMap = VarManager::ObjTypes::ReducedMuon | VarManager::ObjTypes::Pair; // fill map
 
@@ -174,11 +175,6 @@ struct DqJPsiMuonCorrelations {
       for (const auto& dilepton : dileptons) {
         VarManager::FillTrack<FgDimuonsFillMap>(dilepton, fValuesDilepton.data());
 
-        // Dilepton kinematic cuts
-        if ((dilepton.eta() < fConfigDileptonEtaMin || dilepton.eta() > fConfigDileptonEtaMax) ||
-            (dilepton.pt() < fConfigDileptonPtMin || dilepton.pt() > fConfigDileptonPtMax)) {
-          continue;
-        }
         // Dilepton leg kinematic cuts
         if ((dilepton.eta1() < fConfigMuonEtaMin || dilepton.eta1() > fConfigMuonEtaMax) ||
             (dilepton.pt1() < axisPt.value[1] || dilepton.pt1() > axisPt.value.back()) ||

--- a/PWGDQ/Tasks/jPsiMuonCorrelations.cxx
+++ b/PWGDQ/Tasks/jPsiMuonCorrelations.cxx
@@ -110,7 +110,7 @@ struct DqJPsiMuonCorrelations {
   Filter eventFilter = aod::dqanalysisflags::isEventSelected == 1;
 
   // Define the filter for the dileptons
-  Filter dileptonFilter = aod::reducedpair::pt > fConfigDileptonPtMin && aod::reducedpair::pt < fConfigDileptonPtMax && aod::reducedpair::eta > fConfigDileptonEtaMin && aod::reducedpair::eta < fConfigDileptonEtaMax;
+  Filter dileptonFilter = (aod::reducedpair::pt > fConfigDileptonPtMin && aod::reducedpair::pt < fConfigDileptonPtMax) && (aod::reducedpair::eta > fConfigDileptonEtaMin && aod::reducedpair::eta < fConfigDileptonEtaMax);
 
   constexpr static uint32_t FgDimuonsFillMap = VarManager::ObjTypes::ReducedMuon | VarManager::ObjTypes::Pair; // fill map
 

--- a/PWGDQ/Tasks/jPsiMuonCorrelations.cxx
+++ b/PWGDQ/Tasks/jPsiMuonCorrelations.cxx
@@ -36,6 +36,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <TString.h>
 
 using std::string;
 

--- a/PWGDQ/Tasks/jPsiMuonCorrelations.cxx
+++ b/PWGDQ/Tasks/jPsiMuonCorrelations.cxx
@@ -104,7 +104,7 @@ struct DqJPsiMuonCorrelations {
   // Connect to ccdb
   Service<ccdb::BasicCCDBManager> ccdb{};
   Configurable<int64_t> ccdbNoLaterThan{"ccdbNoLaterThan", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(), "latest acceptable timestamp of creation for the object"};
-  Configurable<std::string> ccdbUrl{"ccdbUrl", "http://ccdb-test.cern.ch:8080", "url of the ccdb repository"};
+  Configurable<std::string> ccdbUrl{"ccdbUrl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
 
   // Define the filter for events
   Filter eventFilter = aod::dqanalysisflags::isEventSelected == 1;

--- a/PWGDQ/Tasks/jPsiMuonCorrelations.cxx
+++ b/PWGDQ/Tasks/jPsiMuonCorrelations.cxx
@@ -110,8 +110,7 @@ struct DqJPsiMuonCorrelations {
   Filter eventFilter = aod::dqanalysisflags::isEventSelected == 1;
 
   // Define the filter for the dileptons
-  Filter dileptonFilter = aod::reducedpair::pt > fConfigDileptonPtMin && aod::reducedpair::pt < fConfigDileptonPtMax &&
-                          aod::reducedpair::eta > fConfigDileptonEtaMin && aod::reducedpair::eta < fConfigDileptonEtaMax;
+  Filter dileptonFilter = aod::reducedpair::pt > fConfigDileptonPtMin && aod::reducedpair::pt < fConfigDileptonPtMax && aod::reducedpair::eta > fConfigDileptonEtaMin && aod::reducedpair::eta < fConfigDileptonEtaMax;
 
   constexpr static uint32_t FgDimuonsFillMap = VarManager::ObjTypes::ReducedMuon | VarManager::ObjTypes::Pair; // fill map
 

--- a/PWGDQ/Tasks/jPsiMuonCorrelations.cxx
+++ b/PWGDQ/Tasks/jPsiMuonCorrelations.cxx
@@ -140,14 +140,16 @@ struct DqJPsiMuonCorrelations {
 
     // Define trigger histograms
     ConfigurableAxis axisTriggerMass{"axisTriggerMass", {VARIABLE_WIDTH, fConfigBackgroundLowMass, fConfigDileptonLowMass, fConfigDileptonHighMass, fConfigBackgroundHighMass}, "Invariant Mass (GeV/c^{2}) for trigger counting"};
-    registry.add("h2dDimuonPtInvVsInvMass", "h2dDimuonPtInvVsInvMass", kTH2D, {axisInvMass, axisPt});
-    registry.add("h2dTriggersPtInvVsInvMassRegion", "h2dTriggersPtInvVsInvMassRegion", kTH2D, {axisTriggerMass, axisPt});
+    for (const auto& signDilepton : {"dileptonOS", "dileptonSS"}) {
+      registry.add(Form("%s/h2dDimuonPtInvVsInvMass", signDilepton), "h2dDimuonPtInvVsInvMass", kTH2D, {axisInvMass, axisPt});
+      registry.add(Form("%s/h2dTriggersPtInvVsInvMassRegion", signDilepton), "h2dTriggersPtInvVsInvMassRegion", kTH2D, {axisTriggerMass, axisPt});
 
-    // Define histograms for the dilepton-muon correlations
-    registry.add("h2dDimuonMuonDeltaEtaVsMuonPtSignal", "h2dDimuonMuonDeltaEtaVsMuonPtSignal", kTH2D, {axisDeltaEta, axisPt});
-    registry.add("h2dDimuonMuonDeltaPhiVsMuonPtSignal", "h2dDimuonMuonDeltaPhiVsMuonPtSignal", kTH2D, {axisDeltaPhi, axisPt});
-    registry.add("h2dDimuonMuonDeltaEtaVsMuonPtBackground", "h2dDimuonMuonDeltaEtaVsMuonPtBackground", kTH2D, {axisDeltaEta, axisPt});
-    registry.add("h2dDimuonMuonDeltaPhiVsMuonPtBackground", "h2dDimuonMuonDeltaPhiVsMuonPtBackground", kTH2D, {axisDeltaPhi, axisPt});
+      // Define histograms for the dilepton-muon correlations
+      registry.add(Form("%s/h2dDimuonMuonDeltaEtaVsMuonPtSignal", signDilepton), "h2dDimuonMuonDeltaEtaVsMuonPtSignal", kTH2D, {axisDeltaEta, axisPt});
+      registry.add(Form("%s/h2dDimuonMuonDeltaPhiVsMuonPtSignal", signDilepton), "h2dDimuonMuonDeltaPhiVsMuonPtSignal", kTH2D, {axisDeltaPhi, axisPt});
+      registry.add(Form("%s/h2dDimuonMuonDeltaEtaVsMuonPtBackground", signDilepton), "h2dDimuonMuonDeltaEtaVsMuonPtBackground", kTH2D, {axisDeltaEta, axisPt});
+      registry.add(Form("%s/h2dDimuonMuonDeltaPhiVsMuonPtBackground", signDilepton), "h2dDimuonMuonDeltaPhiVsMuonPtBackground", kTH2D, {axisDeltaPhi, axisPt});
+    }
 
     // QA histograms
     registry.add("hEventPosZMuon", "hEventPosZMuon", kTH1D, {{50, -25, 25}});
@@ -186,8 +188,13 @@ struct DqJPsiMuonCorrelations {
         // Fill invariant mass vs pT histogram for the dileptons and for trigger counting
         double weightDilepton = getWeight(dilepton.pt(), axisPt.value, fConfigBinEffJPsi.value, fConfigDileptonEtaMin, fConfigDileptonEtaMax);
 
-        registry.fill(HIST("h2dDimuonPtInvVsInvMass"), dilepton.mass(), dilepton.pt(), weightDilepton);
-        registry.fill(HIST("h2dTriggersPtInvVsInvMassRegion"), dilepton.mass(), dilepton.pt(), weightDilepton);
+        if (dilepton.sign() == 0) {
+          registry.fill(HIST("dileptonOS/h2dDimuonPtInvVsInvMass"), dilepton.mass(), dilepton.pt(), weightDilepton);
+          registry.fill(HIST("dileptonOS/h2dTriggersPtInvVsInvMassRegion"), dilepton.mass(), dilepton.pt(), weightDilepton);
+        } else {
+          registry.fill(HIST("dileptonSS/h2dDimuonPtInvVsInvMass"), dilepton.mass(), dilepton.pt(), weightDilepton);
+          registry.fill(HIST("dileptonSS/h2dTriggersPtInvVsInvMassRegion"), dilepton.mass(), dilepton.pt(), weightDilepton);
+        }
 
         for (const auto& assoc : assocs) {
           // Check selection bit
@@ -217,11 +224,21 @@ struct DqJPsiMuonCorrelations {
           double weightMuon = getWeight(track.pt(), axisPt.value, fConfigBinEffMuon.value, fConfigMuonEtaMin, fConfigMuonEtaMax);
 
           if (dilepton.mass() > fConfigDileptonLowMass && dilepton.mass() < fConfigDileptonHighMass) {
-            registry.fill(HIST("h2dDimuonMuonDeltaEtaVsMuonPtSignal"), deltaEta, track.pt(), weightDilepton * weightMuon);
-            registry.fill(HIST("h2dDimuonMuonDeltaPhiVsMuonPtSignal"), deltaPhi, track.pt(), weightDilepton * weightMuon);
+            if (dilepton.sign() == 0) {
+              registry.fill(HIST("dileptonOS/h2dDimuonMuonDeltaEtaVsMuonPtSignal"), deltaEta, track.pt(), weightDilepton * weightMuon);
+              registry.fill(HIST("dileptonOS/h2dDimuonMuonDeltaPhiVsMuonPtSignal"), deltaPhi, track.pt(), weightDilepton * weightMuon);
+            } else {
+              registry.fill(HIST("dileptonSS/h2dDimuonMuonDeltaEtaVsMuonPtSignal"), deltaEta, track.pt(), weightDilepton * weightMuon);
+              registry.fill(HIST("dileptonSS/h2dDimuonMuonDeltaPhiVsMuonPtSignal"), deltaPhi, track.pt(), weightDilepton * weightMuon);
+            }
           } else if (dilepton.mass() > fConfigBackgroundLowMass && dilepton.mass() < fConfigBackgroundHighMass) {
-            registry.fill(HIST("h2dDimuonMuonDeltaEtaVsMuonPtBackground"), deltaEta, track.pt(), weightDilepton * weightMuon);
-            registry.fill(HIST("h2dDimuonMuonDeltaPhiVsMuonPtBackground"), deltaPhi, track.pt(), weightDilepton * weightMuon);
+            if (dilepton.sign() == 0) {
+              registry.fill(HIST("dileptonOS/h2dDimuonMuonDeltaEtaVsMuonPtBackground"), deltaEta, track.pt(), weightDilepton * weightMuon);
+              registry.fill(HIST("dileptonOS/h2dDimuonMuonDeltaPhiVsMuonPtBackground"), deltaPhi, track.pt(), weightDilepton * weightMuon);
+            } else {
+              registry.fill(HIST("dileptonSS/h2dDimuonMuonDeltaEtaVsMuonPtBackground"), deltaEta, track.pt(), weightDilepton * weightMuon);
+              registry.fill(HIST("dileptonSS/h2dDimuonMuonDeltaPhiVsMuonPtBackground"), deltaPhi, track.pt(), weightDilepton * weightMuon);
+            }
           }
         }
       }

--- a/PWGDQ/Tasks/jPsiMuonCorrelations.cxx
+++ b/PWGDQ/Tasks/jPsiMuonCorrelations.cxx
@@ -30,13 +30,14 @@
 #include <Framework/InitContext.h>
 #include <Framework/runDataProcessing.h>
 
+#include <TString.h>
+
 #include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>
-#include <TString.h>
 
 using std::string;
 


### PR DESCRIPTION
This PR will add minor changes to J/Psi-muon correlations task:
- Add extraction of SS dilepton pairs and save to different subdirectories
- Remove manual dilepton cuts and use aod filters instead
- Fix default value of ccdb url