### PR TITLE
[PWGJE] Adding bkg indexing to jetCorrelationD0 task

### DIFF
--- a/PWGJE/Tasks/jetCorrelationD0.cxx
+++ b/PWGJE/Tasks/jetCorrelationD0.cxx
@@ -204,7 +204,7 @@ struct JetCorrelationD0 {
   // Configurables
   Configurable<std::string> eventSelections{"eventSelections", "sel8", "choose event selection"};
   Configurable<bool> skipMBGapEvents{"skipMBGapEvents", false, "decide to run over MB gap events or not"};
-  Configurable<bool> applyRCTSelections{"applyRCTSelections", false, "decide to apply RCT selections"};
+  Configurable<bool> applyRCTSelections{"applyRCTSelections", true, "decide to apply RCT selections"};
   Configurable<float> jetPtCutMin{"jetPtCutMin", 5.0, "minimum value of jet pt"};
   Configurable<float> d0PtCutMin{"d0PtCutMin", 1.0, "minimum value of d0 pt"};
   Configurable<float> jetMcPtCutMin{"jetMcPtCutMin", 3.0, "minimum value of jet pt particle level"};

--- a/PWGJE/Tasks/jetCorrelationD0.cxx
+++ b/PWGJE/Tasks/jetCorrelationD0.cxx
@@ -204,7 +204,7 @@ struct JetCorrelationD0 {
   // Configurables
   Configurable<std::string> eventSelections{"eventSelections", "sel8", "choose event selection"};
   Configurable<bool> skipMBGapEvents{"skipMBGapEvents", false, "decide to run over MB gap events or not"};
-  Configurable<bool> applyRCTSelections{"applyRCTSelections", true, "decide to apply RCT selections"};
+  Configurable<bool> applyRCTSelections{"applyRCTSelections", false, "decide to apply RCT selections"};
   Configurable<float> jetPtCutMin{"jetPtCutMin", 5.0, "minimum value of jet pt"};
   Configurable<float> d0PtCutMin{"d0PtCutMin", 1.0, "minimum value of d0 pt"};
   Configurable<float> jetMcPtCutMin{"jetMcPtCutMin", 3.0, "minimum value of jet pt particle level"};

--- a/PWGJE/Tasks/jetCorrelationD0.cxx
+++ b/PWGJE/Tasks/jetCorrelationD0.cxx
@@ -356,6 +356,11 @@ struct JetCorrelationD0 {
       int matchedFrom = 0;
       int selectedAs = 0;
       int category; // 0 signal, 1 reflection, 2-5 correlated backgrounds
+      constexpr int kD0ToKPi = 1;
+      constexpr int kD0ToKPiPi = 2;
+      constexpr int kD0ToPiPi = 3;
+      constexpr int kD0ToPiPiPi = 4;
+      constexpr int kD0ToKK = 5;
 
       if (d0DecayChannel > 0) { // matched to a D0 on truth level (any channel)
         matchedFrom = 1;
@@ -367,23 +372,23 @@ struct JetCorrelationD0 {
       } else if (d0Candidate.candidateSelFlag() & BIT(1)) { // CandidateSelFlag == BIT(1) -> selected as D0bar
         selectedAs = -1;
       }
-      if ((d0DecayChannel == 1) && (selectedAs == matchedFrom)) {
+      if ((d0DecayChannel == kD0ToKPi) && (selectedAs == matchedFrom)) {
         category = 0; // signal -> D0 or D0bar, π+ K− π+
       }
-      if ((d0DecayChannel == 1) && (selectedAs == -1*matchedFrom)) {
+      if ((d0DecayChannel == kD0ToKPi) && (selectedAs == -1*matchedFrom)) {
         category = 1; // reflection
       }
-      if (d0DecayChannel == 2) {
+      if (d0DecayChannel == kD0ToKPiPi) {
         category = 2; // corr bkg: π+ K− π0
       }
 
-      if (d0DecayChannel == 3) {
+      if (d0DecayChannel == kD0ToPiPi) {
         category = 3; // corr bkg: π+ π−
       }
-      if (d0DecayChannel == 4) {
+      if (d0DecayChannel == kD0ToPiPiPi) {
         category = 4; // corr bkg: π+ π− π0
       }
-      if (d0DecayChannel == 5) {
+      if (d0DecayChannel == kD0ToKK) {
         category = 5; // corr bkg: K+ K−
       }
 

--- a/PWGJE/Tasks/jetCorrelationD0.cxx
+++ b/PWGJE/Tasks/jetCorrelationD0.cxx
@@ -87,8 +87,7 @@ DECLARE_SOA_COLUMN(D0MD, d0MD, float);
 DECLARE_SOA_COLUMN(D0PtD, d0PtD, float);
 DECLARE_SOA_COLUMN(D0EtaD, d0EtaD, float);
 DECLARE_SOA_COLUMN(D0PhiD, d0PhiD, float);
-DECLARE_SOA_COLUMN(D0MatchedFrom, d0MatchedFrom, int);
-DECLARE_SOA_COLUMN(D0SelectedAs, d0SelectedAs, int);
+DECLARE_SOA_COLUMN(D0Category, d0Category, int);
 DECLARE_SOA_COLUMN(D0DecayChannel, d0DecayChannel, int8_t);
 } // namespace d0Info
 
@@ -115,9 +114,7 @@ DECLARE_SOA_TABLE(D0McDTables, "AOD", "D0MCDTABLE",
                   d0Info::D0Eta,
                   d0Info::D0Phi,
                   d0Info::D0Y,
-                  d0Info::D0MatchedFrom,
-                  d0Info::D0SelectedAs,
-                  d0Info::D0DecayChannel);
+                  d0Info::D0Category);
 
 DECLARE_SOA_TABLE(D0McPTables, "AOD", "D0MCPTABLE",
                   o2::soa::Index<>,
@@ -358,6 +355,7 @@ struct JetCorrelationD0 {
 
       int matchedFrom = 0;
       int selectedAs = 0;
+      int category; // 0 signal, 1 reflection, 2-5 correlated backgrounds
 
       if (d0DecayChannel > 0) { // matched to a D0 on truth level (any channel)
         matchedFrom = 1;
@@ -369,6 +367,28 @@ struct JetCorrelationD0 {
       } else if (d0Candidate.candidateSelFlag() & BIT(1)) { // CandidateSelFlag == BIT(1) -> selected as D0bar
         selectedAs = -1;
       }
+      if ((d0DecayChannel == 1) && (selectedAs == matchedFrom)) {
+        category = 0; // signal -> D0 or D0bar, π+ K− π+
+      }
+      if ((d0DecayChannel == 1) && (selectedAs == -1*matchedFrom)) {
+        category = 1; // reflection
+      }
+      if (d0DecayChannel == 2) {
+        category = 2; // corr bkg: π+ K− π0
+      }
+
+      if (d0DecayChannel == 3) {
+        category = 3; // corr bkg: π+ π−
+      }
+      if (d0DecayChannel == 4) {
+        category = 4; // corr bkg: π+ π− π0
+      }
+      if (d0DecayChannel == 5) {
+        category = 5; // corr bkg: K+ K−
+      }
+
+
+
 
       tableD0McDetector(tableCollision.lastIndex(), // might want to add some more detector level D0 quantities like prompt or non prompt info
                         scores[2],
@@ -379,9 +399,7 @@ struct JetCorrelationD0 {
                         d0Candidate.eta(),
                         d0Candidate.phi(),
                         d0Candidate.y(),
-                        matchedFrom,
-                        selectedAs,
-                        d0DecayChannel);
+                        category);
       for (const auto& jet : jets) {
         if (jet.pt() < jetPtCutMin) {
           continue;

--- a/PWGJE/Tasks/jetCorrelationD0.cxx
+++ b/PWGJE/Tasks/jetCorrelationD0.cxx
@@ -36,6 +36,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include <math.h>

--- a/PWGJE/Tasks/jetCorrelationD0.cxx
+++ b/PWGJE/Tasks/jetCorrelationD0.cxx
@@ -378,9 +378,7 @@ struct JetCorrelationD0 {
         category = 1; // reflection
       } else if (d0DecayChannel == kD0ToKPiPi) {
         category = 2; // corr bkg: π+ K− π0
-      }
-
-      else if (d0DecayChannel == kD0ToPiPi) {
+      } else if (d0DecayChannel == kD0ToPiPi) {
         category = 3; // corr bkg: π+ π−
       } else if (d0DecayChannel == kD0ToPiPiPi) {
         category = 4; // corr bkg: π+ π− π0

--- a/PWGJE/Tasks/jetCorrelationD0.cxx
+++ b/PWGJE/Tasks/jetCorrelationD0.cxx
@@ -355,7 +355,7 @@ struct JetCorrelationD0 {
 
       int matchedFrom = 0;
       int selectedAs = 0;
-      int category; // 0 signal, 1 reflection, 2-5 correlated backgrounds
+      int category = -1; // -1 undefined, 0 signal, 1 reflection, 2-5 correlated backgrounds
       constexpr int kD0ToKPi = 1;
       constexpr int kD0ToKPiPi = 2;
       constexpr int kD0ToPiPi = 3;
@@ -372,23 +372,23 @@ struct JetCorrelationD0 {
       } else if (d0Candidate.candidateSelFlag() & BIT(1)) { // CandidateSelFlag == BIT(1) -> selected as D0bar
         selectedAs = -1;
       }
-      if ((d0DecayChannel == kD0ToKPi) && (selectedAs == matchedFrom)) {
-        category = 0; // signal -> D0 or D0bar, π+ K− π+
+      if ((std::abs(d0DecayChannel) == kD0ToKPi) && (matchedFrom != 0) && (selectedAs == matchedFrom)) {
+        category = 0; // signal -> D0 or D0bar, π+ K−
       }
-      if ((d0DecayChannel == kD0ToKPi) && (selectedAs == -1*matchedFrom)) {
+      else if ((d0DecayChannel == kD0ToKPi) && (selectedAs == -1*matchedFrom)) {
         category = 1; // reflection
       }
-      if (d0DecayChannel == kD0ToKPiPi) {
+      else if (d0DecayChannel == kD0ToKPiPi) {
         category = 2; // corr bkg: π+ K− π0
       }
 
-      if (d0DecayChannel == kD0ToPiPi) {
+      else if (d0DecayChannel == kD0ToPiPi) {
         category = 3; // corr bkg: π+ π−
       }
-      if (d0DecayChannel == kD0ToPiPiPi) {
+      else if (d0DecayChannel == kD0ToPiPiPi) {
         category = 4; // corr bkg: π+ π− π0
       }
-      if (d0DecayChannel == kD0ToKK) {
+      else if (d0DecayChannel == kD0ToKK) {
         category = 5; // corr bkg: K+ K−
       }
 

--- a/PWGJE/Tasks/jetCorrelationD0.cxx
+++ b/PWGJE/Tasks/jetCorrelationD0.cxx
@@ -374,26 +374,19 @@ struct JetCorrelationD0 {
       }
       if ((std::abs(d0DecayChannel) == kD0ToKPi) && (matchedFrom != 0) && (selectedAs == matchedFrom)) {
         category = 0; // signal -> D0 or D0bar, π+ K−
-      }
-      else if ((d0DecayChannel == kD0ToKPi) && (selectedAs == -1*matchedFrom)) {
+      } else if ((d0DecayChannel == kD0ToKPi) && (selectedAs == -1 * matchedFrom)) {
         category = 1; // reflection
-      }
-      else if (d0DecayChannel == kD0ToKPiPi) {
+      } else if (d0DecayChannel == kD0ToKPiPi) {
         category = 2; // corr bkg: π+ K− π0
       }
 
       else if (d0DecayChannel == kD0ToPiPi) {
         category = 3; // corr bkg: π+ π−
-      }
-      else if (d0DecayChannel == kD0ToPiPiPi) {
+      } else if (d0DecayChannel == kD0ToPiPiPi) {
         category = 4; // corr bkg: π+ π− π0
-      }
-      else if (d0DecayChannel == kD0ToKK) {
+      } else if (d0DecayChannel == kD0ToKK) {
         category = 5; // corr bkg: K+ K−
       }
-
-
-
 
       tableD0McDetector(tableCollision.lastIndex(), // might want to add some more detector level D0 quantities like prompt or non prompt info
                         scores[2],


### PR DESCRIPTION
Removing matchedFrom and selectedAs columns and replacing with category which will be filled with an int corresponding to the signal, reflection, or correlated background.