### PR TITLE
[PWGLF] Add alt. rotational BG and fix correction factors calculation

### DIFF
--- a/PWGLF/Tasks/Resonances/phianalysisTHnSparse.cxx
+++ b/PWGLF/Tasks/Resonances/phianalysisTHnSparse.cxx
@@ -746,7 +746,7 @@ struct PhianalysisTHnSparse {
   }
   PROCESS_SWITCH(PhianalysisTHnSparse, processQA, "Process Event for Data", true);
 
-  void processData(EventCandidate const& collision, TrackCandidates const& tracks)
+  void processData(EventCandidate const& collision, TrackCandidates const& /*tracks*/)
   {
     auto posDaughters = positive->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
     auto negDaughters = negative->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);

--- a/PWGLF/Tasks/Resonances/phianalysisTHnSparse.cxx
+++ b/PWGLF/Tasks/Resonances/phianalysisTHnSparse.cxx
@@ -162,7 +162,7 @@ struct PhianalysisTHnSparse {
   HistogramRegistry registry{"registry"};
   o2::analysis::rsn::Output* rsnOutput = nullptr;
 
-  Service<o2::framework::O2DatabasePDG> pdg;
+  Service<o2::framework::O2DatabasePDG> pdg{};
 
   float massPos = o2::track::PID::getMass(3);
   float massNeg = o2::track::PID::getMass(3);
@@ -553,12 +553,13 @@ struct PhianalysisTHnSparse {
     float tofNsigma = 0.0f;
     int particleType = (track.sign() > 0) ? static_cast<int>(daughterPos) : static_cast<int>(daughterNeg);
 
-    if (particleType == pion)
+    if (particleType == pion) {
       tofNsigma = track.tofNSigmaPi();
-    else if (particleType == kaon)
+    } else if (particleType == kaon) {
       tofNsigma = track.tofNSigmaKa();
-    else if (particleType == proton)
+    } else if (particleType == proton) {
       tofNsigma = track.tofNSigmaPr();
+    }
     return tofNsigma;
   }
   template <typename T>

--- a/PWGLF/Tasks/Resonances/phianalysisTHnSparse.cxx
+++ b/PWGLF/Tasks/Resonances/phianalysisTHnSparse.cxx
@@ -15,6 +15,7 @@
 
 #include "PWGLF/Utils/rsnOutput.h"
 
+#include "Common/CCDB/EventSelectionParams.h"
 #include "Common/DataModel/Centrality.h"
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/Multiplicity.h"
@@ -40,8 +41,9 @@
 #include <Framework/runDataProcessing.h>
 #include <ReconstructionDataFormats/PID.h>
 
-#include <Math/Vector4D.h> // IWYU pragma: keep (do not replace with Math/Vector4Dfwd.h)
-#include <Math/Vector4Dfwd.h>
+#include <Math/GenVector/AxisAngle.h>
+#include <Math/GenVector/Rotation3D.h>
+#include <Math/Vector4D.h>
 #include <TH1.h>
 #include <TH2.h>
 #include <TMath.h>
@@ -62,42 +64,47 @@ struct PhianalysisTHnSparse {
   SliceCache cache;
 
   struct : ConfigurableGroup {
-    Configurable<bool> produceQA{"produceQA", false, "Produce qa histograms."};
-    Configurable<bool> produceStats{"produceStats", false, "Produce statistics histograms."};
-    Configurable<bool> produceTrue{"produceTrue", false, "Produce True and Gen histograms."};
+    Configurable<bool> produceMC{"produceMC", false, "Produce True and Gen histograms."};
     Configurable<bool> produceLikesign{"produceLikesign", false, "Produce Like sign histograms."};
     Configurable<std::string> eventMixing{"eventMixing", "none", "Produce Event Mixing histograms of type."};
     Configurable<bool> produceRotational{"produceRotational", false, "Produce Rotational histograms."};
   } produce;
 
-  Configurable<int> daughterPos{"daughterPos", 3, "Particle type of the positive dauther according to ReconstructionDataFormats/PID.h (Default = Kaon)"};
-  Configurable<int> daughterNeg{"daughterNeg", 3, "Particle type of the negative dauther according to ReconstructionDataFormats/PID.h (Default = Kaon)"};
+  Configurable<int> daughterPos{"daughterPos", 3, "Particle type of the positive daughter according to ReconstructionDataFormats/PID.h (Default = Kaon)"};
+  Configurable<int> daughterNeg{"daughterNeg", 3, "Particle type of the negative daughter according to ReconstructionDataFormats/PID.h (Default = Kaon)"};
   Configurable<int> motherPDG{"motherPDG", 333, "PDG code of mother particle."};
-  Configurable<int> daughterPosPDG{"daughterPosPDG", 321, "PDG code of positive dauther particle."};
-  Configurable<int> daughterNegPDG{"daughterNegPDG", 321, "PDG code of negative dauther particle."};
+  Configurable<int> daughterPosPDG{"daughterPosPDG", 321, "PDG code of positive daughter particle."};
+  Configurable<int> daughterNegPDG{"daughterNegPDG", 321, "PDG code of negative daughter particle."};
 
   struct : ConfigurableGroup {
-    Configurable<float> tpcnSigmaPos{"tpcnSigmaPos", 3.0f, "TPC NSigma cut of the positive particle."};
-    Configurable<float> tpcnSigmaNeg{"tpcnSigmaNeg", 3.0f, "TPC NSigma cut of the negative particle."};
-    Configurable<bool> tpcPidOnly{"tpcPidOnly", false, "Use TPC only for PID."};
-    Configurable<float> combinedNSigma{"combinedNSigma", 3.0f, "Combined NSigma cut for combined TPC and TOF NSigma cut."};
-    Configurable<float> ptTOFThreshold{"ptTOFThreshold", 0.5f, "Threshold for applying TOF."};
-    Configurable<float> rapidity{"rapidity", 0.5f, "Rapidity cut (maximum)."};
-    Configurable<float> etatrack{"etatrack", 0.8f, "Eta cut for track."};
+    Configurable<bool> isTriggerTVX{"isTriggerTVX", false, "Apply IsTriggerTVX cut."};
+    Configurable<bool> noTimeFrameBorder{"noTimeFrameBorder", false, "Apply NoTimeFrameBorder cut."};
+    Configurable<bool> noITSROFrameBorder{"noITSROFrameBorder", false, "Apply NoITSROFrameBorder cut."};
+    Configurable<bool> sel8{"sel8", false, "Apply Sel8 cut."};
+    Configurable<bool> inelGt0{"inelGt0", false, "Select events with INEL>0."};
+    Configurable<float> vzCut{"vzCut", 10.0f, "Cut: Maximal value of Z vertex position."};
+    Configurable<bool> noSameBunchPileup{"noSameBunchPileup", false, "Apply no same bunch pileup cut."};
+    Configurable<bool> isVertexITSTPC{"isVertexITSTPC", false, "Apply IsVertexITSTPC cut."};
+    Configurable<bool> isGoodZvtxFT0vsPV{"isGoodZvtxFT0vsPV", false, "Apply IsGoodZvtxFT0vsPV cut."};
+  } eventCuts;
+
+  struct : ConfigurableGroup {
     Configurable<float> pt{"pt", 0.15f, "Cut: Minimal value of tracks pt."};
+    Configurable<float> etatrack{"etatrack", 1.0f, "Cut: Maximal value of tracks eta."};
     Configurable<float> dcaXY{"dcaXY", 1.0f, "Cut: Maximal value of tracks DCA XY."};
     Configurable<float> dcaZ{"dcaZ", 1.0f, "Cut: Maximal value of tracks DCA Z."};
-    Configurable<bool> globalTrack{"globalTrack", false, "Use global track selection."};
-    Configurable<bool> inelGrater0{"inelGrater0", true, "Select events with INEL>0."};
-    Configurable<int> tpcNClsFound{"tpcNClsFound", 70, "Cut: Minimal value of found TPC clasters"};
-    Configurable<float> vzCut{"vzCut", 10.0f, "Cut: Maximal value of Z vertex position."};
-  } cut;
-
-  struct : ConfigurableGroup {
-    Configurable<int> verboselevel{"verboselevel", 0, "Verbose level"};
-    Configurable<int> refresh{"refresh", 0, "Freqency of print event information."};
-    Configurable<int> refreshIndex{"refreshIndex", 0, "Freqency of print event information index."};
-  } verbose;
+    Configurable<float> tpcnSigmaPos{"tpcnSigmaPos", 10.0f, "Cut: Maximal value of TPC NSigma of the positive particle."};
+    Configurable<float> tpcnSigmaNeg{"tpcnSigmaNeg", 10.0f, "Cut: Maximal value of TPC NSigma of the negative particle."};
+    Configurable<bool> tpcPidOnly{"tpcPidOnly", false, "Use TPC only for PID."};
+    Configurable<float> combinedNSigma{"combinedNSigma", 3.0f, "Cut: Maximal value of NSigma for combined TPC and TOF NSigma cut."};
+    Configurable<float> ptTOFThreshold{"ptTOFThreshold", 0.5f, "Cut: Minimal value of tracks pt for using TOF PID."};
+    Configurable<int> tpcNClsFound{"tpcNClsFound", 155, "Cut: Minimal value of found TPC clusters"};
+    Configurable<int> tpcNClsCrossedRows{"tpcNClsCrossedRows", 155, "Cut: Minimal value of crossed rows in TPC"};
+    Configurable<bool> globalTrack{"globalTrack", false, "Use isGlobalTrack track selection."};
+    Configurable<bool> primaryTrack{"primaryTrack", false, "Use isPrimaryTrack track selection."};
+    Configurable<bool> pvContributor{"pvContributor", false, "Use isPVContributor track selection."};
+    Configurable<float> rapidity{"rapidity", 0.5f, "Cut: Maximal value of particle rapidity."};
+  } trackCuts;
 
   Configurable<std::vector<std::string>> sparseAxes{"sparseAxes", std::vector<std::string>{o2::analysis::rsn::pair_axis::names}, "Axes."};
   Configurable<std::vector<std::string>> sysAxes{"sysAxes", std::vector<std::string>{o2::analysis::rsn::systematic_axis::names}, "Axes."};
@@ -107,69 +114,68 @@ struct PhianalysisTHnSparse {
   ConfigurableAxis vzaxis{"vzaxis", {40, -20., 20.}, "Z vertex position axis binning."};
   ConfigurableAxis multiplicityaxis{"multiplicityaxis", {50, 0., 5000.}, "Multiplicity axis binning."};
   ConfigurableAxis centralityaxis{"centralityaxis", {20, 0., 100.}, "Centrality axis binning."};
-  ConfigurableAxis etaaxis{"etaaxis", {16., -1.0 * static_cast<float>(cut.etatrack), static_cast<float>(cut.etatrack)}, "Pseudorapidity axis binning."};
-  ConfigurableAxis rapidityaxis{"rapidityaxis", {10., -1.0 * static_cast<float>(cut.rapidity), static_cast<float>(cut.rapidity)}, "Rapidity axis binning."};
-  ConfigurableAxis nsigmaaxisPos{"nsigmaaxisPos", {1, -static_cast<float>(cut.tpcnSigmaPos), static_cast<float>(cut.tpcnSigmaPos)}, "NSigma of positive particle axis binning in THnSparse."};
-  ConfigurableAxis nsigmaaxisNeg{"nsigmaaxisNeg", {1, -static_cast<float>(cut.tpcnSigmaNeg), static_cast<float>(cut.tpcnSigmaNeg)}, "NSigma of negative particle axis binning in THnSparse."};
+  ConfigurableAxis etaaxis{"etaaxis", {16., -1.0 * static_cast<float>(trackCuts.etatrack), static_cast<float>(trackCuts.etatrack)}, "Pseudorapidity axis binning."};
+  ConfigurableAxis rapidityaxis{"rapidityaxis", {10., -1.0 * static_cast<float>(trackCuts.rapidity), static_cast<float>(trackCuts.rapidity)}, "Rapidity axis binning."};
+  ConfigurableAxis nsigmaaxisPos{"nsigmaaxisPos", {1, -static_cast<float>(trackCuts.tpcnSigmaPos), static_cast<float>(trackCuts.tpcnSigmaPos)}, "NSigma of positive particle axis binning in THnSparse."};
+  ConfigurableAxis nsigmaaxisNeg{"nsigmaaxisNeg", {1, -static_cast<float>(trackCuts.tpcnSigmaNeg), static_cast<float>(trackCuts.tpcnSigmaNeg)}, "NSigma of negative particle axis binning in THnSparse."};
 
   // mixing
-  using BinningTypeVzMu = ColumnBinningPolicy<aod::collision::PosZ, aod::mult::MultFV0M<aod::mult::MultFV0A, aod::mult::MultFV0C>>;
+  using BinningTypeVzMu = ColumnBinningPolicy<aod::collision::PosZ, aod::mult::MultFT0M<aod::mult::MultFT0A, aod::mult::MultFT0C>>;
   using BinningTypeVzCe = ColumnBinningPolicy<aod::collision::PosZ, aod::cent::CentFT0M>;
-  Configurable<int> numberofMixedEvents{"numberofMixedEvents", 5, "Number of events that should be mixed."};
+  Configurable<int> nMixedEvents{"nMixedEvents", 5, "Number of events that should be mixed."};
   ConfigurableAxis axisVertexMixing{"axisVertexMixing", {5, -10, 10}, "Z vertex axis binning for mixing"};
-  ConfigurableAxis axisMultiplicityMixing{"axisMultiplicityMixing", {5, 0, 5000}, "TPC multiplicity for bin"};
-  ConfigurableAxis axisCentralityMixing{"axisCentralityMixing", {10, 0, 100}, "Multiplicity percentil binning for mixing"};
+  ConfigurableAxis axisMultiplicityMixing{"axisMultiplicityMixing", {5, 0, 5000}, "FT0M amplitude binning for event mixing."};
+  ConfigurableAxis axisCentralityMixing{"axisCentralityMixing", {10, 0, 100}, "FT0M centrality percentile binning for event mixing."};
 
   // rotational
-  Configurable<int> numberofRotations{"numberofRotations", 1, "Number of rotations for rotational background estimation."};
+  Configurable<int> nRotations{"nRotations", 1, "Number of rotations for rotational background estimation."};
   Configurable<int> startingAngle{"startingAngle", 0, "Starting angle for rotational background estimation."};
 
   // other axes
-  ConfigurableAxis axisNch{"axisNch", {1000, 0.0f, +1000.0f}, "Number of charged particles."};
-  ConfigurableAxis axisResolutionPt{"axisResolutionPt", {1001, -1.0f, +1.0f}, "Resolution of Pt."};
-  ConfigurableAxis axisResolutionPtPhi{"axisResolutionPtPhi", {1001, -0.01f, +0.01f}, "Resolution of Pt and Phi."};
-  ConfigurableAxis axisResolutionMass{"axisResolutionMass", {1001, -0.01f, +0.01f}, "Resolution of Mass."};
-  ConfigurableAxis axisResolutionVz{"axisResolutionVz", {1001, -3.0f, +3.0f}, "Resolution of Vz."};
-  ConfigurableAxis massShiftAxis{"massShiftAxis", {1001, -0.02f, 0.02f}, "Mass correction axis."};
+  ConfigurableAxis axisNch{"axisNch", {1000, 0.0, +1000.0}, "Number of charged particles."};
+  ConfigurableAxis axisResolutionPt{"axisResolutionPt", {1001, -1.0, +1.0}, "Resolution of Pt."};
+  ConfigurableAxis axisResolutionPtPhi{"axisResolutionPtPhi", {1001, -0.01, +0.01}, "Resolution of Pt and Phi."};
+  ConfigurableAxis axisResolutionMass{"axisResolutionMass", {1001, -0.01, +0.01}, "Resolution of Mass."};
+  ConfigurableAxis axisResolutionVz{"axisResolutionVz", {1001, -3.0, +3.0}, "Resolution of Vz."};
+  ConfigurableAxis axisQAPt{"axisQAPt", {15, 0.0, 15.0}, "QA Pt axis binning."};
+  ConfigurableAxis axisQAMult{"axisQAMult", {10, 0.0, 100.0}, "QA Multiplicity axis binning."};
+  ConfigurableAxis axisQACent{"axisQACent", {101, 0.0f, 101.0f}, "QA Centrality axis binning."};
 
   // Axes specifications
-  AxisSpec posZaxis = {400, -20., 20., "V_{z} (cm)"};
-  AxisSpec dcaXYaxis = {1000, -1.0, 1.0, "DCA_{xy} (cm)"};
-  AxisSpec dcaZaxis = {1000, -1.0, 1.0, "DCA_{z} (cm)"};
-  AxisSpec etaQAaxis = {1000, -1.0, 1.0, "#eta"};
-  AxisSpec tpcNClsFoundQAaxis = {110, 50., 160., "tpcNClsFound"};
-  AxisSpec massShiftRelAxis = {101, -0.03f, 0.03f, ""};
+  AxisSpec vzQAaxis = {200, -20., 20., "V_{z} (cm)"};
+  AxisSpec dcaXYQAaxis = {200, -0.5, 0.5, "DCA_{xy} (cm)"};
+  AxisSpec dcaZQAaxis = {200, -0.5, 0.5, "DCA_{z} (cm)"};
+  AxisSpec etaQAaxis = {200, -1.0, 1.0, "#eta"};
+  AxisSpec rapidityQAaxis = {200, -1.0, 1.0, "y"};
+  AxisSpec tpcNClsQAaxis = {200, 0., 200., "TPC NClusters"};
+  AxisSpec nSigmaTPCQAaxis = {200, -10., 10., "n#sigma_{TPC} K^{#pm}"};
+  AxisSpec nSigmaTOFQAaxis = {200, -10., 10., "n#sigma_{TOF} K^{#pm}"};
+  AxisSpec pQAaxis = {1490, 0.1, 15.0, "p (GeV/c)"};
+  AxisSpec dEdxQAaxis = {2000, 0., 200., "dE/dx (a.u.)"};
+  AxisSpec betaQAaxis = {700, 0.5, 1.2, "#beta"};
+  AxisSpec dPhiQAaxis = {100, -o2::constants::math::TwoPI, o2::constants::math::TwoPI, "#Delta#phi (rad)"};
+  AxisSpec dThetaQAaxis = {100, -o2::constants::math::PI, o2::constants::math::PI, "#Delta#theta (rad)"};
+  AxisSpec dEtaQAaxis = {200, -1.0, 1.0, "#Delta#eta"};
 
   HistogramRegistry registry{"registry"};
   o2::analysis::rsn::Output* rsnOutput = nullptr;
 
   Service<o2::framework::O2DatabasePDG> pdg;
 
-  int n = 0;
   float massPos = o2::track::PID::getMass(3);
   float massNeg = o2::track::PID::getMass(3);
   int pion = 2;
   int kaon = 3;
   int proton = 4;
   double* pointPair = nullptr;
-  double* pointSys = nullptr;
   ROOT::Math::PxPyPzMVector d1, d2, mother, motherGen;
-  bool produceTrue, produceLikesign, produceQA, produceStats, produceRotational, dataQA, MCTruthQA, globalTrack, inelGrater0, tpcPidOnly = false;
-  float tpcnSigmaPos = 100.0f;
-  float tpcnSigmaNeg = 100.0f;
-  float combinedNSigma = 100.0f;
-  float ptTOFThreshold = 0.5f;
-  int tpcNClsFound = 70;
+  bool dataQA = false;
   int dauSize = 2;
-  float vzCut = 10.0f;
   rsn::MixingType mixingType = rsn::MixingType::none;
-
-  Filter triggerFilter = (o2::aod::evsel::sel8 == true);
-  Filter vtxFilter = (nabs(o2::aod::collision::posZ) < vzCut);
 
   using EventCandidates = soa::Join<aod::Collisions, aod::EvSels, aod::Mults, aod::PVMults, aod::CentFT0Ms>;
   using EventCandidate = EventCandidates::iterator;
-  using TrackCandidates = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection, aod::pidTPCFullKa, aod::pidTOFFullKa, aod::pidTPCFullPi, aod::pidTOFFullPi, aod::pidTPCFullPr, aod::pidTOFFullPr>;
+  using TrackCandidates = soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::TrackSelection, aod::pidTPCFullKa, aod::pidTOFFullKa, aod::pidTPCFullPi, aod::pidTOFFullPi, aod::pidTPCFullPr, aod::pidTOFFullPr, aod::pidTOFbeta>;
 
   using EventCandidatesMC = soa::Join<EventCandidates, aod::McCollisionLabels>;
   using TrackCandidatesMC = soa::Join<TrackCandidates, aod::McTrackLabels>;
@@ -194,13 +200,18 @@ struct PhianalysisTHnSparse {
     LOGF(info, "  Positive: %d, mass: %f", static_cast<int>(daughterPos), massPos);
     LOGF(info, "  Negative: %d, mass: %f", static_cast<int>(daughterNeg), massNeg);
 
+    AxisSpec centQAAxis = {axisQACent, "FT0M (%)"};
+    AxisSpec nchQAAxis = {axisNch, "N_{ch}"};
+    AxisSpec multQAAxis = {axisQAMult, "FT0M (%)"};
+    AxisSpec ptQAAxis = {axisQAPt, "p_{T} (GeV/c)"};
+
     // Sparse axes
     AxisSpec invAxis = {invaxis, "Inv. mass (GeV/c^{2})", "im"};
     AxisSpec ptAxis = {ptaxis, "p_{T} (GeV/c)", "pt"};
-    AxisSpec muAxis = {multiplicityaxis, "N", "mu"};
-    AxisSpec mumAxis = {multiplicityaxis, "N", "mum"};
-    AxisSpec ceAxis = {centralityaxis, "N", "ce"};
-    AxisSpec cemAxis = {centralityaxis, "N", "cem"};
+    AxisSpec muAxis = {multiplicityaxis, "FT0M (Ampl.)", "mu"};
+    AxisSpec mumAxis = {multiplicityaxis, "FT0M (Ampl.)", "mum"};
+    AxisSpec ceAxis = {centralityaxis, "FT0M (%)", "ce"};
+    AxisSpec cemAxis = {centralityaxis, "FT0M (%)", "cem"};
     AxisSpec etaAxis = {etaaxis, "#eta", "eta"};
     AxisSpec yAxis = {rapidityaxis, "y", "y"};
     AxisSpec nsAxisPos = {nsigmaaxisPos, fmt::format("nSigma of positive particle ({})", massPos), "ns1"};
@@ -216,55 +227,43 @@ struct PhianalysisTHnSparse {
     std::vector<AxisSpec> allAxes = {invAxis, ptAxis, muAxis, ceAxis, nsAxisPos, nsAxisNeg, etaAxis, yAxis, vzAxis, mumAxis, cemAxis, vzmAxis};
     std::vector<AxisSpec> allAxesSys = {tpcNClsFoundAxis};
 
-    produceQA = static_cast<bool>(produce.produceQA);
-    produceStats = static_cast<bool>(produce.produceStats);
-    produceTrue = static_cast<bool>(produce.produceTrue);
-    produceLikesign = static_cast<bool>(produce.produceLikesign);
     mixingType = rsn::mixingTypeName(static_cast<std::string>(produce.eventMixing));
-    produceRotational = static_cast<bool>(produce.produceRotational);
-    tpcnSigmaPos = static_cast<float>(cut.tpcnSigmaPos);
-    tpcnSigmaNeg = static_cast<float>(cut.tpcnSigmaNeg);
-    tpcNClsFound = static_cast<int>(cut.tpcNClsFound);
-    globalTrack = static_cast<bool>(cut.globalTrack);
-    inelGrater0 = static_cast<bool>(cut.inelGrater0);
-    combinedNSigma = static_cast<float>(cut.combinedNSigma);
-    tpcPidOnly = static_cast<bool>(cut.tpcPidOnly);
-    ptTOFThreshold = static_cast<float>(cut.ptTOFThreshold);
-    vzCut = static_cast<float>(cut.vzCut);
 
     pointPair = new double[static_cast<int>(o2::analysis::rsn::PairAxisType::unknown)];
-    pointSys = new double[static_cast<int>(o2::analysis::rsn::SystematicsAxisType::unknown)];
     rsnOutput = new o2::analysis::rsn::OutputSparse();
-    rsnOutput->init(sparseAxes, allAxes, sysAxes, allAxesSys, produceTrue, mixingType, produceLikesign, produceRotational, &registry);
+    rsnOutput->init(sparseAxes, allAxes, sysAxes, allAxesSys, static_cast<bool>(produce.produceMC), mixingType, static_cast<bool>(produce.produceLikesign), static_cast<bool>(produce.produceRotational), &registry);
 
     // Print summary of configuration
     LOGF(info, "=== PhianalysisTHnSparse configuration summary ===");
-    LOGF(info, "produceQA: %s", produceQA ? "true" : "false");
-    LOGF(info, "produceStats: %s", produceStats ? "true" : "false");
-    LOGF(info, "produceTrue: %s", static_cast<bool>(produce.produceTrue) ? "true" : "false");
+    LOGF(info, "produceMC: %s", static_cast<bool>(produce.produceMC) ? "true" : "false");
     LOGF(info, "produceLikesign: %s", static_cast<bool>(produce.produceLikesign) ? "true" : "false");
     LOGF(info, "produceRotational: %s", static_cast<bool>(produce.produceRotational) ? "true" : "false");
     LOGF(info, "eventMixing: %s", static_cast<std::string>(produce.eventMixing).c_str());
+    LOGF(info, "inelGt0: %s", static_cast<bool>(eventCuts.inelGt0) ? "true" : "false");
+    LOGF(info, "noSameBunchPileup: %s", static_cast<bool>(eventCuts.noSameBunchPileup) ? "true" : "false");
+    LOGF(info, "isVertexITSTPC: %s", static_cast<bool>(eventCuts.isVertexITSTPC) ? "true" : "false");
+    LOGF(info, "isGoodZvtxFT0vsPV: %s", static_cast<bool>(eventCuts.isGoodZvtxFT0vsPV) ? "true" : "false");
+    LOGF(info, "vzCut: %.2f", static_cast<float>(eventCuts.vzCut));
     LOGF(info, "daughterPos: %d (PDG: %d)", static_cast<int>(daughterPos), static_cast<int>(daughterPosPDG));
     LOGF(info, "daughterNeg: %d (PDG: %d)", static_cast<int>(daughterNeg), static_cast<int>(daughterNegPDG));
     LOGF(info, "motherPDG: %d", static_cast<int>(motherPDG));
-    LOGF(info, "tpcnSigmaPos: %.2f", tpcnSigmaPos);
-    LOGF(info, "tpcnSigmaNeg: %.2f", tpcnSigmaNeg);
-    LOGF(info, "tpcPidOnly: %s", tpcPidOnly ? "true" : "false");
-    LOGF(info, "combinedNSigma: %.2f", combinedNSigma);
-    LOGF(info, "ptTOFThreshold: %.2f", ptTOFThreshold);
-    LOGF(info, "rapidity: %.2f", static_cast<float>(cut.rapidity));
-    LOGF(info, "etatrack: %.2f", static_cast<float>(cut.etatrack));
-    LOGF(info, "pt (min): %.2f", static_cast<float>(cut.pt));
-    LOGF(info, "dcaXY: %.2f", static_cast<float>(cut.dcaXY));
-    LOGF(info, "dcaZ: %.2f", static_cast<float>(cut.dcaZ));
-    LOGF(info, "globalTrack: %s", globalTrack ? "true" : "false");
-    LOGF(info, "inelGrater0: %s", inelGrater0 ? "true" : "false");
-    LOGF(info, "tpcNClsFound: %d", tpcNClsFound);
-    LOGF(info, "vzCut: %.2f", vzCut);
-    LOGF(info, "mixingType: %d", static_cast<int>(mixingType));
-    LOGF(info, "numberofMixedEvents: %d", static_cast<int>(numberofMixedEvents));
-    LOGF(info, "numberofRotations: %d", static_cast<int>(numberofRotations));
+    LOGF(info, "pt (min): %.2f", static_cast<float>(trackCuts.pt));
+    LOGF(info, "eta (max): %.2f", static_cast<float>(trackCuts.etatrack));
+    LOGF(info, "dcaXY: %.2f", static_cast<float>(trackCuts.dcaXY));
+    LOGF(info, "dcaZ: %.2f", static_cast<float>(trackCuts.dcaZ));
+    LOGF(info, "tpcnSigmaPos: %.2f", static_cast<float>(trackCuts.tpcnSigmaPos));
+    LOGF(info, "tpcnSigmaNeg: %.2f", static_cast<float>(trackCuts.tpcnSigmaNeg));
+    LOGF(info, "tpcPidOnly: %s", static_cast<bool>(trackCuts.tpcPidOnly) ? "true" : "false");
+    LOGF(info, "combinedNSigma: %.2f", static_cast<float>(trackCuts.combinedNSigma));
+    LOGF(info, "ptTOFThreshold: %.2f", static_cast<float>(trackCuts.ptTOFThreshold));
+    LOGF(info, "tpcNClsFound: %d", static_cast<int>(trackCuts.tpcNClsFound));
+    LOGF(info, "tpcNClsCrossedRows: %d", static_cast<int>(trackCuts.tpcNClsCrossedRows));
+    LOGF(info, "globalTrack: %s", static_cast<bool>(trackCuts.globalTrack) ? "true" : "false");
+    LOGF(info, "primaryTrack: %s", static_cast<bool>(trackCuts.primaryTrack) ? "true" : "false");
+    LOGF(info, "pvContributor: %s", static_cast<bool>(trackCuts.pvContributor) ? "true" : "false");
+    LOGF(info, "rapidity: %.2f", static_cast<float>(trackCuts.rapidity));
+    LOGF(info, "nMixedEvents: %d", static_cast<int>(nMixedEvents));
+    LOGF(info, "nRotations: %d", static_cast<int>(nRotations));
     LOGF(info, "startingAngle: %d", static_cast<int>(startingAngle));
     LOGF(info, "sparseAxes: ");
     for (const auto& axis : static_cast<std::vector<std::string>>(sparseAxes)) {
@@ -276,210 +275,244 @@ struct PhianalysisTHnSparse {
     }
     LOGF(info, "===============================================");
 
-    if (produceQA) {
-      // Event QA
-      registry.add("QAEvent/hSelection", "Event selection statistics", kTH1D, {{4, 0.0f, 4.0f}});
-      auto hEvent = registry.get<TH1>(HIST("QAEvent/hSelection"));
+    // ------------------- Event QA -------------------
+    registry.add("QA/Event/hSelection", "Event selection statistics", kTH1D, {{11, 0.0f, 11.0f}});
+    auto hEvent = registry.get<TH1>(HIST("QA/Event/hSelection"));
+    hEvent->GetXaxis()->SetBinLabel(1, "all events");
+    hEvent->GetXaxis()->SetBinLabel(2, "isTriggerTVX");
+    hEvent->GetXaxis()->SetBinLabel(3, "noTimeFrameBorder");
+    hEvent->GetXaxis()->SetBinLabel(4, "noITSROFrameBorder");
+    hEvent->GetXaxis()->SetBinLabel(5, "sel8");
+    hEvent->GetXaxis()->SetBinLabel(6, "IsVertexITSTPC");
+    hEvent->GetXaxis()->SetBinLabel(7, "noSameBunchPileup");
+    hEvent->GetXaxis()->SetBinLabel(8, "IsGoodZvtxFT0vsPV");
+    hEvent->GetXaxis()->SetBinLabel(9, Form("|V_{z}| < %0.0f cm", static_cast<float>(eventCuts.vzCut)));
+    hEvent->GetXaxis()->SetBinLabel(10, "INEL");
+    hEvent->GetXaxis()->SetBinLabel(11, "INEL>0");
+    hEvent->SetMinimum(0.1);
 
-      hEvent->GetXaxis()->SetBinLabel(1, "all events");
-      hEvent->GetXaxis()->SetBinLabel(2, "Events passing trigger sel8");
-      hEvent->GetXaxis()->SetBinLabel(3, "Events passing |V_{z}| cut");
-      hEvent->GetXaxis()->SetBinLabel(4, "Events passing INEL>0 cut");
-      hEvent->SetMinimum(0.1);
+    registry.add("QA/Event/hVtxZ", "Vertex position along the z-axis", kTH1F, {vzQAaxis});
+    auto hVtxZ = registry.get<TH1>(HIST("QA/Event/hVtxZ"));
 
-      registry.add("QAEvent/hVtxZ", "Vertex position along the z-axis", kTH1F, {posZaxis});
-      registry.add("QAEvent/hCent", "Distribution of multiplicity percentile", kTH1F, {{101, 0., 101.}});
-      registry.add("QAEvent/hMult", "Multiplicity (amplitude of non-zero channels in the FT0A + FT0C) ", kTH1F, {{300, 0., 30000.}});
+    registry.add("QA/Event/hCent", "FT0M (%)", kTH1F, {{101, 0., 101.}});
+    auto hCent = registry.get<TH1>(HIST("QA/Event/hCent"));
+    hCent->GetXaxis()->SetTitle("FT0M (%)");
 
-      // Track QA
-      registry.add("QATrack/hSelection", "Tracks statistics", kTH1D, {{9, 0.0f, 9.0f}});
-      auto hTrack = registry.get<TH1>(HIST("QATrack/hSelection"));
-      hTrack->GetXaxis()->SetBinLabel(1, "all tracks");
-      hTrack->GetXaxis()->SetBinLabel(2, "passed pT cut");
-      hTrack->GetXaxis()->SetBinLabel(3, "passed eta cut");
-      hTrack->GetXaxis()->SetBinLabel(4, "passed DCA cut");
-      hTrack->GetXaxis()->SetBinLabel(5, "passed PID cut");
-      hTrack->GetXaxis()->SetBinLabel(6, "passed tpcNClsFound cut");
-      hTrack->GetXaxis()->SetBinLabel(7, "passed isPrimaryTrack cut");
-      hTrack->GetXaxis()->SetBinLabel(8, "passed isPVContributor cut");
-      hTrack->GetXaxis()->SetBinLabel(9, "passed all cuts");
-      hTrack->SetMinimum(0.1);
+    registry.add("QA/Event/hMult", "Amplitude of non-zero channels in the FT0A + FT0C) ", kTH1F, {{300, 0., 30000.}});
+    auto hMult = registry.get<TH1>(HIST("QA/Event/hMult"));
+    hMult->GetXaxis()->SetTitle("FT0M Ampl.");
 
-      registry.add("QATrack/hRapidity", "Rapidity distribution of K^{+} and K^{-}", kTH1F, {{200, -1, 1}});
-      registry.add("QATrack/hEta", "Pseudorapidity distribution of K^{+} and K^{-}", kTH1F, {{200, -1, 1}});
-      registry.add("QATrack/hTPCNClsFound", "Distribution of TPC NClsFound of K^{+} and K^{-}", kTH1F, {tpcNClsFoundQAaxis});
-      registry.add("QATrack/hDCAxy", "Distribution of DCA_{xy} of K^{+} and K^{-}", kTH1F, {dcaXYaxis});
-      registry.add("QATrack/hDCAz", "Distribution of DCA_{z} of K^{+} and K^{-}", kTH1F, {dcaZaxis});
-      registry.add("QATrack/hPt", "Distribution of p_{T} of K^{+} and K^{-}", kTH1F, {ptaxis});
+    registry.add("QA/Event/hCentNch", "Event centrality vs multiplicity", kTH2F, {centQAAxis, nchQAAxis});
 
-      // Phi candidate QA
-      registry.add("QAPhi/hRapidity", "Rapidity distribution of #Phi candidates", kTH1F, {{200, -1, 1}});
-      registry.add("QAPhi/hEta", "Pseudorapidity distribution of #Phi candidates", kTH1F, {{200, -1, 1}});
-      registry.add("QAPhi/hdPhi", "Azimuthal distribution (#Delta#phi) of #Phi candidates", kTH1F, {{100, -o2::constants::math::TwoPI, o2::constants::math::TwoPI}});
-      auto hdPhi = registry.get<TH1>(HIST("QAPhi/hdPhi"));
-      hdPhi->GetXaxis()->SetTitle("#Delta#phi (rad)");
+    // ----------------------- Track QA -----------------------
+    registry.add("QA/Track/hSelection", "Track selection statistics", kTH1D, {{9, 0.0f, 9.0f}});
+    auto hTrack = registry.get<TH1>(HIST("QA/Track/hSelection"));
+    hTrack->GetXaxis()->SetBinLabel(1, "all tracks");
+    hTrack->GetXaxis()->SetBinLabel(2, Form("pT > %.2f", static_cast<float>(trackCuts.pt)));
+    hTrack->GetXaxis()->SetBinLabel(3, Form("eta < %.1f", static_cast<float>(trackCuts.etatrack)));
+    hTrack->GetXaxis()->SetBinLabel(4, "DCA cuts");
+    hTrack->GetXaxis()->SetBinLabel(5, "PID cuts");
+    hTrack->GetXaxis()->SetBinLabel(6, Form("tpcNClsFound > %d", static_cast<int>(trackCuts.tpcNClsFound)));
+    hTrack->GetXaxis()->SetBinLabel(7, Form("tpcNClsCrossedRows > %d", static_cast<int>(trackCuts.tpcNClsCrossedRows)));
+    hTrack->GetXaxis()->SetBinLabel(8, Form("%s", static_cast<bool>(trackCuts.globalTrack) ? "isGlobalTrack" : "isPrimaryTrack"));
+    hTrack->GetXaxis()->SetBinLabel(9, "isPVContributor");
+    hTrack->SetMinimum(0.1);
 
-      registry.add("QAPhi/h2dPhiPt", "Azimuthal distribution (#Delta#phi) of #Phi candidates vs p_{T}", kTH2F, {ptaxis, {100, -o2::constants::math::TwoPI, o2::constants::math::TwoPI}});
-      auto h2dPhiPt = registry.get<TH2>(HIST("QAPhi/h2dPhiPt"));
-      h2dPhiPt->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-      h2dPhiPt->GetYaxis()->SetTitle("#Delta#phi (rad)");
+    registry.add("QA/Track/hRapidity", "Rapidity distribution of Tracks", kTH3F, {ptQAAxis, multQAAxis, rapidityQAaxis});
+    registry.add("QA/Track/hEta", "Pseudorapidity distribution of Tracks", kTH3F, {ptQAAxis, multQAAxis, etaQAaxis});
+    registry.add("QA/Track/hTPCNClsFound", "Number of found TPC clusters of Tracks", kTH3F, {ptQAAxis, multQAAxis, tpcNClsQAaxis});
+    registry.add("QA/Track/hTPCNClsCrossedRows", "Number of crossed rows in TPC of Tracks", kTH3F, {ptQAAxis, multQAAxis, tpcNClsQAaxis});
+    registry.add("QA/Track/hDCAxy", "Distribution of DCA_{xy} of Tracks", kTH3F, {ptQAAxis, multQAAxis, dcaXYQAaxis});
+    registry.add("QA/Track/hDCAz", "Distribution of DCA_{z} of Tracks", kTH3F, {ptQAAxis, multQAAxis, dcaZQAaxis});
+    registry.add("QA/Track/hPt", "Distribution of p_{T} of Tracks", kTH2F, {ptQAAxis, multQAAxis});
 
-      registry.add("QAPhi/hTheta", "Polar distribution of #Phi candidates", kTH1F, {{100, 0.0f, o2::constants::math::PI}});
-      auto hTheta = registry.get<TH1>(HIST("QAPhi/hTheta"));
-      hTheta->GetXaxis()->SetTitle("#theta (rad)");
+    registry.add("QA/Kaon/hRapidity", "Rapidity distribution of K^{+} and K^{-}", kTH3F, {ptQAAxis, multQAAxis, rapidityQAaxis});
+    registry.add("QA/Kaon/hEta", "Pseudorapidity distribution of K^{+} and K^{-}", kTH3F, {ptQAAxis, multQAAxis, etaQAaxis});
+    registry.add("QA/Kaon/hTPCNClsFound", "Number of found TPC clusters of K^{+} and K^{-}", kTH3F, {ptQAAxis, multQAAxis, tpcNClsQAaxis});
+    registry.add("QA/Kaon/hTPCNClsCrossedRows", "Number of crossed rows in TPC of K^{+} and K^{-}", kTH3F, {ptQAAxis, multQAAxis, tpcNClsQAaxis});
+    registry.add("QA/Kaon/hDCAxy", "Distribution of DCA_{xy} of K^{+} and K^{-}", kTH3F, {ptQAAxis, multQAAxis, dcaXYQAaxis});
+    registry.add("QA/Kaon/hDCAz", "Distribution of DCA_{z} of K^{+} and K^{-}", kTH3F, {ptQAAxis, multQAAxis, dcaZQAaxis});
+    registry.add("QA/Kaon/hPt", "Distribution of p_{T} of K^{+} and K^{-}", kTH2F, {ptQAAxis, multQAAxis});
 
-      registry.add("QAPhi/h2dThetaPt", "Polar distribution (#Delta#theta) of #Phi candidates vs p_{T}", kTH2F, {ptaxis, {100, -o2::constants::math::PI, o2::constants::math::PI}});
+    // ---------------------- PID QA ----------------------
 
-      auto h2dThetaPt = registry.get<TH2>(HIST("QAPhi/h2dThetaPt"));
-      h2dThetaPt->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-      h2dThetaPt->GetYaxis()->SetTitle("#Delta#theta (rad)");
+    registry.add("QA/PID/hTPCNSigma", "Distribution of TPC nSigma", kTH3F, {ptQAAxis, multQAAxis, nSigmaTPCQAaxis});
+    registry.add("QA/PID/hTPCNSigmaK", "Distribution of TPC nSigma of K^{+} and K^{-}", kTH3F, {ptQAAxis, multQAAxis, nSigmaTPCQAaxis});
+    registry.add("QA/PID/hTOFNSigma", "Distribution of TOF nSigma", kTH3F, {ptQAAxis, multQAAxis, nSigmaTOFQAaxis});
+    registry.add("QA/PID/hTOFNSigmaK", "Distribution of TOF nSigma of K^{+} and K^{-}", kTH3F, {ptQAAxis, multQAAxis, nSigmaTOFQAaxis});
+    registry.add("QA/PID/hTPCTOFnSigma", "", kTH3F, {ptQAAxis, nSigmaTPCQAaxis, nSigmaTOFQAaxis});
 
-      // Rotational background QA
-      if (produceRotational) {
-        registry.add("QARotational/hRapidity", "Rapidity distribution of #Phi candidates from rotational background", kTH1F, {{200, -1, 1}});
-        registry.add("QARotational/hEta", "Pseudorapidity distribution of #Phi candidates from rotational background", kTH1F, {{200, -1, 1}});
-        registry.add("QARotational/hdPhi", "Rotational background: Azimuthal distribution (#Delta#phi)", kTH1F, {{100, -o2::constants::math::TwoPI, o2::constants::math::TwoPI}});
-        auto hRPhi = registry.get<TH1>(HIST("QARotational/hdPhi"));
-        hRPhi->GetXaxis()->SetTitle("#Delta#phi");
+    registry.add("QA/PID/hTPCdEdxP", "dE/dx vs p of charged particles", kTH2F, {pQAaxis, dEdxQAaxis});
+    registry.add("QA/PID/hTPCdEdxPK", "dE/dx vs p of K^{+} and K^{-}", kTH2F, {pQAaxis, dEdxQAaxis});
+    registry.add("QA/PID/hTOFBetaP", "TOF #beta vs p of charged particles", kTH2F, {pQAaxis, betaQAaxis});
+    registry.add("QA/PID/hTOFBetaPK", "TOF #beta vs p of K^{+} and K^{-}", kTH2F, {pQAaxis, betaQAaxis});
 
-        registry.add("QARotational/h2dPhiPt", "Rotational background: Azimuthal distribution (#Delta#phi) vs p_{T}", kTH2F, {ptaxis, {100, -o2::constants::math::TwoPI, o2::constants::math::TwoPI}});
-        auto hR2dPhiPt = registry.get<TH2>(HIST("QARotational/h2dPhiPt"));
-        hR2dPhiPt->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-        hR2dPhiPt->GetYaxis()->SetTitle("#Delta#phi");
+    // ------------------------- MC QA -------------------------
+    if (static_cast<bool>(produce.produceMC)) {
+      // Rec
+      registry.add("QAMC/Rec/hSelection", "MC Rec True Event statistics", kTH1F, {{2, 0.0f, 2.0f}});
+      auto hMCEventTruth = registry.get<TH1>(HIST("QAMC/Rec/hSelection"));
+      hMCEventTruth->GetXaxis()->SetBinLabel(1, "Full MC Rec event statistics");
+      hMCEventTruth->GetXaxis()->SetBinLabel(2, "MC Rec events passing event selection");
+      hMCEventTruth->SetMinimum(0.1);
 
-        registry.add("QARotational/hTheta", "Rotational background: Polar distribution (#theta)", kTH1F, {{100, 0.0f, o2::constants::math::PI}});
-        auto hRdTheta = registry.get<TH1>(HIST("QARotational/hTheta"));
-        hRdTheta->GetXaxis()->SetTitle("#theta (rad)");
+      // Gen
+      registry.add("QAMC/Gen/hSelection", "MC Gen Event statistics", kTH1F, {{3, 0.0f, 3.0f}});
+      auto hMCEventGen = registry.get<TH1>(HIST("QAMC/Gen/hSelection"));
+      hMCEventGen->GetXaxis()->SetBinLabel(1, "Generated collisions");
+      hMCEventGen->GetXaxis()->SetBinLabel(2, "Generated collisions with at least one reconstructed collision");
+      hMCEventGen->GetXaxis()->SetBinLabel(3, "Generated collisions passing event selection");
+      hMCEventGen->SetMinimum(0.1);
 
-        registry.add("QARotational/h2dThetaPt", "Rotational background: Polar distribution (#Delta#theta) vs p_{T}", kTH2F, {ptaxis, {100, -o2::constants::math::PI, o2::constants::math::PI}});
-        auto hR2dThetaPt = registry.get<TH2>(HIST("QARotational/h2dThetaPt"));
-        hR2dThetaPt->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-        hR2dThetaPt->GetYaxis()->SetTitle("#Delta#theta");
-      }
+      // Factors
+      registry.add("QAMC/Factors/hGenEvents", "Generated events", HistType::kTH2F, {nchQAAxis, {4, 0, 4}});
+      auto hGenEvents = registry.get<TH2>(HIST("QAMC/Factors/hGenEvents"));
+      hGenEvents->GetYaxis()->SetBinLabel(1, "All generated events");
+      hGenEvents->GetYaxis()->SetBinLabel(2, "All reconstructed events");
+      hGenEvents->GetYaxis()->SetBinLabel(3, "Generated events with at least one reconstructed event");
+      hGenEvents->GetYaxis()->SetBinLabel(4, "Generated events passing event selection");
 
-      // Mixing QA
-      if (mixingType != rsn::MixingType::none) {
-        registry.add("QAMixing/hSelection", "Event mixing selection statistics", kTH1D, {{1, 0.0f, 1.0f}});
-        auto hEM = registry.get<TH1>(HIST("QAMixing/hSelection"));
-        hEM->GetXaxis()->SetBinLabel(1, "Full event mixing statistics");
-        hEM->SetMinimum(0.1);
+      registry.add("QAMC/Factors/hRecEvents", "Reconstructed events", HistType::kTH2F, {centQAAxis, {2, 0, 2}});
+      auto hRecEvents = registry.get<TH2>(HIST("QAMC/Factors/hRecEvents"));
+      hRecEvents->GetYaxis()->SetBinLabel(1, "All reconstructed events");
+      hRecEvents->GetYaxis()->SetBinLabel(2, "Passing event selection");
 
-        registry.add("QAMixing/h2mu1_mu2", "Event Mixing Multiplicity", kTH2F, {axisMultiplicityMixing, axisMultiplicityMixing});
-        auto h2EMmu = registry.get<TH2>(HIST("QAMixing/h2mu1_mu2"));
-        h2EMmu->GetXaxis()->SetTitle("1.Event multiplicity");
-        h2EMmu->GetYaxis()->SetTitle("2.Event multiplicity");
+      registry.add("QAMC/Factors/hGenALORESelEvents", "Centrality vs. Multiplicity of Generated Events with at least one reconstructed event passing event selection", kTH2F, {centQAAxis, nchQAAxis});
+      registry.add("QAMC/Factors/hGenEventsCentNch", "Event centrality vs MC multiplicity", kTH2F, {centQAAxis, nchQAAxis});
+      registry.add("QAMC/Factors/hNrecInGen", "Number of collisions in MC", kTH1F, {{10, -0.5, 9.5}});
 
-        registry.add("QAMixing/h2ce1_ce2", "Event Mixing Centrality", kTH2F, {axisCentralityMixing, axisCentralityMixing});
-        auto h2EMce = registry.get<TH2>(HIST("QAMixing/h2ce1_ce2"));
-        h2EMce->GetXaxis()->SetTitle("1.Event centrality");
-        h2EMce->GetYaxis()->SetTitle("2.Event centrality");
+      registry.add("QAMC/Factors/hGenPhi", "Generated #Phi", kTH3D, {nchQAAxis, centQAAxis, ptAxis});
+      registry.add("QAMC/Factors/hGenALOREPhi", "Generated #Phi in collisions with at least one reconstructed collision", kTH3F, {nchQAAxis, centQAAxis, ptAxis});
+      registry.add("QAMC/Factors/hRecPhi", "Reconstructed #Phi", kTH2F, {centQAAxis, ptAxis});
 
-        registry.add("QAMixing/h2vz1_vz2", "Event Mixing Vertex z", kTH2F, {axisVertexMixing, axisVertexMixing});
-        auto hEMTvz = registry.get<TH2>(HIST("QAMixing/h2vz1_vz2"));
-        hEMTvz->GetXaxis()->SetTitle("1.Event V_{z}");
-        hEMTvz->GetYaxis()->SetTitle("2.Event V_{z}");
-      }
+      // Resolution
+      registry.add("QAMC/Resolution/h2ResolutionVz", "Resolution of collision V_{z}", kTH2F, {vzaxis, axisResolutionVz});
+      auto hResVz = registry.get<TH2>(HIST("QAMC/Resolution/h2ResolutionVz"));
+      hResVz->GetXaxis()->SetTitle("V_{z}^{rec} (cm)");
+      hResVz->GetYaxis()->SetTitle("#DeltaV_{z} = V_{z}^{rec} - V_{z}^{gen} (cm)");
 
-      // PID QA
-      // TPC
-      registry.add("QAPID/hTPCnSigma", "Distribution of TPC nSigma of K^{+} and K^{-}", kTH1F, {{200, -10, 10}});
-      auto hTPCnSigma = registry.get<TH1>(HIST("QAPID/hTPCnSigma"));
-      hTPCnSigma->GetXaxis()->SetTitle("n#sigma_{TPC} K^{#pm}");
+      registry.add("QAMC/Resolution/h2ResolutionPt", "Resolution of charged particles p_{T}", kTH2F, {ptQAAxis, axisResolutionPt});
+      auto hResPt = registry.get<TH2>(HIST("QAMC/Resolution/h2ResolutionPt"));
+      hResPt->GetXaxis()->SetTitle("p_{T}^{rec} (GeV/c)");
+      hResPt->GetYaxis()->SetTitle("#Deltap_{T} = p_{T}^{rec} - p_{T}^{gen} (GeV/c)");
 
-      registry.add("QAPID/h2TPCnSigma", "", kTH2F, {{200, -10, 10}, {200, -10, 10}});
-      auto h2TPCnSigma = registry.get<TH2>(HIST("QAPID/h2TPCnSigma"));
-      h2TPCnSigma->GetXaxis()->SetTitle("n#sigma_{TPC} K^{+}");
-      h2TPCnSigma->GetYaxis()->SetTitle("n#sigma_{TPC} K^{-}");
+      registry.add("QAMC/Resolution/h2ResolutionPtPhi", "p_{T} resolution vs p_{T}^{rec}", kTH2F, {ptQAAxis, axisResolutionPtPhi});
+      auto hResPtPhi = registry.get<TH2>(HIST("QAMC/Resolution/h2ResolutionPtPhi"));
+      hResPtPhi->GetXaxis()->SetTitle("p_{T}^{rec} (GeV/c)");
+      hResPtPhi->GetYaxis()->SetTitle("#Deltap_{T} = p_{T}^{rec} - p_{T}^{gen} (GeV/c)");
 
-      registry.add("QAPID/h2TPCnSigmaPt", "", kTH2F, {ptaxis, {200, -10, 10}});
-      auto h2TPCnSigmaPt = registry.get<TH2>(HIST("QAPID/h2TPCnSigmaPt"));
-      h2TPCnSigmaPt->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-      h2TPCnSigmaPt->GetYaxis()->SetTitle("n#sigma_{TPC} K^{#pm}");
-
-      // TOF
-      registry.add("QAPID/hTOFnSigma", "Distribution of TOF nSigma of K^{+} and K^{-}", kTH1F, {{200, -10, 10}});
-      auto hTOFnSigma = registry.get<TH1>(HIST("QAPID/hTOFnSigma"));
-      hTOFnSigma->GetXaxis()->SetTitle("n#sigma_{TOF} K^{#pm}");
-
-      registry.add("QAPID/h2TOFnSigma", "", kTH2F, {{200, -10, 10}, {200, -10, 10}});
-      auto h2TOFnSigma = registry.get<TH2>(HIST("QAPID/h2TOFnSigma"));
-      h2TOFnSigma->GetXaxis()->SetTitle("n#sigma_{TOF} K^{+}");
-      h2TOFnSigma->GetYaxis()->SetTitle("n#sigma_{TOF} K^{-}");
-
-      registry.add("QAPID/h2TOFnSigmaPt", "", kTH2F, {ptaxis, {200, -10, 10}});
-      auto h2TOFnSigmaPt = registry.get<TH2>(HIST("QAPID/h2TOFnSigmaPt"));
-      h2TOFnSigmaPt->GetXaxis()->SetTitle("p_{T} (GeV/c)");
-      h2TOFnSigmaPt->GetYaxis()->SetTitle("n#sigma_{TOF} K^{#pm}");
-
-      // MC
-      if (static_cast<bool>(produce.produceTrue)) {
-        // Rec
-        registry.add("QAMC/Rec/hSelection", "MC Rec Event statistics", kTH1F, {{5, 0.0f, 5.0f}});
-        auto hMCEventTruth = registry.get<TH1>(HIST("QAMC/Rec/hSelection"));
-        hMCEventTruth->GetXaxis()->SetBinLabel(1, "Full MC Rec event statistics");
-        hMCEventTruth->GetXaxis()->SetBinLabel(2, "MC Rec events passing sel8 cut");
-        hMCEventTruth->GetXaxis()->SetBinLabel(3, "MC Rec events passing V_{z} cut");
-        hMCEventTruth->GetXaxis()->SetBinLabel(4, "MC Rec events with V_{z} cut and INEL>0");
-        hMCEventTruth->GetXaxis()->SetBinLabel(5, "Reconstructed #Phi candidates matched to true #Phi");
-        hMCEventTruth->SetMinimum(0.1);
-
-        registry.add("QAMC/Rec/hInvMassTrueFalse", "", kTH1F, {invAxis}); // not written events in True distribution due to repetition of mothers
-
-        // Gen
-        registry.add("QAMC/Gen/hSelection", "MC Gen Event statistics", kTH1F, {{4, 0.0f, 4.0f}});
-        auto hMCEventGen = registry.get<TH1>(HIST("QAMC/Gen/hSelection"));
-        hMCEventGen->GetXaxis()->SetBinLabel(1, "Full MC Gen event statistics");
-        hMCEventGen->GetXaxis()->SetBinLabel(2, "MC Gen events within V_{z} cut");
-        hMCEventGen->GetXaxis()->SetBinLabel(3, "MC Gen events with V_{z} cut and INEL>0");
-        hMCEventGen->GetXaxis()->SetBinLabel(4, "Generated #Phi candidates");
-        hMCEventGen->SetMinimum(0.1);
-
-        // Resolution
-        registry.add("Factors/h2ResolutionVz", "Resolution of collision V_{z}", kTH2F, {vzaxis, axisResolutionVz});
-        auto hResVz = registry.get<TH2>(HIST("Factors/h2ResolutionVz"));
-        hResVz->GetXaxis()->SetTitle("V_{z}^{rec} (cm)");
-        hResVz->GetYaxis()->SetTitle("#DeltaV_{z} = V_{z}^{rec} - V_{z}^{gen} (cm)");
-        registry.add("Factors/h2ResolutionPt", "Resolution of charged particles p_{T}", kTH2F, {ptaxis, axisResolutionPt});
-        auto hResPt = registry.get<TH2>(HIST("Factors/h2ResolutionPt"));
-
-        hResPt->GetXaxis()->SetTitle("p_{T}^{rec} (GeV/c)");
-        hResPt->GetYaxis()->SetTitle("#Deltap_{T} = p_{T}^{rec} - p_{T}^{gen} (GeV/c)");
-        registry.add("Factors/h2ResolutionPtPhi", "p_{T} resolution vs p_{T}^{rec}", kTH2F, {ptaxis, axisResolutionPtPhi});
-        auto hResPtPhi = registry.get<TH2>(HIST("Factors/h2ResolutionPtPhi"));
-        hResPtPhi->GetXaxis()->SetTitle("p_{T}^{rec} (GeV/c)");
-        hResPtPhi->GetYaxis()->SetTitle("#Deltap_{T} = p_{T}^{rec} - p_{T}^{gen} (GeV/c)");
-
-        registry.add("Factors/h2MassResolution", "Mass resolution vs p_{T}^{rec}", kTH2F, {ptaxis, axisResolutionMass});
-        auto hResMass = registry.get<TH2>(HIST("Factors/h2MassResolution"));
-        hResMass->GetXaxis()->SetTitle("p_{T}^{rec} (GeV/c)");
-        hResMass->GetYaxis()->SetTitle("#Deltam = m^{gen}_{KK} - m^{rec}_{KK} (GeV/c^{2})");
-
-        registry.add("Factors/h2MassShift", "Mass shift vs p_{T}^{rec}", kTH2F, {ptaxis, massShiftAxis});
-        auto hResMassGen = registry.get<TH2>(HIST("Factors/h2MassShift"));
-        hResMassGen->GetXaxis()->SetTitle("p_{T}^{rec} (GeV/c)");
-        hResMassGen->GetYaxis()->SetTitle("#Deltam = m^{gen}_{#phi} - m^{gen}_{KK} (GeV/c^{2})");
-
-        registry.add("Factors/h2MassShiftRel", "Relative mass shift vs p_{T}^{rec}", kTH2F, {ptaxis, massShiftRelAxis});
-        auto hMassCorr = registry.get<TH2>(HIST("Factors/h2MassShiftRel"));
-        hMassCorr->GetXaxis()->SetTitle("p_{T}^{rec} (GeV/c)");
-        hMassCorr->GetYaxis()->SetTitle("m^{gen}_{#phi} - m^{gen}_{KK}/m^{gen}_{#phi}");
-      }
+      registry.add("QAMC/Resolution/h2MassResolution", "Mass resolution vs p_{T}^{rec}", kTH2F, {ptQAAxis, axisResolutionMass});
+      auto hResMass = registry.get<TH2>(HIST("QAMC/Resolution/h2MassResolution"));
+      hResMass->GetXaxis()->SetTitle("p_{T}^{rec} (GeV/c)");
+      hResMass->GetYaxis()->SetTitle("#Deltam = m^{gen}_{KK} - m^{rec}_{KK} (GeV/c^{2})");
     }
-    // Factors
-    registry.add("Factors/hCentralityVsMultMC", "Event centrality vs MC multiplicity", kTH2F, {{101, 0.0f, 101.0f}, axisNch});
-    registry.add("Factors/hCentralityVsMult", "Event centrality vs multiplicity", kTH2F, {{101, 0.0f, 101.0f}, axisNch});
-    registry.add("Factors/hEventCentrality", "Event centrality", kTH1F, {{101, 0, 101}});
-    registry.add("Factors/hNrecInGen", "Number of collisions in MC", kTH1F, {{3, -0.5, 2.5}});
-    registry.add("Factors/hGenEvents", "Generated events", HistType::kTH2F, {{axisNch}, {4, 0, 4}});
-    auto hGenEvents = registry.get<TH2>(HIST("Factors/hGenEvents"));
-    hGenEvents->GetYaxis()->SetBinLabel(1, "All generated events");
-    hGenEvents->GetYaxis()->SetBinLabel(2, "Generated events passing V_{z} cut");
-    hGenEvents->GetYaxis()->SetBinLabel(3, "Generated events passing INEL>0");
-    hGenEvents->GetYaxis()->SetBinLabel(4, "Generated events with at least one reconstructed event");
-    registry.add("Factors/h2dGenPhi", "Centrality vs p_{T}", kTH2D, {{101, 0.0f, 101.0f}, ptaxis});
-    registry.add("Factors/h3dGenPhiVsMultMCVsCentrality", "MC multiplicity vs centrality vs p_{T}", kTH3D, {axisNch, {101, 0.0f, 101.0f}, ptaxis});
-  }
 
+    // ----------------------- Phi candidate QA -----------------------
+    registry.add("QA/Phi/hRapidity", "Rapidity distribution of #Phi candidates", kTH3F, {ptQAAxis, multQAAxis, rapidityQAaxis});
+    registry.add("QA/Phi/hEta", "Pseudorapidity distribution of #Phi candidates", kTH3F, {ptQAAxis, multQAAxis, etaQAaxis});
+    registry.add("QA/Phi/hdPhi", "Azimuthal distribution (#Delta#phi) of #Phi candidates", kTH3F, {ptQAAxis, multQAAxis, dPhiQAaxis});
+    registry.add("QA/Phi/hdPhideta", "Azimuthal distribution (#Delta#phi) of #Phi candidates vs #eta", kTH2F, {dEtaQAaxis, dPhiQAaxis});
+    registry.add("QA/Phi/hdTheta", "Polar distribution (#Delta#theta) of #Phi candidates vs p_{T}", kTH3F, {ptQAAxis, multQAAxis, dThetaQAaxis});
+
+    // Rotational background QA
+    if (static_cast<bool>(produce.produceRotational)) {
+      // Rotation around z axis
+      registry.add("QA/RotationZ/hRapidity", "Rapidity distribution of #Phi candidates from rotational background", kTH3F, {ptQAAxis, multQAAxis, rapidityQAaxis});
+      registry.add("QA/RotationZ/hEta", "Pseudorapidity distribution of #Phi candidates from rotational background", kTH3F, {ptQAAxis, multQAAxis, etaQAaxis});
+      registry.add("QA/RotationZ/hdPhi", "Rotational background: Azimuthal distribution (#Delta#phi)", kTH3F, {ptQAAxis, multQAAxis, dPhiQAaxis});
+      registry.add("QA/RotationZ/hdPhideta", "Rotational background: Azimuthal distribution (#Delta#phi) vs #eta", kTH2F, {dEtaQAaxis, dPhiQAaxis});
+      registry.add("QA/RotationZ/hdTheta", "Rotational background: Polar distribution (#Delta#theta) vs p_{T}", kTH3F, {ptQAAxis, multQAAxis, dThetaQAaxis});
+      // Momentum-axis rotation
+      registry.add("QA/Rotation/hRapidity", "Rapidity distribution of #Phi candidates from rotational background", kTH3F, {ptQAAxis, multQAAxis, rapidityQAaxis});
+      registry.add("QA/Rotation/hEta", "Pseudorapidity distribution of #Phi candidates from rotational background", kTH3F, {ptQAAxis, multQAAxis, etaQAaxis});
+      registry.add("QA/Rotation/hdPhi", "Rotational background: Azimuthal distribution (#Delta#phi)", kTH3F, {ptQAAxis, multQAAxis, dPhiQAaxis});
+      registry.add("QA/Rotation/hdPhideta", "Rotational background: Azimuthal distribution (#Delta#phi) vs #eta", kTH2F, {dEtaQAaxis, dPhiQAaxis});
+      registry.add("QA/Rotation/hdTheta", "Rotational background: Polar distribution (#Delta#theta) vs p_{T}", kTH3F, {ptQAAxis, multQAAxis, dThetaQAaxis});
+    }
+
+    // Mixing QA
+    if (mixingType != rsn::MixingType::none) {
+
+      registry.add("QA/Mixing/h2mu1_mu2", "Event Mixing Multiplicity", kTH2F, {axisMultiplicityMixing, axisMultiplicityMixing});
+      auto h2EMmu = registry.get<TH2>(HIST("QA/Mixing/h2mu1_mu2"));
+      h2EMmu->GetXaxis()->SetTitle("1.Event multiplicity");
+      h2EMmu->GetYaxis()->SetTitle("2.Event multiplicity");
+
+      registry.add("QA/Mixing/h2ce1_ce2", "Event Mixing Centrality", kTH2F, {axisCentralityMixing, axisCentralityMixing});
+      auto h2EMce = registry.get<TH2>(HIST("QA/Mixing/h2ce1_ce2"));
+      h2EMce->GetXaxis()->SetTitle("1.Event centrality");
+      h2EMce->GetYaxis()->SetTitle("2.Event centrality");
+
+      registry.add("QA/Mixing/h2vz1_vz2", "Event Mixing Vertex z", kTH2F, {axisVertexMixing, axisVertexMixing});
+      auto hEMTvz = registry.get<TH2>(HIST("QA/Mixing/h2vz1_vz2"));
+      hEMTvz->GetXaxis()->SetTitle("1.Event V_{z}");
+      hEMTvz->GetYaxis()->SetTitle("2.Event V_{z}");
+
+      registry.add("QA/Mixing/hdPhideta", "Mixing background: Azimuthal distribution (#Delta#phi) vs #eta", kTH2F, {dEtaQAaxis, dPhiQAaxis});
+    }
+  }
+  template <typename T>
+  bool selectedEvent(const T& collision, bool fillQA = false)
+  {
+    if (fillQA)
+      registry.fill(HIST("QA/Event/hSelection"), 0.5); // all events
+
+    if (static_cast<bool>(eventCuts.isTriggerTVX) && !collision.selection_bit(aod::evsel::kIsTriggerTVX))
+      return false;
+    if (fillQA)
+      registry.fill(HIST("QA/Event/hSelection"), 1.5); // events passing trigger TVX cut
+
+    if (static_cast<bool>(eventCuts.noTimeFrameBorder) && !collision.selection_bit(aod::evsel::kNoTimeFrameBorder))
+      return false;
+    if (fillQA)
+      registry.fill(HIST("QA/Event/hSelection"), 2.5); // events passing no time frame border cut
+
+    if (static_cast<bool>(eventCuts.noITSROFrameBorder) && !collision.selection_bit(aod::evsel::kNoITSROFrameBorder))
+      return false;
+    if (fillQA)
+      registry.fill(HIST("QA/Event/hSelection"), 3.5); // events passing no ITS RO frame border cut
+
+    if (static_cast<bool>(eventCuts.sel8) && !collision.sel8())
+      return false;
+    if (fillQA)
+      registry.fill(HIST("QA/Event/hSelection"), 4.5); // events passing sel8 cut (contains all the previous cuts)
+
+    if (static_cast<bool>(eventCuts.isVertexITSTPC) && !collision.selection_bit(aod::evsel::kIsVertexITSTPC))
+      return false;
+    if (fillQA)
+      registry.fill(HIST("QA/Event/hSelection"), 5.5); // events passing IsVertexITSTPC cut
+
+    if (static_cast<bool>(eventCuts.noSameBunchPileup) && !collision.selection_bit(aod::evsel::kNoSameBunchPileup))
+      return false;
+    if (fillQA)
+      registry.fill(HIST("QA/Event/hSelection"), 6.5); // events passing no same bunch pileup cut
+
+    if (static_cast<bool>(eventCuts.isGoodZvtxFT0vsPV) && !collision.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV))
+      return false;
+    if (fillQA)
+      registry.fill(HIST("QA/Event/hSelection"), 7.5); // events passing IsGoodZvtxFT0vsPV cut
+
+    if (std::abs(collision.posZ()) > static_cast<float>(eventCuts.vzCut))
+      return false;
+    if (fillQA)
+      registry.fill(HIST("QA/Event/hSelection"), 8.5); // events passing V_{z} cut
+
+    if (fillQA)
+      registry.fill(HIST("QA/Event/hSelection"), 9.5); // INEL
+
+    if (static_cast<bool>(eventCuts.inelGt0) && !collision.isInelGt0())
+      return false;
+    if (fillQA)
+      registry.fill(HIST("QA/Event/hSelection"), 10.5); // events passing INEL>0 cut
+
+    if (fillQA) {
+      registry.fill(HIST("QA/Event/hVtxZ"), collision.posZ());
+      registry.fill(HIST("QA/Event/hMult"), getMultiplicity(collision));
+      registry.fill(HIST("QA/Event/hCent"), getCentrality(collision));
+    }
+
+    return true;
+  }
   template <typename T>
   float tpcNsigma(const T& track)
   {
@@ -511,66 +544,69 @@ struct PhianalysisTHnSparse {
   template <typename T>
   bool selectedTrack(const T& track, bool isPositive)
   {
-    if (produceQA && dataQA)
-      registry.fill(HIST("QATrack/hSelection"), 0.5); // all tracks
+    if (dataQA)
+      registry.fill(HIST("QA/Track/hSelection"), 0.5); // all tracks
 
     // Apply pT cut
-    if (track.pt() < static_cast<float>(cut.pt))
+    if (track.pt() < static_cast<float>(trackCuts.pt))
       return false;
-    if (produceQA && dataQA)
-      registry.fill(HIST("QATrack/hSelection"), 1.5);
+    if (dataQA)
+      registry.fill(HIST("QA/Track/hSelection"), 1.5);
 
-    // Apply eta cut
-    if (std::abs(track.eta()) >= static_cast<float>(cut.etatrack))
+    // Apply eta trackCuts
+    if (std::abs(track.eta()) >= static_cast<float>(trackCuts.etatrack))
       return false;
-    if (produceQA && dataQA)
-      registry.fill(HIST("QATrack/hSelection"), 2.5);
+    if (dataQA)
+      registry.fill(HIST("QA/Track/hSelection"), 2.5);
 
     // Apply DCA cuts
-    if (std::abs(track.dcaXY()) >= static_cast<float>(cut.dcaXY) ||
-        std::abs(track.dcaZ()) >= static_cast<float>(cut.dcaZ))
+    if (std::abs(track.dcaXY()) >= static_cast<float>(trackCuts.dcaXY) ||
+        std::abs(track.dcaZ()) >= static_cast<float>(trackCuts.dcaZ))
       return false;
-    if (produceQA && dataQA)
-      registry.fill(HIST("QATrack/hSelection"), 3.5);
+    if (dataQA)
+      registry.fill(HIST("QA/Track/hSelection"), 3.5);
 
     // PID selection: TPC-only for pt < threshold value, TPC+TOF for pt >= threshold value and have TOF, else TPC-only
-    float nSigmaCut = isPositive ? tpcnSigmaPos : tpcnSigmaNeg;
-    if (track.pt() < ptTOFThreshold || !track.hasTOF() || tpcPidOnly) {
+    float nSigmaCut = isPositive ? static_cast<float>(trackCuts.tpcnSigmaPos) : static_cast<float>(trackCuts.tpcnSigmaNeg);
+    if (track.pt() < static_cast<float>(trackCuts.ptTOFThreshold) || !track.hasTOF() || static_cast<bool>(trackCuts.tpcPidOnly)) {
       if (std::abs(tpcNsigma(track)) >= nSigmaCut)
         return false;
     } else {
-      if (std::sqrt(tpcNsigma(track) * tpcNsigma(track) + tofNsigma(track) * tofNsigma(track)) >= combinedNSigma)
+      if (std::sqrt(tpcNsigma(track) * tpcNsigma(track) + tofNsigma(track) * tofNsigma(track)) >= static_cast<float>(trackCuts.combinedNSigma))
         return false;
     }
-    if (produceQA && dataQA)
-      registry.fill(HIST("QATrack/hSelection"), 4.5);
+    if (dataQA)
+      registry.fill(HIST("QA/Track/hSelection"), 4.5);
 
     // Apply tpcNClsFound cut
-    if (track.tpcNClsFound() < tpcNClsFound)
+    if (track.tpcNClsFound() < static_cast<int>(trackCuts.tpcNClsFound))
       return false;
-    if (produceQA && dataQA)
-      registry.fill(HIST("QATrack/hSelection"), 5.5);
+    if (dataQA)
+      registry.fill(HIST("QA/Track/hSelection"), 5.5);
 
-    if (globalTrack) {
+    // Apply tpcNClsCrossedRows cut
+    if (track.tpcNClsCrossedRows() < static_cast<int>(trackCuts.tpcNClsCrossedRows))
+      return false;
+    if (dataQA)
+      registry.fill(HIST("QA/Track/hSelection"), 6.5);
+
+    if (static_cast<bool>(trackCuts.globalTrack)) {
       // Apply Global track cuts
       if (!track.isGlobalTrack())
         return false;
-    } else {
+    } else if (static_cast<bool>(trackCuts.primaryTrack)) {
       // Apply Primary track cuts
       if (!track.isPrimaryTrack())
         return false;
     }
-    if (produceQA && dataQA)
-      registry.fill(HIST("QATrack/hSelection"), 6.5);
+    if (dataQA)
+      registry.fill(HIST("QA/Track/hSelection"), 7.5);
 
     // Apply PV Contributor cuts
-    if (!track.isPVContributor())
+    if (static_cast<bool>(trackCuts.pvContributor) && !track.isPVContributor())
       return false;
-    if (produceQA && dataQA)
-      registry.fill(HIST("QATrack/hSelection"), 7.5);
-
-    if (produceQA && dataQA)
-      registry.fill(HIST("QATrack/hSelection"), 8.5);
+    if (dataQA)
+      registry.fill(HIST("QA/Track/hSelection"), 8.5);
 
     return true;
   }
@@ -581,9 +617,9 @@ struct PhianalysisTHnSparse {
     d2 = ROOT::Math::PxPyPzMVector(track2.px(), track2.py(), track2.pz(), massNeg);
     return d1 + d2;
   }
-  bool seletectedMother(const ROOT::Math::PxPyPzMVector& mother)
+  bool selectedMother(const ROOT::Math::PxPyPzMVector& mother)
   {
-    if (std::abs(mother.Rapidity()) > static_cast<float>(cut.rapidity))
+    if (std::abs(mother.Rapidity()) > static_cast<float>(trackCuts.rapidity))
       return false;
     return true;
   }
@@ -617,58 +653,72 @@ struct PhianalysisTHnSparse {
     return pointPair;
   }
 
-  void processData(EventCandidate const& collision, TrackCandidates const& /*tracks*/)
+  void processQA(EventCandidate const& collision, TrackCandidates const& tracks)
+  {
+    if (!selectedEvent(collision, true))
+      return;
+
+    double centrality = getCentrality(collision);
+
+    for (const auto& track : tracks) {
+
+      registry.fill(HIST("QA/Track/hEta"), track.pt(), centrality, track.eta());
+      registry.fill(HIST("QA/Track/hPt"), track.pt(), centrality);
+      registry.fill(HIST("QA/Track/hDCAxy"), track.pt(), centrality, track.dcaXY());
+      registry.fill(HIST("QA/Track/hDCAz"), track.pt(), centrality, track.dcaZ());
+      registry.fill(HIST("QA/Track/hTPCNClsFound"), track.pt(), centrality, track.tpcNClsFound());
+      registry.fill(HIST("QA/Track/hTPCNClsCrossedRows"), track.pt(), centrality, track.tpcNClsCrossedRows());
+      registry.fill(HIST("QA/Track/hRapidity"), track.pt(), centrality, track.sign() > 0 ? track.rapidity(massPos) : track.rapidity(massNeg));
+
+      registry.fill(HIST("QA/PID/hTPCNSigma"), track.pt(), centrality, tpcNsigma(track));
+      registry.fill(HIST("QA/PID/hTPCdEdxP"), track.p(), track.tpcSignal());
+
+      if (track.hasTOF()) {
+        registry.fill(HIST("QA/PID/hTOFNSigma"), track.pt(), centrality, tofNsigma(track));
+        registry.fill(HIST("QA/PID/hTOFBetaP"), track.p(), track.beta());
+      }
+
+      if (!selectedTrack(track, track.sign() > 0))
+        continue;
+
+      registry.fill(HIST("QA/Kaon/hEta"), track.pt(), centrality, track.eta());
+      registry.fill(HIST("QA/Kaon/hPt"), track.pt(), centrality);
+      registry.fill(HIST("QA/Kaon/hDCAxy"), track.pt(), centrality, track.dcaXY());
+      registry.fill(HIST("QA/Kaon/hDCAz"), track.pt(), centrality, track.dcaZ());
+      registry.fill(HIST("QA/Kaon/hTPCNClsFound"), track.pt(), centrality, track.tpcNClsFound());
+      registry.fill(HIST("QA/Kaon/hTPCNClsCrossedRows"), track.pt(), centrality, track.tpcNClsCrossedRows());
+      registry.fill(HIST("QA/Kaon/hRapidity"), track.pt(), centrality, track.sign() > 0 ? track.rapidity(massPos) : track.rapidity(massNeg));
+
+      registry.fill(HIST("QA/PID/hTPCNSigmaK"), track.pt(), centrality, tpcNsigma(track));
+      registry.fill(HIST("QA/PID/hTPCdEdxPK"), track.p(), track.tpcSignal());
+
+      if (track.hasTOF()) {
+        registry.fill(HIST("QA/PID/hTOFNSigmaK"), track.pt(), centrality, tofNsigma(track));
+        registry.fill(HIST("QA/PID/hTOFBetaPK"), track.p(), track.beta());
+        registry.fill(HIST("QA/PID/hTPCTOFnSigma"), track.pt(), tpcNsigma(track), tofNsigma(track));
+      }
+    }
+  }
+  PROCESS_SWITCH(PhianalysisTHnSparse, processQA, "Process Event for Data", true);
+
+  void processData(EventCandidate const& collision, TrackCandidates const& tracks)
   {
     auto posDaughters = positive->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
     auto negDaughters = negative->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
 
+    if (!selectedEvent(collision))
+      return;
+
     int nch = 0;
-
-    if (produceQA)
-      registry.fill(HIST("QAEvent/hSelection"), 0.5);
-
-    if (!collision.sel8())
-      return;
-
-    if (produceQA)
-      registry.fill(HIST("QAEvent/hSelection"), 1.5);
-
-    if (std::abs(collision.posZ()) > vzCut)
-      return;
-
-    if (produceQA)
-      registry.fill(HIST("QAEvent/hSelection"), 2.5);
-
-    if (inelGrater0 && !collision.isInelGt0())
-      return;
-
-    registry.fill(HIST("Factors/hEventCentrality"), collision.centFT0M());
-
-    if (produceQA) {
-      registry.fill(HIST("QAEvent/hSelection"), 3.5);
-      registry.fill(HIST("QAEvent/hVtxZ"), collision.posZ());
-      registry.fill(HIST("QAEvent/hMult"), getMultiplicity(collision));
-      registry.fill(HIST("QAEvent/hCent"), getCentrality(collision));
-
-      if (produceStats) {
-        dataQA = true;
-        for (const auto& track : posDaughters) {
-          if (track.isPrimaryTrack() && std::abs(track.eta()) >= static_cast<float>(cut.etatrack))
-            nch++;
-          selectedTrack(track, true);
-        }
-        for (const auto& track : negDaughters) {
-          if (track.isPrimaryTrack() && std::abs(track.eta()) >= static_cast<float>(cut.etatrack))
-            nch++;
-          selectedTrack(track, false);
-        }
-        dataQA = false;
-      }
-      registry.fill(HIST("Factors/hCentralityVsMult"), getCentrality(collision), nch);
+    dataQA = true;
+    for (const auto& track : tracks) {
+      if (track.isPrimaryTrack() && std::abs(track.eta()) < static_cast<float>(trackCuts.etatrack))
+        nch++;
+      selectedTrack(track, false);
     }
+    dataQA = false;
 
-    if (static_cast<int>(verbose.verboselevel) > 0 && static_cast<int>(verbose.refresh) > 0 && collision.globalIndex() % static_cast<int>(verbose.refresh) == static_cast<int>(verbose.refreshIndex))
-      LOGF(info, "%d pos=%lld neg=%lld, Z vertex position: %f [cm]", collision.globalIndex(), posDaughters.size(), negDaughters.size(), collision.posZ());
+    registry.fill(HIST("QA/Event/hCentNch"), getCentrality(collision), nch);
 
     for (const auto& [track1, track2] : combinations(o2::soa::CombinationsFullIndexPolicy(posDaughters, negDaughters))) {
 
@@ -678,45 +728,14 @@ struct PhianalysisTHnSparse {
         continue;
 
       mother = calculateMother(track1, track2);
-      if (!seletectedMother(mother))
+      if (!selectedMother(mother))
         continue;
 
-      if (produceQA) {
-        registry.fill(HIST("QAPID/h2TPCnSigma"), tpcNsigma(track1), tpcNsigma(track2));
-        registry.fill(HIST("QAPID/h2TPCnSigmaPt"), track1.pt(), tpcNsigma(track1));
-        registry.fill(HIST("QAPID/h2TPCnSigmaPt"), track2.pt(), tpcNsigma(track2));
-
-        registry.fill(HIST("QAPID/h2TOFnSigma"), tofNsigma(track1), tofNsigma(track2));
-        registry.fill(HIST("QAPID/h2TOFnSigmaPt"), track1.pt(), tofNsigma(track1));
-        registry.fill(HIST("QAPID/h2TOFnSigmaPt"), track2.pt(), tofNsigma(track2));
-
-        registry.fill(HIST("QAPID/hTPCnSigma"), tpcNsigma(track1));
-        registry.fill(HIST("QAPID/hTPCnSigma"), tpcNsigma(track2));
-        if (track1.hasTOF())
-          registry.fill(HIST("QAPID/hTOFnSigma"), tofNsigma(track1));
-        if (track2.hasTOF())
-          registry.fill(HIST("QAPID/hTOFnSigma"), tofNsigma(track2));
-
-        registry.fill(HIST("QATrack/hEta"), track1.eta());
-        registry.fill(HIST("QATrack/hEta"), track2.eta());
-        registry.fill(HIST("QATrack/hPt"), track1.pt());
-        registry.fill(HIST("QATrack/hPt"), track2.pt());
-        registry.fill(HIST("QATrack/hDCAxy"), track1.dcaXY());
-        registry.fill(HIST("QATrack/hDCAxy"), track2.dcaXY());
-        registry.fill(HIST("QATrack/hDCAz"), track1.dcaZ());
-        registry.fill(HIST("QATrack/hDCAz"), track2.dcaZ());
-        registry.fill(HIST("QATrack/hTPCNClsFound"), track1.tpcNClsFound());
-        registry.fill(HIST("QATrack/hTPCNClsFound"), track2.tpcNClsFound());
-        registry.fill(HIST("QATrack/hRapidity"), track1.rapidity(massPos));
-        registry.fill(HIST("QATrack/hRapidity"), track2.rapidity(massNeg));
-
-        registry.fill(HIST("QAPhi/hRapidity"), mother.Rapidity());
-        registry.fill(HIST("QAPhi/hEta"), mother.Eta());
-        registry.fill(HIST("QAPhi/hdPhi"), track1.phi() - track2.phi());
-        registry.fill(HIST("QAPhi/h2dPhiPt"), mother.Pt(), track1.phi() - track2.phi());
-        registry.fill(HIST("QAPhi/hTheta"), mother.Theta());
-        registry.fill(HIST("QAPhi/h2dThetaPt"), mother.Pt(), d1.Theta() - d2.Theta());
-      }
+      registry.fill(HIST("QA/Phi/hRapidity"), mother.Pt(), getCentrality(collision), mother.Rapidity());
+      registry.fill(HIST("QA/Phi/hEta"), mother.Pt(), getCentrality(collision), mother.Eta());
+      registry.fill(HIST("QA/Phi/hdPhi"), mother.Pt(), getCentrality(collision), track1.phi() - track2.phi());
+      registry.fill(HIST("QA/Phi/hdPhideta"), track1.eta() - track2.eta(), track1.phi() - track2.phi());
+      registry.fill(HIST("QA/Phi/hdTheta"), mother.Pt(), getCentrality(collision), d1.Theta() - d2.Theta());
 
       pointPair = fillPointPair(mother.M(),
                                 mother.Pt(),
@@ -732,55 +751,160 @@ struct PhianalysisTHnSparse {
                                 0);
       rsnOutput->fillUnlikepm(pointPair);
 
-      if (produceRotational) {
-        for (int i = 1; i <= static_cast<int>(numberofRotations); i++) {
+      if (static_cast<bool>(produce.produceRotational)) {
+
+        // Rotational background with rotation of track2 around track1
+        for (int i = 1; i <= static_cast<int>(nRotations); i++) {
           float starting = static_cast<float>(startingAngle) * TMath::DegToRad();
-          float angle = starting + i * ((o2::constants::math::TwoPI - 2 * starting) / (static_cast<int>(numberofRotations) + 1));
+          float angle = starting + i * ((o2::constants::math::TwoPI - 2 * starting) / (static_cast<int>(nRotations) + 1));
           float px2new = track2.px() * std::cos(angle) - track2.py() * std::sin(angle);
           float py2new = track2.px() * std::sin(angle) + track2.py() * std::cos(angle);
-          d2 = ROOT::Math::PxPyPzMVector(px2new, py2new, track2.pz(), massNeg);
-          mother = d1 + d2;
+          ROOT::Math::PxPyPzMVector d2rot(px2new, py2new, track2.pz(), massNeg);
+          auto motherRotZ = d1 + d2rot;
 
-          if (produceQA) {
-            registry.fill(HIST("QARotational/hRapidity"), mother.Rapidity());
-            registry.fill(HIST("QARotational/hEta"), mother.Eta());
-            registry.fill(HIST("QARotational/hdPhi"), d1.Phi() - d2.Phi());
-            registry.fill(HIST("QARotational/h2dPhiPt"), mother.Pt(), d1.Phi() - d2.Phi());
-            registry.fill(HIST("QARotational/hTheta"), mother.Theta());
-            registry.fill(HIST("QARotational/h2dThetaPt"), mother.Pt(), d1.Theta() - d2.Theta());
-          }
-          pointPair = fillPointPair(mother.M(),
-                                    mother.Pt(),
+          registry.fill(HIST("QA/RotationZ/hRapidity"), motherRotZ.Pt(), getCentrality(collision), motherRotZ.Rapidity());
+          registry.fill(HIST("QA/RotationZ/hEta"), motherRotZ.Pt(), getCentrality(collision), motherRotZ.Eta());
+          registry.fill(HIST("QA/RotationZ/hdPhi"), motherRotZ.Pt(), getCentrality(collision), d1.Phi() - d2rot.Phi());
+          registry.fill(HIST("QA/RotationZ/hdPhideta"), d1.Eta() - d2rot.Eta(), d1.Phi() - d2rot.Phi());
+          registry.fill(HIST("QA/RotationZ/hdTheta"), motherRotZ.Pt(), getCentrality(collision), d1.Theta() - d2rot.Theta());
+
+          pointPair = fillPointPair(motherRotZ.M(),
+                                    motherRotZ.Pt(),
                                     getMultiplicity(collision),
                                     getCentrality(collision),
                                     tpcNsigma(track1),
                                     tpcNsigma(track2),
-                                    mother.Eta(),
-                                    mother.Rapidity(),
+                                    motherRotZ.Eta(),
+                                    motherRotZ.Rapidity(),
                                     collision.posZ(),
                                     0,
                                     0,
                                     0);
 
-          rsnOutput->fillRotationpm(pointPair);
+          rsnOutput->fillRotationZ(pointPair);
+        }
+
+        // Rotational background with rotation of 90 degrees around mother momentum axis
+        ROOT::Math::AxisAngle rotationAxis(mother.Vect(), constants::math::PIHalf);
+        ROOT::Math::Rotation3D rotationMatrix(rotationAxis);
+
+        const auto rotD1 = rotationMatrix * d1;
+        const auto rotD2 = rotationMatrix * d2;
+
+        if (negDaughters.size() > 1) {
+          for (const auto& track3 : negDaughters) {
+            if (track3.globalIndex() == track1.globalIndex() || track3.globalIndex() == track2.globalIndex())
+              continue;
+            if (!selectedTrack(track3, false))
+              continue;
+            ROOT::Math::PxPyPzMVector d3(track3.px(), track3.py(), track3.pz(), massNeg);
+            auto motherRot = rotD1 + d3;
+
+            registry.fill(HIST("QA/Rotation/hRapidity"), motherRot.Pt(), getCentrality(collision), motherRot.Rapidity());
+            registry.fill(HIST("QA/Rotation/hEta"), motherRot.Pt(), getCentrality(collision), motherRot.Eta());
+            registry.fill(HIST("QA/Rotation/hdPhi"), motherRot.Pt(), getCentrality(collision), rotD1.Phi() - d3.Phi());
+            registry.fill(HIST("QA/Rotation/hdPhideta"), rotD1.Eta() - d3.Eta(), rotD1.Phi() - d3.Phi());
+            registry.fill(HIST("QA/Rotation/hdTheta"), motherRot.Pt(), getCentrality(collision), rotD1.Theta() - d3.Theta());
+
+            pointPair = fillPointPair(motherRot.M(),
+                                      motherRot.Pt(),
+                                      getMultiplicity(collision),
+                                      getCentrality(collision),
+                                      tpcNsigma(track1),
+                                      tpcNsigma(track2),
+                                      motherRot.Eta(),
+                                      motherRot.Rapidity(),
+                                      collision.posZ(),
+                                      0,
+                                      0,
+                                      0);
+
+            rsnOutput->fillRotation(pointPair);
+
+            // Likesign rotation for negative daughters
+            motherRot = rotD2 + d3;
+            pointPair = fillPointPair(motherRot.M(),
+                                      motherRot.Pt(),
+                                      getMultiplicity(collision),
+                                      getCentrality(collision),
+                                      tpcNsigma(track1),
+                                      tpcNsigma(track2),
+                                      motherRot.Eta(),
+                                      motherRot.Rapidity(),
+                                      collision.posZ(),
+                                      0,
+                                      0,
+                                      0);
+
+            rsnOutput->fillRotationLike(pointPair);
+          }
+        }
+
+        if (posDaughters.size() > 1) {
+          for (const auto& track3 : posDaughters) {
+
+            if (track3.globalIndex() == track1.globalIndex() || track3.globalIndex() == track2.globalIndex())
+              continue;
+
+            if (!selectedTrack(track3, true))
+              continue;
+
+            ROOT::Math::PxPyPzMVector d3(track3.px(), track3.py(), track3.pz(), massPos);
+
+            auto motherRot = rotD2 + d3;
+
+            registry.fill(HIST("QA/Rotation/hRapidity"), motherRot.Pt(), getCentrality(collision), motherRot.Rapidity());
+            registry.fill(HIST("QA/Rotation/hEta"), motherRot.Pt(), getCentrality(collision), motherRot.Eta());
+            registry.fill(HIST("QA/Rotation/hdPhi"), motherRot.Pt(), getCentrality(collision), rotD2.Phi() - d3.Phi());
+            registry.fill(HIST("QA/Rotation/hdPhideta"), rotD2.Eta() - d3.Eta(), rotD2.Phi() - d3.Phi());
+            registry.fill(HIST("QA/Rotation/hdTheta"), motherRot.Pt(), getCentrality(collision), rotD2.Theta() - d3.Theta());
+
+            pointPair = fillPointPair(motherRot.M(),
+                                      motherRot.Pt(),
+                                      getMultiplicity(collision),
+                                      getCentrality(collision),
+                                      tpcNsigma(track1),
+                                      tpcNsigma(track2),
+                                      motherRot.Eta(),
+                                      motherRot.Rapidity(),
+                                      collision.posZ(),
+                                      0,
+                                      0,
+                                      0);
+
+            rsnOutput->fillRotation(pointPair);
+
+            // Likesign rotation for positive daughters
+            motherRot = rotD1 + d3;
+            pointPair = fillPointPair(motherRot.M(),
+                                      motherRot.Pt(),
+                                      getMultiplicity(collision),
+                                      getCentrality(collision),
+                                      tpcNsigma(track1),
+                                      tpcNsigma(track2),
+                                      motherRot.Eta(),
+                                      motherRot.Rapidity(),
+                                      collision.posZ(),
+                                      0,
+                                      0,
+                                      0);
+
+            rsnOutput->fillRotationLike(pointPair);
+          }
         }
       }
     }
-
-    if (produceLikesign) {
+    if (static_cast<bool>(produce.produceLikesign)) {
 
       for (const auto& [track1, track2] : combinations(o2::soa::CombinationsStrictlyUpperIndexPolicy(posDaughters, posDaughters))) {
-        if (!selectedTrack(track1, true)) // both positive
+        if (!selectedTrack(track1, true))
           continue;
-        if (!selectedTrack(track2, true)) // both positive
+        if (!selectedTrack(track2, true))
           continue;
 
         mother = calculateMother(track1, track2);
-        if (!seletectedMother(mother))
+        if (!selectedMother(mother))
           continue;
-
-        if (static_cast<int>(verbose.verboselevel) > 1)
-          LOGF(info, "Like-sign positive: d1=%ld , d2=%ld , mother=%f", track1.globalIndex(), track2.globalIndex(), mother.M());
 
         pointPair = fillPointPair(mother.M(),
                                   mother.Pt(),
@@ -799,17 +923,14 @@ struct PhianalysisTHnSparse {
       }
 
       for (const auto& [track1, track2] : combinations(o2::soa::CombinationsStrictlyUpperIndexPolicy(negDaughters, negDaughters))) {
-        if (!selectedTrack(track1, false)) // both negative
+        if (!selectedTrack(track1, false))
           continue;
-        if (!selectedTrack(track2, false)) // both negative
+        if (!selectedTrack(track2, false))
           continue;
 
         mother = calculateMother(track1, track2);
-        if (!seletectedMother(mother))
+        if (!selectedMother(mother))
           continue;
-
-        if (static_cast<int>(verbose.verboselevel) > 1)
-          LOGF(info, "Like-sign negative: d1=%ld , d2=%ld , mother=%f", track1.globalIndex(), track2.globalIndex(), mother.M());
 
         pointPair = fillPointPair(mother.M(),
                                   mother.Pt(),
@@ -832,60 +953,41 @@ struct PhianalysisTHnSparse {
 
   void processTrue(EventCandidatesMC::iterator const& collision, TrackCandidatesMC const& tracks, aod::McParticles const& /*mcParticles*/, aod::McCollisions const& /*mcCollisions*/)
   {
-    if (!static_cast<bool>(produce.produceTrue))
+    if (!static_cast<bool>(produce.produceMC))
       return;
 
     registry.fill(HIST("QAMC/Rec/hSelection"), 0.5);
+    registry.fill(HIST("QAMC/Factors/hRecEvents"), getCentrality(collision), 0.5);
 
-    if (!collision.sel8())
+    if (!selectedEvent(collision))
       return;
 
-    if (produceQA)
-      registry.fill(HIST("QAMC/Rec/hSelection"), 1.5);
+    registry.fill(HIST("QAMC/Rec/hSelection"), 1.5);
+    registry.fill(HIST("QAMC/Factors/hRecEvents"), getCentrality(collision), 1.5);
 
     auto posDaughtersMC = positiveMC->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
     auto negDaughtersMC = negativeMC->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
 
-    if (!collision.has_mcCollision()) {
-      if (static_cast<int>(verbose.verboselevel) > 0)
-        LOGF(warning, "No MC collision for this collision, skip...");
+    if (!collision.has_mcCollision())
       return;
-    }
+
     auto mcCollision = collision.mcCollision();
-    registry.fill(HIST("Factors/h2ResolutionVz"), collision.posZ(), (collision.posZ() - mcCollision.posZ()));
-
-    if (std::abs(mcCollision.posZ()) > vzCut)
-      return;
-
-    if (produceQA)
-      registry.fill(HIST("QAMC/Rec/hSelection"), 2.5);
-
-    if (inelGrater0 && !collision.isInelGt0())
-      return;
-
-    if (produceQA)
-      registry.fill(HIST("QAMC/Rec/hSelection"), 3.5);
+    registry.fill(HIST("QAMC/Resolution/h2ResolutionVz"), collision.posZ(), (collision.posZ() - mcCollision.posZ()));
 
     for (const auto& track : tracks) {
       if (track.has_mcParticle()) {
         auto mctrack = track.mcParticle();
-        registry.fill(HIST("Factors/h2ResolutionPt"), track.pt(), (track.pt() - mctrack.pt()));
+        registry.fill(HIST("QAMC/Resolution/h2ResolutionPt"), track.pt(), (track.pt() - mctrack.pt()));
       }
     }
 
     for (const auto& [track1, track2] : combinations(o2::soa::CombinationsFullIndexPolicy(posDaughtersMC, negDaughtersMC))) {
 
-      if (!track1.has_mcParticle()) {
-        if (static_cast<int>(verbose.verboselevel) > 0)
-          LOGF(warning, "No MC particle for track, skip...");
+      if (!track1.has_mcParticle())
         continue;
-      }
 
-      if (!track2.has_mcParticle()) {
-        if (static_cast<int>(verbose.verboselevel) > 0)
-          LOGF(warning, "No MC particle for track, skip...");
+      if (!track2.has_mcParticle())
         continue;
-      }
 
       if (!selectedTrack(track1, true)) // track1 is positive
         continue;
@@ -900,7 +1002,7 @@ struct PhianalysisTHnSparse {
       if (!(track1PDG == daughterPosPDG && track2PDG == daughterNegPDG)) {
         continue;
       }
-      n = 0;
+      int n = 0;
       for (const auto& mothertrack1 : mctrack1.mothers_as<aod::McParticles>()) {
         for (const auto& mothertrack2 : mctrack2.mothers_as<aod::McParticles>()) {
 
@@ -910,7 +1012,7 @@ struct PhianalysisTHnSparse {
           if (mothertrack1.globalIndex() != mothertrack2.globalIndex())
             continue;
 
-          if (std::abs(mothertrack1.y()) > static_cast<float>(cut.rapidity))
+          if (std::abs(mothertrack1.y()) > static_cast<float>(trackCuts.rapidity))
             continue;
 
           if (std::abs(mothertrack1.pdgCode()) != motherPDG)
@@ -918,20 +1020,11 @@ struct PhianalysisTHnSparse {
 
           mother = calculateMother(track1, track2);
           motherGen = calculateMother(mctrack1, mctrack2);
-          if (!seletectedMother(mother))
+          if (!selectedMother(mother))
             continue;
 
-          if (n > 0) {
-            if (produceQA)
-              registry.fill(HIST("QAMC/Rec/hInvMassTrueFalse"), mother.M());
+          if (n > 0)
             continue;
-          }
-
-          if (static_cast<int>(verbose.verboselevel) > 1) {
-            LOGF(info, "Collision: %ld True: %d, d1=%d (%ld), d2=%d (%ld), mother=%d (%ld)", collision.globalIndex(), n, mctrack1.pdgCode(), mctrack1.globalIndex(), mctrack2.pdgCode(), mctrack2.globalIndex(), mothertrack1.pdgCode(), mothertrack1.globalIndex());
-            LOGF(info, "Track %d px: %f, py=%f, pz=%f, px: %f, py=%f, pz=%f", n, track1.px(), track1.py(), track1.pz(), track2.px(), track2.py(), track2.pz());
-            LOGF(info, "mcTrack %d px: %f, py=%f, pz=%f, px: %f, py=%f, pz=%f", n, mctrack1.px(), mctrack1.py(), mctrack1.pz(), mctrack2.px(), mctrack2.py(), mctrack2.pz());
-          }
 
           pointPair = fillPointPair(mother.M(),
                                     mother.Pt(),
@@ -946,22 +1039,10 @@ struct PhianalysisTHnSparse {
                                     0,
                                     0);
 
-          if (produceQA)
-            registry.fill(HIST("QAMC/Rec/hSelection"), 4.5);
+          registry.fill(HIST("QAMC/Resolution/h2ResolutionPtPhi"), mother.Pt(), (mother.Pt() - mothertrack1.pt()));
+          registry.fill(HIST("QAMC/Resolution/h2MassResolution"), mother.Pt(), (motherGen.M() - mother.M()));
 
-          auto phiP = mothertrack1.p();
-          auto phiE = mothertrack1.e();
-          auto massGen = std::sqrt(phiE * phiE - phiP * phiP);
-
-          registry.fill(HIST("Factors/h2ResolutionPtPhi"), mother.Pt(), (mother.Pt() - mothertrack1.pt()));
-          registry.fill(HIST("Factors/h2MassResolution"), mother.Pt(), (motherGen.M() - mother.M()));
-          registry.fill(HIST("Factors/h2MassShift"), mother.Pt(), (massGen - motherGen.M()));
-          registry.fill(HIST("Factors/h2MassShiftRel"), mother.Pt(), (massGen - motherGen.M()) / massGen);
-
-          if (static_cast<int>(verbose.verboselevel) > 1)
-            LOGF(info, "mother.M()=%f, motherGen.M()=%f, massGen =%f", mother.M(), motherGen.M(), massGen);
-
-          rsnOutput->fillUnliketrue(pointPair);
+          rsnOutput->fillUnlikeTrueRec(pointPair);
 
           pointPair = fillPointPair(motherGen.M(),
                                     motherGen.Pt(),
@@ -976,7 +1057,9 @@ struct PhianalysisTHnSparse {
                                     0,
                                     0);
 
-          rsnOutput->fillUnlikegenOld(pointPair);
+          rsnOutput->fillUnlikeTrueGen(pointPair);
+
+          registry.fill(HIST("QAMC/Factors/hRecPhi"), getCentrality(collision), motherGen.Pt());
 
           n++;
         }
@@ -987,82 +1070,130 @@ struct PhianalysisTHnSparse {
 
   void processGen(McCollisionMults::iterator const& mcCollision, soa::SmallGroups<EventCandidatesMCGen> const& collisions, LabeledTracks const& /*particles*/, aod::McParticles const& mcParticles)
   {
-    if (!static_cast<bool>(produce.produceTrue))
+    if (!static_cast<bool>(produce.produceMC))
       return;
 
-    if (produceQA)
-      registry.fill(HIST("QAMC/Gen/hSelection"), 0.5);
+    registry.fill(HIST("QAMC/Factors/hNrecInGen"), collisions.size());
+    registry.fill(HIST("QAMC/Gen/hSelection"), 0.5);
+    registry.fill(HIST("QAMC/Factors/hGenEvents"), mcCollision.multMCNParticlesEta05(), 0.5);
 
-    if (std::abs(mcCollision.posZ()) > vzCut)
-      return;
-
-    if (produceQA)
+    if (collisions.size() > 0) {
       registry.fill(HIST("QAMC/Gen/hSelection"), 1.5);
+      registry.fill(HIST("QAMC/Factors/hGenEvents"), mcCollision.multMCNParticlesEta05(), 2.5);
+    }
 
-    if (inelGrater0 && !mcCollision.isInelGt0())
-      return;
-
-    if (produceQA)
-      registry.fill(HIST("QAMC/Gen/hSelection"), 2.5);
-
-    if (collisions.size() == 0)
-      return;
+    int nContributors = -1;
+    bool hasSelectedCollision = false;
+    float centrality = 100.5f;
+    float multiplicity = 0.f;
 
     for (const auto& collision : collisions) {
-      auto centralityGen = getCentrality(collision);
-      auto multiplicityGen = getMultiplicity(collision);
+      registry.fill(HIST("QAMC/Factors/hGenEvents"), mcCollision.multMCNParticlesEta05(), 1.5);
+      if (!selectedEvent(collision))
+        continue;
 
-      for (const auto& particle : mcParticles) {
+      if (collision.numContrib() > nContributors) {
+        nContributors = collision.numContrib();
+        centrality = getCentrality(collision);
+        multiplicity = getMultiplicity(collision);
+        hasSelectedCollision = true;
+      }
+    }
 
-        if (std::abs(particle.y()) > static_cast<float>(cut.rapidity))
+    // if (std::abs(mcCollision.posZ()) > static_cast<float>(eventCuts.vzCut) && !mcCollision.isInelGt0())
+    registry.fill(HIST("QAMC/Factors/hGenEventsCentNch"), centrality, mcCollision.multMCNParticlesEta05());
+
+    // All generated Phi mesons
+    for (const auto& particle : mcParticles) {
+
+      if (std::abs(particle.y()) > static_cast<float>(trackCuts.rapidity))
+        continue;
+
+      if (particle.pdgCode() == motherPDG) {
+
+        auto daughters = particle.daughters_as<aod::McParticles>();
+        if (daughters.size() != dauSize)
           continue;
 
-        if (particle.pdgCode() == motherPDG) {
+        auto daup = false;
+        auto daun = false;
 
-          auto daughters = particle.daughters_as<aod::McParticles>();
-          if (daughters.size() != dauSize)
-            continue;
-
-          auto daup = false;
-          auto daun = false;
-
-          for (const auto& dau : daughters) {
-            if (dau.pdgCode() == daughterPosPDG) {
-              daup = true;
-              d1 = ROOT::Math::PxPyPzMVector(dau.px(), dau.py(), dau.pz(), massPos);
-            } else if (dau.pdgCode() == -daughterNegPDG) {
-              daun = true;
-              d2 = ROOT::Math::PxPyPzMVector(dau.px(), dau.py(), dau.pz(), massNeg);
-            }
+        for (const auto& dau : daughters) {
+          if (dau.pdgCode() == daughterPosPDG) {
+            daup = true;
+            d1 = ROOT::Math::PxPyPzMVector(dau.px(), dau.py(), dau.pz(), massPos);
+          } else if (dau.pdgCode() == -daughterNegPDG) {
+            daun = true;
+            d2 = ROOT::Math::PxPyPzMVector(dau.px(), dau.py(), dau.pz(), massNeg);
           }
-          if (!daup || !daun)
-            continue;
-
-          mother = d1 + d2;
-
-          pointPair = fillPointPair(mother.M(),
-                                    mother.Pt(),
-                                    multiplicityGen,
-                                    centralityGen,
-                                    0,
-                                    0,
-                                    mother.Eta(),
-                                    mother.Rapidity(),
-                                    mcCollision.posZ(),
-                                    0,
-                                    0,
-                                    0);
-
-          rsnOutput->fillUnlikegen(pointPair);
-          if (produceQA)
-            registry.fill(HIST("QAMC/Gen/hSelection"), 3.5);
         }
+        if (!daup || !daun)
+          continue;
+
+        mother = d1 + d2;
+
+        registry.fill(HIST("QAMC/Factors/hGenPhi"), mcCollision.multMCNParticlesEta05(), centrality, particle.pt());
+      }
+    }
+
+    if (!hasSelectedCollision)
+      return;
+
+    registry.fill(HIST("QAMC/Gen/hSelection"), 2.5);
+    registry.fill(HIST("QAMC/Factors/hGenEvents"), mcCollision.multMCNParticlesEta05(), 3.5);
+    registry.fill(HIST("QAMC/Factors/hGenALORESelEvents"), centrality, mcCollision.multMCNParticlesEta05());
+
+    // Generated Phi mesons in selected collisions
+    for (const auto& mcParticle : mcParticles) {
+      if (std::abs(mcParticle.y()) > static_cast<float>(trackCuts.rapidity))
+        continue;
+
+      if (mcParticle.pdgCode() == motherPDG) {
+        auto daughters = mcParticle.daughters_as<aod::McParticles>();
+        if (daughters.size() != dauSize)
+          continue;
+
+        auto daup = false;
+        auto daun = false;
+
+        for (const auto& dau : daughters) {
+          if (dau.pdgCode() == daughterPosPDG) {
+            daup = true;
+            d1 = ROOT::Math::PxPyPzMVector(dau.px(), dau.py(), dau.pz(), massPos);
+          } else if (dau.pdgCode() == -daughterNegPDG) {
+            daun = true;
+            d2 = ROOT::Math::PxPyPzMVector(dau.px(), dau.py(), dau.pz(), massNeg);
+          }
+        }
+
+        if (!daup || !daun)
+          continue;
+
+        mother = d1 + d2;
+
+        pointPair = fillPointPair(mother.M(),
+                                  mother.Pt(),
+                                  multiplicity,
+                                  centrality,
+                                  0,
+                                  0,
+                                  mother.Eta(),
+                                  mother.Rapidity(),
+                                  mcCollision.posZ(),
+                                  0,
+                                  0,
+                                  0);
+
+        rsnOutput->fillUnlikeGen(pointPair);
+
+        registry.fill(HIST("QAMC/Factors/hGenALOREPhi"), mcCollision.multMCNParticlesEta05(), centrality, mother.Pt());
       }
     }
   }
+
   PROCESS_SWITCH(PhianalysisTHnSparse, processGen, "Process MC Generated.", false);
 
-  void processMixed(soa::Filtered<EventCandidates> const& collisions, TrackCandidates const& tracks)
+  void processMixed(EventCandidates const& collisions, TrackCandidates const& tracks)
   {
     if (mixingType == rsn::MixingType::none)
       return;
@@ -1070,26 +1201,24 @@ struct PhianalysisTHnSparse {
     auto tracksTuple = std::make_tuple(tracks);
 
     BinningTypeVzCe binningVzCe{{axisVertexMixing, axisCentralityMixing}, true};
-    SameKindPair<EventCandidates, TrackCandidates, BinningTypeVzCe> pairVzCe{binningVzCe, static_cast<int>(numberofMixedEvents), -1, collisions, tracksTuple, &cache};
+    SameKindPair<EventCandidates, TrackCandidates, BinningTypeVzCe> pairVzCe{binningVzCe, static_cast<int>(nMixedEvents), -1, collisions, tracksTuple, &cache};
 
     BinningTypeVzMu binningVzMu{{axisVertexMixing, axisMultiplicityMixing}, true};
-    SameKindPair<EventCandidates, TrackCandidates, BinningTypeVzMu> pairVzMu{binningVzMu, static_cast<int>(numberofMixedEvents), -1, collisions, tracksTuple, &cache};
+    SameKindPair<EventCandidates, TrackCandidates, BinningTypeVzMu> pairVzMu{binningVzMu, static_cast<int>(nMixedEvents), -1, collisions, tracksTuple, &cache};
 
     if (mixingType == rsn::MixingType::ce) {
       for (const auto& [c1, tracks1, c2, tracks2] : pairVzCe) {
-        if (produceQA)
-          registry.fill(HIST("QAMixing/hSelection"), 0.5);
+        if (!selectedEvent(c1) || !selectedEvent(c2))
+          continue;
 
         auto posDaughtersc1 = positive->sliceByCached(aod::track::collisionId, c1.globalIndex(), cache);
         auto posDaughtersc2 = positive->sliceByCached(aod::track::collisionId, c2.globalIndex(), cache);
         auto negDaughtersc1 = negative->sliceByCached(aod::track::collisionId, c1.globalIndex(), cache);
         auto negDaughtersc2 = negative->sliceByCached(aod::track::collisionId, c2.globalIndex(), cache);
 
-        if (produceQA) {
-          registry.fill(HIST("QAMixing/h2mu1_mu2"), getMultiplicity(c1), getMultiplicity(c2));
-          registry.fill(HIST("QAMixing/h2ce1_ce2"), getCentrality(c1), getCentrality(c2));
-          registry.fill(HIST("QAMixing/h2vz1_vz2"), c1.posZ(), c2.posZ());
-        }
+        registry.fill(HIST("QA/Mixing/h2mu1_mu2"), getMultiplicity(c1), getMultiplicity(c2));
+        registry.fill(HIST("QA/Mixing/h2ce1_ce2"), getCentrality(c1), getCentrality(c2));
+        registry.fill(HIST("QA/Mixing/h2vz1_vz2"), c1.posZ(), c2.posZ());
 
         for (const auto& [track1, track2] : combinations(o2::soa::CombinationsFullIndexPolicy(posDaughtersc1, negDaughtersc2))) {
 
@@ -1099,8 +1228,10 @@ struct PhianalysisTHnSparse {
             continue;
 
           mother = calculateMother(track1, track2);
-          if (!seletectedMother(mother))
+          if (!selectedMother(mother))
             continue;
+
+          registry.fill(HIST("QA/Mixing/hdPhideta"), track1.eta() - track2.eta(), track1.phi() - track2.phi());
 
           pointPair = fillPointPair(mother.M(),
                                     mother.Pt(),
@@ -1126,7 +1257,7 @@ struct PhianalysisTHnSparse {
             continue;
 
           mother = calculateMother(track1, track2);
-          if (!seletectedMother(mother))
+          if (!selectedMother(mother))
             continue;
 
           pointPair = fillPointPair(mother.M(),
@@ -1148,19 +1279,17 @@ struct PhianalysisTHnSparse {
     }
     if (mixingType == rsn::MixingType::mu) {
       for (const auto& [c1, tracks1, c2, tracks2] : pairVzMu) {
-        if (produceQA)
-          registry.fill(HIST("QAMixing/hSelection"), 0.5);
+        if (!selectedEvent(c1) || !selectedEvent(c2))
+          continue;
 
         auto posDaughtersc1 = positive->sliceByCached(aod::track::collisionId, c1.globalIndex(), cache);
         auto posDaughtersc2 = positive->sliceByCached(aod::track::collisionId, c2.globalIndex(), cache);
         auto negDaughtersc1 = negative->sliceByCached(aod::track::collisionId, c1.globalIndex(), cache);
         auto negDaughtersc2 = negative->sliceByCached(aod::track::collisionId, c2.globalIndex(), cache);
 
-        if (produceQA) {
-          registry.fill(HIST("QAMixing/h2mu1_mu2"), getMultiplicity(c1), getMultiplicity(c2));
-          registry.fill(HIST("QAMixing/h2ce1_ce2"), getCentrality(c1), getCentrality(c2));
-          registry.fill(HIST("QAMixing/h2vz1_vz2"), c1.posZ(), c2.posZ());
-        }
+        registry.fill(HIST("QA/Mixing/h2mu1_mu2"), getMultiplicity(c1), getMultiplicity(c2));
+        registry.fill(HIST("QA/Mixing/h2ce1_ce2"), getCentrality(c1), getCentrality(c2));
+        registry.fill(HIST("QA/Mixing/h2vz1_vz2"), c1.posZ(), c2.posZ());
 
         for (const auto& [track1, track2] : combinations(o2::soa::CombinationsFullIndexPolicy(posDaughtersc1, negDaughtersc2))) {
 
@@ -1171,7 +1300,7 @@ struct PhianalysisTHnSparse {
             continue;
 
           mother = calculateMother(track1, track2);
-          if (!seletectedMother(mother))
+          if (!selectedMother(mother))
             continue;
 
           pointPair = fillPointPair(mother.M(),
@@ -1199,7 +1328,7 @@ struct PhianalysisTHnSparse {
             continue;
 
           mother = calculateMother(track1, track2);
-          if (!seletectedMother(mother))
+          if (!selectedMother(mother))
             continue;
 
           pointPair = fillPointPair(mother.M(),
@@ -1221,68 +1350,6 @@ struct PhianalysisTHnSparse {
     }
   }
   PROCESS_SWITCH(PhianalysisTHnSparse, processMixed, "Process Mixing Event.", false);
-
-  void processFactors(McCollisionMults::iterator const& mcCollision, soa::SmallGroups<EventCandidatesMCGen> const& collisions, LabeledTracks const& /*particles*/, aod::McParticles const& mcParticles)
-  {
-    registry.fill(HIST("Factors/hGenEvents"), mcCollision.multMCNParticlesEta08(), 0.5);
-
-    if (std::abs(mcCollision.posZ()) > vzCut)
-      return;
-
-    registry.fill(HIST("Factors/hGenEvents"), mcCollision.multMCNParticlesEta08(), 1.5);
-
-    if (inelGrater0 && !mcCollision.isInelGt0())
-      return;
-
-    registry.fill(HIST("Factors/hGenEvents"), mcCollision.multMCNParticlesEta08(), 2.5);
-
-    float centrality = 100.5f;
-    for (auto const& collision : collisions) {
-      centrality = collision.centFT0M();
-    }
-
-    registry.fill(HIST("Factors/hCentralityVsMultMC"), centrality, mcCollision.multMCNParticlesEta08());
-    registry.fill(HIST("Factors/hNrecInGen"), collisions.size());
-
-    for (const auto& particle : mcParticles) {
-
-      if (std::abs(particle.y()) > static_cast<float>(cut.rapidity))
-        continue;
-
-      if (particle.pdgCode() == motherPDG) {
-
-        auto daughters = particle.daughters_as<aod::McParticles>();
-        if (daughters.size() != dauSize)
-          continue;
-
-        auto daup = false;
-        auto daun = false;
-
-        for (const auto& dau : daughters) {
-          if (dau.pdgCode() == daughterPosPDG) {
-            daup = true;
-            d1 = ROOT::Math::PxPyPzMVector(dau.px(), dau.py(), dau.pz(), massPos);
-          } else if (dau.pdgCode() == -daughterNegPDG) {
-            daun = true;
-            d2 = ROOT::Math::PxPyPzMVector(dau.px(), dau.py(), dau.pz(), massNeg);
-          }
-        }
-        if (!daup || !daun)
-          continue;
-
-        mother = d1 + d2;
-
-        registry.fill(HIST("Factors/h2dGenPhi"), centrality, mother.Pt());
-        registry.fill(HIST("Factors/h3dGenPhiVsMultMCVsCentrality"), mcCollision.multMCNParticlesEta08(), centrality, mother.Pt());
-      }
-    }
-
-    if (collisions.size() == 0)
-      return;
-
-    registry.fill(HIST("Factors/hGenEvents"), mcCollision.multMCNParticlesEta08(), 3.5);
-  }
-  PROCESS_SWITCH(PhianalysisTHnSparse, processFactors, "Process to obtain normalization factors from MC.", false);
 };
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {

--- a/PWGLF/Tasks/Resonances/phianalysisTHnSparse.cxx
+++ b/PWGLF/Tasks/Resonances/phianalysisTHnSparse.cxx
@@ -43,10 +43,12 @@
 
 #include <Math/GenVector/AxisAngle.h>
 #include <Math/GenVector/Rotation3D.h>
-#include <Math/Vector4D.h>
+#include <Math/Vector4D.h> // IWYU pragma: keep (do not replace with Math/Vector4Dfwd.h)
+#include <Math/Vector4Dfwd.h>
 #include <TH1.h>
 #include <TH2.h>
 #include <TMath.h>
+#include <TString.h>
 
 #include <fmt/format.h>
 
@@ -452,60 +454,77 @@ struct PhianalysisTHnSparse {
     }
   }
   template <typename T>
-  bool selectedEvent(const T& collision, bool fillQA = false)
+  bool selectedEvent(const T& collision)
   {
-    if (fillQA)
+    if (dataQA) {
       registry.fill(HIST("QA/Event/hSelection"), 0.5); // all events
+    }
 
-    if (static_cast<bool>(eventCuts.isTriggerTVX) && !collision.selection_bit(aod::evsel::kIsTriggerTVX))
+    if (static_cast<bool>(eventCuts.isTriggerTVX) && !collision.selection_bit(aod::evsel::kIsTriggerTVX)) {
       return false;
-    if (fillQA)
+    }
+    if (dataQA) {
       registry.fill(HIST("QA/Event/hSelection"), 1.5); // events passing trigger TVX cut
+    }
 
-    if (static_cast<bool>(eventCuts.noTimeFrameBorder) && !collision.selection_bit(aod::evsel::kNoTimeFrameBorder))
+    if (static_cast<bool>(eventCuts.noTimeFrameBorder) && !collision.selection_bit(aod::evsel::kNoTimeFrameBorder)) {
       return false;
-    if (fillQA)
+    }
+    if (dataQA) {
       registry.fill(HIST("QA/Event/hSelection"), 2.5); // events passing no time frame border cut
+    }
 
-    if (static_cast<bool>(eventCuts.noITSROFrameBorder) && !collision.selection_bit(aod::evsel::kNoITSROFrameBorder))
+    if (static_cast<bool>(eventCuts.noITSROFrameBorder) && !collision.selection_bit(aod::evsel::kNoITSROFrameBorder)) {
       return false;
-    if (fillQA)
+    }
+    if (dataQA) {
       registry.fill(HIST("QA/Event/hSelection"), 3.5); // events passing no ITS RO frame border cut
+    }
 
-    if (static_cast<bool>(eventCuts.sel8) && !collision.sel8())
+    if (static_cast<bool>(eventCuts.sel8) && !collision.sel8()) {
       return false;
-    if (fillQA)
+    }
+    if (dataQA) {
       registry.fill(HIST("QA/Event/hSelection"), 4.5); // events passing sel8 cut (contains all the previous cuts)
+    }
 
-    if (static_cast<bool>(eventCuts.isVertexITSTPC) && !collision.selection_bit(aod::evsel::kIsVertexITSTPC))
+    if (static_cast<bool>(eventCuts.isVertexITSTPC) && !collision.selection_bit(aod::evsel::kIsVertexITSTPC)) {
       return false;
-    if (fillQA)
+    }
+    if (dataQA) {
       registry.fill(HIST("QA/Event/hSelection"), 5.5); // events passing IsVertexITSTPC cut
+    }
 
-    if (static_cast<bool>(eventCuts.noSameBunchPileup) && !collision.selection_bit(aod::evsel::kNoSameBunchPileup))
+    if (static_cast<bool>(eventCuts.noSameBunchPileup) && !collision.selection_bit(aod::evsel::kNoSameBunchPileup)) {
       return false;
-    if (fillQA)
+    }
+    if (dataQA) {
       registry.fill(HIST("QA/Event/hSelection"), 6.5); // events passing no same bunch pileup cut
+    }
 
-    if (static_cast<bool>(eventCuts.isGoodZvtxFT0vsPV) && !collision.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV))
+    if (static_cast<bool>(eventCuts.isGoodZvtxFT0vsPV) && !collision.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV)) {
       return false;
-    if (fillQA)
+    }
+    if (dataQA) {
       registry.fill(HIST("QA/Event/hSelection"), 7.5); // events passing IsGoodZvtxFT0vsPV cut
+    }
 
-    if (std::abs(collision.posZ()) > static_cast<float>(eventCuts.vzCut))
+    if (std::abs(collision.posZ()) > static_cast<float>(eventCuts.vzCut)) {
       return false;
-    if (fillQA)
+    }
+    if (dataQA) {
       registry.fill(HIST("QA/Event/hSelection"), 8.5); // events passing V_{z} cut
+    }
 
-    if (fillQA)
+    if (dataQA) {
       registry.fill(HIST("QA/Event/hSelection"), 9.5); // INEL
+    }
 
-    if (static_cast<bool>(eventCuts.inelGt0) && !collision.isInelGt0())
+    if (static_cast<bool>(eventCuts.inelGt0) && !collision.isInelGt0()) {
       return false;
-    if (fillQA)
+    }
+    if (dataQA) {
       registry.fill(HIST("QA/Event/hSelection"), 10.5); // events passing INEL>0 cut
-
-    if (fillQA) {
       registry.fill(HIST("QA/Event/hVtxZ"), collision.posZ());
       registry.fill(HIST("QA/Event/hMult"), getMultiplicity(collision));
       registry.fill(HIST("QA/Event/hCent"), getCentrality(collision));
@@ -519,12 +538,13 @@ struct PhianalysisTHnSparse {
     float tpcNsigma = 0.0f;
     int particleType = (track.sign() > 0) ? static_cast<int>(daughterPos) : static_cast<int>(daughterNeg);
 
-    if (particleType == pion)
+    if (particleType == pion) {
       tpcNsigma = track.tpcNSigmaPi();
-    else if (particleType == kaon)
+    } else if (particleType == kaon) {
       tpcNsigma = track.tpcNSigmaKa();
-    else if (particleType == proton)
+    } else if (particleType == proton) {
       tpcNsigma = track.tpcNSigmaPr();
+    }
     return tpcNsigma;
   }
   template <typename T>
@@ -544,69 +564,80 @@ struct PhianalysisTHnSparse {
   template <typename T>
   bool selectedTrack(const T& track, bool isPositive)
   {
-    if (dataQA)
-      registry.fill(HIST("QA/Track/hSelection"), 0.5); // all tracks
+    if (dataQA) {
+      registry.fill(HIST("QA/Track/hSelection"), 0.5);
+    }
 
-    // Apply pT cut
-    if (track.pt() < static_cast<float>(trackCuts.pt))
+    if (track.pt() < static_cast<float>(trackCuts.pt)) {
       return false;
-    if (dataQA)
+    }
+    if (dataQA) {
       registry.fill(HIST("QA/Track/hSelection"), 1.5);
+    }
 
-    // Apply eta trackCuts
-    if (std::abs(track.eta()) >= static_cast<float>(trackCuts.etatrack))
+    if (std::abs(track.eta()) >= static_cast<float>(trackCuts.etatrack)) {
       return false;
-    if (dataQA)
+    }
+    if (dataQA) {
       registry.fill(HIST("QA/Track/hSelection"), 2.5);
+    }
 
-    // Apply DCA cuts
     if (std::abs(track.dcaXY()) >= static_cast<float>(trackCuts.dcaXY) ||
-        std::abs(track.dcaZ()) >= static_cast<float>(trackCuts.dcaZ))
+        std::abs(track.dcaZ()) >= static_cast<float>(trackCuts.dcaZ)) {
       return false;
-    if (dataQA)
+    }
+    if (dataQA) {
       registry.fill(HIST("QA/Track/hSelection"), 3.5);
+    }
 
     // PID selection: TPC-only for pt < threshold value, TPC+TOF for pt >= threshold value and have TOF, else TPC-only
     float nSigmaCut = isPositive ? static_cast<float>(trackCuts.tpcnSigmaPos) : static_cast<float>(trackCuts.tpcnSigmaNeg);
     if (track.pt() < static_cast<float>(trackCuts.ptTOFThreshold) || !track.hasTOF() || static_cast<bool>(trackCuts.tpcPidOnly)) {
-      if (std::abs(tpcNsigma(track)) >= nSigmaCut)
+      if (std::abs(tpcNsigma(track)) >= nSigmaCut) {
         return false;
+      }
     } else {
-      if (std::sqrt(tpcNsigma(track) * tpcNsigma(track) + tofNsigma(track) * tofNsigma(track)) >= static_cast<float>(trackCuts.combinedNSigma))
+      if (std::sqrt(tpcNsigma(track) * tpcNsigma(track) + tofNsigma(track) * tofNsigma(track)) >= static_cast<float>(trackCuts.combinedNSigma)) {
         return false;
+      }
     }
-    if (dataQA)
+    if (dataQA) {
       registry.fill(HIST("QA/Track/hSelection"), 4.5);
+    }
 
-    // Apply tpcNClsFound cut
-    if (track.tpcNClsFound() < static_cast<int>(trackCuts.tpcNClsFound))
+    if (track.tpcNClsFound() < static_cast<int>(trackCuts.tpcNClsFound)) {
       return false;
-    if (dataQA)
+    }
+    if (dataQA) {
       registry.fill(HIST("QA/Track/hSelection"), 5.5);
+    }
 
-    // Apply tpcNClsCrossedRows cut
-    if (track.tpcNClsCrossedRows() < static_cast<int>(trackCuts.tpcNClsCrossedRows))
+    if (track.tpcNClsCrossedRows() < static_cast<int>(trackCuts.tpcNClsCrossedRows)) {
       return false;
-    if (dataQA)
+    }
+    if (dataQA) {
       registry.fill(HIST("QA/Track/hSelection"), 6.5);
+    }
 
     if (static_cast<bool>(trackCuts.globalTrack)) {
-      // Apply Global track cuts
-      if (!track.isGlobalTrack())
+      if (!track.isGlobalTrack()) {
         return false;
+      }
     } else if (static_cast<bool>(trackCuts.primaryTrack)) {
-      // Apply Primary track cuts
-      if (!track.isPrimaryTrack())
+      if (!track.isPrimaryTrack()) {
         return false;
+      }
     }
-    if (dataQA)
+    if (dataQA) {
       registry.fill(HIST("QA/Track/hSelection"), 7.5);
+    }
 
-    // Apply PV Contributor cuts
-    if (static_cast<bool>(trackCuts.pvContributor) && !track.isPVContributor())
+    if (static_cast<bool>(trackCuts.pvContributor) && !track.isPVContributor()) {
       return false;
-    if (dataQA)
+    }
+    if (dataQA) {
       registry.fill(HIST("QA/Track/hSelection"), 8.5);
+    }
 
     return true;
   }
@@ -617,11 +648,9 @@ struct PhianalysisTHnSparse {
     d2 = ROOT::Math::PxPyPzMVector(track2.px(), track2.py(), track2.pz(), massNeg);
     return d1 + d2;
   }
-  bool selectedMother(const ROOT::Math::PxPyPzMVector& mother)
+  bool selectedMother(const ROOT::Math::PxPyPzMVector& motherCandidate)
   {
-    if (std::abs(mother.Rapidity()) > static_cast<float>(trackCuts.rapidity))
-      return false;
-    return true;
+    return std::abs(motherCandidate.Rapidity()) <= static_cast<float>(trackCuts.rapidity);
   }
   template <typename T>
   float getMultiplicity(const T& collision)
@@ -655,11 +684,17 @@ struct PhianalysisTHnSparse {
 
   void processQA(EventCandidate const& collision, TrackCandidates const& tracks)
   {
-    if (!selectedEvent(collision, true))
+    dataQA = true;
+    bool selected = selectedEvent(collision);
+    dataQA = false;
+
+    if (!selected) {
       return;
+    }
 
     double centrality = getCentrality(collision);
 
+    int nch = 0;
     for (const auto& track : tracks) {
 
       registry.fill(HIST("QA/Track/hEta"), track.pt(), centrality, track.eta());
@@ -678,8 +713,17 @@ struct PhianalysisTHnSparse {
         registry.fill(HIST("QA/PID/hTOFBetaP"), track.p(), track.beta());
       }
 
-      if (!selectedTrack(track, track.sign() > 0))
+      if (track.isPrimaryTrack() && std::abs(track.eta()) < static_cast<float>(trackCuts.etatrack)) {
+        nch++;
+      }
+
+      dataQA = true;
+      bool selected = selectedTrack(track, track.sign() > 0);
+      dataQA = false;
+
+      if (!selected) {
         continue;
+      }
 
       registry.fill(HIST("QA/Kaon/hEta"), track.pt(), centrality, track.eta());
       registry.fill(HIST("QA/Kaon/hPt"), track.pt(), centrality);
@@ -698,6 +742,7 @@ struct PhianalysisTHnSparse {
         registry.fill(HIST("QA/PID/hTPCTOFnSigma"), track.pt(), tpcNsigma(track), tofNsigma(track));
       }
     }
+    registry.fill(HIST("QA/Event/hCentNch"), getCentrality(collision), nch);
   }
   PROCESS_SWITCH(PhianalysisTHnSparse, processQA, "Process Event for Data", true);
 
@@ -706,30 +751,23 @@ struct PhianalysisTHnSparse {
     auto posDaughters = positive->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
     auto negDaughters = negative->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
 
-    if (!selectedEvent(collision))
+    if (!selectedEvent(collision)) {
       return;
-
-    int nch = 0;
-    dataQA = true;
-    for (const auto& track : tracks) {
-      if (track.isPrimaryTrack() && std::abs(track.eta()) < static_cast<float>(trackCuts.etatrack))
-        nch++;
-      selectedTrack(track, false);
     }
-    dataQA = false;
-
-    registry.fill(HIST("QA/Event/hCentNch"), getCentrality(collision), nch);
 
     for (const auto& [track1, track2] : combinations(o2::soa::CombinationsFullIndexPolicy(posDaughters, negDaughters))) {
 
-      if (!selectedTrack(track1, true)) // track1 is positive
+      if (!selectedTrack(track1, true)) {
         continue;
-      if (!selectedTrack(track2, false)) // track2 is negative
+      }
+      if (!selectedTrack(track2, false)) {
         continue;
+      }
 
       mother = calculateMother(track1, track2);
-      if (!selectedMother(mother))
+      if (!selectedMother(mother)) {
         continue;
+      }
 
       registry.fill(HIST("QA/Phi/hRapidity"), mother.Pt(), getCentrality(collision), mother.Rapidity());
       registry.fill(HIST("QA/Phi/hEta"), mother.Pt(), getCentrality(collision), mother.Eta());
@@ -793,10 +831,12 @@ struct PhianalysisTHnSparse {
 
         if (negDaughters.size() > 1) {
           for (const auto& track3 : negDaughters) {
-            if (track3.globalIndex() == track1.globalIndex() || track3.globalIndex() == track2.globalIndex())
+            if (track3.globalIndex() == track1.globalIndex() || track3.globalIndex() == track2.globalIndex()) {
               continue;
-            if (!selectedTrack(track3, false))
+            }
+            if (!selectedTrack(track3, false)) {
               continue;
+            }
             ROOT::Math::PxPyPzMVector d3(track3.px(), track3.py(), track3.pz(), massNeg);
             auto motherRot = rotD1 + d3;
 
@@ -843,11 +883,13 @@ struct PhianalysisTHnSparse {
         if (posDaughters.size() > 1) {
           for (const auto& track3 : posDaughters) {
 
-            if (track3.globalIndex() == track1.globalIndex() || track3.globalIndex() == track2.globalIndex())
+            if (track3.globalIndex() == track1.globalIndex() || track3.globalIndex() == track2.globalIndex()) {
               continue;
+            }
 
-            if (!selectedTrack(track3, true))
+            if (!selectedTrack(track3, true)) {
               continue;
+            }
 
             ROOT::Math::PxPyPzMVector d3(track3.px(), track3.py(), track3.pz(), massPos);
 
@@ -897,14 +939,17 @@ struct PhianalysisTHnSparse {
     if (static_cast<bool>(produce.produceLikesign)) {
 
       for (const auto& [track1, track2] : combinations(o2::soa::CombinationsStrictlyUpperIndexPolicy(posDaughters, posDaughters))) {
-        if (!selectedTrack(track1, true))
+        if (!selectedTrack(track1, true)) {
           continue;
-        if (!selectedTrack(track2, true))
+        }
+        if (!selectedTrack(track2, true)) {
           continue;
+        }
 
         mother = calculateMother(track1, track2);
-        if (!selectedMother(mother))
+        if (!selectedMother(mother)) {
           continue;
+        }
 
         pointPair = fillPointPair(mother.M(),
                                   mother.Pt(),
@@ -923,14 +968,17 @@ struct PhianalysisTHnSparse {
       }
 
       for (const auto& [track1, track2] : combinations(o2::soa::CombinationsStrictlyUpperIndexPolicy(negDaughters, negDaughters))) {
-        if (!selectedTrack(track1, false))
+        if (!selectedTrack(track1, false)) {
           continue;
-        if (!selectedTrack(track2, false))
+        }
+        if (!selectedTrack(track2, false)) {
           continue;
+        }
 
         mother = calculateMother(track1, track2);
-        if (!selectedMother(mother))
+        if (!selectedMother(mother)) {
           continue;
+        }
 
         pointPair = fillPointPair(mother.M(),
                                   mother.Pt(),
@@ -953,14 +1001,16 @@ struct PhianalysisTHnSparse {
 
   void processTrue(EventCandidatesMC::iterator const& collision, TrackCandidatesMC const& tracks, aod::McParticles const& /*mcParticles*/, aod::McCollisions const& /*mcCollisions*/)
   {
-    if (!static_cast<bool>(produce.produceMC))
+    if (!static_cast<bool>(produce.produceMC)) {
       return;
+    }
 
     registry.fill(HIST("QAMC/Rec/hSelection"), 0.5);
     registry.fill(HIST("QAMC/Factors/hRecEvents"), getCentrality(collision), 0.5);
 
-    if (!selectedEvent(collision))
+    if (!selectedEvent(collision)) {
       return;
+    }
 
     registry.fill(HIST("QAMC/Rec/hSelection"), 1.5);
     registry.fill(HIST("QAMC/Factors/hRecEvents"), getCentrality(collision), 1.5);
@@ -968,8 +1018,9 @@ struct PhianalysisTHnSparse {
     auto posDaughtersMC = positiveMC->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
     auto negDaughtersMC = negativeMC->sliceByCached(aod::track::collisionId, collision.globalIndex(), cache);
 
-    if (!collision.has_mcCollision())
+    if (!collision.has_mcCollision()) {
       return;
+    }
 
     auto mcCollision = collision.mcCollision();
     registry.fill(HIST("QAMC/Resolution/h2ResolutionVz"), collision.posZ(), (collision.posZ() - mcCollision.posZ()));
@@ -983,48 +1034,58 @@ struct PhianalysisTHnSparse {
 
     for (const auto& [track1, track2] : combinations(o2::soa::CombinationsFullIndexPolicy(posDaughtersMC, negDaughtersMC))) {
 
-      if (!track1.has_mcParticle())
+      if (!track1.has_mcParticle()) {
         continue;
+      }
+      if (!track2.has_mcParticle()) {
+        continue;
+      }
 
-      if (!track2.has_mcParticle())
+      if (!selectedTrack(track1, true)) {
         continue;
-
-      if (!selectedTrack(track1, true)) // track1 is positive
+      }
+      if (!selectedTrack(track2, false)) {
         continue;
-      if (!selectedTrack(track2, false)) // track2 is negative
-        continue;
+      }
 
       const auto mctrack1 = track1.mcParticle();
       const auto mctrack2 = track2.mcParticle();
       int track1PDG = std::abs(mctrack1.pdgCode());
       int track2PDG = std::abs(mctrack2.pdgCode());
 
-      if (!(track1PDG == daughterPosPDG && track2PDG == daughterNegPDG)) {
+      if (track1PDG != daughterPosPDG || track2PDG != daughterNegPDG) {
         continue;
       }
+
       int n = 0;
       for (const auto& mothertrack1 : mctrack1.mothers_as<aod::McParticles>()) {
         for (const auto& mothertrack2 : mctrack2.mothers_as<aod::McParticles>()) {
 
-          if (mothertrack1.pdgCode() != mothertrack2.pdgCode())
+          if (mothertrack1.pdgCode() != mothertrack2.pdgCode()) {
             continue;
+          }
 
-          if (mothertrack1.globalIndex() != mothertrack2.globalIndex())
+          if (mothertrack1.globalIndex() != mothertrack2.globalIndex()) {
             continue;
+          }
 
-          if (std::abs(mothertrack1.y()) > static_cast<float>(trackCuts.rapidity))
+          if (std::abs(mothertrack1.y()) > static_cast<float>(trackCuts.rapidity)) {
             continue;
+          }
 
-          if (std::abs(mothertrack1.pdgCode()) != motherPDG)
+          if (std::abs(mothertrack1.pdgCode()) != motherPDG) {
             continue;
+          }
 
           mother = calculateMother(track1, track2);
           motherGen = calculateMother(mctrack1, mctrack2);
-          if (!selectedMother(mother))
+          if (!selectedMother(mother)) {
             continue;
+          }
 
-          if (n > 0)
+          if (n > 0) {
             continue;
+          }
 
           pointPair = fillPointPair(mother.M(),
                                     mother.Pt(),
@@ -1070,8 +1131,9 @@ struct PhianalysisTHnSparse {
 
   void processGen(McCollisionMults::iterator const& mcCollision, soa::SmallGroups<EventCandidatesMCGen> const& collisions, LabeledTracks const& /*particles*/, aod::McParticles const& mcParticles)
   {
-    if (!static_cast<bool>(produce.produceMC))
+    if (!static_cast<bool>(produce.produceMC)) {
       return;
+    }
 
     registry.fill(HIST("QAMC/Factors/hNrecInGen"), collisions.size());
     registry.fill(HIST("QAMC/Gen/hSelection"), 0.5);
@@ -1089,8 +1151,9 @@ struct PhianalysisTHnSparse {
 
     for (const auto& collision : collisions) {
       registry.fill(HIST("QAMC/Factors/hGenEvents"), mcCollision.multMCNParticlesEta05(), 1.5);
-      if (!selectedEvent(collision))
+      if (!selectedEvent(collision)) {
         continue;
+      }
 
       if (collision.numContrib() > nContributors) {
         nContributors = collision.numContrib();
@@ -1100,20 +1163,21 @@ struct PhianalysisTHnSparse {
       }
     }
 
-    // if (std::abs(mcCollision.posZ()) > static_cast<float>(eventCuts.vzCut) && !mcCollision.isInelGt0())
     registry.fill(HIST("QAMC/Factors/hGenEventsCentNch"), centrality, mcCollision.multMCNParticlesEta05());
 
     // All generated Phi mesons
     for (const auto& particle : mcParticles) {
 
-      if (std::abs(particle.y()) > static_cast<float>(trackCuts.rapidity))
+      if (std::abs(particle.y()) > static_cast<float>(trackCuts.rapidity)) {
         continue;
+      }
 
       if (particle.pdgCode() == motherPDG) {
 
         auto daughters = particle.daughters_as<aod::McParticles>();
-        if (daughters.size() != dauSize)
+        if (daughters.size() != dauSize) {
           continue;
+        }
 
         auto daup = false;
         auto daun = false;
@@ -1127,8 +1191,9 @@ struct PhianalysisTHnSparse {
             d2 = ROOT::Math::PxPyPzMVector(dau.px(), dau.py(), dau.pz(), massNeg);
           }
         }
-        if (!daup || !daun)
+        if (!daup || !daun) {
           continue;
+        }
 
         mother = d1 + d2;
 
@@ -1136,8 +1201,9 @@ struct PhianalysisTHnSparse {
       }
     }
 
-    if (!hasSelectedCollision)
+    if (!hasSelectedCollision) {
       return;
+    }
 
     registry.fill(HIST("QAMC/Gen/hSelection"), 2.5);
     registry.fill(HIST("QAMC/Factors/hGenEvents"), mcCollision.multMCNParticlesEta05(), 3.5);
@@ -1145,13 +1211,15 @@ struct PhianalysisTHnSparse {
 
     // Generated Phi mesons in selected collisions
     for (const auto& mcParticle : mcParticles) {
-      if (std::abs(mcParticle.y()) > static_cast<float>(trackCuts.rapidity))
+      if (std::abs(mcParticle.y()) > static_cast<float>(trackCuts.rapidity)) {
         continue;
+      }
 
       if (mcParticle.pdgCode() == motherPDG) {
         auto daughters = mcParticle.daughters_as<aod::McParticles>();
-        if (daughters.size() != dauSize)
+        if (daughters.size() != dauSize) {
           continue;
+        }
 
         auto daup = false;
         auto daun = false;
@@ -1166,8 +1234,9 @@ struct PhianalysisTHnSparse {
           }
         }
 
-        if (!daup || !daun)
+        if (!daup || !daun) {
           continue;
+        }
 
         mother = d1 + d2;
 
@@ -1195,8 +1264,9 @@ struct PhianalysisTHnSparse {
 
   void processMixed(EventCandidates const& collisions, TrackCandidates const& tracks)
   {
-    if (mixingType == rsn::MixingType::none)
+    if (mixingType == rsn::MixingType::none) {
       return;
+    }
 
     auto tracksTuple = std::make_tuple(tracks);
 
@@ -1208,8 +1278,9 @@ struct PhianalysisTHnSparse {
 
     if (mixingType == rsn::MixingType::ce) {
       for (const auto& [c1, tracks1, c2, tracks2] : pairVzCe) {
-        if (!selectedEvent(c1) || !selectedEvent(c2))
+        if (!selectedEvent(c1) || !selectedEvent(c2)) {
           continue;
+        }
 
         auto posDaughtersc1 = positive->sliceByCached(aod::track::collisionId, c1.globalIndex(), cache);
         auto posDaughtersc2 = positive->sliceByCached(aod::track::collisionId, c2.globalIndex(), cache);
@@ -1222,14 +1293,17 @@ struct PhianalysisTHnSparse {
 
         for (const auto& [track1, track2] : combinations(o2::soa::CombinationsFullIndexPolicy(posDaughtersc1, negDaughtersc2))) {
 
-          if (!selectedTrack(track1, true)) // track1 is positive
+          if (!selectedTrack(track1, true)) {
             continue;
-          if (!selectedTrack(track2, false)) // track2 is negative
+          }
+          if (!selectedTrack(track2, false)) {
             continue;
+          }
 
           mother = calculateMother(track1, track2);
-          if (!selectedMother(mother))
+          if (!selectedMother(mother)) {
             continue;
+          }
 
           registry.fill(HIST("QA/Mixing/hdPhideta"), track1.eta() - track2.eta(), track1.phi() - track2.phi());
 
@@ -1251,14 +1325,17 @@ struct PhianalysisTHnSparse {
 
         for (const auto& [track1, track2] : combinations(o2::soa::CombinationsFullIndexPolicy(posDaughtersc2, negDaughtersc1))) {
 
-          if (!selectedTrack(track1, true)) // track1 is positive
+          if (!selectedTrack(track1, true)) {
             continue;
-          if (!selectedTrack(track2, false)) // track2 is negative
+          }
+          if (!selectedTrack(track2, false)) {
             continue;
+          }
 
           mother = calculateMother(track1, track2);
-          if (!selectedMother(mother))
+          if (!selectedMother(mother)) {
             continue;
+          }
 
           pointPair = fillPointPair(mother.M(),
                                     mother.Pt(),
@@ -1279,8 +1356,9 @@ struct PhianalysisTHnSparse {
     }
     if (mixingType == rsn::MixingType::mu) {
       for (const auto& [c1, tracks1, c2, tracks2] : pairVzMu) {
-        if (!selectedEvent(c1) || !selectedEvent(c2))
+        if (!selectedEvent(c1) || !selectedEvent(c2)) {
           continue;
+        }
 
         auto posDaughtersc1 = positive->sliceByCached(aod::track::collisionId, c1.globalIndex(), cache);
         auto posDaughtersc2 = positive->sliceByCached(aod::track::collisionId, c2.globalIndex(), cache);
@@ -1293,15 +1371,18 @@ struct PhianalysisTHnSparse {
 
         for (const auto& [track1, track2] : combinations(o2::soa::CombinationsFullIndexPolicy(posDaughtersc1, negDaughtersc2))) {
 
-          if (!selectedTrack(track1, true)) // track1 is positive
+          if (!selectedTrack(track1, true)) {
             continue;
+          }
 
-          if (!selectedTrack(track2, false)) // track2 is negative
+          if (!selectedTrack(track2, false)) {
             continue;
+          }
 
           mother = calculateMother(track1, track2);
-          if (!selectedMother(mother))
+          if (!selectedMother(mother)) {
             continue;
+          }
 
           pointPair = fillPointPair(mother.M(),
                                     mother.Pt(),
@@ -1321,15 +1402,17 @@ struct PhianalysisTHnSparse {
 
         for (const auto& [track1, track2] : combinations(o2::soa::CombinationsFullIndexPolicy(posDaughtersc2, negDaughtersc1))) {
 
-          if (!selectedTrack(track1, true))
-
+          if (!selectedTrack(track1, true)) {
             continue;
-          if (!selectedTrack(track2, false))
+          }
+          if (!selectedTrack(track2, false)) {
             continue;
+          }
 
           mother = calculateMother(track1, track2);
-          if (!selectedMother(mother))
+          if (!selectedMother(mother)) {
             continue;
+          }
 
           pointPair = fillPointPair(mother.M(),
                                     mother.Pt(),

--- a/PWGLF/Tasks/Resonances/phianalysisTHnSparse.cxx
+++ b/PWGLF/Tasks/Resonances/phianalysisTHnSparse.cxx
@@ -718,10 +718,10 @@ struct PhianalysisTHnSparse {
       }
 
       dataQA = true;
-      bool selected = selectedTrack(track, track.sign() > 0);
+      bool selectedTrackCandidate = selectedTrack(track, track.sign() > 0);
       dataQA = false;
 
-      if (!selected) {
+      if (!selectedTrackCandidate) {
         continue;
       }
 

--- a/PWGLF/Utils/rsnOutput.h
+++ b/PWGLF/Utils/rsnOutput.h
@@ -49,12 +49,14 @@ enum class PairType {
   unlikemp,
   likepp,
   likemm,
-  unliketrue,
+  unliketruerec,
+  unliketruegen,
   unlikegen,
-  unlikegenold,
   mixingpm,
   mixingmp,
-  rotationpm,
+  rotationz,
+  rotation,
+  rotationlike,
   all
 };
 
@@ -209,12 +211,14 @@ class Output
   virtual void fillUnlikemp(double* point) = 0;
   virtual void fillLikepp(double* point) = 0;
   virtual void fillLikemm(double* point) = 0;
-  virtual void fillUnliketrue(double* point) = 0;
-  virtual void fillUnlikegen(double* point) = 0;
-  virtual void fillUnlikegenOld(double* point) = 0;
+  virtual void fillUnlikeTrueRec(double* point) = 0;
+  virtual void fillUnlikeTrueGen(double* point) = 0;
+  virtual void fillUnlikeGen(double* point) = 0;
   virtual void fillMixingpm(double* point) = 0;
   virtual void fillMixingmp(double* point) = 0;
-  virtual void fillRotationpm(double* point) = 0;
+  virtual void fillRotationZ(double* point) = 0;
+  virtual void fillRotation(double* point) = 0;
+  virtual void fillRotationLike(double* point) = 0;
   virtual void fillSystematics(double* point) = 0;
 
   PairAxisType type(std::string name)
@@ -278,16 +282,18 @@ class OutputSparse : public Output
       mHistogramRegistry->add("likemm", "Like MM", *mPairHisto);
     }
     if (produceTrue) {
-      mHistogramRegistry->add("unliketrue", "Unlike True", *mPairHisto);
+      mHistogramRegistry->add("unliketruerec", "Unlike True (Rec)", *mPairHisto);
+      mHistogramRegistry->add("unliketruegen", "Unlike True (Gen)", *mPairHisto);
       mHistogramRegistry->add("unlikegen", "Unlike Gen", *mPairHisto);
-      mHistogramRegistry->add("unlikegenold", "Unlike Gen Old", *mPairHisto);
     }
     if (eventMixing != MixingType::none) {
       mHistogramRegistry->add("mixingpm", "Event Mixing pm", *mPairHisto);
       mHistogramRegistry->add("mixingmp", "Event Mixing mp", *mPairHisto);
     }
     if (produceRotational) {
-      mHistogramRegistry->add("rotationpm", "Rotational pm", *mPairHisto);
+      mHistogramRegistry->add("rotationz", "Rotation around z axis", *mPairHisto);
+      mHistogramRegistry->add("rotation", "Momentum-axis rotation, unlike-sign", *mPairHisto);
+      mHistogramRegistry->add("rotationlike", "Momentum-axis rotation, like-sign", *mPairHisto);
     }
     mHistogramRegistry->add("Mapping/systematics", "Systematics mapping", *mPairHistoSys);
   }
@@ -319,14 +325,14 @@ class OutputSparse : public Output
       case PairType::likemm:
         fillLikemm(point);
         break;
-      case PairType::unliketrue:
-        fillUnliketrue(point);
+      case PairType::unliketruerec:
+        fillUnlikeTrueRec(point);
         break;
       case PairType::unlikegen:
-        fillUnlikegen(point);
+        fillUnlikeGen(point);
         break;
-      case PairType::unlikegenold:
-        fillUnlikegenOld(point);
+      case PairType::unliketruegen:
+        fillUnlikeTrueGen(point);
         break;
       case PairType::mixingpm:
         fillMixingpm(point);
@@ -334,8 +340,14 @@ class OutputSparse : public Output
       case PairType::mixingmp:
         fillMixingmp(point);
         break;
-      case PairType::rotationpm:
-        fillRotationpm(point);
+      case PairType::rotationz:
+        fillRotationZ(point);
+        break;
+      case PairType::rotation:
+        fillRotation(point);
+        break;
+      case PairType::rotationlike:
+        fillRotationLike(point);
         break;
       default:
         break;
@@ -358,17 +370,17 @@ class OutputSparse : public Output
   {
     fillSparse(HIST("likemm"), point);
   }
-  virtual void fillUnliketrue(double* point)
+  virtual void fillUnlikeTrueRec(double* point)
   {
-    fillSparse(HIST("unliketrue"), point);
+    fillSparse(HIST("unliketruerec"), point);
   }
-  virtual void fillUnlikegen(double* point)
+  virtual void fillUnlikeTrueGen(double* point)
+  {
+    fillSparse(HIST("unliketruegen"), point);
+  }
+  virtual void fillUnlikeGen(double* point)
   {
     fillSparse(HIST("unlikegen"), point);
-  }
-  virtual void fillUnlikegenOld(double* point)
-  {
-    fillSparse(HIST("unlikegenold"), point);
   }
   virtual void fillMixingpm(double* point)
   {
@@ -378,9 +390,17 @@ class OutputSparse : public Output
   {
     fillSparse(HIST("mixingmp"), point);
   }
-  virtual void fillRotationpm(double* point)
+  virtual void fillRotationZ(double* point)
   {
-    fillSparse(HIST("rotationpm"), point);
+    fillSparse(HIST("rotationz"), point);
+  }
+  virtual void fillRotation(double* point)
+  {
+    fillSparse(HIST("rotation"), point);
+  }
+  virtual void fillRotationLike(double* point)
+  {
+    fillSparse(HIST("rotationlike"), point);
   }
   virtual void fillSystematics(double* point)
   {

--- a/PWGLF/Utils/rsnOutput.h
+++ b/PWGLF/Utils/rsnOutput.h
@@ -28,9 +28,7 @@
 #include <utility>
 #include <vector>
 
-namespace o2::analysis
-{
-namespace rsn
+namespace o2::analysis::rsn
 {
 enum class EventType {
   zvertex,
@@ -124,7 +122,7 @@ class Output
     for (int i = 0; i < static_cast<int>(PairAxisType::unknown); i++) {
       auto aname = *std::move(allAxes[i].name);
       LOGF(debug, "Check axis '%s' %d", aname.c_str(), i);
-      if (aname != pair_axis::names[static_cast<int>(i)]) {
+      if (aname != pair_axis::names[i]) {
         LOGF(fatal, "rsn::Output::Error: Order in allAxes is not correct !!! Expected axis '%s' and has '%s'.", aname.c_str(), pair_axis::names[static_cast<int>(i)]);
       }
     }
@@ -141,9 +139,8 @@ class Output
       mCurrentAxisTypes.push_back(currentType);
     }
 
-    if (mFillPoint != nullptr) {
-      delete mFillPoint;
-    }
+    delete mFillPoint;
+
     mFillPoint = new double[mCurrentAxisTypes.size()];
 
     LOGF(info, "Number of axis added: %d", mCurrentAxes.size());
@@ -153,7 +150,7 @@ class Output
     for (int i = 0; i < static_cast<int>(SystematicsAxisType::unknown); i++) {
       auto aname = *std::move(allAxes_sys[i].name);
       LOGF(debug, "Check axis '%s' %d", aname.c_str(), i);
-      if (aname != systematic_axis::names[static_cast<int>(i)]) {
+      if (aname != systematic_axis::names[i]) {
         LOGF(fatal, "rsn::Output::Error: Order in allAxes_sys is not correct !!! Expected axis '%s' and has '%s'.", aname.c_str(), systematic_axis::names[static_cast<int>(i)]);
       }
     }
@@ -170,9 +167,8 @@ class Output
       mCurrentAxisTypesSys.push_back(currentTypeSys);
     }
 
-    if (mFillPointSys != nullptr) {
-      delete mFillPointSys;
-    }
+    delete mFillPointSys;
+
     mFillPointSys = new double[mCurrentAxisTypesSys.size()];
 
     LOGF(info, "Number of systematic axis added: %d", mCurrentAxesSys.size());
@@ -180,7 +176,7 @@ class Output
   }
 
   template <typename T>
-  void fillSparse(const T& h, double* point)
+  void fillSparse(const T& h, const double* point)
   {
     int i = 0;
     for (const auto& at : mCurrentAxisTypes) {
@@ -190,7 +186,7 @@ class Output
   }
 
   template <typename T>
-  void fillSparseSys(const T& h, double* point)
+  void fillSparseSys(const T& h, const double* point)
   {
     int i = 0;
     for (const auto& at : mCurrentAxisTypesSys) {
@@ -411,7 +407,6 @@ class OutputSparse : public Output
     fillSparse(HIST("Mapping/systematics"), point);
   }
 };
-} // namespace rsn
-} // namespace o2::analysis
+} // namespace o2::analysis::rsn
 
 #endif // PWGLF_UTILS_RSNOUTPUT_H_

--- a/PWGLF/Utils/rsnOutput.h
+++ b/PWGLF/Utils/rsnOutput.h
@@ -82,13 +82,14 @@ enum class MixingType {
   none
 };
 
-MixingType mixingTypeName(std::string name)
+MixingType mixingTypeName(const std::string& name)
 {
-  if (name == "ce")
+  if (name == "ce") {
     return MixingType::ce;
-  else if (name == "mu")
+  }
+  if (name == "mu") {
     return MixingType::mu;
-
+  }
   return MixingType::none;
 }
 
@@ -96,14 +97,15 @@ enum class SystematicsAxisType {
   ncl,
   unknown
 };
+
 namespace pair_axis
 {
-std::vector<std::string> names{"im", "pt", "mu", "ce", "ns1", "ns2", "eta", "y", "vz", "mum", "cem", "vzm"};
+const std::vector<std::string> names{"im", "pt", "mu", "ce", "ns1", "ns2", "eta", "y", "vz", "mum", "cem", "vzm"};
 }
 
 namespace systematic_axis
 {
-std::vector<std::string> names{"ncl"};
+const std::vector<std::string> names{"ncl"};
 }
 
 class Output
@@ -111,22 +113,23 @@ class Output
  public:
   virtual ~Output() = default;
 
-  virtual void init(std::vector<std::string> const& sparseAxes, std::vector<o2::framework::AxisSpec> const& allAxes, std::vector<std::string> const& sysAxes, std::vector<o2::framework::AxisSpec> const& allAxes_sys, bool /*produceTrue*/ = false, MixingType /*eventMixing*/ = MixingType::none, bool /*produceLikesign*/ = false, bool /*produceRotational*/ = false, o2::framework::HistogramRegistry* registry = nullptr)
+  virtual void init(std::vector<std::string> const& sparseAxes, std::vector<o2::framework::AxisSpec> const& allAxes, std::vector<std::string> const& sysAxes, std::vector<o2::framework::AxisSpec> const& allAxes_sys, bool /*produceTrue*/, MixingType /*eventMixing*/, bool /*produceLikesign*/, bool /*produceRotational*/, o2::framework::HistogramRegistry* registry)
   {
     mHistogramRegistry = registry;
-    if (mHistogramRegistry == nullptr)
+    if (mHistogramRegistry == nullptr) {
       mHistogramRegistry = new o2::framework::HistogramRegistry("registry");
+    }
 
     // check if all axes are added in correct order
     for (int i = 0; i < static_cast<int>(PairAxisType::unknown); i++) {
       auto aname = *std::move(allAxes[i].name);
       LOGF(debug, "Check axis '%s' %d", aname.c_str(), i);
-      if (aname.compare(pair_axis::names[static_cast<int>(i)])) {
+      if (aname != pair_axis::names[static_cast<int>(i)]) {
         LOGF(fatal, "rsn::Output::Error: Order in allAxes is not correct !!! Expected axis '%s' and has '%s'.", aname.c_str(), pair_axis::names[static_cast<int>(i)]);
       }
     }
 
-    PairAxisType currentType;
+    PairAxisType currentType = PairAxisType::unknown;
     for (const auto& c : sparseAxes) {
       currentType = type(c);
       if (currentType >= PairAxisType::unknown) {
@@ -138,8 +141,9 @@ class Output
       mCurrentAxisTypes.push_back(currentType);
     }
 
-    if (mFillPoint != nullptr)
+    if (mFillPoint != nullptr) {
       delete mFillPoint;
+    }
     mFillPoint = new double[mCurrentAxisTypes.size()];
 
     LOGF(info, "Number of axis added: %d", mCurrentAxes.size());
@@ -149,12 +153,12 @@ class Output
     for (int i = 0; i < static_cast<int>(SystematicsAxisType::unknown); i++) {
       auto aname = *std::move(allAxes_sys[i].name);
       LOGF(debug, "Check axis '%s' %d", aname.c_str(), i);
-      if (aname.compare(systematic_axis::names[static_cast<int>(i)])) {
+      if (aname != systematic_axis::names[static_cast<int>(i)]) {
         LOGF(fatal, "rsn::Output::Error: Order in allAxes_sys is not correct !!! Expected axis '%s' and has '%s'.", aname.c_str(), systematic_axis::names[static_cast<int>(i)]);
       }
     }
 
-    SystematicsAxisType currentTypeSys;
+    SystematicsAxisType currentTypeSys = SystematicsAxisType::unknown;
     for (const auto& c : sysAxes) {
       currentTypeSys = typeSys(c);
       if (currentTypeSys >= SystematicsAxisType::unknown) {
@@ -166,8 +170,9 @@ class Output
       mCurrentAxisTypesSys.push_back(currentTypeSys);
     }
 
-    if (mFillPointSys != nullptr)
+    if (mFillPointSys != nullptr) {
       delete mFillPointSys;
+    }
     mFillPointSys = new double[mCurrentAxisTypesSys.size()];
 
     LOGF(info, "Number of systematic axis added: %d", mCurrentAxesSys.size());
@@ -221,7 +226,7 @@ class Output
   virtual void fillRotationLike(double* point) = 0;
   virtual void fillSystematics(double* point) = 0;
 
-  PairAxisType type(std::string name)
+  PairAxisType type(const std::string& name)
   {
     auto it = std::find(pair_axis::names.begin(), pair_axis::names.end(), name);
     if (it == pair_axis::names.end()) {
@@ -230,7 +235,7 @@ class Output
     return static_cast<PairAxisType>(std::distance(pair_axis::names.begin(), it));
   }
 
-  SystematicsAxisType typeSys(std::string name)
+  SystematicsAxisType typeSys(const std::string& name)
   {
     auto it = std::find(systematic_axis::names.begin(), systematic_axis::names.end(), name);
     if (it == systematic_axis::names.end()) {
@@ -239,22 +244,22 @@ class Output
     return static_cast<SystematicsAxisType>(std::distance(systematic_axis::names.begin(), it));
   }
 
-  std::string name(PairAxisType type)
+  std::string name(PairAxisType axisType)
   {
-    return pair_axis::names[(static_cast<int>(type))];
+    return pair_axis::names[(static_cast<int>(axisType))];
   }
 
-  std::string nameSys(SystematicsAxisType type)
+  std::string nameSys(SystematicsAxisType axisType)
   {
-    return systematic_axis::names[(static_cast<int>(type))];
+    return systematic_axis::names[(static_cast<int>(axisType))];
   }
 
-  o2::framework::AxisSpec axis(std::vector<o2::framework::AxisSpec> const& allAxes, PairAxisType type)
+  o2::framework::AxisSpec axis(std::vector<o2::framework::AxisSpec> const& allAxes, PairAxisType axisType)
   {
-    const o2::framework::AxisSpec unknownAxis = {1, 0., 1., "unknown axis", "unknown"};
-    if (type == PairAxisType::unknown)
-      return unknownAxis;
-    return allAxes[static_cast<int>(type)];
+    if (axisType == PairAxisType::unknown) {
+      return {1, 0., 1., "unknown axis", "unknown"};
+    }
+    return allAxes[static_cast<int>(axisType)];
   }
 
  protected:
@@ -272,7 +277,7 @@ class Output
 class OutputSparse : public Output
 {
  public:
-  virtual void init(std::vector<std::string> const& sparseAxes, std::vector<o2::framework::AxisSpec> const& allAxes, std::vector<std::string> const& sysAxes, std::vector<o2::framework::AxisSpec> const& allAxes_sys, bool produceTrue = false, MixingType eventMixing = MixingType::none, bool produceLikesign = false, bool produceRotational = false, o2::framework::HistogramRegistry* registry = nullptr)
+  void init(std::vector<std::string> const& sparseAxes, std::vector<o2::framework::AxisSpec> const& allAxes, std::vector<std::string> const& sysAxes, std::vector<o2::framework::AxisSpec> const& allAxes_sys, bool produceTrue, MixingType eventMixing, bool produceLikesign, bool produceRotational, o2::framework::HistogramRegistry* registry) override
   {
     Output::init(sparseAxes, allAxes, sysAxes, allAxes_sys, produceTrue, eventMixing, produceLikesign, produceRotational, registry);
 
@@ -298,8 +303,7 @@ class OutputSparse : public Output
     mHistogramRegistry->add("Mapping/systematics", "Systematics mapping", *mPairHistoSys);
   }
 
-  virtual void
-    fill(EventType t, double* point)
+  void fill(EventType t, double* point) override
   {
     switch (t) {
       case EventType::zvertex:
@@ -310,7 +314,7 @@ class OutputSparse : public Output
     }
   }
 
-  virtual void fill(PairType t, double* point)
+  void fill(PairType t, double* point) override
   {
     switch (t) {
       case PairType::unlikepm:
@@ -354,55 +358,55 @@ class OutputSparse : public Output
     }
   }
 
-  virtual void fillUnlikepm(double* point)
+  void fillUnlikepm(double* point) override
   {
     fillSparse(HIST("unlikepm"), point);
   }
-  virtual void fillUnlikemp(double* point)
+  void fillUnlikemp(double* point) override
   {
     fillSparse(HIST("unlikemp"), point);
   }
-  virtual void fillLikepp(double* point)
+  void fillLikepp(double* point) override
   {
     fillSparse(HIST("likepp"), point);
   }
-  virtual void fillLikemm(double* point)
+  void fillLikemm(double* point) override
   {
     fillSparse(HIST("likemm"), point);
   }
-  virtual void fillUnlikeTrueRec(double* point)
+  void fillUnlikeTrueRec(double* point) override
   {
     fillSparse(HIST("unliketruerec"), point);
   }
-  virtual void fillUnlikeTrueGen(double* point)
+  void fillUnlikeTrueGen(double* point) override
   {
     fillSparse(HIST("unliketruegen"), point);
   }
-  virtual void fillUnlikeGen(double* point)
+  void fillUnlikeGen(double* point) override
   {
     fillSparse(HIST("unlikegen"), point);
   }
-  virtual void fillMixingpm(double* point)
+  void fillMixingpm(double* point) override
   {
     fillSparse(HIST("mixingpm"), point);
   }
-  virtual void fillMixingmp(double* point)
+  void fillMixingmp(double* point) override
   {
     fillSparse(HIST("mixingmp"), point);
   }
-  virtual void fillRotationZ(double* point)
+  void fillRotationZ(double* point) override
   {
     fillSparse(HIST("rotationz"), point);
   }
-  virtual void fillRotation(double* point)
+  void fillRotation(double* point) override
   {
     fillSparse(HIST("rotation"), point);
   }
-  virtual void fillRotationLike(double* point)
+  void fillRotationLike(double* point) override
   {
     fillSparse(HIST("rotationlike"), point);
   }
-  virtual void fillSystematics(double* point)
+  void fillSystematics(double* point) override
   {
     fillSparse(HIST("Mapping/systematics"), point);
   }


### PR DESCRIPTION
- Add an alternative rotational background method using rotations around the mother-particle momentum axis.
- Fix and merge histograms for event and signal-loss factor calculation into the true and generated MC processes.
- Rework and expand the QA histograms and their organisation.
- general clean up