### PR TITLE
[PWGJE] Adding charge conjugate to correlated decay channels in jetCorrelationD0

### DIFF
--- a/PWGJE/Tasks/jetCorrelationD0.cxx
+++ b/PWGJE/Tasks/jetCorrelationD0.cxx
@@ -40,6 +40,8 @@
 #include <string>
 #include <vector>
 
+#include <cmath>
+
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;

--- a/PWGJE/Tasks/jetCorrelationD0.cxx
+++ b/PWGJE/Tasks/jetCorrelationD0.cxx
@@ -19,8 +19,6 @@
 #include "PWGJE/DataModel/Jet.h"
 #include "PWGJE/DataModel/JetReducedData.h"
 
-#include "PWGHF/Core/DecayChannels.h"
-
 #include "Common/Core/RecoDecay.h"
 
 #include <CommonConstants/MathConstants.h>
@@ -294,13 +292,13 @@ struct JetCorrelationD0 {
     registry.add("hEtaResolution", "#eta resolution;#p_{T,part};Resolution", {HistType::kTH2F, {{400, 0, 400}, {1000, -1.0, 1.0}}});
   }
   enum D0McCategory : int {
-  Undefined = -1,          // no truth match / unclassified
-  Signal = 0,              // correctly identified D0(bar), π+ K−
-  Reflection = 1,          // true D0(bar) reconstructed with swapped mass hypothesis
-  CorrBkgPiKPi0 = 2,       // correlated background: π+ K− π0
-  CorrBkgPiPi = 3,         // correlated background: π+ π−
-  CorrBkgPiPiPi0 = 4,      // correlated background: π+ π− π0
-  CorrBkgKK = 5            // correlated background: K+ K−
+    Undefined = -1,     // no truth match / unclassified
+    Signal = 0,         // correctly identified D0(bar), π+ K−
+    Reflection = 1,     // true D0(bar) reconstructed with swapped mass hypothesis
+    CorrBkgPiKPi0 = 2,  // correlated background: π+ K− π0
+    CorrBkgPiPi = 3,    // correlated background: π+ π−
+    CorrBkgPiPiPi0 = 4, // correlated background: π+ π− π0
+    CorrBkgKK = 5       // correlated background: K+ K−
   };
   void processData(soa::Filtered<aod::JetCollisions>::iterator const& collision,
                    aod::CandidatesD0Data const& d0Candidates,

--- a/PWGJE/Tasks/jetCorrelationD0.cxx
+++ b/PWGJE/Tasks/jetCorrelationD0.cxx
@@ -19,6 +19,8 @@
 #include "PWGJE/DataModel/Jet.h"
 #include "PWGJE/DataModel/JetReducedData.h"
 
+#include "PWGHF/Core/DecayChannels.h"
+
 #include "Common/Core/RecoDecay.h"
 
 #include <CommonConstants/MathConstants.h>
@@ -292,13 +294,13 @@ struct JetCorrelationD0 {
     registry.add("hEtaResolution", "#eta resolution;#p_{T,part};Resolution", {HistType::kTH2F, {{400, 0, 400}, {1000, -1.0, 1.0}}});
   }
   enum D0McCategory : int {
-    Undefined = -1,     // no truth match / unclassified
-    Signal = 0,         // correctly identified D0(bar), π+ K−
-    Reflection = 1,     // true D0(bar) reconstructed with swapped mass hypothesis
-    CorrBkgPiKPi0 = 2,  // correlated background: π+ K− π0
-    CorrBkgPiPi = 3,    // correlated background: π+ π−
-    CorrBkgPiPiPi0 = 4, // correlated background: π+ π− π0
-    CorrBkgKK = 5       // correlated background: K+ K−
+  Undefined = -1,          // no truth match / unclassified
+  Signal = 0,              // correctly identified D0(bar), π+ K−
+  Reflection = 1,          // true D0(bar) reconstructed with swapped mass hypothesis
+  CorrBkgPiKPi0 = 2,       // correlated background: π+ K− π0
+  CorrBkgPiPi = 3,         // correlated background: π+ π−
+  CorrBkgPiPiPi0 = 4,      // correlated background: π+ π− π0
+  CorrBkgKK = 5            // correlated background: K+ K−
   };
   void processData(soa::Filtered<aod::JetCollisions>::iterator const& collision,
                    aod::CandidatesD0Data const& d0Candidates,

--- a/PWGJE/Tasks/jetCorrelationD0.cxx
+++ b/PWGJE/Tasks/jetCorrelationD0.cxx
@@ -201,7 +201,7 @@ struct JetCorrelationD0 {
   // Configurables
   Configurable<std::string> eventSelections{"eventSelections", "sel8", "choose event selection"};
   Configurable<bool> skipMBGapEvents{"skipMBGapEvents", false, "decide to run over MB gap events or not"};
-  Configurable<bool> applyRCTSelections{"applyRCTSelections", false, "decide to apply RCT selections"};
+  Configurable<bool> applyRCTSelections{"applyRCTSelections", true, "decide to apply RCT selections"};
   Configurable<float> jetPtCutMin{"jetPtCutMin", 5.0, "minimum value of jet pt"};
   Configurable<float> d0PtCutMin{"d0PtCutMin", 1.0, "minimum value of d0 pt"};
   Configurable<float> jetMcPtCutMin{"jetMcPtCutMin", 3.0, "minimum value of jet pt particle level"};

--- a/PWGJE/Tasks/jetCorrelationD0.cxx
+++ b/PWGJE/Tasks/jetCorrelationD0.cxx
@@ -201,7 +201,7 @@ struct JetCorrelationD0 {
   // Configurables
   Configurable<std::string> eventSelections{"eventSelections", "sel8", "choose event selection"};
   Configurable<bool> skipMBGapEvents{"skipMBGapEvents", false, "decide to run over MB gap events or not"};
-  Configurable<bool> applyRCTSelections{"applyRCTSelections", true, "decide to apply RCT selections"};
+  Configurable<bool> applyRCTSelections{"applyRCTSelections", false, "decide to apply RCT selections"};
   Configurable<float> jetPtCutMin{"jetPtCutMin", 5.0, "minimum value of jet pt"};
   Configurable<float> d0PtCutMin{"d0PtCutMin", 1.0, "minimum value of d0 pt"};
   Configurable<float> jetMcPtCutMin{"jetMcPtCutMin", 3.0, "minimum value of jet pt particle level"};

--- a/PWGJE/Tasks/jetCorrelationD0.cxx
+++ b/PWGJE/Tasks/jetCorrelationD0.cxx
@@ -293,7 +293,7 @@ struct JetCorrelationD0 {
   }
   enum D0McCategory : int {
     Undefined = -1,     // no truth match / unclassified
-    Signal = 0,         // correctly identified D0(bar), π+ K−
+    Signal = 0,         // correctly identified D0 and (bar), π+ K− + cc
     Reflection = 1,     // true D0(bar) reconstructed with swapped mass hypothesis
     CorrBkgPiKPi0 = 2,  // correlated background: π+ K− π0
     CorrBkgPiPi = 3,    // correlated background: π+ π−
@@ -378,15 +378,15 @@ struct JetCorrelationD0 {
       }
       if ((std::abs(d0DecayChannel) == hf2Prong::DecayChannelMain::D0ToPiK) && (matchedFrom != 0) && (selectedAs == matchedFrom)) {
         category = D0McCategory::Signal; // D0 or D0bar, π+ K−
-      } else if ((d0DecayChannel == hf2Prong::DecayChannelMain::D0ToPiK) && (selectedAs == -1 * matchedFrom)) {
+      } else if ((std::abs(d0DecayChannel) == hf2Prong::DecayChannelMain::D0ToPiK) && (matchedFrom != 0) && (selectedAs == -1 * matchedFrom)) {
         category = D0McCategory::Reflection;
-      } else if (d0DecayChannel == hf2Prong::DecayChannelMain::D0ToPiKPi0) {
+      } else if (std::abs(d0DecayChannel) == hf2Prong::DecayChannelMain::D0ToPiKPi0) {
         category = D0McCategory::CorrBkgPiKPi0;
-      } else if (d0DecayChannel == hf2Prong::DecayChannelMain::D0ToPiPi) {
+      } else if (std::abs(d0DecayChannel) == hf2Prong::DecayChannelMain::D0ToPiPi) {
         category = D0McCategory::CorrBkgPiPi;
-      } else if (d0DecayChannel == hf2Prong::DecayChannelMain::D0ToPiPiPi0) {
+      } else if (std::abs(d0DecayChannel) == hf2Prong::DecayChannelMain::D0ToPiPiPi0) {
         category = D0McCategory::CorrBkgPiPiPi0;
-      } else if (d0DecayChannel == hf2Prong::DecayChannelMain::D0ToKK) {
+      } else if (std::abs(d0DecayChannel) == hf2Prong::DecayChannelMain::D0ToKK) {
         category = D0McCategory::CorrBkgKK;
       }
 

--- a/PWGJE/Tasks/jetCorrelationD0.cxx
+++ b/PWGJE/Tasks/jetCorrelationD0.cxx
@@ -40,8 +40,6 @@
 #include <string>
 #include <vector>
 
-#include <cmath>
-
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;


### PR DESCRIPTION
Data suggests that I am not saving the correlated decays for D0 bars but only D0s. This should fix that by taking the abs of the decay channel when assigning the "category" of the D0Candidate.