### PR TITLE
[Common] Use `const&` and `std::move` to avoid copies

### DIFF
--- a/Common/CCDB/macros/ctpRateF.C
+++ b/Common/CCDB/macros/ctpRateF.C
@@ -29,12 +29,12 @@
 
 struct ctpRateFetcher {
   ctpRateFetcher() = default;
-  double fetch(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber, std::string sourceName);
+  double fetch(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber, const std::string& sourceName);
   void getCTPconfig(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber);
   void getCTPscalers(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber);
   void getLHCIFdata(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber);
   double fetchCTPratesInputs(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber, int input);
-  double fetchCTPratesClasses(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber, std::string className, int inputType = 1);
+  double fetchCTPratesClasses(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber, const std::string& className, int inputType = 1);
   double pileUpCorrection(double rate);
 
   int mRunNumber = -1;
@@ -104,7 +104,7 @@ double ctpRateFetcher::fetchCTPratesInputs(o2::ccdb::BasicCCDBManager* ccdb, uin
     return -1.;
   }
 }
-double ctpRateFetcher::fetchCTPratesClasses(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber, std::string className, int inputType)
+double ctpRateFetcher::fetchCTPratesClasses(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber, const std::string& className, int inputType)
 {
   getCTPscalers(ccdb, timeStamp, runNumber);
   getCTPconfig(ccdb, timeStamp, runNumber);
@@ -125,7 +125,7 @@ double ctpRateFetcher::fetchCTPratesClasses(o2::ccdb::BasicCCDBManager* ccdb, ui
   getLHCIFdata(ccdb, timeStamp, runNumber);
   return pileUpCorrection(rate.second);
 }
-double ctpRateFetcher::fetch(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber, std::string sourceName)
+double ctpRateFetcher::fetch(o2::ccdb::BasicCCDBManager* ccdb, uint64_t timeStamp, int runNumber, const std::string& sourceName)
 {
   if (sourceName.find("ZNC") != std::string::npos) {
     if (runNumber < 544448) {

--- a/Common/Core/EventPlaneHelper.cxx
+++ b/Common/Core/EventPlaneHelper.cxx
@@ -164,19 +164,19 @@ void EventPlaneHelper::DoRescale(float& qx, float& qy, float ap, float am)
     qy /= am;
 }
 
-void EventPlaneHelper::GetCorrRecentering(const std::shared_ptr<TH2> histQ, float& meanX, float& meanY)
+void EventPlaneHelper::GetCorrRecentering(const std::shared_ptr<TH2>& histQ, float& meanX, float& meanY)
 {
   meanX = histQ->GetMean(1);
   meanY = histQ->GetMean(2);
 }
 
-void EventPlaneHelper::GetCorrWidth(const std::shared_ptr<TH2> histQ, float& stdX, float& stdY)
+void EventPlaneHelper::GetCorrWidth(const std::shared_ptr<TH2>& histQ, float& stdX, float& stdY)
 {
   stdX = histQ->GetStdDev(1);
   stdY = histQ->GetStdDev(2);
 }
 
-void EventPlaneHelper::GetCorrTwistRecale(const std::shared_ptr<TH2> histQ,
+void EventPlaneHelper::GetCorrTwistRecale(const std::shared_ptr<TH2>& histQ,
                                           float& aPlus, float& aMinus,
                                           float& lambdaPlus, float& lambdaMinus)
 {

--- a/Common/Core/EventPlaneHelper.h
+++ b/Common/Core/EventPlaneHelper.h
@@ -81,13 +81,13 @@ class EventPlaneHelper
   void DoRescale(float& qx, float& qy, float ap, float am);
 
   // Method to get the recentering correction on the Qx-Qy distribution.
-  void GetCorrRecentering(const std::shared_ptr<TH2> histQ, float& meanX, float& meanY);
+  void GetCorrRecentering(const std::shared_ptr<TH2>& histQ, float& meanX, float& meanY);
 
   // Method to get the std. deviation on the Qx-Qy distribution.
-  void GetCorrWidth(const std::shared_ptr<TH2> histQ, float& stdX, float& stdY);
+  void GetCorrWidth(const std::shared_ptr<TH2>& histQ, float& stdX, float& stdY);
 
   // Method to get the twist and rescale correction on the Qx-Qy distribution.
-  void GetCorrTwistRecale(const std::shared_ptr<TH2> histQ,
+  void GetCorrTwistRecale(const std::shared_ptr<TH2>& histQ,
                           float& aPlus, float& aMinus,
                           float& lambdaPlus, float& lambdaMinus);
 

--- a/Common/Core/PID/PIDTOFParamService.cxx
+++ b/Common/Core/PID/PIDTOFParamService.cxx
@@ -46,7 +46,7 @@ o2::common::core::MetadataHelper o2::pid::tof::TOFResponseImpl::metadataInfo;
 bool o2::pid::tof::TOFResponseImpl::mIsInit = false;
 int o2::pid::tof::TOFResponseImpl::mLastRunNumber = -1;
 
-void o2::pid::tof::TOFResponseImpl::inheritFromBaseTask(o2::framework::InitContext& initContext, const std::string task)
+void o2::pid::tof::TOFResponseImpl::inheritFromBaseTask(o2::framework::InitContext& initContext, const std::string& task)
 {
   if (mIsInit) {
     LOG(fatal) << "TOFResponseImpl already initialized, cannot re-initialize";
@@ -70,7 +70,7 @@ void o2::pid::tof::TOFResponseImpl::inheritFromBaseTask(o2::framework::InitConte
 
 void o2::pid::tof::TOFResponseImpl::initSetup(o2::ccdb::BasicCCDBManager* ccdb,
                                               o2::framework::InitContext& initContext,
-                                              const std::string task)
+                                              const std::string& task)
 {
   if (mIsInit) {
     LOG(fatal) << "TOFResponseImpl already initialized, cannot re-initialize";

--- a/Common/Core/PID/PIDTOFParamService.h
+++ b/Common/Core/PID/PIDTOFParamService.h
@@ -49,7 +49,7 @@ struct TOFResponseImpl {
   /// \note This function should be called in the init function of each task that uses the TOF response
   /// \note The parameters are loaded from the CCDB and stored in the static variable `parameters`
   /// \note The metadata information is also initialized in this function
-  void initSetup(o2::ccdb::BasicCCDBManager* ccdb, o2::framework::InitContext& initContext, const std::string task = "tof-signal");
+  void initSetup(o2::ccdb::BasicCCDBManager* ccdb, o2::framework::InitContext& initContext, const std::string& task = "tof-signal");
 
   /// Initialize the TOF response parameters in the init function of each task
   /// \param ccdb Service pointer to the CCDB manager
@@ -163,7 +163,7 @@ struct TOFResponseImpl {
   o2::common::core::CollisionSystemType::collType cfgCollisionType() const { return mCollisionSystem; }
 
  private:
-  void inheritFromBaseTask(o2::framework::InitContext& initContext, const std::string task = "tof-signal");
+  void inheritFromBaseTask(o2::framework::InitContext& initContext, const std::string& task = "tof-signal");
 
   static bool mIsInit;       //! Flag to check if the parameters are initialized
   static int mLastRunNumber; //! Last run number for which the calibration was loaded

--- a/Common/Core/TrackSelection.cxx
+++ b/Common/Core/TrackSelection.cxx
@@ -119,11 +119,11 @@ void TrackSelection::SetMaxDcaZ(float maxDcaZ)
 
 void TrackSelection::SetMaxDcaXYPtDep(std::function<float(float)> ptDepCut)
 {
-  mMaxDcaXYPtDep = ptDepCut;
+  mMaxDcaXYPtDep = std::move(ptDepCut);
   LOG(info) << "Track selection, set max DCA xy pt dep: " << mMaxDcaXYPtDep(1.0);
 }
 
-void TrackSelection::SetRequireHitsInITSLayers(int8_t minNRequiredHits, std::set<uint8_t> requiredLayers)
+void TrackSelection::SetRequireHitsInITSLayers(int8_t minNRequiredHits, const std::set<uint8_t>& requiredLayers)
 {
   // layer 0 corresponds to the the innermost ITS layer
   uint8_t mask = 0;
@@ -133,7 +133,7 @@ void TrackSelection::SetRequireHitsInITSLayers(int8_t minNRequiredHits, std::set
   mRequiredITSHits.push_back(std::make_pair(minNRequiredHits, mask));
   LOG(info) << "Track selection, set require hits in ITS layers: " << static_cast<int>(minNRequiredHits);
 }
-void TrackSelection::SetRequireNoHitsInITSLayers(std::set<uint8_t> excludedLayers)
+void TrackSelection::SetRequireNoHitsInITSLayers(const std::set<uint8_t>& excludedLayers)
 {
   uint8_t mask = 0;
   for (const auto& layer : excludedLayers) {

--- a/Common/Core/TrackSelection.h
+++ b/Common/Core/TrackSelection.h
@@ -249,8 +249,8 @@ class TrackSelection
   void SetMaxDcaXY(float maxDcaXY);
   void SetMaxDcaZ(float maxDcaZ);
   void SetMaxDcaXYPtDep(std::function<float(float)> ptDepCut);
-  void SetRequireHitsInITSLayers(int8_t minNRequiredHits, std::set<uint8_t> requiredLayers);
-  void SetRequireNoHitsInITSLayers(std::set<uint8_t> excludedLayers);
+  void SetRequireHitsInITSLayers(int8_t minNRequiredHits, const std::set<uint8_t>& requiredLayers);
+  void SetRequireNoHitsInITSLayers(const std::set<uint8_t>& excludedLayers);
   /// @brief Reset ITS requirements
   void ResetITSRequirements() { mRequiredITSHits.clear(); }
   void SetMaxTPCFractionSharedCls(float maxTPCFractionSharedCls);

--- a/Common/Core/Zorro.cxx
+++ b/Common/Core/Zorro.cxx
@@ -52,7 +52,7 @@ int findBin(TH1* hist, const std::string& label)
 }
 } // namespace
 
-void Zorro::populateHistRegistry(o2::framework::HistogramRegistry& histRegistry, int runNumber, std::string folderName)
+void Zorro::populateHistRegistry(o2::framework::HistogramRegistry& histRegistry, int runNumber, const std::string& folderName)
 {
   int runId{-1};
   for (size_t i{0}; i < mRunNumberHistos.size(); ++i) {
@@ -176,7 +176,7 @@ void Zorro::populateExternalHists(int runNumber, TH2* ZorroHisto, TH2* ToiHisto)
   mRunNumberHistos.push_back(runNumber);
 }
 
-std::vector<int> Zorro::initCCDB(o2::ccdb::BasicCCDBManager* ccdb, int runNumber, uint64_t timestamp, std::string tois, int bcRange)
+std::vector<int> Zorro::initCCDB(o2::ccdb::BasicCCDBManager* ccdb, int runNumber, uint64_t timestamp, const std::string& tois, int bcRange)
 {
   if (mRunNumber == runNumber) {
     return mTOIidx;

--- a/Common/Core/Zorro.h
+++ b/Common/Core/Zorro.h
@@ -46,12 +46,12 @@ class Zorro
 {
  public:
   Zorro() = default;
-  std::vector<int> initCCDB(o2::ccdb::BasicCCDBManager* ccdb, int runNumber, uint64_t timestamp, std::string tois, int bcTolerance = 500);
+  std::vector<int> initCCDB(o2::ccdb::BasicCCDBManager* ccdb, int runNumber, uint64_t timestamp, const std::string& tois, int bcTolerance = 500);
   std::bitset<128> fetch(uint64_t bcGlobalId, uint64_t tolerance = 100);
   bool isSelected(uint64_t bcGlobalId, uint64_t tolerance = 100, TH2* toiHisto = nullptr);
   bool isNotSelectedByAny(uint64_t bcGlobalId, uint64_t tolerance = 100);
 
-  void populateHistRegistry(o2::framework::HistogramRegistry& histRegistry, int runNumber, std::string folderName = "Zorro");
+  void populateHistRegistry(o2::framework::HistogramRegistry& histRegistry, int runNumber, const std::string& folderName = "Zorro");
   void populateExternalHists(int runNumber, TH2* zorroHisto = nullptr, TH2* toiHisto = nullptr);
 
   TH1D* getScalers() const { return mScalers; }

--- a/Common/Core/macros/testMetadataHelper.C
+++ b/Common/Core/macros/testMetadataHelper.C
@@ -128,9 +128,9 @@ std::map<std::string, bool> buildMapForCommitHash(const std::string& hash)
   return results;
 }
 
-void populateCCDBWithCommitAvailability(std::map<std::string, bool> hasHashMap,
-                                        const std::string commitHash,
-                                        const std::string ccdbUrl = "http://ccdb-test.cern.ch:8080/")
+void populateCCDBWithCommitAvailability(const std::map<std::string, bool>& hasHashMap,
+                                        const std::string& commitHash,
+                                        const std::string& ccdbUrl = "http://ccdb-test.cern.ch:8080/")
 {
   // First, init the CCDB manager to test if the ccdb is already populated
   o2::ccdb::CcdbApi api;
@@ -157,7 +157,7 @@ void populateCCDBWithCommitAvailability(std::map<std::string, bool> hasHashMap,
   }
 }
 
-void testMetadataHelper(std::string aod = "/tmp/AO2D.root")
+void testMetadataHelper(const std::string& aod = "/tmp/AO2D.root")
 {
   createO2VersionFile();
   const std::string commitHash = "63bc2e3893851ef0f849bb4c98c65eae1ba21e47";

--- a/Common/TableProducer/PID/pidBayes.cxx
+++ b/Common/TableProducer/PID/pidBayes.cxx
@@ -639,7 +639,7 @@ struct bayesPidQa {
     histos.fill(HIST("event/vertexz"), collision.posZ());
     histos.fill(HIST("event/colltime"), collisionTime_ps);
 
-    for (auto t : tracks) {
+    for (const auto& t : tracks) {
       //
       if (!t.hasTOF()) { // Skipping tracks without TOF
         continue;

--- a/Common/TableProducer/eseTableProducer.cxx
+++ b/Common/TableProducer/eseTableProducer.cxx
@@ -405,7 +405,7 @@ struct EseTableProducer {
   }
 
   template <typename TTrack>
-  double getEfficiency(TTrack track)
+  double getEfficiency(const TTrack& track)
   {
     double eff = 1.;
     if (cfg.mEfficiency)
@@ -453,7 +453,7 @@ struct EseTableProducer {
   };
 
   template <typename TCollision>
-  bool eventSelected(TCollision collision, const int& multTrk, const float& centrality)
+  bool eventSelected(const TCollision& collision, const int& multTrk, const float& centrality)
   {
     if (cfgTVXinTRD) {
       if (collision.alias_bit(kTVXinTRD)) {

--- a/Common/TableProducer/match-mft-mch-data-mc.cxx
+++ b/Common/TableProducer/match-mft-mch-data-mc.cxx
@@ -503,7 +503,7 @@ struct match_mft_mch_data_mc {
   };
 
   template <typename MUON>
-  bool isGoodMuonQuality(MUON muontrack)
+  bool isGoodMuonQuality(const MUON& muontrack)
   {
     if (!muontrack.has_collision())
       return false;
@@ -521,7 +521,7 @@ struct match_mft_mch_data_mc {
   }
 
   template <typename MUON>
-  bool isGoodMuonKine(MUON muontrack)
+  bool isGoodMuonKine(const MUON& muontrack)
   {
     if (fEtaMchLow > muontrack.getEta() || muontrack.getEta() > fEtaMchUp)
       return false;
@@ -529,7 +529,7 @@ struct match_mft_mch_data_mc {
   }
 
   template <typename MFT>
-  bool isGoodMFTQuality(MFT mfttrack)
+  bool isGoodMFTQuality(const MFT& mfttrack)
   {
     if (!mfttrack.has_collision())
       return false;
@@ -541,7 +541,7 @@ struct match_mft_mch_data_mc {
   }
 
   template <typename MFT>
-  bool isGoodMFTKine(MFT mfttrack)
+  bool isGoodMFTKine(const MFT& mfttrack)
   {
     if (fEtaMftLow > mfttrack.getEta() || mfttrack.getEta() > fEtaMftUp)
       return false;
@@ -556,7 +556,7 @@ struct match_mft_mch_data_mc {
   template <typename MUONs, typename Collisions>
   void setMUONs(MUONs const& muontracks, Collisions const& collisions)
   {
-    for (auto muontrack : muontracks) {
+    for (const auto& muontrack : muontracks) {
       if (!isGoodMuonQuality(muontrack))
         continue;
       o2::dataformats::GlobalFwdTrack muontrack_at_pv = propagateMUONtoPV(muontrack, collisions);
@@ -595,7 +595,7 @@ struct match_mft_mch_data_mc {
   template <typename MFTs, typename Collisions>
   void setMFTs(MFTs const& mfttracks, Collisions const& collisions, o2::field::MagneticField* field)
   {
-    for (auto mfttrack : mfttracks) {
+    for (const auto& mfttrack : mfttracks) {
       if (!isGoodMFTQuality(mfttrack))
         continue;
 

--- a/Common/TableProducer/match-mft-mch-data.cxx
+++ b/Common/TableProducer/match-mft-mch-data.cxx
@@ -503,7 +503,7 @@ struct match_mft_mch_data_mc {
   };
 
   template <typename MUON>
-  bool isGoodMuonQuality(MUON muontrack)
+  bool isGoodMuonQuality(const MUON& muontrack)
   {
     if (!muontrack.has_collision())
       return false;
@@ -521,7 +521,7 @@ struct match_mft_mch_data_mc {
   }
 
   template <typename MUON>
-  bool isGoodMuonKine(MUON muontrack)
+  bool isGoodMuonKine(const MUON& muontrack)
   {
     if (fEtaMchLow > muontrack.getEta() || muontrack.getEta() > fEtaMchUp)
       return false;
@@ -529,7 +529,7 @@ struct match_mft_mch_data_mc {
   }
 
   template <typename MFT>
-  bool isGoodMFTQuality(MFT mfttrack)
+  bool isGoodMFTQuality(const MFT& mfttrack)
   {
     if (!mfttrack.has_collision())
       return false;
@@ -541,7 +541,7 @@ struct match_mft_mch_data_mc {
   }
 
   template <typename MFT>
-  bool isGoodMFTKine(MFT mfttrack)
+  bool isGoodMFTKine(const MFT& mfttrack)
   {
     if (fEtaMftLow > mfttrack.getEta() || mfttrack.getEta() > fEtaMftUp)
       return false;
@@ -556,7 +556,7 @@ struct match_mft_mch_data_mc {
   template <typename MUONs, typename Collisions>
   void setMUONs(MUONs const& muontracks, Collisions const& collisions)
   {
-    for (auto muontrack : muontracks) {
+    for (const auto& muontrack : muontracks) {
       if (!isGoodMuonQuality(muontrack))
         continue;
       o2::dataformats::GlobalFwdTrack muontrack_at_pv = propagateMUONtoPV(muontrack, collisions);
@@ -595,7 +595,7 @@ struct match_mft_mch_data_mc {
   template <typename MFTs, typename Collisions>
   void setMFTs(MFTs const& mfttracks, Collisions const& collisions, o2::field::MagneticField* field)
   {
-    for (auto mfttrack : mfttracks) {
+    for (const auto& mfttrack : mfttracks) {
       if (!isGoodMFTQuality(mfttrack))
         continue;
 

--- a/Common/TableProducer/qVectorsTable.cxx
+++ b/Common/TableProducer/qVectorsTable.cxx
@@ -390,7 +390,7 @@ struct QVectorsTable {
   }
 
   template <typename TrackType>
-  bool selTrack(const TrackType track)
+  bool selTrack(const TrackType& track)
   {
     if (track.pt() < cfgMinPtOnTPC)
       return false;

--- a/Common/TableProducer/zdcTaskLightIons.cxx
+++ b/Common/TableProducer/zdcTaskLightIons.cxx
@@ -97,7 +97,7 @@ struct ZdcTaskLightIons {
   }
 
   template <typename TCollision>
-  uint8_t eventSelected(TCollision collision)
+  uint8_t eventSelected(const TCollision& collision)
   {
     uint8_t selectionBits = 0;
     bool selected;

--- a/Common/Tasks/centralityStudypp.cxx
+++ b/Common/Tasks/centralityStudypp.cxx
@@ -221,7 +221,7 @@ struct centralityStudypp {
       hCentralityMFT = dynamic_cast<TH1*>(hCentralityObjects->FindObject("hCalibZeqMFT"));
 
       // won't capture null pointers -> explicitly check for those when attempting to evaluate
-      auto reportSuccess = [](TH1* a, std::string name) {
+      auto reportSuccess = [](TH1* a, const std::string& name) {
         if (!a) {
           LOGF(info, "Calibration missing for %s", name);
         } else {

--- a/Common/Tasks/qVectorsCorrection.cxx
+++ b/Common/Tasks/qVectorsCorrection.cxx
@@ -149,7 +149,7 @@ struct qVectorsCorrection {
   }
 
   template <typename TrackType>
-  bool SelTrack(const TrackType track)
+  bool SelTrack(const TrackType& track)
   {
     if (track.pt() < 0.15)
       return false;

--- a/Common/Tools/EventSelectionModule.h
+++ b/Common/Tools/EventSelectionModule.h
@@ -1323,7 +1323,7 @@ class EventSelectionModule
       float vZ = col.posZ();
 
       // ### in-ROF occupancy
-      std::vector<int> vAssocCollInSameROF = vCollsInSameITSROF[colIndex];
+      const std::vector<int>& vAssocCollInSameROF = vCollsInSameITSROF[colIndex];
       int nITS567tracksForSameRofVetoStrict = 0;    // to veto events with other collisions in the same ITS ROF
       int nCollsInRofWithFT0CAboveVetoStandard = 0; // to veto events with other collisions in the same ITS ROF, with per-collision multiplicity above threshold
       int nITS567tracksForRofVetoOnCloseVz = 0;     // to veto events with nearby collisions with close vZ
@@ -1341,7 +1341,7 @@ class EventSelectionModule
       vNoCollInSameRofWithCloseVz[colIndex] = (nITS567tracksForRofVetoOnCloseVz == 0);
 
       // ### occupancy in previous ROF
-      std::vector<int> vAssocCollInPrevROF = vCollsInPrevITSROF[colIndex];
+      const std::vector<int>& vAssocCollInPrevROF = vCollsInPrevITSROF[colIndex];
       float totalFT0amplInPrevROF = 0;
       for (uint32_t iCol = 0; iCol < vAssocCollInPrevROF.size(); iCol++) {
         int thisColIndex = vAssocCollInPrevROF[iCol];
@@ -1351,8 +1351,8 @@ class EventSelectionModule
       vNoHighMultCollInPrevRof[colIndex] = (totalFT0amplInPrevROF < evselOpts.confFT0CamplCutVetoOnCollInROF);
 
       // ### occupancy in time windows
-      std::vector<int> vAssocToThisCol = vCollsInTimeWin[colIndex];
-      std::vector<float> vCollsTimeDeltaWrtGivenColl = vTimeDeltaForColls[colIndex];
+      const std::vector<int>& vAssocToThisCol = vCollsInTimeWin[colIndex];
+      const std::vector<float>& vCollsTimeDeltaWrtGivenColl = vTimeDeltaForColls[colIndex];
       int nITS567tracksInFullTimeWindow = 0;
       float sumAmpFT0CInFullTimeWindow = 0;
       int nITS567tracksForVetoNarrow = 0;      // to veto events with nearby collisions (narrow range) with per-collision multiplicity above threshold

--- a/Common/Tools/Multiplicity/MultModule.h
+++ b/Common/Tools/Multiplicity/MultModule.h
@@ -41,6 +41,7 @@
 #include <cstdlib>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 //__________________________________________
@@ -429,7 +430,7 @@ class MultModule
     float mMCScalePars[6] = {0.0};
     TFormula* mMCScale = nullptr;
     explicit CalibrationInfo(std::string name)
-      : name(name),
+      : name(std::move(name)),
         mCalibrationStored(false),
         mhMultSelCalib(nullptr),
         mMCScalePars{0.0},
@@ -1250,7 +1251,7 @@ class MultModule
       mftInfo.mCalibrationStored = false;
       if (callst != nullptr) {
         LOGF(info, "Getting new histograms with %d run number for %d run number", mRunNumber, bc.runNumber());
-        auto getccdb = [callst, bc](struct CalibrationInfo& estimator, const o2::framework::Configurable<std::string> generatorName) { // TODO: to consider the name inside the estimator structure
+        auto getccdb = [callst, bc](struct CalibrationInfo& estimator, const o2::framework::Configurable<std::string>& generatorName) { // TODO: to consider the name inside the estimator structure
           estimator.mhMultSelCalib = reinterpret_cast<TH1*>(callst->FindObject(TString::Format("hCalibZeq%s", estimator.name.c_str()).Data()));
           estimator.mMCScale = reinterpret_cast<TFormula*>(callst->FindObject(TString::Format("%s-%s", generatorName->c_str(), estimator.name.c_str()).Data()));
           if (estimator.mhMultSelCalib != nullptr) {

--- a/Common/Tools/Multiplicity/macros/runCalibration.C
+++ b/Common/Tools/Multiplicity/macros/runCalibration.C
@@ -33,7 +33,7 @@
 /// @param anchorPointPercentage anchor point percentage to use
 /// @param matchRange width of region in which data/glauber matching is to be done in rolling anchoring test
 /// @param doNpartNcoll wether or not to attempt calculating Npart, Ncoll in centrality bins
-void runCalibration(TString lInputFileName = "results/AR_544122_glauberNBD_ancestorMode2_hFT0C_BCs.root", double anchorPointPercentage = 90.0, double matchRange = 200.0, bool doNpartNcoll = false)
+void runCalibration(const TString& lInputFileName = "results/AR_544122_glauberNBD_ancestorMode2_hFT0C_BCs.root", double anchorPointPercentage = 90.0, double matchRange = 200.0, bool doNpartNcoll = false)
 {
   TFile* file = new TFile(lInputFileName.Data(), "READ");
   file->ls();

--- a/Common/Tools/Multiplicity/macros/runGlauberFit.C
+++ b/Common/Tools/Multiplicity/macros/runGlauberFit.C
@@ -87,7 +87,7 @@ Double_t GetBoundaryForPercentile(TH1* histo, Double_t lPercentileRequested)
 /// @param lFreef free f: keep f value free (default Pb-Pb: fixed at 0.8)
 /// @param lfvalue f value: the value to use for fixed f
 /// @param outputFile name of output file
-int runGlauberFit(TString lInputFileName = "AnalysisResultsLHC24ar.root", TString histogramName = "hFT0C_BCs", int ancestorMode = 2, Bool_t lFreek = kFALSE, Bool_t use_dMu_dNanc = kFALSE, Bool_t lFreef = kFALSE, Float_t lfvalue = 0.800, TString outputFile = "output.root")
+int runGlauberFit(const TString& lInputFileName = "AnalysisResultsLHC24ar.root", const TString& histogramName = "hFT0C_BCs", int ancestorMode = 2, Bool_t lFreek = kFALSE, Bool_t use_dMu_dNanc = kFALSE, Bool_t lFreef = kFALSE, Float_t lfvalue = 0.800, const TString& outputFile = "output.root")
 {
   gStyle->SetLineScalePS(1);
   gStyle->SetOptStat(0);

--- a/Common/Tools/Multiplicity/macros/saveCorrelation.C
+++ b/Common/Tools/Multiplicity/macros/saveCorrelation.C
@@ -26,7 +26,7 @@
 /// @brief function to save Npart x Ncoll correlation to file for glauber fits
 /// @param filename input TGlauberMC ntuple file
 /// @param outputFile output file for Npart x Ncoll correlation TH2D
-void saveCorrelation(TString filename = "gmc-PbPb-snn68.21-md0.40-nd-1.0-rc1-smax99.0.root", TString outputFile = "basehistos.root")
+void saveCorrelation(const TString& filename = "gmc-PbPb-snn68.21-md0.40-nd-1.0-rc1-smax99.0.root", const TString& outputFile = "basehistos.root")
 {
   TFile* fin = new TFile(filename.Data(), "READ");
   TNtuple* ntup = (TNtuple*)fin->Get("nt_Pb_Pb");

--- a/Common/Tools/Multiplicity/multCalibrator.cxx
+++ b/Common/Tools/Multiplicity/multCalibrator.cxx
@@ -319,7 +319,7 @@ bool multCalibrator::IsBinningSane(TH1* histogram)
 }
 
 //________________________________________________________________
-TH1F* multCalibrator::GetCalibrationHistogram(TH1* histoRaw, TString lHistoName)
+TH1F* multCalibrator::GetCalibrationHistogram(TH1* histoRaw, const TString& lHistoName)
 {
   // This function returns a calibration histogram
   //(pp or p-Pb like, no anchor point considered)

--- a/Common/Tools/Multiplicity/multCalibrator.h
+++ b/Common/Tools/Multiplicity/multCalibrator.h
@@ -43,8 +43,8 @@ class multCalibrator : public TNamed
   // Interface: steering functions to be used in calibration macro
 
   // Set Filenames
-  void SetInputFile(TString lFile) { fInputFileName = lFile.Data(); }
-  void SetOutputFile(TString lFile) { fOutputFileName = lFile.Data(); }
+  void SetInputFile(const TString& lFile) { fInputFileName = lFile.Data(); }
+  void SetOutputFile(const TString& lFile) { fOutputFileName = lFile.Data(); }
   // Set Boundaries to find
   void SetBoundaries(Long_t lNB, Double_t* lB)
   {
@@ -68,7 +68,7 @@ class multCalibrator : public TNamed
   Bool_t Calibrate();
 
   // Aux function. Keep public, accessible outside as rather useful utility
-  TH1F* GetCalibrationHistogram(TH1* histoRaw, TString lHistoName = "hCalib");
+  TH1F* GetCalibrationHistogram(TH1* histoRaw, const TString& lHistoName = "hCalib");
 
   // Auxiliary functions
   Double_t GetRawMax(TH1* histo);

--- a/Common/Tools/Multiplicity/multGlauberNBDFitter.cxx
+++ b/Common/Tools/Multiplicity/multGlauberNBDFitter.cxx
@@ -46,6 +46,7 @@
 #include <RtypesCore.h>
 
 #include <iostream> // FIXME
+#include <utility>
 
 using namespace std;
 
@@ -274,7 +275,7 @@ void multGlauberNBDFitter::SetFitRange(Double_t lMin, Double_t lMax)
 //________________________________________________________________
 void multGlauberNBDFitter::SetFitOptions(TString lOpt)
 {
-  fFitOptions = lOpt;
+  fFitOptions = std::move(lOpt);
 }
 
 //________________________________________________________________

--- a/Common/Tools/Multiplicity/multMCCalibrator.h
+++ b/Common/Tools/Multiplicity/multMCCalibrator.h
@@ -41,9 +41,9 @@ class multMCCalibrator : public TNamed
   // Interface: steering functions to be used in calibration macro
 
   // Set Filenames
-  void SetDataInputFile(TString lFile) { fDataInputFileName = lFile.Data(); }
-  void SetSimInputFile(TString lFile) { fSimInputFileName = lFile.Data(); }
-  void SetOutputFile(TString lFile) { fOutputFileName = lFile.Data(); }
+  void SetDataInputFile(const TString& lFile) { fDataInputFileName = lFile.Data(); }
+  void SetSimInputFile(const TString& lFile) { fSimInputFileName = lFile.Data(); }
+  void SetOutputFile(const TString& lFile) { fOutputFileName = lFile.Data(); }
 
   // Master Function in this Class: To be called once filenames are set
   Bool_t Calibrate();

--- a/Common/Tools/PID/pidTPCModule.h
+++ b/Common/Tools/PID/pidTPCModule.h
@@ -309,7 +309,7 @@ class pidTPCModule
     o2::common::core::enableFlagIfTableRequired(context, "DEdxsCorrected", pidTPCopts.savedEdxsCorrected);
 
     // Checking the tables are requested in the workflow and enabling them
-    auto enableFlag = [&](const std::string particle, o2::framework::Configurable<int>& flag) {
+    auto enableFlag = [&](const std::string& particle, o2::framework::Configurable<int>& flag) {
       o2::common::core::enableFlagIfTableRequired(context, "pidTPC" + particle, flag);
     };
     enableFlag("FullEl", pidTPCopts.pidFullEl);

--- a/Common/Tools/TrackTuner.h
+++ b/Common/Tools/TrackTuner.h
@@ -390,7 +390,7 @@ struct TrackTuner : o2::framework::ConfigurableGroup {
         // parameter not found
         LOG(fatal) << "\"" << mapParNames[iPar] << "\" not found in the configuration string";
       }
-      std::string str = *it;
+      const std::string& str = *it;
       if (str.find('=') == std::string::npos || str.back() == '=') {
         // value of the parameter missing in the configuration string
         LOG(fatal) << "Missing value for \"" << mapParNames[iPar] << "\" in the configuration string";


### PR DESCRIPTION
Mostly done automatically by Clang-Tidy.