### PR TITLE
[PWGUD] Use `const&` and `std::move` to avoid copies

### DIFF
--- a/PWGUD/AQC/udQC.cxx
+++ b/PWGUD/AQC/udQC.cxx
@@ -711,7 +711,7 @@ struct UDQC {
       return;
     }
 
-    for (auto fv0 : fv0s) {
+    for (const auto& fv0 : fv0s) {
       registry.get<TH1>(HIST("FV0/hV0A"))->Fill(fv0.time());
       // side A
       for (size_t ind = 0; ind < fv0.channel().size(); ind++) {
@@ -738,7 +738,7 @@ struct UDQC {
         registry.get<TH1>(HIST("FT0/hT0AC"))->Fill(collision.t0AC());
       }
     }
-    for (auto ft0 : ft0s) {
+    for (const auto& ft0 : ft0s) {
       registry.get<TH1>(HIST("FT0/hT0A"))->Fill(ft0.timeA());
       registry.get<TH1>(HIST("FT0/hT0C"))->Fill(ft0.timeC());
 
@@ -760,7 +760,7 @@ struct UDQC {
   {
     // LOGF(debug, "<FDDSignals> %d", fdds.size());
 
-    for (auto fdd : fdds) {
+    for (const auto& fdd : fdds) {
 
       registry.get<TH1>(HIST("FDD/hFDDA"))->Fill(fdd.timeA());
       registry.get<TH1>(HIST("FDD/hFDDC"))->Fill(fdd.timeC());

--- a/PWGUD/Core/DGCutparHolder.cxx
+++ b/PWGUD/Core/DGCutparHolder.cxx
@@ -11,6 +11,7 @@
 
 #include "PWGUD/Core/DGCutparHolder.h"
 
+#include <utility>
 #include <vector>
 
 // setter
@@ -45,7 +46,7 @@ void DGCutparHolder::SetNTracks(int MinNTracks, int MaxNTracks)
 }
 void DGCutparHolder::SetNetCharges(std::vector<int> netCharges)
 {
-  mNetCharges = netCharges;
+  mNetCharges = std::move(netCharges);
 }
 void DGCutparHolder::SetPidHypothesis(int pidHypo)
 {
@@ -102,11 +103,11 @@ void DGCutparHolder::SetMaxFITtime(float maxFITtime)
 }
 void DGCutparHolder::SetFITAmpLimits(std::vector<float> FITAmpLimits)
 {
-  mFITAmpLimits = FITAmpLimits;
+  mFITAmpLimits = std::move(FITAmpLimits);
 }
 void DGCutparHolder::SetCollisionSel(std::vector<int> collisionSel)
 {
-  mCollisionSel = collisionSel;
+  mCollisionSel = std::move(collisionSel);
 }
 
 // getter

--- a/PWGUD/Core/DGCutparHolder.h
+++ b/PWGUD/Core/DGCutparHolder.h
@@ -14,6 +14,7 @@
 
 #include <Rtypes.h>
 
+#include <utility>
 #include <vector>
 
 // object to hold customizable cut values
@@ -40,7 +41,7 @@ class DGCutparHolder
                  bool TOR = true,
                  float maxFITtime = 4,
                  std::vector<float> FITAmpLimits = {0., 0., 0., 0., 0.},
-                 std::vector<int> collisionSel = {1, 1, 1, 0, 1, 0, 0}) : mNDtcoll{ndtcoll}, mMinNBCs{nMinBCs}, mWithFwdTracks{withFwdTracks}, mGlobalTracksOnly{globalTracksOnly}, mITSOnlyTracks{ITSonlyTracks}, mMinRgtrwTOF{minrgtrwTOF}, mMinNTracks{MinNTracks}, mMaxNTracks{MaxNTracks}, mNetCharges{NetCharges}, mPidHypo{pidHypo}, mMinVertexPosz{MinPosz}, mMaxVertexPosz{MaxPosz}, mMinPt{minPt}, mMaxPt{maxPt}, mMinEta{minEta}, mMaxEta{maxEta}, mMinIVM{minIVM}, mMaxIVM{maxIVM}, mMaxNSigmaTPC{maxNSigmaTPC}, mMaxNSigmaTOF{maxNSigmaTOF}, mTVX{TVX}, mTSC{TSC}, mTCE{TCE}, mTOR{TOR}, mMaxFITtime{maxFITtime}, mFITAmpLimits{FITAmpLimits}, mCollisionSel{collisionSel}
+                 std::vector<int> collisionSel = {1, 1, 1, 0, 1, 0, 0}) : mNDtcoll{ndtcoll}, mMinNBCs{nMinBCs}, mWithFwdTracks{withFwdTracks}, mGlobalTracksOnly{globalTracksOnly}, mITSOnlyTracks{ITSonlyTracks}, mMinRgtrwTOF{minrgtrwTOF}, mMinNTracks{MinNTracks}, mMaxNTracks{MaxNTracks}, mNetCharges{std::move(NetCharges)}, mPidHypo{pidHypo}, mMinVertexPosz{MinPosz}, mMaxVertexPosz{MaxPosz}, mMinPt{minPt}, mMaxPt{maxPt}, mMinEta{minEta}, mMaxEta{maxEta}, mMinIVM{minIVM}, mMaxIVM{maxIVM}, mMaxNSigmaTPC{maxNSigmaTPC}, mMaxNSigmaTOF{maxNSigmaTOF}, mTVX{TVX}, mTSC{TSC}, mTCE{TCE}, mTOR{TOR}, mMaxFITtime{maxFITtime}, mFITAmpLimits{std::move(FITAmpLimits)}, mCollisionSel{std::move(collisionSel)}
   {
   }
 

--- a/PWGUD/Core/DGPIDSelector.cxx
+++ b/PWGUD/Core/DGPIDSelector.cxx
@@ -22,6 +22,7 @@
 #include <cstdlib>
 #include <functional>
 #include <string>
+#include <utility>
 #include <vector>
 
 // -----------------------------------------------------------------------------
@@ -87,7 +88,7 @@ DGPIDCuts::DGPIDCuts()
 
 DGPIDCuts::DGPIDCuts(std::vector<float> PIDCutValues)
 {
-  setPIDCuts(PIDCutValues);
+  setPIDCuts(std::move(PIDCutValues));
 }
 
 DGPIDCuts::~DGPIDCuts()
@@ -196,7 +197,7 @@ void DGAnaparHolder::SetdBC(int min, int max)
   mdBCMax = max;
 }
 
-void DGAnaparHolder::SetFITvetoes(std::vector<int> vetoes)
+void DGAnaparHolder::SetFITvetoes(const std::vector<int>& vetoes)
 {
 
   if (vetoes.size() == 5) {
@@ -254,22 +255,22 @@ void DGAnaparHolder::SetnCombine(std::size_t nComb)
 
 void DGAnaparHolder::SetnetCharges(std::vector<int> charges)
 {
-  mNetCharges = charges;
+  mNetCharges = std::move(charges);
 }
 
 void DGAnaparHolder::SetunlikeCharges(std::vector<int> charges)
 {
-  mUnlikeCharges = charges;
+  mUnlikeCharges = std::move(charges);
 }
 
 void DGAnaparHolder::SetlikeCharges(std::vector<int> charges)
 {
-  mLikeCharges = charges;
+  mLikeCharges = std::move(charges);
 }
 
 void DGAnaparHolder::SetPIDs(std::vector<int> pids)
 {
-  mDGPIDs = pids;
+  mDGPIDs = std::move(pids);
 }
 
 // -----------------------------------------------------------------------------
@@ -435,7 +436,7 @@ void DGPIDSelector::Print()
   mAnaPars.Print();
 }
 
-void DGPIDSelector::init(DGAnaparHolder anaPars)
+void DGPIDSelector::init(const DGAnaparHolder& anaPars)
 {
   mAnaPars = anaPars;
   mUnlikeIVMs.clear();

--- a/PWGUD/Core/DGPIDSelector.h
+++ b/PWGUD/Core/DGPIDSelector.h
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdlib>
+#include <utility>
 #include <vector>
 
 const int numDGPIDCutParameters = 9;
@@ -124,7 +125,7 @@ struct DGAnaparHolder {
                  std::vector<int> unlikeCharges = {0},
                  std::vector<int> likeCharges = {-2, 2},
                  std::vector<int> DGPIDs = {211, 211},
-                 std::vector<float> DGPIDCutValues = {}) : mMinNTracks{MinNTracks}, mMaxNTracks{MaxNTracks}, mMinRgtrwTOF{minrgtrwTOF}, mMaxDCAxy{maxDCAxy}, mMaxDCAz{maxDCAz}, mdBCMin{dBCMin}, mdBCMax{dBCMax}, mFITvetoes{FITvetoes}, mITSOnlyTracks{ITSonlyTracks}, mMinNClTPC{minNClTPC}, mMaxNClTPC{maxNClTPC}, mMinChi2NClTPC{minChi2NClTPC}, mMaxChi2NClTPC{maxChi2NClTPC}, mMinpt{minpt}, mMaxpt{maxpt}, mMineta{mineta}, mMaxeta{maxeta}, mMinAlpha{minalpha}, mMaxAlpha{maxalpha}, mMinptsys{minptsys}, mMaxptsys{maxptsys}, mNCombine{nCombine}, mNetCharges{netCharges}, mUnlikeCharges{unlikeCharges}, mLikeCharges{likeCharges}, mDGPIDs{DGPIDs}, mDGPIDCutValues{DGPIDCutValues}
+                 std::vector<float> DGPIDCutValues = {}) : mMinNTracks{MinNTracks}, mMaxNTracks{MaxNTracks}, mMinRgtrwTOF{minrgtrwTOF}, mMaxDCAxy{maxDCAxy}, mMaxDCAz{maxDCAz}, mdBCMin{dBCMin}, mdBCMax{dBCMax}, mFITvetoes{std::move(FITvetoes)}, mITSOnlyTracks{ITSonlyTracks}, mMinNClTPC{minNClTPC}, mMaxNClTPC{maxNClTPC}, mMinChi2NClTPC{minChi2NClTPC}, mMaxChi2NClTPC{maxChi2NClTPC}, mMinpt{minpt}, mMaxpt{maxpt}, mMineta{mineta}, mMaxeta{maxeta}, mMinAlpha{minalpha}, mMaxAlpha{maxalpha}, mMinptsys{minptsys}, mMaxptsys{maxptsys}, mNCombine{nCombine}, mNetCharges{std::move(netCharges)}, mUnlikeCharges{std::move(unlikeCharges)}, mLikeCharges{std::move(likeCharges)}, mDGPIDs{std::move(DGPIDs)}, mDGPIDCutValues{std::move(DGPIDCutValues)}
   {
     if (mdBCMin < -16) {
       mdBCMin = -16;
@@ -148,7 +149,7 @@ struct DGAnaparHolder {
   void SetMinRgtrwTOF(float);
   void SetmaxDCA(float, float);
   void SetdBC(int, int);
-  void SetFITvetoes(std::vector<int>);
+  void SetFITvetoes(const std::vector<int>&);
   void SetITSOnlyTracks(bool);
   void SetNClTPC(int, int);
   void SetChi2NClTPC(float, float);
@@ -239,7 +240,7 @@ struct DGParticle {
  public:
   DGParticle();
   template <typename TTrack>
-  DGParticle(TDatabasePDG* pdg, DGAnaparHolder anaPars, TTrack const& tracks, std::vector<int> comb)
+  DGParticle(TDatabasePDG* pdg, const DGAnaparHolder& anaPars, TTrack const& tracks, const std::vector<int>& comb)
   {
     // compute invariant mass
     TLorentzVector lvtmp;
@@ -284,12 +285,12 @@ struct DGPIDSelector {
   ~DGPIDSelector();
 
   // setters
-  void init(DGAnaparHolder anaPars);
+  void init(const DGAnaparHolder& anaPars);
 
   // getters
   void Print();
   template <typename TTrack>
-  bool isGoodCombination(std::vector<int> comb, TTrack const& tracks, std::vector<int> acceptedCharges)
+  bool isGoodCombination(const std::vector<int>& comb, TTrack const& tracks, std::vector<int> acceptedCharges)
   {
     // compute net charge of track combination
     int netCharge = 0.;

--- a/PWGUD/Core/DGSelector.h
+++ b/PWGUD/Core/DGSelector.h
@@ -37,7 +37,7 @@ class DGSelector
   ~DGSelector() { delete fPDG; }
 
   template <typename CC, typename BCs, typename TCs, typename FWs>
-  int Print(DGCutparHolder /*diffCuts*/, CC& collision, BCs& /*bcRange*/, TCs& /*tracks*/, FWs& /*fwdtracks*/)
+  int Print(const DGCutparHolder& /*diffCuts*/, CC& collision, BCs& /*bcRange*/, TCs& /*tracks*/, FWs& /*fwdtracks*/)
   {
     LOGF(info, "Size of array %i", collision.size());
     return 1;

--- a/PWGUD/Core/SGCutParHolder.cxx
+++ b/PWGUD/Core/SGCutParHolder.cxx
@@ -11,6 +11,7 @@
 
 #include "PWGUD/Core/SGCutParHolder.h"
 
+#include <utility>
 #include <vector>
 
 // setter
@@ -69,7 +70,7 @@ void SGCutParHolder::SetMaxFITtime(float maxFITtime)
 }
 void SGCutParHolder::SetFITAmpLimits(std::vector<float> FITAmpLimits)
 {
-  mFITAmpLimits = FITAmpLimits;
+  mFITAmpLimits = std::move(FITAmpLimits);
 }
 
 // getter

--- a/PWGUD/Core/SGCutParHolder.h
+++ b/PWGUD/Core/SGCutParHolder.h
@@ -14,6 +14,7 @@
 
 #include <Rtypes.h>
 
+#include <utility>
 #include <vector>
 
 // object to hold customizable cut values
@@ -32,7 +33,7 @@ class SGCutParHolder
                  float minEta = -1.0, float maxEta = 1.0,
                  float maxFITtime = 4,
                  float minRgtrwTOF = 0.,
-                 std::vector<float> FITAmpLimits = {0., 0., 0., 0., 0.}) : mNDtcoll{ndtcoll}, mMinNBCs{nMinBCs}, mWithFwdTracks{withFwdTracks}, mGlobalTracksOnly{globalTracksOnly}, mITSOnlyTracks{ITSonlyTracks}, mMinNTracks{MinNTracks}, mMaxNTracks{MaxNTracks}, mPidHypo{pidHypo}, mMinVertexPosz{MinPosz}, mMaxVertexPosz{MaxPosz}, mMinPt{minPt}, mMaxPt{maxPt}, mMinEta{minEta}, mMaxEta{maxEta}, mMaxFITtime{maxFITtime}, mMinRgtrwTOF{minRgtrwTOF}, mFITAmpLimits{FITAmpLimits}
+                 std::vector<float> FITAmpLimits = {0., 0., 0., 0., 0.}) : mNDtcoll{ndtcoll}, mMinNBCs{nMinBCs}, mWithFwdTracks{withFwdTracks}, mGlobalTracksOnly{globalTracksOnly}, mITSOnlyTracks{ITSonlyTracks}, mMinNTracks{MinNTracks}, mMaxNTracks{MaxNTracks}, mPidHypo{pidHypo}, mMinVertexPosz{MinPosz}, mMaxVertexPosz{MaxPosz}, mMinPt{minPt}, mMaxPt{maxPt}, mMinEta{minEta}, mMaxEta{maxEta}, mMaxFITtime{maxFITtime}, mMinRgtrwTOF{minRgtrwTOF}, mFITAmpLimits{std::move(FITAmpLimits)}
   {
   }
 

--- a/PWGUD/Core/UDFSParser.cxx
+++ b/PWGUD/Core/UDFSParser.cxx
@@ -138,8 +138,8 @@ bool UDFSParser::isNumber(std::string s)
 }
 
 // -----------------------------------------------------------------------------
-std::string UDFSParser::trim(std::string str,
-                             std::string whitespace = " \t")
+std::string UDFSParser::trim(const std::string& str,
+                             const std::string& whitespace = " \t")
 {
   const auto strBegin = str.find_first_not_of(whitespace);
   if (strBegin == std::string::npos)

--- a/PWGUD/Core/UDFSParser.h
+++ b/PWGUD/Core/UDFSParser.h
@@ -60,7 +60,7 @@ class UDFSParser
 
   // helper functions for string parsing
   bool isNumber(std::string s);
-  std::string trim(std::string str, std::string whitespace);
+  std::string trim(const std::string& str, const std::string& whitespace);
   std::vector<std::string> tokenize(std::string& str, std::string separator = ",");
   bool isInVector(int num, std::vector<int> vec);
 

--- a/PWGUD/Core/UDGoodRunSelector.cxx
+++ b/PWGUD/Core/UDGoodRunSelector.cxx
@@ -69,7 +69,7 @@ bool UDGoodRunSelector::isGoodRun(int runNumber)
   }
 }
 
-std::vector<int> UDGoodRunSelector::goodRuns(std::string runPeriod)
+std::vector<int> UDGoodRunSelector::goodRuns(const std::string& runPeriod)
 {
   auto it = mrunMap.find(runPeriod.c_str());
   if (it != mrunMap.end()) {

--- a/PWGUD/Core/UDGoodRunSelector.h
+++ b/PWGUD/Core/UDGoodRunSelector.h
@@ -33,7 +33,7 @@ struct UDGoodRunSelector {
   void Print();
   bool isGoodRun(int runNumber);
   std::vector<int> goodRuns() { return mgoodRuns; }
-  std::vector<int> goodRuns(std::string runPeriod);
+  std::vector<int> goodRuns(const std::string& runPeriod);
   int rnumMin() { return mrnMin; }
   int rnumMax() { return mrnMax; }
 

--- a/PWGUD/Core/UDHelpers.h
+++ b/PWGUD/Core/UDHelpers.h
@@ -243,7 +243,7 @@ T MCcompatibleBCs(F const& collision, int const& ndt, T const& bcs, int const& n
 // function to check if track provides good PID information
 // Checks the nSigma for any particle assumption to be within limits.
 template <typename TC>
-bool hasGoodPID(DGCutparHolder diffCuts, TC track)
+bool hasGoodPID(const DGCutparHolder& diffCuts, TC track)
 {
   // El, Mu, Pi, Ka, and Pr are considered
   // at least one nSigma must be within set limits
@@ -891,7 +891,7 @@ bool cleanCalo(T const& bc, o2::aod::Calos& calos, std::vector<float>& /*lims*/,
 // -----------------------------------------------------------------------------
 // check if all tracks come from same MCCollision
 template <typename T>
-int64_t sameMCCollision(T tracks, o2::aod::McCollisions, o2::aod::McParticles)
+int64_t sameMCCollision(T tracks, const o2::aod::McCollisions&, const o2::aod::McParticles&)
 {
   int64_t colID = -1;
   for (auto const& track : tracks) {

--- a/PWGUD/Core/UPCJpsiCentralBarrelCorrHelper.h
+++ b/PWGUD/Core/UPCJpsiCentralBarrelCorrHelper.h
@@ -213,7 +213,7 @@ float* correlation(TLorentzVector* lv1, TLorentzVector* lv2, TLorentzVector* lv)
   return q;
 }
 
-double DeltaPhi(TLorentzVector lv1, TLorentzVector lv2)
+double DeltaPhi(const TLorentzVector& lv1, const TLorentzVector& lv2)
 {
   TLorentzVector lv_sum = lv1 + lv2;
   TLorentzVector lv_diff = lv1 - lv2;
@@ -223,7 +223,7 @@ double DeltaPhi(TLorentzVector lv1, TLorentzVector lv2)
   return dp;
 }
 
-double DeltaPhiRandom(TLorentzVector lv1, TLorentzVector lv2)
+double DeltaPhiRandom(const TLorentzVector& lv1, const TLorentzVector& lv2)
 {
   std::vector<int> indices = {0, 1};
   unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();

--- a/PWGUD/Core/UPCTauCentralBarrelHelperRL.h
+++ b/PWGUD/Core/UPCTauCentralBarrelHelperRL.h
@@ -52,19 +52,19 @@ enum MyTauChannel {
   CH_ENUM_COUNTER = 11
 };
 
-void printLargeMessage(std::string info)
+void printLargeMessage(const std::string& info)
 // Helper to printf info message to terminal
 {
   LOGF(info, "################################### %s ###################################", info);
 }
 
-void printMediumMessage(std::string info)
+void printMediumMessage(const std::string& info)
 // Helper to printf info message to terminal
 {
   LOGF(info, "+++++++++++++ %s +++++++++++++", info);
 }
 
-void printDebugMessage(std::string info)
+void printDebugMessage(const std::string& info)
 // Helper to printf info message to terminal
 {
   LOGF(debug, "X!X!X!X!X!X!X!X!X %s X!X!X!X!X!X!X!X!X", info);

--- a/PWGUD/Core/decayTree.cxx
+++ b/PWGUD/Core/decayTree.cxx
@@ -93,7 +93,7 @@ void pidSelector::Print()
 // angleCut
 angleCut::angleCut(std::pair<std::string, std::string> rnames, double angleMin, double angleMax)
 {
-  fRnames = rnames;
+  fRnames = std::move(rnames);
   fAngleMin = angleMin;
   fAngleMax = angleMax;
 }
@@ -982,7 +982,7 @@ void decayTree::Print()
   }
 }
 
-resonance* decayTree::getResonance(std::string name)
+resonance* decayTree::getResonance(const std::string& name)
 {
   for (const auto& res : fResonances) {
     if (res->name() == name) {

--- a/PWGUD/Core/decayTree.h
+++ b/PWGUD/Core/decayTree.h
@@ -192,9 +192,9 @@ class reconstructedParticle
  public:
   // constructor/destructor
   reconstructedParticle() {}
-  explicit reconstructedParticle(std::string name, TLorentzVector ivm, std::vector<int>& comb)
+  explicit reconstructedParticle(std::string name, const TLorentzVector& ivm, std::vector<int>& comb)
   {
-    fName = name;
+    fName = std::move(name);
     fIVM = ivm;
     fComb = comb;
   };
@@ -219,7 +219,7 @@ class reconstructedEvent
   reconstructedEvent() {}
   explicit reconstructedEvent(recResType recs, int chargeState, std::vector<int>& comb)
   {
-    fRecs = recs;
+    fRecs = std::move(recs);
     fComb = comb;
     fChargeState = chargeState;
   };
@@ -250,7 +250,7 @@ class resonance
 
   void setisFinal() { fisFinal = true; }
   void setCounter(int counter) { fCounter = counter; }
-  void setName(std::string name) { fName = name; }
+  void setName(std::string name) { fName = std::move(name); }
   void setStatus(int status) { fStatus = status; }
   void setPID(int pid) { fPID = pid; }
   void setPIDFun(int pidfun) { fPIDfun = pidfun; }
@@ -259,9 +259,9 @@ class resonance
     fdetectorHits = std::vector<int>{its, tpc, trd, tof};
   }
   void clearParents() { fParents.clear(); }
-  void addParent(std::string parent) { fParents.push_back(parent); }
+  void addParent(const std::string& parent) { fParents.push_back(parent); }
   void setDaughters(std::vector<std::string>& daughters) { fDaughters = daughters; }
-  void setIVM(TLorentzVector ivm)
+  void setIVM(const TLorentzVector& ivm)
   {
     fIVM = ivm;
     fStatus = 1;
@@ -299,8 +299,8 @@ class resonance
     fdcaxyMax = dcaxymax;
     fdcazMax = dcazmax;
   }
-  void setPIDSelector(pidSelector pidcuts) { fpidSelector = pidcuts; }
-  void setAngleCuts(std::vector<angleCut*> anglecuts) { fangleCuts = anglecuts; }
+  void setPIDSelector(const pidSelector& pidcuts) { fpidSelector = pidcuts; }
+  void setAngleCuts(std::vector<angleCut*> anglecuts) { fangleCuts = std::move(anglecuts); }
 
   // histograms
   void setMassHistAxis(int nbins, double binmin, double binmax)
@@ -477,7 +477,7 @@ class decayTree
   // getters
   int nFinals() { return fnFinals; }
   std::vector<resonance*> getResonances() { return fResonances; }
-  resonance* getResonance(std::string name);
+  resonance* getResonance(const std::string& name);
   resonance* getFinal(int counter);
   std::vector<resonance*> getFinals(resonance* res);
   std::vector<int> ntrackRange() { return std::vector<int>{fnTracksMin, fnTracksMax}; }

--- a/PWGUD/TableProducer/SGCandProducer.cxx
+++ b/PWGUD/TableProducer/SGCandProducer.cxx
@@ -224,7 +224,7 @@ struct SGCandProducer {
 
   // function to process reconstructed data
   template <typename TCol>
-  void processReco(std::string histdir, TCol const& collision, BCs const& bcs,
+  void processReco(const std::string& histdir, TCol const& collision, BCs const& bcs,
                    TCs const& tracks, FWs const& fwdtracks,
                    aod::FV0As const& fv0as, aod::FT0s const& ft0s, aod::FDDs const& fdds)
   {

--- a/PWGUD/TableProducer/UPCCandidateProducer.cxx
+++ b/PWGUD/TableProducer/UPCCandidateProducer.cxx
@@ -655,7 +655,7 @@ struct UpcCandProducer {
   }
 
   template <int32_t tracksSwitch, typename TAmbTrack>
-  int64_t getAmbTrackId(TAmbTrack ambTrack)
+  int64_t getAmbTrackId(const TAmbTrack& ambTrack)
   {
     int64_t trkId = -1;
     if constexpr (tracksSwitch == 0) { // central barrel
@@ -671,7 +671,7 @@ struct UpcCandProducer {
   template <int32_t tracksSwitch, typename TBCs, typename TAmbTracks>
   void collectAmbTrackBCs(std::unordered_map<int64_t, uint64_t>& ambTrIds,
                           TBCs const& bcs,
-                          TAmbTracks ambTracks)
+                          const TAmbTracks& ambTracks)
   {
     for (const auto& ambTrk : ambTracks) {
       auto trkId = getAmbTrackId<tracksSwitch>(ambTrk);

--- a/PWGUD/TableProducer/dgCandProducer.cxx
+++ b/PWGUD/TableProducer/dgCandProducer.cxx
@@ -190,7 +190,7 @@ struct DgCandProducer {
     outputTracksLabel(track.globalIndex());
   }
 
-  void createHistograms(std::string histdir)
+  void createHistograms(const std::string& histdir)
   {
     const int nXbinsInStatH = 26;
     std::string labels[nXbinsInStatH] = {
@@ -237,7 +237,7 @@ struct DgCandProducer {
   }
 
   template <typename TBC>
-  void fillFIThistograms(TBC const& bc, std::string histdir)
+  void fillFIThistograms(TBC const& bc, const std::string& histdir)
   {
     LOGF(debug, "");
     std::array<bool, 5> triggers{{true, !udhelpers::cleanFIT(bc, diffCuts.maxFITtime(), diffCuts.FITAmpLimits()),
@@ -295,7 +295,7 @@ struct DgCandProducer {
   }
 
   template <typename TCol>
-  void processReco(std::string histdir, TCol const& collision, BCs const& bcs,
+  void processReco(const std::string& histdir, TCol const& collision, BCs const& bcs,
                    TCs const& tracks, FWs const& fwdtracks,
                    aod::FV0As const& fv0as, aod::FT0s const& ft0s, aod::FDDs const& fdds)
   {

--- a/PWGUD/TableProducer/fwdTrackPropagation.cxx
+++ b/PWGUD/TableProducer/fwdTrackPropagation.cxx
@@ -154,7 +154,7 @@ struct FwdTrackPropagation {
         // debug
         // LOGP(info, "track {}, before: {} {} {} {} {} {}", t.globalIndex(), t.x(), t.y(), t.z(), t.phi(), t.tgl(), t.signed1Pt());
         // LOGP(info, "track {}, after: {} {} {} {} {} {}", t.globalIndex(), pft.getX(), pft.getY(), pft.getZ(), pft.getPhi(), pft.getTgl(), pft.getInvQPt());
-        SMatrix55 cov = pft.getCovariances();
+        const SMatrix55& cov = pft.getCovariances();
         float sigX = std::sqrt(cov(0, 0));
         float sigY = std::sqrt(cov(1, 1));
         float sigPhi = std::sqrt(cov(2, 2));

--- a/PWGUD/TableProducer/tauEventTableProducer.cxx
+++ b/PWGUD/TableProducer/tauEventTableProducer.cxx
@@ -213,7 +213,7 @@ struct TauEventTableProducer {
 
   std::vector<std::pair<int8_t, std::set<uint8_t>>> cutMyRequiredITSHits{};
 
-  void mySetRequireHitsInITSLayers(int8_t minNRequiredHits, std::set<uint8_t> requiredLayers)
+  void mySetRequireHitsInITSLayers(int8_t minNRequiredHits, const std::set<uint8_t>& requiredLayers)
   {
     // layer 0 corresponds to the the innermost ITS layer
     cutMyRequiredITSHits.push_back(std::make_pair(minNRequiredHits, requiredLayers));

--- a/PWGUD/TableProducer/twoTracksEventTableProducer.cxx
+++ b/PWGUD/TableProducer/twoTracksEventTableProducer.cxx
@@ -241,7 +241,7 @@ struct TwoTracksEventTableProducer {
 
   std::vector<std::pair<int8_t, std::set<uint8_t>>> cutMyRequiredITSHits{};
 
-  void mySetRequireHitsInITSLayers(int8_t minNRequiredHits, std::set<uint8_t> requiredLayers)
+  void mySetRequireHitsInITSLayers(int8_t minNRequiredHits, const std::set<uint8_t>& requiredLayers)
   {
     // layer 0 corresponds to the the innermost ITS layer
     cutMyRequiredITSHits.push_back(std::make_pair(minNRequiredHits, requiredLayers));

--- a/PWGUD/Tasks/diffMCDataScanner.cxx
+++ b/PWGUD/Tasks/diffMCDataScanner.cxx
@@ -163,7 +163,7 @@ struct collisionsInfo {
     // count tracks
     int cntAll = 0;
     int netCharge = 0;
-    for (auto track : tracks) {
+    for (const auto& track : tracks) {
       cntAll++;
       netCharge += track.sign();
     }
@@ -198,7 +198,7 @@ struct collisionsInfo {
 
     // loop over FWD tracks
     LOGF(info, "FWD tracks: %i", fwdtracks.size());
-    for (auto fwdtrack : fwdtracks) {
+    for (const auto& fwdtrack : fwdtracks) {
       registry.get<TH1>(HIST("etaFWDAll"))->Fill(fwdtrack.eta());
     }
 
@@ -213,7 +213,7 @@ struct collisionsInfo {
       //      registry.get<TH2>(HIST("globalVsMFTDG"))->Fill(cntGlobal, mfttracks.size());
 
       // loop over FWD tracks
-      for (auto fwdtrack : fwdtracks) {
+      for (const auto& fwdtrack : fwdtracks) {
         registry.get<TH1>(HIST("etaFWDDG"))->Fill(fwdtrack.eta());
       }
     }
@@ -251,7 +251,7 @@ struct BCInfo {
 
     // count collisions with good time resoluton
     auto nColGT = 0;
-    for (auto col : cols) {
+    for (const auto& col : cols) {
       if (col.collisionTimeRes() <= 20.) {
         nColGT++;
       }
@@ -311,7 +311,7 @@ struct TrackTypes {
 
   void process(TCs const& tracks, /*MTs const& mfttracks,*/ FTs const& fwdtracks)
   {
-    for (auto track : tracks) {
+    for (const auto& track : tracks) {
       LOGF(debug, "isGlobal %i Detector map %i %i %i %i time resolution %f", track.isGlobalTrack(),
            track.hasITS(), track.hasTPC(), track.hasTRD(), track.hasTOF(), track.trackTimeRes());
 
@@ -353,7 +353,7 @@ struct TrackTypes {
 
     // ForwardTrackTypeEnum has 5 values
     auto nTypes = 5;
-    for (auto fwdtrack : fwdtracks) {
+    for (const auto& fwdtrack : fwdtracks) {
       registry.get<TH2>(HIST("FwdType"))->Fill(0., 0., 1.);
       if (fwdtrack.collisionId() >= 0) {
         registry.get<TH2>(HIST("FwdType"))->Fill(1., 0., 1.);
@@ -379,7 +379,7 @@ struct MCTracks {
   void process(CCs const& collisions, aod::McCollisions& /*McCols*/, aod::McParticles& McParts)
   {
 
-    for (auto collision : collisions) {
+    for (const auto& collision : collisions) {
 
       // get McCollision which belongs to collision
       auto MCCol = collision.mcCollision();
@@ -397,7 +397,7 @@ struct MCTracks {
       bool hasDiff = false;
       int prongs = 0;
 
-      for (auto mcpart : MCPartSlice) {
+      for (const auto& mcpart : MCPartSlice) {
         LOGF(info, " MCPart: %i %i %i %i %i - %i", mcpart.mcCollisionId(), mcpart.isPhysicalPrimary(), mcpart.getProcess(), mcpart.getGenStatusCode(), mcpart.globalIndex(), mcpart.pdgCode());
         if (mcpart.pdgCode() == 9900110) {
           LOGF(info, "  rho_diff0 energy: %f", mcpart.e());
@@ -413,8 +413,8 @@ struct MCTracks {
         // }
 
         if (hasDiff && mothers.size() > 1) {
-          auto mom1 = mothers[0];
-          auto mom2 = mothers[1];
+          const auto& mom1 = mothers[0];
+          const auto& mom2 = mothers[1];
           if (mcpart.isPhysicalPrimary() &&
               (mcpart.getGenStatusCode() == 1 || mcpart.getGenStatusCode() == 2) &&
               mom1.globalIndex() != mom2.globalIndex() &&
@@ -456,7 +456,7 @@ struct TPCnSigma {
 
   void process(TCwPIDs& tracks, aod::McParticles const& /*mcParticles*/)
   {
-    for (auto track : tracks) {
+    for (const auto& track : tracks) {
       if (track.isGlobalTrack()) {
         nSigmas(track.mcParticle_as<aod::McParticles>().pdgCode(), track.mcParticle_as<aod::McParticles>().pt(),
                 track.tpcNSigmaEl(), track.tpcNSigmaMu(), track.tpcNSigmaPi(),

--- a/PWGUD/Tasks/diffQA.cxx
+++ b/PWGUD/Tasks/diffQA.cxx
@@ -657,7 +657,7 @@ struct DiffQA {
     int64_t lastBCwFV0 = fv0s.begin().bc_as<BCs>().globalBC();
     auto lastOrbit = lastBCwFV0 / o2::constants::lhc::LHCMaxBunches;
 
-    for (auto fv0 : fv0s) {
+    for (const auto& fv0 : fv0s) {
 
       // side A
       for (size_t ind = 0; ind < fv0.channel().size(); ind++) {
@@ -692,7 +692,7 @@ struct DiffQA {
 
     int64_t lastBCwFT0 = ft0s.begin().bc_as<BCs>().globalBC();
     auto lastOrbit = lastBCwFT0 / o2::constants::lhc::LHCMaxBunches;
-    for (auto ft0 : ft0s) {
+    for (const auto& ft0 : ft0s) {
 
       // side A
       for (size_t ind = 0; ind < ft0.channelA().size(); ind++) {
@@ -883,7 +883,7 @@ struct DiffQA {
 
     int64_t lastBCwFDD = fdds.begin().bc_as<BCs>().globalBC();
     auto lastOrbit = lastBCwFDD / o2::constants::lhc::LHCMaxBunches;
-    for (auto fdd : fdds) {
+    for (const auto& fdd : fdds) {
 
       // side A
       for (auto ind = 0; ind < 8; ind++) {
@@ -947,7 +947,7 @@ struct DiffQA {
   void processTest(CCs const& collisions, BCs const& bcs)
   {
     uint64_t bc1, bc2, bc3;
-    for (auto col : collisions) {
+    for (const auto& col : collisions) {
       bc1 = -1;
       bc2 = -2;
       bc3 = -3;

--- a/PWGUD/Tasks/eventByevent.cxx
+++ b/PWGUD/Tasks/eventByevent.cxx
@@ -242,7 +242,7 @@ struct EventByEvent {
         return;
       registry.fill(HIST("hSelectionCounter"), 5);
 
-      for (auto t : tracks) {
+      for (const auto& t : tracks) {
 
         if (!trackselector(t, parameters))
           continue;
@@ -270,14 +270,14 @@ struct EventByEvent {
         registry.fill(HIST("hSelectionCounter"), 6);
         if ((rawPionTracks.size() >= 2) && (allTracks.size() >= 2)) {
 
-          for (auto pion : onlyPionTracks) {
+          for (const auto& pion : onlyPionTracks) {
             p += pion;
           }
 
           registry.fill(HIST("h4TracksPions"), onlyPionTracks.size());
           registry.fill(HIST("hSelectionCounter"), 7);
 
-          for (auto rtrk : rawPionTracks) {
+          for (const auto& rtrk : rawPionTracks) {
 
             TLorentzVector itrk;
             itrk.SetXYZM(rtrk.px(), rtrk.py(), rtrk.pz(), o2::constants::physics::MassPionCharged);
@@ -293,7 +293,7 @@ struct EventByEvent {
 
           int sign = 0;
           TLorentzVector piplus, piminus;
-          for (auto rawPion : rawPionTracks) {
+          for (const auto& rawPion : rawPionTracks) {
             sign += rawPion.sign();
           }
 

--- a/PWGUD/Tasks/exclusivePentaquark.cxx
+++ b/PWGUD/Tasks/exclusivePentaquark.cxx
@@ -135,7 +135,7 @@ struct ExclusivePentaquark {
     std::vector<decltype(tracks.begin())> rawProtonTracks;
     std::vector<decltype(tracks.begin())> rawProtonTracksTOF;
 
-    for (auto trk : tracks) {
+    for (const auto& trk : tracks) {
       if (!trk.isPVContributor()) {
         continue;
       }

--- a/PWGUD/Tasks/exclusivePhi.cxx
+++ b/PWGUD/Tasks/exclusivePhi.cxx
@@ -48,9 +48,9 @@ struct ExclusivePhi {
   HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   //_____________________________________________________________________________
-  Double_t CosThetaHelicityFrame(TLorentzVector pionPositive,
-                                 TLorentzVector pionNegative,
-                                 TLorentzVector possibleRhoZero)
+  Double_t CosThetaHelicityFrame(const TLorentzVector& pionPositive,
+                                 const TLorentzVector& pionNegative,
+                                 const TLorentzVector& possibleRhoZero)
   {
 
     Double_t HalfSqrtSnn = 2680.;
@@ -77,7 +77,7 @@ struct ExclusivePhi {
     return CosThetaHE;
   }
   //------------------------------------------------------------------------------------------------------
-  Double_t PhiHelicityFrame(TLorentzVector muonPositive, TLorentzVector muonNegative, TLorentzVector possibleJPsi)
+  Double_t PhiHelicityFrame(const TLorentzVector& muonPositive, const TLorentzVector& muonNegative, const TLorentzVector& possibleJPsi)
   {
 
     // Half of the energy per pair of the colliding nucleons.
@@ -266,7 +266,7 @@ struct ExclusivePhi {
     std::vector<float> onlyKaonSigma;
     std::vector<decltype(tracks.begin())> rawKaonTracks;
 
-    for (auto trk : tracks) {
+    for (const auto& trk : tracks) {
       registry.fill(HIST("hSelectionCounter"), 1);
       if (!trk.isPVContributor()) {
         continue;
@@ -323,7 +323,7 @@ struct ExclusivePhi {
     if (onlyKaonTracks.size() == 2) {
       registry.fill(HIST("hSelectionCounter"), 7);
 
-      for (auto kaon : onlyKaonTracks) {
+      for (const auto& kaon : onlyKaonTracks) {
         phi += kaon;
       }
 
@@ -373,7 +373,7 @@ struct ExclusivePhi {
     std::vector<TLorentzVector> allTracksAreITSonlyAndFourITSclusters;
 
     int counter = 0;
-    for (auto t : tracks) {
+    for (const auto& t : tracks) {
       registry.fill(HIST("hSelectionCounter2"), 0);
       if (!t.isPVContributor()) {
         continue;
@@ -466,16 +466,16 @@ struct ExclusivePhi {
     // if ((collision.posZ() < -10) || (collision.posZ() > 10)) {
     if (allTracksAreKaons.size() == 2) {
       registry.fill(HIST("hSelectionCounter2"), 7);
-      for (auto kaon : allTracksAreKaons) {
+      for (const auto& kaon : allTracksAreKaons) {
         phiWithoutPID += kaon;
       }
       registry.fill(HIST("hTracksKaons"), allTracksAreKaons.size());
       // kaon mass hypothesis with wrong momentum for one track
-      for (auto kaon : allTracksAreKaonsWrongMomentum) {
+      for (const auto& kaon : allTracksAreKaonsWrongMomentum) {
         phiWrongMomentaWithoutPID += kaon;
       }
       // pion mass hypothesis
-      for (auto pion : allTracksArePions) {
+      for (const auto& pion : allTracksArePions) {
         phiWithoutPIDPionHypothesis += pion;
       }
 
@@ -619,7 +619,7 @@ struct ExclusivePhi {
     if (allTracksAreKaonsBandPID.size() == 2) {
 
       TLorentzVector reallyPhi;
-      for (auto kaon : allTracksAreKaonsBandPID) {
+      for (const auto& kaon : allTracksAreKaonsBandPID) {
         reallyPhi += kaon;
       }
 

--- a/PWGUD/Tasks/exclusivePhiLeptons.cxx
+++ b/PWGUD/Tasks/exclusivePhiLeptons.cxx
@@ -157,7 +157,7 @@ struct ExclusivePhiLeptons {
     std::vector<decltype(tracks.begin())> rawElectronTracksTOF;
 
     int counterPV = 0;
-    for (auto trk : tracks) {
+    for (const auto& trk : tracks) {
       if (!trk.isPVContributor()) {
         continue;
       }

--- a/PWGUD/Tasks/exclusivePhiLeptonsTrees.cxx
+++ b/PWGUD/Tasks/exclusivePhiLeptonsTrees.cxx
@@ -144,7 +144,7 @@ struct ExclusivePhiLeptonsTrees {
     // - (px,py,pz,E)1
     // - (px,py,pz,E)2
     int counterPV = 0;
-    for (auto trk : tracks) {
+    for (const auto& trk : tracks) {
       // ----------------------------------------
       // SELECTIONS:
       // - PV track

--- a/PWGUD/Tasks/exclusiveRhoTo4Pi.cxx
+++ b/PWGUD/Tasks/exclusiveRhoTo4Pi.cxx
@@ -1202,7 +1202,7 @@ struct ExclusiveRhoTo4Pi {
   PROCESS_SWITCH(ExclusiveRhoTo4Pi, processEventCounterMC, "MC Event Counter Function", false);
   PROCESS_SWITCH(ExclusiveRhoTo4Pi, processTrackCounterMC, "MC Track Counter Function", false);
 
-  double collinSoperPhi(PxPyPzMVector twoPionVector, PxPyPzMVector fourPionVector)
+  double collinSoperPhi(const PxPyPzMVector& twoPionVector, const PxPyPzMVector& fourPionVector)
   {
     PxPyPzEVector pProjCM(0., 0., -momentumBeam, halfSqrtSnn * 208); // projectile
     PxPyPzEVector pTargCM(0., 0., momentumBeam, halfSqrtSnn * 208);  // target
@@ -1219,7 +1219,7 @@ struct ExclusiveRhoTo4Pi {
     return phi;
   }
 
-  double collinSoperCosTheta(PxPyPzMVector twoPionVector, PxPyPzMVector fourPionVector)
+  double collinSoperCosTheta(const PxPyPzMVector& twoPionVector, const PxPyPzMVector& fourPionVector)
   {
     PxPyPzEVector pProjCM(0., 0., -momentumBeam, halfSqrtSnn * 208); // projectile
     PxPyPzEVector pTargCM(0., 0., momentumBeam, halfSqrtSnn * 208);  // target

--- a/PWGUD/Tasks/exclusiveTwoProtons.cxx
+++ b/PWGUD/Tasks/exclusiveTwoProtons.cxx
@@ -50,7 +50,7 @@ struct ExclusiveTwoProtons {
   // defining histograms using histogram registry
   HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject};
   //_____________________________________________________________________________
-  Double_t CosThetaHelicityFrame(TLorentzVector posDaughter, TLorentzVector negDaughter, TLorentzVector mother)
+  Double_t CosThetaHelicityFrame(const TLorentzVector& posDaughter, const TLorentzVector& negDaughter, const TLorentzVector& mother)
   {
 
     Double_t HalfSqrtSnn = 2680.;
@@ -77,7 +77,7 @@ struct ExclusiveTwoProtons {
     return CosThetaHE;
   }
   //------------------------------------------------------------------------------------------------------
-  Double_t PhiHelicityFrame(TLorentzVector posDaughter, TLorentzVector negDaughter, TLorentzVector mother)
+  Double_t PhiHelicityFrame(const TLorentzVector& posDaughter, const TLorentzVector& negDaughter, const TLorentzVector& mother)
   {
 
     // Half of the energy per pair of the colliding nucleons.
@@ -190,7 +190,7 @@ struct ExclusiveTwoProtons {
     std::vector<decltype(tracks.begin())> rawProtonTracks;
     std::vector<decltype(tracks.begin())> rawProtonTracksTOF;
 
-    for (auto trk : tracks) {
+    for (const auto& trk : tracks) {
       if (!trk.isPVContributor()) {
         continue;
       }

--- a/PWGUD/Tasks/exclusiveTwoProtonsSG.cxx
+++ b/PWGUD/Tasks/exclusiveTwoProtonsSG.cxx
@@ -53,7 +53,7 @@ struct ExclusiveTwoProtonsSG {
   // defining histograms using histogram registry
   HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject};
   //_____________________________________________________________________________
-  Double_t CosThetaHelicityFrame(TLorentzVector posDaughter, TLorentzVector negDaughter, TLorentzVector mother)
+  Double_t CosThetaHelicityFrame(const TLorentzVector& posDaughter, const TLorentzVector& negDaughter, const TLorentzVector& mother)
   {
 
     Double_t HalfSqrtSnn = 2680.;
@@ -80,7 +80,7 @@ struct ExclusiveTwoProtonsSG {
     return CosThetaHE;
   }
   //------------------------------------------------------------------------------------------------------
-  Double_t PhiHelicityFrame(TLorentzVector posDaughter, TLorentzVector negDaughter, TLorentzVector mother)
+  Double_t PhiHelicityFrame(const TLorentzVector& posDaughter, const TLorentzVector& negDaughter, const TLorentzVector& mother)
   {
 
     // Half of the energy per pair of the colliding nucleons.
@@ -211,7 +211,7 @@ struct ExclusiveTwoProtonsSG {
     std::vector<decltype(tracks.begin())> rawProtonTracks;
     std::vector<decltype(tracks.begin())> rawProtonTracksTOF;
 
-    for (auto trk : tracks) {
+    for (const auto& trk : tracks) {
       if (!trk.isPVContributor()) {
         continue;
       }

--- a/PWGUD/Tasks/flowCumulantsUpc.cxx
+++ b/PWGUD/Tasks/flowCumulantsUpc.cxx
@@ -640,7 +640,7 @@ struct FlowCumulantsUpc {
   }
 
   template <typename TTrack>
-  bool trackSelected(TTrack track)
+  bool trackSelected(const TTrack& track)
   {
     registry.fill(HIST("hTrackCount"), 0.5);
     if (track.pt() < cfgPtCutMin || track.pt() > cfgPtCutMax) {

--- a/PWGUD/Tasks/flowLongRangeCorrUpc.cxx
+++ b/PWGUD/Tasks/flowLongRangeCorrUpc.cxx
@@ -266,7 +266,7 @@ struct FlowLongRangeCorrUpc {
   }
 
   template <typename TTrack>
-  bool trackSelected(TTrack track)
+  bool trackSelected(const TTrack& track)
   {
     if (track.pt() < cfgPtCutMin || track.pt() > cfgPtCutMax) {
       return false;
@@ -334,7 +334,7 @@ struct FlowLongRangeCorrUpc {
   }
 
   template <typename TTracks>
-  double trackCounter(TTracks tracks, float posZ)
+  double trackCounter(const TTracks& tracks, float posZ)
   {
     float weff1 = 1;
     double nTracksRaw = 0.;
@@ -357,7 +357,7 @@ struct FlowLongRangeCorrUpc {
   }
 
   template <typename TCollision, typename TTracks>
-  void fillYield(TCollision collision, TTracks tracks) // function to fill the yield and etaphi histograms.
+  void fillYield(const TCollision& collision, const TTracks& tracks) // function to fill the yield and etaphi histograms.
   {
     float weff1 = 1;
     float vtxz = collision.posZ();
@@ -385,7 +385,7 @@ struct FlowLongRangeCorrUpc {
   }
 
   template <CorrelationContainer::CFStep step, typename TTracks>
-  void fillCorrelationsTPCFT0(TTracks tracks1, aod::UDCollisionFITBits const& fitBits, float posZ, int system, int corType) // function to fill the Output functions (sparse) and the delta eta and delta phi histograms
+  void fillCorrelationsTPCFT0(const TTracks& tracks1, aod::UDCollisionFITBits const& fitBits, float posZ, int system, int corType) // function to fill the Output functions (sparse) and the delta eta and delta phi histograms
   {
     if (fitBits.size() > 1) {
       LOGF(fatal, "fillCorrelationsTPCFT0(): fitBits.size() = %d (expected 0 or 1)", fitBits.size());

--- a/PWGUD/Tasks/fwdMuonsUpc.cxx
+++ b/PWGUD/Tasks/fwdMuonsUpc.cxx
@@ -379,7 +379,7 @@ struct FwdMuonsUpc {
   }
 
   // function to compute phi for azimuth anisotropy
-  void computePhiAnis(ROOT::Math::PxPyPzMVector p1, ROOT::Math::PxPyPzMVector p2, int sign1, float& phiAverage, float& phiCharge)
+  void computePhiAnis(const ROOT::Math::PxPyPzMVector& p1, const ROOT::Math::PxPyPzMVector& p2, int sign1, float& phiAverage, float& phiCharge)
   {
     ROOT::Math::PxPyPzMVector tSum, tDiffAv, tDiffCh;
     tSum = p1 + p2;

--- a/PWGUD/Tasks/polarisationRho.cxx
+++ b/PWGUD/Tasks/polarisationRho.cxx
@@ -48,9 +48,9 @@ struct PolarisationRho {
   HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   //_____________________________________________________________________________
-  Double_t CosThetaHelicityFrame(TLorentzVector pionPositive,
-                                 TLorentzVector pionNegative,
-                                 TLorentzVector possibleRhoZero)
+  Double_t CosThetaHelicityFrame(const TLorentzVector& pionPositive,
+                                 const TLorentzVector& pionNegative,
+                                 const TLorentzVector& possibleRhoZero)
   {
 
     Double_t HalfSqrtSnn = 2680.;
@@ -77,7 +77,7 @@ struct PolarisationRho {
     return CosThetaHE;
   }
   //------------------------------------------------------------------------------------------------------
-  Double_t PhiHelicityFrame(TLorentzVector muonPositive, TLorentzVector muonNegative, TLorentzVector possibleJPsi)
+  Double_t PhiHelicityFrame(const TLorentzVector& muonPositive, const TLorentzVector& muonNegative, const TLorentzVector& possibleJPsi)
   {
 
     // Half of the energy per pair of the colliding nucleons.
@@ -241,7 +241,7 @@ struct PolarisationRho {
     std::vector<TLorentzVector> onlyKaonTracks;
     std::vector<float> onlyKaonSigma;
     std::vector<decltype(tracks.begin())> rawKaonTracks;
-    for (auto t : tracks) {
+    for (const auto& t : tracks) {
       if (!t.isPVContributor()) {
         continue;
       }
@@ -260,7 +260,7 @@ struct PolarisationRho {
     //_____________________________________
     // Creating phis
     if (onlyKaonTracks.size() == 2) {
-      for (auto kaon : onlyKaonTracks) {
+      for (const auto& kaon : onlyKaonTracks) {
         phi += kaon;
       }
       registry.fill(HIST("hNsigEvsKa1"), rawKaonTracks[0].tpcNSigmaKa(), rawKaonTracks[1].tpcNSigmaKa());
@@ -276,7 +276,7 @@ struct PolarisationRho {
     std::vector<TLorentzVector> allTracksAreKaonsWrongMomentum;
     std::vector<TLorentzVector> allTracksArePions;
     int counter = 0;
-    for (auto t : tracks) {
+    for (const auto& t : tracks) {
       if (!t.isPVContributor()) {
         continue;
       }
@@ -304,13 +304,13 @@ struct PolarisationRho {
     //_____________________________________
     // Creating phis
     if (allTracksAreKaons.size() == 2) {
-      for (auto kaon : allTracksAreKaons) {
+      for (const auto& kaon : allTracksAreKaons) {
         phiWithoutPID += kaon;
       }
-      for (auto kaon : allTracksAreKaonsWrongMomentum) {
+      for (const auto& kaon : allTracksAreKaonsWrongMomentum) {
         phiWrongMomentaWithoutPID += kaon;
       }
-      for (auto pion : allTracksArePions) {
+      for (const auto& pion : allTracksArePions) {
         phiWithoutPIDPionHypothesis += pion;
       }
       if (phiWithoutPID.M() < 1.05) {
@@ -336,7 +336,7 @@ struct PolarisationRho {
     std::vector<decltype(tracks.begin())> rawPionTracks;
     registry.fill(HIST("hTracks"), tracks.size());
     float sign = 1.;
-    for (auto t : tracks) {
+    for (const auto& t : tracks) {
       if (!t.isPVContributor()) {
         continue;
       }
@@ -361,7 +361,7 @@ struct PolarisationRho {
     registry.fill(HIST("hTracksPions"), onlyPionTracks.size());
     //_____________________________________
     // Creating rhos
-    for (auto pion : onlyPionTracks) {
+    for (const auto& pion : onlyPionTracks) {
       p += pion;
     }
     //_____________________________________
@@ -369,7 +369,7 @@ struct PolarisationRho {
     if (onlyPionTracks.size() == 4) {
       registry.fill(HIST("hMassFourPions"), p.M());
       int signSum = 0;
-      for (auto rawPion : rawPionTracks) {
+      for (const auto& rawPion : rawPionTracks) {
         if (rawPion.sign() > 0) {
           signSum += 1;
         } else if (rawPion.sign() < 0) {
@@ -385,7 +385,7 @@ struct PolarisationRho {
     if (onlyPionTracks.size() == 6) {
       registry.fill(HIST("hMassSixPions"), p.M());
       int signSum = 0;
-      for (auto rawPion : rawPionTracks) {
+      for (const auto& rawPion : rawPionTracks) {
         if (rawPion.sign() > 0) {
           signSum += 1;
         } else if (rawPion.sign() < 0) {
@@ -394,7 +394,7 @@ struct PolarisationRho {
       }
       if (signSum == 0) {
         registry.fill(HIST("hMassSixPionsRightSign"), p.M());
-        for (auto pion : onlyPionTracks) {
+        for (const auto& pion : onlyPionTracks) {
           registry.fill(HIST("hPhiEtaSixPionsRightSign"), pion.Phi(), pion.Eta());
         }
       }

--- a/PWGUD/Tasks/sgExcUniverse.cxx
+++ b/PWGUD/Tasks/sgExcUniverse.cxx
@@ -140,7 +140,7 @@ struct SGExcUniverse {
     std::vector<int> iskaon;
     std::vector<int> ismuon;
     std::vector<int> iselec;
-    for (auto t : tracks) {
+    for (const auto& t : tracks) {
       TLorentzVector a;
       if (trackselector(t, parameters)) {
         px.push_back(t.px());

--- a/PWGUD/Tasks/sgExclusivePhi.cxx
+++ b/PWGUD/Tasks/sgExclusivePhi.cxx
@@ -57,9 +57,9 @@ struct sgExclusivePhi {
   HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   //_____________________________________________________________________________
-  Double_t CosThetaHelicityFrame(TLorentzVector pionPositive,
-                                 TLorentzVector pionNegative,
-                                 TLorentzVector possibleRhoZero)
+  Double_t CosThetaHelicityFrame(const TLorentzVector& pionPositive,
+                                 const TLorentzVector& pionNegative,
+                                 const TLorentzVector& possibleRhoZero)
   {
 
     Double_t HalfSqrtSnn = 2680.;
@@ -86,7 +86,7 @@ struct sgExclusivePhi {
     return CosThetaHE;
   }
   //------------------------------------------------------------------------------------------------------
-  Double_t PhiHelicityFrame(TLorentzVector muonPositive, TLorentzVector muonNegative, TLorentzVector possibleJPsi)
+  Double_t PhiHelicityFrame(const TLorentzVector& muonPositive, const TLorentzVector& muonNegative, const TLorentzVector& possibleJPsi)
   {
 
     // Half of the energy per pair of the colliding nucleons.
@@ -296,7 +296,7 @@ struct sgExclusivePhi {
       std::vector<float> onlyKaonSigma;
       std::vector<decltype(tracks.begin())> rawKaonTracks;
 
-      for (auto trk : tracks) {
+      for (const auto& trk : tracks) {
         registry.fill(HIST("hSelectionCounter"), 1);
         if (!trk.isPVContributor()) {
           continue;
@@ -357,7 +357,7 @@ struct sgExclusivePhi {
       if (onlyKaonTracks.size() == 2) {
         registry.fill(HIST("hSelectionCounter"), 7);
 
-        for (auto kaon : onlyKaonTracks) {
+        for (const auto& kaon : onlyKaonTracks) {
           phi += kaon;
         }
 
@@ -409,7 +409,7 @@ struct sgExclusivePhi {
       std::vector<int> booleanAvgClusterSizePerTrackITSonly;
 
       int counter = 0;
-      for (auto t : tracks) {
+      for (const auto& t : tracks) {
         registry.fill(HIST("hSelectionCounter2"), 0);
         if (!t.isPVContributor()) {
           continue;
@@ -521,16 +521,16 @@ struct sgExclusivePhi {
       if (fabs(collision.posZ()) < 10.) {
         if (allTracksAreKaons.size() == 2) {
           registry.fill(HIST("hSelectionCounter2"), 7);
-          for (auto kaon : allTracksAreKaons) {
+          for (const auto& kaon : allTracksAreKaons) {
             phiWithoutPID += kaon;
           }
           registry.fill(HIST("hTracksKaons"), allTracksAreKaons.size());
           // kaon mass hypothesis with wrong momentum for one track
-          for (auto kaon : allTracksAreKaonsWrongMomentum) {
+          for (const auto& kaon : allTracksAreKaonsWrongMomentum) {
             phiWrongMomentaWithoutPID += kaon;
           }
           // pion mass hypothesis
-          for (auto pion : allTracksArePions) {
+          for (const auto& pion : allTracksArePions) {
             phiWithoutPIDPionHypothesis += pion;
           }
 
@@ -674,7 +674,7 @@ struct sgExclusivePhi {
       if (allTracksAreKaonsBandPID.size() == 2) {
 
         TLorentzVector reallyPhi;
-        for (auto kaon : allTracksAreKaonsBandPID) {
+        for (const auto& kaon : allTracksAreKaonsBandPID) {
           reallyPhi += kaon;
         }
 

--- a/PWGUD/Tasks/sgExclusivePhiITSselections.cxx
+++ b/PWGUD/Tasks/sgExclusivePhiITSselections.cxx
@@ -168,7 +168,7 @@ struct sgExclusivePhiITSselections {
       std::vector<TLorentzVector> allTracksAreKaons;
       std::vector<TLorentzVector> allTracksAreKaonsBandPID;
       std::vector<TLorentzVector> allTracksAreITSonlyAndFourITSclusters;
-      for (auto t : tracks) {
+      for (const auto& t : tracks) {
         registry.fill(HIST("hSelectionCounter2"), 0);
         if (!t.isPVContributor()) {
           continue;
@@ -267,7 +267,7 @@ struct sgExclusivePhiITSselections {
       // in the case that there are ONLY 2 PV
       if (allTracksAreKaons.size() == 2) {
         registry.fill(HIST("hSelectionCounter2"), 7);
-        for (auto kaon : allTracksAreKaons) {
+        for (const auto& kaon : allTracksAreKaons) {
           phiWithoutPID += kaon;
         }
         registry.fill(HIST("hTracksKaons"), allTracksAreKaons.size());
@@ -314,7 +314,7 @@ struct sgExclusivePhiITSselections {
       if (allTracksAreKaonsBandPID.size() == 2) {
         registry.fill(HIST("hTracksKaons"), allTracksAreKaonsBandPID.size() + 10);
         TLorentzVector reallyPhi;
-        for (auto kaon : allTracksAreKaonsBandPID) {
+        for (const auto& kaon : allTracksAreKaonsBandPID) {
           reallyPhi += kaon;
         }
         registry.fill(HIST("KaonBandPHI/hPtPhiIdentifiedKaons"), reallyPhi.Pt());

--- a/PWGUD/Tasks/sgFITAnalyzer.cxx
+++ b/PWGUD/Tasks/sgFITAnalyzer.cxx
@@ -411,7 +411,7 @@ struct SGFITAnalyzer {
     std::vector<TLorentzVector> goodTracks;
     std::vector<TLorentzVector> muonTracks;
     float sign = 0;
-    for (auto t : dgtracks) {
+    for (const auto& t : dgtracks) {
       TLorentzVector a;
       TLorentzVector b;
       a.SetXYZM(t.px(), t.py(), t.pz(), mpion);
@@ -424,13 +424,13 @@ struct SGFITAnalyzer {
       }
     }
     if (goodTracks.size() == 2) {
-      for (auto pion : goodTracks) {
+      for (const auto& pion : goodTracks) {
         rho += pion;
       }
       if (sign == 0 && TMath::Abs(rho.Rapidity()) < .9 && rho.M() > .5 && rho.M() < 1.2 && rho.Pt() < 0.1)
         coh_rho0 = true;
       if (muonTracks.size() == 2) {
-        for (auto muon : muonTracks) {
+        for (const auto& muon : muonTracks) {
           jpsi += muon;
         }
         if (sign == 0 && TMath::Abs(jpsi.Rapidity()) < .9 && jpsi.M() > 2.8 && jpsi.M() < 3.35 && jpsi.Pt() < 0.1)
@@ -737,7 +737,7 @@ struct SGFITAnalyzer {
       registry.get<TH2>(HIST("ZDC/MACZNA"))->Fill(PVContributors.size(), zna);
       registry.get<TH2>(HIST("ZDC/MACZNC"))->Fill(PVContributors.size(), znc);
     }
-    for (auto track : dgtracks) {
+    for (const auto& track : dgtracks) {
       registry.get<TH1>(HIST("tracks/QCAll"))->Fill(0., 1.);
       registry.get<TH1>(HIST("tracks/QCAll"))->Fill(1., track.hasITS() * 1.);
       registry.get<TH1>(HIST("tracks/QCAll"))->Fill(2., track.hasTPC() * 1.);

--- a/PWGUD/Tasks/sgFourPiAnalyzer.cxx
+++ b/PWGUD/Tasks/sgFourPiAnalyzer.cxx
@@ -114,7 +114,7 @@ struct SGFourPiAnalyzer {
     gapSide = truegapSide;
     std::vector<TLorentzVector> goodTracks;
     float sign = 0;
-    for (auto t : tracks) {
+    for (const auto& t : tracks) {
       int itsNCls = t.itsNCls();
       // if (itsNCls) {
       registry.fill(HIST("ITSNCls"), itsNCls);
@@ -128,7 +128,7 @@ struct SGFourPiAnalyzer {
     }
     //    std::cout << goodTracks.size()<<std::endl;
     if (goodTracks.size() == 4) {
-      for (auto pion : goodTracks) {
+      for (const auto& pion : goodTracks) {
         v01 += pion;
       }
       // Apply pion hypothesis and create pairs

--- a/PWGUD/Tasks/sgPIDSpectra.cxx
+++ b/PWGUD/Tasks/sgPIDSpectra.cxx
@@ -153,7 +153,7 @@ struct SGPIDSpectra {
     // select PV contributors
     std::vector<float> parameters = {PV_cut, dcaZ_cut, dcaXY_cut, tpcChi2_cut, tpcNClsFindable_cut, itsChi2_cut, eta_cut, pt_cut};
     // check rho0 signals
-    for (auto t : tracks) {
+    for (const auto& t : tracks) {
       if (trackselector(t, parameters) && t.hasTPC()) {
         if (truegapSide == 0) {
           if (t.sign() > 0) {

--- a/PWGUD/Tasks/sgPIDSpectraTable.cxx
+++ b/PWGUD/Tasks/sgPIDSpectraTable.cxx
@@ -104,7 +104,7 @@ struct SGPIDSpectraTable {
     float tpcde, tofde, tpcmu, tofmu;
     TVector3 a;
     int goodtracks = 0;
-    for (auto t : tracks) {
+    for (const auto& t : tracks) {
       if (trackselector(t, parameters)) {
         goodtracks++;
       }
@@ -113,7 +113,7 @@ struct SGPIDSpectraTable {
       return;
     SGevents(coll.runNumber(), coll.flags(), truegapSide, coll.energyCommonZNA(), coll.energyCommonZNC(), goodtracks, coll.occupancyInTime(), coll.hadronicRate());
     // SGevents(coll.runNumber(), coll.flags());
-    for (auto t : tracks) {
+    for (const auto& t : tracks) {
       if (trackselector(t, parameters)) {
         a.SetXYZ(t.px(), t.py(), t.pz());
         tpcpi = t.hasTPC() ? t.tpcNSigmaPi() : -999;

--- a/PWGUD/Tasks/sgSixPiAnalyzer.cxx
+++ b/PWGUD/Tasks/sgSixPiAnalyzer.cxx
@@ -113,7 +113,7 @@ struct SGSixPiAnalyzer {
     gapSide = truegapSide;
     std::vector<TLorentzVector> goodTracks;
     float sign = 0;
-    for (auto t : tracks) {
+    for (const auto& t : tracks) {
       int itsNCls = t.itsNCls();
       // if (itsNCls) {
       registry.fill(HIST("ITSNCls"), itsNCls);
@@ -127,7 +127,7 @@ struct SGSixPiAnalyzer {
     }
     //    std::cout << goodTracks.size()<<std::endl;
     if (goodTracks.size() == 6) {
-      for (auto pion : goodTracks) {
+      for (const auto& pion : goodTracks) {
         v01 += pion;
       }
       // Apply pion hypothesis and create pairs

--- a/PWGUD/Tasks/sgTwoPiAnalyzer.cxx
+++ b/PWGUD/Tasks/sgTwoPiAnalyzer.cxx
@@ -131,7 +131,7 @@ struct SGTwoPiAnalyzer {
     std::vector<TLorentzVector> goodTracks;
     // Look for D0 and D0bar
     float sign = 0;
-    for (auto t : tracks) {
+    for (const auto& t : tracks) {
       int itsNCls = t.itsNCls();
       // if (itsNCls) {
       registry.fill(HIST("ITSNCls"), itsNCls);
@@ -145,7 +145,7 @@ struct SGTwoPiAnalyzer {
     }
     //    std::cout << goodTracks.size()<<std::endl;
     if (goodTracks.size() == 2) {
-      for (auto pion : goodTracks) {
+      for (const auto& pion : goodTracks) {
         v01 += pion;
       }
       // Apply pion hypothesis and create pairs

--- a/PWGUD/Tasks/sginclusivePhiKstarSD.cxx
+++ b/PWGUD/Tasks/sginclusivePhiKstarSD.cxx
@@ -512,9 +512,9 @@ struct SginclusivePhiKstarSD {
   }
 
   //_____________________________________________________________________________
-  double cosThetaCollinsSoperFrame(ROOT::Math::PxPyPzMVector pair1,
-                                   ROOT::Math::PxPyPzMVector pair2,
-                                   ROOT::Math::PxPyPzMVector fourpion)
+  double cosThetaCollinsSoperFrame(const ROOT::Math::PxPyPzMVector& pair1,
+                                   const ROOT::Math::PxPyPzMVector& pair2,
+                                   const ROOT::Math::PxPyPzMVector& fourpion)
   {
     double halfSqrtSnn = 2680.;
     double massOfLead208 = 193.6823;
@@ -540,7 +540,7 @@ struct SginclusivePhiKstarSD {
     return cosThetaCs;
   }
 
-  double phiCollinsSoperFrame(ROOT::Math::PxPyPzMVector pair1, ROOT::Math::PxPyPzMVector pair2, ROOT::Math::PxPyPzMVector fourpion)
+  double phiCollinsSoperFrame(const ROOT::Math::PxPyPzMVector& pair1, const ROOT::Math::PxPyPzMVector& pair2, const ROOT::Math::PxPyPzMVector& fourpion)
   {
     // Half of the energy per pair of the colliding nucleons.
     double halfSqrtSnn = 2680.;
@@ -1081,10 +1081,10 @@ struct SginclusivePhiKstarSD {
       if (gapSide == DoubleGap && mult2 == numFourTracks) {
         ROOT::Math::PxPyPzMVector pair1, pair2, pair3, pair4;
         if (static_cast<int>(onlyPionTracksp.size()) == numTwoTracks && static_cast<int>(onlyPionTracksn.size()) == numTwoTracks) {
-          ROOT::Math::PxPyPzMVector k1 = onlyPionTracksp.at(0);
-          ROOT::Math::PxPyPzMVector k2 = onlyPionTracksp.at(1);
-          ROOT::Math::PxPyPzMVector k3 = onlyPionTracksn.at(0);
-          ROOT::Math::PxPyPzMVector k4 = onlyPionTracksn.at(1);
+          const ROOT::Math::PxPyPzMVector& k1 = onlyPionTracksp.at(0);
+          const ROOT::Math::PxPyPzMVector& k2 = onlyPionTracksp.at(1);
+          const ROOT::Math::PxPyPzMVector& k3 = onlyPionTracksn.at(0);
+          const ROOT::Math::PxPyPzMVector& k4 = onlyPionTracksn.at(1);
           phiv = k1 + k2 + k3 + k4;
           pair1 = k1 + k3;
           pair2 = k2 + k4;
@@ -1109,10 +1109,10 @@ struct SginclusivePhiKstarSD {
         if (static_cast<int>(onlyPionTracksp.size()) != numTwoTracks && static_cast<int>(onlyPionTracksn.size()) != numTwoTracks) {
           if (static_cast<int>(onlyPionTracksp.size()) + static_cast<int>(onlyPionTracksn.size()) != numFourTracks)
             return;
-          ROOT::Math::PxPyPzMVector l1 = onlyPionTrackspm.at(0);
-          ROOT::Math::PxPyPzMVector l2 = onlyPionTrackspm.at(1);
-          ROOT::Math::PxPyPzMVector l3 = onlyPionTrackspm.at(2);
-          ROOT::Math::PxPyPzMVector l4 = onlyPionTrackspm.at(3);
+          const ROOT::Math::PxPyPzMVector& l1 = onlyPionTrackspm.at(0);
+          const ROOT::Math::PxPyPzMVector& l2 = onlyPionTrackspm.at(1);
+          const ROOT::Math::PxPyPzMVector& l3 = onlyPionTrackspm.at(2);
+          const ROOT::Math::PxPyPzMVector& l4 = onlyPionTrackspm.at(3);
           phiv1 = l1 + l2 + l3 + l4;
           registry.fill(HIST("os_pppp_pT_2_ls"), phiv1.M(), phiv1.Pt(), phiv1.Rapidity());
         }

--- a/PWGUD/Tasks/upcFwdJpsiRl.cxx
+++ b/PWGUD/Tasks/upcFwdJpsiRl.cxx
@@ -366,7 +366,7 @@ struct UpcFwdJpsiRl {
   }
 
   // compute phi for azimuth anisotropy
-  void computePhiAnis(LorentzVec p1, LorentzVec p2, int sign1, float& phiAverage, float& phiCharge)
+  void computePhiAnis(const LorentzVec& p1, const LorentzVec& p2, int sign1, float& phiAverage, float& phiCharge)
   {
     auto tSum = p1 + p2;
     float halfUnity = 0.5;

--- a/PWGUD/Tasks/upcJpsiCorr.cxx
+++ b/PWGUD/Tasks/upcJpsiCorr.cxx
@@ -793,7 +793,7 @@ struct UpcJpsiCorr {
   }
 
   template <typename C, typename Ts>
-  void fillHistograms(C collision, Ts tracks)
+  void fillHistograms(const C& collision, const Ts& tracks)
   {
     rStatistics.get<TH1>(HIST("Statistics/hCutCounterCollisions"))->Fill(0); // number of collisions without any cuts
 

--- a/PWGUD/Tasks/upcPhotonuclearAnalysisJMG.cxx
+++ b/PWGUD/Tasks/upcPhotonuclearAnalysisJMG.cxx
@@ -551,7 +551,7 @@ struct UpcPhotonuclearAnalysisJMG {
   }
 
   template <typename TTracks>
-  void fillQAUD(const TTracks tracks, float multiplicity)
+  void fillQAUD(const TTracks& tracks, float multiplicity)
   {
     for (const auto& track : tracks) {
       if (isTrackCut(track) == false) {

--- a/PWGUD/Tasks/upcPionAnalysis.cxx
+++ b/PWGUD/Tasks/upcPionAnalysis.cxx
@@ -85,9 +85,9 @@ struct UPCPionAnalysis {
   HistogramRegistry registry{"registry", {}, OutputObjHandlingPolicy::AnalysisObject};
 
   //_____________________________________________________________________________________________
-  Double_t CosThetaHelicityFrame(TLorentzVector pionPositive,
-                                 TLorentzVector pionNegative,
-                                 TLorentzVector possibleRhoZero)
+  Double_t CosThetaHelicityFrame(const TLorentzVector& pionPositive,
+                                 const TLorentzVector& pionNegative,
+                                 const TLorentzVector& possibleRhoZero)
   {
 
     Double_t HalfSqrtSnn = 2680.;
@@ -114,7 +114,7 @@ struct UPCPionAnalysis {
     return CosThetaHE;
   }
   //------------------------------------------------------------------------------------------------------
-  Double_t PhiHelicityFrame(TLorentzVector piPositive, TLorentzVector piNegative, TLorentzVector possibleRho)
+  Double_t PhiHelicityFrame(const TLorentzVector& piPositive, const TLorentzVector& piNegative, const TLorentzVector& possibleRho)
   {
 
     // Half of the energy per pair of the colliding nucleons.
@@ -281,7 +281,7 @@ struct UPCPionAnalysis {
     return q;
   }
 
-  double DeltaPhi(TLorentzVector lv1, TLorentzVector lv2)
+  double DeltaPhi(const TLorentzVector& lv1, const TLorentzVector& lv2)
   {
     TLorentzVector lv_sum = lv1 + lv2;
     TLorentzVector lv_diff = lv1 - lv2;
@@ -492,7 +492,7 @@ struct UPCPionAnalysis {
         return;
       registry.fill(HIST("hSelectionCounter"), 5);
 
-      for (auto t : tracks) {
+      for (const auto& t : tracks) {
 
         /*if (!t.isPVContributor()) {
           continue;
@@ -527,7 +527,7 @@ struct UPCPionAnalysis {
       registry.fill(HIST("hTracksPions"), onlyPionTracks.size());
       //_____________________________________
       // Creating rhos
-      for (auto pion : onlyPionTracks) {
+      for (const auto& pion : onlyPionTracks) {
         p += pion;
       }
       //_____________________________________
@@ -558,7 +558,7 @@ struct UPCPionAnalysis {
 
           int sign = 0;
           TLorentzVector piplus, piminus;
-          for (auto rawPion : rawPionTracks) {
+          for (const auto& rawPion : rawPionTracks) {
             sign += rawPion.sign();
             if (rawPion.sign() > 0) {
               piplus = onlyPionTracks[0];
@@ -600,7 +600,7 @@ struct UPCPionAnalysis {
                 registry.fill(HIST("hRap4Pion"), p.Rapidity());
                 registry.fill(HIST("hEta4Pion"), p.Eta());
               }
-              for (auto pion : onlyPionTracks) {
+              for (const auto& pion : onlyPionTracks) {
                 registry.fill(HIST("hPhiEtaFourPionsRightSign"), pion.Phi(), pion.Eta());
               }
             }
@@ -614,7 +614,7 @@ struct UPCPionAnalysis {
 
           int sign = 0;
           TLorentzVector piplus, piminus;
-          for (auto rawPion : rawPionTracks) {
+          for (const auto& rawPion : rawPionTracks) {
             sign += rawPion.sign();
             if (rawPion.sign() > 0) {
               piplus = onlyPionTracks[0];
@@ -655,7 +655,7 @@ struct UPCPionAnalysis {
               registry.fill(HIST("hRap6Pion"), p.Rapidity());
               registry.fill(HIST("hEta6Pion"), p.Eta());
               registry.fill(HIST("hPt6PionRightSign"), p.Pt());
-              for (auto pion : onlyPionTracks) {
+              for (const auto& pion : onlyPionTracks) {
                 registry.fill(HIST("hPhiEtaSixPionsRightSign"), pion.Phi(), pion.Eta());
               }
             }
@@ -668,7 +668,7 @@ struct UPCPionAnalysis {
         if ((rawPionTracks.size() == 8) && (onlyPionTracks.size() == 8)) {
           TLorentzVector piplus, piminus;
           int sign = 0;
-          for (auto rawPion : rawPionTracks) {
+          for (const auto& rawPion : rawPionTracks) {
             sign += rawPion.sign();
 
             if (rawPion.sign() > 0) {
@@ -713,7 +713,7 @@ struct UPCPionAnalysis {
               registry.fill(HIST("hMPt3"), p.M(), p.Pt());
               registry.fill(HIST("hRap8pion"), p.Rapidity());
               registry.fill(HIST("hEta8Pion"), p.Eta());
-              for (auto pion : onlyPionTracks) {
+              for (const auto& pion : onlyPionTracks) {
                 registry.fill(HIST("hPhiEta8PionsRightSign"), pion.Phi(), pion.Eta());
               }
             }

--- a/PWGUD/Tasks/upcQuarkoniaCentralBarrel.cxx
+++ b/PWGUD/Tasks/upcQuarkoniaCentralBarrel.cxx
@@ -230,7 +230,7 @@ struct upcQuarkoniaCentralBarrel {
   }
 
   template <typename TCollision>
-  void fillEventHistograms(TCollision collision, int& selGapSide)
+  void fillEventHistograms(const TCollision& collision, int& selGapSide)
   {
     // in case we want to push the analysis to Pb-Pb UPC
     int gapSide = collision.gapSide();
@@ -252,7 +252,7 @@ struct upcQuarkoniaCentralBarrel {
   }
 
   template <typename TTrack>
-  bool isTrackSelected(TTrack track)
+  bool isTrackSelected(const TTrack& track)
   {
     //
     // acceptance cut
@@ -321,7 +321,7 @@ struct upcQuarkoniaCentralBarrel {
   }
 
   template <typename TTrack, typename TTrackMC>
-  bool checkMCAssociation(TTrack track, TTrackMC trackMC)
+  bool checkMCAssociation(const TTrack& track, const TTrackMC& trackMC)
   // MC association (if asked)
   {
     if (track.sign() * trackMC.pdgCode() != 2212)
@@ -332,7 +332,7 @@ struct upcQuarkoniaCentralBarrel {
   }
 
   template <typename TTrack>
-  void fillQAplot(TTrack track, bool afterSel = false)
+  void fillQAplot(const TTrack& track, bool afterSel = false)
   { // fill QA information about proton/antiproton track
     if (afterSel) {
       if (track.sign() > 0) { // Proton Candidates after selections
@@ -395,7 +395,7 @@ struct upcQuarkoniaCentralBarrel {
   }
 
   template <typename TTrack, typename TTrackMCs>
-  void analyseTrackPairCandidate(TTrack proton, TTrack antiProton, TTrackMCs const& fullTrackMCs, uint8_t gapSide)
+  void analyseTrackPairCandidate(const TTrack& proton, const TTrack& antiProton, TTrackMCs const& fullTrackMCs, uint8_t gapSide)
   // fill information related to the quarkonium mother
   {
     float pt = RecoDecay::pt(proton.px() + antiProton.px(), proton.py() + antiProton.py());
@@ -477,7 +477,7 @@ struct upcQuarkoniaCentralBarrel {
   }
 
   template <typename TTracks, typename TTrackMCs>
-  void buildProtonAntiProtonPairs(TTracks const& fullTracks, TTrackMCs const& fullMCTracks, std::vector<bool> selProtonIndices, std::vector<bool> selAntiProtonIndices, uint8_t gapSide)
+  void buildProtonAntiProtonPairs(TTracks const& fullTracks, TTrackMCs const& fullMCTracks, const std::vector<bool>& selProtonIndices, const std::vector<bool>& selAntiProtonIndices, uint8_t gapSide)
   {
     // 1st loop over all protons
     for (const auto& proton : fullTracks) {

--- a/PWGUD/Tasks/upcSemiFwdJpsiRl.cxx
+++ b/PWGUD/Tasks/upcSemiFwdJpsiRl.cxx
@@ -337,7 +337,7 @@ struct UpcSemiFwdJpsiRl {
   }
 
   // azimuth anisotropy phi
-  void computePhiAnis(LorentzVec p1, LorentzVec p2, int sign1, float& phiAverage, float& phiCharge)
+  void computePhiAnis(const LorentzVec& p1, const LorentzVec& p2, int sign1, float& phiAverage, float& phiCharge)
   {
     auto tSum = p1 + p2;
     float halfUnity = 0.5;

--- a/PWGUD/Tasks/upcTauRl.cxx
+++ b/PWGUD/Tasks/upcTauRl.cxx
@@ -683,7 +683,7 @@ struct UpcTauRl {
 
   std::vector<std::pair<int8_t, std::set<uint8_t>>> cutMyRequiredITSHits{};
 
-  void mySetRequireHitsInITSLayers(int8_t minNRequiredHits, std::set<uint8_t> requiredLayers)
+  void mySetRequireHitsInITSLayers(int8_t minNRequiredHits, const std::set<uint8_t>& requiredLayers)
   {
     // layer 0 corresponds to the the innermost ITS layer
     cutMyRequiredITSHits.push_back(std::make_pair(minNRequiredHits, requiredLayers));

--- a/PWGUD/Tasks/upcTauTau13topo.cxx
+++ b/PWGUD/Tasks/upcTauTau13topo.cxx
@@ -1640,7 +1640,7 @@ struct TauTau13topo {
   }
 
   // helper function to calculate delta alpha
-  float deltaAlpha(auto particle1, auto particle2)
+  float deltaAlpha(const auto& particle1, const auto& particle2)
   {
 
     TVector3 vtmp(particle1.px(), particle1.py(), particle1.pz());
@@ -1657,7 +1657,7 @@ struct TauTau13topo {
   //  }
 
   //  float calculateDeltaPhi(TLorentzVector p, TLorentzVector p1)
-  float calculateDeltaPhi(ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double>> p, ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double>> p1)
+  float calculateDeltaPhi(const ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double>>& p, const ROOT::Math::LorentzVector<ROOT::Math::PxPyPzE4D<double>>& p1)
   {
     //    float delta = p.Phi();
     float delta = RecoDecay::constrainAngle(p.Phi());
@@ -1708,7 +1708,7 @@ struct TauTau13topo {
   //  }
 
   // helper function to calculate scalar asymmetry
-  float scalarAsymMC(auto particle1, auto particle2)
+  float scalarAsymMC(const auto& particle1, const auto& particle2)
   {
     // auto pt1 = pt(particle1.px(), particle1.py());
     auto pt1 = RecoDecay::pt(particle1.px(), particle1.py());
@@ -1719,7 +1719,7 @@ struct TauTau13topo {
   }
 
   // helper function to calculate vector asymmetry
-  float vectorAsym(auto particle1, auto particle2)
+  float vectorAsym(const auto& particle1, const auto& particle2)
   {
     auto delta = std::sqrt((particle1.px() - particle2.px()) * (particle1.px() - particle2.px()) +
                            (particle1.py() - particle2.py()) * (particle1.py() - particle2.py()));
@@ -1796,7 +1796,7 @@ struct TauTau13topo {
   }
 
   template <typename T>
-  int trackCheck(T track)
+  int trackCheck(const T& track)
   {
     // 1
     if (track.hasITS() && !track.hasTPC() && !track.hasTRD() && !track.hasTOF())
@@ -1837,7 +1837,7 @@ struct TauTau13topo {
 
   // global track check + histogram cuts separatelly
   template <typename T>
-  bool isGlobalTrackCheck(T track)
+  bool isGlobalTrackCheck(const T& track)
   {
     bool isGlobalTrack = true;
     registry.get<TH1>(HIST("global/hTrackEfficiencyPVGlobal"))->Fill(0., 1.);
@@ -1921,7 +1921,7 @@ struct TauTau13topo {
 
   // analysis track quality check with histogram filling
   template <typename T>
-  bool isGoodTrackCheckHisto(T track)
+  bool isGoodTrackCheckHisto(const T& track)
   {
     bool isGoodTrack = true;
     registry.get<TH1>(HIST("global/hTrackPVGood"))->Fill(0., 1.);
@@ -1973,7 +1973,7 @@ struct TauTau13topo {
 
   // analysis track quality check
   template <typename T>
-  bool isGoodTrackCheck(T track)
+  bool isGoodTrackCheck(const T& track)
   {
     if (!track.hasTPC())
       return false;
@@ -1994,7 +1994,7 @@ struct TauTau13topo {
 
   // analysis track quality check
   template <typename T>
-  bool isGoodTOFTrackCheckHisto(T track)
+  bool isGoodTOFTrackCheckHisto(const T& track)
   {
     bool isGoodTrack = true;
     if (track.hasTOF()) {
@@ -2012,7 +2012,7 @@ struct TauTau13topo {
 
   // analysis track quality check
   template <typename T>
-  bool isGoodTOFTrackCheck(T track)
+  bool isGoodTOFTrackCheck(const T& track)
   {
     if (!track.hasTOF())
       return false;
@@ -2024,7 +2024,7 @@ struct TauTau13topo {
   // check ITS clusters, how many -1,0,1,7 + 10 if 0,1,2 layers were fired
   // analysis track quality check
   template <typename T>
-  int numberOfItsClustersCheck(T track)
+  int numberOfItsClustersCheck(const T& track)
   {
     if (!track.hasITS())
       return -1;


### PR DESCRIPTION
Mostly done automatically by Clang-Tidy.