### PR TITLE
[PWGHF] correlatorD0Hadrons.cxx: Expand histograms for reflection correction

### DIFF
--- a/PWGHF/HFC/TableProducer/correlatorD0Hadrons.cxx
+++ b/PWGHF/HFC/TableProducer/correlatorD0Hadrons.cxx
@@ -293,6 +293,8 @@ struct HfCorrelatorD0Hadrons {
     AxisSpec axisBdtScoreNonPrompt = {binsBdtScoreNonPrompt, "Bdt score Nonprompt"};
     AxisSpec axisOrigin = {10, 0., 10., "Candidate origin"};
     AxisSpec axisCent = {binsCentFt0m, "Centrality"};
+    AxisSpec const axisCandidateStatusMcRec = {64, -0.5, 63.5, "MC candidate status"};
+    AxisSpec const axisRecoHypothesis = {4, -0.5, 3.5, "Reconstructed hypothesis"};
 
     // Histograms for Data
     registry.add("hPtCand", "D0, D0bar candidates", {HistType::kTH1F, {axisPtD}});
@@ -339,6 +341,11 @@ struct HfCorrelatorD0Hadrons {
     registry.add("hPtVsMultiplicityRecNonPrompt", "Multiplicity FT0M - MC Rec Non Prompt", {HistType::kTH2F, {{axisPtD}, {axisMultFT0M}}});
     registry.add("hPtParticleAssocVsCandRec", "Associated Particle - MC reco", {HistType::kTH2F, {{axisPtHadron}, {axisPtD}}});
     registry.add("hPtPrimaryParticleAssocVsCandRec", "Associated Particle - MC reco", {HistType::kTH2F, {{axisPtHadron}, {axisPtD}}});
+    if (useCentrality) {
+      registry.add("hMLScoresVsMassVsPtVsEtaVsOriginVsCandidateStatusVsHypothesisVsCent", "MCRec template information with centrality", {HistType::kTHnSparseD, {{axisBdtScoreBkg}, {axisBdtScorePrompt}, {axisBdtScoreNonPrompt}, {axisMassD}, {axisPtD}, {axisEta}, {axisOrigin}, {axisCandidateStatusMcRec}, {axisRecoHypothesis}, {axisCent}}});
+    } else {
+      registry.add("hMLScoresVsMassVsPtVsEtaVsOriginVsCandidateStatusVsHypothesis", "MCRec template information", {HistType::kTHnSparseD, {{axisBdtScoreBkg}, {axisBdtScorePrompt}, {axisBdtScoreNonPrompt}, {axisMassD}, {axisPtD}, {axisEta}, {axisOrigin}, {axisCandidateStatusMcRec}, {axisRecoHypothesis}}});
+    }
     // Histograms for MC Gen
     registry.add("hEvtCountGen", "Event counter - MC gen", {HistType::kTH1F, {axisEvtCount}});
     registry.add("hPtCandGen", "D0, D0bar candidates - MC gen", {HistType::kTH1F, {axisPtD}});
@@ -681,7 +688,13 @@ struct HfCorrelatorD0Hadrons {
       const auto invMassD0 = HfHelper::invMassD0ToPiK(candidate);
       const auto invMassD0bar = HfHelper::invMassD0barToKPi(candidate);
 
-      if (candidate.isSelD0() >= selectionFlagD0 || candidate.isSelD0bar() >= selectionFlagD0bar) {
+      const bool selectedD0 = candidate.isSelD0() >= selectionFlagD0;
+      const bool selectedD0bar = candidate.isSelD0bar() >= selectionFlagD0bar;
+      const int recoHypothesis = selectedD0 && selectedD0bar ? aod::hf_correlation_d0_hadron::ParticleTypeData::D0D0barBoth : selectedD0    ? aod::hf_correlation_d0_hadron::ParticleTypeData::D0Only
+                                                                                                                            : selectedD0bar ? aod::hf_correlation_d0_hadron::ParticleTypeData::D0barOnly
+                                                                                                                                            : 0;
+
+      if (selectedD0 || selectedD0bar) {
         hasAcceptedD0ForOfflineMixing = true;
       }
 
@@ -696,9 +709,13 @@ struct HfCorrelatorD0Hadrons {
         registry.fill(HIST("hSelectionStatusRec"), candidate.isSelD0bar() + (candidate.isSelD0() * 2));
       }
       // fill invariant mass plots from D0/D0bar signal and background candidates
-      if (candidate.isSelD0() >= selectionFlagD0) {                                                  // only reco as D0
-        if (candidate.flagMcMatchRec() == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) { // also matched as D0
+      if (selectedD0) { // reconstructed under the D0 hypothesis
+        int candidateStatus = 0;
+
+        if (candidate.flagMcMatchRec() == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
+          SETBIT(candidateStatus, aod::hf_correlation_d0_hadron::ParticleTypeMcRec::D0Sig);
           registry.fill(HIST("hMassD0RecSig"), invMassD0, candidate.pt(), efficiencyWeight);
+
           if (isD0Prompt) {
             registry.fill(HIST("hPtCandRecSigPrompt"), candidate.pt());
             registry.fill(HIST("hPtVsMultiplicityRecPrompt"), candidate.pt(), collision.multFT0M());
@@ -709,22 +726,41 @@ struct HfCorrelatorD0Hadrons {
             registry.fill(HIST("hPtVsMLScoresVsEtaRecSigNonPrompt"), outputMlD0[0], outputMlD0[1], outputMlD0[2], candidate.pt(), candidate.eta());
           }
         } else if (candidate.flagMcMatchRec() == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
+          SETBIT(candidateStatus, aod::hf_correlation_d0_hadron::ParticleTypeMcRec::D0Ref);
           registry.fill(HIST("hMassD0RecRef"), invMassD0, candidate.pt(), efficiencyWeight);
-          if (candidate.isSelD0bar() < selectionFlagD0bar) {
+
+          if (!selectedD0bar) {
             registry.fill(HIST("hMassD0RecRefAfterRejectBoth"), invMassD0, candidate.pt(), efficiencyWeight);
           }
         } else {
+          SETBIT(candidateStatus, aod::hf_correlation_d0_hadron::ParticleTypeMcRec::D0Bg);
           registry.fill(HIST("hMassD0RecBg"), invMassD0, candidate.pt(), efficiencyWeight);
         }
+
         for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
           outputMlD0[iclass] = candidate.mlProbD0()[classMl->at(iclass)];
         }
+
         registry.fill(HIST("hMLScoresVsMassVsPtVsEtaVsOriginVsCent"), outputMlD0[0], outputMlD0[1], outputMlD0[2], invMassD0, candidate.pt(), candidate.eta(), isD0Prompt, cent, efficiencyWeight);
-        entryD0(candidate.phi(), candidate.eta(), candidate.pt(), invMassD0, poolBin, gCollisionId, timeStamp, (candidate.isSelD0bar() != 0) ? o2::aod::hf_correlation_d0_hadron::D0D0barBoth : o2::aod::hf_correlation_d0_hadron::D0Only);
+
+        if (useCentrality) {
+          registry.fill(HIST("hMLScoresVsMassVsPtVsEtaVsOriginVsCandidateStatusVsHypothesisVsCent"), outputMlD0[0], outputMlD0[1], outputMlD0[2], invMassD0, candidate.pt(), candidate.eta(), isD0Prompt,
+                        candidateStatus, recoHypothesis, cent, efficiencyWeight);
+        } else {
+          registry.fill(HIST("hMLScoresVsMassVsPtVsEtaVsOriginVsCandidateStatusVsHypothesis"), outputMlD0[0], outputMlD0[1], outputMlD0[2], invMassD0, candidate.pt(), candidate.eta(), isD0Prompt,
+                        candidateStatus, recoHypothesis, efficiencyWeight);
+        }
+
+        entryD0(candidate.phi(), candidate.eta(), candidate.pt(), invMassD0, poolBin, gCollisionId, timeStamp, selectedD0bar ? o2::aod::hf_correlation_d0_hadron::D0D0barBoth : o2::aod::hf_correlation_d0_hadron::D0Only);
       }
-      if (candidate.isSelD0bar() >= selectionFlagD0bar) {                                             // only reco as D0bar
-        if (candidate.flagMcMatchRec() == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) { // also matched as D0bar
+
+      if (selectedD0bar) { // reconstructed under the D0bar hypothesis
+        int candidateStatus = 0;
+
+        if (candidate.flagMcMatchRec() == -o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
+          SETBIT(candidateStatus, aod::hf_correlation_d0_hadron::ParticleTypeMcRec::D0barSig);
           registry.fill(HIST("hMassD0barRecSig"), invMassD0bar, candidate.pt(), efficiencyWeight);
+
           if (isD0Prompt) {
             registry.fill(HIST("hPtCandRecSigPrompt"), candidate.pt());
             registry.fill(HIST("hPtVsMultiplicityRecPrompt"), candidate.pt(), collision.multFT0M());
@@ -735,18 +771,32 @@ struct HfCorrelatorD0Hadrons {
             registry.fill(HIST("hPtVsMLScoresVsEtaRecSigNonPrompt"), outputMlD0bar[0], outputMlD0bar[1], outputMlD0bar[2], candidate.pt(), candidate.eta());
           }
         } else if (candidate.flagMcMatchRec() == o2::hf_decay::hf_cand_2prong::DecayChannelMain::D0ToPiK) {
+          SETBIT(candidateStatus, aod::hf_correlation_d0_hadron::ParticleTypeMcRec::D0barRef);
           registry.fill(HIST("hMassD0barRecRef"), invMassD0bar, candidate.pt(), efficiencyWeight);
-          if (candidate.isSelD0() < selectionFlagD0) {
+
+          if (!selectedD0) {
             registry.fill(HIST("hMassD0barRecRefAfterRejectBoth"), invMassD0bar, candidate.pt(), efficiencyWeight);
           }
         } else {
+          SETBIT(candidateStatus, aod::hf_correlation_d0_hadron::ParticleTypeMcRec::D0barBg);
           registry.fill(HIST("hMassD0barRecBg"), invMassD0bar, candidate.pt(), efficiencyWeight);
         }
+
         for (unsigned int iclass = 0; iclass < classMl->size(); iclass++) {
           outputMlD0bar[iclass] = candidate.mlProbD0bar()[classMl->at(iclass)];
         }
+
         registry.fill(HIST("hMLScoresVsMassVsPtVsEtaVsOriginVsCent"), outputMlD0bar[0], outputMlD0bar[1], outputMlD0bar[2], invMassD0bar, candidate.pt(), candidate.eta(), isD0Prompt, cent, efficiencyWeight);
-        entryD0(candidate.phi(), candidate.eta(), candidate.pt(), invMassD0bar, poolBin, gCollisionId, timeStamp, (candidate.isSelD0() != 0) ? o2::aod::hf_correlation_d0_hadron::D0D0barBoth : o2::aod::hf_correlation_d0_hadron::D0barOnly);
+
+        if (useCentrality) {
+          registry.fill(HIST("hMLScoresVsMassVsPtVsEtaVsOriginVsCandidateStatusVsHypothesisVsCent"), outputMlD0bar[0], outputMlD0bar[1], outputMlD0bar[2], invMassD0bar, candidate.pt(), candidate.eta(),
+                        isD0Prompt, candidateStatus, recoHypothesis, cent, efficiencyWeight);
+        } else {
+          registry.fill(HIST("hMLScoresVsMassVsPtVsEtaVsOriginVsCandidateStatusVsHypothesis"), outputMlD0bar[0], outputMlD0bar[1], outputMlD0bar[2], invMassD0bar, candidate.pt(), candidate.eta(), isD0Prompt,
+                        candidateStatus, recoHypothesis, efficiencyWeight);
+        }
+
+        entryD0(candidate.phi(), candidate.eta(), candidate.pt(), invMassD0bar, poolBin, gCollisionId, timeStamp, selectedD0 ? o2::aod::hf_correlation_d0_hadron::D0D0barBoth : o2::aod::hf_correlation_d0_hadron::D0barOnly);
       }
       entryD0CandRecoInfo(invMassD0, invMassD0bar, candidate.pt(), outputMlD0[0], outputMlD0[1], outputMlD0[2], outputMlD0bar[0], outputMlD0bar[1], outputMlD0bar[2]);
       entryD0CandGenInfo(isD0Prompt);


### PR DESCRIPTION
Extend the D0–hadron correlator MC-reconstructed output for reflection correction studies.

- Add MC-reco template THnSparse histograms including:
    - ML scores
    - invariant mass
    - candidate pT and η
    - candidate origin
    - MC candidate status
    - reconstructed D0/D0-bar hypothesis
    - centrality, when enabled
  - Distinguish signal, reflection, and background candidates using candidate-status bits.
  - Handle simultaneous D0 and D0-bar reconstruction hypotheses consistently.
  - Preserve separate D0 and D0-bar candidate information.