### PR TITLE
[Infrastructure] Clang-Tidy: Demote some errors to warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -111,6 +111,8 @@ WarningsAsErrors: >-
   *,
   -readability-braces-around-statements,
   -readability-suspicious-call-argument,
+  -modernize-*,
+  -readability-*,
 CheckOptions:
   modernize-avoid-c-arrays.AllowStringArrays: true
   # Common tolerated conversions


### PR DESCRIPTION
Demote errors from `modernize` and `readability` categories to prioritise more severe issues.
Affects 12319 out of 22758 currently reported errors (i.e. reduces the number of reported errors by 54 %).
@ktf @dsekihat 