### PR TITLE
[Common] Add centrality estimator using FT0C and the outer channels from FT0A

### DIFF
--- a/Common/DataModel/Centrality.h
+++ b/Common/DataModel/Centrality.h
@@ -38,7 +38,7 @@ DECLARE_SOA_COLUMN(CentFDDM, centFDDM, float);                   //! Run 3 cent.
 DECLARE_SOA_COLUMN(CentNTPV, centNTPV, float);                   //! Run 3 cent. from the number of tracks contributing to the PV
 DECLARE_SOA_COLUMN(CentNGlobal, centNGlobal, float);             //! Run 3 cent. from the number of global tracks
 DECLARE_SOA_COLUMN(CentMFT, centMFT, float);                     //! Run 3 cent. from the number of tracks in the MFT
-DECLARE_SOA_COLUMN(CentFT0MVariant3, centFT0MVariant3, float); //! Run 3 cent. from FT0AOuter+FT0C multiplicity
+DECLARE_SOA_COLUMN(CentFT0MOuterA, centFT0MOuterA, float);       //! Run 3 cent. from FT0AOuter+FT0C multiplicity
 } // namespace cent
 
 // Run 2 tables
@@ -66,7 +66,7 @@ DECLARE_SOA_TABLE(CentFT0CVariant1s, "AOD", "CENTFT0Cvar1", cent::CentFT0CVarian
 DECLARE_SOA_TABLE(CentFT0CVariant2s, "AOD", "CENTFT0Cvar2", cent::CentFT0CVariant2);  //! Run 3 FT0C variant 2 - uses truncated Nancestors in glauber fit. Not recommended! for cross-checks only
 DECLARE_SOA_TABLE(CentFT0MAnchorCols, "AOD", "CENTFT0MCOL", cent::CentFT0MAnchorCol); //! Run 3 FT0M with anchored Glauber. Colliison based calibration. Not recommended! for cross-checks only
 DECLARE_SOA_TABLE(CentFT0MAnchorBCs, "AOD", "CENTFT0MBC", cent::CentFT0MAnchorBC);    //! Run 3 FT0M with anchored Glauber. Bunch crossing based calibration. Not recommended! for cross-checks only
-DECLARE_SOA_TABLE(CentFT0MVariant3s, "AOD", "CENTFT0Mvar3", cent::CentFT0MVariant3); //! Run 3 FT0M variant 3 - excludes FT0A channels that saturates in PbPb (channel id < 31)
+DECLARE_SOA_TABLE(CentFT0MOuterAs, "AOD", "CENTFT0Mvar3", cent::CentFT0MOuterA); //! Run 3 FT0M variant 3 - excludes FT0A channels that saturates in PbPb (channel id < 31)
 
 // Run 3 centrality per BC (joinable with BC)
 DECLARE_SOA_TABLE(BCCentFT0Ms, "AOD", "BCCENTFT0M", cent::CentFT0M, o2::soa::Marker<1>); //! Run 3 FT0M BC centrality table
@@ -92,7 +92,7 @@ using CentMFT = CentMFTs::iterator;
 
 using CentFT0CVariant1 = CentFT0CVariant1s::iterator;
 using CentFT0CVariant2 = CentFT0CVariant2s::iterator;
-using CentFT0MVariant3 = CentFT0MVariant3s::iterator;
+using CentFT0MOuterA = CentFT0MOuterAs::iterator;
 
 using BCCentFT0M = BCCentFT0Ms::iterator;
 using BCCentFT0A = BCCentFT0As::iterator;

--- a/Common/DataModel/Centrality.h
+++ b/Common/DataModel/Centrality.h
@@ -66,7 +66,7 @@ DECLARE_SOA_TABLE(CentFT0CVariant1s, "AOD", "CENTFT0Cvar1", cent::CentFT0CVarian
 DECLARE_SOA_TABLE(CentFT0CVariant2s, "AOD", "CENTFT0Cvar2", cent::CentFT0CVariant2);  //! Run 3 FT0C variant 2 - uses truncated Nancestors in glauber fit. Not recommended! for cross-checks only
 DECLARE_SOA_TABLE(CentFT0MAnchorCols, "AOD", "CENTFT0MCOL", cent::CentFT0MAnchorCol); //! Run 3 FT0M with anchored Glauber. Colliison based calibration. Not recommended! for cross-checks only
 DECLARE_SOA_TABLE(CentFT0MAnchorBCs, "AOD", "CENTFT0MBC", cent::CentFT0MAnchorBC);    //! Run 3 FT0M with anchored Glauber. Bunch crossing based calibration. Not recommended! for cross-checks only
-DECLARE_SOA_TABLE(CentFT0MOuterAs, "AOD", "CENTFT0Mvar3", cent::CentFT0MOuterA); //! Run 3 FT0M variant 3 - excludes FT0A channels that saturates in PbPb (channel id < 31)
+DECLARE_SOA_TABLE(CentFT0MOuterAs, "AOD", "CENTFT0Mvar3", cent::CentFT0MOuterA);      //! Run 3 FT0MOuterA - excludes FT0A channels that saturates in PbPb (channel id < 31)
 
 // Run 3 centrality per BC (joinable with BC)
 DECLARE_SOA_TABLE(BCCentFT0Ms, "AOD", "BCCENTFT0M", cent::CentFT0M, o2::soa::Marker<1>); //! Run 3 FT0M BC centrality table

--- a/Common/DataModel/Centrality.h
+++ b/Common/DataModel/Centrality.h
@@ -38,6 +38,7 @@ DECLARE_SOA_COLUMN(CentFDDM, centFDDM, float);                   //! Run 3 cent.
 DECLARE_SOA_COLUMN(CentNTPV, centNTPV, float);                   //! Run 3 cent. from the number of tracks contributing to the PV
 DECLARE_SOA_COLUMN(CentNGlobal, centNGlobal, float);             //! Run 3 cent. from the number of global tracks
 DECLARE_SOA_COLUMN(CentMFT, centMFT, float);                     //! Run 3 cent. from the number of tracks in the MFT
+DECLARE_SOA_COLUMN(CentFT0MVariant3, centFT0MVariant3, float); //! Run 3 cent. from FT0AOuter+FT0C multiplicity
 } // namespace cent
 
 // Run 2 tables
@@ -65,6 +66,7 @@ DECLARE_SOA_TABLE(CentFT0CVariant1s, "AOD", "CENTFT0Cvar1", cent::CentFT0CVarian
 DECLARE_SOA_TABLE(CentFT0CVariant2s, "AOD", "CENTFT0Cvar2", cent::CentFT0CVariant2);  //! Run 3 FT0C variant 2 - uses truncated Nancestors in glauber fit. Not recommended! for cross-checks only
 DECLARE_SOA_TABLE(CentFT0MAnchorCols, "AOD", "CENTFT0MCOL", cent::CentFT0MAnchorCol); //! Run 3 FT0M with anchored Glauber. Colliison based calibration. Not recommended! for cross-checks only
 DECLARE_SOA_TABLE(CentFT0MAnchorBCs, "AOD", "CENTFT0MBC", cent::CentFT0MAnchorBC);    //! Run 3 FT0M with anchored Glauber. Bunch crossing based calibration. Not recommended! for cross-checks only
+DECLARE_SOA_TABLE(CentFT0MVariant3s, "AOD", "CENTFT0Mvar3", cent::CentFT0MVariant3); //! Run 3 FT0M variant 3 - excludes FT0A channels that saturates in PbPb (channel id < 31)
 
 // Run 3 centrality per BC (joinable with BC)
 DECLARE_SOA_TABLE(BCCentFT0Ms, "AOD", "BCCENTFT0M", cent::CentFT0M, o2::soa::Marker<1>); //! Run 3 FT0M BC centrality table
@@ -87,6 +89,10 @@ using CentFDDM = CentFDDMs::iterator;
 using CentNTPV = CentNTPVs::iterator;
 using CentNGlobal = CentNGlobals::iterator;
 using CentMFT = CentMFTs::iterator;
+
+using CentFT0CVariant1 = CentFT0CVariant1s::iterator;
+using CentFT0CVariant2 = CentFT0CVariant2s::iterator;
+using CentFT0MVariant3 = CentFT0MVariant3s::iterator;
 
 using BCCentFT0M = BCCentFT0Ms::iterator;
 using BCCentFT0A = BCCentFT0As::iterator;

--- a/Common/DataModel/Multiplicity.h
+++ b/Common/DataModel/Multiplicity.h
@@ -143,6 +143,7 @@ DECLARE_SOA_TABLE(MFTMults, "AOD", "MFTMULT", //! Multiplicity with MFT
 
 DECLARE_SOA_TABLE(FITExtraMults, "AOD", "FITEXTRAMULT", //! Extra information from FIT detectors
                   mult::MultFV0AOuter,
+                  mult::MultFT0AOuter,
                   mult::FT0TriggerMask);
 
 using BarrelMults = soa::Join<TrackletMults, TPCMults, PVMults>;

--- a/Common/Tasks/centralityQa.cxx
+++ b/Common/Tasks/centralityQa.cxx
@@ -306,9 +306,9 @@ struct CentralityQa {
 
       est.hCentrality = dynamic_cast<TH1*>(hCentralityObjects->FindObject(Form("hCalibZeq%s", est.name.c_str())));
       if (!est.hCentrality) {
-        LOGF(info, "Calibration missing for %s", est.name.c_str());
+        LOGF(debug, "Calibration missing for %s", est.name.c_str());
       } else {
-        LOGF(info, "Calibration loaded for %s", est.name.c_str());
+        LOGF(debug, "Calibration loaded for %s", est.name.c_str());
       }
     }
 
@@ -326,7 +326,7 @@ struct CentralityQa {
       requires { collision.centFT0C(); } ||
       requires { collision.centFT0CVariant1(); } ||
       requires { collision.centFT0CVariant2(); } ||
-      requires { collision.centFT0MVariant3(); } ||
+      requires { collision.centFT0MOuterA(); } ||
       requires { collision.centFDDM(); } ||
       requires { collision.centNTPV(); } ||
       requires { collision.centNGlobal(); } ||
@@ -688,15 +688,19 @@ struct CentralityQa {
   }
   PROCESS_SWITCH(CentralityQa, processRun3_FT0M, "Process with Run 3 FT0M estimator", false);
 
-  void processRun3_FT0MOuterA(soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0MOuterAs>::iterator const& col)
+  void processRun3_FT0MOuterA(soa::Join<aod::Collisions, aod::EvSels, aod::MultsRun3, aod::FITExtraMults, aod::CentFT0MOuterAs>::iterator const& col, aod::BCs const&)
   {
     if (!isCollisionAccepted(col)) {
       return;
     }
-    LOGF(debug, "centFT0MOuterA=%.0f", col.centFT0MOuterA());
-    histos.fill(HIST("hCentFT0MOuterA"), col.centFT0MOuterA());
-    histos.fill(HIST("hCentProfileFT0MOuterA"), col.centFT0MOuterA(), col.multNTracksPVetaHalf());
-    histos.fill(HIST("hMultEta05VsCentFT0MOuterA"), col.centFT0MOuterA(), col.multNTracksPVetaHalf());
+
+    Estimator ft0mOuterA = initEstimator(col, "FT0MOuterA");
+    const float centFT0MOuterA = ft0mOuterA.getCentrality(col.multFT0AOuter() + col.multFT0C(), col.centFT0MOuterA());
+
+    LOGF(debug, "centFT0MOuterA=%.0f", centFT0MOuterA);
+    histos.fill(HIST("hCentFT0MOuterA"), centFT0MOuterA);
+    histos.fill(HIST("hCentProfileFT0MOuterA"), centFT0MOuterA, col.multNTracksPVetaHalf());
+    histos.fill(HIST("hMultEta05VsCentFT0MOuterA"), centFT0MOuterA, col.multNTracksPVetaHalf());
   }
   PROCESS_SWITCH(CentralityQa, processRun3_FT0MOuterA, "Process with Run 3 FT0M estimator", false);
 

--- a/Common/Tasks/centralityQa.cxx
+++ b/Common/Tasks/centralityQa.cxx
@@ -206,6 +206,7 @@ struct CentralityQa {
     } else {
       histos.add("hCentFV0A", ";FV0A centrality (%)", kTH1D, {{nBins, 0, 105.}});
       histos.add("hCentFT0M", ";FT0M centrality (%)", kTH1D, {{nBins, 0, 105.}});
+      histos.add("hCentFT0MVar3", ";FT0M centrality (%)", kTH1D, {{nBins, 0, 105.}});
       histos.add("hCentFT0A", ";FT0A centrality (%)", kTH1D, {{nBins, 0, 105.}});
       histos.add("hCentFT0C", ";FT0C centrality (%)", kTH1D, {{nBins, 0, 105.}});
       histos.add("hCentFT0CVar1", ";FT0CVar1 centrality (%)", kTH1D, {{nBins, 0, 105.}});
@@ -220,6 +221,7 @@ struct CentralityQa {
       // profiles of midrapidity multiplicity density
       histos.add("hCentProfileFV0A", ";FV0A centrality (%)", kTProfile, {{nBins, 0, 105.}});
       histos.add("hCentProfileFT0M", ";FT0M centrality (%)", kTProfile, {{nBins, 0, 105.}});
+      histos.add("hCentProfileFT0MVar3", ";FT0M centrality (%)", kTProfile, {{nBins, 0, 105.}});
       histos.add("hCentProfileFT0A", ";FT0A centrality (%)", kTProfile, {{nBins, 0, 105.}});
       histos.add("hCentProfileFT0C", ";FT0C centrality (%)", kTProfile, {{nBins, 0, 105.}});
       histos.add("hCentProfileFT0CVar1", ";FT0CVar1 centrality (%)", kTProfile, {{nBins, 0, 105.}});
@@ -233,6 +235,7 @@ struct CentralityQa {
 
       histos.add("hMultEta05VsCentFV0A", ";FV0A centrality (%); Multiplicity PV contributors (|#it{#eta}| < 0.5)", kTH2D, {{nBins, 0, 105.}, axisMultiplicityPV});
       histos.add("hMultEta05VsCentFT0M", ";FT0M centrality (%); Multiplicity PV contributors (|#it{#eta}| < 0.5)", kTH2D, {{nBins, 0, 105.}, axisMultiplicityPV});
+      histos.add("hMultEta05VsCentFT0MVar3", ";FT0M centrality (%); Multiplicity PV contributors (|#it{#eta}| < 0.5)", kTH2D, {{nBins, 0, 105.}, axisMultiplicityPV});
       histos.add("hMultEta05VsCentFT0A", ";FT0A centrality (%); Multiplicity PV contributors (|#it{#eta}| < 0.5)", kTH2D, {{nBins, 0, 105.}, axisMultiplicityPV});
       histos.add("hMultEta05VsCentFT0C", ";FT0C centrality (%); Multiplicity PV contributors (|#it{#eta}| < 0.5)", kTH2D, {{nBins, 0, 105.}, axisMultiplicityPV});
       histos.add("hMultEta05VsCentFT0CVar1", ";FT0CVar1 centrality (%); Multiplicity PV contributors (|#it{#eta}| < 0.5)", kTH2D, {{nBins, 0, 105.}, axisMultiplicityPV});
@@ -323,6 +326,7 @@ struct CentralityQa {
       requires { collision.centFT0C(); } ||
       requires { collision.centFT0CVariant1(); } ||
       requires { collision.centFT0CVariant2(); } ||
+      requires { collision.centFT0MVariant3(); } ||
       requires { collision.centFDDM(); } ||
       requires { collision.centNTPV(); } ||
       requires { collision.centNGlobal(); } ||
@@ -684,7 +688,19 @@ struct CentralityQa {
   }
   PROCESS_SWITCH(CentralityQa, processRun3_FT0M, "Process with Run 3 FT0M estimator", false);
 
-  void processRun3_FT0A(soa::Join<aod::Collisions, aod::EvSels, aod::MultsRun3, aod::CentFT0As>::iterator const& col, aod::BCs const&)
+  void processRun3_FT0Mvar3(soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0MVariant3s>::iterator const& col)
+  {
+    if (!isCollisionAccepted(col)) {
+      return;
+    }
+    LOGF(debug, "centFT0MVar3=%.0f", col.centFT0MVariant3());
+    histos.fill(HIST("hCentFT0MVar3"), col.centFT0MVariant3());
+    histos.fill(HIST("hCentProfileFT0MVar3"), col.centFT0MVariant3(), col.multNTracksPVetaHalf());
+    histos.fill(HIST("hMultEta05VsCentFT0MVar3"), col.centFT0MVariant3(), col.multNTracksPVetaHalf());
+  }
+  PROCESS_SWITCH(CentralityQa, processRun3_FT0Mvar3, "Process with Run 3 FT0M estimator", false);
+
+  void processRun3_FT0A(soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0As>::iterator const& col)
   {
     if (!isCollisionAccepted(col)) {
       return;

--- a/Common/Tasks/centralityQa.cxx
+++ b/Common/Tasks/centralityQa.cxx
@@ -206,7 +206,7 @@ struct CentralityQa {
     } else {
       histos.add("hCentFV0A", ";FV0A centrality (%)", kTH1D, {{nBins, 0, 105.}});
       histos.add("hCentFT0M", ";FT0M centrality (%)", kTH1D, {{nBins, 0, 105.}});
-      histos.add("hCentFT0MVar3", ";FT0M centrality (%)", kTH1D, {{nBins, 0, 105.}});
+      histos.add("hCentFT0MOuterA", ";FT0M centrality (%)", kTH1D, {{nBins, 0, 105.}});
       histos.add("hCentFT0A", ";FT0A centrality (%)", kTH1D, {{nBins, 0, 105.}});
       histos.add("hCentFT0C", ";FT0C centrality (%)", kTH1D, {{nBins, 0, 105.}});
       histos.add("hCentFT0CVar1", ";FT0CVar1 centrality (%)", kTH1D, {{nBins, 0, 105.}});
@@ -221,7 +221,7 @@ struct CentralityQa {
       // profiles of midrapidity multiplicity density
       histos.add("hCentProfileFV0A", ";FV0A centrality (%)", kTProfile, {{nBins, 0, 105.}});
       histos.add("hCentProfileFT0M", ";FT0M centrality (%)", kTProfile, {{nBins, 0, 105.}});
-      histos.add("hCentProfileFT0MVar3", ";FT0M centrality (%)", kTProfile, {{nBins, 0, 105.}});
+      histos.add("hCentProfileFT0MOuterA", ";FT0M centrality (%)", kTProfile, {{nBins, 0, 105.}});
       histos.add("hCentProfileFT0A", ";FT0A centrality (%)", kTProfile, {{nBins, 0, 105.}});
       histos.add("hCentProfileFT0C", ";FT0C centrality (%)", kTProfile, {{nBins, 0, 105.}});
       histos.add("hCentProfileFT0CVar1", ";FT0CVar1 centrality (%)", kTProfile, {{nBins, 0, 105.}});
@@ -235,7 +235,7 @@ struct CentralityQa {
 
       histos.add("hMultEta05VsCentFV0A", ";FV0A centrality (%); Multiplicity PV contributors (|#it{#eta}| < 0.5)", kTH2D, {{nBins, 0, 105.}, axisMultiplicityPV});
       histos.add("hMultEta05VsCentFT0M", ";FT0M centrality (%); Multiplicity PV contributors (|#it{#eta}| < 0.5)", kTH2D, {{nBins, 0, 105.}, axisMultiplicityPV});
-      histos.add("hMultEta05VsCentFT0MVar3", ";FT0M centrality (%); Multiplicity PV contributors (|#it{#eta}| < 0.5)", kTH2D, {{nBins, 0, 105.}, axisMultiplicityPV});
+      histos.add("hMultEta05VsCentFT0MOuterA", ";FT0M centrality (%); Multiplicity PV contributors (|#it{#eta}| < 0.5)", kTH2D, {{nBins, 0, 105.}, axisMultiplicityPV});
       histos.add("hMultEta05VsCentFT0A", ";FT0A centrality (%); Multiplicity PV contributors (|#it{#eta}| < 0.5)", kTH2D, {{nBins, 0, 105.}, axisMultiplicityPV});
       histos.add("hMultEta05VsCentFT0C", ";FT0C centrality (%); Multiplicity PV contributors (|#it{#eta}| < 0.5)", kTH2D, {{nBins, 0, 105.}, axisMultiplicityPV});
       histos.add("hMultEta05VsCentFT0CVar1", ";FT0CVar1 centrality (%); Multiplicity PV contributors (|#it{#eta}| < 0.5)", kTH2D, {{nBins, 0, 105.}, axisMultiplicityPV});
@@ -688,17 +688,17 @@ struct CentralityQa {
   }
   PROCESS_SWITCH(CentralityQa, processRun3_FT0M, "Process with Run 3 FT0M estimator", false);
 
-  void processRun3_FT0Mvar3(soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0MVariant3s>::iterator const& col)
+  void processRun3_FT0MOuterA(soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0MOuterAs>::iterator const& col)
   {
     if (!isCollisionAccepted(col)) {
       return;
     }
-    LOGF(debug, "centFT0MVar3=%.0f", col.centFT0MVariant3());
-    histos.fill(HIST("hCentFT0MVar3"), col.centFT0MVariant3());
-    histos.fill(HIST("hCentProfileFT0MVar3"), col.centFT0MVariant3(), col.multNTracksPVetaHalf());
-    histos.fill(HIST("hMultEta05VsCentFT0MVar3"), col.centFT0MVariant3(), col.multNTracksPVetaHalf());
+    LOGF(debug, "centFT0MOuterA=%.0f", col.centFT0MOuterA());
+    histos.fill(HIST("hCentFT0MOuterA"), col.centFT0MOuterA());
+    histos.fill(HIST("hCentProfileFT0MOuterA"), col.centFT0MOuterA(), col.multNTracksPVetaHalf());
+    histos.fill(HIST("hMultEta05VsCentFT0MOuterA"), col.centFT0MOuterA(), col.multNTracksPVetaHalf());
   }
-  PROCESS_SWITCH(CentralityQa, processRun3_FT0Mvar3, "Process with Run 3 FT0M estimator", false);
+  PROCESS_SWITCH(CentralityQa, processRun3_FT0MOuterA, "Process with Run 3 FT0M estimator", false);
 
   void processRun3_FT0A(soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::CentFT0As>::iterator const& col)
   {

--- a/Common/Tools/Multiplicity/MultModule.h
+++ b/Common/Tools/Multiplicity/MultModule.h
@@ -145,6 +145,7 @@ static const int defaultParameters[nTablesConst][nParameters]{
   {-1},
   {-1},
   {-1},
+  {-1},
   {-1}};
 
 // table index : match order above
@@ -743,6 +744,7 @@ class MultModule
     } else {
       mults.multFT0A = -999.f;
       mults.multFT0C = -999.f;
+      mults.multFT0AOuter = -999.f;
     }
     if (collision.has_foundFDD()) {
       const auto& fdd = collision.foundFDD();

--- a/Common/Tools/Multiplicity/MultModule.h
+++ b/Common/Tools/Multiplicity/MultModule.h
@@ -100,7 +100,7 @@ static const std::vector<std::string> tableNames{
   "BCCentFT0Cs",
   "CentFT0MAnchorCols",
   "CentFT0MAnchorBCs",
-  "CentFT0MVariant3s"};
+  "CentFT0MOuterAs"};
 
 static constexpr int nTablesConst = 42;
 static const std::vector<std::string> parameterNames{"enable"};
@@ -191,7 +191,7 @@ enum tableIndex { kFV0Mults,       // standard
                   kBCCentFT0Cs,        // bc centrality
                   kCentFT0MAnchorCols, // standard Run 3
                   kCentFT0MAnchorBCs,  // standard Run 3
-                  kCentFT0MVariant3s, // standard Run 3
+                  kCentFT0MOuterAs,    // standard Run 3
                   kNTables };
 
 struct products : o2::framework::ProducesGroup {
@@ -229,7 +229,7 @@ struct products : o2::framework::ProducesGroup {
   o2::framework::Produces<aod::CentRun2CL1s> centRun2CL1;
   o2::framework::Produces<aod::CentFV0As> centFV0A;
   o2::framework::Produces<aod::CentFT0Ms> centFT0M;
-  o2::framework::Produces<aod::CentFT0MVariant3s> centFT0MVariant3;
+  o2::framework::Produces<aod::CentFT0MOuterAs> centFT0MOuterA;
   o2::framework::Produces<aod::CentFT0As> centFT0A;
   o2::framework::Produces<aod::CentFT0Cs> centFT0C;
   o2::framework::Produces<aod::CentFT0CVariant1s> centFT0CVariant1;
@@ -457,7 +457,7 @@ class MultModule
   CalibrationInfo ft0mInfo = CalibrationInfo("FT0");
   CalibrationInfo ft0mColInfo = CalibrationInfo("FT0AnchorCol");
   CalibrationInfo ft0mBcInfo = CalibrationInfo("FT0AnchorBc");
-  CalibrationInfo ft0mVariant3Info = CalibrationInfo("FT0Mvar3");
+  CalibrationInfo FT0MOuterAInfo = CalibrationInfo("FT0MOuterA");
   CalibrationInfo ft0aInfo = CalibrationInfo("FT0A");
   CalibrationInfo ft0cInfo = CalibrationInfo("FT0C");
   CalibrationInfo ft0cVariant1Info = CalibrationInfo("FT0Cvar1");
@@ -1237,7 +1237,7 @@ class MultModule
       ft0mInfo.mCalibrationStored = false;
       ft0mColInfo.mCalibrationStored = false;
       ft0mBcInfo.mCalibrationStored = false;
-      ft0mVariant3Info.mCalibrationStored = false;
+      FT0MOuterAInfo.mCalibrationStored = false;
       ft0aInfo.mCalibrationStored = false;
       ft0cInfo.mCalibrationStored = false;
       ft0cVariant1Info.mCalibrationStored = false;
@@ -1279,8 +1279,8 @@ class MultModule
           getccdb(ft0mColInfo, internalOpts.generatorName);
         if (internalOpts.mEnabledTables[kCentFT0MAnchorBCs])
           getccdb(ft0mBcInfo, internalOpts.generatorName);
-        if (internalOpts.mEnabledTables[kCentFT0MVariant3s])
-          getccdb(ft0mVariant3Info, internalOpts.generatorName);
+        if (internalOpts.mEnabledTables[kCentFT0MOuterAs])
+          getccdb(FT0MOuterAInfo, internalOpts.generatorName);
         if (internalOpts.mEnabledTables[kCentFT0As] || internalOpts.mEnabledTables[kBCCentFT0As])
           getccdb(ft0aInfo, internalOpts.generatorName);
         if (internalOpts.mEnabledTables[kCentFT0Cs] || internalOpts.mEnabledTables[kBCCentFT0Cs])
@@ -1369,8 +1369,8 @@ class MultModule
           populateTable(cursors.centFT0MAnchorCol, ft0mColInfo, mults[iEv].multFT0AZeq + mults[iEv].multFT0CZeq, isInelGt0);
         if (internalOpts.mEnabledTables[kCentFT0Ms])
           populateTable(cursors.centFT0MAnchorBC, ft0mBcInfo, mults[iEv].multFT0AZeq + mults[iEv].multFT0CZeq, isInelGt0);
-        if (internalOpts.mEnabledTables[kCentFT0MVariant3s])
-          populateTable(cursors.centFT0MVariant3, ft0mVariant3Info, mults[iEv].multFT0AOuterZeq + mults[iEv].multFT0CZeq, isInelGt0);
+        if (internalOpts.mEnabledTables[kCentFT0MOuterAs])
+          populateTable(cursors.centFT0MOuterA, FT0MOuterAInfo, mults[iEv].multFT0AOuterZeq + mults[iEv].multFT0CZeq, isInelGt0);
         if (internalOpts.mEnabledTables[kCentFT0As])
           populateTable(cursors.centFT0A, ft0aInfo, mults[iEv].multFT0AZeq, isInelGt0);
         if (internalOpts.mEnabledTables[kCentFT0Cs])

--- a/Common/Tools/Multiplicity/MultModule.h
+++ b/Common/Tools/Multiplicity/MultModule.h
@@ -816,9 +816,9 @@ class MultModule
         mults.multFT0AZeq = 0.0f;
       }
       if (mults.multFT0AOuter > -1.0f && std::fabs(collision.posZ()) < 15.0f && lCalibLoaded) {
-        mults.multFT0AOuter = hVtxZFT0A->Interpolate(0.0) * mults.multFT0AOuter / hVtxZFT0A->Interpolate(collision.posZ());
+        mults.multFT0AOuterZeq = hVtxZFT0A->Interpolate(0.0) * mults.multFT0AOuter / hVtxZFT0A->Interpolate(collision.posZ());
       } else {
-        mults.multFT0AOuter = 0.0f;
+        mults.multFT0AOuterZeq = 0.0f;
       }
       if (mults.multFT0C > -1.0f && std::fabs(collision.posZ()) < 15.0f && lCalibLoaded) {
         mults.multFT0CZeq = hVtxZFT0C->Interpolate(0.0) * mults.multFT0C / hVtxZFT0C->Interpolate(collision.posZ());

--- a/Common/Tools/Multiplicity/MultModule.h
+++ b/Common/Tools/Multiplicity/MultModule.h
@@ -99,10 +99,10 @@ static const std::vector<std::string> tableNames{
   "BCCentFT0As",
   "BCCentFT0Cs",
   "CentFT0MAnchorCols",
-  "CentFT0MAnchorBCs"};
+  "CentFT0MAnchorBCs",
+  "CentFT0MVariant3s"};
 
-static constexpr int nTablesConst = 41;
-
+static constexpr int nTablesConst = 42;
 static const std::vector<std::string> parameterNames{"enable"};
 static const int defaultParameters[nTablesConst][nParameters]{
   {-1},
@@ -191,6 +191,7 @@ enum tableIndex { kFV0Mults,       // standard
                   kBCCentFT0Cs,        // bc centrality
                   kCentFT0MAnchorCols, // standard Run 3
                   kCentFT0MAnchorBCs,  // standard Run 3
+                  kCentFT0MVariant3s, // standard Run 3
                   kNTables };
 
 struct products : o2::framework::ProducesGroup {
@@ -228,6 +229,7 @@ struct products : o2::framework::ProducesGroup {
   o2::framework::Produces<aod::CentRun2CL1s> centRun2CL1;
   o2::framework::Produces<aod::CentFV0As> centFV0A;
   o2::framework::Produces<aod::CentFT0Ms> centFT0M;
+  o2::framework::Produces<aod::CentFT0MVariant3s> centFT0MVariant3;
   o2::framework::Produces<aod::CentFT0As> centFT0A;
   o2::framework::Produces<aod::CentFT0Cs> centFT0C;
   o2::framework::Produces<aod::CentFT0CVariant1s> centFT0CVariant1;
@@ -255,6 +257,7 @@ struct multEntry {
   float multFV0C = 0.0f;
   float multFV0AOuter = 0.0f;
   float multFT0A = 0.0f;
+  float multFT0AOuter = 0.0f;
   float multFT0C = 0.0f;
   float multFDDA = 0.0f;
   float multFDDC = 0.0f;
@@ -284,6 +287,7 @@ struct multEntry {
   float multFV0AZeq = -999.0f;
   float multFV0CZeq = -999.0f;
   float multFT0AZeq = -999.0f;
+  float multFT0AOuterZeq = -999.0f;
   float multFT0CZeq = -999.0f;
   float multFDDAZeq = -999.0f;
   float multFDDCZeq = -999.0f;
@@ -453,6 +457,7 @@ class MultModule
   CalibrationInfo ft0mInfo = CalibrationInfo("FT0");
   CalibrationInfo ft0mColInfo = CalibrationInfo("FT0AnchorCol");
   CalibrationInfo ft0mBcInfo = CalibrationInfo("FT0AnchorBc");
+  CalibrationInfo ft0mVariant3Info = CalibrationInfo("FT0Mvar3");
   CalibrationInfo ft0aInfo = CalibrationInfo("FT0A");
   CalibrationInfo ft0cInfo = CalibrationInfo("FT0C");
   CalibrationInfo ft0cVariant1Info = CalibrationInfo("FT0Cvar1");
@@ -715,7 +720,7 @@ class MultModule
         auto amplitude = fv0.amplitude()[ii];
         auto channel = fv0.channel()[ii];
         mults.multFV0A += amplitude;
-        if (channel > 7) {
+        if (channel > 7) { // Outer ring only
           mults.multFV0AOuter += amplitude;
         }
       }
@@ -726,8 +731,11 @@ class MultModule
     if (collision.has_foundFT0()) {
       const auto& ft0 = collision.foundFT0();
       mults.fitTriggerMask = ft0.triggerMask();
-      for (const auto& amplitude : ft0.amplitudeA()) {
-        mults.multFT0A += amplitude;
+      for (size_t ii = 0; ii < ft0.amplitudeA().size(); ii++) {
+        mults.multFT0A += ft0.amplitudeA()[ii];
+        if (ft0.channelA()[ii] > 31) { // Outer ring only
+          mults.multFT0AOuter += ft0.amplitudeA()[ii];
+        }
       }
       for (const auto& amplitude : ft0.amplitudeC()) {
         mults.multFT0C += amplitude;
@@ -806,6 +814,11 @@ class MultModule
         mults.multFT0AZeq = hVtxZFT0A->Interpolate(0.0) * mults.multFT0A / hVtxZFT0A->Interpolate(collision.posZ());
       } else {
         mults.multFT0AZeq = 0.0f;
+      }
+      if (mults.multFT0AOuter > -1.0f && std::fabs(collision.posZ()) < 15.0f && lCalibLoaded) {
+        mults.multFT0AOuter = hVtxZFT0A->Interpolate(0.0) * mults.multFT0AOuter / hVtxZFT0A->Interpolate(collision.posZ());
+      } else {
+        mults.multFT0AOuter = 0.0f;
       }
       if (mults.multFT0C > -1.0f && std::fabs(collision.posZ()) < 15.0f && lCalibLoaded) {
         mults.multFT0CZeq = hVtxZFT0C->Interpolate(0.0) * mults.multFT0C / hVtxZFT0C->Interpolate(collision.posZ());
@@ -1224,6 +1237,7 @@ class MultModule
       ft0mInfo.mCalibrationStored = false;
       ft0mColInfo.mCalibrationStored = false;
       ft0mBcInfo.mCalibrationStored = false;
+      ft0mVariant3Info.mCalibrationStored = false;
       ft0aInfo.mCalibrationStored = false;
       ft0cInfo.mCalibrationStored = false;
       ft0cVariant1Info.mCalibrationStored = false;
@@ -1265,6 +1279,8 @@ class MultModule
           getccdb(ft0mColInfo, internalOpts.generatorName);
         if (internalOpts.mEnabledTables[kCentFT0MAnchorBCs])
           getccdb(ft0mBcInfo, internalOpts.generatorName);
+        if (internalOpts.mEnabledTables[kCentFT0MVariant3s])
+          getccdb(ft0mVariant3Info, internalOpts.generatorName);
         if (internalOpts.mEnabledTables[kCentFT0As] || internalOpts.mEnabledTables[kBCCentFT0As])
           getccdb(ft0aInfo, internalOpts.generatorName);
         if (internalOpts.mEnabledTables[kCentFT0Cs] || internalOpts.mEnabledTables[kBCCentFT0Cs])
@@ -1353,6 +1369,8 @@ class MultModule
           populateTable(cursors.centFT0MAnchorCol, ft0mColInfo, mults[iEv].multFT0AZeq + mults[iEv].multFT0CZeq, isInelGt0);
         if (internalOpts.mEnabledTables[kCentFT0Ms])
           populateTable(cursors.centFT0MAnchorBC, ft0mBcInfo, mults[iEv].multFT0AZeq + mults[iEv].multFT0CZeq, isInelGt0);
+        if (internalOpts.mEnabledTables[kCentFT0MVariant3s])
+          populateTable(cursors.centFT0MVariant3, ft0mVariant3Info, mults[iEv].multFT0AOuterZeq + mults[iEv].multFT0CZeq, isInelGt0);
         if (internalOpts.mEnabledTables[kCentFT0As])
           populateTable(cursors.centFT0A, ft0aInfo, mults[iEv].multFT0AZeq, isInelGt0);
         if (internalOpts.mEnabledTables[kCentFT0Cs])

--- a/Common/Tools/Multiplicity/MultModule.h
+++ b/Common/Tools/Multiplicity/MultModule.h
@@ -780,7 +780,7 @@ class MultModule
       cursors.tableFV0(mults.multFV0A, mults.multFV0C);
     }
     if (internalOpts.mEnabledTables[kFITExtraMults]) {
-      cursors.tableFITExtraMults(mults.multFV0AOuter, mults.fitTriggerMask);
+      cursors.tableFITExtraMults(mults.multFV0AOuter, mults.multFT0AOuter, mults.fitTriggerMask);
       cursors.tableFV0AOuterMults(mults.multFV0AOuter); // Keep for backwards compatibility
     }
     if (internalOpts.mEnabledTables[kFT0Mults]) {


### PR DESCRIPTION
This PR adds the centrality estimator FT0MOuterA which as the title mentions, uses both A and C side. However, the inner channels on the A side (the channels that saturate) are excluded.

Tagging @ddobrigk 