### PR TITLE
[PWGHF] update track selection and Z-hadron QA in taskElectronWeakBoson

### DIFF
--- a/PWGHF/HFL/Tasks/taskElectronWeakBoson.cxx
+++ b/PWGHF/HFL/Tasks/taskElectronWeakBoson.cxx
@@ -307,9 +307,10 @@ struct HfTaskElectronWeakBoson {
     registry.add("hEventCounterInit", "hEventCounterInit", kTH1D, {axisCounter});
     registry.add("hEventCounter", "hEventCounter", kTH1D, {axisCounter});
     registry.add("hCentrality", "Centrality distribution", kTH1D, {axisCentrality});
-    registry.add("hCentMultCorr", "Centrality distribution", kTH2D, {{axisCentrality}, {axisMultFT0}});
-    registry.add("hMultPV", "multiplicity  distribution for PV", kTH1D, {axisMultPV});
-    registry.add("hMultFT0", "multiplicity distribution for FT0", kTH1D, {axisMultFT0});
+    registry.add("hCentMultFT0Corr", "Centrality distribution vs. FT0 Mult", kTH2D, {{axisCentrality}, {axisMultFT0}});
+    registry.add("hCentMultPVCorr", "Centrality distribution vs. PV Mult", kTH2D, {{axisCentrality}, {axisMultPV}});
+    registry.add("hMultPV", "multiplicity  distribution for PV", kTH2D, {{axisZvtx}, {axisMultPV}});
+    registry.add("hMultFT0", "multiplicity distribution for FT0", kTH2D, {{axisZvtx}, {axisMultFT0}});
     registry.add("hMultFT0PV", "multiplicity distribution", kTH2D, {{axisMultFT0}, {axisMultPV}});
     registry.add("hITSchi2", "ITS #chi^{2}", kTH1F, {axisChi2});
     registry.add("hTPCchi2", "TPC #chi^{2}", kTH1F, {axisChi2});
@@ -320,6 +321,7 @@ struct HfTaskElectronWeakBoson {
     registry.add("hPt", "track pt", kTH1F, {axisPt});
     registry.add("hTPCNsigma", "TPC electron Nsigma", kTH2F, {{axisPt}, {axisNsigma}});
     registry.add("hEnergy", "EMC cluster energy", kTH1F, {axisE});
+    registry.add("hEnergyMult", "EMC cluster energy vs Multiplicity", kTH2F, {{axisCentrality}, {axisE}});
     registry.add("hEnergyNcell", "EMC cluster energy and cell", kTH2F, {{axisE}, {axisNcell}});
     registry.add("hTrMatchR", "Track EMC Match in radius", kTH2F, {{axisPt}, {axisdR}});
     registry.add("hTrMatch_mim", "Track EMC Match minimu minimumm", kTH2F, {{axisdPhi}, {axisdEta}});
@@ -610,7 +612,8 @@ struct HfTaskElectronWeakBoson {
       if (centrality < centralityMin || centrality > centralityMax) {
         return;
       }
-      registry.fill(HIST("hCentMultCorr"), centrality, collision.multFT0M());
+      registry.fill(HIST("hCentMultFT0Corr"), centrality, collision.multFT0M());
+      registry.fill(HIST("hCentMultPVCorr"), centrality, collision.multNTracksPV());
     }
 
     if (enableMultiplicityFT0MAnalysis || enableMultiplicityPVAnalysis) {
@@ -620,8 +623,8 @@ struct HfTaskElectronWeakBoson {
         centrality = collision.multNTracksPV();
       // LOG(info) << "raw mult PV = " << collision.multNTracksPV();
       // LOG(info) << "raw mult FT0M = " << collision.multFT0M();
-      registry.fill(HIST("hMultPV"), collision.multNTracksPV());
-      registry.fill(HIST("hMultFT0"), collision.multFT0M());
+      registry.fill(HIST("hMultPV"), collision.posZ(), collision.multNTracksPV());
+      registry.fill(HIST("hMultFT0"), collision.posZ(), collision.multFT0M());
       registry.fill(HIST("hMultFT0PV"), collision.multFT0M(), collision.multNTracksPV());
     }
 
@@ -752,6 +755,7 @@ struct HfTaskElectronWeakBoson {
             registry.fill(HIST("hTHnTrMatch"), match.track_as<TrackEle>().pt(), dPhi, dEta);
             registry.fill(HIST("hEMCtime"), timeEmc);
             registry.fill(HIST("hEnergy"), energyEmc);
+            registry.fill(HIST("hEnergyMult"), centrality, energyEmc);
 
             if (std::abs(dPhi) > rMatchMax || std::abs(dEta) > rMatchMax) {
               continue;

--- a/PWGHF/HFL/Tasks/taskElectronWeakBoson.cxx
+++ b/PWGHF/HFL/Tasks/taskElectronWeakBoson.cxx
@@ -178,7 +178,7 @@ struct HfTaskElectronWeakBoson {
   // pp
   // using TrackEle = o2::soa::Filtered<o2::soa::Join<o2::aod::Tracks, o2::aod::FullTracks, o2::aod::TracksDCA, o2::aod::TrackSelection, o2::aod::pidTPCEl, o2::aod::pidTOFEl>>;
 
-  Filter eventFilter = (applySel8 ? (o2::aod::evsel::sel8 == true) : (o2::aod::evsel::sel8 == o2::aod::evsel::sel8)); // FIXME: both sides of overloaded operator are equivalent
+  Filter eventFilter = ifnode(as<bool>(applySel8), o2::aod::evsel::sel8 == true, true);
   Filter posZFilter = (nabs(o2::aod::collision::posZ) < vtxZ);
 
   Filter etafilter = (aod::track::eta < etaTrMax) && (aod::track::eta > etaTrMin);
@@ -508,10 +508,10 @@ struct HfTaskElectronWeakBoson {
       registry.fill(HIST("hInvMassZee"), centrality, track.sign() * charge, kfpIsoEle.GetPt(), invMassEE);
 
       // reco by KFparticle
-      const KFParticle* electronPairs[2] = {&kfpIsoEle, &kfpAssEle};
+      std::array<const KFParticle*, 2> electronPairs = {&kfpIsoEle, &kfpAssEle};
       KFParticle zeeKF;
       zeeKF.SetConstructMethod(kfConstructMethod);
-      zeeKF.Construct(electronPairs, 2);
+      zeeKF.Construct(electronPairs.data(), 2);
       // LOG(info) << "Invarimass cal by KF particle Chi2/NDF = " << zeeKF.GetChi2()/zeeKF.GetNDF();
       float const chiSqNdf = zeeKF.GetChi2() / zeeKF.GetNDF();
       if (zeeKF.GetNDF() < 1) {
@@ -617,10 +617,12 @@ struct HfTaskElectronWeakBoson {
     }
 
     if (enableMultiplicityFT0MAnalysis || enableMultiplicityPVAnalysis) {
-      if (enableMultiplicityFT0MAnalysis)
+      if (enableMultiplicityFT0MAnalysis) {
         centrality = collision.multFT0M();
-      if (enableMultiplicityPVAnalysis)
+      }
+      if (enableMultiplicityPVAnalysis) {
         centrality = collision.multNTracksPV();
+      }
       // LOG(info) << "raw mult PV = " << collision.multNTracksPV();
       // LOG(info) << "raw mult FT0M = " << collision.multFT0M();
       registry.fill(HIST("hMultPV"), collision.posZ(), collision.multNTracksPV());

--- a/PWGHF/HFL/Tasks/taskElectronWeakBoson.cxx
+++ b/PWGHF/HFL/Tasks/taskElectronWeakBoson.cxx
@@ -655,24 +655,24 @@ struct HfTaskElectronWeakBoson {
         continue;
       }
       if (applyTrackSys) {
-	 if (track.tpcNClsCrossedRows() < nclcrossTpcMin) {
-	   continue;
-	 }
-	 if (std::abs(track.dcaXY()) > dcaxyMax) {
-	   continue;
-	 }
-	 if (track.itsChi2NCl() > chi2ItsMax) {
-	   continue;
-	 }
-	 if (track.tpcChi2NCl() > chi2TpcMax) {
-	   continue;
-         }
-         if (track.tpcNClsFound() < nclTpcMin) {
-           continue;
-         }
-         if (track.itsNCls() < nclItsMin) {
-           continue;
-         }
+        if (track.tpcNClsCrossedRows() < nclcrossTpcMin) {
+          continue;
+        }
+        if (std::abs(track.dcaXY()) > dcaxyMax) {
+          continue;
+        }
+        if (track.itsChi2NCl() > chi2ItsMax) {
+          continue;
+        }
+        if (track.tpcChi2NCl() > chi2TpcMax) {
+          continue;
+        }
+        if (track.tpcNClsFound() < nclTpcMin) {
+          continue;
+        }
+        if (track.itsNCls() < nclItsMin) {
+          continue;
+        }
       }
       registry.fill(HIST("hEta"), track.eta());
       registry.fill(HIST("hITSchi2"), track.itsChi2NCl());

--- a/PWGHF/HFL/Tasks/taskElectronWeakBoson.cxx
+++ b/PWGHF/HFL/Tasks/taskElectronWeakBoson.cxx
@@ -76,6 +76,7 @@ struct HfTaskElectronWeakBoson {
 
   Configurable<float> vtxZ{"vtxZ", 10.f, ""};
 
+  Configurable<bool> applyTrackSys{"applyTrackSys", false, "apply additional track cuts for systematic study"};
   Configurable<float> etaTrMin{"etaTrMin", -1.0f, "minimun track eta"};
   Configurable<float> etaTrMax{"etaTrMax", 1.0f, "maximum track eta"};
   Configurable<float> etaEmcMax{"etaEmcMax", 0.6f, "maximum track eta"};
@@ -173,7 +174,7 @@ struct HfTaskElectronWeakBoson {
   using SelectedClusters = o2::aod::EMCALClusters;
   // PbPb
   // using TrackEle = o2::soa::Join<o2::aod::Tracks, o2::aod::FullTracks, o2::aod::TracksExtra, o2::aod::TracksDCA, o2::aod::TrackSelection, o2::aod::pidTPCFullEl>;
-  using TrackEle = o2::soa::Join<o2::aod::Tracks, o2::aod::TracksCov, o2::aod::FullTracks, o2::aod::TracksExtra, o2::aod::TracksDCA, o2::aod::TrackSelection, o2::aod::pidTPCFullEl>;
+  using TrackEle = o2::soa::Join<o2::aod::Tracks, o2::aod::TracksCov, o2::aod::FullTracks, o2::aod::TracksExtra, o2::aod::TracksDCA, o2::aod::TrackSelection, o2::aod::pidTPCFullEl, o2::aod::pidTPCFullPi>;
 
   // pp
   // using TrackEle = o2::soa::Filtered<o2::soa::Join<o2::aod::Tracks, o2::aod::FullTracks, o2::aod::TracksDCA, o2::aod::TrackSelection, o2::aod::pidTPCEl, o2::aod::pidTOFEl>>;
@@ -201,6 +202,7 @@ struct HfTaskElectronWeakBoson {
   ConfigurableAxis confaxisIsoEnergy{"confaxisIsoEnergy", {255, 0, 2.0}, "E_{iso}"};
   ConfigurableAxis confaxisIsoMomentum{"confaxisIsoMomentum", {255, 0, 2.0}, "p_{iso}"};
   ConfigurableAxis confaxisIsoTrack{"confaxisIsoTrack", {25, -0.5, 24.5}, "Isolation Track"};
+  ConfigurableAxis confaxisDedxTrack{"confaxisDedxTrack", {200, -10, 10}, "dEdx"};
   ConfigurableAxis confaxisInvMassZgamma{"confaxisInvMassZgamma", {150, 0, 150}, "M_{ee} (GeV/c^{2})"};
   ConfigurableAxis confaxisInvMassZ{"confaxisInvMassZ", {130, 20, 150}, "M_{ee} (GeV/c^{2})"};
   ConfigurableAxis confaxisZfrag{"confaxisZfrag", {200, 0, 2.0}, "p_{T,h}/p_{T,Z}"};
@@ -259,7 +261,7 @@ struct HfTaskElectronWeakBoson {
     const AxisSpec axisNsigma{100, -5, 5, "N#sigma"};
     const AxisSpec axisNsigmaZneg{100, -5, 5, "N#sigma_{pos}"};
     const AxisSpec axisNsigmaZpos{100, -5, 5, "N#sigma_{neg}"};
-    const AxisSpec axisDedx{150, 0, 150, "dEdx"};
+    const AxisSpec axisDedx{confaxisDedxTrack, "dEdx"};
     const AxisSpec axisE{nBinsE, 0, binEmax, "Energy"};
     const AxisSpec axisM02{100, 0, 1, "M02"};
     const AxisSpec axisM02neg{100, 0, 1, "M02(neg)"};
@@ -343,7 +345,7 @@ struct HfTaskElectronWeakBoson {
     registry.add("hTHnTrMatch", "Track EMC Match", HistType::kTHnSparseF, {axisPt, axisdPhi, axisdEta});
 
     // Z-hadron correlation histograms
-    registry.add("hZHadronDphi", "Z-hadron #Delta#phi correlation", HistType::kTHnSparseF, {axisCentrality, axisSign, axisPtZ, axisDPhiZh, axisDEtaZh, axisZfrag, axisPtHadron});
+    registry.add("hZHadronDphi", "Z-hadron #Delta#phi correlation", HistType::kTHnSparseF, {axisCentrality, axisSign, axisPtZ, axisDPhiZh, axisDEtaZh, axisZfrag, axisPtHadron, axisDedx});
     registry.add("hZptSpectrum", "Z boson p_{T} spectrum", kTH2F, {{axisSign}, {axisPtZ}});
 
     // hisotgram for EMCal trigger
@@ -646,28 +648,32 @@ struct HfTaskElectronWeakBoson {
     // track loop
     for (const auto& track : tracks) {
 
+      if (!track.isGlobalTrackWoPtEta()) {
+        continue;
+      }
       if (std::abs(track.eta()) > etaTrMax) {
         continue;
       }
-      if (track.tpcNClsCrossedRows() < nclcrossTpcMin) {
-        continue;
+      if (applyTrackSys) {
+	 if (track.tpcNClsCrossedRows() < nclcrossTpcMin) {
+	   continue;
+	 }
+	 if (std::abs(track.dcaXY()) > dcaxyMax) {
+	   continue;
+	 }
+	 if (track.itsChi2NCl() > chi2ItsMax) {
+	   continue;
+	 }
+	 if (track.tpcChi2NCl() > chi2TpcMax) {
+	   continue;
+         }
+         if (track.tpcNClsFound() < nclTpcMin) {
+           continue;
+         }
+         if (track.itsNCls() < nclItsMin) {
+           continue;
+         }
       }
-      if (std::abs(track.dcaXY()) > dcaxyMax) {
-        continue;
-      }
-      if (track.itsChi2NCl() > chi2ItsMax) {
-        continue;
-      }
-      if (track.tpcChi2NCl() > chi2TpcMax) {
-        continue;
-      }
-      if (track.tpcNClsFound() < nclTpcMin) {
-        continue;
-      }
-      if (track.itsNCls() < nclItsMin) {
-        continue;
-      }
-
       registry.fill(HIST("hEta"), track.eta());
       registry.fill(HIST("hITSchi2"), track.itsChi2NCl());
       registry.fill(HIST("hTPCchi2"), track.tpcChi2NCl());
@@ -694,7 +700,7 @@ struct HfTaskElectronWeakBoson {
           eop,
           isoEnergy,
           isoMomentum,
-          track.tpcNSigmaEl(),
+          track.tpcNSigmaPi() * track.sign(),
           m02,
           trackCount,
           track.tpcNClsCrossedRows(),
@@ -873,7 +879,7 @@ struct HfTaskElectronWeakBoson {
           double const deltaPhi = RecoDecay::constrainAngle(trackAss.phi - zBoson.phi, -o2::constants::math::PIHalf);
           double const ptRatio = trackAss.pt / zBoson.pt;
           double const deltaEta = zBoson.eta - trackAss.eta;
-          registry.fill(HIST("hZHadronDphi"), centrality, zBoson.charge, zBoson.pt, deltaPhi, deltaEta, ptRatio, trackAss.pt);
+          registry.fill(HIST("hZHadronDphi"), centrality, zBoson.charge, zBoson.pt, deltaPhi, deltaEta, ptRatio, trackAss.pt, trackAss.dedxTrk);
         }
       }
     } // end of Z-hadron correlation


### PR DESCRIPTION
- Use `isGlobalTrackWoPtEta()` as the baseline track selection.
- Add `applyTrackSys` to optionally apply additional track-quality cuts for systematic studies.
- Add the pion TPC PID table (`pidTPCFullPi`) to the track definition.
- Extend `hZHadronDphi` with the associated-track dE/dx information.