### PR TITLE
[PWGCF] Increase bit mask size for v0s and cascades in femto framework

### DIFF
--- a/PWGCF/Femto/Core/cascadeBuilder.h
+++ b/PWGCF/Femto/Core/cascadeBuilder.h
@@ -507,7 +507,7 @@ class CascadeBuilder
       LOG(info) << "Initialize femto Xi builder...";
       mProduceLiteXis = utils::enableTable("FLiteXis_001", table.produceLiteXis.value, initContext);
       mProduceXis = utils::enableTable("FXis_001", table.produceXis.value, initContext);
-      mProduceXiMasks = utils::enableTable("FXiMasks_001", table.produceXiMasks.value, initContext);
+      mProduceXiMasks = utils::enableTable("FXiMasks_002", table.produceXiMasks.value, initContext);
       mProduceXiExtras = utils::enableTable("FXiExtras_001", table.produceXiExtras.value, initContext);
 
       if (mProduceXis && mProduceLiteXis) {
@@ -530,7 +530,7 @@ class CascadeBuilder
       LOG(info) << "Initialize femto Omega builder...";
       mProduceOmegas = utils::enableTable("FOmegas_001", table.produceOmegas.value, initContext);
       mProduceLiteOmegas = utils::enableTable("FLiteOmegas_001", table.produceLiteOmegas.value, initContext);
-      mProduceOmegaMasks = utils::enableTable("FOmegaMasks_001", table.produceOmegaMasks.value, initContext);
+      mProduceOmegaMasks = utils::enableTable("FOmegaMasks_002", table.produceOmegaMasks.value, initContext);
       mProduceOmegaExtras = utils::enableTable("FOmegaExtras_001", table.produceOmegaExtras.value, initContext);
 
       if (mProduceOmegas && mProduceLiteOmegas) {

--- a/PWGCF/Femto/Core/dataTypes.h
+++ b/PWGCF/Femto/Core/dataTypes.h
@@ -31,7 +31,8 @@ using TrackMaskType = uint64_t;
 using TrackType = uint16_t;
 
 // datatypes for v0s
-using V0MaskType = uint16_t;
+using V0MaskType = uint32_t;
+using V0MaskType001 = uint16_t;
 using V0Type = uint16_t;
 
 // datatypes for kinks
@@ -44,7 +45,8 @@ using TwoTrackResonanceMaskType = uint32_t;
 using TwoTrackResonanceType = uint16_t;
 
 // datatypes for cascades
-using CascadeMaskType = uint16_t;
+using CascadeMaskType = uint32_t;
+using CascadeMaskType001 = uint16_t;
 using CascadeType = uint16_t;
 
 // datatype for origin of mc particle

--- a/PWGCF/Femto/Core/dataTypes.h
+++ b/PWGCF/Femto/Core/dataTypes.h
@@ -32,7 +32,7 @@ using TrackType = uint16_t;
 
 // datatypes for v0s
 using V0MaskType = uint32_t;
-using V0MaskType001 = uint16_t;
+using V0MaskType001 = uint16_t; // old data type, was too narrow
 using V0Type = uint16_t;
 
 // datatypes for kinks
@@ -46,7 +46,7 @@ using TwoTrackResonanceType = uint16_t;
 
 // datatypes for cascades
 using CascadeMaskType = uint32_t;
-using CascadeMaskType001 = uint16_t;
+using CascadeMaskType001 = uint16_t; // old data type, was too narrow
 using CascadeType = uint16_t;
 
 // datatype for origin of mc particle

--- a/PWGCF/Femto/Core/v0Builder.h
+++ b/PWGCF/Femto/Core/v0Builder.h
@@ -496,7 +496,7 @@ class V0Builder
       }
       mProduceLambdas = utils::enableTable("FLambdas_001", table.produceLambdas.value, initContext);
       mProduceLiteLambdas = utils::enableTable("FLiteLambdas_001", table.produceLiteLambdas.value, initContext);
-      mProduceLambdaMasks = utils::enableTable("FLambdaMasks_001", table.produceLambdaMasks.value, initContext);
+      mProduceLambdaMasks = utils::enableTable("FLambdaMasks_002", table.produceLambdaMasks.value, initContext);
       mProduceLambdaExtras = utils::enableTable("FLambdaExtras_001", table.produceLambdaExtras.value, initContext);
 
       if (mProduceLambdas && mProduceLiteLambdas) {
@@ -519,7 +519,7 @@ class V0Builder
       LOG(info) << "Initialize femto K0short builder...";
       mProduceK0shorts = utils::enableTable("FK0shorts_001", table.produceK0shorts.value, initContext);
       mProduceLiteK0shorts = utils::enableTable("FLiteK0shorts_001", table.produceLiteK0shorts.value, initContext);
-      mProduceK0shortMasks = utils::enableTable("FK0shortMasks_001", table.produceK0shortMasks.value, initContext);
+      mProduceK0shortMasks = utils::enableTable("FK0shortMasks_002", table.produceK0shortMasks.value, initContext);
       mProduceK0shortExtras = utils::enableTable("FK0shortExtras_001", table.produceK0shortExtras.value, initContext);
 
       if (mProduceK0shorts && mProduceLiteK0shorts) {

--- a/PWGCF/Femto/DataModel/FemtoTables.h
+++ b/PWGCF/Femto/DataModel/FemtoTables.h
@@ -550,6 +550,11 @@ namespace femtov0s
 {
 // columns for bit masks
 DECLARE_SOA_COLUMN(Mask, mask, o2::analysis::femto::datatypes::V0MaskType); //! Bitmask for v0 selections
+//
+namespace legacy001
+{
+DECLARE_SOA_COLUMN(Mask, mask, o2::analysis::femto::datatypes::V0MaskType001); //! Bitmask for v0 selections
+}
 
 // columns for debug information
 DECLARE_SOA_COLUMN(MassAnti, massAnti, float);             //! mass of particle using antiparticle hypothesis (for Lambda/AntiLambda extra table)
@@ -649,10 +654,14 @@ using FLiteLambdas = FLiteLambdas_001;
 using FLiteLambda = FLiteLambdas::iterator;
 using StoredFLiteLambdas = StoredFLiteLambdas_001;
 
-DECLARE_SOA_TABLE_STAGED_VERSIONED(FLambdaMasks_001, "FLAMBDAMASK", 1, //! lambda masks
+DECLARE_SOA_TABLE_STAGED_VERSIONED(FLambdaMasks_001, "FLAMBDAMASK", 1, //! legacy lambda mask
+                                   femtov0s::legacy001::Mask);
+
+DECLARE_SOA_TABLE_STAGED_VERSIONED(FLambdaMasks_002, "FLAMBDAMASK", 2, //! lambda mask
                                    femtov0s::Mask);
-using FLambdaMasks = FLambdaMasks_001;
-using StoredFLambdaMasks = StoredFLambdaMasks_001;
+
+using FLambdaMasks = FLambdaMasks_002;
+using StoredFLambdaMasks = StoredFLambdaMasks_002;
 
 DECLARE_SOA_TABLE_STAGED_VERSIONED(FLambdaExtras_001, "FLAMBDAEXTRA", 1, //! lambda extra information
                                    femtov0s::MassAnti,                   // put mass of antiparticle, i.e. antilambda mass for lambdas and vice versa
@@ -703,10 +712,13 @@ using FLiteK0shorts = FLiteK0shorts_001;
 using FLiteK0short = FLiteK0shorts::iterator;
 using StoredFLiteK0shorts = StoredFLiteK0shorts_001;
 
-DECLARE_SOA_TABLE_STAGED_VERSIONED(FK0shortMasks_001, "FK0SHORTMASK", 1, //! k0short masks
+DECLARE_SOA_TABLE_STAGED_VERSIONED(FK0shortMasks_001, "FK0SHORTMASK", 1, //! legacy k0short masks
+                                   femtov0s::legacy001::Mask);
+
+DECLARE_SOA_TABLE_STAGED_VERSIONED(FK0shortMasks_002, "FK0SHORTMASK", 2, //! k0short masks
                                    femtov0s::Mask);
-using FK0shortMasks = FK0shortMasks_001;
-using StoredFK0shortMasks = StoredFK0shortMasks_001;
+using FK0shortMasks = FK0shortMasks_002;
+using StoredFK0shortMasks = StoredFK0shortMasks_002;
 
 DECLARE_SOA_TABLE_STAGED_VERSIONED(FK0shortExtras_001, "FK0SHORTEXTRA", 1, //! k0short extra information
                                    femtov0s::MassLambda,
@@ -893,6 +905,11 @@ namespace femtocascades
 // columns for cascade bit masks
 DECLARE_SOA_COLUMN(Mask, mask, o2::analysis::femto::datatypes::CascadeMaskType); //! Bitmask for cascade selections
 
+namespace legacy001
+{
+DECLARE_SOA_COLUMN(Mask, mask, o2::analysis::femto::datatypes::CascadeMaskType001); //! Bitmask for cascade selections
+}
+
 // columns for cascad debug information
 DECLARE_SOA_COLUMN(MassXi, massXi, float);                         //! Mass of xi
 DECLARE_SOA_COLUMN(MassOmega, massOmega, float);                   //! Mass of omega
@@ -987,10 +1004,13 @@ using FLiteXis = FLiteXis_001;
 using FLiteXi = FLiteXis::iterator;
 using StoredFLiteXis = StoredFLiteXis_001;
 
-DECLARE_SOA_TABLE_STAGED_VERSIONED(FXiMasks_001, "FXIMASK", 1, //! xi masks
+DECLARE_SOA_TABLE_STAGED_VERSIONED(FXiMasks_001, "FXIMASK", 1, //! legacy xi masks
+                                   femtocascades::legacy001::Mask);
+
+DECLARE_SOA_TABLE_STAGED_VERSIONED(FXiMasks_002, "FXIMASK", 2, //! xi masks
                                    femtocascades::Mask);
-using FXiMasks = FXiMasks_001;
-using StoredFXiMasks = StoredFXiMasks_001;
+using FXiMasks = FXiMasks_002;
+using StoredFXiMasks = StoredFXiMasks_002;
 
 DECLARE_SOA_TABLE_STAGED_VERSIONED(FXiExtras_001, "FXIEXTRA", 1, //! xi extra information
                                    femtocascades::MassOmega,
@@ -1046,10 +1066,13 @@ using FLiteOmegas = FLiteOmegas_001;
 using FLiteOmega = FLiteOmegas::iterator;
 using StoredFLiteOmegas = StoredFLiteOmegas_001;
 
-DECLARE_SOA_TABLE_STAGED_VERSIONED(FOmegaMasks_001, "FOMEGAMASK", 1, //! omega masks
+DECLARE_SOA_TABLE_STAGED_VERSIONED(FOmegaMasks_001, "FOMEGAMASK", 1, //! legacy omega masks
+                                   femtocascades::legacy001::Mask);
+
+DECLARE_SOA_TABLE_STAGED_VERSIONED(FOmegaMasks_002, "FOMEGAMASK", 2, //! omega masks
                                    femtocascades::Mask);
-using FOmegaMasks = FOmegaMasks_001;
-using StoredFOmegaMasks = StoredFOmegaMasks_001;
+using FOmegaMasks = FOmegaMasks_002;
+using StoredFOmegaMasks = StoredFOmegaMasks_002;
 
 DECLARE_SOA_TABLE_STAGED_VERSIONED(FOmegaExtras_001, "FOMEGAEXTRA", 1, //! omega extra information
                                    femtocascades::MassXi,

--- a/PWGCF/Femto/TableProducer/CMakeLists.txt
+++ b/PWGCF/Femto/TableProducer/CMakeLists.txt
@@ -29,6 +29,11 @@ o2physics_add_dpl_workflow(femto-producer-kink-pt-converter
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
           COMPONENT_NAME Analysis)
 
+o2physics_add_dpl_workflow(femto-producer-mask-converter-001-to-002
+          SOURCES ./femtoProducerMaskConverter001To002.cxx
+          PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+          COMPONENT_NAME Analysis)
+
 o2physics_add_dpl_workflow(femto-producer-resonances
           SOURCES ./femtoProducerResonances.cxx
           PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore

--- a/PWGCF/Femto/TableProducer/femtoProducerMaskConverter001To002.cxx
+++ b/PWGCF/Femto/TableProducer/femtoProducerMaskConverter001To002.cxx
@@ -1,0 +1,67 @@
+// Copyright 2019-2025 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file femtoProducerMaskConverter001To002.cxx
+/// \brief Task that converts *Masks_001 tables to *Masks_002
+/// \author Anton Riedel, TU München, anton.riedel@cern.ch
+
+#include "PWGCF/Femto/Core/dataTypes.h"
+#include "PWGCF/Femto/DataModel/FemtoTables.h"
+
+#include <Framework/AnalysisDataModel.h>
+#include <Framework/AnalysisHelpers.h>
+#include <Framework/AnalysisTask.h>
+#include <Framework/Configurable.h>
+#include <Framework/InitContext.h>
+#include <Framework/runDataProcessing.h>
+
+using namespace o2::analysis::femto;
+
+struct FemtoProducerMaskConverter001To002 {
+  o2::framework::Produces<o2::aod::FLambdaMasks_002> producedLambdaMasks;
+  o2::framework::Produces<o2::aod::FK0shortMasks_002> producedK0shortMasks;
+  o2::framework::Produces<o2::aod::FXiMasks_002> producedXiMasks;
+  o2::framework::Produces<o2::aod::FOmegaMasks_002> producedOmegaMasks;
+
+  void init(o2::framework::InitContext&)
+  {
+  }
+
+  void processLambdaMasks001(o2::aod::FLambdaMasks_001::iterator const& lambdaMaskOld)
+  {
+    producedLambdaMasks(static_cast<datatypes::V0MaskType>(lambdaMaskOld.mask()));
+  }
+  PROCESS_SWITCH(FemtoProducerMaskConverter001To002, processLambdaMasks001, "Convert LambdaMasks_001 to LambdaMasks_002", false);
+
+  void processK0shortMasks001(o2::aod::FK0shortMasks_001::iterator const& k0shortOld)
+  {
+    producedK0shortMasks(static_cast<datatypes::V0MaskType>(k0shortOld.mask()));
+  }
+  PROCESS_SWITCH(FemtoProducerMaskConverter001To002, processK0shortMasks001, "Convert K0shortMasks_001 to K0shortMasks_002", false);
+
+  void processXiMasks001(o2::aod::FXiMasks_001::iterator const& xiMaskOld)
+  {
+    producedXiMasks(static_cast<datatypes::CascadeMaskType>(xiMaskOld.mask()));
+  }
+  PROCESS_SWITCH(FemtoProducerMaskConverter001To002, processXiMasks001, "Convert XiMasks_001 to XiMasks_002", false);
+
+  void processOmegaMasks001(o2::aod::FOmegaMasks_001::iterator const& omegaMaskOld)
+  {
+    producedOmegaMasks(static_cast<datatypes::CascadeMaskType>(omegaMaskOld.mask()));
+  }
+  PROCESS_SWITCH(FemtoProducerMaskConverter001To002, processOmegaMasks001, "Convert OmegaMasks_001 to OmegaMasks_002", false);
+};
+
+o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& context)
+{
+  o2::framework::WorkflowSpec workflow{o2::framework::adaptAnalysisTask<FemtoProducerMaskConverter001To002>(context)};
+  return workflow;
+}


### PR DESCRIPTION
Increase the bit mask size for cascades and v0s from 16 to 32 bits. Accompying convert task has been implemented to use existing derived data.