### PR TITLE
[PWGJE] Fix EA interval selection with ConfigurableAxis

### DIFF
--- a/PWGJE/Tasks/recoilJets.cxx
+++ b/PWGJE/Tasks/recoilJets.cxx
@@ -1320,7 +1320,11 @@ struct RecoilJets {
                       float weight = 1.)
   {
     // Get the configured scaled FT0M percentile boundaries
-    const std::vector<double> ft0mEdges = hist.multFT0MThresh;
+    const std::vector<double> rawFT0MEdges = hist.multFT0MThresh;
+
+    const std::vector<double> ft0mEdges{
+      rawFT0MEdges.begin() + 1,
+      rawFT0MEdges.end()};
 
     bool bSigEv = false;
     std::vector<double> vPhiOfTT;


### PR DESCRIPTION
For variable-width axes, the first element of the ConfigurableAxis vector is the VARIABLE_WIDTH marker and is not a physical bin edge. Remove this element before using the vector for EA interval selection to keep the percentile indices aligned with the actual FT0M boundaries.