### PR TITLE
[PWGJE] Fix type issue in BerkeleyTree

### DIFF
--- a/PWGJE/TableProducer/berkeleyTreeProducer.cxx
+++ b/PWGJE/TableProducer/berkeleyTreeProducer.cxx
@@ -51,7 +51,7 @@ DECLARE_SOA_COLUMN(DetPt, detPt, std::vector<float>);
 DECLARE_SOA_COLUMN(DetEta, detEta, std::vector<float>);
 DECLARE_SOA_COLUMN(DetPhi, detPhi, std::vector<float>);
 DECLARE_SOA_COLUMN(DetTrackSel, detTrackSel, std::vector<uint8_t>);
-DECLARE_SOA_COLUMN(DetMcId, detMcId, std::vector<int>);
+DECLARE_SOA_COLUMN(DetMcId, detMcId, std::vector<int64_t>);
 
 DECLARE_SOA_COLUMN(GenPt, genPt, std::vector<float>);
 DECLARE_SOA_COLUMN(GenEta, genEta, std::vector<float>);
@@ -146,7 +146,7 @@ struct BerkeleyTreeProducer {
 
     std::vector<float> detPt, detEta, detPhi;
     std::vector<uint8_t> detTrackSel;
-    std::vector<int> detMcId; // track.mcParticleId() returns int/int32_t
+    std::vector<int64_t> detMcId; // track.mcParticleId() returns int/int32_t, casting to int64_t
 
     std::vector<float> genPt, genEta, genPhi, genE;
     std::vector<int> genCharge, pdgId;


### PR DESCRIPTION
Having two different types for detector-level and generator-level MC ID is causing some headaches in downstream analysis, so we're making them consistent. track.mcParticleId() returns int/int32_t, which can be safely casted to int64_t with no data loss.