### PR TITLE
[PWGCF] Fix derived to derived processing of femto tracks with mass

### DIFF
--- a/PWGCF/Femto/Core/cascadeBuilder.h
+++ b/PWGCF/Femto/Core/cascadeBuilder.h
@@ -779,8 +779,8 @@ class CascadeBuilder
 
 struct ConfCascadeTablesDerivedToDerived : o2::framework::ConfigurableGroup {
   std::string prefix = std::string("CascadeTables");
-  o2::framework::Configurable<int> limitXi{"limitXi", 1, "Require at least this many Xis in the collision. Set to 0 to skip Xis entirely (not written to output)."}; 
-  o2::framework::Configurable<int> limitOmega{"limitOmega", 0, "Require at least this many Omegas in the collision. Set to 0 to skip Omegas entirely (not written to output)."}; 
+  o2::framework::Configurable<int> limitXi{"limitXi", 1, "Require at least this many Xis in the collision. Set to 0 to skip Xis entirely (not written to output)."};
+  o2::framework::Configurable<int> limitOmega{"limitOmega", 0, "Require at least this many Omegas in the collision. Set to 0 to skip Omegas entirely (not written to output)."};
 };
 
 struct CascadeBuilderDerivedToDerivedProducts : o2::framework::ProducesGroup {

--- a/PWGCF/Femto/Core/cascadeBuilder.h
+++ b/PWGCF/Femto/Core/cascadeBuilder.h
@@ -779,8 +779,8 @@ class CascadeBuilder
 
 struct ConfCascadeTablesDerivedToDerived : o2::framework::ConfigurableGroup {
   std::string prefix = std::string("CascadeTables");
-  o2::framework::Configurable<int> limitXi{"limitXi", 1, "At least this many xi need to be in the collision"};
-  o2::framework::Configurable<int> limitOmega{"limitOmega", 0, "At least this many omega need to be in the collision"};
+  o2::framework::Configurable<int> limitXi{"limitXi", 1, "Require at least this many Xis in the collision. Set to 0 to skip Xis entirely (not written to output)."}; 
+  o2::framework::Configurable<int> limitOmega{"limitOmega", 0, "Require at least this many Omegas in the collision. Set to 0 to skip Omegas entirely (not written to output)."}; 
 };
 
 struct CascadeBuilderDerivedToDerivedProducts : o2::framework::ProducesGroup {

--- a/PWGCF/Femto/Core/kinkBuilder.h
+++ b/PWGCF/Femto/Core/kinkBuilder.h
@@ -725,8 +725,8 @@ class KinkBuilder
 
 struct ConfKinkTablesDerivedToDerived : o2::framework::ConfigurableGroup {
   std::string prefix = std::string("KinkTables");
-  o2::framework::Configurable<int> limitSigma{"limitSigma", 1, "Require at least this many Sigmas in the collision. Set to 0 to skip Sigmas entirely (not written to output)."}; 
-  o2::framework::Configurable<int> limitSigmaPlus{"limitSigmaPlus", 0, "Require at least this many SigmaPlus in the collision. Set to 0 to skip SigmaPlus entirely (not written to output)."}; 
+  o2::framework::Configurable<int> limitSigma{"limitSigma", 1, "Require at least this many Sigmas in the collision. Set to 0 to skip Sigmas entirely (not written to output)."};
+  o2::framework::Configurable<int> limitSigmaPlus{"limitSigmaPlus", 0, "Require at least this many SigmaPlus in the collision. Set to 0 to skip SigmaPlus entirely (not written to output)."};
 };
 
 struct KinkBuilderDerivedToDerivedProducts : o2::framework::ProducesGroup {

--- a/PWGCF/Femto/Core/kinkBuilder.h
+++ b/PWGCF/Femto/Core/kinkBuilder.h
@@ -725,8 +725,8 @@ class KinkBuilder
 
 struct ConfKinkTablesDerivedToDerived : o2::framework::ConfigurableGroup {
   std::string prefix = std::string("KinkTables");
-  o2::framework::Configurable<int> limitSigma{"limitSigma", 1, "At least this many sigmas need to be in the collision"};
-  o2::framework::Configurable<int> limitSigmaPlus{"limitSigmaPlus", 0, "At least this many sigma pluses need to be in the collision"};
+  o2::framework::Configurable<int> limitSigma{"limitSigma", 1, "Require at least this many Sigmas in the collision. Set to 0 to skip Sigmas entirely (not written to output)."}; 
+  o2::framework::Configurable<int> limitSigmaPlus{"limitSigmaPlus", 0, "Require at least this many SigmaPlus in the collision. Set to 0 to skip SigmaPlus entirely (not written to output)."}; 
 };
 
 struct KinkBuilderDerivedToDerivedProducts : o2::framework::ProducesGroup {

--- a/PWGCF/Femto/Core/trackBuilder.h
+++ b/PWGCF/Femto/Core/trackBuilder.h
@@ -841,8 +841,8 @@ struct TrackBuilderDerivedToDerivedProducts : o2::framework::ProducesGroup {
 
 struct ConfTrackTablesDerivedToDerived : o2::framework::ConfigurableGroup {
   std::string prefix = std::string("TrackTables");
-  o2::framework::Configurable<int> limitTrack1{"limitTrack1", 1, "At least this many tracks of type 1 need to be in the collision. Ignored if set to 0."};
-  o2::framework::Configurable<int> limitTrack2{"limitTrack2", 0, "At least this many tracks of type 2 need to be in the collision. Ignored if set to 0."};
+  o2::framework::Configurable<int> limitTrack1{"limitTrack1", 1, "Require at least this many tracks of type 1 in the collision. Set to 0 to skip this track species entirely (not written to output)."};
+  o2::framework::Configurable<int> limitTrack2{"limitTrack2", 1, "Require at least this many tracks of type 2 in the collision. Set to 0 to skip this track species entirely (not written to output)."};
 };
 
 class TrackBuilderDerivedToDerived
@@ -863,13 +863,18 @@ class TrackBuilderDerivedToDerived
   }
 
   template <typename T1, typename T2, typename T3, typename T4, typename T5>
-  bool collisionHasTooFewTracks(T1& col, T2& /*trackTable*/, T3& partitionTrack1, T4& partitionTrack2, T5& cache)
+  bool collisionHasTooFewTracks(T1 const& col, T2 const& /*tracks*/, T3& partitionTrack1, T4& partitionTrack2, T5& cache) const
   {
-    auto trackSlice1 = partitionTrack1->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
-    auto trackSlice2 = partitionTrack2->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
-
-    const bool tooFew1 = (mLimitTrack1 > 0) && (trackSlice1.size() < static_cast<int64_t>(mLimitTrack1));
-    const bool tooFew2 = (mLimitTrack2 > 0) && (trackSlice2.size() < static_cast<int64_t>(mLimitTrack2));
+    bool tooFew1 = false;
+    if (mLimitTrack1 > 0) {
+      auto slice1 = partitionTrack1->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
+      tooFew1 = slice1.size() < static_cast<int64_t>(mLimitTrack1);
+    }
+    bool tooFew2 = false;
+    if (mLimitTrack2 > 0) {
+      auto slice2 = partitionTrack2->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
+      tooFew2 = slice2.size() < static_cast<int64_t>(mLimitTrack2);
+    }
     return tooFew1 || tooFew2;
   }
 

--- a/PWGCF/Femto/Core/v0Builder.h
+++ b/PWGCF/Femto/Core/v0Builder.h
@@ -770,9 +770,9 @@ class V0Builder
 
 struct ConfV0TablesDerivedToDerived : o2::framework::ConfigurableGroup {
   std::string prefix = std::string("V0Tables");
-  o2::framework::Configurable<int> limitLambda{"limitLambda", 1, "Require at least this many Lambdas in the collision. Set to 0 to skip Lambdas entirely (not written to output)."}; 
+  o2::framework::Configurable<int> limitLambda{"limitLambda", 1, "Require at least this many Lambdas in the collision. Set to 0 to skip Lambdas entirely (not written to output)."};
 
-  o2::framework::Configurable<int> limitK0short{"limitK0short", 0, "Require at least this many K0shorts in the collision. Set to 0 to skip K0shorts entirely (not written to output)."}; 
+  o2::framework::Configurable<int> limitK0short{"limitK0short", 0, "Require at least this many K0shorts in the collision. Set to 0 to skip K0shorts entirely (not written to output)."};
 };
 
 struct V0BuilderDerivedToDerivedProducts : o2::framework::ProducesGroup {

--- a/PWGCF/Femto/Core/v0Builder.h
+++ b/PWGCF/Femto/Core/v0Builder.h
@@ -770,8 +770,9 @@ class V0Builder
 
 struct ConfV0TablesDerivedToDerived : o2::framework::ConfigurableGroup {
   std::string prefix = std::string("V0Tables");
-  o2::framework::Configurable<int> limitLambda{"limitLambda", 1, "At least this many lambdas need to be in the collision"};
-  o2::framework::Configurable<int> limitK0short{"limitK0short", 0, "At least this many k0short need to be in the collision"};
+  o2::framework::Configurable<int> limitLambda{"limitLambda", 1, "Require at least this many Lambdas in the collision. Set to 0 to skip Lambdas entirely (not written to output)."}; 
+
+  o2::framework::Configurable<int> limitK0short{"limitK0short", 0, "Require at least this many K0shorts in the collision. Set to 0 to skip K0shorts entirely (not written to output)."}; 
 };
 
 struct V0BuilderDerivedToDerivedProducts : o2::framework::ProducesGroup {

--- a/PWGCF/Femto/TableProducer/femtoProducerDerivedToDerived.cxx
+++ b/PWGCF/Femto/TableProducer/femtoProducerDerivedToDerived.cxx
@@ -67,6 +67,10 @@ struct FemtoProducerDerivedToDerived {
   o2::framework::Partition<FemtoTracks> trackPartition2 = MAKE_TRACK_PARTITION(trackSelections2);
   o2::framework::Preslice<FemtoTracks> perColTracks = o2::aod::femtobase::stored::fColId;
 
+  o2::framework::Partition<FemtoTracksWithMass> trackWithMassPartition1 = MAKE_TRACK_PARTITION_WITH_MASS(trackSelections1);
+  o2::framework::Partition<FemtoTracksWithMass> trackWithMassPartition2 = MAKE_TRACK_PARTITION_WITH_MASS(trackSelections2);
+  o2::framework::Preslice<FemtoTracksWithMass> perColTracksWithMass = o2::aod::femtobase::stored::fColId;
+
   // v0 builder
   v0builder::V0BuilderDerivedToDerived v0Builder;
   v0builder::V0BuilderDerivedToDerivedProducts v0BuilderProducts;
@@ -138,12 +142,12 @@ struct FemtoProducerDerivedToDerived {
 
   void processTracksWithMass(FilteredFemtoCollision const& col, FemtoTracksWithMass const& tracks)
   {
-    if (trackBuilder.collisionHasTooFewTracks(col, tracks, trackPartition1, trackPartition2, cache)) {
+    if (trackBuilder.collisionHasTooFewTracks(col, tracks, trackWithMassPartition1, trackWithMassPartition2, cache)) {
       return;
     }
     trackBuilder.reset(tracks);
     collisionBuilder.processCollision(col, collisionBuilderProducts);
-    trackBuilder.processTracks(col, tracks, trackPartition1, trackPartition2, cache, trackBuilderProducts, collisionBuilderProducts);
+    trackBuilder.processTracks(col, tracks, trackWithMassPartition1, trackWithMassPartition2, cache, trackBuilderProducts, collisionBuilderProducts);
   }
   PROCESS_SWITCH(FemtoProducerDerivedToDerived, processTracksWithMass, "Process tracks with mass", false);
 


### PR DESCRIPTION
The FemtoTracksWithMass partitions in femtoProducerDerivedToDerived.cxx were declared incorrectly, so processTracksWithMass was broken.