### PR TITLE
[PWGDQ] Use `const&` and `std::move` to avoid copies

### DIFF
--- a/PWGDQ/Core/MCProng.cxx
+++ b/PWGDQ/Core/MCProng.cxx
@@ -92,19 +92,19 @@ MCProng::MCProng(int n, int m) : fNGenerations(n),
 }
 
 //________________________________________________________________________________________________________________
-MCProng::MCProng(int n, const std::vector<int> pdgs, const std::vector<bool> checkBothCharges, const std::vector<bool> excludePDG,
-                 const std::vector<uint64_t> sourceBits, const std::vector<uint64_t> excludeSource,
-                 const std::vector<bool> useANDonSourceBitMap, bool checkGenerationsInTime,
-                 const std::vector<int> checkIfPDGInHistory, const std::vector<bool> excludePDGInHistory) : fNGenerations(n),
-                                                                                                            fPDGcodes(pdgs),
-                                                                                                            fCheckBothCharges(checkBothCharges),
-                                                                                                            fExcludePDG(excludePDG),
-                                                                                                            fSourceBits(sourceBits),
-                                                                                                            fExcludeSource(excludeSource),
-                                                                                                            fUseANDonSourceBitMap(useANDonSourceBitMap),
-                                                                                                            fCheckGenerationsInTime(checkGenerationsInTime),
-                                                                                                            fPDGInHistory(checkIfPDGInHistory),
-                                                                                                            fExcludePDGInHistory(excludePDGInHistory) {}
+MCProng::MCProng(int n, const std::vector<int>& pdgs, const std::vector<bool>& checkBothCharges, const std::vector<bool>& excludePDG,
+                 const std::vector<uint64_t>& sourceBits, const std::vector<uint64_t>& excludeSource,
+                 const std::vector<bool>& useANDonSourceBitMap, bool checkGenerationsInTime,
+                 const std::vector<int>& checkIfPDGInHistory, const std::vector<bool>& excludePDGInHistory) : fNGenerations(n),
+                                                                                                              fPDGcodes(pdgs),
+                                                                                                              fCheckBothCharges(checkBothCharges),
+                                                                                                              fExcludePDG(excludePDG),
+                                                                                                              fSourceBits(sourceBits),
+                                                                                                              fExcludeSource(excludeSource),
+                                                                                                              fUseANDonSourceBitMap(useANDonSourceBitMap),
+                                                                                                              fCheckGenerationsInTime(checkGenerationsInTime),
+                                                                                                              fPDGInHistory(checkIfPDGInHistory),
+                                                                                                              fExcludePDGInHistory(excludePDGInHistory) {}
 
 //________________________________________________________________________________________________________________
 void MCProng::SetPDGcode(int generation, int code, bool checkBothCharges /*= false*/, bool exclude /*= false*/)

--- a/PWGDQ/Core/MCProng.h
+++ b/PWGDQ/Core/MCProng.h
@@ -89,9 +89,9 @@ class MCProng
   MCProng();
   explicit MCProng(int n);
   MCProng(int n, int m);
-  MCProng(int n, std::vector<int> pdgs, std::vector<bool> checkBothCharges, std::vector<bool> excludePDG,
-          std::vector<uint64_t> sourceBits, std::vector<uint64_t> excludeSource, std::vector<bool> useANDonSourceBitMap,
-          bool checkGenerationsInTime = false, std::vector<int> checkIfPDGInHistory = {}, std::vector<bool> excludePDGInHistory = {});
+  MCProng(int n, const std::vector<int>& pdgs, const std::vector<bool>& checkBothCharges, const std::vector<bool>& excludePDG,
+          const std::vector<uint64_t>& sourceBits, const std::vector<uint64_t>& excludeSource, const std::vector<bool>& useANDonSourceBitMap,
+          bool checkGenerationsInTime = false, const std::vector<int>& checkIfPDGInHistory = {}, const std::vector<bool>& excludePDGInHistory = {});
   MCProng(const MCProng& c) = default;
   virtual ~MCProng() = default;
 

--- a/PWGDQ/Core/MCSignal.cxx
+++ b/PWGDQ/Core/MCSignal.cxx
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <iostream>
+#include <utility>
 #include <vector>
 
 using std::cout;
@@ -52,28 +53,28 @@ MCSignal::MCSignal(int nProngs, const char* name /*= ""*/, const char* title /*=
 }
 
 //________________________________________________________________________________________________
-MCSignal::MCSignal(const char* name, const char* title, std::vector<MCProng> prongs, std::vector<int8_t> commonAncestors, bool excludeCommonAncestor) : TNamed(name, title),
-                                                                                                                                                        fProngs(prongs),
-                                                                                                                                                        fNProngs(prongs.size()),
-                                                                                                                                                        fCommonAncestorIdxs(commonAncestors),
-                                                                                                                                                        fExcludeCommonAncestor(excludeCommonAncestor),
-                                                                                                                                                        fDecayChannelIsExclusive(false),
-                                                                                                                                                        fDecayChannelIsNotExclusive(false),
-                                                                                                                                                        fNAncestorDirectProngs(0),
-                                                                                                                                                        fTempAncestorLabel(-1)
+MCSignal::MCSignal(const char* name, const char* title, const std::vector<MCProng>& prongs, std::vector<int8_t> commonAncestors, bool excludeCommonAncestor) : TNamed(name, title),
+                                                                                                                                                               fProngs(prongs),
+                                                                                                                                                               fNProngs(prongs.size()),
+                                                                                                                                                               fCommonAncestorIdxs(std::move(commonAncestors)),
+                                                                                                                                                               fExcludeCommonAncestor(excludeCommonAncestor),
+                                                                                                                                                               fDecayChannelIsExclusive(false),
+                                                                                                                                                               fDecayChannelIsNotExclusive(false),
+                                                                                                                                                               fNAncestorDirectProngs(0),
+                                                                                                                                                               fTempAncestorLabel(-1)
 {
 }
 
 //________________________________________________________________________________________________
 void MCSignal::SetProngs(std::vector<MCProng> prongs, std::vector<int8_t> commonAncestors)
 {
-  fProngs = prongs;
+  fProngs = std::move(prongs);
   fNProngs = fProngs.size();
-  fCommonAncestorIdxs = commonAncestors;
+  fCommonAncestorIdxs = std::move(commonAncestors);
 }
 
 //________________________________________________________________________________________________
-void MCSignal::AddProng(MCProng prong, int8_t commonAncestor)
+void MCSignal::AddProng(const MCProng& prong, int8_t commonAncestor)
 {
   if (fProngs.size() < fNProngs) {
     fProngs.push_back(prong);

--- a/PWGDQ/Core/MCSignal.h
+++ b/PWGDQ/Core/MCSignal.h
@@ -68,12 +68,12 @@ class MCSignal : public TNamed
  public:
   MCSignal();
   MCSignal(int nProngs, const char* name = "", const char* title = ""); // NOLINT
-  MCSignal(const char* name, const char* title, std::vector<MCProng> prongs, std::vector<int8_t> commonAncestors, bool excludeCommonAncestor = false);
+  MCSignal(const char* name, const char* title, const std::vector<MCProng>& prongs, std::vector<int8_t> commonAncestors, bool excludeCommonAncestor = false);
   MCSignal(const MCSignal& c) = default;
   ~MCSignal() override = default;
 
   void SetProngs(std::vector<MCProng> prongs, std::vector<int8_t> commonAncestors);
-  void AddProng(MCProng prong, int8_t commonAncestor = -1);
+  void AddProng(const MCProng& prong, int8_t commonAncestor = -1);
   void SetDecayChannelIsExclusive(int nProngs, bool option = true)
   {
     fDecayChannelIsExclusive = option;

--- a/PWGDQ/Core/MixingHandler.cxx
+++ b/PWGDQ/Core/MixingHandler.cxx
@@ -58,7 +58,7 @@ MixingHandler::~MixingHandler()
 }
 
 //_________________________________________________________________________
-void MixingHandler::AddMixingVariable(int var, std::vector<float> binLims)
+void MixingHandler::AddMixingVariable(int var, const std::vector<float>& binLims)
 {
   fVariables[var] = fVariableLimits.size();
   fVariableLimits.push_back(binLims);

--- a/PWGDQ/Core/MixingHandler.h
+++ b/PWGDQ/Core/MixingHandler.h
@@ -174,7 +174,7 @@ class MixingHandler : public TNamed
   virtual ~MixingHandler();
 
   // setters
-  void AddMixingVariable(int var, std::vector<float> binLims);
+  void AddMixingVariable(int var, const std::vector<float>& binLims);
   void SetPoolDepth(int16_t depth) { fPoolDepth = depth; }
 
   // getters

--- a/PWGDQ/Macros/dqFlowAccWeights.C
+++ b/PWGDQ/Macros/dqFlowAccWeights.C
@@ -32,7 +32,7 @@
 using namespace o2;
 using namespace std;
 
-void dqFlowAccWeights(int64_t tmin = 1546300800000, int64_t tmax = 1577833200000, std::string Period = "LHC23zzh_pass2", std::string SubDir = "d-q-event-qvector", std::string FileName = "AnalysisResults.root")
+void dqFlowAccWeights(int64_t tmin = 1546300800000, int64_t tmax = 1577833200000, const std::string& Period = "LHC23zzh_pass2", const std::string& SubDir = "d-q-event-qvector", const std::string& FileName = "AnalysisResults.root")
 {
   if (tmax < tmin) {
     LOG(fatal) << "Wrong validity syntax!";

--- a/PWGDQ/TableProducer/tableMaker.cxx
+++ b/PWGDQ/TableProducer/tableMaker.cxx
@@ -1246,7 +1246,7 @@ struct TableMaker {
     } // end if constexpr (TMuonFillMap)
   } // end fullSkimming()
 
-  void DefineHistograms(TString histClasses)
+  void DefineHistograms(const TString& histClasses)
   {
     std::unique_ptr<TObjArray> objArray(histClasses.Tokenize(";"));
     for (Int_t iclass = 0; iclass < objArray->GetEntries(); ++iclass) {

--- a/PWGDQ/TableProducer/tableMakerMC.cxx
+++ b/PWGDQ/TableProducer/tableMakerMC.cxx
@@ -1534,7 +1534,7 @@ struct TableMakerMC {
     fEventLabels.clear();
   }
 
-  void DefineHistograms(TString histClasses)
+  void DefineHistograms(const TString& histClasses)
   {
     std::unique_ptr<TObjArray> objArray(histClasses.Tokenize(";"));
     for (Int_t iclass = 0; iclass < objArray->GetEntries(); ++iclass) {

--- a/PWGDQ/TableProducer/tableMakerMuonMchTrkEfficiency.cxx
+++ b/PWGDQ/TableProducer/tableMakerMuonMchTrkEfficiency.cxx
@@ -246,7 +246,7 @@ struct tableMakerMuonMchTrkEfficiency {
 
   /// extrapolate tracks to a given r value (spherical coordinates)
   ///   to mimic the (x,y) position in a given chamber
-  void extrapolate(TLorentzVector vec, int ich, double& x, double& y)
+  void extrapolate(const TLorentzVector& vec, int ich, double& x, double& y)
   { // i = 0..9
     double zposCh[10] = {5, 5, 7, 7, 10, 10, 12.5, 12.5, 14.5, 14.5};
     double theta = vec.Theta();
@@ -396,7 +396,7 @@ struct tableMakerMuonMchTrkEfficiency {
 
   /// Event selection
   template <uint32_t TEventFillMap, typename TEvent>
-  void runEventSelection(TEvent event)
+  void runEventSelection(const TEvent& event)
   {
     VarManager::ResetValues(0, VarManager::kNEventWiseVariables);
     VarManager::FillEvent<TEventFillMap>(event); // extract event information and place it in the fValues array

--- a/PWGDQ/Tasks/TagAndProbe.cxx
+++ b/PWGDQ/Tasks/TagAndProbe.cxx
@@ -79,7 +79,7 @@ constexpr static uint32_t gkEventFillMapWithCov = VarManager::ObjTypes::ReducedE
 constexpr static uint32_t gkMuonFillMapWithCov = VarManager::ObjTypes::ReducedMuon | VarManager::ObjTypes::ReducedMuonExtra | VarManager::ObjTypes::ReducedMuonCov;
 
 // Global function used to define needed histogram classes
-void DefineHistograms(HistogramManager* histMan, TString histClasses, const char* histGroups); // defines histograms for all tasks
+void DefineHistograms(HistogramManager* histMan, const TString& histClasses, const char* histGroups); // defines histograms for all tasks
 
 template <typename TMap>
 void PrintBitMap(TMap map, int nbits)
@@ -348,7 +348,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     adaptAnalysisTask<AnalysisTagAndProbe>(cfgc)};
 }
 
-void DefineHistograms(HistogramManager* histMan, TString histClasses, const char* histGroups)
+void DefineHistograms(HistogramManager* histMan, const TString& histClasses, const char* histGroups)
 {
   //
   // Define here the histograms for all the classes required in analysis.

--- a/PWGDQ/Tasks/dqCorrelation.cxx
+++ b/PWGDQ/Tasks/dqCorrelation.cxx
@@ -286,7 +286,7 @@ struct DqCumulantFlow {
     float weff = 1.0, wacc = 1.0;
 
     if (dileptons.size() > 0) {
-      for (auto track : tracks) {
+      for (const auto& track : tracks) {
         trackGlobalIndexes.push_back(track.globalIndex());
       }
 
@@ -316,7 +316,7 @@ struct DqCumulantFlow {
         }
       }
 
-      for (auto dilepton : dileptons) {
+      for (const auto& dilepton : dileptons) {
         registry.fill(HIST("dimuon_mass"), dilepton.mass());
 
         VarManager::FillTrack<fgDimuonsFillMap>(dilepton, fValuesDilepton);

--- a/PWGDQ/Tasks/dqEfficiency.cxx
+++ b/PWGDQ/Tasks/dqEfficiency.cxx
@@ -95,7 +95,7 @@ constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::ReducedMuon | Va
 constexpr static uint32_t gkMuonFillMapWithCov = VarManager::ObjTypes::ReducedMuon | VarManager::ObjTypes::ReducedMuonExtra | VarManager::ObjTypes::ReducedMuonCov;
 constexpr static uint32_t gkParticleMCFillMap = VarManager::ObjTypes::ParticleMC;
 
-void DefineHistograms(HistogramManager* histMan, TString histClasses);
+void DefineHistograms(HistogramManager* histMan, const TString& histClasses);
 
 struct AnalysisEventSelection {
   Produces<aod::EventCuts> eventSel;
@@ -1197,12 +1197,12 @@ struct AnalysisDileptonTrack {
     std::vector<int> trackGlobalIndexes;
 
     if (dileptons.size() > 0) {
-      for (auto track : tracks) {
+      for (const auto& track : tracks) {
         trackGlobalIndexes.push_back(track.globalIndex());
         // std::cout << track.index() << " " << track.globalIndex() << std::endl;
       }
     }
-    for (auto dilepton : dileptons) {
+    for (const auto& dilepton : dileptons) {
 
       int indexLepton1 = dilepton.index0Id();
       int indexLepton2 = dilepton.index1Id();
@@ -1504,14 +1504,14 @@ struct AnalysisDileptonTrackTrack {
     std::vector<int> trackGlobalIndexes;
 
     if (dileptons.size() > 0) {
-      for (auto track : tracks) {
+      for (const auto& track : tracks) {
         trackGlobalIndexes.push_back(track.globalIndex());
         // std::cout << track.index() << " " << track.globalIndex() << std::endl;
       }
     }
 
     // loop over dileptons
-    for (auto dilepton : dileptons) {
+    for (const auto& dilepton : dileptons) {
       VarManager::FillTrack<fgDileptonFillMap>(dilepton, fValuesQuadruplet);
 
       // apply the dilepton cut
@@ -1665,7 +1665,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     adaptAnalysisTask<AnalysisDileptonTrackTrack>(cfgc)};
 }
 
-void DefineHistograms(HistogramManager* histMan, TString histClasses)
+void DefineHistograms(HistogramManager* histMan, const TString& histClasses)
 {
   //
   // Define here the histograms for all the classes required in analysis.

--- a/PWGDQ/Tasks/dqEfficiency_withAssoc_direct.cxx
+++ b/PWGDQ/Tasks/dqEfficiency_withAssoc_direct.cxx
@@ -301,7 +301,7 @@ constexpr static uint32_t gkTrackFillMapWithCovNoTOF = VarManager::ObjTypes::Tra
 constexpr static uint32_t gkDileptonFillMap = VarManager::ObjTypes::ReducedTrack | VarManager::ObjTypes::Pair; // fill map
 
 // Global function used to define needed histogram classes
-void DefineHistograms(HistogramManager* histMan, TString histClasses, const char* histGroups); // defines histograms for all tasks
+void DefineHistograms(HistogramManager* histMan, const TString& histClasses, const char* histGroups); // defines histograms for all tasks
 
 template <typename TMap>
 void PrintBitMap(TMap map, int nbits)
@@ -2737,7 +2737,7 @@ struct AnalysisDileptonTrack {
 
     auto bc = event.template bc_as<TBCs>();
 
-    for (auto dilepton : dileptons) {
+    for (const auto& dilepton : dileptons) {
       // get full track info of tracks based on the index
       auto lepton1 = tracks.rawIteratorAt(dilepton.index0Id());
       auto lepton2 = tracks.rawIteratorAt(dilepton.index1Id());
@@ -3180,7 +3180,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     adaptAnalysisTask<AnalysisDileptonTrack>(cfgc)};
 }
 
-void DefineHistograms(HistogramManager* histMan, TString histClasses, const char* histGroups)
+void DefineHistograms(HistogramManager* histMan, const TString& histClasses, const char* histGroups)
 {
   //
   // Define here the histograms for all the classes required in analysis.

--- a/PWGDQ/Tasks/dqEnergyCorrelator_direct.cxx
+++ b/PWGDQ/Tasks/dqEnergyCorrelator_direct.cxx
@@ -84,7 +84,7 @@ constexpr static uint32_t gkEventFillMapWithMults = VarManager::ObjTypes::BC | V
 constexpr static uint32_t gkTrackFillMapWithCov = VarManager::ObjTypes::Track | VarManager::ObjTypes::TrackExtra | VarManager::ObjTypes::TrackDCA | VarManager::ObjTypes::TrackCov | VarManager::ObjTypes::TrackPID;
 
 // Forward declarations
-void DefineHistograms(HistogramManager* histMan, TString histClasses, const char* histGroups); // defines histograms for all tasks
+void DefineHistograms(HistogramManager* histMan, const TString& histClasses, const char* histGroups); // defines histograms for all tasks
 
 struct AnalysisEnergyCorrelator {
   OutputObj<THashList> fOutputList{"output"};
@@ -1182,7 +1182,7 @@ struct AnalysisEnergyCorrelator {
 };
 
 // Histogram definitions
-void DefineHistograms(HistogramManager* histMan, TString histClasses, const char* histGroups)
+void DefineHistograms(HistogramManager* histMan, const TString& histClasses, const char* histGroups)
 {
   std::unique_ptr<TObjArray> objArray(histClasses.Tokenize(";"));
   for (Int_t iclass = 0; iclass < objArray->GetEntries(); ++iclass) {

--- a/PWGDQ/Tasks/dqFlow.cxx
+++ b/PWGDQ/Tasks/dqFlow.cxx
@@ -100,7 +100,7 @@ constexpr static uint32_t gkEventFillMapRun3 = VarManager::ObjTypes::BC | VarMan
 constexpr static uint32_t gkEventFillMapRun3Qvect = VarManager::ObjTypes::BC | VarManager::ObjTypes::Collision | VarManager::ObjTypes::CollisionCent | VarManager::ObjTypes::CollisionQvectCentr;
 constexpr static uint32_t gkTrackFillMap = VarManager::ObjTypes::Track | VarManager::ObjTypes::TrackExtra | VarManager::ObjTypes::TrackDCA | VarManager::ObjTypes::TrackSelection | VarManager::ObjTypes::TrackPID;
 
-void DefineHistograms(HistogramManager* histMan, TString histClasses);
+void DefineHistograms(HistogramManager* histMan, const TString& histClasses);
 
 struct DQEventQvector {
 
@@ -142,7 +142,7 @@ struct DQEventQvector {
   ConfigurableAxis axisMultiplicity{"axisMultiplicity", {VARIABLE_WIDTH, 0, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100.1}, "multiplicity / centrality axis for histograms"};
 
   // Define the filter for barrel tracks and forward tracks
-  Filter trackFilter = (requireGlobalTrackInFilter()) || (aod::track::isGlobalTrackSDD == (uint8_t) true);
+  Filter trackFilter = (requireGlobalTrackInFilter()) || (aod::track::isGlobalTrackSDD == (uint8_t)true);
   Filter fwdFilter = (aod::fwdtrack::eta < -2.45f) && (aod::fwdtrack::eta > -3.6f);
 
   // Histograms used for optionnal efficiency and non-uniform acceptance corrections
@@ -656,7 +656,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     adaptAnalysisTask<DQEventQvector>(cfgc)};
 }
 
-void DefineHistograms(HistogramManager* histMan, TString histClasses)
+void DefineHistograms(HistogramManager* histMan, const TString& histClasses)
 {
   //
   // Define here the histograms for all the classes required in analysis.

--- a/PWGDQ/Tasks/filterPP.cxx
+++ b/PWGDQ/Tasks/filterPP.cxx
@@ -106,7 +106,7 @@ constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::BC | VarManager
 constexpr static uint32_t gkTrackFillMap = VarManager::ObjTypes::Track | VarManager::ObjTypes::TrackExtra | VarManager::ObjTypes::TrackDCA | VarManager::ObjTypes::TrackSelection | VarManager::ObjTypes::TrackPID;
 constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::Muon;
 
-void DefineHistograms(HistogramManager* histMan, TString histClasses);
+void DefineHistograms(HistogramManager* histMan, const TString& histClasses);
 
 struct DQEventSelectionTask {
   Produces<aod::DQEventCuts> eventSel;
@@ -521,7 +521,7 @@ struct DQFilterPPTask {
 
     std::vector<int> objCountersBarrel(fNBarrelCuts, 0); // init all counters to zero
     // count the number of barrel tracks fulfilling each cut
-    for (auto track : tracksBarrel) {
+    for (const auto& track : tracksBarrel) {
       for (int i = 0; i < fNBarrelCuts; ++i) {
         if (track.isDQBarrelSelected() & (static_cast<uint32_t>(1) << i)) {
           objCountersBarrel[i] += 1;
@@ -585,7 +585,7 @@ struct DQFilterPPTask {
 
     std::vector<int> objCountersMuon(fNMuonCuts, 0); // init all counters to zero
     // count the number of muon tracks fulfilling each selection
-    for (auto muon : muons) {
+    for (const auto& muon : muons) {
       for (int i = 0; i < fNMuonCuts; ++i) {
         if (muon.isDQMuonSelected() & (static_cast<uint32_t>(1) << i)) {
           objCountersMuon[i] += 1;
@@ -701,7 +701,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     adaptAnalysisTask<DQFilterPPTask>(cfgc)};
 }
 
-void DefineHistograms(HistogramManager* histMan, TString histClasses)
+void DefineHistograms(HistogramManager* histMan, const TString& histClasses)
 {
   //
   // Define here the histograms for all the classes required in analysis.

--- a/PWGDQ/Tasks/filterPPwithAssociation.cxx
+++ b/PWGDQ/Tasks/filterPPwithAssociation.cxx
@@ -123,7 +123,7 @@ constexpr static uint32_t gkTrackFillMap = VarManager::ObjTypes::Track | VarMana
 constexpr static uint32_t gkTrackFillMapTPCPID = VarManager::ObjTypes::Track | VarManager::ObjTypes::TrackExtra | VarManager::ObjTypes::TrackDCA | VarManager::ObjTypes::TrackTPCPID;
 constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::Muon | VarManager::ObjTypes::MuonCov;
 
-void DefineHistograms(HistogramManager* histMan, TString histClasses, TString subgroups = "");
+void DefineHistograms(HistogramManager* histMan, const TString& histClasses, const TString& subgroups = "");
 
 template <typename TMap>
 void PrintBitMap(TMap map, int nbits)
@@ -720,7 +720,7 @@ struct DQFilterPPTask {
     uint32_t pairFilter = 0;
     // count the number of barrel tracks fulfilling each cut
     if constexpr (static_cast<bool>(TTrackFillMap)) {
-      for (auto trackAssoc : barrelAssocs) {
+      for (const auto& trackAssoc : barrelAssocs) {
         for (int i = 0; i < fNBarrelCuts; ++i) {
           if (trackAssoc.isDQBarrelSelected() & (static_cast<uint32_t>(1) << i)) {
             objCountersBarrel[i] += 1;
@@ -1227,7 +1227,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     adaptAnalysisTask<DQFilterPPTask>(cfgc)};
 }
 
-void DefineHistograms(HistogramManager* histMan, TString histClasses, TString subgroups)
+void DefineHistograms(HistogramManager* histMan, const TString& histClasses, const TString& subgroups)
 {
   //
   // Define here the histograms for all the classes required in analysis.

--- a/PWGDQ/Tasks/quarkoniaToHyperons.cxx
+++ b/PWGDQ/Tasks/quarkoniaToHyperons.cxx
@@ -1203,7 +1203,7 @@ struct QuarkoniaToHyperons {
   }
 
   template <typename TCollision>
-  bool isEventAccepted(TCollision collision, bool fillHists)
+  bool isEventAccepted(const TCollision& collision, bool fillHists)
   // check whether the collision passes our collision selections
   {
     if (fillHists)
@@ -1295,7 +1295,7 @@ struct QuarkoniaToHyperons {
   }
 
   template <typename TCollision>
-  void fillEventHistograms(TCollision collision, float& centrality, int& selGapSide)
+  void fillEventHistograms(const TCollision& collision, float& centrality, int& selGapSide)
   {
     if (isPP) { //
       centrality = collision.centFT0M();
@@ -1337,7 +1337,7 @@ struct QuarkoniaToHyperons {
   }
 
   template <typename TV0, typename TCollision>
-  uint64_t computeReconstructionBitmap(TV0 v0, TCollision collision, float rapidityLambda, float rapidityK0Short, float /*pT*/)
+  uint64_t computeReconstructionBitmap(const TV0& v0, const TCollision& collision, float rapidityLambda, float rapidityK0Short, float /*pT*/)
   // precalculate this information so that a check is one mask operation, not many
   {
     uint64_t bitMap = 0;
@@ -1492,7 +1492,7 @@ struct QuarkoniaToHyperons {
   }
 
   template <typename TCascade, typename TCollision>
-  bool isCascadeSelected(TCascade casc, TCollision collision, float rapidity, bool isXi)
+  bool isCascadeSelected(const TCascade& casc, const TCollision& collision, float rapidity, bool isXi)
   // precalculate this information so that a check is one mask operation, not many
   {
     //
@@ -1728,7 +1728,7 @@ struct QuarkoniaToHyperons {
   }
 
   template <typename TV0>
-  uint64_t computeMCAssociation(TV0 v0)
+  uint64_t computeMCAssociation(const TV0& v0)
   // precalculate this information so that a check is one mask operation, not many
   {
     uint64_t bitMap = 0;
@@ -1758,7 +1758,7 @@ struct QuarkoniaToHyperons {
   }
 
   template <typename TV0>
-  void analyseV0Candidate(TV0 v0, float pt, uint64_t selMap, std::vector<int>& selK0ShortIndices, std::vector<int>& selLambdaIndices, std::vector<int>& selAntiLambdaIndices /*, int v0TableOffset*/)
+  void analyseV0Candidate(const TV0& v0, float pt, uint64_t selMap, std::vector<int>& selK0ShortIndices, std::vector<int>& selLambdaIndices, std::vector<int>& selAntiLambdaIndices /*, int v0TableOffset*/)
   // precalculate this information so that a check is one mask operation, not many
   {
     bool passK0ShortSelections = false;
@@ -1825,7 +1825,7 @@ struct QuarkoniaToHyperons {
   }
 
   template <typename TCollision, typename THyperon>
-  void fillQAplot(TCollision collision, PairTopoInfo pair, THyperon hyperon, THyperon antiHyperon, float pt, float invmass, int type)
+  void fillQAplot(const TCollision& collision, PairTopoInfo pair, const THyperon& hyperon, const THyperon& antiHyperon, float pt, float invmass, int type)
   { // fill QA information about hyperon - antihyperon pair
     if (type == 0) {
       if constexpr (requires { hyperon.mK0Short(); antiHyperon.mK0Short(); }) { // check if v0 information is available
@@ -2152,7 +2152,7 @@ struct QuarkoniaToHyperons {
   }
 
   template <typename TCollision, typename THyperon>
-  void analyseHyperonPairCandidate(TCollision collision, THyperon hyperon, THyperon antiHyperon, float centrality, uint8_t gapSide, int type)
+  void analyseHyperonPairCandidate(const TCollision& collision, const THyperon& hyperon, const THyperon& antiHyperon, float centrality, uint8_t gapSide, int type)
   // fill information related to the quarkonium mother
   // type = 0 (Lambda), 1 (Xi), 2 (Omega)
   {
@@ -2408,7 +2408,7 @@ struct QuarkoniaToHyperons {
 
   // function to check that the hyperon and antihyperon have different daughter tracks
   template <typename THyperon>
-  bool checkTrackIndices(THyperon hyperon, THyperon antiHyperon)
+  bool checkTrackIndices(const THyperon& hyperon, const THyperon& antiHyperon)
   {
     if constexpr (requires { hyperon.template bachTrackExtra_as<DauTracks>(); }) { // cascade case: check if bachelor information is available
       // check that bachelor track from hyperon is different from daughter tracks of antiHyperon

--- a/PWGDQ/Tasks/tableReader.cxx
+++ b/PWGDQ/Tasks/tableReader.cxx
@@ -158,7 +158,7 @@ constexpr static int pairTypeMuMu = VarManager::kDecayToMuMu;
 constexpr static int pairTypeEMu = VarManager::kElectronMuon;
 
 // Global function used to define needed histogram classes
-void DefineHistograms(HistogramManager* histMan, TString histClasses, Configurable<std::string> configVar); // defines histograms for all tasks
+void DefineHistograms(HistogramManager* histMan, const TString& histClasses, const Configurable<std::string>& configVar); // defines histograms for all tasks
 
 struct AnalysisEventSelection {
   Produces<aod::EventCuts> eventSel;
@@ -1984,13 +1984,13 @@ struct AnalysisDileptonHadron {
     std::vector<int> trackGlobalIndexes;
 
     if (dileptons.size() > 0) {
-      for (auto track : tracks) {
+      for (const auto& track : tracks) {
         trackGlobalIndexes.push_back(track.globalIndex());
         // std::cout << track.index() << " " << track.globalIndex() << std::endl;
       }
     }
     // loop once over dileptons for QA purposes
-    for (auto dilepton : dileptons) {
+    for (const auto& dilepton : dileptons) {
       VarManager::FillTrack<fgDileptonFillMap>(dilepton, fValuesDilepton);
       fHistMan->FillHistClass("DileptonsSelected", fValuesDilepton);
 
@@ -2062,7 +2062,7 @@ struct AnalysisDileptonHadron {
       auto evTracks = tracks.sliceBy(perEventTracks, event2.globalIndex());
       evTracks.bindExternalIndices(&events);
 
-      for (auto dilepton : evDileptons) {
+      for (const auto& dilepton : evDileptons) {
         for (auto& track : evTracks) {
 
           if (!(static_cast<uint32_t>(track.isBarrelSelected()) & (static_cast<uint32_t>(1) << fNHadronCutBit))) {
@@ -2189,14 +2189,14 @@ struct AnalysisDileptonTrackTrack {
     std::vector<int> trackGlobalIndexes;
 
     if (dileptons.size() > 0) {
-      for (auto track : tracks) {
+      for (const auto& track : tracks) {
         trackGlobalIndexes.push_back(track.globalIndex());
         // std::cout << track.index() << " " << track.globalIndex() << std::endl;
       }
     }
 
     // loop over dileptons
-    for (auto dilepton : dileptons) {
+    for (const auto& dilepton : dileptons) {
       VarManager::FillTrack<fgDileptonFillMap>(dilepton, fValuesQuadruplet);
 
       // apply the dilepton cut
@@ -2315,7 +2315,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     adaptAnalysisTask<AnalysisDileptonTrackTrack>(cfgc)};
 }
 
-void DefineHistograms(HistogramManager* histMan, TString histClasses, Configurable<std::string> configVar)
+void DefineHistograms(HistogramManager* histMan, const TString& histClasses, const Configurable<std::string>& configVar)
 {
   //
   // Define here the histograms for all the classes required in analysis.

--- a/PWGDQ/Tasks/tableReader_withAssoc_direct.cxx
+++ b/PWGDQ/Tasks/tableReader_withAssoc_direct.cxx
@@ -258,7 +258,7 @@ constexpr static uint32_t gkTrackFillMapWithCovNoTOF = VarManager::ObjTypes::Tra
 constexpr static uint32_t gkMuonFillMapWithCov = VarManager::ObjTypes::Muon | VarManager::ObjTypes::MuonCov;
 
 // Global function used to define needed histogram classes
-void DefineHistograms(HistogramManager* histMan, TString histClasses, const char* histGroups); // defines histograms for all tasks
+void DefineHistograms(HistogramManager* histMan, const TString& histClasses, const char* histGroups); // defines histograms for all tasks
 
 // Enum containing the ordering of statistics histograms to be written in the QA file
 enum ZorroStatHist {
@@ -2013,7 +2013,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
   // adaptAnalysisTask<AnalysisDileptonTrack>(cfgc)};
 }
 
-void DefineHistograms(HistogramManager* histMan, TString histClasses, const char* histGroups)
+void DefineHistograms(HistogramManager* histMan, const TString& histClasses, const char* histGroups)
 {
   //
   // Define here the histograms for all the classes required in analysis.

--- a/PWGDQ/Tasks/taskFwdTrackPid.cxx
+++ b/PWGDQ/Tasks/taskFwdTrackPid.cxx
@@ -56,7 +56,7 @@ constexpr static uint32_t gkEventFillMap = VarManager::ObjTypes::ReducedEvent | 
 constexpr static uint32_t gkMCEventFillMap = VarManager::ObjTypes::ReducedEventMC;
 constexpr static uint32_t gkMuonFillMap = VarManager::ObjTypes::ReducedMuon | VarManager::ObjTypes::ReducedMuonExtra;
 
-void DefineHistograms(HistogramManager* histMan, TString histClasses);
+void DefineHistograms(HistogramManager* histMan, const TString& histClasses);
 
 struct taskFwdTrackPid {
   Produces<aod::FwdPidsAll> fwdPidAllList;
@@ -243,7 +243,7 @@ WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
     adaptAnalysisTask<taskFwdTrackPid>(cfgc)};
 }
 
-void DefineHistograms(HistogramManager* histMan, TString histClasses)
+void DefineHistograms(HistogramManager* histMan, const TString& histClasses)
 {
   std::unique_ptr<TObjArray> objArray(histClasses.Tokenize(";"));
   for (Int_t iclass = 0; iclass < objArray->GetEntries(); ++iclass) {

--- a/PWGDQ/Tasks/v0selector.cxx
+++ b/PWGDQ/Tasks/v0selector.cxx
@@ -762,7 +762,7 @@ struct trackPIDQA {
     } // end of track loop
   } // end of process
 
-  void DefineHistograms(TString histClasses)
+  void DefineHistograms(const TString& histClasses)
   {
     std::unique_ptr<TObjArray> objArray(histClasses.Tokenize(";"));
     for (Int_t iclass = 0; iclass < objArray->GetEntries(); ++iclass) {


### PR DESCRIPTION
Mostly done automatically by Clang-Tidy.