### PR TITLE
[PWGCF] Femto: Allow multiple registries for SH histograms

### DIFF
--- a/PWGCF/Femto/Core/pairBuilder.h
+++ b/PWGCF/Femto/Core/pairBuilder.h
@@ -86,15 +86,17 @@ class PairTrackTrackBuilder
             std::map<T11, std::vector<o2::framework::AxisSpec>> const& trackHistSpec1,
             std::map<T12, std::vector<o2::framework::AxisSpec>> const& trackHistSpec2,
             std::map<T13, std::vector<o2::framework::AxisSpec>> const& pairHistSpec,
-            std::map<T14, std::vector<o2::framework::AxisSpec>> const& cprHistSpec)
+            std::map<T14, std::vector<o2::framework::AxisSpec>> const& cprHistSpec,
+            std::vector<o2::framework::HistogramRegistry*> const& shRegistriesSe = {},
+            std::vector<o2::framework::HistogramRegistry*> const& shRegistriesMe = {})
   {
 
     // check if correlate the same tracks or not
     mSameSpecies = confMixing.sameSpecies.value;
 
     mColHistManager.template init<modeSe>(registry, colHistSpec, confCollisionBinning);
-    mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
-    mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
+    mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing, shRegistriesSe);
+    mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing, shRegistriesMe);
     mPc.template init<modeSe>(confPairCuts);
 
     if (mSameSpecies) {
@@ -348,7 +350,9 @@ class PairV0V0Builder
             std::map<T17, std::vector<o2::framework::AxisSpec>> const& NegDauHistSpec2,
             std::map<T18, std::vector<o2::framework::AxisSpec>> const& pairHistSpec,
             std::map<T19, std::vector<o2::framework::AxisSpec>> const& cprHistSpecPos,
-            std::map<T20, std::vector<o2::framework::AxisSpec>> const& cprHistSpecNeg)
+            std::map<T20, std::vector<o2::framework::AxisSpec>> const& cprHistSpecNeg,
+            std::vector<o2::framework::HistogramRegistry*> const& shRegistriesSe = {},
+            std::vector<o2::framework::HistogramRegistry*> const& shRegistriesMe = {})
   {
     mSameSpecies = confMixing.sameSpecies.value;
 
@@ -371,8 +375,8 @@ class PairV0V0Builder
     }
 
     mColHistManager.template init<modeSe>(registry, colHistSpec, confCollisionBinning);
-    mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
-    mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
+    mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing, shRegistriesSe);
+    mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing, shRegistriesMe);
     mPc.template init<modeSe>(confPairCuts);
 
     mV0Cleaner1.init(confV0Cleaner1);
@@ -612,7 +616,9 @@ class PairTrackD0Builder
             std::map<T13, std::vector<o2::framework::AxisSpec>>& posDauHistSpec,
             std::map<T14, std::vector<o2::framework::AxisSpec>>& negDauHistSpec,
             std::map<T15, std::vector<o2::framework::AxisSpec>>& pairHistSpec,
-            std::map<T16, std::vector<o2::framework::AxisSpec>>& cprHistSpec)
+            std::map<T16, std::vector<o2::framework::AxisSpec>>& cprHistSpec,
+            std::vector<o2::framework::HistogramRegistry*> const& shRegistriesSe = {},
+            std::vector<o2::framework::HistogramRegistry*> const& shRegistriesMe = {})
   {
     mColHistManager.template init<modeSe>(registry, colHistSpec, confCollisionBinning);
 
@@ -635,12 +641,12 @@ class PairTrackD0Builder
       negDauPdg = PDG_t::kPiMinus;
     }
 
-    mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
+    mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing, shRegistriesSe);
     mPairHistManagerSe.setMass(confTrackSelection.pdgCodeAbs.value, 0, 0, confD0Selection.pdgCodeAbs.value, posDauPdg, negDauPdg);
     mPairHistManagerSe.setCharge(confTrackSelection.chargeAbs.value, 1);
     mCprSe.init(registry, cprHistSpec, confCpr, confTrackSelection.chargeAbs.value);
 
-    mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
+    mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing, shRegistriesMe);
     mPairHistManagerMe.setMass(confTrackSelection.pdgCodeAbs.value, 0, 0, confD0Selection.pdgCodeAbs.value, posDauPdg, negDauPdg);
     mPairHistManagerMe.setCharge(confTrackSelection.chargeAbs.value, 1);
     mCprMe.init(registry, cprHistSpec, confCpr, confTrackSelection.chargeAbs.value);
@@ -777,7 +783,9 @@ class PairTrackV0Builder
             std::map<T13, std::vector<o2::framework::AxisSpec>>& posDauHistSpec,
             std::map<T14, std::vector<o2::framework::AxisSpec>>& negDauHistSpec,
             std::map<T15, std::vector<o2::framework::AxisSpec>>& pairHistSpec,
-            std::map<T16, std::vector<o2::framework::AxisSpec>>& cprHistSpec)
+            std::map<T16, std::vector<o2::framework::AxisSpec>>& cprHistSpec,
+            std::vector<o2::framework::HistogramRegistry*> const& shRegistriesSe = {},
+            std::vector<o2::framework::HistogramRegistry*> const& shRegistriesMe = {})
   {
     mColHistManager.template init<modeSe>(registry, colHistSpec, confCollisionBinning);
 
@@ -802,12 +810,12 @@ class PairTrackV0Builder
       }
     }
 
-    mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
+    mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing, shRegistriesSe);
     mPairHistManagerSe.setMass(confTrackSelection.pdgCodeAbs.value, 0, 0, confV0Selection.pdgCodeAbs.value, pdgCodePosDau, pdgCodeNegDau);
     mPairHistManagerSe.setCharge(confTrackSelection.chargeAbs.value, 1);
     mCprSe.init(registry, cprHistSpec, confCpr, confTrackSelection.chargeAbs.value);
 
-    mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
+    mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing, shRegistriesMe);
     mPairHistManagerMe.setMass(confTrackSelection.pdgCodeAbs.value, 0, 0, confV0Selection.pdgCodeAbs.value, pdgCodePosDau, pdgCodeNegDau);
     mPairHistManagerMe.setCharge(confTrackSelection.chargeAbs.value, 1);
     mCprMe.init(registry, cprHistSpec, confCpr, confTrackSelection.chargeAbs.value);
@@ -940,19 +948,21 @@ class PairTrackTwoTrackResonanceBuilder
             std::map<T11, std::vector<o2::framework::AxisSpec>> const& posDauHistSpec,
             std::map<T12, std::vector<o2::framework::AxisSpec>> const& negDauHistSpec,
             std::map<T13, std::vector<o2::framework::AxisSpec>> const& pairHistSpec,
-            std::map<T14, std::vector<o2::framework::AxisSpec>> const& cprHistSpec)
+            std::map<T14, std::vector<o2::framework::AxisSpec>> const& cprHistSpec,
+            std::vector<o2::framework::HistogramRegistry*> const& shRegistriesSe = {},
+            std::vector<o2::framework::HistogramRegistry*> const& shRegistriesMe = {})
   {
     mColHistManager.template init<modeSe>(registry, colHistSpec, confCollisionBinning);
 
     mTrackHistManager.template init<modeSe>(registry, trackHistSpec, confTrackSelection);
     mResonanceHistManager.template init<modeSe>(registry, resonanceHistSpec, confResonanceSelection, posDauHistSpec, negDauHistSpec);
 
-    mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
+    mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing, shRegistriesSe);
     mPairHistManagerSe.setMass(confTrackSelection.pdgCodeAbs.value, confResonanceSelection.pdgCodeAbs.value);
     mPairHistManagerSe.setCharge(confTrackSelection.chargeAbs.value, 1);
     mCprSe.init(registry, cprHistSpec, confCpr, confTrackSelection.chargeAbs.value);
 
-    mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
+    mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing, shRegistriesMe);
     mPairHistManagerMe.setMass(confTrackSelection.pdgCodeAbs.value, confResonanceSelection.pdgCodeAbs.value);
     mPairHistManagerMe.setCharge(confTrackSelection.chargeAbs.value, 1);
     mCprMe.init(registry, cprHistSpec, confCpr, confTrackSelection.chargeAbs.value);
@@ -1064,19 +1074,21 @@ class PairV0TwoTrackResonanceBuilder
             std::map<T15, std::vector<o2::framework::AxisSpec>> const& ResonanceNegDauHistSpec,
             std::map<T16, std::vector<o2::framework::AxisSpec>> const& pairHistSpec,
             std::map<T17, std::vector<o2::framework::AxisSpec>> const& cprHistSpecPos,
-            std::map<T18, std::vector<o2::framework::AxisSpec>> const& cprHistSpecNeg)
+            std::map<T18, std::vector<o2::framework::AxisSpec>> const& cprHistSpecNeg,
+            std::vector<o2::framework::HistogramRegistry*> const& shRegistriesSe = {},
+            std::vector<o2::framework::HistogramRegistry*> const& shRegistriesMe = {})
   {
     mColHistManager.template init<modeSe>(registry, colHistSpec, confCollisionBinning);
 
     mV0HistManager.template init<modeSe>(registry, v0HistSpec, confV0Selection, V0posDauHistSpec, V0negDauHistSpec);
     mResonanceHistManager.template init<modeSe>(registry, resonanceHistSpec, confResonanceSelection, ResonancePosDauHistSpec, ResonanceNegDauHistSpec);
 
-    mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
+    mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing, shRegistriesSe);
     mPairHistManagerSe.setMass(confV0Selection.pdgCodeAbs.value, confResonanceSelection.pdgCodeAbs.value);
     mPairHistManagerSe.setCharge(1, 1); // set charge to 1
     mCprSe.init(registry, cprHistSpecPos, cprHistSpecNeg, confCprPos, confCprNeg);
 
-    mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
+    mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing, shRegistriesMe);
     mPairHistManagerMe.setMass(confV0Selection.pdgCodeAbs.value, confResonanceSelection.pdgCodeAbs.value);
     mPairHistManagerMe.setCharge(1, 1); // set charge to 1
     mCprMe.init(registry, cprHistSpecPos, cprHistSpecNeg, confCprPos, confCprNeg);
@@ -1176,7 +1188,9 @@ class PairTrackKinkBuilder
             std::map<T12, std::vector<o2::framework::AxisSpec>> const& kinkHistSpec,
             std::map<T13, std::vector<o2::framework::AxisSpec>> const& chaDauHistSpec,
             std::map<T14, std::vector<o2::framework::AxisSpec>> const& pairHistSpec,
-            std::map<T15, std::vector<o2::framework::AxisSpec>> const& cprHistSpec)
+            std::map<T15, std::vector<o2::framework::AxisSpec>> const& cprHistSpec,
+            std::vector<o2::framework::HistogramRegistry*> const& shRegistriesSe = {},
+            std::vector<o2::framework::HistogramRegistry*> const& shRegistriesMe = {})
   {
     mColHistManager.template init<modeSe>(registry, colHistSpec, confCollisionBinning);
 
@@ -1186,12 +1200,12 @@ class PairTrackKinkBuilder
     mTrackCleaner.init(confTrackCleaner);
     mKinkCleaner.init(confKinkCleaner);
 
-    mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
+    mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing, shRegistriesSe);
     mPairHistManagerSe.setMass(confTrackSelection.pdgCodeAbs.value, confKinkSelection.pdgCodeAbs.value);
     mPairHistManagerSe.setCharge(confTrackSelection.chargeAbs.value, 1); // abs charge of kink daughter is always 1
     mCprSe.init(registry, cprHistSpec, confCpr, confTrackSelection.chargeAbs.value);
 
-    mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
+    mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing, shRegistriesMe);
     mPairHistManagerMe.setMass(confTrackSelection.pdgCodeAbs.value, confKinkSelection.pdgCodeAbs.value);
     mPairHistManagerMe.setCharge(confTrackSelection.chargeAbs.value, 1); // abs charge of kink daughter is always 1
     mCprMe.init(registry, cprHistSpec, confCpr, confTrackSelection.chargeAbs.value);
@@ -1337,7 +1351,9 @@ class PairTrackCascadeBuilder
             std::map<T16, std::vector<o2::framework::AxisSpec>> const& negDauHistSpec,
             std::map<T17, std::vector<o2::framework::AxisSpec>> const& pairHistSpec,
             std::map<T18, std::vector<o2::framework::AxisSpec>> const& cprHistSpecBachelor,
-            std::map<T19, std::vector<o2::framework::AxisSpec>> const& cprHistSpecV0Daughter)
+            std::map<T19, std::vector<o2::framework::AxisSpec>> const& cprHistSpecV0Daughter,
+            std::vector<o2::framework::HistogramRegistry*> const& shRegistriesSe = {},
+            std::vector<o2::framework::HistogramRegistry*> const& shRegistriesMe = {})
   {
     mColHistManager.template init<modeSe>(registry, colHistSpec, confCollisionBinning);
 
@@ -1347,12 +1363,12 @@ class PairTrackCascadeBuilder
     mTrackCleaner.init(confTrackCleaner);
     mCascadeCleaner.init(confCascadeCleaner);
 
-    mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
+    mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing, shRegistriesSe);
     mPairHistManagerSe.setMass(confTrackSelection.pdgCodeAbs.value, confCascadeSelection.pdgCodeAbs.value);
     mPairHistManagerSe.setCharge(confTrackSelection.chargeAbs.value, 1);
     mCprSe.init(registry, cprHistSpecBachelor, cprHistSpecV0Daughter, confCprBachelor, confCprV0Daughter, confTrackSelection.chargeAbs.value);
 
-    mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
+    mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing, shRegistriesMe);
     mPairHistManagerMe.setMass(confTrackSelection.pdgCodeAbs.value, confCascadeSelection.pdgCodeAbs.value);
     mPairHistManagerMe.setCharge(confTrackSelection.chargeAbs.value, 1);
     mCprMe.init(registry, cprHistSpecBachelor, cprHistSpecV0Daughter, confCprBachelor, confCprV0Daughter, confTrackSelection.chargeAbs.value);
@@ -1480,15 +1496,17 @@ class PairMcParticleMcParticleBuilder
             std::map<T13, std::vector<o2::framework::AxisSpec>> const& mcParticleHistSpec1,
             std::map<T14, std::vector<o2::framework::AxisSpec>> const& mcParticleHistSpec2,
             std::map<T15, std::vector<o2::framework::AxisSpec>> const& pairHistSpec,
-            std::map<T16, std::vector<o2::framework::AxisSpec>> const& cprHistSpec)
+            std::map<T16, std::vector<o2::framework::AxisSpec>> const& cprHistSpec,
+            std::vector<o2::framework::HistogramRegistry*> const& shRegistriesSe = {},
+            std::vector<o2::framework::HistogramRegistry*> const& shRegistriesMe = {})
   {
 
     // check if correlate the same tracks or not
     mSameSpecies = confMixing.sameSpecies.value;
 
     mColHistManager.template init<modeSe>(registry, colHistSpec, confCollisionBinning);
-    mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
-    mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
+    mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing, shRegistriesSe);
+    mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing, shRegistriesMe);
     mPc.template init<modeSe>(confPairCuts);
 
     if (mSameSpecies) {

--- a/PWGCF/Femto/Core/pairHistManager.h
+++ b/PWGCF/Femto/Core/pairHistManager.h
@@ -535,9 +535,12 @@ class PairHistManager
             std::map<PairHist, std::vector<o2::framework::AxisSpec>> const& Specs,
             T1 const& ConfPairBinning,
             T2 const& ConfPairCuts,
-            T3 const& ConfMixing)
+            T3 const& ConfMixing,
+            std::vector<o2::framework::HistogramRegistry*> const& shRegistries = {})
   {
     mHistogramRegistry = registry;
+    mShRegistries = shRegistries;
+    mShRegistryFill.assign(mShRegistries.size(), 0);
 
     mUsePdgMass = ConfPairBinning.usePdgMass.value;
 
@@ -1039,21 +1042,24 @@ class PairHistManager
         mSh1D[iCent].resize(nKt);
         mShBinCount[iCent].resize(nKt);
         // folder name: mult_{low}_{high}
-        const std::string centFolder = "mult_" + std::to_string(static_cast<int>(mShCentEdges[iCent])) +
-                                       "_" + std::to_string(static_cast<int>(mShCentEdges[iCent + 1]));
+        const std::string centFolder = "mult_" + std::to_string(std::lround(mShCentEdges[iCent])) +
+                                       "_" + std::to_string(std::lround(mShCentEdges[iCent + 1]));
         for (int iKt = 0; iKt < nKt; ++iKt) {
           mShReal[iCent][iKt].resize(nJM);
           mShImag[iCent][iKt].resize(nJM);
           // folder name: kT_{low*100}_{high*100}
           std::string ktFolder = "kT_";
-          ktFolder += std::to_string(static_cast<int>(mShKtEdges[iKt] * 100.0));
+          ktFolder += std::to_string(std::lround(mShKtEdges[iKt] * 100.0));
           ktFolder += "_";
-          ktFolder += std::to_string(static_cast<int>(mShKtEdges[iKt + 1] * 100.0));
+          ktFolder += std::to_string(std::lround(mShKtEdges[iKt + 1] * 100.0));
           std::string dir = std::string(prefix) + std::string(AnalysisDir) + "SH/";
           dir += centFolder;
           dir += "/";
           dir += ktFolder;
           dir += "/";
+
+          const int nHistPerCell = 2 * nJM + 2 + (mShPlot1D ? 1 : 0);
+          o2::framework::HistogramRegistry* shReg = shRegistryFor(nHistPerCell);
 
           int ihist = 0;
           for (int l = 0; l <= mShLMax; ++l) {
@@ -1078,8 +1084,8 @@ class PairHistManager
               std::string titleIm = "Im ";
               titleIm += ylmLabel;
               titleIm += "; k* (GeV/#it{c}); Im[A_{l}^{m}]";
-              mShReal[iCent][iKt][ihist] = mHistogramRegistry->add<TH1>(nameRe.c_str(), titleRe.c_str(), o2::framework::kTH1D, {mShKstarSpec});
-              mShImag[iCent][iKt][ihist] = mHistogramRegistry->add<TH1>(nameIm.c_str(), titleIm.c_str(), o2::framework::kTH1D, {mShKstarSpec});
+              mShReal[iCent][iKt][ihist] = shReg->add<TH1>(nameRe.c_str(), titleRe.c_str(), o2::framework::kTH1D, {mShKstarSpec});
+              mShImag[iCent][iKt][ihist] = shReg->add<TH1>(nameIm.c_str(), titleIm.c_str(), o2::framework::kTH1D, {mShKstarSpec});
               mShReal[iCent][iKt][ihist]->Sumw2();
               mShImag[iCent][iKt][ihist]->Sumw2();
               ++ihist;
@@ -1091,17 +1097,17 @@ class PairHistManager
           const o2::framework::AxisSpec covLmAxis{nAxisLM, -0.5, static_cast<double>(nAxisLM) - 0.5, "l,m #times (re,im)"};
           std::string nameCov = dir;
           nameCov += "Cov";
-          mShCov[iCent][iKt] = mHistogramRegistry->add<TH3>(nameCov.c_str(), "SH covariance; k* (GeV/#it{c}); l,m; l,m", o2::framework::kTH3D, {mShKstarSpec, covLmAxis, covLmAxis});
+          mShCov[iCent][iKt] = shReg->add<TH3>(nameCov.c_str(), "SH covariance; k* (GeV/#it{c}); l,m; l,m", o2::framework::kTH3D, {mShKstarSpec, covLmAxis, covLmAxis});
           mShCov[iCent][iKt]->Sumw2();
 
           std::string nameBinCount = dir;
           nameBinCount += "BinCount";
-          mShBinCount[iCent][iKt] = mHistogramRegistry->add<TH1>(nameBinCount.c_str(), "SH bin occupancy; k* (GeV/#it{c}); Entries", o2::framework::kTH1D, {mShKstarSpec});
+          mShBinCount[iCent][iKt] = shReg->add<TH1>(nameBinCount.c_str(), "SH bin occupancy; k* (GeV/#it{c}); Entries", o2::framework::kTH1D, {mShKstarSpec});
 
           if (mShPlot1D) {
             std::string name1D = dir;
             name1D += "h1D";
-            mSh1D[iCent][iKt] = mHistogramRegistry->add<TH1>(name1D.c_str(), "1D distribution; k* (GeV/#it{c}); Entries", o2::framework::kTH1D, {mShKstarSpec});
+            mSh1D[iCent][iKt] = shReg->add<TH1>(name1D.c_str(), "1D distribution; k* (GeV/#it{c}); Entries", o2::framework::kTH1D, {mShKstarSpec});
             mSh1D[iCent][iKt]->Sumw2();
           }
         }
@@ -1456,6 +1462,23 @@ class PairHistManager
     return static_cast<float>(0.5 * std::sqrt(std::max(0.0, kallen) / s));
   }
 
+  o2::framework::HistogramRegistry* shRegistryFor(int nHist)
+  {
+    if (mShRegistries.empty()) {
+      return mHistogramRegistry;
+    }
+    constexpr int MaxHistPerRegistry = 512;
+    for (std::size_t i = 0; i < mShRegistries.size(); ++i) {
+      if (mShRegistryFill[i] + nHist <= MaxHistPerRegistry) {
+        mShRegistryFill[i] += nHist;
+        return mShRegistries[i];
+      }
+    }
+    LOG(fatal) << "SH histograms do not fit into the provided registry pool; "
+               << "add more registries to the task or reduce the centrality/kT binning or shLMax";
+    return nullptr;
+  }
+
   std::tuple<float, float, float> computeBertschPrattLCMS(ROOT::Math::PtEtaPhiMVector const& part1, ROOT::Math::PtEtaPhiMVector const& part2)
   {
     const ROOT::Math::PxPyPzEVector p1(part1);
@@ -1701,6 +1724,9 @@ class PairHistManager
   // SH histograms binned in [iCent][iKt][ihist]; ihist = l*(l+1)+m
   std::vector<std::vector<std::vector<std::shared_ptr<TH1>>>> mShReal;
   std::vector<std::vector<std::vector<std::shared_ptr<TH1>>>> mShImag;
+  // pool of extra registries for SH histograms;
+  std::vector<o2::framework::HistogramRegistry*> mShRegistries;
+  std::vector<int> mShRegistryFill;
   // SH covariance matrix per [iCent][iKt]; TH3d: k* on X, 2*nJM (l,m x re/im)
   std::vector<std::vector<std::shared_ptr<TH3>>> mShCov;
   bool mShPlot1D = false;

--- a/PWGCF/Femto/Tasks/femtoPairTrackTrack.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackTrack.cxx
@@ -115,6 +115,12 @@ struct FemtoPairTrackTrack {
   pairhistmanager::ConfMixing confMixing;
 
   o2::framework::HistogramRegistry hRegistry{"FemtoTrackTrack", {}, o2::framework::OutputObjHandlingPolicy::AnalysisObject};
+  o2::framework::HistogramRegistry hShSe0{"FemtoTrackTrackShSe0", {}, o2::framework::OutputObjHandlingPolicy::AnalysisObject};
+  o2::framework::HistogramRegistry hShSe1{"FemtoTrackTrackShSe1", {}, o2::framework::OutputObjHandlingPolicy::AnalysisObject};
+  o2::framework::HistogramRegistry hShSe2{"FemtoTrackTrackShSe2", {}, o2::framework::OutputObjHandlingPolicy::AnalysisObject};
+  o2::framework::HistogramRegistry hShMe0{"FemtoTrackTrackShMe0", {}, o2::framework::OutputObjHandlingPolicy::AnalysisObject};
+  o2::framework::HistogramRegistry hShMe1{"FemtoTrackTrackShMe1", {}, o2::framework::OutputObjHandlingPolicy::AnalysisObject};
+  o2::framework::HistogramRegistry hShMe2{"FemtoTrackTrackShMe2", {}, o2::framework::OutputObjHandlingPolicy::AnalysisObject};
 
   void init(o2::framework::InitContext&)
   {
@@ -145,13 +151,13 @@ struct FemtoPairTrackTrack {
       trackHistSpec1 = trackhistmanager::makeTrackHistSpecMap(confTrackBinning1);
       trackHistSpec2 = trackhistmanager::makeTrackHistSpecMap(confTrackBinning2);
       pairHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning, confMixing);
-      pairTrackTrackBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confTrackCleaner1, confTrackCleaner2, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec1, trackHistSpec2, pairHistSpec, cprHistSpec);
+      pairTrackTrackBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confTrackCleaner1, confTrackCleaner2, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec1, trackHistSpec2, pairHistSpec, cprHistSpec, {&hShSe0, &hShSe1, &hShSe2}, {&hShMe0, &hShMe1, &hShMe2});
     } else {
       colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
       trackHistSpec1 = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning1);
       trackHistSpec2 = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning2);
       pairHistSpec = pairhistmanager::makePairMcHistSpecMap(confPairBinning, confMixing);
-      pairTrackTrackBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confTrackCleaner1, confTrackCleaner2, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec1, trackHistSpec2, pairHistSpec, cprHistSpec);
+      pairTrackTrackBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confTrackCleaner1, confTrackCleaner2, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec1, trackHistSpec2, pairHistSpec, cprHistSpec, {&hShSe0, &hShSe1, &hShSe2}, {&hShMe0, &hShMe1, &hShMe2});
     }
     hRegistry.print();
   };


### PR DESCRIPTION
## Problem

SH histograms scale as `nCent * nKt * (2 * nJM + 2)` and overflow the
512-histogram limit of a single `HistogramRegistry`. 

## Solution

`PairHistManager::init()` takes an optional pool of registries for SH
histograms and assigns each (cent, kT) cell to one with room. Builders
forward separate pools for same-event and mixed-event.