### PR TITLE
[ALICE3] Use `const&` and `std::move` to avoid copies

### DIFF
--- a/ALICE3/Core/DelphesO2LutWriter.cxx
+++ b/ALICE3/Core/DelphesO2LutWriter.cxx
@@ -376,7 +376,7 @@ void DelphesO2LutWriter::diagonalise(lutEntry_t& lutEntry)
   // m.Print();
   TMatrixDSymEigen eigen(m);
   // eigenvalues vector
-  TVectorD eigenVal = eigen.GetEigenValues();
+  const TVectorD& eigenVal = eigen.GetEigenValues();
   for (int i = 0; i < kEig; ++i)
     lutEntry.eigval[i] = eigenVal[i];
   // eigenvectors matrix

--- a/ALICE3/Core/FastTracker.cxx
+++ b/ALICE3/Core/FastTracker.cxx
@@ -51,7 +51,7 @@ namespace fastsim
 
 // +-~-<*>-~-+-~-<*>-~-+-~-<*>-~-+-~-<*>-~-+-~-<*>-~-+-~-<*>-~-+-~-<*>-~-+-~-<*>-~-+
 
-DetLayer* FastTracker::AddLayer(TString name, float r, float z, float x0, float xrho, float resRPhi, float resZ, float eff, int type)
+DetLayer* FastTracker::AddLayer(const TString& name, float r, float z, float x0, float xrho, float resRPhi, float resZ, float eff, int type)
 {
   LOG(debug) << "Adding layer " << name << " r=" << r << " z=" << z << " x0=" << x0 << " xrho=" << xrho << " resRPhi=" << resRPhi << " resZ=" << resZ << " eff=" << eff << " type=" << type;
   DetLayer newLayer(name, r, z, x0, xrho, resRPhi, resZ, eff, type);
@@ -154,7 +154,7 @@ void FastTracker::AddTPC(float phiResMean, float zResMean)
   }
 }
 
-void FastTracker::AddGenericDetector(o2::fastsim::GeometryEntry configMap, o2::ccdb::BasicCCDBManager* ccdbManager)
+void FastTracker::AddGenericDetector(const o2::fastsim::GeometryEntry& configMap, o2::ccdb::BasicCCDBManager* ccdbManager)
 {
   // Layers
   for (const auto& layer : configMap.getLayerNames()) {
@@ -586,7 +586,7 @@ int FastTracker::FastTrack(o2::track::TrackParCov inputTrack, o2::track::TrackPa
   m.SetMatrixArray(reinterpret_cast<double*>(fcovm));
   TMatrixDSymEigen eigen(m);
   TMatrixD eigVec = eigen.GetEigenVectors();
-  TVectorD eigVal = eigen.GetEigenValues();
+  const TVectorD& eigVal = eigen.GetEigenValues();
   bool negEigVal = false;
   for (int ii = 0; ii < 5; ii++) {
     if (eigVal[ii] < 0.0f)

--- a/ALICE3/Core/FastTracker.h
+++ b/ALICE3/Core/FastTracker.h
@@ -46,7 +46,7 @@ class FastTracker
   virtual ~FastTracker() {}
 
   // Layer and layer configuration
-  DetLayer* AddLayer(TString name, float r, float z, float x0, float xrho, float resRPhi = 0.0f, float resZ = 0.0f, float eff = 0.0f, int type = 0);
+  DetLayer* AddLayer(const TString& name, float r, float z, float x0, float xrho, float resRPhi = 0.0f, float resZ = 0.0f, float eff = 0.0f, int type = 0);
 
   /// Add a dead region in phi for a specific layer
   /// \param layerName Name of the layer to modify
@@ -59,11 +59,11 @@ class FastTracker
   size_t GetNLayers() const { return layers.size(); }
   bool IsLayerInert(const int layer) const { return layers[layer].isInert(); }
   void ClearLayers() { layers.clear(); }
-  void SetRadiationLength(const std::string layerName, float x0) { layers[GetLayerIndex(layerName)].setRadiationLength(x0); }
-  void SetRadius(const std::string layerName, float r) { layers[GetLayerIndex(layerName)].setRadius(r); }
-  void SetResolutionRPhi(const std::string layerName, float resRPhi) { layers[GetLayerIndex(layerName)].setResolutionRPhi(resRPhi); }
-  void SetResolutionZ(const std::string layerName, float resZ) { layers[GetLayerIndex(layerName)].setResolutionZ(resZ); }
-  void SetResolution(const std::string layerName, float resRPhi, float resZ)
+  void SetRadiationLength(const std::string& layerName, float x0) { layers[GetLayerIndex(layerName)].setRadiationLength(x0); }
+  void SetRadius(const std::string& layerName, float r) { layers[GetLayerIndex(layerName)].setRadius(r); }
+  void SetResolutionRPhi(const std::string& layerName, float resRPhi) { layers[GetLayerIndex(layerName)].setResolutionRPhi(resRPhi); }
+  void SetResolutionZ(const std::string& layerName, float resZ) { layers[GetLayerIndex(layerName)].setResolutionZ(resZ); }
+  void SetResolution(const std::string& layerName, float resRPhi, float resZ)
   {
     SetResolutionRPhi(layerName, resRPhi);
     SetResolutionZ(layerName, resZ);
@@ -80,7 +80,7 @@ class FastTracker
    *
    * @param configMap Configuration map describing the detector.
    */
-  void AddGenericDetector(o2::fastsim::GeometryEntry configMap, o2::ccdb::BasicCCDBManager* ccdbManager = nullptr);
+  void AddGenericDetector(const o2::fastsim::GeometryEntry& configMap, o2::ccdb::BasicCCDBManager* ccdbManager = nullptr);
 
   void Print();
 

--- a/ALICE3/Core/FlatLutWriter.cxx
+++ b/ALICE3/Core/FlatLutWriter.cxx
@@ -392,7 +392,7 @@ void FlatLutWriter::diagonalise(lutEntry_t& lutEntry)
   TMatrixDSymEigen eigen(m);
 
   // Eigenvalues
-  TVectorD eigenVal = eigen.GetEigenValues();
+  const TVectorD& eigenVal = eigen.GetEigenValues();
   for (int i = 0; i < kEig; ++i)
     lutEntry.eigval[i] = eigenVal[i];
 

--- a/ALICE3/Core/GeometryContainer.cxx
+++ b/ALICE3/Core/GeometryContainer.cxx
@@ -159,7 +159,7 @@ void GeometryEntry::replaceValue(const std::string& layerName, const std::string
   setValue(layerName, key, value);
 }
 
-std::string GeometryEntry::accessFile(const std::string& path, const std::string downloadPath, o2::ccdb::BasicCCDBManager* ccdb, int timeoutSeconds)
+std::string GeometryEntry::accessFile(const std::string& path, const std::string& downloadPath, o2::ccdb::BasicCCDBManager* ccdb, int timeoutSeconds)
 {
 
   if (path.rfind("ccdb:", 0) == 0) {

--- a/ALICE3/Core/GeometryContainer.h
+++ b/ALICE3/Core/GeometryContainer.h
@@ -33,7 +33,7 @@ namespace o2::fastsim
 struct GeometryEntry {
   // Default constructor
   GeometryEntry() = default;
-  explicit GeometryEntry(std::string filename, o2::ccdb::BasicCCDBManager* ccdb = nullptr)
+  explicit GeometryEntry(const std::string& filename, o2::ccdb::BasicCCDBManager* ccdb = nullptr)
   {
     mFileName = accessFile(filename, "./.ALICE3/Configuration/", ccdb);
     mConfigurations = GeometryEntry::parseTEnvConfiguration(mFileName, mLayerNames);
@@ -59,7 +59,7 @@ struct GeometryEntry {
    * @param timeoutSeconds If positive, then this function will wait for these seconds after download before removing the downloaded file.
    * @return The local path to the file, either the original local path or the path to the retrieved file from ccdb
    */
-  static std::string accessFile(const std::string& path, const std::string downloadPath = "/tmp/GeometryContainer/", o2::ccdb::BasicCCDBManager* ccdb = nullptr, int timeoutSeconds = 0);
+  static std::string accessFile(const std::string& path, const std::string& downloadPath = "/tmp/GeometryContainer/", o2::ccdb::BasicCCDBManager* ccdb = nullptr, int timeoutSeconds = 0);
 
   std::map<std::string, std::map<std::string, std::string>> getConfigurations() const { return mConfigurations; }
   std::map<std::string, std::string> getConfiguration(const std::string& layerName) const;

--- a/ALICE3/Macros/testFastTracker.C
+++ b/ALICE3/Macros/testFastTracker.C
@@ -19,7 +19,7 @@
 
 #include <string>
 
-void testFastTracker(std::string geometryFile = "a3geo.ini")
+void testFastTracker(const std::string& geometryFile = "a3geo.ini")
 {
 
   fair::Logger::SetConsoleSeverity(fair::Severity::debug);

--- a/ALICE3/TableProducer/OTF/onTheFlyTracker.cxx
+++ b/ALICE3/TableProducer/OTF/onTheFlyTracker.cxx
@@ -423,7 +423,7 @@ struct OnTheFlyTracker {
     std::get<std::shared_ptr<T>>(it->second)->Fill(std::forward<Args>(args)...);
   }
 
-  void insertHist(const std::string& name, const std::string& title, HistType type, std::vector<AxisSpec> axisSpecs)
+  void insertHist(const std::string& name, const std::string& title, HistType type, const std::vector<AxisSpec>& axisSpecs)
   {
     histPointers[name] = histos.add(name.c_str(), title.c_str(), type, axisSpecs);
   }

--- a/ALICE3/TableProducer/OTF/onTheFlyTrackerPid.cxx
+++ b/ALICE3/TableProducer/OTF/onTheFlyTrackerPid.cxx
@@ -304,7 +304,7 @@ struct OnTheFlyTrackerPid {
     return (measuredToT - expectedToT) / resolution;
   }
 
-  float getToTMeanFromMomentumSlice(std::shared_ptr<TH2> hist, float momentum)
+  float getToTMeanFromMomentumSlice(const std::shared_ptr<TH2>& hist, float momentum)
   {
     if (!hist)
       return -1.f;
@@ -319,7 +319,7 @@ struct OnTheFlyTrackerPid {
     return mean;
   }
 
-  float getToTResolutionFromMomentumSlice(std::shared_ptr<TH2> hist, float momentum)
+  float getToTResolutionFromMomentumSlice(const std::shared_ptr<TH2>& hist, float momentum)
   {
     if (!hist)
       return -1.f;

--- a/ALICE3/TableProducer/alice3TrackingTranslator.cxx
+++ b/ALICE3/TableProducer/alice3TrackingTranslator.cxx
@@ -54,6 +54,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 TString inputPath;
@@ -113,7 +114,7 @@ struct Alice3TrackingTranslator {
   }
 
   struct FileStruct {
-    FileStruct(std::string filename, std::string treename) : mFile(filename.c_str(), "READ")
+    FileStruct(const std::string& filename, const std::string& treename) : mFile(filename.c_str(), "READ")
     {
       if (mFile.IsZombie()) {
         LOG(fatal) << "Could not open file '" << filename << "'";
@@ -137,7 +138,7 @@ struct Alice3TrackingTranslator {
   };
 
   struct ParticleStruct : public FileStruct {
-    ParticleStruct(std::string filename, std::string treename) : FileStruct(filename, treename)
+    ParticleStruct(const std::string& filename, const std::string& treename) : FileStruct(std::move(filename), std::move(treename))
     {
       // mTree->Print();
       SETADDRESS("particle_type", m_particle_type);
@@ -180,7 +181,7 @@ struct Alice3TrackingTranslator {
   };
 
   struct VertexStruct : public FileStruct {
-    VertexStruct(std::string filename, std::string treename) : FileStruct(filename, treename)
+    VertexStruct(const std::string& filename, const std::string& treename) : FileStruct(filename, treename)
     {
       SETADDRESS("vx", m_x);
       SETADDRESS("vy", m_y);
@@ -214,7 +215,7 @@ struct Alice3TrackingTranslator {
   };
 
   struct TrackStruct : public FileStruct {
-    TrackStruct(std::string filename, std::string treename) : FileStruct(filename, treename)
+    TrackStruct(const std::string& filename, const std::string& treename) : FileStruct(std::move(filename), std::move(treename))
     {
       mTree->Print();
       // Set branch addresses for ACTS track parameters
@@ -288,7 +289,7 @@ struct Alice3TrackingTranslator {
   };
 
   struct HitsStruct : public FileStruct {
-    HitsStruct(std::string filename, std::string treename) : FileStruct(filename, treename)
+    HitsStruct(const std::string& filename, const std::string& treename) : FileStruct(std::move(filename), std::move(treename))
     {
       mTree->Print();
       SETADDRESS("barcode", barcode);


### PR DESCRIPTION
Mostly done automatically by Clang-Tidy.