### PR TITLE
[Tutorial,PWGCF,PWGEM,PWGLF,PWGUD] Use `const&` and `std::move` to avoid copies

### DIFF
--- a/Tutorials/PWGCF/EventPlane/src/qVectorstutorial.cxx
+++ b/Tutorials/PWGCF/EventPlane/src/qVectorstutorial.cxx
@@ -98,7 +98,7 @@ struct qVectorstutorial {
   }
 
   template <typename TrackType>
-  bool SelTrack(const TrackType track)
+  bool SelTrack(const TrackType& track)
   {
     if (track.pt() < cfgMinPt)
       return false;

--- a/Tutorials/PWGEM/Cocktail/plotLFCocktail.C
+++ b/Tutorials/PWGEM/Cocktail/plotLFCocktail.C
@@ -30,7 +30,7 @@ TString histLegends[nHists] = {
   "#phi#rightarrow#etae^{+}e^{-}, #phi#rightarrow#pi^{0}e^{+}e^{-}, "
   "#phi#rightarrowe^{+}e^{-}"};
 
-void loadHistos(TFile* file, TH1F* hists[], TString name_extra, int rebin,
+void loadHistos(TFile* file, TH1F* hists[], const TString& name_extra, int rebin,
                 int nEvents)
 {
   for (int i = 0; i < nHists; i++) {
@@ -42,7 +42,7 @@ void loadHistos(TFile* file, TH1F* hists[], TString name_extra, int rebin,
   }
 }
 
-void plotLFCocktail(TString filename = "AnalysisResults.root", int rebin = 1)
+void plotLFCocktail(const TString& filename = "AnalysisResults.root", int rebin = 1)
 {
 
   TFile* file = TFile::Open(filename.Data());

--- a/Tutorials/PWGLF/Resonance/resonancesCombine.cxx
+++ b/Tutorials/PWGLF/Resonance/resonancesCombine.cxx
@@ -93,7 +93,7 @@ struct ResonanceCombine {
   }
 
   template <typename TrackType>
-  bool trackCut(const TrackType track)
+  bool trackCut(const TrackType& track)
   {
     if (std::abs(track.pt()) < cMinPtcut)
       return false;

--- a/Tutorials/PWGLF/Resonance/resonancesMicrotrack.cxx
+++ b/Tutorials/PWGLF/Resonance/resonancesMicrotrack.cxx
@@ -90,7 +90,7 @@ struct ResonancesMicrotrack {
   }
 
   template <bool IsResoMicrotrack, typename TrackType>
-  bool trackCut(const TrackType track)
+  bool trackCut(const TrackType& track)
   {
     if constexpr (!IsResoMicrotrack) {
       if (std::abs(track.pt()) < cMinPtcut)

--- a/Tutorials/PWGLF/Resonance/resonances_step0.cxx
+++ b/Tutorials/PWGLF/Resonance/resonances_step0.cxx
@@ -47,7 +47,7 @@ struct resonances_tutorial {
 
   // Track selection
   template <typename TrackType>
-  bool trackCut(const TrackType track)
+  bool trackCut(const TrackType& track)
   {
     // basic track cuts
     if (std::abs(track.pt()) < cMinPtcut)
@@ -60,7 +60,7 @@ struct resonances_tutorial {
   template <bool IsMC, bool IsMix, typename CollisionType, typename TracksType>
   void fillHistograms(const CollisionType& /*collision*/, const TracksType& dTracks1, const TracksType& /*dTracks2*/)
   {
-    for (auto track1 : dTracks1) { // loop over all dTracks1
+    for (const auto& track1 : dTracks1) { // loop over all dTracks1
       if (!trackCut(track1))
         continue; // track selection and PID selection
       histos.fill(HIST("hEta"), track1.eta());

--- a/Tutorials/PWGLF/Resonance/resonances_step1.cxx
+++ b/Tutorials/PWGLF/Resonance/resonances_step1.cxx
@@ -84,7 +84,7 @@ struct resonances_tutorial {
 
   // Track selection
   template <typename TrackType>
-  bool trackCut(const TrackType track)
+  bool trackCut(const TrackType& track)
   {
     // basic track cuts
     if (std::abs(track.pt()) < cMinPtcut)
@@ -121,7 +121,7 @@ struct resonances_tutorial {
   void fillHistograms(const CollisionType& collision, const TracksType& dTracks1, const TracksType& dTracks2)
   {
     auto multiplicity = collision.cent();
-    for (auto track1 : dTracks1) { // loop over all dTracks1
+    for (const auto& track1 : dTracks1) { // loop over all dTracks1
       if (!trackCut(track1) || !selectionPID(track1)) {
         continue; // track selection and PID selection
       }
@@ -133,7 +133,7 @@ struct resonances_tutorial {
       if (track1.hasTOF()) {
         histos.fill(HIST("hNsigmaKaonTOF"), track1.tofNSigmaKa());
       }
-      for (auto track2 : dTracks2) { // loop over all dTracks2
+      for (const auto& track2 : dTracks2) { // loop over all dTracks2
         if (!trackCut(track2) || !selectionPID(track2)) {
           continue; // track selection and PID selection
         }

--- a/Tutorials/PWGLF/Resonance/resonances_step2.cxx
+++ b/Tutorials/PWGLF/Resonance/resonances_step2.cxx
@@ -96,7 +96,7 @@ struct resonances_tutorial {
 
   // Track selection
   template <typename TrackType>
-  bool trackCut(const TrackType track)
+  bool trackCut(const TrackType& track)
   {
     // basic track cuts
     if (std::abs(track.pt()) < cMinPtcut)
@@ -133,7 +133,7 @@ struct resonances_tutorial {
   void fillHistograms(const CollisionType& collision, const TracksType& dTracks1, const TracksType& dTracks2)
   {
     auto multiplicity = collision.cent();
-    for (auto track1 : dTracks1) { // loop over all dTracks1
+    for (const auto& track1 : dTracks1) { // loop over all dTracks1
       if (!trackCut(track1) || !selectionPID(track1)) {
         continue; // track selection and PID selection
       }
@@ -145,7 +145,7 @@ struct resonances_tutorial {
       if (track1.hasTOF()) {
         histos.fill(HIST("hNsigmaKaonTOF"), track1.tofNSigmaKa());
       }
-      for (auto track2 : dTracks2) { // loop over all dTracks2
+      for (const auto& track2 : dTracks2) { // loop over all dTracks2
         if (!trackCut(track2) || !selectionPID(track2)) {
           continue; // track selection and PID selection
         }

--- a/Tutorials/PWGLF/Resonance/resonances_step3.cxx
+++ b/Tutorials/PWGLF/Resonance/resonances_step3.cxx
@@ -47,7 +47,7 @@ struct resonances_tutorial {
 
   // MC particle selection
   template <typename ParticleType>
-  bool ptCut(const ParticleType resoParents)
+  bool ptCut(const ParticleType& resoParents)
   {
     // basic pt cuts
     if (std::abs(resoParents.pt()) < cMinPtcut)
@@ -60,7 +60,7 @@ struct resonances_tutorial {
   template <typename CollisionType, typename ParticleType>
   void fillHistograms(const CollisionType& /*collision*/, const ParticleType& resoParents)
   {
-    for (auto part : resoParents) { // loop over all resoParents
+    for (const auto& part : resoParents) { // loop over all resoParents
       if (!ptCut(part))
         continue; // pt selection
 

--- a/Tutorials/PWGLF/Resonance/resonances_step4.cxx
+++ b/Tutorials/PWGLF/Resonance/resonances_step4.cxx
@@ -63,7 +63,7 @@ struct resonances_tutorial {
 
   // MC particle selection
   template <typename ParticleType>
-  bool ptCut(const ParticleType resoParents)
+  bool ptCut(const ParticleType& resoParents)
   {
     // basic pt cuts
     if (std::abs(resoParents.pt()) < cMinPtcut)

--- a/Tutorials/PWGLF/Resonance/resonances_step5.cxx
+++ b/Tutorials/PWGLF/Resonance/resonances_step5.cxx
@@ -80,7 +80,7 @@ struct resonances_tutorial {
 
   // Track selection
   template <typename TrackType>
-  bool trackCut(const TrackType track)
+  bool trackCut(const TrackType& track)
   {
     // basic track cuts
     if (std::abs(track.pt()) < cMinPtcut)
@@ -113,7 +113,7 @@ struct resonances_tutorial {
   template <typename CollisionType, typename TracksType>
   void fillHistograms(const CollisionType& /* collision */, const TracksType& dTracks)
   {
-    for (auto track : dTracks) { // loop over all dTracks
+    for (const auto& track : dTracks) { // loop over all dTracks
       if (!trackCut(track) || !selectionPID(track)) {
         continue; // track selection and PID selection
       }

--- a/Tutorials/PWGLF/Resonance/resonances_step6.cxx
+++ b/Tutorials/PWGLF/Resonance/resonances_step6.cxx
@@ -103,7 +103,7 @@ struct resonances_tutorial {
 
   // Track selection
   template <typename TrackType>
-  bool trackCut(const TrackType track)
+  bool trackCut(const TrackType& track)
   {
     // basic track cuts
     if (std::abs(track.pt()) < cMinPtcut)
@@ -140,7 +140,7 @@ struct resonances_tutorial {
   void fillHistograms(const CollisionType& collision, const TracksType& dTracks1, const TracksType& dTracks2)
   {
     auto multiplicity = collision.cent();
-    for (auto track1 : dTracks1) { // loop over all dTracks1
+    for (const auto& track1 : dTracks1) { // loop over all dTracks1
       if (!trackCut(track1) || !selectionPID(track1)) {
         continue; // track selection and PID selection
       }
@@ -152,7 +152,7 @@ struct resonances_tutorial {
       if (track1.hasTOF()) {
         histos.fill(HIST("hNsigmaKaonTOF"), track1.tofNSigmaKa());
       }
-      for (auto track2 : dTracks2) { // loop over all dTracks2
+      for (const auto& track2 : dTracks2) { // loop over all dTracks2
         if (!trackCut(track2) || !selectionPID(track2)) {
           continue; // track selection and PID selection
         }

--- a/Tutorials/PWGUD/UDTutorial_01.cxx
+++ b/Tutorials/PWGUD/UDTutorial_01.cxx
@@ -109,7 +109,7 @@ struct UDTutorial01 {
       LOGF(info, "<UDTutorial01>   Number of tracks %d", dgtracks.size());
       LOGF(info, "<UDTutorial01>   Number of PV contributors %d", PVContributors.size());
     }
-    for (auto track : dgtracks) {
+    for (const auto& track : dgtracks) {
       registry.get<TH1>(HIST("tracks/QCAll"))->Fill(0., 1.);
       registry.get<TH1>(HIST("tracks/QCAll"))->Fill(1., track.hasITS() * 1.);
       registry.get<TH1>(HIST("tracks/QCAll"))->Fill(2., track.hasTPC() * 1.);

--- a/Tutorials/PWGUD/UDTutorial_02a.cxx
+++ b/Tutorials/PWGUD/UDTutorial_02a.cxx
@@ -129,7 +129,7 @@ struct UDTutorial02a {
 
     // check PID of tracks, use nSigmaTPC
     // cut on track pT
-    for (auto trk : PVContributors) {
+    for (const auto& trk : PVContributors) {
       if (trk.tpcNSigmaPi() < -3. || trk.tpcNSigmaPi() > 3.) {
         if (verbose) {
           LOGF(info, "<UDTutorials02> Candidate rejected: nSigmaTPC pion is %f", trk.tpcNSigmaPi());
@@ -148,7 +148,7 @@ struct UDTutorial02a {
     TParticlePDG* pion = pdg->GetParticle(211);
     TLorentzVector lvtmp;
     auto ivm = TLorentzVector(0., 0., 0., 0.);
-    for (auto trk : PVContributors) {
+    for (const auto& trk : PVContributors) {
       lvtmp.SetXYZM(trk.px(), trk.py(), trk.pz(), pion->Mass());
       ivm += lvtmp;
     }
@@ -166,7 +166,7 @@ struct UDTutorial02a {
       LOGF(info, "<UDTutorials02> Candidate accepted!");
     }
     registry.get<TH2>(HIST("dgcandidates/IVMptsys"))->Fill(ivm.M(), ivm.Perp());
-    for (auto trk : PVContributors) {
+    for (const auto& trk : PVContributors) {
       registry.get<TH2>(HIST("dgcandidates/IVMpttrk"))->Fill(ivm.M(), trk.pt());
 
       // fill nSigma histograms

--- a/Tutorials/PWGUD/UDTutorial_03a.cxx
+++ b/Tutorials/PWGUD/UDTutorial_03a.cxx
@@ -104,7 +104,7 @@ struct UDTutorial03a {
   }
 
   // check if a reconstructed track is a muon candidate
-  bool isMuonCandidate_rec(TC track)
+  bool isMuonCandidate_rec(const TC& track)
   {
     if (abs(track.tpcNSigmaMu()) > 3.) {
       return false;
@@ -142,7 +142,7 @@ struct UDTutorial03a {
     // and be muon candidates
     int netCharge = 0;
     int ind = -1;
-    for (auto track : tracks) {
+    for (const auto& track : tracks) {
       ind++;
       if (track.isPVContributor()) {
         if (!isMuonCandidate_rec(track)) {
@@ -297,7 +297,7 @@ struct UDTutorial03a {
     TLorentzVector* lv_gen = new TLorentzVector();
 
     // loop over all genererated collisions
-    for (auto mccollision : mccollisions) {
+    for (const auto& mccollision : mccollisions) {
       registry.get<TH1>(HIST("MC/Stat"))->Fill(0., 1.);
 
       // get McParticles which belong to mccollision
@@ -350,7 +350,7 @@ struct UDTutorial03a {
     registry.get<TH1>(HIST("Reco/Stat"))->Fill(0., 1.);
     registry.get<TH1>(HIST("Reco/nTracks"))->Fill(tracks.size(), 1.);
     int nContributors = 0;
-    for (auto track : tracks) {
+    for (const auto& track : tracks) {
       if (track.isPVContributor()) {
         nContributors++;
       }

--- a/Tutorials/PWGUD/UDTutorial_03b.cxx
+++ b/Tutorials/PWGUD/UDTutorial_03b.cxx
@@ -116,7 +116,7 @@ struct UDTutorial03b {
   }
 
   // check if a reconstructed track represents a muon candidate
-  bool isMuonCandidate_rec(TC track)
+  bool isMuonCandidate_rec(const TC& track)
   {
     if (abs(track.tpcNSigmaMu()) > 3.) {
       return false;
@@ -140,7 +140,7 @@ struct UDTutorial03b {
 
   // find the McParticles belongin to given tracks
   template <typename MCTrack>
-  std::vector<int64_t> getDaughterParts_rec(TCs const& tracks, std::vector<int64_t> trackIds, MCTrack const& /*parts*/)
+  std::vector<int64_t> getDaughterParts_rec(TCs const& tracks, const std::vector<int64_t>& trackIds, MCTrack const& /*parts*/)
   {
     std::vector<int64_t> emptySelection;
     std::vector<int64_t> selectedParts;
@@ -158,7 +158,7 @@ struct UDTutorial03b {
 
   // retrieve the reconstructed tracks which are associated with the given McParticles
   template <typename McPart>
-  std::vector<int64_t> getDaughterTracks_gen(McPart const& parts, std::vector<int64_t> partIds, TCs const& tracks)
+  std::vector<int64_t> getDaughterTracks_gen(McPart const& parts, const std::vector<int64_t>& partIds, TCs const& tracks)
   {
     // return a vector of track indices
     std::vector<int64_t> emptySelection;
@@ -173,7 +173,7 @@ struct UDTutorial03b {
       if (trs.size() > 1) {
         LOGF(info, "%d tracks belong to same McParticle!", trs.size());
       }
-      for (auto tr : trs) {
+      for (const auto& tr : trs) {
         selectedTracks.push_back(tr.globalIndex());
       }
     }
@@ -196,7 +196,7 @@ struct UDTutorial03b {
     // and be muon candidates
     int netCharge = 0;
     int ind = -1;
-    for (auto track : tracks) {
+    for (const auto& track : tracks) {
       ind++;
       if (track.isPVContributor()) {
         if (!isMuonCandidate_rec(track)) {
@@ -328,7 +328,7 @@ struct UDTutorial03b {
     TLorentzVector* lv_rec = new TLorentzVector();
 
     // loop over all generated collisions
-    for (auto mccollision : mccollisions) {
+    for (const auto& mccollision : mccollisions) {
       registry.get<TH1>(HIST("MC/Stat"))->Fill(0., 1.);
 
       // get reconstructed collision which belongs to mccollision
@@ -400,14 +400,14 @@ struct UDTutorial03b {
       registry.get<TH2>(HIST("MC/selMPt"))->Fill(lv_rec->M(), lv_rec->Pt(), 1.);
 
       // compute the difference between generated and reconstructed particle momentum
-      for (auto McPart : partSlice) {
+      for (const auto& McPart : partSlice) {
         // get track which corresponds to McPart
         auto trackSlice = tracks.sliceBy(trackPerMcParticle, McPart.globalIndex());
         registry.get<TH1>(HIST("MC/nRecTracks"))->Fill(trackSlice.size(), 1.);
 
         // are there reconstructed tracks?
         if (trackSlice.size() > 0) {
-          for (auto track : trackSlice) {
+          for (const auto& track : trackSlice) {
             auto pTrack = track.p();
             auto pPart = McPart.p();
             auto pDiff = pTrack - pPart;
@@ -436,7 +436,7 @@ struct UDTutorial03b {
     registry.get<TH1>(HIST("Reco/Stat"))->Fill(0., 1.);
     registry.get<TH1>(HIST("Reco/nTracks"))->Fill(tracks.size(), 1.);
     int nContributors = 0;
-    for (auto track : tracks) {
+    for (const auto& track : tracks) {
       if (track.isPVContributor()) {
         nContributors++;
       }
@@ -489,7 +489,7 @@ struct UDTutorial03b {
     }
 
     // compute the difference between generated and reconstructed momentum
-    for (auto track : tracks) {
+    for (const auto& track : tracks) {
       // is there an associated McParticle?
       if (track.has_mcParticle()) {
         auto pTrack = track.p();

--- a/Tutorials/PWGUD/UDTutorial_04.cxx
+++ b/Tutorials/PWGUD/UDTutorial_04.cxx
@@ -113,7 +113,7 @@ struct UDTutorial04 {
   }
 
   // check if a reconstructed track represents a muon candidate
-  bool isMuonCandidate_rec(TC track)
+  bool isMuonCandidate_rec(const TC& track)
   {
     if (abs(track.tpcNSigmaMu()) > 3.) {
       return false;
@@ -137,7 +137,7 @@ struct UDTutorial04 {
 
   // find the McParticles belongin to given tracks
   template <typename MCTrack>
-  std::vector<int64_t> getDaughterParts_rec(TCs const& tracks, std::vector<int64_t> trackIds, MCTrack const& /*parts*/)
+  std::vector<int64_t> getDaughterParts_rec(TCs const& tracks, const std::vector<int64_t>& trackIds, MCTrack const& /*parts*/)
   {
     std::vector<int64_t> emptySelection;
     std::vector<int64_t> selectedParts;
@@ -155,7 +155,7 @@ struct UDTutorial04 {
 
   // retrieve the reconstructed tracks which are associated with the given McParticles
   template <typename McPart>
-  std::vector<int64_t> getDaughterTracks_gen(McPart const& parts, std::vector<int64_t> partIds, TCs const& tracks)
+  std::vector<int64_t> getDaughterTracks_gen(McPart const& parts, const std::vector<int64_t>& partIds, TCs const& tracks)
   {
     // return a vector of track indices
     std::vector<int64_t> emptySelection;
@@ -170,7 +170,7 @@ struct UDTutorial04 {
       if (trs.size() > 1) {
         LOGF(info, "%d tracks belong to same McParticle!", trs.size());
       }
-      for (auto tr : trs) {
+      for (const auto& tr : trs) {
         selectedTracks.push_back(tr.globalIndex());
       }
     }
@@ -193,7 +193,7 @@ struct UDTutorial04 {
     // and be muon candidates
     int netCharge = 0;
     int ind = -1;
-    for (auto track : tracks) {
+    for (const auto& track : tracks) {
       ind++;
       if (track.isPVContributor()) {
         if (!isMuonCandidate_rec(track)) {
@@ -325,7 +325,7 @@ struct UDTutorial04 {
     TLorentzVector* lv_rec = new TLorentzVector();
 
     // loop over all generated collisions
-    for (auto mccollision : mccollisions) {
+    for (const auto& mccollision : mccollisions) {
       registry.get<TH1>(HIST("MC/Stat"))->Fill(0., 1.);
 
       // get reconstructed collision which belongs to mccollision
@@ -400,14 +400,14 @@ struct UDTutorial04 {
       registry.get<TH2>(HIST("MC/selMPt"))->Fill(lv_rec->M(), lv_rec->Pt(), 1.);
 
       // compute the difference between generated and reconstructed particle momentum
-      for (auto McPart : partSlice) {
+      for (const auto& McPart : partSlice) {
         // get track which corresponds to McPart
         auto trackSlice = tracks.sliceBy(trackPerMcParticle, McPart.globalIndex());
         registry.get<TH1>(HIST("MC/nRecTracks"))->Fill(trackSlice.size(), 1.);
 
         // compute momentum difference between MCTruth and Reconstruction
         if (trackSlice.size() > 0) {
-          for (auto track : trackSlice) {
+          for (const auto& track : trackSlice) {
             auto pTrack = sqrt(track.px() * track.px() + track.py() * track.py() + track.pz() * track.pz());
             auto pPart = sqrt(McPart.px() * McPart.px() + McPart.py() * McPart.py() + McPart.pz() * McPart.pz());
             auto pDiff = pTrack - pPart;
@@ -490,7 +490,7 @@ struct UDTutorial04 {
     }
 
     // compute the difference between generated and reconstructed momentum
-    for (auto track : tracks) {
+    for (const auto& track : tracks) {
       // is there an associated McParticle?
       if (track.has_udMcParticle()) {
         auto pTrack = sqrt(track.px() * track.px() + track.py() * track.py() + track.pz() * track.pz());

--- a/Tutorials/PWGUD/UDTutorial_05.cxx
+++ b/Tutorials/PWGUD/UDTutorial_05.cxx
@@ -178,7 +178,7 @@ struct UDTutorial05 {
 
       registry.fill(HIST("hTracks"), tracks.size());
 
-      for (auto t : tracks) {
+      for (const auto& t : tracks) {
         // Apply good track selection criteria
         if (!trackselector(t, parameters))
           continue;
@@ -205,7 +205,7 @@ struct UDTutorial05 {
       registry.fill(HIST("hTracksPions"), onlyPionTracks.size());
       //_____________________________________
       // Adding all onlypiontracks
-      for (auto pion : onlyPionTracks) {
+      for (const auto& pion : onlyPionTracks) {
         p += pion;
       }
 

--- a/Tutorials/PWGUD/UDTutorial_07.cxx
+++ b/Tutorials/PWGUD/UDTutorial_07.cxx
@@ -175,7 +175,7 @@ struct UDTutorial07 {
 
       registry.fill(HIST("hSelectionCounter"), 3);
 
-      for (auto t : tracks) {
+      for (const auto& t : tracks) {
 
         // Apply good track selection criteria
         if (!trackselector(t, parameters))
@@ -208,11 +208,11 @@ struct UDTutorial07 {
           registry.fill(HIST("hSelectionCounter"), 4);
 
           // Creating rhos
-          for (auto pion : onlyPionTracks) {
+          for (const auto& pion : onlyPionTracks) {
             p += pion;
           }
 
-          for (auto rtrk : rawPionTracks) {
+          for (const auto& rtrk : rawPionTracks) {
             TLorentzVector itrk;
             itrk.SetXYZM(rtrk.px(), rtrk.py(), rtrk.pz(), o2::constants::physics::MassPionCharged);
             trackpt.push_back(itrk.Pt());
@@ -223,7 +223,7 @@ struct UDTutorial07 {
           }
 
           int sign = 0;
-          for (auto rawPion : rawPionTracks) {
+          for (const auto& rawPion : rawPionTracks) {
             sign += rawPion.sign();
           }
           // Filling tree, make to be consistent with the declared tables

--- a/Tutorials/Skimming/spectraNucleiAnalyser.cxx
+++ b/Tutorials/Skimming/spectraNucleiAnalyser.cxx
@@ -50,7 +50,7 @@ struct NucleiSpectraAnalyserTask {
 
     spectra.fill(HIST("fCollZpos"), collision.posZ());
 
-    for (auto track : tracks) { // start loop over tracks
+    for (const auto& track : tracks) { // start loop over tracks
       TLorentzVector cutVector{};
       cutVector.SetPtEtaPhiM(track.pt() * 2.0, track.eta(), track.phi(), constants::physics::MassHelium3);
       if (cutVector.Rapidity() < yMin + yBeam || cutVector.Rapidity() > yMax + yBeam) {

--- a/Tutorials/Skimming/spectraNucleiProvider.cxx
+++ b/Tutorials/Skimming/spectraNucleiProvider.cxx
@@ -82,7 +82,7 @@ struct NucleiSpectraProviderTask {
       outputCollisions(collision.posZ());
       uint32_t pNsigma = 0xFFFFFF00; // 15 bit precision for Nsigma - does this respect the sign?
       outputTracks.reserve(tracks.size());
-      for (auto track : tracks) {
+      for (const auto& track : tracks) {
         outputTracks(outputCollisions.lastIndex(), track.pt(), track.eta(), track.phi(),
                      // truncateFloatFraction(track.tpcNSigmaEl(), pNsigma), truncateFloatFraction(track.tpcNSigmaMu(), pNsigma),
                      truncateFloatFraction(track.tpcNSigmaPi(), pNsigma), truncateFloatFraction(track.tpcNSigmaKa(), pNsigma),

--- a/Tutorials/Skimming/spectraNucleiReference.cxx
+++ b/Tutorials/Skimming/spectraNucleiReference.cxx
@@ -84,7 +84,7 @@ struct NucleiSpectraReferenceTask {
     //
     spectra.fill(HIST("fCollZpos"), collision.posZ());
     //
-    for (auto track : tracks) { // start loop over tracks
+    for (const auto& track : tracks) { // start loop over tracks
 
       TLorentzVector cutVector{};
       cutVector.SetPtEtaPhiM(track.pt() * 2.0, track.eta(), track.phi(), constants::physics::MassHelium3);

--- a/Tutorials/Skimming/spectraTPCReference.cxx
+++ b/Tutorials/Skimming/spectraTPCReference.cxx
@@ -85,7 +85,7 @@ struct TPCSpectraReferenceTask {
                                                   aod::TrackSelection>>;
   void process(soa::Filtered<aod::Collisions>::iterator const& /*collision*/, TrackCandidates const& tracks)
   {
-    for (auto track : tracks) {
+    for (const auto& track : tracks) {
       const float nsigma[Np] = {track.tpcNSigmaEl(), track.tpcNSigmaMu(), track.tpcNSigmaPi(),
                                 track.tpcNSigmaKa(), track.tpcNSigmaPr(), track.tpcNSigmaDe(),
                                 track.tpcNSigmaTr(), track.tpcNSigmaHe(), track.tpcNSigmaAl()};

--- a/Tutorials/include/configurableCut.h
+++ b/Tutorials/include/configurableCut.h
@@ -18,6 +18,7 @@
 
 #include <iosfwd>
 #include <string>
+#include <utility>
 #include <vector>
 
 static constexpr double default_matrix[3][3] = {{1.1, 1.2, 1.3}, {2.1, 2.2, 2.3}, {3.1, 3.2, 3.3}};
@@ -29,7 +30,7 @@ class configurableCut
                   std::vector<float> bins_ = {0.5, 1.5, 2.5},
                   std::vector<std::string> labels_ = {"l1", "l2", "l3"},
                   o2::framework::Array2D<double> cuts_ = {&default_matrix[0][0], 3, 3})
-    : cut{cut_}, state{state_}, option{option_}, bins{bins_}, labels{labels_}, cuts{cuts_}
+    : cut{cut_}, state{state_}, option{option_}, bins{std::move(bins_)}, labels{std::move(labels_)}, cuts{std::move(cuts_)}
   {
   }
 


### PR DESCRIPTION
Mostly done automatically by Clang-Tidy.