### PR TITLE
[PWGCF] Femto framework add first mother ancestor option

### DIFF
--- a/PWGCF/Femto/Core/pairCleaner.h
+++ b/PWGCF/Femto/Core/pairCleaner.h
@@ -34,6 +34,7 @@ class BasePairCleaner
     if constexpr (modes::isFlagSet(mode, modes::Mode::kMc)) {
       mMixPairsWithCommonAncestor = pairCuts.mixOnlyCommonAncestor.value;
       mMixPairsWithNonCommonAncestor = pairCuts.mixOnlyNonCommonAncestor.value;
+      mUseMotherAsAncestor = pairCuts.useMotherAsAncestor.value;
       if (mMixPairsWithCommonAncestor && mMixPairsWithNonCommonAncestor) {
         LOG(fatal) << "Both mixing with common and non-common ancestor is activated. Breaking...";
       }
@@ -48,34 +49,31 @@ class BasePairCleaner
   };
 
   // mc only
+  // ancestry is checked either with the partonic mother or with the first ancestor (i.e. the direct mother), depending on mUseMotherAsAncestor
   template <typename T1, typename T2, typename T3>
-  bool mcPairHasCommonAncestor(T1 const& particle1, T2 const& particle2, T3 const& /*partonicMothers*/) const
+  bool mcPairHasCommonAncestor(T1 const& particle1, T2 const& particle2, T3 const& partonicMothers) const
   {
-    // if one of the two particles has no associated partonic mother, we cannot know if they have a common anchestor, so we break out with false
-    if (!particle1.has_fMcPartMoth() || !particle2.has_fMcPartMoth()) {
-      return false;
+    if (mUseMotherAsAncestor) {
+      return this->mcPairHasCommonMother(particle1, particle2);
     }
-
-    // get partonic mothers
-    auto partonicMother1 = particle1.template fMcPartMoth_as<T3>();
-    auto partonicMother2 = particle2.template fMcPartMoth_as<T3>();
-
-    return partonicMother1.globalIndex() == partonicMother2.globalIndex();
+    return this->mcPairHasCommonPartonicMother(particle1, particle2, partonicMothers);
   };
 
   template <typename T1, typename T2, typename T3>
-  bool mcPairHasNonCommonAncestor(T1 const& particle1, T2 const& particle2, T3 const& /*partonicMothers*/) const
+  bool mcPairHasNonCommonAncestor(T1 const& particle1, T2 const& particle2, T3 const& partonicMothers) const
   {
+    if (mUseMotherAsAncestor) {
+      // if one of the two particles has no associated mother, we cannot know if they have a common anchestor, so we break out with false
+      if (!particle1.has_fMcMother() || !particle2.has_fMcMother()) {
+        return false;
+      }
+      return !this->mcPairHasCommonMother(particle1, particle2);
+    }
     // if one of the two particles has no associated partonic mother, we cannot know if they have a common anchestor, so we break out with false
     if (!particle1.has_fMcPartMoth() || !particle2.has_fMcPartMoth()) {
       return false;
     }
-
-    // get partonic mothers
-    auto partonicMother1 = particle1.template fMcPartMoth_as<T3>();
-    auto partonicMother2 = particle2.template fMcPartMoth_as<T3>();
-
-    return partonicMother1.globalIndex() != partonicMother2.globalIndex();
+    return !this->mcPairHasCommonPartonicMother(particle1, particle2, partonicMothers);
   };
 
   // reco + mc
@@ -111,6 +109,38 @@ class BasePairCleaner
 
   bool mMixPairsWithCommonAncestor = false;
   bool mMixPairsWithNonCommonAncestor = false;
+
+ private:
+  // require both particles to originate from the same partonic mother
+  template <typename T1, typename T2, typename T3>
+  bool mcPairHasCommonPartonicMother(T1 const& particle1, T2 const& particle2, T3 const& /*partonicMothers*/) const
+  {
+    // if one of the two particles has no associated partonic mother, we cannot know if they have a common anchestor, so we break out with false
+    if (!particle1.has_fMcPartMoth() || !particle2.has_fMcPartMoth()) {
+      return false;
+    }
+
+    // get partonic mothers
+    auto partonicMother1 = particle1.template fMcPartMoth_as<T3>();
+    auto partonicMother2 = particle2.template fMcPartMoth_as<T3>();
+
+    return partonicMother1.globalIndex() == partonicMother2.globalIndex();
+  };
+
+  // require both particles to have the same first ancestor, i.e. the same direct mother
+  // there is exactly one row in the mother table per generated mother, so comparing the indices is sufficient
+  template <typename T1, typename T2>
+  bool mcPairHasCommonMother(T1 const& particle1, T2 const& particle2) const
+  {
+    // if one of the two particles has no associated mother, we cannot know if they have a common anchestor, so we break out with false
+    if (!particle1.has_fMcMother() || !particle2.has_fMcMother()) {
+      return false;
+    }
+
+    return particle1.fMcMotherId() == particle2.fMcMotherId();
+  };
+
+  bool mUseMotherAsAncestor = false;
 };
 
 class TrackTrackPairCleaner : public BasePairCleaner

--- a/PWGCF/Femto/Core/pairHistManager.h
+++ b/PWGCF/Femto/Core/pairHistManager.h
@@ -249,6 +249,7 @@ struct ConfPairCuts : o2::framework::ConfigurableGroup {
   o2::framework::Configurable<float> massInvMax{"massInvMax", -1, "Maximal invariant mass (set to -1 to deactivate)"};
   o2::framework::Configurable<bool> mixOnlyCommonAncestor{"mixOnlyCommonAncestor", false, "Require pair to have common anchestor (in the same event)"};
   o2::framework::Configurable<bool> mixOnlyNonCommonAncestor{"mixOnlyNonCommonAncestor", false, "Require pair to have non-common anchestor (in the same event)"};
+  o2::framework::Configurable<bool> useMotherAsAncestor{"useMotherAsAncestor", false, "Use the first ancestor (i.e. the direct mother) instead of the partonic mother when requiring (non-)common ancestry"};
 };
 
 // the enum gives the correct index in the array

--- a/PWGCF/Femto/Core/tripletHistManager.h
+++ b/PWGCF/Femto/Core/tripletHistManager.h
@@ -140,6 +140,7 @@ struct ConfTripletCuts : o2::framework::ConfigurableGroup {
   o2::framework::Configurable<float> mtMin{"mtMin", -1, "Minimal mt (set to -1 to deactivate)"};
   o2::framework::Configurable<bool> mixOnlyCommonAncestor{"mixOnlyCommonAncestor", false, "Require pair to have common anchestor (in the same event)"};
   o2::framework::Configurable<bool> mixOnlyNonCommonAncestor{"mixOnlyNonCommonAncestor", false, "Require pair to have non-common anchestor (in the same event)"};
+  o2::framework::Configurable<bool> useMotherAsAncestor{"useMotherAsAncestor", false, "Use the first ancestor (i.e. the direct mother) instead of the partonic mother when requiring (non-)common ancestry"};
 };
 
 // the enum gives the correct index in the array


### PR DESCRIPTION
Added option for first mother as required ancestor for tracks. Is used to calculate the acceptance x tracking efficiency in MC.