### PR TITLE
[PWGHF] Fixed mc gen of taskCharmResoDTrkReduced to mirror MC rec

### DIFF
--- a/PWGHF/D2H/Tasks/taskCharmResoToDTrkReduced.cxx
+++ b/PWGHF/D2H/Tasks/taskCharmResoToDTrkReduced.cxx
@@ -412,9 +412,11 @@ struct HfTaskCharmResoToDTrkReduced {
       std::array<float, 2> ptProngs = {particle.ptProng0(), particle.ptProng1()};
       std::array<float, 2> etaProngs = {particle.etaProng0(), particle.etaProng1()};
       bool const prongsInAcc = isProngInAcceptance(etaProngs[0], ptProngs[0]) && isProngInAcceptance(etaProngs[1], ptProngs[1]);
-      if (Channel == DecayChannel::D0Kplus &&
-          !hf_decay::hf_cand_reso::particlesToD0Kplus.contains(static_cast<hf_decay::hf_cand_reso::DecayChannelMain>(std::abs(flag)))) {
-        continue;
+      if (fillOnlySignal) {
+        if (Channel == DecayChannel::D0Kplus &&
+            !hf_decay::hf_cand_reso::particlesToD0Kplus.contains(static_cast<hf_decay::hf_cand_reso::DecayChannelMain>(std::abs(flag)))) {
+          continue;
+        }
       }
       registry.fill(HIST("hYGenAll"), ptParticle, yParticle);
       if (yCandGenMax >= 0. && std::abs(yParticle) > yCandGenMax) {

--- a/PWGHF/D2H/Tasks/taskCharmResoToDTrkReduced.cxx
+++ b/PWGHF/D2H/Tasks/taskCharmResoToDTrkReduced.cxx
@@ -412,8 +412,8 @@ struct HfTaskCharmResoToDTrkReduced {
       std::array<float, 2> ptProngs = {particle.ptProng0(), particle.ptProng1()};
       std::array<float, 2> etaProngs = {particle.etaProng0(), particle.etaProng1()};
       bool const prongsInAcc = isProngInAcceptance(etaProngs[0], ptProngs[0]) && isProngInAcceptance(etaProngs[1], ptProngs[1]);
-      if (fillOnlySignal) {
-        if (Channel == DecayChannel::D0Kplus &&
+      if constexpr (Channel == DecayChannel::D0Kplus) {
+        if (fillOnlySignal &&
             !hf_decay::hf_cand_reso::particlesToD0Kplus.contains(static_cast<hf_decay::hf_cand_reso::DecayChannelMain>(std::abs(flag)))) {
           continue;
         }


### PR DESCRIPTION
Fixed small bug, MC gen tree was not filled for correlated backgrounds even if fillOnlySignal was false