### PR TITLE
[Infrastructure,Common] Fix precompiled header creation

### DIFF
--- a/Common/Core/CMakeLists.txt
+++ b/Common/Core/CMakeLists.txt
@@ -30,8 +30,12 @@ o2physics_add_library(AnalysisCore
 # Skipped under recc, which caches compilations remotely instead -- the two do
 # not combine, as a PCH is a local artefact of one compiler invocation.
 #
-# The link libraries have to match what the reusing targets compile with, so
-# this carries only what every workflow already links.
+# The reusing targets must compile with the same preprocessor state as this
+# carrier, which does not follow from the link list: AnalysisCore reaches
+# O2::rANS and its INTERFACE -DRANS_ENABLE_JSON, whereas a bare workflow links
+# only O2::Framework. o2physics_add_dpl_workflow therefore copies this target's
+# compile definitions onto every consumer; keep that in mind when changing what
+# is linked here.
 add_library(AnalysisPCH OBJECT analysisPCH.cxx)
 target_link_libraries(AnalysisPCH PUBLIC O2::Framework O2Physics::AnalysisCore)
 if(NOT DEFINED ENV{USE_RECC})

--- a/cmake/O2PhysicsAddWorkflow.cmake
+++ b/cmake/O2PhysicsAddWorkflow.cmake
@@ -64,6 +64,16 @@ function(o2physics_add_dpl_workflow baseTargetName)
   # A target cannot reuse its own PCH, and the carrier is not built when recc
   # is caching compilations remotely instead.
   if(_pch AND NOT _pch STREQUAL targetExeName AND NOT DEFINED ENV{USE_RECC})
+    # GCC refuses a PCH built with a different preprocessor state than the
+    # consumer's, and -Werror turns that refusal into a build failure:
+    #   cmake_pch.hxx.gch: not used because `RANS_ENABLE_JSON' not defined
+    # The carrier links O2Physics::AnalysisCore, which reaches O2::rANS and its
+    # INTERFACE -DRANS_ENABLE_JSON, while a workflow that links only
+    # O2::Framework (the converters, the tutorials) never sees it. Hand every
+    # consumer the carrier's definitions so the two agree. Definitions only --
+    # this must not add link dependencies to targets that do not want them.
+    target_compile_definitions(${targetExeName} PRIVATE
+                               $<TARGET_PROPERTY:${_pch},COMPILE_DEFINITIONS>)
     target_precompile_headers(${targetExeName} REUSE_FROM ${_pch})
   endif()
 


### PR DESCRIPTION

Needs to propagate defines to the precompiled header.

Why it now depends on rANS, yet to be understood.
