### PR TITLE
[PWGJE] Use `const&` and `std::move` to avoid copies

### DIFF
--- a/PWGJE/Core/JetBkgSubUtils.cxx
+++ b/PWGJE/Core/JetBkgSubUtils.cxx
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 #include <math.h>
@@ -41,7 +42,7 @@ JetBkgSubUtils::JetBkgSubUtils(float jetBkgR_out, float bkgEtaMin_out, float bkg
                                                                                                                                                                                                                                                           constSubAlpha(constSubAlpha_out),
                                                                                                                                                                                                                                                           constSubRMax(constSubRMax_out),
                                                                                                                                                                                                                                                           nHardReject(nHardReject_out),
-                                                                                                                                                                                                                                                          ghostAreaSpec(ghostAreaSpec_out)
+                                                                                                                                                                                                                                                          ghostAreaSpec(std::move(ghostAreaSpec_out))
 
 {
 }
@@ -162,11 +163,11 @@ std::vector<fastjet::PseudoJet> JetBkgSubUtils::doJetConstSub(std::vector<fastje
   return constituentSub(jets);
 }
 
-double JetBkgSubUtils::getMd(fastjet::PseudoJet jet) const
+double JetBkgSubUtils::getMd(const fastjet::PseudoJet& jet) const
 {
   // Refere to https://arxiv.org/abs/1211.2811 for the rhoM caclulation
   double sum(0);
-  for (auto constituent : jet.constituents()) {
+  for (const auto& constituent : jet.constituents()) {
     sum += TMath::Sqrt(constituent.m() * constituent.m() + constituent.pt() * constituent.pt()) - constituent.pt();
   }
 

--- a/PWGJE/Core/JetBkgSubUtils.h
+++ b/PWGJE/Core/JetBkgSubUtils.h
@@ -24,6 +24,7 @@
 #include <fastjet/Selector.hh>
 
 #include <tuple>
+#include <utility>
 #include <vector>
 
 #include <math.h>
@@ -107,7 +108,7 @@ class JetBkgSubUtils
     constSubRMax = rmax_out;
   }
   void setDoRhoMassSub(bool doMSub_out = true) { doRhoMassSub = doMSub_out; }
-  void setGhostAreaSpec(fastjet::GhostedAreaSpec ghostAreaSpec_out) { ghostAreaSpec = ghostAreaSpec_out; }
+  void setGhostAreaSpec(fastjet::GhostedAreaSpec ghostAreaSpec_out) { ghostAreaSpec = std::move(ghostAreaSpec_out); }
 
   // Getters
   float getJetBkgR() const { return jetBkgR; }
@@ -124,7 +125,7 @@ class JetBkgSubUtils
   fastjet::Selector getRhoSelector() const { return selRho; }
 
   // Calculate the jet mass
-  double getMd(fastjet::PseudoJet jet) const;
+  double getMd(const fastjet::PseudoJet& jet) const;
 
  protected:
   float jetBkgR = 0.2;

--- a/PWGJE/Core/JetDerivedDataUtilities.h
+++ b/PWGJE/Core/JetDerivedDataUtilities.h
@@ -63,7 +63,7 @@ enum JCollisionSubGeneratorId {
 };
 
 template <typename T>
-bool selectCollision(T const& collision, const std::vector<int>& eventSelectionMaskBits, bool skipMBGapEvents = true, bool rctSelection = true, std::string rctLabel = "CBT_hadronPID", bool rejectLimitedAcceptanceRct = false, bool requireZDCRct = false)
+bool selectCollision(T const& collision, const std::vector<int>& eventSelectionMaskBits, bool skipMBGapEvents = true, bool rctSelection = true, const std::string& rctLabel = "CBT_hadronPID", bool rejectLimitedAcceptanceRct = false, bool requireZDCRct = false)
 {
 
   if (skipMBGapEvents && collision.getSubGeneratorId() == JCollisionSubGeneratorId::mbGap) {
@@ -96,7 +96,7 @@ bool selectCollision(T const& collision, const std::vector<int>& eventSelectionM
   return !isOrCondition;
 }
 
-bool eventSelectionMasksContainSelection(const std::string& eventSelectionMasks, std::string selection)
+bool eventSelectionMasksContainSelection(const std::string& eventSelectionMasks, const std::string& selection)
 {
   size_t position = 0;
   while ((position = eventSelectionMasks.find(selection, position)) != std::string::npos) {
@@ -325,7 +325,7 @@ bool selectTrigger(T const& collision, int triggerMaskBit)
   return collision.triggerSel() & (1ULL << triggerMaskBit);
 }
 
-bool triggerMasksContainTrigger(const std::string& triggerMasks, std::string trigger)
+bool triggerMasksContainTrigger(const std::string& triggerMasks, const std::string& trigger)
 {
   size_t position = 0;
   while ((position = triggerMasks.find(trigger, position)) != std::string::npos) {
@@ -733,7 +733,7 @@ bool selectTrackDcaZ(T const& track, double dcaZmax = 99.)
   return std::abs(track.dcaZ()) < dcaZmax;
 }
 
-std::vector<int> initialiseClusterDefinitions(const std::string clusterDefinitions)
+std::vector<int> initialiseClusterDefinitions(const std::string& clusterDefinitions)
 {
   std::vector<int> clusterDefinitionsVec;
   if (clusterDefinitions.empty()) {

--- a/PWGJE/Core/JetFindingUtilities.h
+++ b/PWGJE/Core/JetFindingUtilities.h
@@ -38,6 +38,7 @@
 #include <memory>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include <math.h>
@@ -278,9 +279,9 @@ bool analyseV0s(std::vector<fastjet::PseudoJet>& inputParticles, T const& v0s, f
  * @param doHFJetFinding set whether only jets containing a HF candidate are saved
  */
 template <typename T, typename U, typename V>
-void findJets(JetFinder& jetFinder, std::vector<fastjet::PseudoJet>& inputParticles, float jetPtMin, float jetPtMax, std::vector<double> jetRadius, float jetAreaFractionMin, T const& collision, U& jetsTable, V& constituentsTable, std::shared_ptr<THn> thnSparseJet, bool fillThnSparse, bool doCandidateJetFinding = false)
+void findJets(JetFinder& jetFinder, std::vector<fastjet::PseudoJet>& inputParticles, float jetPtMin, float jetPtMax, std::vector<double> jetRadius, float jetAreaFractionMin, T const& collision, U& jetsTable, V& constituentsTable, const std::shared_ptr<THn>& thnSparseJet, bool fillThnSparse, bool doCandidateJetFinding = false)
 {
-  auto jetRValues = static_cast<std::vector<double>>(jetRadius);
+  auto jetRValues = static_cast<std::vector<double>>(std::move(jetRadius));
   jetFinder.jetPtMin = jetPtMin;
   jetFinder.jetPtMax = jetPtMax;
   for (auto R : jetRValues) {

--- a/PWGJE/Core/MlResponseHfTagging.h
+++ b/PWGJE/Core/MlResponseHfTagging.h
@@ -34,10 +34,9 @@
 // Fill the map of available input features
 // the key is the feature's name (std::string)
 // the value is the corresponding value in EnumInputFeatures
-#define FILL_MAP_BJET(FEATURE)                                 \
-  {                                                            \
-    #FEATURE, static_cast<uint8_t>(InputFeaturesBTag::FEATURE) \
-  }
+#define FILL_MAP_BJET(FEATURE) \
+  {                            \
+    #FEATURE, static_cast<uint8_t>(InputFeaturesBTag::FEATURE)}
 
 // Check if the index of mCachedIndices (index associated to a FEATURE)
 // matches the entry in EnumInputFeatures associated to this FEATURE
@@ -424,7 +423,7 @@ class GNNBjetAllocator : public TensorAllocator
 
  public:
   GNNBjetAllocator() : TensorAllocator(), nJetFeat(4), nTrkFeat(13), nFlav(3), nTrkOrigin(5), maxNNodes(40), tfFunc([](float x) { return x; }) {}
-  GNNBjetAllocator(int64_t nJetFeat, int64_t nTrkFeat, int64_t nFlav, int64_t nTrkOrigin, std::vector<float>& tfJetMean, std::vector<float>& tfJetStdev, std::vector<float>& tfTrkMean, std::vector<float>& tfTrkStdev, int64_t maxNNodes = 40, std::string tfFuncType = "linear")
+  GNNBjetAllocator(int64_t nJetFeat, int64_t nTrkFeat, int64_t nFlav, int64_t nTrkOrigin, std::vector<float>& tfJetMean, std::vector<float>& tfJetStdev, std::vector<float>& tfTrkMean, std::vector<float>& tfTrkStdev, int64_t maxNNodes = 40, const std::string& tfFuncType = "linear")
     : TensorAllocator(), nJetFeat(nJetFeat), nTrkFeat(nTrkFeat), nFlav(nFlav), nTrkOrigin(nTrkOrigin), maxNNodes(maxNNodes), tfJetMean(tfJetMean), tfJetStdev(tfJetStdev), tfTrkMean(tfTrkMean), tfTrkStdev(tfTrkStdev), tfFunc([](float x) { return x; })
   {
     if (tfFuncType == "asinh") {

--- a/PWGJE/DataModel/EMCALClusterDefinition.h
+++ b/PWGJE/DataModel/EMCALClusterDefinition.h
@@ -17,6 +17,7 @@
 #define PWGJE_DATAMODEL_EMCALCLUSTERDEFINITION_H_
 
 #include <string>
+#include <utility>
 
 namespace o2::aod
 {
@@ -50,7 +51,7 @@ struct EMCALClusterDefinition {
     algorithm = pAlgorithm;
     storageID = pStorageID;
     selectedCellType = pSelectedCellType;
-    name = pName;
+    name = std::move(pName);
     seedEnergy = pSeedEnergy;
     minCellEnergy = pMinCellEnergy;
     timeMin = pTimeMin;

--- a/PWGJE/TableProducer/derivedDataProducer.cxx
+++ b/PWGJE/TableProducer/derivedDataProducer.cxx
@@ -620,7 +620,7 @@ struct JetDerivedDataProducerTask {
   void processClusters(aod::Collision const&, aod::EMCALClusters const& clusters, aod::EMCALClusterCells const& cells, aod::Calos const&, aod::EMCALMatchedTracks const& matchedTracks, soa::Join<aod::Tracks, aod::TracksExtra> const&)
   {
 
-    for (auto cluster : clusters) {
+    for (const auto& cluster : clusters) {
 
       auto const clusterCells = cells.sliceBy(preslices.perClusterCells, cluster.globalIndex());
 

--- a/PWGJE/TableProducer/derivedDataSelector.cxx
+++ b/PWGJE/TableProducer/derivedDataSelector.cxx
@@ -155,9 +155,9 @@ struct JetDerivedDataSelector {
 
   void processSelectMcCollisionsPerCollision(aod::JMcCollisions const& mcCollisions, soa::Join<aod::JCollisions, aod::JMcCollisionLbs> const& collisions)
   {
-    for (auto mcCollision : mcCollisions) {
+    for (const auto& mcCollision : mcCollisions) {
       const auto collisionsPerMcCollision = collisions.sliceBy(CollisionsPerMcCollision, mcCollision.globalIndex());
-      for (auto collision : collisionsPerMcCollision) {
+      for (const auto& collision : collisionsPerMcCollision) {
         if (collisionFlag[collision.globalIndex()]) {
           mcCollisionFlag[mcCollision.globalIndex()] = true;
         }

--- a/PWGJE/TableProducer/derivedDataWriter.cxx
+++ b/PWGJE/TableProducer/derivedDataWriter.cxx
@@ -711,11 +711,11 @@ struct JetDerivedDataWriter {
 
         const auto particlesPerMcCollision = particles.sliceBy(preslices.ParticlesPerMcCollision, mcCollision.globalIndex());
 
-        for (auto particle : particlesPerMcCollision) {
+        for (const auto& particle : particlesPerMcCollision) {
           particleMapping[particle.globalIndex()] = particleTableIndex;
           particleTableIndex++;
         }
-        for (auto particle : particlesPerMcCollision) {
+        for (const auto& particle : particlesPerMcCollision) {
 
           std::vector<int32_t> mothersIds;
           int daughtersIds[2] = {-1, -1};

--- a/PWGJE/TableProducer/mcOutlierRejector.cxx
+++ b/PWGJE/TableProducer/mcOutlierRejector.cxx
@@ -69,7 +69,7 @@ struct McOutlierRejectorTask {
     if (selectionObjects.size() != 0) {
       float selectionObjectPt = 0.0;
       if constexpr (std::is_same_v<std::decay_t<T>, aod::JetTracksMCD> || std::is_same_v<std::decay_t<T>, aod::JetParticles>) {
-        for (auto selectionObject : selectionObjects) {
+        for (const auto& selectionObject : selectionObjects) {
           selectionObjectPt = selectionObject.pt();
           // may be slow - could save only MC particle then check difference only for tracks IDd as outliers?
           if constexpr (std::is_same_v<std::decay_t<T>, aod::JetTracksMCD>) { // tracks

--- a/PWGJE/Tasks/emcalGammaGammaBcWise.cxx
+++ b/PWGJE/Tasks/emcalGammaGammaBcWise.cxx
@@ -116,7 +116,7 @@ bool isPhotonAccepted(Photon const& p, emcal::Geometry* emcalGeom = nullptr)
 }
 
 struct Meson {
-  Meson(Photon p1, Photon p2) : p1(p1), p2(p2)
+  Meson(const Photon& p1, const Photon& p2) : p1(p1), p2(p2)
   {
     pMeson = p1.photon + p2.photon;
   }

--- a/PWGJE/Tasks/emcalPi0EnergyScaleCalib.cxx
+++ b/PWGJE/Tasks/emcalPi0EnergyScaleCalib.cxx
@@ -178,8 +178,8 @@ struct Photon {
 };
 
 struct Meson {
-  Meson(Photon p1, Photon p2) : pgamma1(p1),
-                                pgamma2(p2)
+  Meson(const Photon& p1, const Photon& p2) : pgamma1(p1),
+                                              pgamma2(p2)
   {
     pMeson = p1.photon + p2.photon;
   }

--- a/PWGJE/Tasks/fullJetSpectra.cxx
+++ b/PWGJE/Tasks/fullJetSpectra.cxx
@@ -1185,7 +1185,7 @@ struct FullJetSpectra {
     if (bcs.size() == 0) {
       return;
     }
-    for (auto bc : bcs) {
+    for (const auto& bc : bcs) {
       registry.fill(HIST("hBCCounter"), 0.5); // All BC
       if (bc.selection_bit(aod::evsel::EventSelectionFlags::kIsTriggerTVX)) {
         registry.fill(HIST("hBCCounter"), 1.5); // BC+TVX
@@ -1197,7 +1197,7 @@ struct FullJetSpectra {
         }
       }
       auto collisionsInBC = collisions.sliceBy(perFoundBC, bc.globalIndex());
-      for (auto collision : collisionsInBC) {
+      for (const auto& collision : collisionsInBC) {
         registry.fill(HIST("hBCCounter"), 4.5); // CollinBC
         if (collision.selection_bit(o2::aod::evsel::kIsTriggerTVX)) {
           registry.fill(HIST("hBCCounter"), 5.5); // CollinBC+TVX

--- a/PWGJE/Tasks/fullJetTriggerQATask.cxx
+++ b/PWGJE/Tasks/fullJetTriggerQATask.cxx
@@ -420,7 +420,7 @@ struct JetTriggerQA {
   }
 
   template <typename T, typename U>
-  void check_maxJetPt(T const jet, U& vecMaxJet)
+  void check_maxJetPt(T const& jet, U& vecMaxJet)
   {
     for (unsigned int i = 0; i < vecMaxJet.size(); i++) {
       auto maxJet = vecMaxJet[i];

--- a/PWGJE/Tasks/jetD0AngSubstructure.cxx
+++ b/PWGJE/Tasks/jetD0AngSubstructure.cxx
@@ -698,7 +698,7 @@ struct JetD0AngSubstructure {
             typename JetTableMCP,
             typename CandidatesMCD,
             typename CandidatesMCP>
-  void analyseMonteCarlo(MCPJetsPerMCCollissionPreslice jetmcpreslice,
+  void analyseMonteCarlo(const MCPJetsPerMCCollissionPreslice& jetmcpreslice,
                          aod::JetMcCollisions const& mccollisions,
                          aod::JetCollisionsMCD const& collisions,
                          JetTableMCD const& /*mcdjets*/,

--- a/PWGJE/Tasks/jetDebug.cxx
+++ b/PWGJE/Tasks/jetDebug.cxx
@@ -147,7 +147,7 @@ struct JetDebugTask {
     if (jetderiveddatautilities::selectCollision(collision, eventSelection, false, false)) {
       registry.fill(HIST("h_collisions"), 2.0);
     }
-    for (auto track : tracks) {
+    for (const auto& track : tracks) {
       registry.fill(HIST("h_track_pt"), track.pt());
       registry.fill(HIST("h_track_phi"), track.phi());
       registry.fill(HIST("h_track_eta"), track.eta());
@@ -218,7 +218,7 @@ struct JetDebugTask {
     if (jetderiveddatautilities::selectCollision(collision, eventSelection, false, false)) {
       registry.fill(HIST("h_collisions"), 2.0);
     }
-    for (auto track : tracks) {
+    for (const auto& track : tracks) {
       registry.fill(HIST("h_track_pt"), track.pt());
       registry.fill(HIST("h_track_phi"), track.phi());
       registry.fill(HIST("h_track_eta"), track.eta());
@@ -299,7 +299,7 @@ struct JetDebugTask {
 
   void processMCPCharged(aod::JMcCollision const&, soa::Join<aod::ChargedMCParticleLevelJets, aod::ChargedMCParticleLevelJetConstituents> const& jets, aod::JMcParticles const& tracks)
   {
-    for (auto track : tracks) {
+    for (const auto& track : tracks) {
       registry.fill(HIST("h_particle_pt"), track.pt());
       registry.fill(HIST("h_particle_phi"), track.phi());
       registry.fill(HIST("h_particle_eta"), track.eta());

--- a/PWGJE/Tasks/jetFinderQA.cxx
+++ b/PWGJE/Tasks/jetFinderQA.cxx
@@ -982,7 +982,7 @@ struct JetFinderQATask {
     if (!jetderiveddatautilities::selectCollision(collision, eventSelectionBits)) {
       return;
     }
-    for (auto jet : jets) {
+    for (const auto& jet : jets) {
       if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
         continue;
       }
@@ -1004,7 +1004,7 @@ struct JetFinderQATask {
     if (!jetderiveddatautilities::selectCollision(collision, eventSelectionBits)) {
       return;
     }
-    for (auto jet : jets) {
+    for (const auto& jet : jets) {
       if (!jetfindingutilities::isInEtaAcceptance(jet, jetEtaMin, jetEtaMax, trackEtaMin, trackEtaMax)) {
         continue;
       }

--- a/PWGJE/Tasks/jetSubstructureOutput.cxx
+++ b/PWGJE/Tasks/jetSubstructureOutput.cxx
@@ -308,7 +308,7 @@ struct JetSubstructureOutputTask {
   void processClearMapsMCP(aod::JetMcCollisions const& mcCollisions)
   {
     jetMappingMCP.clear();
-    for (auto mcCollision : mcCollisions) {
+    for (const auto& mcCollision : mcCollisions) {
       mcCollisionOutputTable(mcCollision.posZ(), mcCollision.accepted(), mcCollision.attempted(), mcCollision.xsectGen(), mcCollision.xsectErr(), mcCollision.weight());
     }
   }

--- a/PWGJE/Tasks/jetTutorial.cxx
+++ b/PWGJE/Tasks/jetTutorial.cxx
@@ -335,7 +335,7 @@ struct JetTutorialTask {
     if (!jetderiveddatautilities::selectCollision(collision, eventSelectionBits)) {
       return;
     }
-    for (auto jet : jets) {
+    for (const auto& jet : jets) {
       registry.fill(HIST("h_jet_pt"), jet.pt());
       registry.fill(HIST("h_jet_pt_rhosub"), jet.pt() - (collision.rho() * jet.area()));
       registry.fill(HIST("h_jet_eta"), jet.eta());
@@ -349,7 +349,7 @@ struct JetTutorialTask {
     if (!jetderiveddatautilities::selectCollision(collision, eventSelectionBits)) {
       return;
     }
-    for (auto jet : jets) {
+    for (const auto& jet : jets) {
       registry.fill(HIST("h_jet_pt_constsub"), jet.pt());
       registry.fill(HIST("h_jet_eta"), jet.eta());
       registry.fill(HIST("h_jet_phi"), jet.phi());
@@ -362,7 +362,7 @@ struct JetTutorialTask {
     if (!jetderiveddatautilities::selectCollision(collision, eventSelectionBits)) {
       return;
     }
-    for (auto jet : jets) {
+    for (const auto& jet : jets) {
       registry.fill(HIST("h_jet_pt_constsub"), jet.pt());
       registry.fill(HIST("h_jet_eta"), jet.eta());
       registry.fill(HIST("h_jet_phi"), jet.phi());

--- a/PWGJE/Tasks/jetValidationQA.cxx
+++ b/PWGJE/Tasks/jetValidationQA.cxx
@@ -410,7 +410,7 @@ struct mcJetTrackCollisionQa {
 
   // fill qa histograms for selected tracks in collision
   template <class ValidationTracks, typename coll>
-  void fillMcTrackHistos(ValidationTracks const& mct, coll collision, bool mc) // could give collision as argument for additional association
+  void fillMcTrackHistos(ValidationTracks const& mct, const coll& collision, bool mc) // could give collision as argument for additional association
   {
     for (const auto& track : mct) {
       if (!jetderiveddatautilities::selectTrack(track, trackSelection) || !(track.collisionId() == collision.globalIndex())) {

--- a/PWGJE/Tasks/mcGeneratorStudies.cxx
+++ b/PWGJE/Tasks/mcGeneratorStudies.cxx
@@ -224,7 +224,7 @@ struct MCGeneratorStudies {
   }
 
   template <typename TMCParticle, typename TMCParticles>
-  bool isGammaGammaDecay(TMCParticle mcParticle, TMCParticles mcParticles)
+  bool isGammaGammaDecay(const TMCParticle& mcParticle, const TMCParticles& mcParticles)
   {
     auto daughtersIds = mcParticle.daughtersIds();
     if (daughtersIds.size() != 2)
@@ -237,7 +237,7 @@ struct MCGeneratorStudies {
   }
 
   template <typename TMCParticle, typename TMCParticles>
-  bool isAccepted(TMCParticle mcParticle, TMCParticles mcParticles)
+  bool isAccepted(const TMCParticle& mcParticle, const TMCParticles& mcParticles)
   {
     auto daughtersIds = mcParticle.daughtersIds();
     if (daughtersIds.size() != 2)

--- a/PWGJE/Tasks/nucleiInJets.cxx
+++ b/PWGJE/Tasks/nucleiInJets.cxx
@@ -791,7 +791,7 @@ struct nucleiInJets {
   }
 
   template <typename TrackType>
-  bool isTrackSelectedWithoutDcaxy(const TrackType track)
+  bool isTrackSelectedWithoutDcaxy(const TrackType& track)
   {
     // standard track selection
     if (track.pt() < cfgtrkMinPt)
@@ -822,7 +822,7 @@ struct nucleiInJets {
   }
 
   template <typename TrackType>
-  bool isTrackSelected(const TrackType track)
+  bool isTrackSelected(const TrackType& track)
   {
     if (!isTrackSelectedWithoutDcaxy(track))
       return false;

--- a/PWGJE/Tasks/phiInJets.cxx
+++ b/PWGJE/Tasks/phiInJets.cxx
@@ -294,7 +294,7 @@ struct phiInJets {
   /////////////////////////////////////////////////////////////////////////////
   /////////////////////////////////////////////////////////////////////////////
   template <typename TrackType>
-  bool trackSelection(const TrackType track)
+  bool trackSelection(const TrackType& track)
   {
     // basic track cuts
     if (track.pt() < cfgtrkMinPt)
@@ -396,7 +396,7 @@ struct phiInJets {
   /////////////////////////////////////////////////////////////////////////////
 
   template <typename JetType>
-  double DistinguishJets(const JetType& jets, const TLorentzVector lResonance)
+  double DistinguishJets(const JetType& jets, const TLorentzVector& lResonance)
   {
     if (cDebugLevel > 0)
       std::cout << "oof, multiple jets fit to the same phi. Time to find the best phi-jet link" << std::endl;
@@ -419,7 +419,7 @@ struct phiInJets {
   }
 
   template <typename Jet_pt, typename Jet_phi, typename Jet_eta>
-  double DistinguishJetsMC(const Jet_pt& jet_pt, const Jet_phi& jet_phi, const Jet_eta& jet_eta, const TLorentzVector lResonance)
+  double DistinguishJetsMC(const Jet_pt& jet_pt, const Jet_phi& jet_phi, const Jet_eta& jet_eta, const TLorentzVector& lResonance)
   {
     if (cDebugLevel > 0)
       std::cout << "oof, multiple jets fit to the same phi. Time to find the best phi-jet link" << std::endl;
@@ -593,7 +593,7 @@ struct phiInJets {
     JEhistos.fill(HIST("hNResoPerEventInJet"), nResoInTrig);
 
     int nJets = 0;
-    for (auto chargedjet : chargedjets) {
+    for (const auto& chargedjet : chargedjets) {
       JEhistos.fill(HIST("FJetaHistogram"), chargedjet.eta());
       JEhistos.fill(HIST("FJphiHistogram"), chargedjet.phi());
       JEhistos.fill(HIST("FJptHistogram"), chargedjet.pt());

--- a/PWGJE/Tasks/photonIsolationQA.cxx
+++ b/PWGJE/Tasks/photonIsolationQA.cxx
@@ -269,7 +269,7 @@ struct PhotonIsolationQA {
     return Pt_Iso;
   }
 
-  void fillclusterhistos(const auto cluster, HistogramRegistry registry, double weight = 1.0)
+  void fillclusterhistos(const auto& cluster, HistogramRegistry registry, double weight = 1.0)
   {
     registry.fill(HIST("hClusterLocation"), cluster.eta(), cluster.phi());
     if (isMC == true) {
@@ -397,7 +397,7 @@ struct PhotonIsolationQA {
   // process monte carlo data
   void processMC(aod::BCs const& bcs, selectedMcCollisions const& Collisions, selectedMCClusters const& mcclusters, aod::McParticles const&, myGlobTracks const& tracks, o2::aod::EMCALMatchedTracks const& matchedtracks, aod::Calos const&, aod::EMCALClusterCells const& ClusterCells)
   {
-    for (auto bc : bcs) {
+    for (const auto& bc : bcs) {
       auto collisionsInBC = Collisions.sliceBy(McCollisionsPerBC, bc.globalIndex());
       MC_Info.fill(HIST("hCollperBC"), collisionsInBC.size());
       if (collisionsInBC.size() == 1) {
@@ -461,7 +461,7 @@ struct PhotonIsolationQA {
 
   void processData(aod::BCs const& bcs, selectedCollisions const& Collisions, selectedClusters const& clusters, o2::aod::EMCALMatchedTracks const& matchedtracks, myGlobTracks const& tracks, aod::Calos const&, aod::EMCALClusterCells const& ClusterCells)
   {
-    for (auto bc : bcs) {
+    for (const auto& bc : bcs) {
       auto collisionsInBC = Collisions.sliceBy(collisionsPerBC, bc.globalIndex());
       Data_Info.fill(HIST("hCollperBC"), collisionsInBC.size());
       if (collisionsInBC.size() == 1) {

--- a/PWGJE/Tasks/statPromptPhoton.cxx
+++ b/PWGJE/Tasks/statPromptPhoton.cxx
@@ -426,7 +426,7 @@ struct statPromptPhoton {
   /////////////////////////////////////////////////////////////////////////////
   /////////////////////////////////////////////////////////////////////////////
   template <typename TrackType>
-  bool trackSelection(const TrackType track)
+  bool trackSelection(const TrackType& track)
   {
     // basic track cuts
     if (track.pt() < cfgtrkMinPt)

--- a/PWGJE/Tasks/trackEfficiency.cxx
+++ b/PWGJE/Tasks/trackEfficiency.cxx
@@ -173,7 +173,7 @@ struct TrackEfficiency {
   }
 
   template <typename TMCCollision, typename TCollisions, typename TParticles, typename TTracks>
-  void fillParticlesHistograms(TMCCollision const& /*mcCollision*/, TCollisions const& collisions, TParticles const& mcparticles, TTracks tracks, float weight = 1.0)
+  void fillParticlesHistograms(TMCCollision const& /*mcCollision*/, TCollisions const& collisions, TParticles const& mcparticles, const TTracks& tracks, float weight = 1.0)
   {
     // float centrality = checkCentFT0M ? mcCollision.centFT0M() : mcCollision.centFT0C(); mcCollision.centFT0C() isn't filled at the moment; can be added back when it is
     float centrality = checkCentFT0M ? collisions.begin().centFT0M() : collisions.begin().centFT0C();


### PR DESCRIPTION
Mostly done automatically by Clang-Tidy.