### PR TITLE
[PWGHF] Cut variation: add efficiency-related functional

### DIFF
--- a/PWGHF/D2H/Macros/compute_fraction_cutvar.py
+++ b/PWGHF/D2H/Macros/compute_fraction_cutvar.py
@@ -205,14 +205,16 @@ def main(config):
         )
 
     pt_bin_to_process_name_suffix = ""
-    if pt_bin_to_process != -1: pt_bin_to_process_name_suffix = "_bin_" + str(pt_bin_to_process)
+    if pt_bin_to_process != -1:
+        pt_bin_to_process_name_suffix = "_bin_" + str(pt_bin_to_process)
 
     output_name_template = cfg['output']['file'].replace(".root", "") + pt_bin_to_process_name_suffix + ".root"
     output = ROOT.TFile(os.path.join(cfg["output"]["directory"], output_name_template), "recreate")
     n_sets = len(hist_rawy)
     pt_axis_title = hist_rawy[0].GetXaxis().GetTitle()
     for ipt in range(hist_rawy[0].GetNbinsX()):
-        if pt_bin_to_process !=-1 and ipt+1 != pt_bin_to_process: continue
+        if pt_bin_to_process !=-1 and ipt+1 != pt_bin_to_process:
+            continue
         all_vectors_monotonous = MinimisationStatus.Success
         pt_min = hist_rawy[0].GetXaxis().GetBinLowEdge(ipt + 1)
         pt_max = hist_rawy[0].GetXaxis().GetBinUpEdge(ipt + 1)
@@ -280,45 +282,56 @@ def main(config):
             hist_bin_title_rawy = hist_bin_title if is_draw_title[PlotType.Rawy] else ""
             canv_rawy, histos_rawy, leg_r = minimiser.plot_result(f"_pt_{pt_min}_to_{pt_max}", hist_bin_title_rawy)
             output.cd()
-            if is_save_to_root_file[ObjectToSave.Canvas]: canv_rawy.Write()
+            if is_save_to_root_file[ObjectToSave.Canvas]:
+                canv_rawy.Write()
             if is_save_to_root_file[ObjectToSave.RawYield]:
                 for _, hist in histos_rawy.items():
                     hist.Write()
-            if is_save_canvas_as_macro[PlotType.Rawy]: canv_rawy.SaveAs(f"canv_rawy_{ipt+1}.C")
+            if is_save_canvas_as_macro[PlotType.Rawy]:
+                canv_rawy.SaveAs(f"canv_rawy_{ipt+1}.C")
 
             hist_bin_title_unc = hist_bin_title if is_draw_title[PlotType.Unc] else ""
             canv_unc, histos_unc, leg_unc = minimiser.plot_uncertainties(f"_pt_{pt_min}_to_{pt_max}", hist_bin_title_unc)
             output.cd()
-            if is_save_to_root_file[ObjectToSave.Canvas]: canv_unc.Write()
+            if is_save_to_root_file[ObjectToSave.Canvas]:
+                canv_unc.Write()
             if is_save_to_root_file[ObjectToSave.Uncertainty]:
                 for _, hist in histos_unc.items():
                     hist.Write()
-            if is_save_canvas_as_macro[PlotType.Unc]: canv_unc.SaveAs(f"canv_unc_{ipt+1}.C")
+            if is_save_canvas_as_macro[PlotType.Unc]:
+                canv_unc.SaveAs(f"canv_unc_{ipt+1}.C")
 
             hist_bin_title_eff = hist_bin_title if is_draw_title[PlotType.Eff] else ""
             canv_eff, histos_eff, leg_e = minimiser.plot_efficiencies(f"_pt_{pt_min}_to_{pt_max}", hist_bin_title_eff)
             output.cd()
-            if is_save_to_root_file[ObjectToSave.Canvas]: canv_eff.Write()
+            if is_save_to_root_file[ObjectToSave.Canvas]:
+                canv_eff.Write()
             if is_save_to_root_file[ObjectToSave.Efficiency]:
                 for _, hist in histos_eff.items():
                     hist.Write()
-            if is_save_canvas_as_macro[PlotType.Eff]: canv_eff.SaveAs(f"canv_eff_{ipt+1}.C")
+            if is_save_canvas_as_macro[PlotType.Eff]:
+                canv_eff.SaveAs(f"canv_eff_{ipt+1}.C")
 
             hist_bin_title_frac = hist_bin_title if is_draw_title[PlotType.Frac] else ""
             canv_frac, histos_frac, leg_f = minimiser.plot_fractions(f"_pt_{pt_min}_to_{pt_max}", hist_bin_title_frac)
             output.cd()
-            if is_save_to_root_file[ObjectToSave.Canvas]: canv_frac.Write()
+            if is_save_to_root_file[ObjectToSave.Canvas]:
+                canv_frac.Write()
             if is_save_to_root_file[ObjectToSave.Fraction]:
                 for _, hist in histos_frac.items():
                     hist.Write()
-            if is_save_canvas_as_macro[PlotType.Frac]: canv_frac.SaveAs(f"canv_frac_{ipt+1}.C")
+            if is_save_canvas_as_macro[PlotType.Frac]:
+                canv_frac.SaveAs(f"canv_frac_{ipt+1}.C")
 
             hist_bin_title_cov = hist_bin_title if is_draw_title[PlotType.Cov] else ""
             canv_cov, histo_cov = minimiser.plot_cov_matrix(True, f"_pt_{pt_min}_to_{pt_max}", hist_bin_title_cov)
             output.cd()
-            if is_save_to_root_file[ObjectToSave.Canvas]: canv_cov.Write()
-            if is_save_to_root_file[ObjectToSave.CorrelationMatrix]: histo_cov.Write()
-            if is_save_canvas_as_macro[PlotType.Cov]: canv_cov.SaveAs(f"canv_cov_{ipt+1}.C")
+            if is_save_to_root_file[ObjectToSave.Canvas]:
+                canv_cov.Write()
+            if is_save_to_root_file[ObjectToSave.CorrelationMatrix]:
+                histo_cov.Write()
+            if is_save_canvas_as_macro[PlotType.Cov]:
+                canv_cov.SaveAs(f"canv_cov_{ipt+1}.C")
         else:
             print(f"Minimization for pT {pt_min}, {pt_max} not successful")
             hist_minimisation_status.SetBinContent(ipt + 1, MinimisationStatus.Fail)

--- a/PWGHF/D2H/Macros/cut_variation.py
+++ b/PWGHF/D2H/Macros/cut_variation.py
@@ -580,7 +580,8 @@ class CutVarMinimiser:
         hist_raw_yield_sum.Draw("histsame")
         tex = ROOT.TLatex()
         tex.SetTextSize(0.04)
-        tex.DrawLatexNDC(0.05, 0.95, title)
+        tex.SetTextAlign(31)
+        tex.DrawLatexNDC(0.95, 0.95, title)
         canvas.Modified()
         canvas.Update()
 
@@ -651,7 +652,8 @@ class CutVarMinimiser:
         hist_corr_matrix.Draw("colz")
         tex = ROOT.TLatex()
         tex.SetTextSize(0.04)
-        tex.DrawLatexNDC(0.05, 0.95, title)
+        tex.SetTextAlign(31)
+        tex.DrawLatexNDC(0.95, 0.95, title)
         canvas.Modified()
         canvas.Update()
 
@@ -743,7 +745,8 @@ class CutVarMinimiser:
         leg.Draw()
         tex = ROOT.TLatex()
         tex.SetTextSize(0.04)
-        tex.DrawLatexNDC(0.05, 0.95, title)
+        tex.SetTextAlign(31)
+        tex.DrawLatexNDC(0.95, 0.95, title)
         canvas.Modified()
         canvas.Update()
 
@@ -828,7 +831,8 @@ class CutVarMinimiser:
         leg.Draw()
         tex = ROOT.TLatex()
         tex.SetTextSize(0.04)
-        tex.DrawLatexNDC(0.05, 0.95, title)
+        tex.SetTextAlign(31)
+        tex.DrawLatexNDC(0.95, 0.95, title)
         canvas.Modified()
         canvas.Update()
 
@@ -905,7 +909,8 @@ class CutVarMinimiser:
         hist_residual_unc.Draw("histsame")
         tex = ROOT.TLatex()
         tex.SetTextSize(0.04)
-        tex.DrawLatexNDC(0.05, 0.95, title)
+        tex.SetTextAlign(31)
+        tex.DrawLatexNDC(0.95, 0.95, title)
         canvas.Modified()
         canvas.Update()
 


### PR DESCRIPTION
* Fixed MegaLinter error (`Multiple statements on one line (colon)`) introduced by PR [#16297](https://github.com/AliceO2Group/O2Physics/pull/16297);
* Added function which draws relative error of the raw yield and both efficiencies (prompt and nonprompt) as a function of cut set number. Corresponding canvas is plotted in a separate pdf;
* Added possibility artificially to make efficiency uncertainties equal to zero (in order not to propagate uncertainties due to finite MC size into statistical uncertainty of the result), and to shift efficiency central value by $\pm n\sigma$ (in order to be able to variate them and calculate systematic uncertainty associated to statistical uncertainty of the MC-driven efficiency). Default settings (both in script code and json config example) are conservative, i.e. zeroing and shifting are switched off.