### PR TITLE
[PWGEM,Photon] Add option to correct eta for vertex shift in event mi…

### DIFF
--- a/PWGEM/PhotonMeson/Tasks/taskPi0FlowEMC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/taskPi0FlowEMC.cxx
@@ -247,6 +247,8 @@ struct TaskPi0FlowEMC {
     Configurable<bool> cfgApplySPresolution{"cfgApplySPresolution", false, "Apply resolution correction"};
     Configurable<bool> doEMCalCalib{"doEMCalCalib", false, "Produce output for EMCal calibration"};
     Configurable<bool> cfgEnableNonLin{"cfgEnableNonLin", false, "flag to turn extra non linear energy calibration on/off"};
+    Configurable<float> cfgEmcalEffRadius{"cfgEmcalEffRadius", 430.f, "effective EMCal radius (cm) used for mixed-event vertex-swap correction"};
+    Configurable<bool> cfgCorrectMixedVtxEta{"cfgCorrectMixedVtxEta", true, "re-project cluster2 eta onto collision1's vertex in mixed event"};
   } correctionConfig;
 
   SliceCache cache;
@@ -526,6 +528,18 @@ struct TaskPi0FlowEMC {
     static constexpr std::array<std::string_view, 3> HistTypes = {"hSparsePi0", "hSparseBkgRot", "hSparseBkgMix"};
     registry.fill(HIST(FlowHistTypes[histType]), mass, pt, cent, sp);
     registry.fill(HIST(HistTypes[histType]), mass, pt, cent);
+  }
+
+  /// \brief eta a cluster would have if its own vertex vzOld is swapped for vzNew,
+  /// assuming a nominal cylindrical EMCal surface at transverse radius emcalR (cm).
+  /// phi is untouched: transverse vertex spread is negligible next to emcalR.
+  /// \param etaOld old eta value
+  /// \param vzOld old primary vertex z position
+  /// \param vzNew new primary vertex z position
+  /// \param emcalR radius of the EMCal
+  static float correctEtaForVertexShift(float etaOld, float vzOld, float vzNew, float emcalR)
+  {
+    return std::asinh(std::sinh(etaOld) + (vzOld - vzNew) / emcalR);
   }
 
   /// Get the centrality
@@ -1202,7 +1216,13 @@ struct TaskPi0FlowEMC {
           }
         }
         ROOT::Math::PtEtaPhiMVector v1(g1.corrPt(), g1.eta(), g1.phi(), 0.);
-        ROOT::Math::PtEtaPhiMVector v2(g2.corrPt(), g2.eta(), g2.phi(), 0.);
+
+        // changing the eta position of cluster 2 from collision 2 to match the z-vertex position of collision 1
+        float eta2 = g2.eta();
+        if (correctionConfig.cfgCorrectMixedVtxEta.value) {
+          eta2 = correctEtaForVertexShift(g2.eta(), c2.posZ(), c1.posZ(), correctionConfig.cfgEmcalEffRadius.value);
+        }
+        ROOT::Math::PtEtaPhiMVector v2(g2.corrPt(), eta2, g2.phi(), 0.);
         ROOT::Math::PtEtaPhiMVector vMeson = v1 + v2;
 
         float dTheta = v1.Theta() - v2.Theta();


### PR DESCRIPTION
…xing

In event mixing two collisions with slightly different z vertex position can be used. Since clusters are corrected for the vertex position the possible eta values for single cell clusters depend on the z vertex position. In same event combinations these possible discrete values are the same resulting in discrete combined eta values. In mixed event without correcting for this the eta position of clusters from collion A and clusters from collision B can have different discrete values resuting in different discrete combined values. This new option aims to make eta values from mixed event pairs look more similar to same event pairs by shifting the eta value of all clusters from collision B according to the verte position of collision A.