### PR TITLE
[PWGLF] Add new workflow for event loss and store occupancy in the output

### DIFF
--- a/PWGLF/DataModel/LFhe3HadronTables.h
+++ b/PWGLF/DataModel/LFhe3HadronTables.h
@@ -85,6 +85,7 @@ DECLARE_SOA_COLUMN(ZVertex, zVertex, float);
 DECLARE_SOA_COLUMN(Multiplicity, multiplicity, uint16_t);
 DECLARE_SOA_COLUMN(CentralityFT0C, centFT0C, float);
 DECLARE_SOA_COLUMN(MultiplicityFT0C, multiplicityFT0C, float);
+DECLARE_SOA_COLUMN(TrackOccupancy, trackOccupancy, int);
 
 /* Flags: 0 - both primary,
           1 - both from Li4,
@@ -137,7 +138,8 @@ DECLARE_SOA_TABLE(he3HadronMult, "AOD", "HE3HADMULT",
                   he3HadronTablesNS::ZVertex,
                   he3HadronTablesNS::Multiplicity,
                   he3HadronTablesNS::CentralityFT0C,
-                  he3HadronTablesNS::MultiplicityFT0C)
+                  he3HadronTablesNS::MultiplicityFT0C,
+                  he3HadronTablesNS::TrackOccupancy)
 DECLARE_SOA_TABLE(he3HadronQa, "AOD", "HE3HADQA",
                   he3HadronTablesNS::TrackIDHe3,
                   he3HadronTablesNS::TrackIDHad,

--- a/PWGLF/TableProducer/Nuspex/he3HadronFemto.cxx
+++ b/PWGLF/TableProducer/Nuspex/he3HadronFemto.cxx
@@ -403,34 +403,6 @@ struct he3HadronFemto {
       {"hhe3HadInvMass", "; M(^{3}He + p) (GeV/#it{c}^{2})", {HistType::kTH1F, {{300, 3.74f, 4.34f}}}},
       {"hhe3HadKstar", "; #it{k}* (GeV/#it{c})", {HistType::kTH1F, {{300, 0.f, 0.8f}}}},
       {"hKstarRecVsKstarGen", "; #it{k}*_{gen} (GeV/#it{c}); #it{k}*_{rec} (GeV/#it{c})", {HistType::kTH2F, {{400, 0.f, 0.8f}, {400, 0.f, 0.8f}}}},
-      /*
-      {"EventLoss/hEvtMC", ";; ", {HistType::kTH1D, {{3, -0.5f, 2.5f}}}},
-      {"EventLoss/hImpactParamGen", "Impact parameter of generated MC events; Impact Parameter (b); Counts", {HistType::kTH1D, {{200, 0.0f, 20.0f}}}},
-      {"EventLoss/hImpactParamReco", "Impact parameter of generated MC events with at least one rec. evt; Impact Parameter (b); Counts", {HistType::kTH1D, {{200, 0.0f, 20.0f}}}},
-      {"EventLoss/hRecoCentrality", "Centrality distribution of reconstructed MC events passed the event selection; Centrality FT0C (%); Counts", {HistType::kTH1D, {{100, 0.0f, 100.0f}}}},
-      {"EventLoss/hRecoCentralityColvsMultiplicityRecoEta05", "; Centrality FT0C (%); Multiplicity #eta <0.5", {HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 500.0f}}}},
-      {"EventLoss/hRecoCentralityColvsMultiplicityRecoEta08", "; Centrality FT0C (%); Multiplicity #eta <0.8", {HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 500.0f}}}},
-      {"EventLoss/hRecoCentralityColvsMultiplicityFT0C", "; Centrality FT0C (%); FT0C multiplicity", {HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 3000.0f}}}},
-      {"EventLoss/hRecoCentralityColvsImpactParamReco", "; Centrality FT0C (%); Impact Parameter (b)", {HistType::kTH2D, {{100, 0.0f, 100.0f}, {200, 0.0f, 20.0f}}}},
-      {"EventLoss/hGenEventsNchEta05", ";Multiplicity #eta <0.5;", {HistType::kTH2D, {{500, 0.0f, 500.0f}, {2, -0.5f, 1.5f}}}},
-      {"EventLoss/hGenEventsNchEta08", ";Multiplicity #eta <0.8;", {HistType::kTH2D, {{500, 0.0f, 500.0f}, {2, -0.5f, 1.5f}}}},
-      {"EventLoss/hImpactParamGenOneReco", "Impact parameter of generated MC events with at least one rec. evt and passed the event selection; Impact Parameter (b); Counts", {HistType::kTH1D, {{200, 0.0f, 20.0f}}}},
-      {"EventLoss/hGenOneRecoCentrality", "Centrality distribution of generated MC events with at least one rec. evt and passed the event selection; Centrality FT0C (%); Counts", {HistType::kTH1D, {{100, 0.0f, 100.0f}}}},
-      {"EventLoss/hGenCentralityColvsMultiplicityGenEta05", "; Centrality FT0C (%); Multiplicity #eta <0.5", {HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 500.0f}}}},
-      {"EventLoss/hGenCentralityColvsMultiplicityGenEta08", "; Centrality FT0C (%); Multiplicity #eta <0.8", {HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 500.0f}}}},
-      {"EventLoss/hGenCentralityColvsMultiplicityFT0C", "; Centrality FT0C (%); FT0C multiplicity", {HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 3000.0f}}}},
-      {"EventLoss/hGenCentralityColvsImpactParamGen", "; Centrality FT0C (%); Impact Parameter (b)", {HistType::kTH2D, {{100, 0.0f, 100.0f}, {200, 0.0f, 20.0f}}}},
-      {"EventLoss/hGenLi4BeforeEvtSel", "Li4 generated #it{p}_{T} distribution in all gen evt; #it{p}_{T} (GeV/#it{c}); Counts", {HistType::kTH1D, {{240, 0.0f, 12.0f}}}},
-      {"EventLoss/hGenLi4vsImpactParameterBeforeEvtSel", "; #it{p}_{T} (GeV/#it{c}); Impact Parameter (b)", {HistType::kTH2D, {{240, 0.0f, 12.0f}, {200, 0.0f, 20.0f}}}},
-      {"EventLoss/hGenLi4vsMultiplicityGenEta05BeforeEvtSel", "; #it{p}_{T} (GeV/#it{c}); Multiplicity #eta <0.5", {HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 500.0f}}}},
-      {"EventLoss/hGenLi4vsMultiplicityGenEta08BeforeEvtSel", "; #it{p}_{T} (GeV/#it{c}); Multiplicity #eta <0.8", {HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 500.0f}}}},
-      {"EventLoss/hGenLi4vsMultiplicityFT0CBeforeEvtSel", "; #it{p}_{T} (GeV/#it{c}); FT0C multiplicity", {HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 3000.0f}}}},
-      {"EventLoss/hGenLi4AfterSel", "Li4 generated #it{p}_{T} distribution in gen. evts with at least one rec. evt; #it{p}_{T} (GeV/#it{c}); Counts", {HistType::kTH1D, {{240, 0.0f, 12.0f}}}},
-      {"EventLoss/hGenLi4vsImpactParameterAfterSel", "; #it{p}_{T} (GeV/#it{c}); Impact Parameter (b)", {HistType::kTH2D, {{240, 0.0f, 12.0f}, {200, 0.0f, 20.0f}}}},
-      {"EventLoss/hGenLi4vsMultiplicityGenEta05AfterSel", "; #it{p}_{T} (GeV/#it{c}); Multiplicity #eta <0.5", {HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 500.0f}}}},
-      {"EventLoss/hGenLi4vsMultiplicityGenEta08AfterSel", "; #it{p}_{T} (GeV/#it{c}); Multiplicity #eta <0.8", {HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 500.0f}}}},
-      {"EventLoss/hGenLi4vsMultiplicityFT0CAfterSel", "; #it{p}_{T} (GeV/#it{c}); FT0C multiplicity", {HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 3000.0f}}}},
-      */
 
       {"He3/hDCAxyHe3", "^{3}He;DCA_{xy} (cm)", {HistType::kTH1F, {{200, -0.5f, 0.5f}}}},
       {"He3/hDCAzHe3", "^{3}He;DCA_{z} (cm)", {HistType::kTH1F, {{200, -1.0f, 1.0f}}}},
@@ -544,17 +516,6 @@ struct he3HadronFemto {
     mQaRegistry.get<TH1>(HIST("hEmptyPool"))->GetXaxis()->SetBinLabel(1, "False");
     mQaRegistry.get<TH1>(HIST("hEmptyPool"))->GetXaxis()->SetBinLabel(2, "True");
 
-    /*
-    mQaRegistry.get<TH1>(HIST("EventLoss/hEvtMC"))->GetXaxis()->SetBinLabel(1, "All gen evts");
-    mQaRegistry.get<TH1>(HIST("EventLoss/hEvtMC"))->GetXaxis()->SetBinLabel(2, "Gen evts with al least one reconstructed");
-    mQaRegistry.get<TH1>(HIST("EventLoss/hEvtMC"))->GetXaxis()->SetBinLabel(3, "Gen evts with no reconstructed collisions");
-
-    mQaRegistry.get<TH2>(HIST("EventLoss/hGenEventsNchEta05"))->GetYaxis()->SetBinLabel(1, "All gen. events");
-    mQaRegistry.get<TH2>(HIST("EventLoss/hGenEventsNchEta05"))->GetYaxis()->SetBinLabel(2, "Gen evts with at least 1 rec. collisions");
-    mQaRegistry.get<TH2>(HIST("EventLoss/hGenEventsNchEta08"))->GetYaxis()->SetBinLabel(1, "All gen. events");
-    mQaRegistry.get<TH2>(HIST("EventLoss/hGenEventsNchEta08"))->GetYaxis()->SetBinLabel(2, "Gen evts with at least 1 rec. collisions");
-    */
-
     if (doprocessEventLossMC) {
       hEvtMC = mQaRegistry.add<TH1>("EventLoss/hEvtMC", ";; ", HistType::kTH1D, {{3, -0.5, 2.5}});
       hEvtMC->GetXaxis()->SetBinLabel(1, "All gen evts");
@@ -568,32 +529,32 @@ struct he3HadronFemto {
       hGenEventsNchEta08->GetYaxis()->SetBinLabel(1, "All gen. events");
       hGenEventsNchEta08->GetYaxis()->SetBinLabel(2, "Gen evts with at least 1 rec. collisions");
 
-      hImpactParamGen = mQaRegistry.add<TH1>("EventLoss/hImpactParamGen", "...", HistType::kTH1D, {{200, 0.0f, 20.0f}});
-      hImpactParamReco = mQaRegistry.add<TH1>("EventLoss/hImpactParamReco", "...", HistType::kTH1D, {{200, 0.0f, 20.0f}});
-      hRecoCentrality = mQaRegistry.add<TH1>("EventLoss/hRecoCentrality", "...", HistType::kTH1D, {{100, 0.0f, 100.0f}});
-      hRecoCentralityColvsMultiplicityRecoEta05 = mQaRegistry.add<TH2>("EventLoss/hRecoCentralityColvsMultiplicityRecoEta05", "...", HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 500.0f}});
-      hRecoCentralityColvsMultiplicityRecoEta08 = mQaRegistry.add<TH2>("EventLoss/hRecoCentralityColvsMultiplicityRecoEta08", "...", HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 500.0f}});
-      hRecoCentralityColvsMultiplicityFT0C = mQaRegistry.add<TH2>("EventLoss/hRecoCentralityColvsMultiplicityFT0C", "...", HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 3000.0f}});
-      hRecoCentralityColvsImpactParamReco = mQaRegistry.add<TH2>("EventLoss/hRecoCentralityColvsImpactParamReco", "...", HistType::kTH2D, {{100, 0.0f, 100.0f}, {200, 0.0f, 20.0f}});
+      hImpactParamGen = mQaRegistry.add<TH1>("EventLoss/hImpactParamGen", "Impact parameter of generated MC events; Impact Parameter (b); Counts", HistType::kTH1D, {{200, 0.0f, 20.0f}});
+      hImpactParamReco = mQaRegistry.add<TH1>("EventLoss/hImpactParamReco", "Impact parameter of generated MC events with at least one rec. evt; Impact Parameter (b); Counts", HistType::kTH1D, {{200, 0.0f, 20.0f}});
+      hRecoCentrality = mQaRegistry.add<TH1>("EventLoss/hRecoCentrality", "Centrality distribution of reconstructed MC events passed the event selection; Centrality FT0C (%); Counts", HistType::kTH1D, {{100, 0.0f, 100.0f}});
+      hRecoCentralityColvsMultiplicityRecoEta05 = mQaRegistry.add<TH2>("EventLoss/hRecoCentralityColvsMultiplicityRecoEta05", "; Centrality FT0C (%); Multiplicity #eta <0.5", HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 500.0f}});
+      hRecoCentralityColvsMultiplicityRecoEta08 = mQaRegistry.add<TH2>("EventLoss/hRecoCentralityColvsMultiplicityRecoEta08", "; Centrality FT0C (%); Multiplicity #eta <0.8", HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 500.0f}});
+      hRecoCentralityColvsMultiplicityFT0C = mQaRegistry.add<TH2>("EventLoss/hRecoCentralityColvsMultiplicityFT0C", "; Centrality FT0C (%); FT0C multiplicity", HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 3000.0f}});
+      hRecoCentralityColvsImpactParamReco = mQaRegistry.add<TH2>("EventLoss/hRecoCentralityColvsImpactParamReco", "; Centrality FT0C (%); Impact Parameter (b)", HistType::kTH2D, {{100, 0.0f, 100.0f}, {200, 0.0f, 20.0f}});
 
-      hImpactParamGenOneReco = mQaRegistry.add<TH1>("EventLoss/hImpactParamGenOneReco", "...", HistType::kTH1D, {{200, 0.0f, 20.0f}});
-      hGenOneRecoCentrality = mQaRegistry.add<TH1>("EventLoss/hGenOneRecoCentrality", "...", HistType::kTH1D, {{100, 0.0f, 100.0f}});
-      hGenCentralityColvsMultiplicityGenEta05 = mQaRegistry.add<TH2>("EventLoss/hGenCentralityColvsMultiplicityGenEta05", "...", HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 500.0f}});
-      hGenCentralityColvsMultiplicityGenEta08 = mQaRegistry.add<TH2>("EventLoss/hGenCentralityColvsMultiplicityGenEta08", "...", HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 500.0f}});
-      hGenCentralityColvsMultiplicityFT0C = mQaRegistry.add<TH2>("EventLoss/hGenCentralityColvsMultiplicityFT0C", "...", HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 3000.0f}});
-      hGenCentralityColvsImpactParamGen = mQaRegistry.add<TH2>("EventLoss/hGenCentralityColvsImpactParamGen", "...", HistType::kTH2D, {{100, 0.0f, 100.0f}, {200, 0.0f, 20.0f}});
+      hImpactParamGenOneReco = mQaRegistry.add<TH1>("EventLoss/hImpactParamGenOneReco", "Impact parameter of generated MC events with at least one rec. evt and passed the event selection; Impact Parameter (b); Counts", HistType::kTH1D, {{200, 0.0f, 20.0f}});
+      hGenOneRecoCentrality = mQaRegistry.add<TH1>("EventLoss/hGenOneRecoCentrality", "Centrality distribution of generated MC events with at least one rec. evt and passed the event selection; Centrality FT0C (%); Counts", HistType::kTH1D, {{100, 0.0f, 100.0f}});
+      hGenCentralityColvsMultiplicityGenEta05 = mQaRegistry.add<TH2>("EventLoss/hGenCentralityColvsMultiplicityGenEta05", "; Centrality FT0C (%); Multiplicity #eta <0.5", HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 500.0f}});
+      hGenCentralityColvsMultiplicityGenEta08 = mQaRegistry.add<TH2>("EventLoss/hGenCentralityColvsMultiplicityGenEta08", "; Centrality FT0C (%); Multiplicity #eta <0.8", HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 500.0f}});
+      hGenCentralityColvsMultiplicityFT0C = mQaRegistry.add<TH2>("EventLoss/hGenCentralityColvsMultiplicityFT0C", "; Centrality FT0C (%); FT0C multiplicity", HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 3000.0f}});
+      hGenCentralityColvsImpactParamGen = mQaRegistry.add<TH2>("EventLoss/hGenCentralityColvsImpactParamGen", "; Centrality FT0C (%); Impact Parameter (b)", HistType::kTH2D, {{100, 0.0f, 100.0f}, {200, 0.0f, 20.0f}});
 
-      hGenLi4BeforeEvtSel = mQaRegistry.add<TH1>("EventLoss/hGenLi4BeforeEvtSel", "...", HistType::kTH1D, {{240, 0.0f, 12.0f}});
-      hGenLi4vsImpactParameterBeforeEvtSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsImpactParameterBeforeEvtSel", "...", HistType::kTH2D, {{240, 0.0f, 12.0f}, {200, 0.0f, 20.0f}});
-      hGenLi4vsMultiplicityGenEta05BeforeEvtSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsMultiplicityGenEta05BeforeEvtSel", "...", HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 500.0f}});
-      hGenLi4vsMultiplicityGenEta08BeforeEvtSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsMultiplicityGenEta08BeforeEvtSel", "...", HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 500.0f}});
-      hGenLi4vsMultiplicityFT0CBeforeEvtSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsMultiplicityFT0CBeforeEvtSel", "...", HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 3000.0f}});
+      hGenLi4BeforeEvtSel = mQaRegistry.add<TH1>("EventLoss/hGenLi4BeforeEvtSel", "Li4 generated #it{p}_{T} distribution in all gen evt; #it{p}_{T} (GeV/#it{c}); Counts", HistType::kTH1D, {{240, 0.0f, 12.0f}});
+      hGenLi4vsImpactParameterBeforeEvtSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsImpactParameterBeforeEvtSel", "; #it{p}_{T} (GeV/#it{c}); Impact Parameter (b)", HistType::kTH2D, {{240, 0.0f, 12.0f}, {200, 0.0f, 20.0f}});
+      hGenLi4vsMultiplicityGenEta05BeforeEvtSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsMultiplicityGenEta05BeforeEvtSel", "; #it{p}_{T} (GeV/#it{c}); Multiplicity #eta <0.5", HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 500.0f}});
+      hGenLi4vsMultiplicityGenEta08BeforeEvtSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsMultiplicityGenEta08BeforeEvtSel", "; #it{p}_{T} (GeV/#it{c}); Multiplicity #eta <0.8", HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 500.0f}});
+      hGenLi4vsMultiplicityFT0CBeforeEvtSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsMultiplicityFT0CBeforeEvtSel", "; #it{p}_{T} (GeV/#it{c}); FT0C multiplicity", HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 3000.0f}});
 
-      hGenLi4AfterSel = mQaRegistry.add<TH1>("EventLoss/hGenLi4AfterSel", "...", HistType::kTH1D, {{240, 0.0f, 12.0f}});
-      hGenLi4vsImpactParameterAfterSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsImpactParameterAfterSel", "...", HistType::kTH2D, {{240, 0.0f, 12.0f}, {200, 0.0f, 20.0f}});
-      hGenLi4vsMultiplicityGenEta05AfterSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsMultiplicityGenEta05AfterSel", "...", HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 500.0f}});
-      hGenLi4vsMultiplicityGenEta08AfterSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsMultiplicityGenEta08AfterSel", "...", HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 500.0f}});
-      hGenLi4vsMultiplicityFT0CAfterSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsMultiplicityFT0CAfterSel", "...", HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 3000.0f}});
+      hGenLi4AfterSel = mQaRegistry.add<TH1>("EventLoss/hGenLi4AfterSel", "Li4 generated #it{p}_{T} distribution in gen. evts with at least one rec. evt; #it{p}_{T} (GeV/#it{c}); Counts", HistType::kTH1D, {{240, 0.0f, 12.0f}});
+      hGenLi4vsImpactParameterAfterSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsImpactParameterAfterSel", "; #it{p}_{T} (GeV/#it{c}); Impact Parameter (b)", HistType::kTH2D, {{240, 0.0f, 12.0f}, {200, 0.0f, 20.0f}});
+      hGenLi4vsMultiplicityGenEta05AfterSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsMultiplicityGenEta05AfterSel", "; #it{p}_{T} (GeV/#it{c}); Multiplicity #eta <0.5", HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 500.0f}});
+      hGenLi4vsMultiplicityGenEta08AfterSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsMultiplicityGenEta08AfterSel", "; #it{p}_{T} (GeV/#it{c}); Multiplicity #eta <0.8", HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 500.0f}});
+      hGenLi4vsMultiplicityFT0CAfterSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsMultiplicityFT0CAfterSel", "; #it{p}_{T} (GeV/#it{c}); FT0C multiplicity", HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 3000.0f}});
     }
   }
 
@@ -1557,27 +1518,12 @@ struct he3HadronFemto {
     }
 
     //////////// Event loss estimation via impact parameter and multiplicity by MCFT0C
-
-    LOG(info) << "Processing MC";
-    /*
-    mQaRegistry.fill(HIST("EventLoss/hEvtMC"), 0);
-    mQaRegistry.fill(HIST("EventLoss/hImpactParamGen"), mcCollision.impactParameter());
-    mQaRegistry.fill(HIST("EventLoss/hGenEventsNchEta05"), mcCollision.multMCNParticlesEta05(), 0);
-    mQaRegistry.fill(HIST("EventLoss/hGenEventsNchEta08"), mcCollision.multMCNParticlesEta08(), 0);
-    */
     hEvtMC->Fill(0);
-    LOG(info) << "Filled hEvtMC";
     hImpactParamGen->Fill(mcCollision.impactParameter());
-    LOG(info) << "Filled hImpactParamGen";
-    const auto multEta05 = mcCollision.multMCNParticlesEta05();
-    LOG(info) << "multEta05: " << multEta05;
-    hGenEventsNchEta05->Fill(multEta05, 0);
-    LOG(info) << "Filled hGenEventsNchEta05";
+    hGenEventsNchEta05->Fill(mcCollision.multMCNParticlesEta05(), 0);
     hGenEventsNchEta08->Fill(mcCollision.multMCNParticlesEta08(), 0);
-    LOG(info) << "Filled hGenEventsNchEta08";
 
     if (collisions.size() == 0) {
-      /*mQaRegistry.fill(HIST("EventLoss/hEvtMC"), 1);*/
       hEvtMC->Fill(1);
     }
 
@@ -1599,15 +1545,6 @@ struct he3HadronFemto {
       }
 
       atLeastOneRecoEvt = true;
-      LOG(info) << "First fill";
-      /*
-      mQaRegistry.fill(HIST("EventLoss/hImpactParamReco"), mcCollision.impactParameter());
-      mQaRegistry.fill(HIST("EventLoss/hRecoCentrality"), col.centFT0C());
-      mQaRegistry.fill(HIST("EventLoss/hRecoCentralityColvsMultiplicityRecoEta05"), col.centFT0C(), mcCollision.multMCNParticlesEta05());
-      mQaRegistry.fill(HIST("EventLoss/hRecoCentralityColvsMultiplicityRecoEta08"), col.centFT0C(), mcCollision.multMCNParticlesEta08());
-      mQaRegistry.fill(HIST("EventLoss/hRecoCentralityColvsMultiplicityFT0C"), col.centFT0C(), mcCollision.multMCFT0C());
-      mQaRegistry.fill(HIST("EventLoss/hRecoCentralityColvsImpactParamReco"), col.centFT0C(), mcCollision.impactParameter());
-      */
       hImpactParamReco->Fill(mcCollision.impactParameter());
       hRecoCentrality->Fill(col.centFT0C());
       hRecoCentralityColvsMultiplicityRecoEta05->Fill(col.centFT0C(), mcCollision.multMCNParticlesEta05());
@@ -1617,18 +1554,6 @@ struct he3HadronFemto {
     }
 
     if (atLeastOneRecoEvt) {
-      LOG(info) << "Second fill";
-      /*
-      mQaRegistry.fill(HIST("EventLoss/hEvtMC"), 2);
-      mQaRegistry.fill(HIST("EventLoss/hGenEventsNchEta05"), mcCollision.multMCNParticlesEta05(), 1);
-      mQaRegistry.fill(HIST("EventLoss/hGenEventsNchEta08"), mcCollision.multMCNParticlesEta08(), 1);
-      mQaRegistry.fill(HIST("EventLoss/hImpactParamGenOneReco"), mcCollision.impactParameter());
-      mQaRegistry.fill(HIST("EventLoss/hGenOneRecoCentrality"), centralityFT0C);
-      mQaRegistry.fill(HIST("EventLoss/hGenCentralityColvsMultiplicityGenEta05"), centralityFT0C, mcCollision.multMCNParticlesEta05());
-      mQaRegistry.fill(HIST("EventLoss/hGenCentralityColvsMultiplicityGenEta08"), centralityFT0C, mcCollision.multMCNParticlesEta08());
-      mQaRegistry.fill(HIST("EventLoss/hGenCentralityColvsMultiplicityFT0C"), centralityFT0C, mcCollision.multMCFT0C());
-      mQaRegistry.fill(HIST("EventLoss/hGenCentralityColvsImpactParamGen"), centralityFT0C, mcCollision.impactParameter());
-      */
       hEvtMC->Fill(2);
       hGenEventsNchEta05->Fill(mcCollision.multMCNParticlesEta05(), 1);
       hGenEventsNchEta08->Fill(mcCollision.multMCNParticlesEta08(), 1);
@@ -1672,14 +1597,6 @@ struct he3HadronFemto {
 
       mother = daughHe3 + daughHad;
 
-      LOG(info) << "Third fill";
-      /*
-      mQaRegistry.fill(HIST("EventLoss/hGenLi4BeforeEvtSel"), mother.pt());
-      mQaRegistry.fill(HIST("EventLoss/hGenLi4vsImpactParameterBeforeEvtSel"), mother.pt(), mcCollision.impactParameter());
-      mQaRegistry.fill(HIST("EventLoss/hGenLi4vsMultiplicityGenEta05BeforeEvtSel"), mother.pt(), mcCollision.multMCNParticlesEta05());
-      mQaRegistry.fill(HIST("EventLoss/hGenLi4vsMultiplicityGenEta08BeforeEvtSel"), mother.pt(), mcCollision.multMCNParticlesEta08());
-      mQaRegistry.fill(HIST("EventLoss/hGenLi4vsMultiplicityFT0CBeforeEvtSel"), mother.pt(), mcCollision.multMCFT0C());
-      */
       hGenLi4BeforeEvtSel->Fill(mother.pt());
       hGenLi4vsImpactParameterBeforeEvtSel->Fill(mother.pt(), mcCollision.impactParameter());
       hGenLi4vsMultiplicityGenEta05BeforeEvtSel->Fill(mother.pt(), mcCollision.multMCNParticlesEta05());
@@ -1687,14 +1604,6 @@ struct he3HadronFemto {
       hGenLi4vsMultiplicityFT0CBeforeEvtSel->Fill(mother.pt(), mcCollision.multMCFT0C());
 
       if (atLeastOneRecoEvt) {
-        LOG(info) << "Fourth fill";
-        /*
-        mQaRegistry.fill(HIST("EventLoss/hGenLi4AfterSel"), mother.pt());
-        mQaRegistry.fill(HIST("EventLoss/hGenLi4vsImpactParameterAfterSel"), mother.pt(), mcCollision.impactParameter());
-        mQaRegistry.fill(HIST("EventLoss/hGenLi4vsMultiplicityGenEta05AfterSel"), mother.pt(), mcCollision.multMCNParticlesEta05());
-        mQaRegistry.fill(HIST("EventLoss/hGenLi4vsMultiplicityGenEta08AfterSel"), mother.pt(), mcCollision.multMCNParticlesEta08());
-        mQaRegistry.fill(HIST("EventLoss/hGenLi4vsMultiplicityFT0CAfterSel"), mother.pt(), mcCollision.multMCFT0C());
-        */
         hGenLi4AfterSel->Fill(mother.pt());
         hGenLi4vsImpactParameterAfterSel->Fill(mother.pt(), mcCollision.impactParameter());
         hGenLi4vsMultiplicityGenEta05AfterSel->Fill(mother.pt(), mcCollision.multMCNParticlesEta05());

--- a/PWGLF/TableProducer/Nuspex/he3HadronFemto.cxx
+++ b/PWGLF/TableProducer/Nuspex/he3HadronFemto.cxx
@@ -202,6 +202,28 @@ constexpr std::array<double, 3> kHePidTrkPParamsHeDefault = {0., 0., 0.};
 
 } // namespace
 
+struct CollisionInfo {
+  int64_t collisionID = -1;
+  uint32_t selectionFlags = 0;
+  float posZ = -999.f;
+  int numContributors = -1;
+  float centFT0C = -999.f;
+  int multFT0C = -1;
+  float occupancy = -999.f;
+
+  template <typename Collision>
+  void fillFromCollision(const Collision& collision, uint32_t collisionSelectionFlag)
+  {
+    collisionID = collision.globalIndex();
+    selectionFlags = collisionSelectionFlag;
+    posZ = collision.posZ();
+    numContributors = collision.numContrib();
+    centFT0C = collision.centFT0C();
+    multFT0C = collision.multFT0C();
+    occupancy = collision.trackOccupancyInTimeRange();
+  }
+};
+
 struct He3HadCandidate {
 
   [[nodiscard]] float recoPtHe3() const { return signHe3 * std::hypot(momHe3[0], momHe3[1]); }
@@ -378,6 +400,8 @@ struct he3HadronFemto {
   o2::aod::ITSResponse mResponseITS;
 
   std::vector<bool> mGoodCollisions;
+  std::vector<bool> mRecoMcCollisions;
+  std::vector<int> mMcCollisionIdToRecoCollisionId;
   std::vector<uint32_t> mCollisionSelectionFlags;
   std::vector<SVCand> mTrackPairs;
   o2::vertexing::DCAFitterN<2> mFitter;
@@ -603,6 +627,11 @@ struct he3HadronFemto {
   bool selectCollision(const Tcollision& collision, const aod::BCsWithTimestamps&, uint32_t& collisionSelectionFlag)
   {
     mQaRegistry.fill(HIST("hEvents"), 0);
+    if constexpr (isMC) {
+      if (collision.has_mcCollision()) {
+        mMcCollisionIdToRecoCollisionId[collision.mcCollisionId()] = collision.globalIndex();
+      }
+    }
 
     auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
     initCCDB(bc);
@@ -610,10 +639,17 @@ struct he3HadronFemto {
     if (!nuclei::eventSelection(collision, mQaRegistry, settingEventSelections, cutSettings.settingCutVertex, collisionSelectionFlag)) {
       return false;
     }
+
     if (settingSkimmedProcessing) {
       bool zorroSelected = mZorro.isSelected(collision.template bc_as<aod::BCsWithTimestamps>().globalBC());
       if (zorroSelected) {
         mQaRegistry.fill(HIST("hEvents"), 2);
+      }
+    }
+
+    if constexpr (isMC) {
+      if (collision.has_mcCollision()) {
+        mRecoMcCollisions[collision.mcCollisionId()] = true;
       }
     }
 
@@ -1048,10 +1084,8 @@ struct he3HadronFemto {
     }
   }
 
-  template <typename Tcoll>
-  void fillTable(const He3HadCandidate& he3Hadcand, const Tcoll& collision, bool isMC = false)
+  void fillTable(const He3HadCandidate& he3Hadcand, const CollisionInfo& collisionInfo, bool isMC = false)
   {
-    const uint32_t collisionSelectionFlag = mCollisionSelectionFlags[he3Hadcand.collisionID];
     outputDataTable(
       he3Hadcand.recoPtHe3(), he3Hadcand.recoEtaHe3(), he3Hadcand.recoPhiHe3(),
       he3Hadcand.recoPtHad(), he3Hadcand.recoEtaHad(), he3Hadcand.recoPhiHad(),
@@ -1072,9 +1106,9 @@ struct he3HadronFemto {
         he3Hadcand.l4PtMC, he3Hadcand.l4MassMC, he3Hadcand.flags);
     }
     outputMultiplicityTable(
-      collision.globalIndex(), collisionSelectionFlag, collision.posZ(),
-      collision.numContrib(), collision.centFT0C(), collision.multFT0C(), 
-      collision.trackOccupancyInTimeRange());
+      collisionInfo.collisionID,  collisionInfo.selectionFlags, collisionInfo.posZ,
+      collisionInfo.numContributors, collisionInfo.centFT0C, collisionInfo.multFT0C,
+      collisionInfo.occupancy);
     outputQaTable(
       he3Hadcand.trackIDHe3, he3Hadcand.trackIDHad, he3Hadcand.massTOFHe3,
       he3Hadcand.pidtrkHad, he3Hadcand.sharedClustersHad);
@@ -1125,7 +1159,9 @@ struct he3HadronFemto {
       }
       fillHistograms(he3Hadcand);
       auto collision = collisions.rawIteratorAt(he3Hadcand.collisionID);
-      fillTable(he3Hadcand, collision, /*isMC*/ false);
+      CollisionInfo collisionInfo;
+      collisionInfo.fillFromCollision(collision, mCollisionSelectionFlags[he3Hadcand.collisionID]);
+      fillTable(he3Hadcand, collisionInfo, /*isMC*/ false);
     }
   }
 
@@ -1219,8 +1255,15 @@ struct he3HadronFemto {
         He3HadCandidate he3Hadcand;
         fillCandidateInfoMC(mcHe3, mcHad, he3Hadcand);
         fillMotherInfoMC(mcHe3, mcHad, mcParticle, he3Hadcand);
-        auto collision = collisions.rawIteratorAt(he3Hadcand.collisionID);
-        fillTable(he3Hadcand, collision, /*isMC*/ true);
+        
+        const auto mcCollisionId = mcParticle.mcCollisionId();
+        const auto collisionId = mMcCollisionIdToRecoCollisionId[mcCollisionId];
+        CollisionInfo collisionInfo;
+        if (collisionId >= 0) {
+          auto collision = collisions.rawIteratorAt(collisionId);
+          collisionInfo.fillFromCollision(collision, mCollisionSelectionFlags[collisionId]);
+        }
+        fillTable(he3Hadcand, collisionInfo, /*isMC*/ true);
       }
     }
   }
@@ -1287,12 +1330,16 @@ struct he3HadronFemto {
   }
   PROCESS_SWITCH(he3HadronFemto, processMixedEvent, "Process Mixed event", false);
 
-  void processMC(const CollisionsFullMC& collisions, const aod::BCsWithTimestamps& bcs, const TrackCandidatesMC& tracks, const aod::McParticles& mcParticles)
+  void processMC(const CollisionsFullMC& collisions, const aod::McCollisions& mcCollisions, const aod::BCsWithTimestamps& bcs, const TrackCandidatesMC& tracks, const aod::McParticles& mcParticles)
   {
     std::vector<unsigned int> filledMothers;
 
     mGoodCollisions.clear();
     mGoodCollisions.resize(collisions.size(), false);
+    mRecoMcCollisions.clear();
+    mRecoMcCollisions.resize(mcCollisions.size(), false);
+    mMcCollisionIdToRecoCollisionId.clear();
+    mMcCollisionIdToRecoCollisionId.resize(mcCollisions.size(), -1);
     mCollisionSelectionFlags.clear();
     mCollisionSelectionFlags.resize(collisions.size(), 0);
 
@@ -1383,9 +1430,11 @@ struct he3HadronFemto {
           fillMotherInfoMC(mctrackHe3, mctrackHad, motherParticle, he3Hadcand);
           filledMothers.push_back(motherParticle.globalIndex());
         }
-
         fillHistograms(he3Hadcand, /*isMc*/ true);
-        fillTable(he3Hadcand, collision, /*isMC*/ true);
+
+        CollisionInfo collisionInfo;
+        collisionInfo.fillFromCollision(collision, collisionSelectionFlag);
+        fillTable(he3Hadcand, collisionInfo, /*isMC*/ true);
       }
     }
 
@@ -1532,9 +1581,10 @@ struct he3HadronFemto {
     int biggestNContribs = -1;
 
     for (const auto& col : collisions) {
-      
+
       uint32_t collisionSelectionFlag = 0;
-      if (!selectCollision</*isMC*/ true>(col, bcs, collisionSelectionFlag)) {
+      // isMC == true only fills the collision vectors, which are not used in this workflow
+      if (!selectCollision</*isMC*/ false>(col, bcs, collisionSelectionFlag)) {
         continue;
       }
 

--- a/PWGLF/TableProducer/Nuspex/he3HadronFemto.cxx
+++ b/PWGLF/TableProducer/Nuspex/he3HadronFemto.cxx
@@ -1106,7 +1106,7 @@ struct he3HadronFemto {
         he3Hadcand.l4PtMC, he3Hadcand.l4MassMC, he3Hadcand.flags);
     }
     outputMultiplicityTable(
-      collisionInfo.collisionID,  collisionInfo.selectionFlags, collisionInfo.posZ,
+      collisionInfo.collisionID, collisionInfo.selectionFlags, collisionInfo.posZ,
       collisionInfo.numContributors, collisionInfo.centFT0C, collisionInfo.multFT0C,
       collisionInfo.occupancy);
     outputQaTable(
@@ -1255,7 +1255,7 @@ struct he3HadronFemto {
         He3HadCandidate he3Hadcand;
         fillCandidateInfoMC(mcHe3, mcHad, he3Hadcand);
         fillMotherInfoMC(mcHe3, mcHad, mcParticle, he3Hadcand);
-        
+
         const auto mcCollisionId = mcParticle.mcCollisionId();
         const auto collisionId = mMcCollisionIdToRecoCollisionId[mcCollisionId];
         CollisionInfo collisionInfo;
@@ -1663,7 +1663,6 @@ struct he3HadronFemto {
     }
   }
   PROCESS_SWITCH(he3HadronFemto, processEventLossMC, "Event loss analysis", false);
-
 };
 
 WorkflowSpec defineDataProcessing(const ConfigContext& cfgc)

--- a/PWGLF/TableProducer/Nuspex/he3HadronFemto.cxx
+++ b/PWGLF/TableProducer/Nuspex/he3HadronFemto.cxx
@@ -1573,7 +1573,7 @@ struct he3HadronFemto {
     hGenEventsNchEta08->Fill(mcCollision.multMCNParticlesEta08(), 0);
 
     if (collisions.size() == 0) {
-      hEvtMC->Fill(1);
+      hEvtMC->Fill(2);
     }
 
     bool atLeastOneRecoEvt = false;
@@ -1604,7 +1604,7 @@ struct he3HadronFemto {
     }
 
     if (atLeastOneRecoEvt) {
-      hEvtMC->Fill(2);
+      hEvtMC->Fill(1);
       hGenEventsNchEta05->Fill(mcCollision.multMCNParticlesEta05(), 1);
       hGenEventsNchEta08->Fill(mcCollision.multMCNParticlesEta08(), 1);
       hImpactParamGenOneReco->Fill(mcCollision.impactParameter());

--- a/PWGLF/TableProducer/Nuspex/he3HadronFemto.cxx
+++ b/PWGLF/TableProducer/Nuspex/he3HadronFemto.cxx
@@ -85,9 +85,38 @@ using CollisionsFull = soa::Join<aod::Collisions, aod::EvSels, aod::CentFT0As, a
 using CollisionsFullMC = soa::Join<aod::Collisions, aod::McCollisionLabels, aod::EvSels, aod::CentFT0As, aod::CentFT0Cs, aod::FT0Mults>;
 using TrackCandidates = soa::Join<aod::TracksIU, aod::TracksExtra, aod::TracksCovIU, aod::TracksDCA, aod::TrackSelection, aod::pidTPCFullPr, aod::pidTOFFullPr, aod::pidTPCFullPi, aod::pidTOFFullPi, aod::pidTPCFullKa, aod::pidTOFFullKa, aod::TOFSignal, aod::TOFEvTime>;
 using TrackCandidatesMC = soa::Join<aod::TracksIU, aod::TracksExtra, aod::TracksCovIU, aod::TracksDCA, aod::TrackSelection, aod::pidTPCFullPr, aod::pidTOFFullPr, aod::pidTPCFullPi, aod::pidTOFFullPi, aod::pidTPCFullKa, aod::pidTOFFullKa, aod::TOFSignal, aod::TOFEvTime, aod::McTrackLabels>;
+using McCollisionMults = soa::Join<aod::McCollisions, aod::MultMCExtras>;
+using EventCandidatesMC = soa::Join<aod::Collisions, aod::EvSels, aod::McCollisionLabels, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs, aod::CentFV0As, aod::Mults>;
 
 namespace
 {
+
+std::shared_ptr<TH1> hEvtMC;
+std::shared_ptr<TH1> hImpactParamGen;
+std::shared_ptr<TH1> hImpactParamReco;
+std::shared_ptr<TH1> hRecoCentrality;
+std::shared_ptr<TH1> hImpactParamGenOneReco;
+std::shared_ptr<TH1> hGenOneRecoCentrality;
+std::shared_ptr<TH2> hGenEventsNchEta05;
+std::shared_ptr<TH2> hGenEventsNchEta08;
+std::shared_ptr<TH2> hRecoCentralityColvsMultiplicityRecoEta05;
+std::shared_ptr<TH2> hRecoCentralityColvsMultiplicityRecoEta08;
+std::shared_ptr<TH2> hRecoCentralityColvsMultiplicityFT0C;
+std::shared_ptr<TH2> hRecoCentralityColvsImpactParamReco;
+std::shared_ptr<TH2> hGenCentralityColvsMultiplicityGenEta05;
+std::shared_ptr<TH2> hGenCentralityColvsMultiplicityGenEta08;
+std::shared_ptr<TH2> hGenCentralityColvsMultiplicityFT0C;
+std::shared_ptr<TH2> hGenCentralityColvsImpactParamGen;
+std::shared_ptr<TH1> hGenLi4BeforeEvtSel;
+std::shared_ptr<TH2> hGenLi4vsImpactParameterBeforeEvtSel;
+std::shared_ptr<TH2> hGenLi4vsMultiplicityGenEta05BeforeEvtSel;
+std::shared_ptr<TH2> hGenLi4vsMultiplicityGenEta08BeforeEvtSel;
+std::shared_ptr<TH2> hGenLi4vsMultiplicityFT0CBeforeEvtSel;
+std::shared_ptr<TH1> hGenLi4AfterSel;
+std::shared_ptr<TH2> hGenLi4vsImpactParameterAfterSel;
+std::shared_ptr<TH2> hGenLi4vsMultiplicityGenEta05AfterSel;
+std::shared_ptr<TH2> hGenLi4vsMultiplicityGenEta08AfterSel;
+std::shared_ptr<TH2> hGenLi4vsMultiplicityFT0CAfterSel;
 
 constexpr int Li4PDG = o2::constants::physics::Pdg::kLithium4;
 constexpr int H3LPDG = o2::constants::physics::Pdg::kHyperTriton;
@@ -374,6 +403,34 @@ struct he3HadronFemto {
       {"hhe3HadInvMass", "; M(^{3}He + p) (GeV/#it{c}^{2})", {HistType::kTH1F, {{300, 3.74f, 4.34f}}}},
       {"hhe3HadKstar", "; #it{k}* (GeV/#it{c})", {HistType::kTH1F, {{300, 0.f, 0.8f}}}},
       {"hKstarRecVsKstarGen", "; #it{k}*_{gen} (GeV/#it{c}); #it{k}*_{rec} (GeV/#it{c})", {HistType::kTH2F, {{400, 0.f, 0.8f}, {400, 0.f, 0.8f}}}},
+      /*
+      {"EventLoss/hEvtMC", ";; ", {HistType::kTH1D, {{3, -0.5f, 2.5f}}}},
+      {"EventLoss/hImpactParamGen", "Impact parameter of generated MC events; Impact Parameter (b); Counts", {HistType::kTH1D, {{200, 0.0f, 20.0f}}}},
+      {"EventLoss/hImpactParamReco", "Impact parameter of generated MC events with at least one rec. evt; Impact Parameter (b); Counts", {HistType::kTH1D, {{200, 0.0f, 20.0f}}}},
+      {"EventLoss/hRecoCentrality", "Centrality distribution of reconstructed MC events passed the event selection; Centrality FT0C (%); Counts", {HistType::kTH1D, {{100, 0.0f, 100.0f}}}},
+      {"EventLoss/hRecoCentralityColvsMultiplicityRecoEta05", "; Centrality FT0C (%); Multiplicity #eta <0.5", {HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 500.0f}}}},
+      {"EventLoss/hRecoCentralityColvsMultiplicityRecoEta08", "; Centrality FT0C (%); Multiplicity #eta <0.8", {HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 500.0f}}}},
+      {"EventLoss/hRecoCentralityColvsMultiplicityFT0C", "; Centrality FT0C (%); FT0C multiplicity", {HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 3000.0f}}}},
+      {"EventLoss/hRecoCentralityColvsImpactParamReco", "; Centrality FT0C (%); Impact Parameter (b)", {HistType::kTH2D, {{100, 0.0f, 100.0f}, {200, 0.0f, 20.0f}}}},
+      {"EventLoss/hGenEventsNchEta05", ";Multiplicity #eta <0.5;", {HistType::kTH2D, {{500, 0.0f, 500.0f}, {2, -0.5f, 1.5f}}}},
+      {"EventLoss/hGenEventsNchEta08", ";Multiplicity #eta <0.8;", {HistType::kTH2D, {{500, 0.0f, 500.0f}, {2, -0.5f, 1.5f}}}},
+      {"EventLoss/hImpactParamGenOneReco", "Impact parameter of generated MC events with at least one rec. evt and passed the event selection; Impact Parameter (b); Counts", {HistType::kTH1D, {{200, 0.0f, 20.0f}}}},
+      {"EventLoss/hGenOneRecoCentrality", "Centrality distribution of generated MC events with at least one rec. evt and passed the event selection; Centrality FT0C (%); Counts", {HistType::kTH1D, {{100, 0.0f, 100.0f}}}},
+      {"EventLoss/hGenCentralityColvsMultiplicityGenEta05", "; Centrality FT0C (%); Multiplicity #eta <0.5", {HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 500.0f}}}},
+      {"EventLoss/hGenCentralityColvsMultiplicityGenEta08", "; Centrality FT0C (%); Multiplicity #eta <0.8", {HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 500.0f}}}},
+      {"EventLoss/hGenCentralityColvsMultiplicityFT0C", "; Centrality FT0C (%); FT0C multiplicity", {HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 3000.0f}}}},
+      {"EventLoss/hGenCentralityColvsImpactParamGen", "; Centrality FT0C (%); Impact Parameter (b)", {HistType::kTH2D, {{100, 0.0f, 100.0f}, {200, 0.0f, 20.0f}}}},
+      {"EventLoss/hGenLi4BeforeEvtSel", "Li4 generated #it{p}_{T} distribution in all gen evt; #it{p}_{T} (GeV/#it{c}); Counts", {HistType::kTH1D, {{240, 0.0f, 12.0f}}}},
+      {"EventLoss/hGenLi4vsImpactParameterBeforeEvtSel", "; #it{p}_{T} (GeV/#it{c}); Impact Parameter (b)", {HistType::kTH2D, {{240, 0.0f, 12.0f}, {200, 0.0f, 20.0f}}}},
+      {"EventLoss/hGenLi4vsMultiplicityGenEta05BeforeEvtSel", "; #it{p}_{T} (GeV/#it{c}); Multiplicity #eta <0.5", {HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 500.0f}}}},
+      {"EventLoss/hGenLi4vsMultiplicityGenEta08BeforeEvtSel", "; #it{p}_{T} (GeV/#it{c}); Multiplicity #eta <0.8", {HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 500.0f}}}},
+      {"EventLoss/hGenLi4vsMultiplicityFT0CBeforeEvtSel", "; #it{p}_{T} (GeV/#it{c}); FT0C multiplicity", {HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 3000.0f}}}},
+      {"EventLoss/hGenLi4AfterSel", "Li4 generated #it{p}_{T} distribution in gen. evts with at least one rec. evt; #it{p}_{T} (GeV/#it{c}); Counts", {HistType::kTH1D, {{240, 0.0f, 12.0f}}}},
+      {"EventLoss/hGenLi4vsImpactParameterAfterSel", "; #it{p}_{T} (GeV/#it{c}); Impact Parameter (b)", {HistType::kTH2D, {{240, 0.0f, 12.0f}, {200, 0.0f, 20.0f}}}},
+      {"EventLoss/hGenLi4vsMultiplicityGenEta05AfterSel", "; #it{p}_{T} (GeV/#it{c}); Multiplicity #eta <0.5", {HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 500.0f}}}},
+      {"EventLoss/hGenLi4vsMultiplicityGenEta08AfterSel", "; #it{p}_{T} (GeV/#it{c}); Multiplicity #eta <0.8", {HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 500.0f}}}},
+      {"EventLoss/hGenLi4vsMultiplicityFT0CAfterSel", "; #it{p}_{T} (GeV/#it{c}); FT0C multiplicity", {HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 3000.0f}}}},
+      */
 
       {"He3/hDCAxyHe3", "^{3}He;DCA_{xy} (cm)", {HistType::kTH1F, {{200, -0.5f, 0.5f}}}},
       {"He3/hDCAzHe3", "^{3}He;DCA_{z} (cm)", {HistType::kTH1F, {{200, -1.0f, 1.0f}}}},
@@ -486,6 +543,58 @@ struct he3HadronFemto {
 
     mQaRegistry.get<TH1>(HIST("hEmptyPool"))->GetXaxis()->SetBinLabel(1, "False");
     mQaRegistry.get<TH1>(HIST("hEmptyPool"))->GetXaxis()->SetBinLabel(2, "True");
+
+    /*
+    mQaRegistry.get<TH1>(HIST("EventLoss/hEvtMC"))->GetXaxis()->SetBinLabel(1, "All gen evts");
+    mQaRegistry.get<TH1>(HIST("EventLoss/hEvtMC"))->GetXaxis()->SetBinLabel(2, "Gen evts with al least one reconstructed");
+    mQaRegistry.get<TH1>(HIST("EventLoss/hEvtMC"))->GetXaxis()->SetBinLabel(3, "Gen evts with no reconstructed collisions");
+
+    mQaRegistry.get<TH2>(HIST("EventLoss/hGenEventsNchEta05"))->GetYaxis()->SetBinLabel(1, "All gen. events");
+    mQaRegistry.get<TH2>(HIST("EventLoss/hGenEventsNchEta05"))->GetYaxis()->SetBinLabel(2, "Gen evts with at least 1 rec. collisions");
+    mQaRegistry.get<TH2>(HIST("EventLoss/hGenEventsNchEta08"))->GetYaxis()->SetBinLabel(1, "All gen. events");
+    mQaRegistry.get<TH2>(HIST("EventLoss/hGenEventsNchEta08"))->GetYaxis()->SetBinLabel(2, "Gen evts with at least 1 rec. collisions");
+    */
+
+    if (doprocessEventLossMC) {
+      hEvtMC = mQaRegistry.add<TH1>("EventLoss/hEvtMC", ";; ", HistType::kTH1D, {{3, -0.5, 2.5}});
+      hEvtMC->GetXaxis()->SetBinLabel(1, "All gen evts");
+      hEvtMC->GetXaxis()->SetBinLabel(2, "Gen evts with al least one reconstructed");
+      hEvtMC->GetXaxis()->SetBinLabel(3, "Gen evts with no reconstructed collisions");
+
+      hGenEventsNchEta05 = mQaRegistry.add<TH2>("EventLoss/hGenEventsNchEta05", ";;", HistType::kTH2D, {{500, 0.0f, 500.0f}, {2, -0.5f, 1.5f}});
+      hGenEventsNchEta05->GetYaxis()->SetBinLabel(1, "All gen. events");
+      hGenEventsNchEta05->GetYaxis()->SetBinLabel(2, "Gen evts with at least 1 rec. collisions");
+      hGenEventsNchEta08 = mQaRegistry.add<TH2>("EventLoss/hGenEventsNchEta08", ";;", HistType::kTH2D, {{500, 0.0f, 500.0f}, {2, -0.5f, 1.5f}});
+      hGenEventsNchEta08->GetYaxis()->SetBinLabel(1, "All gen. events");
+      hGenEventsNchEta08->GetYaxis()->SetBinLabel(2, "Gen evts with at least 1 rec. collisions");
+
+      hImpactParamGen = mQaRegistry.add<TH1>("EventLoss/hImpactParamGen", "...", HistType::kTH1D, {{200, 0.0f, 20.0f}});
+      hImpactParamReco = mQaRegistry.add<TH1>("EventLoss/hImpactParamReco", "...", HistType::kTH1D, {{200, 0.0f, 20.0f}});
+      hRecoCentrality = mQaRegistry.add<TH1>("EventLoss/hRecoCentrality", "...", HistType::kTH1D, {{100, 0.0f, 100.0f}});
+      hRecoCentralityColvsMultiplicityRecoEta05 = mQaRegistry.add<TH2>("EventLoss/hRecoCentralityColvsMultiplicityRecoEta05", "...", HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 500.0f}});
+      hRecoCentralityColvsMultiplicityRecoEta08 = mQaRegistry.add<TH2>("EventLoss/hRecoCentralityColvsMultiplicityRecoEta08", "...", HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 500.0f}});
+      hRecoCentralityColvsMultiplicityFT0C = mQaRegistry.add<TH2>("EventLoss/hRecoCentralityColvsMultiplicityFT0C", "...", HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 3000.0f}});
+      hRecoCentralityColvsImpactParamReco = mQaRegistry.add<TH2>("EventLoss/hRecoCentralityColvsImpactParamReco", "...", HistType::kTH2D, {{100, 0.0f, 100.0f}, {200, 0.0f, 20.0f}});
+
+      hImpactParamGenOneReco = mQaRegistry.add<TH1>("EventLoss/hImpactParamGenOneReco", "...", HistType::kTH1D, {{200, 0.0f, 20.0f}});
+      hGenOneRecoCentrality = mQaRegistry.add<TH1>("EventLoss/hGenOneRecoCentrality", "...", HistType::kTH1D, {{100, 0.0f, 100.0f}});
+      hGenCentralityColvsMultiplicityGenEta05 = mQaRegistry.add<TH2>("EventLoss/hGenCentralityColvsMultiplicityGenEta05", "...", HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 500.0f}});
+      hGenCentralityColvsMultiplicityGenEta08 = mQaRegistry.add<TH2>("EventLoss/hGenCentralityColvsMultiplicityGenEta08", "...", HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 500.0f}});
+      hGenCentralityColvsMultiplicityFT0C = mQaRegistry.add<TH2>("EventLoss/hGenCentralityColvsMultiplicityFT0C", "...", HistType::kTH2D, {{100, 0.0f, 100.0f}, {500, 0.0f, 3000.0f}});
+      hGenCentralityColvsImpactParamGen = mQaRegistry.add<TH2>("EventLoss/hGenCentralityColvsImpactParamGen", "...", HistType::kTH2D, {{100, 0.0f, 100.0f}, {200, 0.0f, 20.0f}});
+
+      hGenLi4BeforeEvtSel = mQaRegistry.add<TH1>("EventLoss/hGenLi4BeforeEvtSel", "...", HistType::kTH1D, {{240, 0.0f, 12.0f}});
+      hGenLi4vsImpactParameterBeforeEvtSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsImpactParameterBeforeEvtSel", "...", HistType::kTH2D, {{240, 0.0f, 12.0f}, {200, 0.0f, 20.0f}});
+      hGenLi4vsMultiplicityGenEta05BeforeEvtSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsMultiplicityGenEta05BeforeEvtSel", "...", HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 500.0f}});
+      hGenLi4vsMultiplicityGenEta08BeforeEvtSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsMultiplicityGenEta08BeforeEvtSel", "...", HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 500.0f}});
+      hGenLi4vsMultiplicityFT0CBeforeEvtSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsMultiplicityFT0CBeforeEvtSel", "...", HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 3000.0f}});
+
+      hGenLi4AfterSel = mQaRegistry.add<TH1>("EventLoss/hGenLi4AfterSel", "...", HistType::kTH1D, {{240, 0.0f, 12.0f}});
+      hGenLi4vsImpactParameterAfterSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsImpactParameterAfterSel", "...", HistType::kTH2D, {{240, 0.0f, 12.0f}, {200, 0.0f, 20.0f}});
+      hGenLi4vsMultiplicityGenEta05AfterSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsMultiplicityGenEta05AfterSel", "...", HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 500.0f}});
+      hGenLi4vsMultiplicityGenEta08AfterSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsMultiplicityGenEta08AfterSel", "...", HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 500.0f}});
+      hGenLi4vsMultiplicityFT0CAfterSel = mQaRegistry.add<TH2>("EventLoss/hGenLi4vsMultiplicityFT0CAfterSel", "...", HistType::kTH2D, {{240, 0.0f, 12.0f}, {500, 0.0f, 3000.0f}});
+    }
   }
 
   void initCCDB(const aod::BCsWithTimestamps::iterator& bc)
@@ -1003,7 +1112,8 @@ struct he3HadronFemto {
     }
     outputMultiplicityTable(
       collision.globalIndex(), collisionSelectionFlag, collision.posZ(),
-      collision.numContrib(), collision.centFT0C(), collision.multFT0C());
+      collision.numContrib(), collision.centFT0C(), collision.multFT0C(), 
+      collision.trackOccupancyInTimeRange());
     outputQaTable(
       he3Hadcand.trackIDHe3, he3Hadcand.trackIDHad, he3Hadcand.massTOFHe3,
       he3Hadcand.pidtrkHad, he3Hadcand.sharedClustersHad);
@@ -1439,6 +1549,162 @@ struct he3HadronFemto {
     }
   }
   PROCESS_SWITCH(he3HadronFemto, processPurityMc, "Process for purity studies mc", false);
+
+  void processEventLossMC(McCollisionMults::iterator const& mcCollision, soa::SmallGroups<EventCandidatesMC> const& collisions, aod::BCsWithTimestamps const& bcs, aod::McParticles const& mcParticles)
+  {
+    if (std::abs(mcCollision.posZ()) > cutSettings.settingCutVertex) {
+      return;
+    }
+
+    //////////// Event loss estimation via impact parameter and multiplicity by MCFT0C
+
+    LOG(info) << "Processing MC";
+    /*
+    mQaRegistry.fill(HIST("EventLoss/hEvtMC"), 0);
+    mQaRegistry.fill(HIST("EventLoss/hImpactParamGen"), mcCollision.impactParameter());
+    mQaRegistry.fill(HIST("EventLoss/hGenEventsNchEta05"), mcCollision.multMCNParticlesEta05(), 0);
+    mQaRegistry.fill(HIST("EventLoss/hGenEventsNchEta08"), mcCollision.multMCNParticlesEta08(), 0);
+    */
+    hEvtMC->Fill(0);
+    LOG(info) << "Filled hEvtMC";
+    hImpactParamGen->Fill(mcCollision.impactParameter());
+    LOG(info) << "Filled hImpactParamGen";
+    const auto multEta05 = mcCollision.multMCNParticlesEta05();
+    LOG(info) << "multEta05: " << multEta05;
+    hGenEventsNchEta05->Fill(multEta05, 0);
+    LOG(info) << "Filled hGenEventsNchEta05";
+    hGenEventsNchEta08->Fill(mcCollision.multMCNParticlesEta08(), 0);
+    LOG(info) << "Filled hGenEventsNchEta08";
+
+    if (collisions.size() == 0) {
+      /*mQaRegistry.fill(HIST("EventLoss/hEvtMC"), 1);*/
+      hEvtMC->Fill(1);
+    }
+
+    bool atLeastOneRecoEvt = false;
+    auto centralityFT0C = -999.;
+    int biggestNContribs = -1;
+
+    for (const auto& col : collisions) {
+      
+      uint32_t collisionSelectionFlag = 0;
+      if (!selectCollision</*isMC*/ true>(col, bcs, collisionSelectionFlag)) {
+        continue;
+      }
+
+      // In case of multiple reconstructed collisions associated to the same generated one, only consider the one with the biggest number of contributors
+      if (biggestNContribs < col.numContrib()) {
+        biggestNContribs = col.numContrib();
+        centralityFT0C = col.centFT0C();
+      }
+
+      atLeastOneRecoEvt = true;
+      LOG(info) << "First fill";
+      /*
+      mQaRegistry.fill(HIST("EventLoss/hImpactParamReco"), mcCollision.impactParameter());
+      mQaRegistry.fill(HIST("EventLoss/hRecoCentrality"), col.centFT0C());
+      mQaRegistry.fill(HIST("EventLoss/hRecoCentralityColvsMultiplicityRecoEta05"), col.centFT0C(), mcCollision.multMCNParticlesEta05());
+      mQaRegistry.fill(HIST("EventLoss/hRecoCentralityColvsMultiplicityRecoEta08"), col.centFT0C(), mcCollision.multMCNParticlesEta08());
+      mQaRegistry.fill(HIST("EventLoss/hRecoCentralityColvsMultiplicityFT0C"), col.centFT0C(), mcCollision.multMCFT0C());
+      mQaRegistry.fill(HIST("EventLoss/hRecoCentralityColvsImpactParamReco"), col.centFT0C(), mcCollision.impactParameter());
+      */
+      hImpactParamReco->Fill(mcCollision.impactParameter());
+      hRecoCentrality->Fill(col.centFT0C());
+      hRecoCentralityColvsMultiplicityRecoEta05->Fill(col.centFT0C(), mcCollision.multMCNParticlesEta05());
+      hRecoCentralityColvsMultiplicityRecoEta08->Fill(col.centFT0C(), mcCollision.multMCNParticlesEta08());
+      hRecoCentralityColvsMultiplicityFT0C->Fill(col.centFT0C(), mcCollision.multMCFT0C());
+      hRecoCentralityColvsImpactParamReco->Fill(col.centFT0C(), mcCollision.impactParameter());
+    }
+
+    if (atLeastOneRecoEvt) {
+      LOG(info) << "Second fill";
+      /*
+      mQaRegistry.fill(HIST("EventLoss/hEvtMC"), 2);
+      mQaRegistry.fill(HIST("EventLoss/hGenEventsNchEta05"), mcCollision.multMCNParticlesEta05(), 1);
+      mQaRegistry.fill(HIST("EventLoss/hGenEventsNchEta08"), mcCollision.multMCNParticlesEta08(), 1);
+      mQaRegistry.fill(HIST("EventLoss/hImpactParamGenOneReco"), mcCollision.impactParameter());
+      mQaRegistry.fill(HIST("EventLoss/hGenOneRecoCentrality"), centralityFT0C);
+      mQaRegistry.fill(HIST("EventLoss/hGenCentralityColvsMultiplicityGenEta05"), centralityFT0C, mcCollision.multMCNParticlesEta05());
+      mQaRegistry.fill(HIST("EventLoss/hGenCentralityColvsMultiplicityGenEta08"), centralityFT0C, mcCollision.multMCNParticlesEta08());
+      mQaRegistry.fill(HIST("EventLoss/hGenCentralityColvsMultiplicityFT0C"), centralityFT0C, mcCollision.multMCFT0C());
+      mQaRegistry.fill(HIST("EventLoss/hGenCentralityColvsImpactParamGen"), centralityFT0C, mcCollision.impactParameter());
+      */
+      hEvtMC->Fill(2);
+      hGenEventsNchEta05->Fill(mcCollision.multMCNParticlesEta05(), 1);
+      hGenEventsNchEta08->Fill(mcCollision.multMCNParticlesEta08(), 1);
+      hImpactParamGenOneReco->Fill(mcCollision.impactParameter());
+      hGenOneRecoCentrality->Fill(centralityFT0C);
+      hGenCentralityColvsMultiplicityGenEta05->Fill(centralityFT0C, mcCollision.multMCNParticlesEta05());
+      hGenCentralityColvsMultiplicityGenEta08->Fill(centralityFT0C, mcCollision.multMCNParticlesEta08());
+      hGenCentralityColvsMultiplicityFT0C->Fill(centralityFT0C, mcCollision.multMCFT0C());
+      hGenCentralityColvsImpactParamGen->Fill(centralityFT0C, mcCollision.impactParameter());
+    }
+
+    // Construct the Li4 (He3 + hadron) 4-vector from generated daughters by PDG
+    ROOT::Math::PxPyPzMVector daughHe3, daughHad, mother;
+    const double hadMass = settingHadPDGCode == PDG_t::kPiPlus ? o2::constants::physics::MassPiPlus : o2::constants::physics::MassProton;
+
+    for (const auto& genParticle : mcParticles) {
+      if (std::abs(genParticle.y()) > 1)
+        continue;
+      if (std::abs(genParticle.pdgCode()) != Li4PDG)
+        continue;
+
+      auto daughters = genParticle.daughters_as<aod::McParticles>();
+
+      bool dauHe3 = false, dauHad = false;
+      int he3Sign = 0, hadSign = 0;
+
+      for (const auto& daughter : daughters) {
+        if (std::abs(daughter.pdgCode()) == He3PDG) {
+          dauHe3 = true;
+          he3Sign = daughter.pdgCode() > 0 ? 1 : -1;
+          daughHe3 = ROOT::Math::PxPyPzMVector(daughter.px(), daughter.py(), daughter.pz(), o2::constants::physics::MassHelium3);
+        } else if (std::abs(daughter.pdgCode()) == settingHadPDGCode) {
+          dauHad = true;
+          hadSign = daughter.pdgCode() > 0 ? 1 : -1;
+          daughHad = ROOT::Math::PxPyPzMVector(daughter.px(), daughter.py(), daughter.pz(), hadMass);
+        }
+      }
+      // Only keep the charge combination consistent with a genuine Li4 decay
+      if (!dauHe3 || !dauHad || (he3Sign * hadSign) < 0)
+        continue;
+
+      mother = daughHe3 + daughHad;
+
+      LOG(info) << "Third fill";
+      /*
+      mQaRegistry.fill(HIST("EventLoss/hGenLi4BeforeEvtSel"), mother.pt());
+      mQaRegistry.fill(HIST("EventLoss/hGenLi4vsImpactParameterBeforeEvtSel"), mother.pt(), mcCollision.impactParameter());
+      mQaRegistry.fill(HIST("EventLoss/hGenLi4vsMultiplicityGenEta05BeforeEvtSel"), mother.pt(), mcCollision.multMCNParticlesEta05());
+      mQaRegistry.fill(HIST("EventLoss/hGenLi4vsMultiplicityGenEta08BeforeEvtSel"), mother.pt(), mcCollision.multMCNParticlesEta08());
+      mQaRegistry.fill(HIST("EventLoss/hGenLi4vsMultiplicityFT0CBeforeEvtSel"), mother.pt(), mcCollision.multMCFT0C());
+      */
+      hGenLi4BeforeEvtSel->Fill(mother.pt());
+      hGenLi4vsImpactParameterBeforeEvtSel->Fill(mother.pt(), mcCollision.impactParameter());
+      hGenLi4vsMultiplicityGenEta05BeforeEvtSel->Fill(mother.pt(), mcCollision.multMCNParticlesEta05());
+      hGenLi4vsMultiplicityGenEta08BeforeEvtSel->Fill(mother.pt(), mcCollision.multMCNParticlesEta08());
+      hGenLi4vsMultiplicityFT0CBeforeEvtSel->Fill(mother.pt(), mcCollision.multMCFT0C());
+
+      if (atLeastOneRecoEvt) {
+        LOG(info) << "Fourth fill";
+        /*
+        mQaRegistry.fill(HIST("EventLoss/hGenLi4AfterSel"), mother.pt());
+        mQaRegistry.fill(HIST("EventLoss/hGenLi4vsImpactParameterAfterSel"), mother.pt(), mcCollision.impactParameter());
+        mQaRegistry.fill(HIST("EventLoss/hGenLi4vsMultiplicityGenEta05AfterSel"), mother.pt(), mcCollision.multMCNParticlesEta05());
+        mQaRegistry.fill(HIST("EventLoss/hGenLi4vsMultiplicityGenEta08AfterSel"), mother.pt(), mcCollision.multMCNParticlesEta08());
+        mQaRegistry.fill(HIST("EventLoss/hGenLi4vsMultiplicityFT0CAfterSel"), mother.pt(), mcCollision.multMCFT0C());
+        */
+        hGenLi4AfterSel->Fill(mother.pt());
+        hGenLi4vsImpactParameterAfterSel->Fill(mother.pt(), mcCollision.impactParameter());
+        hGenLi4vsMultiplicityGenEta05AfterSel->Fill(mother.pt(), mcCollision.multMCNParticlesEta05());
+        hGenLi4vsMultiplicityGenEta08AfterSel->Fill(mother.pt(), mcCollision.multMCNParticlesEta08());
+        hGenLi4vsMultiplicityFT0CAfterSel->Fill(mother.pt(), mcCollision.multMCFT0C());
+      }
+    }
+  }
+  PROCESS_SWITCH(he3HadronFemto, processEventLossMC, "Event loss analysis", false);
+
 };
 
 WorkflowSpec defineDataProcessing(const ConfigContext& cfgc)

--- a/PWGLF/Utils/nucleiUtils.h
+++ b/PWGLF/Utils/nucleiUtils.h
@@ -374,7 +374,6 @@ bool eventSelection(const Tcollision& collision, o2::framework::HistogramRegistr
   checkCut(evSel::kNoHighMultCollInPrevRof, collision.selection_bit(o2::aod::evsel::kNoHighMultCollInPrevRof));
   checkCut(evSel::kNoCollInTimeRangeStandard, collision.selection_bit(o2::aod::evsel::kNoCollInTimeRangeStandard));
 
-  
   registry.fill(HIST("hVtxZ"), collision.posZ());
 
   return isSelected;

--- a/PWGLF/Utils/nucleiUtils.h
+++ b/PWGLF/Utils/nucleiUtils.h
@@ -374,6 +374,7 @@ bool eventSelection(const Tcollision& collision, o2::framework::HistogramRegistr
   checkCut(evSel::kNoHighMultCollInPrevRof, collision.selection_bit(o2::aod::evsel::kNoHighMultCollInPrevRof));
   checkCut(evSel::kNoCollInTimeRangeStandard, collision.selection_bit(o2::aod::evsel::kNoCollInTimeRangeStandard));
 
+  
   registry.fill(HIST("hVtxZ"), collision.posZ());
 
   return isSelected;


### PR DESCRIPTION
* Add a new workflow to compute the signal/event loss
* Handle properly the collision id in the processMC workflow
* Store occupancy information in the output table