### PR TITLE
[Common] Reduce verbosity of ctpRateFetcher when trigger classes are not found

### DIFF
--- a/Common/CCDB/ctpRateFetcher.cxx
+++ b/Common/CCDB/ctpRateFetcher.cxx
@@ -47,7 +47,7 @@ double ctpRateFetcher::fetch(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStam
     } else {
       double_t ret = fetchCTPratesClasses(ccdb, timeStamp, runNumber, "CMTVX-B-NOPF");
       if (ret < 0.) {
-        LOG(info) << "Trying different class";
+        LOG(debug) << "Trying different class";
         ret = fetchCTPratesClasses(ccdb, timeStamp, runNumber, "CMTVX-NONE");
         if ((ret < 0) && fCrashOnNull) {
           LOG(fatal) << "None of the classes used for lumi found";
@@ -72,7 +72,7 @@ double ctpRateFetcher::fetchCTPratesClasses(o2::ccdb::BasicCCDBManager* /*ccdb*/
     }
   }
   if (classIndex == -1) {
-    LOG(warn) << "Trigger class " << className << " not found in CTPConfiguration";
+    LOG(debug) << "Trigger class " << className << " not found in CTPConfiguration";
     return -1.;
   }
   auto rate{mScalers->getRateGivenT(timeStamp * 1.e-3, classIndex, inputType, 1)};


### PR DESCRIPTION
In part of 2023 the trigger name changed, so the `CMTVX-B-NOPF` trigger class for some periods  is not found. Both the "Trying different class" and the "class not found" message were logged at info/warn level, and since fetch() is called per collision in the TPC PID service task https://github.com/AliceO2Group/O2Physics/blob/ede5910ec1e08ac14a6db845829558bfca637957/Common/Tools/PID/pidTPCModule.h#L523
this produced very large log files, causing jobs to fail because of `Too much disk space used`: https://alimonitor.cern.ch/agent/jobs/details.jsp?pid=3677551603
This PR demotes both messages to `LOG(debug)`