### PR TITLE
[PWGLF] SigmaPlus reco improved selections and tables

### DIFF
--- a/PWGLF/DataModel/LFKinkDecayTables.h
+++ b/PWGLF/DataModel/LFKinkDecayTables.h
@@ -25,6 +25,7 @@
 
 #include <array>
 #include <cmath>
+#include <cstdint>
 
 namespace o2::aod
 {

--- a/PWGLF/DataModel/LFKinkDecayTables.h
+++ b/PWGLF/DataModel/LFKinkDecayTables.h
@@ -216,6 +216,7 @@ DECLARE_SOA_COLUMN(GammaGMotherPdgCode, gammaGMotherPdgCode, int); //! PDG code 
 DECLARE_SOA_COLUMN(XDecVtxMC, xDecVtxMC, float);         //! MC-truth Sigma+ decay vertex (x direction)
 DECLARE_SOA_COLUMN(YDecVtxMC, yDecVtxMC, float);         //! MC-truth Sigma+ decay vertex (y direction)
 DECLARE_SOA_COLUMN(ZDecVtxMC, zDecVtxMC, float);         //! MC-truth Sigma+ decay vertex (z direction)
+DECLARE_SOA_COLUMN(DecayRadiusMC, decayRadiusMC, float); //! MC-truth Sigma+ decay radius
 DECLARE_SOA_COLUMN(PxSigmaPlusMC, pxSigmaPlusMC, float); //! MC-truth Sigma+ mother Px
 DECLARE_SOA_COLUMN(PySigmaPlusMC, pySigmaPlusMC, float); //! MC-truth Sigma+ mother Py
 DECLARE_SOA_COLUMN(PzSigmaPlusMC, pzSigmaPlusMC, float); //! MC-truth Sigma+ mother Pz
@@ -296,6 +297,44 @@ DECLARE_SOA_TABLE(SigmaPlusCandsMC, "AOD", "SIGMAPLUSMC",
                   sigmapluscand::XDecVtxMC, sigmapluscand::YDecVtxMC, sigmapluscand::ZDecVtxMC,
                   sigmapluscand::PxProtonMC, sigmapluscand::PyProtonMC, sigmapluscand::PzProtonMC,
                   sigmapluscand::PxGammaMC, sigmapluscand::PyGammaMC, sigmapluscand::PzGammaMC,
+                  sigmapluscand::PxSigmaPlusMC, sigmapluscand::PySigmaPlusMC, sigmapluscand::PzSigmaPlusMC,
+
+                  // dynamic columns
+                  sigmapluscand::PxSigmaPlus<sigmapluscand::PxProton, sigmapluscand::PxGamma1, sigmapluscand::PxGamma2>,
+                  sigmapluscand::PySigmaPlus<sigmapluscand::PyProton, sigmapluscand::PyGamma1, sigmapluscand::PyGamma2>,
+                  sigmapluscand::PzSigmaPlus<sigmapluscand::PzProton, sigmapluscand::PzGamma1, sigmapluscand::PzGamma2>,
+                  sigmapluscand::PtSigmaPlus<sigmapluscand::PxProton, sigmapluscand::PxGamma1, sigmapluscand::PxGamma2, sigmapluscand::PyProton, sigmapluscand::PyGamma1, sigmapluscand::PyGamma2>,
+                  sigmapluscand::MassSigmaPlus<sigmapluscand::PxProton, sigmapluscand::PyProton, sigmapluscand::PzProton, sigmapluscand::PxGamma1, sigmapluscand::PyGamma1, sigmapluscand::PzGamma1, sigmapluscand::PxGamma2, sigmapluscand::PyGamma2, sigmapluscand::PzGamma2>,
+                  sigmapluscand::PtSigmaPlusMC<sigmapluscand::PxSigmaPlusMC, sigmapluscand::PySigmaPlusMC>,
+                  sigmapluscand::YSigmaPlusMC<sigmapluscand::PxSigmaPlusMC, sigmapluscand::PySigmaPlusMC, sigmapluscand::PzSigmaPlusMC>);
+
+DECLARE_SOA_TABLE(SlimSigmaPlusCands, "AOD", "SLIMSIGMAPLUS",
+                  sigmapluscand::Radius, sigmapluscand::DcaProtonGamma,
+                  sigmapluscand::PxProton, sigmapluscand::PyProton, sigmapluscand::PzProton,
+                  sigmapluscand::PxGamma1, sigmapluscand::PyGamma1, sigmapluscand::PzGamma1,
+                  sigmapluscand::PxGamma2, sigmapluscand::PyGamma2, sigmapluscand::PzGamma2,
+                  sigmapluscand::NSigmaTPCProton, sigmapluscand::NSigmaTOFProton,
+                  sigmapluscand::NSigmaTPCElPos, sigmapluscand::NSigmaTPCElNeg,
+                  sigmapluscand::PhotonMass,
+
+                  // dynamic columns
+                  sigmapluscand::PxSigmaPlus<sigmapluscand::PxProton, sigmapluscand::PxGamma1, sigmapluscand::PxGamma2>,
+                  sigmapluscand::PySigmaPlus<sigmapluscand::PyProton, sigmapluscand::PyGamma1, sigmapluscand::PyGamma2>,
+                  sigmapluscand::PzSigmaPlus<sigmapluscand::PzProton, sigmapluscand::PzGamma1, sigmapluscand::PzGamma2>,
+                  sigmapluscand::PtSigmaPlus<sigmapluscand::PxProton, sigmapluscand::PxGamma1, sigmapluscand::PxGamma2, sigmapluscand::PyProton, sigmapluscand::PyGamma1, sigmapluscand::PyGamma2>,
+                  sigmapluscand::MassSigmaPlus<sigmapluscand::PxProton, sigmapluscand::PyProton, sigmapluscand::PzProton, sigmapluscand::PxGamma1, sigmapluscand::PyGamma1, sigmapluscand::PzGamma1, sigmapluscand::PxGamma2, sigmapluscand::PyGamma2, sigmapluscand::PzGamma2>);
+
+DECLARE_SOA_TABLE(SlimSigmaPlusCandsMC, "AOD", "SLIMSIGMAPLUSMC",
+                  sigmapluscand::Radius, sigmapluscand::DcaProtonGamma,
+                  sigmapluscand::PxProton, sigmapluscand::PyProton, sigmapluscand::PzProton,
+                  sigmapluscand::PxGamma1, sigmapluscand::PyGamma1, sigmapluscand::PzGamma1,
+                  sigmapluscand::PxGamma2, sigmapluscand::PyGamma2, sigmapluscand::PzGamma2,
+                  sigmapluscand::NSigmaTPCProton, sigmapluscand::NSigmaTOFProton,
+                  sigmapluscand::NSigmaTPCElPos, sigmapluscand::NSigmaTPCElNeg,
+                  sigmapluscand::PhotonMass,
+                  sigmapluscand::ProtonPdgCode, sigmapluscand::ProtonMotherPdgCode,
+                  sigmapluscand::GammaPdgCode, sigmapluscand::GammaMotherPdgCode, sigmapluscand::GammaGMotherPdgCode,
+                  sigmapluscand::DecayRadiusMC,
                   sigmapluscand::PxSigmaPlusMC, sigmapluscand::PySigmaPlusMC, sigmapluscand::PzSigmaPlusMC,
 
                   // dynamic columns

--- a/PWGLF/DataModel/LFKinkDecayTables.h
+++ b/PWGLF/DataModel/LFKinkDecayTables.h
@@ -212,15 +212,18 @@ DECLARE_SOA_COLUMN(GammaPdgCode, gammaPdgCode, int);               //! PDG code 
 DECLARE_SOA_COLUMN(GammaMotherPdgCode, gammaMotherPdgCode, int);   //! PDG code of the photon's MC mother (expected: pi0)
 DECLARE_SOA_COLUMN(GammaGMotherPdgCode, gammaGMotherPdgCode, int); //! PDG code of the photon's MC grandmother (expected: Sigma+)
 
-DECLARE_SOA_COLUMN(XDecVtxMC, xDecVtxMC, float);   //! MC-truth Sigma+ decay vertex (x direction)
-DECLARE_SOA_COLUMN(YDecVtxMC, yDecVtxMC, float);   //! MC-truth Sigma+ decay vertex (y direction)
-DECLARE_SOA_COLUMN(ZDecVtxMC, zDecVtxMC, float);   //! MC-truth Sigma+ decay vertex (z direction)
-DECLARE_SOA_COLUMN(PxProtonMC, pxProtonMC, float); //! MC-truth proton Px
-DECLARE_SOA_COLUMN(PyProtonMC, pyProtonMC, float); //! MC-truth proton Py
-DECLARE_SOA_COLUMN(PzProtonMC, pzProtonMC, float); //! MC-truth proton Pz
-DECLARE_SOA_COLUMN(PxGammaMC, pxGammaMC, float);   //! MC-truth momentum of the measured photon (Px)
-DECLARE_SOA_COLUMN(PyGammaMC, pyGammaMC, float);   //! MC-truth momentum of the measured photon (Py)
-DECLARE_SOA_COLUMN(PzGammaMC, pzGammaMC, float);   //! MC-truth momentum of the measured photon (Pz)
+DECLARE_SOA_COLUMN(XDecVtxMC, xDecVtxMC, float);         //! MC-truth Sigma+ decay vertex (x direction)
+DECLARE_SOA_COLUMN(YDecVtxMC, yDecVtxMC, float);         //! MC-truth Sigma+ decay vertex (y direction)
+DECLARE_SOA_COLUMN(ZDecVtxMC, zDecVtxMC, float);         //! MC-truth Sigma+ decay vertex (z direction)
+DECLARE_SOA_COLUMN(PxSigmaPlusMC, pxSigmaPlusMC, float); //! MC-truth Sigma+ mother Px
+DECLARE_SOA_COLUMN(PySigmaPlusMC, pySigmaPlusMC, float); //! MC-truth Sigma+ mother Py
+DECLARE_SOA_COLUMN(PzSigmaPlusMC, pzSigmaPlusMC, float); //! MC-truth Sigma+ mother Pz
+DECLARE_SOA_COLUMN(PxProtonMC, pxProtonMC, float);       //! MC-truth proton Px
+DECLARE_SOA_COLUMN(PyProtonMC, pyProtonMC, float);       //! MC-truth proton Py
+DECLARE_SOA_COLUMN(PzProtonMC, pzProtonMC, float);       //! MC-truth proton Pz
+DECLARE_SOA_COLUMN(PxGammaMC, pxGammaMC, float);         //! MC-truth momentum of the measured photon (Px)
+DECLARE_SOA_COLUMN(PyGammaMC, pyGammaMC, float);         //! MC-truth momentum of the measured photon (Py)
+DECLARE_SOA_COLUMN(PzGammaMC, pzGammaMC, float);         //! MC-truth momentum of the measured photon (Pz)
 
 // DYNAMIC COLUMNS
 
@@ -243,6 +246,12 @@ DECLARE_SOA_DYNAMIC_COLUMN(MassSigmaPlus, massSigmaPlus, //! Invariant mass of t
                                                                                                                         std::array{pxGamma1, pyGamma1, pzGamma1},
                                                                                                                         std::array{pxGamma2, pyGamma2, pzGamma2}},
                                                                                                              std::array{o2::constants::physics::MassProton, o2::constants::physics::MassGamma, o2::constants::physics::MassGamma}); });
+
+DECLARE_SOA_DYNAMIC_COLUMN(PtSigmaPlusMC, ptSigmaPlusMC, //! True pT of the Sigma+ mother
+                           [](float pxSigmaPlusMC, float pySigmaPlusMC) -> float { return std::hypot(pxSigmaPlusMC, pySigmaPlusMC); });
+
+DECLARE_SOA_DYNAMIC_COLUMN(YSigmaPlusMC, ySigmaPlusMC, //! True rapidity of the Sigma+ mother
+                           [](float pxSigmaPlusMC, float pySigmaPlusMC, float pzSigmaPlusMC) -> float { return RecoDecay::y(std::array{pxSigmaPlusMC, pySigmaPlusMC, pzSigmaPlusMC}, o2::constants::physics::MassSigmaPlus); });
 
 } // namespace sigmapluscand
 
@@ -286,13 +295,16 @@ DECLARE_SOA_TABLE(SigmaPlusCandsMC, "AOD", "SIGMAPLUSMC",
                   sigmapluscand::XDecVtxMC, sigmapluscand::YDecVtxMC, sigmapluscand::ZDecVtxMC,
                   sigmapluscand::PxProtonMC, sigmapluscand::PyProtonMC, sigmapluscand::PzProtonMC,
                   sigmapluscand::PxGammaMC, sigmapluscand::PyGammaMC, sigmapluscand::PzGammaMC,
+                  sigmapluscand::PxSigmaPlusMC, sigmapluscand::PySigmaPlusMC, sigmapluscand::PzSigmaPlusMC,
 
                   // dynamic columns
                   sigmapluscand::PxSigmaPlus<sigmapluscand::PxProton, sigmapluscand::PxGamma1, sigmapluscand::PxGamma2>,
                   sigmapluscand::PySigmaPlus<sigmapluscand::PyProton, sigmapluscand::PyGamma1, sigmapluscand::PyGamma2>,
                   sigmapluscand::PzSigmaPlus<sigmapluscand::PzProton, sigmapluscand::PzGamma1, sigmapluscand::PzGamma2>,
                   sigmapluscand::PtSigmaPlus<sigmapluscand::PxProton, sigmapluscand::PxGamma1, sigmapluscand::PxGamma2, sigmapluscand::PyProton, sigmapluscand::PyGamma1, sigmapluscand::PyGamma2>,
-                  sigmapluscand::MassSigmaPlus<sigmapluscand::PxProton, sigmapluscand::PyProton, sigmapluscand::PzProton, sigmapluscand::PxGamma1, sigmapluscand::PyGamma1, sigmapluscand::PzGamma1, sigmapluscand::PxGamma2, sigmapluscand::PyGamma2, sigmapluscand::PzGamma2>);
+                  sigmapluscand::MassSigmaPlus<sigmapluscand::PxProton, sigmapluscand::PyProton, sigmapluscand::PzProton, sigmapluscand::PxGamma1, sigmapluscand::PyGamma1, sigmapluscand::PzGamma1, sigmapluscand::PxGamma2, sigmapluscand::PyGamma2, sigmapluscand::PzGamma2>,
+                  sigmapluscand::PtSigmaPlusMC<sigmapluscand::PxSigmaPlusMC, sigmapluscand::PySigmaPlusMC>,
+                  sigmapluscand::YSigmaPlusMC<sigmapluscand::PxSigmaPlusMC, sigmapluscand::PySigmaPlusMC, sigmapluscand::PzSigmaPlusMC>);
 
 } // namespace o2::aod
 

--- a/PWGLF/TableProducer/Strangeness/sigmaHadCorr.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigmaHadCorr.cxx
@@ -37,7 +37,8 @@
 #include <Framework/runDataProcessing.h>
 
 #include <Math/GenVector/Boost.h>
-#include <Math/Vector4D.h>
+#include <Math/Vector4D.h> // IWYU pragma: keep (do not replace with Math/Vector4Dfwd.h)
+#include <Math/Vector4Dfwd.h>
 #include <TPDGCode.h>
 
 #include <array>

--- a/PWGLF/TableProducer/Strangeness/sigmaHadCorr.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigmaHadCorr.cxx
@@ -98,7 +98,6 @@ struct SigmaHadCand {
 
 struct SigmaHadCorr {
 
-  std::vector<SigmaHadCand> sigmaHadCandidates;        // Vector to store Sigma-hadron candidates
   Produces<aod::SigmaProtonCands> outputDataTable;     // Output table for Sigma-hadron candidates
   Produces<aod::SigmaProtonMCCands> outputDataTableMC; // Output table for Sigma-hadron candidates in MC
   Produces<aod::SlimKinkCandsMC> outputKinkCandsMC;    // Single-Sigma-level MC truth record, filled before hadron pairing
@@ -499,8 +498,9 @@ struct SigmaHadCorr {
   }
 
   template <bool IsMC, typename Ttrack, typename Tcollision>
-  void fillTreeAndHistograms(aod::KinkCands const& kinkCands, Ttrack const& tracksDauSigma, Ttrack const& tracks, Tcollision const& collision)
+  std::vector<SigmaHadCand> fillTreeAndHistograms(aod::KinkCands const& kinkCands, Ttrack const& tracksDauSigma, Ttrack const& tracks, Tcollision const& collision)
   {
+    std::vector<SigmaHadCand> sigmaHadCandidates;
     for (const auto& sigmaCand : kinkCands) {
       auto kinkDauTrack = tracksDauSigma.rawIteratorAt(sigmaCand.trackDaugId());
       if (!selectSigma(sigmaCand, kinkDauTrack)) {
@@ -612,20 +612,20 @@ struct SigmaHadCorr {
         sigmaHadCandidates.push_back(candidate);
       }
     }
+    return sigmaHadCandidates;
   }
 
   void processSameEvent(CollisionsFull const& collisions, aod::KinkCands const& kinkCands, TracksFull const& tracks)
   {
     for (auto const& collision : collisions) {
 
-      sigmaHadCandidates.clear();
       auto kinkCandsC = kinkCands.sliceBy(kinkCandsPerCollisionPreslice, collision.globalIndex());
       auto tracksC = tracks.sliceBy(tracksPerCollisionPreslice, collision.globalIndex());
       if (std::abs(collision.posZ()) > cutZVertex || !collision.sel8()) {
         continue;
       }
       rEventSelection.fill(HIST("hVertexZRec"), collision.posZ());
-      fillTreeAndHistograms<false>(kinkCandsC, tracks, tracksC, collision);
+      auto sigmaHadCandidates = fillTreeAndHistograms<false>(kinkCandsC, tracks, tracksC, collision);
       if (fillOutputTree) {
         // Fill output table
         for (const auto& candidate : sigmaHadCandidates) {
@@ -663,14 +663,13 @@ struct SigmaHadCorr {
            selfCombinations(BinningTypeMultNTracksPV{{cfgVtxBins, cfgMultBins}, true}, nEvtMixingBkg, -1, collisions, collisions)) {
         if (collision1.index() == collision2.index())
           continue;
-        sigmaHadCandidates.clear();
         if (std::abs(collision1.posZ()) > cutZVertex || !collision1.sel8())
           continue;
         if (std::abs(collision2.posZ()) > cutZVertex || !collision2.sel8())
           continue;
         auto kinkCandsC1 = kinkCands.sliceBy(kinkCandsPerCollisionPreslice, collision1.globalIndex());
         auto tracksC2 = tracks.sliceBy(tracksPerCollisionPreslice, collision2.globalIndex());
-        fillTreeAndHistograms<false>(kinkCandsC1, tracks, tracksC2, collision1);
+        auto sigmaHadCandidates = fillTreeAndHistograms<false>(kinkCandsC1, tracks, tracksC2, collision1);
         if (fillOutputTree) {
           for (const auto& candidate : sigmaHadCandidates) {
             outputDataTable(candidate.sigmaCharge, candidate.sigmaPx, candidate.sigmaPy, candidate.sigmaPz,
@@ -686,14 +685,13 @@ struct SigmaHadCorr {
            selfCombinations(BinningTypeNumContrib{{cfgVtxBins, cfgMultBins}, true}, nEvtMixingBkg, -1, collisions, collisions)) {
         if (collision1.index() == collision2.index())
           continue;
-        sigmaHadCandidates.clear();
         if (std::abs(collision1.posZ()) > cutZVertex || !collision1.sel8())
           continue;
         if (std::abs(collision2.posZ()) > cutZVertex || !collision2.sel8())
           continue;
         auto kinkCandsC1 = kinkCands.sliceBy(kinkCandsPerCollisionPreslice, collision1.globalIndex());
         auto tracksC2 = tracks.sliceBy(tracksPerCollisionPreslice, collision2.globalIndex());
-        fillTreeAndHistograms<false>(kinkCandsC1, tracks, tracksC2, collision1);
+        auto sigmaHadCandidates = fillTreeAndHistograms<false>(kinkCandsC1, tracks, tracksC2, collision1);
         if (fillOutputTree) {
           for (const auto& candidate : sigmaHadCandidates) {
             outputDataTable(candidate.sigmaCharge, candidate.sigmaPx, candidate.sigmaPy, candidate.sigmaPz,
@@ -712,7 +710,6 @@ struct SigmaHadCorr {
   {
     for (auto const& collision : collisions) {
 
-      sigmaHadCandidates.clear();
       auto kinkCandsC = kinkCands.sliceBy(kinkCandsPerCollisionPreslice, collision.globalIndex());
       auto tracksC = tracks.sliceBy(tracksMCPerCollisionPreslice, collision.globalIndex());
 
@@ -720,7 +717,7 @@ struct SigmaHadCorr {
         continue;
       }
       rEventSelection.fill(HIST("hVertexZRec"), collision.posZ());
-      fillTreeAndHistograms<true>(kinkCandsC, tracks, tracksC, collision);
+      auto sigmaHadCandidates = fillTreeAndHistograms<true>(kinkCandsC, tracks, tracksC, collision);
       for (const auto& candidate : sigmaHadCandidates) {
         auto mcLabelSigma = tracks.rawIteratorAt(candidate.sigmaID);
         auto mcLabelSigmaDau = tracks.rawIteratorAt(candidate.kinkDauID);
@@ -832,14 +829,13 @@ struct SigmaHadCorr {
            selfCombinations(BinningTypeMultNTracksPV{{cfgVtxBins, cfgMultBins}, true}, nEvtMixingBkg, -1, collisions, collisions)) {
         if (collision1.index() == collision2.index())
           continue;
-        sigmaHadCandidates.clear();
         if (std::abs(collision1.posZ()) > cutZVertex || !collision1.sel8())
           continue;
         if (std::abs(collision2.posZ()) > cutZVertex || !collision2.sel8())
           continue;
         auto kinkCandsC1 = kinkCands.sliceBy(kinkCandsPerCollisionPreslice, collision1.globalIndex());
         auto tracksC2 = tracks.sliceBy(tracksPerCollisionPreslice, collision2.globalIndex());
-        fillTreeAndHistograms<true>(kinkCandsC1, tracks, tracksC2, collision1);
+        auto sigmaHadCandidates = fillTreeAndHistograms<true>(kinkCandsC1, tracks, tracksC2, collision1);
         for (const auto& candidate : sigmaHadCandidates) {
           auto mcLabelSigma = tracks.rawIteratorAt(candidate.sigmaID);
           auto mcLabelSigmaDau = tracks.rawIteratorAt(candidate.kinkDauID);
@@ -881,14 +877,13 @@ struct SigmaHadCorr {
            selfCombinations(BinningTypeNumContrib{{cfgVtxBins, cfgMultBins}, true}, nEvtMixingBkg, -1, collisions, collisions)) {
         if (collision1.index() == collision2.index())
           continue;
-        sigmaHadCandidates.clear();
         if (std::abs(collision1.posZ()) > cutZVertex || !collision1.sel8())
           continue;
         if (std::abs(collision2.posZ()) > cutZVertex || !collision2.sel8())
           continue;
         auto kinkCandsC1 = kinkCands.sliceBy(kinkCandsPerCollisionPreslice, collision1.globalIndex());
         auto tracksC2 = tracks.sliceBy(tracksPerCollisionPreslice, collision2.globalIndex());
-        fillTreeAndHistograms<true>(kinkCandsC1, tracks, tracksC2, collision1);
+        auto sigmaHadCandidates = fillTreeAndHistograms<true>(kinkCandsC1, tracks, tracksC2, collision1);
         for (const auto& candidate : sigmaHadCandidates) {
           auto mcLabelSigma = tracks.rawIteratorAt(candidate.sigmaID);
           auto mcLabelSigmaDau = tracks.rawIteratorAt(candidate.kinkDauID);

--- a/PWGLF/TableProducer/Strangeness/sigmaHadCorr.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigmaHadCorr.cxx
@@ -708,7 +708,7 @@ struct SigmaHadCorr {
   }
   PROCESS_SWITCH(SigmaHadCorr, processMixedEvent, "Process Mixed event", false);
 
-  void processSameEventMC(CollisionsFullMC const& collisions, aod::KinkCands const& kinkCands, TracksFullMC const& tracks, aod::McParticles const& mcParticles)
+  void processSameEventMC(CollisionsFullMC const& collisions, aod::KinkCands const& kinkCands, TracksFullMC const& tracks, aod::McParticles const& mcParticles, aod::McCollisions const&)
   {
     for (auto const& collision : collisions) {
 
@@ -825,7 +825,7 @@ struct SigmaHadCorr {
   }
   PROCESS_SWITCH(SigmaHadCorr, processSameEventMC, "Process Same event MC", false);
 
-  void processMixedEventMC(const CollisionsFullMC& collisions, const aod::KinkCands& kinkCands, const TracksFullMC& tracks, const aod::McParticles& mcParticles)
+  void processMixedEventMC(const CollisionsFullMC& collisions, const aod::KinkCands& kinkCands, const TracksFullMC& tracks, const aod::McParticles& mcParticles, aod::McCollisions const&)
   {
     if (useMultNTracksPV.value) {
       for (auto const& [collision1, collision2] :

--- a/PWGLF/TableProducer/Strangeness/sigmaHadCorr.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigmaHadCorr.cxx
@@ -37,7 +37,7 @@
 #include <Framework/runDataProcessing.h>
 
 #include <Math/GenVector/Boost.h>
-#include <TLorentzVector.h>
+#include <Math/Vector4D.h>
 #include <TPDGCode.h>
 
 #include <array>
@@ -56,7 +56,7 @@ using TracksFullMC = soa::Join<aod::TracksIU, aod::TracksExtra, aod::TracksCovIU
 using CollisionsFull = soa::Join<aod::Collisions, aod::EvSel, aod::PVMults>;
 using CollisionsFullMC = soa::Join<aod::Collisions, aod::McCollisionLabels, aod::EvSels, aod::PVMults>;
 
-struct sigmaHadCand {
+struct SigmaHadCand {
 
   float ptHad() const
   {
@@ -96,16 +96,17 @@ struct sigmaHadCand {
   float multiplicity = -1.f;
 };
 
-struct sigmaHadCorrTask {
+struct SigmaHadCorr {
 
-  std::vector<sigmaHadCand> sigmaHadCandidates;        // Vector to store Sigma-hadron candidates
+  std::vector<SigmaHadCand> sigmaHadCandidates;        // Vector to store Sigma-hadron candidates
   Produces<aod::SigmaProtonCands> outputDataTable;     // Output table for Sigma-hadron candidates
   Produces<aod::SigmaProtonMCCands> outputDataTableMC; // Output table for Sigma-hadron candidates in MC
+  Produces<aod::SlimKinkCandsMC> outputKinkCandsMC;    // Single-Sigma-level MC truth record, filled before hadron pairing
   // Histograms are defined with HistogramRegistry
   HistogramRegistry rEventSelection{"eventSelection", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
   HistogramRegistry rSigmaHad{"sigmaHad", {}, OutputObjHandlingPolicy::AnalysisObject, true, true};
   // Configurable for event selection
-  Configurable<float> cutzvertex{"cutZVertex", 10.0f, "Accepted z-vertex range (cm)"};
+  Configurable<float> cutZVertex{"cutZVertex", 10.0f, "Accepted z-vertex range (cm)"};
 
   Configurable<bool> doSigmaPion{"doSigmaPion", false, "If true, pair Sigma with pions instead of protons"};
   Configurable<bool> doSigmaMinus{"doSigmaMinus", true, "If true, pair Sigma- candidates, else Sigma+"};
@@ -119,7 +120,7 @@ struct sigmaHadCorrTask {
   Configurable<float> alphaAPCut{"alphaAPCut", 0., "Alpha AP cut for Sigma candidates"};
   Configurable<float> qtAPCutLow{"qtAPCutLow", 0.15, "Lower qT AP cut for Sigma candidates (GeV/c)"};
   Configurable<float> qtAPCutHigh{"qtAPCutHigh", 0.2, "Upper qT AP cut for Sigma candidates (GeV/c)"};
-  Configurable<float> cutEtaDaught{"cutEtaDaughter", 0.8f, "Eta cut for daughter tracks"};
+  Configurable<float> cutEtaDaughter{"cutEtaDaughter", 0.8f, "Eta cut for daughter tracks"};
   Configurable<float> ptMinTOFKinkDau{"ptMinTOFKinkDau", 0.75f, "Minimum pT to require TOF for kink daughter PID (GeV/c)"};
   Configurable<bool> applyTOFPIDKinkDaughter{"applyTOFPIDKinkDaughter", false, "If true, apply TOF PID cut to the kink daughter track"};
 
@@ -136,8 +137,8 @@ struct sigmaHadCorrTask {
   Configurable<bool> useMultNTracksPV{"useMultNTracksPV", false, "If true, use multNTracksPV for multiplicity and mixing bins; if false, use numContrib"};
   Configurable<bool> findLastPartonicMother{"findLastPartonicMother", true, "If true, store the initial hard-scattering parton (last partonic mother). If false, store the last parton before hadronization (first partonic mother)"};
 
-  ConfigurableAxis CfgVtxBins{"CfgVtxBins", {10, -10, 10}, "Mixing bins - z-vertex"};
-  ConfigurableAxis CfgMultBins{"CfgMultBins", {VARIABLE_WIDTH, 0.0, 40.0, 80.0, 500.0}, "Mixing bins - number of contributor"};
+  ConfigurableAxis cfgVtxBins{"cfgVtxBins", {10, -10, 10}, "Mixing bins - z-vertex"};
+  ConfigurableAxis cfgMultBins{"cfgMultBins", {VARIABLE_WIDTH, 0.0, 40.0, 80.0, 500.0}, "Mixing bins - number of contributor"};
   Configurable<int> nEvtMixingBkg{"nEvtMixingBkg", 5, "Number of events to mix for background reconstruction"};
 
   Preslice<aod::KinkCands> kinkCandsPerCollisionPreslice = aod::kinkcand::collisionId;
@@ -222,12 +223,13 @@ struct sigmaHadCorrTask {
   {
     // Sigma- -> n + pi-  (charged daughter = pion, neutral daughter = neutron)
     // Sigma+ -> p + pi0  (charged daughter = proton, neutral daughter = pi0)
+    const float epsilon = 1e-6f;
     float massChargedDau = doSigmaMinus ? o2::constants::physics::MassPionCharged : o2::constants::physics::MassProton;
     float massNeutralDau = doSigmaMinus ? o2::constants::physics::MassNeutron : o2::constants::physics::MassPionNeutral;
     float massSigma = doSigmaMinus ? o2::constants::physics::MassSigmaMinus : o2::constants::physics::MassSigmaPlus;
 
     float pMother = std::sqrt(sigmaPx * sigmaPx + sigmaPy * sigmaPy + sigmaPz * sigmaPz);
-    if (pMother < 1e-6f) {
+    if (pMother < epsilon) {
       return -999.f;
     }
     float versorX = sigmaPx / pMother;
@@ -239,7 +241,7 @@ struct sigmaHadCorrTask {
     float A = 4.f * (eChDau * eChDau - a * a);
     float B = -4.f * a * K;
     float C = 4.f * eChDau * eChDau * massSigma * massSigma - K * K;
-    if (std::abs(A) < 1e-6f) {
+    if (std::abs(A) < epsilon) {
       return -999.f;
     }
     float D = B * B - 4.f * A * C;
@@ -309,8 +311,9 @@ struct sigmaHadCorrTask {
   template <typename TMcParticle, typename TMcParticles>
   int findFirstPartonicMotherPDG(const TMcParticle& mcParticle, const TMcParticles& mcParticles)
   {
+    const int notFoundPdg = -999;
     if (!mcParticle.has_mothers()) {
-      return -999;
+      return notFoundPdg;
     }
     auto motherIds = mcParticle.mothersIds();
     const int defaultMotherSize = 2;
@@ -331,10 +334,10 @@ struct sigmaHadCorrTask {
         return mother.pdgCode();
       }
       int found = findFirstPartonicMotherPDG(mother, mcParticles);
-      if (found != -999)
+      if (found != notFoundPdg)
         return found;
     }
-    return -999;
+    return notFoundPdg;
   }
 
   // Walk up the decay chain iteratively and return the PDG of the last quark or gluon before beam remnants
@@ -403,24 +406,19 @@ struct sigmaHadCorrTask {
     return doSigmaPion ? track.tofNSigmaPi() : track.tofNSigmaPr();
   }
 
-  TLorentzVector trackSum, PartOneCMS, PartTwoCMS, trackRelK;
   float getKStar(float sigmaPx, float sigmaPy, float sigmaPz, float pxHad, float pyHad, float pzHad)
   {
-    TLorentzVector part1; // Sigma
-    TLorentzVector part2; // Hadron track (proton/pion)
-    part1.SetXYZM(sigmaPx, sigmaPy, sigmaPz, getSigmaMassForKstar());
-    part2.SetXYZM(pxHad, pyHad, pzHad, getHadTrackMass());
-    trackSum = part1 + part2;
+    ROOT::Math::PxPyPzMVector part1(sigmaPx, sigmaPy, sigmaPz, getSigmaMassForKstar()); // Sigma
+    ROOT::Math::PxPyPzMVector part2(pxHad, pyHad, pzHad, getHadTrackMass());            // Hadron track (proton/pion)
+    ROOT::Math::PxPyPzMVector trackSum = part1 + part2;
     const float beta = trackSum.Beta();
     const float betax = beta * std::cos(trackSum.Phi()) * std::sin(trackSum.Theta());
     const float betay = beta * std::sin(trackSum.Phi()) * std::sin(trackSum.Theta());
     const float betaz = beta * std::cos(trackSum.Theta());
-    PartOneCMS.SetXYZM(part1.Px(), part1.Py(), part1.Pz(), part1.M());
-    PartTwoCMS.SetXYZM(part2.Px(), part2.Py(), part2.Pz(), part2.M());
     const ROOT::Math::Boost boostPRF = ROOT::Math::Boost(-betax, -betay, -betaz);
-    PartOneCMS = boostPRF(PartOneCMS);
-    PartTwoCMS = boostPRF(PartTwoCMS);
-    trackRelK = PartOneCMS - PartTwoCMS;
+    ROOT::Math::PxPyPzMVector partOneCMS = boostPRF(part1);
+    ROOT::Math::PxPyPzMVector partTwoCMS = boostPRF(part2);
+    ROOT::Math::PxPyPzMVector trackRelK = partOneCMS - partTwoCMS;
     return 0.5 * trackRelK.P();
   }
 
@@ -430,7 +428,7 @@ struct sigmaHadCorrTask {
     if (candidate.pt() < ptMinHad) {
       return false;
     }
-    if (std::abs(getTPCNSigmaHad(candidate)) > cutNSigmaTPC || candidate.tpcNClsFound() < cutNTPCClusHad || std::abs(candidate.eta()) > cutEtaDaught) {
+    if (std::abs(getTPCNSigmaHad(candidate)) > cutNSigmaTPC || candidate.tpcNClsFound() < cutNTPCClusHad || std::abs(candidate.eta()) > cutEtaDaughter) {
       return false;
     }
 
@@ -500,8 +498,8 @@ struct sigmaHadCorrTask {
     return true;
   }
 
-  template <typename Ttrack, typename Tcollision>
-  void fillTreeAndHistograms(aod::KinkCands const& kinkCands, Ttrack const& tracksDauSigma, Ttrack const& tracks, Tcollision const& collision, bool isMC)
+  template <bool IsMC, typename Ttrack, typename Tcollision>
+  void fillTreeAndHistograms(aod::KinkCands const& kinkCands, Ttrack const& tracksDauSigma, Ttrack const& tracks, Tcollision const& collision)
   {
     for (const auto& sigmaCand : kinkCands) {
       auto kinkDauTrack = tracksDauSigma.rawIteratorAt(sigmaCand.trackDaugId());
@@ -528,6 +526,30 @@ struct sigmaHadCorrTask {
       rSigmaHad.fill(HIST("QA/hSigmaPtRecal"), sigmaPtRecal);
       rSigmaHad.fill(HIST("QA/h2InvMassVsPtSigma"), sigmaPtRecal, sigmaMassForQa);
 
+      // single-Sigma-level MC truth record, filled once per accepted candidate, independent of hadron pairing
+      if constexpr (IsMC) {
+        auto mothTrack = tracksDauSigma.rawIteratorAt(sigmaCand.trackMothId());
+        if (mothTrack.has_mcParticle() && kinkDauTrack.has_mcParticle()) {
+          auto mcMoth = mothTrack.template mcParticle_as<aod::McParticles>();
+          auto mcDaug = kinkDauTrack.template mcParticle_as<aod::McParticles>();
+          float massMC = std::sqrt(mcMoth.e() * mcMoth.e() - mcMoth.p() * mcMoth.p());
+          float decayRadiusMC = std::hypot(mcDaug.vx() - mcMoth.vx(), mcDaug.vy() - mcMoth.vy());
+          bool collisionIdCheck = false;
+          if (collision.has_mcCollision()) {
+            collisionIdCheck = collision.mcCollision().globalIndex() == mcDaug.mcCollisionId();
+          }
+          outputKinkCandsMC(sigmaCand.xDecVtx(), sigmaCand.yDecVtx(), sigmaCand.zDecVtx(),
+                            sigmaCand.pxMoth(), sigmaCand.pyMoth(), sigmaCand.pzMoth(),
+                            sigmaCand.pxDaug(), sigmaCand.pyDaug(), sigmaCand.pzDaug(),
+                            sigmaCand.dcaMothPv(), sigmaCand.dcaDaugPv(), sigmaCand.dcaKinkTopo(),
+                            sigmaCand.mothSign(),
+                            kinkDauTrack.tpcNSigmaPi(), kinkDauTrack.tpcNSigmaPr(), -999.f,
+                            kinkDauTrack.tofNSigmaPi(), kinkDauTrack.tofNSigmaPr(), -999.f,
+                            mcMoth.pdgCode(), mcDaug.pdgCode(),
+                            mcMoth.pt(), mcMoth.pz(), massMC, decayRadiusMC, collisionIdCheck);
+        }
+      }
+
       for (const auto& hadTrack : tracks) {
         if (hadTrack.globalIndex() == sigmaCand.trackDaugId()) {
           continue;
@@ -537,7 +559,7 @@ struct sigmaHadCorrTask {
           continue;
         }
 
-        sigmaHadCand candidate;
+        SigmaHadCand candidate;
         candidate.sigmaCharge = sigmaCand.mothSign();
         candidate.sigmaPx = sigmaCand.pxMoth();
         candidate.sigmaPy = sigmaCand.pyMoth();
@@ -575,15 +597,17 @@ struct sigmaHadCorrTask {
         if (hadTrack.hasTOF()) {
           rSigmaHad.fill(HIST("QA/h2TOFNSigmaHadVsPtHad"), candidate.ptHad(), candidate.nSigmaTOFHad);
         }
-        if (fillSparseInvMassKstar && !isMC) {
-          rSigmaHad.fill(HIST("hSparseSigmaHad"),
-                         candidate.sigmaMass,
-                         kStar,
-                         candidate.sigmaCharge,
-                         candidate.chargeHad,
-                         candidate.sigmaDecRadius,
-                         candidate.sigmaCosPA,
-                         sigmaPtRecal);
+        if constexpr (!IsMC) {
+          if (fillSparseInvMassKstar) {
+            rSigmaHad.fill(HIST("hSparseSigmaHad"),
+                           candidate.sigmaMass,
+                           kStar,
+                           candidate.sigmaCharge,
+                           candidate.chargeHad,
+                           candidate.sigmaDecRadius,
+                           candidate.sigmaCosPA,
+                           sigmaPtRecal);
+          }
         }
         sigmaHadCandidates.push_back(candidate);
       }
@@ -595,13 +619,13 @@ struct sigmaHadCorrTask {
     for (auto const& collision : collisions) {
 
       sigmaHadCandidates.clear();
-      auto kinkCands_c = kinkCands.sliceBy(kinkCandsPerCollisionPreslice, collision.globalIndex());
-      auto tracks_c = tracks.sliceBy(tracksPerCollisionPreslice, collision.globalIndex());
-      if (std::abs(collision.posZ()) > cutzvertex || !collision.sel8()) {
+      auto kinkCandsC = kinkCands.sliceBy(kinkCandsPerCollisionPreslice, collision.globalIndex());
+      auto tracksC = tracks.sliceBy(tracksPerCollisionPreslice, collision.globalIndex());
+      if (std::abs(collision.posZ()) > cutZVertex || !collision.sel8()) {
         continue;
       }
       rEventSelection.fill(HIST("hVertexZRec"), collision.posZ());
-      fillTreeAndHistograms(kinkCands_c, tracks, tracks_c, collision, false);
+      fillTreeAndHistograms<false>(kinkCandsC, tracks, tracksC, collision);
       if (fillOutputTree) {
         // Fill output table
         for (const auto& candidate : sigmaHadCandidates) {
@@ -625,7 +649,7 @@ struct sigmaHadCorrTask {
       }
     }
   }
-  PROCESS_SWITCH(sigmaHadCorrTask, processSameEvent, "Process Same event", true);
+  PROCESS_SWITCH(SigmaHadCorr, processSameEvent, "Process Same event", true);
 
   // Processing Event Mixing
   SliceCache cache;
@@ -636,17 +660,17 @@ struct sigmaHadCorrTask {
   {
     if (useMultNTracksPV.value) {
       for (auto const& [collision1, collision2] :
-           selfCombinations(BinningTypeMultNTracksPV{{CfgVtxBins, CfgMultBins}, true}, nEvtMixingBkg, -1, collisions, collisions)) {
+           selfCombinations(BinningTypeMultNTracksPV{{cfgVtxBins, cfgMultBins}, true}, nEvtMixingBkg, -1, collisions, collisions)) {
         if (collision1.index() == collision2.index())
           continue;
         sigmaHadCandidates.clear();
-        if (std::abs(collision1.posZ()) > cutzvertex || !collision1.sel8())
+        if (std::abs(collision1.posZ()) > cutZVertex || !collision1.sel8())
           continue;
-        if (std::abs(collision2.posZ()) > cutzvertex || !collision2.sel8())
+        if (std::abs(collision2.posZ()) > cutZVertex || !collision2.sel8())
           continue;
-        auto kinkCands_c1 = kinkCands.sliceBy(kinkCandsPerCollisionPreslice, collision1.globalIndex());
-        auto tracks_c2 = tracks.sliceBy(tracksPerCollisionPreslice, collision2.globalIndex());
-        fillTreeAndHistograms(kinkCands_c1, tracks, tracks_c2, collision1, false);
+        auto kinkCandsC1 = kinkCands.sliceBy(kinkCandsPerCollisionPreslice, collision1.globalIndex());
+        auto tracksC2 = tracks.sliceBy(tracksPerCollisionPreslice, collision2.globalIndex());
+        fillTreeAndHistograms<false>(kinkCandsC1, tracks, tracksC2, collision1);
         if (fillOutputTree) {
           for (const auto& candidate : sigmaHadCandidates) {
             outputDataTable(candidate.sigmaCharge, candidate.sigmaPx, candidate.sigmaPy, candidate.sigmaPz,
@@ -659,17 +683,17 @@ struct sigmaHadCorrTask {
       }
     } else {
       for (auto const& [collision1, collision2] :
-           selfCombinations(BinningTypeNumContrib{{CfgVtxBins, CfgMultBins}, true}, nEvtMixingBkg, -1, collisions, collisions)) {
+           selfCombinations(BinningTypeNumContrib{{cfgVtxBins, cfgMultBins}, true}, nEvtMixingBkg, -1, collisions, collisions)) {
         if (collision1.index() == collision2.index())
           continue;
         sigmaHadCandidates.clear();
-        if (std::abs(collision1.posZ()) > cutzvertex || !collision1.sel8())
+        if (std::abs(collision1.posZ()) > cutZVertex || !collision1.sel8())
           continue;
-        if (std::abs(collision2.posZ()) > cutzvertex || !collision2.sel8())
+        if (std::abs(collision2.posZ()) > cutZVertex || !collision2.sel8())
           continue;
-        auto kinkCands_c1 = kinkCands.sliceBy(kinkCandsPerCollisionPreslice, collision1.globalIndex());
-        auto tracks_c2 = tracks.sliceBy(tracksPerCollisionPreslice, collision2.globalIndex());
-        fillTreeAndHistograms(kinkCands_c1, tracks, tracks_c2, collision1, false);
+        auto kinkCandsC1 = kinkCands.sliceBy(kinkCandsPerCollisionPreslice, collision1.globalIndex());
+        auto tracksC2 = tracks.sliceBy(tracksPerCollisionPreslice, collision2.globalIndex());
+        fillTreeAndHistograms<false>(kinkCandsC1, tracks, tracksC2, collision1);
         if (fillOutputTree) {
           for (const auto& candidate : sigmaHadCandidates) {
             outputDataTable(candidate.sigmaCharge, candidate.sigmaPx, candidate.sigmaPy, candidate.sigmaPz,
@@ -682,21 +706,21 @@ struct sigmaHadCorrTask {
       }
     }
   }
-  PROCESS_SWITCH(sigmaHadCorrTask, processMixedEvent, "Process Mixed event", false);
+  PROCESS_SWITCH(SigmaHadCorr, processMixedEvent, "Process Mixed event", false);
 
   void processSameEventMC(CollisionsFullMC const& collisions, aod::KinkCands const& kinkCands, TracksFullMC const& tracks, aod::McParticles const& mcParticles)
   {
     for (auto const& collision : collisions) {
 
       sigmaHadCandidates.clear();
-      auto kinkCands_c = kinkCands.sliceBy(kinkCandsPerCollisionPreslice, collision.globalIndex());
-      auto tracks_c = tracks.sliceBy(tracksMCPerCollisionPreslice, collision.globalIndex());
+      auto kinkCandsC = kinkCands.sliceBy(kinkCandsPerCollisionPreslice, collision.globalIndex());
+      auto tracksC = tracks.sliceBy(tracksMCPerCollisionPreslice, collision.globalIndex());
 
-      if (std::abs(collision.posZ()) > cutzvertex || !collision.sel8()) {
+      if (std::abs(collision.posZ()) > cutZVertex || !collision.sel8()) {
         continue;
       }
       rEventSelection.fill(HIST("hVertexZRec"), collision.posZ());
-      fillTreeAndHistograms(kinkCands_c, tracks, tracks_c, collision, true);
+      fillTreeAndHistograms<true>(kinkCandsC, tracks, tracksC, collision);
       for (const auto& candidate : sigmaHadCandidates) {
         auto mcLabelSigma = tracks.rawIteratorAt(candidate.sigmaID);
         auto mcLabelSigmaDau = tracks.rawIteratorAt(candidate.kinkDauID);
@@ -763,24 +787,59 @@ struct sigmaHadCorrTask {
         }
       }
     }
+
+    // all generated Sigma -> chargedDau + neutralDau decays
+    int pdgChargedDauAbs = doSigmaMinus ? PDG_t::kPiPlus : PDG_t::kProton;
+    for (const auto& mcPart : mcParticles) {
+      int pdgMothAbs = std::abs(mcPart.pdgCode());
+      bool isValidMother = doSigmaMinus ? (pdgMothAbs == PDG_t::kSigmaMinus || pdgMothAbs == PDG_t::kSigmaPlus) : (pdgMothAbs == PDG_t::kSigmaPlus);
+      if (!isValidMother) {
+        continue;
+      }
+      bool hasChargedDaughter = false;
+      std::array<float, 3> genDecVtx{-999.f, -999.f, -999.f};
+      int daugPdgCode = 0;
+      for (const auto& daughter : mcPart.daughters_as<aod::McParticles>()) {
+        if (std::abs(daughter.pdgCode()) == pdgChargedDauAbs) {
+          hasChargedDaughter = true;
+          genDecVtx = {daughter.vx(), daughter.vy(), daughter.vz()};
+          daugPdgCode = daughter.pdgCode();
+          break;
+        }
+      }
+      if (!hasChargedDaughter) {
+        continue;
+      }
+      float massMC = std::sqrt(mcPart.e() * mcPart.e() - mcPart.p() * mcPart.p());
+      float decayRadiusMC = std::hypot(genDecVtx[0] - mcPart.vx(), genDecVtx[1] - mcPart.vy());
+      outputKinkCandsMC(-999.f, -999.f, -999.f,
+                        -999.f, -999.f, -999.f,
+                        -999.f, -999.f, -999.f,
+                        -999.f, -999.f, -999.f,
+                        mcPart.pdgCode() > 0 ? 1 : -1,
+                        -999.f, -999.f, -999.f,
+                        -999.f, -999.f, -999.f,
+                        mcPart.pdgCode(), daugPdgCode,
+                        mcPart.pt(), mcPart.pz(), massMC, decayRadiusMC, false);
+    }
   }
-  PROCESS_SWITCH(sigmaHadCorrTask, processSameEventMC, "Process Same event MC", false);
+  PROCESS_SWITCH(SigmaHadCorr, processSameEventMC, "Process Same event MC", false);
 
   void processMixedEventMC(const CollisionsFullMC& collisions, const aod::KinkCands& kinkCands, const TracksFullMC& tracks, const aod::McParticles& mcParticles)
   {
     if (useMultNTracksPV.value) {
       for (auto const& [collision1, collision2] :
-           selfCombinations(BinningTypeMultNTracksPV{{CfgVtxBins, CfgMultBins}, true}, nEvtMixingBkg, -1, collisions, collisions)) {
+           selfCombinations(BinningTypeMultNTracksPV{{cfgVtxBins, cfgMultBins}, true}, nEvtMixingBkg, -1, collisions, collisions)) {
         if (collision1.index() == collision2.index())
           continue;
         sigmaHadCandidates.clear();
-        if (std::abs(collision1.posZ()) > cutzvertex || !collision1.sel8())
+        if (std::abs(collision1.posZ()) > cutZVertex || !collision1.sel8())
           continue;
-        if (std::abs(collision2.posZ()) > cutzvertex || !collision2.sel8())
+        if (std::abs(collision2.posZ()) > cutZVertex || !collision2.sel8())
           continue;
-        auto kinkCands_c1 = kinkCands.sliceBy(kinkCandsPerCollisionPreslice, collision1.globalIndex());
-        auto tracks_c2 = tracks.sliceBy(tracksPerCollisionPreslice, collision2.globalIndex());
-        fillTreeAndHistograms(kinkCands_c1, tracks, tracks_c2, collision1, true);
+        auto kinkCandsC1 = kinkCands.sliceBy(kinkCandsPerCollisionPreslice, collision1.globalIndex());
+        auto tracksC2 = tracks.sliceBy(tracksPerCollisionPreslice, collision2.globalIndex());
+        fillTreeAndHistograms<true>(kinkCandsC1, tracks, tracksC2, collision1);
         for (const auto& candidate : sigmaHadCandidates) {
           auto mcLabelSigma = tracks.rawIteratorAt(candidate.sigmaID);
           auto mcLabelSigmaDau = tracks.rawIteratorAt(candidate.kinkDauID);
@@ -819,17 +878,17 @@ struct sigmaHadCorrTask {
       }
     } else {
       for (auto const& [collision1, collision2] :
-           selfCombinations(BinningTypeNumContrib{{CfgVtxBins, CfgMultBins}, true}, nEvtMixingBkg, -1, collisions, collisions)) {
+           selfCombinations(BinningTypeNumContrib{{cfgVtxBins, cfgMultBins}, true}, nEvtMixingBkg, -1, collisions, collisions)) {
         if (collision1.index() == collision2.index())
           continue;
         sigmaHadCandidates.clear();
-        if (std::abs(collision1.posZ()) > cutzvertex || !collision1.sel8())
+        if (std::abs(collision1.posZ()) > cutZVertex || !collision1.sel8())
           continue;
-        if (std::abs(collision2.posZ()) > cutzvertex || !collision2.sel8())
+        if (std::abs(collision2.posZ()) > cutZVertex || !collision2.sel8())
           continue;
-        auto kinkCands_c1 = kinkCands.sliceBy(kinkCandsPerCollisionPreslice, collision1.globalIndex());
-        auto tracks_c2 = tracks.sliceBy(tracksPerCollisionPreslice, collision2.globalIndex());
-        fillTreeAndHistograms(kinkCands_c1, tracks, tracks_c2, collision1, true);
+        auto kinkCandsC1 = kinkCands.sliceBy(kinkCandsPerCollisionPreslice, collision1.globalIndex());
+        auto tracksC2 = tracks.sliceBy(tracksPerCollisionPreslice, collision2.globalIndex());
+        fillTreeAndHistograms<true>(kinkCandsC1, tracks, tracksC2, collision1);
         for (const auto& candidate : sigmaHadCandidates) {
           auto mcLabelSigma = tracks.rawIteratorAt(candidate.sigmaID);
           auto mcLabelSigmaDau = tracks.rawIteratorAt(candidate.kinkDauID);
@@ -868,10 +927,10 @@ struct sigmaHadCorrTask {
       }
     }
   }
-  PROCESS_SWITCH(sigmaHadCorrTask, processMixedEventMC, "Process Mixed event MC", false);
+  PROCESS_SWITCH(SigmaHadCorr, processMixedEventMC, "Process Mixed event MC", false);
 };
 WorkflowSpec defineDataProcessing(ConfigContext const& cfgc)
 {
   return WorkflowSpec{
-    adaptAnalysisTask<sigmaHadCorrTask>(cfgc)};
+    adaptAnalysisTask<SigmaHadCorr>(cfgc)};
 }

--- a/PWGLF/TableProducer/Strangeness/sigmaplusbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigmaplusbuilder.cxx
@@ -320,12 +320,12 @@ struct Sigmaplusbuilder {
   // photon (electron/positron conversion pair) candidate
   template <typename TTrack>
   struct PhotonCand {
-    float x, y, z;
-    float px, py, pz;
-    float mGamma;
-    float alpha;
-    float qtarm;
-    float radius;
+    float x = 0.f, y = 0.f, z = 0.f;
+    float px = 0.f, py = 0.f, pz = 0.f;
+    float mGamma = 0.f;
+    float alpha = 0.f;
+    float qtarm = 0.f;
+    float radius = 0.f;
     TTrack negTrack;
     TTrack posTrack;
   };

--- a/PWGLF/TableProducer/Strangeness/sigmaplusbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigmaplusbuilder.cxx
@@ -28,9 +28,13 @@
 #include <DataFormatsParameters/GRPMagField.h>
 #include <DetectorsBase/Propagator.h>
 #include <Framework/AnalysisDataModel.h>
+#include <Framework/AnalysisHelpers.h>
 #include <Framework/AnalysisTask.h>
 #include <Framework/Configurable.h>
 #include <Framework/HistogramRegistry.h>
+#include <Framework/HistogramSpec.h>
+#include <Framework/InitContext.h>
+#include <Framework/OutputObjHeader.h>
 #include <Framework/runDataProcessing.h>
 #include <ReconstructionDataFormats/PID.h>
 #include <ReconstructionDataFormats/Track.h>
@@ -98,7 +102,7 @@ struct Sigmaplusbuilder {
   Produces<aod::SigmaPlusCands> sigmaPlusCands;
   Produces<aod::SigmaPlusCandsMC> sigmaPlusCandsMC;
 
-  Service<o2::ccdb::BasicCCDBManager> ccdb;
+  Service<o2::ccdb::BasicCCDBManager> ccdb{};
   o2::vertexing::DCAFitterN<2> fitter;
   int mRunNumber = 0;
   float mBz = 0;
@@ -400,8 +404,8 @@ struct Sigmaplusbuilder {
         }
         fillPhotonStep(5);
 
-        std::array<float, 3> pNeg;
-        std::array<float, 3> pPos;
+        std::array<float, 3> pNeg{};
+        std::array<float, 3> pPos{};
         fitter.getTrack(0).getPxPyPzGlo(pNeg);
         fitter.getTrack(1).getPxPyPzGlo(pPos);
         std::array<float, 3> pGamma{pNeg[0] + pPos[0], pNeg[1] + pPos[1], pNeg[2] + pPos[2]};
@@ -746,8 +750,8 @@ struct Sigmaplusbuilder {
     std::array<float, 3> nHat = normalize3(flightVec);
     float flightDistance = std::sqrt(dot3(flightVec, flightVec));
 
-    std::array<float, 3> pProton;
-    std::array<float, 3> pGamma1;
+    std::array<float, 3> pProton{};
+    std::array<float, 3> pGamma1{};
     fitter.getTrack(0).getPxPyPzGlo(pProton);
     fitter.getTrack(1).getPxPyPzGlo(pGamma1);
 

--- a/PWGLF/TableProducer/Strangeness/sigmaplusbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigmaplusbuilder.cxx
@@ -69,7 +69,6 @@ struct Sigmaplusbuilder {
   Configurable<float> photonMaxDCAV0Dau{"photonMaxDCAV0Dau", 3.5, "Max DCA between photon daughters (cm)"};
   Configurable<float> photonMaxQt{"photonMaxQt", 0.15, "Max Armenteros qT for photons (GeV/c)"};
   Configurable<float> photonMaxAlpha{"photonMaxAlpha", 1.0, "Max |Armenteros alpha| for photons"};
-  Configurable<float> photonMaxTPCNSigmaEl{"photonMaxTPCNSigmaEl", 15, "Max |TPC nSigma_el| for photon daughters"};
 
   // proton selection
   Configurable<float> protonMinPt{"protonMinPt", 0.3, "Minimum proton pT (GeV/c)"};
@@ -123,6 +122,7 @@ struct Sigmaplusbuilder {
     fitter.setMinParamChange(1e-3);
     fitter.setMinRelChi2Change(0.9);
     fitter.setMaxDZIni(1e9);
+    fitter.setMaxDXYIni(1e9);
     fitter.setMaxChi2(1e9);
     fitter.setUseAbsDCA(true);
 
@@ -150,16 +150,16 @@ struct Sigmaplusbuilder {
     histos.add("Photon/hSelectionCounter", "Photon/hSelectionCounter", kTH1F, {axisPhotonSel});
     auto hPhotonSel = histos.get<TH1>(HIST("Photon/hSelectionCounter"));
     hPhotonSel->GetXaxis()->SetBinLabel(1, "All");
-    hPhotonSel->GetXaxis()->SetBinLabel(2, "Mass");
-    hPhotonSel->GetXaxis()->SetBinLabel(3, "Rapidity");
-    hPhotonSel->GetXaxis()->SetBinLabel(4, "Neg eta");
-    hPhotonSel->GetXaxis()->SetBinLabel(5, "Pos eta");
-    hPhotonSel->GetXaxis()->SetBinLabel(6, "DCA daughters");
-    hPhotonSel->GetXaxis()->SetBinLabel(7, "Radius");
-    hPhotonSel->GetXaxis()->SetBinLabel(8, "CosPA");
+    hPhotonSel->GetXaxis()->SetBinLabel(2, "Neg eta");
+    hPhotonSel->GetXaxis()->SetBinLabel(3, "Pos eta");
+    hPhotonSel->GetXaxis()->SetBinLabel(4, "Vertex fit");
+    hPhotonSel->GetXaxis()->SetBinLabel(5, "DCA daughters");
+    hPhotonSel->GetXaxis()->SetBinLabel(6, "Radius");
+    hPhotonSel->GetXaxis()->SetBinLabel(7, "CosPA");
+    hPhotonSel->GetXaxis()->SetBinLabel(8, "Rapidity");
     hPhotonSel->GetXaxis()->SetBinLabel(9, "Qt");
     hPhotonSel->GetXaxis()->SetBinLabel(10, "Alpha");
-    hPhotonSel->GetXaxis()->SetBinLabel(11, "TPC nSigma el");
+    hPhotonSel->GetXaxis()->SetBinLabel(11, "Mass");
 
     histos.add("Photon/hMass", "Photon/hMass", kTH1F, {axisPhotonMass});
     histos.add("Photon/hPt", "Photon/hPt", kTH1F, {axisPhotonPt});
@@ -210,16 +210,16 @@ struct Sigmaplusbuilder {
       histos.add("Photon/True/hSelectionCounter", "Photon/True/hSelectionCounter", kTH1F, {axisPhotonSel});
       auto hPhotonSelSignal = histos.get<TH1>(HIST("Photon/True/hSelectionCounter"));
       hPhotonSelSignal->GetXaxis()->SetBinLabel(1, "All");
-      hPhotonSelSignal->GetXaxis()->SetBinLabel(2, "Mass");
-      hPhotonSelSignal->GetXaxis()->SetBinLabel(3, "Rapidity");
-      hPhotonSelSignal->GetXaxis()->SetBinLabel(4, "Neg eta");
-      hPhotonSelSignal->GetXaxis()->SetBinLabel(5, "Pos eta");
-      hPhotonSelSignal->GetXaxis()->SetBinLabel(6, "DCA daughters");
-      hPhotonSelSignal->GetXaxis()->SetBinLabel(7, "Radius");
-      hPhotonSelSignal->GetXaxis()->SetBinLabel(8, "CosPA");
+      hPhotonSelSignal->GetXaxis()->SetBinLabel(2, "Neg eta");
+      hPhotonSelSignal->GetXaxis()->SetBinLabel(3, "Pos eta");
+      hPhotonSelSignal->GetXaxis()->SetBinLabel(4, "Vertex fit");
+      hPhotonSelSignal->GetXaxis()->SetBinLabel(5, "DCA daughters");
+      hPhotonSelSignal->GetXaxis()->SetBinLabel(6, "Radius");
+      hPhotonSelSignal->GetXaxis()->SetBinLabel(7, "CosPA");
+      hPhotonSelSignal->GetXaxis()->SetBinLabel(8, "Rapidity");
       hPhotonSelSignal->GetXaxis()->SetBinLabel(9, "Qt");
       hPhotonSelSignal->GetXaxis()->SetBinLabel(10, "Alpha");
-      hPhotonSelSignal->GetXaxis()->SetBinLabel(11, "TPC nSigma el");
+      hPhotonSelSignal->GetXaxis()->SetBinLabel(11, "Mass");
 
       histos.add("Photon/True/hMass", "Photon/True/hMass", kTH1F, {axisPhotonMass});
       histos.add("Photon/True/hPt", "Photon/True/hPt", kTH1F, {axisPhotonPt});
@@ -291,6 +291,7 @@ struct Sigmaplusbuilder {
       histos.add("Findable/hPhotonMomentumResolution", "Findable/hPhotonMomentumResolution", kTH1F, {axisPhotonMomResolution});
       histos.add("Findable/hPhotonCosPA", "Findable/hPhotonCosPA", kTH1F, {axisPhotonCosPA});
       histos.add("Findable/hConversionPairV0Presence", "Findable/hConversionPairV0Presence", kTH1F, {axisV0Presence});
+      histos.add("Findable/hPhotonSearchPresence", "Findable/hPhotonSearchPresence", kTH1F, {axisV0Presence});
       histos.add("Findable/hDuplicateConversionTrackCounter", "Findable/hDuplicateConversionTrackCounter", kTH1F, {axisDuplicateTrack});
       histos.add("Findable/hDuplicateElectronTPCNClsFound", "Findable/hDuplicateElectronTPCNClsFound", kTH1F, {axisTPCClusters});
       histos.add("Findable/hDuplicatePositronTPCNClsFound", "Findable/hDuplicatePositronTPCNClsFound", kTH1F, {axisTPCClusters});
@@ -299,6 +300,9 @@ struct Sigmaplusbuilder {
       auto hConversionPairV0Presence = histos.get<TH1>(HIST("Findable/hConversionPairV0Presence"));
       hConversionPairV0Presence->GetXaxis()->SetBinLabel(1, "valid pair");
       hConversionPairV0Presence->GetXaxis()->SetBinLabel(2, "in V0");
+      auto hPhotonSearchPresence = histos.get<TH1>(HIST("Findable/hPhotonSearchPresence"));
+      hPhotonSearchPresence->GetXaxis()->SetBinLabel(1, "valid pair");
+      hPhotonSearchPresence->GetXaxis()->SetBinLabel(2, "found by findPhotons");
       auto hDuplicateConversionTrackCounter = histos.get<TH1>(HIST("Findable/hDuplicateConversionTrackCounter"));
       hDuplicateConversionTrackCounter->GetXaxis()->SetBinLabel(1, "e^{-}");
       hDuplicateConversionTrackCounter->GetXaxis()->SetBinLabel(2, "e^{+}");
@@ -313,90 +317,145 @@ struct Sigmaplusbuilder {
     }
   }
 
-  // photon (PCM) candidate selection
-  template <bool IsMC, typename TTracks, typename TV0>
-  bool selectPhoton(const TV0& v0)
+  // photon (electron/positron conversion pair) candidate
+  template <typename TTrack>
+  struct PhotonCand {
+    float x, y, z;
+    float px, py, pz;
+    float mGamma;
+    float alpha;
+    float qtarm;
+    float radius;
+    TTrack negTrack;
+    TTrack posTrack;
+  };
+
+  // photon (PCM) candidate search: pair up all neg/pos tracks in the collision and fit a common vertex ourselves
+  template <bool IsMC, typename TTracks>
+  std::vector<PhotonCand<typename TTracks::iterator>> findPhotons(const TTracks& tracks, const std::array<float, 3>& pv)
   {
-    auto posTrack = v0.template posTrack_as<TTracks>();
-    auto negTrack = v0.template negTrack_as<TTracks>();
+    std::vector<PhotonCand<typename TTracks::iterator>> photons;
 
-    bool isSignal = false;
-    if constexpr (IsMC) {
-      if (posTrack.has_mcParticle() && negTrack.has_mcParticle()) {
-        auto mcPos = posTrack.template mcParticle_as<aod::McParticles>();
-        auto mcNeg = negTrack.template mcParticle_as<aod::McParticles>();
-        isSignal = findSigmaPlusMotherOfPhoton(mcPos, mcNeg) >= 0;
+    for (const auto& negTrack : tracks) {
+      if (negTrack.sign() > 0) {
+        continue;
       }
-    }
-
-    auto fillPhotonStep = [&](int step) {
-      histos.fill(HIST("Photon/hSelectionCounter"), step);
-      if constexpr (IsMC) {
-        if (isSignal) {
-          histos.fill(HIST("Photon/True/hSelectionCounter"), step);
+      for (const auto& posTrack : tracks) {
+        if (posTrack.sign() < 0) {
+          continue;
         }
+
+        bool isSignal = false;
+        if constexpr (IsMC) {
+          if (posTrack.has_mcParticle() && negTrack.has_mcParticle()) {
+            auto mcPos = posTrack.template mcParticle_as<aod::McParticles>();
+            auto mcNeg = negTrack.template mcParticle_as<aod::McParticles>();
+            isSignal = findSigmaPlusMotherOfPhoton(mcPos, mcNeg) >= 0;
+          }
+        }
+
+        auto fillPhotonStep = [&](int step) {
+          histos.fill(HIST("Photon/hSelectionCounter"), step);
+          if constexpr (IsMC) {
+            if (isSignal) {
+              histos.fill(HIST("Photon/True/hSelectionCounter"), step);
+            }
+          }
+        };
+        fillPhotonStep(0);
+
+        if (negTrack.eta() < photonDauEtaMin || negTrack.eta() > photonDauEtaMax) {
+          continue;
+        }
+        fillPhotonStep(1);
+
+        if (posTrack.eta() < photonDauEtaMin || posTrack.eta() > photonDauEtaMax) {
+          continue;
+        }
+        fillPhotonStep(2);
+
+        auto negTrackParCov = getTrackParCov(negTrack);
+        auto posTrackParCov = getTrackParCov(posTrack);
+        int nCand = 0;
+        try {
+          nCand = fitter.process(negTrackParCov, posTrackParCov);
+        } catch (...) {
+          continue;
+        }
+        if (nCand == 0 || !fitter.propagateTracksToVertex()) {
+          continue;
+        }
+        fillPhotonStep(3);
+
+        float dcaDaughters = std::sqrt(fitter.getChi2AtPCACandidate());
+        if (dcaDaughters > photonMaxDCAV0Dau) {
+          continue;
+        }
+        fillPhotonStep(4);
+
+        std::array<float, 3> secVtx = fitter.getPCACandidatePos();
+        float radius = std::hypot(secVtx[0], secVtx[1]);
+        if (radius < photonMinRadius || radius > photonMaxRadius) {
+          continue;
+        }
+        fillPhotonStep(5);
+
+        std::array<float, 3> pNeg;
+        std::array<float, 3> pPos;
+        fitter.getTrack(0).getPxPyPzGlo(pNeg);
+        fitter.getTrack(1).getPxPyPzGlo(pPos);
+        std::array<float, 3> pGamma{pNeg[0] + pPos[0], pNeg[1] + pPos[1], pNeg[2] + pPos[2]};
+        float gammaP = std::sqrt(dot3(pGamma, pGamma));
+
+        std::array<float, 3> flightVec{secVtx[0] - pv[0], secVtx[1] - pv[1], secVtx[2] - pv[2]};
+        float flightNorm = std::sqrt(dot3(flightVec, flightVec));
+        float cosPA = dot3(flightVec, pGamma) / (flightNorm * gammaP);
+        if (cosPA < photonMinV0cospa) {
+          continue;
+        }
+        fillPhotonStep(6);
+
+        float photonY = RecoDecay::y(pGamma, o2::constants::physics::MassGamma);
+        if (photonY < photonMinRapidity || photonY > photonMaxRapidity) {
+          continue;
+        }
+        fillPhotonStep(7);
+
+        float qLNeg = dot3(pNeg, pGamma) / gammaP;
+        float qLPos = dot3(pPos, pGamma) / gammaP;
+        float alpha = (qLPos - qLNeg) / (qLPos + qLNeg);
+        float qtarm = std::sqrt(std::max(dot3(pNeg, pNeg) - qLNeg * qLNeg, 0.f));
+        if (qtarm > photonMaxQt) {
+          continue;
+        }
+        fillPhotonStep(8);
+
+        if (std::abs(alpha) > photonMaxAlpha) {
+          continue;
+        }
+        fillPhotonStep(9);
+
+        constexpr float MassEl = o2::constants::physics::MassElectron;
+        float eNeg = std::sqrt(dot3(pNeg, pNeg) + MassEl * MassEl);
+        float ePos = std::sqrt(dot3(pPos, pPos) + MassEl * MassEl);
+        float mGamma2 = (eNeg + ePos) * (eNeg + ePos) - gammaP * gammaP;
+        if (mGamma2 < 0.f || std::sqrt(mGamma2) > photonMaxMass) {
+          continue;
+        }
+        float mGamma = std::sqrt(mGamma2);
+        fillPhotonStep(10);
+
+        histos.fill(HIST("Photon/hMass"), mGamma);
+        histos.fill(HIST("Photon/hPt"), std::hypot(pGamma[0], pGamma[1]));
+        histos.fill(HIST("Photon/hRadius"), radius);
+        histos.fill(HIST("Photon/h2ArmenterosPodolanski"), alpha, qtarm);
+        histos.fill(HIST("Photon/h2ConvPointXY"), secVtx[0], secVtx[1]);
+
+        photons.push_back({secVtx[0], secVtx[1], secVtx[2], pGamma[0], pGamma[1], pGamma[2], mGamma, alpha, qtarm, radius, negTrack, posTrack});
       }
-    };
-    fillPhotonStep(0);
-
-    if (v0.mGamma() < 0 || v0.mGamma() > photonMaxMass) {
-      return false;
     }
-    fillPhotonStep(1);
 
-    float photonY = RecoDecay::y(std::array{v0.px(), v0.py(), v0.pz()}, o2::constants::physics::MassGamma);
-    if (photonY < photonMinRapidity || photonY > photonMaxRapidity) {
-      return false;
-    }
-    fillPhotonStep(2);
-
-    if (v0.negativeeta() < photonDauEtaMin || v0.negativeeta() > photonDauEtaMax) {
-      return false;
-    }
-    fillPhotonStep(3);
-
-    if (v0.positiveeta() < photonDauEtaMin || v0.positiveeta() > photonDauEtaMax) {
-      return false;
-    }
-    fillPhotonStep(4);
-
-    if (std::abs(v0.dcaV0daughters()) > photonMaxDCAV0Dau) {
-      return false;
-    }
-    fillPhotonStep(5);
-
-    if (v0.v0radius() < photonMinRadius || v0.v0radius() > photonMaxRadius) {
-      return false;
-    }
-    fillPhotonStep(6);
-
-    if (v0.v0cosPA() < photonMinV0cospa) {
-      return false;
-    }
-    fillPhotonStep(7);
-
-    if (v0.qtarm() > photonMaxQt) {
-      return false;
-    }
-    fillPhotonStep(8);
-
-    if (std::abs(v0.alpha()) > photonMaxAlpha) {
-      return false;
-    }
-    fillPhotonStep(9);
-
-    if (std::abs(posTrack.tpcNSigmaEl()) > photonMaxTPCNSigmaEl || std::abs(negTrack.tpcNSigmaEl()) > photonMaxTPCNSigmaEl) {
-      return false;
-    }
-    fillPhotonStep(10);
-
-    histos.fill(HIST("Photon/hMass"), v0.mGamma());
-    histos.fill(HIST("Photon/hPt"), v0.pt());
-    histos.fill(HIST("Photon/hRadius"), v0.v0radius());
-    histos.fill(HIST("Photon/h2ArmenterosPodolanski"), v0.alpha(), v0.qtarm());
-    histos.fill(HIST("Photon/h2ConvPointXY"), v0.x(), v0.y());
-
-    return true;
+    return photons;
   }
 
   // proton candidate selection
@@ -562,16 +621,19 @@ struct Sigmaplusbuilder {
   }
 
   // Build a Sigma+ -> p pi0 candidate from a proton track and a PCM photon
-  template <bool IsMC, typename TTracks, typename TTrack, typename TV0>
-  void buildSigmaPlusCandidate(const TTrack& protonTrack, const TV0& photon, const std::array<float, 3>& pv)
+  // Returns the MC index of the matched true Sigma+ mother if a signal candidate was built, -1 otherwise
+  template <bool IsMC, typename TTrack, typename TPhotonTrack>
+  int buildSigmaPlusCandidate(const TTrack& protonTrack, const PhotonCand<TPhotonTrack>& photon, const std::array<float, 3>& pv)
   {
-    auto posTrack = photon.template posTrack_as<TTracks>();
-    auto negTrack = photon.template negTrack_as<TTracks>();
+    auto posTrack = photon.posTrack;
+    auto negTrack = photon.negTrack;
 
     bool isSignal = false;
-    std::array<float, 3> mcTrueVtx{};       // Sigma+ decay vertex
-    std::array<float, 3> mcTrueMomProton{}; // true MC proton momentum
-    std::array<float, 3> mcTrueMomGamma{};  // true MC momentum of the measured photon
+    std::array<float, 3> mcTrueVtx{};          // Sigma+ decay vertex
+    std::array<float, 3> mcTrueMomProton{};    // true MC proton momentum
+    std::array<float, 3> mcTrueMomGamma{};     // true MC momentum of the measured photon
+    std::array<float, 3> mcTrueMomSigmaPlus{}; // true MC momentum of the Sigma+ mother
+    int matchedSigmaId = -1;
     int protonPdgCode = 0;
     int protonMotherPdgCode = 0;
     int gammaPdgCode = 0;
@@ -617,6 +679,8 @@ struct Sigmaplusbuilder {
         if (isSignal) {
           mcTrueVtx = {mcProton.vx(), mcProton.vy(), mcProton.vz()};
           mcTrueMomProton = {mcProton.px(), mcProton.py(), mcProton.pz()};
+          mcTrueMomSigmaPlus = {protonMothers.front().px(), protonMothers.front().py(), protonMothers.front().pz()};
+          matchedSigmaId = protonMothers.front().globalIndex();
         }
       }
     }
@@ -634,7 +698,7 @@ struct Sigmaplusbuilder {
     auto protonTrackParCov = getTrackParCov(protonTrack);
 
     std::array<float, 21> zeroCov{};
-    auto photonTrackParCov = o2::track::TrackParCov({photon.x(), photon.y(), photon.z()}, {photon.px(), photon.py(), photon.pz()}, zeroCov, 0, true);
+    auto photonTrackParCov = o2::track::TrackParCov({photon.x, photon.y, photon.z}, {photon.px, photon.py, photon.pz}, zeroCov, 0, true);
     photonTrackParCov.setAbsCharge(0);
     photonTrackParCov.setPID(o2::track::PID::Photon);
 
@@ -642,10 +706,10 @@ struct Sigmaplusbuilder {
     try {
       nCand = fitter.process(protonTrackParCov, photonTrackParCov);
     } catch (...) {
-      return;
+      return -1;
     }
     if (nCand == 0 || !fitter.propagateTracksToVertex()) {
-      return;
+      return -1;
     }
     fillCandStep(1); // Vertex fit
 
@@ -658,7 +722,7 @@ struct Sigmaplusbuilder {
       }
     }
     if (dcaProtonGamma > candMaxDcaProtonGamma) {
-      return;
+      return -1;
     }
     fillCandStep(2); // DCA(p,gamma)
 
@@ -673,7 +737,7 @@ struct Sigmaplusbuilder {
       }
     }
     if (radius < candMinRadius || radius > candMaxRadius) {
-      return;
+      return -1;
     }
     fillCandStep(3); // radius
 
@@ -770,7 +834,7 @@ struct Sigmaplusbuilder {
       }
     }
     if (discriminant < 0.f) {
-      return;
+      return -1;
     }
     fillCandStep(4); // real root
 
@@ -802,7 +866,7 @@ struct Sigmaplusbuilder {
       }
     }
     if (!haveCandidate) {
-      return;
+      return -1;
     }
     fillCandStep(5); // valid root
 
@@ -825,12 +889,12 @@ struct Sigmaplusbuilder {
     float photonOpeningAngle = std::acos(std::clamp(dot3(pPosDau, pNegDau) / std::sqrt(dot3(pPosDau, pPosDau) * dot3(pNegDau, pNegDau)), -1.f, 1.f));
 
     // photon pointing angle: angle between the fitted photon momentum and the line from its conversion point to the p-gamma decay vertex
-    std::array<float, 3> convToDecVtx{secVtx[0] - photon.x(), secVtx[1] - photon.y(), secVtx[2] - photon.z()};
+    std::array<float, 3> convToDecVtx{secVtx[0] - photon.x, secVtx[1] - photon.y, secVtx[2] - photon.z};
     float photonPointingAngle = std::acos(std::clamp(dot3(pGamma1, convToDecVtx) / std::sqrt(dot3(pGamma1, pGamma1) * dot3(convToDecVtx, convToDecVtx)), -1.f, 1.f));
 
     // photon DCA to PV: distance from the PV to the line through the conversion point along the photon momentum direction
-    std::array<float, 3> convPoint{photon.x(), photon.y(), photon.z()};
-    std::array<float, 3> photonDir = normalize3({photon.px(), photon.py(), photon.pz()});
+    std::array<float, 3> convPoint{photon.x, photon.y, photon.z};
+    std::array<float, 3> photonDir = normalize3({photon.px, photon.py, photon.pz});
     std::array<float, 3> pvToConv{pv[0] - convPoint[0], pv[1] - convPoint[1], pv[2] - convPoint[2]};
     std::array<float, 3> pvToConvCrossDir = cross3(pvToConv, photonDir);
     float photonDcaToPV = std::sqrt(dot3(pvToConvCrossDir, pvToConvCrossDir));
@@ -843,7 +907,7 @@ struct Sigmaplusbuilder {
                        bestMomGamma2[0], bestMomGamma2[1], bestMomGamma2[2],
                        protonTrack.tpcNSigmaPr(), protonTrack.tofNSigmaPr(),
                        posTrack.tpcNSigmaEl(), negTrack.tpcNSigmaEl(),
-                       photon.mGamma(), photon.alpha(), photon.qtarm(), photon.v0radius(),
+                       photon.mGamma, photon.alpha, photon.qtarm, photon.radius,
                        photonOpeningAngle, photonPointingAngle, photonDcaToPV,
                        protonTrack.itsNCls(), protonTrack.tpcNClsFound(), protonTrack.dcaXY(), protonTrack.dcaZ(),
                        posTrack.itsNCls(), posTrack.tpcNClsFound(), negTrack.itsNCls(), negTrack.tpcNClsFound(),
@@ -852,7 +916,8 @@ struct Sigmaplusbuilder {
                        gammaPdgCode, gammaMotherPdgCode, gammaGMotherPdgCode,
                        mcTrueVtx[0], mcTrueVtx[1], mcTrueVtx[2],
                        mcTrueMomProton[0], mcTrueMomProton[1], mcTrueMomProton[2],
-                       mcTrueMomGamma[0], mcTrueMomGamma[1], mcTrueMomGamma[2]);
+                       mcTrueMomGamma[0], mcTrueMomGamma[1], mcTrueMomGamma[2],
+                       mcTrueMomSigmaPlus[0], mcTrueMomSigmaPlus[1], mcTrueMomSigmaPlus[2]);
     } else {
       sigmaPlusCands(secVtx[0], secVtx[1], secVtx[2],
                      radius, flightDistance, dcaProtonGamma, fitChi2,
@@ -861,11 +926,12 @@ struct Sigmaplusbuilder {
                      bestMomGamma2[0], bestMomGamma2[1], bestMomGamma2[2],
                      protonTrack.tpcNSigmaPr(), protonTrack.tofNSigmaPr(),
                      posTrack.tpcNSigmaEl(), negTrack.tpcNSigmaEl(),
-                     photon.mGamma(), photon.alpha(), photon.qtarm(), photon.v0radius(),
+                     photon.mGamma, photon.alpha, photon.qtarm, photon.radius,
                      photonOpeningAngle, photonPointingAngle, photonDcaToPV,
                      protonTrack.itsNCls(), protonTrack.tpcNClsFound(), protonTrack.dcaXY(), protonTrack.dcaZ(),
                      posTrack.itsNCls(), posTrack.tpcNClsFound(), negTrack.itsNCls(), negTrack.tpcNClsFound());
     }
+    return matchedSigmaId;
   }
 
   void initCCDB(aod::BCs::iterator const& bc)
@@ -881,22 +947,17 @@ struct Sigmaplusbuilder {
     LOG(info) << "Task initialized for run " << mRunNumber << " with magnetic field " << mBz << " kZG";
   }
 
-  void processData(CollisionsFull const& collisions, aod::V0Datas const& v0s, TracksFull const& tracks, aod::BCs const&)
+  void processData(CollisionsFull const& collisions, TracksFull const& tracks, aod::BCs const&)
   {
     for (const auto& collision : collisions) {
       initCCDB(collision.bc_as<aod::BCs>());
       histos.fill(HIST("hVertexZ"), collision.posZ());
       std::array<float, 3> pv{collision.posX(), collision.posY(), collision.posZ()};
 
-      auto v0sThisCollision = v0s.sliceBy(v0PerCollision, collision.globalIndex());
-      std::vector<aod::V0Datas::iterator> acceptedPhotons;
-      for (const auto& v0 : v0sThisCollision) {
-        if (selectPhoton<false, TracksFull>(v0)) {
-          acceptedPhotons.push_back(v0);
-        }
-      }
-
       auto tracksThisCollision = tracks.sliceBy(tracksPerCollision, collision.globalIndex());
+
+      auto acceptedPhotons = findPhotons<false>(tracksThisCollision, pv);
+
       std::vector<TracksFull::iterator> acceptedProtons;
       for (const auto& track : tracksThisCollision) {
         if (selectProton(track)) {
@@ -906,53 +967,52 @@ struct Sigmaplusbuilder {
 
       for (const auto& photon : acceptedPhotons) {
         for (const auto& proton : acceptedProtons) {
-          buildSigmaPlusCandidate<false, TracksFull>(proton, photon, pv);
+          buildSigmaPlusCandidate<false>(proton, photon, pv);
         }
       }
     }
   }
   PROCESS_SWITCH(Sigmaplusbuilder, processData, "Process data", true);
 
-  void processMc(CollisionsFullMC const& collisions, aod::V0Datas const& v0s, TracksFullMC const& tracks, aod::BCs const&, aod::McParticles const& mcParticles)
+  void processMc(CollisionsFullMC const& collisions, TracksFullMC const& tracks, aod::BCs const&, aod::McParticles const& mcParticles)
   {
+    std::vector<int> matchedSigmaPlusMcIds; // Sigma+ MC indices that got at least one signal candidate
+
     for (const auto& collision : collisions) {
       initCCDB(collision.bc_as<aod::BCs>());
       histos.fill(HIST("hVertexZ"), collision.posZ());
       std::array<float, 3> pv{collision.posX(), collision.posY(), collision.posZ()};
 
-      auto v0sThisCollision = v0s.sliceBy(v0PerCollision, collision.globalIndex());
-      std::vector<aod::V0Datas::iterator> acceptedPhotons;
-      for (const auto& v0 : v0sThisCollision) {
-        if (selectPhoton<true, TracksFullMC>(v0)) {
-          acceptedPhotons.push_back(v0);
+      auto tracksThisCollision = tracks.sliceBy(tracksPerCollisionMC, collision.globalIndex());
 
-          histos.fill(HIST("MC/hPhotonTruthQA"), 0);
-          auto posTrack = v0.template posTrack_as<TracksFullMC>();
-          auto negTrack = v0.template negTrack_as<TracksFullMC>();
-          if (posTrack.has_mcParticle() && negTrack.has_mcParticle()) {
-            histos.fill(HIST("MC/hPhotonTruthQA"), 1);
-            auto mcPos = posTrack.template mcParticle_as<aod::McParticles>();
-            auto mcNeg = negTrack.template mcParticle_as<aod::McParticles>();
+      auto acceptedPhotons = findPhotons<true>(tracksThisCollision, pv);
+      for (const auto& photon : acceptedPhotons) {
+        histos.fill(HIST("MC/hPhotonTruthQA"), 0);
+        auto posTrack = photon.posTrack;
+        auto negTrack = photon.negTrack;
+        if (posTrack.has_mcParticle() && negTrack.has_mcParticle()) {
+          histos.fill(HIST("MC/hPhotonTruthQA"), 1);
+          auto mcPos = posTrack.template mcParticle_as<aod::McParticles>();
+          auto mcNeg = negTrack.template mcParticle_as<aod::McParticles>();
 
-            auto const& posMothers = mcPos.template mothers_as<aod::McParticles>();
-            auto const& negMothers = mcNeg.template mothers_as<aod::McParticles>();
-            if (!posMothers.empty() && !negMothers.empty()) {
-              auto mcGamma = posMothers.front();
-              if (mcGamma.globalIndex() == negMothers.front().globalIndex() && mcGamma.pdgCode() == PDG_t::kGamma) {
-                histos.fill(HIST("MC/hPhotonTruthQA"), 2);
-                auto const& pi0Mothers = mcGamma.template mothers_as<aod::McParticles>();
-                if (!pi0Mothers.empty() && std::abs(pi0Mothers.front().pdgCode()) == PDG_t::kPi0) {
-                  histos.fill(HIST("MC/hPhotonTruthQA"), 3);
-                  auto const& sigmaMothers = pi0Mothers.front().template mothers_as<aod::McParticles>();
-                  if (!sigmaMothers.empty() && std::abs(sigmaMothers.front().pdgCode()) == PDG_t::kSigmaPlus) {
-                    histos.fill(HIST("MC/hPhotonTruthQA"), 4);
+          auto const& posMothers = mcPos.template mothers_as<aod::McParticles>();
+          auto const& negMothers = mcNeg.template mothers_as<aod::McParticles>();
+          if (!posMothers.empty() && !negMothers.empty()) {
+            auto mcGamma = posMothers.front();
+            if (mcGamma.globalIndex() == negMothers.front().globalIndex() && mcGamma.pdgCode() == PDG_t::kGamma) {
+              histos.fill(HIST("MC/hPhotonTruthQA"), 2);
+              auto const& pi0Mothers = mcGamma.template mothers_as<aod::McParticles>();
+              if (!pi0Mothers.empty() && std::abs(pi0Mothers.front().pdgCode()) == PDG_t::kPi0) {
+                histos.fill(HIST("MC/hPhotonTruthQA"), 3);
+                auto const& sigmaMothers = pi0Mothers.front().template mothers_as<aod::McParticles>();
+                if (!sigmaMothers.empty() && std::abs(sigmaMothers.front().pdgCode()) == PDG_t::kSigmaPlus) {
+                  histos.fill(HIST("MC/hPhotonTruthQA"), 4);
 
-                    histos.fill(HIST("Photon/True/hMass"), v0.mGamma());
-                    histos.fill(HIST("Photon/True/hPt"), v0.pt());
-                    histos.fill(HIST("Photon/True/hRadius"), v0.v0radius());
-                    histos.fill(HIST("Photon/True/h2ArmenterosPodolanski"), v0.alpha(), v0.qtarm());
-                    histos.fill(HIST("Photon/True/h2ConvPointXY"), v0.x(), v0.y());
-                  }
+                  histos.fill(HIST("Photon/True/hMass"), photon.mGamma);
+                  histos.fill(HIST("Photon/True/hPt"), std::hypot(photon.px, photon.py));
+                  histos.fill(HIST("Photon/True/hRadius"), photon.radius);
+                  histos.fill(HIST("Photon/True/h2ArmenterosPodolanski"), photon.alpha, photon.qtarm);
+                  histos.fill(HIST("Photon/True/h2ConvPointXY"), photon.x, photon.y);
                 }
               }
             }
@@ -960,7 +1020,6 @@ struct Sigmaplusbuilder {
         }
       }
 
-      auto tracksThisCollision = tracks.sliceBy(tracksPerCollisionMC, collision.globalIndex());
       std::vector<TracksFullMC::iterator> acceptedProtons;
       for (const auto& track : tracksThisCollision) {
         if (selectProton(track)) {
@@ -985,25 +1044,69 @@ struct Sigmaplusbuilder {
 
       for (const auto& photon : acceptedPhotons) {
         for (const auto& proton : acceptedProtons) {
-          buildSigmaPlusCandidate<true, TracksFullMC>(proton, photon, pv);
+          int matchedId = buildSigmaPlusCandidate<true>(proton, photon, pv);
+          if (matchedId >= 0) {
+            matchedSigmaPlusMcIds.push_back(matchedId);
+          }
         }
       }
     }
 
     // all generated Sigma+ -> p pi0 decays, regardless of reconstruction
     for (const auto& mcPart : mcParticles) {
-      if (isSigmaPlusToProtonPi0(mcPart)) {
-        histos.fill(HIST("MC/hGenSigmaPlusPt"), mcPart.pt());
+      if (!isSigmaPlusToProtonPi0(mcPart)) {
+        continue;
       }
+      histos.fill(HIST("MC/hGenSigmaPlusPt"), mcPart.pt());
+
+      bool wasReconstructed = std::find(matchedSigmaPlusMcIds.begin(), matchedSigmaPlusMcIds.end(), mcPart.globalIndex()) != matchedSigmaPlusMcIds.end();
+      if (wasReconstructed) {
+        continue;
+      }
+
+      // this true Sigma+ never made it into any signal candidate: still record its truth info,
+      // with the reconstructed-side columns set to -999
+      int pdgProton = mcPart.pdgCode() > 0 ? PDG_t::kProton : PDG_t::kProtonBar;
+      std::array<float, 3> genDecVtx{-999.f, -999.f, -999.f};
+      std::array<float, 3> genMomProton{-999.f, -999.f, -999.f};
+      for (const auto& daughter : mcPart.template daughters_as<aod::McParticles>()) {
+        if (daughter.pdgCode() == pdgProton) {
+          genDecVtx = {daughter.vx(), daughter.vy(), daughter.vz()};
+          genMomProton = {daughter.px(), daughter.py(), daughter.pz()};
+          break;
+        }
+      }
+
+      sigmaPlusCandsMC(-999.f, -999.f, -999.f,
+                       -999.f, -999.f, -999.f, -999.f,
+                       -999.f, -999.f, -999.f,
+                       -999.f, -999.f, -999.f,
+                       -999.f, -999.f, -999.f,
+                       -999.f, -999.f,
+                       -999.f, -999.f,
+                       -999.f, -999.f, -999.f, -999.f,
+                       -999.f, -999.f, -999.f,
+                       0, -999, -999.f, -999.f,
+                       0, -999, 0, -999,
+                       true,
+                       pdgProton, mcPart.pdgCode(),
+                       0, 0, 0,
+                       genDecVtx[0], genDecVtx[1], genDecVtx[2],
+                       genMomProton[0], genMomProton[1], genMomProton[2],
+                       -999.f, -999.f, -999.f,
+                       mcPart.px(), mcPart.py(), mcPart.pz());
     }
   }
   PROCESS_SWITCH(Sigmaplusbuilder, processMc, "Process MC", false);
 
   void processFindable(CollisionsFullMC const& collisions, aod::V0Datas const& v0s, TracksFullMC const& tracks, aod::McParticles const&)
   {
+    constexpr int MinDauTpcCls = 90;
     for (const auto& collision : collisions) {
       auto tracksThisCollision = tracks.sliceBy(tracksPerCollisionMC, collision.globalIndex());
       auto v0sThisCollision = v0s.sliceBy(v0PerCollision, collision.globalIndex());
+      std::array<float, 3> pv{collision.posX(), collision.posY(), collision.posZ()};
+      auto acceptedPhotons = findPhotons<true>(tracksThisCollision, pv);
 
       for (const auto& protonTrack : tracksThisCollision) {
         if (!protonTrack.has_mcParticle()) {
@@ -1035,7 +1138,7 @@ struct Sigmaplusbuilder {
             continue;
           }
 
-          if (electronTrack.tpcNClsFound() < 90 || electronTrack.sign() > 0) {
+          if (electronTrack.tpcNClsFound() < MinDauTpcCls || electronTrack.sign() > 0) {
             continue;
           }
 
@@ -1055,7 +1158,7 @@ struct Sigmaplusbuilder {
               continue;
             }
 
-            if (positronTrack.tpcNClsFound() < 90 || positronTrack.sign() < 0) {
+            if (positronTrack.tpcNClsFound() < MinDauTpcCls || positronTrack.sign() < 0) {
               continue;
             }
 
@@ -1121,10 +1224,10 @@ struct Sigmaplusbuilder {
 
             std::array<float, 3> recoGammaMom{electronTrack.px() + positronTrack.px(), electronTrack.py() + positronTrack.py(), electronTrack.pz() + positronTrack.pz()};
             float recoGammaP = std::sqrt(dot3(recoGammaMom, recoGammaMom));
-            constexpr float electronMass = o2::constants::physics::MassElectron;
+            constexpr float ElectronMass = o2::constants::physics::MassElectron;
             float electronP2 = electronTrack.px() * electronTrack.px() + electronTrack.py() * electronTrack.py() + electronTrack.pz() * electronTrack.pz();
             float positronP2 = positronTrack.px() * positronTrack.px() + positronTrack.py() * positronTrack.py() + positronTrack.pz() * positronTrack.pz();
-            float pairEnergy = std::sqrt(electronP2 + electronMass * electronMass) + std::sqrt(positronP2 + electronMass * electronMass);
+            float pairEnergy = std::sqrt(electronP2 + ElectronMass * ElectronMass) + std::sqrt(positronP2 + ElectronMass * ElectronMass);
             float pairMass2 = pairEnergy * pairEnergy - recoGammaP * recoGammaP;
             histos.fill(HIST("Findable/hElectronPositronMass"), std::sqrt(std::max(pairMass2, 0.f)));
 
@@ -1152,6 +1255,16 @@ struct Sigmaplusbuilder {
               bool sameChargeMatched = posTrack.globalIndex() == positronTrack.globalIndex() && negTrack.globalIndex() == electronTrack.globalIndex();
               if (sameChargeMatched) {
                 histos.fill(HIST("Findable/hConversionPairV0Presence"), 1);
+                break;
+              }
+            }
+
+            histos.fill(HIST("Findable/hPhotonSearchPresence"), 0);
+            for (const auto& photon : acceptedPhotons) {
+              bool sameChargeMatched = photon.posTrack.globalIndex() == positronTrack.globalIndex() && photon.negTrack.globalIndex() == electronTrack.globalIndex();
+              if (sameChargeMatched) {
+                histos.fill(HIST("Findable/hPhotonSearchPresence"), 1);
+                histos.fill(HIST("Findable/hSigmaPlusPtFoundByPhotonSearch"), mcSigmaPlus.pt());
                 break;
               }
             }

--- a/PWGLF/TableProducer/Strangeness/sigmaplusbuilder.cxx
+++ b/PWGLF/TableProducer/Strangeness/sigmaplusbuilder.cxx
@@ -73,6 +73,8 @@ struct Sigmaplusbuilder {
   Configurable<float> photonMaxDCAV0Dau{"photonMaxDCAV0Dau", 3.5, "Max DCA between photon daughters (cm)"};
   Configurable<float> photonMaxQt{"photonMaxQt", 0.15, "Max Armenteros qT for photons (GeV/c)"};
   Configurable<float> photonMaxAlpha{"photonMaxAlpha", 1.0, "Max |Armenteros alpha| for photons"};
+  Configurable<float> photonDauMinTPCNSigmaEl{"photonDauMinTPCNSigmaEl", -5., "Min TPC nSigma_el of the photon daughters"};
+  Configurable<float> photonDauMaxTPCNSigmaEl{"photonDauMaxTPCNSigmaEl", 5., "Max TPC nSigma_el of the photon daughters"};
 
   // proton selection
   Configurable<float> protonMinPt{"protonMinPt", 0.3, "Minimum proton pT (GeV/c)"};
@@ -96,11 +98,15 @@ struct Sigmaplusbuilder {
   Configurable<float> discrRetryPhiPar0{"discrRetryPhiPar0", 0.000129845, "par0 of the delta-phi resolution function"};
   Configurable<float> discrRetryPhiPar1{"discrRetryPhiPar1", 0.00199688, "par1 of the delta-phi resolution function"};
 
+  Configurable<bool> fillSlimTables{"fillSlimTables", false, "write the slim candidate tables instead of the full ones"};
+
   Configurable<std::string> ccdbPath{"ccdbPath", "http://alice-ccdb.cern.ch", "url of the ccdb repository"};
   Configurable<std::string> grpmagPath{"grpmagPath", "GLO/Config/GRPMagField", "CCDB path of the GRPMagField object"};
 
   Produces<aod::SigmaPlusCands> sigmaPlusCands;
   Produces<aod::SigmaPlusCandsMC> sigmaPlusCandsMC;
+  Produces<aod::SlimSigmaPlusCands> slimSigmaPlusCands;
+  Produces<aod::SlimSigmaPlusCandsMC> slimSigmaPlusCandsMC;
 
   Service<o2::ccdb::BasicCCDBManager> ccdb{};
   o2::vertexing::DCAFitterN<2> fitter;
@@ -144,6 +150,7 @@ struct Sigmaplusbuilder {
     const AxisSpec axisAlpha{100, -1., 1., "#alpha_{AP}"};
     const AxisSpec axisQt{100, 0., 0.3, "q_{T,AP} (GeV/c)"};
     const AxisSpec axisConvXY{200, -100., 100., "conv. point (cm)"};
+    const AxisSpec axisNSigmaEl{100, -10., 10., "n#sigma_{el}"};
 
     const AxisSpec axisProtonSel{5, -0.5, 4.5, "selection step"};
     const AxisSpec axisProtonPt{100, 0., 5., "#it{p}_{T,p} (GeV/c)"};
@@ -156,7 +163,7 @@ struct Sigmaplusbuilder {
     hPhotonSel->GetXaxis()->SetBinLabel(1, "All");
     hPhotonSel->GetXaxis()->SetBinLabel(2, "Neg eta");
     hPhotonSel->GetXaxis()->SetBinLabel(3, "Pos eta");
-    hPhotonSel->GetXaxis()->SetBinLabel(4, "Vertex fit");
+    hPhotonSel->GetXaxis()->SetBinLabel(4, "TPC nSigma_{el}");
     hPhotonSel->GetXaxis()->SetBinLabel(5, "DCA daughters");
     hPhotonSel->GetXaxis()->SetBinLabel(6, "Radius");
     hPhotonSel->GetXaxis()->SetBinLabel(7, "CosPA");
@@ -170,6 +177,8 @@ struct Sigmaplusbuilder {
     histos.add("Photon/hRadius", "Photon/hRadius", kTH1F, {axisPhotonRadius});
     histos.add("Photon/h2ArmenterosPodolanski", "Photon/h2ArmenterosPodolanski", kTH2F, {axisAlpha, axisQt});
     histos.add("Photon/h2ConvPointXY", "Photon/h2ConvPointXY", kTH2F, {axisConvXY, axisConvXY});
+    histos.add("Photon/h2TPCNSigmaElPosVsPt", "Photon/h2TPCNSigmaElPosVsPt", kTH2F, {axisPhotonPt, axisNSigmaEl});
+    histos.add("Photon/h2TPCNSigmaElNegVsPt", "Photon/h2TPCNSigmaElNegVsPt", kTH2F, {axisPhotonPt, axisNSigmaEl});
 
     histos.add("Proton/hSelectionCounter", "Proton/hSelectionCounter", kTH1F, {axisProtonSel});
     auto hProtonSel = histos.get<TH1>(HIST("Proton/hSelectionCounter"));
@@ -210,13 +219,13 @@ struct Sigmaplusbuilder {
     const AxisSpec axisDiscrIter{discrRetryMaxIter + 2, -0.5, discrRetryMaxIter + 1.5, "discriminant retry iteration"};
     histos.add("Candidate/hDiscriminantRetryIter", "Candidate/hDiscriminantRetryIter", kTH1F, {axisDiscrIter});
 
-    if (doprocessMc) {
+    if (doprocessMc || doprocessFindable) {
       histos.add("Photon/True/hSelectionCounter", "Photon/True/hSelectionCounter", kTH1F, {axisPhotonSel});
       auto hPhotonSelSignal = histos.get<TH1>(HIST("Photon/True/hSelectionCounter"));
       hPhotonSelSignal->GetXaxis()->SetBinLabel(1, "All");
       hPhotonSelSignal->GetXaxis()->SetBinLabel(2, "Neg eta");
       hPhotonSelSignal->GetXaxis()->SetBinLabel(3, "Pos eta");
-      hPhotonSelSignal->GetXaxis()->SetBinLabel(4, "Vertex fit");
+      hPhotonSelSignal->GetXaxis()->SetBinLabel(4, "TPC nSigma_{el}");
       hPhotonSelSignal->GetXaxis()->SetBinLabel(5, "DCA daughters");
       hPhotonSelSignal->GetXaxis()->SetBinLabel(6, "Radius");
       hPhotonSelSignal->GetXaxis()->SetBinLabel(7, "CosPA");
@@ -224,7 +233,9 @@ struct Sigmaplusbuilder {
       hPhotonSelSignal->GetXaxis()->SetBinLabel(9, "Qt");
       hPhotonSelSignal->GetXaxis()->SetBinLabel(10, "Alpha");
       hPhotonSelSignal->GetXaxis()->SetBinLabel(11, "Mass");
+    }
 
+    if (doprocessMc) {
       histos.add("Photon/True/hMass", "Photon/True/hMass", kTH1F, {axisPhotonMass});
       histos.add("Photon/True/hPt", "Photon/True/hPt", kTH1F, {axisPhotonPt});
       histos.add("Photon/True/hRadius", "Photon/True/hRadius", kTH1F, {axisPhotonRadius});
@@ -281,11 +292,11 @@ struct Sigmaplusbuilder {
     if (doprocessFindable) {
       const AxisSpec axisDetectorPresence{3, -0.5, 2.5, "detector"};
       const AxisSpec axisDuplicateTrack{2, -0.5, 1.5, "track"};
-      const AxisSpec axisV0Presence{2, -0.5, 1.5, "V0 match"};
       const AxisSpec axisTPCClusters{160, -0.5, 159.5, "TPC clusters"};
       const AxisSpec axisPhotonMomResolution{200, -1., 1., "(#it{p}_{reco,#gamma} - #it{p}_{MC,#gamma})/#it{p}_{MC,#gamma}"};
       const AxisSpec axisPhotonCosPA{200, -1., 1., "cosPA_{#gamma}"};
       const AxisSpec axisPairMass{200, 0., 0.1, "m_{e^{+}e^{-}} (GeV/#it{c}^{2})"};
+      const AxisSpec axisV0Presence{2, -0.5, 1.5, "V0 match"};
       histos.add("Findable/hSigmaPlusPt", "Findable/hSigmaPlusPt", kTH1F, {axisSigmaPt});
       histos.add("Findable/h2ProtonPtVsSigmaPlusPt", "Findable/h2ProtonPtVsSigmaPlusPt", kTH2F, {axisSigmaPt, axisMomentum});
       histos.add("Findable/hElectronPt", "Findable/hElectronPt", kTH1F, {axisMomentum});
@@ -301,12 +312,13 @@ struct Sigmaplusbuilder {
       histos.add("Findable/hDuplicatePositronTPCNClsFound", "Findable/hDuplicatePositronTPCNClsFound", kTH1F, {axisTPCClusters});
       histos.add("Findable/hElectronDetectorPresence", "Findable/hElectronDetectorPresence", kTH1F, {axisDetectorPresence});
       histos.add("Findable/hPositronDetectorPresence", "Findable/hPositronDetectorPresence", kTH1F, {axisDetectorPresence});
+
       auto hConversionPairV0Presence = histos.get<TH1>(HIST("Findable/hConversionPairV0Presence"));
       hConversionPairV0Presence->GetXaxis()->SetBinLabel(1, "valid pair");
       hConversionPairV0Presence->GetXaxis()->SetBinLabel(2, "in V0");
       auto hPhotonSearchPresence = histos.get<TH1>(HIST("Findable/hPhotonSearchPresence"));
       hPhotonSearchPresence->GetXaxis()->SetBinLabel(1, "valid pair");
-      hPhotonSearchPresence->GetXaxis()->SetBinLabel(2, "found by findPhotons");
+      hPhotonSearchPresence->GetXaxis()->SetBinLabel(2, "passed photon selection");
       auto hDuplicateConversionTrackCounter = histos.get<TH1>(HIST("Findable/hDuplicateConversionTrackCounter"));
       hDuplicateConversionTrackCounter->GetXaxis()->SetBinLabel(1, "e^{-}");
       hDuplicateConversionTrackCounter->GetXaxis()->SetBinLabel(2, "e^{+}");
@@ -334,129 +346,109 @@ struct Sigmaplusbuilder {
     TTrack posTrack;
   };
 
-  // photon (PCM) candidate search: pair up all neg/pos tracks in the collision and fit a common vertex ourselves
-  template <bool IsMC, typename TTracks>
-  std::vector<PhotonCand<typename TTracks::iterator>> findPhotons(const TTracks& tracks, const std::array<float, 3>& pv)
+  // photon candidates
+  template <bool IsMC, typename TV0s, typename TTracks>
+  std::vector<PhotonCand<typename TTracks::iterator>> findPhotonsFromV0s(const TV0s& v0s, const TTracks&, const std::array<float, 3>& pv)
   {
     std::vector<PhotonCand<typename TTracks::iterator>> photons;
 
-    for (const auto& negTrack : tracks) {
-      if (negTrack.sign() > 0) {
+    for (const auto& v0 : v0s) {
+      auto posTrack = v0.template posTrack_as<TTracks>();
+      auto negTrack = v0.template negTrack_as<TTracks>();
+
+      bool isSignal = false;
+      if constexpr (IsMC) {
+        if (posTrack.has_mcParticle() && negTrack.has_mcParticle()) {
+          auto mcPos = posTrack.template mcParticle_as<aod::McParticles>();
+          auto mcNeg = negTrack.template mcParticle_as<aod::McParticles>();
+          isSignal = findSigmaPlusMotherOfPhoton(mcPos, mcNeg) >= 0;
+        }
+      }
+
+      auto fillPhotonStep = [&](int step) {
+        histos.fill(HIST("Photon/hSelectionCounter"), step);
+        if constexpr (IsMC) {
+          if (isSignal) {
+            histos.fill(HIST("Photon/True/hSelectionCounter"), step);
+          }
+        }
+      };
+      fillPhotonStep(0);
+
+      if (negTrack.eta() < photonDauEtaMin || negTrack.eta() > photonDauEtaMax) {
         continue;
       }
-      for (const auto& posTrack : tracks) {
-        if (posTrack.sign() < 0) {
-          continue;
-        }
+      fillPhotonStep(1);
 
-        bool isSignal = false;
-        if constexpr (IsMC) {
-          if (posTrack.has_mcParticle() && negTrack.has_mcParticle()) {
-            auto mcPos = posTrack.template mcParticle_as<aod::McParticles>();
-            auto mcNeg = negTrack.template mcParticle_as<aod::McParticles>();
-            isSignal = findSigmaPlusMotherOfPhoton(mcPos, mcNeg) >= 0;
-          }
-        }
-
-        auto fillPhotonStep = [&](int step) {
-          histos.fill(HIST("Photon/hSelectionCounter"), step);
-          if constexpr (IsMC) {
-            if (isSignal) {
-              histos.fill(HIST("Photon/True/hSelectionCounter"), step);
-            }
-          }
-        };
-        fillPhotonStep(0);
-
-        if (negTrack.eta() < photonDauEtaMin || negTrack.eta() > photonDauEtaMax) {
-          continue;
-        }
-        fillPhotonStep(1);
-
-        if (posTrack.eta() < photonDauEtaMin || posTrack.eta() > photonDauEtaMax) {
-          continue;
-        }
-        fillPhotonStep(2);
-
-        auto negTrackParCov = getTrackParCov(negTrack);
-        auto posTrackParCov = getTrackParCov(posTrack);
-        int nCand = 0;
-        try {
-          nCand = fitter.process(negTrackParCov, posTrackParCov);
-        } catch (...) {
-          continue;
-        }
-        if (nCand == 0 || !fitter.propagateTracksToVertex()) {
-          continue;
-        }
-        fillPhotonStep(3);
-
-        float dcaDaughters = std::sqrt(fitter.getChi2AtPCACandidate());
-        if (dcaDaughters > photonMaxDCAV0Dau) {
-          continue;
-        }
-        fillPhotonStep(4);
-
-        std::array<float, 3> secVtx = fitter.getPCACandidatePos();
-        float radius = std::hypot(secVtx[0], secVtx[1]);
-        if (radius < photonMinRadius || radius > photonMaxRadius) {
-          continue;
-        }
-        fillPhotonStep(5);
-
-        std::array<float, 3> pNeg{};
-        std::array<float, 3> pPos{};
-        fitter.getTrack(0).getPxPyPzGlo(pNeg);
-        fitter.getTrack(1).getPxPyPzGlo(pPos);
-        std::array<float, 3> pGamma{pNeg[0] + pPos[0], pNeg[1] + pPos[1], pNeg[2] + pPos[2]};
-        float gammaP = std::sqrt(dot3(pGamma, pGamma));
-
-        std::array<float, 3> flightVec{secVtx[0] - pv[0], secVtx[1] - pv[1], secVtx[2] - pv[2]};
-        float flightNorm = std::sqrt(dot3(flightVec, flightVec));
-        float cosPA = dot3(flightVec, pGamma) / (flightNorm * gammaP);
-        if (cosPA < photonMinV0cospa) {
-          continue;
-        }
-        fillPhotonStep(6);
-
-        float photonY = RecoDecay::y(pGamma, o2::constants::physics::MassGamma);
-        if (photonY < photonMinRapidity || photonY > photonMaxRapidity) {
-          continue;
-        }
-        fillPhotonStep(7);
-
-        float qLNeg = dot3(pNeg, pGamma) / gammaP;
-        float qLPos = dot3(pPos, pGamma) / gammaP;
-        float alpha = (qLPos - qLNeg) / (qLPos + qLNeg);
-        float qtarm = std::sqrt(std::max(dot3(pNeg, pNeg) - qLNeg * qLNeg, 0.f));
-        if (qtarm > photonMaxQt) {
-          continue;
-        }
-        fillPhotonStep(8);
-
-        if (std::abs(alpha) > photonMaxAlpha) {
-          continue;
-        }
-        fillPhotonStep(9);
-
-        constexpr float MassEl = o2::constants::physics::MassElectron;
-        float eNeg = std::sqrt(dot3(pNeg, pNeg) + MassEl * MassEl);
-        float ePos = std::sqrt(dot3(pPos, pPos) + MassEl * MassEl);
-        float mGamma2 = (eNeg + ePos) * (eNeg + ePos) - gammaP * gammaP;
-        if (mGamma2 < 0.f || std::sqrt(mGamma2) > photonMaxMass) {
-          continue;
-        }
-        float mGamma = std::sqrt(mGamma2);
-        fillPhotonStep(10);
-
-        histos.fill(HIST("Photon/hMass"), mGamma);
-        histos.fill(HIST("Photon/hPt"), std::hypot(pGamma[0], pGamma[1]));
-        histos.fill(HIST("Photon/hRadius"), radius);
-        histos.fill(HIST("Photon/h2ArmenterosPodolanski"), alpha, qtarm);
-        histos.fill(HIST("Photon/h2ConvPointXY"), secVtx[0], secVtx[1]);
-
-        photons.push_back({secVtx[0], secVtx[1], secVtx[2], pGamma[0], pGamma[1], pGamma[2], mGamma, alpha, qtarm, radius, negTrack, posTrack});
+      if (posTrack.eta() < photonDauEtaMin || posTrack.eta() > photonDauEtaMax) {
+        continue;
       }
+      fillPhotonStep(2);
+
+      histos.fill(HIST("Photon/h2TPCNSigmaElPosVsPt"), posTrack.pt(), posTrack.tpcNSigmaEl());
+      histos.fill(HIST("Photon/h2TPCNSigmaElNegVsPt"), negTrack.pt(), negTrack.tpcNSigmaEl());
+      if (posTrack.tpcNSigmaEl() < photonDauMinTPCNSigmaEl || posTrack.tpcNSigmaEl() > photonDauMaxTPCNSigmaEl ||
+          negTrack.tpcNSigmaEl() < photonDauMinTPCNSigmaEl || negTrack.tpcNSigmaEl() > photonDauMaxTPCNSigmaEl) {
+        continue;
+      }
+      fillPhotonStep(3);
+
+      if (v0.dcaV0daughters() > photonMaxDCAV0Dau) {
+        continue;
+      }
+      fillPhotonStep(4);
+
+      std::array<float, 3> secVtx{v0.x(), v0.y(), v0.z()};
+      float radius = v0.v0radius();
+      if (radius < photonMinRadius || radius > photonMaxRadius) {
+        continue;
+      }
+      fillPhotonStep(5);
+
+      std::array<float, 3> pNeg{v0.pxneg(), v0.pyneg(), v0.pzneg()};
+      std::array<float, 3> pPos{v0.pxpos(), v0.pypos(), v0.pzpos()};
+      std::array<float, 3> pGamma{pNeg[0] + pPos[0], pNeg[1] + pPos[1], pNeg[2] + pPos[2]};
+      float gammaP = std::sqrt(dot3(pGamma, pGamma));
+
+      std::array<float, 3> flightVec{secVtx[0] - pv[0], secVtx[1] - pv[1], secVtx[2] - pv[2]};
+      float flightNorm = std::sqrt(dot3(flightVec, flightVec));
+      float cosPA = dot3(flightVec, pGamma) / (flightNorm * gammaP);
+      if (cosPA < photonMinV0cospa) {
+        continue;
+      }
+      fillPhotonStep(6);
+
+      float photonY = RecoDecay::y(pGamma, o2::constants::physics::MassGamma);
+      if (photonY < photonMinRapidity || photonY > photonMaxRapidity) {
+        continue;
+      }
+      fillPhotonStep(7);
+
+      float qtarm = v0.qtarm();
+      float alpha = v0.alpha();
+      if (qtarm > photonMaxQt) {
+        continue;
+      }
+      fillPhotonStep(8);
+
+      if (std::abs(alpha) > photonMaxAlpha) {
+        continue;
+      }
+      fillPhotonStep(9);
+
+      float mGamma = v0.mGamma();
+      if (mGamma > photonMaxMass) {
+        continue;
+      }
+      fillPhotonStep(10);
+
+      histos.fill(HIST("Photon/hMass"), mGamma);
+      histos.fill(HIST("Photon/hPt"), std::hypot(pGamma[0], pGamma[1]));
+      histos.fill(HIST("Photon/hRadius"), radius);
+      histos.fill(HIST("Photon/h2ArmenterosPodolanski"), alpha, qtarm);
+      histos.fill(HIST("Photon/h2ConvPointXY"), secVtx[0], secVtx[1]);
+
+      photons.push_back({secVtx[0], secVtx[1], secVtx[2], pGamma[0], pGamma[1], pGamma[2], mGamma, alpha, qtarm, radius, negTrack, posTrack});
     }
 
     return photons;
@@ -904,6 +896,20 @@ struct Sigmaplusbuilder {
     float photonDcaToPV = std::sqrt(dot3(pvToConvCrossDir, pvToConvCrossDir));
 
     if constexpr (IsMC) {
+      if (fillSlimTables) {
+        slimSigmaPlusCandsMC(radius, dcaProtonGamma,
+                             pProton[0], pProton[1], pProton[2],
+                             pGamma1[0], pGamma1[1], pGamma1[2],
+                             bestMomGamma2[0], bestMomGamma2[1], bestMomGamma2[2],
+                             protonTrack.tpcNSigmaPr(), protonTrack.tofNSigmaPr(),
+                             posTrack.tpcNSigmaEl(), negTrack.tpcNSigmaEl(),
+                             photon.mGamma,
+                             protonPdgCode, protonMotherPdgCode,
+                             gammaPdgCode, gammaMotherPdgCode, gammaGMotherPdgCode,
+                             std::hypot(mcTrueVtx[0], mcTrueVtx[1]),
+                             mcTrueMomSigmaPlus[0], mcTrueMomSigmaPlus[1], mcTrueMomSigmaPlus[2]);
+        return matchedSigmaId;
+      }
       sigmaPlusCandsMC(secVtx[0], secVtx[1], secVtx[2],
                        radius, flightDistance, dcaProtonGamma, fitChi2,
                        pProton[0], pProton[1], pProton[2],
@@ -923,6 +929,16 @@ struct Sigmaplusbuilder {
                        mcTrueMomGamma[0], mcTrueMomGamma[1], mcTrueMomGamma[2],
                        mcTrueMomSigmaPlus[0], mcTrueMomSigmaPlus[1], mcTrueMomSigmaPlus[2]);
     } else {
+      if (fillSlimTables) {
+        slimSigmaPlusCands(radius, dcaProtonGamma,
+                           pProton[0], pProton[1], pProton[2],
+                           pGamma1[0], pGamma1[1], pGamma1[2],
+                           bestMomGamma2[0], bestMomGamma2[1], bestMomGamma2[2],
+                           protonTrack.tpcNSigmaPr(), protonTrack.tofNSigmaPr(),
+                           posTrack.tpcNSigmaEl(), negTrack.tpcNSigmaEl(),
+                           photon.mGamma);
+        return matchedSigmaId;
+      }
       sigmaPlusCands(secVtx[0], secVtx[1], secVtx[2],
                      radius, flightDistance, dcaProtonGamma, fitChi2,
                      pProton[0], pProton[1], pProton[2],
@@ -951,7 +967,7 @@ struct Sigmaplusbuilder {
     LOG(info) << "Task initialized for run " << mRunNumber << " with magnetic field " << mBz << " kZG";
   }
 
-  void processData(CollisionsFull const& collisions, TracksFull const& tracks, aod::BCs const&)
+  void processData(CollisionsFull const& collisions, aod::V0Datas const& v0s, TracksFull const& tracks, aod::BCs const&)
   {
     for (const auto& collision : collisions) {
       initCCDB(collision.bc_as<aod::BCs>());
@@ -959,8 +975,9 @@ struct Sigmaplusbuilder {
       std::array<float, 3> pv{collision.posX(), collision.posY(), collision.posZ()};
 
       auto tracksThisCollision = tracks.sliceBy(tracksPerCollision, collision.globalIndex());
+      auto v0sThisCollision = v0s.sliceBy(v0PerCollision, collision.globalIndex());
 
-      auto acceptedPhotons = findPhotons<false>(tracksThisCollision, pv);
+      auto acceptedPhotons = findPhotonsFromV0s<false>(v0sThisCollision, tracksThisCollision, pv);
 
       std::vector<TracksFull::iterator> acceptedProtons;
       for (const auto& track : tracksThisCollision) {
@@ -978,7 +995,7 @@ struct Sigmaplusbuilder {
   }
   PROCESS_SWITCH(Sigmaplusbuilder, processData, "Process data", true);
 
-  void processMc(CollisionsFullMC const& collisions, TracksFullMC const& tracks, aod::BCs const&, aod::McParticles const& mcParticles)
+  void processMc(CollisionsFullMC const& collisions, aod::V0Datas const& v0s, TracksFullMC const& tracks, aod::BCs const&, aod::McParticles const& mcParticles)
   {
     std::vector<int> matchedSigmaPlusMcIds; // Sigma+ MC indices that got at least one signal candidate
 
@@ -988,8 +1005,9 @@ struct Sigmaplusbuilder {
       std::array<float, 3> pv{collision.posX(), collision.posY(), collision.posZ()};
 
       auto tracksThisCollision = tracks.sliceBy(tracksPerCollisionMC, collision.globalIndex());
+      auto v0sThisCollision = v0s.sliceBy(v0PerCollision, collision.globalIndex());
 
-      auto acceptedPhotons = findPhotons<true>(tracksThisCollision, pv);
+      auto acceptedPhotons = findPhotonsFromV0s<true>(v0sThisCollision, tracksThisCollision, pv);
       for (const auto& photon : acceptedPhotons) {
         histos.fill(HIST("MC/hPhotonTruthQA"), 0);
         auto posTrack = photon.posTrack;
@@ -1081,6 +1099,21 @@ struct Sigmaplusbuilder {
         }
       }
 
+      if (fillSlimTables) {
+        slimSigmaPlusCandsMC(-999.f, -999.f,
+                             -999.f, -999.f, -999.f,
+                             -999.f, -999.f, -999.f,
+                             -999.f, -999.f, -999.f,
+                             -999.f, -999.f,
+                             -999.f, -999.f,
+                             -999.f,
+                             pdgProton, mcPart.pdgCode(),
+                             0, 0, 0,
+                             std::hypot(genDecVtx[0], genDecVtx[1]),
+                             mcPart.px(), mcPart.py(), mcPart.pz());
+        continue;
+      }
+
       sigmaPlusCandsMC(-999.f, -999.f, -999.f,
                        -999.f, -999.f, -999.f, -999.f,
                        -999.f, -999.f, -999.f,
@@ -1103,14 +1136,15 @@ struct Sigmaplusbuilder {
   }
   PROCESS_SWITCH(Sigmaplusbuilder, processMc, "Process MC", false);
 
-  void processFindable(CollisionsFullMC const& collisions, aod::V0Datas const& v0s, TracksFullMC const& tracks, aod::McParticles const&)
+  void processFindable(CollisionsFullMC const& collisions, aod::V0Datas const& v0s, TracksFullMC const& tracks, aod::McParticles const&, aod::BCs const&)
   {
     constexpr int MinDauTpcCls = 90;
     for (const auto& collision : collisions) {
+      initCCDB(collision.bc_as<aod::BCs>());
       auto tracksThisCollision = tracks.sliceBy(tracksPerCollisionMC, collision.globalIndex());
       auto v0sThisCollision = v0s.sliceBy(v0PerCollision, collision.globalIndex());
       std::array<float, 3> pv{collision.posX(), collision.posY(), collision.posZ()};
-      auto acceptedPhotons = findPhotons<true>(tracksThisCollision, pv);
+      auto acceptedPhotons = findPhotonsFromV0s<true>(v0sThisCollision, tracksThisCollision, pv);
 
       for (const auto& protonTrack : tracksThisCollision) {
         if (!protonTrack.has_mcParticle()) {
@@ -1268,7 +1302,6 @@ struct Sigmaplusbuilder {
               bool sameChargeMatched = photon.posTrack.globalIndex() == positronTrack.globalIndex() && photon.negTrack.globalIndex() == electronTrack.globalIndex();
               if (sameChargeMatched) {
                 histos.fill(HIST("Findable/hPhotonSearchPresence"), 1);
-                histos.fill(HIST("Findable/hSigmaPlusPtFoundByPhotonSearch"), mcSigmaPlus.pt());
                 break;
               }
             }


### PR DESCRIPTION
This PR features:

- A configurable for the pT and rapidity of the MCgen particles with the sigmaHadCorr task, which are saved in the tables (decrease output size)
- Similar cuts added in the sigmaplusbuilder which uses the PCM method for the reconstruction of one of the photons from the pi0 decay
- Added selections for the PCM and sigmaplus reco, similar to what was done for the Run2 studies for this method, and added the necessary tables in the DataModel