### PR TITLE
[Common] Only automatically set generator name if not provided in MultModule.h

### DIFF
--- a/Common/Tools/Multiplicity/MultModule.h
+++ b/Common/Tools/Multiplicity/MultModule.h
@@ -1198,13 +1198,13 @@ class MultModule
       LOGF(info, "centrality loading procedure for timestamp=%llu, run number=%d", bc.timestamp(), bc.runNumber());
 
       // capture the need for PYTHIA calibration in Pb-Pb runs
-      if (metadataInfo.isMC() && mRunNumber >= 544013 && mRunNumber <= 545367 && internalOpts.generatorName.empty()) {
+      if (metadataInfo.isMC() && mRunNumber >= 544013 && mRunNumber <= 545367 && internalOpts.generatorName.value.empty()) {
         LOGF(info, "This is MC for Pb-Pb. Setting generatorName automatically to PYTHIA");
         internalOpts.generatorName.value = "PYTHIA";
       }
 
       // capture the need for PYTHIA calibration in light ion runs automatically
-      if (metadataInfo.isMC() && mRunNumber >= 564250 && mRunNumber <= 564472 && internalOpts.generatorName.empty()) {
+      if (metadataInfo.isMC() && mRunNumber >= 564250 && mRunNumber <= 564472 && internalOpts.generatorName.value.empty()) {
         LOGF(info, "This is MC for light ion runs. Setting generatorName automatically to PYTHIA");
         internalOpts.generatorName.value = "PYTHIA";
       }

--- a/Common/Tools/Multiplicity/MultModule.h
+++ b/Common/Tools/Multiplicity/MultModule.h
@@ -11,7 +11,7 @@
 
 /// \file MultModule.h
 /// \brief combined multiplicity + centrality module with autodetect features
-/// \author ALICE
+/// \author ALICE Collaboration
 
 #ifndef COMMON_TOOLS_MULTIPLICITY_MULTMODULE_H_
 #define COMMON_TOOLS_MULTIPLICITY_MULTMODULE_H_

--- a/Common/Tools/Multiplicity/MultModule.h
+++ b/Common/Tools/Multiplicity/MultModule.h
@@ -1198,13 +1198,13 @@ class MultModule
       LOGF(info, "centrality loading procedure for timestamp=%llu, run number=%d", bc.timestamp(), bc.runNumber());
 
       // capture the need for PYTHIA calibration in Pb-Pb runs
-      if (metadataInfo.isMC() && mRunNumber >= 544013 && mRunNumber <= 545367) {
+      if (metadataInfo.isMC() && mRunNumber >= 544013 && mRunNumber <= 545367 && internalOpts.generatorName.empty()) {
         LOGF(info, "This is MC for Pb-Pb. Setting generatorName automatically to PYTHIA");
         internalOpts.generatorName.value = "PYTHIA";
       }
 
       // capture the need for PYTHIA calibration in light ion runs automatically
-      if (metadataInfo.isMC() && mRunNumber >= 564250 && mRunNumber <= 564472) {
+      if (metadataInfo.isMC() && mRunNumber >= 564250 && mRunNumber <= 564472 && internalOpts.generatorName.empty()) {
         LOGF(info, "This is MC for light ion runs. Setting generatorName automatically to PYTHIA");
         internalOpts.generatorName.value = "PYTHIA";
       }


### PR DESCRIPTION
- Add condition to automatically set generator name IF not provided (prevents the generator name configurable to get overwritten)

Tagging @jesgum who spotted the issue.

@ddobrigk for your information