### PR TITLE
[PWGEM] Add table for detailed event normalization purposes

### DIFF
--- a/PWGEM/Dilepton/DataModel/dileptonTables.h
+++ b/PWGEM/Dilepton/DataModel/dileptonTables.h
@@ -127,6 +127,28 @@ uint32_t reduceSelectionBit(TBC const& bc)
   }
   return bitMap;
 }
+
+// enum that is used as an index for an event-counter during the DD production.
+// This keeps the DD size minimal as its only filled once per DF
+enum EMEventSelectionBits {
+  kAll = 0, // o2-linter: disable=magic-number (enum)
+  kHasMCColl,
+  kGoodZVtx,
+  kIsFT0AND,
+  kNoTFB,
+  kITSROFB,
+  kNoSameBunchPileUp,
+  kGoodZVtxFTOPV,
+  kNoCollInTimeRange,
+  kGoodTrackOccupancy,
+  kGoodFT0Occupancy,
+  kTVXInEMC,
+  kGoodCent,
+  kGoodRCT,
+  kGoodSel8,
+  kSize
+};
+
 } // namespace emevsel
 
 namespace emevent
@@ -193,18 +215,19 @@ DECLARE_SOA_COLUMN(QyZDCC, qyZDCC, float);   //! Qy in ZDCC (i.e. negative eta)
 DECLARE_SOA_COLUMN(SpherocityPtWeighted, spherocity_ptweighted, float);     //! transverse spherocity
 DECLARE_SOA_COLUMN(SpherocityPtUnWeighted, spherocity_ptunweighted, float); //! transverse spherocity
 DECLARE_SOA_COLUMN(NtrackSpherocity, ntspherocity, int);
-DECLARE_SOA_COLUMN(IsSelected, isSelected, bool);                //! MB event selection info
-DECLARE_SOA_COLUMN(IsEoI, isEoI, bool);                          //! lepton or photon exists in MB event (not for CEFP)
-DECLARE_SOA_COLUMN(PosX, posX, float);                           //! only for treeCreatetorML.cxx
-DECLARE_SOA_COLUMN(PosY, posY, float);                           //! only for treeCreatetorML.cxx
-DECLARE_SOA_COLUMN(PosZint16, posZint16, int16_t);               //! this is only to reduce data size
-DECLARE_SOA_COLUMN(CentFT0Cuint16, centFT0Cuint16, uint16_t);    //! this is only to reduce data size
-DECLARE_SOA_COLUMN(PosZint8, posZint8, int8_t);                  //! this is only to reduce data size
-DECLARE_SOA_COLUMN(CentFT0Cuint8, centFT0Cuint8, uint8_t);       //! this is only to reduce data size
-DECLARE_SOA_COLUMN(CentNTPVuint8, centNTPVuint8, uint8_t);       //! this is only to reduce data size
-DECLARE_SOA_COLUMN(CentNGlobaluint8, centNGlobaluint8, uint8_t); //! this is only to reduce data size
-DECLARE_SOA_COLUMN(CentFT0Muint8, centFT0Muint8, uint8_t);       //! this is only to reduce data size
-DECLARE_SOA_COLUMN(CentFT0Auint8, centFT0Auint8, uint8_t);       //! this is only to reduce data size
+DECLARE_SOA_COLUMN(IsSelected, isSelected, bool);                                //! MB event selection info
+DECLARE_SOA_COLUMN(EventSelectionBit, eventSelectionBit, std::vector<uint64_t>); //! Event selection info stored in binned data for each DF
+DECLARE_SOA_COLUMN(IsEoI, isEoI, bool);                                          //! lepton or photon exists in MB event (not for CEFP)
+DECLARE_SOA_COLUMN(PosX, posX, float);                                           //! only for treeCreatetorML.cxx
+DECLARE_SOA_COLUMN(PosY, posY, float);                                           //! only for treeCreatetorML.cxx
+DECLARE_SOA_COLUMN(PosZint16, posZint16, int16_t);                               //! this is only to reduce data size
+DECLARE_SOA_COLUMN(CentFT0Cuint16, centFT0Cuint16, uint16_t);                    //! this is only to reduce data size
+DECLARE_SOA_COLUMN(PosZint8, posZint8, int8_t);                                  //! this is only to reduce data size
+DECLARE_SOA_COLUMN(CentFT0Cuint8, centFT0Cuint8, uint8_t);                       //! this is only to reduce data size
+DECLARE_SOA_COLUMN(CentNTPVuint8, centNTPVuint8, uint8_t);                       //! this is only to reduce data size
+DECLARE_SOA_COLUMN(CentNGlobaluint8, centNGlobaluint8, uint8_t);                 //! this is only to reduce data size
+DECLARE_SOA_COLUMN(CentFT0Muint8, centFT0Muint8, uint8_t);                       //! this is only to reduce data size
+DECLARE_SOA_COLUMN(CentFT0Auint8, centFT0Auint8, uint8_t);                       //! this is only to reduce data size
 // DECLARE_SOA_COLUMN(CentFT0Cuint8, centFT0Cuint8, uint8_t);       //! this is only to reduce data size
 // DECLARE_SOA_COLUMN(CentNTPVuint8, centNTPVuint8, uint8_t);       //! this is only to reduce data size
 // DECLARE_SOA_COLUMN(CentNGlobaluint8, centNGlobaluint8, uint8_t); //! this is only to reduce data size
@@ -434,6 +457,10 @@ using EMEventNee = EMEventsNee::iterator;
 DECLARE_SOA_TABLE(EMEvSels, "AOD", "EMEVSEL", //! joinable to o2::aod::Collisions
                   emevent::IsSelected);
 using EMEvSel = EMEvSels::iterator;
+
+DECLARE_SOA_TABLE(EMEvSelBits, "AOD", "EMEVSELBITS", //! produces binned data that can be loaded in analysis task for event counting
+                  emevent::EventSelectionBit);
+using EMEvSelBit = EMEvSelBits::iterator;
 
 DECLARE_SOA_TABLE(EMEoIs, "AOD", "EMEOI", //! joinable to o2::aod::Collisions in createEMEventDilepton.cxx
                   emevent::IsEoI);

--- a/PWGEM/Dilepton/TableProducer/eventSelection.cxx
+++ b/PWGEM/Dilepton/TableProducer/eventSelection.cxx
@@ -37,6 +37,7 @@ using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::soa;
+using EventSelectionBits = o2::aod::emevsel::EMEventSelectionBits;
 
 using MyCollisions = soa::Join<aod::Collisions, aod::EvSels>;
 using MyCollisions_Cent = soa::Join<MyCollisions, aod::Mults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs>;
@@ -46,6 +47,7 @@ using MyCollisionsMC_Cent = soa::Join<MyCollisionsMC, aod::Mults, aod::CentFT0Ms
 
 struct EMEventSelection {
   Produces<o2::aod::EMEvSels> emevsel;
+  Produces<o2::aod::EMEvSelBits> emevselbits;
 
   // Configurables
   Configurable<int> cfgCentEstimator{"cfgCentEstimator", 2, "FT0M:0, FT0A:1, FT0C:2"};
@@ -73,61 +75,78 @@ struct EMEventSelection {
 
   Configurable<bool> cfgRequireTVXinEMC{"cfgRequireTVXinEMC", false, "require kTVXinEMC (only for EMC analyses)"};
 
+  Configurable<bool> cfgRequireSel8{"cfgRequireSel8", false, "require sel8 condition"};
+
   o2::aod::rctsel::RCTFlagsChecker rctChecker;
+
+  std::vector<uint64_t> vecEvSelBits;
 
   void init(InitContext&)
   {
     rctChecker.init(cfgRCTLabel.value, cfgCheckZDC.value, cfgTreatLimitedAcceptanceAsBad.value);
+    vecEvSelBits.assign(EventSelectionBits::kSize, 0);
   }
 
   template <typename TCollision>
   bool isSelectedEvent(TCollision const& collision)
   {
+    vecEvSelBits[EventSelectionBits::kAll]++;
     if constexpr (std::is_same_v<std::decay_t<TCollision>, MyCollisionsMC::iterator> || std::is_same_v<std::decay_t<TCollision>, MyCollisionsMC_Cent::iterator>) {
       if (!collision.has_mcCollision()) {
         return false;
       }
     }
+    vecEvSelBits[EventSelectionBits::kHasMCColl]++;
 
     if (collision.posZ() < cfgZvtxMin || cfgZvtxMax < collision.posZ()) {
       return false;
     }
+    vecEvSelBits[EventSelectionBits::kGoodZVtx]++;
 
     if (cfgRequireFT0AND && !collision.selection_bit(o2::aod::evsel::kIsTriggerTVX)) {
       return false;
     }
+    vecEvSelBits[EventSelectionBits::kIsFT0AND]++;
 
     if (cfgRequireNoTFB && !collision.selection_bit(o2::aod::evsel::kNoTimeFrameBorder)) {
       return false;
     }
+    vecEvSelBits[EventSelectionBits::kNoTFB]++;
 
     if (cfgRequireNoITSROFB && !collision.selection_bit(o2::aod::evsel::kNoITSROFrameBorder)) {
       return false;
     }
+    vecEvSelBits[EventSelectionBits::kITSROFB]++;
 
     if (cfgRequireNoSameBunchPileup && !collision.selection_bit(o2::aod::evsel::kNoSameBunchPileup)) {
       return false;
     }
+    vecEvSelBits[EventSelectionBits::kNoSameBunchPileUp]++;
 
     if (cfgRequireGoodZvtxFT0vsPV && !collision.selection_bit(o2::aod::evsel::kIsGoodZvtxFT0vsPV)) {
       return false;
     }
+    vecEvSelBits[EventSelectionBits::kGoodZVtxFTOPV]++;
 
     if (cfgRequireNoCollInTimeRangeStandard && !collision.selection_bit(o2::aod::evsel::kNoCollInTimeRangeStandard)) {
       return false;
     }
+    vecEvSelBits[EventSelectionBits::kNoCollInTimeRange]++;
 
     if (!(cfgTrackOccupancyMin <= collision.trackOccupancyInTimeRange() && collision.trackOccupancyInTimeRange() < cfgTrackOccupancyMax)) {
       return false;
     }
+    vecEvSelBits[EventSelectionBits::kGoodTrackOccupancy]++;
 
     if (!(cfgFT0COccupancyMin <= collision.ft0cOccupancyInTimeRange() && collision.ft0cOccupancyInTimeRange() < cfgFT0COccupancyMax)) {
       return false;
     }
+    vecEvSelBits[EventSelectionBits::kGoodFT0Occupancy]++;
 
     if (cfgRequireTVXinEMC && !collision.alias_bit(triggerAliases::kTVXinEMC)) {
       return false;
     }
+    vecEvSelBits[EventSelectionBits::kTVXInEMC]++;
 
     if constexpr (std::is_same_v<std::decay_t<TCollision>, MyCollisions_Cent::iterator>) {
       const float centralities[3] = {collision.centFT0M(), collision.centFT0A(), collision.centFT0C()};
@@ -135,11 +154,18 @@ struct EMEventSelection {
         return false;
       }
     }
+    vecEvSelBits[EventSelectionBits::kGoodCent]++;
 
     if (cfgRequireGoodRCT && !rctChecker.checkTable(collision)) {
       // LOGF(info, "rejected by RCT flag");
       return false;
     }
+    vecEvSelBits[EventSelectionBits::kGoodRCT]++;
+
+    if (cfgRequireSel8 && !collision.sel8()) {
+      return false;
+    }
+    vecEvSelBits[EventSelectionBits::kGoodSel8]++;
 
     return true;
   }
@@ -147,9 +173,14 @@ struct EMEventSelection {
   template <typename TCollisions>
   void processEventSelection(TCollisions const& collisions)
   {
+    // reset the event counter to zero for all elements
+    vecEvSelBits.assign(EventSelectionBits::kSize, 0);
+
     for (const auto& collision : collisions) {
       emevsel(isSelectedEvent(collision));
     } // end of collision loop
+    // Write event selection info at the end of DF
+    emevselbits(vecEvSelBits);
   } // end of process
 
   PROCESS_SWITCH_FULL(EMEventSelection, processEventSelection<MyCollisions>, processEventSelection, "event selection", true);


### PR DESCRIPTION
- Table is filled only once per DF to reduce output size. Essentially an event-normalization histogram that can then be loaded in the analysis task runnnig over derived data
- Allows to keep track of reject reasons for the events
- Should be extended for multiplicity dependent analyses