### PR TITLE
[PWGCF] Add efficiency-corrected multiplicity information to CF derived data

### DIFF
--- a/PWGCF/DataModel/CorrelationsDerived.h
+++ b/PWGCF/DataModel/CorrelationsDerived.h
@@ -40,7 +40,7 @@ using CFMcCollisionWithExtra = CFMcCollisionsWithExtra::iterator;
 
 namespace cfmcparticle
 {
-DECLARE_SOA_INDEX_COLUMN(CFMcCollision, cfMcCollision); //! Index to reduced MC collision
+DECLARE_SOA_INDEX_COLUMN(CFMcCollision, cfMcCollision); //! Index to reduced MC collision; o2-linter: disable=name/o2-column (preserve the established derived-table API)
 DECLARE_SOA_COLUMN(Pt, pt, float);                      //! pT (GeV/c)
 DECLARE_SOA_COLUMN(Eta, eta, float);                    //! Pseudorapidity
 DECLARE_SOA_COLUMN(Phi, phi, float);                    //! Phi angle
@@ -58,7 +58,7 @@ using CFMcParticle = CFMcParticles::iterator;
 namespace cfmultiplicity
 {
 DECLARE_SOA_COLUMN(Multiplicity, multiplicity, float);
-DECLARE_SOA_COLUMN(Estimator, multiplicityEstimator, uint8_t); //! Source used for the multiplicity value
+DECLARE_SOA_COLUMN(MultiplicityEstimator, multiplicityEstimator, uint8_t); //! Source used for the multiplicity value
 enum EstimatorType : uint8_t {
   Tracks,
   FT0M,
@@ -71,13 +71,13 @@ enum EstimatorType : uint8_t {
   MCParticles,
 };
 } // namespace cfmultiplicity
-DECLARE_SOA_TABLE(CFMultiplicities, "AOD", "CFMULTIPLICITY", cfmultiplicity::Multiplicity, cfmultiplicity::Estimator);
+DECLARE_SOA_TABLE(CFMultiplicities, "AOD", "CFMULTIPLICITY", cfmultiplicity::Multiplicity, cfmultiplicity::MultiplicityEstimator);
 
 using CFMultiplicity = CFMultiplicities::iterator;
 
 namespace cfcollision
 {
-DECLARE_SOA_INDEX_COLUMN(CFMcCollision, cfMcCollision); //! Index to reduced MC collision
+DECLARE_SOA_INDEX_COLUMN(CFMcCollision, cfMcCollision); //! Index to reduced MC collision; o2-linter: disable=name/o2-column (preserve the established derived-table API)
 DECLARE_SOA_COLUMN(Multiplicity, multiplicity, float);  //! Centrality/multiplicity value
 } // namespace cfcollision
 DECLARE_SOA_TABLE(CFCollisions, "AOD", "CFCOLLISION", //! Reduced collision table
@@ -103,8 +103,8 @@ using CFCollisionWithExtra = CFCollisionsWithExtra::iterator;
 
 namespace cftrack
 {
-DECLARE_SOA_INDEX_COLUMN(CFCollision, cfCollision);   //! Index to collision
-DECLARE_SOA_INDEX_COLUMN(CFMcParticle, cfMCParticle); //! Index to MC particle
+DECLARE_SOA_INDEX_COLUMN(CFCollision, cfCollision);   //! Index to collision; o2-linter: disable=name/o2-column (preserve the established derived-table API)
+DECLARE_SOA_INDEX_COLUMN(CFMcParticle, cfMCParticle); //! Index to MC particle; o2-linter: disable=name/o2-column (preserve the established derived-table API)
 DECLARE_SOA_COLUMN(Pt, pt, float);                    //! pT (GeV/c)
 DECLARE_SOA_COLUMN(Eta, eta, float);                  //! Pseudorapidity
 DECLARE_SOA_COLUMN(Phi, phi, float);                  //! Phi angle
@@ -169,8 +169,8 @@ using CFMcParticleRef = CFMcParticleRefs::iterator;
 
 namespace cf2prongtrack
 {
-DECLARE_SOA_INDEX_COLUMN_FULL(CFTrackProng0, cfTrackProng0, int, CFTracks, "_0"); //! Index to prong 1 CFTrack
-DECLARE_SOA_INDEX_COLUMN_FULL(CFTrackProng1, cfTrackProng1, int, CFTracks, "_1"); //! Index to prong 2 CFTrack
+DECLARE_SOA_INDEX_COLUMN_FULL(CFTrackProng0, cfTrackProng0, int, CFTracks, "_0"); //! Index to prong 1 CFTrack; o2-linter: disable=name/o2-column (preserve the established derived-table API)
+DECLARE_SOA_INDEX_COLUMN_FULL(CFTrackProng1, cfTrackProng1, int, CFTracks, "_1"); //! Index to prong 2 CFTrack; o2-linter: disable=name/o2-column (preserve the established derived-table API)
 DECLARE_SOA_COLUMN(Pt, pt, float);                                                //! pT (GeV/c)
 DECLARE_SOA_COLUMN(Eta, eta, float);                                              //! Pseudorapidity
 DECLARE_SOA_COLUMN(Phi, phi, float);                                              //! Phi angle
@@ -223,8 +223,8 @@ using CF2ProngTrackml = CF2ProngTrackmls::iterator;
 
 namespace cf2prongmcpart
 {
-DECLARE_SOA_INDEX_COLUMN_FULL(CFParticleDaugh0, cfParticleDaugh0, int, CFMcParticles, "_0");         //! Index to prong 1 CFMcParticle
-DECLARE_SOA_INDEX_COLUMN_FULL(CFParticleDaugh1, cfParticleDaugh1, int, CFMcParticles, "_1");         //! Index to prong 2 CFMcParticle
+DECLARE_SOA_INDEX_COLUMN_FULL(CFParticleDaugh0, cfParticleDaugh0, int, CFMcParticles, "_0");         //! Index to prong 1 CFMcParticle; o2-linter: disable=name/o2-column (preserve the established derived-table API)
+DECLARE_SOA_INDEX_COLUMN_FULL(CFParticleDaugh1, cfParticleDaugh1, int, CFMcParticles, "_1");         //! Index to prong 2 CFMcParticle; o2-linter: disable=name/o2-column (preserve the established derived-table API)
 DECLARE_SOA_COLUMN(Decay, decay, uint8_t);                                                           //! Particle decay and flags
 DECLARE_SOA_DYNAMIC_COLUMN(McDecay, mcDecay, [](uint8_t decay) -> uint8_t { return decay & 0x3f; }); //! MC particle decay
 enum ParticleDecayFlags {

--- a/PWGCF/DataModel/CorrelationsDerived.h
+++ b/PWGCF/DataModel/CorrelationsDerived.h
@@ -65,13 +65,14 @@ using CFMultiplicity = CFMultiplicities::iterator;
 
 namespace cfcollision
 {
-DECLARE_SOA_INDEX_COLUMN(CFMcCollision, cfMcCollision); //! Index to reduced MC collision
-DECLARE_SOA_COLUMN(Multiplicity, multiplicity, float);  //! Centrality/multiplicity value
+DECLARE_SOA_INDEX_COLUMN(CFMcCollision, cfMcCollision);                  //! Index to reduced MC collision
+DECLARE_SOA_COLUMN(Multiplicity, multiplicity, float);                   //! Centrality/multiplicity value
+DECLARE_SOA_COLUMN(MultiplicityCorrected, multiplicityCorrected, float); //! Efficiency-corrected track count; original multiplicity when correction is disabled
 } // namespace cfcollision
 DECLARE_SOA_TABLE(CFCollisions, "AOD", "CFCOLLISION", //! Reduced collision table
                   o2::soa::Index<>,
                   bc::RunNumber, collision::PosZ,
-                  cfcollision::Multiplicity, timestamp::Timestamp);
+                  cfcollision::Multiplicity, timestamp::Timestamp, cfcollision::MultiplicityCorrected);
 DECLARE_SOA_TABLE(CFCollLabels, "AOD", "CFCOLLLABEL", //! Labels for reduced collision table
                   cfcollision::CFMcCollisionId);
 using CFCollision = CFCollisions::iterator;

--- a/PWGCF/DataModel/CorrelationsDerived.h
+++ b/PWGCF/DataModel/CorrelationsDerived.h
@@ -58,8 +58,20 @@ using CFMcParticle = CFMcParticles::iterator;
 namespace cfmultiplicity
 {
 DECLARE_SOA_COLUMN(Multiplicity, multiplicity, float);
-}
-DECLARE_SOA_TABLE(CFMultiplicities, "AOD", "CFMULTIPLICITY", cfmultiplicity::Multiplicity);
+DECLARE_SOA_COLUMN(Estimator, multiplicityEstimator, uint8_t); //! Source used for the multiplicity value
+enum EstimatorType : uint8_t {
+  Tracks,
+  FT0M,
+  FT0C,
+  FT0CVariant1,
+  FT0CVariant2,
+  FT0A,
+  CentNGlobal,
+  Run2V0M,
+  MCParticles,
+};
+} // namespace cfmultiplicity
+DECLARE_SOA_TABLE(CFMultiplicities, "AOD", "CFMULTIPLICITY", cfmultiplicity::Multiplicity, cfmultiplicity::Estimator);
 
 using CFMultiplicity = CFMultiplicities::iterator;
 

--- a/PWGCF/DataModel/CorrelationsDerived.h
+++ b/PWGCF/DataModel/CorrelationsDerived.h
@@ -65,20 +65,29 @@ using CFMultiplicity = CFMultiplicities::iterator;
 
 namespace cfcollision
 {
-DECLARE_SOA_INDEX_COLUMN(CFMcCollision, cfMcCollision);                  //! Index to reduced MC collision
-DECLARE_SOA_COLUMN(Multiplicity, multiplicity, float);                   //! Centrality/multiplicity value
-DECLARE_SOA_COLUMN(MultiplicityCorrected, multiplicityCorrected, float); //! Efficiency-corrected track count; original multiplicity when correction is disabled
+DECLARE_SOA_INDEX_COLUMN(CFMcCollision, cfMcCollision); //! Index to reduced MC collision
+DECLARE_SOA_COLUMN(Multiplicity, multiplicity, float);  //! Centrality/multiplicity value
 } // namespace cfcollision
 DECLARE_SOA_TABLE(CFCollisions, "AOD", "CFCOLLISION", //! Reduced collision table
                   o2::soa::Index<>,
                   bc::RunNumber, collision::PosZ,
-                  cfcollision::Multiplicity, timestamp::Timestamp, cfcollision::MultiplicityCorrected);
+                  cfcollision::Multiplicity, timestamp::Timestamp);
 DECLARE_SOA_TABLE(CFCollLabels, "AOD", "CFCOLLLABEL", //! Labels for reduced collision table
                   cfcollision::CFMcCollisionId);
 using CFCollision = CFCollisions::iterator;
 using CFCollLabel = CFCollLabels::iterator;
 using CFCollisionsWithLabel = soa::Join<CFCollisions, CFCollLabels>;
 using CFCollisionWithLabel = CFCollisionsWithLabel::iterator;
+
+namespace cfcollisionextra
+{
+DECLARE_SOA_COLUMN(MultiplicityCorrected, multiplicityCorrected, float); //! Efficiency-corrected track count
+} // namespace cfcollisionextra
+DECLARE_SOA_TABLE(CFCollisionsExtra, "AOD", "CFCOLLSEXTRA", //! Row-aligned extension of CFCollisions; filled only when multiplicity efficiency is configured
+                  cfcollisionextra::MultiplicityCorrected);
+using CFCollisionExtra = CFCollisionsExtra::iterator;
+using CFCollisionsWithExtra = soa::Join<CFCollisions, CFCollisionsExtra>;
+using CFCollisionWithExtra = CFCollisionsWithExtra::iterator;
 
 namespace cftrack
 {

--- a/PWGCF/DataModel/CorrelationsDerived.h
+++ b/PWGCF/DataModel/CorrelationsDerived.h
@@ -58,34 +58,24 @@ using CFMcParticle = CFMcParticles::iterator;
 namespace cfmultiplicity
 {
 DECLARE_SOA_COLUMN(Multiplicity, multiplicity, float);
-DECLARE_SOA_COLUMN(MultiplicityEstimator, multiplicityEstimator, uint8_t); //! Source used for the multiplicity value
-enum EstimatorType : uint8_t {
-  Tracks,
-  FT0M,
-  FT0C,
-  FT0CVariant1,
-  FT0CVariant2,
-  FT0A,
-  CentNGlobal,
-  Run2V0M,
-  MCParticles,
-};
+DECLARE_SOA_COLUMN(IsTrackMultiplicity, isTrackMultiplicity, bool); //! Whether MultiplicitySelector::processTracks produced the multiplicity
 } // namespace cfmultiplicity
-DECLARE_SOA_TABLE(CFMultiplicities, "AOD", "CFMULTIPLICITY", cfmultiplicity::Multiplicity, cfmultiplicity::MultiplicityEstimator);
+DECLARE_SOA_TABLE(CFMultiplicities, "AOD", "CFMULTIPLICITY", cfmultiplicity::Multiplicity, cfmultiplicity::IsTrackMultiplicity);
 
 using CFMultiplicity = CFMultiplicities::iterator;
 
 namespace cfcollision
 {
-DECLARE_SOA_INDEX_COLUMN(CFMcCollision, cfMcCollision); //! Index to reduced MC collision; o2-linter: disable=name/o2-column (preserve the established derived-table API)
-DECLARE_SOA_COLUMN(Multiplicity, multiplicity, float);  //! Centrality/multiplicity value
+DECLARE_SOA_INDEX_COLUMN(CFMcCollision, cfMcCollision);         //! Index to reduced MC collision; o2-linter: disable=name/o2-column (preserve the established derived-table API)
+DECLARE_SOA_COLUMN(Multiplicity, multiplicity, float);          //! Centrality/multiplicity value
+DECLARE_SOA_COLUMN(BestRecoCollision, bestRecoCollision, bool); //! Whether this is the best reconstructed collision for the associated MC collision (largest number of contributors)
 } // namespace cfcollision
 DECLARE_SOA_TABLE(CFCollisions, "AOD", "CFCOLLISION", //! Reduced collision table
                   o2::soa::Index<>,
                   bc::RunNumber, collision::PosZ,
                   cfcollision::Multiplicity, timestamp::Timestamp);
 DECLARE_SOA_TABLE(CFCollLabels, "AOD", "CFCOLLLABEL", //! Labels for reduced collision table
-                  cfcollision::CFMcCollisionId);
+                  cfcollision::CFMcCollisionId, cfcollision::BestRecoCollision);
 using CFCollision = CFCollisions::iterator;
 using CFCollLabel = CFCollLabels::iterator;
 using CFCollisionsWithLabel = soa::Join<CFCollisions, CFCollLabels>;
@@ -136,7 +126,6 @@ enum MultiplicityEstimators : uint8_t {
   MultNTracksGlobal = 0x8,
   CentFT0M = 0x10,
 };
-
 inline constexpr uint32_t NMultiplicityEstimators = __builtin_ctz(CentFT0M) + 1;
 
 } // namespace cfmultset

--- a/PWGCF/DataModel/CorrelationsDerived.h
+++ b/PWGCF/DataModel/CorrelationsDerived.h
@@ -58,9 +58,8 @@ using CFMcParticle = CFMcParticles::iterator;
 namespace cfmultiplicity
 {
 DECLARE_SOA_COLUMN(Multiplicity, multiplicity, float);
-DECLARE_SOA_COLUMN(IsTrackMultiplicity, isTrackMultiplicity, bool); //! Whether MultiplicitySelector::processTracks produced the multiplicity
 } // namespace cfmultiplicity
-DECLARE_SOA_TABLE(CFMultiplicities, "AOD", "CFMULTIPLICITY", cfmultiplicity::Multiplicity, cfmultiplicity::IsTrackMultiplicity);
+DECLARE_SOA_TABLE(CFMultiplicities, "AOD", "CFMULTIPLICITY", cfmultiplicity::Multiplicity);
 
 using CFMultiplicity = CFMultiplicities::iterator;
 

--- a/PWGCF/TableProducer/filterCorrelations.cxx
+++ b/PWGCF/TableProducer/filterCorrelations.cxx
@@ -21,6 +21,7 @@
 #include "Common/DataModel/PIDResponseTPC.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 
+#include <CCDB/BasicCCDBManager.h>
 #include <Framework/AnalysisDataModel.h>
 #include <Framework/AnalysisHelpers.h>
 #include <Framework/AnalysisTask.h>
@@ -35,14 +36,21 @@
 #include <MathUtils/detail/TypeTruncation.h>
 #include <ReconstructionDataFormats/PID.h>
 
+#include <TFile.h>
 #include <TH3.h>
+#include <THn.h>
 #include <TParticlePDG.h>
 
 #include <Rtypes.h>
 
 #include <algorithm>
+#include <array>
+#include <cmath>
 #include <cstdint>
 #include <experimental/type_traits> // required for is_detected
+#include <limits>
+#include <memory>
+#include <string>
 #include <type_traits>
 #include <vector>
 
@@ -58,6 +66,7 @@ using namespace o2::math_utils::detail;
 
 struct FilterCF {
   Service<o2::framework::O2DatabasePDG> pdg;
+  Service<o2::ccdb::BasicCCDBManager> ccdb;
 
   enum TrackSelectionCuts1 : uint8_t {
     kTrackSelected = BIT(0),
@@ -103,6 +112,10 @@ struct FilterCF {
   O2_DEFINE_CONFIGURABLE(chi2peritscluster, float, 36, "maximum Chi2 / cluster for the ITS track segment")
   O2_DEFINE_CONFIGURABLE(cfgEstimatorBitMask, uint16_t, 0, "BitMask for multiplicity estimators to be included in the CFMultSet tables.");
 
+  O2_DEFINE_CONFIGURABLE(cfgEfficiencyMultiplicity, std::string, "", "Multiplicity efficiency (RecoAll / MC): CCDB path or local ROOT file with a 4D ccdb_object (eta, pT, multiplicity, z-vtx); empty copies the original multiplicity")
+  O2_DEFINE_CONFIGURABLE(cfgLocalEfficiency, int, 0, "0 = CCDB efficiency, 1 = local ROOT efficiency")
+  O2_DEFINE_CONFIGURABLE(cfgMultiplicityTrackBitMask, uint16_t, 0, "Required track-type bits for corrected multiplicity; match cfgTrackBitMask used to produce the efficiency (0 = all stored tracks)")
+
   // Filters and input definitions
   Filter collisionZVtxFilter = nabs(aod::collision::posZ) < cfgCutVertex;
   Filter collisionVertexTypeFilter = (cfgCollisionFlags == 0) || ((aod::collision::flags & cfgCollisionFlags) == cfgCollisionFlags);
@@ -135,12 +148,36 @@ struct FilterCF {
   Produces<aod::CFMultSets> outputMultSets;
   std::vector<float> multiplicities{};
 
+  // Own local histograms independently of their input file. CCDB owns its objects.
+  std::unique_ptr<THn> localMultiplicityEfficiency;
+
   // persistent caches
   std::vector<bool> mcReconstructedCache;
   std::vector<int> mcParticleLabelsCache;
 
   void init(InitContext&)
   {
+    if (!cfgEfficiencyMultiplicity.value.empty()) {
+      if (cfgLocalEfficiency != 0 && cfgLocalEfficiency != 1) {
+        LOGF(fatal, "cfgLocalEfficiency must be 0 (CCDB) or 1 (local ROOT file)");
+      }
+      if (cfgMultiplicityTrackBitMask > std::numeric_limits<uint8_t>::max()) {
+        LOGF(fatal, "cfgMultiplicityTrackBitMask must fit the 8-bit track type");
+      }
+      if (cfgLocalEfficiency == 1) {
+        std::unique_ptr<TFile> file(TFile::Open(cfgEfficiencyMultiplicity.value.c_str(), "READ"));
+        if (!file || file->IsZombie()) {
+          LOGF(fatal, "Could not open multiplicity efficiency file %s", cfgEfficiencyMultiplicity.value.c_str());
+        }
+        auto* efficiency = dynamic_cast<THn*>(file->Get("ccdb_object"));
+        validateMultiplicityEfficiency(efficiency);
+        localMultiplicityEfficiency.reset(static_cast<THn*>(efficiency->Clone()));
+      } else {
+        ccdb->setURL("http://alice-ccdb.cern.ch");
+        ccdb->setCaching(true);
+        ccdb->setLocalObjectValidityChecking();
+      }
+    }
     if (doprocessTrackQA) {
       registrytrackQA.add("zvtx", "Z Vertex position;  posz (cm); Events", HistType::kTH1F, {{100, -12, 12}});
       registrytrackQA.add("eta", "eta distribution;  eta; arb. units", HistType::kTH1F, {{100, -2, 2}});
@@ -280,6 +317,68 @@ struct FilterCF {
     return dcaXyConst + dcaXySlope / pt; // a + b/pT
   }
 
+  void validateMultiplicityEfficiency(const THn* efficiency) const
+  {
+    if (!efficiency || efficiency->GetNdimensions() != 4) {
+      LOGF(fatal, "Multiplicity efficiency from %s must be a 4D THn with axes (eta, pT, multiplicity, z-vtx)", cfgEfficiencyMultiplicity.value.c_str());
+    }
+  }
+
+  THn* loadMultiplicityEfficiency(uint64_t timestamp)
+  {
+    if (cfgLocalEfficiency == 1) {
+      return localMultiplicityEfficiency.get();
+    }
+    // Query each collision so the manager can refresh its cache at validity boundaries.
+    auto* efficiency = ccdb->getForTimeStamp<THnT<float>>(cfgEfficiencyMultiplicity.value, timestamp);
+    validateMultiplicityEfficiency(efficiency);
+    return efficiency;
+  }
+
+  template <bool applyDCA, typename TCollision, typename TTracks>
+  float getCorrectedMultiplicity(const TCollision& collision, const TTracks& tracks, uint64_t timestamp)
+  {
+    if (cfgEfficiencyMultiplicity.value.empty()) {
+      return collision.multiplicity();
+    }
+
+    auto* efficiency = loadMultiplicityEfficiency(timestamp);
+    double correctedMultiplicity = 0.;
+    for (const auto& track : tracks) {
+      // Match the tracks written by the corresponding data/MC producer path.
+      if constexpr (applyDCA) {
+        if (std::abs(track.dcaXY()) > getMaxDCAxy(track.pt()) || std::abs(track.dcaZ()) > dcazmax) {
+          continue;
+        }
+      }
+      const auto mask = static_cast<uint8_t>(cfgMultiplicityTrackBitMask.value);
+      if (mask != 0 && (getTrackType(track) & mask) != mask) {
+        continue;
+      }
+
+      // The map contains RecoAll / MC, not inverse-efficiency weights.
+      // Keep the original estimator as the map coordinate, including for centrality.
+      const std::array<double, 4> values{track.eta(), track.pt(), collision.multiplicity(), collision.posZ()};
+      std::array<int, 4> bins{};
+      for (int axis = 0; axis < 4; ++axis) {
+        auto* efficiencyAxis = efficiency->GetAxis(axis);
+        bins[axis] = efficiencyAxis->FindFixBin(values[axis]);
+        if (!std::isfinite(values[axis]) || bins[axis] < 1 || bins[axis] > efficiencyAxis->GetNbins()) {
+          LOGF(fatal, "Multiplicity efficiency from %s does not cover axis %d value %g", cfgEfficiencyMultiplicity.value.c_str(), axis, values[axis]);
+        }
+      }
+      const double eff = efficiency->GetBinContent(bins.data());
+      if (!std::isfinite(eff) || eff <= 0.) {
+        LOGF(fatal, "Invalid multiplicity efficiency %g from %s at bins (%d, %d, %d, %d)", eff, cfgEfficiencyMultiplicity.value.c_str(), bins[0], bins[1], bins[2], bins[3]);
+      }
+      correctedMultiplicity += 1. / eff;
+    }
+    if (!std::isfinite(correctedMultiplicity) || correctedMultiplicity > std::numeric_limits<float>::max()) {
+      LOGF(fatal, "Corrected multiplicity cannot be represented as a float: %g", correctedMultiplicity);
+    }
+    return static_cast<float>(correctedMultiplicity);
+  }
+
   template <class T>
   using HasMultTables = decltype(std::declval<T&>().multNTracksPV());
 
@@ -298,7 +397,7 @@ struct FilterCF {
     }
 
     auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
-    outputCollisions(bc.runNumber(), collision.posZ(), collision.multiplicity(), bc.timestamp());
+    outputCollisions(bc.runNumber(), collision.posZ(), collision.multiplicity(), bc.timestamp(), getCorrectedMultiplicity<true>(collision, tracks, bc.timestamp()));
 
     if constexpr (std::experimental::is_detected<HasMultTables, C1>::value) {
       multiplicities.clear();
@@ -476,7 +575,7 @@ struct FilterCF {
 
       auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
       // NOTE works only when we store all MC collisions (as we do here)
-      outputCollisions(bc.runNumber(), collision.posZ(), collision.multiplicity(), bc.timestamp());
+      outputCollisions(bc.runNumber(), collision.posZ(), collision.multiplicity(), bc.timestamp(), getCorrectedMultiplicity<false>(collision, groupedTracks, bc.timestamp()));
       outputMcCollisionLabels(collision.mcCollisionId());
 
       if constexpr (std::experimental::is_detected<HasMultTables, C1>::value) {

--- a/PWGCF/TableProducer/filterCorrelations.cxx
+++ b/PWGCF/TableProducer/filterCorrelations.cxx
@@ -112,7 +112,7 @@ struct FilterCF {
   O2_DEFINE_CONFIGURABLE(chi2peritscluster, float, 36, "maximum Chi2 / cluster for the ITS track segment")
   O2_DEFINE_CONFIGURABLE(cfgEstimatorBitMask, uint16_t, 0, "BitMask for multiplicity estimators to be included in the CFMultSet tables.");
 
-  O2_DEFINE_CONFIGURABLE(cfgEfficiencyMultiplicity, std::string, "", "Multiplicity efficiency (RecoAll / MC): CCDB path or local ROOT file with a 4D ccdb_object (eta, pT, multiplicity, z-vtx); empty copies the original multiplicity")
+  O2_DEFINE_CONFIGURABLE(cfgEfficiencyMultiplicity, std::string, "", "Multiplicity efficiency (RecoAll / MC): CCDB path or local ROOT file with a 4D ccdb_object (eta, pT, multiplicity, z-vtx); empty disables CFCollisionsExtra output")
   O2_DEFINE_CONFIGURABLE(cfgLocalEfficiency, int, 0, "0 = CCDB efficiency, 1 = local ROOT efficiency")
   O2_DEFINE_CONFIGURABLE(cfgMultiplicityTrackBitMask, uint16_t, 0, "Required track-type bits for corrected multiplicity; match cfgTrackBitMask used to produce the efficiency (0 = all stored tracks)")
 
@@ -132,6 +132,7 @@ struct FilterCF {
   HistogramRegistry registrytrackQA{"TrackQA", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
 
   Produces<aod::CFCollisions> outputCollisions;
+  Produces<aod::CFCollisionsExtra> outputCollisionsExtra;
   Produces<aod::CFTracks> outputTracks;
 
   Produces<aod::CFCollLabels> outputMcCollisionLabels;
@@ -338,10 +339,6 @@ struct FilterCF {
   template <bool applyDCA, typename TCollision, typename TTracks>
   float getCorrectedMultiplicity(const TCollision& collision, const TTracks& tracks, uint64_t timestamp)
   {
-    if (cfgEfficiencyMultiplicity.value.empty()) {
-      return collision.multiplicity();
-    }
-
     auto* efficiency = loadMultiplicityEfficiency(timestamp);
     double correctedMultiplicity = 0.;
     for (const auto& track : tracks) {
@@ -397,7 +394,10 @@ struct FilterCF {
     }
 
     auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
-    outputCollisions(bc.runNumber(), collision.posZ(), collision.multiplicity(), bc.timestamp(), getCorrectedMultiplicity<true>(collision, tracks, bc.timestamp()));
+    outputCollisions(bc.runNumber(), collision.posZ(), collision.multiplicity(), bc.timestamp());
+    if (!cfgEfficiencyMultiplicity.value.empty()) {
+      outputCollisionsExtra(getCorrectedMultiplicity<true>(collision, tracks, bc.timestamp()));
+    }
 
     if constexpr (std::experimental::is_detected<HasMultTables, C1>::value) {
       multiplicities.clear();
@@ -575,7 +575,10 @@ struct FilterCF {
 
       auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
       // NOTE works only when we store all MC collisions (as we do here)
-      outputCollisions(bc.runNumber(), collision.posZ(), collision.multiplicity(), bc.timestamp(), getCorrectedMultiplicity<false>(collision, groupedTracks, bc.timestamp()));
+      outputCollisions(bc.runNumber(), collision.posZ(), collision.multiplicity(), bc.timestamp());
+      if (!cfgEfficiencyMultiplicity.value.empty()) {
+        outputCollisionsExtra(getCorrectedMultiplicity<false>(collision, groupedTracks, bc.timestamp()));
+      }
       outputMcCollisionLabels(collision.mcCollisionId());
 
       if constexpr (std::experimental::is_detected<HasMultTables, C1>::value) {

--- a/PWGCF/TableProducer/filterCorrelations.cxx
+++ b/PWGCF/TableProducer/filterCorrelations.cxx
@@ -9,6 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
+// o2-linter: disable=name/workflow-file (historic file contains several table-producer tasks)
 #include "PWGCF/DataModel/CorrelationsDerived.h"
 
 #include "Common/CCDB/EventSelectionParams.h"
@@ -151,6 +152,7 @@ struct FilterCF {
 
   // Own local histograms independently of their input file. CCDB owns its objects.
   std::unique_ptr<THn> localMultiplicityEfficiency;
+  static constexpr int MultiplicityEfficiencyDimensions = 4;
 
   // persistent caches
   std::vector<bool> mcReconstructedCache;
@@ -167,8 +169,13 @@ struct FilterCF {
       }
       if (cfgLocalEfficiency == 1) {
         std::unique_ptr<TFile> file(TFile::Open(cfgEfficiencyMultiplicity.value.c_str(), "READ"));
-        if (!file || file->IsZombie()) {
+        if (!file) {
           LOGF(fatal, "Could not open multiplicity efficiency file %s", cfgEfficiencyMultiplicity.value.c_str());
+          return;
+        }
+        if (file->IsZombie()) {
+          LOGF(fatal, "Multiplicity efficiency file %s is invalid", cfgEfficiencyMultiplicity.value.c_str());
+          return;
         }
         auto* efficiency = dynamic_cast<THn*>(file->Get("ccdb_object"));
         validateMultiplicityEfficiency(efficiency);
@@ -194,7 +201,7 @@ struct FilterCF {
   }
 
   template <typename TCollision>
-  bool keepCollision(TCollision& collision)
+  bool keepCollision(const TCollision& collision)
   {
     bool isMultSelected = false;
     if (collision.multiplicity() >= cfgMinMultiplicity)
@@ -202,23 +209,23 @@ struct FilterCF {
 
     if (cfgTrigger == 0) {
       return true;
-    } else if (cfgTrigger == 7) {
+    } else if (cfgTrigger == 7) { // o2-linter: disable=magic-number (documented legacy trigger-selection code)
       return isMultSelected && collision.alias_bit(kINT7) && collision.sel7();
-    } else if (cfgTrigger == 8) {
+    } else if (cfgTrigger == 8) { // o2-linter: disable=magic-number (documented legacy trigger-selection code)
       return isMultSelected && collision.sel8();
-    } else if (cfgTrigger == 9) { // relevant only for Pb-Pb
+    } else if (cfgTrigger == 9) { // relevant only for Pb-Pb; o2-linter: disable=magic-number (documented legacy trigger-selection code)
       return isMultSelected && collision.sel8() && collision.selection_bit(aod::evsel::kNoSameBunchPileup) && collision.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV) && collision.selection_bit(aod::evsel::kIsGoodITSLayersAll);
-    } else if (cfgTrigger == 10) { // TVX trigger only (sel8 selection before April, 2024)
+    } else if (cfgTrigger == 10) { // TVX trigger only (sel8 selection before April, 2024); o2-linter: disable=magic-number (documented legacy trigger-selection code)
       return isMultSelected && collision.selection_bit(aod::evsel::kIsTriggerTVX);
-    } else if (cfgTrigger == 11) { // sel8 selection for MC
+    } else if (cfgTrigger == 11) { // sel8 selection for MC; o2-linter: disable=magic-number (documented legacy trigger-selection code)
       return isMultSelected && collision.selection_bit(aod::evsel::kIsTriggerTVX) && collision.selection_bit(aod::evsel::kNoTimeFrameBorder);
-    } else if (cfgTrigger == 12) { // relevant only for Pb-Pb with occupancy cuts and rejection of the collisions which have other events nearby
+    } else if (cfgTrigger == 12) { // relevant only for Pb-Pb with occupancy cuts and rejection of nearby collisions; o2-linter: disable=magic-number (documented legacy trigger-selection code)
       int occupancy = collision.trackOccupancyInTimeRange();
       if (occupancy >= cfgMinOcc && occupancy < cfgMaxOcc)
         return isMultSelected && collision.sel8() && collision.selection_bit(aod::evsel::kNoSameBunchPileup) && collision.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV) && collision.selection_bit(aod::evsel::kNoCollInTimeRangeStandard) && collision.selection_bit(aod::evsel::kIsGoodITSLayersAll);
       else
         return false;
-    } else if (cfgTrigger == 13) { // relevant for pO/OO/NeNe --recommended by Physics Board on 27.01.2026
+    } else if (cfgTrigger == 13) { // relevant for pO/OO/NeNe, recommended by Physics Board on 27.01.2026; o2-linter: disable=magic-number (documented legacy trigger-selection code)
       return isMultSelected && collision.sel8() && collision.selection_bit(aod::evsel::kNoSameBunchPileup) && collision.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV);
     }
     return false;
@@ -231,18 +238,18 @@ struct FilterCF {
   {
     o2::aod::ITSResponse itsResponse;
 
-    if (ITSProtonselection && candidate.pt() <= 0.6 && !(itsResponse.nSigmaITS<o2::track::PID::Proton>(candidate) > nsigmaCutITSProton)) {
+    if (ITSProtonselection && candidate.pt() <= 0.6 && !(itsResponse.nSigmaITS<o2::track::PID::Proton>(candidate) > nsigmaCutITSProton)) { // o2-linter: disable=magic-number (established proton PID momentum boundary)
       return false;
     }
-    if (ITSProtonselection && candidate.pt() > 0.6 && candidate.pt() <= 0.8 && !(itsResponse.nSigmaITS<o2::track::PID::Proton>(candidate) > nsigmaCutITSProton)) {
+    if (ITSProtonselection && candidate.pt() > 0.6 && candidate.pt() <= 0.8 && !(itsResponse.nSigmaITS<o2::track::PID::Proton>(candidate) > nsigmaCutITSProton)) { // o2-linter: disable=magic-number (established proton PID momentum boundaries)
       return false;
     }
 
     if (candidate.hasTOF()) {
-      if (candidate.pt() < 0.7 && std::abs(candidate.tpcNSigmaPr()) < nsigmaCutTPCProton) {
+      if (candidate.pt() < 0.7 && std::abs(candidate.tpcNSigmaPr()) < nsigmaCutTPCProton) { // o2-linter: disable=magic-number (established proton PID momentum boundary)
         return true;
       }
-      if (candidate.p() >= 0.7 && std::abs(candidate.tpcNSigmaPr()) < nsigmaCutTPCProton && std::abs(candidate.tofNSigmaPr()) < nsigmaCutTOFProton) {
+      if (candidate.p() >= 0.7 && std::abs(candidate.tpcNSigmaPr()) < nsigmaCutTPCProton && std::abs(candidate.tofNSigmaPr()) < nsigmaCutTOFProton) { // o2-linter: disable=magic-number (established proton PID momentum boundary)
         return true;
       }
     } else {
@@ -296,7 +303,7 @@ struct FilterCF {
         }
       }
       return trackType;
-    } else if (cfgTrackSelection == 2) {
+    } else if (cfgTrackSelection == 2) { // o2-linter: disable=magic-number (documented track-selection mode)
       uint8_t trackType = 0;
       if constexpr (HasProtonPID<TTrack>::value) {
         if (track.isGlobalTrack() && (track.itsNCls() >= itsnclusters) && (track.tpcNClsCrossedRows() >= tpcncrossedrows) && selectionPIDProton(track)) {
@@ -320,7 +327,7 @@ struct FilterCF {
 
   void validateMultiplicityEfficiency(const THn* efficiency) const
   {
-    if (!efficiency || efficiency->GetNdimensions() != 4) {
+    if (!efficiency || efficiency->GetNdimensions() != MultiplicityEfficiencyDimensions) {
       LOGF(fatal, "Multiplicity efficiency from %s must be a 4D THn with axes (eta, pT, multiplicity, z-vtx)", cfgEfficiencyMultiplicity.value.c_str());
     }
   }
@@ -358,9 +365,9 @@ struct FilterCF {
 
       // The map contains RecoAll / MC, not inverse-efficiency weights.
       // Keep the original estimator as the map coordinate, including for centrality.
-      const std::array<double, 4> values{track.eta(), track.pt(), collision.multiplicity(), collision.posZ()};
-      std::array<int, 4> bins{};
-      for (int axis = 0; axis < 4; ++axis) {
+      const std::array<double, MultiplicityEfficiencyDimensions> values{track.eta(), track.pt(), collision.multiplicity(), collision.posZ()};
+      std::array<int, MultiplicityEfficiencyDimensions> bins{};
+      for (int axis = 0; axis < MultiplicityEfficiencyDimensions; ++axis) {
         auto* efficiencyAxis = efficiency->GetAxis(axis);
         bins[axis] = efficiencyAxis->FindFixBin(values[axis]);
         if (!std::isfinite(values[axis]) || bins[axis] < 1 || bins[axis] > efficiencyAxis->GetNbins()) {
@@ -419,7 +426,7 @@ struct FilterCF {
 
     if (cfgTransientTables)
       outputCollRefs(collision.globalIndex());
-    for (auto& track : tracks) {
+    for (const auto& track : tracks) {
       float maxDCAxy = getMaxDCAxy(track.pt());
       if ((std::abs(track.dcaXY()) > maxDCAxy) || (std::abs(track.dcaZ()) > dcazmax)) {
         continue;
@@ -504,7 +511,7 @@ struct FilterCF {
     }
 
     // PASS 1 on collisions: check which particles are kept
-    for (auto& collision : allCollisions) {
+    for (const auto& collision : allCollisions) {
       auto groupedTracks = tracks.sliceBy(perCollision, collision.globalIndex());
       if (cfgVerbosity > 0) {
         LOGF(info, "processMC:   Tracks for collision %d: %d | Vertex: %.1f (%d) | INT7: %d", collision.globalIndex(), groupedTracks.size(), collision.posZ(), collision.flags(), collision.sel7());
@@ -514,14 +521,14 @@ struct FilterCF {
         continue;
       }
 
-      for (auto& track : groupedTracks) {
+      for (const auto& track : groupedTracks) {
         if (track.has_mcParticle()) {
           mcReconstructedCache[track.mcParticleId()] = true;
         }
       }
     }
 
-    for (auto& mcCollision : mcCollisions) {
+    for (const auto& mcCollision : mcCollisions) {
       auto particles = allParticles.sliceBy(perMcCollision, mcCollision.globalIndex());
 
       if (cfgVerbosity > 0) {
@@ -530,7 +537,7 @@ struct FilterCF {
 
       // Store selected MC particles and MC collisions
       int multiplicity = 0;
-      for (auto& particle : particles) {
+      for (const auto& particle : particles) {
         int8_t sign = 0;
         TParticlePDG* pdgparticle = pdg->GetParticle(particle.pdgCode());
         if (pdgparticle != nullptr) {
@@ -566,7 +573,7 @@ struct FilterCF {
     }
 
     // PASS 2 on collisions: store collisions and tracks
-    for (auto& collision : allCollisions) {
+    for (const auto& collision : allCollisions) {
       auto groupedTracks = tracks.sliceBy(perCollision, collision.globalIndex());
       if (cfgVerbosity > 0) {
         LOGF(info, "processMC:   Tracks for collision %d: %d | Vertex: %.1f (%d) | INT7: %d", collision.globalIndex(), groupedTracks.size(), collision.posZ(), collision.flags(), collision.sel7());
@@ -602,7 +609,7 @@ struct FilterCF {
       if (cfgTransientTables)
         outputCollRefs(collision.globalIndex());
 
-      for (auto& track : groupedTracks) {
+      for (const auto& track : groupedTracks) {
         int mcParticleId = track.mcParticleId();
         if (mcParticleId >= 0) {
           mcParticleId = mcParticleLabelsCache[track.mcParticleId()];
@@ -657,7 +664,7 @@ struct FilterCF {
   void processMCGen(McCollisionsWithHepMC::iterator const& mcCollision, aod::McParticles const& particles)
   {
     float multiplicity = 0.0f;
-    for (auto& particle : particles) {
+    for (const auto& particle : particles) {
       if (!particle.isPhysicalPrimary() || std::abs(particle.eta()) > cfgCutMCEta || particle.pt() < cfgCutMCPt)
         continue;
       int8_t sign = 0;
@@ -728,7 +735,7 @@ struct MultiplicitySelector {
 
   void processFT0M(aod::CentFT0Ms const& centralities)
   {
-    for (auto& c : centralities) {
+    for (const auto& c : centralities) {
       output(c.centFT0M(), aod::cfmultiplicity::FT0M);
     }
   }
@@ -736,7 +743,7 @@ struct MultiplicitySelector {
 
   void processFT0C(aod::CentFT0Cs const& centralities)
   {
-    for (auto& c : centralities) {
+    for (const auto& c : centralities) {
       output(c.centFT0C(), aod::cfmultiplicity::FT0C);
     }
   }
@@ -744,7 +751,7 @@ struct MultiplicitySelector {
 
   void processFT0CVariant1(aod::CentFT0CVariant1s const& centralities)
   {
-    for (auto& c : centralities) {
+    for (const auto& c : centralities) {
       output(c.centFT0CVariant1(), aod::cfmultiplicity::FT0CVariant1);
     }
   }
@@ -752,7 +759,7 @@ struct MultiplicitySelector {
 
   void processFT0CVariant2(aod::CentFT0CVariant2s const& centralities)
   {
-    for (auto& c : centralities) {
+    for (const auto& c : centralities) {
       output(c.centFT0CVariant2(), aod::cfmultiplicity::FT0CVariant2);
     }
   }
@@ -760,7 +767,7 @@ struct MultiplicitySelector {
 
   void processFT0A(aod::CentFT0As const& centralities)
   {
-    for (auto& c : centralities) {
+    for (const auto& c : centralities) {
       output(c.centFT0A(), aod::cfmultiplicity::FT0A);
     }
   }
@@ -768,7 +775,7 @@ struct MultiplicitySelector {
 
   void processCentNGlobal(aod::CentNGlobals const& centralities)
   {
-    for (auto& c : centralities) {
+    for (const auto& c : centralities) {
       output(c.centNGlobal(), aod::cfmultiplicity::CentNGlobal);
     }
   }
@@ -776,7 +783,7 @@ struct MultiplicitySelector {
 
   void processRun2V0M(aod::CentRun2V0Ms const& centralities)
   {
-    for (auto& c : centralities) {
+    for (const auto& c : centralities) {
       output(c.centRun2V0M(), aod::cfmultiplicity::Run2V0M);
     }
   }

--- a/PWGCF/TableProducer/filterCorrelations.cxx
+++ b/PWGCF/TableProducer/filterCorrelations.cxx
@@ -339,6 +339,9 @@ struct FilterCF {
   template <bool applyDCA, typename TCollision, typename TTracks>
   float getCorrectedMultiplicity(const TCollision& collision, const TTracks& tracks, uint64_t timestamp)
   {
+    if (collision.multiplicityEstimator() != aod::cfmultiplicity::Tracks) {
+      LOGF(fatal, "Efficiency-corrected multiplicity requires MultiplicitySelector::processTracks, but estimator type %u was configured", static_cast<unsigned int>(collision.multiplicityEstimator()));
+    }
     auto* efficiency = loadMultiplicityEfficiency(timestamp);
     double correctedMultiplicity = 0.;
     for (const auto& track : tracks) {
@@ -719,14 +722,14 @@ struct MultiplicitySelector {
 
   void processTracks(aod::Collision const&, soa::Filtered<soa::Join<aod::Tracks, aod::TrackSelection>> const& tracks)
   {
-    output(tracks.size());
+    output(tracks.size(), aod::cfmultiplicity::Tracks);
   }
   PROCESS_SWITCH(MultiplicitySelector, processTracks, "Select track count as multiplicity", false);
 
   void processFT0M(aod::CentFT0Ms const& centralities)
   {
     for (auto& c : centralities) {
-      output(c.centFT0M());
+      output(c.centFT0M(), aod::cfmultiplicity::FT0M);
     }
   }
   PROCESS_SWITCH(MultiplicitySelector, processFT0M, "Select FT0M centrality as multiplicity", false);
@@ -734,7 +737,7 @@ struct MultiplicitySelector {
   void processFT0C(aod::CentFT0Cs const& centralities)
   {
     for (auto& c : centralities) {
-      output(c.centFT0C());
+      output(c.centFT0C(), aod::cfmultiplicity::FT0C);
     }
   }
   PROCESS_SWITCH(MultiplicitySelector, processFT0C, "Select FT0C centrality as multiplicity", false);
@@ -742,7 +745,7 @@ struct MultiplicitySelector {
   void processFT0CVariant1(aod::CentFT0CVariant1s const& centralities)
   {
     for (auto& c : centralities) {
-      output(c.centFT0CVariant1());
+      output(c.centFT0CVariant1(), aod::cfmultiplicity::FT0CVariant1);
     }
   }
   PROCESS_SWITCH(MultiplicitySelector, processFT0CVariant1, "Select FT0CVariant1 centrality as multiplicity", false);
@@ -750,7 +753,7 @@ struct MultiplicitySelector {
   void processFT0CVariant2(aod::CentFT0CVariant2s const& centralities)
   {
     for (auto& c : centralities) {
-      output(c.centFT0CVariant2());
+      output(c.centFT0CVariant2(), aod::cfmultiplicity::FT0CVariant2);
     }
   }
   PROCESS_SWITCH(MultiplicitySelector, processFT0CVariant2, "Select FT0CVariant2 centrality as multiplicity", false);
@@ -758,7 +761,7 @@ struct MultiplicitySelector {
   void processFT0A(aod::CentFT0As const& centralities)
   {
     for (auto& c : centralities) {
-      output(c.centFT0A());
+      output(c.centFT0A(), aod::cfmultiplicity::FT0A);
     }
   }
   PROCESS_SWITCH(MultiplicitySelector, processFT0A, "Select FT0A centrality as multiplicity", false);
@@ -766,7 +769,7 @@ struct MultiplicitySelector {
   void processCentNGlobal(aod::CentNGlobals const& centralities)
   {
     for (auto& c : centralities) {
-      output(c.centNGlobal());
+      output(c.centNGlobal(), aod::cfmultiplicity::CentNGlobal);
     }
   }
   PROCESS_SWITCH(MultiplicitySelector, processCentNGlobal, "Select CentNGlobal centrality as multiplicity", false);
@@ -774,14 +777,14 @@ struct MultiplicitySelector {
   void processRun2V0M(aod::CentRun2V0Ms const& centralities)
   {
     for (auto& c : centralities) {
-      output(c.centRun2V0M());
+      output(c.centRun2V0M(), aod::cfmultiplicity::Run2V0M);
     }
   }
   PROCESS_SWITCH(MultiplicitySelector, processRun2V0M, "Select V0M centrality as multiplicity", true);
 
   void processMCGen(aod::McCollision const&, aod::McParticles const& particles)
   {
-    output(particles.size());
+    output(particles.size(), aod::cfmultiplicity::MCParticles);
   }
   PROCESS_SWITCH(MultiplicitySelector, processMCGen, "Select MC particle count as multiplicity", false);
 };

--- a/PWGCF/TableProducer/filterCorrelations.cxx
+++ b/PWGCF/TableProducer/filterCorrelations.cxx
@@ -14,6 +14,7 @@
 
 #include "Common/CCDB/EventSelectionParams.h"
 #include "Common/CCDB/TriggerAliases.h"
+#include "Common/Core/TableHelper.h"
 #include "Common/DataModel/Centrality.h"
 #include "Common/DataModel/EventSelection.h"
 #include "Common/DataModel/Multiplicity.h"
@@ -161,9 +162,16 @@ struct FilterCF {
   std::vector<bool> mcReconstructedCache;
   std::vector<int> mcParticleLabelsCache;
 
-  void init(InitContext&)
+  void init(InitContext& initContext)
   {
     if (!cfgEfficiencyMultiplicity.value.empty()) {
+      bool processTracksEnabled = false;
+      if (!o2::common::core::getTaskOptionValue(initContext, "multiplicity-selector", "processTracks", processTracksEnabled, false)) {
+        LOGF(fatal, "Could not determine whether MultiplicitySelector::processTracks is enabled");
+      }
+      if (!processTracksEnabled) {
+        LOGF(fatal, "Efficiency-corrected multiplicity requires MultiplicitySelector::processTracks");
+      }
       if (cfgLocalEfficiency != 0 && cfgLocalEfficiency != 1) {
         LOGF(fatal, "cfgLocalEfficiency must be 0 (CCDB) or 1 (local ROOT file)");
       }
@@ -358,9 +366,6 @@ struct FilterCF {
   template <typename TCollision, typename TTracks>
   float getCorrectedMultiplicity(const TCollision& collision, const TTracks& tracks, uint64_t timestamp)
   {
-    if (!collision.isTrackMultiplicity()) {
-      LOGF(fatal, "Efficiency-corrected multiplicity requires MultiplicitySelector::processTracks");
-    }
     auto* efficiency = loadMultiplicityEfficiency(timestamp);
     double correctedMultiplicity = 0.;
     size_t skippedTracks = 0;
@@ -778,14 +783,14 @@ struct MultiplicitySelector {
 
   void processTracks(aod::Collision const&, soa::Filtered<soa::Join<aod::Tracks, aod::TrackSelection>> const& tracks)
   {
-    output(tracks.size(), true);
+    output(tracks.size());
   }
   PROCESS_SWITCH(MultiplicitySelector, processTracks, "Select track count as multiplicity", false);
 
   void processFT0M(aod::CentFT0Ms const& centralities)
   {
     for (const auto& c : centralities) {
-      output(c.centFT0M(), false);
+      output(c.centFT0M());
     }
   }
   PROCESS_SWITCH(MultiplicitySelector, processFT0M, "Select FT0M centrality as multiplicity", false);
@@ -793,7 +798,7 @@ struct MultiplicitySelector {
   void processFT0C(aod::CentFT0Cs const& centralities)
   {
     for (const auto& c : centralities) {
-      output(c.centFT0C(), false);
+      output(c.centFT0C());
     }
   }
   PROCESS_SWITCH(MultiplicitySelector, processFT0C, "Select FT0C centrality as multiplicity", false);
@@ -801,7 +806,7 @@ struct MultiplicitySelector {
   void processFT0CVariant1(aod::CentFT0CVariant1s const& centralities)
   {
     for (const auto& c : centralities) {
-      output(c.centFT0CVariant1(), false);
+      output(c.centFT0CVariant1());
     }
   }
   PROCESS_SWITCH(MultiplicitySelector, processFT0CVariant1, "Select FT0CVariant1 centrality as multiplicity", false);
@@ -809,7 +814,7 @@ struct MultiplicitySelector {
   void processFT0CVariant2(aod::CentFT0CVariant2s const& centralities)
   {
     for (const auto& c : centralities) {
-      output(c.centFT0CVariant2(), false);
+      output(c.centFT0CVariant2());
     }
   }
   PROCESS_SWITCH(MultiplicitySelector, processFT0CVariant2, "Select FT0CVariant2 centrality as multiplicity", false);
@@ -817,7 +822,7 @@ struct MultiplicitySelector {
   void processFT0A(aod::CentFT0As const& centralities)
   {
     for (const auto& c : centralities) {
-      output(c.centFT0A(), false);
+      output(c.centFT0A());
     }
   }
   PROCESS_SWITCH(MultiplicitySelector, processFT0A, "Select FT0A centrality as multiplicity", false);
@@ -825,7 +830,7 @@ struct MultiplicitySelector {
   void processCentNGlobal(aod::CentNGlobals const& centralities)
   {
     for (const auto& c : centralities) {
-      output(c.centNGlobal(), false);
+      output(c.centNGlobal());
     }
   }
   PROCESS_SWITCH(MultiplicitySelector, processCentNGlobal, "Select CentNGlobal centrality as multiplicity", false);
@@ -833,14 +838,14 @@ struct MultiplicitySelector {
   void processRun2V0M(aod::CentRun2V0Ms const& centralities)
   {
     for (const auto& c : centralities) {
-      output(c.centRun2V0M(), false);
+      output(c.centRun2V0M());
     }
   }
   PROCESS_SWITCH(MultiplicitySelector, processRun2V0M, "Select V0M centrality as multiplicity", true);
 
   void processMCGen(aod::McCollision const&, aod::McParticles const& particles)
   {
-    output(particles.size(), false);
+    output(particles.size());
   }
   PROCESS_SWITCH(MultiplicitySelector, processMCGen, "Select MC particle count as multiplicity", false);
 };

--- a/PWGCF/TableProducer/filterCorrelations.cxx
+++ b/PWGCF/TableProducer/filterCorrelations.cxx
@@ -48,6 +48,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <experimental/type_traits> // required for is_detected
 #include <limits>

--- a/PWGCF/TableProducer/filterCorrelations.cxx
+++ b/PWGCF/TableProducer/filterCorrelations.cxx
@@ -153,6 +153,7 @@ struct FilterCF {
 
   // Own local histograms independently of their input file. CCDB owns its objects.
   std::unique_ptr<THn> localMultiplicityEfficiency;
+  THn* mEfficiency = nullptr;
   static constexpr int MultiplicityEfficiencyDimensions = 4;
 
   // persistent caches
@@ -179,7 +180,10 @@ struct FilterCF {
           return;
         }
         auto* efficiency = dynamic_cast<THn*>(file->Get("ccdb_object"));
-        validateMultiplicityEfficiency(efficiency);
+        if (!efficiency || efficiency->GetNdimensions() != MultiplicityEfficiencyDimensions) {
+          LOGF(fatal, "Multiplicity efficiency from %s must be a 4D THn with axes (eta, pT, multiplicity, z-vtx)", cfgEfficiencyMultiplicity.value.c_str());
+          return;
+        }
         localMultiplicityEfficiency.reset(dynamic_cast<THn*>(efficiency->Clone()));
       } else {
         ccdb->setURL("http://alice-ccdb.cern.ch");
@@ -336,65 +340,67 @@ struct FilterCF {
     return dcaXyConst + dcaXySlope / pt; // a + b/pT
   }
 
-  void validateMultiplicityEfficiency(const THn* efficiency) const
-  {
-    if (!efficiency || efficiency->GetNdimensions() != MultiplicityEfficiencyDimensions) {
-      LOGF(fatal, "Multiplicity efficiency from %s must be a 4D THn with axes (eta, pT, multiplicity, z-vtx)", cfgEfficiencyMultiplicity.value.c_str());
-    }
-  }
-
   THn* loadMultiplicityEfficiency(uint64_t timestamp)
   {
     if (cfgLocalEfficiency == 1) {
       return localMultiplicityEfficiency.get();
     }
-    // Query each collision so the manager can refresh its cache at validity boundaries.
-    auto* efficiency = ccdb->getForTimeStamp<THnT<float>>(cfgEfficiencyMultiplicity.value, timestamp);
-    validateMultiplicityEfficiency(efficiency);
-    return efficiency;
+    if (!mEfficiency || !ccdb->isCachedObjectValid(cfgEfficiencyMultiplicity.value, timestamp)) {
+      mEfficiency = ccdb->getForTimeStamp<THnT<float>>(cfgEfficiencyMultiplicity.value, timestamp);
+    }
+    if (!mEfficiency || mEfficiency->GetNdimensions() != MultiplicityEfficiencyDimensions) {
+      LOGF(fatal, "Multiplicity efficiency from %s must be a 4D THn with axes (eta, pT, multiplicity, z-vtx)", cfgEfficiencyMultiplicity.value.c_str());
+    }
+    return mEfficiency;
   }
 
-  template <bool applyDCA, typename TCollision, typename TTracks>
+  template <typename TCollision, typename TTracks>
   float getCorrectedMultiplicity(const TCollision& collision, const TTracks& tracks, uint64_t timestamp)
   {
-    if (collision.multiplicityEstimator() != aod::cfmultiplicity::Tracks) {
-      LOGF(fatal, "Efficiency-corrected multiplicity requires MultiplicitySelector::processTracks, but estimator type %u was configured", static_cast<unsigned int>(collision.multiplicityEstimator()));
+    if (!collision.isTrackMultiplicity()) {
+      LOGF(fatal, "Efficiency-corrected multiplicity requires MultiplicitySelector::processTracks");
     }
     auto* efficiency = loadMultiplicityEfficiency(timestamp);
     double correctedMultiplicity = 0.;
+    size_t skippedTracks = 0;
     for (const auto& track : tracks) {
       // Match the tracks written by the corresponding data/MC producer path.
-      if constexpr (applyDCA) {
-        if (std::abs(track.dcaXY()) > getMaxDCAxy(track.pt()) || std::abs(track.dcaZ()) > dcazmax) {
-          continue;
-        }
-      }
-      const auto mask = static_cast<uint8_t>(cfgMultiplicityTrackBitMask.value);
-      if (mask != 0 && (getTrackType(track) & mask) != mask) {
+      if (!isTrackSelected(track, true)) {
         continue;
       }
-
       // The map contains RecoAll / MC, not inverse-efficiency weights.
       // Keep the original estimator as the map coordinate, including for centrality.
       const std::array<double, MultiplicityEfficiencyDimensions> values{track.eta(), track.pt(), collision.multiplicity(), collision.posZ()};
-      std::array<int, MultiplicityEfficiencyDimensions> bins{};
-      for (int axis = 0; axis < MultiplicityEfficiencyDimensions; ++axis) {
-        auto* efficiencyAxis = efficiency->GetAxis(axis);
-        bins[axis] = efficiencyAxis->FindFixBin(values[axis]);
-        if (!std::isfinite(values[axis]) || bins[axis] < 1 || bins[axis] > efficiencyAxis->GetNbins()) {
-          LOGF(fatal, "Multiplicity efficiency from %s does not cover axis %d value %g", cfgEfficiencyMultiplicity.value.c_str(), axis, values[axis]);
-        }
-      }
-      const double eff = efficiency->GetBinContent(bins.data());
+      const double eff = efficiency->GetBinContent(efficiency->GetBin(values.data()));
       if (!std::isfinite(eff) || eff <= 0.) {
-        LOGF(fatal, "Invalid multiplicity efficiency %g from %s at bins (%d, %d, %d, %d)", eff, cfgEfficiencyMultiplicity.value.c_str(), bins[0], bins[1], bins[2], bins[3]);
+        ++skippedTracks;
+        continue;
       }
       correctedMultiplicity += 1. / eff;
+    }
+    if (cfgVerbosity > 0 && skippedTracks > 0) {
+      LOGF(warning, "Skipped %zu tracks with invalid efficiency while correcting collision %lld", skippedTracks, static_cast<int64_t>(collision.globalIndex()));
     }
     if (!std::isfinite(correctedMultiplicity) || correctedMultiplicity > std::numeric_limits<float>::max()) {
       LOGF(fatal, "Corrected multiplicity cannot be represented as a float: %g", correctedMultiplicity);
     }
     return static_cast<float>(correctedMultiplicity);
+  }
+
+  template <typename TTrack>
+  bool isTrackSelected(const TTrack& track, bool checkTrackBitMask = false)
+  {
+    const float maxDCAxy = getMaxDCAxy(track.pt());
+    if (std::abs(track.dcaXY()) > maxDCAxy || std::abs(track.dcaZ()) > dcazmax) {
+      return false;
+    }
+    if (checkTrackBitMask) {
+      const auto mask = static_cast<uint8_t>(cfgMultiplicityTrackBitMask.value);
+      if (mask != 0 && (getTrackType(track) & mask) != mask) {
+        return false;
+      }
+    }
+    return true;
   }
 
   template <class T>
@@ -417,7 +423,7 @@ struct FilterCF {
     auto bc = collision.template bc_as<aod::BCsWithTimestamps>();
     outputCollisions(bc.runNumber(), collision.posZ(), collision.multiplicity(), bc.timestamp());
     if (!cfgEfficiencyMultiplicity.value.empty()) {
-      outputCollisionsExtra(getCorrectedMultiplicity<true>(collision, tracks, bc.timestamp()));
+      outputCollisionsExtra(getCorrectedMultiplicity(collision, tracks, bc.timestamp()));
     }
 
     if constexpr (std::experimental::is_detected<HasMultTables, C1>::value) {
@@ -444,8 +450,7 @@ struct FilterCF {
       outputCollRefs(collision.globalIndex());
     }
     for (const auto& track : tracks) {
-      float maxDCAxy = getMaxDCAxy(track.pt());
-      if ((std::abs(track.dcaXY()) > maxDCAxy) || (std::abs(track.dcaZ()) > dcazmax)) {
+      if (!isTrackSelected(track)) {
         continue;
       }
 
@@ -487,8 +492,7 @@ struct FilterCF {
       if (!track.isGlobalTrack()) {
         continue; // trackQA for global tracks only
       }
-      float maxDCAxy = getMaxDCAxy(track.pt());
-      if ((std::abs(track.dcaXY()) > maxDCAxy) || (std::abs(track.dcaZ()) > dcazmax)) {
+      if (!isTrackSelected(track)) {
         continue;
       }
       registrytrackQA.fill(HIST("eta"), track.eta());
@@ -530,6 +534,9 @@ struct FilterCF {
       mcParticleLabelsCache.push_back(-1);
     }
 
+    std::vector<int64_t> bestRecoCollisionIndices(mcCollisions.size(), -1);
+    std::vector<int> bestRecoCollisionNContrib(mcCollisions.size(), -1);
+
     // PASS 1 on collisions: check which particles are kept
     for (const auto& collision : allCollisions) {
       auto groupedTracks = tracks.sliceBy(perCollision, collision.globalIndex());
@@ -539,6 +546,12 @@ struct FilterCF {
 
       if (!keepCollision(collision)) {
         continue;
+      }
+
+      const auto mcCollisionId = collision.mcCollisionId();
+      if (mcCollisionId >= 0 && mcCollisionId < static_cast<int64_t>(bestRecoCollisionIndices.size()) && collision.numContrib() > bestRecoCollisionNContrib[mcCollisionId]) {
+        bestRecoCollisionNContrib[mcCollisionId] = collision.numContrib();
+        bestRecoCollisionIndices[mcCollisionId] = collision.globalIndex();
       }
 
       for (const auto& track : groupedTracks) {
@@ -608,9 +621,12 @@ struct FilterCF {
       // NOTE works only when we store all MC collisions (as we do here)
       outputCollisions(bc.runNumber(), collision.posZ(), collision.multiplicity(), bc.timestamp());
       if (!cfgEfficiencyMultiplicity.value.empty()) {
-        outputCollisionsExtra(getCorrectedMultiplicity<false>(collision, groupedTracks, bc.timestamp()));
+        outputCollisionsExtra(getCorrectedMultiplicity(collision, groupedTracks, bc.timestamp()));
       }
-      outputMcCollisionLabels(collision.mcCollisionId());
+
+      const auto mcCollisionId = collision.mcCollisionId();
+      const bool bestRecoCollision = mcCollisionId >= 0 && mcCollisionId < static_cast<int64_t>(bestRecoCollisionIndices.size()) && bestRecoCollisionIndices[mcCollisionId] == collision.globalIndex();
+      outputMcCollisionLabels(mcCollisionId, bestRecoCollision);
 
       if constexpr (std::experimental::is_detected<HasMultTables, C1>::value) {
         multiplicities.clear();
@@ -662,7 +678,7 @@ struct FilterCF {
   using McCollisionsWithHepMC = soa::Join<aod::McCollisions, aod::HepMCXSections>;
   void processMC(McCollisionsWithHepMC const& mcCollisions, aod::McParticles const& allParticles,
                  soa::Join<aod::McCollisionLabels, aod::Collisions, aod::EvSels, aod::CFMultiplicities> const& allCollisions,
-                 soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::McTrackLabels, aod::TrackSelection>> const& tracks,
+                 soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::McTrackLabels, aod::TrackSelection>> const& tracks,
                  aod::BCsWithTimestamps const& bcs)
   {
     processMCT(mcCollisions, allParticles, allCollisions, tracks, bcs);
@@ -681,7 +697,7 @@ struct FilterCF {
 
   void processMCMults(McCollisionsWithHepMC const& mcCollisions, aod::McParticles const& allParticles,
                       soa::Join<aod::McCollisionLabels, aod::Collisions, aod::EvSels, aod::CFMultiplicities, aod::CentFT0Cs, aod::PVMults, aod::FV0Mults, aod::MultsGlobal> const& allCollisions,
-                      soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::McTrackLabels, aod::TrackSelection>> const& tracks,
+                      soa::Filtered<soa::Join<aod::Tracks, aod::TracksExtra, aod::TracksDCA, aod::McTrackLabels, aod::TrackSelection>> const& tracks,
                       aod::BCsWithTimestamps const& bcs)
   {
     processMCT(mcCollisions, allParticles, allCollisions, tracks, bcs);
@@ -761,14 +777,14 @@ struct MultiplicitySelector {
 
   void processTracks(aod::Collision const&, soa::Filtered<soa::Join<aod::Tracks, aod::TrackSelection>> const& tracks)
   {
-    output(tracks.size(), aod::cfmultiplicity::Tracks);
+    output(tracks.size(), true);
   }
   PROCESS_SWITCH(MultiplicitySelector, processTracks, "Select track count as multiplicity", false);
 
   void processFT0M(aod::CentFT0Ms const& centralities)
   {
     for (const auto& c : centralities) {
-      output(c.centFT0M(), aod::cfmultiplicity::FT0M);
+      output(c.centFT0M(), false);
     }
   }
   PROCESS_SWITCH(MultiplicitySelector, processFT0M, "Select FT0M centrality as multiplicity", false);
@@ -776,7 +792,7 @@ struct MultiplicitySelector {
   void processFT0C(aod::CentFT0Cs const& centralities)
   {
     for (const auto& c : centralities) {
-      output(c.centFT0C(), aod::cfmultiplicity::FT0C);
+      output(c.centFT0C(), false);
     }
   }
   PROCESS_SWITCH(MultiplicitySelector, processFT0C, "Select FT0C centrality as multiplicity", false);
@@ -784,7 +800,7 @@ struct MultiplicitySelector {
   void processFT0CVariant1(aod::CentFT0CVariant1s const& centralities)
   {
     for (const auto& c : centralities) {
-      output(c.centFT0CVariant1(), aod::cfmultiplicity::FT0CVariant1);
+      output(c.centFT0CVariant1(), false);
     }
   }
   PROCESS_SWITCH(MultiplicitySelector, processFT0CVariant1, "Select FT0CVariant1 centrality as multiplicity", false);
@@ -792,7 +808,7 @@ struct MultiplicitySelector {
   void processFT0CVariant2(aod::CentFT0CVariant2s const& centralities)
   {
     for (const auto& c : centralities) {
-      output(c.centFT0CVariant2(), aod::cfmultiplicity::FT0CVariant2);
+      output(c.centFT0CVariant2(), false);
     }
   }
   PROCESS_SWITCH(MultiplicitySelector, processFT0CVariant2, "Select FT0CVariant2 centrality as multiplicity", false);
@@ -800,7 +816,7 @@ struct MultiplicitySelector {
   void processFT0A(aod::CentFT0As const& centralities)
   {
     for (const auto& c : centralities) {
-      output(c.centFT0A(), aod::cfmultiplicity::FT0A);
+      output(c.centFT0A(), false);
     }
   }
   PROCESS_SWITCH(MultiplicitySelector, processFT0A, "Select FT0A centrality as multiplicity", false);
@@ -808,7 +824,7 @@ struct MultiplicitySelector {
   void processCentNGlobal(aod::CentNGlobals const& centralities)
   {
     for (const auto& c : centralities) {
-      output(c.centNGlobal(), aod::cfmultiplicity::CentNGlobal);
+      output(c.centNGlobal(), false);
     }
   }
   PROCESS_SWITCH(MultiplicitySelector, processCentNGlobal, "Select CentNGlobal centrality as multiplicity", false);
@@ -816,14 +832,14 @@ struct MultiplicitySelector {
   void processRun2V0M(aod::CentRun2V0Ms const& centralities)
   {
     for (const auto& c : centralities) {
-      output(c.centRun2V0M(), aod::cfmultiplicity::Run2V0M);
+      output(c.centRun2V0M(), false);
     }
   }
   PROCESS_SWITCH(MultiplicitySelector, processRun2V0M, "Select V0M centrality as multiplicity", true);
 
   void processMCGen(aod::McCollision const&, aod::McParticles const& particles)
   {
-    output(particles.size(), aod::cfmultiplicity::MCParticles);
+    output(particles.size(), false);
   }
   PROCESS_SWITCH(MultiplicitySelector, processMCGen, "Select MC particle count as multiplicity", false);
 };

--- a/PWGCF/TableProducer/filterCorrelations.cxx
+++ b/PWGCF/TableProducer/filterCorrelations.cxx
@@ -9,7 +9,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-// o2-linter: disable=name/workflow-file (historic file contains several table-producer tasks)
+// o2-linter: disable=name/workflow-file (file contains several table-producer tasks)
 #include "PWGCF/DataModel/CorrelationsDerived.h"
 
 #include "Common/CCDB/EventSelectionParams.h"
@@ -22,6 +22,7 @@
 #include "Common/DataModel/PIDResponseTPC.h"
 #include "Common/DataModel/TrackSelectionTables.h"
 
+#include "CommonConstants/MathConstants.h"
 #include <CCDB/BasicCCDBManager.h>
 #include <Framework/AnalysisDataModel.h>
 #include <Framework/AnalysisHelpers.h>
@@ -55,19 +56,19 @@
 #include <type_traits>
 #include <vector>
 
-#include <math.h>
-
 using namespace o2;
 using namespace o2::framework;
 using namespace o2::framework::expressions;
 using namespace o2::math_utils::detail;
 
-#define FLOAT_PRECISION 0xFFFFFFF0
-#define O2_DEFINE_CONFIGURABLE(NAME, TYPE, DEFAULT, HELP) Configurable<TYPE> NAME{#NAME, DEFAULT, HELP};
+constexpr std::uint32_t kFloatPrecision = 0xFFFFFFF0u;
+// clang-format off
+#define O2_DEFINE_CONFIGURABLE(NAME, TYPE, DEFAULT, HELP) Configurable<TYPE> NAME { #NAME, (DEFAULT), (HELP) } // NOLINT(bugprone-macro-parentheses)
+// clang-format on
 
 struct FilterCF {
-  Service<o2::framework::O2DatabasePDG> pdg;
-  Service<o2::ccdb::BasicCCDBManager> ccdb;
+  Service<o2::framework::O2DatabasePDG> pdg{};
+  Service<o2::ccdb::BasicCCDBManager> ccdb{};
 
   enum TrackSelectionCuts1 : uint8_t {
     kTrackSelected = BIT(0),
@@ -83,39 +84,39 @@ struct FilterCF {
   };
 
   // Configuration
-  O2_DEFINE_CONFIGURABLE(cfgCutVertex, float, 7.0f, "Accepted z-vertex range")
-  O2_DEFINE_CONFIGURABLE(cfgCutPt, float, 0.5f, "Minimal pT for tracks")
-  O2_DEFINE_CONFIGURABLE(cfgCutEta, float, 0.8f, "Eta range for tracks")
-  O2_DEFINE_CONFIGURABLE(cfgCutMCPt, float, 0.5f, "Minimal pT for particles")
-  O2_DEFINE_CONFIGURABLE(cfgCutMCEta, float, 0.8f, "Eta range for particles")
-  O2_DEFINE_CONFIGURABLE(cfgVerbosity, int, 1, "Verbosity level (0 = major, 1 = per collision)")
-  O2_DEFINE_CONFIGURABLE(cfgTrigger, int, 7, "Trigger choice: (0 = none, 7 = sel7, 8 = sel8, 9 = sel8 + kNoSameBunchPileup + kIsGoodZvtxFT0vsPV, 10 = sel8 before April, 2024, 11 = sel8 for MC, 12 = sel8 with low occupancy cut, 13 = sel8 + kNoSameBunchPileup + kIsGoodITSLayersAll -- for OO/NeNe) ")
-  O2_DEFINE_CONFIGURABLE(cfgMinOcc, int, 0, "minimum occupancy selection")
-  O2_DEFINE_CONFIGURABLE(cfgMaxOcc, int, 3000, "maximum occupancy selection")
-  O2_DEFINE_CONFIGURABLE(cfgCollisionFlags, uint16_t, aod::collision::CollisionFlagsRun2::Run2VertexerTracks, "Request collision flags if non-zero (0 = off, 1 = Run2VertexerTracks)")
-  O2_DEFINE_CONFIGURABLE(cfgTransientTables, bool, false, "Output transient tables for collision and track IDs to enable successive filtering tasks")
-  O2_DEFINE_CONFIGURABLE(cfgTrackSelection, int, 0, "Type of track selection (0 = Run 2/3 without systematics | 1 = Run 3 with systematics |  2 = Run 3 with proton pid selection)")
-  O2_DEFINE_CONFIGURABLE(cfgMinMultiplicity, float, -1, "Minimum multiplicity considered for filtering (if value positive)")
-  O2_DEFINE_CONFIGURABLE(cfgMcSpecialPDGs, std::vector<int>, {}, "Special MC PDG codes to include in the MC primary particle output (additional to charged particles). Empty = charged particles only.") // needed for some neutral particles
-  O2_DEFINE_CONFIGURABLE(nsigmaCutTPCProton, float, 3, "proton nsigma TPC")
-  O2_DEFINE_CONFIGURABLE(nsigmaCutTOFProton, float, 3, "proton nsigma TOF")
-  O2_DEFINE_CONFIGURABLE(ITSProtonselection, bool, false, "flag for ITS proton nsigma selection")
-  O2_DEFINE_CONFIGURABLE(nsigmaCutITSProton, float, 3, "proton nsigma ITS")
-  O2_DEFINE_CONFIGURABLE(dcaxymax, float, 999.f, "maximum dcaxy of tracks")
-  O2_DEFINE_CONFIGURABLE(dcazmax, float, 999.f, "maximum dcaz of tracks")
-  O2_DEFINE_CONFIGURABLE(enablePtDepDCAxy, bool, false, "Enable pT-dependent DCAxy cut: |DCAxy| < a + b/pT")
-  O2_DEFINE_CONFIGURABLE(dcaXyConst, float, 0.004f, "Constant term 'a' for pT-dependent DCAxy cut: |DCAxy| < a + b/pT (cm)")
-  O2_DEFINE_CONFIGURABLE(dcaXySlope, float, 0.013f, "Slope term 'b' for pT-dependent DCAxy cut: |DCAxy| < a + b/pT (cm x GeV/c)")
-  O2_DEFINE_CONFIGURABLE(itsnclusters, int, 5, "minimum number of ITS clusters for tracks")
-  O2_DEFINE_CONFIGURABLE(tpcncrossedrows, int, 80, "minimum number of TPC crossed rows for tracks")
-  O2_DEFINE_CONFIGURABLE(tpcnclusters, int, 50, "minimum number of TPC clusters found")
-  O2_DEFINE_CONFIGURABLE(chi2pertpccluster, float, 2.5, "maximum Chi2 / cluster for the TPC track segment")
-  O2_DEFINE_CONFIGURABLE(chi2peritscluster, float, 36, "maximum Chi2 / cluster for the ITS track segment")
+  O2_DEFINE_CONFIGURABLE(cfgCutVertex, float, 7.0f, "Accepted z-vertex range");
+  O2_DEFINE_CONFIGURABLE(cfgCutPt, float, 0.5f, "Minimal pT for tracks");
+  O2_DEFINE_CONFIGURABLE(cfgCutEta, float, 0.8f, "Eta range for tracks");
+  O2_DEFINE_CONFIGURABLE(cfgCutMCPt, float, 0.5f, "Minimal pT for particles");
+  O2_DEFINE_CONFIGURABLE(cfgCutMCEta, float, 0.8f, "Eta range for particles");
+  O2_DEFINE_CONFIGURABLE(cfgVerbosity, int, 1, "Verbosity level (0 = major, 1 = per collision)");
+  O2_DEFINE_CONFIGURABLE(cfgTrigger, int, 7, "Trigger choice: (0 = none, 7 = sel7, 8 = sel8, 9 = sel8 + kNoSameBunchPileup + kIsGoodZvtxFT0vsPV, 10 = sel8 before April, 2024, 11 = sel8 for MC, 12 = sel8 with low occupancy cut, 13 = sel8 + kNoSameBunchPileup + kIsGoodITSLayersAll -- for OO/NeNe) ");
+  O2_DEFINE_CONFIGURABLE(cfgMinOcc, int, 0, "minimum occupancy selection");
+  O2_DEFINE_CONFIGURABLE(cfgMaxOcc, int, 3000, "maximum occupancy selection");
+  O2_DEFINE_CONFIGURABLE(cfgCollisionFlags, uint16_t, aod::collision::CollisionFlagsRun2::Run2VertexerTracks, "Request collision flags if non-zero (0 = off, 1 = Run2VertexerTracks)");
+  O2_DEFINE_CONFIGURABLE(cfgTransientTables, bool, false, "Output transient tables for collision and track IDs to enable successive filtering tasks");
+  O2_DEFINE_CONFIGURABLE(cfgTrackSelection, int, 0, "Type of track selection (0 = Run 2/3 without systematics | 1 = Run 3 with systematics |  2 = Run 3 with proton pid selection)");
+  O2_DEFINE_CONFIGURABLE(cfgMinMultiplicity, float, -1, "Minimum multiplicity considered for filtering (if value positive)");
+  O2_DEFINE_CONFIGURABLE(cfgMcSpecialPDGs, std::vector<int>, std::vector<int>{}, "Special MC PDG codes to include in the MC primary particle output (additional to charged particles). Empty = charged particles only."); // needed for some neutral particles
+  O2_DEFINE_CONFIGURABLE(nsigmaCutTPCProton, float, 3, "proton nsigma TPC");
+  O2_DEFINE_CONFIGURABLE(nsigmaCutTOFProton, float, 3, "proton nsigma TOF");
+  O2_DEFINE_CONFIGURABLE(ITSProtonselection, bool, false, "flag for ITS proton nsigma selection");
+  O2_DEFINE_CONFIGURABLE(nsigmaCutITSProton, float, 3, "proton nsigma ITS");
+  O2_DEFINE_CONFIGURABLE(dcaxymax, float, 999.f, "maximum dcaxy of tracks");
+  O2_DEFINE_CONFIGURABLE(dcazmax, float, 999.f, "maximum dcaz of tracks");
+  O2_DEFINE_CONFIGURABLE(enablePtDepDCAxy, bool, false, "Enable pT-dependent DCAxy cut: |DCAxy| < a + b/pT");
+  O2_DEFINE_CONFIGURABLE(dcaXyConst, float, 0.004f, "Constant term 'a' for pT-dependent DCAxy cut: |DCAxy| < a + b/pT (cm)");
+  O2_DEFINE_CONFIGURABLE(dcaXySlope, float, 0.013f, "Slope term 'b' for pT-dependent DCAxy cut: |DCAxy| < a + b/pT (cm x GeV/c)");
+  O2_DEFINE_CONFIGURABLE(itsnclusters, int, 5, "minimum number of ITS clusters for tracks");
+  O2_DEFINE_CONFIGURABLE(tpcncrossedrows, int, 80, "minimum number of TPC crossed rows for tracks");
+  O2_DEFINE_CONFIGURABLE(tpcnclusters, int, 50, "minimum number of TPC clusters found");
+  O2_DEFINE_CONFIGURABLE(chi2pertpccluster, float, 2.5, "maximum Chi2 / cluster for the TPC track segment");
+  O2_DEFINE_CONFIGURABLE(chi2peritscluster, float, 36, "maximum Chi2 / cluster for the ITS track segment");
   O2_DEFINE_CONFIGURABLE(cfgEstimatorBitMask, uint16_t, 0, "BitMask for multiplicity estimators to be included in the CFMultSet tables.");
 
-  O2_DEFINE_CONFIGURABLE(cfgEfficiencyMultiplicity, std::string, "", "Multiplicity efficiency (RecoAll / MC): CCDB path or local ROOT file with a 4D ccdb_object (eta, pT, multiplicity, z-vtx); empty disables CFCollisionsExtra output")
-  O2_DEFINE_CONFIGURABLE(cfgLocalEfficiency, int, 0, "0 = CCDB efficiency, 1 = local ROOT efficiency")
-  O2_DEFINE_CONFIGURABLE(cfgMultiplicityTrackBitMask, uint16_t, 0, "Required track-type bits for corrected multiplicity; match cfgTrackBitMask used to produce the efficiency (0 = all stored tracks)")
+  O2_DEFINE_CONFIGURABLE(cfgEfficiencyMultiplicity, std::string, "", "Multiplicity efficiency (RecoAll / MC): CCDB path or local ROOT file with a 4D ccdb_object (eta, pT, multiplicity, z-vtx); empty disables CFCollisionsExtra output");
+  O2_DEFINE_CONFIGURABLE(cfgLocalEfficiency, int, 0, "0 = CCDB efficiency, 1 = local ROOT efficiency");
+  O2_DEFINE_CONFIGURABLE(cfgMultiplicityTrackBitMask, uint16_t, 0, "Required track-type bits for corrected multiplicity; match cfgTrackBitMask used to produce the efficiency (0 = all stored tracks)");
 
   // Filters and input definitions
   Filter collisionZVtxFilter = nabs(aod::collision::posZ) < cfgCutVertex;
@@ -128,7 +129,7 @@ struct FilterCF {
   Filter mcCollisionFilter = nabs(aod::mccollision::posZ) < cfgCutVertex;
 
   OutputObj<TH3F> yields{TH3F("yields", "centrality vs pT vs eta", 100, 0, 100, 40, 0, 20, 100, -2, 2)};
-  OutputObj<TH3F> etaphi{TH3F("etaphi", "centrality vs eta vs phi", 100, 0, 100, 100, -2, 2, 200, 0, 2 * M_PI)};
+  OutputObj<TH3F> etaphi{TH3F("etaphi", "centrality vs eta vs phi", 100, 0, 100, 100, -2, 2, 200, 0, o2::constants::math::TwoPI)};
 
   HistogramRegistry registrytrackQA{"TrackQA", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
 
@@ -148,7 +149,7 @@ struct FilterCF {
   Produces<aod::CFMcParticleRefs> outputMcParticleRefs;
 
   Produces<aod::CFMultSets> outputMultSets;
-  std::vector<float> multiplicities{};
+  std::vector<float> multiplicities;
 
   // Own local histograms independently of their input file. CCDB owns its objects.
   std::unique_ptr<THn> localMultiplicityEfficiency;
@@ -179,7 +180,7 @@ struct FilterCF {
         }
         auto* efficiency = dynamic_cast<THn*>(file->Get("ccdb_object"));
         validateMultiplicityEfficiency(efficiency);
-        localMultiplicityEfficiency.reset(static_cast<THn*>(efficiency->Clone()));
+        localMultiplicityEfficiency.reset(dynamic_cast<THn*>(efficiency->Clone()));
       } else {
         ccdb->setURL("http://alice-ccdb.cern.ch");
         ccdb->setCaching(true);
@@ -204,28 +205,35 @@ struct FilterCF {
   bool keepCollision(const TCollision& collision)
   {
     bool isMultSelected = false;
-    if (collision.multiplicity() >= cfgMinMultiplicity)
+    if (collision.multiplicity() >= cfgMinMultiplicity) {
       isMultSelected = true;
-
+    }
     if (cfgTrigger == 0) {
       return true;
-    } else if (cfgTrigger == 7) { // o2-linter: disable=magic-number (documented legacy trigger-selection code)
+    }
+    if (cfgTrigger == 7) { // o2-linter: disable=magic-number (documented legacy trigger-selection code)
       return isMultSelected && collision.alias_bit(kINT7) && collision.sel7();
-    } else if (cfgTrigger == 8) { // o2-linter: disable=magic-number (documented legacy trigger-selection code)
+    }
+    if (cfgTrigger == 8) { // o2-linter: disable=magic-number (documented legacy trigger-selection code)
       return isMultSelected && collision.sel8();
-    } else if (cfgTrigger == 9) { // relevant only for Pb-Pb; o2-linter: disable=magic-number (documented legacy trigger-selection code)
+    }
+    if (cfgTrigger == 9) { // relevant only for Pb-Pb; o2-linter: disable=magic-number (documented legacy trigger-selection code)
       return isMultSelected && collision.sel8() && collision.selection_bit(aod::evsel::kNoSameBunchPileup) && collision.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV) && collision.selection_bit(aod::evsel::kIsGoodITSLayersAll);
-    } else if (cfgTrigger == 10) { // TVX trigger only (sel8 selection before April, 2024); o2-linter: disable=magic-number (documented legacy trigger-selection code)
+    }
+    if (cfgTrigger == 10) { // TVX trigger only (sel8 selection before April, 2024); o2-linter: disable=magic-number (documented legacy trigger-selection code)
       return isMultSelected && collision.selection_bit(aod::evsel::kIsTriggerTVX);
-    } else if (cfgTrigger == 11) { // sel8 selection for MC; o2-linter: disable=magic-number (documented legacy trigger-selection code)
+    }
+    if (cfgTrigger == 11) { // sel8 selection for MC; o2-linter: disable=magic-number (documented legacy trigger-selection code)
       return isMultSelected && collision.selection_bit(aod::evsel::kIsTriggerTVX) && collision.selection_bit(aod::evsel::kNoTimeFrameBorder);
-    } else if (cfgTrigger == 12) { // relevant only for Pb-Pb with occupancy cuts and rejection of nearby collisions; o2-linter: disable=magic-number (documented legacy trigger-selection code)
+    }
+    if (cfgTrigger == 12) { // relevant only for Pb-Pb with occupancy cuts and rejection of nearby collisions; o2-linter: disable=magic-number (documented legacy trigger-selection code)
       int occupancy = collision.trackOccupancyInTimeRange();
-      if (occupancy >= cfgMinOcc && occupancy < cfgMaxOcc)
+      if (occupancy >= cfgMinOcc && occupancy < cfgMaxOcc) {
         return isMultSelected && collision.sel8() && collision.selection_bit(aod::evsel::kNoSameBunchPileup) && collision.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV) && collision.selection_bit(aod::evsel::kNoCollInTimeRangeStandard) && collision.selection_bit(aod::evsel::kIsGoodITSLayersAll);
-      else
-        return false;
-    } else if (cfgTrigger == 13) { // relevant for pO/OO/NeNe, recommended by Physics Board on 27.01.2026; o2-linter: disable=magic-number (documented legacy trigger-selection code)
+      }
+      return false;
+    }
+    if (cfgTrigger == 13) { // relevant for pO/OO/NeNe, recommended by Physics Board on 27.01.2026; o2-linter: disable=magic-number (documented legacy trigger-selection code)
       return isMultSelected && collision.sel8() && collision.selection_bit(aod::evsel::kNoSameBunchPileup) && collision.selection_bit(aod::evsel::kIsGoodZvtxFT0vsPV);
     }
     return false;
@@ -278,11 +286,13 @@ struct FilterCF {
     if (cfgTrackSelection == 0) {
       if (track.isGlobalTrack()) {
         return 1;
-      } else if (track.isGlobalTrackSDD()) {
+      }
+      if (track.isGlobalTrackSDD()) {
         return 2;
       }
       return 0;
-    } else if (cfgTrackSelection == 1) {
+    }
+    if (cfgTrackSelection == 1) {
       uint8_t trackType = 0;
       if (track.isGlobalTrack()) {
         trackType |= kTrackSelected;
@@ -303,7 +313,8 @@ struct FilterCF {
         }
       }
       return trackType;
-    } else if (cfgTrackSelection == 2) { // o2-linter: disable=magic-number (documented track-selection mode)
+    }
+    if (cfgTrackSelection == 2) { // o2-linter: disable=magic-number (documented track-selection mode)
       uint8_t trackType = 0;
       if constexpr (HasProtonPID<TTrack>::value) {
         if (track.isGlobalTrack() && (track.itsNCls() >= itsnclusters) && (track.tpcNClsCrossedRows() >= tpcncrossedrows) && selectionPIDProton(track)) {
@@ -411,21 +422,27 @@ struct FilterCF {
 
     if constexpr (std::experimental::is_detected<HasMultTables, C1>::value) {
       multiplicities.clear();
-      if (cfgEstimatorBitMask & aod::cfmultset::CentFT0C)
+      if (cfgEstimatorBitMask & aod::cfmultset::CentFT0C) {
         multiplicities.push_back(collision.centFT0C());
-      if (cfgEstimatorBitMask & aod::cfmultset::MultFV0A)
+      }
+      if (cfgEstimatorBitMask & aod::cfmultset::MultFV0A) {
         multiplicities.push_back(collision.multFV0A());
-      if (cfgEstimatorBitMask & aod::cfmultset::MultNTracksPV)
+      }
+      if (cfgEstimatorBitMask & aod::cfmultset::MultNTracksPV) {
         multiplicities.push_back(collision.multNTracksPV());
-      if (cfgEstimatorBitMask & aod::cfmultset::MultNTracksGlobal)
+      }
+      if (cfgEstimatorBitMask & aod::cfmultset::MultNTracksGlobal) {
         multiplicities.push_back(collision.multNTracksGlobal());
-      if (cfgEstimatorBitMask & aod::cfmultset::CentFT0M)
+      }
+      if (cfgEstimatorBitMask & aod::cfmultset::CentFT0M) {
         multiplicities.push_back(collision.centFT0M());
+      }
       outputMultSets(multiplicities);
     }
 
-    if (cfgTransientTables)
+    if (cfgTransientTables) {
       outputCollRefs(collision.globalIndex());
+    }
     for (const auto& track : tracks) {
       float maxDCAxy = getMaxDCAxy(track.pt());
       if ((std::abs(track.dcaXY()) > maxDCAxy) || (std::abs(track.dcaZ()) > dcazmax)) {
@@ -433,8 +450,9 @@ struct FilterCF {
       }
 
       outputTracks(outputCollisions.lastIndex(), track.pt(), track.eta(), track.phi(), track.sign(), getTrackType(track));
-      if (cfgTransientTables)
+      if (cfgTransientTables) {
         outputTrackRefs(collision.globalIndex(), track.globalIndex());
+      }
 
       yields->Fill(collision.multiplicity(), track.pt(), track.eta());
       etaphi->Fill(collision.multiplicity(), track.eta(), track.phi());
@@ -480,10 +498,12 @@ struct FilterCF {
       registrytrackQA.fill(HIST("tpcxrows"), track.tpcNClsCrossedRows());
       registrytrackQA.fill(HIST("tpcnclst"), track.tpcNClsFound());
       registrytrackQA.fill(HIST("itsnclst"), track.itsNCls());
-      if (track.tpcNClsFound() > 0)
+      if (track.tpcNClsFound() > 0) {
         registrytrackQA.fill(HIST("chi2tpc"), track.tpcChi2NCl());
-      if (track.itsNCls() > 0)
+      }
+      if (track.itsNCls() > 0) {
         registrytrackQA.fill(HIST("chi2its"), track.itsChi2NCl());
+      }
     }
   }
   PROCESS_SWITCH(FilterCF, processTrackQA, "Process track QA", false);
@@ -541,7 +561,7 @@ struct FilterCF {
         int8_t sign = 0;
         TParticlePDG* pdgparticle = pdg->GetParticle(particle.pdgCode());
         if (pdgparticle != nullptr) {
-          sign = (pdgparticle->Charge() > 0) ? 1.0 : ((pdgparticle->Charge() < 0) ? -1.0 : 0.0);
+          sign = (pdgparticle->Charge() > 0) ? 1 : ((pdgparticle->Charge() < 0) ? -1 : 0);
         }
 
         bool special = !cfgMcSpecialPDGs->empty() && std::find(cfgMcSpecialPDGs->begin(), cfgMcSpecialPDGs->end(), particle.pdgCode()) != cfgMcSpecialPDGs->end();
@@ -559,10 +579,11 @@ struct FilterCF {
           }
 
           // NOTE using "outputMcCollisions.lastIndex()+1" here to allow filling of outputMcCollisions *after* the loop
-          outputMcParticles(outputMcCollisions.lastIndex() + 1, truncateFloatFraction(particle.pt(), FLOAT_PRECISION), truncateFloatFraction(particle.eta(), FLOAT_PRECISION),
-                            truncateFloatFraction(particle.phi(), FLOAT_PRECISION), sign, particle.pdgCode(), flags);
-          if (cfgTransientTables)
+          outputMcParticles(outputMcCollisions.lastIndex() + 1, truncateFloatFraction(particle.pt(), kFloatPrecision), truncateFloatFraction(particle.eta(), kFloatPrecision),
+                            truncateFloatFraction(particle.phi(), kFloatPrecision), sign, particle.pdgCode(), flags);
+          if (cfgTransientTables) {
             outputMcParticleRefs(outputMcCollisions.lastIndex() + 1, particle.globalIndex());
+          }
 
           // relabeling array
           mcParticleLabelsCache[particle.globalIndex()] = outputMcParticles.lastIndex();
@@ -593,21 +614,27 @@ struct FilterCF {
 
       if constexpr (std::experimental::is_detected<HasMultTables, C1>::value) {
         multiplicities.clear();
-        if (cfgEstimatorBitMask & aod::cfmultset::CentFT0C)
+        if (cfgEstimatorBitMask & aod::cfmultset::CentFT0C) {
           multiplicities.push_back(collision.centFT0C());
-        if (cfgEstimatorBitMask & aod::cfmultset::MultFV0A)
+        }
+        if (cfgEstimatorBitMask & aod::cfmultset::MultFV0A) {
           multiplicities.push_back(collision.multFV0A());
-        if (cfgEstimatorBitMask & aod::cfmultset::MultNTracksPV)
+        }
+        if (cfgEstimatorBitMask & aod::cfmultset::MultNTracksPV) {
           multiplicities.push_back(collision.multNTracksPV());
-        if (cfgEstimatorBitMask & aod::cfmultset::MultNTracksGlobal)
+        }
+        if (cfgEstimatorBitMask & aod::cfmultset::MultNTracksGlobal) {
           multiplicities.push_back(collision.multNTracksGlobal());
-        if (cfgEstimatorBitMask & aod::cfmultset::CentFT0M)
+        }
+        if (cfgEstimatorBitMask & aod::cfmultset::CentFT0M) {
           multiplicities.push_back(collision.centFT0M());
+        }
         outputMultSets(multiplicities);
       }
 
-      if (cfgTransientTables)
+      if (cfgTransientTables) {
         outputCollRefs(collision.globalIndex());
+      }
 
       for (const auto& track : groupedTracks) {
         int mcParticleId = track.mcParticleId();
@@ -619,8 +646,9 @@ struct FilterCF {
         }
         outputTracks(outputCollisions.lastIndex(), truncateFloatFraction(track.pt()), truncateFloatFraction(track.eta()), truncateFloatFraction(track.phi()), track.sign(), getTrackType(track));
         outputTrackLabels(mcParticleId);
-        if (cfgTransientTables)
+        if (cfgTransientTables) {
           outputTrackRefs(collision.globalIndex(), track.globalIndex());
+        }
 
         yields->Fill(collision.multiplicity(), track.pt(), track.eta());
         etaphi->Fill(collision.multiplicity(), track.eta(), track.phi());
@@ -665,15 +693,19 @@ struct FilterCF {
   {
     float multiplicity = 0.0f;
     for (const auto& particle : particles) {
-      if (!particle.isPhysicalPrimary() || std::abs(particle.eta()) > cfgCutMCEta || particle.pt() < cfgCutMCPt)
+      if (!particle.isPhysicalPrimary() || std::abs(particle.eta()) > cfgCutMCEta || particle.pt() < cfgCutMCPt) {
         continue;
+      }
       int8_t sign = 0;
-      if (TParticlePDG* pdgparticle = pdg->GetParticle(particle.pdgCode()))
-        if ((sign = pdgparticle->Charge()) != 0)
+      if (TParticlePDG* pdgparticle = pdg->GetParticle(particle.pdgCode())) {
+        sign = static_cast<int>(pdgparticle->Charge());
+        if (sign != 0) {
           multiplicity += 1.0f;
-      outputMcParticles(outputMcCollisions.lastIndex() + 1, truncateFloatFraction(particle.pt(), FLOAT_PRECISION),
-                        truncateFloatFraction(particle.eta(), FLOAT_PRECISION),
-                        truncateFloatFraction(particle.phi(), FLOAT_PRECISION),
+        }
+      }
+      outputMcParticles(outputMcCollisions.lastIndex() + 1, truncateFloatFraction(particle.pt(), kFloatPrecision),
+                        truncateFloatFraction(particle.eta(), kFloatPrecision),
+                        truncateFloatFraction(particle.phi(), kFloatPrecision),
                         sign, particle.pdgCode(), particle.flags());
     }
     outputMcCollisions(mcCollision.posZ(), multiplicity);
@@ -685,8 +717,8 @@ struct FilterCF {
 struct MultiplicitySelector {
   Produces<aod::CFMultiplicities> output;
 
-  O2_DEFINE_CONFIGURABLE(cfgCutPt, float, 0.5f, "Minimal pT for tracks")
-  O2_DEFINE_CONFIGURABLE(cfgCutEta, float, 0.8f, "Eta range for tracks")
+  O2_DEFINE_CONFIGURABLE(cfgCutPt, float, 0.5f, "Minimal pT for tracks");
+  O2_DEFINE_CONFIGURABLE(cfgCutEta, float, 0.8f, "Eta range for tracks");
 
   Filter trackFilter = (nabs(aod::track::eta) < cfgCutEta) && (aod::track::pt > cfgCutPt);
   Filter trackSelection = (requireGlobalTrackInFilter()) || (aod::track::isGlobalTrackSDD == (uint8_t)true);

--- a/PWGCF/Tasks/correlations.cxx
+++ b/PWGCF/Tasks/correlations.cxx
@@ -105,6 +105,7 @@ struct CorrelationTask {
   O2_DEFINE_CONFIGURABLE(cfgLocalEfficiency, int, 0, "0 = OFF and 1 = ON for local efficiency");
   O2_DEFINE_CONFIGURABLE(cfgDropStepRECO, bool, false, "choice to drop step RECO if efficiency correction is used")
   O2_DEFINE_CONFIGURABLE(cfgCentBinsForMC, int, 0, "0 = OFF and 1 = ON for data like multiplicity/centrality bins for MC steps");
+  O2_DEFINE_CONFIGURABLE(cfgRequireRecoCollision, int, 1, "0 = all generated collisions; 1 = only generated collisions with exactly 1 reconstructed collision; 2 = select reconstructed collision with largest number of contributors per generated collision")
   O2_DEFINE_CONFIGURABLE(cfgTrackBitMask, uint16_t, 0, "BitMask for track selection systematics; refer to the enum TrackSelectionCuts in filtering task");
   O2_DEFINE_CONFIGURABLE(cfgMultCorrelationsMask, uint16_t, 0, "Selection bitmask for the multiplicity correlations. This should match the filter selection cfgEstimatorBitMask.")
   O2_DEFINE_CONFIGURABLE(cfgMultCutFormula, std::string, "", "Multiplicity correlations cut formula. A result greater than zero results in accepted event. Parameters: [cFT0C] FT0C centrality, [mFV0A] V0A multiplicity, [mGlob] global track multiplicity, [mPV] PV track multiplicity, [cFT0M] FT0M centrality")
@@ -193,8 +194,17 @@ struct CorrelationTask {
   using DerivedCollisions = soa::Filtered<aod::CFCollisions>;
   using DerivedTracks = soa::Filtered<aod::CFTracks>;
 
+  enum RecoCollisionSelection {
+    AllGeneratedCollisions = 0,
+    RequireOneRecoCollision,
+    RequireBestRecoCollision
+  };
+
   void init(o2::framework::InitContext&)
   {
+    if (cfgRequireRecoCollision < 0 || cfgRequireRecoCollision > RecoCollisionSelection::RequireBestRecoCollision) {
+      LOGF(fatal, "Unsupported cfgRequireRecoCollision=%d; use 0 (no reco. collision required), 1 (exactly one reco. collision required), 2 (at least one. reco, and best reco. collision selected)", cfgRequireRecoCollision.value);
+    }
     if (doprocessSame2ProngDerivedML || doprocessSame2Prong2ProngML || doprocessMixed2ProngDerivedML || doprocessMixed2Prong2ProngML || doprocessMCEfficiency2ProngML || doprocessMCReflection2ProngML) {
       if (cfgPtDepMLbkg->empty() || cfgPtCentDepMLbkgSel->empty())
         LOGF(fatal, "cfgPtDepMLbkg or cfgPtCentDepMLbkgSel can not be empty when ML 2-prong selections are used.");
@@ -1211,13 +1221,30 @@ struct CorrelationTask {
       LOGF(info, "MC collision at vtx-z = %f with %d mc particles and %d reconstructed collisions", mcCollision.posZ(), mcParticles.size(), collisions.size());
     }
 
+    // Select reconstructed collisions as specified by cfgRequireRecoCollision
     auto multiplicity = mcCollision.multiplicity();
-    if (cfgCentBinsForMC > 0) {
+    if (cfgRequireRecoCollision > 0) {
       if (collisions.size() == 0) {
         return;
       }
-      for (const auto& collision : collisions) {
-        multiplicity = collision.multiplicity();
+      if (cfgRequireRecoCollision == RecoCollisionSelection::RequireOneRecoCollision) { // cfgRequireRecoCollision == 1
+        if (collisions.size() != 1) {
+          return;
+        }
+        multiplicity = collisions.begin().multiplicity();
+      }
+      if (cfgRequireRecoCollision == RecoCollisionSelection::RequireBestRecoCollision) { // cfgRequireRecoCollision == 2
+        bool foundBestCollision = false;
+        for (const auto& collision : collisions) {
+          if (collision.bestRecoCollision()) {
+            multiplicity = collision.multiplicity();
+            foundBestCollision = true;
+            break;
+          }
+        }
+        if (!foundBestCollision) {
+          return;
+        }
       }
     }
     // Primaries
@@ -1226,7 +1253,11 @@ struct CorrelationTask {
         same->getTrackHistEfficiency()->Fill(CorrelationContainer::MC, mcParticle.eta(), mcParticle.pt(), getSpecies(mcParticle.pdgCode()), multiplicity, mcCollision.posZ());
       }
     }
+    const bool useBestCollision = cfgRequireRecoCollision == RecoCollisionSelection::AllGeneratedCollisions || cfgRequireRecoCollision == RecoCollisionSelection::RequireBestRecoCollision; // For cfgRequireRecoCollision == 0 still need to reject split vertices
     for (const auto& collision : collisions) {
+      if (useBestCollision && !collision.bestRecoCollision()) {
+        continue;
+      }
       auto groupedTracks = tracks.sliceBy(perCollision, collision.globalIndex());
       if (cfgVerbosity > 0) {
         LOGF(info, "  Reconstructed collision at vtx-z = %f", collision.posZ());

--- a/PWGCF/Tasks/correlations.cxx
+++ b/PWGCF/Tasks/correlations.cxx
@@ -13,6 +13,8 @@
 /// \brief task for the correlation calculations with CF-filtered tracks for O2 analysis
 /// \author Jan Fiete Grosse-Oetringhaus <jan.fiete.grosse-oetringhaus@cern.ch>, Jasper Parkkila <jasper.parkkila@cern.ch>
 
+// o2-linter: disable=name/workflow-file (preserve the established workflow filename and executable name)
+
 #include "PWGCF/Core/CorrelationContainer.h"
 #include "PWGCF/Core/PairCuts.h"
 #include "PWGCF/DataModel/CorrelationsDerived.h"
@@ -45,7 +47,6 @@
 #include <TFile.h>
 #include <TFormula.h>
 #include <THn.h>
-#include <TMath.h>
 #include <TVector2.h>
 
 #include <sys/types.h>
@@ -84,7 +85,7 @@ using namespace constants::math;
 //                   cfcorreff::Correction);
 // } // namespace o2::aod
 
-static constexpr float kCfgPairCutDefaults[1][5] = {{-1, -1, -1, -1, -1}};
+static constexpr float kCfgPairCutDefaults[1][5] = {{-1, -1, -1, -1, -1}}; // o2-linter: disable=name/constexpr-constant (preserve the established configurable-default identifier)
 
 struct CorrelationTask {
   SliceCache cache;
@@ -449,10 +450,10 @@ struct CorrelationTask {
 
               if (cfgCorrelationMethod == 1 && track1.decay() != track2.decay())
                 continue;
-              if (cfgCorrelationMethod == 2 && track1.decay() == track2.decay())
+              if (cfgCorrelationMethod == 2 && track1.decay() == track2.decay()) // o2-linter: disable=magic-number (value is the established ddbar correlation-method mode)
                 continue;
               registry.fill(HIST("invMassTwoPart"), track1.invMass(), track2.invMass(), track1.pt(), track2.pt(), multiplicity);
-              registry.fill(HIST("invMassTwoPartDPhi"), track1.invMass(), track2.invMass(), track1.pt(), track2.pt(), TVector2::Phi_0_2pi(track1.phi() - track2.phi() + TMath::Pi() / 2.0) - TMath::Pi() / 2.0);
+              registry.fill(HIST("invMassTwoPartDPhi"), track1.invMass(), track2.invMass(), track1.pt(), track2.pt(), TVector2::Phi_0_2pi(track1.phi() - track2.phi() + PIHalf) - PIHalf);
               if (std::abs(track1.phi() - track2.phi()) < constants::math::PI * 0.5) {
                 registry.fill(HIST("invMassTwoPartDEta"), track1.invMass(), track2.invMass(), track1.pt(), track2.pt(), track1.eta() - track2.eta());
               }
@@ -570,7 +571,7 @@ struct CorrelationTask {
 
     const float p2 = px * px + py * py + pz * pz;
 
-    const float E = std::sqrt(p2 + mass * mass);
+    const float E = std::sqrt(p2 + mass * mass); // o2-linter: disable=name/function-variable (E is the conventional symbol for particle energy)
     return {true, 0.5f * std::log((E + pz) / (E - pz))};
   }
 
@@ -743,7 +744,7 @@ struct CorrelationTask {
         if constexpr (std::experimental::is_detected<HasDecay, typename TTracks1::iterator>::value && std::experimental::is_detected<HasDecay, typename TTracks2::iterator>::value) {
           if (cfgCorrelationMethod == 1 && track1.decay() != track2.decay())
             continue;
-          if (cfgCorrelationMethod == 2 && track1.decay() == track2.decay())
+          if (cfgCorrelationMethod == 2 && track1.decay() == track2.decay()) // o2-linter: disable=magic-number (value is the established ddbar correlation-method mode)
             continue;
         }
 
@@ -857,7 +858,7 @@ struct CorrelationTask {
       if (cfg.mEfficiencyTrigger == nullptr) {
         LOGF(fatal, "Could not load efficiency histogram for trigger particles from %s", cfgEfficiencyTrigger.value.c_str());
       }
-      LOGF(info, "Loaded efficiency histogram for trigger particles from %s (%p)", cfgEfficiencyTrigger.value.c_str(), (void*)cfg.mEfficiencyTrigger);
+      LOGF(info, "Loaded efficiency histogram for trigger particles from %s (%p)", cfgEfficiencyTrigger.value.c_str(), static_cast<void*>(cfg.mEfficiencyTrigger));
     }
     if (cfgEfficiencyAssociated.value.empty() == false) {
       if (cfgLocalEfficiency > 0) {
@@ -869,7 +870,7 @@ struct CorrelationTask {
       if (cfg.mEfficiencyAssociated == nullptr) {
         LOGF(fatal, "Could not load efficiency histogram for associated particles from %s", cfgEfficiencyAssociated.value.c_str());
       }
-      LOGF(info, "Loaded efficiency histogram for associated particles from %s (%p)", cfgEfficiencyAssociated.value.c_str(), (void*)cfg.mEfficiencyAssociated);
+      LOGF(info, "Loaded efficiency histogram for associated particles from %s (%p)", cfgEfficiencyAssociated.value.c_str(), static_cast<void*>(cfg.mEfficiencyAssociated));
     }
     cfg.efficiencyLoaded = true;
   }
@@ -1286,7 +1287,7 @@ struct CorrelationTask {
   PROCESS_SWITCH(CorrelationTask, processMCEfficiency, "MC: Extract efficiencies", false);
 
   template <bool reflectionSpec, class p2type>
-  void processMCEfficiency2ProngT(soa::Filtered<aod::CFMcCollisions>::iterator const& mcCollision, soa::Join<aod::CFMcParticles, aod::CF2ProngMcParts> const& mcParticles, soa::SmallGroups<aod::CFCollisionsWithLabel> const& collisions, aod::CFTracksWithLabel const&, p2type const& p2tracks, Preslice<p2type>& perCollision2Prong)
+  void processMCEfficiency2ProngT(soa::Filtered<aod::CFMcCollisions>::iterator const& mcCollision, soa::Join<aod::CFMcParticles, aod::CF2ProngMcParts> const& mcParticles, soa::SmallGroups<aod::CFCollisionsWithLabel> const& collisions, aod::CFTracksWithLabel const&, p2type const& p2tracks, Preslice<p2type>& collision2ProngPreslice)
   {
     auto multiplicity = mcCollision.multiplicity();
     if (cfgCentBinsForMC > 0) {
@@ -1313,7 +1314,7 @@ struct CorrelationTask {
       }
     }
     for (const auto& collision : collisions) {
-      auto grouped2ProngTracks = p2tracks.sliceBy(perCollision2Prong, collision.globalIndex());
+      auto grouped2ProngTracks = p2tracks.sliceBy(collision2ProngPreslice, collision.globalIndex());
 
       for (const auto& p2track : grouped2ProngTracks) {
         if constexpr (!reflectionSpec) {

--- a/PWGCF/TwoParticleCorrelations/Tasks/twoParticleCorrelationsMpi.cxx
+++ b/PWGCF/TwoParticleCorrelations/Tasks/twoParticleCorrelationsMpi.cxx
@@ -99,7 +99,7 @@ struct TwoParticleCorrelationsMpi {
   ;
   Configurable<int> cfgLocalEfficiency{"cfgLocalEfficiency", 0, "0 = OFF and 1 = ON for local efficiency"};
   Configurable<bool> cfgDropStepRECO{"cfgDropStepRECO", false, "choice to drop step RECO if efficiency correction is used"};
-  Configurable<int> cfgCentBinsForMC{"cfgCentBinsForMC", 0, "0 = OFF and 1 = ON for data like multiplicity/centrality bins for MC steps"};
+  Configurable<int> cfgCentBinsForMC{"cfgCentBinsForMC", 0, "0 = generated multiplicity; 1 = reconstructed multiplicity and all associated collisions; 2 = reconstructed multiplicity and first associated collision only in processMCEfficiency"};
   Configurable<uint16_t> cfgTrackBitMask{"cfgTrackBitMask", 0, "BitMask for track selection systematics; refer to the enum TrackSelectionCuts in filtering task"};
   Configurable<uint16_t> cfgMultCorrelationsMask{"cfgMultCorrelationsMask", 0, "Selection bitmask for the multiplicity correlations. This should match the filter selection cfgEstimatorBitMask."};
   Configurable<std::string> cfgMultCutFormula{"cfgMultCutFormula", "", "Multiplicity correlations cut formula. A result greater than zero results in accepted event. Parameters: [cFT0C] FT0C centrality, [mFV0A] V0A multiplicity, [mGlob] global track multiplicity, [mPV] PV track multiplicity, [cFT0M] FT0M centrality"};
@@ -290,6 +290,9 @@ struct TwoParticleCorrelationsMpi {
   {
     if (cfgUserAxis < NoUserAxis || cfgUserAxis > EventSeedAxis) {
       LOGF(fatal, "Unsupported cfgUserAxis=%d; use 0 (off), 1 (invariant mass), or 2 (event seed)", cfgUserAxis.value);
+    }
+    if (cfgCentBinsForMC < 0 || cfgCentBinsForMC > 2) {
+      LOGF(fatal, "Unsupported cfgCentBinsForMC=%d; use 0 (generated multiplicity), 1 (all reconstructed collisions), or 2 (first reconstructed collision only for efficiency)", cfgCentBinsForMC.value);
     }
     if (doprocessMCSameDerived && (doprocessSameDerived || doprocessSameDerivedMultSet)) {
       LOGF(fatal, "processMCSameDerived is mutually exclusive with the reconstructed derived same-event processes because it also fills those outputs");
@@ -1926,12 +1929,17 @@ struct TwoParticleCorrelationsMpi {
     }
 
     auto multiplicity = mcCollision.multiplicity();
+    const bool useSingleRecoCollision = cfgCentBinsForMC == 2;
     if (cfgCentBinsForMC > 0) {
       if (collisions.size() == 0) {
         return;
       }
-      for (const auto& collision : collisions) {
-        multiplicity = collision.multiplicity();
+      if (useSingleRecoCollision) {
+        multiplicity = collisions.begin().multiplicity();
+      } else {
+        for (const auto& collision : collisions) {
+          multiplicity = collision.multiplicity();
+        }
       }
     }
     // Primaries
@@ -1941,6 +1949,9 @@ struct TwoParticleCorrelationsMpi {
       }
     }
     for (const auto& collision : collisions) {
+      if (useSingleRecoCollision && collision.globalIndex() != collisions.begin().globalIndex()) {
+        continue;
+      }
       auto groupedTracks = tracks.sliceBy(perCollision, collision.globalIndex());
       if (cfgVerbosity > 0) {
         LOGF(info, "  Reconstructed collision at vtx-z = %f", collision.posZ());

--- a/PWGCF/TwoParticleCorrelations/Tasks/twoParticleCorrelationsMpi.cxx
+++ b/PWGCF/TwoParticleCorrelations/Tasks/twoParticleCorrelationsMpi.cxx
@@ -285,6 +285,7 @@ struct TwoParticleCorrelationsMpi {
   using AodTracks = soa::Filtered<soa::Join<aod::Tracks, aod::TrackSelection>>;
 
   using DerivedCollisions = soa::Filtered<aod::CFCollisions>;
+  using DerivedCollisionsCorrected = soa::Filtered<aod::CFCollisionsWithExtra>;
   using DerivedTracks = soa::Filtered<aod::CFTracks>;
 
   void init(o2::framework::InitContext&)
@@ -295,7 +296,15 @@ struct TwoParticleCorrelationsMpi {
     if (cfgCentBinsForMC < 0 || cfgCentBinsForMC > 2) {
       LOGF(fatal, "Unsupported cfgCentBinsForMC=%d; use 0 (generated multiplicity), 1 (all reconstructed collisions), or 2 (first reconstructed collision only for efficiency)", cfgCentBinsForMC.value);
     }
-    if (doprocessMCSameDerived && (doprocessSameDerived || doprocessSameDerivedMultSet)) {
+    const int enabledDerivedSameProcesses = doprocessSameDerived + doprocessSameDerivedCorrected + doprocessSameDerivedMultSet + doprocessSameDerivedMultSetCorrected;
+    if (enabledDerivedSameProcesses > 1) {
+      LOGF(fatal, "Only one reconstructed derived same-event process can be enabled");
+    }
+    const int enabledDerivedMixedProcesses = doprocessMixedDerived + doprocessMixedDerivedCorrected + doprocessMixedDerivedMultSet + doprocessMixedDerivedMultSetCorrected;
+    if (enabledDerivedMixedProcesses > 1) {
+      LOGF(fatal, "Only one reconstructed derived mixed-event process can be enabled");
+    }
+    if (doprocessMCSameDerived && enabledDerivedSameProcesses > 0) {
       LOGF(fatal, "processMCSameDerived is mutually exclusive with the reconstructed derived same-event processes because it also fills those outputs");
     }
     if (doprocessSameGenMC && doprocessMCSameDerived) {
@@ -351,7 +360,7 @@ struct TwoParticleCorrelationsMpi {
 
     registry.add("yields", "multiplicity/centrality vs pT vs eta", {HistType::kTH3F, {{100, 0, 100, "/multiplicity/centrality"}, {40, 0, 20, "p_{T}"}, {100, -2, 2, "#eta"}}});
     registry.add("etaphi", "multiplicity/centrality vs eta vs phi", {HistType::kTH3F, {{100, 0, 100, "multiplicity/centrality"}, {100, -2, 2, "#eta"}, {200, 0, o2::constants::math::TwoPI, "#varphi"}}});
-    if (doprocessSameDerivedMultSet) {
+    if (doprocessSameDerivedMultSet || doprocessSameDerivedMultSetCorrected) {
       if (cfgMultCorrelationsMask == 0) {
         LOGF(fatal, "cfgMultCorrelationsMask can not be 0 when MultSet process functions are in use.");
       }
@@ -568,6 +577,18 @@ struct TwoParticleCorrelationsMpi {
 
   template <class T>
   using HasMultSet = decltype(std::declval<T&>().multiplicities());
+
+  template <class T>
+  using HasCorrectedMultiplicity = decltype(std::declval<T&>().multiplicityCorrected());
+
+  template <typename TCollision>
+  static float getAnalysisMultiplicity(const TCollision& collision)
+  {
+    if constexpr (std::experimental::is_detected<HasCorrectedMultiplicity, TCollision>::value) {
+      return collision.multiplicityCorrected();
+    }
+    return collision.multiplicity();
+  }
 
   template <typename TCollision, typename TTracks>
   void fillQA(const TCollision& collision, float multiplicity, const TTracks& tracks)
@@ -1684,22 +1705,22 @@ struct TwoParticleCorrelationsMpi {
   template <class CollType, class TTracks1, class TTracks2>
   void processSameDerivedT(CollType const& collision, TTracks1 const& tracks1, TTracks2 const& tracks2, const int* trueNMPI = nullptr)
   {
-    using BinningTypeDerived = ColumnBinningPolicy<aod::collision::PosZ, aod::cfcollision::Multiplicity>;
-    BinningTypeDerived configurableBinningDerived{{axisVertex, axisMultiplicity}, true}; // true is for 'ignore overflows' (true by default). Underflows and overflows will have bin -1.
+    auto getMultiplicity = [](auto& col) { return getAnalysisMultiplicity(col); };
+    using BinningTypeDerived = FlexibleBinningPolicy<std::tuple<decltype(getMultiplicity)>, aod::collision::PosZ, decltype(getMultiplicity)>;
+    BinningTypeDerived configurableBinningDerived{{getMultiplicity}, {axisVertex, axisMultiplicity}, true}; // true is for 'ignore overflows' (true by default). Underflows and overflows will have bin -1.
+    const auto multiplicity = getAnalysisMultiplicity(collision);
     if (cfgVerbosity > 0) {
-      LOGF(info, "processSameDerivedT: Tracks for collision: %d/%d | Vertex: %.1f | Multiplicity/Centrality: %.1f", tracks1.size(), tracks2.size(), collision.posZ(), collision.multiplicity());
+      LOGF(info, "processSameDerivedT: Tracks for collision: %d/%d | Vertex: %.1f | Multiplicity/Centrality: %.1f", tracks1.size(), tracks2.size(), collision.posZ(), multiplicity);
     }
     loadEfficiency(collision.timestamp());
     loadCcdbYieldTemplates(collision.timestamp());
-
-    const auto multiplicity = collision.multiplicity();
 
     int field = 0;
     if (cfgTwoTrackCut > 0) {
       field = getMagneticField(collision.timestamp());
     }
 
-    int bin = configurableBinningDerived.getBin({collision.posZ(), collision.multiplicity()});
+    int bin = configurableBinningDerived.getBin(std::tuple(collision.posZ(), multiplicity));
     registry.fill(HIST("eventcount_same"), bin);
     registry.fill(HIST("trackcount_same"), bin, tracks1.size());
     if constexpr (std::experimental::is_detected<HasDecay, typename TTracks1::iterator>::value) {
@@ -1762,6 +1783,12 @@ struct TwoParticleCorrelationsMpi {
   }
   PROCESS_SWITCH(TwoParticleCorrelationsMpi, processSameDerived, "Process same event on derived data", false);
 
+  void processSameDerivedCorrected(DerivedCollisionsCorrected::iterator const& collision, soa::Filtered<aod::CFTracks> const& tracks)
+  {
+    processSameDerivedT(collision, tracks, tracks);
+  }
+  PROCESS_SWITCH(TwoParticleCorrelationsMpi, processSameDerivedCorrected, "Process same event on derived data with corrected multiplicity", false);
+
   void processSameDerivedMultSet(soa::Filtered<soa::Join<aod::CFCollisions, aod::CFMultSets>>::iterator const& collision, soa::Filtered<aod::CFTracks> const& tracks)
   {
     if (!passOutlier(collision)) {
@@ -1770,6 +1797,15 @@ struct TwoParticleCorrelationsMpi {
     processSameDerivedT(collision, tracks, tracks);
   }
   PROCESS_SWITCH(TwoParticleCorrelationsMpi, processSameDerivedMultSet, "Process same event on derived data with multiplicity sets", false);
+
+  void processSameDerivedMultSetCorrected(soa::Filtered<soa::Join<aod::CFCollisions, aod::CFCollisionsExtra, aod::CFMultSets>>::iterator const& collision, soa::Filtered<aod::CFTracks> const& tracks)
+  {
+    if (!passOutlier(collision)) {
+      return;
+    }
+    processSameDerivedT(collision, tracks, tracks);
+  }
+  PROCESS_SWITCH(TwoParticleCorrelationsMpi, processSameDerivedMultSetCorrected, "Process same event on derived data with corrected multiplicity and multiplicity sets", false);
 
   using BinningTypeAOD = ColumnBinningPolicy<aod::collision::PosZ, aod::cent::CentRun2V0M>;
   void processMixedAOD(AodCollisions const& collisions, AodTracks const& tracks, aod::BCsWithTimestamps const&)
@@ -1832,7 +1868,7 @@ struct TwoParticleCorrelationsMpi {
         } else {
           (void)this; // fix compile error on unused 'this' capture
         }
-        return col.multiplicity();
+        return getAnalysisMultiplicity(col);
       };
 
     using BinningTypeDerived = FlexibleBinningPolicy<std::tuple<decltype(getMultiplicity)>, aod::collision::PosZ, decltype(getMultiplicity)>;
@@ -1855,7 +1891,7 @@ struct TwoParticleCorrelationsMpi {
       }
 
       if (cfgVerbosity > 0) {
-        LOGF(info, "processMixedDerived: Mixed collisions bin: %d pair: [%d, %d] %d (%.3f, %.3f), %d (%.3f, %.3f)", bin, it.isNewWindow(), it.currentWindowNeighbours(), collision1.globalIndex(), collision1.posZ(), collision1.multiplicity(), collision2.globalIndex(), collision2.posZ(), collision2.multiplicity());
+        LOGF(info, "processMixedDerived: Mixed collisions bin: %d pair: [%d, %d] %d (%.3f, %.3f), %d (%.3f, %.3f)", bin, it.isNewWindow(), it.currentWindowNeighbours(), collision1.globalIndex(), collision1.posZ(), multiplicity, collision2.globalIndex(), collision2.posZ(), getAnalysisMultiplicity(collision2));
       }
 
       bool hasEfficiencyMixed = (cfg.mEfficiencyAssociated != nullptr || cfg.mEfficiencyTrigger != nullptr);
@@ -1869,14 +1905,14 @@ struct TwoParticleCorrelationsMpi {
         if (cfgUserAxis == EventSeedAxis) {
           loadCcdbYieldTemplates(collision1.timestamp());
           if constexpr (std::is_same_v<std::remove_cvref_t<TA>, std::remove_cvref_t<TB>>) {
-            triggerEventSeed = getEventSeedUserAxisValue(collision1.multiplicity(), estimateEventSeedWithoutFilling<CorrelationContainer::kCFStepReconstructed>(mixed, tracks1, collision1.multiplicity(), collision1.posZ(), field));
+            triggerEventSeed = getEventSeedUserAxisValue(multiplicity, estimateEventSeedWithoutFilling<CorrelationContainer::kCFStepReconstructed>(mixed, tracks1, multiplicity, collision1.posZ(), field));
           } else {
             LOGF(fatal, "Event-seed user axis for mixed events requires the same trigger and associated track table so the trigger event can be estimated independently");
           }
         }
 
         if (fillRecoMixed) {
-          fillContainerEvent(mixed, collision1.multiplicity(), CorrelationContainer::kCFStepReconstructed);
+          fillContainerEvent(mixed, multiplicity, CorrelationContainer::kCFStepReconstructed);
         }
       }
 
@@ -1885,14 +1921,14 @@ struct TwoParticleCorrelationsMpi {
       registry.fill(HIST("eventcount_mixed"), bin);
       registry.fill(HIST("trackcount_mixed"), bin, tracks1.size(), tracks2.size());
       if (fillRecoMixed) {
-        fillCorrelations<CorrelationContainer::kCFStepReconstructed>(mixed, tracks1, tracks2, collision1.multiplicity(), collision1.posZ(), field, eventWeight, nullptr, nullptr, nullptr, triggerEventSeed);
+        fillCorrelations<CorrelationContainer::kCFStepReconstructed>(mixed, tracks1, tracks2, multiplicity, collision1.posZ(), field, eventWeight, nullptr, nullptr, nullptr, triggerEventSeed);
       }
 
       if (hasEfficiencyMixed) {
         if (it.isNewWindow()) {
-          fillContainerEvent(mixed, collision1.multiplicity(), CorrelationContainer::kCFStepCorrected);
+          fillContainerEvent(mixed, multiplicity, CorrelationContainer::kCFStepCorrected);
         }
-        fillCorrelations<CorrelationContainer::kCFStepCorrected>(mixed, tracks1, tracks2, collision1.multiplicity(), collision1.posZ(), field, eventWeight, nullptr, nullptr, nullptr, triggerEventSeed);
+        fillCorrelations<CorrelationContainer::kCFStepCorrected>(mixed, tracks1, tracks2, multiplicity, collision1.posZ(), field, eventWeight, nullptr, nullptr, nullptr, triggerEventSeed);
       }
     }
   }
@@ -1903,11 +1939,23 @@ struct TwoParticleCorrelationsMpi {
   }
   PROCESS_SWITCH(TwoParticleCorrelationsMpi, processMixedDerived, "Process mixed events on derived data", false);
 
+  void processMixedDerivedCorrected(DerivedCollisionsCorrected const& collisions, DerivedTracks const& tracks)
+  {
+    processMixedDerivedT(collisions, tracks);
+  }
+  PROCESS_SWITCH(TwoParticleCorrelationsMpi, processMixedDerivedCorrected, "Process mixed events on derived data with corrected multiplicity", false);
+
   void processMixedDerivedMultSet(soa::Filtered<soa::Join<aod::CFCollisions, aod::CFMultSets>> const& collisions, DerivedTracks const& tracks)
   {
     processMixedDerivedT(collisions, tracks);
   }
   PROCESS_SWITCH(TwoParticleCorrelationsMpi, processMixedDerivedMultSet, "Process mixed events on derived data with multiplicity sets", false);
+
+  void processMixedDerivedMultSetCorrected(soa::Filtered<soa::Join<aod::CFCollisions, aod::CFCollisionsExtra, aod::CFMultSets>> const& collisions, DerivedTracks const& tracks)
+  {
+    processMixedDerivedT(collisions, tracks);
+  }
+  PROCESS_SWITCH(TwoParticleCorrelationsMpi, processMixedDerivedMultSetCorrected, "Process mixed events on derived data with corrected multiplicity and multiplicity sets", false);
 
   int getSpecies(int pdgCode)
   {
@@ -2029,7 +2077,7 @@ struct TwoParticleCorrelationsMpi {
       }
     }
 
-    if (!(doprocessMCSameDerived || doprocessSameDerived || doprocessSameDerivedMultSet)) {
+    if (!(doprocessMCSameDerived || doprocessSameDerived || doprocessSameDerivedCorrected || doprocessSameDerivedMultSet || doprocessSameDerivedMultSetCorrected)) {
       if constexpr (std::experimental::is_detected<HasDecay, typename Particles1::iterator>::value) {
         fillQA(mcCollision, multiplicity, mcCollision.posZ(), mcParticles1, mcParticles2);
       } else {

--- a/PWGCF/TwoParticleCorrelations/Tasks/twoParticleCorrelationsMpi.cxx
+++ b/PWGCF/TwoParticleCorrelations/Tasks/twoParticleCorrelationsMpi.cxx
@@ -287,13 +287,14 @@ struct TwoParticleCorrelationsMpi {
   using DerivedCollisions = soa::Filtered<aod::CFCollisions>;
   using DerivedCollisionsCorrected = soa::Filtered<aod::CFCollisionsWithExtra>;
   using DerivedTracks = soa::Filtered<aod::CFTracks>;
+  static constexpr int McEfficiencySingleRecoCollisionMode = 2;
 
   void init(o2::framework::InitContext&)
   {
     if (cfgUserAxis < NoUserAxis || cfgUserAxis > EventSeedAxis) {
       LOGF(fatal, "Unsupported cfgUserAxis=%d; use 0 (off), 1 (invariant mass), or 2 (event seed)", cfgUserAxis.value);
     }
-    if (cfgCentBinsForMC < 0 || cfgCentBinsForMC > 2) {
+    if (cfgCentBinsForMC < 0 || cfgCentBinsForMC > McEfficiencySingleRecoCollisionMode) {
       LOGF(fatal, "Unsupported cfgCentBinsForMC=%d; use 0 (generated multiplicity), 1 (all reconstructed collisions), or 2 (first reconstructed collision only for efficiency)", cfgCentBinsForMC.value);
     }
     const int enabledDerivedSameProcesses = doprocessSameDerived + doprocessSameDerivedCorrected + doprocessSameDerivedMultSet + doprocessSameDerivedMultSetCorrected;
@@ -1705,7 +1706,7 @@ struct TwoParticleCorrelationsMpi {
   template <class CollType, class TTracks1, class TTracks2>
   void processSameDerivedT(CollType const& collision, TTracks1 const& tracks1, TTracks2 const& tracks2, const int* trueNMPI = nullptr)
   {
-    auto getMultiplicity = [](auto& col) { return getAnalysisMultiplicity(col); };
+    auto getMultiplicity = [](const auto& col) { return getAnalysisMultiplicity(col); };
     using BinningTypeDerived = FlexibleBinningPolicy<std::tuple<decltype(getMultiplicity)>, aod::collision::PosZ, decltype(getMultiplicity)>;
     BinningTypeDerived configurableBinningDerived{{getMultiplicity}, {axisVertex, axisMultiplicity}, true}; // true is for 'ignore overflows' (true by default). Underflows and overflows will have bin -1.
     const auto multiplicity = getAnalysisMultiplicity(collision);
@@ -1860,7 +1861,7 @@ struct TwoParticleCorrelationsMpi {
   void processMixedDerivedT(CollType const& collisions, TrackTypes&&... tracks)
   {
     auto getMultiplicity =
-      [this](auto& col) {
+      [this](const auto& col) {
         if constexpr (std::experimental::is_detected<HasMultSet, CollType>::value) {
           if (!passOutlier(col)) {
             return -1.0f;
@@ -1988,7 +1989,7 @@ struct TwoParticleCorrelationsMpi {
     }
 
     auto multiplicity = mcCollision.multiplicity();
-    const bool useSingleRecoCollision = cfgCentBinsForMC == 2;
+    const bool useSingleRecoCollision = cfgCentBinsForMC == McEfficiencySingleRecoCollisionMode;
     if (cfgCentBinsForMC > 0) {
       if (collisions.size() == 0) {
         return;

--- a/PWGCF/TwoParticleCorrelations/Tasks/twoParticleCorrelationsMpi.cxx
+++ b/PWGCF/TwoParticleCorrelations/Tasks/twoParticleCorrelationsMpi.cxx
@@ -70,6 +70,7 @@
 #include <string>
 #include <tuple>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -373,6 +374,16 @@ struct TwoParticleCorrelationsMpi {
       registry.add("multCorrelations", "Multiplicity correlations", {HistType::kTHnSparseF, multAxes});
     }
     registry.add("multiplicity", "event multiplicity", {HistType::kTH1F, {{1000, 0, 100, "/multiplicity/centrality"}}});
+    if (doprocessMCEfficiency) {
+      registry.add("mcEfficiencyDiagnostics/reconstructedTracks", "selected reconstructed tracks per collision;N_{tracks};collisions", {HistType::kTH1F, {{1001, -0.5, 1000.5}}});
+      registry.add("mcEfficiencyDiagnostics/matchedTracks", "MC-matched reconstructed tracks per collision;N_{matched};collisions", {HistType::kTH1F, {{1001, -0.5, 1000.5}}});
+      registry.add("mcEfficiencyDiagnostics/uniqueMatchedParticles", "unique matched MC particles per collision;N_{unique labels};collisions", {HistType::kTH1F, {{1001, -0.5, 1000.5}}});
+      registry.add("mcEfficiencyDiagnostics/duplicateMatchedTracks", "matched tracks beyond one per MC label;N_{matched}-N_{unique labels};collisions", {HistType::kTH1F, {{501, -0.5, 500.5}}});
+      registry.add("mcEfficiencyDiagnostics/duplicateFraction", "fraction of matched tracks sharing an MC label;(N_{matched}-N_{unique labels})/N_{matched};collisions", {HistType::kTH1F, {{101, -0.005, 1.005}}});
+      registry.add("mcEfficiencyDiagnostics/tracksPerMcParticle", "reconstructed tracks per matched MC-particle label;tracks per MC label;MC labels", {HistType::kTH1F, {{21, -0.5, 20.5}}});
+      registry.add("mcEfficiencyDiagnostics/generatedVsUniqueMatchedPrimaries", "generated versus uniquely matched physical primaries;N_{generated primary};N_{unique matched primary}", {HistType::kTH2F, {{501, -0.5, 500.5}, {501, -0.5, 500.5}}});
+      registry.add("mcEfficiencyDiagnostics/primaryTracksPerMcParticle", "reconstructed tracks per matched physical-primary label;tracks per primary MC label;MC labels", {HistType::kTH1F, {{21, -0.5, 20.5}}});
+    }
     if (eventSeedEstimatorEnabled) {
       registry.add("eventSeedEstimator", "event-level template estimator", {HistType::kTHnSparseF, {{100, 0, 100, "multiplicity"}, {100, -0.5, 99.5, "N_{trig}"}, {200, 0, 20, "Y_{near}"}, {200, 0, 20, "Y_{away}"}, {200, 0, 100, "N_{uncorrelated seeds}"}}});
       registry.add("eventSeedPairProbabilities", "summed pair probabilities", {HistType::kTH3F, {{200, 0, 200, "#Sigma P_{baseline}"}, {200, 0, 200, "#Sigma P_{near}"}, {200, 0, 200, "#Sigma P_{away}"}}});
@@ -1943,8 +1954,10 @@ struct TwoParticleCorrelationsMpi {
       }
     }
     // Primaries
+    int generatedPrimaries = 0;
     for (const auto& mcParticle : mcParticles) {
       if (mcParticle.isPhysicalPrimary() && mcParticle.sign() != 0 && !(std::find(cfgMcTriggerPDGs->begin(), cfgMcTriggerPDGs->end(), mcParticle.pdgCode()) != cfgMcTriggerPDGs->end())) {
+        ++generatedPrimaries;
         same->getTrackHistEfficiency()->Fill(CorrelationContainer::MC, mcParticle.eta(), mcParticle.pt(), getSpecies(mcParticle.pdgCode()), multiplicity, mcCollision.posZ());
       }
     }
@@ -1953,6 +1966,10 @@ struct TwoParticleCorrelationsMpi {
         continue;
       }
       auto groupedTracks = tracks.sliceBy(perCollision, collision.globalIndex());
+      int reconstructedTracks = 0;
+      int matchedTracks = 0;
+      std::unordered_map<int64_t, int> tracksPerMcParticle;
+      std::unordered_map<int64_t, int> primaryTracksPerMcParticle;
       if (cfgVerbosity > 0) {
         LOGF(info, "  Reconstructed collision at vtx-z = %f", collision.posZ());
         LOGF(info, "  which has %d tracks", groupedTracks.size());
@@ -1962,9 +1979,13 @@ struct TwoParticleCorrelationsMpi {
         if (cfgTrackBitMask > 0 && (track.trackType() & (uint8_t)cfgTrackBitMask) != (uint8_t)cfgTrackBitMask) {
           continue;
         }
+        ++reconstructedTracks;
         if (track.has_cfMCParticle()) {
+          ++matchedTracks;
+          ++tracksPerMcParticle[track.cfMCParticleId()];
           const auto& mcParticle = track.cfMCParticle();
           if (mcParticle.isPhysicalPrimary()) {
+            ++primaryTracksPerMcParticle[track.cfMCParticleId()];
             same->getTrackHistEfficiency()->Fill(CorrelationContainer::RecoPrimaries, mcParticle.eta(), mcParticle.pt(), getSpecies(mcParticle.pdgCode()), multiplicity, mcCollision.posZ());
           }
           same->getTrackHistEfficiency()->Fill(CorrelationContainer::RecoAll, mcParticle.eta(), mcParticle.pt(), getSpecies(mcParticle.pdgCode()), multiplicity, mcCollision.posZ());
@@ -1974,6 +1995,19 @@ struct TwoParticleCorrelationsMpi {
           same->getTrackHistEfficiency()->Fill(CorrelationContainer::Fake, track.eta(), track.pt(), 0, multiplicity, mcCollision.posZ());
         }
       }
+      const int duplicateMatchedTracks = matchedTracks - static_cast<int>(tracksPerMcParticle.size());
+      registry.fill(HIST("mcEfficiencyDiagnostics/reconstructedTracks"), reconstructedTracks);
+      registry.fill(HIST("mcEfficiencyDiagnostics/matchedTracks"), matchedTracks);
+      registry.fill(HIST("mcEfficiencyDiagnostics/uniqueMatchedParticles"), tracksPerMcParticle.size());
+      registry.fill(HIST("mcEfficiencyDiagnostics/duplicateMatchedTracks"), duplicateMatchedTracks);
+      registry.fill(HIST("mcEfficiencyDiagnostics/duplicateFraction"), matchedTracks > 0 ? static_cast<float>(duplicateMatchedTracks) / matchedTracks : 0.f);
+      for (const auto& entry : tracksPerMcParticle) {
+        registry.fill(HIST("mcEfficiencyDiagnostics/tracksPerMcParticle"), entry.second);
+      }
+      for (const auto& entry : primaryTracksPerMcParticle) {
+        registry.fill(HIST("mcEfficiencyDiagnostics/primaryTracksPerMcParticle"), entry.second);
+      }
+      registry.fill(HIST("mcEfficiencyDiagnostics/generatedVsUniqueMatchedPrimaries"), generatedPrimaries, primaryTracksPerMcParticle.size());
     }
   }
   PROCESS_SWITCH(TwoParticleCorrelationsMpi, processMCEfficiency, "MC: Extract efficiencies", false);

--- a/PWGCF/TwoParticleCorrelations/Tasks/twoParticleCorrelationsMpi.cxx
+++ b/PWGCF/TwoParticleCorrelations/Tasks/twoParticleCorrelationsMpi.cxx
@@ -100,7 +100,8 @@ struct TwoParticleCorrelationsMpi {
   ;
   Configurable<int> cfgLocalEfficiency{"cfgLocalEfficiency", 0, "0 = OFF and 1 = ON for local efficiency"};
   Configurable<bool> cfgDropStepRECO{"cfgDropStepRECO", false, "choice to drop step RECO if efficiency correction is used"};
-  Configurable<int> cfgCentBinsForMC{"cfgCentBinsForMC", 0, "0 = generated multiplicity; 1 = reconstructed multiplicity and all associated collisions; 2 = reconstructed multiplicity and first associated collision only in processMCEfficiency"};
+  Configurable<int> cfgCentBinsForMC{"cfgCentBinsForMC", 0, "0 = generated multiplicity; 1 = reconstructed multiplicity and all associated collisions"};
+  Configurable<int> cfgRequireRecoCollision{"cfgRequireRecoCollision", 1, "0 = all generated collisions; 1 = only generated collisions with exactly 1 reconstructed collision; 2 = select reconstructed collision with largest number of contributors per generated collision"};
   Configurable<uint16_t> cfgTrackBitMask{"cfgTrackBitMask", 0, "BitMask for track selection systematics; refer to the enum TrackSelectionCuts in filtering task"};
   Configurable<uint16_t> cfgMultCorrelationsMask{"cfgMultCorrelationsMask", 0, "Selection bitmask for the multiplicity correlations. This should match the filter selection cfgEstimatorBitMask."};
   Configurable<std::string> cfgMultCutFormula{"cfgMultCutFormula", "", "Multiplicity correlations cut formula. A result greater than zero results in accepted event. Parameters: [cFT0C] FT0C centrality, [mFV0A] V0A multiplicity, [mGlob] global track multiplicity, [mPV] PV track multiplicity, [cFT0M] FT0M centrality"};
@@ -286,16 +287,21 @@ struct TwoParticleCorrelationsMpi {
 
   using DerivedCollisions = soa::Filtered<aod::CFCollisions>;
   using DerivedCollisionsCorrected = soa::Filtered<aod::CFCollisionsWithExtra>;
+  using DerivedCollisionsMultSet = soa::Filtered<soa::Join<aod::CFCollisions, aod::CFMultSets>>;
+  using DerivedCollisionsMultSetCorrected = soa::Filtered<soa::Join<aod::CFCollisions, aod::CFCollisionsExtra, aod::CFMultSets>>;
   using DerivedTracks = soa::Filtered<aod::CFTracks>;
-  static constexpr int McEfficiencySingleRecoCollisionMode = 2;
+  static constexpr int RequireRecoCollisionBestMode = 2;
 
   void init(o2::framework::InitContext&)
   {
     if (cfgUserAxis < NoUserAxis || cfgUserAxis > EventSeedAxis) {
       LOGF(fatal, "Unsupported cfgUserAxis=%d; use 0 (off), 1 (invariant mass), or 2 (event seed)", cfgUserAxis.value);
     }
-    if (cfgCentBinsForMC < 0 || cfgCentBinsForMC > McEfficiencySingleRecoCollisionMode) {
-      LOGF(fatal, "Unsupported cfgCentBinsForMC=%d; use 0 (generated multiplicity), 1 (all reconstructed collisions), or 2 (first reconstructed collision only for efficiency)", cfgCentBinsForMC.value);
+    if (cfgCentBinsForMC < 0 || cfgCentBinsForMC > 1) {
+      LOGF(fatal, "Unsupported cfgCentBinsForMC=%d; use 0 (generated multiplicity), 1 (reconstructed multiplicity and all associated collisions)", cfgCentBinsForMC.value);
+    }
+    if (cfgRequireRecoCollision < 0 || cfgRequireRecoCollision > RequireRecoCollisionBestMode) {
+      LOGF(fatal, "Unsupported cfgRequireRecoCollision=%d; use 0 (no reco. collision required), 1 (exactly one reco. collision required), 2 (at least one. reco, and best reco. collision selected)", cfgRequireRecoCollision.value);
     }
     const int enabledDerivedSameProcesses = static_cast<int>(doprocessSameDerived) + static_cast<int>(doprocessSameDerivedCorrected) + static_cast<int>(doprocessSameDerivedMultSet) + static_cast<int>(doprocessSameDerivedMultSetCorrected);
     if (enabledDerivedSameProcesses > 1) {
@@ -383,7 +389,7 @@ struct TwoParticleCorrelationsMpi {
       }
       registry.add("multCorrelations", "Multiplicity correlations", {HistType::kTHnSparseF, multAxes});
     }
-    registry.add("multiplicity", "event multiplicity", {HistType::kTH1F, {{1000, 0, 100, "/multiplicity/centrality"}}});
+    registry.add("multiplicity", "event multiplicity", {HistType::kTH1F, {{100, 0, 100, "/multiplicity/centrality"}}});
     if (doprocessMCEfficiency) {
       registry.add("mcEfficiencyDiagnostics/reconstructedTracks", "selected reconstructed tracks per collision;N_{tracks};collisions", {HistType::kTH1F, {{1001, -0.5, 1000.5}}});
       registry.add("mcEfficiencyDiagnostics/matchedTracks", "MC-matched reconstructed tracks per collision;N_{matched};collisions", {HistType::kTH1F, {{1001, -0.5, 1000.5}}});
@@ -638,11 +644,10 @@ struct TwoParticleCorrelationsMpi {
   template <typename TTarget>
   bool fillContainerEvent(TTarget target, float multiplicity, CorrelationContainer::CFStep step)
   {
-    const float containerMultiplicity = getCorrelationContainerMultiplicity(multiplicity);
-    if (containerMultiplicity < 0.f) {
+    if (multiplicity < 0.f) {
       return false;
     }
-    target->fillEvent(containerMultiplicity, step);
+    target->fillEvent(multiplicity, step);
     return true;
   }
 
@@ -1349,8 +1354,7 @@ struct TwoParticleCorrelationsMpi {
   template <CorrelationContainer::CFStep step, typename TTarget, typename TTracks1, typename TTracks2>
   void fillCorrelations(TTarget target, TTracks1& tracks1, TTracks2& tracks2, float multiplicity, float posZ, int magField, float eventWeight, EventSeedEstimate* seedEstimate = nullptr, std::vector<PendingSeedTriggerFill>* pendingTriggerFills = nullptr, std::vector<PendingSeedPairFill>* pendingPairFills = nullptr, double eventSeed = -1.0, bool fillEstimatorAcceptanceQA = true, bool fillLoopQA = true)
   {
-    const float containerMultiplicity = getCorrelationContainerMultiplicity(multiplicity);
-    if (containerMultiplicity < 0.f) {
+    if (multiplicity < 0.f) {
       return;
     }
 
@@ -1428,22 +1432,22 @@ struct TwoParticleCorrelationsMpi {
 
       if (cfgUserAxis == EventSeedAxis) {
         if (pendingTriggerFills) {
-          pendingTriggerFills->push_back({track1.pt(), containerMultiplicity, posZ, triggerWeight});
+          pendingTriggerFills->push_back({track1.pt(), multiplicity, posZ, triggerWeight});
         } else {
-          target->getTriggerHist()->Fill(step, track1.pt(), containerMultiplicity, posZ, eventSeed, triggerWeight);
+          target->getTriggerHist()->Fill(step, track1.pt(), multiplicity, posZ, eventSeed, triggerWeight);
         }
       } else if (cfgUserAxis == InvariantMassAxis) {
         if constexpr (std::experimental::is_detected<HasInvMass, typename TTracks1::iterator>::value) {
-          target->getTriggerHist()->Fill(step, track1.pt(), containerMultiplicity, posZ, track1.invMass(), triggerWeight);
+          target->getTriggerHist()->Fill(step, track1.pt(), multiplicity, posZ, track1.invMass(), triggerWeight);
         } else if constexpr (std::experimental::is_detected<HasPDGCode, typename TTracks1::iterator>::value) {
           // TParticlePDG *p = pdg->GetParticle(track1.pdgCode());
           // target->getTriggerHist()->Fill(step, track1.pt(), multiplicity, posZ, p->Mass(), triggerWeight);
-          target->getTriggerHist()->Fill(step, track1.pt(), containerMultiplicity, posZ, 1.8, triggerWeight);
+          target->getTriggerHist()->Fill(step, track1.pt(), multiplicity, posZ, 1.8, triggerWeight);
         } else {
           LOGF(fatal, "Can not fill invariant-mass user axis without invMass column. Disable cfgUserAxis or select another mode.");
         }
       } else {
-        target->getTriggerHist()->Fill(step, track1.pt(), containerMultiplicity, posZ, triggerWeight);
+        target->getTriggerHist()->Fill(step, track1.pt(), multiplicity, posZ, triggerWeight);
       }
 
       const bool triggerHasTemplate = seedEstimate && hasTriggerTemplate(multiplicity, track1.pt());
@@ -1558,20 +1562,20 @@ struct TwoParticleCorrelationsMpi {
         // last param is the weight
         if (cfgUserAxis == EventSeedAxis) {
           if (pendingPairFills) {
-            pendingPairFills->push_back({deltaEta, track2.pt(), track1.pt(), containerMultiplicity, deltaPhi, posZ, associatedWeight});
+            pendingPairFills->push_back({deltaEta, track2.pt(), track1.pt(), multiplicity, deltaPhi, posZ, associatedWeight});
           } else {
-            target->getPairHist()->Fill(step, deltaEta, track2.pt(), track1.pt(), containerMultiplicity, deltaPhi, posZ, eventSeed, associatedWeight);
+            target->getPairHist()->Fill(step, deltaEta, track2.pt(), track1.pt(), multiplicity, deltaPhi, posZ, eventSeed, associatedWeight);
           }
         } else if (cfgUserAxis == InvariantMassAxis) {
           if constexpr (std::experimental::is_detected<HasInvMass, typename TTracks1::iterator>::value) {
-            target->getPairHist()->Fill(step, deltaEta, track2.pt(), track1.pt(), containerMultiplicity, deltaPhi, posZ, track1.invMass(), associatedWeight);
+            target->getPairHist()->Fill(step, deltaEta, track2.pt(), track1.pt(), multiplicity, deltaPhi, posZ, track1.invMass(), associatedWeight);
           } else if constexpr (std::experimental::is_detected<HasPDGCode, typename TTracks1::iterator>::value) {
-            target->getPairHist()->Fill(step, deltaEta, track2.pt(), track1.pt(), containerMultiplicity, deltaPhi, posZ, 1.8, associatedWeight); // p->Mass()
+            target->getPairHist()->Fill(step, deltaEta, track2.pt(), track1.pt(), multiplicity, deltaPhi, posZ, 1.8, associatedWeight); // p->Mass()
           } else {
             LOGF(fatal, "Can not fill invariant-mass user axis without invMass column. Disable cfgUserAxis or select another mode.");
           }
         } else {
-          target->getPairHist()->Fill(step, deltaEta, track2.pt(), track1.pt(), containerMultiplicity, deltaPhi, posZ, associatedWeight);
+          target->getPairHist()->Fill(step, deltaEta, track2.pt(), track1.pt(), multiplicity, deltaPhi, posZ, associatedWeight);
         }
       }
     }
@@ -1617,11 +1621,6 @@ struct TwoParticleCorrelationsMpi {
     effVars[2] = eff->GetAxis(2)->FindBin(multiplicity);
     effVars[3] = eff->GetAxis(3)->FindBin(posZ);
     return eff->GetBinContent(effVars.data());
-  }
-
-  float getCorrelationContainerMultiplicity(float multiplicity) const
-  {
-    return multiplicity;
   }
 
   template <typename TCollision, typename TTracks>
@@ -1706,10 +1705,12 @@ struct TwoParticleCorrelationsMpi {
   template <class CollType, class TTracks1, class TTracks2>
   void processSameDerivedT(CollType const& collision, TTracks1 const& tracks1, TTracks2 const& tracks2, const int* trueNMPI = nullptr)
   {
-    auto getMultiplicity = [](const auto& col) { return getAnalysisMultiplicity(col); };
+    auto getMultiplicity = [](const auto& col) {
+      return getAnalysisMultiplicity(col);
+    };
     using BinningTypeDerived = FlexibleBinningPolicy<std::tuple<decltype(getMultiplicity)>, aod::collision::PosZ, decltype(getMultiplicity)>;
     BinningTypeDerived configurableBinningDerived{{getMultiplicity}, {axisVertex, axisMultiplicity}, true}; // true is for 'ignore overflows' (true by default). Underflows and overflows will have bin -1.
-    const auto multiplicity = getAnalysisMultiplicity(collision);
+    const auto multiplicity = getMultiplicity(collision);
     if (cfgVerbosity > 0) {
       LOGF(info, "processSameDerivedT: Tracks for collision: %d/%d | Vertex: %.1f | Multiplicity/Centrality: %.1f", tracks1.size(), tracks2.size(), collision.posZ(), multiplicity);
     }
@@ -1778,19 +1779,19 @@ struct TwoParticleCorrelationsMpi {
     }
   }
 
-  void processSameDerived(DerivedCollisions::iterator const& collision, soa::Filtered<aod::CFTracks> const& tracks)
+  void processSameDerived(DerivedCollisions::iterator const& collision, DerivedTracks const& tracks)
   {
     processSameDerivedT(collision, tracks, tracks);
   }
   PROCESS_SWITCH(TwoParticleCorrelationsMpi, processSameDerived, "Process same event on derived data", false);
 
-  void processSameDerivedCorrected(DerivedCollisionsCorrected::iterator const& collision, soa::Filtered<aod::CFTracks> const& tracks)
+  void processSameDerivedCorrected(DerivedCollisionsCorrected::iterator const& collision, DerivedTracks const& tracks)
   {
     processSameDerivedT(collision, tracks, tracks);
   }
   PROCESS_SWITCH(TwoParticleCorrelationsMpi, processSameDerivedCorrected, "Process same event on derived data with corrected multiplicity", false);
 
-  void processSameDerivedMultSet(soa::Filtered<soa::Join<aod::CFCollisions, aod::CFMultSets>>::iterator const& collision, soa::Filtered<aod::CFTracks> const& tracks)
+  void processSameDerivedMultSet(DerivedCollisionsMultSet::iterator const& collision, DerivedTracks const& tracks)
   {
     if (!passOutlier(collision)) {
       return;
@@ -1799,7 +1800,7 @@ struct TwoParticleCorrelationsMpi {
   }
   PROCESS_SWITCH(TwoParticleCorrelationsMpi, processSameDerivedMultSet, "Process same event on derived data with multiplicity sets", false);
 
-  void processSameDerivedMultSetCorrected(soa::Filtered<soa::Join<aod::CFCollisions, aod::CFCollisionsExtra, aod::CFMultSets>>::iterator const& collision, soa::Filtered<aod::CFTracks> const& tracks)
+  void processSameDerivedMultSetCorrected(DerivedCollisionsMultSetCorrected::iterator const& collision, DerivedTracks const& tracks)
   {
     if (!passOutlier(collision)) {
       return;
@@ -1946,13 +1947,13 @@ struct TwoParticleCorrelationsMpi {
   }
   PROCESS_SWITCH(TwoParticleCorrelationsMpi, processMixedDerivedCorrected, "Process mixed events on derived data with corrected multiplicity", false);
 
-  void processMixedDerivedMultSet(soa::Filtered<soa::Join<aod::CFCollisions, aod::CFMultSets>> const& collisions, DerivedTracks const& tracks)
+  void processMixedDerivedMultSet(DerivedCollisionsMultSet const& collisions, DerivedTracks const& tracks)
   {
     processMixedDerivedT(collisions, tracks);
   }
   PROCESS_SWITCH(TwoParticleCorrelationsMpi, processMixedDerivedMultSet, "Process mixed events on derived data with multiplicity sets", false);
 
-  void processMixedDerivedMultSetCorrected(soa::Filtered<soa::Join<aod::CFCollisions, aod::CFCollisionsExtra, aod::CFMultSets>> const& collisions, DerivedTracks const& tracks)
+  void processMixedDerivedMultSetCorrected(DerivedCollisionsMultSetCorrected const& collisions, DerivedTracks const& tracks)
   {
     processMixedDerivedT(collisions, tracks);
   }
@@ -1988,30 +1989,42 @@ struct TwoParticleCorrelationsMpi {
       LOGF(info, "MC collision at vtx-z = %f with %d mc particles and %d reconstructed collisions", mcCollision.posZ(), mcParticles.size(), collisions.size());
     }
 
+    // Select reconstructed collisions as specified by cfgRequireRecoCollision
     auto multiplicity = mcCollision.multiplicity();
-    const bool useSingleRecoCollision = cfgCentBinsForMC == McEfficiencySingleRecoCollisionMode;
-    if (cfgCentBinsForMC > 0) {
+    if (cfgRequireRecoCollision > 0) {
       if (collisions.size() == 0) {
         return;
       }
-      if (useSingleRecoCollision) {
+      if (cfgRequireRecoCollision == 1) {
+        if (collisions.size() != 1) {
+          return;
+        }
         multiplicity = collisions.begin().multiplicity();
-      } else {
+      } else { // cfgRequireRecoCollision == 2
+        bool foundBestCollision = false;
         for (const auto& collision : collisions) {
-          multiplicity = collision.multiplicity();
+          if (collision.bestRecoCollision()) {
+            multiplicity = collision.multiplicity();
+            foundBestCollision = true;
+            break;
+          }
+        }
+        if (!foundBestCollision) {
+          return;
         }
       }
     }
     // Primaries
     int generatedPrimaries = 0;
     for (const auto& mcParticle : mcParticles) {
-      if (mcParticle.isPhysicalPrimary() && mcParticle.sign() != 0 && !(std::find(cfgMcTriggerPDGs->begin(), cfgMcTriggerPDGs->end(), mcParticle.pdgCode()) != cfgMcTriggerPDGs->end())) {
+      if (mcParticle.isPhysicalPrimary() && mcParticle.sign() != 0 && std::find(cfgMcTriggerPDGs->begin(), cfgMcTriggerPDGs->end(), mcParticle.pdgCode()) == cfgMcTriggerPDGs->end()) {
         ++generatedPrimaries;
         same->getTrackHistEfficiency()->Fill(CorrelationContainer::MC, mcParticle.eta(), mcParticle.pt(), getSpecies(mcParticle.pdgCode()), multiplicity, mcCollision.posZ());
       }
     }
+    const bool useBestCollision = cfgRequireRecoCollision == 0 || cfgRequireRecoCollision == RequireRecoCollisionBestMode; // For cfgRequireRecoCollision == 0 still need to reject split vertices
     for (const auto& collision : collisions) {
-      if (useSingleRecoCollision && collision.globalIndex() != collisions.begin().globalIndex()) {
+      if (useBestCollision && !collision.bestRecoCollision()) {
         continue;
       }
       auto groupedTracks = tracks.sliceBy(perCollision, collision.globalIndex());

--- a/PWGCF/TwoParticleCorrelations/Tasks/twoParticleCorrelationsMpi.cxx
+++ b/PWGCF/TwoParticleCorrelations/Tasks/twoParticleCorrelationsMpi.cxx
@@ -297,11 +297,11 @@ struct TwoParticleCorrelationsMpi {
     if (cfgCentBinsForMC < 0 || cfgCentBinsForMC > McEfficiencySingleRecoCollisionMode) {
       LOGF(fatal, "Unsupported cfgCentBinsForMC=%d; use 0 (generated multiplicity), 1 (all reconstructed collisions), or 2 (first reconstructed collision only for efficiency)", cfgCentBinsForMC.value);
     }
-    const int enabledDerivedSameProcesses = doprocessSameDerived + doprocessSameDerivedCorrected + doprocessSameDerivedMultSet + doprocessSameDerivedMultSetCorrected;
+    const int enabledDerivedSameProcesses = static_cast<int>(doprocessSameDerived) + static_cast<int>(doprocessSameDerivedCorrected) + static_cast<int>(doprocessSameDerivedMultSet) + static_cast<int>(doprocessSameDerivedMultSetCorrected);
     if (enabledDerivedSameProcesses > 1) {
       LOGF(fatal, "Only one reconstructed derived same-event process can be enabled");
     }
-    const int enabledDerivedMixedProcesses = doprocessMixedDerived + doprocessMixedDerivedCorrected + doprocessMixedDerivedMultSet + doprocessMixedDerivedMultSetCorrected;
+    const int enabledDerivedMixedProcesses = static_cast<int>(doprocessMixedDerived) + static_cast<int>(doprocessMixedDerivedCorrected) + static_cast<int>(doprocessMixedDerivedMultSet) + static_cast<int>(doprocessMixedDerivedMultSetCorrected);
     if (enabledDerivedMixedProcesses > 1) {
       LOGF(fatal, "Only one reconstructed derived mixed-event process can be enabled");
     }
@@ -1341,7 +1341,7 @@ struct TwoParticleCorrelationsMpi {
     std::vector<PendingSeedPairFill> discardedPairFills;
     discardedTriggerFills.reserve(tracks.size());
     discardedPairFills.reserve(tracks.size() * tracks.size());
-    fillCorrelations<step>(target, tracks, tracks, multiplicity, posZ, magField, 1.0f, &estimate, &discardedTriggerFills, &discardedPairFills, -1.f, false, false);
+    fillCorrelations<step>(std::move(target), tracks, tracks, multiplicity, posZ, magField, 1.0f, &estimate, &discardedTriggerFills, &discardedPairFills, -1.f, false, false);
     finalizeEventSeedEstimate(estimate);
     return estimate.nuncSeeds();
   }

--- a/PWGCF/TwoParticleCorrelations/Tasks/twoParticleCorrelationsMpi.cxx
+++ b/PWGCF/TwoParticleCorrelations/Tasks/twoParticleCorrelationsMpi.cxx
@@ -70,7 +70,6 @@
 #include <string>
 #include <tuple>
 #include <type_traits>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -101,7 +100,6 @@ struct TwoParticleCorrelationsMpi {
   Configurable<int> cfgLocalEfficiency{"cfgLocalEfficiency", 0, "0 = OFF and 1 = ON for local efficiency"};
   Configurable<bool> cfgDropStepRECO{"cfgDropStepRECO", false, "choice to drop step RECO if efficiency correction is used"};
   Configurable<int> cfgCentBinsForMC{"cfgCentBinsForMC", 0, "0 = generated multiplicity; 1 = reconstructed multiplicity and all associated collisions"};
-  Configurable<int> cfgRequireRecoCollision{"cfgRequireRecoCollision", 1, "0 = all generated collisions; 1 = only generated collisions with exactly 1 reconstructed collision; 2 = select reconstructed collision with largest number of contributors per generated collision"};
   Configurable<uint16_t> cfgTrackBitMask{"cfgTrackBitMask", 0, "BitMask for track selection systematics; refer to the enum TrackSelectionCuts in filtering task"};
   Configurable<uint16_t> cfgMultCorrelationsMask{"cfgMultCorrelationsMask", 0, "Selection bitmask for the multiplicity correlations. This should match the filter selection cfgEstimatorBitMask."};
   Configurable<std::string> cfgMultCutFormula{"cfgMultCutFormula", "", "Multiplicity correlations cut formula. A result greater than zero results in accepted event. Parameters: [cFT0C] FT0C centrality, [mFV0A] V0A multiplicity, [mGlob] global track multiplicity, [mPV] PV track multiplicity, [cFT0M] FT0M centrality"};
@@ -290,7 +288,6 @@ struct TwoParticleCorrelationsMpi {
   using DerivedCollisionsMultSet = soa::Filtered<soa::Join<aod::CFCollisions, aod::CFMultSets>>;
   using DerivedCollisionsMultSetCorrected = soa::Filtered<soa::Join<aod::CFCollisions, aod::CFCollisionsExtra, aod::CFMultSets>>;
   using DerivedTracks = soa::Filtered<aod::CFTracks>;
-  static constexpr int RequireRecoCollisionBestMode = 2;
 
   void init(o2::framework::InitContext&)
   {
@@ -299,9 +296,6 @@ struct TwoParticleCorrelationsMpi {
     }
     if (cfgCentBinsForMC < 0 || cfgCentBinsForMC > 1) {
       LOGF(fatal, "Unsupported cfgCentBinsForMC=%d; use 0 (generated multiplicity), 1 (reconstructed multiplicity and all associated collisions)", cfgCentBinsForMC.value);
-    }
-    if (cfgRequireRecoCollision < 0 || cfgRequireRecoCollision > RequireRecoCollisionBestMode) {
-      LOGF(fatal, "Unsupported cfgRequireRecoCollision=%d; use 0 (no reco. collision required), 1 (exactly one reco. collision required), 2 (at least one. reco, and best reco. collision selected)", cfgRequireRecoCollision.value);
     }
     const int enabledDerivedSameProcesses = static_cast<int>(doprocessSameDerived) + static_cast<int>(doprocessSameDerivedCorrected) + static_cast<int>(doprocessSameDerivedMultSet) + static_cast<int>(doprocessSameDerivedMultSetCorrected);
     if (enabledDerivedSameProcesses > 1) {
@@ -390,16 +384,6 @@ struct TwoParticleCorrelationsMpi {
       registry.add("multCorrelations", "Multiplicity correlations", {HistType::kTHnSparseF, multAxes});
     }
     registry.add("multiplicity", "event multiplicity", {HistType::kTH1F, {{100, 0, 100, "/multiplicity/centrality"}}});
-    if (doprocessMCEfficiency) {
-      registry.add("mcEfficiencyDiagnostics/reconstructedTracks", "selected reconstructed tracks per collision;N_{tracks};collisions", {HistType::kTH1F, {{1001, -0.5, 1000.5}}});
-      registry.add("mcEfficiencyDiagnostics/matchedTracks", "MC-matched reconstructed tracks per collision;N_{matched};collisions", {HistType::kTH1F, {{1001, -0.5, 1000.5}}});
-      registry.add("mcEfficiencyDiagnostics/uniqueMatchedParticles", "unique matched MC particles per collision;N_{unique labels};collisions", {HistType::kTH1F, {{1001, -0.5, 1000.5}}});
-      registry.add("mcEfficiencyDiagnostics/duplicateMatchedTracks", "matched tracks beyond one per MC label;N_{matched}-N_{unique labels};collisions", {HistType::kTH1F, {{501, -0.5, 500.5}}});
-      registry.add("mcEfficiencyDiagnostics/duplicateFraction", "fraction of matched tracks sharing an MC label;(N_{matched}-N_{unique labels})/N_{matched};collisions", {HistType::kTH1F, {{101, -0.005, 1.005}}});
-      registry.add("mcEfficiencyDiagnostics/tracksPerMcParticle", "reconstructed tracks per matched MC-particle label;tracks per MC label;MC labels", {HistType::kTH1F, {{21, -0.5, 20.5}}});
-      registry.add("mcEfficiencyDiagnostics/generatedVsUniqueMatchedPrimaries", "generated versus uniquely matched physical primaries;N_{generated primary};N_{unique matched primary}", {HistType::kTH2F, {{501, -0.5, 500.5}, {501, -0.5, 500.5}}});
-      registry.add("mcEfficiencyDiagnostics/primaryTracksPerMcParticle", "reconstructed tracks per matched physical-primary label;tracks per primary MC label;MC labels", {HistType::kTH1F, {{21, -0.5, 20.5}}});
-    }
     if (eventSeedEstimatorEnabled) {
       registry.add("eventSeedEstimator", "event-level template estimator", {HistType::kTHnSparseF, {{100, 0, 100, "multiplicity"}, {100, -0.5, 99.5, "N_{trig}"}, {200, 0, 20, "Y_{near}"}, {200, 0, 20, "Y_{away}"}, {200, 0, 100, "N_{uncorrelated seeds}"}}});
       registry.add("eventSeedPairProbabilities", "summed pair probabilities", {HistType::kTH3F, {{200, 0, 200, "#Sigma P_{baseline}"}, {200, 0, 200, "#Sigma P_{near}"}, {200, 0, 200, "#Sigma P_{away}"}}});
@@ -1958,121 +1942,6 @@ struct TwoParticleCorrelationsMpi {
     processMixedDerivedT(collisions, tracks);
   }
   PROCESS_SWITCH(TwoParticleCorrelationsMpi, processMixedDerivedMultSetCorrected, "Process mixed events on derived data with corrected multiplicity and multiplicity sets", false);
-
-  int getSpecies(int pdgCode)
-  {
-    switch (pdgCode) {
-      case 211: // pion
-      case -211:
-        return 0;
-      case 321: // Kaon
-      case -321:
-        return 1;
-      case 2212: // proton
-      case -2212:
-        return 2;
-      default:
-        break;
-    }
-    if (std::find(cfgMcTriggerPDGs->begin(), cfgMcTriggerPDGs->end(), pdgCode) != cfgMcTriggerPDGs->end()) {
-      return 4;
-    }
-    // The efficiency histogram is hardcoded to contain 5 species. Anything special will have the 4th slot.
-    return 3;
-  }
-
-  // NOTE SmallGroups includes soa::Filtered always
-  Preslice<aod::CFTracksWithLabel> perCollision = aod::cftrack::cfCollisionId;
-  void processMCEfficiency(soa::Filtered<aod::CFMcCollisions>::iterator const& mcCollision, aod::CFMcParticles const& mcParticles, soa::SmallGroups<aod::CFCollisionsWithLabel> const& collisions, aod::CFTracksWithLabel const& tracks)
-  {
-    if (cfgVerbosity > 0) {
-      LOGF(info, "MC collision at vtx-z = %f with %d mc particles and %d reconstructed collisions", mcCollision.posZ(), mcParticles.size(), collisions.size());
-    }
-
-    // Select reconstructed collisions as specified by cfgRequireRecoCollision
-    auto multiplicity = mcCollision.multiplicity();
-    if (cfgRequireRecoCollision > 0) {
-      if (collisions.size() == 0) {
-        return;
-      }
-      if (cfgRequireRecoCollision == 1) {
-        if (collisions.size() != 1) {
-          return;
-        }
-        multiplicity = collisions.begin().multiplicity();
-      } else { // cfgRequireRecoCollision == 2
-        bool foundBestCollision = false;
-        for (const auto& collision : collisions) {
-          if (collision.bestRecoCollision()) {
-            multiplicity = collision.multiplicity();
-            foundBestCollision = true;
-            break;
-          }
-        }
-        if (!foundBestCollision) {
-          return;
-        }
-      }
-    }
-    // Primaries
-    int generatedPrimaries = 0;
-    for (const auto& mcParticle : mcParticles) {
-      if (mcParticle.isPhysicalPrimary() && mcParticle.sign() != 0 && std::find(cfgMcTriggerPDGs->begin(), cfgMcTriggerPDGs->end(), mcParticle.pdgCode()) == cfgMcTriggerPDGs->end()) {
-        ++generatedPrimaries;
-        same->getTrackHistEfficiency()->Fill(CorrelationContainer::MC, mcParticle.eta(), mcParticle.pt(), getSpecies(mcParticle.pdgCode()), multiplicity, mcCollision.posZ());
-      }
-    }
-    const bool useBestCollision = cfgRequireRecoCollision == 0 || cfgRequireRecoCollision == RequireRecoCollisionBestMode; // For cfgRequireRecoCollision == 0 still need to reject split vertices
-    for (const auto& collision : collisions) {
-      if (useBestCollision && !collision.bestRecoCollision()) {
-        continue;
-      }
-      auto groupedTracks = tracks.sliceBy(perCollision, collision.globalIndex());
-      int reconstructedTracks = 0;
-      int matchedTracks = 0;
-      std::unordered_map<int64_t, int> tracksPerMcParticle;
-      std::unordered_map<int64_t, int> primaryTracksPerMcParticle;
-      if (cfgVerbosity > 0) {
-        LOGF(info, "  Reconstructed collision at vtx-z = %f", collision.posZ());
-        LOGF(info, "  which has %d tracks", groupedTracks.size());
-      }
-
-      for (const auto& track : groupedTracks) {
-        if (cfgTrackBitMask > 0 && (track.trackType() & (uint8_t)cfgTrackBitMask) != (uint8_t)cfgTrackBitMask) {
-          continue;
-        }
-        ++reconstructedTracks;
-        if (track.has_cfMCParticle()) {
-          ++matchedTracks;
-          ++tracksPerMcParticle[track.cfMCParticleId()];
-          const auto& mcParticle = track.cfMCParticle();
-          if (mcParticle.isPhysicalPrimary()) {
-            ++primaryTracksPerMcParticle[track.cfMCParticleId()];
-            same->getTrackHistEfficiency()->Fill(CorrelationContainer::RecoPrimaries, mcParticle.eta(), mcParticle.pt(), getSpecies(mcParticle.pdgCode()), multiplicity, mcCollision.posZ());
-          }
-          same->getTrackHistEfficiency()->Fill(CorrelationContainer::RecoAll, mcParticle.eta(), mcParticle.pt(), getSpecies(mcParticle.pdgCode()), multiplicity, mcCollision.posZ());
-          // LOGF(info, "Filled track %d", track.globalIndex());
-        } else {
-          // fake track
-          same->getTrackHistEfficiency()->Fill(CorrelationContainer::Fake, track.eta(), track.pt(), 0, multiplicity, mcCollision.posZ());
-        }
-      }
-      const int duplicateMatchedTracks = matchedTracks - static_cast<int>(tracksPerMcParticle.size());
-      registry.fill(HIST("mcEfficiencyDiagnostics/reconstructedTracks"), reconstructedTracks);
-      registry.fill(HIST("mcEfficiencyDiagnostics/matchedTracks"), matchedTracks);
-      registry.fill(HIST("mcEfficiencyDiagnostics/uniqueMatchedParticles"), tracksPerMcParticle.size());
-      registry.fill(HIST("mcEfficiencyDiagnostics/duplicateMatchedTracks"), duplicateMatchedTracks);
-      registry.fill(HIST("mcEfficiencyDiagnostics/duplicateFraction"), matchedTracks > 0 ? static_cast<float>(duplicateMatchedTracks) / matchedTracks : 0.f);
-      for (const auto& entry : tracksPerMcParticle) {
-        registry.fill(HIST("mcEfficiencyDiagnostics/tracksPerMcParticle"), entry.second);
-      }
-      for (const auto& entry : primaryTracksPerMcParticle) {
-        registry.fill(HIST("mcEfficiencyDiagnostics/primaryTracksPerMcParticle"), entry.second);
-      }
-      registry.fill(HIST("mcEfficiencyDiagnostics/generatedVsUniqueMatchedPrimaries"), generatedPrimaries, primaryTracksPerMcParticle.size());
-    }
-  }
-  PROCESS_SWITCH(TwoParticleCorrelationsMpi, processMCEfficiency, "MC: Extract efficiencies", false);
 
   template <class McCollision, class Particles1, class Particles2>
   void processMCSameDerivedT(McCollision const& mcCollision, Particles1 const& mcParticles1, Particles2 const& mcParticles2, soa::SmallGroups<aod::CFCollisionsWithLabel> const& collisions)


### PR DESCRIPTION
* CorrelationsDerived.h: Efficiency-corrected multiplicity now stored in dedicated CFCollisionsExtra table as sum of per track weight
* Keep track of track-based multiplicity in transient CFMultiplicities for efficiency correction purposes
* filterCorrelations.cxx: fill efficiency-corrected multiplicity when an efficiency file is supplied to the table producer
   * Only filled when the track-based multiplicity is used
* twoParticleCorrelationsMpi.cxx: utilise the efficiency-corrected multiplicity
    * dedicated process functions
    * compile-time lookup to switch on multiplicity
    * Added option for MC efficiency calculations to only use one reconstructed event per generated collision
    