### PR TITLE
[PWGUD] Remove ZDC fields from MC output

### DIFF
--- a/PWGUD/DataModel/TauThreeProngEventTables.h
+++ b/PWGUD/DataModel/TauThreeProngEventTables.h
@@ -180,8 +180,9 @@ DECLARE_SOA_TABLE(TrueTauFourTracks, "AOD", "TRUETAU",
                   // tautree::Trs, tautree::Trofs, tautree::Hmpr,
                   // tautree::Tfb, tautree::ItsRofb, tautree::Sbp, tautree::ZvtxFT0vsPv, tautree::VtxITSTPC,
                   //
-                  tautree::ZdcAenergy, tautree::ZdcCenergy,
-                  tautree::ZdcAtime, tautree::ZdcCtime,
+                  // zdc information do not exist in MC
+                  // tautree::ZdcAenergy, tautree::ZdcCenergy,
+                  // tautree::ZdcAtime, tautree::ZdcCtime,
                   // tautree::Qtot,
                   tautree::TotalFT0AmplitudeA, tautree::TotalFT0AmplitudeC, tautree::TotalFV0AmplitudeA,
                   // tautree::TimeFT0A, tautree::TimeFT0C, tautree::TimeFV0A,
@@ -248,8 +249,9 @@ DECLARE_SOA_TABLE(TrueTauSixTracks, "AOD", "TRUETAUSIX",
                   // tautree::Trs, tautree::Trofs, tautree::Hmpr,
                   // tautree::Tfb, tautree::ItsRofb, tautree::Sbp, tautree::ZvtxFT0vsPv, tautree::VtxITSTPC,
                   //
-                  tautree::ZdcAenergy, tautree::ZdcCenergy,
-                  tautree::ZdcAtime, tautree::ZdcCtime,
+                  // ZDC information do not exist in MC
+                  // tautree::ZdcAenergy, tautree::ZdcCenergy,
+                  // tautree::ZdcAtime, tautree::ZdcCtime,
                   // tautree::Qtot,
                   tautree::TotalFT0AmplitudeA, tautree::TotalFT0AmplitudeC, tautree::TotalFV0AmplitudeA,
                   // tautree::TimeFT0A, tautree::TimeFT0C, tautree::TimeFV0A,

--- a/PWGUD/TableProducer/tauThreeProngEventTableProducer.cxx
+++ b/PWGUD/TableProducer/tauThreeProngEventTableProducer.cxx
@@ -1304,10 +1304,10 @@ struct TauThreeProngEventTableProducer {
       int8_t bcSels[8] = {-99, -99, -99, -99, -99, -99, -99, -99};
       uint8_t bcSelBits = 0;
       // zdc information - there is no information in MC
-      float energyZNA = -999.;
-      float energyZNC = -999.;
-      float timeZNA = -999.;
-      float timeZNC = -999.;
+      // float energyZNA = -999.;
+      // float energyZNC = -999.;
+      // float timeZNA = -999.;
+      // float timeZNC = -999.;
 
       float amplitudesFIT[3] = {-999., -999., -999.}; // FT0A, FT0C, FV0
       // float timesFIT[3] = {-999., -999., -999.};      // FT0A, FT0C, FV0
@@ -1624,8 +1624,8 @@ struct TauThreeProngEventTableProducer {
                             bcSelBits,
                             // bcSels[0], bcSels[1], bcSels[2], // to test it
                             // bcSels[3], bcSels[4], bcSels[5], bcSels[6], bcSels[7],
-                            energyZNA, energyZNC,
-                            timeZNA, timeZNC,
+                            // energyZNA, energyZNC,
+                            // timeZNA, timeZNC,
                             // qtot, <<-------- comment out
                             amplitudesFIT[0], amplitudesFIT[1], amplitudesFIT[2],
                             // timesFIT[0], timesFIT[1], timesFIT[2],
@@ -1656,8 +1656,8 @@ struct TauThreeProngEventTableProducer {
                            bcSelBits,
                            // bcSels[0], bcSels[1], bcSels[2], // to test it
                            // bcSels[3], bcSels[4], bcSels[5], bcSels[6], bcSels[7],
-                           energyZNA, energyZNC,
-                           timeZNA, timeZNC,
+                           // energyZNA, energyZNC,
+                           // timeZNA, timeZNC,
                            // qtot, <<-------- comment out
                            amplitudesFIT[0], amplitudesFIT[1], amplitudesFIT[2],
                            // timesFIT[0], timesFIT[1], timesFIT[2],
@@ -1890,22 +1890,6 @@ struct TauThreeProngEventTableProducer {
         registrySkim.get<TH1>(HIST("gen/efficiencyMC"))->Fill(8., 1.);
       }
 
-      bool trueHasRecoColl = false;
-      // find reconstructed collisions associated to the generated collision
-      auto const& collFromMcColls = collisions.sliceBy(colPerMcCollision, mccoll.globalIndex());
-      if (verbose)
-        LOGF(info, "-- coll from MC Coll %d", collFromMcColls.size());
-      // check the generated collision was reconstructed
-      if (collFromMcColls.size() > 0) { // get the truth and reco-level info
-        trueHasRecoColl = true;
-        registrySkim.get<TH1>(HIST("gen/efficiencyMC"))->Fill(9., 1.);
-        if (verbose)
-          LOGF(info, "--- MC Collision has reconstructed collision!");
-      } else { // get only the truth information.
-        if (verbose)
-          LOGF(info, "MC Collision has NO reconstructed collision!");
-      }
-
       // get particles associated to generated collision
       auto const& partsFromMcColl = mcParticles.sliceBy(partPerMcCollision, mccoll.globalIndex());
       if (verbose)
@@ -1958,6 +1942,25 @@ struct TauThreeProngEventTableProducer {
 
       // decide the channel and set the variable.
       trueChannel = trueChannel + countPi0 * 10 + zerothTau * 100;
+
+      //
+      // check whwther event is reconstructed
+      //
+      bool trueHasRecoColl = false;
+      // find reconstructed collisions associated to the generated collision
+      auto const& collFromMcColls = collisions.sliceBy(colPerMcCollision, mccoll.globalIndex());
+      if (verbose)
+        LOGF(info, "-- coll from MC Coll %d", collFromMcColls.size());
+      // check the generated collision was reconstructed
+      if (collFromMcColls.size() > 0) { // get the truth and reco-level info
+        trueHasRecoColl = true;
+        registrySkim.get<TH1>(HIST("gen/efficiencyMC"))->Fill(9., 1.);
+        if (verbose)
+          LOGF(info, "--- MC Collision has reconstructed collision!");
+      } else { // get only the truth information.
+        if (verbose)
+          LOGF(info, "MC Collision has NO reconstructed collision!");
+      }
 
       // LOGF(info, "Should be written!");
 

--- a/PWGUD/TableProducer/tauThreeProngEventTableProducer.cxx
+++ b/PWGUD/TableProducer/tauThreeProngEventTableProducer.cxx
@@ -834,6 +834,7 @@ struct TauThreeProngEventTableProducer {
     // different events flags
     int8_t bcSels[8] = {-99, -99, -99, -99, -99, -99, -99, -99};
     uint8_t bcSelBits = 0;
+    const int nBitsMax = 8;
     bcSels[0] = dgcand.trs();
     bcSels[1] = dgcand.trofs();
     bcSels[2] = dgcand.hmpr();
@@ -845,7 +846,7 @@ struct TauThreeProngEventTableProducer {
 
     const int offset = 1;
     bcSelBits = bcSels[0]; // initialization
-    for (int ibit = 1; ibit < 8; ibit++) {
+    for (int ibit = 1; ibit < nBitsMax; ibit++) {
       bcSelBits = (bcSelBits << offset); // shift by 1 position towards left
       bcSelBits += bcSels[ibit];         // add next bit to the pool
     }
@@ -1257,7 +1258,7 @@ struct TauThreeProngEventTableProducer {
         continue;
       }
 
-      registrySkim.get<TH1>(HIST("skim/efficiencyMC"))->Fill(3., 1.); // particles from tau in |eta|<0.9
+      registrySkim.get<TH1>(HIST("skim/efficiencyMC"))->Fill(3., 1.); // charged particles from tau in |eta|<0.9
 
       registrySkim.get<TH1>(HIST("skim/nChPartMC"))->Fill(nChargedDaughtersTau[0] + nChargedDaughtersTau[1]); // N charged particles from taus
       // check number of charged particles in MC event
@@ -1267,18 +1268,12 @@ struct TauThreeProngEventTableProducer {
         continue;
       }
 
-      registrySkim.get<TH1>(HIST("skim/efficiencyMC"))->Fill(4., 1.);        // 1+3 (3+3) topology
-      if (nChargedDaughtersTau[0] + nChargedDaughtersTau[1] == fourTracks) { // 4
-        registrySkim.get<TH1>(HIST("skim/efficiencyMC"))->Fill(5., 1.);
-      } else if (nChargedDaughtersTau[0] + nChargedDaughtersTau[1] == sixTracks) { // 6
-        registrySkim.get<TH1>(HIST("skim/efficiencyMC"))->Fill(6., 1.);
-      }
-
-      //      if (nChargedDaughtersTau[0] + nChargedDaughtersTau[1] == fourTracks) { // 4
-      //        registrySkim.get<TH1>(HIST("skim/efficiencyMC"))->Fill(7., 1.);
-      //      } else if (nChargedDaughtersTau[0] + nChargedDaughtersTau[1] == sixTracks) { // 6
-      //        registrySkim.get<TH1>(HIST("skim/efficiencyMC"))->Fill(8., 1.);
-      //      }
+      registrySkim.get<TH1>(HIST("skim/efficiencyMC"))->Fill(4., 1.); // 1+3 (3+3) topology = 4 or 6 tracks
+      // if (nChargedDaughtersTau[0] + nChargedDaughtersTau[1] == fourTracks) { // 4
+      //   registrySkim.get<TH1>(HIST("skim/efficiencyMC"))->Fill(5., 1.);
+      // } else if (nChargedDaughtersTau[0] + nChargedDaughtersTau[1] == sixTracks) { // 6
+      //   registrySkim.get<TH1>(HIST("skim/efficiencyMC"))->Fill(6., 1.);
+      // }
 
       if ((nChargedDaughtersTau[0] == oneProng) ||                                          // 1
           (nChargedDaughtersTau[0] == threeProng && nChargedDaughtersTau[1] == threeProng)) // 3 and 3
@@ -1303,6 +1298,7 @@ struct TauThreeProngEventTableProducer {
       double hadronicRate = -999.;
       int8_t bcSels[8] = {-99, -99, -99, -99, -99, -99, -99, -99};
       uint8_t bcSelBits = 0;
+      const int nBitsMax = 8;
       // zdc information - there is no information in MC
       // float energyZNA = -999.;
       // float energyZNC = -999.;
@@ -1350,7 +1346,7 @@ struct TauThreeProngEventTableProducer {
       float trueDaugY[6] = {-998., -998., -998., -998., -998., -998.};
       float trueDaugZ[6] = {-998., -998., -998., -998., -998., -998.};
       int trueDaugPdgCode[6] = {-999, -999, -999, -999, -999, -999};
-      //      bool problem = false;
+
       MyRecoProblem problem = NO_PROBLEM;
       registrySkim.get<TH1>(HIST("skim/problemMC"))->Fill(NO_PROBLEM);
 
@@ -1360,14 +1356,19 @@ struct TauThreeProngEventTableProducer {
       // 3 = pi+3pi
       // 4 = 3pi+3pi
 
-      if (nElec == oneProng && nPi == threeProng) // 1 + 3
+      if (nElec == oneProng && nPi == threeProng) { // 1 + 3
         trueChannel = 1;
-      else if (nMuon == oneProng && nPi == threeProng) // 1 + 3
+        registrySkim.get<TH1>(HIST("skim/efficiencyMC"))->Fill(5., 1.);
+      } else if (nMuon == oneProng && nPi == threeProng) { // 1 + 3
         trueChannel = 2;
-      else if (nPi == fourTracks) // 4
+        registrySkim.get<TH1>(HIST("skim/efficiencyMC"))->Fill(6., 1.);
+      } else if (nPi == fourTracks) { // 4
         trueChannel = 3;
-      else if (nPi == sixTracks) // 6
+        registrySkim.get<TH1>(HIST("skim/efficiencyMC"))->Fill(7., 1.);
+      } else if (nPi == sixTracks) { // 6
         trueChannel = 4;
+        registrySkim.get<TH1>(HIST("skim/efficiencyMC"))->Fill(8., 1.);
+      }
 
       // LOGF(info, "MC Coll global index %d", mccoll.globalIndex());
       // LOGF(info, "2. <MC> UDMcCollision size %d, Collisions size %d, UDtracks %d, UDMcParticles %d", mcCollisions.size(), collisions.size(), tracks.size(), mcParticles.size());
@@ -1383,6 +1384,7 @@ struct TauThreeProngEventTableProducer {
       if (collFromMcColls.size() > 0) { // get the truth and reco-level info
         if (verbose)
           LOGF(info, "--- MC Collision has reconstructed collision!");
+        registrySkim.get<TH1>(HIST("skim/efficiencyMC"))->Fill(9., 1.);
         // trueHasRecoColl = true;
         // check there is exactly one reco-level collision associated to generated collision
         if (collFromMcColls.size() > 1) {
@@ -1446,7 +1448,7 @@ struct TauThreeProngEventTableProducer {
 
           const int offset = 1;
           bcSelBits = bcSels[0]; // initialization
-          for (int ibit = 1; ibit < 8; ibit++) {
+          for (int ibit = 1; ibit < nBitsMax; ibit++) {
             bcSelBits = (bcSelBits << offset); // shift by 1 position towards left
             bcSelBits += bcSels[ibit];         // add next bit to the pool
           }
@@ -1839,7 +1841,7 @@ struct TauThreeProngEventTableProducer {
         continue;
       }
 
-      registrySkim.get<TH1>(HIST("gen/efficiencyMC"))->Fill(3., 1.); // particles from tau in |eta|<=0.9
+      registrySkim.get<TH1>(HIST("gen/efficiencyMC"))->Fill(3., 1.); // charged particles from tau in |eta|<=0.9
 
       registrySkim.get<TH1>(HIST("gen/nChPartMC"))->Fill(nChargedDaughtersTau[0] + nChargedDaughtersTau[1]); // N charged particles from taus
       // check number of charged particles in MC event
@@ -1850,11 +1852,6 @@ struct TauThreeProngEventTableProducer {
       }
 
       registrySkim.get<TH1>(HIST("gen/efficiencyMC"))->Fill(4., 1.); // 1+3 (3+3) topology = 4 or 6 tracks
-                                                                     //      if (nChargedDaughtersTau[0] + nChargedDaughtersTau[1] == fourTracks) { // 4
-                                                                     //        registrySkim.get<TH1>(HIST("gen/efficiencyMC"))->Fill(5., 1.);
-                                                                     //      } else if (nChargedDaughtersTau[0] + nChargedDaughtersTau[1] == sixTracks) { // 6
-                                                                     //        registrySkim.get<TH1>(HIST("gen/efficiencyMC"))->Fill(6., 1.);
-                                                                     //      }
 
       if ((nChargedDaughtersTau[0] == oneProng) ||                                          // 1
           (nChargedDaughtersTau[0] == threeProng && nChargedDaughtersTau[1] == threeProng)) // 3 and 3


### PR DESCRIPTION
Remove ZDC energy and time fields from MC output. These ZDC information does not exist in MC
Shifted information about reconstruction in a code