### PR TITLE
[PWGDQ] added configurable magnetic feield z bias

### DIFF
--- a/PWGDQ/Tasks/global-muon-matcher.cxx
+++ b/PWGDQ/Tasks/global-muon-matcher.cxx
@@ -202,6 +202,9 @@ struct GlobalMuonMatching {
     Configurable<float> cfgMFTAlignmentCorrYOffsetBottom{"cfgMFTAlignmentCorrYOffsetBottom", 0.f, "MFT Y offset correction - bottom half"};
   } configMftAlignmentCorrections;
 
+  // Magnetic field position bias
+  Configurable<float> cfgFieldOriginBiasZ{"cfgFieldOriginBiasZ", 0.0f, "Bias applied to the magnetic field z position"};
+
   // Variables for CCDB objects access and retrieval
   struct : ConfigurableGroup {
     Configurable<std::string> cfgCcdbUrl{"cfgCcdbUrl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
@@ -754,6 +757,9 @@ struct GlobalMuonMatching {
     ccdbManager->setLocalObjectValidityChecking();
     fCCDBApi.init(configCcdb.cfgCcdbUrl);
     mRunNumber = 0;
+
+    // configure magnetic field position bias
+    o2::conf::ConfigurableParam::setValue("FieldOriginBias.z", std::to_string(cfgFieldOriginBiasZ.value));
 
     // Configuration for track fitter
     const auto& trackerParam = mch::TrackerParam::Instance();

--- a/PWGDQ/Tasks/muonGlobalAlignment.cxx
+++ b/PWGDQ/Tasks/muonGlobalAlignment.cxx
@@ -148,6 +148,8 @@ struct muonGlobalAlignment {
 
   Configurable<uint32_t> fMftTracksMultiplicityMax{"cfgMftTracksMultiplicityMax", 0, "Maximum number of MFT tracks to be processed per event (zero means no limit)"};
 
+  // Magnetic field position bias
+  Configurable<float> cfgFieldOriginBiasZ{"cfgFieldOriginBiasZ", 0.0f, "Bias applied to the magnetic field z position"};
   Configurable<float> fVertexZshift{"cfgVertexZshift", 0.0f, "Correction to the vertex z position"};
   Configurable<float> fDipoleZshift{"cfgDipoleZshift", 0.0f, "Correction to the dipole z position"};
 
@@ -418,10 +420,8 @@ struct muonGlobalAlignment {
     ccdbApi.init(configCCDB.ccdburl);
     mRunNumber = 0;
 
-    if (!o2::base::GeometryManager::isGeometryLoaded()) {
-      LOGF(info, "Load geometry from CCDB");
-      ccdbManager->get<TGeoManager>(configCCDB.geoPath);
-    }
+    // configure magnetic field position bias
+    o2::conf::ConfigurableParam::setValue("FieldOriginBias.z", std::to_string(cfgFieldOriginBiasZ.value));
 
     // Configuration for track fitter
     const auto& trackerParam = TrackerParam::Instance();
@@ -430,6 +430,9 @@ struct muonGlobalAlignment {
     trackFitter.smoothTracks(true);
     trackFitter.useChamberResolution();
     mImproveCutChi2 = 2. * configRealign.fSigmaCutImprove * configRealign.fSigmaCutImprove;
+
+    // use the Runge-Kutta extrapolation v2
+    TrackExtrap::useExtrapV2();
 
     // Fill table of MCH alignment corrections
     rapidjson::Document document;


### PR DESCRIPTION
The z bias parameter allows to apply a longitudinal shift to the magnetic field map, which then affects all track extrapolations and refitting.