### PR TITLE
[PWGCF] Update PC and CPR in femto framework

### DIFF
--- a/PWGCF/Femto/Core/closePairRejection.h
+++ b/PWGCF/Femto/Core/closePairRejection.h
@@ -53,6 +53,7 @@ enum CprHist {
   kRadius6,
   kRadius7,
   kRadius8,
+  kKinematic, // kinematic variable of the pair/triplet which are blocked
   kPhi1VsPhi2,
   kEta1VsEta2,
   kCprHistogramLast
@@ -64,15 +65,18 @@ struct ConfCpr : o2::framework::ConfigurableGroup {
   std::string prefix = std::string(Prefix);
   o2::framework::Configurable<bool> cutAverage{"cutAverage", true, "Apply CPR if the average deta-dphistar is below the configured values"};
   o2::framework::Configurable<bool> cutAnyRadius{"cutAnyRadius", false, "Apply CPR if the deta-dphistar is below the configured values at any radius"};
+  o2::framework::Configurable<bool> cutElipsoidal{"cutElipsoidal", true, "If true, apply CPR as episoidal cut. If false use rectangluar cut."};
   o2::framework::Configurable<bool> plotAllRadii{"plotAllRadii", true, "Plot deta-dphi distribution at all radii"};
   o2::framework::Configurable<bool> plotAverage{"plotAverage", true, "Plot average deta dphi distribution"};
   o2::framework::Configurable<bool> plotAngularCorrelation{"plotAngularCorrelation", false, "Plot angular correlation of particles (eta1 vs eta2 & phi1 vs phi2"};
+  o2::framework::Configurable<bool> plotKinematic{"plotKinematic", true, "Plot kinematic (kstar/Q3) distribution of blocked pairs/triplets"};
   o2::framework::Configurable<float> detaMax{"detaMax", 0.01f, "Maximium deta"};
   o2::framework::Configurable<float> dphistarMax{"dphistarMax", 0.01f, "Maximum dphistar"};
   o2::framework::Configurable<float> detaCenter{"detaCenter", 0.f, "Center of deta cut"};
   o2::framework::Configurable<float> dphistarCenter{"dphistarCenter", 0.f, "Center of dphistar cut"};
   o2::framework::Configurable<float> kinematicMin{"kinematicMin", -1.f, "Minimum kstar/Q3 of pair/triplet for plotting (Set to negative value to turn off the cut)"};
   o2::framework::Configurable<float> kinematicMax{"kinematicMax", -1.f, "Maximum kstar/Q3 of pair/triplet for plotting (Set to negative value to turn off the cut)"};
+  o2::framework::ConfigurableAxis binningKinematic{"binningKinematic", {100, 0, 1}, "Binning of kinematic variable of pair/triplet which are cut"};
   o2::framework::ConfigurableAxis binningDeta{"binningDeta", {{250, -0.5, 0.5}}, "deta"};
   o2::framework::ConfigurableAxis binningDphistar{"binningDphistar", {{250, -0.5, 0.5}}, "dphi"};
   o2::framework::ConfigurableAxis binningCorrelationPhi{"binningCorrelationPhi", {{720, 0, o2::constants::math::TwoPI}}, "Phi binning for correlation plot"};
@@ -165,6 +169,7 @@ constexpr std::array<histmanager::HistInfo<CprHist>, kCprHistogramLast> HistTabl
    {kRadius6, o2::framework::HistType::kTH2F, "hRadius6", "Radius 6: #Delta #eta vs #Delta #phi*; #Delta #eta; #Delta #phi*"},
    {kRadius7, o2::framework::HistType::kTH2F, "hRadius7", "Radius 7: #Delta #eta vs #Delta #phi*; #Delta #eta; #Delta #phi*"},
    {kRadius8, o2::framework::HistType::kTH2F, "hRadius8", "Radius 8: #Delta #eta vs #Delta #phi*; #Delta #eta; #Delta #phi*"},
+   {kKinematic, o2::framework::HistType::kTH1F, "hKinematic", "Kinematic distribution of blocked pairs; kinematic Variable (GeV/c#it{c}); Entries"},
    {kPhi1VsPhi2, o2::framework::HistType::kTH2F, "hPhi1vsPhi2", "#phi_{1} vs #phi_{2}; #phi_{1}; #phi_{2}"},
    {kEta1VsEta2, o2::framework::HistType::kTH2F, "hEta1VsEta2", "#eta_{1} vs #eta_{2}; #eta_{1}; #eta_{2}"}}};
 
@@ -182,6 +187,7 @@ auto makeCprHistSpecMap(const T& confCpr)
     {kRadius6, {confCpr.binningDeta, confCpr.binningDphistar}},
     {kRadius7, {confCpr.binningDeta, confCpr.binningDphistar}},
     {kRadius8, {confCpr.binningDeta, confCpr.binningDphistar}},
+    {kKinematic, {confCpr.binningKinematic}},
     {kPhi1VsPhi2, {confCpr.binningCorrelationPhi, confCpr.binningCorrelationPhi}},
     {kEta1VsEta2, {confCpr.binningCorrelationEta, confCpr.binningCorrelationEta}},
   };
@@ -217,6 +223,7 @@ class CloseTrackRejection
 
     mCutAverage = confCpr.cutAverage.value;
     mCutAnyRadius = confCpr.cutAnyRadius.value;
+    mUseEpisoidalCut = confCpr.cutElipsoidal.value;
 
     mKinematicMin = confCpr.kinematicMin.value;
     mKinematicMax = confCpr.kinematicMax.value;
@@ -225,6 +232,7 @@ class CloseTrackRejection
     mPlotAllRadii = confCpr.plotAllRadii.value;
 
     mPlotAngularCorrelation = confCpr.plotAngularCorrelation.value;
+    mPlotKinematic = confCpr.plotKinematic.value;
 
     if (confCpr.seed.value >= 0) {
       uint64_t randomSeed = 0;
@@ -237,10 +245,14 @@ class CloseTrackRejection
       mRng = std::mt19937(randomSeed);
     }
 
-    // check if we need to apply any cut a plot is requested
+    // check if we need to apply any cut or if a plot is requested
     mIsActivated = mCutAverage || mCutAnyRadius || mPlotAverage || mPlotAllRadii;
 
     mHistogramRegistry = registry;
+
+    if (mPlotKinematic) {
+      mHistogramRegistry->add(std::string(prefix) + getHistNameV2(kKinematic, HistTable), getHistDesc(kKinematic, HistTable), getHistType(kKinematic, HistTable), {specs.at(kKinematic)});
+    }
 
     if (mPlotAverage) {
       mHistogramRegistry->add(std::string(prefix) + getHistNameV2(kAverage, HistTable), getHistDesc(kAverage, HistTable), getHistType(kAverage, HistTable), {specs.at(kAverage)});
@@ -265,12 +277,34 @@ class CloseTrackRejection
 
   void setMagField(float magField) { mMagField = magField; }
 
+  // checks if the cut is activated; if so, computes deta/dphistar for the pair,
+  // fills the "blocked" or "passed" histograms accordingly, and returns whether
+  // the pair was rejected. If the cut is not activated, does nothing and returns false.
+  // pairHistManager must expose getKinematic() (same interface PcManager::isCleanPair expects).
+  template <typename T1, typename T2, typename T3>
+  [[nodiscard]] bool isClosePair(T1 const& track1, T2 const& track2, T3 const& pairHistManager)
+  {
+    if (!mIsActivated) {
+      return false;
+    }
+
+    compute(track1, track2);
+
+    bool isClose = mUseEpisoidalCut ? isClosePairEpisoidalCut() : isClosePairRectengularCut();
+
+    if (isClose) {
+      fillBlocked(pairHistManager.getKinematic());
+    } else {
+      fillPassed(pairHistManager.getKinematic());
+    }
+
+    return isClose;
+  }
+
+ private:
   template <typename T1, typename T2>
   void compute(T1 const& track1, T2 const& track2)
   {
-    if (!mIsActivated) {
-      return;
-    }
     // reset values
     mAverageDphistar = 0.f;
     int count = 0;
@@ -283,14 +317,14 @@ class CloseTrackRejection
       swapTracks = (mSwapDist(mRng) == 1);
     }
 
-    auto const& t1 = swapTracks ? track2 : track1;
-    auto const& t2 = swapTracks ? track1 : track2;
+    auto t1 = swapTracks ? track2 : track1;
+    auto t2 = swapTracks ? track1 : track2;
 
     mDeta = t1.eta() - t2.eta();
 
     for (size_t i = 0; i < TpcRadii.size(); i++) {
-      auto phistar1 = phistar(mMagField, TpcRadii[i], mChargeAbsTrack1 * t1.signedPt(), t1.phi());
-      auto phistar2 = phistar(mMagField, TpcRadii[i], mChargeAbsTrack2 * t2.signedPt(), t2.phi());
+      auto phistar1 = phistar(mMagField, TpcRadii.at(i), mChargeAbsTrack1 * t1.signedPt(), t1.phi());
+      auto phistar2 = phistar(mMagField, TpcRadii.at(i), mChargeAbsTrack2 * t2.signedPt(), t2.phi());
       if (phistar1 && phistar2) {
         mDphistar.at(i) = RecoDecay::constrainAngle(phistar1.value() - phistar2.value(), -o2::constants::math::PI); // constrain angular difference between -pi and pi
         mDphistarMask.at(i) = true;
@@ -312,12 +346,65 @@ class CloseTrackRejection
     }
   }
 
-  void fill(float kinematic)
+  std::optional<float> phistar(float magfield, float radius, float signedPt, float phi)
   {
-    if (!mIsActivated) {
-      return;
+    double arg = 0.3 * (0.1 * magfield) * (0.01 * radius) / (2. * signedPt);
+    if (std::fabs(arg) <= 1.) {
+      double angle = phi - std::asin(arg);
+      return static_cast<float>(RecoDecay::constrainAngle(angle));
+    }
+    return std::nullopt;
+  }
+
+  [[nodiscard]] bool isClosePairEpisoidalCut() const
+  {
+    bool isCloseAverage = false;
+    bool isCloseAnyRadius = false;
+
+    if (mCutAverage) {
+      isCloseAverage = std::hypot((mAverageDphistar - mDphistarCenter) / mDphistarMax, (mDeta - mDetaCenter) / mDetaMax) < 1.f;
     }
 
+    if (mCutAnyRadius) {
+      for (size_t i = 0; i < TpcRadii.size(); i++) {
+        if (isCloseAnyRadius) {
+          break;
+        }
+        if (mDphistarMask.at(i)) {
+          isCloseAnyRadius = std::hypot((mDphistar.at(i) - mDphistarCenter) / mDphistarMax, (mDeta - mDetaCenter) / mDetaMax) < 1.f;
+        }
+      }
+    }
+    return isCloseAverage || isCloseAnyRadius;
+  }
+
+  [[nodiscard]] bool isClosePairRectengularCut() const
+  {
+    bool isCloseAverage = false;
+    bool isCloseAnyRadius = false;
+
+    if (mCutAverage) {
+      isCloseAverage = std::fabs(mAverageDphistar - mDphistarCenter) < mDphistarMax &&
+                       std::fabs(mDeta - mDetaCenter) < mDetaMax;
+    }
+
+    if (mCutAnyRadius) {
+      for (size_t i = 0; i < TpcRadii.size(); i++) {
+        if (isCloseAnyRadius) {
+          break;
+        }
+        if (mDphistarMask.at(i)) {
+          isCloseAnyRadius = std::fabs(mDphistar.at(i) - mDphistarCenter) < mDphistarMax &&
+                             std::fabs(mDeta - mDetaCenter) < mDetaMax;
+        }
+      }
+    }
+    return isCloseAverage || isCloseAnyRadius;
+  }
+
+  // fill the "normal" distributions (deta-dphistar, angular correlation) for pairs that passed the cut
+  void fillPassed(float kinematic) const
+  {
     if (mKinematicMin > 0.f && kinematic < mKinematicMin) {
       return;
     }
@@ -340,82 +427,63 @@ class CloseTrackRejection
     if (mPlotAllRadii) {
       if (mDphistarMask.at(0)) {
         mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius0, HistTable)), mDeta, mDphistar.at(0));
-      }
-      if (mDphistarMask.at(1)) {
-        mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius1, HistTable)), mDeta, mDphistar.at(1));
-      }
-      if (mDphistarMask.at(2)) {
-        mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius2, HistTable)), mDeta, mDphistar.at(2));
-      }
-      if (mDphistarMask.at(3)) {
-        mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius3, HistTable)), mDeta, mDphistar.at(3));
-      }
-      if (mDphistarMask.at(4)) {
-        mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius4, HistTable)), mDeta, mDphistar.at(4));
-      }
-      if (mDphistarMask.at(5)) {
-        mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius5, HistTable)), mDeta, mDphistar.at(5));
-      }
-      if (mDphistarMask.at(6)) {
-        mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius6, HistTable)), mDeta, mDphistar.at(6));
-      }
-      if (mDphistarMask.at(7)) {
-        mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius7, HistTable)), mDeta, mDphistar.at(7));
-      }
-      if (mDphistarMask.at(8)) {
-        mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius8, HistTable)), mDeta, mDphistar.at(8));
+        if (mDphistarMask.at(1)) {
+          mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius1, HistTable)), mDeta, mDphistar.at(1));
+        }
+        if (mDphistarMask.at(2)) {
+          mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius2, HistTable)), mDeta, mDphistar.at(2));
+        }
+        if (mDphistarMask.at(3)) {
+          mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius3, HistTable)), mDeta, mDphistar.at(3));
+        }
+        if (mDphistarMask.at(4)) {
+          mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius4, HistTable)), mDeta, mDphistar.at(4));
+        }
+        if (mDphistarMask.at(5)) {
+          mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius5, HistTable)), mDeta, mDphistar.at(5));
+        }
+        if (mDphistarMask.at(6)) {
+          mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius6, HistTable)), mDeta, mDphistar.at(6));
+        }
+        if (mDphistarMask.at(7)) {
+          mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius7, HistTable)), mDeta, mDphistar.at(7));
+        }
+        if (mDphistarMask.at(8)) {
+          mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kRadius8, HistTable)), mDeta, mDphistar.at(8));
+        }
       }
     }
   }
 
-  [[nodiscard]] bool isClosePair() const
+  // fill the kinematic (kstar/Q3) distribution of pairs that were blocked by the CPR cut
+  void fillBlocked(float kinematic) const
   {
-    if (!mIsActivated) {
-      return false;
-    }
-    bool isCloseAverage = false;
-    bool isCloseAnyRadius = false;
-
-    if (mCutAverage) {
-      isCloseAverage = std::hypot((mAverageDphistar - mDphistarCenter) / mDphistarMax, (mDeta - mDetaCenter) / mDetaMax) < 1.f;
+    if (!mPlotKinematic) {
+      return;
     }
 
-    if (mCutAnyRadius) {
-      for (size_t i = 0; i < TpcRadii.size(); i++) {
-        if (isCloseAnyRadius) {
-          break;
-        }
-        if (mDphistarMask.at(i)) {
-          isCloseAnyRadius = std::hypot((mDphistar.at(i) - mDphistarCenter) / mDphistarMax, (mDeta - mDetaCenter) / mDetaMax) < 1.f;
-        }
-      }
+    if (mKinematicMin > 0.f && kinematic < mKinematicMin) {
+      return;
     }
-    return isCloseAverage || isCloseAnyRadius;
-  }
 
-  [[nodiscard]] bool isActivated() const { return mIsActivated; }
-
- private:
-  std::optional<float> phistar(float magfield, float radius, float signedPt, float phi)
-  {
-    double arg = 0.3 * (0.1 * magfield) * (0.01 * radius) / (2. * signedPt);
-    if (std::fabs(arg) <= 1.) {
-      double angle = phi - std::asin(arg);
-      return static_cast<float>(RecoDecay::constrainAngle(angle));
+    if (mKinematicMax > 0.f && kinematic > mKinematicMax) {
+      return;
     }
-    return std::nullopt;
+    mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kKinematic, HistTable)), kinematic);
   }
 
   o2::framework::HistogramRegistry* mHistogramRegistry = nullptr;
   bool mPlotAllRadii = false;
   bool mPlotAverage = false;
   bool mPlotAngularCorrelation = false;
+  bool mPlotKinematic = false;
 
   float mKinematicMin = -1.f;
   float mKinematicMax = -1.f;
 
   bool mCutAverage = false;
   bool mCutAnyRadius = false;
+  bool mUseEpisoidalCut = true;
 
   bool mIsActivated = false;
 
@@ -458,13 +526,12 @@ class ClosePairRejectionTrackTrack
   }
 
   void setMagField(float magField) { mCtr.setMagField(magField); }
-  template <typename T1, typename T2, typename T3>
-  void setPair(T1 const& track1, T2 const& track2, T3 const& /*tracks*/) // pass track table for compatibility with other classes
+
+  template <typename T1, typename T2, typename T3, typename T4>
+  [[nodiscard]] bool isClosePair(T1 const& track1, T2 const& track2, T3 const& /*tracks*/, T4 const& pairHistManager)
   {
-    mCtr.compute(track1, track2);
+    return mCtr.isClosePair(track1, track2, pairHistManager);
   }
-  [[nodiscard]] bool isClosePair() const { return mCtr.isClosePair(); }
-  void fill(float kstar) { mCtr.fill(kstar); }
 
  private:
   CloseTrackRejection<prefix> mCtr;
@@ -491,24 +558,18 @@ class ClosePairRejectionV0V0
     mCtrNeg.setMagField(magField);
   }
 
-  template <typename T1, typename T2, typename T3>
-  void setPair(T1 const& v01, T2 const& v02, T3 const& tracks)
+  template <typename T1, typename T2, typename T3, typename T4>
+  [[nodiscard]] bool isClosePair(T1 const& v01, T2 const& v02, T3 const& tracks, T4 const& pairHistManager)
   {
     auto posDau1 = tracks.rawIteratorAt(v01.posDauId() - tracks.offset());
     auto posDau2 = tracks.rawIteratorAt(v02.posDauId() - tracks.offset());
-    mCtrPos.compute(posDau1, posDau2);
+    bool isClosePos = mCtrPos.isClosePair(posDau1, posDau2, pairHistManager);
 
     auto negDau1 = tracks.rawIteratorAt(v01.negDauId() - tracks.offset());
     auto negDau2 = tracks.rawIteratorAt(v02.negDauId() - tracks.offset());
-    mCtrNeg.compute(negDau1, negDau2);
-  }
+    bool isCloseNeg = mCtrNeg.isClosePair(negDau1, negDau2, pairHistManager);
 
-  [[nodiscard]] bool isClosePair() const { return mCtrPos.isClosePair() || mCtrNeg.isClosePair(); }
-
-  void fill(float kstar)
-  {
-    mCtrPos.fill(kstar);
-    mCtrNeg.fill(kstar);
+    return isClosePos || isCloseNeg;
   }
 
  private:
@@ -531,21 +592,16 @@ class ClosePairRejectionTrackV0 // can also be used for any particle type that h
 
   void setMagField(float magField) { mCtr.setMagField(magField); }
 
-  template <typename T1, typename T2, typename T3>
-  void setPair(T1 const& track, T2 const& v0, T3 const& trackTable)
+  template <typename T1, typename T2, typename T3, typename T4>
+  [[nodiscard]] bool isClosePair(T1 const& track, T2 const& v0, T3 const& trackTable, T4 const& pairHistManager)
   {
     if (track.sign() > 0) {
       auto posDau = trackTable.rawIteratorAt(v0.posDauId() - trackTable.offset());
-      mCtr.compute(track, posDau);
-    } else {
-      auto negDau = trackTable.rawIteratorAt(v0.negDauId() - trackTable.offset());
-      mCtr.compute(track, negDau);
+      return mCtr.isClosePair(track, posDau, pairHistManager);
     }
+    auto negDau = trackTable.rawIteratorAt(v0.negDauId() - trackTable.offset());
+    return mCtr.isClosePair(track, negDau, pairHistManager);
   }
-
-  [[nodiscard]] bool isClosePair() const { return mCtr.isClosePair(); }
-
-  void fill(float kstar) { mCtr.fill(kstar); }
 
  private:
   CloseTrackRejection<prefixTrackV0> mCtr;
@@ -577,24 +633,19 @@ class ClosePairRejectionTrackLc
     mCtrPion.setMagField(magField);
   }
 
-  template <typename T1, typename T2, typename T3>
-  void setPair(T1 const& track, T2 const& lc, T3 const& trackTable)
+  template <typename T1, typename T2, typename T3, typename T4>
+  [[nodiscard]] bool isClosePair(T1 const& track, T2 const& lc, T3 const& trackTable, T4 const& pairHistManager)
   {
     auto prong0 = trackTable.rawIteratorAt(lc.prong0DauId() - trackTable.offset());
-    mCtrProton.compute(track, prong0);
+    bool isCloseProton = mCtrProton.isClosePair(track, prong0, pairHistManager);
+
     auto prong1 = trackTable.rawIteratorAt(lc.prong1DauId() - trackTable.offset());
-    mCtrKaon.compute(track, prong1);
+    bool isCloseKaon = mCtrKaon.isClosePair(track, prong1, pairHistManager);
+
     auto prong2 = trackTable.rawIteratorAt(lc.prong2DauId() - trackTable.offset());
-    mCtrPion.compute(track, prong2);
-  }
+    bool isClosePion = mCtrPion.isClosePair(track, prong2, pairHistManager);
 
-  [[nodiscard]] bool isClosePair() const { return mCtrProton.isClosePair() || mCtrKaon.isClosePair() || mCtrPion.isClosePair(); }
-
-  void fill(float kstar)
-  {
-    mCtrProton.fill(kstar);
-    mCtrKaon.fill(kstar);
-    mCtrPion.fill(kstar);
+    return isCloseProton || isCloseKaon || isClosePion;
   }
 
  private:
@@ -625,27 +676,22 @@ class ClosePairRejectionTrackCascade
     mCtrV0Daughter.setMagField(magField);
   }
 
-  template <typename T1, typename T2, typename T3>
-  void setPair(T1 const& track, T2 const& cascade, T3 const& trackTable)
+  template <typename T1, typename T2, typename T3, typename T4>
+  [[nodiscard]] bool isClosePair(T1 const& track, T2 const& cascade, T3 const& trackTable, T4 const& pairHistManager)
   {
     auto bachelor = trackTable.rawIteratorAt(cascade.bachelorId() - trackTable.offset());
-    mCtrBachelor.compute(track, bachelor);
+    bool isCloseBachelor = mCtrBachelor.isClosePair(track, bachelor, pairHistManager);
 
+    bool isCloseV0Daughter = false;
     if (track.sign() > 0) {
       auto posDau = trackTable.rawIteratorAt(cascade.posDauId() - trackTable.offset());
-      mCtrV0Daughter.compute(track, posDau);
+      isCloseV0Daughter = mCtrV0Daughter.isClosePair(track, posDau, pairHistManager);
     } else {
       auto negDau = trackTable.rawIteratorAt(cascade.negDauId() - trackTable.offset());
-      mCtrV0Daughter.compute(track, negDau);
+      isCloseV0Daughter = mCtrV0Daughter.isClosePair(track, negDau, pairHistManager);
     }
-  }
 
-  [[nodiscard]] bool isClosePair() const { return mCtrBachelor.isClosePair() || mCtrV0Daughter.isClosePair(); }
-
-  void fill(float kstar)
-  {
-    mCtrBachelor.fill(kstar);
-    mCtrV0Daughter.fill(kstar);
+    return isCloseBachelor || isCloseV0Daughter;
   }
 
  private:
@@ -671,15 +717,12 @@ class ClosePairRejectionTrackKink
     mCtr.setMagField(magField);
   }
 
-  template <typename T1, typename T2, typename T3>
-  void setPair(T1 const& track, T2 const& kink, T3 const& trackTable)
+  template <typename T1, typename T2, typename T3, typename T4>
+  [[nodiscard]] bool isClosePair(T1 const& track, T2 const& kink, T3 const& trackTable, T4 const& pairHistManager)
   {
     auto daughter = trackTable.rawIteratorAt(kink.chaDauId() - trackTable.offset());
-    mCtr.compute(track, daughter);
+    return mCtr.isClosePair(track, daughter, pairHistManager);
   }
-
-  [[nodiscard]] bool isClosePair() const { return mCtr.isClosePair(); }
-  void fill(float kstar) { mCtr.fill(kstar); }
 
  private:
   CloseTrackRejection<prefix> mCtr;
@@ -697,13 +740,12 @@ class ClosePairRejectionMcParticleMcParticle
     mCtr.init(registry, specs, confCpr, 1, 1);
     mCtr.setMagField(confCpr.magField.value);
   }
-  template <typename T1, typename T2>
-  void setPair(T1 const& mcParticle1, T2 const& mcParticle2)
+
+  template <typename T1, typename T2, typename T3>
+  [[nodiscard]] bool isClosePair(T1 const& mcParticle1, T2 const& mcParticle2, T3 const& pairHistManager)
   {
-    mCtr.compute(mcParticle1, mcParticle2);
+    return mCtr.isClosePair(mcParticle1, mcParticle2, pairHistManager);
   }
-  [[nodiscard]] bool isClosePair() const { return mCtr.isClosePair(); }
-  void fill(float kstar) { mCtr.fill(kstar); }
 
  private:
   CloseTrackRejection<prefix> mCtr;

--- a/PWGCF/Femto/Core/closeTripletRejection.h
+++ b/PWGCF/Femto/Core/closeTripletRejection.h
@@ -27,7 +27,12 @@
 namespace o2::analysis::femto::closetripletrejection
 {
 constexpr const char PrefixCtrTrackTrackTrack[] = "CtrTrackTrackTrack";
+constexpr const char PrefixCtrTrackTrackV0[] = "CtrTrackTrackV0";
+constexpr const char PrefixCtrTrackTrackCascade[] = "CtrTrackTrackCascade";
+
 using ConfCtrTrackTrackTrack = closepairrejection::ConfCpr<PrefixCtrTrackTrackTrack>;
+using ConfCtrTrackTrackV0 = closepairrejection::ConfCpr<PrefixCtrTrackTrackV0>;
+using ConfCtrTrackTrackCascade = closepairrejection::ConfCpr<PrefixCtrTrackTrackCascade>;
 
 // directory names
 constexpr char PrefixTrack1Track2Se[] = "CPR_Track1Track2/SE/";
@@ -85,23 +90,17 @@ class CloseTripletRejectionTrackTrackTrack
     mCtrTrack23.setMagField(magField);
     mCtrTrack13.setMagField(magField);
   }
-  template <typename T1, typename T2, typename T3, typename T4>
-  void setTriplet(T1 const& track1, T2 const& track2, T3 const& track3, T4 const& trackTable)
-  {
-    mCtrTrack12.setPair(track1, track2, trackTable);
-    mCtrTrack23.setPair(track2, track3, trackTable);
-    mCtrTrack13.setPair(track1, track3, trackTable);
-  }
-  [[nodiscard]] bool isCloseTriplet() const
-  {
-    return mCtrTrack12.isClosePair() || mCtrTrack23.isClosePair() || mCtrTrack13.isClosePair();
-  }
 
-  void fill(float q3)
+  // checks all three constituent pairs of the triplet; fills the deta-dphi/kinematic
+  // histograms of each pair internally and returns whether the triplet is rejected.
+  // tripletHistManager must expose getKinematic() (same interface CloseTrackRejection expects).
+  template <typename T1, typename T2, typename T3, typename T4, typename T5>
+  [[nodiscard]] bool isCloseTriplet(T1 const& track1, T2 const& track2, T3 const& track3, T4 const& trackTable, T5 const& tripletHistManager)
   {
-    mCtrTrack12.fill(q3);
-    mCtrTrack23.fill(q3);
-    mCtrTrack13.fill(q3);
+    bool isClose12 = mCtrTrack12.isClosePair(track1, track2, trackTable, tripletHistManager);
+    bool isClose23 = mCtrTrack23.isClosePair(track2, track3, trackTable, tripletHistManager);
+    bool isClose13 = mCtrTrack13.isClosePair(track1, track3, trackTable, tripletHistManager);
+    return isClose12 || isClose23 || isClose13;
   }
 
  private:
@@ -137,23 +136,16 @@ class CloseTripletRejectionTrackTrackV0
     mCtrTrack1V0.setMagField(magField);
     mCtrTrack2V0.setMagField(magField);
   }
-  template <typename T1, typename T2, typename T3, typename T4>
-  void setTriplet(T1 const& track1, T2 const& track2, T3 const& v0, T4 const& trackTable)
-  {
-    mCtrTrack12.setPair(track1, track2, trackTable);
-    mCtrTrack1V0.setPair(track1, v0, trackTable);
-    mCtrTrack2V0.setPair(track2, v0, trackTable);
-  }
-  [[nodiscard]] bool isCloseTriplet() const
-  {
-    return mCtrTrack12.isClosePair() || mCtrTrack1V0.isClosePair() || mCtrTrack2V0.isClosePair();
-  }
 
-  void fill(float q3)
+  // checks track1-track2, track1-v0 and track2-v0; fills the deta-dphi/kinematic
+  // histograms of each pair internally and returns whether the triplet is rejected.
+  template <typename T1, typename T2, typename T3, typename T4, typename T5>
+  [[nodiscard]] bool isCloseTriplet(T1 const& track1, T2 const& track2, T3 const& v0, T4 const& trackTable, T5 const& tripletHistManager)
   {
-    mCtrTrack12.fill(q3);
-    mCtrTrack1V0.fill(q3);
-    mCtrTrack2V0.fill(q3);
+    bool isClose12 = mCtrTrack12.isClosePair(track1, track2, trackTable, tripletHistManager);
+    bool isClose1V0 = mCtrTrack1V0.isClosePair(track1, v0, trackTable, tripletHistManager);
+    bool isClose2V0 = mCtrTrack2V0.isClosePair(track2, v0, trackTable, tripletHistManager);
+    return isClose12 || isClose1V0 || isClose2V0;
   }
 
  private:
@@ -195,23 +187,16 @@ class CloseTripletRejectionTrackTrackCascade
     mCtrTrack1Cascade.setMagField(magField);
     mCtrTrack2Cascade.setMagField(magField);
   }
-  template <typename T1, typename T2, typename T3, typename T4>
-  void setTriplet(T1 const& track1, T2 const& track2, T3 const& cascade, T4 const& trackTable)
-  {
-    mCtrTrack12.setPair(track1, track2, trackTable);
-    mCtrTrack1Cascade.setPair(track1, cascade, trackTable);
-    mCtrTrack2Cascade.setPair(track2, cascade, trackTable);
-  }
-  [[nodiscard]] bool isCloseTriplet() const
-  {
-    return mCtrTrack12.isClosePair() || mCtrTrack1Cascade.isClosePair() || mCtrTrack2Cascade.isClosePair();
-  }
 
-  void fill(float q3)
+  // checks track1-track2, track1-cascade and track2-cascade; fills the deta-dphi/kinematic
+  // histograms of each pair internally and returns whether the triplet is rejected.
+  template <typename T1, typename T2, typename T3, typename T4, typename T5>
+  [[nodiscard]] bool isCloseTriplet(T1 const& track1, T2 const& track2, T3 const& cascade, T4 const& trackTable, T5 const& tripletHistManager)
   {
-    mCtrTrack12.fill(q3);
-    mCtrTrack1Cascade.fill(q3);
-    mCtrTrack2Cascade.fill(q3);
+    bool isClose12 = mCtrTrack12.isClosePair(track1, track2, trackTable, tripletHistManager);
+    bool isClose1Cascade = mCtrTrack1Cascade.isClosePair(track1, cascade, trackTable, tripletHistManager);
+    bool isClose2Cascade = mCtrTrack2Cascade.isClosePair(track2, cascade, trackTable, tripletHistManager);
+    return isClose12 || isClose1Cascade || isClose2Cascade;
   }
 
  private:

--- a/PWGCF/Femto/Core/dataTypes.h
+++ b/PWGCF/Femto/Core/dataTypes.h
@@ -67,6 +67,9 @@ using CharmHadronType = uint16_t;
 using QvecDetectorType = uint8_t;
 using QvecHarmonicType = uint8_t;
 
+// datatype for kinematic variable
+using KinematicVariableType = uint8_t;
+
 } // namespace o2::analysis::femto::datatypes
 
 #endif // PWGCF_FEMTO_CORE_DATATYPES_H_

--- a/PWGCF/Femto/Core/modes.h
+++ b/PWGCF/Femto/Core/modes.h
@@ -190,5 +190,13 @@ enum class QvecHarmonic : o2::analysis::femto::datatypes::QvecHarmonicType {
   kQvecHarmonicLast = 4
 };
 
+enum class KinematicVariable : o2::analysis::femto::datatypes::KinematicVariableType {
+  kKstar = 1,
+  kKt = 2,
+  kMt = 3,
+  kQ3 = 4,
+  kKinematicVariableLast = 5
+};
+
 }; // namespace o2::analysis::femto::modes
 #endif // PWGCF_FEMTO_CORE_MODES_H_

--- a/PWGCF/Femto/Core/pairBuilder.h
+++ b/PWGCF/Femto/Core/pairBuilder.h
@@ -72,7 +72,8 @@ class PairTrackTrackBuilder
             typename T11,
             typename T12,
             typename T13,
-            typename T14>
+            typename T14,
+            typename T15>
   void init(o2::framework::HistogramRegistry* registry,
             T1 const& confCollisionBinning,
             T2 const& confTrackSelection1,
@@ -87,7 +88,8 @@ class PairTrackTrackBuilder
             std::map<T11, std::vector<o2::framework::AxisSpec>> const& trackHistSpec1,
             std::map<T12, std::vector<o2::framework::AxisSpec>> const& trackHistSpec2,
             std::map<T13, std::vector<o2::framework::AxisSpec>> const& pairHistSpec,
-            std::map<T14, std::vector<o2::framework::AxisSpec>> const& cprHistSpec)
+            std::map<T14, std::vector<o2::framework::AxisSpec>> const& cprHistSpec,
+            std::map<T15, std::vector<o2::framework::AxisSpec>> const& pairCleanerHistSpec)
   {
 
     // check if correlate the same tracks or not
@@ -96,7 +98,8 @@ class PairTrackTrackBuilder
     mColHistManager.template init<modeSe>(registry, colHistSpec, confCollisionBinning);
     mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
     mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
-    mPc.template init<modeSe>(confPairCuts);
+    mPcSe.template init<modeSe>(registry, pairCleanerHistSpec, confPairCuts);
+    mPcMe.template init<modeMe>(registry, pairCleanerHistSpec, confPairCuts);
 
     if (mSameSpecies) {
       mTrackCleaner1.init(confTrackCleaner1);
@@ -158,7 +161,7 @@ class PairTrackTrackBuilder
       if (mMixIdenticalParticles) {
         pairOrder = static_cast<pairprocesshelpers::PairOrder>(mDist(mRng));
       }
-      pairprocesshelpers::processSameEvent<mode>(trackSlice1, trackTable, col, mTrackHistManager1, mPairHistManagerSe, mCprSe, mPc, pairOrder);
+      pairprocesshelpers::processSameEvent<mode>(trackSlice1, trackTable, col, mTrackHistManager1, mPairHistManagerSe, mCprSe, mPcSe, pairOrder);
     } else {
       auto trackSlice1 = partition1->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
       auto trackSlice2 = partition2->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
@@ -167,7 +170,7 @@ class PairTrackTrackBuilder
       }
       mColHistManager.template fill<mode>(col);
       mCprSe.setMagField(col.magField());
-      pairprocesshelpers::processSameEvent<mode>(trackSlice1, trackSlice2, trackTable, col, mTrackHistManager1, mTrackHistManager2, mPairHistManagerSe, mCprSe, mPc);
+      pairprocesshelpers::processSameEvent<mode>(trackSlice1, trackSlice2, trackTable, col, mTrackHistManager1, mTrackHistManager2, mPairHistManagerSe, mCprSe, mPcSe);
     }
   }
 
@@ -186,7 +189,7 @@ class PairTrackTrackBuilder
       if (mMixIdenticalParticles) {
         pairOrder = static_cast<pairprocesshelpers::PairOrder>(mDist(mRng));
       }
-      pairprocesshelpers::processSameEvent<mode>(trackSlice1, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager1, mPairHistManagerSe, mTrackCleaner1, mCprSe, mPc, pairOrder);
+      pairprocesshelpers::processSameEvent<mode>(trackSlice1, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager1, mPairHistManagerSe, mTrackCleaner1, mCprSe, mPcSe, pairOrder);
     } else {
       auto trackSlice1 = partition1->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
       auto trackSlice2 = partition2->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
@@ -195,7 +198,7 @@ class PairTrackTrackBuilder
       }
       mColHistManager.template fill<mode>(col, mcCols);
       mCprSe.setMagField(col.magField());
-      pairprocesshelpers::processSameEvent<mode>(trackSlice1, trackSlice2, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager1, mTrackHistManager2, mPairHistManagerSe, mTrackCleaner1, mTrackCleaner2, mCprSe, mPc);
+      pairprocesshelpers::processSameEvent<mode>(trackSlice1, trackSlice2, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager1, mTrackHistManager2, mPairHistManagerSe, mTrackCleaner1, mTrackCleaner2, mCprSe, mPcSe);
     }
   }
 
@@ -206,13 +209,13 @@ class PairTrackTrackBuilder
     if (mSameSpecies) {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -220,13 +223,13 @@ class PairTrackTrackBuilder
     } else {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -240,13 +243,13 @@ class PairTrackTrackBuilder
     if (mSameSpecies) {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mTrackCleaner1, mTrackCleaner1, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mTrackCleaner1, mTrackCleaner1, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner1, mTrackCleaner1, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner1, mTrackCleaner1, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner1, mTrackCleaner1, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner1, mTrackCleaner1, mCprMe, mPcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -254,13 +257,13 @@ class PairTrackTrackBuilder
     } else {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mTrackCleaner1, mTrackCleaner2, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mTrackCleaner1, mTrackCleaner2, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner1, mTrackCleaner2, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner1, mTrackCleaner2, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner1, mTrackCleaner2, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner1, mTrackCleaner2, mCprMe, mPcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -276,7 +279,8 @@ class PairTrackTrackBuilder
   pairhistmanager::PairHistManager<prefixMe, modes::Particle::kTrack, modes::Particle::kTrack> mPairHistManagerMe;
   closepairrejection::ClosePairRejectionTrackTrack<prefixCprSe> mCprSe;
   closepairrejection::ClosePairRejectionTrackTrack<prefixCprMe> mCprMe;
-  paircleaner::TrackTrackPairCleaner mPc;
+  paircleaner::TrackTrackPairCleaner<paircleaner::PrefixPairCleanerTrackTrackSe> mPcSe;
+  paircleaner::TrackTrackPairCleaner<paircleaner::PrefixPairCleanerTrackTrackMe> mPcMe;
   particlecleaner::ParticleCleaner mTrackCleaner1;
   particlecleaner::ParticleCleaner mTrackCleaner2;
   pairhistmanager::MixingPolicy mMixingPolicy = pairhistmanager::MixingPolicy::kVtxMult;
@@ -328,7 +332,8 @@ class PairV0V0Builder
             typename T17,
             typename T18,
             typename T19,
-            typename T20>
+            typename T20,
+            typename T21>
   void init(o2::framework::HistogramRegistry* registry,
             T1 const& confCollisionBinning,
             T2 const& confV0Selection1,
@@ -349,7 +354,8 @@ class PairV0V0Builder
             std::map<T17, std::vector<o2::framework::AxisSpec>> const& NegDauHistSpec2,
             std::map<T18, std::vector<o2::framework::AxisSpec>> const& pairHistSpec,
             std::map<T19, std::vector<o2::framework::AxisSpec>> const& cprHistSpecPos,
-            std::map<T20, std::vector<o2::framework::AxisSpec>> const& cprHistSpecNeg)
+            std::map<T20, std::vector<o2::framework::AxisSpec>> const& cprHistSpecNeg,
+            std::map<T21, std::vector<o2::framework::AxisSpec>> const& pairCleanerHistSpec)
   {
     mSameSpecies = confMixing.sameSpecies.value;
 
@@ -374,7 +380,8 @@ class PairV0V0Builder
     mColHistManager.template init<modeSe>(registry, colHistSpec, confCollisionBinning);
     mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
     mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
-    mPc.template init<modeSe>(confPairCuts);
+    mPcSe.template init<modeSe>(registry, pairCleanerHistSpec, confPairCuts);
+    mPcMe.template init<modeMe>(registry, pairCleanerHistSpec, confPairCuts);
 
     mV0Cleaner1.init(confV0Cleaner1);
     mV0Cleaner2.init(confV0Cleaner2);
@@ -434,7 +441,7 @@ class PairV0V0Builder
       if (mMixIdenticalParticles) {
         pairOrder = static_cast<pairprocesshelpers::PairOrder>(mDist(mRng));
       }
-      pairprocesshelpers::processSameEvent<mode>(v0Slice1, trackTable, col, mV0HistManager1, mPairHistManagerSe, mCprSe, mPc, pairOrder);
+      pairprocesshelpers::processSameEvent<mode>(v0Slice1, trackTable, col, mV0HistManager1, mPairHistManagerSe, mCprSe, mPcSe, pairOrder);
     } else {
       auto v0Slice1 = partition1->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
       auto v0Slice2 = partition2->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
@@ -443,7 +450,7 @@ class PairV0V0Builder
       }
       mColHistManager.template fill<mode>(col);
       mCprSe.setMagField(col.magField());
-      pairprocesshelpers::processSameEvent<mode>(v0Slice1, v0Slice2, trackTable, col, mV0HistManager1, mV0HistManager2, mPairHistManagerSe, mCprSe, mPc);
+      pairprocesshelpers::processSameEvent<mode>(v0Slice1, v0Slice2, trackTable, col, mV0HistManager1, mV0HistManager2, mPairHistManagerSe, mCprSe, mPcSe);
     }
   }
 
@@ -462,7 +469,7 @@ class PairV0V0Builder
       if (mMixIdenticalParticles) {
         pairOrder = static_cast<pairprocesshelpers::PairOrder>(mDist(mRng));
       }
-      pairprocesshelpers::processSameEvent<mode>(v0Slice1, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mV0HistManager1, mPairHistManagerSe, mV0Cleaner1, mCprSe, mPc, pairOrder);
+      pairprocesshelpers::processSameEvent<mode>(v0Slice1, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mV0HistManager1, mPairHistManagerSe, mV0Cleaner1, mCprSe, mPcSe, pairOrder);
     } else {
       auto v0Slice1 = partition1->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
       auto v0Slice2 = partition2->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
@@ -471,7 +478,7 @@ class PairV0V0Builder
       }
       mColHistManager.template fill<mode>(col, mcCols);
       mCprSe.setMagField(col.magField());
-      pairprocesshelpers::processSameEvent<mode>(v0Slice1, v0Slice2, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mV0HistManager1, mV0HistManager2, mPairHistManagerSe, mV0Cleaner1, mV0Cleaner2, mCprSe, mPc);
+      pairprocesshelpers::processSameEvent<mode>(v0Slice1, v0Slice2, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mV0HistManager1, mV0HistManager2, mPairHistManagerSe, mV0Cleaner1, mV0Cleaner2, mCprSe, mPcSe);
     }
   }
 
@@ -482,13 +489,13 @@ class PairV0V0Builder
     if (mSameSpecies) {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -496,13 +503,13 @@ class PairV0V0Builder
     } else {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -516,13 +523,13 @@ class PairV0V0Builder
     if (mSameSpecies) {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mV0Cleaner1, mV0Cleaner1, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mV0Cleaner1, mV0Cleaner1, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mV0Cleaner1, mV0Cleaner1, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mV0Cleaner1, mV0Cleaner1, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mV0Cleaner1, mV0Cleaner1, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mV0Cleaner1, mV0Cleaner1, mCprMe, mPcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -530,13 +537,13 @@ class PairV0V0Builder
     } else {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mV0Cleaner1, mV0Cleaner2, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mV0Cleaner1, mV0Cleaner2, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mV0Cleaner1, mV0Cleaner2, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mV0Cleaner1, mV0Cleaner2, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mV0Cleaner1, mV0Cleaner2, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mV0Cleaner1, mV0Cleaner2, mCprMe, mPcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -554,7 +561,8 @@ class PairV0V0Builder
   pairhistmanager::PairHistManager<prefixMe, modes::Particle::kV0, modes::Particle::kV0> mPairHistManagerMe;
   closepairrejection::ClosePairRejectionV0V0<prefixCprPosSe, prefixCprNegSe> mCprSe;
   closepairrejection::ClosePairRejectionV0V0<prefixCprPosMe, prefixCprNegMe> mCprMe;
-  paircleaner::V0V0PairCleaner mPc;
+  paircleaner::V0V0PairCleaner<paircleaner::PrefixPairCleanerV0V0Se> mPcSe;
+  paircleaner::V0V0PairCleaner<paircleaner::PrefixPairCleanerV0V0Me> mPcMe;
   pairhistmanager::MixingPolicy mMixingPolicy = pairhistmanager::MixingPolicy::kVtxMult;
   bool mSameSpecies = false;
   int mMixingDepth = 5;
@@ -605,7 +613,8 @@ class PairD0D0Builder
             typename T17,
             typename T18,
             typename T19,
-            typename T20>
+            typename T20,
+            typename T21>
   void init(o2::framework::HistogramRegistry* registry,
             T1 const& confCollisionBinning,
             T2 const& confD0Selection1,
@@ -626,7 +635,8 @@ class PairD0D0Builder
             std::map<T17, std::vector<o2::framework::AxisSpec>> const& NegDauHistSpec2,
             std::map<T18, std::vector<o2::framework::AxisSpec>> const& pairHistSpec,
             std::map<T19, std::vector<o2::framework::AxisSpec>> const& cprHistSpecPos,
-            std::map<T20, std::vector<o2::framework::AxisSpec>> const& cprHistSpecNeg)
+            std::map<T20, std::vector<o2::framework::AxisSpec>> const& cprHistSpecNeg,
+            std::map<T21, std::vector<o2::framework::AxisSpec>> const& pairCleanerHistSpec)
   {
     mSameSpecies = confMixing.sameSpecies.value;
 
@@ -648,7 +658,8 @@ class PairD0D0Builder
     mColHistManager.template init<modeSe>(registry, colHistSpec, confCollisionBinning);
     mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
     mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
-    mPc.template init<modeSe>(confPairCuts);
+    mPcSe.template init<modeSe>(registry, pairCleanerHistSpec, confPairCuts);
+    mPcMe.template init<modeMe>(registry, pairCleanerHistSpec, confPairCuts);
 
     mD0Cleaner1.init(confD0Cleaner1);
     mD0Cleaner2.init(confD0Cleaner2);
@@ -715,7 +726,7 @@ class PairD0D0Builder
       if (mMixIdenticalParticles) {
         pairOrder = static_cast<pairprocesshelpers::PairOrder>(mDist(mRng));
       }
-      pairprocesshelpers::processSameEvent<mode>(d0Slice1, trackTable, col, mD0HistManager1, mPairHistManagerSe, mCprSe, mPc, pairOrder);
+      pairprocesshelpers::processSameEvent<mode>(d0Slice1, trackTable, col, mD0HistManager1, mPairHistManagerSe, mCprSe, mPcSe, pairOrder);
     } else {
       auto d0Slice1 = partition1->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
       auto d0Slice2 = partition2->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
@@ -724,7 +735,7 @@ class PairD0D0Builder
       }
       mColHistManager.template fill<mode>(col);
       mCprSe.setMagField(col.magField());
-      pairprocesshelpers::processSameEvent<mode>(d0Slice1, d0Slice2, trackTable, col, mD0HistManager1, mD0HistManager2, mPairHistManagerSe, mCprSe, mPc);
+      pairprocesshelpers::processSameEvent<mode>(d0Slice1, d0Slice2, trackTable, col, mD0HistManager1, mD0HistManager2, mPairHistManagerSe, mCprSe, mPcSe);
     }
   }
 
@@ -743,7 +754,7 @@ class PairD0D0Builder
       if (mMixIdenticalParticles) {
         pairOrder = static_cast<pairprocesshelpers::PairOrder>(mDist(mRng));
       }
-      pairprocesshelpers::processSameEvent<mode>(d0Slice1, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mD0HistManager1, mPairHistManagerSe, mD0Cleaner1, mCprSe, mPc, pairOrder);
+      pairprocesshelpers::processSameEvent<mode>(d0Slice1, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mD0HistManager1, mPairHistManagerSe, mD0Cleaner1, mCprSe, mPcSe, pairOrder);
     } else {
       auto d0Slice1 = partition1->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
       auto d0Slice2 = partition2->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
@@ -752,7 +763,7 @@ class PairD0D0Builder
       }
       mColHistManager.template fill<mode>(col, mcCols);
       mCprSe.setMagField(col.magField());
-      pairprocesshelpers::processSameEvent<mode>(d0Slice1, d0Slice2, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mD0HistManager1, mD0HistManager2, mPairHistManagerSe, mD0Cleaner1, mD0Cleaner2, mCprSe, mPc);
+      pairprocesshelpers::processSameEvent<mode>(d0Slice1, d0Slice2, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mD0HistManager1, mD0HistManager2, mPairHistManagerSe, mD0Cleaner1, mD0Cleaner2, mCprSe, mPcSe);
     }
   }
 
@@ -762,13 +773,13 @@ class PairD0D0Builder
     if (mSameSpecies) {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -776,13 +787,13 @@ class PairD0D0Builder
     } else {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -796,13 +807,13 @@ class PairD0D0Builder
     if (mSameSpecies) {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mD0Cleaner1, mD0Cleaner1, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mD0Cleaner1, mD0Cleaner1, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mD0Cleaner1, mD0Cleaner1, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mD0Cleaner1, mD0Cleaner1, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mD0Cleaner1, mD0Cleaner1, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mD0Cleaner1, mD0Cleaner1, mCprMe, mPcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -810,13 +821,13 @@ class PairD0D0Builder
     } else {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mD0Cleaner1, mD0Cleaner2, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mD0Cleaner1, mD0Cleaner2, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mD0Cleaner1, mD0Cleaner2, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mD0Cleaner1, mD0Cleaner2, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mD0Cleaner1, mD0Cleaner2, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mD0Cleaner1, mD0Cleaner2, mCprMe, mPcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -834,7 +845,8 @@ class PairD0D0Builder
   pairhistmanager::PairHistManager<prefixMe, modes::Particle::kCharmHadron, modes::Particle::kCharmHadron> mPairHistManagerMe;
   closepairrejection::ClosePairRejectionV0V0<prefixCprPosSe, prefixCprNegSe> mCprSe;
   closepairrejection::ClosePairRejectionV0V0<prefixCprPosMe, prefixCprNegMe> mCprMe;
-  paircleaner::V0V0PairCleaner mPc;
+  paircleaner::V0V0PairCleaner<paircleaner::PrefixPairCleanerD0D0Se> mPcSe;
+  paircleaner::V0V0PairCleaner<paircleaner::PrefixPairCleanerD0D0Me> mPcMe;
   pairhistmanager::MixingPolicy mMixingPolicy = pairhistmanager::MixingPolicy::kVtxMult;
   bool mSameSpecies = false;
   int mMixingDepth = 5;
@@ -876,7 +888,8 @@ class PairTrackD0Builder
             typename T13,
             typename T14,
             typename T15,
-            typename T16>
+            typename T16,
+            typename T17>
   void init(o2::framework::HistogramRegistry* registry,
             T1 const& confCollisionBinning,
             T2 const& confTrackSelection,
@@ -893,7 +906,8 @@ class PairTrackD0Builder
             std::map<T13, std::vector<o2::framework::AxisSpec>>& posDauHistSpec,
             std::map<T14, std::vector<o2::framework::AxisSpec>>& negDauHistSpec,
             std::map<T15, std::vector<o2::framework::AxisSpec>>& pairHistSpec,
-            std::map<T16, std::vector<o2::framework::AxisSpec>>& cprHistSpec)
+            std::map<T16, std::vector<o2::framework::AxisSpec>>& cprHistSpec,
+            std::map<T17, std::vector<o2::framework::AxisSpec>>& pairCleanerHistSpec)
   {
     mColHistManager.template init<modeSe>(registry, colHistSpec, confCollisionBinning);
 
@@ -925,7 +939,8 @@ class PairTrackD0Builder
     mPairHistManagerMe.setMass(confTrackSelection.pdgCodeAbs.value, 0, 0, confD0Selection.pdgCodeAbs.value, posDauPdg, negDauPdg);
     mPairHistManagerMe.setCharge(confTrackSelection.chargeAbs.value, 1);
     mCprMe.init(registry, cprHistSpec, confCpr, confTrackSelection.chargeAbs.value);
-    mPc.template init<modeSe>(confPairCuts);
+    mPcSe.template init<modeSe>(registry, pairCleanerHistSpec, confPairCuts);
+    mPcMe.template init<modeMe>(registry, pairCleanerHistSpec, confPairCuts);
 
     // setup mixing
     mMixingPolicy = static_cast<pairhistmanager::MixingPolicy>(confMixing.policy.value);
@@ -942,7 +957,7 @@ class PairTrackD0Builder
     }
     mColHistManager.template fill<mode>(col);
     mCprSe.setMagField(col.magField());
-    pairprocesshelpers::processSameEvent<mode>(trackSlice, d0Slice, trackTable, col, mTrackHistManager, mD0HistManager, mPairHistManagerSe, mCprSe, mPc);
+    pairprocesshelpers::processSameEvent<mode>(trackSlice, d0Slice, trackTable, col, mTrackHistManager, mD0HistManager, mPairHistManagerSe, mCprSe, mPcSe);
   }
 
   template <modes::Mode mode, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
@@ -950,13 +965,13 @@ class PairTrackD0Builder
   {
     switch (mMixingPolicy) {
       case static_cast<int>(pairhistmanager::kVtxMult):
-        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, d0Partition, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, d0Partition, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, d0Partition, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, d0Partition, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxMultCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, d0Partition, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, d0Partition, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
         break;
       default:
         LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -973,7 +988,7 @@ class PairTrackD0Builder
     }
     mColHistManager.template fill<mode>(col, mcCols);
     mCprSe.setMagField(col.magField());
-    pairprocesshelpers::processSameEvent<mode>(trackSlice, d0Slice, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager, mD0HistManager, mPairHistManagerSe, mTrackCleaner, mD0Cleaner, mCprSe, mPc);
+    pairprocesshelpers::processSameEvent<mode>(trackSlice, d0Slice, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager, mD0HistManager, mPairHistManagerSe, mTrackCleaner, mD0Cleaner, mCprSe, mPcSe);
   }
 
   template <modes::Mode mode, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12>
@@ -981,13 +996,13 @@ class PairTrackD0Builder
   {
     switch (mMixingPolicy) {
       case static_cast<int>(pairhistmanager::kVtxMult):
-        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, d0Partition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mD0Cleaner, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, d0Partition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mD0Cleaner, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, d0Partition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mD0Cleaner, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, d0Partition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mD0Cleaner, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxMultCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, d0Partition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mD0Cleaner, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, d0Partition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mD0Cleaner, mCprMe, mPcMe);
         break;
       default:
         LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -1004,7 +1019,8 @@ class PairTrackD0Builder
   pairhistmanager::PairHistManager<prefixMe, modes::Particle::kTrack, modes::Particle::kCharmHadron> mPairHistManagerMe;
   closepairrejection::ClosePairRejectionTrackV0<prefixCprSe> mCprSe;
   closepairrejection::ClosePairRejectionTrackV0<prefixCprMe> mCprMe;
-  paircleaner::TrackV0PairCleaner mPc;
+  paircleaner::TrackV0PairCleaner<paircleaner::PrefixPairCleanerTrackD0Se> mPcSe;
+  paircleaner::TrackV0PairCleaner<paircleaner::PrefixPairCleanerTrackD0Me> mPcMe;
   pairhistmanager::MixingPolicy mMixingPolicy = pairhistmanager::MixingPolicy::kVtxMult;
   int mMixingDepth = 5;
 };
@@ -1033,7 +1049,7 @@ class PairTrackLcBuilder
             modes::Mode modeMe,
             typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7,
             typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename T14,
-            typename T15, typename T16, typename T17, typename T18, typename T19>
+            typename T15, typename T16, typename T17, typename T18, typename T19, typename T20>
   void init(o2::framework::HistogramRegistry* registry,
             T1 const& confCollisionBinning,
             T2 const& confTrackSelection,
@@ -1053,7 +1069,8 @@ class PairTrackLcBuilder
             std::map<T16, std::vector<o2::framework::AxisSpec>>& kaonDauHistSpec,
             std::map<T17, std::vector<o2::framework::AxisSpec>>& pionDauHistSpec,
             std::map<T18, std::vector<o2::framework::AxisSpec>>& pairHistSpec,
-            std::map<T19, std::vector<o2::framework::AxisSpec>>& cprHistSpec)
+            std::map<T19, std::vector<o2::framework::AxisSpec>>& cprHistSpec,
+            std::map<T20, std::vector<o2::framework::AxisSpec>>& pairCleanerHistSpec)
   {
     mColHistManager.template init<modeSe>(registry, colHistSpec, confCollisionBinning);
 
@@ -1078,7 +1095,8 @@ class PairTrackLcBuilder
     mPairHistManagerMe.setMass(confTrackSelection.pdgCodeAbs.value, 0, 0, confLcSelection.pdgCodeAbs.value, protonDauPdg, kaonDauPdg);
     mPairHistManagerMe.setCharge(confTrackSelection.chargeAbs.value, 1);
     mCprMe.init(registry, cprHistSpec, cprHistSpec, cprHistSpec, confCprProton, confCprKaon, confCprPion, confTrackSelection.chargeAbs.value);
-    mPc.template init<modeSe>(confPairCuts);
+    mPcSe.template init<modeSe>(registry, pairCleanerHistSpec, confPairCuts);
+    mPcMe.template init<modeMe>(registry, pairCleanerHistSpec, confPairCuts);
 
     // setup mixing
     mMixingPolicy = static_cast<pairhistmanager::MixingPolicy>(confMixing.policy.value);
@@ -1095,7 +1113,7 @@ class PairTrackLcBuilder
     }
     mColHistManager.template fill<mode>(col);
     mCprSe.setMagField(col.magField());
-    pairprocesshelpers::processSameEvent<mode>(trackSlice, lcSlice, trackTable, col, mTrackHistManager, mLcHistManager, mPairHistManagerSe, mCprSe, mPc);
+    pairprocesshelpers::processSameEvent<mode>(trackSlice, lcSlice, trackTable, col, mTrackHistManager, mLcHistManager, mPairHistManagerSe, mCprSe, mPcSe);
   }
 
   template <modes::Mode mode, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
@@ -1103,13 +1121,13 @@ class PairTrackLcBuilder
   {
     switch (mMixingPolicy) {
       case static_cast<int>(pairhistmanager::kVtxMult):
-        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, lcPartition, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, lcPartition, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, lcPartition, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, lcPartition, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxMultCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, lcPartition, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, lcPartition, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
         break;
       default:
         LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -1126,7 +1144,7 @@ class PairTrackLcBuilder
     }
     mColHistManager.template fill<mode>(col, mcCols);
     mCprSe.setMagField(col.magField());
-    pairprocesshelpers::processSameEvent<mode>(trackSlice, lcSlice, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager, mLcHistManager, mPairHistManagerSe, mTrackCleaner, mLcCleaner, mCprSe, mPc);
+    pairprocesshelpers::processSameEvent<mode>(trackSlice, lcSlice, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager, mLcHistManager, mPairHistManagerSe, mTrackCleaner, mLcCleaner, mCprSe, mPcSe);
   }
 
   template <modes::Mode mode, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10, typename T11, typename T12>
@@ -1134,13 +1152,13 @@ class PairTrackLcBuilder
   {
     switch (mMixingPolicy) {
       case static_cast<int>(pairhistmanager::kVtxMult):
-        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, lcPartition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mLcCleaner, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, lcPartition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mLcCleaner, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, lcPartition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mLcCleaner, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, lcPartition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mLcCleaner, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxMultCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, lcPartition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mLcCleaner, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, lcPartition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mLcCleaner, mCprMe, mPcMe);
         break;
       default:
         LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -1157,7 +1175,8 @@ class PairTrackLcBuilder
   pairhistmanager::PairHistManager<prefixMe, modes::Particle::kTrack, modes::Particle::kCharmHadron> mPairHistManagerMe;
   closepairrejection::ClosePairRejectionTrackLc<prefixCprProtonSe, prefixCprKaonSe, prefixCprPionSe> mCprSe;
   closepairrejection::ClosePairRejectionTrackLc<prefixCprProtonMe, prefixCprKaonMe, prefixCprPionMe> mCprMe;
-  paircleaner::TrackLcPairCleaner mPc;
+  paircleaner::TrackLcPairCleaner<paircleaner::PrefixPairCleanerTrackLcSe> mPcSe;
+  paircleaner::TrackLcPairCleaner<paircleaner::PrefixPairCleanerTrackLcMe> mPcMe;
   pairhistmanager::MixingPolicy mMixingPolicy = pairhistmanager::MixingPolicy::kVtxMult;
   int mMixingDepth = 5;
 };
@@ -1194,7 +1213,8 @@ class PairTrackV0Builder
             typename T13,
             typename T14,
             typename T15,
-            typename T16>
+            typename T16,
+            typename T17>
   void init(o2::framework::HistogramRegistry* registry,
             T1 const& confCollisionBinning,
             T2 const& confTrackSelection,
@@ -1211,7 +1231,8 @@ class PairTrackV0Builder
             std::map<T13, std::vector<o2::framework::AxisSpec>>& posDauHistSpec,
             std::map<T14, std::vector<o2::framework::AxisSpec>>& negDauHistSpec,
             std::map<T15, std::vector<o2::framework::AxisSpec>>& pairHistSpec,
-            std::map<T16, std::vector<o2::framework::AxisSpec>>& cprHistSpec)
+            std::map<T16, std::vector<o2::framework::AxisSpec>>& cprHistSpec,
+            std::map<T17, std::vector<o2::framework::AxisSpec>>& pairCleanerHistSpec)
   {
     mColHistManager.template init<modeSe>(registry, colHistSpec, confCollisionBinning);
 
@@ -1245,7 +1266,8 @@ class PairTrackV0Builder
     mPairHistManagerMe.setMass(confTrackSelection.pdgCodeAbs.value, 0, 0, confV0Selection.pdgCodeAbs.value, pdgCodePosDau, pdgCodeNegDau);
     mPairHistManagerMe.setCharge(confTrackSelection.chargeAbs.value, 1);
     mCprMe.init(registry, cprHistSpec, confCpr, confTrackSelection.chargeAbs.value);
-    mPc.template init<modeSe>(confPairCuts);
+    mPcSe.template init<modeSe>(registry, pairCleanerHistSpec, confPairCuts);
+    mPcMe.template init<modeMe>(registry, pairCleanerHistSpec, confPairCuts);
 
     // setup mixing
     mMixingPolicy = static_cast<pairhistmanager::MixingPolicy>(confMixing.policy.value);
@@ -1262,7 +1284,7 @@ class PairTrackV0Builder
     }
     mColHistManager.template fill<mode>(col);
     mCprSe.setMagField(col.magField());
-    pairprocesshelpers::processSameEvent<mode>(trackSlice, v0Slice, trackTable, col, mTrackHistManager, mV0HistManager, mPairHistManagerSe, mCprSe, mPc);
+    pairprocesshelpers::processSameEvent<mode>(trackSlice, v0Slice, trackTable, col, mTrackHistManager, mV0HistManager, mPairHistManagerSe, mCprSe, mPcSe);
   }
 
   template <modes::Mode mode, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10>
@@ -1275,7 +1297,7 @@ class PairTrackV0Builder
     }
     mColHistManager.template fill<mode>(col, mcCols);
     mCprSe.setMagField(col.magField());
-    pairprocesshelpers::processSameEvent<mode>(trackSlice, v0Slice, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager, mV0HistManager, mPairHistManagerSe, mTrackCleaner, mV0Cleaner, mCprSe, mPc);
+    pairprocesshelpers::processSameEvent<mode>(trackSlice, v0Slice, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager, mV0HistManager, mPairHistManagerSe, mTrackCleaner, mV0Cleaner, mCprSe, mPcSe);
   }
 
   template <modes::Mode mode, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
@@ -1283,13 +1305,13 @@ class PairTrackV0Builder
   {
     switch (mMixingPolicy) {
       case static_cast<int>(pairhistmanager::kVtxMult):
-        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, v0Partition, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, v0Partition, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, v0Partition, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, v0Partition, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxMultCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, v0Partition, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, v0Partition, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
         break;
       default:
         LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -1301,13 +1323,13 @@ class PairTrackV0Builder
   {
     switch (mMixingPolicy) {
       case static_cast<int>(pairhistmanager::kVtxMult):
-        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, v0Partition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mV0Cleaner, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, v0Partition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mV0Cleaner, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, v0Partition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mV0Cleaner, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, v0Partition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mV0Cleaner, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxMultCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, v0Partition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mV0Cleaner, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, v0Partition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mV0Cleaner, mCprMe, mPcMe);
         break;
       default:
         LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -1324,7 +1346,8 @@ class PairTrackV0Builder
   pairhistmanager::PairHistManager<prefixMe, modes::Particle::kTrack, modes::Particle::kV0> mPairHistManagerMe;
   closepairrejection::ClosePairRejectionTrackV0<prefixCprSe> mCprSe;
   closepairrejection::ClosePairRejectionTrackV0<prefixCprMe> mCprMe;
-  paircleaner::TrackV0PairCleaner mPc;
+  paircleaner::TrackV0PairCleaner<paircleaner::PrefixPairCleanerTrackV0Se> mPcSe;
+  paircleaner::TrackV0PairCleaner<paircleaner::PrefixPairCleanerTrackV0Me> mPcMe;
   pairhistmanager::MixingPolicy mMixingPolicy = pairhistmanager::MixingPolicy::kVtxMult;
   int mMixingDepth = 5;
 };
@@ -1359,7 +1382,8 @@ class PairTrackTwoTrackResonanceBuilder
             typename T11,
             typename T12,
             typename T13,
-            typename T14>
+            typename T14,
+            typename T15>
   void init(o2::framework::HistogramRegistry* registry,
             T1 const& confCollisionBinning,
             T2 const& confTrackSelection,
@@ -1374,7 +1398,8 @@ class PairTrackTwoTrackResonanceBuilder
             std::map<T11, std::vector<o2::framework::AxisSpec>> const& posDauHistSpec,
             std::map<T12, std::vector<o2::framework::AxisSpec>> const& negDauHistSpec,
             std::map<T13, std::vector<o2::framework::AxisSpec>> const& pairHistSpec,
-            std::map<T14, std::vector<o2::framework::AxisSpec>> const& cprHistSpec)
+            std::map<T14, std::vector<o2::framework::AxisSpec>> const& cprHistSpec,
+            std::map<T15, std::vector<o2::framework::AxisSpec>> const& pairCleanerHistSpec)
   {
     mColHistManager.template init<modeSe>(registry, colHistSpec, confCollisionBinning);
 
@@ -1390,6 +1415,8 @@ class PairTrackTwoTrackResonanceBuilder
     mPairHistManagerMe.setMass(confTrackSelection.pdgCodeAbs.value, confResonanceSelection.pdgCodeAbs.value);
     mPairHistManagerMe.setCharge(confTrackSelection.chargeAbs.value, 1);
     mCprMe.init(registry, cprHistSpec, confCpr, confTrackSelection.chargeAbs.value);
+    mPcSe.template init<modeSe>(registry, pairCleanerHistSpec, confPairCuts);
+    mPcMe.template init<modeMe>(registry, pairCleanerHistSpec, confPairCuts);
 
     // setup mixing
     mMixingPolicy = static_cast<pairhistmanager::MixingPolicy>(confMixing.policy.value);
@@ -1406,7 +1433,7 @@ class PairTrackTwoTrackResonanceBuilder
     }
     mColHistManager.template fill<mode>(col);
     mCprSe.setMagField(col.magField());
-    pairprocesshelpers::processSameEvent<mode>(trackSlice, resonanaceSlice, trackTable, col, mTrackHistManager, mResonanceHistManager, mPairHistManagerSe, mCprSe, mPc);
+    pairprocesshelpers::processSameEvent<mode>(trackSlice, resonanaceSlice, trackTable, col, mTrackHistManager, mResonanceHistManager, mPairHistManagerSe, mCprSe, mPcSe);
   }
 
   template <modes::Mode mode, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
@@ -1414,13 +1441,13 @@ class PairTrackTwoTrackResonanceBuilder
   {
     switch (mMixingPolicy) {
       case static_cast<int>(pairhistmanager::kVtxMult):
-        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, resonancePartition, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, resonancePartition, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, resonancePartition, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, resonancePartition, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxMultCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, resonancePartition, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, resonancePartition, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
         break;
       default:
         LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -1433,9 +1460,10 @@ class PairTrackTwoTrackResonanceBuilder
   twotrackresonancehistmanager::TwoTrackResonanceHistManager<prefixResonance, prefixPosDau, prefixNegDau, resonanceType> mResonanceHistManager;
   pairhistmanager::PairHistManager<prefixSe, modes::Particle::kTrack, modes::Particle::kTwoTrackResonance> mPairHistManagerSe;
   pairhistmanager::PairHistManager<prefixMe, modes::Particle::kTrack, modes::Particle::kTwoTrackResonance> mPairHistManagerMe;
-  closepairrejection::ClosePairRejectionTrackV0<prefixCprSe> mCprSe; // cpr for twotrackresonances and v0 work the same way
-  closepairrejection::ClosePairRejectionTrackV0<prefixCprMe> mCprMe; // cpr for twotrackresonances and v0 work the same way
-  paircleaner::TrackV0PairCleaner mPc;                               // pc for twotrackresonances and v0 work the same way
+  closepairrejection::ClosePairRejectionTrackV0<prefixCprSe> mCprSe;                     // cpr for twotrackresonances and v0 work the same way
+  closepairrejection::ClosePairRejectionTrackV0<prefixCprMe> mCprMe;                     // cpr for twotrackresonances and v0 work the same way
+  paircleaner::TrackV0PairCleaner<paircleaner::PrefixPairCleanerTrackResonanceSe> mPcSe; // pc for twotrackresonances and v0 work the same way
+  paircleaner::TrackV0PairCleaner<paircleaner::PrefixPairCleanerTrackResonanceMe> mPcMe; // pc for twotrackresonances and v0 work the same way
   pairhistmanager::MixingPolicy mMixingPolicy = pairhistmanager::MixingPolicy::kVtxMult;
   int mMixingDepth = 5;
 };
@@ -1479,7 +1507,8 @@ class PairV0TwoTrackResonanceBuilder
             typename T15,
             typename T16,
             typename T17,
-            typename T18>
+            typename T18,
+            typename T19>
   void init(o2::framework::HistogramRegistry* registry,
             T1 const& confCollisionBinning,
             T2 const& confV0Selection,
@@ -1498,7 +1527,8 @@ class PairV0TwoTrackResonanceBuilder
             std::map<T15, std::vector<o2::framework::AxisSpec>> const& ResonanceNegDauHistSpec,
             std::map<T16, std::vector<o2::framework::AxisSpec>> const& pairHistSpec,
             std::map<T17, std::vector<o2::framework::AxisSpec>> const& cprHistSpecPos,
-            std::map<T18, std::vector<o2::framework::AxisSpec>> const& cprHistSpecNeg)
+            std::map<T18, std::vector<o2::framework::AxisSpec>> const& cprHistSpecNeg,
+            std::map<T19, std::vector<o2::framework::AxisSpec>> const& pairCleanerHistSpec)
   {
     mColHistManager.template init<modeSe>(registry, colHistSpec, confCollisionBinning);
 
@@ -1514,6 +1544,8 @@ class PairV0TwoTrackResonanceBuilder
     mPairHistManagerMe.setMass(confV0Selection.pdgCodeAbs.value, confResonanceSelection.pdgCodeAbs.value);
     mPairHistManagerMe.setCharge(1, 1); // set charge to 1
     mCprMe.init(registry, cprHistSpecPos, cprHistSpecNeg, confCprPos, confCprNeg);
+    mPcSe.template init<modeSe>(registry, pairCleanerHistSpec, confPairCuts);
+    mPcMe.template init<modeMe>(registry, pairCleanerHistSpec, confPairCuts);
 
     // setup mixing
     mMixingPolicy = static_cast<pairhistmanager::MixingPolicy>(confMixing.policy.value);
@@ -1530,7 +1562,7 @@ class PairV0TwoTrackResonanceBuilder
     }
     mColHistManager.template fill<mode>(col);
     mCprSe.setMagField(col.magField());
-    pairprocesshelpers::processSameEvent<mode>(v0Slice, resonanaceSlice, trackTable, col, mV0HistManager, mResonanceHistManager, mPairHistManagerSe, mCprSe, mPc);
+    pairprocesshelpers::processSameEvent<mode>(v0Slice, resonanaceSlice, trackTable, col, mV0HistManager, mResonanceHistManager, mPairHistManagerSe, mCprSe, mPcSe);
   }
 
   template <modes::Mode mode, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
@@ -1538,13 +1570,13 @@ class PairV0TwoTrackResonanceBuilder
   {
     switch (mMixingPolicy) {
       case static_cast<int>(pairhistmanager::kVtxMult):
-        pairprocesshelpers::processMixedEvent<mode>(cols, v0Partition, resonancePartition, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, v0Partition, resonancePartition, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, v0Partition, resonancePartition, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, v0Partition, resonancePartition, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxMultCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, v0Partition, resonancePartition, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, v0Partition, resonancePartition, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
         break;
       default:
         LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -1559,7 +1591,8 @@ class PairV0TwoTrackResonanceBuilder
   pairhistmanager::PairHistManager<prefixMe, modes::Particle::kV0, modes::Particle::kTwoTrackResonance> mPairHistManagerMe;
   closepairrejection::ClosePairRejectionV0V0<prefixCprPosSe, prefixCprNegSe> mCprSe; // cpr for twotrackresonances and v0 work the same way
   closepairrejection::ClosePairRejectionV0V0<prefixCprPosMe, prefixCprNegMe> mCprMe; // cpr for twotrackresonances and v0 work the same way
-  paircleaner::V0V0PairCleaner mPc;                                                  // pc for twotrackresonances and v0 work the same way
+  paircleaner::V0V0PairCleaner<paircleaner::PrefixPairCleanerV0ResonanceSe> mPcSe;   // pc for twotrackresonances and v0 work the same way
+  paircleaner::V0V0PairCleaner<paircleaner::PrefixPairCleanerV0ResonanceMe> mPcMe;   // pc for twotrackresonances and v0 work the same way
   pairhistmanager::MixingPolicy mMixingPolicy = pairhistmanager::MixingPolicy::kVtxMult;
   int mMixingDepth = 5;
 };
@@ -1594,7 +1627,8 @@ class PairTrackKinkBuilder
             typename T12,
             typename T13,
             typename T14,
-            typename T15>
+            typename T15,
+            typename T16>
   void init(o2::framework::HistogramRegistry* registry,
             T1 const& confCollisionBinning,
             T2 const& confTrackSelection,
@@ -1610,7 +1644,8 @@ class PairTrackKinkBuilder
             std::map<T12, std::vector<o2::framework::AxisSpec>> const& kinkHistSpec,
             std::map<T13, std::vector<o2::framework::AxisSpec>> const& chaDauHistSpec,
             std::map<T14, std::vector<o2::framework::AxisSpec>> const& pairHistSpec,
-            std::map<T15, std::vector<o2::framework::AxisSpec>> const& cprHistSpec)
+            std::map<T15, std::vector<o2::framework::AxisSpec>> const& cprHistSpec,
+            std::map<T16, std::vector<o2::framework::AxisSpec>> const& pairCleanerHistSpec)
   {
     mColHistManager.template init<modeSe>(registry, colHistSpec, confCollisionBinning);
 
@@ -1629,7 +1664,8 @@ class PairTrackKinkBuilder
     mPairHistManagerMe.setMass(confTrackSelection.pdgCodeAbs.value, confKinkSelection.pdgCodeAbs.value);
     mPairHistManagerMe.setCharge(confTrackSelection.chargeAbs.value, 1); // abs charge of kink daughter is always 1
     mCprMe.init(registry, cprHistSpec, confCpr, confTrackSelection.chargeAbs.value);
-    mPc.template init<modeSe>(confPairCuts);
+    mPcSe.template init<modeSe>(registry, pairCleanerHistSpec, confPairCuts);
+    mPcMe.template init<modeMe>(registry, pairCleanerHistSpec, confPairCuts);
 
     // setup mixing
     mMixingPolicy = static_cast<pairhistmanager::MixingPolicy>(confMixing.policy.value);
@@ -1646,7 +1682,7 @@ class PairTrackKinkBuilder
     }
     mColHistManager.template fill<mode>(col);
     mCprSe.setMagField(col.magField());
-    pairprocesshelpers::processSameEvent<mode>(trackSlice, kinkSlice, trackTable, col, mTrackHistManager, mKinkHistManager, mPairHistManagerSe, mCprSe, mPc);
+    pairprocesshelpers::processSameEvent<mode>(trackSlice, kinkSlice, trackTable, col, mTrackHistManager, mKinkHistManager, mPairHistManagerSe, mCprSe, mPcSe);
   }
 
   template <modes::Mode mode, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10>
@@ -1659,7 +1695,7 @@ class PairTrackKinkBuilder
     }
     mColHistManager.template fill<mode>(col, mcCols);
     mCprSe.setMagField(col.magField());
-    pairprocesshelpers::processSameEvent<mode>(trackSlice, kinkSlice, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager, mKinkHistManager, mPairHistManagerSe, mTrackCleaner, mKinkCleaner, mCprSe, mPc);
+    pairprocesshelpers::processSameEvent<mode>(trackSlice, kinkSlice, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager, mKinkHistManager, mPairHistManagerSe, mTrackCleaner, mKinkCleaner, mCprSe, mPcSe);
   }
 
   template <modes::Mode mode, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
@@ -1667,13 +1703,13 @@ class PairTrackKinkBuilder
   {
     switch (mMixingPolicy) {
       case static_cast<int>(pairhistmanager::kVtxMult):
-        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, kinkPartition, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, kinkPartition, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, kinkPartition, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, kinkPartition, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxMultCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, kinkPartition, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, kinkPartition, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
         break;
       default:
         LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -1685,13 +1721,13 @@ class PairTrackKinkBuilder
   {
     switch (mMixingPolicy) {
       case static_cast<int>(pairhistmanager::kVtxMult):
-        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, kinkPartition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mKinkCleaner, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, kinkPartition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mKinkCleaner, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, kinkPartition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mKinkCleaner, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, kinkPartition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mKinkCleaner, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxMultCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, kinkPartition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mKinkCleaner, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, kinkPartition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mKinkCleaner, mCprMe, mPcMe);
         break;
       default:
         LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -1708,7 +1744,8 @@ class PairTrackKinkBuilder
   pairhistmanager::PairHistManager<prefixMe, modes::Particle::kTrack, modes::Particle::kKink> mPairHistManagerMe;
   closepairrejection::ClosePairRejectionTrackKink<prefixCprSe> mCprSe;
   closepairrejection::ClosePairRejectionTrackKink<prefixCprMe> mCprMe;
-  paircleaner::TrackKinkPairCleaner mPc;
+  paircleaner::TrackKinkPairCleaner<paircleaner::PrefixPairCleanerTrackKinkSe> mPcSe;
+  paircleaner::TrackKinkPairCleaner<paircleaner::PrefixPairCleanerTrackKinkMe> mPcMe;
   pairhistmanager::MixingPolicy mMixingPolicy = pairhistmanager::MixingPolicy::kVtxMult;
   int mMixingDepth = 5;
 };
@@ -1751,7 +1788,8 @@ class PairTrackCascadeBuilder
             typename T16,
             typename T17,
             typename T18,
-            typename T19>
+            typename T19,
+            typename T20>
   void init(o2::framework::HistogramRegistry* registry,
             T1 const& confCollisionBinning,
             T2 const& confTrackSelection,
@@ -1771,7 +1809,8 @@ class PairTrackCascadeBuilder
             std::map<T16, std::vector<o2::framework::AxisSpec>> const& negDauHistSpec,
             std::map<T17, std::vector<o2::framework::AxisSpec>> const& pairHistSpec,
             std::map<T18, std::vector<o2::framework::AxisSpec>> const& cprHistSpecBachelor,
-            std::map<T19, std::vector<o2::framework::AxisSpec>> const& cprHistSpecV0Daughter)
+            std::map<T19, std::vector<o2::framework::AxisSpec>> const& cprHistSpecV0Daughter,
+            std::map<T20, std::vector<o2::framework::AxisSpec>> const& pairCleanerHistSpec)
   {
     mColHistManager.template init<modeSe>(registry, colHistSpec, confCollisionBinning);
 
@@ -1790,6 +1829,8 @@ class PairTrackCascadeBuilder
     mPairHistManagerMe.setMass(confTrackSelection.pdgCodeAbs.value, confCascadeSelection.pdgCodeAbs.value);
     mPairHistManagerMe.setCharge(confTrackSelection.chargeAbs.value, 1);
     mCprMe.init(registry, cprHistSpecBachelor, cprHistSpecV0Daughter, confCprBachelor, confCprV0Daughter, confTrackSelection.chargeAbs.value);
+    mPcSe.template init<modeSe>(registry, pairCleanerHistSpec, confPairCuts);
+    mPcMe.template init<modeMe>(registry, pairCleanerHistSpec, confPairCuts);
 
     // setup mixing
     mMixingPolicy = static_cast<pairhistmanager::MixingPolicy>(confMixing.policy.value);
@@ -1806,7 +1847,7 @@ class PairTrackCascadeBuilder
     }
     mColHistManager.template fill<mode>(col);
     mCprSe.setMagField(col.magField());
-    pairprocesshelpers::processSameEvent<mode>(trackSlice, cascadeSlice, trackTable, col, mTrackHistManager, mCascadeHistManager, mPairHistManagerSe, mCprSe, mPc);
+    pairprocesshelpers::processSameEvent<mode>(trackSlice, cascadeSlice, trackTable, col, mTrackHistManager, mCascadeHistManager, mPairHistManagerSe, mCprSe, mPcSe);
   }
 
   template <modes::Mode mode, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8, typename T9, typename T10>
@@ -1819,7 +1860,7 @@ class PairTrackCascadeBuilder
     }
     mColHistManager.template fill<mode>(col, mcCols);
     mCprSe.setMagField(col.magField());
-    pairprocesshelpers::processSameEvent<mode>(trackSlice, cascadeSlice, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager, mCascadeHistManager, mPairHistManagerSe, mTrackCleaner, mCascadeCleaner, mCprSe, mPc);
+    pairprocesshelpers::processSameEvent<mode>(trackSlice, cascadeSlice, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager, mCascadeHistManager, mPairHistManagerSe, mTrackCleaner, mCascadeCleaner, mCprSe, mPcSe);
   }
 
   template <modes::Mode mode, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7, typename T8>
@@ -1827,13 +1868,13 @@ class PairTrackCascadeBuilder
   {
     switch (mMixingPolicy) {
       case static_cast<int>(pairhistmanager::kVtxMult):
-        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, v0Partition, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, v0Partition, trackTable, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, v0Partition, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, v0Partition, trackTable, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxMultCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, v0Partition, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, trackPartition, v0Partition, trackTable, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mCprMe, mPcMe);
         break;
       default:
         LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -1845,13 +1886,13 @@ class PairTrackCascadeBuilder
   {
     switch (mMixingPolicy) {
       case static_cast<int>(pairhistmanager::kVtxMult):
-        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, cascadePartition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mCascadeCleaner, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, cascadePartition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mCascadeCleaner, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, cascadePartition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mCascadeCleaner, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, cascadePartition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mCascadeCleaner, mCprMe, mPcMe);
         break;
       case static_cast<int>(pairhistmanager::kVtxMultCent):
-        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, cascadePartition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mCascadeCleaner, mCprMe, mPc);
+        pairprocesshelpers::processMixedEvent<mode>(cols, mcCols, trackPartition, cascadePartition, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mTrackCleaner, mCascadeCleaner, mCprMe, mPcMe);
         break;
       default:
         LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -1868,7 +1909,8 @@ class PairTrackCascadeBuilder
   pairhistmanager::PairHistManager<prefixMe, modes::Particle::kTrack, modes::Particle::kCascade> mPairHistManagerMe;
   closepairrejection::ClosePairRejectionTrackCascade<prefixCprBachelorSe, prefixCprV0DaughterSe> mCprSe;
   closepairrejection::ClosePairRejectionTrackCascade<prefixCprBachelorMe, prefixCprV0DaughterMe> mCprMe;
-  paircleaner::TrackCascadePairCleaner mPc;
+  paircleaner::TrackCascadePairCleaner<paircleaner::PrefixPairCleanerTrackCascadeSe> mPcSe;
+  paircleaner::TrackCascadePairCleaner<paircleaner::PrefixPairCleanerTrackCascadeMe> mPcMe;
   pairhistmanager::MixingPolicy mMixingPolicy = pairhistmanager::MixingPolicy::kVtxMult;
   int mMixingDepth = 5;
 };
@@ -1897,7 +1939,8 @@ class PairMcParticleMcParticleBuilder
             typename T13,
             typename T14,
             typename T15,
-            typename T16>
+            typename T16,
+            typename T17>
   void init(o2::framework::HistogramRegistry* registry,
             T1 const& confCollisionBinning,
             T2 const& confMcParticleSelection1,
@@ -1914,7 +1957,8 @@ class PairMcParticleMcParticleBuilder
             std::map<T13, std::vector<o2::framework::AxisSpec>> const& mcParticleHistSpec1,
             std::map<T14, std::vector<o2::framework::AxisSpec>> const& mcParticleHistSpec2,
             std::map<T15, std::vector<o2::framework::AxisSpec>> const& pairHistSpec,
-            std::map<T16, std::vector<o2::framework::AxisSpec>> const& cprHistSpec)
+            std::map<T16, std::vector<o2::framework::AxisSpec>> const& cprHistSpec,
+            std::map<T17, std::vector<o2::framework::AxisSpec>> const& pairCleanerHistSpec)
   {
 
     // check if correlate the same tracks or not
@@ -1923,7 +1967,8 @@ class PairMcParticleMcParticleBuilder
     mColHistManager.template init<modeSe>(registry, colHistSpec, confCollisionBinning);
     mPairHistManagerSe.template init<modeSe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
     mPairHistManagerMe.template init<modeMe>(registry, pairHistSpec, confPairBinning, confPairCuts, confMixing);
-    mPc.template init<modeSe>(confPairCuts);
+    mPcSe.template init<modeSe>(registry, pairCleanerHistSpec, confPairCuts);
+    mPcMe.template init<modeMe>(registry, pairCleanerHistSpec, confPairCuts);
 
     if (mSameSpecies) {
       mMcParticleCleaner1.init(confMcParticleCleaner1);
@@ -1985,7 +2030,7 @@ class PairMcParticleMcParticleBuilder
       if (mMixIdenticalParticles) {
         pairOrder = static_cast<pairprocesshelpers::PairOrder>(mDist(mRng));
       }
-      pairprocesshelpers::processSameEvent<mode>(mcParticleSlice, mcParticles, mcMothers, mcPartonicMothers, col, mMcParticleHistManager1, mPairHistManagerSe, mMcParticleCleaner1, mCprSe, mPc, pairOrder);
+      pairprocesshelpers::processSameEvent<mode>(mcParticleSlice, mcParticles, mcMothers, mcPartonicMothers, col, mMcParticleHistManager1, mPairHistManagerSe, mMcParticleCleaner1, mCprSe, mPcSe, pairOrder);
     } else {
       auto mcParticleSlice1 = partition1->sliceByCached(o2::aod::femtomcparticle::fMcColId, col.globalIndex(), cache);
       auto mcParticleSlice2 = partition2->sliceByCached(o2::aod::femtomcparticle::fMcColId, col.globalIndex(), cache);
@@ -1993,7 +2038,7 @@ class PairMcParticleMcParticleBuilder
         return;
       }
       mColHistManager.template fill<mode>(col);
-      pairprocesshelpers::processSameEvent<mode>(mcParticleSlice1, mcParticleSlice2, mcParticles, mcMothers, mcPartonicMothers, col, mMcParticleHistManager1, mMcParticleHistManager2, mPairHistManagerSe, mMcParticleCleaner1, mMcParticleCleaner2, mCprSe, mPc);
+      pairprocesshelpers::processSameEvent<mode>(mcParticleSlice1, mcParticleSlice2, mcParticles, mcMothers, mcPartonicMothers, col, mMcParticleHistManager1, mMcParticleHistManager2, mPairHistManagerSe, mMcParticleCleaner1, mMcParticleCleaner2, mCprSe, mPcSe);
     }
   }
 
@@ -2003,13 +2048,13 @@ class PairMcParticleMcParticleBuilder
     if (mSameSpecies) {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mMcParticleCleaner1, mMcParticleCleaner1, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mMcParticleCleaner1, mMcParticleCleaner1, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mMcParticleCleaner1, mMcParticleCleaner1, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mMcParticleCleaner1, mMcParticleCleaner1, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mMcParticleCleaner1, mMcParticleCleaner1, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mMcParticleCleaner1, mMcParticleCleaner1, mCprMe, mPcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -2017,13 +2062,13 @@ class PairMcParticleMcParticleBuilder
     } else {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mMcParticleCleaner1, mMcParticleCleaner2, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mPairHistManagerMe, mMcParticleCleaner1, mMcParticleCleaner2, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mMcParticleCleaner1, mMcParticleCleaner2, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mPairHistManagerMe, mMcParticleCleaner1, mMcParticleCleaner2, mCprMe, mPcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mMcParticleCleaner1, mMcParticleCleaner2, mCprMe, mPc);
+          pairprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mPairHistManagerMe, mMcParticleCleaner1, mMcParticleCleaner2, mCprMe, mPcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policiy specifed. Breaking...";
@@ -2039,7 +2084,8 @@ class PairMcParticleMcParticleBuilder
   pairhistmanager::PairHistManager<prefixMe, modes::Particle::kTrack, modes::Particle::kTrack> mPairHistManagerMe;
   closepairrejection::ClosePairRejectionMcParticleMcParticle<prefixCprSe> mCprSe;
   closepairrejection::ClosePairRejectionMcParticleMcParticle<prefixCprMe> mCprMe;
-  paircleaner::McParticleMcParticlePairCleaner mPc;
+  paircleaner::McParticleMcParticlePairCleaner<paircleaner::PrefixPairCleanerMcParticleMcParticleSe> mPcSe;
+  paircleaner::McParticleMcParticlePairCleaner<paircleaner::PrefixPairCleanerMcParticleMcParticleMe> mPcMe;
   particlecleaner::ParticleCleaner mMcParticleCleaner1;
   particlecleaner::ParticleCleaner mMcParticleCleaner2;
   pairhistmanager::MixingPolicy mMixingPolicy = pairhistmanager::MixingPolicy::kVtxMult;

--- a/PWGCF/Femto/Core/pairCleaner.h
+++ b/PWGCF/Femto/Core/pairCleaner.h
@@ -16,20 +16,97 @@
 #ifndef PWGCF_FEMTO_CORE_PAIRCLEANER_H_
 #define PWGCF_FEMTO_CORE_PAIRCLEANER_H_
 
+#include "PWGCF/Femto/Core/histManager.h"
 #include "PWGCF/Femto/Core/modes.h"
 
+#include <Framework/Configurable.h>
+#include <Framework/HistogramRegistry.h>
+#include <Framework/HistogramSpec.h>
 #include <Framework/Logger.h>
+
+#include <TH1.h>
+
+#include <Rtypes.h>
+
+#include <array>
+#include <map>
+#include <string>
+#include <string_view>
+#include <vector>
 
 namespace o2::analysis::femto::paircleaner
 {
+
+// enum for pair cleaner histograms
+enum PairCleanerHist {
+  // standard 1D
+  kStats,
+  kKinematic, // kinematic variable of the pair/triplet
+  kPairCleanerHistLast
+};
+
+// bin indices (0-based fill values) for the kStats histogram
+enum PairCleanerStatsBin {
+  kAllAnalyzed = 0,
+  kAllBlocked = 1,
+  kPairCleanerStatsBinLast = 2,
+};
+
+struct ConfPairCleanerBinning : o2::framework::ConfigurableGroup {
+  std::string prefix = std::string("PairCleanerBinning");
+  o2::framework::ConfigurableAxis kinematic{"kinematic", {{100, 0.f, 1.f}}, "kinematic"};
+};
+
+constexpr std::array<histmanager::HistInfo<PairCleanerHist>, kPairCleanerHistLast>
+  HistTable = {
+    {
+      // 1D
+      {kStats, o2::framework::HistType::kTH1F, "hStats", "Stats; ; Entries"},
+      {kKinematic, o2::framework::HistType::kTH1F, "hKinematic", "Kinematic of blocked pairs; Kinematic variable (GeV/#it{c}); Entries"},
+    }};
+
+template <typename T>
+auto makePairCleanerHistSpecMap(const T& confPairCleaner)
+{
+  return std::map<PairCleanerHist, std::vector<o2::framework::AxisSpec>>{
+    {kKinematic, {confPairCleaner.kinematic}},
+  };
+};
+
+constexpr char PrefixPairCleanerTrackTrackSe[] = "TrackTrackCleaner/SE/";
+constexpr char PrefixPairCleanerTrackTrackMe[] = "TrackTrackCleaner/ME/";
+constexpr char PrefixPairCleanerV0V0Se[] = "V0V0Cleaner/SE/";
+constexpr char PrefixPairCleanerV0V0Me[] = "V0V0Cleaner/ME/";
+constexpr char PrefixPairCleanerD0D0Se[] = "D0D0Cleaner/SE/";
+constexpr char PrefixPairCleanerD0D0Me[] = "D0D0Cleaner/ME/";
+constexpr char PrefixPairCleanerTrackV0Se[] = "TrackV0Cleaner/SE/";
+constexpr char PrefixPairCleanerTrackV0Me[] = "TrackV0Cleaner/ME/";
+constexpr char PrefixPairCleanerTrackD0Se[] = "TrackD0Cleaner/SE/";
+constexpr char PrefixPairCleanerTrackD0Me[] = "TrackD0Cleaner/ME/";
+constexpr char PrefixPairCleanerTrackLcSe[] = "TrackLcCleaner/SE/";
+constexpr char PrefixPairCleanerTrackLcMe[] = "TrackLcCleaner/ME/";
+constexpr char PrefixPairCleanerTrackResonanceSe[] = "TrackResonanceCleaner/SE/";
+constexpr char PrefixPairCleanerTrackResonanceMe[] = "TrackResonanceCleaner/ME/";
+constexpr char PrefixPairCleanerV0ResonanceSe[] = "V0ResonanceCleaner/SE/";
+constexpr char PrefixPairCleanerV0ResonanceMe[] = "V0ResonanceCleaner/ME/";
+constexpr char PrefixPairCleanerTrackKinkSe[] = "TrackKinkCleaner/SE/";
+constexpr char PrefixPairCleanerTrackKinkMe[] = "TrackKinkCleaner/ME/";
+constexpr char PrefixPairCleanerTrackCascadeSe[] = "TrackCascadeCleaner/SE/";
+constexpr char PrefixPairCleanerTrackCascadeMe[] = "TrackCascadeCleaner/ME/";
+constexpr char PrefixPairCleanerMcParticleMcParticleSe[] = "McParticleMcParticleCleaner/SE/";
+constexpr char PrefixPairCleanerMcParticleMcParticleMe[] = "McParticleMcParticleCleaner/ME/";
+
+template <auto& prefix>
 class BasePairCleaner
 {
  public:
   BasePairCleaner() = default;
   virtual ~BasePairCleaner() = default;
 
-  template <modes::Mode mode, typename T>
-  void init(T const& pairCuts)
+  template <modes::Mode mode, typename T1, typename T2>
+  void init(o2::framework::HistogramRegistry* registry,
+            T1 const& specs,
+            T2 const& pairCuts) // pair cuts configurable is defined in pairHistManager.h
   {
     if constexpr (modes::isFlagSet(mode, modes::Mode::kMc)) {
       mMixPairsWithCommonAncestor = pairCuts.mixOnlyCommonAncestor.value;
@@ -39,6 +116,14 @@ class BasePairCleaner
         LOG(fatal) << "Both mixing with common and non-common ancestor is activated. Breaking...";
       }
     }
+
+    mHistogramRegistry = registry;
+    int nStatBins = static_cast<int>(kPairCleanerStatsBinLast);
+    const o2::framework::AxisSpec axisStats = {nStatBins, -0.5, nStatBins - 0.5};
+    mHistogramRegistry->add(std::string(prefix) + getHistNameV2(kStats, HistTable), getHistDesc(kStats, HistTable), getHistType(kStats, HistTable), {axisStats});
+    mHistogramRegistry->get<TH1>(HIST(prefix) + HIST(histmanager::getHistName(kStats, HistTable)))->GetXaxis()->SetBinLabel(1, "All analyzed reco pairs");
+    mHistogramRegistry->get<TH1>(HIST(prefix) + HIST(histmanager::getHistName(kStats, HistTable)))->GetXaxis()->SetBinLabel(2, "All blocked reco pairs");
+    mHistogramRegistry->add(std::string(prefix) + getHistNameV2(kKinematic, HistTable), getHistDesc(kKinematic, HistTable), getHistType(kKinematic, HistTable), {specs.at(kKinematic)});
   }
 
  protected:
@@ -47,6 +132,19 @@ class BasePairCleaner
   {
     return particle1.globalIndex() != particle2.globalIndex();
   };
+
+  // const: only mutates *mHistogramRegistry through the stored pointer, not the pointer itself,
+  // so it can be called from the const isCleanPair() overloads below.
+  void fillAll() const
+  {
+    mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kStats, HistTable)), kAllAnalyzed);
+  }
+
+  void fillBlocked(float kinematic) const
+  {
+    mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kStats, HistTable)), kAllBlocked);
+    mHistogramRegistry->fill(HIST(prefix) + HIST(getHistName(kKinematic, HistTable)), kinematic);
+  }
 
   // mc only
   // ancestry is checked either with the partonic mother or with the first ancestor (i.e. the direct mother), depending on mUseMotherAsAncestor
@@ -140,216 +238,264 @@ class BasePairCleaner
     return particle1.fMcMotherId() == particle2.fMcMotherId();
   };
 
+  o2::framework::HistogramRegistry* mHistogramRegistry = nullptr;
   bool mUseMotherAsAncestor = false;
 };
 
-class TrackTrackPairCleaner : public BasePairCleaner
+template <auto& prefix>
+class TrackTrackPairCleaner : public BasePairCleaner<prefix>
 {
  public:
   TrackTrackPairCleaner() = default;
 
-  template <typename T1, typename T2, typename T3>
-  bool isCleanPair(T1 const& track1, T2 const& track2, T3 const& /*trackTable*/) const
+  template <typename T1, typename T2, typename T3, typename T4>
+  bool isCleanPair(T1 const& track1, T2 const& track2, T3 const& /*trackTable*/, T4 const& pairHistManager) const
   {
-    return this->isCleanParticlePair(track1, track2);
+    this->fillAll();
+    bool isClean = this->isCleanParticlePair(track1, track2);
+    if (!isClean) {
+      this->fillBlocked(pairHistManager.getKinematic());
+    }
+    return isClean;
   }
 
-  template <typename T1, typename T2, typename T3, typename T4, typename T5>
-  bool isCleanPair(T1 const& track1, T2 const& track2, T3 const& trackTable, T4 const& mcParticles, T5 const& partonicMothers) const
+  template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
+  bool isCleanPair(T1 const& track1, T2 const& track2, T3 const& trackTable, T4 const& mcParticles, T5 const& partonicMothers, T6 const& pairHistManager) const
   {
-    if (!this->isCleanPair(track1, track2, trackTable)) {
+    if (!this->isCleanPair(track1, track2, trackTable, pairHistManager)) {
       return false;
     }
     // pair is clean
     // no check if we require common or non-common ancestry
-    if (mMixPairsWithCommonAncestor) {
+    if (this->mMixPairsWithCommonAncestor) {
       return this->pairHasCommonAncestor(track1, track2, mcParticles, partonicMothers);
     }
-    if (mMixPairsWithNonCommonAncestor) {
+    if (this->mMixPairsWithNonCommonAncestor) {
       return this->pairHasNonCommonAncestor(track1, track2, mcParticles, partonicMothers);
     }
     return true;
   }
 };
 
-class V0V0PairCleaner : public BasePairCleaner // also works for particles decaying into a positive and negative daughter, like resonances
+template <auto& prefix>
+class V0V0PairCleaner : public BasePairCleaner<prefix> // also works for particles decaying into a positive and negative daughter, like resonances
 {
  public:
   V0V0PairCleaner() = default;
-  template <typename T1, typename T2, typename T3>
-  bool isCleanPair(T1 const& v01, T2 const& v02, T3 const& trackTable) const
+
+  template <typename T1, typename T2, typename T3, typename T4>
+  bool isCleanPair(T1 const& v01, T2 const& v02, T3 const& trackTable, T4 const& pairHistManager) const
   {
+    this->fillAll();
     auto posDaughter1 = trackTable.rawIteratorAt(v01.posDauId() - trackTable.offset());
     auto negDaughter1 = trackTable.rawIteratorAt(v01.negDauId() - trackTable.offset());
     auto posDaughter2 = trackTable.rawIteratorAt(v02.posDauId() - trackTable.offset());
     auto negDaughter2 = trackTable.rawIteratorAt(v02.negDauId() - trackTable.offset());
-    return this->isCleanParticlePair(v01, v02) &&
-           this->isCleanParticlePair(posDaughter1, posDaughter2) && this->isCleanParticlePair(negDaughter1, negDaughter2) &&
-           this->isCleanParticlePair(posDaughter1, negDaughter2) && this->isCleanParticlePair(negDaughter1, posDaughter2);
+    bool isClean = this->isCleanParticlePair(v01, v02) &&
+                   this->isCleanParticlePair(posDaughter1, posDaughter2) && this->isCleanParticlePair(negDaughter1, negDaughter2) &&
+                   this->isCleanParticlePair(posDaughter1, negDaughter2) && this->isCleanParticlePair(negDaughter1, posDaughter2);
+    if (!isClean) {
+      this->fillBlocked(pairHistManager.getKinematic());
+    }
+    return isClean;
   }
 
-  template <typename T1, typename T2, typename T3, typename T4, typename T5>
-  bool isCleanPair(T1 const& v01, T2 const& v02, T3 const& trackTable, T4 const& mcParticles, T5 const& partonicMothers) const
+  template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
+  bool isCleanPair(T1 const& v01, T2 const& v02, T3 const& trackTable, T4 const& mcParticles, T5 const& partonicMothers, T6 const& pairHistManager) const
   {
-    if (!this->isCleanPair(v01, v02, trackTable)) {
+    if (!this->isCleanPair(v01, v02, trackTable, pairHistManager)) {
       return false;
     }
     // pair is clean
     // no check if we require common or non-common ancestry
-    if (mMixPairsWithCommonAncestor) {
+    if (this->mMixPairsWithCommonAncestor) {
       return this->pairHasCommonAncestor(v01, v02, mcParticles, partonicMothers);
     }
-    if (mMixPairsWithNonCommonAncestor) {
+    if (this->mMixPairsWithNonCommonAncestor) {
       return this->pairHasNonCommonAncestor(v01, v02, mcParticles, partonicMothers);
     }
     return true;
   }
 };
 
-class TrackV0PairCleaner : public BasePairCleaner // also works for particles decaying into a positive and negative daughter, like resonances
+template <auto& prefix>
+class TrackV0PairCleaner : public BasePairCleaner<prefix> // also works for particles decaying into a positive and negative daughter, like resonances
 {
  public:
   TrackV0PairCleaner() = default;
-  template <typename T1, typename T2, typename T3>
-  bool isCleanPair(T1 const& track, T2 const& v0, T3 const& trackTable) const
+
+  template <typename T1, typename T2, typename T3, typename T4>
+  bool isCleanPair(T1 const& track, T2 const& v0, T3 const& trackTable, T4 const& pairHistManager) const
   {
+    this->fillAll();
     auto posDaughter = trackTable.rawIteratorAt(v0.posDauId() - trackTable.offset());
     auto negDaughter = trackTable.rawIteratorAt(v0.negDauId() - trackTable.offset());
-    return (this->isCleanParticlePair(posDaughter, track) && this->isCleanParticlePair(negDaughter, track));
+    bool isClean = this->isCleanParticlePair(posDaughter, track) && this->isCleanParticlePair(negDaughter, track);
+    if (!isClean) {
+      this->fillBlocked(pairHistManager.getKinematic());
+    }
+    return isClean;
   }
 
-  template <typename T1, typename T2, typename T3, typename T4, typename T5>
-  bool isCleanPair(T1 const& track1, T2 const& v0, T3 const& trackTable, T4 const& mcParticles, T5 const& partonicMothers) const
+  template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
+  bool isCleanPair(T1 const& track1, T2 const& v0, T3 const& trackTable, T4 const& mcParticles, T5 const& partonicMothers, T6 const& pairHistManager) const
   {
-    if (!this->isCleanPair(track1, v0, trackTable)) {
+    if (!this->isCleanPair(track1, v0, trackTable, pairHistManager)) {
       return false;
     }
     // pair is clean
     // now check if we require common or non-common ancestry
-    if (mMixPairsWithCommonAncestor) {
+    if (this->mMixPairsWithCommonAncestor) {
       return this->pairHasCommonAncestor(track1, v0, mcParticles, partonicMothers);
     }
-    if (mMixPairsWithNonCommonAncestor) {
+    if (this->mMixPairsWithNonCommonAncestor) {
       return this->pairHasNonCommonAncestor(track1, v0, mcParticles, partonicMothers);
     }
     return true;
   }
 };
 
-class TrackKinkPairCleaner : public BasePairCleaner
+template <auto& prefix>
+class TrackKinkPairCleaner : public BasePairCleaner<prefix>
 {
  public:
   TrackKinkPairCleaner() = default;
-  template <typename T1, typename T2, typename T3>
-  bool isCleanPair(T1 const& track, T2 const& kink, T3 const& trackTable) const
+
+  template <typename T1, typename T2, typename T3, typename T4>
+  bool isCleanPair(T1 const& track, T2 const& kink, T3 const& trackTable, T4 const& pairHistManager) const
   {
+    this->fillAll();
     auto chaDaughter = trackTable.rawIteratorAt(kink.chaDauId() - trackTable.offset());
-    return this->isCleanParticlePair(chaDaughter, track);
+    bool isClean = this->isCleanParticlePair(chaDaughter, track);
+    if (!isClean) {
+      this->fillBlocked(pairHistManager.getKinematic());
+    }
+    return isClean;
   }
 
-  template <typename T1, typename T2, typename T3, typename T4, typename T5>
-  bool isCleanPair(T1 const& track1, T2 const& kink, T3 const& trackTable, T4 const& mcParticles, T5 const& partonicMothers) const
+  template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
+  bool isCleanPair(T1 const& track1, T2 const& kink, T3 const& trackTable, T4 const& mcParticles, T5 const& partonicMothers, T6 const& pairHistManager) const
   {
-    if (!this->isCleanPair(track1, kink, trackTable)) {
+    if (!this->isCleanPair(track1, kink, trackTable, pairHistManager)) {
       return false;
     }
     // pair is clean
     // now check if we require common or non-common ancestry
-    if (mMixPairsWithCommonAncestor) {
+    if (this->mMixPairsWithCommonAncestor) {
       return this->pairHasCommonAncestor(track1, kink, mcParticles, partonicMothers);
     }
-    if (mMixPairsWithNonCommonAncestor) {
+    if (this->mMixPairsWithNonCommonAncestor) {
       return this->pairHasNonCommonAncestor(track1, kink, mcParticles, partonicMothers);
     }
     return true;
   }
 };
 
-class TrackCascadePairCleaner : public BasePairCleaner
+template <auto& prefix>
+class TrackCascadePairCleaner : public BasePairCleaner<prefix>
 {
  public:
   TrackCascadePairCleaner() = default;
-  template <typename T1, typename T2, typename T3>
-  bool isCleanPair(T1 const& track, T2 const& cascade, T3 const& trackTable) const
+
+  template <typename T1, typename T2, typename T3, typename T4>
+  bool isCleanPair(T1 const& track, T2 const& cascade, T3 const& trackTable, T4 const& pairHistManager) const
   {
+    this->fillAll();
     auto bachelor = trackTable.rawIteratorAt(cascade.bachelorId() - trackTable.offset());
     auto posDaughter = trackTable.rawIteratorAt(cascade.posDauId() - trackTable.offset());
     auto negDaughter = trackTable.rawIteratorAt(cascade.negDauId() - trackTable.offset());
-    return (this->isCleanParticlePair(bachelor, track) && this->isCleanParticlePair(posDaughter, track) && this->isCleanParticlePair(negDaughter, track));
+    bool isClean = this->isCleanParticlePair(bachelor, track) && this->isCleanParticlePair(posDaughter, track) && this->isCleanParticlePair(negDaughter, track);
+    if (!isClean) {
+      this->fillBlocked(pairHistManager.getKinematic());
+    }
+    return isClean;
   }
 
-  template <typename T1, typename T2, typename T3, typename T4, typename T5>
-  bool isCleanPair(T1 const& track1, T2 const& cascade, T3 const& trackTable, T4 const& mcParticles, T5 const& partonicMothers) const
+  template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
+  bool isCleanPair(T1 const& track1, T2 const& cascade, T3 const& trackTable, T4 const& mcParticles, T5 const& partonicMothers, T6 const& pairHistManager) const
   {
-    if (!this->isCleanPair(track1, cascade, trackTable)) {
+    if (!this->isCleanPair(track1, cascade, trackTable, pairHistManager)) {
       return false;
     }
     // pair is clean
     // now check if we require common or non-common ancestry
-    if (mMixPairsWithCommonAncestor) {
+    if (this->mMixPairsWithCommonAncestor) {
       return this->pairHasCommonAncestor(track1, cascade, mcParticles, partonicMothers);
     }
-    if (mMixPairsWithNonCommonAncestor) {
+    if (this->mMixPairsWithNonCommonAncestor) {
       return this->pairHasNonCommonAncestor(track1, cascade, mcParticles, partonicMothers);
     }
     return true;
   }
 };
 
-class TrackLcPairCleaner : public BasePairCleaner
+template <auto& prefix>
+class TrackLcPairCleaner : public BasePairCleaner<prefix>
 {
  public:
   TrackLcPairCleaner() = default;
-  template <typename T1, typename T2, typename T3>
-  bool isCleanPair(T1 const& track, T2 const& lc, T3 const& trackTable) const
+
+  template <typename T1, typename T2, typename T3, typename T4>
+  bool isCleanPair(T1 const& track, T2 const& lc, T3 const& trackTable, T4 const& pairHistManager) const
   {
+    this->fillAll();
     auto prong0 = trackTable.rawIteratorAt(lc.prong0DauId() - trackTable.offset());
     auto prong1 = trackTable.rawIteratorAt(lc.prong1DauId() - trackTable.offset());
     auto prong2 = trackTable.rawIteratorAt(lc.prong2DauId() - trackTable.offset());
-    return (this->isCleanParticlePair(prong0, track) && this->isCleanParticlePair(prong1, track) && this->isCleanParticlePair(prong2, track));
+    bool isClean = this->isCleanParticlePair(prong0, track) && this->isCleanParticlePair(prong1, track) && this->isCleanParticlePair(prong2, track);
+    if (!isClean) {
+      this->fillBlocked(pairHistManager.getKinematic());
+    }
+    return isClean;
   }
 
-  template <typename T1, typename T2, typename T3, typename T4, typename T5>
-  bool isCleanPair(T1 const& track1, T2 const& lc, T3 const& trackTable, T4 const& mcParticles, T5 const& partonicMothers) const
+  template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
+  bool isCleanPair(T1 const& track1, T2 const& lc, T3 const& trackTable, T4 const& mcParticles, T5 const& partonicMothers, T6 const& pairHistManager) const
   {
-    if (!this->isCleanPair(track1, lc, trackTable)) {
+    if (!this->isCleanPair(track1, lc, trackTable, pairHistManager)) {
       return false;
     }
     // pair is clean
     // now check if we require common or non-common ancestry
-    if (mMixPairsWithCommonAncestor) {
+    if (this->mMixPairsWithCommonAncestor) {
       return this->pairHasCommonAncestor(track1, lc, mcParticles, partonicMothers);
     }
-    if (mMixPairsWithNonCommonAncestor) {
+    if (this->mMixPairsWithNonCommonAncestor) {
       return this->pairHasNonCommonAncestor(track1, lc, mcParticles, partonicMothers);
     }
     return true;
   }
 };
 
-class McParticleMcParticlePairCleaner : public BasePairCleaner
+template <auto& prefix>
+class McParticleMcParticlePairCleaner : public BasePairCleaner<prefix>
 {
  public:
   McParticleMcParticlePairCleaner() = default;
 
-  template <typename T1, typename T2>
-  bool isCleanPair(T1 const& particle1, T2 const& particle2) const
+  template <typename T1, typename T2, typename T3>
+  bool isCleanPair(T1 const& particle1, T2 const& particle2, T3 const& pairHistManager) const
   {
-    return this->isCleanParticlePair(particle1, particle2);
+    this->fillAll();
+    bool isClean = this->isCleanParticlePair(particle1, particle2);
+    if (!isClean) {
+      this->fillBlocked(pairHistManager.getKinematic());
+    }
+    return isClean;
   }
 
-  template <typename T1, typename T2, typename T3>
-  bool isCleanPair(T1 const& particle1, T2 const& particle2, T3 const& partonicMothers) const
+  template <typename T1, typename T2, typename T3, typename T4>
+  bool isCleanPair(T1 const& particle1, T2 const& particle2, T3 const& partonicMothers, T4 const& pairHistManager) const
   {
-    if (!this->isCleanPair(particle1, particle2)) {
+    if (!this->isCleanPair(particle1, particle2, pairHistManager)) {
       return false;
     }
     // pair is clean
     // no check if we require common or non-common ancestry
-    if (mMixPairsWithCommonAncestor) {
+    if (this->mMixPairsWithCommonAncestor) {
       return this->mcPairHasCommonAncestor(particle1, particle2, partonicMothers);
     }
-    if (mMixPairsWithNonCommonAncestor) {
+    if (this->mMixPairsWithNonCommonAncestor) {
       return this->mcPairHasNonCommonAncestor(particle1, particle2, partonicMothers);
     }
     return true;

--- a/PWGCF/Femto/Core/pairHistManager.h
+++ b/PWGCF/Femto/Core/pairHistManager.h
@@ -221,6 +221,7 @@ struct ConfPairBinning : o2::framework::ConfigurableGroup {
   o2::framework::ConfigurableAxis dalitzM12{"dalitzM12", {{100, 0, 10}}, "Mass12 binning of darlitz plot"};
   o2::framework::ConfigurableAxis dalitzM13{"dalitzM13", {{100, 0, 10}}, "Mass13 binning of darlitz plot"};
   o2::framework::Configurable<int> transverseMassType{"transverseMassType", static_cast<int>(modes::TransverseMassType::kAveragePdgMass), "Type of transverse mass (0-> Average Pdg Mass, 1-> Reduced Pdg Mass, 2-> Mt from combined 4 vector)"};
+  o2::framework::Configurable<int> kinematicVariable{"kinematicVariable", static_cast<int>(modes::KinematicVariable::kKstar), "Type of kinematic variable (0->kstar, 1->kT, 2->mT) for PC and CPR plots"};
   o2::framework::ConfigurableAxis binningDeltaEta{"binningDeltaEta", {{35, -1.6, 1.6}}, "Delta eta"};
   o2::framework::ConfigurableAxis binningDeltaPhi{"binningDeltaPhi", {{35, -o2::constants::math::PIHalf, 3 * o2::constants::math::PIHalf}}, "Delta phi"};
   o2::framework::Configurable<bool> plotBertschPratt{"plotBertschPratt", false, "(Reco/Mc) Enable 1D projections and 3D (q_out, q_side, q_long) Bertsch-Pratt histograms in LCMS"};
@@ -596,6 +597,9 @@ class PairHistManager
     // transverse mass type
     mMtType = static_cast<modes::TransverseMassType>(ConfPairBinning.transverseMassType.value);
 
+    // kinematic variable
+    mKinematicVariable = static_cast<modes::KinematicVariable>(ConfPairBinning.kinematicVariable.value);
+
     // values for cuts
     mKstarMin = ConfPairCuts.kstarMin.value;
     mKstarMax = ConfPairCuts.kstarMax.value;
@@ -918,7 +922,23 @@ class PairHistManager
     }
   }
 
-  float getKstar() const { return mKstar; }
+  float getKinematic() const
+  {
+    switch (mKinematicVariable) {
+      case modes::KinematicVariable::kKstar:
+        return mKstar;
+        break;
+      case modes::KinematicVariable::kKt:
+        return mKt;
+        break;
+      case modes::KinematicVariable::kMt:
+        return mMt;
+        break;
+      default:
+        LOG(fatal) << "Invalid kinematic Variable, breaking...";
+    }
+    return mKstar;
+  }
 
  private:
   void initAnalysis(std::map<PairHist, std::vector<o2::framework::AxisSpec>> const& Specs)
@@ -1601,6 +1621,7 @@ class PairHistManager
   double mPdgMassNegDau2 = 0;
 
   modes::TransverseMassType mMtType = modes::TransverseMassType::kAveragePdgMass;
+  modes::KinematicVariable mKinematicVariable = modes::KinematicVariable::kKstar;
 
   int mAbsCharge1 = 1;
   int mAbsCharge2 = 1;

--- a/PWGCF/Femto/Core/pairProcessHelpers.h
+++ b/PWGCF/Femto/Core/pairProcessHelpers.h
@@ -55,16 +55,7 @@ void processSameEvent(T1 const& SliceParticle,
     ParticleHistManager.template fill<mode>(part, TrackTable);
   }
   for (auto const& [p1, p2] : o2::soa::combinations(o2::soa::CombinationsStrictlyUpperIndexPolicy(SliceParticle, SliceParticle))) {
-    // check if pair is clean
-    if (!PcManager.isCleanPair(p1, p2, TrackTable)) {
-      continue;
-    }
-    // check if pair is close
-    CprManager.setPair(p1, p2, TrackTable);
-    if (CprManager.isClosePair()) {
-      continue;
-    }
-    // Randomize pair order if enabled
+    // Randomize pair order if enabled, then compute the kinematic (kstar) for this pair
     switch (pairOrder) {
       case kOrder12:
         PairHistManager.setPair(p1, p2, TrackTable, Collision);
@@ -75,8 +66,14 @@ void processSameEvent(T1 const& SliceParticle,
       default:
         PairHistManager.setPair(p1, p2, TrackTable, Collision);
     }
-    // fill deta-dphi histograms with kstar cutoff
-    CprManager.fill(PairHistManager.getKstar());
+    // check if pair is clean
+    if (!PcManager.isCleanPair(p1, p2, TrackTable, PairHistManager)) {
+      continue;
+    }
+    // check if pair is close; fills deta-dphi/kinematic histograms internally
+    if (CprManager.isClosePair(p1, p2, TrackTable, PairHistManager)) {
+      continue;
+    }
     // if pair cuts are configured check them before filling
     if (PairHistManager.checkPairCuts()) {
       PairHistManager.template fill<mode>();
@@ -127,16 +124,7 @@ void processSameEvent(T1 const& SliceParticle,
         !ParticleCleaner.isClean(p2, mcParticles, mcMothers, mcPartonicMothers)) {
       continue;
     }
-    // check if pair is clean
-    if (!PcManager.isCleanPair(p1, p2, TrackTable, mcParticles, mcPartonicMothers)) {
-      continue;
-    }
-    // check if pair is close
-    CprManager.setPair(p1, p2, TrackTable);
-    if (CprManager.isClosePair()) {
-      continue;
-    }
-    // Randomize pair order if enabled
+    // Randomize pair order if enabled, then compute the kinematic (kstar) for this pair
     switch (pairOrder) {
       case kOrder12:
         PairHistManager.setPairMc(p1, p2, TrackTable, mcParticles, Collision, mcCollisions);
@@ -147,8 +135,14 @@ void processSameEvent(T1 const& SliceParticle,
       default:
         PairHistManager.setPairMc(p1, p2, TrackTable, mcParticles, Collision, mcCollisions);
     }
-    // fill deta-dphi histograms with kstar cutoff
-    CprManager.fill(PairHistManager.getKstar());
+    // check if pair is clean
+    if (!PcManager.isCleanPair(p1, p2, TrackTable, mcParticles, mcPartonicMothers, PairHistManager)) {
+      continue;
+    }
+    // check if pair is close; fills deta-dphi/kinematic histograms internally
+    if (CprManager.isClosePair(p1, p2, TrackTable, PairHistManager)) {
+      continue;
+    }
     // if pair cuts are configured check them before filling
     if (PairHistManager.checkPairCuts()) {
       PairHistManager.template fill<mode>();
@@ -188,17 +182,16 @@ void processSameEvent(T1 const& SliceParticle1,
     ParticleHistManager2.template fill<mode>(part, TrackTable);
   }
   for (auto const& [p1, p2] : o2::soa::combinations(o2::soa::CombinationsFullIndexPolicy(SliceParticle1, SliceParticle2))) {
-    // pair cleaning
-    if (!PcManager.isCleanPair(p1, p2, TrackTable)) {
-      continue;
-    }
-    // Close pair rejection
-    CprManager.setPair(p1, p2, TrackTable);
-    if (CprManager.isClosePair()) {
-      continue;
-    }
+    // compute the kinematic (kstar) for this pair
     PairHistManager.setPair(p1, p2, TrackTable, Collision);
-    CprManager.fill(PairHistManager.getKstar());
+    // pair cleaning
+    if (!PcManager.isCleanPair(p1, p2, TrackTable, PairHistManager)) {
+      continue;
+    }
+    // Close pair rejection; fills deta-dphi/kinematic histograms internally
+    if (CprManager.isClosePair(p1, p2, TrackTable, PairHistManager)) {
+      continue;
+    }
     if (PairHistManager.checkPairCuts()) {
       PairHistManager.template fill<mode>();
       PairHistManager.trackParticlesPerEvent(p1, p2);
@@ -260,17 +253,16 @@ void processSameEvent(T1 const& SliceParticle1,
         !ParticleCleaner2.isClean(p2, mcParticles, mcMothers, mcPartonicMothers)) {
       continue;
     }
-    // pair cleaning
-    if (!PcManager.isCleanPair(p1, p2, TrackTable, mcParticles, mcPartonicMothers)) {
-      continue;
-    }
-    // Close pair rejection
-    CprManager.setPair(p1, p2, TrackTable);
-    if (CprManager.isClosePair()) {
-      continue;
-    }
+    // compute the kinematic (kstar) for this pair
     PairHistManager.setPairMc(p1, p2, TrackTable, mcParticles, Collision, mcCollisions);
-    CprManager.fill(PairHistManager.getKstar());
+    // pair cleaning
+    if (!PcManager.isCleanPair(p1, p2, TrackTable, mcParticles, mcPartonicMothers, PairHistManager)) {
+      continue;
+    }
+    // Close pair rejection; fills deta-dphi/kinematic histograms internally
+    if (CprManager.isClosePair(p1, p2, TrackTable, PairHistManager)) {
+      continue;
+    }
     if (PairHistManager.checkPairCuts()) {
       PairHistManager.template fill<mode>();
       PairHistManager.trackParticlesPerEvent(p1, p2);
@@ -314,13 +306,7 @@ void processSameEvent(T1 const& SliceParticle,
         !ParticleCleaner.isClean(p2, mcMothers, mcPartonicMothers)) {
       continue;
     }
-    if (!PcManager.isCleanPair(p1, p2, mcPartonicMothers)) {
-      continue;
-    }
-    CprManager.setPair(p1, p2);
-    if (CprManager.isClosePair()) {
-      continue;
-    }
+    // Randomize pair order if enabled, then compute the kinematic (kstar) for this pair
     switch (pairOrder) {
       case kOrder12:
         PairHistManager.setPairMcTruth(p1, p2, Collision);
@@ -331,7 +317,13 @@ void processSameEvent(T1 const& SliceParticle,
       default:
         PairHistManager.setPairMcTruth(p1, p2, Collision);
     }
-    CprManager.fill(PairHistManager.getKstar());
+    if (!PcManager.isCleanPair(p1, p2, mcPartonicMothers, PairHistManager)) {
+      continue;
+    }
+    // Close pair rejection; fills deta-dphi/kinematic histograms internally
+    if (CprManager.isClosePair(p1, p2, PairHistManager)) {
+      continue;
+    }
     if (PairHistManager.checkPairCuts()) {
       PairHistManager.template fill<mode>();
       PairHistManager.trackParticlesPerEvent(p1, p2);
@@ -387,15 +379,15 @@ void processSameEvent(T1 const& SliceParticle1,
         !ParticleCleaner2.isClean(p2, mcMothers, mcPartonicMothers)) {
       continue;
     }
-    if (!PcManager.isCleanPair(p1, p2, mcPartonicMothers)) {
-      continue;
-    }
-    CprManager.setPair(p1, p2);
-    if (CprManager.isClosePair()) {
-      continue;
-    }
+    // compute the kinematic (kstar) for this pair
     PairHistManager.setPairMcTruth(p1, p2, Collision);
-    CprManager.fill(PairHistManager.getKstar());
+    if (!PcManager.isCleanPair(p1, p2, mcPartonicMothers, PairHistManager)) {
+      continue;
+    }
+    // Close pair rejection; fills deta-dphi/kinematic histograms internally
+    if (CprManager.isClosePair(p1, p2, PairHistManager)) {
+      continue;
+    }
     if (PairHistManager.checkPairCuts()) {
       PairHistManager.template fill<mode>();
       PairHistManager.trackParticlesPerEvent(p1, p2);
@@ -472,17 +464,17 @@ void processMixedEvent(T1 const& Collisions,
     PairHistManager.fillMixingQaMe(collision1, collision2);
     for (auto const& [p1, p2] : o2::soa::combinations(o2::soa::CombinationsFullIndexPolicy(*sliceParticle1, sliceParticle2))) {
 
-      if (!PcManager.isCleanPair(p1, p2, TrackTable)) {
-        continue;
-      }
-
-      CprManager.setPair(p1, p2, TrackTable);
-      if (CprManager.isClosePair()) {
-        continue;
-      }
-
+      // compute the kinematic (kstar) for this pair
       PairHistManager.setPair(p1, p2, TrackTable, collision1, collision2);
-      CprManager.fill(PairHistManager.getKstar());
+
+      if (!PcManager.isCleanPair(p1, p2, TrackTable, PairHistManager)) {
+        continue;
+      }
+
+      // Close pair rejection; fills deta-dphi/kinematic histograms internally
+      if (CprManager.isClosePair(p1, p2, TrackTable, PairHistManager)) {
+        continue;
+      }
 
       if (PairHistManager.checkPairCuts()) {
         hasValidPair = true;
@@ -588,18 +580,17 @@ void processMixedEvent(T1 const& Collisions,
         continue;
       }
 
-      if (!PcManager.isCleanPair(p1, p2, TrackTable)) {
-        continue;
-      }
-
-      CprManager.setPair(p1, p2, TrackTable);
-      if (CprManager.isClosePair()) {
-        continue;
-      }
-
+      // compute the kinematic (kstar) for this pair
       PairHistManager.setPairMc(p1, p2, TrackTable, mcParticles, collision1, collision2, mcCollisions);
 
-      CprManager.fill(PairHistManager.getKstar());
+      if (!PcManager.isCleanPair(p1, p2, TrackTable, PairHistManager)) {
+        continue;
+      }
+
+      // Close pair rejection; fills deta-dphi/kinematic histograms internally
+      if (CprManager.isClosePair(p1, p2, TrackTable, PairHistManager)) {
+        continue;
+      }
 
       if (PairHistManager.checkPairCuts()) {
         hasValidPair = true;
@@ -689,18 +680,17 @@ void processMixedEvent(T1 const& Collisions,
         continue;
       }
 
-      if (!PcManager.isCleanPair(p1, p2, mcPartonicMothers)) {
-        continue;
-      }
-
-      CprManager.setPair(p1, p2);
-      if (CprManager.isClosePair()) {
-        continue;
-      }
-
+      // compute the kinematic (kstar) for this pair
       PairHistManager.setPairMcTruth(p1, p2, collision1, collision2);
 
-      CprManager.fill(PairHistManager.getKstar());
+      if (!PcManager.isCleanPair(p1, p2, mcPartonicMothers, PairHistManager)) {
+        continue;
+      }
+
+      // Close pair rejection; fills deta-dphi/kinematic histograms internally
+      if (CprManager.isClosePair(p1, p2, PairHistManager)) {
+        continue;
+      }
 
       if (PairHistManager.checkPairCuts()) {
         hasValidPair = true;

--- a/PWGCF/Femto/Core/tripletBuilder.h
+++ b/PWGCF/Femto/Core/tripletBuilder.h
@@ -80,7 +80,8 @@ class TripletTrackTrackTrackBuilder
             typename T14,
             typename T15,
             typename T16,
-            typename T17>
+            typename T17,
+            typename T18>
   void init(o2::framework::HistogramRegistry* registry,
             T1 const& confCollisionBinning,
             T2 const& confTrackSelection1,
@@ -98,21 +99,23 @@ class TripletTrackTrackTrackBuilder
             std::map<T14, std::vector<o2::framework::AxisSpec>> const& trackHistSpec2,
             std::map<T15, std::vector<o2::framework::AxisSpec>> const& trackHistSpec3,
             std::map<T16, std::vector<o2::framework::AxisSpec>> const& pairHistSpec,
-            std::map<T17, std::vector<o2::framework::AxisSpec>> const& cprHistSpec)
+            std::map<T17, std::vector<o2::framework::AxisSpec>> const& cprHistSpec,
+            std::map<T18, std::vector<o2::framework::AxisSpec>> const& tripletCleanerHistSpec)
   {
     // check if correlate the same tracks or not
     mTrack1Track2Track3AreSameSpecies = confMixing.particle123AreSameSpecies.value;
     mTrack1Track2AreSameSpecies = confMixing.particle12AreSameSpecies.value;
 
     if (mTrack1Track2Track3AreSameSpecies && mTrack1Track2AreSameSpecies) {
-      LOG(fatal) << "Option Track 1&2 are identical and Option Track 1&2&3 are identical is activated. Breaking...";
+      LOG(fatal) << "Option Track 1&2 are identical and Option Track 1&2&3 are identical are activated. Breaking...";
     }
 
     mColHistManager.template init<modeSe>(registry, colHistSpec, confCollisionBinning);
     mTripletHistManagerSe.template init<modeSe>(registry, pairHistSpec, confTripletBinning, confTripletCuts, confMixing);
     mTripletHistManagerMe.template init<modeMe>(registry, pairHistSpec, confTripletBinning, confTripletCuts, confMixing);
 
-    mTc.template init<modeSe>(confTripletCuts);
+    mTcSe.template init<modeSe>(registry, tripletCleanerHistSpec, confTripletCuts);
+    mTcMe.template init<modeMe>(registry, tripletCleanerHistSpec, confTripletCuts);
 
     if (mTrack1Track2Track3AreSameSpecies) {
       // Track1 & Track2 & Track3 are the same particle species
@@ -196,7 +199,7 @@ class TripletTrackTrackTrackBuilder
       if (mMixIdenticalParticles) {
         tripletOrder = static_cast<tripletprocesshelpers::TripletOrder>(mDist(mRng));
       }
-      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, trackTable, col, mTrackHistManager1, mTripletHistManagerSe, mCtrSe, mTc, tripletOrder);
+      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, trackTable, col, mTrackHistManager1, mTripletHistManagerSe, mCtrSe, mTcSe, tripletOrder);
     } else if (mTrack1Track2AreSameSpecies) {
       auto trackSlice1 = partition1->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
       auto trackSlice3 = partition3->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
@@ -208,7 +211,7 @@ class TripletTrackTrackTrackBuilder
       if (mMixIdenticalParticles) {
         tripletOrder = static_cast<tripletprocesshelpers::TripletOrder>(mDist(mRng));
       }
-      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, trackSlice3, trackTable, col, mTrackHistManager1, mTrackHistManager3, mTripletHistManagerSe, mCtrSe, mTc, tripletOrder);
+      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, trackSlice3, trackTable, col, mTrackHistManager1, mTrackHistManager3, mTripletHistManagerSe, mCtrSe, mTcSe, tripletOrder);
     } else {
       auto trackSlice1 = partition1->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
       auto trackSlice2 = partition2->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
@@ -218,7 +221,7 @@ class TripletTrackTrackTrackBuilder
       }
       mColHistManager.template fill<mode>(col);
       mCtrSe.setMagField(col.magField());
-      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, trackSlice2, trackSlice3, trackTable, col, mTrackHistManager1, mTrackHistManager2, mTrackHistManager3, mTripletHistManagerSe, mCtrSe, mTc);
+      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, trackSlice2, trackSlice3, trackTable, col, mTrackHistManager1, mTrackHistManager2, mTrackHistManager3, mTripletHistManagerSe, mCtrSe, mTcSe);
     }
   }
 
@@ -237,7 +240,7 @@ class TripletTrackTrackTrackBuilder
       if (mMixIdenticalParticles) {
         tripletOrder = static_cast<tripletprocesshelpers::TripletOrder>(mDist(mRng));
       }
-      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager1, mTripletHistManagerSe, mCleaner1, mCtrSe, mTc, tripletOrder);
+      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager1, mTripletHistManagerSe, mCleaner1, mCtrSe, mTcSe, tripletOrder);
     } else if (mTrack1Track2AreSameSpecies) {
       auto trackSlice1 = partition1->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
       auto trackSlice3 = partition3->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
@@ -249,7 +252,7 @@ class TripletTrackTrackTrackBuilder
       if (mMixIdenticalParticles) {
         tripletOrder = static_cast<tripletprocesshelpers::TripletOrder>(mDist(mRng));
       }
-      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, trackSlice3, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager1, mTrackHistManager3, mTripletHistManagerSe, mCleaner1, mCleaner3, mCtrSe, mTc, tripletOrder);
+      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, trackSlice3, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager1, mTrackHistManager3, mTripletHistManagerSe, mCleaner1, mCleaner3, mCtrSe, mTcSe, tripletOrder);
     } else {
       auto trackSlice1 = partition1->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
       auto trackSlice2 = partition2->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
@@ -259,7 +262,7 @@ class TripletTrackTrackTrackBuilder
       }
       mColHistManager.template fill<mode>(col, mcCols);
       mCtrSe.setMagField(col.magField());
-      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, trackSlice2, trackSlice3, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager1, mTrackHistManager2, mTrackHistManager3, mTripletHistManagerSe, mCleaner1, mCleaner2, mCleaner3, mCtrSe, mTc);
+      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, trackSlice2, trackSlice3, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager1, mTrackHistManager2, mTrackHistManager3, mTripletHistManagerSe, mCleaner1, mCleaner2, mCleaner3, mCtrSe, mTcSe);
     }
   }
 
@@ -270,13 +273,13 @@ class TripletTrackTrackTrackBuilder
     if (mTrack1Track2Track3AreSameSpecies) {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition1, trackTable, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition1, trackTable, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition1, trackTable, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition1, trackTable, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition1, trackTable, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition1, trackTable, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policy specifed. Breaking...";
@@ -284,13 +287,13 @@ class TripletTrackTrackTrackBuilder
     } else if (mTrack1Track2AreSameSpecies) {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition3, trackTable, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition3, trackTable, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition3, trackTable, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition3, trackTable, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition3, trackTable, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition3, trackTable, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policy specifed. Breaking...";
@@ -298,13 +301,13 @@ class TripletTrackTrackTrackBuilder
     } else {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, partition3, trackTable, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, partition3, trackTable, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, partition3, trackTable, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, partition3, trackTable, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, partition3, trackTable, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, partition3, trackTable, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policy specifed. Breaking...";
@@ -319,13 +322,13 @@ class TripletTrackTrackTrackBuilder
     if (mTrack1Track2Track3AreSameSpecies) {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner1, mCleaner1, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner1, mCleaner1, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner1, mCleaner1, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner1, mCleaner1, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner1, mCleaner1, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition1, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner1, mCleaner1, mCtrMe, mTcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policy specifed. Breaking...";
@@ -333,13 +336,13 @@ class TripletTrackTrackTrackBuilder
     } else if (mTrack1Track2AreSameSpecies) {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner1, mCleaner3, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner1, mCleaner3, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner1, mCleaner3, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner1, mCleaner3, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner1, mCleaner3, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner1, mCleaner3, mCtrMe, mTcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policy specifed. Breaking...";
@@ -347,13 +350,13 @@ class TripletTrackTrackTrackBuilder
     } else {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner2, mCleaner3, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner2, mCleaner3, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner2, mCleaner3, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner2, mCleaner3, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner2, mCleaner3, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner2, mCleaner3, mCtrMe, mTcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policy specifed. Breaking...";
@@ -374,7 +377,8 @@ class TripletTrackTrackTrackBuilder
 
   closetripletrejection::CloseTripletRejectionTrackTrackTrack<prefixCtrSeTrack1Track2, prefixCtrSeTrack2Track3, prefixCtrSeTrack1Track3> mCtrSe;
   closetripletrejection::CloseTripletRejectionTrackTrackTrack<prefixCtrMeTrack1Track2, prefixCtrMeTrack2Track3, prefixCtrMeTrack1Track3> mCtrMe;
-  tripletcleaner::TrackTrackTrackTripletCleaner mTc;
+  tripletcleaner::TrackTrackTrackTripletCleaner<tripletcleaner::PrefixTripletCleanerTrackTrackTrackSe> mTcSe;
+  tripletcleaner::TrackTrackTrackTripletCleaner<tripletcleaner::PrefixTripletCleanerTrackTrackTrackMe> mTcMe;
   triplethistmanager::MixingPolicy mMixingPolicy = triplethistmanager::MixingPolicy::kVtxMult;
   bool mTrack1Track2Track3AreSameSpecies = false;
   bool mTrack1Track2AreSameSpecies = false;
@@ -424,7 +428,8 @@ class TripletTrackTrackV0Builder
             typename T16,
             typename T17,
             typename T18,
-            typename T19>
+            typename T19,
+            typename T20>
   void init(o2::framework::HistogramRegistry* registry,
             T1 const& confCollisionBinning,
             T2 const& confTrackSelection1,
@@ -444,7 +449,8 @@ class TripletTrackTrackV0Builder
             std::map<T16, std::vector<o2::framework::AxisSpec>> const& posDauhistSpec,
             std::map<T17, std::vector<o2::framework::AxisSpec>> const& negDauhistSpec,
             std::map<T18, std::vector<o2::framework::AxisSpec>> const& tripletHistSpec,
-            std::map<T19, std::vector<o2::framework::AxisSpec>> const& ctrHistSpec)
+            std::map<T19, std::vector<o2::framework::AxisSpec>> const& ctrHistSpec,
+            std::map<T20, std::vector<o2::framework::AxisSpec>> const& tripletCleanerHistSpec)
   {
     // check if correlate the same tracks or not
     mTrack1Track2AreSameSpecies = confMixing.particle12AreSameSpecies.value;
@@ -453,7 +459,8 @@ class TripletTrackTrackV0Builder
     mTripletHistManagerSe.template init<modeSe>(registry, tripletHistSpec, confTripletBinning, confTripletCuts, confMixing);
     mTripletHistManagerMe.template init<modeMe>(registry, tripletHistSpec, confTripletBinning, confTripletCuts, confMixing);
 
-    mTc.template init<modeSe>(confTripletCuts);
+    mTcSe.template init<modeSe>(registry, tripletCleanerHistSpec, confTripletCuts);
+    mTcMe.template init<modeMe>(registry, tripletCleanerHistSpec, confTripletCuts);
 
     mV0Cleaner.init(confV0Cleaner);
 
@@ -521,7 +528,7 @@ class TripletTrackTrackV0Builder
       if (mMixIdenticalParticles) {
         tripletOrder = static_cast<tripletprocesshelpers::TripletOrder>(mDist(mRng));
       }
-      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, v0Slice, trackTable, col, mTrackHistManager1, mV0HistManager, mTripletHistManagerSe, mCtrSe, mTc, tripletOrder);
+      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, v0Slice, trackTable, col, mTrackHistManager1, mV0HistManager, mTripletHistManagerSe, mCtrSe, mTcSe, tripletOrder);
     } else {
       auto trackSlice1 = partition1->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
       auto trackSlice2 = partition2->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
@@ -531,7 +538,7 @@ class TripletTrackTrackV0Builder
       }
       mColHistManager.template fill<mode>(col);
       mCtrSe.setMagField(col.magField());
-      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, trackSlice2, v0Slice, trackTable, col, mTrackHistManager1, mTrackHistManager2, mV0HistManager, mTripletHistManagerSe, mCtrSe, mTc);
+      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, trackSlice2, v0Slice, trackTable, col, mTrackHistManager1, mTrackHistManager2, mV0HistManager, mTripletHistManagerSe, mCtrSe, mTcSe);
     }
   }
 
@@ -551,7 +558,7 @@ class TripletTrackTrackV0Builder
       if (mMixIdenticalParticles) {
         tripletOrder = static_cast<tripletprocesshelpers::TripletOrder>(mDist(mRng));
       }
-      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, v0Slice, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager1, mV0HistManager, mTripletHistManagerSe, mCleaner1, mV0Cleaner, mCtrSe, mTc, tripletOrder);
+      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, v0Slice, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager1, mV0HistManager, mTripletHistManagerSe, mCleaner1, mV0Cleaner, mCtrSe, mTcSe, tripletOrder);
     } else {
       auto trackSlice1 = partition1->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
       auto trackSlice2 = partition2->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
@@ -561,7 +568,7 @@ class TripletTrackTrackV0Builder
       }
       mColHistManager.template fill<mode>(col, mcCols);
       mCtrSe.setMagField(col.magField());
-      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, trackSlice2, v0Slice, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager1, mTrackHistManager2, mV0HistManager, mTripletHistManagerSe, mCleaner1, mCleaner2, mV0Cleaner, mCtrSe, mTc);
+      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, trackSlice2, v0Slice, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager1, mTrackHistManager2, mV0HistManager, mTripletHistManagerSe, mCleaner1, mCleaner2, mV0Cleaner, mCtrSe, mTcSe);
     }
   }
 
@@ -572,13 +579,13 @@ class TripletTrackTrackV0Builder
     if (mTrack1Track2AreSameSpecies) {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition3, trackTable, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition3, trackTable, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition3, trackTable, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition3, trackTable, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition3, trackTable, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition3, trackTable, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policy specifed. Breaking...";
@@ -586,13 +593,13 @@ class TripletTrackTrackV0Builder
     } else {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, partition3, trackTable, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, partition3, trackTable, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, partition3, trackTable, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, partition3, trackTable, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, partition3, trackTable, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, partition3, trackTable, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policy specifed. Breaking...";
@@ -607,13 +614,13 @@ class TripletTrackTrackV0Builder
     if (mTrack1Track2AreSameSpecies) {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner1, mV0Cleaner, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner1, mV0Cleaner, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner1, mV0Cleaner, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner1, mV0Cleaner, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner1, mV0Cleaner, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner1, mV0Cleaner, mCtrMe, mTcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policy specifed. Breaking...";
@@ -621,13 +628,13 @@ class TripletTrackTrackV0Builder
     } else {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner2, mV0Cleaner, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner2, mV0Cleaner, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner2, mV0Cleaner, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner2, mV0Cleaner, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner2, mV0Cleaner, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCleaner1, mCleaner2, mV0Cleaner, mCtrMe, mTcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policy specifed. Breaking...";
@@ -648,7 +655,8 @@ class TripletTrackTrackV0Builder
 
   closetripletrejection::CloseTripletRejectionTrackTrackV0<prefixCtrSeTrack1Track2, prefixCtrSeTrack1V0, prefixCtrSeTrack2V0> mCtrSe;
   closetripletrejection::CloseTripletRejectionTrackTrackV0<prefixCtrMeTrack1Track2, prefixCtrMeTrack1V0, prefixCtrMeTrack2V0> mCtrMe;
-  tripletcleaner::TrackTrackV0TripletCleaner mTc;
+  tripletcleaner::TrackTrackV0TripletCleaner<tripletcleaner::PrefixTripletCleanerTrackTrackV0Se> mTcSe;
+  tripletcleaner::TrackTrackV0TripletCleaner<tripletcleaner::PrefixTripletCleanerTrackTrackV0Me> mTcMe;
   triplethistmanager::MixingPolicy mMixingPolicy = triplethistmanager::MixingPolicy::kVtxMult;
   bool mTrack1Track2AreSameSpecies = false;
   int mMixingDepth = 5;
@@ -707,7 +715,8 @@ class TripletTrackTrackCascadeBuilder
             typename T21,
             typename T22,
             typename T23,
-            typename T24>
+            typename T24,
+            typename T25>
 
   void init(o2::framework::HistogramRegistry* registry,
             T1 const& confCollisionBinning,
@@ -733,7 +742,8 @@ class TripletTrackTrackCascadeBuilder
             std::map<T21, std::vector<o2::framework::AxisSpec>> const& tripletHistSpec,
             std::map<T22, std::vector<o2::framework::AxisSpec>> const& cprHistSpecBachelor,
             std::map<T23, std::vector<o2::framework::AxisSpec>> const& cprHistSpecV0Daughter,
-            std::map<T24, std::vector<o2::framework::AxisSpec>> const& ctrHistSpec)
+            std::map<T24, std::vector<o2::framework::AxisSpec>> const& ctrHistSpec,
+            std::map<T25, std::vector<o2::framework::AxisSpec>> const& tripletCleanerHistSpec)
   {
     // check if correlate the same tracks or not
     mTrack1Track2AreSameSpecies = confMixing.particle12AreSameSpecies.value;
@@ -741,7 +751,8 @@ class TripletTrackTrackCascadeBuilder
     mTripletHistManagerSe.template init<modeSe>(registry, tripletHistSpec, confTripletBinning, confTripletCuts, confMixing);
     mTripletHistManagerMe.template init<modeMe>(registry, tripletHistSpec, confTripletBinning, confTripletCuts, confMixing);
 
-    mTc.template init<modeSe>(confTripletCuts);
+    mTcSe.template init<modeSe>(registry, tripletCleanerHistSpec, confTripletCuts);
+    mTcMe.template init<modeMe>(registry, tripletCleanerHistSpec, confTripletCuts);
 
     mCascadeCleaner.init(confCascadeCleaner);
     if (mTrack1Track2AreSameSpecies) {
@@ -805,7 +816,7 @@ class TripletTrackTrackCascadeBuilder
       if (mMixIdenticalParticles) {
         tripletOrder = static_cast<tripletprocesshelpers::TripletOrder>(mDist(mRng));
       }
-      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, cascadeSlice, trackTable, col, mTrackHistManager1, mCascadeHistManager, mTripletHistManagerSe, mCtrSe, mTc, tripletOrder);
+      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, cascadeSlice, trackTable, col, mTrackHistManager1, mCascadeHistManager, mTripletHistManagerSe, mCtrSe, mTcSe, tripletOrder);
     } else {
       auto trackSlice1 = partition1->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
       auto trackSlice2 = partition2->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
@@ -815,7 +826,7 @@ class TripletTrackTrackCascadeBuilder
       }
       mColHistManager.template fill<mode>(col);
       mCtrSe.setMagField(col.magField());
-      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, trackSlice2, cascadeSlice, trackTable, col, mTrackHistManager1, mTrackHistManager2, mCascadeHistManager, mTripletHistManagerSe, mCtrSe, mTc);
+      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, trackSlice2, cascadeSlice, trackTable, col, mTrackHistManager1, mTrackHistManager2, mCascadeHistManager, mTripletHistManagerSe, mCtrSe, mTcSe);
     }
   }
 
@@ -835,7 +846,7 @@ class TripletTrackTrackCascadeBuilder
       if (mMixIdenticalParticles) {
         tripletOrder = static_cast<tripletprocesshelpers::TripletOrder>(mDist(mRng));
       }
-      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, cascadeSlice, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager1, mCascadeHistManager, mTripletHistManagerSe, mTrackCleaner1, mCascadeCleaner, mCtrSe, mTc, tripletOrder);
+      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, cascadeSlice, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager1, mCascadeHistManager, mTripletHistManagerSe, mTrackCleaner1, mCascadeCleaner, mCtrSe, mTcSe, tripletOrder);
     } else {
       auto trackSlice1 = partition1->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
       auto trackSlice2 = partition2->sliceByCached(o2::aod::femtobase::stored::fColId, col.globalIndex(), cache);
@@ -845,7 +856,7 @@ class TripletTrackTrackCascadeBuilder
       }
       mColHistManager.template fill<mode>(col, mcCols);
       mCtrSe.setMagField(col.magField());
-      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, trackSlice2, cascadeSlice, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager1, mTrackHistManager2, mCascadeHistManager, mTripletHistManagerSe, mTrackCleaner1, mTrackCleaner2, mCascadeCleaner, mCtrSe, mTc);
+      tripletprocesshelpers::processSameEvent<mode>(trackSlice1, trackSlice2, cascadeSlice, trackTable, mcParticles, mcMothers, mcPartonicMothers, col, mcCols, mTrackHistManager1, mTrackHistManager2, mCascadeHistManager, mTripletHistManagerSe, mTrackCleaner1, mTrackCleaner2, mCascadeCleaner, mCtrSe, mTcSe);
     }
   }
 
@@ -856,14 +867,13 @@ class TripletTrackTrackCascadeBuilder
     if (mTrack1Track2AreSameSpecies) {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition3, trackTable, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTc);
-
+          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition3, trackTable, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition3, trackTable, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition3, trackTable, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition3, trackTable, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition1, partition3, trackTable, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policy specifed. Breaking...";
@@ -871,13 +881,13 @@ class TripletTrackTrackCascadeBuilder
     } else {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, partition3, trackTable, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, partition3, trackTable, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, partition3, trackTable, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, partition3, trackTable, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, partition3, trackTable, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, partition1, partition2, partition3, trackTable, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mCtrMe, mTcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policy specifed. Breaking...";
@@ -892,13 +902,13 @@ class TripletTrackTrackCascadeBuilder
     if (mTrack1Track2AreSameSpecies) {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mTrackCleaner1, mTrackCleaner1, mCascadeCleaner, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mTrackCleaner1, mTrackCleaner1, mCascadeCleaner, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mTrackCleaner1, mTrackCleaner1, mCascadeCleaner, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mTrackCleaner1, mTrackCleaner1, mCascadeCleaner, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mTrackCleaner1, mTrackCleaner1, mCascadeCleaner, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition1, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mTrackCleaner1, mTrackCleaner1, mCascadeCleaner, mCtrMe, mTcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policy specifed. Breaking...";
@@ -906,13 +916,13 @@ class TripletTrackTrackCascadeBuilder
     } else {
       switch (mMixingPolicy) {
         case static_cast<int>(pairhistmanager::kVtxMult):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mTrackCleaner1, mTrackCleaner2, mCascadeCleaner, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMult, mMixingDepth, mTripletHistManagerMe, mTrackCleaner1, mTrackCleaner2, mCascadeCleaner, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mTrackCleaner1, mTrackCleaner2, mCascadeCleaner, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxCent, mMixingDepth, mTripletHistManagerMe, mTrackCleaner1, mTrackCleaner2, mCascadeCleaner, mCtrMe, mTcMe);
           break;
         case static_cast<int>(pairhistmanager::kVtxMultCent):
-          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mTrackCleaner1, mTrackCleaner2, mCascadeCleaner, mCtrMe, mTc);
+          tripletprocesshelpers::processMixedEvent<mode>(cols, mcCols, partition1, partition2, partition3, trackTable, mcParticles, mcMothers, mcPartonicMothers, cache, binsVtxMultCent, mMixingDepth, mTripletHistManagerMe, mTrackCleaner1, mTrackCleaner2, mCascadeCleaner, mCtrMe, mTcMe);
           break;
         default:
           LOG(fatal) << "Invalid binning policy specifed. Breaking...";
@@ -933,7 +943,8 @@ class TripletTrackTrackCascadeBuilder
 
   closetripletrejection::CloseTripletRejectionTrackTrackCascade<prefixCtrTrack1Track2Se, prefixCprBachelorTrack1Se, prefixCprV0DaughterTrack1Se, prefixCprBachelorTrack2Se, prefixCprV0DaughterTrack2Se> mCtrSe;
   closetripletrejection::CloseTripletRejectionTrackTrackCascade<prefixCtrTrack1Track2Me, prefixCprBachelorTrack1Me, prefixCprV0DaughterTrack1Me, prefixCprBachelorTrack2Me, prefixCprV0DaughterTrack2Me> mCtrMe;
-  tripletcleaner::TrackTrackCascadeTripletCleaner mTc;
+  tripletcleaner::TrackTrackCascadeTripletCleaner<tripletcleaner::PrefixTripletCleanerTrackTrackCascadeSe> mTcSe;
+  tripletcleaner::TrackTrackCascadeTripletCleaner<tripletcleaner::PrefixTripletCleanerTrackTrackCascadeMe> mTcMe;
   triplethistmanager::MixingPolicy mMixingPolicy = triplethistmanager::MixingPolicy::kVtxMult;
   bool mTrack1Track2AreSameSpecies = false;
   int mMixingDepth = 5;

--- a/PWGCF/Femto/Core/tripletCleaner.h
+++ b/PWGCF/Femto/Core/tripletCleaner.h
@@ -17,37 +17,50 @@
 #define PWGCF_FEMTO_CORE_TRIPLETCLEANER_H_
 
 #include "PWGCF/Femto/Core/pairCleaner.h"
-
 namespace o2::analysis::femto::tripletcleaner
 {
-class TrackTrackTrackTripletCleaner : public paircleaner::BasePairCleaner
+
+constexpr char PrefixTripletCleanerTrackTrackTrackSe[] = "TrackTrackTrackCleaner/SE/";
+constexpr char PrefixTripletCleanerTrackTrackTrackMe[] = "TrackTrackTrackCleaner/ME/";
+constexpr char PrefixTripletCleanerTrackTrackV0Se[] = "TrackTrackV0Cleaner/SE/";
+constexpr char PrefixTripletCleanerTrackTrackV0Me[] = "TrackTrackV0Cleaner/ME/";
+constexpr char PrefixTripletCleanerTrackTrackCascadeSe[] = "TrackTrackCascadeCleaner/SE/";
+constexpr char PrefixTripletCleanerTrackTrackCascadeMe[] = "TrackTrackCascadeCleaner/ME/";
+
+template <auto& prefix>
+class TrackTrackTrackTripletCleaner : public paircleaner::BasePairCleaner<prefix>
 {
  public:
   TrackTrackTrackTripletCleaner() = default;
   ~TrackTrackTrackTripletCleaner() override = default;
 
-  template <typename T1, typename T2, typename T3, typename T4>
-  bool isCleanTriplet(T1 const& track1, T2 const& track2, T3 const& track3, T4 const& /*trackTable*/) const
+  template <typename T1, typename T2, typename T3, typename T4, typename T5>
+  bool isCleanTriplet(T1 const& track1, T2 const& track2, T3 const& track3, T4 const& /*trackTable*/, T5 const& tripletHistManager) const
   {
-    return this->isCleanParticlePair(track1, track2) &&
-           this->isCleanParticlePair(track2, track3) &&
-           this->isCleanParticlePair(track1, track3);
+    this->fillAll();
+    bool isClean = this->isCleanParticlePair(track1, track2) &&
+                   this->isCleanParticlePair(track2, track3) &&
+                   this->isCleanParticlePair(track1, track3);
+    if (!isClean) {
+      this->fillBlocked(tripletHistManager.getKinematic());
+    }
+    return isClean;
   }
 
-  template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
-  bool isCleanTriplet(T1 const& track1, T2 const& track2, T3 const& track3, T4 const& trackTable, T5 const& mcParticles, T6 const& partonicMothers) const
+  template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>
+  bool isCleanTriplet(T1 const& track1, T2 const& track2, T3 const& track3, T4 const& trackTable, T5 const& mcParticles, T6 const& partonicMothers, T7 const& tripletHistManager) const
   {
-    if (!this->isCleanTriplet(track1, track2, track3, trackTable)) {
+    if (!this->isCleanTriplet(track1, track2, track3, trackTable, tripletHistManager)) {
       return false;
     }
     // pair is clean
     // no check if we require common or non-common ancestry
-    if (mMixPairsWithCommonAncestor) {
+    if (this->mMixPairsWithCommonAncestor) {
       return this->pairHasCommonAncestor(track1, track2, mcParticles, partonicMothers) &&
              this->pairHasCommonAncestor(track2, track3, mcParticles, partonicMothers) &&
              this->pairHasCommonAncestor(track1, track3, mcParticles, partonicMothers);
     }
-    if (mMixPairsWithNonCommonAncestor) {
+    if (this->mMixPairsWithNonCommonAncestor) {
       return this->pairHasNonCommonAncestor(track1, track2, mcParticles, partonicMothers) &&
              this->pairHasNonCommonAncestor(track2, track3, mcParticles, partonicMothers) &&
              this->pairHasNonCommonAncestor(track1, track3, mcParticles, partonicMothers);
@@ -56,38 +69,44 @@ class TrackTrackTrackTripletCleaner : public paircleaner::BasePairCleaner
   }
 };
 
-class TrackTrackV0TripletCleaner : public paircleaner::BasePairCleaner
+template <auto& prefix>
+class TrackTrackV0TripletCleaner : public paircleaner::BasePairCleaner<prefix>
 {
  public:
   TrackTrackV0TripletCleaner() = default;
   ~TrackTrackV0TripletCleaner() override = default;
 
-  template <typename T1, typename T2, typename T3, typename T4>
-  bool isCleanTriplet(T1 const& track1, T2 const& track2, T3 const& v0, T4 const& trackTable) const
+  template <typename T1, typename T2, typename T3, typename T4, typename T5>
+  bool isCleanTriplet(T1 const& track1, T2 const& track2, T3 const& v0, T4 const& trackTable, T5 const& tripletHistManager) const
   {
+    this->fillAll();
     auto posDaughter = trackTable.rawIteratorAt(v0.posDauId() - trackTable.offset());
     auto negDaughter = trackTable.rawIteratorAt(v0.negDauId() - trackTable.offset());
-    return this->isCleanParticlePair(track1, track2) &&
-           this->isCleanParticlePair(track1, posDaughter) &&
-           this->isCleanParticlePair(track1, negDaughter) &&
-           this->isCleanParticlePair(track2, posDaughter) &&
-           this->isCleanParticlePair(track2, negDaughter);
+    bool isClean = this->isCleanParticlePair(track1, track2) &&
+                   this->isCleanParticlePair(track1, posDaughter) &&
+                   this->isCleanParticlePair(track1, negDaughter) &&
+                   this->isCleanParticlePair(track2, posDaughter) &&
+                   this->isCleanParticlePair(track2, negDaughter);
+    if (!isClean) {
+      this->fillBlocked(tripletHistManager.getKinematic());
+    }
+    return isClean;
   }
 
-  template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
-  bool isCleanTriplet(T1 const& track1, T2 const& track2, T3 const& v0, T4 const& trackTable, T5 const& mcParticles, T6 const& partonicMothers) const
+  template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>
+  bool isCleanTriplet(T1 const& track1, T2 const& track2, T3 const& v0, T4 const& trackTable, T5 const& mcParticles, T6 const& partonicMothers, T7 const& tripletHistManager) const
   {
-    if (!this->isCleanTriplet(track1, track2, v0, trackTable)) {
+    if (!this->isCleanTriplet(track1, track2, v0, trackTable, tripletHistManager)) {
       return false;
     }
     // pair is clean
     // no check if we require common or non-common ancestry
-    if (mMixPairsWithCommonAncestor) {
+    if (this->mMixPairsWithCommonAncestor) {
       return this->pairHasCommonAncestor(track1, track2, mcParticles, partonicMothers) &&
              this->pairHasCommonAncestor(track1, v0, mcParticles, partonicMothers) &&
              this->pairHasCommonAncestor(track2, v0, mcParticles, partonicMothers);
     }
-    if (mMixPairsWithNonCommonAncestor) {
+    if (this->mMixPairsWithNonCommonAncestor) {
       return this->pairHasNonCommonAncestor(track1, track2, mcParticles, partonicMothers) &&
              this->pairHasNonCommonAncestor(track1, v0, mcParticles, partonicMothers) &&
              this->pairHasNonCommonAncestor(track2, v0, mcParticles, partonicMothers);
@@ -96,41 +115,47 @@ class TrackTrackV0TripletCleaner : public paircleaner::BasePairCleaner
   }
 };
 
-class TrackTrackCascadeTripletCleaner : public paircleaner::BasePairCleaner
+template <auto& prefix>
+class TrackTrackCascadeTripletCleaner : public paircleaner::BasePairCleaner<prefix>
 {
  public:
   TrackTrackCascadeTripletCleaner() = default;
   ~TrackTrackCascadeTripletCleaner() override = default;
 
-  template <typename T1, typename T2, typename T3, typename T4>
-  bool isCleanTriplet(T1 const& track1, T2 const& track2, T3 const& cascade, T4 const& trackTable) const
+  template <typename T1, typename T2, typename T3, typename T4, typename T5>
+  bool isCleanTriplet(T1 const& track1, T2 const& track2, T3 const& cascade, T4 const& trackTable, T5 const& tripletHistManager) const
   {
+    this->fillAll();
     auto bachelor = trackTable.rawIteratorAt(cascade.bachelorId() - trackTable.offset());
     auto posDaughter = trackTable.rawIteratorAt(cascade.posDauId() - trackTable.offset());
     auto negDaughter = trackTable.rawIteratorAt(cascade.negDauId() - trackTable.offset());
-    return this->isCleanParticlePair(track1, track2) &&
-           this->isCleanParticlePair(track1, posDaughter) &&
-           this->isCleanParticlePair(track1, negDaughter) &&
-           this->isCleanParticlePair(track1, bachelor) &&
-           this->isCleanParticlePair(track2, posDaughter) &&
-           this->isCleanParticlePair(track2, negDaughter) &&
-           this->isCleanParticlePair(track2, bachelor);
+    bool isClean = this->isCleanParticlePair(track1, track2) &&
+                   this->isCleanParticlePair(track1, posDaughter) &&
+                   this->isCleanParticlePair(track1, negDaughter) &&
+                   this->isCleanParticlePair(track1, bachelor) &&
+                   this->isCleanParticlePair(track2, posDaughter) &&
+                   this->isCleanParticlePair(track2, negDaughter) &&
+                   this->isCleanParticlePair(track2, bachelor);
+    if (!isClean) {
+      this->fillBlocked(tripletHistManager.getKinematic());
+    }
+    return isClean;
   }
 
-  template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
-  bool isCleanTriplet(T1 const& track1, T2 const& track2, T3 const& cascade, T4 const& trackTable, T5 const& mcParticles, T6 const& partonicMothers) const
+  template <typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>
+  bool isCleanTriplet(T1 const& track1, T2 const& track2, T3 const& cascade, T4 const& trackTable, T5 const& mcParticles, T6 const& partonicMothers, T7 const& tripletHistManager) const
   {
-    if (!this->isCleanTriplet(track1, track2, cascade, trackTable)) {
+    if (!this->isCleanTriplet(track1, track2, cascade, trackTable, tripletHistManager)) {
       return false;
     }
     // pair is clean
     // no check if we require common or non-common ancestry
-    if (mMixPairsWithCommonAncestor) {
+    if (this->mMixPairsWithCommonAncestor) {
       return this->pairHasCommonAncestor(track1, track2, mcParticles, partonicMothers) &&
              this->pairHasCommonAncestor(track1, cascade, mcParticles, partonicMothers) &&
              this->pairHasCommonAncestor(track2, cascade, mcParticles, partonicMothers);
     }
-    if (mMixPairsWithNonCommonAncestor) {
+    if (this->mMixPairsWithNonCommonAncestor) {
       return this->pairHasNonCommonAncestor(track1, track2, mcParticles, partonicMothers) &&
              this->pairHasNonCommonAncestor(track1, cascade, mcParticles, partonicMothers) &&
              this->pairHasNonCommonAncestor(track2, cascade, mcParticles, partonicMothers);
@@ -138,7 +163,6 @@ class TrackTrackCascadeTripletCleaner : public paircleaner::BasePairCleaner
     return true;
   }
 };
-
 } // namespace o2::analysis::femto::tripletcleaner
 
 #endif // PWGCF_FEMTO_CORE_TRIPLETCLEANER_H_

--- a/PWGCF/Femto/Core/tripletHistManager.h
+++ b/PWGCF/Femto/Core/tripletHistManager.h
@@ -44,7 +44,7 @@ namespace o2::analysis::femto::triplethistmanager
 enum TripletHist {
   // standard 1D
   kQ3,
-  kMt, // averate mt of all pairs in the triplet
+  kMt, // average mt of all pairs in the triplet
   // kstar betweeen single particles
   kKstar12,
   kKstar13,
@@ -130,6 +130,7 @@ struct ConfTripletBinning : o2::framework::ConfigurableGroup {
   o2::framework::ConfigurableAxis mass2{"mass2", {{100, 0, 2}}, "Mass binning for particle 2 (if particle has mass getter, otherwise PDG mass)"};
   o2::framework::ConfigurableAxis mass3{"mass3", {{100, 0, 2}}, "Mass binning for particle 3 (if particle has mass getter, otherwise PDG mass)"};
   o2::framework::Configurable<int> transverseMassType{"transverseMassType", static_cast<int>(modes::TransverseMassType::kAveragePdgMass), "Type of transverse mass (0-> Average Pdg Mass, 1-> Reduced Pdg Mass, 2-> Mt from combined 4 vector)"};
+  o2::framework::Configurable<int> kinematicVariable{"kinematicVariable", static_cast<int>(modes::KinematicVariable::kQ3), "Type of kinematic variable (2->mT, 3->Q3) for PC and CPR plots"};
 };
 
 struct ConfTripletCuts : o2::framework::ConfigurableGroup {
@@ -268,6 +269,7 @@ class TripletHistManager
 
     // transverse mass type
     mMtType = static_cast<modes::TransverseMassType>(ConfTripletBinning.transverseMassType.value);
+    mKinematicVariable = static_cast<modes::KinematicVariable>(ConfTripletBinning.kinematicVariable.value);
 
     // values for cuts
     mQ3Min = ConfTripletCuts.q3Min.value;
@@ -437,7 +439,20 @@ class TripletHistManager
     }
   }
 
-  float getQ3() const { return mQ3; }
+  float getKinematic() const
+  {
+    switch (mKinematicVariable) {
+      case modes::KinematicVariable::kMt:
+        return mMt;
+        break;
+      case modes::KinematicVariable::kQ3:
+        return mQ3;
+        break;
+      default:
+        LOG(fatal) << "Invalid kinematic Variable, breaking...";
+    }
+    return mQ3;
+  }
 
   template <typename T1, typename T2, typename T3>
   void trackParticlesPerEvent(T1 const& particle1, T2 const& particle2, T3 const& particle3)
@@ -513,7 +528,7 @@ class TripletHistManager
     auto q23 = getqij(p2, p3);
     auto q31 = getqij(p3, p1);
     double q = q12.M2() + q23.M2() + q31.M2();
-    return static_cast<float>(std::sqrt(-q));
+    return static_cast<float>(std::sqrt(std::max(0.0, -q)));
   }
 
   float getKstar(ROOT::Math::PtEtaPhiMVector const& part1, ROOT::Math::PtEtaPhiMVector const& part2)
@@ -695,6 +710,7 @@ class TripletHistManager
   double mPdgMass3 = 0.;
 
   modes::TransverseMassType mMtType = modes::TransverseMassType::kAveragePdgMass;
+  modes::KinematicVariable mKinematicVariable = modes::KinematicVariable::kQ3;
 
   int mAbsCharge1 = 1;
   int mAbsCharge2 = 1;

--- a/PWGCF/Femto/Core/tripletProcessHelpers.h
+++ b/PWGCF/Femto/Core/tripletProcessHelpers.h
@@ -60,18 +60,7 @@ void processSameEvent(T1 const& SliceParticle,
 
   for (auto const& [p1, p2, p3] : o2::soa::combinations(o2::soa::CombinationsStrictlyUpperIndexPolicy(SliceParticle, SliceParticle, SliceParticle))) {
 
-    // check if triplet is clean
-    if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable)) {
-      continue;
-    }
-
-    // check if triplet is close
-    CtrManager.setTriplet(p1, p2, p3, TrackTable);
-    if (CtrManager.isCloseTriplet()) {
-      continue;
-    }
-
-    // Randomize pair order if enabled
+    // Randomize triplet order if enabled, then compute the kinematic (Q3) for this triplet
     switch (tripletOrder) {
       case kOrder123:
         TripletHistManager.setTriplet(p1, p2, p3, Collision);
@@ -90,8 +79,15 @@ void processSameEvent(T1 const& SliceParticle,
         break;
     }
 
-    // fill deta-dphi histograms with q3 cutoff
-    CtrManager.fill(TripletHistManager.getQ3());
+    // check if triplet is clean
+    if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable, TripletHistManager)) {
+      continue;
+    }
+
+    // check if triplet is close; fills deta-dphi/kinematic histograms internally
+    if (CtrManager.isCloseTriplet(p1, p2, p3, TrackTable, TripletHistManager)) {
+      continue;
+    }
 
     // if triplet cuts are configured check them before filling
     if (TripletHistManager.checkTripletCuts()) {
@@ -130,18 +126,7 @@ void processSameEvent(T1 const& SliceParticle1, // 1&2 have same species
   for (auto const& p3 : SliceParticle3) {
     for (auto const& [p1, p2] : o2::soa::combinations(o2::soa::CombinationsStrictlyUpperIndexPolicy(SliceParticle1, SliceParticle1))) {
 
-      // check if triplet is clean
-      if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable)) {
-        continue;
-      }
-
-      // check if triplet is close
-      CtrManager.setTriplet(p1, p2, p3, TrackTable);
-      if (CtrManager.isCloseTriplet()) {
-        continue;
-      }
-
-      // Randomize triplet order if enabled
+      // Randomize triplet order if enabled, then compute the kinematic (Q3) for this triplet
       // only kOrder123 and kOrder213 are meaningful here since particle 1 & 2 are the same species
       switch (tripletOrder) {
         case kOrder213:
@@ -153,8 +138,15 @@ void processSameEvent(T1 const& SliceParticle1, // 1&2 have same species
           break;
       }
 
-      // fill deta-dphi histograms with q3 cutoff
-      CtrManager.fill(TripletHistManager.getQ3());
+      // check if triplet is clean
+      if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable, TripletHistManager)) {
+        continue;
+      }
+
+      // check if triplet is close; fills deta-dphi/kinematic histograms internally
+      if (CtrManager.isCloseTriplet(p1, p2, p3, TrackTable, TripletHistManager)) {
+        continue;
+      }
 
       // if triplet cuts are configured check them before filling
       if (TripletHistManager.checkTripletCuts()) {
@@ -206,21 +198,18 @@ void processSameEvent(T1 const& SliceParticle1,
 
   for (auto const& [p1, p2, p3] : o2::soa::combinations(o2::soa::CombinationsFullIndexPolicy(SliceParticle1, SliceParticle2, SliceParticle3))) {
 
-    // check if triplet is clean
-    if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable)) {
-      continue;
-    }
-
-    // check if triplet is close
-    CtrManager.setTriplet(p1, p2, p3, TrackTable);
-    if (CtrManager.isCloseTriplet()) {
-      continue;
-    }
-
+    // compute the kinematic (Q3) for this triplet
     TripletHistManager.setTriplet(p1, p2, p3, Collision);
 
-    // fill deta-dphi histograms with q3 cutoff
-    CtrManager.fill(TripletHistManager.getQ3());
+    // check if triplet is clean
+    if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable, TripletHistManager)) {
+      continue;
+    }
+
+    // check if triplet is close; fills deta-dphi/kinematic histograms internally
+    if (CtrManager.isCloseTriplet(p1, p2, p3, TrackTable, TripletHistManager)) {
+      continue;
+    }
 
     // if triplet cuts are configured check them before filling
     if (TripletHistManager.checkTripletCuts()) {
@@ -276,16 +265,8 @@ void processSameEvent(T1 const& SliceParticle,
         !Cleaner.isClean(p3, mcParticles, mcMothers, mcPartonicMothers)) {
       continue;
     }
-    // check if triplet is clean
-    if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable, mcParticles, mcPartonicMothers)) {
-      continue;
-    }
-    // check if triplet is close
-    CtrManager.setTriplet(p1, p2, p3, TrackTable);
-    if (CtrManager.isCloseTriplet()) {
-      continue;
-    }
-    // Randomize triplet order if enabled
+
+    // Randomize triplet order if enabled, then compute the kinematic (Q3) for this triplet
     switch (tripletOrder) {
       case kOrder123:
         TripletHistManager.setTripletMc(p1, p2, p3, mcParticles, Collision, mcCollisions);
@@ -303,8 +284,17 @@ void processSameEvent(T1 const& SliceParticle,
         TripletHistManager.setTripletMc(p1, p2, p3, mcParticles, Collision, mcCollisions);
         break;
     }
-    // fill deta-dphi histograms with q3 cutoff
-    CtrManager.fill(TripletHistManager.getQ3());
+
+    // check if triplet is clean
+    if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable, mcParticles, mcPartonicMothers, TripletHistManager)) {
+      continue;
+    }
+
+    // check if triplet is close; fills deta-dphi/kinematic histograms internally
+    if (CtrManager.isCloseTriplet(p1, p2, p3, TrackTable, TripletHistManager)) {
+      continue;
+    }
+
     // if triplet cuts are configured check them before filling
     if (TripletHistManager.checkTripletCuts()) {
       TripletHistManager.template fill<mode>();
@@ -359,16 +349,8 @@ void processSameEvent(T1 const& SliceParticle1,
           !Cleaner3.isClean(p3, mcParticles, mcMothers, mcPartonicMothers)) {
         continue;
       }
-      // check if triplet is clean
-      if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable, mcParticles, mcPartonicMothers)) {
-        continue;
-      }
-      // check if triplet is close
-      CtrManager.setTriplet(p1, p2, p3, TrackTable);
-      if (CtrManager.isCloseTriplet()) {
-        continue;
-      }
-      // Randomize triplet order if enabled
+
+      // Randomize triplet order if enabled, then compute the kinematic (Q3) for this triplet
       // only kOrder123 and kOrder213 are meaningful here since particle 1 & 2 are the same species
       switch (tripletOrder) {
         case kOrder213:
@@ -379,8 +361,17 @@ void processSameEvent(T1 const& SliceParticle1,
           TripletHistManager.setTripletMc(p1, p2, p3, mcParticles, Collision, mcCollisions);
           break;
       }
-      // fill deta-dphi histograms with q3 cutoff
-      CtrManager.fill(TripletHistManager.getQ3());
+
+      // check if triplet is clean
+      if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable, mcParticles, mcPartonicMothers, TripletHistManager)) {
+        continue;
+      }
+
+      // check if triplet is close; fills deta-dphi/kinematic histograms internally
+      if (CtrManager.isCloseTriplet(p1, p2, p3, TrackTable, TripletHistManager)) {
+        continue;
+      }
+
       // if triplet cuts are configured check them before filling
       if (TripletHistManager.checkTripletCuts()) {
         TripletHistManager.template fill<mode>();
@@ -460,18 +451,20 @@ void processSameEvent(T1 const& SliceParticle1,
         !Cleaner3.isClean(p3, mcParticles, mcMothers, mcPartonicMothers)) {
       continue;
     }
-    // check if triplet is clean
-    if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable, mcParticles, mcPartonicMothers)) {
-      continue;
-    }
-    // check if triplet is close
-    CtrManager.setTriplet(p1, p2, p3, TrackTable);
-    if (CtrManager.isCloseTriplet()) {
-      continue;
-    }
+
+    // compute the kinematic (Q3) for this triplet
     TripletHistManager.setTripletMc(p1, p2, p3, mcParticles, Collision, mcCollisions);
-    // fill deta-dphi histograms with q3 cutoff
-    CtrManager.fill(TripletHistManager.getQ3());
+
+    // check if triplet is clean
+    if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable, mcParticles, mcPartonicMothers, TripletHistManager)) {
+      continue;
+    }
+
+    // check if triplet is close; fills deta-dphi/kinematic histograms internally
+    if (CtrManager.isCloseTriplet(p1, p2, p3, TrackTable, TripletHistManager)) {
+      continue;
+    }
+
     // if triplet cuts are configured check them before filling
     if (TripletHistManager.checkTripletCuts()) {
       TripletHistManager.template fill<mode>();
@@ -562,18 +555,19 @@ void processMixedEvent(T1 const& Collisions,
     TripletHistManager.fillMixingQaMe(collision1, collision2, collision3);
 
     for (auto const& [p1, p2, p3] : o2::soa::combinations(o2::soa::CombinationsFullIndexPolicy(*sliceParticle1, *sliceParticle2, sliceParticle3))) {
-      // pair cleaning
-      if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable)) {
-        continue;
-      }
-      // Close pair rejection
-      CtrManager.setTriplet(p1, p2, p3, TrackTable);
-      if (CtrManager.isCloseTriplet()) {
+
+      // compute the kinematic (Q3) for this triplet
+      TripletHistManager.setTriplet(p1, p2, p3, collision1, collision2, collision3);
+
+      // triplet cleaning
+      if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable, TripletHistManager)) {
         continue;
       }
 
-      TripletHistManager.setTriplet(p1, p2, p3, collision1, collision2, collision3);
-      CtrManager.fill(TripletHistManager.getQ3());
+      // Close triplet rejection; fills deta-dphi/kinematic histograms internally
+      if (CtrManager.isCloseTriplet(p1, p2, p3, TrackTable, TripletHistManager)) {
+        continue;
+      }
 
       if (TripletHistManager.checkTripletCuts()) {
         hasValidTriplet = true;
@@ -690,24 +684,26 @@ void processMixedEvent(T1 const& Collisions,
     TripletHistManager.fillMixingQaMe(collision1, collision2, collision3);
 
     for (auto const& [p1, p2, p3] : o2::soa::combinations(o2::soa::CombinationsFullIndexPolicy(*sliceParticle1, *sliceParticle2, sliceParticle3))) {
+
       // particle cleaning
       if (!Cleaner1.isClean(p1, mcParticles, mcMothers, mcPartonicMothers) ||
           !Cleaner2.isClean(p2, mcParticles, mcMothers, mcPartonicMothers) ||
           !Cleaner3.isClean(p3, mcParticles, mcMothers, mcPartonicMothers)) {
         continue;
       }
-      // pair cleaning
-      if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable, mcParticles, mcPartonicMothers)) {
-        continue;
-      }
-      // Close pair rejection
-      CtrManager.setTriplet(p1, p2, p3, TrackTable);
-      if (CtrManager.isCloseTriplet()) {
+
+      // compute the kinematic (Q3) for this triplet
+      TripletHistManager.setTripletMc(p1, p2, p3, mcParticles, collision1, collision2, collision3, mcCollisions);
+
+      // triplet cleaning
+      if (!TcManager.isCleanTriplet(p1, p2, p3, TrackTable, mcParticles, mcPartonicMothers, TripletHistManager)) {
         continue;
       }
 
-      TripletHistManager.setTripletMc(p1, p2, p3, mcParticles, collision1, collision2, collision3, mcCollisions);
-      CtrManager.fill(TripletHistManager.getQ3());
+      // Close triplet rejection; fills deta-dphi/kinematic histograms internally
+      if (CtrManager.isCloseTriplet(p1, p2, p3, TrackTable, TripletHistManager)) {
+        continue;
+      }
 
       if (TripletHistManager.checkTripletCuts()) {
         hasValidTriplet = true;

--- a/PWGCF/Femto/Tasks/femtoPairD0D0.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairD0D0.cxx
@@ -20,6 +20,7 @@
 #include "PWGCF/Femto/Core/collisionHistManager.h"
 #include "PWGCF/Femto/Core/modes.h"
 #include "PWGCF/Femto/Core/pairBuilder.h"
+#include "PWGCF/Femto/Core/pairCleaner.h"
 #include "PWGCF/Femto/Core/pairHistManager.h"
 #include "PWGCF/Femto/Core/particleCleaner.h"
 #include "PWGCF/Femto/Core/partitions.h"
@@ -100,6 +101,7 @@ struct FemtoPairD0D0 {
   // setup pairs
   pairhistmanager::ConfPairBinning confPairBinning;
   pairhistmanager::ConfPairCuts confPairCuts;
+  paircleaner::ConfPairCleanerBinning confPairCleaner;
 
   pairbuilder::PairD0D0Builder<
     charmhadronhistmanager::PrefixD01,
@@ -162,6 +164,7 @@ struct FemtoPairD0D0 {
     std::map<pairhistmanager::PairHist, std::vector<o2::framework::AxisSpec>> pairD0D0HistSpec;
     std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpecPos = closepairrejection::makeCprHistSpecMap(confCprPos);
     std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpecNeg = closepairrejection::makeCprHistSpecMap(confCprNeg);
+    std::map<paircleaner::PairCleanerHist, std::vector<o2::framework::AxisSpec>> pairCleanerHistSpec = paircleaner::makePairCleanerHistSpecMap(confPairCleaner);
 
     if (processData) {
       colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
@@ -172,7 +175,7 @@ struct FemtoPairD0D0 {
       d0HistSpec1 = charmhadronhistmanager::makeCharmHadronHistSpecMap(confD0Binning1);
       d0HistSpec2 = charmhadronhistmanager::makeCharmHadronHistSpecMap(confD0Binning2);
       pairD0D0HistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning, confMixing);
-      pairD0D0Builder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confD0Selection1, confD0Selection2, confD0Cleaner1, confD0Cleaner2, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, d0HistSpec1, d0HistSpec2, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairD0D0HistSpec, cprHistSpecPos, cprHistSpecNeg);
+      pairD0D0Builder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confD0Selection1, confD0Selection2, confD0Cleaner1, confD0Cleaner2, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, d0HistSpec1, d0HistSpec2, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairD0D0HistSpec, cprHistSpecPos, cprHistSpecNeg, pairCleanerHistSpec);
     } else {
       colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
       posDauSpec1 = trackhistmanager::makeTrackMcHistSpecMap(confD01PosDauBinning);
@@ -182,8 +185,9 @@ struct FemtoPairD0D0 {
       d0HistSpec1 = charmhadronhistmanager::makeCharmHadronMcHistSpecMap(confD0Binning1);
       d0HistSpec2 = charmhadronhistmanager::makeCharmHadronMcHistSpecMap(confD0Binning2);
       pairD0D0HistSpec = pairhistmanager::makePairMcHistSpecMap(confPairBinning, confMixing);
-      pairD0D0Builder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confD0Selection1, confD0Selection2, confD0Cleaner1, confD0Cleaner2, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, d0HistSpec1, d0HistSpec2, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairD0D0HistSpec, cprHistSpecPos, cprHistSpecNeg);
+      pairD0D0Builder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confD0Selection1, confD0Selection2, confD0Cleaner1, confD0Cleaner2, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, d0HistSpec1, d0HistSpec2, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairD0D0HistSpec, cprHistSpecPos, cprHistSpecNeg, pairCleanerHistSpec);
     }
+    hRegistry.print();
   }
 
   void processSameEvent(FilteredFemtoCollision const& col, FemtoTracks const& tracks, FemtoD0s const& d0s)

--- a/PWGCF/Femto/Tasks/femtoPairMcParticleMcParticle.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairMcParticleMcParticle.cxx
@@ -19,6 +19,7 @@
 #include "PWGCF/Femto/Core/mcParticleHistManager.h"
 #include "PWGCF/Femto/Core/modes.h"
 #include "PWGCF/Femto/Core/pairBuilder.h"
+#include "PWGCF/Femto/Core/pairCleaner.h"
 #include "PWGCF/Femto/Core/pairHistManager.h"
 #include "PWGCF/Femto/Core/particleCleaner.h"
 #include "PWGCF/Femto/Core/partitions.h"
@@ -73,13 +74,14 @@ struct FemtoPairMcParticleMcParticle {
   particlecleaner::ConfMcParticleCleaner2 confMcParticleCleaner2;
   particlecleaner::ParticleCleaner mcParticleCleaner2;
 
-  o2::framework::Partition<FemtoMcParticles> mcParticlesPartition2 = MAKE_MC_PARTICLE_PARTITION(confMcParticleSelection1);
+  o2::framework::Partition<FemtoMcParticles> mcParticlesPartition2 = MAKE_MC_PARTICLE_PARTITION(confMcParticleSelection2);
 
   o2::framework::Preslice<FemtoMcParticles> perColParticles = o2::aod::femtomcparticle::fMcColId;
 
   // setup pairs
   pairhistmanager::ConfPairBinning confPairBinning;
   pairhistmanager::ConfPairCuts confPairCuts;
+  paircleaner::ConfPairCleanerBinning confPairCleaner;
 
   closepairrejection::ConfCprTrackTrack confCpr;
 
@@ -117,12 +119,13 @@ struct FemtoPairMcParticleMcParticle {
     std::map<mcparticlehistmanager::McParticleHist, std::vector<o2::framework::AxisSpec>> mcParticleHistSpec2;
     std::map<pairhistmanager::PairHist, std::vector<o2::framework::AxisSpec>> pairHistSpec;
     std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpec = closepairrejection::makeCprHistSpecMap(confCpr);
+    std::map<paircleaner::PairCleanerHist, std::vector<o2::framework::AxisSpec>> pairCleanerHistSpec = paircleaner::makePairCleanerHistSpecMap(confPairCleaner);
 
     colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
     mcParticleHistSpec1 = mcparticlehistmanager::makeMcParticleHistSpecMap(confMcParticleBinning1);
     mcParticleHistSpec2 = mcparticlehistmanager::makeMcParticleHistSpecMap(confMcParticleBinning2);
     pairHistSpec = pairhistmanager::makePairMcTruthHistSpecMap(confPairBinning, confMixing);
-    pairMcParticleMcParticleBuilder.init<modes::Mode::kSe_Mc, modes::Mode::kMe_Mc>(&hRegistry, confCollisionBinning, confMcParticleSelection1, confMcParticleSelection2, confMcParticleBinning1, confMcParticleBinning2, confMcParticleCleaner1, confMcParticleCleaner2, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, mcParticleHistSpec1, mcParticleHistSpec2, pairHistSpec, cprHistSpec);
+    pairMcParticleMcParticleBuilder.init<modes::Mode::kSe_Mc, modes::Mode::kMe_Mc>(&hRegistry, confCollisionBinning, confMcParticleSelection1, confMcParticleSelection2, confMcParticleBinning1, confMcParticleBinning2, confMcParticleCleaner1, confMcParticleCleaner2, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, mcParticleHistSpec1, mcParticleHistSpec2, pairHistSpec, cprHistSpec, pairCleanerHistSpec);
 
     hRegistry.print();
   };

--- a/PWGCF/Femto/Tasks/femtoPairTrackCascade.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackCascade.cxx
@@ -20,6 +20,7 @@
 #include "PWGCF/Femto/Core/collisionHistManager.h"
 #include "PWGCF/Femto/Core/modes.h"
 #include "PWGCF/Femto/Core/pairBuilder.h"
+#include "PWGCF/Femto/Core/pairCleaner.h"
 #include "PWGCF/Femto/Core/pairHistManager.h"
 #include "PWGCF/Femto/Core/particleCleaner.h"
 #include "PWGCF/Femto/Core/partitions.h"
@@ -60,8 +61,8 @@ struct FemtoPairTrackCascade {
   using FemtoOmegas = o2::soa::Join<o2::aod::FOmegas, o2::aod::FOmegaMasks>;
 
   using FemtoTracksWithLabel = o2::soa::Join<FemtoTracks, o2::aod::FTrackLabels>;
-  using FemtoXisWithLabel = o2::soa::Join<FemtoXis, o2::aod::FLambdaLabels>;
-  using FemtoOmegasWithLabel = o2::soa::Join<FemtoOmegas, o2::aod::FK0shortLabels>;
+  using FemtoXisWithLabel = o2::soa::Join<FemtoXis, o2::aod::FXiLabels>;
+  using FemtoOmegasWithLabel = o2::soa::Join<FemtoOmegas, o2::aod::FOmegaLabels>;
 
   using FemtoMcParticlesWithLabel = o2::soa::Join<o2::aod::FMcParticles, o2::aod::FMcMotherLabels>;
 
@@ -113,6 +114,7 @@ struct FemtoPairTrackCascade {
   // setup pairs
   pairhistmanager::ConfPairBinning confPairBinning;
   pairhistmanager::ConfPairCuts confPairCuts;
+  paircleaner::ConfPairCleanerBinning confPairCleaner;
 
   pairbuilder::PairTrackCascadeBuilder<
     trackhistmanager::PrefixTrack1,
@@ -192,6 +194,7 @@ struct FemtoPairTrackCascade {
 
     std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpecBachelor = closepairrejection::makeCprHistSpecMap(confCprBachelor);
     std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpecV0Daughter = closepairrejection::makeCprHistSpecMap(confCprV0Daughter);
+    std::map<paircleaner::PairCleanerHist, std::vector<o2::framework::AxisSpec>> pairCleanerHistSpec = paircleaner::makePairCleanerHistSpecMap(confPairCleaner);
 
     if (processData) {
       colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
@@ -202,11 +205,11 @@ struct FemtoPairTrackCascade {
       pairTrackCascadeHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning, confMixing);
       if (processXi) {
         xiHistSpec = cascadehistmanager::makeCascadeHistSpecMap(confXiBinning);
-        pairTrackXiBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, confXiSelection, confXiCleaner, confCprBachelor, confCprV0Daughter, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, xiHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, pairTrackCascadeHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter);
+        pairTrackXiBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, confXiSelection, confXiCleaner, confCprBachelor, confCprV0Daughter, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, xiHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, pairTrackCascadeHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter, pairCleanerHistSpec);
       } else {
         omegaHistSpec = cascadehistmanager::makeCascadeHistSpecMap(confOmegaBinning);
         pairTrackCascadeHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning, confMixing);
-        pairTrackOmegaBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, confOmegaSelection, confOmegaCleaner, confCprBachelor, confCprV0Daughter, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, omegaHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, pairTrackCascadeHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter);
+        pairTrackOmegaBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, confOmegaSelection, confOmegaCleaner, confCprBachelor, confCprV0Daughter, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, omegaHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, pairTrackCascadeHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter, pairCleanerHistSpec);
       }
     } else {
       colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
@@ -217,12 +220,13 @@ struct FemtoPairTrackCascade {
       pairTrackCascadeHistSpec = pairhistmanager::makePairMcHistSpecMap(confPairBinning, confMixing);
       if (processXi) {
         xiHistSpec = cascadehistmanager::makeCascadeMcHistSpecMap(confXiBinning);
-        pairTrackXiBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, confXiSelection, confXiCleaner, confCprBachelor, confCprV0Daughter, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, xiHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, pairTrackCascadeHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter);
+        pairTrackXiBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, confXiSelection, confXiCleaner, confCprBachelor, confCprV0Daughter, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, xiHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, pairTrackCascadeHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter, pairCleanerHistSpec);
       } else {
         omegaHistSpec = cascadehistmanager::makeCascadeMcHistSpecMap(confOmegaBinning);
-        pairTrackOmegaBuilder.init<modes::Mode::kReco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, confOmegaSelection, confOmegaCleaner, confCprBachelor, confCprV0Daughter, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, omegaHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, pairTrackCascadeHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter);
+        pairTrackOmegaBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, confOmegaSelection, confOmegaCleaner, confCprBachelor, confCprV0Daughter, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, omegaHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, pairTrackCascadeHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter, pairCleanerHistSpec);
       }
     }
+    hRegistry.print();
   };
 
   void processXiSameEvent(FilteredFemtoCollision const& col, FemtoTracks const& tracks, FemtoXis const& xis)
@@ -267,7 +271,7 @@ struct FemtoPairTrackCascade {
   }
   PROCESS_SWITCH(FemtoPairTrackCascade, processOmegaMixedEvent, "Enable processing mixed event processing for tracks and omegas", false);
 
-  void processOmegaMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoXisWithLabel const& /*xis*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
+  void processOmegaMixedEventMc(FilteredFemtoCollisionsWithLabel const& cols, o2::aod::FMcCols const& mcCols, FemtoTracksWithLabel const& tracks, FemtoOmegasWithLabel const& /*omegas*/, FemtoMcParticlesWithLabel const& mcParticles, o2::aod::FMcMothers const& mcMothers, o2::aod::FMcPartMoths const& mcPartonicMothers)
   {
     pairTrackOmegaBuilder.processMixedEvent<modes::Mode::kMe_Reco_Mc>(cols, mcCols, tracks, trackWithLabelPartition, omegaWithLabelPartition, mcParticles, mcMothers, mcPartonicMothers, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }

--- a/PWGCF/Femto/Tasks/femtoPairTrackCharmHadron.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackCharmHadron.cxx
@@ -20,6 +20,7 @@
 #include "PWGCF/Femto/Core/collisionHistManager.h"
 #include "PWGCF/Femto/Core/modes.h"
 #include "PWGCF/Femto/Core/pairBuilder.h"
+#include "PWGCF/Femto/Core/pairCleaner.h"
 #include "PWGCF/Femto/Core/pairHistManager.h"
 #include "PWGCF/Femto/Core/particleCleaner.h"
 #include "PWGCF/Femto/Core/partitions.h"
@@ -116,6 +117,7 @@ struct FemtoPairTrackCharmHadron {
   // setup pairs
   pairhistmanager::ConfPairBinning confPairBinning;
   pairhistmanager::ConfPairCuts confPairCuts;
+  paircleaner::ConfPairCleanerBinning confPairCleaner;
 
   pairbuilder::PairTrackD0Builder<
     trackhistmanager::PrefixTrack1,
@@ -194,6 +196,8 @@ struct FemtoPairTrackCharmHadron {
     std::map<pairhistmanager::PairHist, std::vector<o2::framework::AxisSpec>> pairTrackD0HistSpec;
     std::map<pairhistmanager::PairHist, std::vector<o2::framework::AxisSpec>> pairTrackLcHistSpec;
     std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpec = closepairrejection::makeCprHistSpecMap(confCpr);
+    std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpecLc = closepairrejection::makeCprHistSpecMap(confCprLcProton);
+    std::map<paircleaner::PairCleanerHist, std::vector<o2::framework::AxisSpec>> pairCleanerHistSpec = paircleaner::makePairCleanerHistSpecMap(confPairCleaner);
 
     if (processData) {
       colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
@@ -203,7 +207,7 @@ struct FemtoPairTrackCharmHadron {
         negDauSpec = trackhistmanager::makeTrackHistSpecMap(confNegDauBinning);
         d0HistSpec = charmhadronhistmanager::makeCharmHadronHistSpecMap(confD0Binning);
         pairTrackD0HistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning, confMixing);
-        pairTrackD0Builder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, d0Selection, confD0Cleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, d0HistSpec, posDauSpec, negDauSpec, pairTrackD0HistSpec, cprHistSpec);
+        pairTrackD0Builder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, d0Selection, confD0Cleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, d0HistSpec, posDauSpec, negDauSpec, pairTrackD0HistSpec, cprHistSpec, pairCleanerHistSpec);
       }
       if (processLc) {
         protonDauSpec = trackhistmanager::makeTrackHistSpecMap(confProtonDauBinning);
@@ -211,7 +215,7 @@ struct FemtoPairTrackCharmHadron {
         pionDauSpec = trackhistmanager::makeTrackHistSpecMap(confPionDauBinning);
         lcHistSpec = charmhadronhistmanager::makeCharmHadronHistSpecMap(confLcBinning);
         pairTrackLcHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning, confMixing);
-        pairTrackLcBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, lcSelection, confLcCleaner, confCprLcProton, confCprLcKaon, confCprLcPion, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, lcHistSpec, protonDauSpec, kaonDauSpec, pionDauSpec, pairTrackLcHistSpec, cprHistSpec);
+        pairTrackLcBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, lcSelection, confLcCleaner, confCprLcProton, confCprLcKaon, confCprLcPion, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, lcHistSpec, protonDauSpec, kaonDauSpec, pionDauSpec, pairTrackLcHistSpec, cprHistSpecLc, pairCleanerHistSpec);
       }
     } else {
       colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
@@ -221,7 +225,7 @@ struct FemtoPairTrackCharmHadron {
         negDauSpec = trackhistmanager::makeTrackMcHistSpecMap(confNegDauBinning);
         d0HistSpec = charmhadronhistmanager::makeCharmHadronMcHistSpecMap(confD0Binning);
         pairTrackD0HistSpec = pairhistmanager::makePairMcHistSpecMap(confPairBinning, confMixing);
-        pairTrackD0Builder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, d0Selection, confD0Cleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, d0HistSpec, posDauSpec, negDauSpec, pairTrackD0HistSpec, cprHistSpec);
+        pairTrackD0Builder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, d0Selection, confD0Cleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, d0HistSpec, posDauSpec, negDauSpec, pairTrackD0HistSpec, cprHistSpec, pairCleanerHistSpec);
       }
       if (processLcMc) {
         protonDauSpec = trackhistmanager::makeTrackMcHistSpecMap(confProtonDauBinning);
@@ -229,7 +233,7 @@ struct FemtoPairTrackCharmHadron {
         pionDauSpec = trackhistmanager::makeTrackMcHistSpecMap(confPionDauBinning);
         lcHistSpec = charmhadronhistmanager::makeCharmHadronMcHistSpecMap(confLcBinning);
         pairTrackLcHistSpec = pairhistmanager::makePairMcHistSpecMap(confPairBinning, confMixing);
-        pairTrackLcBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, lcSelection, confLcCleaner, confCprLcProton, confCprLcKaon, confCprLcPion, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, lcHistSpec, protonDauSpec, kaonDauSpec, pionDauSpec, pairTrackLcHistSpec, cprHistSpec);
+        pairTrackLcBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, lcSelection, confLcCleaner, confCprLcProton, confCprLcKaon, confCprLcPion, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, lcHistSpec, protonDauSpec, kaonDauSpec, pionDauSpec, pairTrackLcHistSpec, cprHistSpecLc, pairCleanerHistSpec);
       }
     }
 

--- a/PWGCF/Femto/Tasks/femtoPairTrackKink.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackKink.cxx
@@ -21,6 +21,7 @@
 #include "PWGCF/Femto/Core/kinkHistManager.h"
 #include "PWGCF/Femto/Core/modes.h"
 #include "PWGCF/Femto/Core/pairBuilder.h"
+#include "PWGCF/Femto/Core/pairCleaner.h"
 #include "PWGCF/Femto/Core/pairHistManager.h"
 #include "PWGCF/Femto/Core/particleCleaner.h"
 #include "PWGCF/Femto/Core/partitions.h"
@@ -112,6 +113,7 @@ struct FemtoPairTrackKink {
   // setup pairs
   pairhistmanager::ConfPairBinning confPairBinning;
   pairhistmanager::ConfPairCuts confPairCuts;
+  paircleaner::ConfPairCleanerBinning confPairCleaner;
 
   pairbuilder::PairTrackKinkBuilder<
     trackhistmanager::PrefixTrack1,
@@ -178,6 +180,7 @@ struct FemtoPairTrackKink {
     std::map<kinkhistmanager::KinkHist, std::vector<o2::framework::AxisSpec>> sigmaPlusHistSpec;
     std::map<pairhistmanager::PairHist, std::vector<o2::framework::AxisSpec>> pairTrackKinkHistSpec;
     std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpec = closepairrejection::makeCprHistSpecMap(confCpr);
+    std::map<paircleaner::PairCleanerHist, std::vector<o2::framework::AxisSpec>> pairCleanerHistSpec = paircleaner::makePairCleanerHistSpecMap(confPairCleaner);
 
     if (processData) {
       colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
@@ -186,10 +189,10 @@ struct FemtoPairTrackKink {
       pairTrackKinkHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning, confMixing);
       if (processSigma) {
         sigmaHistSpec = kinkhistmanager::makeKinkHistSpecMap(confSigmaBinning);
-        pairTrackSigmaBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, confSigmaSelection, confSigmaCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, sigmaHistSpec, chaDauSpec, pairTrackKinkHistSpec, cprHistSpec);
+        pairTrackSigmaBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, confSigmaSelection, confSigmaCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, sigmaHistSpec, chaDauSpec, pairTrackKinkHistSpec, cprHistSpec, pairCleanerHistSpec);
       } else {
         sigmaPlusHistSpec = kinkhistmanager::makeKinkHistSpecMap(confSigmaPlusBinning);
-        pairTrackSigmaPlusBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, confSigmaPlusSelection, confSigmaPlusCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, sigmaPlusHistSpec, chaDauSpec, pairTrackKinkHistSpec, cprHistSpec);
+        pairTrackSigmaPlusBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, confSigmaPlusSelection, confSigmaPlusCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, sigmaPlusHistSpec, chaDauSpec, pairTrackKinkHistSpec, cprHistSpec, pairCleanerHistSpec);
       }
     } else {
       colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
@@ -198,10 +201,10 @@ struct FemtoPairTrackKink {
       pairTrackKinkHistSpec = pairhistmanager::makePairMcHistSpecMap(confPairBinning, confMixing);
       if (processSigma) {
         sigmaHistSpec = kinkhistmanager::makeKinkMcHistSpecMap(confSigmaBinning);
-        pairTrackSigmaBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, confSigmaSelection, confSigmaCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, sigmaHistSpec, chaDauSpec, pairTrackKinkHistSpec, cprHistSpec);
+        pairTrackSigmaBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, confSigmaSelection, confSigmaCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, sigmaHistSpec, chaDauSpec, pairTrackKinkHistSpec, cprHistSpec, pairCleanerHistSpec);
       } else {
         sigmaPlusHistSpec = kinkhistmanager::makeKinkMcHistSpecMap(confSigmaPlusBinning);
-        pairTrackSigmaPlusBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, confSigmaPlusSelection, confSigmaPlusCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, sigmaPlusHistSpec, chaDauSpec, pairTrackKinkHistSpec, cprHistSpec);
+        pairTrackSigmaPlusBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, confSigmaPlusSelection, confSigmaPlusCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, sigmaPlusHistSpec, chaDauSpec, pairTrackKinkHistSpec, cprHistSpec, pairCleanerHistSpec);
       }
     }
     hRegistry.print();
@@ -245,7 +248,7 @@ struct FemtoPairTrackKink {
 
   void processSigmaPlusMixedEvent(FilteredFemtoCollisions const& cols, FemtoTracks const& tracks, FemtoSigmaPlus const& /*sigmaplus*/)
   {
-    pairTrackSigmaPlusBuilder.processMixedEvent<modes::Mode::kSe_Reco>(cols, tracks, trackPartition, sigmaPlusPartition, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
+    pairTrackSigmaPlusBuilder.processMixedEvent<modes::Mode::kMe_Reco>(cols, tracks, trackPartition, sigmaPlusPartition, cache, mixBinsVtxMult, mixBinsVtxCent, mixBinsVtxMultCent);
   }
   PROCESS_SWITCH(FemtoPairTrackKink, processSigmaPlusMixedEvent, "Enable processing mixed event processing for tracks and sigma plus", false);
 

--- a/PWGCF/Femto/Tasks/femtoPairTrackTrack.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackTrack.cxx
@@ -18,6 +18,7 @@
 #include "PWGCF/Femto/Core/collisionHistManager.h"
 #include "PWGCF/Femto/Core/modes.h"
 #include "PWGCF/Femto/Core/pairBuilder.h"
+#include "PWGCF/Femto/Core/pairCleaner.h"
 #include "PWGCF/Femto/Core/pairHistManager.h"
 #include "PWGCF/Femto/Core/particleCleaner.h"
 #include "PWGCF/Femto/Core/partitions.h"
@@ -93,6 +94,7 @@ struct FemtoPairTrackTrack {
   // setup pairs
   pairhistmanager::ConfPairBinning confPairBinning;
   pairhistmanager::ConfPairCuts confPairCuts;
+  paircleaner::ConfPairCleanerBinning confPairCleaner;
 
   closepairrejection::ConfCprTrackTrack confCpr;
 
@@ -139,19 +141,20 @@ struct FemtoPairTrackTrack {
     std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> trackHistSpec2;
     std::map<pairhistmanager::PairHist, std::vector<o2::framework::AxisSpec>> pairHistSpec;
     std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpec = closepairrejection::makeCprHistSpecMap(confCpr);
+    std::map<paircleaner::PairCleanerHist, std::vector<o2::framework::AxisSpec>> pairCleanerHistSpec = paircleaner::makePairCleanerHistSpecMap(confPairCleaner);
 
     if (processData) {
       colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
       trackHistSpec1 = trackhistmanager::makeTrackHistSpecMap(confTrackBinning1);
       trackHistSpec2 = trackhistmanager::makeTrackHistSpecMap(confTrackBinning2);
       pairHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning, confMixing);
-      pairTrackTrackBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confTrackCleaner1, confTrackCleaner2, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec1, trackHistSpec2, pairHistSpec, cprHistSpec);
+      pairTrackTrackBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confTrackCleaner1, confTrackCleaner2, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec1, trackHistSpec2, pairHistSpec, cprHistSpec, pairCleanerHistSpec);
     } else {
       colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
       trackHistSpec1 = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning1);
       trackHistSpec2 = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning2);
       pairHistSpec = pairhistmanager::makePairMcHistSpecMap(confPairBinning, confMixing);
-      pairTrackTrackBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confTrackCleaner1, confTrackCleaner2, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec1, trackHistSpec2, pairHistSpec, cprHistSpec);
+      pairTrackTrackBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confTrackCleaner1, confTrackCleaner2, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec1, trackHistSpec2, pairHistSpec, cprHistSpec, pairCleanerHistSpec);
     }
     hRegistry.print();
   };

--- a/PWGCF/Femto/Tasks/femtoPairTrackTwoTrackResonance.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackTwoTrackResonance.cxx
@@ -18,6 +18,7 @@
 #include "PWGCF/Femto/Core/collisionHistManager.h"
 #include "PWGCF/Femto/Core/modes.h"
 #include "PWGCF/Femto/Core/pairBuilder.h"
+#include "PWGCF/Femto/Core/pairCleaner.h"
 #include "PWGCF/Femto/Core/pairHistManager.h"
 #include "PWGCF/Femto/Core/partitions.h"
 #include "PWGCF/Femto/Core/trackBuilder.h"
@@ -94,6 +95,7 @@ struct FemtoPairTrackTwoTrackResonance {
   // setup pairs
   pairhistmanager::ConfPairBinning confPairBinning;
   pairhistmanager::ConfPairCuts confPairCuts;
+  paircleaner::ConfPairCleanerBinning confPairCleaner;
 
   // setup for track-phi pairs
   pairbuilder::PairTrackTwoTrackResonanceBuilder<
@@ -167,27 +169,30 @@ struct FemtoPairTrackTwoTrackResonance {
     auto posDauSpec = trackhistmanager::makeTrackHistSpecMap(confPosDauBinning);
     auto negDauSpec = trackhistmanager::makeTrackHistSpecMap(confNegDauBinning);
     auto cprHistSpec = closepairrejection::makeCprHistSpecMap(confCpr);
+    auto pairCleanerHistSpec = paircleaner::makePairCleanerHistSpecMap(confPairCleaner);
 
     // setup for phi
     if (doprocessPhiSameEvent || doprocessPhiMixedEvent) {
       auto phiHistSpec = twotrackresonancehistmanager::makeTwoTrackResonanceHistSpecMap(confPhiBinning);
       auto pairTrackPhiHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning, confMixing);
-      pairTrackPhiBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, trackSelection, phiSelection, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, phiHistSpec, posDauSpec, negDauSpec, pairTrackPhiHistSpec, cprHistSpec);
+      pairTrackPhiBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, trackSelection, phiSelection, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, phiHistSpec, posDauSpec, negDauSpec, pairTrackPhiHistSpec, cprHistSpec, pairCleanerHistSpec);
     }
 
     // setup for kstar0
     if (doprocessKstar0SameEvent || doprocessKstar0MixedEvent) {
       auto kstar0HistSpec = twotrackresonancehistmanager::makeTwoTrackResonanceHistSpecMap(confKstar0Binning);
       auto pairTrackKstar0HistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning, confMixing);
-      pairTrackKstar0Builder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, trackSelection, kstar0Selection, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, kstar0HistSpec, posDauSpec, negDauSpec, pairTrackKstar0HistSpec, cprHistSpec);
+      pairTrackKstar0Builder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, trackSelection, kstar0Selection, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, kstar0HistSpec, posDauSpec, negDauSpec, pairTrackKstar0HistSpec, cprHistSpec, pairCleanerHistSpec);
     }
 
     // setup for kstar0
     if (doprocessRho0SameEvent || doprocessRho0MixedEvent) {
       auto rho0HistSpec = twotrackresonancehistmanager::makeTwoTrackResonanceHistSpecMap(confRho0Binning);
       auto pairTrackRho0HistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning, confMixing);
-      pairTrackRho0Builder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, trackSelection, rho0Selection, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, rho0HistSpec, posDauSpec, negDauSpec, pairTrackRho0HistSpec, cprHistSpec);
+      pairTrackRho0Builder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, trackSelection, rho0Selection, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, rho0HistSpec, posDauSpec, negDauSpec, pairTrackRho0HistSpec, cprHistSpec, pairCleanerHistSpec);
     }
+
+    hRegistry.print();
   };
 
   void processPhiSameEvent(FilteredCollision const& col, FemtoTracks const& tracks, FemtoPhis const& phis)

--- a/PWGCF/Femto/Tasks/femtoPairTrackV0.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairTrackV0.cxx
@@ -18,6 +18,7 @@
 #include "PWGCF/Femto/Core/collisionHistManager.h"
 #include "PWGCF/Femto/Core/modes.h"
 #include "PWGCF/Femto/Core/pairBuilder.h"
+#include "PWGCF/Femto/Core/pairCleaner.h"
 #include "PWGCF/Femto/Core/pairHistManager.h"
 #include "PWGCF/Femto/Core/particleCleaner.h"
 #include "PWGCF/Femto/Core/partitions.h"
@@ -112,6 +113,7 @@ struct FemtoPairTrackV0 {
   // setup pairs
   pairhistmanager::ConfPairBinning confPairBinning;
   pairhistmanager::ConfPairCuts confPairCuts;
+  paircleaner::ConfPairCleanerBinning confPairCleaner;
 
   pairbuilder::PairTrackV0Builder<
     trackhistmanager::PrefixTrack1,
@@ -181,6 +183,7 @@ struct FemtoPairTrackV0 {
     std::map<v0histmanager::V0Hist, std::vector<o2::framework::AxisSpec>> k0shortHistSpec;
     std::map<pairhistmanager::PairHist, std::vector<o2::framework::AxisSpec>> pairTrackV0HistSpec;
     std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpec = closepairrejection::makeCprHistSpecMap(confCpr);
+    std::map<paircleaner::PairCleanerHist, std::vector<o2::framework::AxisSpec>> pairCleanerHistSpec = paircleaner::makePairCleanerHistSpecMap(confPairCleaner);
 
     if (processData) {
       colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
@@ -190,10 +193,10 @@ struct FemtoPairTrackV0 {
       pairTrackV0HistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning, confMixing);
       if (processLambda) {
         lambdaHistSpec = v0histmanager::makeV0HistSpecMap(confLambdaBinning);
-        pairTrackLambdaBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, lambdaSelection, confLambdaCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, lambdaHistSpec, posDauSpec, negDauSpec, pairTrackV0HistSpec, cprHistSpec);
+        pairTrackLambdaBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, lambdaSelection, confLambdaCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, lambdaHistSpec, posDauSpec, negDauSpec, pairTrackV0HistSpec, cprHistSpec, pairCleanerHistSpec);
       } else {
         k0shortHistSpec = v0histmanager::makeV0HistSpecMap(confK0shortBinning);
-        pairTrackK0shortBuilder.init<modes::Mode::kReco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, lambdaSelection, confTrackCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, k0shortHistSpec, posDauSpec, negDauSpec, pairTrackV0HistSpec, cprHistSpec);
+        pairTrackK0shortBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, k0shortSelection, confK0shortCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, k0shortHistSpec, posDauSpec, negDauSpec, pairTrackV0HistSpec, cprHistSpec, pairCleanerHistSpec);
       }
     } else {
       colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
@@ -203,10 +206,10 @@ struct FemtoPairTrackV0 {
       pairTrackV0HistSpec = pairhistmanager::makePairMcHistSpecMap(confPairBinning, confMixing);
       if (processLambda) {
         lambdaHistSpec = v0histmanager::makeV0McHistSpecMap(confLambdaBinning);
-        pairTrackLambdaBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, lambdaSelection, confLambdaCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, lambdaHistSpec, posDauSpec, negDauSpec, pairTrackV0HistSpec, cprHistSpec);
+        pairTrackLambdaBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, lambdaSelection, confLambdaCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, lambdaHistSpec, posDauSpec, negDauSpec, pairTrackV0HistSpec, cprHistSpec, pairCleanerHistSpec);
       } else {
         k0shortHistSpec = v0histmanager::makeV0McHistSpecMap(confK0shortBinning);
-        pairTrackK0shortBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, lambdaSelection, confLambdaCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, k0shortHistSpec, posDauSpec, negDauSpec, pairTrackV0HistSpec, cprHistSpec);
+        pairTrackK0shortBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelection, confTrackCleaner, k0shortSelection, confK0shortCleaner, confCpr, confMixing, confPairBinning, confPairCuts, colHistSpec, trackHistSpec, k0shortHistSpec, posDauSpec, negDauSpec, pairTrackV0HistSpec, cprHistSpec, pairCleanerHistSpec);
       }
     }
     hRegistry.print();

--- a/PWGCF/Femto/Tasks/femtoPairV0TwoTrackResonance.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairV0TwoTrackResonance.cxx
@@ -18,6 +18,7 @@
 #include "PWGCF/Femto/Core/collisionHistManager.h"
 #include "PWGCF/Femto/Core/modes.h"
 #include "PWGCF/Femto/Core/pairBuilder.h"
+#include "PWGCF/Femto/Core/pairCleaner.h"
 #include "PWGCF/Femto/Core/pairHistManager.h"
 #include "PWGCF/Femto/Core/particleCleaner.h"
 #include "PWGCF/Femto/Core/partitions.h"
@@ -114,6 +115,7 @@ struct FemtoPairV0TwoTrackResonance {
   // setup pairs
   pairhistmanager::ConfPairBinning confPairBinning;
   pairhistmanager::ConfPairCuts confPairCuts;
+  paircleaner::ConfPairCleanerBinning confPairCleaner;
 
   // setup for lambda-phi pairs
   pairbuilder::PairV0TwoTrackResonanceBuilder<
@@ -273,47 +275,51 @@ struct FemtoPairV0TwoTrackResonance {
 
     auto pairV0TwoTrackResonanceHistSpec = pairhistmanager::makePairHistSpecMap(confPairBinning, confMixing);
 
+    auto pairCleanerHistSpec = paircleaner::makePairCleanerHistSpecMap(confPairCleaner);
+
     // setup for lambda-phi
     if (doprocessLambdaPhiSameEvent || doprocessLambdaPhiMixedEvent) {
       auto lambdaHistSpec = v0histmanager::makeV0HistSpecMap(confLambdaBinning);
       auto phiHistSpec = twotrackresonancehistmanager::makeTwoTrackResonanceHistSpecMap(confPhiBinning);
-      pairLambdaPhiBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, lambdaSelection, phiSelection, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec, v0PosDauSpec, v0NegDauSpec, phiHistSpec, resoPosDauSpec, resoNegDauSpec, pairV0TwoTrackResonanceHistSpec, cprHistSpecPos, cprHistSpecNeg);
+      pairLambdaPhiBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, lambdaSelection, phiSelection, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec, v0PosDauSpec, v0NegDauSpec, phiHistSpec, resoPosDauSpec, resoNegDauSpec, pairV0TwoTrackResonanceHistSpec, cprHistSpecPos, cprHistSpecNeg, pairCleanerHistSpec);
     }
 
     // setup for lambda-kstar0
     if (doprocessLambdaKstar0SameEvent || doprocessLambdaKstar0MixedEvent) {
       auto lambdaHistSpec = v0histmanager::makeV0HistSpecMap(confLambdaBinning);
       auto kstar0HistSpec = twotrackresonancehistmanager::makeTwoTrackResonanceHistSpecMap(confKstar0Binning);
-      pairLambdaKstar0Builder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, lambdaSelection, kstar0Selection, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec, v0PosDauSpec, v0NegDauSpec, kstar0HistSpec, resoPosDauSpec, resoNegDauSpec, pairV0TwoTrackResonanceHistSpec, cprHistSpecPos, cprHistSpecNeg);
+      pairLambdaKstar0Builder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, lambdaSelection, kstar0Selection, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec, v0PosDauSpec, v0NegDauSpec, kstar0HistSpec, resoPosDauSpec, resoNegDauSpec, pairV0TwoTrackResonanceHistSpec, cprHistSpecPos, cprHistSpecNeg, pairCleanerHistSpec);
     }
 
     // setup for lambda-rho0
     if (doprocessLambdaRho0SameEvent || doprocessLambdaRho0MixedEvent) {
       auto lambdaHistSpec = v0histmanager::makeV0HistSpecMap(confLambdaBinning);
       auto rho0HistSpec = twotrackresonancehistmanager::makeTwoTrackResonanceHistSpecMap(confRho0Binning);
-      pairLambdaRho0Builder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, lambdaSelection, rho0Selection, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec, v0PosDauSpec, v0NegDauSpec, rho0HistSpec, resoPosDauSpec, resoNegDauSpec, pairV0TwoTrackResonanceHistSpec, cprHistSpecPos, cprHistSpecNeg);
+      pairLambdaRho0Builder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, lambdaSelection, rho0Selection, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec, v0PosDauSpec, v0NegDauSpec, rho0HistSpec, resoPosDauSpec, resoNegDauSpec, pairV0TwoTrackResonanceHistSpec, cprHistSpecPos, cprHistSpecNeg, pairCleanerHistSpec);
     }
 
     // setup for k0short-phi
     if (doprocessK0shortPhiSameEvent || doprocessK0shortPhiMixedEvent) {
       auto k0shortHistSpec = v0histmanager::makeV0HistSpecMap(confK0shortBinning);
       auto phiHistSpec = twotrackresonancehistmanager::makeTwoTrackResonanceHistSpecMap(confPhiBinning);
-      pairK0shortPhiBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, k0shortSelection, phiSelection, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, k0shortHistSpec, v0PosDauSpec, v0NegDauSpec, phiHistSpec, resoPosDauSpec, resoNegDauSpec, pairV0TwoTrackResonanceHistSpec, cprHistSpecPos, cprHistSpecNeg);
+      pairK0shortPhiBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, k0shortSelection, phiSelection, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, k0shortHistSpec, v0PosDauSpec, v0NegDauSpec, phiHistSpec, resoPosDauSpec, resoNegDauSpec, pairV0TwoTrackResonanceHistSpec, cprHistSpecPos, cprHistSpecNeg, pairCleanerHistSpec);
     }
 
     // setup for k0short-kstar0
     if (doprocessK0shortKstar0SameEvent || doprocessK0shortKstar0MixedEvent) {
       auto k0shortHistSpec = v0histmanager::makeV0HistSpecMap(confK0shortBinning);
       auto kstar0HistSpec = twotrackresonancehistmanager::makeTwoTrackResonanceHistSpecMap(confKstar0Binning);
-      pairK0shortKstar0Builder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, k0shortSelection, kstar0Selection, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, k0shortHistSpec, v0PosDauSpec, v0NegDauSpec, kstar0HistSpec, resoPosDauSpec, resoNegDauSpec, pairV0TwoTrackResonanceHistSpec, cprHistSpecPos, cprHistSpecNeg);
+      pairK0shortKstar0Builder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, k0shortSelection, kstar0Selection, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, k0shortHistSpec, v0PosDauSpec, v0NegDauSpec, kstar0HistSpec, resoPosDauSpec, resoNegDauSpec, pairV0TwoTrackResonanceHistSpec, cprHistSpecPos, cprHistSpecNeg, pairCleanerHistSpec);
     }
 
     // setup for k0short-rho0
     if (doprocessK0shortRho0SameEvent || doprocessK0shortRho0MixedEvent) {
       auto k0shortHistSpec = v0histmanager::makeV0HistSpecMap(confK0shortBinning);
       auto rho0HistSpec = twotrackresonancehistmanager::makeTwoTrackResonanceHistSpecMap(confRho0Binning);
-      pairK0shortRho0Builder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, k0shortSelection, rho0Selection, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, k0shortHistSpec, v0PosDauSpec, v0NegDauSpec, rho0HistSpec, resoPosDauSpec, resoNegDauSpec, pairV0TwoTrackResonanceHistSpec, cprHistSpecPos, cprHistSpecNeg);
+      pairK0shortRho0Builder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, k0shortSelection, rho0Selection, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, k0shortHistSpec, v0PosDauSpec, v0NegDauSpec, rho0HistSpec, resoPosDauSpec, resoNegDauSpec, pairV0TwoTrackResonanceHistSpec, cprHistSpecPos, cprHistSpecNeg, pairCleanerHistSpec);
     }
+
+    hRegistry.print();
   }
 
   // lambda-phi

--- a/PWGCF/Femto/Tasks/femtoPairV0V0.cxx
+++ b/PWGCF/Femto/Tasks/femtoPairV0V0.cxx
@@ -18,6 +18,7 @@
 #include "PWGCF/Femto/Core/collisionHistManager.h"
 #include "PWGCF/Femto/Core/modes.h"
 #include "PWGCF/Femto/Core/pairBuilder.h"
+#include "PWGCF/Femto/Core/pairCleaner.h"
 #include "PWGCF/Femto/Core/pairHistManager.h"
 #include "PWGCF/Femto/Core/particleCleaner.h"
 #include "PWGCF/Femto/Core/partitions.h"
@@ -121,6 +122,7 @@ struct FemtoPairV0V0 {
   // setup pairs
   pairhistmanager::ConfPairBinning confPairBinning;
   pairhistmanager::ConfPairCuts confPairCuts;
+  paircleaner::ConfPairCleanerBinning confPairCleaner;
 
   pairbuilder::PairV0V0Builder<
     v0histmanager::PrefixLambda1,
@@ -234,6 +236,7 @@ struct FemtoPairV0V0 {
     std::map<pairhistmanager::PairHist, std::vector<o2::framework::AxisSpec>> pairV0V0HistSpec;
     std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpecPos = closepairrejection::makeCprHistSpecMap(confCprPos);
     std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpecNeg = closepairrejection::makeCprHistSpecMap(confCprNeg);
+    std::map<paircleaner::PairCleanerHist, std::vector<o2::framework::AxisSpec>> pairCleanerHistSpec = paircleaner::makePairCleanerHistSpecMap(confPairCleaner);
 
     if (processData) {
       colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
@@ -246,19 +249,19 @@ struct FemtoPairV0V0 {
       if (processLambdaLambda) {
         lambdaHistSpec1 = v0histmanager::makeV0HistSpecMap(confLambdaBinning1);
         lambdaHistSpec2 = v0histmanager::makeV0HistSpecMap(confLambdaBinning2);
-        pairLambdaLambdaBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confLambdaSelection1, confLambdaSelection2, confLambdaCleaner1, confLambdaCleaner2, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec1, lambdaHistSpec2, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg);
+        pairLambdaLambdaBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confLambdaSelection1, confLambdaSelection2, confLambdaCleaner1, confLambdaCleaner2, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec1, lambdaHistSpec2, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg, pairCleanerHistSpec);
       }
 
       if (processK0shortK0short) {
         k0shortHistSpec1 = v0histmanager::makeV0HistSpecMap(confK0shortBinning1);
         k0shortHistSpec2 = v0histmanager::makeV0HistSpecMap(confK0shortBinning2);
-        pairK0shortK0shortBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confK0shortSelection1, confK0shortSelection2, confK0shortCleaner1, confK0shortCleaner2, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, k0shortHistSpec1, k0shortHistSpec2, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg);
+        pairK0shortK0shortBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confK0shortSelection1, confK0shortSelection2, confK0shortCleaner1, confK0shortCleaner2, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, k0shortHistSpec1, k0shortHistSpec2, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg, pairCleanerHistSpec);
       }
 
       if (processLambdaK0short) {
         lambdaHistSpec1 = v0histmanager::makeV0HistSpecMap(confLambdaBinning1);
         k0shortHistSpec2 = v0histmanager::makeV0HistSpecMap(confK0shortBinning2);
-        pairLambdaK0shortBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confLambdaSelection1, confK0shortSelection2, confLambdaCleaner1, confK0shortCleaner2, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec1, k0shortHistSpec2, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg);
+        pairLambdaK0shortBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confLambdaSelection1, confK0shortSelection2, confLambdaCleaner1, confK0shortCleaner2, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec1, k0shortHistSpec2, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg, pairCleanerHistSpec);
       }
     } else {
       colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
@@ -271,21 +274,22 @@ struct FemtoPairV0V0 {
       if (processLambdaLambda) {
         lambdaHistSpec1 = v0histmanager::makeV0McHistSpecMap(confLambdaBinning1);
         lambdaHistSpec2 = v0histmanager::makeV0McHistSpecMap(confLambdaBinning2);
-        pairLambdaLambdaBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confLambdaSelection1, confLambdaSelection2, confLambdaCleaner1, confLambdaCleaner2, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec1, lambdaHistSpec2, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg);
+        pairLambdaLambdaBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confLambdaSelection1, confLambdaSelection2, confLambdaCleaner1, confLambdaCleaner2, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec1, lambdaHistSpec2, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg, pairCleanerHistSpec);
       }
 
       if (processK0shortK0short) {
         k0shortHistSpec1 = v0histmanager::makeV0McHistSpecMap(confK0shortBinning1);
         k0shortHistSpec2 = v0histmanager::makeV0McHistSpecMap(confK0shortBinning2);
-        pairK0shortK0shortBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confK0shortSelection1, confK0shortSelection2, confK0shortCleaner1, confK0shortCleaner2, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, k0shortHistSpec1, k0shortHistSpec2, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg);
+        pairK0shortK0shortBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confK0shortSelection1, confK0shortSelection2, confK0shortCleaner1, confK0shortCleaner2, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, k0shortHistSpec1, k0shortHistSpec2, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg, pairCleanerHistSpec);
       }
 
       if (processLambdaK0short) {
         lambdaHistSpec1 = v0histmanager::makeV0McHistSpecMap(confLambdaBinning1);
         k0shortHistSpec2 = v0histmanager::makeV0McHistSpecMap(confK0shortBinning2);
-        pairLambdaK0shortBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confLambdaSelection1, confK0shortSelection2, confLambdaCleaner1, confK0shortCleaner2, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec1, k0shortHistSpec2, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg);
+        pairLambdaK0shortBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confLambdaSelection1, confK0shortSelection2, confLambdaCleaner1, confK0shortCleaner2, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec1, k0shortHistSpec2, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg, pairCleanerHistSpec);
       }
     }
+    hRegistry.print();
   }
 
   void processLambdaLambdaSameEvent(FilteredFemtoCollision const& col, FemtoTracks const& tracks, FemtoLambdas const& lambdas)

--- a/PWGCF/Femto/Tasks/femtoTripletTrackTrackCascade.cxx
+++ b/PWGCF/Femto/Tasks/femtoTripletTrackTrackCascade.cxx
@@ -20,6 +20,7 @@
 #include "PWGCF/Femto/Core/collisionBuilder.h"
 #include "PWGCF/Femto/Core/collisionHistManager.h"
 #include "PWGCF/Femto/Core/modes.h"
+#include "PWGCF/Femto/Core/pairCleaner.h"
 #include "PWGCF/Femto/Core/particleCleaner.h"
 #include "PWGCF/Femto/Core/partitions.h"
 #include "PWGCF/Femto/Core/trackBuilder.h"
@@ -117,6 +118,7 @@ struct FemtoTripletTrackTrackCascade {
   // setup triplets
   triplethistmanager::ConfTripletBinning confTripletBinning;
   triplethistmanager::ConfTripletCuts confTripletCuts;
+  paircleaner::ConfPairCleanerBinning confTripletCleanerBinning;
 
   closetripletrejection::ConfCtrTrackTrackTrack confCtr;
 
@@ -217,6 +219,7 @@ struct FemtoTripletTrackTrackCascade {
     std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpecBachelor = closepairrejection::makeCprHistSpecMap(confCprBachelor);
     std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpecV0Daughter = closepairrejection::makeCprHistSpecMap(confCprV0Daughter);
     std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> ctrHistSpec = closepairrejection::makeCprHistSpecMap(confCtr);
+    std::map<paircleaner::PairCleanerHist, std::vector<o2::framework::AxisSpec>> tripletCleanerHistSpec = paircleaner::makePairCleanerHistSpecMap(confTripletCleanerBinning);
 
     if (processData) {
       colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
@@ -229,10 +232,10 @@ struct FemtoTripletTrackTrackCascade {
 
       if (processXi) {
         xiHistSpec = cascadehistmanager::makeCascadeHistSpecMap(confXiBinning);
-        tripletTrackTrackXiBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confTrackCleaner1, confTrackCleaner2, confCtr, confXiSelection, confXiCleaner, confCprBachelor, confCprV0Daughter, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, xiHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, tripletTrackTrackCascadeHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter, ctrHistSpec);
+        tripletTrackTrackXiBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confTrackCleaner1, confTrackCleaner2, confCtr, confXiSelection, confXiCleaner, confCprBachelor, confCprV0Daughter, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, xiHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, tripletTrackTrackCascadeHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter, ctrHistSpec, tripletCleanerHistSpec);
       } else {
         omegaHistSpec = cascadehistmanager::makeCascadeHistSpecMap(confOmegaBinning);
-        tripletTrackTrackOmegaBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confTrackCleaner1, confTrackCleaner2, confCtr, confOmegaSelection, confOmegaCleaner, confCprBachelor, confCprV0Daughter, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, omegaHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, tripletTrackTrackCascadeHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter, ctrHistSpec);
+        tripletTrackTrackOmegaBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confTrackCleaner1, confTrackCleaner2, confCtr, confOmegaSelection, confOmegaCleaner, confCprBachelor, confCprV0Daughter, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, omegaHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, tripletTrackTrackCascadeHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter, ctrHistSpec, tripletCleanerHistSpec);
       }
     } else {
       colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
@@ -244,10 +247,10 @@ struct FemtoTripletTrackTrackCascade {
       tripletTrackTrackCascadeHistSpec = triplethistmanager::makeTripletMcHistSpecMap(confTripletBinning, confMixing);
       if (processXi) {
         xiHistSpec = cascadehistmanager::makeCascadeMcHistSpecMap(confXiBinning);
-        tripletTrackTrackXiBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confTrackCleaner1, confTrackCleaner2, confCtr, confXiSelection, confXiCleaner, confCprBachelor, confCprV0Daughter, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, xiHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, tripletTrackTrackCascadeHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter, ctrHistSpec);
+        tripletTrackTrackXiBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confTrackCleaner1, confTrackCleaner2, confCtr, confXiSelection, confXiCleaner, confCprBachelor, confCprV0Daughter, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, xiHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, tripletTrackTrackCascadeHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter, ctrHistSpec, tripletCleanerHistSpec);
       } else {
         omegaHistSpec = cascadehistmanager::makeCascadeMcHistSpecMap(confOmegaBinning);
-        tripletTrackTrackOmegaBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confTrackCleaner1, confTrackCleaner2, confCtr, confOmegaSelection, confOmegaCleaner, confCprBachelor, confCprV0Daughter, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, omegaHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, tripletTrackTrackCascadeHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter, ctrHistSpec);
+        tripletTrackTrackOmegaBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confTrackCleaner1, confTrackCleaner2, confCtr, confOmegaSelection, confOmegaCleaner, confCprBachelor, confCprV0Daughter, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, omegaHistSpec, bachelorHistSpec, posDauSpec, negDauSpec, tripletTrackTrackCascadeHistSpec, cprHistSpecBachelor, cprHistSpecV0Daughter, ctrHistSpec, tripletCleanerHistSpec);
       }
     }
     hRegistry.print();

--- a/PWGCF/Femto/Tasks/femtoTripletTrackTrackTrack.cxx
+++ b/PWGCF/Femto/Tasks/femtoTripletTrackTrackTrack.cxx
@@ -18,6 +18,7 @@
 #include "PWGCF/Femto/Core/collisionBuilder.h"
 #include "PWGCF/Femto/Core/collisionHistManager.h"
 #include "PWGCF/Femto/Core/modes.h"
+#include "PWGCF/Femto/Core/pairCleaner.h"
 #include "PWGCF/Femto/Core/particleCleaner.h"
 #include "PWGCF/Femto/Core/partitions.h"
 #include "PWGCF/Femto/Core/trackBuilder.h"
@@ -93,6 +94,7 @@ struct FemtoTripletTrackTrackTrack {
   // setup triplets
   triplethistmanager::ConfTripletBinning confTripletBinning;
   triplethistmanager::ConfTripletCuts confTripletCuts;
+  paircleaner::ConfPairCleanerBinning confTripletCleanerBinning;
 
   closetripletrejection::ConfCtrTrackTrackTrack confCtr;
 
@@ -146,6 +148,7 @@ struct FemtoTripletTrackTrackTrack {
     std::map<trackhistmanager::TrackHist, std::vector<o2::framework::AxisSpec>> trackHistSpec3;
     std::map<triplethistmanager::TripletHist, std::vector<o2::framework::AxisSpec>> tripletHistSpec;
     std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> ctrHistSpec = closepairrejection::makeCprHistSpecMap(confCtr);
+    std::map<paircleaner::PairCleanerHist, std::vector<o2::framework::AxisSpec>> tripletCleanerHistSpec = paircleaner::makePairCleanerHistSpecMap(confTripletCleanerBinning);
 
     if (processData) {
       colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
@@ -153,14 +156,14 @@ struct FemtoTripletTrackTrackTrack {
       trackHistSpec2 = trackhistmanager::makeTrackHistSpecMap(confTrackBinning2);
       trackHistSpec3 = trackhistmanager::makeTrackHistSpecMap(confTrackBinning3);
       tripletHistSpec = triplethistmanager::makeTripletHistSpecMap(confTripletBinning, confMixing);
-      tripletTrackTrackTrackBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confTrackSelections3, confTrackCleaner1, confTrackCleaner2, confTrackCleaner3, confCtr, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, trackHistSpec3, tripletHistSpec, ctrHistSpec);
+      tripletTrackTrackTrackBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confTrackSelections3, confTrackCleaner1, confTrackCleaner2, confTrackCleaner3, confCtr, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, trackHistSpec3, tripletHistSpec, ctrHistSpec, tripletCleanerHistSpec);
     } else {
       colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
       trackHistSpec1 = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning1);
       trackHistSpec2 = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning2);
       trackHistSpec3 = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning3);
       tripletHistSpec = triplethistmanager::makeTripletMcHistSpecMap(confTripletBinning, confMixing);
-      tripletTrackTrackTrackBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confTrackSelections3, confTrackCleaner1, confTrackCleaner2, confTrackCleaner3, confCtr, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, trackHistSpec3, tripletHistSpec, ctrHistSpec);
+      tripletTrackTrackTrackBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confTrackSelections3, confTrackCleaner1, confTrackCleaner2, confTrackCleaner3, confCtr, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, trackHistSpec3, tripletHistSpec, ctrHistSpec, tripletCleanerHistSpec);
     }
     hRegistry.print();
   };

--- a/PWGCF/Femto/Tasks/femtoTripletTrackTrackV0.cxx
+++ b/PWGCF/Femto/Tasks/femtoTripletTrackTrackV0.cxx
@@ -18,6 +18,7 @@
 #include "PWGCF/Femto/Core/collisionBuilder.h"
 #include "PWGCF/Femto/Core/collisionHistManager.h"
 #include "PWGCF/Femto/Core/modes.h"
+#include "PWGCF/Femto/Core/pairCleaner.h"
 #include "PWGCF/Femto/Core/particleCleaner.h"
 #include "PWGCF/Femto/Core/partitions.h"
 #include "PWGCF/Femto/Core/trackBuilder.h"
@@ -110,8 +111,9 @@ struct FemtoTripletTrackTrackV0 {
   // setup triplets
   triplethistmanager::ConfTripletBinning confTripletBinning;
   triplethistmanager::ConfTripletCuts confTripletCuts;
+  paircleaner::ConfPairCleanerBinning confTripletCleanerBinning;
 
-  closetripletrejection::ConfCtrTrackTrackTrack confCtr;
+  closetripletrejection::ConfCtrTrackTrackV0 confCtr;
 
   tripletbuilder::TripletTrackTrackV0Builder<
     modes::V0::kLambda,
@@ -119,7 +121,7 @@ struct FemtoTripletTrackTrackV0 {
     trackhistmanager::PrefixTrack2,
     v0histmanager::PrefixLambda1,
     trackhistmanager::PrefixV01PosDaughter,
-    trackhistmanager::PrefixV02NegDaughter,
+    trackhistmanager::PrefixV01NegDaughter,
     triplethistmanager::PrefixTrackTrackLambdaSe,
     triplethistmanager::PrefixTrackTrackLambdaMe,
     closetripletrejection::PrefixTrack1Track2Se,
@@ -168,6 +170,7 @@ struct FemtoTripletTrackTrackV0 {
     std::map<v0histmanager::V0Hist, std::vector<o2::framework::AxisSpec>> lambdaHistSpec;
     std::map<triplethistmanager::TripletHist, std::vector<o2::framework::AxisSpec>> tripletHistSpec;
     std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> ctrHistSpec = closepairrejection::makeCprHistSpecMap(confCtr);
+    std::map<paircleaner::PairCleanerHist, std::vector<o2::framework::AxisSpec>> tripletCleanerHistSpec = paircleaner::makePairCleanerHistSpecMap(confTripletCleanerBinning);
 
     if (processData) {
       colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
@@ -177,7 +180,7 @@ struct FemtoTripletTrackTrackV0 {
       posDauSpec = trackhistmanager::makeTrackHistSpecMap(confPosDauBinning);
       negDauSpec = trackhistmanager::makeTrackHistSpecMap(confNegDauBinning);
       tripletHistSpec = triplethistmanager::makeTripletHistSpecMap(confTripletBinning, confMixing);
-      tripletTrackTrackLambdaBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confLambdaSelection, confTrackCleaner1, confTrackCleaner2, confLambdaCleaner, confCtr, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, lambdaHistSpec, posDauSpec, negDauSpec, tripletHistSpec, ctrHistSpec);
+      tripletTrackTrackLambdaBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confLambdaSelection, confTrackCleaner1, confTrackCleaner2, confLambdaCleaner, confCtr, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, lambdaHistSpec, posDauSpec, negDauSpec, tripletHistSpec, ctrHistSpec, tripletCleanerHistSpec);
     } else {
       colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
       trackHistSpec1 = trackhistmanager::makeTrackMcHistSpecMap(confTrackBinning1);
@@ -186,7 +189,7 @@ struct FemtoTripletTrackTrackV0 {
       posDauSpec = trackhistmanager::makeTrackMcHistSpecMap(confPosDauBinning);
       negDauSpec = trackhistmanager::makeTrackMcHistSpecMap(confNegDauBinning);
       tripletHistSpec = triplethistmanager::makeTripletMcHistSpecMap(confTripletBinning, confMixing);
-      tripletTrackTrackLambdaBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confLambdaSelection, confTrackCleaner1, confTrackCleaner2, confLambdaCleaner, confCtr, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, lambdaHistSpec, posDauSpec, negDauSpec, tripletHistSpec, ctrHistSpec);
+      tripletTrackTrackLambdaBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confTrackSelections1, confTrackSelections2, confLambdaSelection, confTrackCleaner1, confTrackCleaner2, confLambdaCleaner, confCtr, confMixing, confTripletBinning, confTripletCuts, colHistSpec, trackHistSpec1, trackHistSpec2, lambdaHistSpec, posDauSpec, negDauSpec, tripletHistSpec, ctrHistSpec, tripletCleanerHistSpec);
     }
     hRegistry.print();
   };

--- a/PWGCF/FemtoWorld/Tasks/femtoPairLambdaAntilambda.cxx
+++ b/PWGCF/FemtoWorld/Tasks/femtoPairLambdaAntilambda.cxx
@@ -19,6 +19,7 @@
 #include "PWGCF/Femto/Core/collisionHistManager.h"
 #include "PWGCF/Femto/Core/modes.h"
 #include "PWGCF/Femto/Core/pairBuilder.h"
+#include "PWGCF/Femto/Core/pairCleaner.h"
 #include "PWGCF/Femto/Core/pairHistManager.h"
 #include "PWGCF/Femto/Core/particleCleaner.h"
 #include "PWGCF/Femto/Core/partitions.h"
@@ -108,6 +109,7 @@ struct FemtoPairLambdaAntilambda {
   // setup pairs
   pairhistmanager::ConfPairBinning confPairBinning;
   pairhistmanager::ConfPairCuts confPairCuts;
+  paircleaner::ConfPairCleanerBinning confPairCleaner;
 
   pairbuilder::PairV0V0Builder<
     v0histmanager::PrefixLambda1,
@@ -186,6 +188,7 @@ struct FemtoPairLambdaAntilambda {
     std::map<pairhistmanager::PairHist, std::vector<o2::framework::AxisSpec>> pairV0V0HistSpec;
     std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpecPos = closepairrejection::makeCprHistSpecMap(confCprPos);
     std::map<closepairrejection::CprHist, std::vector<o2::framework::AxisSpec>> cprHistSpecNeg = closepairrejection::makeCprHistSpecMap(confCprNeg);
+    std::map<paircleaner::PairCleanerHist, std::vector<o2::framework::AxisSpec>> pairCleanerHistSpec = paircleaner::makePairCleanerHistSpecMap(confPairCleaner);
 
     if (processData) {
       colHistSpec = colhistmanager::makeColHistSpecMap(confCollisionBinning);
@@ -197,12 +200,12 @@ struct FemtoPairLambdaAntilambda {
 
       if (processLambdaLambda) {
         lambdaHistSpec = v0histmanager::makeV0HistSpecMap(confLambdaBinning);
-        pairLambdaLambdaBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confLambdaSelection, confLambdaSelection2, confLambdaCleaner, confLambdaCleaner, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec, lambdaHistSpec, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg);
+        pairLambdaLambdaBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confLambdaSelection, confLambdaSelection2, confLambdaCleaner, confLambdaCleaner, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec, lambdaHistSpec, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg, pairCleanerHistSpec);
       }
 
       if (processK0shortK0short) {
         k0shortHistSpec = v0histmanager::makeV0HistSpecMap(confK0shortBinning);
-        pairK0shortK0shortBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confK0shortSelection, confK0shortSelection, confK0shortCleaner, confK0shortCleaner, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, k0shortHistSpec, k0shortHistSpec, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg);
+        pairK0shortK0shortBuilder.init<modes::Mode::kSe_Reco, modes::Mode::kMe_Reco>(&hRegistry, confCollisionBinning, confK0shortSelection, confK0shortSelection, confK0shortCleaner, confK0shortCleaner, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, k0shortHistSpec, k0shortHistSpec, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg, pairCleanerHistSpec);
       }
     } else {
       colHistSpec = colhistmanager::makeColMcHistSpecMap(confCollisionBinning);
@@ -214,12 +217,12 @@ struct FemtoPairLambdaAntilambda {
 
       if (processLambdaLambda) {
         lambdaHistSpec = v0histmanager::makeV0McHistSpecMap(confLambdaBinning);
-        pairLambdaLambdaBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confLambdaSelection, confLambdaSelection2, confLambdaCleaner, confLambdaCleaner, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec, lambdaHistSpec, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg);
+        pairLambdaLambdaBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confLambdaSelection, confLambdaSelection2, confLambdaCleaner, confLambdaCleaner, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, lambdaHistSpec, lambdaHistSpec, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg, pairCleanerHistSpec);
       }
 
       if (processK0shortK0short) {
         k0shortHistSpec = v0histmanager::makeV0McHistSpecMap(confK0shortBinning);
-        pairK0shortK0shortBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confK0shortSelection, confK0shortSelection, confK0shortCleaner, confK0shortCleaner, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, k0shortHistSpec, k0shortHistSpec, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg);
+        pairK0shortK0shortBuilder.init<modes::Mode::kSe_Reco_Mc, modes::Mode::kMe_Reco_Mc>(&hRegistry, confCollisionBinning, confK0shortSelection, confK0shortSelection, confK0shortCleaner, confK0shortCleaner, confCprPos, confCprNeg, confMixing, confPairBinning, confPairCuts, colHistSpec, k0shortHistSpec, k0shortHistSpec, posDauSpec1, negDauSpec1, posDauSpec2, negDauSpec2, pairV0V0HistSpec, cprHistSpecPos, cprHistSpecNeg, pairCleanerHistSpec);
       }
     }
   }


### PR DESCRIPTION
In this PR:
- Add diagnostic histograms to the pair cleaner to inspect the kinematic distribution of blocked pairs.
- Add a rectangular cut to the close-pair rejection and enable plotting of the kinematic distribution of blocked pairs.
- Apply the same changes to the corresponding 3-body pair cleaners.
