### PR TITLE
[PWGHF] add flag to store only soft-pi tracking info.

### DIFF
--- a/PWGHF/D2H/Tasks/taskSigmac.cxx
+++ b/PWGHF/D2H/Tasks/taskSigmac.cxx
@@ -69,6 +69,7 @@ struct HfTaskSigmac {
   Configurable<bool> addMassDiffAbsLambdaCToSigmacSparse{"addMassDiffAbsLambdaCToSigmacSparse", false, "enable the filling of |M(pkpi, piKp) - M(LambdaC)| in the Σc0,++ THnSparse"};
   Configurable<float> deltaMassSigmacRecoMax{"deltaMassSigmacRecoMax", 1000, "Maximum allowed value for Sigmac deltaMass. Conceived to reduce the output size (i.e. reject background above a certain threshold)"};
   Configurable<float> ptMinSc{"ptMinSc", -1.f, "Minimum accepted value for SigmaC-hadron pt (GeV/c)"};
+  Configurable<bool> trackingInfo4SoftPiOnly{"trackingInfo4SoftPiOnly", false, "Flag to enable the storage of tracking info about the soft pion only"};
 
   bool isMc{};
   bool storeTrackProp{};
@@ -578,7 +579,13 @@ struct HfTaskSigmac {
                 const auto& trackLcProng0 = candidateLc.template prong0_as<TRK>();
                 const auto& trackLcProng1 = candidateLc.template prong1_as<TRK>();
                 const auto& trackLcProng2 = candidateLc.template prong2_as<TRK>();
-                getTrackingInfo(std::vector{trackLcProng0, trackLcProng1, trackLcProng2, trackSoftPi}, absEtaTrackMin, numItsClsMin, numTpcClsMin);
+                if (trackingInfo4SoftPiOnly) {
+                  /// soft pion info only
+                  getTrackingInfo(std::vector{trackSoftPi}, absEtaTrackMin, numItsClsMin, numTpcClsMin);
+                } else {
+                  /// info from soft pion and also Lc daughters
+                  getTrackingInfo(std::vector{trackLcProng0, trackLcProng1, trackLcProng2, trackSoftPi}, absEtaTrackMin, numItsClsMin, numTpcClsMin);
+                }
               }
               if (addSoftPiDcaToSigmacSparse) {
                 /// dcaXY,Z of soft pion track stored
@@ -745,7 +752,13 @@ struct HfTaskSigmac {
                 const auto& trackLcProng0 = candidateLc.template prong0_as<TRK>();
                 const auto& trackLcProng1 = candidateLc.template prong1_as<TRK>();
                 const auto& trackLcProng2 = candidateLc.template prong2_as<TRK>();
-                getTrackingInfo(std::vector{trackLcProng0, trackLcProng1, trackLcProng2, trackSoftPi}, absEtaTrackMin, numItsClsMin, numTpcClsMin);
+                if (trackingInfo4SoftPiOnly) {
+                  /// soft pion info only
+                  getTrackingInfo(std::vector{trackSoftPi}, absEtaTrackMin, numItsClsMin, numTpcClsMin);
+                } else {
+                  /// info from soft pion and also Lc daughters
+                  getTrackingInfo(std::vector{trackLcProng0, trackLcProng1, trackLcProng2, trackSoftPi}, absEtaTrackMin, numItsClsMin, numTpcClsMin);
+                }
               }
               if (addSoftPiDcaToSigmacSparse) {
                 /// dcaXY,Z of soft pion track stored
@@ -1301,7 +1314,13 @@ struct HfTaskSigmac {
                 const auto& trackLcProng1 = candidateLc.template prong1_as<TRK>();
                 const auto& trackLcProng2 = candidateLc.template prong2_as<TRK>();
                 const auto& trackSoftPi = candSc.template prong1_as<TRK>();
-                getTrackingInfo(std::vector{trackLcProng0, trackLcProng1, trackLcProng2, trackSoftPi}, absEtaTrackMin, numItsClsMin, numTpcClsMin);
+                if (trackingInfo4SoftPiOnly) {
+                  /// soft pion info only
+                  getTrackingInfo(std::vector{trackSoftPi}, absEtaTrackMin, numItsClsMin, numTpcClsMin);
+                } else {
+                  /// info from soft pion and also Lc daughters
+                  getTrackingInfo(std::vector{trackLcProng0, trackLcProng1, trackLcProng2, trackSoftPi}, absEtaTrackMin, numItsClsMin, numTpcClsMin);
+                }
               }
               if (addSoftPiDcaToSigmacSparse) {
                 /// dcaXY,Z of soft pion track stored
@@ -1470,7 +1489,13 @@ struct HfTaskSigmac {
                 const auto& trackLcProng1 = candidateLc.template prong1_as<TRK>();
                 const auto& trackLcProng2 = candidateLc.template prong2_as<TRK>();
                 const auto& trackSoftPi = candSc.template prong1_as<TRK>();
-                getTrackingInfo(std::vector{trackLcProng0, trackLcProng1, trackLcProng2, trackSoftPi}, absEtaTrackMin, numItsClsMin, numTpcClsMin);
+                if (trackingInfo4SoftPiOnly) {
+                  /// soft pion info only
+                  getTrackingInfo(std::vector{trackSoftPi}, absEtaTrackMin, numItsClsMin, numTpcClsMin);
+                } else {
+                  /// info from soft pion and also Lc daughters
+                  getTrackingInfo(std::vector{trackLcProng0, trackLcProng1, trackLcProng2, trackSoftPi}, absEtaTrackMin, numItsClsMin, numTpcClsMin);
+                }
               }
               if (addSoftPiDcaToSigmacSparse) {
                 /// dcaXY,Z of soft pion track stored
@@ -1676,7 +1701,13 @@ struct HfTaskSigmac {
                 const auto& trackLcProng1 = candidateLc.template prong1_as<TRK>();
                 const auto& trackLcProng2 = candidateLc.template prong2_as<TRK>();
                 const auto& trackSoftPi = candSc.template prong1_as<TRK>();
-                getTrackingInfo(std::vector{trackLcProng0, trackLcProng1, trackLcProng2, trackSoftPi}, absEtaTrackMin, numItsClsMin, numTpcClsMin);
+                if (trackingInfo4SoftPiOnly) {
+                  /// soft pion info only
+                  getTrackingInfo(std::vector{trackSoftPi}, absEtaTrackMin, numItsClsMin, numTpcClsMin);
+                } else {
+                  /// info from soft pion and also Lc daughters
+                  getTrackingInfo(std::vector{trackLcProng0, trackLcProng1, trackLcProng2, trackSoftPi}, absEtaTrackMin, numItsClsMin, numTpcClsMin);
+                }
               }
               if (addSoftPiDcaToSigmacSparse) {
                 /// dcaXY,Z of soft pion track stored
@@ -1843,7 +1874,13 @@ struct HfTaskSigmac {
                 const auto& trackLcProng1 = candidateLc.template prong1_as<TRK>();
                 const auto& trackLcProng2 = candidateLc.template prong2_as<TRK>();
                 const auto& trackSoftPi = candSc.template prong1_as<TRK>();
-                getTrackingInfo(std::vector{trackLcProng0, trackLcProng1, trackLcProng2, trackSoftPi}, absEtaTrackMin, numItsClsMin, numTpcClsMin);
+                if (trackingInfo4SoftPiOnly) {
+                  /// soft pion info only
+                  getTrackingInfo(std::vector{trackSoftPi}, absEtaTrackMin, numItsClsMin, numTpcClsMin);
+                } else {
+                  /// info from soft pion and also Lc daughters
+                  getTrackingInfo(std::vector{trackLcProng0, trackLcProng1, trackLcProng2, trackSoftPi}, absEtaTrackMin, numItsClsMin, numTpcClsMin);
+                }
               }
               if (addSoftPiDcaToSigmacSparse) {
                 /// dcaXY,Z of soft pion track stored


### PR DESCRIPTION
The new flag `Configurable<bool> trackingInfo4SoftPiOnly` allows us to fill the trackingi nfo only for the soft-pion track and we can rerun and study the tracking systematics only focusing on the soft pion.

@arossi81 @Mingyu3360715 