### PR TITLE
[DPG] Use `const&` and `std::move` to avoid copies

### DIFF
--- a/DPG/Tasks/AOTEvent/detectorOccupancyQa.cxx
+++ b/DPG/Tasks/AOTEvent/detectorOccupancyQa.cxx
@@ -779,8 +779,8 @@ struct DetectorOccupancyQaTask {
       if (!col.selection_bit(kNoITSROFrameBorder))
         continue;
 
-      std::vector<int> vCollsAssocToGivenColl = vCollsInTimeWin[colIndex];
-      std::vector<float> vCollsTimeDeltaWrtGivenColl = vTimeDeltaForColls[colIndex];
+      const std::vector<int>& vCollsAssocToGivenColl = vCollsInTimeWin[colIndex];
+      const std::vector<float>& vCollsTimeDeltaWrtGivenColl = vTimeDeltaForColls[colIndex];
 
       LOGP(debug, "  >> vCollsAssocToGivenColl.size={}", vCollsAssocToGivenColl.size());
 

--- a/DPG/Tasks/AOTEvent/eventSelectionQa.cxx
+++ b/DPG/Tasks/AOTEvent/eventSelectionQa.cxx
@@ -1415,7 +1415,7 @@ struct EventSelectionQaTask {
         bool isVertexUPC = flags & dataformats::Vertex<o2::dataformats::TimeStamp<int>>::Flags::UPCMode; // is vertex with UPC settings
 
         // the second collision in ROF
-        std::vector<int> vAssocToSameROF = vCollsInSameITSROF[colIndex];
+        const std::vector<int>& vAssocToSameROF = vCollsInSameITSROF[colIndex];
         int thisColIndex = vAssocToSameROF[0];
         float vZassoc = vCollVz[thisColIndex];               // vZ of the second collision in the same ROF
         float nPVassoc = vTracksITS567perColl[thisColIndex]; // n PV tracks of the second collision in the same ROF

--- a/DPG/Tasks/AOTEvent/rofOccupancyQa.cxx
+++ b/DPG/Tasks/AOTEvent/rofOccupancyQa.cxx
@@ -754,7 +754,7 @@ struct RofOccupancyQaTask {
       // LOGP(info, "#### starting new coll: bc={} bcInTF={} bcInITSROF={} rofId={};  noROFborder={};   rofOffset={} rofLength={}", vFoundGlobalBC[colIndex], bcInTF, bcInITSROF, rofId, bc.selection_bit(kNoITSROFrameBorder), rofOffset, rofLength);
       // LOGP(info, "#### starting new coll: bcInTF={} bcInITSROF={} rofIdInTF={};  noROFborder={},  vZ={} mult={};   rofOffset={} rofLength={}", bcInTF, bcInITSROF, rofIdInTF, bc.selection_bit(kNoITSROFrameBorder), vZ, vTracksITS567perColl[colIndex], rofOffset, rofLength);
 
-      std::vector<int> vAssocToSameROF = vCollsInSameITSROF[colIndex];
+      const std::vector<int>& vAssocToSameROF = vCollsInSameITSROF[colIndex];
       int nITS567tracksForRofVetoStrict = 0;  // to veto events with other collisions in the same ITS ROF
       float nSumAmplFT0CforRofVetoStrict = 0; // to veto events with other collisions in the same ITS ROF
       // int nITS567tracksForRofVetoStandard = 0;           // to veto events with other collisions in the same ITS ROF, with per-collision multiplicity above threshold
@@ -836,8 +836,8 @@ struct RofOccupancyQaTask {
         vArrNoCollInSameRofWithCloseVz.push_back(vVzCutThisColl);
         continue;
       }
-      std::vector<int> vAssocToThisCol = vCollsInTimeWin[colIndex];
-      std::vector<float> vCollsTimeDeltaWrtGivenColl = vTimeDeltaForColls[colIndex];
+      const std::vector<int>& vAssocToThisCol = vCollsInTimeWin[colIndex];
+      const std::vector<float>& vCollsTimeDeltaWrtGivenColl = vTimeDeltaForColls[colIndex];
       int nITS567tracksInFullTimeWindow = 0;
       int sumAmpFT0CInFullTimeWindow = 0;
       int nITS567tracksForVetoNarrow = 0;      // to veto events with nearby collisions (narrower range)

--- a/DPG/Tasks/AOTTrack/PID/TOF/qaPIDTOF.cxx
+++ b/DPG/Tasks/AOTTrack/PID/TOF/qaPIDTOF.cxx
@@ -379,7 +379,7 @@ struct tofPidQa {
     int evtimeflag = 0;
 
     if constexpr (fillHistograms) {
-      for (auto t : tracks) {
+      for (const auto& t : tracks) {
         if (!t.hasTOF()) { // Skipping tracks without TOF
           continue;
         }
@@ -529,7 +529,7 @@ struct tofPidQa {
                soa::Filtered<TrackCandidates> const& tracks)
   {
     isEventSelected<true>(collision, tracks);
-    for (auto t : tracks) {
+    for (const auto& t : tracks) {
       isTrackSelected<true>(collision, t);
     }
   }
@@ -543,7 +543,7 @@ struct tofPidQa {
       return;
     }
 
-    for (auto t : tracks) {
+    for (const auto& t : tracks) {
       if (!isTrackSelected<false>(collision, t)) {
         continue;
       }

--- a/DPG/Tasks/AOTTrack/PID/TOF/qaPIDTOFDynamic.cxx
+++ b/DPG/Tasks/AOTTrack/PID/TOF/qaPIDTOFDynamic.cxx
@@ -401,7 +401,7 @@ struct tofPidQaDynamic {
     int evtimeflag = 0;
 
     if constexpr (fillHistograms) {
-      for (auto t : tracks) {
+      for (const auto& t : tracks) {
         if (!t.hasTOF()) { // Skipping tracks without TOF
           continue;
         }
@@ -554,7 +554,7 @@ struct tofPidQaDynamic {
     tofResponse->processSetup(collision.bc_as<o2::aod::BCsWithTimestamps>());
 
     isEventSelected<true>(collision, tracks);
-    for (auto t : tracks) {
+    for (const auto& t : tracks) {
       isTrackSelected<true>(collision, t);
     }
   }
@@ -568,7 +568,7 @@ struct tofPidQaDynamic {
       return;
     }
 
-    for (auto t : tracks) {
+    for (const auto& t : tracks) {
       if (!isTrackSelected<false>(collision, t)) {
         continue;
       }

--- a/DPG/Tasks/AOTTrack/PID/TOF/qaPIDTOFEvTime.cxx
+++ b/DPG/Tasks/AOTTrack/PID/TOF/qaPIDTOFEvTime.cxx
@@ -167,7 +167,7 @@ struct tofPidCollisionTimeQa {
       }
 
       listEfficiency.setObject(new THashList);
-      auto makeEfficiency = [&](TString effname, TString efftitle) {
+      auto makeEfficiency = [&](const TString& effname, const TString& efftitle) {
         listEfficiency->Add(new TEfficiency(effname, efftitle + ";TOF multiplicity;Efficiency", nBinsMultiplicity, 0, rangeMultiplicity));
       };
 

--- a/DPG/Tasks/AOTTrack/V0Cascades/perfK0sResolution.cxx
+++ b/DPG/Tasks/AOTTrack/V0Cascades/perfK0sResolution.cxx
@@ -345,7 +345,7 @@ struct perfK0sResolution {
   }
 
   template <typename TCollision>
-  bool isEventAccepted(TCollision collision, bool fillHists)
+  bool isEventAccepted(const TCollision& collision, bool fillHists)
   // check whether the collision passes our collision selections
   {
     if (fillHists)

--- a/DPG/Tasks/AOTTrack/qaEfficiency.cxx
+++ b/DPG/Tasks/AOTTrack/qaEfficiency.cxx
@@ -500,7 +500,7 @@ struct QaEfficiency {
     subList->SetName(partName);
     listEfficiencyMC->Add(subList);
 
-    auto makeEfficiency = [&](const TString effname, auto h) { // 1D efficiencies
+    auto makeEfficiency = [&](const TString& effname, const auto& h) { // 1D efficiencies
       LOG(debug) << " Making 1D TEfficiency " << effname << " from " << h->GetName();
       const TAxis* axis = h->GetXaxis();
       TString efftitle = h->GetTitle();
@@ -563,7 +563,7 @@ struct QaEfficiency {
     makeEfficiency("ITS-TPC_vsPhi_Prm_Trk", hPhiTrkItsTpcPrm[histogramIndex]);
     makeEfficiency("ITS-TPC-TOF_vsPhi_Prm", hPhiItsTpcTofPrm[histogramIndex]);
 
-    auto makeEfficiency2D = [&](const TString effname, auto h) { // 2D efficiencies
+    auto makeEfficiency2D = [&](const TString& effname, const auto& h) { // 2D efficiencies
       LOG(debug) << " Making 2D TEfficiency " << effname << " from " << h->GetName();
       const TAxis* axisX = h->GetXaxis();
       const TAxis* axisY = h->GetYaxis();
@@ -898,7 +898,7 @@ struct QaEfficiency {
     listEfficiencyData.setObject(new THashList);
     if (makeEff) {
       LOG(debug) << "Making TEfficiency for Data";
-      auto makeEfficiency = [&](TString effname, TString efftitle, auto templateHisto, TEfficiency*& eff) {
+      auto makeEfficiency = [&](const TString& effname, const TString& efftitle, auto templateHisto, TEfficiency*& eff) {
         TAxis* axis = histos.get<TH1>(templateHisto)->GetXaxis();
         if (axis->IsVariableBinSize()) {
           eff = new TEfficiency(effname, efftitle, axis->GetNbins(), axis->GetXbins()->GetArray());
@@ -927,7 +927,7 @@ struct QaEfficiency {
                      "TPC-TOF M.E. in data " + tagPhi + ";#it{#varphi} (rad);Efficiency", HIST("Data/pos/phi/its_tpc_tof"),
                      effTPCTOFMatchingVsPhi);
 
-      auto makeEfficiency2D = [&](TString effname, TString efftitle, auto templateHistoX, auto templateHistoY, TEfficiency*& eff) {
+      auto makeEfficiency2D = [&](const TString& effname, const TString& efftitle, auto templateHistoX, auto templateHistoY, TEfficiency*& eff) {
         TAxis* axisX = histos.get<TH1>(templateHistoX)->GetXaxis();
         TAxis* axisY = histos.get<TH1>(templateHistoY)->GetYaxis();
         if (axisX->IsVariableBinSize() || axisY->IsVariableBinSize()) {
@@ -1366,7 +1366,7 @@ struct QaEfficiency {
     }
 
     // Filling 1D efficiencies
-    auto doFillEfficiency = [&](const TString effname, auto num, auto den) {
+    auto doFillEfficiency = [&](const TString& effname, const auto& num, const auto& den) {
       TEfficiency* eff = static_cast<TEfficiency*>(subList->FindObject(effname));
       if (!eff) {
         LOG(warning) << "Cannot find TEfficiency " << effname;
@@ -1436,7 +1436,7 @@ struct QaEfficiency {
     }
 
     // Filling 2D efficiencies
-    auto fillEfficiency2D = [&](const TString effname, auto num, auto den) {
+    auto fillEfficiency2D = [&](const TString& effname, const auto& num, const auto& den) {
       TEfficiency* eff = static_cast<TEfficiency*>(subList->FindObject(effname));
       if (!eff) {
         LOG(warning) << "Cannot find TEfficiency " << effname;

--- a/DPG/Tasks/AOTTrack/qaEventTrackLite.cxx
+++ b/DPG/Tasks/AOTTrack/qaEventTrackLite.cxx
@@ -154,7 +154,7 @@ struct qaEventTrackLite {
       ///
       return initBBok ? mMip * o2::common::BetheBlochAleph(x[0] / par[0], mBetheBlockAleph[0], mBetheBlockAleph[1], mBetheBlockAleph[2], mBetheBlockAleph[3], mBetheBlockAleph[4]) * std::pow(par[1], mChargeFactor) : 0.;
     }
-    void setUpBetheBlockAleph(std::string str_case)
+    void setUpBetheBlockAleph(const std::string& str_case)
     {
       if (str_case.find("LHC22c") != std::string::npos) {
         // From A. Kalteyer (2022 Jul 18)
@@ -418,7 +418,7 @@ struct qaEventTrackLite {
     histos.fill(HIST("Tracks/TPC/dEdxvsP"), p, track.tpcSignal());
     histos.fill(HIST("Tracks/TPC/dEdxvsPvsEta"), p, track.eta(), track.tpcSignal());
     if (betheBlock.initBBok) {
-      auto tpcdEdxRes = [&](TF1 func) { return track.tpcSignal() - func.Eval(p); };
+      auto tpcdEdxRes = [&](const TF1& func) { return track.tpcSignal() - func.Eval(p); };
       if (b_tpcResProton) {
         histos.fill(HIST("Tracks/TPC/dEdxvsPproton"), p, tpcdEdxRes(funcBBproton));
         histos.fill(HIST("Tracks/TPC/dEdxvsPprotonvsEta"), p, track.eta(), tpcdEdxRes(funcBBproton));

--- a/DPG/Tasks/AOTTrack/qaTrackSplitting.cxx
+++ b/DPG/Tasks/AOTTrack/qaTrackSplitting.cxx
@@ -35,6 +35,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <type_traits>
 #include <vector>
 
 using namespace o2;
@@ -134,10 +135,11 @@ struct qaTrackSplitting {
     if (!collision.sel8()) {
       return;
     }
-    typedef std::shared_ptr<TrackCandidatesMC::iterator> trkType;
+    using TrackType = const TrackCandidatesMC::iterator;
+    using TrackTypePtr = std::shared_ptr<TrackType>;
 
-    std::map<int64_t, std::vector<trkType>> particleUsageCounter;
-    for (auto track : tracks) {
+    std::map<int64_t, std::vector<TrackTypePtr>> particleUsageCounter;
+    for (const auto& track : tracks) {
       histos.fill(HIST("tracks"), 0);
       if (!track.has_mcParticle()) {
         continue;
@@ -156,7 +158,7 @@ struct qaTrackSplitting {
         continue;
       }
       histos.fill(HIST("tracks"), 4);
-      particleUsageCounter[track.mcParticleId()].push_back(std::make_shared<decltype(track)>(track));
+      particleUsageCounter[track.mcParticleId()].push_back(std::make_shared<TrackType>(track));
     }
     for (const auto& [mcId, tracksMatched] : particleUsageCounter) {
       histos.fill(HIST("numberOfRecoed"), tracksMatched.size());

--- a/DPG/Tasks/AOTTrack/tagAndProbeDmesons.cxx
+++ b/DPG/Tasks/AOTTrack/tagAndProbeDmesons.cxx
@@ -1296,7 +1296,7 @@ struct ProbeThirdTrack {
   }
 
   template <uint8_t channel, bool doMc, typename TTrackIndices, typename TTrack, typename TTracks, typename PParticles>
-  void loopOverThirdTrack(TTrackIndices const& groupedTrackThirdIndices, TTracks const& /*tracks*/, TTrack const& trackFirst, TTrack const& trackSecond, PParticles const mcParticles, const int motherIdxTag, const float radius)
+  void loopOverThirdTrack(TTrackIndices const& groupedTrackThirdIndices, TTracks const& /*tracks*/, TTrack const& trackFirst, TTrack const& trackSecond, PParticles const& mcParticles, const int motherIdxTag, const float radius)
   {
     for (const auto& trackIndex : groupedTrackThirdIndices) {
       auto trackThird = trackIndex.template track_as<TTracks>();

--- a/DPG/Tasks/ITS/filterTracks.cxx
+++ b/DPG/Tasks/ITS/filterTracks.cxx
@@ -225,7 +225,7 @@ struct FilterTracks {
   {
   }
 
-  void fillTableData(auto track)
+  void fillTableData(const auto& track)
   {
 
     filteredTracksCollIdx(track.collisionId());
@@ -235,7 +235,7 @@ struct FilterTracks {
     filteredTracksTableExtraDet(track.itsClusterSizes(), track.itsChi2NCl(), track.tpcChi2NCl(), track.tpcNClsFound(), track.trackTime());
   }
 
-  void fillTableDataMC(auto track, aod::McParticles const& mcParticles)
+  void fillTableDataMC(const auto& track, aod::McParticles const& mcParticles)
   {
 
     fillTableData(track);


### PR DESCRIPTION
Mostly done automatically by Clang-Tidy.