### PR TITLE
[Infrastructure] Clang-Tidy: Report errors only for new and being-fixed positives

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -113,6 +113,56 @@ WarningsAsErrors: >-
   -readability-suspicious-call-argument,
   -modernize-*,
   -readability-*,
+  -bugprone-assignment-in-if-condition,
+  -bugprone-branch-clone,
+  -bugprone-copy-constructor-init,
+  -bugprone-empty-catch,
+  -bugprone-exception-escape,
+  -bugprone-fold-init-type,
+  -bugprone-incorrect-roundings,
+  -bugprone-integer-division,
+  -bugprone-macro-parentheses,
+  -bugprone-narrowing-conversions,
+  -bugprone-non-zero-enum-to-bool-conversion,
+  -bugprone-redundant-branch-condition,
+  -bugprone-reserved-identifier,
+  -bugprone-suspicious-include,
+  -bugprone-suspicious-missing-comma,
+  -bugprone-switch-missing-default-case,
+  -bugprone-too-small-loop-variable,
+  -bugprone-unchecked-optional-access,
+  -bugprone-unsafe-functions,
+  -bugprone-unused-local-non-trivial-variable,
+  -cppcoreguidelines-avoid-const-or-ref-data-members,
+  -cppcoreguidelines-avoid-non-const-global-variables,
+  -cppcoreguidelines-init-variables,
+  -cppcoreguidelines-macro-usage,
+  -cppcoreguidelines-missing-std-forward,
+  -cppcoreguidelines-prefer-member-initializer,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-type-const-cast,
+  -cppcoreguidelines-pro-type-cstyle-cast,
+  -cppcoreguidelines-pro-type-member-init,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  -cppcoreguidelines-pro-type-static-cast-downcast,
+  -cppcoreguidelines-pro-type-union-access,
+  -cppcoreguidelines-slicing,
+  -cppcoreguidelines-virtual-class-destructor,
+# Positives for the following checks are currently being fixed and should be reported as errors.
+# clang-analyzer-*
+# clang-diagnostic-*
+# google-default-arguments
+# misc-include-cleaner
+# misc-redundant-expression
+# misc-unused-parameters
+# performance-for-range-copy
+# performance-inefficient-string-concatenation
+# performance-inefficient-vector-operation
+# performance-move-const-arg
+# performance-no-automatic-move
+# performance-type-promotion-in-math-fn
+# performance-unnecessary-copy-initialization
+# performance-unnecessary-value-param
 CheckOptions:
   modernize-avoid-c-arrays.AllowStringArrays: true
   # Common tolerated conversions


### PR DESCRIPTION
Demotes currently reported positives to warnings, except for checks selected for immediate fixes.
So if errors are reported, they are either new or fall in the scope of the ongoing cleanup campaign and should be fixed immediately.
As agreed with @ktf and @dsekihat .