### PR TITLE
[PWGJE] Fix setSingleTrackSelectionBit not setting notBadMcTrack bit

### DIFF
--- a/PWGJE/Core/JetDerivedDataUtilities.h
+++ b/PWGJE/Core/JetDerivedDataUtilities.h
@@ -716,6 +716,7 @@ uint8_t setSingleTrackSelectionBit(int trackSelection)
   if (trackSelection != -1) {
     SETBIT(bit, trackSelection);
   }
+  SETBIT(bit, JTrackSel::notBadMcTrack);
   return bit;
 }
 


### PR DESCRIPTION
setTrackSelectionBit defaults setNotBadMcTrack=true, but setSingleTrackSelectionBit (the only bit-builder used for JTrackSub, in eventwiseConstituentSubtractor.cxx) never sets it. Since selectTrack() gates unconditionally on notBadMcTrack, every event-wise constituent-subtracted track fails selection regardless of configured trackSelections, silently zeroing all downstream subtracted-jet finding.

This brings setSingleTrackSelectionBit in line with the existing default behavior of setTrackSelectionBit.