### PR TITLE
[PWGJE] add track occupancy selection to SlimTablesProducer

### DIFF
--- a/PWGJE/TableProducer/slimTablesProducer.cxx
+++ b/PWGJE/TableProducer/slimTablesProducer.cxx
@@ -111,7 +111,7 @@ struct SlimTablesProducer {
   Configurable<int> trackOccupancyInTimeRangeMax{"trackOccupancyInTimeRangeMax", 999999, "maximum track occupancy of tracks in neighbouring collisions in a given time range; only applied to reconstructed collisions (data and mcd jets), not mc collisions (mcp jets)"};
   Configurable<int> trackOccupancyInTimeRangeMin{"trackOccupancyInTimeRangeMin", -999999, "minimum track occupancy of tracks in neighbouring collisions in a given time range; only applied to reconstructed collisions (data and mcd jets), not mc collisions (mcp jets)"};
   std::vector<int> eventSelectionBits;
-  Service<o2::framework::O2DatabasePDG> pdgDatabase;
+  Service<o2::framework::O2DatabasePDG> pdgDatabase{};
   int trackSelection = -1;
   bool doSumw2 = false;
 
@@ -231,21 +231,25 @@ struct SlimTablesProducer {
       auto slimCollIndex = slimCollisions.lastIndex();
       auto slicedTracks = tracks.sliceBy(perCollisionTracks, collision.globalIndex()); // tracks associated to the rec collision
       for (const auto& track : slicedTracks) {
-        if (!jetderiveddatautilities::selectTrack(track, trackSelection))
+        if (!jetderiveddatautilities::selectTrack(track, trackSelection)) {
           continue;
+        }
         histos.fill(HIST("Ntracks_pT"), track.pt(), eventWeight);
         slimTracks(slimCollIndex, track.px(), track.py(), track.pz());
       }
       slimMcCollisions(mccollision.posZ(), eventWeightMC);
       auto slimMcCollIndex = slimMcCollisions.lastIndex();
       for (const auto& particle : particles) {
-        if (!particle.isPhysicalPrimary())
+        if (!particle.isPhysicalPrimary()) {
           continue;
+        }
         auto pdgParticle = pdgDatabase->GetParticle(particle.pdgCode());
-        if (!pdgParticle)
+        if (!pdgParticle) {
           continue;
-        if (pdgParticle->Charge() == 0) // keep charged particles, exclude neutrals
+        }
+        if (pdgParticle->Charge() == 0) { // keep charged particles, exclude neutrals
           continue;
+        }
         histos.fill(HIST("Nparticles_pT"), particle.pt(), eventWeightMC);
         slimParticles(slimMcCollIndex, particle.px(), particle.py(), particle.pz(), particle.energy());
       }

--- a/PWGJE/TableProducer/slimTablesProducer.cxx
+++ b/PWGJE/TableProducer/slimTablesProducer.cxx
@@ -108,7 +108,8 @@ struct SlimTablesProducer {
   Configurable<std::string> trackSelections{"trackSelections", "globalTracks", "set track selections; other option: uniformTracks"};
   Configurable<bool> skipMBGapEvents{"skipMBGapEvents", false, "flag to choose to reject min. bias gap events; jet-level rejection can also be applied at the jet finder level for jets only, here rejection is applied for collision and track process functions for the first time, and on jets in case it was set to false at the jet finder level"};
   Configurable<bool> applyRCTSelections{"applyRCTSelections", true, "decide to apply RCT selections"};
-
+  Configurable<int> trackOccupancyInTimeRangeMax{"trackOccupancyInTimeRangeMax", 999999, "maximum track occupancy of tracks in neighbouring collisions in a given time range; only applied to reconstructed collisions (data and mcd jets), not mc collisions (mcp jets)"};
+  Configurable<int> trackOccupancyInTimeRangeMin{"trackOccupancyInTimeRangeMin", -999999, "minimum track occupancy of tracks in neighbouring collisions in a given time range; only applied to reconstructed collisions (data and mcd jets), not mc collisions (mcp jets)"};
   std::vector<int> eventSelectionBits;
   Service<o2::framework::O2DatabasePDG> pdgDatabase;
   int trackSelection = -1;
@@ -125,12 +126,14 @@ struct SlimTablesProducer {
     auto hColl = histos.get<TH1>(HIST("h_collisions"));
     hColl->GetXaxis()->SetBinLabel(1, "All");
     hColl->GetXaxis()->SetBinLabel(2, "eventSelection");
+    hColl->GetXaxis()->SetBinLabel(3, "occupancycut");
 
     histos.add("h_mcCollMCD_counts_weight", "MC event status;event status;weighted entries", {HistType::kTH1F, {{5, 0.0, 5.0}}});
     auto hMCD = histos.get<TH1>(HIST("h_mcCollMCD_counts_weight"));
     hMCD->GetXaxis()->SetBinLabel(1, "All");
     hMCD->GetXaxis()->SetBinLabel(2, "hasMcCollision");
     hMCD->GetXaxis()->SetBinLabel(3, "selectCollision");
+    hMCD->GetXaxis()->SetBinLabel(4, "occupancycut");
 
     histos.add("h_mcCollMCP_counts_weight", "MC event status;event status;weighted entries", {HistType::kTH1F, {{7, 0.0, 7.0}}});
     auto hMCP = histos.get<TH1>(HIST("h_mcCollMCP_counts_weight"));
@@ -171,6 +174,10 @@ struct SlimTablesProducer {
       return;
     }
     histos.fill(HIST("h_collisions"), 1.5);
+    if (collision.trackOccupancyInTimeRange() < trackOccupancyInTimeRangeMin || trackOccupancyInTimeRangeMax < collision.trackOccupancyInTimeRange()) {
+      return;
+    }
+    histos.fill(HIST("h_collisions"), 2.5);
     slimCollisions(collision.posZ(), collision.collisionTime(), 1.0);
     auto slimCollIndex = slimCollisions.lastIndex();
     for (const auto& track : tracks) {
@@ -211,6 +218,11 @@ struct SlimTablesProducer {
         continue;
       }
       histos.fill(HIST("h_mcCollMCD_counts_weight"), 2.5, eventWeightMC);
+      // occupancy cut only applied to the reconstructed (MCD) collision, not to the mcCollision
+      if (collision.trackOccupancyInTimeRange() < trackOccupancyInTimeRangeMin || trackOccupancyInTimeRangeMax < collision.trackOccupancyInTimeRange()) {
+        continue;
+      }
+      histos.fill(HIST("h_mcCollMCD_counts_weight"), 3.5, eventWeightMC);
       slimCollisions(collision.posZ(), collision.collisionTime(), eventWeight);
       auto slimCollIndex = slimCollisions.lastIndex();
       auto slicedTracks = tracks.sliceBy(perCollisionTracks, collision.globalIndex()); // tracks associated to the rec collision

--- a/PWGJE/TableProducer/slimTablesProducer.cxx
+++ b/PWGJE/TableProducer/slimTablesProducer.cxx
@@ -123,6 +123,8 @@ struct SlimTablesProducer {
 
     histos.add("h_collisions", "event status;event status;entries", {HistType::kTH1F, {{4, 0.0, 4.0}}});
     histos.add("h2_centrality_collisions", "event status vs. centrality;entries;centrality", {HistType::kTH2F, {centralityAxis, {4, 0.0, 4.0}}}, doSumw2);
+    histos.add("h_occupancy_raw", "occupancy;occupancy;entries", {HistType::kTH1F, {{200, -10, 10000}}});
+
     auto hColl = histos.get<TH1>(HIST("h_collisions"));
     hColl->GetXaxis()->SetBinLabel(1, "All");
     hColl->GetXaxis()->SetBinLabel(2, "eventSelection");
@@ -218,6 +220,7 @@ struct SlimTablesProducer {
         continue;
       }
       histos.fill(HIST("h_mcCollMCD_counts_weight"), 2.5, eventWeightMC);
+      histos.fill(HIST("h_occupancy_raw"), collision.trackOccupancyInTimeRange()); // <-- ici
       // occupancy cut only applied to the reconstructed (MCD) collision, not to the mcCollision
       if (collision.trackOccupancyInTimeRange() < trackOccupancyInTimeRangeMin || trackOccupancyInTimeRangeMax < collision.trackOccupancyInTimeRange()) {
         continue;

--- a/PWGJE/TableProducer/slimTablesProducer.cxx
+++ b/PWGJE/TableProducer/slimTablesProducer.cxx
@@ -176,6 +176,7 @@ struct SlimTablesProducer {
       return;
     }
     histos.fill(HIST("h_collisions"), 1.5);
+    histos.fill(HIST("h_occupancy_raw"), collision.trackOccupancyInTimeRange());
     if (collision.trackOccupancyInTimeRange() < trackOccupancyInTimeRangeMin || trackOccupancyInTimeRangeMax < collision.trackOccupancyInTimeRange()) {
       return;
     }
@@ -220,7 +221,7 @@ struct SlimTablesProducer {
         continue;
       }
       histos.fill(HIST("h_mcCollMCD_counts_weight"), 2.5, eventWeightMC);
-      histos.fill(HIST("h_occupancy_raw"), collision.trackOccupancyInTimeRange()); // <-- ici
+      histos.fill(HIST("h_occupancy_raw"), collision.trackOccupancyInTimeRange());
       // occupancy cut only applied to the reconstructed (MCD) collision, not to the mcCollision
       if (collision.trackOccupancyInTimeRange() < trackOccupancyInTimeRangeMin || trackOccupancyInTimeRangeMax < collision.trackOccupancyInTimeRange()) {
         continue;


### PR DESCRIPTION
Adds the possibility to select collisions based on `trackOccupancyInTimeRange` in the `slim-tables-producer` task, following the same approach already used in `jetSpectraCharged.cxx`

Two new configurables are introduced:
- `trackOccupancyInTimeRangeMin` (default: -999999)
- `trackOccupancyInTimeRangeMax` (default: 999999)

The cut is only applied to reconstructed collisions (data and MCD), not to generator-level MC collisions, since `trackOccupancyInTimeRange` is only meaningful at the reconstructed level

## Changes

- `processData`: added occupancy cut after event selection, before filling `SlimCollisions`/`SlimTracks`.
- `processMC`: added occupancy cut on the reconstructed (MCD) collision associated to each MC collision, before filling the corresponding tables
- Updated `h_collisions` and `h_mcCollMCD_counts_weight` histogram bin labels to include the new "occupancycut" step.

## Testing

Ran locally on LHC25b6 (pp, apass4) MC and LHC23zzh (PbPb) Data - 1 AO2D