### PR TITLE
[PWGHF] Fix tree creator output consistency

### DIFF
--- a/PWGHF/TableProducer/treeCreatorD0ToKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorD0ToKPi.cxx
@@ -289,7 +289,7 @@ struct HfTreeCreatorD0ToKPi {
 
   template <bool ApplyMl, typename T>
   auto fillTable(const T& candidate, int candFlag, double invMass, double topoChi2,
-                 double ct, double y, double e, int8_t flagMc, int8_t flagMcDecay, int8_t origin, int8_t flagBmother)
+                 double ct, double y, double e, int8_t flagMc, int8_t flagMcDecay, int8_t origin, int8_t pdgBmother)
   {
     if (fillCandidateLiteTable) {
       rowCandidateLite(
@@ -329,7 +329,7 @@ struct HfTreeCreatorD0ToKPi {
         flagMc,
         flagMcDecay,
         origin,
-        flagBmother);
+        pdgBmother);
     } else {
       double cosThetaStar = candFlag == 0 ? HfHelper::cosThetaStarD0(candidate) : HfHelper::cosThetaStarD0bar(candidate);
       rowCandidateFull(
@@ -393,7 +393,7 @@ struct HfTreeCreatorD0ToKPi {
         flagMc,
         flagMcDecay,
         origin,
-        flagBmother);
+        pdgBmother);
     }
     if constexpr (ApplyMl) {
       if (candFlag == 0) {
@@ -453,10 +453,10 @@ struct HfTreeCreatorD0ToKPi {
         massD0bar = HfHelper::invMassD0barToKPi(candidate);
       }
       if (candidate.isSelD0()) {
-        fillTable<ApplyMl>(candidate, 0, massD0, topolChi2PerNdf, ctD, yD, eD, 0, 0, 0, -1);
+        fillTable<ApplyMl>(candidate, 0, massD0, topolChi2PerNdf, ctD, yD, eD, 0, 0, 0, 0);
       }
       if (candidate.isSelD0bar()) {
-        fillTable<ApplyMl>(candidate, 1, massD0bar, topolChi2PerNdf, ctD, yD, eD, 0, 0, 0, -1);
+        fillTable<ApplyMl>(candidate, 1, massD0bar, topolChi2PerNdf, ctD, yD, eD, 0, 0, 0, 0);
       }
     }
   }
@@ -554,10 +554,10 @@ struct HfTreeCreatorD0ToKPi {
         massD0bar = HfHelper::invMassD0barToKPi(candidate);
       }
       if (candidate.isSelD0()) {
-        fillTable<ApplyMl>(candidate, 0, massD0, topolChi2PerNdf, ctD, yD, eD, candidate.flagMcMatchRec(), candidate.flagMcDecayChanRec(), candidate.originMcRec(), o2::analysis::getBHadMotherFlag(candidate.pdgBhadMotherPart()));
+        fillTable<ApplyMl>(candidate, 0, massD0, topolChi2PerNdf, ctD, yD, eD, candidate.flagMcMatchRec(), candidate.flagMcDecayChanRec(), candidate.originMcRec(), candidate.pdgBhadMotherPart());
       }
       if (candidate.isSelD0bar()) {
-        fillTable<ApplyMl>(candidate, 1, massD0bar, topolChi2PerNdf, ctD, yD, eD, candidate.flagMcMatchRec(), candidate.flagMcDecayChanRec(), candidate.originMcRec(), o2::analysis::getBHadMotherFlag(candidate.pdgBhadMotherPart()));
+        fillTable<ApplyMl>(candidate, 1, massD0bar, topolChi2PerNdf, ctD, yD, eD, candidate.flagMcMatchRec(), candidate.flagMcDecayChanRec(), candidate.originMcRec(), candidate.pdgBhadMotherPart());
       }
     }
 

--- a/PWGHF/TableProducer/treeCreatorDplusToPiKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorDplusToPiKPi.cxx
@@ -308,12 +308,12 @@ struct HfTreeCreatorDplusToPiKPi {
     int8_t flagMc = 0;
     int8_t originMc = 0;
     int8_t channelMc = 0;
-    int8_t bMotherFlag = -1;
+    int8_t bMotherPdg = 0;
     if constexpr (DoMc) {
       flagMc = candidate.flagMcMatchRec();
       originMc = candidate.originMcRec();
       channelMc = candidate.flagMcDecayChanRec();
-      bMotherFlag = o2::analysis::getBHadMotherFlag(candidate.pdgBhadMotherPart());
+      bMotherPdg = candidate.pdgBhadMotherPart();
     }
 
     std::vector<float> outputMl = {-999., -999.};
@@ -380,7 +380,7 @@ struct HfTreeCreatorDplusToPiKPi {
         flagMc,
         originMc,
         channelMc,
-        bMotherFlag);
+        bMotherPdg);
     } else {
       rowCandidateFull(
         coll.numContrib(),
@@ -462,7 +462,7 @@ struct HfTreeCreatorDplusToPiKPi {
         flagMc,
         originMc,
         channelMc,
-        bMotherFlag);
+        bMotherPdg);
     }
   }
 

--- a/PWGHF/TableProducer/treeCreatorDsToKKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorDsToKKPi.cxx
@@ -349,7 +349,7 @@ struct HfTreeCreatorDsToKKPi {
     int8_t flagMc{0};
     int8_t originMc{0};
     int8_t channelMc{0};
-    int8_t bMotherFlag{-1};
+    int8_t bMotherPdg{0};
     int8_t isSwapped{MassHypo}; // 0 if KKPi, 1 if PiKK
     float eCand{0.f};
     float ctCand{0.f};
@@ -359,7 +359,7 @@ struct HfTreeCreatorDsToKKPi {
       originMc = candidate.originMcRec();
       channelMc = candidate.flagMcDecayChanRec();
       isSwapped = candidate.isCandidateSwapped();
-      bMotherFlag = o2::analysis::getBHadMotherFlag(candidate.pdgBhadMotherPart());
+      bMotherPdg = candidate.pdgBhadMotherPart();
       if (fillDplusMc && candidate.flagMcDecayChanRec() == channelsResonant[Mother::Dplus][decayChannel]) {
         eCand = HfHelper::eDplus(candidate);
         ctCand = HfHelper::ctDplus(candidate);
@@ -425,7 +425,7 @@ struct HfTreeCreatorDsToKKPi {
         flagMc,
         originMc,
         channelMc,
-        bMotherFlag,
+        bMotherPdg,
         isSwapped,
         prong0.sign() + prong1.sign() + prong2.sign());
     } else {
@@ -499,7 +499,7 @@ struct HfTreeCreatorDsToKKPi {
         flagMc,
         originMc,
         channelMc,
-        bMotherFlag,
+        bMotherPdg,
         isSwapped,
         prong0.sign() + prong1.sign() + prong2.sign());
     }


### PR DESCRIPTION
Make tree creators actually produce the pdg code of B mother instead of its flag