### PR TITLE
[PWGHF] Use `const&` and `std::move` to avoid copies

### DIFF
--- a/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
+++ b/PWGHF/D2H/TableProducer/dataCreatorCharmHadPiReduced.cxx
@@ -488,7 +488,7 @@ struct HfDataCreatorCharmHadPiReduced {
                       const PParticles& particlesMc,
                       const std::vector<TTrack>& vecDaughtersB,
                       int& indexHfCandCharm,
-                      std::map<int64_t, int64_t> selectedTracksPion,
+                      const std::map<int64_t, int64_t>& selectedTracksPion,
                       const int64_t indexCollisionMaxNumContrib)
   {
 
@@ -619,7 +619,7 @@ struct HfDataCreatorCharmHadPiReduced {
         }
         tables.rowHfDPiMcCheckReduced(pdgCodeBeautyMother, pdgCodeCharmMother, pdgCodeProng0, pdgCodeProng1, pdgCodeProng2, pdgCodeProng3);
       }
-      tables.rowHfDPiMcRecReduced(indexHfCandCharm, selectedTracksPion[vecDaughtersB.back().globalIndex()], flag, flagWrongCollision, debug, motherPt);
+      tables.rowHfDPiMcRecReduced(indexHfCandCharm, selectedTracksPion.at(vecDaughtersB.back().globalIndex()), flag, flagWrongCollision, debug, motherPt);
     } else if constexpr (DecChannel == DecayChannel::BsToDsminusPi) {
       // Bs → Ds- π+ → (K- K+ π-) π+
       auto indexRec = RecoDecay::getMatchedMCRec<true, false, false, true, true>(particlesMc, std::array{vecDaughtersB[0], vecDaughtersB[1], vecDaughtersB[2], vecDaughtersB[3]}, Pdg::kBS, std::array{-kKPlus, +kKPlus, -kPiPlus, +kPiPlus}, true, &sign, 3);
@@ -774,7 +774,7 @@ struct HfDataCreatorCharmHadPiReduced {
         }
         tables.rowHfDsPiMcCheckReduced(pdgCodeBeautyMother, pdgCodeCharmMother, pdgCodeProng0, pdgCodeProng1, pdgCodeProng2, pdgCodeProng3);
       }
-      tables.rowHfDsPiMcRecReduced(indexHfCandCharm, selectedTracksPion[vecDaughtersB.back().globalIndex()], flag, flagWrongCollision, debug, motherPt);
+      tables.rowHfDsPiMcRecReduced(indexHfCandCharm, selectedTracksPion.at(vecDaughtersB.back().globalIndex()), flag, flagWrongCollision, debug, motherPt);
     } else if constexpr (DecChannel == DecayChannel::BplusToD0barPi) {
       // B+ → D0(bar) π+ → (K+ π-) π+
       auto indexRec = RecoDecay::getMatchedMCRec<false, false, false, true, true>(particlesMc, std::array{vecDaughtersB[0], vecDaughtersB[1], vecDaughtersB[2]}, Pdg::kBPlus, std::array{+kPiPlus, +kKPlus, -kPiPlus}, true, &sign, 2);
@@ -871,7 +871,7 @@ struct HfDataCreatorCharmHadPiReduced {
         }
         tables.rowHfD0PiMcCheckReduced(pdgCodeBeautyMother, pdgCodeCharmMother, pdgCodeProng0, pdgCodeProng1, pdgCodeProng2);
       }
-      tables.rowHfD0PiMcRecReduced(indexHfCandCharm, selectedTracksPion[vecDaughtersB.back().globalIndex()], flag, flagWrongCollision, debug, motherPt);
+      tables.rowHfD0PiMcRecReduced(indexHfCandCharm, selectedTracksPion.at(vecDaughtersB.back().globalIndex()), flag, flagWrongCollision, debug, motherPt);
     } else if constexpr (DecChannel == DecayChannel::LbToLcplusPi) {
       // Lb → Lc+ π- → (p K- π+) π-
       auto indexRec = RecoDecay::getMatchedMCRec<false, false, false, true, true>(particlesMc, std::array{vecDaughtersB[0], vecDaughtersB[1], vecDaughtersB[2], vecDaughtersB[3]}, Pdg::kLambdaB0, std::array{+kProton, -kKPlus, +kPiPlus, -kPiPlus}, true, &sign, 3);
@@ -975,7 +975,7 @@ struct HfDataCreatorCharmHadPiReduced {
         }
         tables.rowHfLcPiMcCheckReduced(pdgCodeBeautyMother, pdgCodeCharmMother, pdgCodeProng0, pdgCodeProng1, pdgCodeProng2, pdgCodeProng3);
       }
-      tables.rowHfLcPiMcRecReduced(indexHfCandCharm, selectedTracksPion[vecDaughtersB.back().globalIndex()], flag, flagWrongCollision, debug, motherPt);
+      tables.rowHfLcPiMcRecReduced(indexHfCandCharm, selectedTracksPion.at(vecDaughtersB.back().globalIndex()), flag, flagWrongCollision, debug, motherPt);
     } else if constexpr (DecChannel == DecayChannel::B0ToDstarPi) {
       // B0 → D*+ π- → (D0 π+) π- → (K- π+ π+) π-
       auto indexRec = RecoDecay::getMatchedMCRec<true, false, false, true, true>(particlesMc, std::array{vecDaughtersB[0], vecDaughtersB[1], vecDaughtersB[2], vecDaughtersB[3]}, Pdg::kB0, std::array{+kKPlus, -kPiPlus, -kPiPlus, +kPiPlus}, true, &sign, 4);
@@ -1012,7 +1012,7 @@ struct HfDataCreatorCharmHadPiReduced {
           checkWrongCollision(particleMother, collision, indexCollisionMaxNumContrib, flagWrongCollision);
         }
       }
-      tables.rowHfDStarPiMcRecReduced(indexHfCandCharm, selectedTracksPion[vecDaughtersB.back().globalIndex()], flag, flagWrongCollision, debug, motherPt);
+      tables.rowHfDStarPiMcRecReduced(indexHfCandCharm, selectedTracksPion.at(vecDaughtersB.back().globalIndex()), flag, flagWrongCollision, debug, motherPt);
     }
   }
 
@@ -1444,7 +1444,7 @@ struct HfDataCreatorCharmHadPiReduced {
           tables.hfCandPidProng1(candC.nSigTpcPi1(), candC.nSigTofPi1(), candC.nSigTpcKa1(), candC.nSigTofKa1(), nSigmaTpcPr1, nSigmaTofPr1, charmHadDauTracks[1].hasTOF(), charmHadDauTracks[1].hasTPC());
 
           // Soft pion tables
-          auto trackSoftPion = charmHadDauTracks.back();
+          const auto& trackSoftPion = charmHadDauTracks.back();
           auto trackParCovSoftPion = getTrackParCov(trackSoftPion);
           std::array<float, 2> dcaSoftPion{trackSoftPion.dcaXY(), trackSoftPion.dcaZ()};
           std::array<float, 3> pVecSoftPion = trackSoftPion.pVector();

--- a/PWGHF/D2H/Tasks/taskDstarToD0Pi.cxx
+++ b/PWGHF/D2H/Tasks/taskDstarToD0Pi.cxx
@@ -418,7 +418,7 @@ struct HfTaskDstarToD0Pi {
   /// @param selectedCands selected candidates with selection flag
   /// @param preslice preslice to slice
   template <bool ApplyMl, typename T1, typename T2>
-  void runTaskDstar(CollisionsWCent const& cols, T1 selectedCands, T2 preslice)
+  void runTaskDstar(CollisionsWCent const& cols, const T1& selectedCands, const T2& preslice)
   {
     for (const auto& col : cols) {
       auto nPVContributors = col.numContrib();

--- a/PWGHF/HFC/Macros/DhCorrelationExtraction.cxx
+++ b/PWGHF/HFC/Macros/DhCorrelationExtraction.cxx
@@ -201,7 +201,7 @@ Bool_t DhCorrelationExtraction::setDmesonSpecie(DmesonSpecie k)
   return kTRUE;
 }
 
-Bool_t DhCorrelationExtraction::extractCorrelations(Double_t ptCandMin, Double_t ptCandMax, Double_t ptHadMin, Double_t ptHadMax, TString codeName)
+Bool_t DhCorrelationExtraction::extractCorrelations(Double_t ptCandMin, Double_t ptCandMax, Double_t ptHadMin, Double_t ptHadMax, const TString& codeName)
 {
 
   if (fSubtractSoftPiME) {
@@ -1513,7 +1513,7 @@ Double_t DhCorrelationExtraction::calculateBaselineError(TH1D*& histo, Bool_t to
   return errBaseline;
 }
 
-void DhCorrelationExtraction::setTH1HistoStyle(TH1D*& histo, TString hTitle, TString hXaxisTitle, TString hYaxisTitle,
+void DhCorrelationExtraction::setTH1HistoStyle(TH1D*& histo, const TString& hTitle, const TString& hXaxisTitle, const TString& hYaxisTitle,
                                                Style_t markerStyle, Color_t markerColor, Double_t markerSize,
                                                Color_t lineColor, Int_t lineWidth, Float_t hTitleXaxisOffset, Float_t hTitleYaxisOffset,
                                                Float_t hTitleXaxisSize, Float_t hTitleYaxisSize, Float_t hLabelXaxisSize, Float_t hLabelYaxisSize,
@@ -1538,7 +1538,7 @@ void DhCorrelationExtraction::setTH1HistoStyle(TH1D*& histo, TString hTitle, TSt
   histo->GetYaxis()->CenterTitle(centerYaxisTitle);
 }
 
-void DhCorrelationExtraction::setTH2HistoStyle(TH2D*& histo, TString hTitle, TString hXaxisTitle, TString hYaxisTitle, TString hZaxisTitle,
+void DhCorrelationExtraction::setTH2HistoStyle(TH2D*& histo, const TString& hTitle, const TString& hXaxisTitle, const TString& hYaxisTitle, const TString& hZaxisTitle,
                                                Float_t hTitleXaxisOffset, Float_t hTitleYaxisOffset, Float_t hTitleZaxisOffset,
                                                Float_t hTitleXaxisSize, Float_t hTitleYaxisSize, Float_t hTitleZaxisSize,
                                                Float_t hLabelXaxisSize, Float_t hLabelYaxisSize, Float_t hLabelZaxisSize,

--- a/PWGHF/HFC/Macros/DhCorrelationExtraction.h
+++ b/PWGHF/HFC/Macros/DhCorrelationExtraction.h
@@ -29,6 +29,8 @@
 #include <Rtypes.h>
 #include <RtypesCore.h>
 
+#include <utility>
+
 class DhCorrelationExtraction : public TObject
 {
 
@@ -53,39 +55,39 @@ class DhCorrelationExtraction : public TObject
   /// Methods to set the input configuration
   // Input files, directories and histograms
   Bool_t setDmesonSpecie(DmesonSpecie k);
-  void setInputFilenameMass(TString filenameMass) { fFileNameMass = filenameMass; }
-  void setInputFilenameSe(TString filenameSE) { fFileNameSE = filenameSE; }
-  void setInputFilenameMe(TString filenameME) { fFileNameME = filenameME; }
-  void setInputFilenameSecPart(TString filenameSecPart) { fFileSecPartName = filenameSecPart; }
+  void setInputFilenameMass(TString filenameMass) { fFileNameMass = std::move(filenameMass); }
+  void setInputFilenameSe(TString filenameSE) { fFileNameSE = std::move(filenameSE); }
+  void setInputFilenameMe(TString filenameME) { fFileNameME = std::move(filenameME); }
+  void setInputFilenameSecPart(TString filenameSecPart) { fFileSecPartName = std::move(filenameSecPart); }
   void setInputFilenameBiasBtoD(TString filenamePromptMcRec, TString filenameNonPromptMcRec)
   {
-    fFilePromptMcRecName = filenamePromptMcRec;
-    fFileNonPromptMcRecName = filenameNonPromptMcRec;
+    fFilePromptMcRecName = std::move(filenamePromptMcRec);
+    fFileNonPromptMcRecName = std::move(filenameNonPromptMcRec);
   }
-  void setDirNameSe(TString dirNameSE) { fDirNameSE = dirNameSE; }
-  void setDirNameMe(TString dirNameME) { fDirNameME = dirNameME; }
-  void setDirNameSecPart(TString dirNameSecPart) { fDirSecPartName = dirNameSecPart; }
-  void setMassHistoNameSgn(TString massHistoNameSgn) { fMassHistoNameSgn = massHistoNameSgn; }
-  void setMassHistoNameBkg(TString massHistoNameBkg) { fMassHistoNameBkg = massHistoNameBkg; }
-  void setMassHistoNameSBs(TString massHistoNameSBs) { fMassHistoNameSBs = massHistoNameSBs; }
-  void setSeCorrelHistoSignalName(TString correlNameSigSE) { fSECorrelSignalRegionName = correlNameSigSE; }
-  void setSeCorrelHistoSidebandName(TString correlNameSbSE) { fSECorrelSidebandsName = correlNameSbSE; }
-  void setSeCorrelHistoSidebandLeftName(TString correlNameSbSE) { fSECorrelSidebandLeftName = correlNameSbSE; }
-  void setSeCorrelHistoSidebandRightName(TString correlNameSbSE) { fSECorrelSidebandRightName = correlNameSbSE; }
-  void setMeCorrelHistoSignalName(TString correlNameSigME) { fMECorrelSignalRegionName = correlNameSigME; }
-  void setMeCorrelHistoSidebandName(TString correlNameSbME) { fMECorrelSidebandsName = correlNameSbME; }
-  void setMeCorrelHistoSidebandLeftName(TString correlNameSbME) { fMECorrelSidebandLeftName = correlNameSbME; }
-  void setMeCorrelHistoSidebandRightName(TString correlNameSbME) { fMECorrelSidebandRightName = correlNameSbME; }
+  void setDirNameSe(TString dirNameSE) { fDirNameSE = std::move(dirNameSE); }
+  void setDirNameMe(TString dirNameME) { fDirNameME = std::move(dirNameME); }
+  void setDirNameSecPart(TString dirNameSecPart) { fDirSecPartName = std::move(dirNameSecPart); }
+  void setMassHistoNameSgn(TString massHistoNameSgn) { fMassHistoNameSgn = std::move(massHistoNameSgn); }
+  void setMassHistoNameBkg(TString massHistoNameBkg) { fMassHistoNameBkg = std::move(massHistoNameBkg); }
+  void setMassHistoNameSBs(TString massHistoNameSBs) { fMassHistoNameSBs = std::move(massHistoNameSBs); }
+  void setSeCorrelHistoSignalName(TString correlNameSigSE) { fSECorrelSignalRegionName = std::move(correlNameSigSE); }
+  void setSeCorrelHistoSidebandName(TString correlNameSbSE) { fSECorrelSidebandsName = std::move(correlNameSbSE); }
+  void setSeCorrelHistoSidebandLeftName(TString correlNameSbSE) { fSECorrelSidebandLeftName = std::move(correlNameSbSE); }
+  void setSeCorrelHistoSidebandRightName(TString correlNameSbSE) { fSECorrelSidebandRightName = std::move(correlNameSbSE); }
+  void setMeCorrelHistoSignalName(TString correlNameSigME) { fMECorrelSignalRegionName = std::move(correlNameSigME); }
+  void setMeCorrelHistoSidebandName(TString correlNameSbME) { fMECorrelSidebandsName = std::move(correlNameSbME); }
+  void setMeCorrelHistoSidebandLeftName(TString correlNameSbME) { fMECorrelSidebandLeftName = std::move(correlNameSbME); }
+  void setMeCorrelHistoSidebandRightName(TString correlNameSbME) { fMECorrelSidebandRightName = std::move(correlNameSbME); }
   void setHistoSecPartName(TString histoPrimaryPartName, TString histoAllPartName)
   {
-    fHistoPrimaryPartName = histoPrimaryPartName;
-    fHistoAllPartName = histoAllPartName;
+    fHistoPrimaryPartName = std::move(histoPrimaryPartName);
+    fHistoAllPartName = std::move(histoAllPartName);
   }
-  void setInputFilenameFdTemplate(TString filenameFDTemplate) { fFileFDTemplateName = filenameFDTemplate; }
-  void setInputFilenameFdPromptFrac(TString filenameFDPromptFrac) { fFileFDPromptFracName = filenameFDPromptFrac; }
-  void setInputHistoNameFdTemplatePrompt(TString hNameFDTemplatePrompt) { fHistoFDTemplatePromptName = hNameFDTemplatePrompt; }
-  void setInputHistoNameFdTemplateNonPrompt(TString hNameFDTemplateNonPrompt) { fHistoFDTemplateNonPromptName = hNameFDTemplateNonPrompt; }
-  void setInputHistoNameFdPromptFrac(TString hNameFDPromptFrac) { fHistoFDPromptFracName = hNameFDPromptFrac; }
+  void setInputFilenameFdTemplate(TString filenameFDTemplate) { fFileFDTemplateName = std::move(filenameFDTemplate); }
+  void setInputFilenameFdPromptFrac(TString filenameFDPromptFrac) { fFileFDPromptFracName = std::move(filenameFDPromptFrac); }
+  void setInputHistoNameFdTemplatePrompt(TString hNameFDTemplatePrompt) { fHistoFDTemplatePromptName = std::move(hNameFDTemplatePrompt); }
+  void setInputHistoNameFdTemplateNonPrompt(TString hNameFDTemplateNonPrompt) { fHistoFDTemplateNonPromptName = std::move(hNameFDTemplateNonPrompt); }
+  void setInputHistoNameFdPromptFrac(TString hNameFDPromptFrac) { fHistoFDPromptFracName = std::move(hNameFDPromptFrac); }
 
   // Input conditions: PtCand, PtHad, PoolBins
   void setNpools(Int_t npools) { fNpools = npools; }
@@ -143,15 +145,15 @@ class DhCorrelationExtraction : public TObject
   Bool_t readInputInvMass();
   Bool_t readInputFdSubtr();
   Bool_t readInputSecondaryPartContamination();
-  Bool_t extractCorrelations(Double_t ptCandMin, Double_t ptCandMax, Double_t ptHadMin, Double_t ptHadMax, TString codeName);
+  Bool_t extractCorrelations(Double_t ptCandMin, Double_t ptCandMax, Double_t ptHadMin, Double_t ptHadMax, const TString& codeName);
   TH1D* getCorrectedCorrHisto() { return fCorrectedCorrHisto; }
   TH1D* getCorrectedCorrHistoBaselineSubtr() { return fCorrectedCorrHistoBaselineSubtr; }
   TH1D* getCorrectedCorrHistoReflected() { return fCorrectedCorrHistoReflected; }
   TH1D* getCorrectedCorrHistoReflectedBaselineSubtr() { return fCorrectedCorrHistoReflectedBaselineSubtr; }
 
   /// Histogram style
-  void setTH1HistoStyle(TH1D*& histo, TString hTitle, TString hXaxisTitle, TString hYaxisTitle, Style_t markerStyle = kFullCircle, Color_t markerColor = kRed + 1, Double_t markerSize = 1.4, Color_t lineColor = kRed + 1, Int_t lineWidth = 3, Float_t hTitleXaxisOffset = 1.0, Float_t hTitleYaxisOffset = 1.0, Float_t hTitleXaxisSize = 0.060, Float_t hTitleYaxisSize = 0.060, Float_t hLabelXaxisSize = 0.060, Float_t hLabelYaxisSize = 0.060, Bool_t centerXaxisTitle = false, Bool_t centerYaxisTitle = false);
-  void setTH2HistoStyle(TH2D*& histo, TString hTitle, TString hXaxisTitle, TString hYaxisTitle, TString hZaxisTitle, Float_t hTitleXaxisOffset = 1.8, Float_t hTitleYaxisOffset = 1.8, Float_t hTitleZaxisOffset = 1.2, Float_t hTitleXaxisSize = 0.060, Float_t hTitleYaxisSize = 0.060, Float_t hTitleZaxisSize = 0.060, Float_t hLabelXaxisSize = 0.060, Float_t hLabelYaxisSize = 0.060, Float_t hLabelZaxisSize = 0.060, Bool_t centerXaxisTitle = true, Bool_t centerYaxisTitle = true);
+  void setTH1HistoStyle(TH1D*& histo, const TString& hTitle, const TString& hXaxisTitle, const TString& hYaxisTitle, Style_t markerStyle = kFullCircle, Color_t markerColor = kRed + 1, Double_t markerSize = 1.4, Color_t lineColor = kRed + 1, Int_t lineWidth = 3, Float_t hTitleXaxisOffset = 1.0, Float_t hTitleYaxisOffset = 1.0, Float_t hTitleXaxisSize = 0.060, Float_t hTitleYaxisSize = 0.060, Float_t hLabelXaxisSize = 0.060, Float_t hLabelYaxisSize = 0.060, Bool_t centerXaxisTitle = false, Bool_t centerYaxisTitle = false);
+  void setTH2HistoStyle(TH2D*& histo, const TString& hTitle, const TString& hXaxisTitle, const TString& hYaxisTitle, const TString& hZaxisTitle, Float_t hTitleXaxisOffset = 1.8, Float_t hTitleYaxisOffset = 1.8, Float_t hTitleZaxisOffset = 1.2, Float_t hTitleXaxisSize = 0.060, Float_t hTitleYaxisSize = 0.060, Float_t hTitleZaxisSize = 0.060, Float_t hLabelXaxisSize = 0.060, Float_t hLabelYaxisSize = 0.060, Float_t hLabelZaxisSize = 0.060, Bool_t centerXaxisTitle = true, Bool_t centerYaxisTitle = true);
 
  private:
   TFile* fFileMass;         // File containing the mass histograms

--- a/PWGHF/HFC/Macros/ExtractOutputCorrel.C
+++ b/PWGHF/HFC/Macros/ExtractOutputCorrel.C
@@ -55,13 +55,13 @@ void parseStringArray(const Value& jsonArray, std::vector<std::string>& output)
   }
 }
 
-void setInputCorrelNames(DhCorrelationExtraction* plotter, TString pathFileSE, TString pathFileME, TString dirSE, TString dirME, TString histoNameCorrSignal, TString histoNameCorrSideba, TString histoNameCorrSidebaLeft, TString histoNameCorrSidebaRight);
-void setInputHistoInvMassNames(DhCorrelationExtraction* plotter, TString pathFileMass, std::vector<std::string> inputMassNames);
-void setInputHistoFdSubtraction(DhCorrelationExtraction* plotter, TString pathFileFDTemplate, TString pathFileFDPromptFrac, TString histoNameFDTemplatePrompt, TString histoNameFDTemplateNonPrompt, TString histoNameRawFracPrompt);
-void setInputHistoSecPart(DhCorrelationExtraction* plotter, TString pathFileSecPart, TString dirSecPartName, TString histoNamePrimaryPart, TString histoNameAllPart);
-void setInputHistoBiasBtoD(DhCorrelationExtraction* plotter, TString pathfFilePromptMcRec, TString pathfFileNonPromptMcRec);
+void setInputCorrelNames(DhCorrelationExtraction* plotter, const TString& pathFileSE, const TString& pathFileME, const TString& dirSE, const TString& dirME, const TString& histoNameCorrSignal, const TString& histoNameCorrSideba, const TString& histoNameCorrSidebaLeft, const TString& histoNameCorrSidebaRight);
+void setInputHistoInvMassNames(DhCorrelationExtraction* plotter, const TString& pathFileMass, std::vector<std::string> inputMassNames);
+void setInputHistoFdSubtraction(DhCorrelationExtraction* plotter, const TString& pathFileFDTemplate, const TString& pathFileFDPromptFrac, const TString& histoNameFDTemplatePrompt, const TString& histoNameFDTemplateNonPrompt, const TString& histoNameRawFracPrompt);
+void setInputHistoSecPart(DhCorrelationExtraction* plotter, const TString& pathFileSecPart, const TString& dirSecPartName, const TString& histoNamePrimaryPart, const TString& histoNameAllPart);
+void setInputHistoBiasBtoD(DhCorrelationExtraction* plotter, const TString& pathfFilePromptMcRec, const TString& pathfFileNonPromptMcRec);
 
-void extractOutputCorrelDs(const TString cfgFileName = "config_CorrAnalysis.json")
+void extractOutputCorrelDs(const TString& cfgFileName = "config_CorrAnalysis.json")
 {
   // gStyle -> SetOptStat(0);
   gStyle->SetPadLeftMargin(0.15);
@@ -274,7 +274,7 @@ void extractOutputCorrelDs(const TString cfgFileName = "config_CorrAnalysis.json
   outFileReflectedBaselineSubtr->Close();
 }
 
-void setInputCorrelNames(DhCorrelationExtraction* plotter, TString pathFileSE, TString pathFileME, TString dirSE, TString dirME, TString histoNameCorrSignal, TString histoNameCorrSideba, TString histoNameCorrSidebaLeft, TString histoNameCorrSidebaRight)
+void setInputCorrelNames(DhCorrelationExtraction* plotter, const TString& pathFileSE, const TString& pathFileME, const TString& dirSE, const TString& dirME, const TString& histoNameCorrSignal, const TString& histoNameCorrSideba, const TString& histoNameCorrSidebaLeft, const TString& histoNameCorrSidebaRight)
 {
 
   // Ds paths
@@ -292,7 +292,7 @@ void setInputCorrelNames(DhCorrelationExtraction* plotter, TString pathFileSE, T
   plotter->setMeCorrelHistoSidebandRightName(histoNameCorrSidebaRight.Data());
 }
 
-void setInputHistoInvMassNames(DhCorrelationExtraction* plotter, TString pathFileMass, std::vector<std::string> inputMassNames)
+void setInputHistoInvMassNames(DhCorrelationExtraction* plotter, const TString& pathFileMass, std::vector<std::string> inputMassNames)
 { // to use if sgn and bkg extraction is done apart
 
   plotter->setInputFilenameMass(pathFileMass.Data());
@@ -301,7 +301,7 @@ void setInputHistoInvMassNames(DhCorrelationExtraction* plotter, TString pathFil
   plotter->setMassHistoNameSBs(inputMassNames[2].data());
 }
 
-void setInputHistoFdSubtraction(DhCorrelationExtraction* plotter, TString pathFileFDTemplate, TString pathFileFDPromptFrac, TString histoNameFDTemplatePrompt, TString histoNameFDTemplateNonPrompt, TString histoNameRawFracPrompt)
+void setInputHistoFdSubtraction(DhCorrelationExtraction* plotter, const TString& pathFileFDTemplate, const TString& pathFileFDPromptFrac, const TString& histoNameFDTemplatePrompt, const TString& histoNameFDTemplateNonPrompt, const TString& histoNameRawFracPrompt)
 {
 
   plotter->setInputFilenameFdTemplate(pathFileFDTemplate.Data());
@@ -311,7 +311,7 @@ void setInputHistoFdSubtraction(DhCorrelationExtraction* plotter, TString pathFi
   plotter->setInputHistoNameFdPromptFrac(histoNameRawFracPrompt.Data());
 }
 
-void setInputHistoSecPart(DhCorrelationExtraction* plotter, TString pathFileSecPart, TString dirSecPartName, TString histoNamePrimaryPart, TString histoNameAllPart)
+void setInputHistoSecPart(DhCorrelationExtraction* plotter, const TString& pathFileSecPart, const TString& dirSecPartName, const TString& histoNamePrimaryPart, const TString& histoNameAllPart)
 {
 
   plotter->setInputFilenameSecPart(pathFileSecPart.Data());
@@ -319,7 +319,7 @@ void setInputHistoSecPart(DhCorrelationExtraction* plotter, TString pathFileSecP
   plotter->setHistoSecPartName(histoNamePrimaryPart.Data(), histoNameAllPart.Data());
 }
 
-void setInputHistoBiasBtoD(DhCorrelationExtraction* plotter, TString pathfFilePromptMcRec, TString pathfFileNonPromptMcRec)
+void setInputHistoBiasBtoD(DhCorrelationExtraction* plotter, const TString& pathfFilePromptMcRec, const TString& pathfFileNonPromptMcRec)
 {
 
   plotter->setInputFilenameBiasBtoD(pathfFilePromptMcRec.Data(), pathfFileNonPromptMcRec.Data());

--- a/PWGHF/HFC/Macros/FitCorrel.C
+++ b/PWGHF/HFC/Macros/FitCorrel.C
@@ -54,18 +54,18 @@ void readArray(const Value& jsonArray, vector<ValueType>& output)
   }
 }
 
-void setTH1HistoStyle(TH1D*& histo, TString hTitle, TString hXaxisTitle, TString hYaxisTitle,
+void setTH1HistoStyle(TH1D*& histo, const TString& hTitle, const TString& hXaxisTitle, const TString& hYaxisTitle,
                       Style_t markerStyle, Color_t markerColor, Double_t markerSize,
                       Color_t lineColor, Int_t lineWidth, Float_t hTitleXaxisOffset = 1.3, Float_t hTitleYaxisOffset = 1.3,
                       Float_t hTitleXaxisSize = 0.045, Float_t hTitleYaxisSize = 0.045, Float_t hLabelXaxisSize = 0.045, Float_t hLabelYaxisSize = 0.045,
                       Bool_t centerXaxisTitle = false, Bool_t centerYaxisTitle = false);
-void setTH1HistoStyle(TH1F*& histo, TString hTitle, TString hXaxisTitle, TString hYaxisTitle,
+void setTH1HistoStyle(TH1F*& histo, const TString& hTitle, const TString& hXaxisTitle, const TString& hYaxisTitle,
                       Style_t markerStyle, Color_t markerColor, Double_t markerSize,
                       Color_t lineColor, Int_t lineWidth, Float_t hTitleXaxisOffset = 1.3, Float_t hTitleYaxisOffset = 1.3,
                       Float_t hTitleXaxisSize = 0.045, Float_t hTitleYaxisSize = 0.045, Float_t hLabelXaxisSize = 0.045, Float_t hLabelYaxisSize = 0.045,
                       Bool_t centerXaxisTitle = false, Bool_t centerYaxisTitle = false);
 
-void fitCorrelDs(const TString cfgFileName = "config_CorrAnalysis.json")
+void fitCorrelDs(const TString& cfgFileName = "config_CorrAnalysis.json")
 {
   gStyle->SetOptStat(0);
   gStyle->SetPadLeftMargin(0.2);
@@ -456,7 +456,7 @@ void fitCorrelDs(const TString cfgFileName = "config_CorrAnalysis.json")
   }
 }
 
-void setTH1HistoStyle(TH1D*& histo, TString hTitle, TString hXaxisTitle, TString hYaxisTitle,
+void setTH1HistoStyle(TH1D*& histo, const TString& hTitle, const TString& hXaxisTitle, const TString& hYaxisTitle,
                       Style_t markerStyle, Color_t markerColor, Double_t markerSize,
                       Color_t lineColor, Int_t lineWidth, Float_t hTitleXaxisOffset, Float_t hTitleYaxisOffset,
                       Float_t hTitleXaxisSize, Float_t hTitleYaxisSize, Float_t hLabelXaxisSize, Float_t hLabelYaxisSize,
@@ -481,7 +481,7 @@ void setTH1HistoStyle(TH1D*& histo, TString hTitle, TString hXaxisTitle, TString
   histo->GetYaxis()->CenterTitle(centerYaxisTitle);
 }
 
-void setTH1HistoStyle(TH1F*& histo, TString hTitle, TString hXaxisTitle, TString hYaxisTitle,
+void setTH1HistoStyle(TH1F*& histo, const TString& hTitle, const TString& hXaxisTitle, const TString& hYaxisTitle,
                       Style_t markerStyle, Color_t markerColor, Double_t markerSize,
                       Color_t lineColor, Int_t lineWidth, Float_t hTitleXaxisOffset, Float_t hTitleYaxisOffset,
                       Float_t hTitleXaxisSize, Float_t hTitleYaxisSize, Float_t hLabelXaxisSize, Float_t hLabelYaxisSize,

--- a/PWGHF/HFC/TableProducer/correlatorFlowCharmHadronsReduced.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorFlowCharmHadronsReduced.cxx
@@ -262,7 +262,7 @@ struct HfCorrelatorFlowCharmHadronsReduced {
   template <bool FillSparses, bool FillTables, typename TPair, typename TTrigCand, typename TBinningType>
   void fillSameEvent(TPair const& pair,
                      TTrigCand const& trigCand,
-                     TBinningType binPolicy)
+                     const TBinningType& binPolicy)
   {
     auto collision = pair.template hfcRedCorrColl_as<o2::aod::HfcRedCorrColls>();
     if (collision.centrality() < centralityMin || collision.centrality() > centralityMax) {
@@ -311,7 +311,7 @@ struct HfCorrelatorFlowCharmHadronsReduced {
   /// \param binPolicy is the binning policy for the correlation
   template <bool FillSparses, bool FillTables, typename TPairs, typename TBinningType>
   void fillMixedEvent(TPairs const& pairs,
-                      TBinningType binPolicy)
+                      const TBinningType& binPolicy)
   {
     for (const auto& [trigColl, trigCands, assocColl, assocTracks] : pairs) {
       if (trigCands.size() == 0 || assocTracks.size() == 0) {
@@ -423,7 +423,7 @@ struct HfCorrelatorFlowCharmHadronsReduced {
   void doCorrelationsMixedEvent(const TCollision& collisions,
                                 const TTrigCand& trigCands,
                                 const TTrackAssoc& assocTracks,
-                                TBinningType binPolicy)
+                                const TBinningType& binPolicy)
   {
     auto tracksTuple = std::make_tuple(trigCands, assocTracks);
 

--- a/PWGHF/HFC/TableProducer/producerCharmHadronsTrackFemtoDream.cxx
+++ b/PWGHF/HFC/TableProducer/producerCharmHadronsTrackFemtoDream.cxx
@@ -493,7 +493,7 @@ struct HfProducerCharmHadronsTrackFemtoDream {
           // list of mothers is not empty
         } else if (particleMc.getProcess() == TMCProcess::kPDecay && particleMc.getGenStatusCode() == GenFromTransport && !motherparticlesMc.empty()) {
           // get direct mother
-          auto motherparticleMc = motherparticlesMc.front();
+          const auto& motherparticleMc = motherparticlesMc.front();
           pdgCodeMother = motherparticleMc.pdgCode();
           particleOrigin = checkDaughterType(fdparttype, motherparticleMc.pdgCode(), pdgCode);
           // check if particle is material
@@ -1068,7 +1068,7 @@ struct HfProducerCharmHadronsTrackFemtoDream {
   }
 
   template <DecayChannel Channel, typename ParticleType>
-  void fillCharmHadMcGen(ParticleType particles)
+  void fillCharmHadMcGen(const ParticleType& particles)
   {
     // Filling particle properties
     tables.rowCandCharmHadGen.reserve(particles.size() + 1);

--- a/PWGHF/HFC/TableProducer/producerCharmHadronsV0FemtoDream.cxx
+++ b/PWGHF/HFC/TableProducer/producerCharmHadronsV0FemtoDream.cxx
@@ -526,7 +526,7 @@ struct HfProducerCharmHadronsV0FemtoDream {
           // list of mothers is not empty
         } else if (particleMc.getProcess() == TMCProcess::kPDecay && particleMc.getGenStatusCode() == GenFromTransport && !motherparticlesMc.empty()) {
           // get direct mother
-          auto motherparticleMc = motherparticlesMc.front();
+          const auto& motherparticleMc = motherparticlesMc.front();
           pdgCodeMother = motherparticleMc.pdgCode();
           particleOrigin = checkDaughterType(fdparttype, motherparticleMc.pdgCode(), pdgCode);
           // check if particle is material
@@ -1175,7 +1175,7 @@ struct HfProducerCharmHadronsV0FemtoDream {
   }
 
   template <DecayChannel Channel, typename ParticleType>
-  void fillCharmHadMcGen(ParticleType particles)
+  void fillCharmHadMcGen(const ParticleType& particles)
   {
     // Filling particle properties
     rowCandCharmHadGen.reserve(particles.size() + 1);

--- a/PWGHF/HFC/Tasks/taskFlow.cxx
+++ b/PWGHF/HFC/Tasks/taskFlow.cxx
@@ -1000,7 +1000,7 @@ struct HfTaskFlow {
   // }
 
   template <typename TCollision>
-  int64_t getMultiplicityEstimator(TCollision collision, bool isSameEvent)
+  int64_t getMultiplicityEstimator(const TCollision& collision, bool isSameEvent)
   {
     switch (configCollision.multiplicityEstimator) {
       case MultiplicityEstimators::MultNTracksPV:
@@ -1292,7 +1292,7 @@ struct HfTaskFlow {
   }
 
   template <typename TTracks>
-  double getCorrectedMultiplicity(TTracks tracks) // function to count the number of tracks in the event and fill the histogram
+  double getCorrectedMultiplicity(const TTracks& tracks) // function to count the number of tracks in the event and fill the histogram
   {
     auto trackCounter = 0;
     auto weightMultiplicity = 1.0f;

--- a/PWGHF/TableProducer/trackIndexSkimCreator.cxx
+++ b/PWGHF/TableProducer/trackIndexSkimCreator.cxx
@@ -2071,7 +2071,7 @@ struct HfTrackIndexSkimCreator {
   /// \param outputScores is the array of vectors with the output scores to be filled
   /// \param isSelected ia s bitmap with selection outcome
   template <bool UsePidForHfFiltersBdt>
-  void applyMlSelectionForHfFilters3Prong(std::vector<float> featuresCand, std::vector<float> featuresCandPid, std::array<std::vector<float>, kN3ProngDecaysUsedMlForHfFilters>& outputScores, auto& isSelected)
+  void applyMlSelectionForHfFilters3Prong(std::vector<float> featuresCand, const std::vector<float>& featuresCandPid, std::array<std::vector<float>, kN3ProngDecaysUsedMlForHfFilters>& outputScores, auto& isSelected)
   {
     if (isSelected == 0) {
       return;

--- a/PWGHF/Tasks/taskMcEfficiency.cxx
+++ b/PWGHF/Tasks/taskMcEfficiency.cxx
@@ -118,7 +118,7 @@ struct HfTaskMcEfficiency {
   }
 
   template <typename T>
-  bool checkTrack(T track)
+  bool checkTrack(const T& track)
   {
     // TODO configurable?
     return track.isGlobalTrackWoDCA();
@@ -424,7 +424,7 @@ struct HfTaskMcEfficiency {
   }
 
   template <typename C>
-  void candidate2ProngMcLoop(C const& candidates, TracksWithSelectionMC const& tracks, aod::McParticles const& mcParticles, aod::McCollisionLabels const&, std::vector<int> pdgCodes)
+  void candidate2ProngMcLoop(C const& candidates, TracksWithSelectionMC const& tracks, aod::McParticles const& mcParticles, aod::McCollisionLabels const&, const std::vector<int>& pdgCodes)
   {
     candidate2ProngLoop<true>(candidates, tracks, mcParticles, pdgCodes);
 
@@ -537,7 +537,7 @@ struct HfTaskMcEfficiency {
   /// 3-prong analyses
 
   template <bool HasDplus, bool HasDs, bool HasLc, bool HasXicPlus, typename C>
-  void candidate3ProngMcLoop(C const& candidates, TracksWithSelectionMC const& tracks, aod::McParticles const& mcParticles, aod::McCollisionLabels const&, std::vector<int> pdgCodes)
+  void candidate3ProngMcLoop(C const& candidates, TracksWithSelectionMC const& tracks, aod::McParticles const& mcParticles, aod::McCollisionLabels const&, const std::vector<int>& pdgCodes)
   {
     candidate3ProngLoop<true, HasDplus, HasDs, HasLc, HasXicPlus>(candidates, tracks, mcParticles, pdgCodes);
 

--- a/PWGHF/Tasks/taskMcValidation.cxx
+++ b/PWGHF/Tasks/taskMcValidation.cxx
@@ -1154,8 +1154,8 @@ struct HfTaskMcValidationRec {
                   aod::McCollisions const&,
                   aod::BCsWithTimestamps const&,
                   Coll const& collisions,
-                  Preslice<HfCand2ProngWithMCRec> cand2ProngsPerCollision,
-                  Preslice<HfCand3ProngWithMCRec> cand3ProngsPerCollision)
+                  const Preslice<HfCand2ProngWithMCRec>& cand2ProngsPerCollision,
+                  const Preslice<HfCand3ProngWithMCRec>& cand3ProngsPerCollision)
   {
     // loop over collisions
     for (const auto& collision : collisions) {


### PR DESCRIPTION
Mostly done automatically by Clang-Tidy.