### PR TITLE
[PWGCF] Modified the MC reconstructed task

### DIFF
--- a/PWGCF/EbyEFluctuations/Tasks/CMakeLists.txt
+++ b/PWGCF/EbyEFluctuations/Tasks/CMakeLists.txt
@@ -10,7 +10,7 @@
 # or submit itself to any jurisdiction.
 
 o2physics_add_dpl_workflow(meanpt-fluctuations
-                    SOURCES MeanptFluctuations.cxx
+                    SOURCES meanptFluctuations.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2Physics::PWGCFCore
                     COMPONENT_NAME Analysis)
 

--- a/PWGCF/EbyEFluctuations/Tasks/meanptFluctuations.cxx
+++ b/PWGCF/EbyEFluctuations/Tasks/meanptFluctuations.cxx
@@ -33,7 +33,6 @@
 #include <Framework/InitContext.h>
 #include <Framework/OutputObjHeader.h>
 #include <Framework/runDataProcessing.h>
-#include <ReconstructionDataFormats/PID.h>
 
 #include <TF1.h>
 #include <THn.h>
@@ -56,7 +55,7 @@ using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 
-#define O2_DEFINE_CONFIGURABLE(NAME, TYPE, DEFAULT, HELP) Configurable<TYPE> NAME{#NAME, DEFAULT, HELP};
+#define O2_DEFINE_CONFIGURABLE(NAME, TYPE, DEFAULT, HELP) Configurable<TYPE> NAME{#NAME, (DEFAULT), (HELP)};
 
 struct MeanptFluctuations {
 
@@ -144,7 +143,7 @@ struct MeanptFluctuations {
   Filter trackFilter = (nabs(aod::track::eta) < cfgCutPreSelEta) && (aod::track::pt > cfgCutPtLower) && (aod::track::pt < cfgCutPreSelPt) && (requireGlobalTrackInFilter()) && (aod::track::tpcChi2NCl < cfgCutTpcChi2NCl) && (aod::track::itsChi2NCl < cfgCutItsChi2NCl) && (nabs(aod::track::dcaZ) < cfgCutTrackDcaZ);
 
   // Connect to ccdb
-  Service<ccdb::BasicCCDBManager> ccdb;
+  Service<ccdb::BasicCCDBManager> ccdb{};
   Configurable<int64_t> ccdbnolaterthan{"ccdbnolaterthan", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count(), "latest acceptable timestamp of creation for the object"};
   Configurable<std::string> ccdburl{"ccdburl", "http://ccdb-test.cern.ch:8080", "url of the ccdb repository"};
 
@@ -319,21 +318,21 @@ struct MeanptFluctuations {
       cfgFuncParas.multGlobalPVCutPars = cfgFuncParas.cfgMultGlobalPVCutPars;
       cfgFuncParas.multMultV0ACutPars = cfgFuncParas.cfgMultMultV0ACutPars;
       cfgFuncParas.fMultPVT0CCutLow = new TF1("fMultPVT0CCutLow", cfgFuncParas.cfgMultCentLowCutFunction->c_str(), 0, 100);
-      cfgFuncParas.fMultPVT0CCutLow->SetParameters(&(cfgFuncParas.multPVT0CCutPars[0]));
+      cfgFuncParas.fMultPVT0CCutLow->SetParameters(cfgFuncParas.multPVT0CCutPars.data());
       cfgFuncParas.fMultPVT0CCutHigh = new TF1("fMultPVT0CCutHigh", cfgFuncParas.cfgMultCentHighCutFunction->c_str(), 0, 100);
-      cfgFuncParas.fMultPVT0CCutHigh->SetParameters(&(cfgFuncParas.multPVT0CCutPars[0]));
+      cfgFuncParas.fMultPVT0CCutHigh->SetParameters(cfgFuncParas.multPVT0CCutPars.data());
       cfgFuncParas.fMultT0CCutLow = new TF1("fMultT0CCutLow", cfgFuncParas.cfgMultCentLowCutFunction->c_str(), 0, 100);
-      cfgFuncParas.fMultT0CCutLow->SetParameters(&(cfgFuncParas.multT0CCutPars[0]));
+      cfgFuncParas.fMultT0CCutLow->SetParameters(cfgFuncParas.multT0CCutPars.data());
       cfgFuncParas.fMultT0CCutHigh = new TF1("fMultT0CCutHigh", cfgFuncParas.cfgMultCentHighCutFunction->c_str(), 0, 100);
-      cfgFuncParas.fMultT0CCutHigh->SetParameters(&(cfgFuncParas.multT0CCutPars[0]));
+      cfgFuncParas.fMultT0CCutHigh->SetParameters(cfgFuncParas.multT0CCutPars.data());
       cfgFuncParas.fMultGlobalPVCutLow = new TF1("fMultGlobalPVCutLow", cfgFuncParas.cfgMultMultPVLowCutFunction->c_str(), 0, 4000);
-      cfgFuncParas.fMultGlobalPVCutLow->SetParameters(&(cfgFuncParas.multGlobalPVCutPars[0]));
+      cfgFuncParas.fMultGlobalPVCutLow->SetParameters(cfgFuncParas.multGlobalPVCutPars.data());
       cfgFuncParas.fMultGlobalPVCutHigh = new TF1("fMultGlobalPVCutHigh", cfgFuncParas.cfgMultMultPVHighCutFunction->c_str(), 0, 4000);
-      cfgFuncParas.fMultGlobalPVCutHigh->SetParameters(&(cfgFuncParas.multGlobalPVCutPars[0]));
+      cfgFuncParas.fMultGlobalPVCutHigh->SetParameters(cfgFuncParas.multGlobalPVCutPars.data());
       cfgFuncParas.fMultMultV0ACutLow = new TF1("fMultMultV0ACutLow", cfgFuncParas.cfgMultMultV0ALowCutFunction->c_str(), 0, 4000);
-      cfgFuncParas.fMultMultV0ACutLow->SetParameters(&(cfgFuncParas.multMultV0ACutPars[0]));
+      cfgFuncParas.fMultMultV0ACutLow->SetParameters(cfgFuncParas.multMultV0ACutPars.data());
       cfgFuncParas.fMultMultV0ACutHigh = new TF1("fMultMultV0ACutHigh", cfgFuncParas.cfgMultMultV0AHighCutFunction->c_str(), 0, 4000);
-      cfgFuncParas.fMultMultV0ACutHigh->SetParameters(&(cfgFuncParas.multMultV0ACutPars[0]));
+      cfgFuncParas.fMultMultV0ACutHigh->SetParameters(cfgFuncParas.multMultV0ACutPars.data());
       cfgFuncParas.fT0AV0AMean = new TF1("fT0AV0AMean", "[0]+[1]*x", 0, 200000);
       cfgFuncParas.fT0AV0AMean->SetParameters(-1601.0581, 9.417652e-01);
       cfgFuncParas.fT0AV0ASigma = new TF1("fT0AV0ASigma", "[0]+[1]*x+[2]*x*x+[3]*x*x*x+[4]*x*x*x*x", 0, 200000);
@@ -350,7 +349,7 @@ struct MeanptFluctuations {
   } //! end init function
 
   template <typename TCollision>
-  bool eventSelected(TCollision collision, const int& multTrk, const float& centrality)
+  bool eventSelected(TCollision const& collision, const int& multTrk, const float& centrality)
   {
     if (collision.alias_bit(kTVXinTRD)) {
       // TRD triggered
@@ -362,71 +361,87 @@ struct MeanptFluctuations {
       float zRes = std::sqrt(collision.covZZ());
       float zResMax = 0.25;
       float numContribMin = 20;
-      if (zRes > zResMax && collision.numContrib() < numContribMin)
+      if (zRes > zResMax && collision.numContrib() < numContribMin) {
         vtxz = -999;
+      }
     }
     auto multNTracksPV = collision.multNTracksPV();
 
-    if ((vtxz > cfgCutVertex) || (vtxz < -1.0 * cfgCutVertex))
+    if ((vtxz > cfgCutVertex) || (vtxz < -1.0 * cfgCutVertex)) {
       return 0;
-    if (multNTracksPV < fMultPVCutLow->Eval(centrality))
+    }
+    if (multNTracksPV < fMultPVCutLow->Eval(centrality)) {
       return 0;
-    if (multNTracksPV > fMultPVCutHigh->Eval(centrality))
+    }
+    if (multNTracksPV > fMultPVCutHigh->Eval(centrality)) {
       return 0;
-    if (multTrk < fMultCutLow->Eval(centrality))
+    }
+    if (multTrk < fMultCutLow->Eval(centrality)) {
       return 0;
-    if (multTrk > fMultCutHigh->Eval(centrality))
+    }
+    if (multTrk > fMultCutHigh->Eval(centrality)) {
       return 0;
-    if (multTrk > fMultMultPVCut->Eval(multNTracksPV))
+    }
+    if (multTrk > fMultMultPVCut->Eval(multNTracksPV)) {
       return 0;
+    }
 
     return 1;
   }
 
   template <typename TCollision>
-  bool eventSelectedSmallion(TCollision collision, const int multTrk, const float centrality)
+  bool eventSelectedSmallion(TCollision const& collision, const int multTrk, const float centrality)
   {
     auto multNTracksPV = collision.multNTracksPV();
 
     if (cfgEvSelMultCorrelation) {
       if (cfgFuncParas.cfgMultPVT0CCutEnabled) {
-        if (multNTracksPV < cfgFuncParas.fMultPVT0CCutLow->Eval(centrality))
+        if (multNTracksPV < cfgFuncParas.fMultPVT0CCutLow->Eval(centrality)) {
           return 0;
-        if (multNTracksPV > cfgFuncParas.fMultPVT0CCutHigh->Eval(centrality))
+        }
+        if (multNTracksPV > cfgFuncParas.fMultPVT0CCutHigh->Eval(centrality)) {
           return 0;
+        }
       }
 
       if (cfgFuncParas.cfgMultT0CCutEnabled) {
-        if (multTrk < cfgFuncParas.fMultT0CCutLow->Eval(centrality))
+        if (multTrk < cfgFuncParas.fMultT0CCutLow->Eval(centrality)) {
           return 0;
-        if (multTrk > cfgFuncParas.fMultT0CCutHigh->Eval(centrality))
+        }
+        if (multTrk > cfgFuncParas.fMultT0CCutHigh->Eval(centrality)) {
           return 0;
+        }
       }
 
       if (cfgFuncParas.cfgMultGlobalPVCutEnabled) {
-        if (multTrk < cfgFuncParas.fMultGlobalPVCutLow->Eval(multNTracksPV))
+        if (multTrk < cfgFuncParas.fMultGlobalPVCutLow->Eval(multNTracksPV)) {
           return 0;
-        if (multTrk > cfgFuncParas.fMultGlobalPVCutHigh->Eval(multNTracksPV))
+        }
+        if (multTrk > cfgFuncParas.fMultGlobalPVCutHigh->Eval(multNTracksPV)) {
           return 0;
+        }
       }
 
       if (cfgFuncParas.cfgMultMultV0ACutEnabled) {
-        if (collision.multFV0A() < cfgFuncParas.fMultMultV0ACutLow->Eval(multTrk))
+        if (collision.multFV0A() < cfgFuncParas.fMultMultV0ACutLow->Eval(multTrk)) {
           return 0;
-        if (collision.multFV0A() > cfgFuncParas.fMultMultV0ACutHigh->Eval(multTrk))
+        }
+        if (collision.multFV0A() > cfgFuncParas.fMultMultV0ACutHigh->Eval(multTrk)) {
           return 0;
+        }
       }
     }
 
     float sigma = 5.0;
-    if (cfgEvSelV0AT0ACut && (std::fabs(collision.multFV0A() - cfgFuncParas.fT0AV0AMean->Eval(collision.multFT0A())) > sigma * cfgFuncParas.fT0AV0ASigma->Eval(collision.multFT0A())))
+    if (cfgEvSelV0AT0ACut && (std::fabs(collision.multFV0A() - cfgFuncParas.fT0AV0AMean->Eval(collision.multFT0A())) > sigma * cfgFuncParas.fT0AV0ASigma->Eval(collision.multFT0A()))) {
       return 0;
+    }
 
     return 1;
   }
 
   template <typename TCollision>
-  bool eventSelectionDefaultCuts(TCollision coll)
+  bool eventSelectionDefaultCuts(TCollision const& coll)
   {
     histos.fill(HIST("hEventStatData"), 0.5);
     if (!coll.sel8()) {
@@ -490,7 +505,7 @@ struct MeanptFluctuations {
     if (std::abs(mcCollision.posZ()) < cfgCutVertex) {
       histos.fill(HIST("MCGenerated/hMC"), 1.5);
     }
-    auto cent = 0;
+    auto cent = 0.0f;
 
     int nchInel = 0;
     for (const auto& mcParticle : mcParticles) {
@@ -501,8 +516,9 @@ struct MeanptFluctuations {
         }
       }
     }
-    if (nchInel > 0 && std::abs(mcCollision.posZ()) < cfgCutVertex)
+    if (nchInel > 0 && std::abs(mcCollision.posZ()) < cfgCutVertex) {
       histos.fill(HIST("MCGenerated/hMC"), 2.5);
+    }
     std::vector<int64_t> selectedEvents(collisions.size());
     int nevts = 0;
 
@@ -557,16 +573,17 @@ struct MeanptFluctuations {
     float nChgen = 0.0;
 
     for (const auto& mcParticle : mcParticles) {
-      if (!mcParticle.has_mcCollision())
+      if (!mcParticle.has_mcCollision()) {
         continue;
+      }
 
       // charged check
       auto pdgcode = std::abs(mcParticle.pdgCode());
-      if (!(pdgcode == PDG_t::kPiPlus ||
-            pdgcode == PDG_t::kKPlus ||
-            pdgcode == PDG_t::kProton ||
-            pdgcode == PDG_t::kElectron ||
-            pdgcode == PDG_t::kMuonMinus)) {
+      if (pdgcode != PDG_t::kPiPlus &&
+          pdgcode != PDG_t::kKPlus &&
+          pdgcode != PDG_t::kProton &&
+          pdgcode != PDG_t::kElectron &&
+          pdgcode != PDG_t::kMuonMinus) {
         continue; // skip this track
       }
 
@@ -592,8 +609,9 @@ struct MeanptFluctuations {
     } //! end particle loop
 
     // Generated MeanPt distribution
-    if (nNgen > 0.0f)
+    if (nNgen > 0.0f) {
       histos.fill(HIST("MCGenerated/hMeanPt"), cent, pTsumgen / nNgen);
+    }
 
     // calculating observables
     if (nChgen > cfgMinNch) {
@@ -670,10 +688,12 @@ struct MeanptFluctuations {
     fillMultCorrPlotsBeforeSel(bestColl, tracksThisCollision);
 
     const auto centralityFT0C = bestColl.centFT0C();
-    if (cfgUse22sEventCut && !eventSelected(bestColl, tracksThisCollision.size(), centralityFT0C))
+    if (cfgUse22sEventCut && !eventSelected(bestColl, tracksThisCollision.size(), centralityFT0C)) {
       return;
-    if (cfgUseSmallIonAdditionalEventCut && !eventSelectedSmallion(bestColl, tracksThisCollision.size(), centralityFT0C))
+    }
+    if (cfgUseSmallIonAdditionalEventCut && !eventSelectedSmallion(bestColl, tracksThisCollision.size(), centralityFT0C)) {
       return;
+    }
 
     if (cfgUseSmallIonAdditionalEventCut) {
       fillMultCorrPlotsAfterSel(bestColl, tracksThisCollision);
@@ -687,14 +707,15 @@ struct MeanptFluctuations {
     int centChoiceFT0A = 2;
     int centChoiceFT0M = 3;
     int centChoiceFV0A = 4;
-    if (cfgCentralityEstimator == centChoiceFT0C)
+    if (cfgCentralityEstimator == centChoiceFT0C) {
       cent = bestColl.centFT0C();
-    else if (cfgCentralityEstimator == centChoiceFT0A)
+    } else if (cfgCentralityEstimator == centChoiceFT0A) {
       cent = bestColl.centFT0A();
-    else if (cfgCentralityEstimator == centChoiceFT0M)
+    } else if (cfgCentralityEstimator == centChoiceFT0M) {
       cent = bestColl.centFT0M();
-    else if (cfgCentralityEstimator == centChoiceFV0A)
+    } else if (cfgCentralityEstimator == centChoiceFV0A) {
       cent = bestColl.centFV0A();
+    }
 
     histos.fill(HIST("hCentrality"), cent);
 
@@ -707,16 +728,17 @@ struct MeanptFluctuations {
     auto particlesThisEvent = mcParticles.sliceBy(perMcCollision, mcCollision.globalIndex());
 
     for (const auto& mcParticle : particlesThisEvent) {
-      if (!mcParticle.has_mcCollision())
+      if (!mcParticle.has_mcCollision()) {
         continue;
+      }
 
       // charged check
       auto pdgcode = std::abs(mcParticle.pdgCode());
-      if (!(pdgcode == PDG_t::kPiPlus ||
-            pdgcode == PDG_t::kKPlus ||
-            pdgcode == PDG_t::kProton ||
-            pdgcode == PDG_t::kElectron ||
-            pdgcode == PDG_t::kMuonMinus)) {
+      if (pdgcode != PDG_t::kPiPlus &&
+          pdgcode != PDG_t::kKPlus &&
+          pdgcode != PDG_t::kProton &&
+          pdgcode != PDG_t::kElectron &&
+          pdgcode != PDG_t::kMuonMinus) {
         continue; // skip this track
       }
 
@@ -803,8 +825,9 @@ struct MeanptFluctuations {
     histos.fill(HIST("MCGenerated/hNgenVsNrec"), noGen, nCh);
 
     // MeanPt
-    if (nN > 0.0f)
+    if (nN > 0.0f) {
       histos.fill(HIST("hMeanPt"), cent, pTsum / nN);
+    }
 
     // calculating observables
     if (nCh > cfgMinNch) {
@@ -853,10 +876,12 @@ struct MeanptFluctuations {
     fillMultCorrPlotsBeforeSel(coll, inputTracks);
 
     const auto centralityFT0C = coll.centFT0C();
-    if (cfgUse22sEventCut && !eventSelected(coll, inputTracks.size(), centralityFT0C))
+    if (cfgUse22sEventCut && !eventSelected(coll, inputTracks.size(), centralityFT0C)) {
       return;
-    if (cfgUseSmallIonAdditionalEventCut && !eventSelectedSmallion(coll, inputTracks.size(), centralityFT0C))
+    }
+    if (cfgUseSmallIonAdditionalEventCut && !eventSelectedSmallion(coll, inputTracks.size(), centralityFT0C)) {
       return;
+    }
 
     if (cfgUseSmallIonAdditionalEventCut) {
       fillMultCorrPlotsAfterSel(coll, inputTracks);
@@ -871,14 +896,15 @@ struct MeanptFluctuations {
     int centChoiceFT0A = 2;
     int centChoiceFT0M = 3;
     int centChoiceFV0A = 4;
-    if (cfgCentralityEstimator == centChoiceFT0C)
+    if (cfgCentralityEstimator == centChoiceFT0C) {
       cent = coll.centFT0C();
-    else if (cfgCentralityEstimator == centChoiceFT0A)
+    } else if (cfgCentralityEstimator == centChoiceFT0A) {
       cent = coll.centFT0A();
-    else if (cfgCentralityEstimator == centChoiceFT0M)
+    } else if (cfgCentralityEstimator == centChoiceFT0M) {
       cent = coll.centFT0M();
-    else if (cfgCentralityEstimator == centChoiceFV0A)
+    } else if (cfgCentralityEstimator == centChoiceFV0A) {
       cent = coll.centFV0A();
+    }
 
     histos.fill(HIST("hCentrality"), cent);
 
@@ -942,8 +968,9 @@ struct MeanptFluctuations {
       }
     }
     // MeanPt
-    if (nN > 0.0f)
+    if (nN > 0.0f) {
       histos.fill(HIST("hMeanPt"), cent, pTsum / nN);
+    }
 
     // calculating observables
     if (nCh > cfgMinNch) {

--- a/PWGCF/EbyEFluctuations/Tasks/meanptFluctuations.cxx
+++ b/PWGCF/EbyEFluctuations/Tasks/meanptFluctuations.cxx
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-/// \file MeanptFluctuations.cxx
+/// \file meanptFluctuations.cxx
 /// \brief Task for analyzing <pT> fluctuation upto fourth order of inclusive hadrons
 /// \author Swati Saha
 
@@ -33,8 +33,8 @@
 #include <Framework/InitContext.h>
 #include <Framework/OutputObjHeader.h>
 #include <Framework/runDataProcessing.h>
+#include <ReconstructionDataFormats/PID.h>
 
-#include <TDatabasePDG.h>
 #include <TF1.h>
 #include <THn.h>
 #include <TPDGCode.h>
@@ -58,7 +58,7 @@ using namespace o2::framework::expressions;
 
 #define O2_DEFINE_CONFIGURABLE(NAME, TYPE, DEFAULT, HELP) Configurable<TYPE> NAME{#NAME, DEFAULT, HELP};
 
-struct MeanptFluctuationsAnalysis {
+struct MeanptFluctuations {
 
   // MC
   Configurable<bool> cfgIsMC{"cfgIsMC", true, "Run MC"};
@@ -561,11 +561,14 @@ struct MeanptFluctuationsAnalysis {
         continue;
 
       // charged check
-      auto pdgEntry = TDatabasePDG::Instance()->GetParticle(mcParticle.pdgCode());
-      if (!pdgEntry)
-        continue;
-      if (pdgEntry->Charge() == 0)
-        continue;
+      auto pdgcode = std::abs(mcParticle.pdgCode());
+      if (!(pdgcode == PDG_t::kPiPlus ||
+            pdgcode == PDG_t::kKPlus ||
+            pdgcode == PDG_t::kProton ||
+            pdgcode == PDG_t::kElectron ||
+            pdgcode == PDG_t::kMuonMinus)) {
+        continue; // skip this track
+      }
 
       if (mcParticle.isPhysicalPrimary()) {
         if ((mcParticle.pt() > cfgCutPtLower) && (mcParticle.pt() < cfgCutPreSelPt) && (std::abs(mcParticle.eta()) < cfgCutPreSelEta)) {
@@ -627,36 +630,57 @@ struct MeanptFluctuationsAnalysis {
     }
     //-------------------------------------------------------------------------------------------
   }
-  PROCESS_SWITCH(MeanptFluctuationsAnalysis, processMCGen, "Process Generated MC data", true);
+  PROCESS_SWITCH(MeanptFluctuations, processMCGen, "Process Generated MC data", true);
 
-  void processMCRec(MyMCRecCollisions::iterator const& collision, MyMCTracks const& tracks, aod::McCollisions const&, aod::McParticles const& mcParticles)
+  void processMCRec(aod::McCollision const& mcCollision, aod::McParticles const& mcParticles, const soa::SmallGroups<EventCandidatesMC>& collisions, MyMCTracks const& tracks)
   {
     histos.fill(HIST("MCGenerated/hMC"), 5.5);
 
-    if (!collision.has_mcCollision()) {
+    if (collisions.size() == 0) {
+      return; // this generated event was never reconstructed at all
+    }
+
+    auto bestColl = collisions.begin();
+    bool foundValidColl = false;
+    for (auto const& coll : collisions) {
+      if (!foundValidColl || coll.numContrib() > bestColl.numContrib()) {
+        bestColl = coll;
+        foundValidColl = true;
+      }
+    }
+    if (!foundValidColl) {
+      return;
+    }
+
+    if (!bestColl.has_mcCollision()) {
       return;
     }
     histos.fill(HIST("MCGenerated/hMC"), 6.5);
 
-    if (!eventSelectionDefaultCuts(collision)) {
+    if (std::abs(bestColl.posZ()) >= cfgCutVertex) {
+      return;
+    }
+    if (!eventSelectionDefaultCuts(bestColl)) {
       return;
     }
     histos.fill(HIST("MCGenerated/hMC"), 7.5);
 
-    fillMultCorrPlotsBeforeSel(collision, tracks);
+    auto tracksThisCollision = tracks.sliceBy(perCollision, bestColl.globalIndex());
 
-    const auto centralityFT0C = collision.centFT0C();
-    if (cfgUse22sEventCut && !eventSelected(collision, tracks.size(), centralityFT0C))
+    fillMultCorrPlotsBeforeSel(bestColl, tracksThisCollision);
+
+    const auto centralityFT0C = bestColl.centFT0C();
+    if (cfgUse22sEventCut && !eventSelected(bestColl, tracksThisCollision.size(), centralityFT0C))
       return;
-    if (cfgUseSmallIonAdditionalEventCut && !eventSelectedSmallion(collision, tracks.size(), centralityFT0C))
+    if (cfgUseSmallIonAdditionalEventCut && !eventSelectedSmallion(bestColl, tracksThisCollision.size(), centralityFT0C))
       return;
 
     if (cfgUseSmallIonAdditionalEventCut) {
-      fillMultCorrPlotsAfterSel(collision, tracks);
+      fillMultCorrPlotsAfterSel(bestColl, tracksThisCollision);
     }
 
     histos.fill(HIST("MCGenerated/hMC"), 8.5);
-    histos.fill(HIST("hZvtx_after_sel"), collision.posZ());
+    histos.fill(HIST("hZvtx_after_sel"), bestColl.posZ());
 
     double cent = 0.0;
     int centChoiceFT0C = 1;
@@ -664,35 +688,37 @@ struct MeanptFluctuationsAnalysis {
     int centChoiceFT0M = 3;
     int centChoiceFV0A = 4;
     if (cfgCentralityEstimator == centChoiceFT0C)
-      cent = collision.centFT0C();
+      cent = bestColl.centFT0C();
     else if (cfgCentralityEstimator == centChoiceFT0A)
-      cent = collision.centFT0A();
+      cent = bestColl.centFT0A();
     else if (cfgCentralityEstimator == centChoiceFT0M)
-      cent = collision.centFT0M();
+      cent = bestColl.centFT0M();
     else if (cfgCentralityEstimator == centChoiceFV0A)
-      cent = collision.centFV0A();
+      cent = bestColl.centFV0A();
 
     histos.fill(HIST("hCentrality"), cent);
 
-    histos.fill(HIST("Hist2D_globalTracks_PVTracks"), collision.multNTracksPV(), tracks.size());
-    histos.fill(HIST("Hist2D_cent_nch"), tracks.size(), centralityFT0C);
+    histos.fill(HIST("Hist2D_globalTracks_PVTracks"), bestColl.multNTracksPV(), tracksThisCollision.size());
+    histos.fill(HIST("Hist2D_cent_nch"), tracksThisCollision.size(), centralityFT0C);
 
     // Calculating generated no of particles for the collision event
     double noGen = 0.0;
-    auto mcColl = collision.mcCollision();
     // Slice particles belonging only to this MC collision
-    auto particlesThisEvent = mcParticles.sliceBy(perMcCollision, mcColl.globalIndex());
+    auto particlesThisEvent = mcParticles.sliceBy(perMcCollision, mcCollision.globalIndex());
 
     for (const auto& mcParticle : particlesThisEvent) {
       if (!mcParticle.has_mcCollision())
         continue;
 
       // charged check
-      auto pdgEntry = TDatabasePDG::Instance()->GetParticle(mcParticle.pdgCode());
-      if (!pdgEntry)
-        continue;
-      if (pdgEntry->Charge() == 0)
-        continue;
+      auto pdgcode = std::abs(mcParticle.pdgCode());
+      if (!(pdgcode == PDG_t::kPiPlus ||
+            pdgcode == PDG_t::kKPlus ||
+            pdgcode == PDG_t::kProton ||
+            pdgcode == PDG_t::kElectron ||
+            pdgcode == PDG_t::kMuonMinus)) {
+        continue; // skip this track
+      }
 
       if (mcParticle.isPhysicalPrimary()) {
         if ((mcParticle.pt() > cfgCutPtLower) && (mcParticle.pt() < cfgCutPreSelPt) && (std::abs(mcParticle.eta()) < cfgCutPreSelEta)) {
@@ -713,7 +739,7 @@ struct MeanptFluctuationsAnalysis {
     float q4 = 0.0;
     float nCh = 0.0;
 
-    for (const auto& track : tracks) { // Loop over tracks
+    for (const auto& track : tracksThisCollision) { // Loop over tracks
 
       if (!track.has_collision()) {
         continue;
@@ -815,7 +841,7 @@ struct MeanptFluctuationsAnalysis {
     }
     //-------------------------------------------------------------------------------------------
   }
-  PROCESS_SWITCH(MeanptFluctuationsAnalysis, processMCRec, "Process MC Reconstructed Data", true);
+  PROCESS_SWITCH(MeanptFluctuations, processMCRec, "Process MC Reconstructed Data", true);
 
   // void process(aod::Collision const& coll, aod::Tracks const& inputTracks)
   void processData(AodCollisions::iterator const& coll, aod::BCsWithTimestamps const&, AodTracks const& inputTracks)
@@ -944,12 +970,12 @@ struct MeanptFluctuationsAnalysis {
     }
     //-------------------------------------------------------------------------------------------
   }
-  PROCESS_SWITCH(MeanptFluctuationsAnalysis, processData, "Process Real Data", true);
+  PROCESS_SWITCH(MeanptFluctuations, processData, "Process Real Data", true);
 };
 
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   // Equivalent to the AddTask in AliPhysics
   return WorkflowSpec{
-    adaptAnalysisTask<MeanptFluctuationsAnalysis>(cfgc)};
+    adaptAnalysisTask<MeanptFluctuations>(cfgc)};
 }


### PR DESCRIPTION
[1] When multiple reconstructed collisions map to the same generated MC collision, keep only the one with the most contributors and discard the rest
[2] Changed the filename to fix o2-linter error in the CMakeLists.txt file