### PR TITLE
[Trigger,PWGCF,PWGEM,PWGLF,PWGUD] Use `const&` and `std::move` to avoid copies

### DIFF
--- a/EventFiltering/PWGCF/CFFilterAll.cxx
+++ b/EventFiltering/PWGCF/CFFilterAll.cxx
@@ -1087,7 +1087,7 @@ struct CFFilterAll {
   }
 
   template <typename T>
-  bool checkTrack(T const& track, std::string trackName)
+  bool checkTrack(T const& track, const std::string& trackName)
   {
     if (track.pt() < TrackSelections.momentum->get(trackName.c_str(), "PtMin")) {
       return false;
@@ -1135,7 +1135,7 @@ struct CFFilterAll {
   }
 
   template <typename T>
-  bool checkTrackPid(T const& track, std::string trackName)
+  bool checkTrackPid(T const& track, const std::string& trackName)
   {
     float momentum = -99;
 
@@ -1236,8 +1236,8 @@ struct CFFilterAll {
     return true;
   }
 
-  float getkstar(const ROOT::Math::PtEtaPhiMVector part1,
-                 const ROOT::Math::PtEtaPhiMVector part2)
+  float getkstar(const ROOT::Math::PtEtaPhiMVector& part1,
+                 const ROOT::Math::PtEtaPhiMVector& part2)
   {
     const ROOT::Math::PtEtaPhiMVector trackSum = part1 + part2;
     const float beta = trackSum.Beta();
@@ -1257,7 +1257,7 @@ struct CFFilterAll {
   }
 
   ROOT::Math::PxPyPzEVector
-    getqij(const ROOT::Math::PtEtaPhiMVector parti, const ROOT::Math::PtEtaPhiMVector partj)
+    getqij(const ROOT::Math::PtEtaPhiMVector& parti, const ROOT::Math::PtEtaPhiMVector& partj)
   {
     ROOT::Math::PxPyPzEVector vecparti(parti);
     ROOT::Math::PxPyPzEVector vecpartj(partj);
@@ -1266,7 +1266,7 @@ struct CFFilterAll {
     float scaling = trackDifference.Dot(trackSum) / trackSum.Dot(trackSum);
     return trackDifference - scaling * trackSum;
   }
-  float getQ3(const ROOT::Math::PtEtaPhiMVector part1, const ROOT::Math::PtEtaPhiMVector part2, const ROOT::Math::PtEtaPhiMVector part3)
+  float getQ3(const ROOT::Math::PtEtaPhiMVector& part1, const ROOT::Math::PtEtaPhiMVector& part2, const ROOT::Math::PtEtaPhiMVector& part3)
   {
     ROOT::Math::PxPyPzEVector q12 = getqij(part1, part2);
     ROOT::Math::PxPyPzEVector q23 = getqij(part2, part3);

--- a/EventFiltering/PWGEM/HeavyNeutralMesonFilter.cxx
+++ b/EventFiltering/PWGEM/HeavyNeutralMesonFilter.cxx
@@ -289,8 +289,8 @@ struct HeavyNeutralMesonFilter {
     return true;
   }
 
-  float getkstar(const ROOT::Math::PtEtaPhiMVector part1,
-                 const ROOT::Math::PtEtaPhiMVector part2)
+  float getkstar(const ROOT::Math::PtEtaPhiMVector& part1,
+                 const ROOT::Math::PtEtaPhiMVector& part2)
   {
     const ROOT::Math::PtEtaPhiMVector trackSum = part1 + part2;
     const float beta = trackSum.Beta();
@@ -306,8 +306,8 @@ struct HeavyNeutralMesonFilter {
     return 0.5 * trackRelK.P();
   }
 
-  ROOT::Math::PxPyPzEVector getqij(const ROOT::Math::PtEtaPhiMVector parti,
-                                   const ROOT::Math::PtEtaPhiMVector partj)
+  ROOT::Math::PxPyPzEVector getqij(const ROOT::Math::PtEtaPhiMVector& parti,
+                                   const ROOT::Math::PtEtaPhiMVector& partj)
   {
     ROOT::Math::PxPyPzEVector vecparti(parti);
     ROOT::Math::PxPyPzEVector vecpartj(partj);
@@ -316,9 +316,9 @@ struct HeavyNeutralMesonFilter {
     float scaling = trackDifference.Dot(trackSum) / trackSum.Dot(trackSum);
     return trackDifference - scaling * trackSum;
   }
-  float getQ3(const ROOT::Math::PtEtaPhiMVector part1,
-              const ROOT::Math::PtEtaPhiMVector part2,
-              const ROOT::Math::PtEtaPhiMVector part3)
+  float getQ3(const ROOT::Math::PtEtaPhiMVector& part1,
+              const ROOT::Math::PtEtaPhiMVector& part2,
+              const ROOT::Math::PtEtaPhiMVector& part3)
   {
     ROOT::Math::PxPyPzEVector q12 = getqij(part1, part2);
     ROOT::Math::PxPyPzEVector q23 = getqij(part2, part3);

--- a/EventFiltering/PWGLF/filterdoublephi.cxx
+++ b/EventFiltering/PWGLF/filterdoublephi.cxx
@@ -188,7 +188,7 @@ struct filterdoublephi {
     if (collision.sel8()) {
       auto posThisColl = posTracks->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
       auto negThisColl = negTracks->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
-      for (auto track1 : posThisColl) {
+      for (const auto& track1 : posThisColl) {
         // track selection
         if (!selectionTrack(track1)) {
           continue;
@@ -209,7 +209,7 @@ struct filterdoublephi {
           qaRegistry.fill(HIST("hNsigmaPtkaonTOF"), track1.tofNSigmaKa(), track1.pt());
         }
         auto track1ID = track1.globalIndex();
-        for (auto track2 : negThisColl) {
+        for (const auto& track2 : negThisColl) {
           // track selection
           if (!selectionTrack(track2)) {
             continue;

--- a/EventFiltering/PWGLF/filterf1proton.cxx
+++ b/EventFiltering/PWGLF/filterf1proton.cxx
@@ -419,8 +419,8 @@ struct filterf1proton {
     return true;
   }
 
-  float getkstar(const ROOT::Math::PtEtaPhiMVector part1,
-                 const ROOT::Math::PtEtaPhiMVector part2)
+  float getkstar(const ROOT::Math::PtEtaPhiMVector& part1,
+                 const ROOT::Math::PtEtaPhiMVector& part2)
   {
     const ROOT::Math::PtEtaPhiMVector trackSum = part1 + part2;
     const float beta = trackSum.Beta();
@@ -439,7 +439,7 @@ struct filterf1proton {
     return 0.5 * trackRelK.P();
   }
 
-  std::vector<double> setValuesBB(o2::ccdb::CcdbApi& ccdbApi, aod::BCsWithTimestamps::iterator const& bunchCrossing, const std::string ccdbPath)
+  std::vector<double> setValuesBB(o2::ccdb::CcdbApi& ccdbApi, aod::BCsWithTimestamps::iterator const& bunchCrossing, const std::string& ccdbPath)
   {
     std::map<std::string, std::string> metadata;
     auto h = ccdbApi.retrieveFromTFileAny<TH1F>(ccdbPath, metadata, bunchCrossing.timestamp());

--- a/EventFiltering/PWGLF/nucleiFilter.cxx
+++ b/EventFiltering/PWGLF/nucleiFilter.cxx
@@ -413,7 +413,7 @@ struct nucleiFilter {
           continue;
         }
         const auto& h3vector = h3vectors[iH3];
-        auto pivector = trackVector;
+        const auto& pivector = trackVector;
         auto cm = h3vector + trackVector;
         const ROOT::Math::Boost boost(cm.BoostToCM());
         boost(pivector);

--- a/EventFiltering/PWGLF/strangenessFilter.cxx
+++ b/EventFiltering/PWGLF/strangenessFilter.cxx
@@ -266,23 +266,23 @@ struct strangenessFilter {
   {
     return track.pt() > cfgHMOmegaCuts.hMinPtHM && std::abs(track.eta()) < cfgHMOmegaCuts.hEtaHM && track.tpcNClsCrossedRows() >= tpcmincrossedrows && track.tpcChi2NCl() <= 4.f && track.itsChi2NCl() <= 36.f && (track.itsClusterMap() & 0x7) != 0;
   }
-  float getV0V0DCA(TVector3 v01pos, TVector3 v01mom, TVector3 v02pos, TVector3 v02mom)
+  float getV0V0DCA(const TVector3& v01pos, const TVector3& v01mom, const TVector3& v02pos, const TVector3& v02mom)
   {
     TVector3 posdiff = v02pos - v01pos;
     TVector3 cross = v01mom.Cross(v02mom);
     TVector3 dcaVec = (posdiff.Dot(cross) / cross.Mag2()) * cross;
     return dcaVec.Mag();
   }
-  float getV0V0CPA(TVector3 v01mom, TVector3 v02mom)
+  float getV0V0CPA(const TVector3& v01mom, const TVector3& v02mom)
   {
     return v01mom.Dot(v02mom) / (v01mom.Mag() * v02mom.Mag());
   }
-  float getV0V0Distance(TVector3 v01pos, TVector3 v02pos)
+  float getV0V0Distance(const TVector3& v01pos, const TVector3& v02pos)
   {
     TVector3 posdiff = v02pos - v01pos;
     return posdiff.Mag();
   }
-  float getV0V0Radius(TVector3 v01pos, TVector3 v01mom, TVector3 v02pos, TVector3 v02mom)
+  float getV0V0Radius(const TVector3& v01pos, TVector3 v01mom, const TVector3& v02pos, TVector3 v02mom)
   {
     TVector3 posdiff = v02pos - v01pos;
     v01mom *= 1. / v01mom.Mag();
@@ -296,7 +296,7 @@ struct strangenessFilter {
     radVec *= 0.5;
     return radVec.Mag();
   }
-  bool isSelectedV0V0(TVector3 v01pos, TVector3 v01mom, TVector3 v02pos, TVector3 v02mom)
+  bool isSelectedV0V0(const TVector3& v01pos, const TVector3& v01mom, const TVector3& v02pos, const TVector3& v02mom)
   {
     if (getV0V0DCA(v01pos, v01mom, v02pos, v02mom) > cfgLLCuts.cfgMaxDCAV0V0)
       return false;
@@ -1217,7 +1217,7 @@ struct strangenessFilter {
 
     // QA tracks
     int triggcounterAllEv = 0;
-    for (auto track : tracks) { // start loop over tracks
+    for (const auto& track : tracks) { // start loop over tracks
       if (cfgTrackCuts.isTrackFilter && !selectTrack(track)) {
         continue;
       }
@@ -1524,7 +1524,7 @@ struct strangenessFilter {
       QAHistosSigma.fill(HIST("hDecayRadiusSigma"), decRad);
       // pair a proton
       bool isProtonPaired = false;
-      for (auto track : tracks) {
+      for (const auto& track : tracks) {
         if (track.globalIndex() == dauTrack.globalIndex()) {
           continue;
         }

--- a/EventFiltering/PWGUD/diffractionBCFilter.cxx
+++ b/EventFiltering/PWGUD/diffractionBCFilter.cxx
@@ -321,7 +321,7 @@ struct DGBCFilterRun3 {
 
     // loop over bcs
     int isDGBC;
-    for (auto bc : bcs) {
+    for (const auto& bc : bcs) {
       auto bcnum = bc.globalBC();
       auto ccs = false;
 

--- a/EventFiltering/PWGUD/diffractionFilter.cxx
+++ b/EventFiltering/PWGUD/diffractionFilter.cxx
@@ -284,7 +284,7 @@ struct DGFilterRun3 {
 
     // forward tracks
     int nforwardTracks[5] = {0};
-    for (auto track : fwdtracks) {
+    for (const auto& track : fwdtracks) {
       nforwardTracks[track.trackType()]++;
       registry.fill(HIST("forwardTracks/timeResolution"), track.trackType(), track.trackTimeRes());
     }

--- a/EventFiltering/macros/checkBCrangesSkimming.C
+++ b/EventFiltering/macros/checkBCrangesSkimming.C
@@ -181,7 +181,7 @@ void checkNearbyBCs(std::vector<selectedFrames>& frames, ULong64_t bcDiffToleran
 }
 
 // Get RunNumber
-std::string getRunNumber(std::string fileName)
+std::string getRunNumber(const std::string& fileName)
 {
   std::string runNumber = "";
   std::regex re("/5[0-9]*");

--- a/EventFiltering/macros/checkSkimming.C
+++ b/EventFiltering/macros/checkSkimming.C
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-void checkSkimming(std::string original_path = "AnalysisResults.root", std::string skimmed_path = "AnalysisResults_skimmed.root", TFile* outputFile = nullptr, bool skipDownscaled = true)
+void checkSkimming(const std::string& original_path = "AnalysisResults.root", const std::string& skimmed_path = "AnalysisResults_skimmed.root", TFile* outputFile = nullptr, bool skipDownscaled = true)
 {
   gStyle->SetOptStat(0);
   std::string runNumber = "";
@@ -57,7 +57,7 @@ void checkSkimming(std::string original_path = "AnalysisResults.root", std::stri
 
   // Find the bins corresponding to the desired labels
   std::vector<double> selected_bins1, selected_bins2;
-  for (auto lab : labels) {
+  for (const auto& lab : labels) {
     int bin1 = hist1->GetXaxis()->FindBin(lab.c_str());
     if (bin1 == -1) {
       std::cerr << "Error: Label " << lab << " not found in histogram 1." << std::endl;
@@ -104,7 +104,7 @@ void checkSkimming(std::string original_path = "AnalysisResults.root", std::stri
   }
 }
 
-void checkSkimming(std::string listName = "period.txt", bool skipDownscaled = true)
+void checkSkimming(const std::string& listName = "period.txt", bool skipDownscaled = true)
 {
   std::string periodName = listName.substr(0, listName.find_last_of('.'));
   std::ifstream file(listName);

--- a/EventFiltering/macros/getMenu.C
+++ b/EventFiltering/macros/getMenu.C
@@ -27,7 +27,7 @@
 #include <string>
 #include <vector>
 
-void getMenu(int runNumber, std::string baseCCDBPath = "Users/m/mpuccio/EventFiltering/OTS/Chunked/")
+void getMenu(int runNumber, const std::string& baseCCDBPath = "Users/m/mpuccio/EventFiltering/OTS/Chunked/")
 {
   auto& ccdb = o2::ccdb::BasicCCDBManager::instance();
   TH1* counters = ccdb.getForRun<TH1>(baseCCDBPath + "FilterCounters", runNumber);
@@ -84,7 +84,7 @@ std::vector<std::string> getMenuForPeriod(std::string period)
   return binLabels;
 }
 
-void getMenu(std::string periods)
+void getMenu(const std::string& periods)
 {
   std::stringstream ss(periods);
   std::string period;

--- a/EventFiltering/macros/selectivityPlot.C
+++ b/EventFiltering/macros/selectivityPlot.C
@@ -23,7 +23,7 @@
 
 #include <string>
 
-void selectivityPlot(int runNumber = 550781, TString inputfile = "AnalysisResults_550781.root", TString outputfolder = "")
+void selectivityPlot(int runNumber = 550781, const TString& inputfile = "AnalysisResults_550781.root", const TString& outputfolder = "")
 {
   TCanvas* Canvas_1 = new TCanvas("Canvas_1", "Canvas_1", 928, 592);
   gStyle->SetOptFit(0);

--- a/EventFiltering/macros/uploadOTSobjects.C
+++ b/EventFiltering/macros/uploadOTSobjects.C
@@ -39,7 +39,7 @@
 
 constexpr uint32_t chunkSize = 1000000;
 
-void uploadOTSobjects(std::string inputList, std::string passName, bool useAlien, bool chunkedProcessing = true)
+void uploadOTSobjects(std::string inputList, const std::string& passName, bool useAlien, bool chunkedProcessing = true)
 {
   const std::string kBaseCCDBPath = "EventFiltering/Zorro/";
   std::string baseCCDBpath = passName.empty() ? kBaseCCDBPath : kBaseCCDBPath + passName + "/";


### PR DESCRIPTION
Mostly done automatically by Clang-Tidy.