### PR TITLE
[PWGLF] Compile CascadeMlResponse header

### DIFF
--- a/PWGLF/Utils/CMakeLists.txt
+++ b/PWGLF/Utils/CMakeLists.txt
@@ -36,3 +36,7 @@ o2physics_add_library(LfStrangenessBuilderHelper
 o2physics_add_library(LfStrangenessBuilderModule
     SOURCES strangenessBuilderModule.cxx
     PUBLIC_LINK_LIBRARIES O2Physics::AnalysisCore KFParticle::KFParticle)
+
+o2physics_add_library(LfCascadeMlResponse
+    SOURCES cascadeMlResponse.cxx
+    PUBLIC_LINK_LIBRARIES O2Physics::MLCore)

--- a/PWGLF/Utils/cascadeMlResponse.cxx
+++ b/PWGLF/Utils/cascadeMlResponse.cxx
@@ -1,0 +1,18 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+/// \file cascadeMlResponse.cxx
+/// \brief Helper file providing the compilation command for the CascadeMlResponse header.
+///
+/// \author ALICE Collaboration
+
+// o2-linter: disable=name/workflow-file (not a workflow file)
+#include "CascadeMlResponse.h" // IWYU pragma: keep


### PR DESCRIPTION
Provides missing compile commands needed by Clang-Tidy.