### PR TITLE
[PWGEM] Add seperate event selection for photons and event-norm table

### DIFF
--- a/PWGEM/PhotonMeson/Core/EMPhotonEventCut.h
+++ b/PWGEM/PhotonMeson/Core/EMPhotonEventCut.h
@@ -50,8 +50,8 @@ class EMPhotonEventCut
     kNCuts
   };
 
-  const std::string getName() const { return name; }
-  const std::string getTitle() const { return title; }
+  [[nodiscard]] const std::string& getName() const { return name; }
+  [[nodiscard]] const std::string& getTitle() const { return title; }
 
   template <typename T>
   bool IsSelected(T const& collision) const

--- a/PWGEM/PhotonMeson/DataModel/EventTables.h
+++ b/PWGEM/PhotonMeson/DataModel/EventTables.h
@@ -29,36 +29,37 @@
 #include <Rtypes.h> // for BIT
 
 #include <cstdint>
+#include <vector>
 
 namespace o2::aod
 {
 
 namespace pmevsel
 {
-// Event selection criteria. See O2Physics/Common/CCDB/EventSelectionParams.h
-enum EventSelectionFlags {
-  kIsTriggerTVX = 0,          // FT0 vertex (acceptable FT0C-FT0A time difference) at trigger level
-  kNoITSROFrameBorder,        // bunch crossing is far from ITS RO Frame border
-  kNoTimeFrameBorder,         // bunch crossing is far from Time Frame borders
-  kNoSameBunchPileup,         // reject collisions in case of pileup with another collision in the same foundBC
-  kIsGoodZvtxFT0vsPV,         // small difference between z-vertex from PV and from FT0
-  kIsVertexITSTPC,            // at least one ITS-TPC track (reject vertices built from ITS-only tracks)
-  kIsVertexTOFmatched,        // at least one of vertex contributors is matched to TOF
-  kIsVertexTRDmatched,        // at least one of vertex contributors is matched to TRD
-  kNoCollInTimeRangeNarrow,   // no other collisions in specified time range (narrower than Strict)
-  kNoCollInTimeRangeStrict,   // no other collisions in specified time range
-  kNoCollInTimeRangeStandard, // no other collisions in specified time range with per-collision multiplicity above threshold
-  kNoCollInRofStrict,         // no other collisions in this Readout Frame
-  kNoCollInRofStandard,       // no other collisions in this Readout Frame with per-collision multiplicity above threshold
-  kNoHighMultCollInPrevRof,   // veto an event if FT0C amplitude in previous ITS ROF is above threshold
-  kIsGoodITSLayer3,           // number of inactive chips on ITS layer 3 is below maximum allowed value
-  kIsGoodITSLayer0123,        // numbers of inactive chips on ITS layers 0-3 are below maximum allowed values
-  kIsGoodITSLayersAll,        // numbers of inactive chips on all ITS layers are below maximum allowed values
-  kNsel                       // counter
-};
 
-DECLARE_SOA_BITMAP_COLUMN(Selection, selection, 32); //! Bitmask of selection flags
-DECLARE_SOA_DYNAMIC_COLUMN(Sel8, sel8, [](uint32_t selection_bit) -> bool { return (selection_bit & BIT(o2::aod::pmevsel::kIsTriggerTVX)) && (selection_bit & BIT(o2::aod::pmevsel::kNoTimeFrameBorder)) && (selection_bit & BIT(o2::aod::pmevsel::kNoITSROFrameBorder)); });
+DECLARE_SOA_DYNAMIC_COLUMN(Sel8, sel8, [](uint64_t selection_bit, int runNumber) -> bool {
+  return (selection_bit & BIT(o2::aod::evsel::kIsTriggerTVX)) && (selection_bit & BIT(o2::aod::evsel::kNoTimeFrameBorder)) && (runNumber < 568873 ? (selection_bit & BIT(o2::aod::evsel::kNoITSROFrameBorder)) : true); // o2-linter: disable=magic-number (hard-coded run range to indicate 2026 datataking)
+});
+
+// Enum used for filling table for event-norm purposes
+enum EventAcceptanceBits {
+  kAll = 0, // o2-linter: disable=magic-number (enum)
+  kHasMCColl,
+  kGoodZVtx,
+  kIsFT0AND,
+  kNoTFB,
+  kITSROFB,
+  kNoSameBunchPileUp,
+  kGoodZVtxFTOPV,
+  kNoCollInTimeRange,
+  kGoodTrackOccupancy,
+  kGoodFT0Occupancy,
+  kTVXInEMC,
+  kGoodCent,
+  kGoodRCT,
+  kGoodSel8,
+  kSize
+};
 
 } // namespace pmevsel
 
@@ -66,15 +67,26 @@ namespace pmevent
 {
 DECLARE_SOA_COLUMN(CollisionId, collisionId, int);
 
-DECLARE_SOA_DYNAMIC_COLUMN(Sel8, sel8, [](uint64_t selection_bit) -> bool { return (selection_bit & BIT(o2::aod::evsel::kIsTriggerTVX)) && (selection_bit & BIT(o2::aod::evsel::kNoTimeFrameBorder)) && (selection_bit & BIT(o2::aod::evsel::kNoITSROFrameBorder)); });
 } // namespace pmevent
 
 DECLARE_SOA_TABLE(PMEvents, "AOD", "PMEVENT", //!   Main event information table
                   o2::soa::Index<>, pmevent::CollisionId, bc::RunNumber, bc::GlobalBC, evsel::Selection, evsel::Rct, timestamp::Timestamp,
                   collision::PosZ,
-                  collision::NumContrib, evsel::NumTracksInTimeRange, evsel::SumAmpFT0CInTimeRange, pmevent::Sel8<evsel::Selection>);
+                  collision::NumContrib, evsel::NumTracksInTimeRange, evsel::SumAmpFT0CInTimeRange, pmevsel::Sel8<evsel::Selection, bc::RunNumber>);
 
 using PMEvent = PMEvents::iterator;
+
+// Tables for event selection and event bookkeeping
+
+DECLARE_SOA_COLUMN(IsSelected, isSelected, bool); //! MB event selection info
+DECLARE_SOA_TABLE(PMEvSels, "AOD", "PMEVSEL",     //! joinable to o2::aod::Collisions
+                  IsSelected);
+using PMEvSel = PMEvSels::iterator;
+
+DECLARE_SOA_COLUMN(EventSelectionBit, eventSelectionBit, std::vector<uint64_t>); //! Event selection info stored in binned data for each DF
+DECLARE_SOA_TABLE(PMEvSelBits, "AOD", "PMEVSELBITS",                             //! produces binned data that can be loaded in analysis task for event counting
+                  EventSelectionBit);
+using PMEvSelBit = PMEvSelBits::iterator;
 
 namespace ccdbPcm
 {

--- a/PWGEM/PhotonMeson/TableProducer/CMakeLists.txt
+++ b/PWGEM/PhotonMeson/TableProducer/CMakeLists.txt
@@ -60,3 +60,8 @@ o2physics_add_dpl_workflow(material-budget-weights
                     SOURCES materialBudgetWeights.cxx
                     PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore O2::CCDB ROOT::Hist ROOT::Core
                     COMPONENT_NAME Analysis)
+
+o2physics_add_dpl_workflow(event-selection-photon
+                    SOURCES eventSelection.cxx
+                    PUBLIC_LINK_LIBRARIES O2::Framework O2Physics::AnalysisCore
+                    COMPONENT_NAME Analysis)

--- a/PWGEM/PhotonMeson/TableProducer/associateMCinfoPhoton.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/associateMCinfoPhoton.cxx
@@ -13,6 +13,7 @@
 /// \brief This code produces EmMc tables were the McParticleIds get reshuffled due to not storing all McParticles
 /// \author Daiki Sekihata (daiki.sekihata@cern.ch), Marvin Hemmer (marvin.hemmer@cern.ch), Nicolas Strangmann (nicolas.strangmann@cern.ch)
 
+#include "PWGEM/PhotonMeson/DataModel/EventTables.h"
 #include "PWGEM/PhotonMeson/DataModel/GammaTablesRedux.h"
 #include "PWGEM/PhotonMeson/DataModel/gammaTables.h"
 #include "PWGEM/PhotonMeson/Utils/MCUtilities.h"
@@ -56,7 +57,7 @@ using namespace o2::soa;
 using namespace o2::aod::pwgem::photonmeson::utils::mcutil;
 using namespace o2::constants::physics;
 
-using MyCollisionsMC = soa::Join<aod::Collisions, aod::McCollisionLabels, aod::EvSels, aod::EMEvSels>;
+using MyCollisionsMC = soa::Join<aod::Collisions, aod::McCollisionLabels, aod::EvSels, aod::PMEvSels>;
 using TracksMC = soa::Join<aod::TracksIU, aod::McTrackLabels>;
 using FwdTracksMC = soa::Join<aod::FwdTracks, aod::McFwdTrackLabels>;
 using MyEMCClusters = soa::Join<aod::MinClusters, aod::EMCClusterMCLabels_001>;

--- a/PWGEM/PhotonMeson/TableProducer/createEMEventPhoton.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/createEMEventPhoton.cxx
@@ -50,7 +50,7 @@ using namespace o2::soa;
 using MyBCs = soa::Join<aod::BCsWithTimestamps, aod::BcSels>;
 using MyQvectors = soa::Join<aod::QvectorFT0CVecs, aod::QvectorFT0AVecs, aod::QvectorFT0MVecs, aod::QvectorFV0AVecs, aod::QvectorBPosVecs, aod::QvectorBNegVecs, aod::QvectorBTotVecs>;
 
-using MyCollisions = soa::Join<aod::Collisions, aod::EvSels, aod::EMEvSels, aod::EMEoIs, aod::Mults>;
+using MyCollisions = soa::Join<aod::Collisions, aod::EvSels, aod::PMEvSels, aod::EMEoIs, aod::Mults>;
 using MyCollisionsCent = soa::Join<MyCollisions, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs>; // centrality table has dependency on multiplicity table.
 using MyCollisionsCentQvec = soa::Join<MyCollisionsCent, MyQvectors>;
 
@@ -95,6 +95,7 @@ struct CreateEMEventPhoton {
   template <bool isMC, bool isTriggerAnalysis, EMEventType eventtype, typename TCollisions, typename TBCs>
   void skimEvent(TCollisions const& collisions, TBCs const&)
   {
+
     for (const auto& collision : collisions) {
       if constexpr (isMC) {
         if (!collision.has_mcCollision()) {

--- a/PWGEM/PhotonMeson/TableProducer/eventSelection.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/eventSelection.cxx
@@ -1,0 +1,196 @@
+// Copyright 2019-2020 CERN and copyright holders of ALICE O2.
+// See https://alice-o2.web.cern.ch/copyright for details of the copyright holders.
+// All rights not expressly granted are reserved.
+//
+// This software is distributed under the terms of the GNU General Public
+// License v3 (GPL Version 3), copied verbatim in the file "COPYING".
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+//
+// ========================
+//
+// This code produces event selection table for PWG-EM Photon/Meson.
+
+#include "PWGEM/PhotonMeson/DataModel/EventTables.h"
+//
+#include "Common/CCDB/EventSelectionParams.h"
+#include "Common/CCDB/RCTSelectionFlags.h"
+#include "Common/CCDB/TriggerAliases.h"
+#include "Common/DataModel/Centrality.h"
+#include "Common/DataModel/EventSelection.h"
+#include "Common/DataModel/Multiplicity.h"
+
+#include <Framework/AnalysisDataModel.h>
+#include <Framework/AnalysisHelpers.h>
+#include <Framework/AnalysisTask.h>
+#include <Framework/Configurable.h>
+#include <Framework/InitContext.h>
+#include <Framework/runDataProcessing.h>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+using namespace o2;
+using namespace o2::framework;
+using namespace o2::framework::expressions;
+using namespace o2::soa;
+using EventAccBits = o2::aod::pmevsel::EventAcceptanceBits;
+
+using MyCollisions = soa::Join<aod::Collisions, aod::EvSels>;
+using MyCollisions_Cent = soa::Join<MyCollisions, aod::Mults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs>;
+
+using MyCollisionsMC = soa::Join<MyCollisions, aod::McCollisionLabels>;
+using MyCollisionsMC_Cent = soa::Join<MyCollisionsMC, aod::Mults, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs>;
+
+struct PMEventSelection {
+  Produces<o2::aod::PMEvSels> pmevsel;
+  Produces<o2::aod::PMEvSelBits> pmevselbits;
+
+  // Configurables
+  Configurable<int> cfgCentEstimator{"cfgCentEstimator", 2, "FT0M:0, FT0A:1, FT0C:2"};
+  Configurable<float> cfgCentMin{"cfgCentMin", -1.f, "min. centrality"};
+  Configurable<float> cfgCentMax{"cfgCentMax", 999.f, "max. centrality"};
+
+  // for RCT
+  Configurable<bool> cfgRequireGoodRCT{"cfgRequireGoodRCT", false, "require good detector flag in run condtion table"};
+  Configurable<std::string> cfgRCTLabel{"cfgRCTLabel", "CBT_hadronPID", "select 1 [CBT, CBT_hadronPID, CBT_muon_glo] see O2Physics/Common/CCDB/RCTSelectionFlags.h"};
+  Configurable<bool> cfgCheckZDC{"cfgCheckZDC", false, "set ZDC flag for PbPb"};
+  Configurable<bool> cfgTreatLimitedAcceptanceAsBad{"cfgTreatLimitedAcceptanceAsBad", false, "reject all events where the detectors relevant for the specified Runlist are flagged as LimitedAcceptance"};
+
+  Configurable<float> cfgZvtxMin{"cfgZvtxMin", -1e+10, "min. Zvtx"};
+  Configurable<float> cfgZvtxMax{"cfgZvtxMax", 1e+10, "max. Zvtx"};
+  Configurable<bool> cfgRequireFT0AND{"cfgRequireFT0AND", false, "require FT0AND in event cut"};
+  Configurable<bool> cfgRequireNoTFB{"cfgRequireNoTFB", false, "require No time frame border in event cut"};
+  Configurable<bool> cfgRequireNoITSROFB{"cfgRequireNoITSROFB", false, "require no ITS readout frame border in event cut"};
+  Configurable<bool> cfgRequireNoSameBunchPileup{"cfgRequireNoSameBunchPileup", false, "require no same bunch pileup in event cut"};
+  Configurable<bool> cfgRequireGoodZvtxFT0vsPV{"cfgRequireGoodZvtxFT0vsPV", false, "require good Zvtx between FT0 vs. PV in event cut"};
+  Configurable<int> cfgTrackOccupancyMin{"cfgTrackOccupancyMin", -2, "min. track occupancy"};
+  Configurable<int> cfgTrackOccupancyMax{"cfgTrackOccupancyMax", 1000000000, "max. track occupancy"};
+  Configurable<float> cfgFT0COccupancyMin{"cfgFT0COccupancyMin", -2, "min. occupancy"};
+  Configurable<float> cfgFT0COccupancyMax{"cfgFT0COccupancyMax", 1000000000, "max. occupancy"};
+  Configurable<bool> cfgRequireNoCollInTimeRangeStandard{"cfgRequireNoCollInTimeRangeStandard", false, "require no collision in time range standard"};
+
+  Configurable<bool> cfgRequireTVXinEMC{"cfgRequireTVXinEMC", false, "require kTVXinEMC (only for EMC analyses)"};
+
+  Configurable<bool> cfgRequireSel8{"cfgRequireSel8", false, "require sel8 condition"};
+
+  o2::aod::rctsel::RCTFlagsChecker rctChecker;
+
+  std::vector<uint64_t> vecEvSelBits;
+
+  void init(InitContext&)
+  {
+    rctChecker.init(cfgRCTLabel.value, cfgCheckZDC.value, cfgTreatLimitedAcceptanceAsBad.value);
+    vecEvSelBits.assign(EventAccBits::kSize, 0);
+  }
+
+  template <typename TCollision>
+  bool isSelectedEvent(TCollision const& collision)
+  {
+    vecEvSelBits[EventAccBits::kAll]++;
+    if constexpr (std::is_same_v<std::decay_t<TCollision>, MyCollisionsMC::iterator> || std::is_same_v<std::decay_t<TCollision>, MyCollisionsMC_Cent::iterator>) {
+      if (!collision.has_mcCollision()) {
+        return false;
+      }
+    }
+    vecEvSelBits[EventAccBits::kHasMCColl]++;
+
+    if (collision.posZ() < cfgZvtxMin || cfgZvtxMax < collision.posZ()) {
+      return false;
+    }
+    vecEvSelBits[EventAccBits::kGoodZVtx]++;
+
+    if (cfgRequireFT0AND && !collision.selection_bit(o2::aod::evsel::kIsTriggerTVX)) {
+      return false;
+    }
+    vecEvSelBits[EventAccBits::kIsFT0AND]++;
+
+    if (cfgRequireNoTFB && !collision.selection_bit(o2::aod::evsel::kNoTimeFrameBorder)) {
+      return false;
+    }
+    vecEvSelBits[EventAccBits::kNoTFB]++;
+
+    if (cfgRequireNoITSROFB && !collision.selection_bit(o2::aod::evsel::kNoITSROFrameBorder)) {
+      return false;
+    }
+    vecEvSelBits[EventAccBits::kITSROFB]++;
+
+    if (cfgRequireNoSameBunchPileup && !collision.selection_bit(o2::aod::evsel::kNoSameBunchPileup)) {
+      return false;
+    }
+    vecEvSelBits[EventAccBits::kNoSameBunchPileUp]++;
+
+    if (cfgRequireGoodZvtxFT0vsPV && !collision.selection_bit(o2::aod::evsel::kIsGoodZvtxFT0vsPV)) {
+      return false;
+    }
+    vecEvSelBits[EventAccBits::kGoodZVtxFTOPV]++;
+
+    if (cfgRequireNoCollInTimeRangeStandard && !collision.selection_bit(o2::aod::evsel::kNoCollInTimeRangeStandard)) {
+      return false;
+    }
+    vecEvSelBits[EventAccBits::kNoCollInTimeRange]++;
+
+    if (!(cfgTrackOccupancyMin <= collision.trackOccupancyInTimeRange() && collision.trackOccupancyInTimeRange() < cfgTrackOccupancyMax)) {
+      return false;
+    }
+    vecEvSelBits[EventAccBits::kGoodTrackOccupancy]++;
+
+    if (!(cfgFT0COccupancyMin <= collision.ft0cOccupancyInTimeRange() && collision.ft0cOccupancyInTimeRange() < cfgFT0COccupancyMax)) {
+      return false;
+    }
+    vecEvSelBits[EventAccBits::kGoodFT0Occupancy]++;
+
+    if (cfgRequireTVXinEMC && !collision.alias_bit(triggerAliases::kTVXinEMC)) {
+      return false;
+    }
+    vecEvSelBits[EventAccBits::kTVXInEMC]++;
+
+    if constexpr (std::is_same_v<std::decay_t<TCollision>, MyCollisions_Cent::iterator>) {
+      std::array<float, 3> centralities = {collision.centFT0M(), collision.centFT0A(), collision.centFT0C()};
+      if (centralities[cfgCentEstimator] < cfgCentMin || cfgCentMax < centralities[cfgCentEstimator]) {
+        return false;
+      }
+    }
+    vecEvSelBits[EventAccBits::kGoodCent]++;
+
+    if (cfgRequireGoodRCT && !rctChecker.checkTable(collision)) {
+      // LOGF(info, "rejected by RCT flag");
+      return false;
+    }
+    vecEvSelBits[EventAccBits::kGoodRCT]++;
+
+    if (cfgRequireSel8 && !collision.sel8()) {
+      return false;
+    }
+    vecEvSelBits[EventAccBits::kGoodSel8]++;
+
+    return true;
+  }
+
+  template <typename TCollisions>
+  void processEventSelection(TCollisions const& collisions)
+  {
+    // reset the event counter to zero for all elements
+    vecEvSelBits.assign(EventAccBits::kSize, 0);
+
+    for (const auto& collision : collisions) {
+      pmevsel(isSelectedEvent(collision));
+    } // end of collision loop
+    // Write event selection info at the end of DF
+    pmevselbits(vecEvSelBits);
+  } // end of process
+
+  PROCESS_SWITCH_FULL(PMEventSelection, processEventSelection<MyCollisions>, processEventSelection, "event selection", true);
+  PROCESS_SWITCH_FULL(PMEventSelection, processEventSelection<MyCollisions_Cent>, processEventSelection_Cent, "event selection with cent", false);
+  PROCESS_SWITCH_FULL(PMEventSelection, processEventSelection<MyCollisionsMC>, processEventSelectionMC, "event selection MC", false);
+  PROCESS_SWITCH_FULL(PMEventSelection, processEventSelection<MyCollisionsMC_Cent>, processEventSelectionMC_Cent, "event selection MC with cent", false);
+};
+WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& context)
+{
+  return WorkflowSpec{adaptAnalysisTask<PMEventSelection>(context, TaskName{"em-event-selection"})};
+}

--- a/PWGEM/PhotonMeson/TableProducer/photonconversionbuilder.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/photonconversionbuilder.cxx
@@ -88,7 +88,7 @@ using namespace o2::constants::physics;
 using namespace o2::pwgem::photonmeson;
 using std::array;
 
-using MyCollisions = soa::Join<aod::Collisions, aod::EvSels, aod::EMEvSels, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs>;
+using MyCollisions = soa::Join<aod::Collisions, aod::EvSels, aod::PMEvSels, aod::CentFT0Ms, aod::CentFT0As, aod::CentFT0Cs>;
 // using MyCollisionsWithSWT = soa::Join<MyCollisions, aod::EMSWTriggerBitsTMP>;
 using MyCollisionsMC = soa::Join<MyCollisions, aod::McCollisionLabels>;
 using MyBCs = soa::Join<aod::BCsWithTimestamps, aod::PcmObjects>;

--- a/PWGEM/PhotonMeson/TableProducer/skimmerGammaCalo.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/skimmerGammaCalo.cxx
@@ -14,6 +14,7 @@
 /// \author marvin.hemmer@cern.ch
 /// dependencies: emcal-correction-task
 
+#include "PWGEM/PhotonMeson/DataModel/EventTables.h"
 #include "PWGEM/PhotonMeson/DataModel/GammaTablesRedux.h"
 #include "PWGEM/PhotonMeson/DataModel/gammaTables.h"
 #include "PWGEM/PhotonMeson/Utils/emcalHistoDefinitions.h"
@@ -311,19 +312,19 @@ struct SkimmerGammaCalo {
     }
   }
 
-  void processRec(soa::Join<aod::Collisions, aod::EvSels, aod::EMEvSels>::iterator const& collision, aod::EMCALClusters const& emcclusters, aod::EMCALClusterCells const& emcclustercells, aod::EMCALMatchedTracks const& emcmatchedtracks, aod::FullTracks const& tracks)
+  void processRec(soa::Join<aod::Collisions, aod::EvSels, aod::PMEvSels>::iterator const& collision, aod::EMCALClusters const& emcclusters, aod::EMCALClusterCells const& emcclustercells, aod::EMCALMatchedTracks const& emcmatchedtracks, aod::FullTracks const& tracks)
   {
     runAnalysis(collision, emcclusters, emcclustercells, emcmatchedtracks, tracks);
   }
   PROCESS_SWITCH(SkimmerGammaCalo, processRec, "process only reconstructed info", true);
 
-  void processRecWithSecondaries(soa::Join<aod::Collisions, aod::EvSels, aod::EMEvSels>::iterator const& collision, aod::EMCALClusters const& emcclusters, aod::EMCALClusterCells const& emcclustercells, aod::EMCALMatchedTracks const& emcmatchedtracks, aod::FullTracks const& tracks, aod::EMCMatchSecs const& emcmatchedsecondaries)
+  void processRecWithSecondaries(soa::Join<aod::Collisions, aod::EvSels, aod::PMEvSels>::iterator const& collision, aod::EMCALClusters const& emcclusters, aod::EMCALClusterCells const& emcclustercells, aod::EMCALMatchedTracks const& emcmatchedtracks, aod::FullTracks const& tracks, aod::EMCMatchSecs const& emcmatchedsecondaries)
   {
     runAnalysis(collision, emcclusters, emcclustercells, emcmatchedtracks, tracks, emcmatchedsecondaries);
   }
   PROCESS_SWITCH(SkimmerGammaCalo, processRecWithSecondaries, "process reconstructed info with secondary track matching.", false);
 
-  void processRecMC(soa::Join<aod::Collisions, aod::EvSels, aod::EMEvSels>::iterator const& collision,
+  void processRecMC(soa::Join<aod::Collisions, aod::EvSels, aod::PMEvSels>::iterator const& collision,
                     soa::Join<aod::EMCALClusters, aod::EMCALMCClusters> const& emcclusters,
                     aod::EMCALClusterCells const& emcclustercells, aod::EMCALMatchedTracks const& emcmatchedtracks,
                     aod::FullTracks const& tracks)
@@ -332,7 +333,7 @@ struct SkimmerGammaCalo {
   }
   PROCESS_SWITCH(SkimmerGammaCalo, processRecMC, "process reconstructed info + MC labels at once", false);
 
-  void processRecMCWithSecondaries(soa::Join<aod::Collisions, aod::EvSels, aod::EMEvSels>::iterator const& collision,
+  void processRecMCWithSecondaries(soa::Join<aod::Collisions, aod::EvSels, aod::PMEvSels>::iterator const& collision,
                                    soa::Join<aod::EMCALClusters, aod::EMCALMCClusters> const& emcclusters,
                                    aod::EMCALClusterCells const& emcclustercells, aod::EMCALMatchedTracks const& emcmatchedtracks,
                                    aod::FullTracks const& tracks, aod::EMCMatchSecs const& emcmatchedsecondaries)

--- a/PWGEM/PhotonMeson/TableProducer/skimmerPrimaryElectronFromDalitzEE.cxx
+++ b/PWGEM/PhotonMeson/TableProducer/skimmerPrimaryElectronFromDalitzEE.cxx
@@ -64,7 +64,7 @@ using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::constants::physics;
 
-using MyCollisions = soa::Join<aod::Collisions, aod::EvSels, aod::EMEvSels>;
+using MyCollisions = soa::Join<aod::Collisions, aod::EvSels, aod::PMEvSels>;
 using MyCollisionsWithSWT = soa::Join<MyCollisions, aod::EMSWTriggerBitsTMP>;
 using MyBCs = soa::Join<aod::BCsWithTimestamps, aod::PcmObjects>;
 

--- a/PWGEM/PhotonMeson/Utils/EventHistograms.h
+++ b/PWGEM/PhotonMeson/Utils/EventHistograms.h
@@ -47,34 +47,13 @@ inline void addEventHistograms(o2::framework::HistogramRegistry* fRegistry, bool
   hCollisionCounter->GetXaxis()->SetBinLabel(11, "EMC L0 Triggered");
   hCollisionCounter->GetXaxis()->SetBinLabel(12, "accepted");
 
-  const o2::framework::AxisSpec axis_cent_ft0m{{0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-                                                20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
-                                                40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
-                                                60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
-                                                80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110},
-                                               "centrality FT0M (%)"};
-
-  const o2::framework::AxisSpec axis_cent_ft0a{{0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-                                                20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
-                                                40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
-                                                60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
-                                                80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110},
-                                               "centrality FT0A (%)"};
-
-  const o2::framework::AxisSpec axis_cent_ft0c{{0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-                                                20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
-                                                40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59,
-                                                60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
-                                                80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110},
-                                               "centrality FT0C (%)"};
-
   fRegistry->add("Event/before/hZvtx", "vertex z; Z_{vtx} (cm)", o2::framework::HistType::kTH1D, {{220, -11, +11}}, useWeight);
   fRegistry->add("Event/before/hMultNTracksPV", "hMultNTracksPV; N_{track} to PV", o2::framework::HistType::kTH1F, {{6001, -0.5, 6000.5}}, useWeight);
   fRegistry->add("Event/before/hMultNTracksPVeta1", "hMultNTracksPVeta1; N_{track} to PV", o2::framework::HistType::kTH1F, {{6001, -0.5, 6000.5}}, useWeight);
   fRegistry->add("Event/before/hMultFT0", "hMultFT0;mult. FT0A;mult. FT0C", o2::framework::HistType::kTH2F, {{200, 0, 200000}, {60, 0, 60000}}, useWeight);
-  fRegistry->add("Event/before/hCentFT0A", "hCentFT0A;centrality FT0A (%)", o2::framework::HistType::kTH1F, {{axis_cent_ft0a}}, useWeight);
-  fRegistry->add("Event/before/hCentFT0C", "hCentFT0C;centrality FT0C (%)", o2::framework::HistType::kTH1F, {{axis_cent_ft0c}}, useWeight);
-  fRegistry->add("Event/before/hCentFT0M", "hCentFT0M;centrality FT0M (%)", o2::framework::HistType::kTH1F, {{axis_cent_ft0m}}, useWeight);
+  fRegistry->add("Event/before/hCentFT0A", "hCentFT0A;centrality FT0A (%)", o2::framework::HistType::kTH1F, {{100, 0., 100.}}, useWeight);
+  fRegistry->add("Event/before/hCentFT0C", "hCentFT0C;centrality FT0C (%)", o2::framework::HistType::kTH1F, {{100, 0., 100.}}, useWeight);
+  fRegistry->add("Event/before/hCentFT0M", "hCentFT0M;centrality FT0M (%)", o2::framework::HistType::kTH1F, {{100, 0., 100.}}, useWeight);
   fRegistry->add("Event/before/hCentFT0CvsMultNTracksPV", "hCentFT0CvsMultNTracksPV;centrality FT0C (%);N_{track} to PV", o2::framework::HistType::kTH2F, {{110, 0, 110}, {500, 0, 5000}}, useWeight);
   fRegistry->add("Event/before/hMultFT0CvsMultNTracksPV", "hMultFT0CvsMultNTracksPV;mult. FT0C;N_{track} to PV", o2::framework::HistType::kTH2F, {{60, 0, 60000}, {500, 0, 5000}}, useWeight);
   fRegistry->add("Event/before/hMultFT0CvsOccupancy", "hMultFT0CvsOccupancy;mult. FT0C;N_{track} in time range", o2::framework::HistType::kTH2F, {{60, 0, 60000}, {500, 0, 10000}}, useWeight);


### PR DESCRIPTION
- Add event-selection for photons, basically the same as for dileptons
- Fix for trigger-bits: Add reduction function for bits to fit in uint32_t format
- Add fix for sel8 definition in 2026 data for dynamic column
- Add option for table that writes trigger selection for each DF so that one can keep track of the event selection decision in the analysis task when running over DD