### PR TITLE
[PWGHF] Lc decay time: fix definition and provide additional info

### DIFF
--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -338,6 +338,10 @@ struct HfTaskLc {
     return o2::hf_centrality::getCentralityColl<Coll>(collision);
   }
 
+  /// Evaluate decay time of generated particle
+  /// \param mcParticleProng0 one of generated particle's daughters
+  /// \param motherParticle generated particle
+  /// \return decay time in picoseconds. For nonprompt particles it is evaluated as if it was prompt (as it is calculated for data)
   float evaluateMcGenDecayTime(const McParticles3ProngMatched::iterator& mcParticleProng0, const McParticles3ProngMatched::iterator& motherParticle)
   {
     const auto mcCollision = motherParticle.template mcCollision_as<aod::McCollisions>();

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -270,6 +270,7 @@ struct HfTaskLc {
       const AxisSpec thnAxisTracklets{thnConfigAxisNumPvContr, "Number of PV contributors"};
       const AxisSpec thnAxisOccupancy{thnConfigAxisOccupancy, "Occupancy"};
       const AxisSpec thnAxisProperDecayTime{thnConfigAxisProperDecayTime, "#it{t}_{proper} (ps)"};
+      const AxisSpec thnAxisProperDecayTimeGen{thnConfigAxisProperDecayTime, "#it{t}_{proper, gen} (ps)"};
 
       bool const isDataWithMl = doprocessDataWithMl || doprocessDataWithMlWithFT0C || doprocessDataWithMlWithFT0M;
       bool const isMcWithMl = doprocessMcWithMl || doprocessMcWithMlWithFT0C || doprocessMcWithMlWithFT0M;
@@ -305,6 +306,9 @@ struct HfTaskLc {
         for (const auto& axes : std::array<std::vector<AxisSpec>*, 3>{&axesWithBdt, &axesStd, &axesGen}) {
           if (!axes->empty()) {
             axes->push_back(thnAxisProperDecayTime);
+            if (!isData && axes != &axesGen) {
+              axes->push_back(thnAxisProperDecayTimeGen);
+            }
           }
         }
       }
@@ -421,6 +425,18 @@ struct HfTaskLc {
         const auto numPvContributors = collision.numContrib();
         const auto ptRecB = candidate.ptBhadMotherPart();
 
+        const auto mcCollision = particleMother.template mcCollision_as<aod::McCollisions>();
+        const auto p = particleMother.p();
+        const float pvX = mcCollision.posX();
+        const float pvY = mcCollision.posY();
+        const float pvZ = mcCollision.posZ();
+        const float svX = mcParticleProng0.vx();
+        const float svY = mcParticleProng0.vy();
+        const float svZ = mcParticleProng0.vz();
+
+        const float decayLengthGen = static_cast<float>(RecoDecay::distance(std::array<float, 3>{svX, svY, svZ}, std::array<float, 3>{pvX, pvY, pvZ}));
+        const float properDecayTimeGen = decayLengthGen * static_cast<float>(MassLambdaCPlus) / LightSpeedCm2PS / p;
+
         /// MC reconstructed signal
         fillHistogramsRecSig<Signal>(candidate);
 
@@ -464,6 +480,7 @@ struct HfTaskLc {
             }
             if (storeProperDecayTime) {
               valuesToFill.push_back(properDecayTime);
+              valuesToFill.push_back(properDecayTimeGen);
             }
             if constexpr (FillMl) {
               registry.get<THnSparse>(HIST("hnLcVarsWithBdt"))->Fill(valuesToFill.data());

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -123,7 +123,6 @@ struct HfTaskLc {
 
   // Factors for conversion between units
   constexpr static float CtToProperDecayTimePs = 1.f / o2::constants::physics::LightSpeedCm2PS;
-  constexpr static float NanoToPico = 1000.f;
   // Names of folders and suffixes for MC signal histograms
   constexpr static std::string_view SignalFolders[] = {"signal", "prompt", "nonprompt"};
   constexpr static std::string_view SignalSuffixes[] = {"", "Prompt", "NonPrompt"};
@@ -339,8 +338,7 @@ struct HfTaskLc {
     return o2::hf_centrality::getCentralityColl<Coll>(collision);
   }
 
-  template <typename McDaughter, typename CandLcMcGen>
-  float evaluateMcGenDecayTime(const McDaughter& mcParticleProng0, const CandLcMcGen& motherParticle)
+  float evaluateMcGenDecayTime(const McParticles3ProngMatched::iterator& mcParticleProng0, const McParticles3ProngMatched::iterator& motherParticle)
   {
     const auto mcCollision = motherParticle.template mcCollision_as<aod::McCollisions>();
     const float pMother = motherParticle.p();
@@ -363,7 +361,7 @@ struct HfTaskLc {
   template <int SignalType, typename CandidateType>
   void fillHistogramsRecSig(CandidateType const& candidate)
   {
-    const auto& mcParticleProng0 = candidate.template prong0_as<aod::TracksWMc>().template mcParticle_as<soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>>();
+    const auto& mcParticleProng0 = candidate.template prong0_as<aod::TracksWMc>().template mcParticle_as<McParticles3ProngMatched>();
     const auto pdgCodeProng0 = std::abs(mcParticleProng0.pdgCode());
     if ((candidate.isSelLcToPKPi() >= selectionFlagLc) && pdgCodeProng0 == kProton) {
       registry.fill(HIST("MC/reconstructed/") + HIST(SignalFolders[SignalType]) + HIST("/hMassRecSig") + HIST(SignalSuffixes[SignalType]), HfHelper::invMassLcToPKPi(candidate));
@@ -408,8 +406,8 @@ struct HfTaskLc {
 
   /// Fill MC histograms at reconstruction level
   /// \tparam FillMl switch to fill ML histograms
-  template <bool FillMl, typename CollType, typename CandLcMcRec, typename CandLcMcGen>
-  void fillHistosMcRec(CollType const& collision, CandLcMcRec const& candidates, CandLcMcGen const& mcParticles)
+  template <bool FillMl, typename CollType, typename CandLcMcRec>
+  void fillHistosMcRec(CollType const& collision, CandLcMcRec const& candidates, McParticles3ProngMatched const& mcParticles)
   {
     const auto thisCollId = collision.globalIndex();
     const auto& groupedLcCandidates = candidates.sliceBy(candLcPerCollision, thisCollId);
@@ -426,7 +424,7 @@ struct HfTaskLc {
 
       if (std::abs(candidate.flagMcMatchRec()) == hf_decay::hf_cand_3prong::DecayChannelMain::LcToPKPi) {
         // Get the corresponding MC particle.
-        const auto& mcParticleProng0 = candidate.template prong0_as<aod::TracksWMc>().template mcParticle_as<soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>>();
+        const auto& mcParticleProng0 = candidate.template prong0_as<aod::TracksWMc>().template mcParticle_as<McParticles3ProngMatched>();
         const auto pdgCodeProng0 = std::abs(mcParticleProng0.pdgCode());
         const auto indexMother = RecoDecay::getMother(mcParticles, mcParticleProng0, o2::constants::physics::Pdg::kLambdaCPlus, true);
         const auto particleMother = mcParticles.rawIteratorAt(indexMother);
@@ -511,8 +509,8 @@ struct HfTaskLc {
   /// Helper function for filling MC generated histograms for prompt, nonpromt and common (signal)
   /// \param particle is a generated particle
   /// \tparam SignalType is an enum defining which histogram in which folder (signal, prompt or nonpromt) to fill
-  template <int SignalType, typename ParticleType>
-  void fillHistogramsGen(ParticleType const& particle)
+  template <int SignalType>
+  void fillHistogramsGen(McParticles3ProngMatched::iterator const& particle)
   {
     registry.fill(HIST("MC/generated/") + HIST(SignalFolders[SignalType]) + HIST("/hPtGen") + HIST(SignalSuffixes[SignalType]), particle.pt());
     registry.fill(HIST("MC/generated/") + HIST(SignalFolders[SignalType]) + HIST("/hEtaGen") + HIST(SignalSuffixes[SignalType]), particle.eta());
@@ -524,8 +522,8 @@ struct HfTaskLc {
   }
 
   /// Fill MC histograms at generated level
-  template <typename CandLcMcGen, typename Coll>
-  void fillHistosMcGen(CandLcMcGen const& mcParticles, Coll const& recoCollisions)
+  template <typename Coll>
+  void fillHistosMcGen(McParticles3ProngMatched const& mcParticles, Coll const& recoCollisions)
   {
     // MC gen.
     for (const auto& particle : mcParticles) {
@@ -548,7 +546,7 @@ struct HfTaskLc {
           occ = o2::hf_occupancy::getOccupancyGenColl(recoCollsPerMcColl, occEstimator);
         }
 
-        const auto mcDaughter0 = particle.template daughters_as<soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>>().begin();
+        const auto mcDaughter0 = particle.template daughters_as<McParticles3ProngMatched>().begin();
 
         const float properDecayTime = evaluateMcGenDecayTime(mcDaughter0, particle);
 
@@ -712,10 +710,10 @@ struct HfTaskLc {
 
   /// Run the analysis on MC data
   /// \tparam FillMl switch to fill ML histograms
-  template <bool FillMl, typename CollType, typename CandType, typename CandLcMcGen>
+  template <bool FillMl, typename CollType, typename CandType>
   void runAnalysisPerCollisionMc(CollType const& collisions,
                                  CandType const& candidates,
-                                 CandLcMcGen const& mcParticles)
+                                 McParticles3ProngMatched const& mcParticles)
   {
     for (const auto& collision : collisions) {
       // MC Rec.

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -121,12 +121,6 @@ struct HfTaskLc {
   ConfigurableAxis thnConfigAxisProperDecayTime{"thnConfigAxisProperDecayTime", {200, 0, 2}, "Proper decay time, ps"};
   HistogramRegistry registry{"registry", {}};
 
-  // Factors for conversion between units
-  constexpr static float CtToProperDecayTimePs = 1.f / o2::constants::physics::LightSpeedCm2PS;
-  // Names of folders and suffixes for MC signal histograms
-  constexpr static std::string_view SignalFolders[] = {"signal", "prompt", "nonprompt"};
-  constexpr static std::string_view SignalSuffixes[] = {"", "Prompt", "NonPrompt"};
-
   enum MlClasses : int {
     MlClassBackground = 0,
     MlClassPrompt,
@@ -137,8 +131,15 @@ struct HfTaskLc {
   enum SignalClasses : int {
     Signal = 0,
     Prompt,
-    NonPrompt
+    NonPrompt,
+    NumberOfSignalClasses
   };
+
+  // Factor for conversion between units
+  constexpr static float CtToProperDecayTimePs = 1.f / o2::constants::physics::LightSpeedCm2PS;
+  // Names of folders and suffixes for MC signal histograms
+  constexpr static std::array<std::string_view, NumberOfSignalClasses> SignalFolders = {"signal", "prompt", "nonprompt"};
+  constexpr static std::array<std::string_view, NumberOfSignalClasses> SignalSuffixes = {"", "Prompt", "NonPrompt"};
 
   void init(InitContext&)
   {

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -339,6 +339,24 @@ struct HfTaskLc {
     return o2::hf_centrality::getCentralityColl<Coll>(collision);
   }
 
+  template <typename McDaughter, typename CandLcMcGen>
+  float evaluateMcGenDecayTime(const McDaughter& mcParticleProng0, const CandLcMcGen& motherParticle)
+  {
+    const auto mcCollision = motherParticle.template mcCollision_as<aod::McCollisions>();
+    const float pMother = motherParticle.p();
+    const float pvX = mcCollision.posX();
+    const float pvY = mcCollision.posY();
+    const float pvZ = mcCollision.posZ();
+    const float svX = mcParticleProng0.vx();
+    const float svY = mcParticleProng0.vy();
+    const float svZ = mcParticleProng0.vz();
+
+    const float decayLength = static_cast<float>(RecoDecay::distance(std::array<float, 3>{svX, svY, svZ}, std::array<float, 3>{pvX, pvY, pvZ}));
+    const float properDecayTime = decayLength * static_cast<float>(MassLambdaCPlus) / LightSpeedCm2PS / pMother;
+
+    return properDecayTime;
+  }
+
   /// Helper function for filling MC reconstructed histograms for prompt, nonpromt and common (signal)
   /// \param candidate is a reconstructed candidate
   /// \tparam SignalType is an enum defining which histogram in which folder (signal, prompt or nonpromt) to fill
@@ -425,17 +443,7 @@ struct HfTaskLc {
         const auto numPvContributors = collision.numContrib();
         const auto ptRecB = candidate.ptBhadMotherPart();
 
-        const auto mcCollision = particleMother.template mcCollision_as<aod::McCollisions>();
-        const auto p = particleMother.p();
-        const float pvX = mcCollision.posX();
-        const float pvY = mcCollision.posY();
-        const float pvZ = mcCollision.posZ();
-        const float svX = mcParticleProng0.vx();
-        const float svY = mcParticleProng0.vy();
-        const float svZ = mcParticleProng0.vz();
-
-        const float decayLengthGen = static_cast<float>(RecoDecay::distance(std::array<float, 3>{svX, svY, svZ}, std::array<float, 3>{pvX, pvY, pvZ}));
-        const float properDecayTimeGen = decayLengthGen * static_cast<float>(MassLambdaCPlus) / LightSpeedCm2PS / p;
+        const float properDecayTimeGen = evaluateMcGenDecayTime(mcParticleProng0, particleMother);
 
         /// MC reconstructed signal
         fillHistogramsRecSig<Signal>(candidate);
@@ -541,17 +549,8 @@ struct HfTaskLc {
         }
 
         const auto mcDaughter0 = particle.template daughters_as<soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>>().begin();
-        const auto mcCollision = particle.template mcCollision_as<aod::McCollisions>();
-        const auto p = particle.p();
-        const float pvX = mcCollision.posX();
-        const float pvY = mcCollision.posY();
-        const float pvZ = mcCollision.posZ();
-        const float svX = mcDaughter0.vx();
-        const float svY = mcDaughter0.vy();
-        const float svZ = mcDaughter0.vz();
 
-        const float decayLength = static_cast<float>(RecoDecay::distance(std::array<float, 3>{svX, svY, svZ}, std::array<float, 3>{pvX, pvY, pvZ}));
-        const float properDecayTime = decayLength * static_cast<float>(MassLambdaCPlus) / LightSpeedCm2PS / p;
+        const float properDecayTime = evaluateMcGenDecayTime(mcDaughter0, particle);
 
         fillHistogramsGen<Signal>(particle);
 

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -74,7 +74,7 @@ struct HfTaskLc {
   Configurable<bool> fillTHn{"fillTHn", false, "fill THn"};
   Configurable<bool> storeOccupancy{"storeOccupancy", true, "Flag to store occupancy information"};
   Configurable<int> occEstimator{"occEstimator", 2, "Occupancy estimation (None: 0, ITS: 1, FT0C: 2)"};
-  Configurable<bool> storeProperLifetime{"storeProperLifetime", false, "Flag to store proper lifetime"};
+  Configurable<bool> storeProperDecayTime{"storeProperDecayTime", false, "Flag to store proper decay time"};
   // CCDB configuration
   Configurable<std::string> ccdbUrl{"ccdbUrl", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::string> ccdbPathGrp{"ccdbPathGrp", "GLO/GRP/GRP", "Path of the grp file (Run 2)"};
@@ -117,11 +117,11 @@ struct HfTaskLc {
   ConfigurableAxis thnConfigAxisGenPtB{"thnConfigAxisGenPtB", {1000, 0, 100}, "Gen Pt B"};
   ConfigurableAxis thnConfigAxisNumPvContr{"thnConfigAxisNumPvContr", {200, -0.5, 199.5}, "Number of PV contributors"};
   ConfigurableAxis thnConfigAxisOccupancy{"thnConfigAxisOccupancy", {14, 0, 14000}, "axis for centrality"};
-  ConfigurableAxis thnConfigAxisProperLifetime{"thnConfigAxisProperLifetime", {200, 0, 2}, "Proper lifetime, ps"};
+  ConfigurableAxis thnConfigAxisProperDecayTime{"thnConfigAxisProperDecayTime", {200, 0, 2}, "Proper decay time, ps"};
   HistogramRegistry registry{"registry", {}};
 
   // Factors for conversion between units
-  constexpr static float CtToProperLifetimePs = 1.f / o2::constants::physics::LightSpeedCm2PS;
+  constexpr static float CtToProperDecayTimePs = 1.f / o2::constants::physics::LightSpeedCm2PS;
   constexpr static float NanoToPico = 1000.f;
   // Names of folders and suffixes for MC signal histograms
   constexpr static std::string_view SignalFolders[] = {"signal", "prompt", "nonprompt"};
@@ -186,8 +186,8 @@ struct HfTaskLc {
     addHistogramsRec("hDecLength", "decay length (cm)", "entries", {HistType::kTH1F, {{400, 0., 1.}}});
     /// decay length xy candidate
     addHistogramsRec("hDecLengthxy", "decay length xy (cm)", "entries", {HistType::kTH1F, {{400, 0., 1.}}});
-    /// proper lifetime
-    addHistogramsRec("hCt", "proper lifetime (#Lambda_{c}) * #it{c} (cm)", "entries", {HistType::kTH1F, {{100, 0., 0.2}}});
+    /// proper decay time
+    addHistogramsRec("hCt", "proper decay time (#Lambda_{c}) * #it{c} (cm)", "entries", {HistType::kTH1F, {{100, 0., 0.2}}});
     /// cosine of pointing angle
     addHistogramsRec("hCPA", "cosine of pointing angle", "entries", {HistType::kTH1F, {{110, -1.1, 1.1}}});
     /// cosine of pointing angle xy
@@ -219,8 +219,8 @@ struct HfTaskLc {
     /// decay length xy candidate
     addHistogramsRec("hDecLengthxyVsPt", "decay length xy (cm)", "#it{p}_{T} (GeV/#it{c})", {HistType::kTH2F, {{400, 0., 1.}, {vbins}}});
 
-    /// proper lifetime
-    addHistogramsRec("hCtVsPt", "proper lifetime (#Lambda_{c}) * #it{c} (cm)", "#it{p}_{T} (GeV/#it{c})", {HistType::kTH2F, {{100, 0., 0.2}, {vbins}}});
+    /// proper decay time
+    addHistogramsRec("hCtVsPt", "proper decay time (#Lambda_{c}) * #it{c} (cm)", "#it{p}_{T} (GeV/#it{c})", {HistType::kTH2F, {{100, 0., 0.2}, {vbins}}});
 
     /// cosine of pointing angle
     addHistogramsRec("hCPAVsPt", "cosine of pointing angle", "#it{p}_{T} (GeV/#it{c})", {HistType::kTH2F, {{110, -1.1, 1.1}, {vbins}}});
@@ -268,7 +268,7 @@ struct HfTaskLc {
       const AxisSpec thnAxisPtB{thnConfigAxisGenPtB, "#it{p}_{T}^{B} (GeV/#it{c})"};
       const AxisSpec thnAxisTracklets{thnConfigAxisNumPvContr, "Number of PV contributors"};
       const AxisSpec thnAxisOccupancy{thnConfigAxisOccupancy, "Occupancy"};
-      const AxisSpec thnAxisProperLifetime{thnConfigAxisProperLifetime, "T_{proper} (ps)"};
+      const AxisSpec thnAxisProperDecayTime{thnConfigAxisProperDecayTime, "#it{t}_{proper} (ps)"};
 
       bool const isDataWithMl = doprocessDataWithMl || doprocessDataWithMlWithFT0C || doprocessDataWithMlWithFT0M;
       bool const isMcWithMl = doprocessMcWithMl || doprocessMcWithMlWithFT0C || doprocessMcWithMlWithFT0M;
@@ -300,10 +300,10 @@ struct HfTaskLc {
           }
         }
       }
-      if (storeProperLifetime) {
+      if (storeProperDecayTime) {
         for (const auto& axes : std::array<std::vector<AxisSpec>*, 3>{&axesWithBdt, &axesStd, &axesGen}) {
           if (!axes->empty()) {
-            axes->push_back(thnAxisProperLifetime);
+            axes->push_back(thnAxisProperDecayTime);
           }
         }
       }
@@ -438,7 +438,7 @@ struct HfTaskLc {
             occ = o2::hf_occupancy::getOccupancyColl(collision, occEstimator);
           }
           double outputBkg(-1), outputPrompt(-1), outputFD(-1);
-          const float properLifetime = HfHelper::ctLc(candidate) * CtToProperLifetimePs;
+          const float properDecayTime = HfHelper::ctLc(candidate) * CtToProperDecayTimePs;
 
           auto fillTHnRecSig = [&](bool isPKPi) {
             const auto massLc = isPKPi ? HfHelper::invMassLcToPKPi(candidate) : HfHelper::invMassLcToPiKP(candidate);
@@ -461,8 +461,8 @@ struct HfTaskLc {
             if (storeOccupancy && occEstimator != o2::hf_occupancy::OccupancyEstimator::None) {
               valuesToFill.push_back(occ);
             }
-            if (storeProperLifetime) {
-              valuesToFill.push_back(properLifetime);
+            if (storeProperDecayTime) {
+              valuesToFill.push_back(properDecayTime);
             }
             if constexpr (FillMl) {
               registry.get<THnSparse>(HIST("hnLcVarsWithBdt"))->Fill(valuesToFill.data());
@@ -524,8 +524,8 @@ struct HfTaskLc {
 
         const auto& mcDaughter0 = particle.template daughters_as<soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>>().begin();
         const float p2m = particle.p() / o2::constants::physics::MassLambdaCPlus;
-        const float gamma = std::sqrt(1 + p2m * p2m);                       // mother's particle Lorentz factor
-        const float properLifetime = mcDaughter0.vt() * NanoToPico / gamma; // from ns to ps * from lab time to proper time
+        const float gamma = std::sqrt(1 + p2m * p2m);                        // mother's particle Lorentz factor
+        const float properDecayTime = mcDaughter0.vt() * NanoToPico / gamma; // from ns to ps * from lab time to proper time
 
         fillHistogramsGen<Signal>(particle);
 
@@ -537,8 +537,8 @@ struct HfTaskLc {
             if (storeOccupancy && occEstimator != o2::hf_occupancy::OccupancyEstimator::None) {
               valuesToFill.push_back(occ);
             }
-            if (storeProperLifetime) {
-              valuesToFill.push_back(properLifetime);
+            if (storeProperDecayTime) {
+              valuesToFill.push_back(properDecayTime);
             }
             registry.get<THnSparse>(HIST("hnLcVarsGen"))->Fill(valuesToFill.data());
           }
@@ -631,7 +631,7 @@ struct HfTaskLc {
           occ = o2::hf_occupancy::getOccupancyColl(collision, occEstimator);
         }
         double outputBkg(-1), outputPrompt(-1), outputFD(-1);
-        const float properLifetime = HfHelper::ctLc(candidate) * CtToProperLifetimePs;
+        const float properDecayTime = HfHelper::ctLc(candidate) * CtToProperDecayTimePs;
 
         auto fillTHnData = [&](bool isPKPi) {
           const auto massLc = isPKPi ? HfHelper::invMassLcToPKPi(candidate) : HfHelper::invMassLcToPiKP(candidate);
@@ -654,8 +654,8 @@ struct HfTaskLc {
           if (storeOccupancy && occEstimator != o2::hf_occupancy::OccupancyEstimator::None) {
             valuesToFill.push_back(occ);
           }
-          if (storeProperLifetime) {
-            valuesToFill.push_back(properLifetime);
+          if (storeProperDecayTime) {
+            valuesToFill.push_back(properDecayTime);
           }
           if constexpr (FillMl) {
             registry.get<THnSparse>(HIST("hnLcVarsWithBdt"))->Fill(valuesToFill.data());

--- a/PWGHF/D2H/Tasks/taskLc.cxx
+++ b/PWGHF/D2H/Tasks/taskLc.cxx
@@ -63,6 +63,7 @@ using namespace o2::framework::expressions;
 using namespace o2::hf_centrality;
 using namespace o2::hf_occupancy;
 using namespace o2::hf_evsel;
+using namespace o2::constants::physics;
 
 /// Λc± → p± K∓ π± analysis task
 struct HfTaskLc {
@@ -522,10 +523,18 @@ struct HfTaskLc {
           occ = o2::hf_occupancy::getOccupancyGenColl(recoCollsPerMcColl, occEstimator);
         }
 
-        const auto& mcDaughter0 = particle.template daughters_as<soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>>().begin();
-        const float p2m = particle.p() / o2::constants::physics::MassLambdaCPlus;
-        const float gamma = std::sqrt(1 + p2m * p2m);                        // mother's particle Lorentz factor
-        const float properDecayTime = mcDaughter0.vt() * NanoToPico / gamma; // from ns to ps * from lab time to proper time
+        const auto mcDaughter0 = particle.template daughters_as<soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>>().begin();
+        const auto mcCollision = particle.template mcCollision_as<aod::McCollisions>();
+        const auto p = particle.p();
+        const float pvX = mcCollision.posX();
+        const float pvY = mcCollision.posY();
+        const float pvZ = mcCollision.posZ();
+        const float svX = mcDaughter0.vx();
+        const float svY = mcDaughter0.vy();
+        const float svZ = mcDaughter0.vz();
+
+        const float decayLength = static_cast<float>(RecoDecay::distance(std::array<float, 3>{svX, svY, svZ}, std::array<float, 3>{pvX, pvY, pvZ}));
+        const float properDecayTime = decayLength * static_cast<float>(MassLambdaCPlus) / LightSpeedCm2PS / p;
 
         fillHistogramsGen<Signal>(particle);
 

--- a/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
@@ -144,8 +144,8 @@ DECLARE_SOA_COLUMN(Chi2Topo, chi2Topo, float);                           //! chi
 DECLARE_SOA_COLUMN(DecayLength, decayLength, float);                     //! decay length, cm
 DECLARE_SOA_COLUMN(DecayLengthError, decayLengthError, float);           //! decay length error
 DECLARE_SOA_COLUMN(DecayLengthNormalised, decayLengthNormalised, float); //! decay length over its error
-DECLARE_SOA_COLUMN(T, t, float);                                         //! proper lifetime, ps
-DECLARE_SOA_COLUMN(ErrT, errT, float);                                   //! lifetime error
+DECLARE_SOA_COLUMN(T, t, float);                                         //! proper decay time, ps
+DECLARE_SOA_COLUMN(ErrT, errT, float);                                   //! decay time error
 DECLARE_SOA_COLUMN(MassInv, massInv, float);                             //! invariant mass
 DECLARE_SOA_COLUMN(P, p, float);                                         //! momentum
 DECLARE_SOA_COLUMN(Pt, pt, float);                                       //! transverse momentum
@@ -183,7 +183,7 @@ DECLARE_SOA_COLUMN(XDecay, xDecay, float); //! Secondary (decay) vertex X coordi
 DECLARE_SOA_COLUMN(YDecay, yDecay, float); //! Secondary (decay) vertex Y coordinate, cm
 DECLARE_SOA_COLUMN(ZDecay, zDecay, float); //! Secondary (decay) vertex Z coordinate, cm
 DECLARE_SOA_COLUMN(LDecay, lDecay, float); //! Decay length, cm (distance between PV and SV, curvature is neglected)
-DECLARE_SOA_COLUMN(TDecay, tDecay, float); //! Proper lifetime, ps
+DECLARE_SOA_COLUMN(TDecay, tDecay, float); //! Proper decay time, ps
 DECLARE_SOA_COLUMN(XEvent, xEvent, float); //! Primary (event) vertex X coordinate, cm
 DECLARE_SOA_COLUMN(YEvent, yEvent, float); //! Primary (event) vertex Y coordinate, cm
 DECLARE_SOA_COLUMN(ZEvent, zEvent, float); //! Primary (event) vertex Z coordinate, cm
@@ -911,7 +911,7 @@ struct HfTreeCreatorLcToPKPi {
     const float deltaP = std::sqrt(pt * pt * deltaPt * deltaPt +
                                    candidate.kfPz() * candidate.kfPz() * candidate.kfErrorPz() * candidate.kfErrorPz()) /
                          p;
-    const float lifetime = decayLength * static_cast<float>(MassLambdaCPlus) / LightSpeedCm2PS / p;
+    const float decayTime = decayLength * static_cast<float>(MassLambdaCPlus) / LightSpeedCm2PS / p;
     const float deltaT = dl * static_cast<float>(MassLambdaCPlus) / LightSpeedCm2PS / p;
     rowCandidateKF(
       svX, svY, svZ, svErrX, svErrY, svErrZ,
@@ -919,7 +919,7 @@ struct HfTreeCreatorLcToPKPi {
       chi2primProton, chi2primKaon, chi2primPion,
       dcaProtonKaon, dcaProtonPion, dcaPionKaon,
       chi2GeoProtonKaon, chi2GeoProtonPion, chi2GeoPionKaon,
-      chi2Geo, chi2Topo, decayLength, dl, decayLength / dl, lifetime, deltaT,
+      chi2Geo, chi2Topo, decayLength, dl, decayLength / dl, decayTime, deltaT,
       mass, p, pt, deltaP, deltaPt,
       functionSelection, sigbgstatus,
       collision.multNTracksPV(),
@@ -983,7 +983,7 @@ struct HfTreeCreatorLcToPKPi {
             fillKFTable(candidate, collision, candFlag, functionSelection, sigbgstatus);
           }
           if (fillCandidateMcTable) {
-            float p{}, pt{}, svX{}, svY{}, svZ{}, pvX{}, pvY{}, pvZ{}, decayLength{}, lifetime{};
+            float p{}, pt{}, svX{}, svY{}, svZ{}, pvX{}, pvY{}, pvZ{}, decayLength{}, decayTime{};
             if (!isMcCandidateSignal) {
               p = UndefValueFloat;
               pt = UndefValueFloat;
@@ -994,7 +994,7 @@ struct HfTreeCreatorLcToPKPi {
               pvY = UndefValueFloat;
               pvZ = UndefValueFloat;
               decayLength = UndefValueFloat;
-              lifetime = UndefValueFloat;
+              decayTime = UndefValueFloat;
             } else {
               const auto mcParticleProng0 = candidate.template prong0_as<soa::Join<TracksWPid, o2::aod::McTrackLabels>>().template mcParticle_as<soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>>();
               const auto indexMother = RecoDecay::getMother(particles, mcParticleProng0, o2::constants::physics::Pdg::kLambdaCPlus, true);
@@ -1011,11 +1011,11 @@ struct HfTreeCreatorLcToPKPi {
               svY = mcParticleProng0.vy();
               svZ = mcParticleProng0.vz();
               decayLength = static_cast<float>(RecoDecay::distance(std::array<float, 3>{svX, svY, svZ}, std::array<float, 3>{pvX, pvY, pvZ}));
-              lifetime = mcParticleProng0.vt() * NanoToPico / gamma; // from ns to ps * from lab time to proper time
+              decayTime = mcParticleProng0.vt() * NanoToPico / gamma; // from ns to ps * from lab time to proper time
             }
             rowCandidateMC(
               p, pt,
-              svX, svY, svZ, decayLength, lifetime,
+              svX, svY, svZ, decayLength, decayTime,
               pvX, pvY, pvZ);
           }
         }

--- a/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
@@ -419,9 +419,9 @@ struct HfTreeCreatorLcToPKPi {
   // number showing MC status of the candidate (signal or background, prompt or non-prompt etc.)
   enum SigBgStatus : int {
     Background = 0, // combinatorial background, at least one of the prongs do not originate from the Lc decay
-    Prompt,         // signal with Lc produced directly in the event
-    NonPrompt,      // signal with Lc produced aftewards the event, e.g. during decay of beauty particle
-    WrongOrder,     // all the prongs are from Lc decay, but proton and pion hypothesis are swapped
+    Prompt = 1,     // signal with Lc produced directly in the event
+    NonPrompt = 2,  // signal with Lc produced aftewards the event, e.g. during decay of beauty particle
+    WrongOrder = 3, // all the prongs are from Lc decay, but proton and pion hypothesis are swapped
     Default = -1    // impossible, should not be the case, to catch logical error if any
   };
 
@@ -952,7 +952,7 @@ struct HfTreeCreatorLcToPKPi {
 
     fillEventProperties<UseCentrality, IsMc>(collisions);
 
-    const int64_t candidatesSize = static_cast<int64_t>(candidates.size());
+    const auto candidatesSize = static_cast<int64_t>(candidates.size());
     reserveTables<ReconstructionType>(candidatesSize, IsMc);
 
     int iCand{0};

--- a/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
@@ -1035,8 +1035,8 @@ struct HfTreeCreatorLcToPKPi {
         const float svX = mcDaughter0.vx();
         const float svY = mcDaughter0.vy();
         const float svZ = mcDaughter0.vz();
-        const float l = static_cast<float>(RecoDecay::distance(std::array<float, 3>{svX, svY, svZ}, std::array<float, 3>{pvX, pvY, pvZ}));
-        const float t = l * static_cast<float>(MassLambdaCPlus) / LightSpeedCm2PS / p;
+        const float decayLength = static_cast<float>(RecoDecay::distance(std::array<float, 3>{svX, svY, svZ}, std::array<float, 3>{pvX, pvY, pvZ}));
+        const float decayTime = decayLength * static_cast<float>(MassLambdaCPlus) / LightSpeedCm2PS / p;
         rowCandidateFullParticles(
           particle.pt(),
           particle.eta(),
@@ -1045,7 +1045,7 @@ struct HfTreeCreatorLcToPKPi {
           particle.flagMcMatchGen(),
           particle.originMcGen(),
           p,
-          svX, svY, svZ, l, t,
+          svX, svY, svZ, decayLength, decayTime,
           pvX, pvY, pvZ);
       }
     }

--- a/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
+++ b/PWGHF/TableProducer/treeCreatorLcToPKPi.cxx
@@ -412,7 +412,6 @@ struct HfTreeCreatorLcToPKPi {
 
   constexpr static float UndefValueFloat = -999.f;
   constexpr static int UndefValueInt = -999;
-  constexpr static float NanoToPico = 1000.f;
 
   using TracksWPid = soa::Join<aod::Tracks, aod::TracksPidPi, aod::PidTpcTofFullPi, aod::TracksPidKa, aod::PidTpcTofFullKa, aod::TracksPidPr, aod::PidTpcTofFullPr>;
   using Cents = soa::Join<aod::CentFV0As, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::CentFDDMs>;
@@ -1002,8 +1001,6 @@ struct HfTreeCreatorLcToPKPi {
               const auto mcCollision = particleMother.template mcCollision_as<aod::McCollisions>();
               p = particleMother.p();
               pt = particleMother.pt();
-              const float p2m = p / static_cast<float>(MassLambdaCPlus);
-              const float gamma = std::sqrt(1 + p2m * p2m); // mother's particle Lorentz factor
               pvX = mcCollision.posX();
               pvY = mcCollision.posY();
               pvZ = mcCollision.posZ();
@@ -1011,7 +1008,7 @@ struct HfTreeCreatorLcToPKPi {
               svY = mcParticleProng0.vy();
               svZ = mcParticleProng0.vz();
               decayLength = static_cast<float>(RecoDecay::distance(std::array<float, 3>{svX, svY, svZ}, std::array<float, 3>{pvX, pvY, pvZ}));
-              decayTime = mcParticleProng0.vt() * NanoToPico / gamma; // from ns to ps * from lab time to proper time
+              decayTime = decayLength * static_cast<float>(MassLambdaCPlus) / LightSpeedCm2PS / p;
             }
             rowCandidateMC(
               p, pt,
@@ -1032,8 +1029,6 @@ struct HfTreeCreatorLcToPKPi {
         const auto mcDaughter0 = particle.template daughters_as<soa::Join<aod::McParticles, aod::HfCand3ProngMcGen>>().begin();
         const auto mcCollision = particle.template mcCollision_as<aod::McCollisions>();
         const auto p = particle.p();
-        const float p2m = p / static_cast<float>(MassLambdaCPlus);
-        const float gamma = std::sqrt(1 + p2m * p2m); // mother's particle Lorentz factor
         const float pvX = mcCollision.posX();
         const float pvY = mcCollision.posY();
         const float pvZ = mcCollision.posZ();
@@ -1041,7 +1036,7 @@ struct HfTreeCreatorLcToPKPi {
         const float svY = mcDaughter0.vy();
         const float svZ = mcDaughter0.vz();
         const float l = static_cast<float>(RecoDecay::distance(std::array<float, 3>{svX, svY, svZ}, std::array<float, 3>{pvX, pvY, pvZ}));
-        const float t = mcDaughter0.vt() * NanoToPico / gamma; // from ns to ps * from lab time to proper time
+        const float t = l * static_cast<float>(MassLambdaCPlus) / LightSpeedCm2PS / p;
         rowCandidateFullParticles(
           particle.pt(),
           particle.eta(),


### PR DESCRIPTION
**1. Fix definition of MC-gen decay time**
In the current version of code the decay time of MC generated $\Lambda_{\mathrm{c}}^+$ particle is defined as $t^{\mathrm{gen}} = t / \gamma$, where $t$ is the lab-frame production time of one of the daughters, and $\gamma$ is the Lorentz factor of $\Lambda_{\mathrm{c}}^+$.
This PR proposes to define the decay time of MC generated $\Lambda_{\mathrm{c}}^+$ particle as $t^{\mathrm{kin}} = \frac{Lm}{pc}$, where $L$ and $p$ are MC-defined decay length and momentum of the mother particle.
For prompt $\Lambda_{\mathrm{c}}^+$ there should be no difference between these two definitions. The existing difference (left panels of the attached picture) are probably related to numeric artifacts and/or neglecting the curvature of $\Lambda_{\mathrm{c}}^+$ trajectory (?)
For nonprompt $\Lambda_{\mathrm{c}}^+$ the difference is more pronounced (right panels of the picture). The motivation to use the $t^{\mathrm{kin}}$ definition is that we are interested not in real proper decay time of nonprompt particle, but in its proxy, the quantity which we would obtain in data-driven way, _if this particle was prompt_ (since for reconstructed decay candidates both in MC and data we use exactly this definition).
<img width="2364" height="1218" alt="out" src="https://github.com/user-attachments/assets/8fb462f0-3c9b-4e83-8b07-d3fb67426508" />
**2.** The THnSparse with reconstructed MC candidates is extended with yet another axis, containing decay time of matched generated particle (for obtaining the response matrix in order to enable unfolding / forward-folding).
**3.** The name `lifetime` in code variables is replaced with `decay time`, since the former is the property of particle species (PDG constant), while the latter is the property of particular particle instance.
**4. Code cleaning**
-- unneeded template typename replaced with explicit specification of parameter's type;
-- some variables are named less cryptic;
-- fixed clang-tidy errors.