### PR TITLE
[PWGEM,Photon] Remove unnecessary registry argument from task function

### DIFF
--- a/PWGEM/PhotonMeson/Core/TaggingPi0MC.h
+++ b/PWGEM/PhotonMeson/Core/TaggingPi0MC.h
@@ -77,7 +77,7 @@ using MyMCCollision = MyMCCollisions::iterator;
 using MyV0Photons = o2::soa::Join<o2::aod::V0PhotonsKF, o2::aod::V0KFEMEventIds>;
 using MyV0Photon = MyV0Photons::iterator;
 
-using MyEMCClusters = o2::soa::Join<o2::aod::SkimEMCClusters, o2::aod::EMEMCClusterMCLabels, o2::aod::EMCEMEventIds>;
+using MyEMCClusters = o2::soa::Join<o2::aod::SkimEMCClusters, o2::aod::EMEMCClusterMCLabels_001, o2::aod::EMCEMEventIds>;
 using MyEMCCluster = MyEMCClusters::iterator;
 
 // using MyPHOSClusters = o2::soa::Join<o2::aod::PHOSClusters, o2::aod::PHOSEMEventIds>;

--- a/PWGEM/PhotonMeson/Tasks/Pi0EtaToGammaGammaMCEMCEMC.cxx
+++ b/PWGEM/PhotonMeson/Tasks/Pi0EtaToGammaGammaMCEMCEMC.cxx
@@ -27,7 +27,7 @@ using namespace o2::aod;
 using namespace o2::framework;
 using namespace o2::aod::pwgem::photonmeson::photonpair;
 
-using MyEMCClusters = soa::Join<aod::MinClusters, aod::EMEMCClusterMCLabels, aod::EMCEMEventIds>;
+using MyEMCClusters = soa::Join<aod::MinClusters, aod::EMEMCClusterMCLabels_001, aod::EMCEMEventIds>;
 
 WorkflowSpec defineDataProcessing(ConfigContext const& context)
 {

--- a/PWGEM/PhotonMeson/Tasks/emcalMcTask.cxx
+++ b/PWGEM/PhotonMeson/Tasks/emcalMcTask.cxx
@@ -133,7 +133,7 @@ struct EmcalMcTask {
 
   SliceCache cache;
 
-  using EMCalPhotons = soa::Join<aod::EMCEMEventIds, aod::MinClusters, aod::EMEMCClusterMCLabels>;
+  using EMCalPhotons = soa::Join<aod::EMCEMEventIds, aod::MinClusters, aod::EMEMCClusterMCLabels_001>;
 
   using Colls = soa::Join<aod::PMEvents, aod::EMEventsAlias, aod::EMEventsMult_000, aod::EMEventsCent_000, aod::EMMCEventLabels, aod::EmMagFields>;
 
@@ -299,11 +299,11 @@ struct EmcalMcTask {
   template <const int type, o2::soa::is_iterator TCluster, o2::soa::is_iterator TMC>
   void fillClusterHistos(TCluster const& cluster, TMC const& mcPart, float centOrMult)
   {
-    static constexpr std::string_view subDir = kSubDirs[type];
+    static constexpr std::string_view SubDir = kSubDirs[type];
 
-    registry.fill(HIST(subDir) + HIST("hM02"), cluster.m02(), cluster.e(), centOrMult);
-    registry.fill(HIST(subDir) + HIST("hEtaRel"), cluster.eta() - mcPart.eta(), cluster.e(), centOrMult);
-    registry.fill(HIST(subDir) + HIST("hPhiRel"), cluster.phi() - mcPart.phi(), cluster.e(), centOrMult);
+    registry.fill(HIST(SubDir) + HIST("hM02"), cluster.m02(), cluster.e(), centOrMult);
+    registry.fill(HIST(SubDir) + HIST("hEtaRel"), cluster.eta() - mcPart.eta(), cluster.e(), centOrMult);
+    registry.fill(HIST(SubDir) + HIST("hPhiRel"), cluster.phi() - mcPart.phi(), cluster.e(), centOrMult);
   }
 
   // PCM-EMCal same event

--- a/PWGEM/PhotonMeson/Tasks/emcalMcTask.cxx
+++ b/PWGEM/PhotonMeson/Tasks/emcalMcTask.cxx
@@ -341,9 +341,9 @@ struct EmcalMcTask {
 
         if (std::abs(mcPhoton1.pdgCode()) == PDG_t::kGamma) {
           fillClusterHistos<o2::em::emcal::mc::ParticleType::kPhoton>(photonEMC, mcPhoton1, centOrMult);
-        } else if (std::abs(mcPhoton1.pdgCode()) == PDG_t::kElectron) {
+        } else if (mcPhoton1.pdgCode() == PDG_t::kElectron) {
           fillClusterHistos<o2::em::emcal::mc::ParticleType::kElectron>(photonEMC, mcPhoton1, centOrMult);
-        } else if (mcPhoton1.pdgCode() == -PDG_t::kElectron) {
+        } else if (mcPhoton1.pdgCode() == PDG_t::kPositron) {
           fillClusterHistos<o2::em::emcal::mc::ParticleType::kPositron>(photonEMC, mcPhoton1, centOrMult);
         } else if (std::abs(mcPhoton1.pdgCode()) == PDG_t::kPi0) {
           fillClusterHistos<o2::em::emcal::mc::ParticleType::kPi0>(photonEMC, mcPhoton1, centOrMult);

--- a/PWGEM/PhotonMeson/Tasks/emcalMcTask.cxx
+++ b/PWGEM/PhotonMeson/Tasks/emcalMcTask.cxx
@@ -297,13 +297,13 @@ struct EmcalMcTask {
 
   // One templated fill function instead of 9 copy-pasted blocks
   template <const int type, o2::soa::is_iterator TCluster, o2::soa::is_iterator TMC>
-  void fillClusterHistos(HistogramRegistry& histRegistry, TCluster const& clu, TMC const& mcPart, float centOrMult)
+  void fillClusterHistos(TCluster const& cluster, TMC const& mcPart, float centOrMult)
   {
     static constexpr std::string_view subDir = kSubDirs[type];
 
-    histRegistry.fill(HIST(subDir) + HIST("hM02"), clu.m02(), clu.e(), centOrMult);
-    histRegistry.fill(HIST(subDir) + HIST("hEtaRel"), clu.eta() - mcPart.eta(), clu.e(), centOrMult);
-    histRegistry.fill(HIST(subDir) + HIST("hPhiRel"), clu.phi() - mcPart.phi(), clu.e(), centOrMult);
+    registry.fill(HIST(subDir) + HIST("hM02"), cluster.m02(), cluster.e(), centOrMult);
+    registry.fill(HIST(subDir) + HIST("hEtaRel"), cluster.eta() - mcPart.eta(), cluster.e(), centOrMult);
+    registry.fill(HIST(subDir) + HIST("hPhiRel"), cluster.phi() - mcPart.phi(), cluster.e(), centOrMult);
   }
 
   // PCM-EMCal same event
@@ -340,23 +340,23 @@ struct EmcalMcTask {
         mcPhoton1.setCursor(photonEMC.emmcparticleIds()[0]);
 
         if (std::abs(mcPhoton1.pdgCode()) == PDG_t::kGamma) {
-          fillClusterHistos<o2::em::emcal::mc::ParticleType::kPhoton>(registry, photonEMC, mcPhoton1, centOrMult);
+          fillClusterHistos<o2::em::emcal::mc::ParticleType::kPhoton>(photonEMC, mcPhoton1, centOrMult);
         } else if (std::abs(mcPhoton1.pdgCode()) == PDG_t::kElectron) {
-          fillClusterHistos<o2::em::emcal::mc::ParticleType::kElectron>(registry, photonEMC, mcPhoton1, centOrMult);
+          fillClusterHistos<o2::em::emcal::mc::ParticleType::kElectron>(photonEMC, mcPhoton1, centOrMult);
         } else if (mcPhoton1.pdgCode() == -PDG_t::kElectron) {
-          fillClusterHistos<o2::em::emcal::mc::ParticleType::kPositron>(registry, photonEMC, mcPhoton1, centOrMult);
+          fillClusterHistos<o2::em::emcal::mc::ParticleType::kPositron>(photonEMC, mcPhoton1, centOrMult);
         } else if (std::abs(mcPhoton1.pdgCode()) == PDG_t::kPi0) {
-          fillClusterHistos<o2::em::emcal::mc::ParticleType::kPi0>(registry, photonEMC, mcPhoton1, centOrMult);
+          fillClusterHistos<o2::em::emcal::mc::ParticleType::kPi0>(photonEMC, mcPhoton1, centOrMult);
         } else if (std::abs(mcPhoton1.pdgCode()) == o2::constants::physics::Pdg::kEta) {
-          fillClusterHistos<o2::em::emcal::mc::ParticleType::kEta>(registry, photonEMC, mcPhoton1, centOrMult);
+          fillClusterHistos<o2::em::emcal::mc::ParticleType::kEta>(photonEMC, mcPhoton1, centOrMult);
         } else if (std::abs(mcPhoton1.pdgCode()) == o2::constants::physics::Pdg::kOmega) {
-          fillClusterHistos<o2::em::emcal::mc::ParticleType::kOmega>(registry, photonEMC, mcPhoton1, centOrMult);
+          fillClusterHistos<o2::em::emcal::mc::ParticleType::kOmega>(photonEMC, mcPhoton1, centOrMult);
         } else if (std::abs(mcPhoton1.pdgCode()) == PDG_t::kPiPlus) {
-          fillClusterHistos<o2::em::emcal::mc::ParticleType::kPion>(registry, photonEMC, mcPhoton1, centOrMult);
+          fillClusterHistos<o2::em::emcal::mc::ParticleType::kPion>(photonEMC, mcPhoton1, centOrMult);
         } else if (std::abs(mcPhoton1.pdgCode()) == PDG_t::kKPlus) {
-          fillClusterHistos<o2::em::emcal::mc::ParticleType::kKaon>(registry, photonEMC, mcPhoton1, centOrMult);
+          fillClusterHistos<o2::em::emcal::mc::ParticleType::kKaon>(photonEMC, mcPhoton1, centOrMult);
         } else {
-          fillClusterHistos<o2::em::emcal::mc::ParticleType::kOther>(registry, photonEMC, mcPhoton1, centOrMult);
+          fillClusterHistos<o2::em::emcal::mc::ParticleType::kOther>(photonEMC, mcPhoton1, centOrMult);
         }
       } // for (const auto& photonEMC : photonsEMCPerCollision) {
     }

--- a/PWGEM/PhotonMeson/Tasks/photonResoTask.cxx
+++ b/PWGEM/PhotonMeson/Tasks/photonResoTask.cxx
@@ -177,7 +177,7 @@ struct PhotonResoTask {
 
   SliceCache cache;
 
-  using EMCalPhotons = soa::Join<aod::EMCEMEventIds, aod::MinClusters, aod::EMEMCClusterMCLabels>;
+  using EMCalPhotons = soa::Join<aod::EMCEMEventIds, aod::MinClusters, aod::EMEMCClusterMCLabels_001>;
   using PcmPhotons = soa::Join<aod::V0PhotonsKF, aod::V0KFEMEventIds>;
 
   using PcmMcLegs = soa::Join<aod::V0Legs, aod::V0LegMCLabels>;


### PR DESCRIPTION
- Bump `EMEMCClusterMCLabels` to `EMEMCClusterMCLabels_001` in all PWGEM tasks where the old version was still wrongly used.
- Fix PDG value check for electrons. This used std::abs() which was also true for positrons. Now it's explicitly only electrons.
- Remove unnecessary registry argument from emcal-mc-task function
