### PR TITLE
[PWGJE,EMCal] Tick off TODO to change argument type of `setUseWeightE…

### DIFF
--- a/PWGJE/TableProducer/emcalCorrectionTask.cxx
+++ b/PWGJE/TableProducer/emcalCorrectionTask.cxx
@@ -265,8 +265,7 @@ struct EmcalCorrectionTask {
     mClusterFactories.setExoticCellDiffTime(exoticCellDiffTime);
     mClusterFactories.setExoticCellMinAmplitude(exoticCellMinAmplitude);
     mClusterFactories.setExoticCellInCrossMinAmplitude(exoticCellInCrossMinAmplitude);
-    // TODO: Fix setUseWeightExotic in the O2 code to use bool as argument not float!
-    mClusterFactories.setUseWeightExotic(static_cast<float>(useWeightExotic));
+    mClusterFactories.setUseWeightExotic(useWeightExotic);
     for (const auto& clusterDefinition : mClusterDefinitions) {
       mClusterizers.emplace_back(std::make_unique<o2::emcal::Clusterizer<o2::emcal::Cell>>(clusterDefinition.timeDiff, clusterDefinition.timeMin, clusterDefinition.timeMax, clusterDefinition.gradientCut, clusterDefinition.doGradientCut, clusterDefinition.seedEnergy, clusterDefinition.minCellEnergy));
       LOG(info) << "Cluster definition initialized: " << clusterDefinition.toString();


### PR DESCRIPTION
…xotic`

In the [PR #15706](https://github.com/AliceO2Group/AliceO2/pull/15706) the function `setUseWeightExotic` got its argument type fixed from float to bool. This commit is now adapenting this change in the function call in the emcal correction task.